### PR TITLE
fix DS and IX for CoinControl in litemode

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -52,6 +52,8 @@ SendCoinsDialog::SendCoinsDialog(QWidget *parent) :
         ui->checkUseDarksend->setChecked(false);
         ui->checkUseDarksend->setVisible(false);
         ui->checkInstantX->setVisible(false);
+        CoinControlDialog::coinControl->useDarkSend = false;
+        CoinControlDialog::coinControl->useInstantX = false;
     }
     connect(ui->checkUseDarksend, SIGNAL(stateChanged ( int )), this, SLOT(updateDisplayUnit()));
     connect(ui->checkInstantX, SIGNAL(stateChanged ( int )), this, SLOT(updateInstantX()));


### PR DESCRIPTION
The issue https://dashtalk.org/threads/11-2-dash-release.4515/page-25#post-50961