### PR TITLE
Included new "Peers list" tab into CSS theme

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>740</width>
+    <width>769</width>
     <height>485</height>
    </rect>
   </property>
@@ -717,6 +717,8 @@
          <property name="font">
           <font>
            <pointsize>10</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
           </font>
          </property>
          <property name="cursor">
@@ -726,7 +728,7 @@
           <string>Select a peer to view detailed information.</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignHCenter|Qt::AlignTop</set>
+          <set>Qt::AlignCenter</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -651,6 +651,10 @@ min-height:25px;
 min-width:180px;
 }
 
+QDialog#RPCConsole QWidget#tab_peers  QLabel#peerHeading { /* Peers Info Header */
+color:#3398CC;
+}
+
 QDialog#RPCConsole QPushButton#openDebugLogfileButton {
 max-width:60px;
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -233,7 +233,6 @@ RPCConsole::RPCConsole(QWidget *parent) :
     startExecutor();
     setTrafficGraphRange(INITIAL_TRAFFIC_GRAPH_MINS);
 
-    ui->detailWidget->hide();
     ui->peerHeading->setText(tr("Select a peer to view detailed information."));
 
     clear();
@@ -596,7 +595,6 @@ void RPCConsole::peerLayoutChanged()
         // detail node dissapeared from table (node disconnected)
         fUnselect = true;
         cachedNodeid = -1;
-        ui->detailWidget->hide();
         ui->peerHeading->setText(tr("Select a peer to view detailed information."));
     }
     else

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -102,8 +102,8 @@ private:
 
     enum ColumnWidths
     {
-        ADDRESS_COLUMN_WIDTH = 200,
-        SUBVERSION_COLUMN_WIDTH = 100,
+        ADDRESS_COLUMN_WIDTH = 170,
+        SUBVERSION_COLUMN_WIDTH = 140,
         PING_COLUMN_WIDTH = 80
     };
 


### PR DESCRIPTION
... plus some minor resizing to make the longer locales fit (both CSS and vanilla theme).

Looks like this now:
![peers](https://cloud.githubusercontent.com/assets/10080039/7219747/12386b50-e6af-11e4-98e9-c1c3d403175e.png)
