### PR TITLE
samba.org redirects to www.samba.org now. Gitian does not like that.

### DIFF
--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,6 +1,6 @@
 package=native_ccache
 $(package)_version=3.1.9
-$(package)_download_path=http://samba.org/ftp/ccache
+$(package)_download_path=http://www.samba.org/ftp/ccache
 $(package)_file_name=ccache-$($(package)_version).tar.bz2
 $(package)_sha256_hash=04d3e2e438ac8d4cc4b110b68cdd61bd59226c6588739a4a386869467f5ced7c
 


### PR DESCRIPTION
Nasty little bugger, the log just states that it can't resolve samba.org.

It's only a problem with Gitian, native builds don't care.