### PR TITLE
Fix for addressbook header problem on Windows + changed default transaction filter

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -788,8 +788,7 @@ QString loadStyleSheet()
         settings.setValue("theme", "drkblue");
     }
     
-//    QFile qFile(cssName);      
-    QFile qFile("drkblue.css");
+    QFile qFile(cssName);      
     if (qFile.open(QFile::ReadOnly)) {
         styleSheet = QLatin1String(qFile.readAll());
     }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -788,7 +788,8 @@ QString loadStyleSheet()
         settings.setValue("theme", "drkblue");
     }
     
-    QFile qFile(cssName);      
+//    QFile qFile(cssName);      
+    QFile qFile("drkblue.css");
     if (qFile.open(QFile::ReadOnly)) {
         styleSheet = QLatin1String(qFile.readAll());
     }

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -581,6 +581,10 @@ QWidget#AddressBookPage QTableView { /* Address Listing */
 font-size:12px;
 }
 
+QWidget#AddressBookPage QHeaderView::section { /* Min width for Windows fix */
+min-width:260px;
+}
+
 /* SETTINGS MENU */
 
 /* Encrypt Wallet and Change Passphrase Dialog */

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -21,7 +21,7 @@ TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :
     dateFrom(MIN_DATE),
     dateTo(MAX_DATE),
     addrPrefix(),
-    typeFilter(ALL_TYPES),
+    typeFilter(COMMON_TYPES),
     minAmount(0),
     limitRows(-1),
     showInactive(true)

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -22,7 +22,9 @@ public:
     static const QDateTime MAX_DATE;
     /** Type filter bit field (all types) */
     static const quint32 ALL_TYPES = 0xFFFFFFFF;
-
+    /** Type filter bit field (all types but Darksend-SPAM) */
+    static const quint32 COMMON_TYPES = 4223;   
+    
     static quint32 TYPE(int type) { return 1<<type; }
 
     void setDateRange(const QDateTime &from, const QDateTime &to);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -73,6 +73,7 @@ TransactionView::TransactionView(QWidget *parent) :
     typeWidget->setFixedWidth(TYPE_COLUMN_WIDTH);
 #endif
 
+    typeWidget->addItem(tr("Most Common"), TransactionFilterProxy::COMMON_TYPES);
     typeWidget->addItem(tr("All"), TransactionFilterProxy::ALL_TYPES);
     typeWidget->addItem(tr("Received with"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) |
                                         TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));


### PR DESCRIPTION
Reference: https://dashtalk.org/threads/11-2-dash-release.4515/page-27#post-52224

Problem only shows up:
* on Windows
* when the user has never created a sending address

Seems to be a bug of the Qt-CSS-implementation for Windows,
```cpp
ui->tableView->horizontalHeader()->setResizeMode(AddressTableModel::Address, QHeaderView::ResizeToContents);
```
should actually take care of this but doesn't.

I fixed it in the CSS, tests on Windows and several Linux-distributions look good now:
![address](https://cloud.githubusercontent.com/assets/10080039/7336772/238b5822-ec0e-11e4-8489-7647b6c65a0a.jpg)
