### PR TITLE
v0.12.0.x tooltip for submited denoms

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -508,8 +508,8 @@
            </item>
            <item row="4" column="1">
             <widget class="QLabel" name="labelSubmittedDenom">
-             <property name="statusTip">
-              <string>The denominations you submitted to the Masternode. To mix, other users must submit the exact same denominations.</string>
+             <property name="toolTip">
+              <string>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</string>
              </property>
              <property name="text">
               <string>n/a</string>


### PR DESCRIPTION
Small visual fix.

I'm not sure why it was statusTip because it doesn't fit in status bar anyway and thus is unreadable. So changing to toolTip now just like for any other element there and breaking it in 2 lines to make it look a bit more compact and nice.