### PR TITLE
Fix boost::get build error on ArchLinux

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -297,7 +297,7 @@ Value listunspent(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(pk, address))
             {
-                const CScriptID& hash = boost::get<const CScriptID&>(address);
+                const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));


### PR DESCRIPTION
https://dashtalk.org/threads/problem-with-dash-on-arch-linux.4838/ seems to be the same issue with boost::get as https://github.com/bitcoin/bitcoin/issues/6113

Shouldn't break anything: compiles fine on mac and ubuntu for me.