### PR TITLE
Do not disconnect MN, just set the state and let ThreadSocketHandler do the job

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -535,8 +535,8 @@ void CMasternodeMan::ProcessMasternodeConnections()
         if(darkSendPool.pSubmittedToMasternode->addr == pnode->addr) continue;
 
         if(pnode->fDarkSendMaster){
-            LogPrintf("Closing Masternode connection %s \n", pnode->addr.ToString().c_str());
-            pnode->CloseSocketDisconnect();
+            LogPrintf("Asking to close Masternode connection %s \n", pnode->addr.ToString().c_str());
+            pnode->fDisconnect = true;
         }
     }
 }


### PR DESCRIPTION
I guess I found the reason for too often "skipping" blocks appearance and following ORPHANs. I think we shouldn't disconnect masternodes by ourselves but should just set "disconnected" state and let ThreadSocketHandler to take care of connections. Otherwise wallet marks block as orphan, then it tries to ask exactly the same node we got current (ORPHAN) block from to provide previous block (the one that we still don't have) and if that node was masternode we was connected to wallet could fail to fetch previous block because at the very same moment we just broke connection in a "hard" way.

Tested for ~1 day and it looks good for me on Mac.