### PR TITLE
V0.12.0.x ds rand denom

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -318,7 +318,6 @@ public:
     int sessionDenom; //Users must submit an denom matching this
     int sessionUsers; //N Users have said they'll join
     bool sessionFoundMasternode; //If we've found a compatible Masternode
-    int64_t sessionTotalValue; //used for autoDenom
     std::vector<CTransaction> vecSessionCollateral;
 
     int cachedLastSuccess;
@@ -494,14 +493,14 @@ public:
     bool CreateDenominated(int64_t nTotalValue);
 
     /// Get the denominations for a list of outputs (returns a bitshifted integer)
-    int GetDenominations(const std::vector<CTxOut>& vout);
+    int GetDenominations(const std::vector<CTxOut>& vout, bool fRandDenom = false);
     int GetDenominations(const std::vector<CTxDSOut>& vout);
 
     void GetDenominationsToString(int nDenom, std::string& strDenom);
 
     /// Get the denominations for a specific amount of dash.
-    int GetDenominationsByAmount(int64_t nAmount, int nDenomTarget=0);
-    int GetDenominationsByAmounts(std::vector<int64_t>& vecAmount);
+    int GetDenominationsByAmount(int64_t nAmount, int nDenomTarget=0); // is not used anymore?
+    int GetDenominationsByAmounts(std::vector<int64_t>& vecAmount, bool fRandDenom = false);
 
     std::string GetMessageByID(int messageID);
 


### PR DESCRIPTION
- Randomize denoms calculated out of vecAmounts. Should help to find partners faster/more often and maybe slightly improve anonymity also.
- sessionTotal doesn't makes sense anymore, got rid of it.
- GetDenominationsByAmount cleaned a little but it is not used anywhere else so maybe it should be removed too (placed a comment there but didn't remove it yet).