### PR TITLE
V0.12.0.x block value/mn payment fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1541,10 +1541,10 @@ int64_t GetBlockValue(int nBits, int nHeight, const CAmount& nFees)
         for(int i = 210240; i <= nHeight; i += 210240) nSubsidy -= nSubsidy/14;
     }
 
-    if(nHeight > 158000+((576*30)* 7)) nSubsidy -= nSubsidy/40; // 278960 - 47.5% - 2015-06-01
-    if(nHeight > 158000+((576*30)* 9)) nSubsidy -= nSubsidy/40; // 313520 - 50.0% - 2015-08-03
-    if(nHeight > 158000+((576*30)*11)) nSubsidy -= nSubsidy/40; // 348080 - 52.5% - 2015-10-05
-    if(nHeight > 158000+((576*30)*13)) nSubsidy -= nSubsidy/40; // 382640 - 55.0% - 2015-12-07
+    if     (nHeight > 158000+((576*30)*15)) nSubsidy -= nSubsidy/40*4; // 417200 - 10.0% - 2016-02-08
+    else if(nHeight > 158000+((576*30)*13)) nSubsidy -= nSubsidy/40*3; // 382640 -  7.5% - 2015-12-07
+    else if(nHeight > 158000+((576*30)*11)) nSubsidy -= nSubsidy/40*2; // 348080 -  5.0% - 2015-10-05
+    else if(nHeight > 158000+((576*30)* 9)) nSubsidy -= nSubsidy/40;   // 313520 -  2.5% - 2015-08-03
 
     return nSubsidy + nFees;
 }
@@ -1571,7 +1571,7 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue)
     if(nHeight > 158000+((576*30)* 4)) ret += blockValue / 40; // 227120 - 40.0% - 2015-02-27
     if(nHeight > 158000+((576*30)* 5)) ret += blockValue / 40; // 244400 - 42.5% - 2015-03-30
     if(nHeight > 158000+((576*30)* 6)) ret += blockValue / 40; // 261680 - 45.0% - 2015-05-01
-    if(nHeight > 158000+((576*30)*15)) ret += blockValue / 40; // 417200 - 47.5% - 2016-02-08
+    if(nHeight > 158000+((576*30)* 7)) ret += blockValue / 40; // 278960 - 47.5% - 2015-06-01
     if(nHeight > 158000+((576*30)*17)) ret += blockValue / 40; // 451760 - 50.0% - 2016-04-11
 
     return ret;


### PR DESCRIPTION
- fix block value decrease calculation (was not accurate imo)
- reschedule block value decrease and mn payments (otherwise we won't be able to run on mainnet)
- fix comments (%% in block decrease)