### PR TITLE
V0.12.0.x add recent (tip - 12) blockhash to mnping

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -309,6 +309,7 @@ class CMasternodePing
 public:
 
     CTxIn vin;
+    uint256 blockHash;
     std::vector<unsigned char> vchSig;
     int64_t sigTime; //dsee message times
     //removed stop
@@ -321,6 +322,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(vin);
+        READWRITE(blockHash);
         READWRITE(sigTime);
         READWRITE(vchSig);
     }


### PR DESCRIPTION
We have lots of MNs stuck on old blocks. I think I know the root cause of it (orphans), why it happens (peers announce they have block but fail to deliver it) and how to fix it for 0.11.2 (https://github.com/UdjinM6/dash/commit/cf1e6774f6f4b31c5178e0a27aee8d6b03643e86 - it's a bit dumb way but should work). But 0.12 has a new way of handling such stalling peers and corresponding blocks so (I hope) this "fix" will not be needed.

Anyway, I believe such stuck orphans is the reason for increasing DS and IX failure rates, lots of "MN rank too high/low" messages (and failing PoSe) and so on. So here is an idea how to solve this: masternodes should include some recent block hash in their mnping messages to verify that they are not only running but actually are synced. I propose to send (tip - 12) which is ~30 minutes in the past and accept mnpings only if it contains block hash no older then (tip - 24) which is ~1 hour. That should give a reasonable "acceptance window" imo: MN still can stuck for a few blocks (up to 12) and it's ok if it catch up later AND at the same time MN should be aware of most recent inputs so there should be a lot less problems for IX (DS still could fail more often then IX but should be way better than it's now imo or we can tweak it later if it's needed).