### PR TITLE
Masternode broadcast's and ping's GetHash method fix

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -291,10 +291,10 @@ public:
     }
     
     uint256 GetHash(){
-         return Hash(
-            BEGIN(sigTime), END(sigTime), 
-            BEGIN(pubkey), END(pubkey)
-        );
+        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+        ss << sigTime;
+        ss << pubkey;
+        return ss.GetHash();
     }
 
 };
@@ -330,7 +330,10 @@ public:
     void Relay();    
 
     uint256 GetHash(){
-         return Hash(BEGIN(vin), END(vin), BEGIN(sigTime), END(sigTime));
+        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+        ss << vin;
+        ss << sigTime;
+        return ss.GetHash();
     }
 };
 #endif


### PR DESCRIPTION
We at btcsoft explored your sources in an effort to write our java implementation of DASH protocol for wallets. We've found a place in the code that raised our concern. That's GetHash() methods of CMasternodeBroadcast and CMasternodePing classes. It uses 
```C++
Hash(BEGIN(...), END(...))
``` 
structures that casts objects to byte arrays. I'm not an C++ expert but as far as I know that's very platform dependent, i.e. code compiled on Windows 32x and Ubuntu 64x gcc will produce different result (not even mentioning data endinnesses of different architectures). That might introduce a problem in a protocol when "problematic" nodes will calculate it's own hash of message and store it once again in a "seen" vector and broadcast message to the network once again. Also it introduces a complication in different programming languages implementations (e.g. java) which will be forced to mimic C++ (on some isolated platform) way to store objects in memory.
Keeping in mind that v0.12 will introduce severe protocol changes I think it's a good time to slip that little fix in: calculate those hashes like bitcoin core developers did with core coin objects - using serialization streams.

Regards,
Michael Kulikov, Btcsoft lead developer
adios@btcsoft.com
http://btcsoft.com/