### PR TITLE
V0.12.0.x SecondsSincePayment

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -245,6 +245,19 @@ void CMasternode::Check()
     activeState = MASTERNODE_ENABLED; // OK
 }
 
+int64_t CMasternode::SecondsSincePayment() {
+    int64_t sec = (GetAdjustedTime() - nLastPaid);
+    int64_t month = 60*60*24*30;
+    if(sec < month) return sec; //if it's less than 30 days, give seconds
+
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << vin;
+    ss << sigTime;
+    uint256 hash =  ss.GetHash();
+
+    // return some deterministic value for unknown/unpaid but force it to be more than 30 days old
+    return month + hash.GetCompact(false);
+}
 
 CMasternodeBroadcast::CMasternodeBroadcast()
 {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -163,19 +163,7 @@ public:
             READWRITE(nVotedTimes);
     }
 
-    int64_t SecondsSincePayment()
-    {
-        int64_t sec = (GetAdjustedTime() - nLastPaid);
-        if(sec < 60*60*24*30) return sec; //if it's less than 30 days, give seconds
-
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << vin;
-        ss << sigTime;
-        uint256 hash =  ss.GetHash();
-
-        memcpy(&sec, &hash, 64);
-        return sec;
-    }
+    int64_t SecondsSincePayment();
 
     void UpdateFromNewBroadcast(CMasternodeBroadcast& mnb);
 


### PR DESCRIPTION
Changes to SecondsSincePayment:
- fix buffer overflow (memcpy from uint256 to int64_t was causing it, using GetCompact now instead)
- change logic (force unknown/unpaid it to be more than 30 days old)
- move implementation to cpp