### PR TITLE
V0.12.0.x remove nLastPaid from CMasternodeBroadcast

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -162,7 +162,7 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb)
     donationPercentage = mnb.donationPercentage;
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
-    nLastPaid = mnb.nLastPaid;
+    nLastPaid = 0;
     nVotedTimes = 0;
 }
 
@@ -178,7 +178,6 @@ void CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
     addr = mnb.addr;
     donationAddress = mnb.donationAddress;
     donationPercentage = mnb.donationPercentage;
-    nLastPaid = mnb.nLastPaid;
 }
 
 //

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -275,7 +275,6 @@ public:
         READWRITE(protocolVersion);
         READWRITE(donationAddress);
         READWRITE(donationPercentage);
-        READWRITE(nLastPaid);
     }
     
     uint256 GetHash(){


### PR DESCRIPTION
We should not update nLastPaid from broadcasted messages