### PR TITLE
Adding explicit information how to build GUI client.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,6 +2,12 @@ Building Dash
 
 Use the autogen script to prepare the build environment.
 
+1. To build GUI client
+    ./autogen.sh
+    ./configure --with-gui
+    make
+
+2. To build headless daemon only (dashd)
     ./autogen.sh
     ./configure
     make


### PR DESCRIPTION
This way it should be easier for user to find information how to build either dashd or dash-qt.