### PR TITLE
V0.12.0.x move ds pool status out of overviewpage

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -386,6 +386,8 @@ public:
         return state;
     }
 
+    std::string GetStatus();
+
     int GetEntriesCount() const
     {
         if(fMasterNode){

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -140,8 +140,6 @@ OverviewPage::OverviewPage(QWidget *parent) :
     ui->labelDarksendSyncStatus->setText("(" + tr("out of sync") + ")");
     ui->labelTransactionsStatus->setText("(" + tr("out of sync") + ")");
 
-    showingDarkSendMessage = 0;
-    darksendActionCheck = 0;
     lastNewBlock = 0;
 
     if(fLiteMode){
@@ -436,61 +434,7 @@ void OverviewPage::darkSendStatus()
         ui->darksendEnabled->setText(tr("Enabled"));
     }
 
-    int state = darkSendPool.GetState();
-    int entries = darkSendPool.GetEntriesCount();
-    int accepted = darkSendPool.GetLastEntryAccepted();
-
-    /* ** @TODO this string creation really needs some clean ups ---vertoe ** */
-    QString strStatus;
-
-    if(chainActive.Tip()->nHeight - darkSendPool.cachedLastSuccess < darkSendPool.minBlockSpacing) {
-        strStatus = QString(darkSendPool.strAutoDenomResult.c_str());
-    } else if(state == POOL_STATUS_IDLE) {
-        strStatus = tr("Darksend is idle.");
-    } else if(state == POOL_STATUS_ACCEPTING_ENTRIES) {
-        if(entries == 0) {
-            if(darkSendPool.strAutoDenomResult.size() == 0){
-                strStatus = tr("Mixing in progress...");
-            } else {
-                strStatus = QString(darkSendPool.strAutoDenomResult.c_str());
-            }
-            showingDarkSendMessage = 0;
-        } else if (accepted == 1) {
-            strStatus = tr("Darksend request complete:") + " " + tr("Your transaction was accepted into the pool!");
-            if(showingDarkSendMessage % 10 > 8) {
-                darkSendPool.lastEntryAccepted = 0;
-                showingDarkSendMessage = 0;
-            }
-        } else {
-            if(showingDarkSendMessage % 70 <= 40) strStatus = tr("Submitted following entries to masternode: %1 / %2").arg(entries).arg(darkSendPool.GetMaxPoolTransactions());
-            else if(showingDarkSendMessage % 70 <= 50) strStatus = tr("Submitted to masternode, waiting for more entries ( %1 / %2 ) %3").arg(entries).arg(darkSendPool.GetMaxPoolTransactions()).arg(" .");
-            else if(showingDarkSendMessage % 70 <= 60) strStatus = tr("Submitted to masternode, waiting for more entries ( %1 / %2 ) %3").arg(entries).arg(darkSendPool.GetMaxPoolTransactions()).arg(" ..");
-            else if(showingDarkSendMessage % 70 <= 70) strStatus = tr("Submitted to masternode, waiting for more entries ( %1 / %2 ) %3").arg(entries).arg(darkSendPool.GetMaxPoolTransactions()).arg(" ...");
-        }
-    } else if(state == POOL_STATUS_SIGNING) {
-        if(showingDarkSendMessage % 70 <= 10) strStatus = tr("Found enough users, signing ...");
-        else if(showingDarkSendMessage % 70 <= 20) strStatus = tr("Found enough users, signing ( waiting %1 )").arg(".");
-        else if(showingDarkSendMessage % 70 <= 30) strStatus = tr("Found enough users, signing ( waiting %1 )").arg("..");
-        else if(showingDarkSendMessage % 70 <= 40) strStatus = tr("Found enough users, signing ( waiting %1 )").arg("...");
-    } else if(state == POOL_STATUS_TRANSMISSION) {
-        strStatus = tr("Transmitting final transaction.");
-    } else if (state == POOL_STATUS_IDLE) {
-        strStatus = tr("Darksend is idle.");
-    } else if (state == POOL_STATUS_FINALIZE_TRANSACTION) {
-        strStatus = tr("Finalizing transaction.");
-    } else if(state == POOL_STATUS_ERROR) {
-        strStatus = tr("Darksend request incomplete:") + " " + tr(darkSendPool.lastMessage.c_str()) + " " + tr("Will retry...");
-    } else if(state == POOL_STATUS_SUCCESS) {
-        strStatus = tr("Darksend request complete:") + " " + tr(darkSendPool.lastMessage.c_str());
-    } else if(state == POOL_STATUS_QUEUE) {
-        if(showingDarkSendMessage % 70 <= 50) strStatus = tr("Submitted to masternode, waiting in queue %1").arg(".");
-        else if(showingDarkSendMessage % 70 <= 60) strStatus = tr("Submitted to masternode, waiting in queue %1").arg("..");
-        else if(showingDarkSendMessage % 70 <= 70) strStatus = tr("Submitted to masternode, waiting in queue %1").arg("...");
-    } else {
-        strStatus = tr("Unknown state: id = %1").arg(state);
-    }
-
-    if(state == POOL_STATUS_ERROR || state == POOL_STATUS_SUCCESS) darkSendPool.Check();
+    QString strStatus = QString(darkSendPool.GetStatus().c_str());
 
     QString s = tr("Last Darksend message:\n") + strStatus;
 
@@ -508,10 +452,6 @@ void OverviewPage::darkSendStatus()
         ui->labelSubmittedDenom->setText(s2);
     }
 
-    showingDarkSendMessage++;
-    darksendActionCheck++;
-
-    // Get DarkSend Denomination Status
 }
 
 void OverviewPage::darksendAuto(){

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -60,8 +60,6 @@ private:
     qint64 cachedTxLocks;
     qint64 lastNewBlock;
 
-    int showingDarkSendMessage;
-    int darksendActionCheck;
     int cachedNumBlocks;
 
     TxViewDelegate *txdelegate;


### PR DESCRIPTION
Move some logic to ds pool itself making human readable status available there instead of qt part of wallet only. Makes more sense and could be further useful for implementing ds for cli. Still more to be moved/decoupled but should be a bit cleaner now :)
Also 3x increased speed of switching for (. .. ...) kind of statuses. Looks a bit more "responsive" imo.