### PR TITLE
V0.12.0.x small ds code cleanups

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2258,7 +2258,6 @@ void ThreadCheckDarkSendPool()
     RenameThread("dash-darksend");
 
     unsigned int c = 0;
-    std::string errorMessage;
 
     while (true)
     {

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -162,7 +162,7 @@ void CDarksendPool::ProcessMessageDarksend(CNode* pfrom, std::string& strCommand
         }
 
     } else if (strCommand == "dsi") { //DarkSend vIn
-        int errorID = MSG_NOERR;
+
         if (pfrom->nVersion < MIN_POOL_PEER_PROTO_VERSION) {
             LogPrintf("dsi -- incompatible version! \n");
             errorID = ERR_VERSION;
@@ -1070,7 +1070,7 @@ bool CDarksendPool::AddEntry(const std::vector<CTxIn>& newInput, const int64_t& 
     entries.push_back(v);
 
     if(fDebug) LogPrintf("CDarksendPool::AddEntry -- adding %s\n", newInput[0].ToString().c_str());
-    errorID = MSG_NOERR;
+    errorID = MSG_ENTRIES_ADDED;
 
     return true;
 }
@@ -2072,6 +2072,7 @@ std::string CDarksendPool::GetMessageByID(int messageID) {
     case ERR_MISSING_TX: return _("Missing input transaction information.");
     case ERR_VERSION: return _("Incompatible version.");
     case MSG_SUCCESS: return _("Transaction created successfully.");
+    case MSG_ENTRIES_ADDED: return _("Your entries added successfully.");
     case MSG_NOERR:
     default:
         return "";

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -592,7 +592,7 @@ void CDarksendPool::Check()
     if((state == POOL_STATUS_ERROR || state == POOL_STATUS_SUCCESS) && GetTimeMillis()-lastTimeChanged >= 10000) {
         if(fDebug) LogPrintf("CDarksendPool::Check() -- RESETTING MESSAGE \n");
         SetNull(true);
-        if(fMasterNode) RelayStatus(darkSendPool.sessionID, darkSendPool.GetState(), darkSendPool.GetEntriesCount(), MASTERNODE_RESET);
+        if(fMasterNode) RelayStatus(sessionID, GetState(), GetEntriesCount(), MASTERNODE_RESET);
         UnlockCoins();
     }
 }
@@ -670,7 +670,7 @@ void CDarksendPool::CheckFinalTransaction()
             if(fDebug) LogPrintf("CDarksendPool::Check() -- COMPLETED -- RESETTING \n");
             SetNull(true);
             UnlockCoins();
-            if(fMasterNode) RelayStatus(darkSendPool.sessionID, darkSendPool.GetState(), darkSendPool.GetEntriesCount(), MASTERNODE_RESET);
+            if(fMasterNode) RelayStatus(sessionID, GetState(), GetEntriesCount(), MASTERNODE_RESET);
             pwalletMain->Lock();
         }
     }
@@ -873,7 +873,7 @@ void CDarksendPool::CheckTimeout(){
                     UnlockCoins();
                 }
                 if(fMasterNode){
-                    RelayStatus(darkSendPool.sessionID, darkSendPool.GetState(), darkSendPool.GetEntriesCount(), MASTERNODE_RESET);
+                    RelayStatus(sessionID, GetState(), GetEntriesCount(), MASTERNODE_RESET);
                 }
                 break;
             }
@@ -1128,7 +1128,7 @@ bool CDarksendPool::SignaturesComplete(){
 // This is only ran from clients
 //
 void CDarksendPool::SendDarksendDenominate(std::vector<CTxIn>& vin, std::vector<CTxOut>& vout, int64_t amount){
-    if(darkSendPool.txCollateral == CMutableTransaction()){
+    if(txCollateral == CMutableTransaction()){
         LogPrintf ("CDarksendPool:SendDarksendDenominate() - Darksend collateral not set");
         return;
     }
@@ -1415,8 +1415,8 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
         return false;
     }
 
-    if(darkSendPool.GetState() != POOL_STATUS_ERROR && darkSendPool.GetState() != POOL_STATUS_SUCCESS){
-        if(darkSendPool.GetMyTransactionCount() > 0){
+    if(GetState() != POOL_STATUS_ERROR && GetState() != POOL_STATUS_SUCCESS){
+        if(GetMyTransactionCount() > 0){
             return true;
         }
     }
@@ -2229,7 +2229,7 @@ void CDarksendPool::RelayIn(const std::vector<CTxDSIn>& vin, const int64_t& nAmo
     BOOST_FOREACH(CNode* pnode, vNodes)
     {
         if(!pSubmittedToMasternode) return;
-        if((CNetAddr)darkSendPool.pSubmittedToMasternode->addr != (CNetAddr)pnode->addr) continue;
+        if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)pnode->addr) continue;
         LogPrintf("RelayIn - found master, relaying message - %s \n", pnode->addr.ToString().c_str());
         pnode->PushMessage("dsi", vin2, nAmount, txCollateral, vout2);
     }

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -287,7 +287,8 @@ public:
         ERR_MISSING_TX,
         ERR_VERSION,
         MSG_NOERR,
-        MSG_SUCCESS
+        MSG_SUCCESS,
+        MSG_ENTRIES_ADDED
     };
 
     std::vector<CDarkSendEntry> myEntries; // clients entries


### PR DESCRIPTION
Few small fixes:
- add missing MSG_ENTRIES_ADDED for proper ds status display (btw no need for proto bump for this)
- remove unneeded "darkSendPool." in DS pool class functions
- slight optimizations/readability improvements for ds
- remove unused variable