### PR TITLE
V0.12.0.x sum tx separator and negative value highlight

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -449,7 +449,6 @@ void TransactionView::showDetails()
 /** Compute sum of all selected transactions */
 void TransactionView::computeSum()
 {
-    QString amountText;
     qint64 amount = 0;
     int nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
     if(!transactionView->selectionModel())
@@ -460,7 +459,8 @@ void TransactionView::computeSum()
         foreach (QModelIndex index, selection){
             amount += index.data(TransactionTableModel::AmountRole).toLongLong();
         }
-        QString strAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, amount, true));
+        QString strAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, amount, true, BitcoinUnits::separatorAlways));
+        if (amount < 0) strAmount = "<span style='color:red;'>" + strAmount + "</span>";
         emit trxAmount(strAmount);
     }
 }


### PR DESCRIPTION
Always show separator for sum tx amount and highlight (red) negative amounts. Should look like this:
![screen shot 2015-06-28 at 17 30 14](https://cloud.githubusercontent.com/assets/1935069/8396725/682782d8-1dbb-11e5-8287-70d458f55e41.png)
