### PR TITLE
V0.12.0.x Various DS related fixes for overview page

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -179,7 +179,7 @@
              </widget>
             </item>
             <item row="4" column="0" colspan="2">
-             <widget class="Line" name="line">
+             <widget class="Line" name="lineSpendableBalance">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -481,7 +481,7 @@
               </font>
              </property>
              <property name="text">
-              <string>0 DASH</string>
+              <string notr="true">0 DASH</string>
              </property>
             </widget>
            </item>
@@ -974,7 +974,7 @@
            <string>Start/Stop Mixing</string>
           </property>
          </widget>
-         <widget class="Line" name="line">
+         <widget class="Line" name="lineLastMessage">
           <property name="geometry">
            <rect>
             <x>10</x>

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -31,7 +31,7 @@
         <item row="7" column="2">
          <widget class="QCheckBox" name="reuseAddress">
           <property name="toolTip">
-           <string>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</string>
+           <string>Reuse one of the previously used receiving addresses.&lt;br&gt;Reusing addresses has security and privacy issues.&lt;br&gt;Do not use this unless re-generating a payment request made before.</string>
           </property>
           <property name="text">
            <string>R&amp;euse an existing receiving address (not recommended)</string>
@@ -71,7 +71,7 @@
         <item row="6" column="2">
          <widget class="QLineEdit" name="reqMessage">
           <property name="toolTip">
-           <string>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Dash network.</string>
+           <string>An optional message to attach to the payment request, which will be displayed when the request is opened.&lt;br&gt;Note: The message will not be sent with the payment over the Dash network.</string>
           </property>
          </widget>
         </item>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -455,11 +455,14 @@ bool ToolTipToRichTextFilter::eventFilter(QObject *obj, QEvent *evt)
     {
         QWidget *widget = static_cast<QWidget*>(obj);
         QString tooltip = widget->toolTip();
-        if(tooltip.size() > size_threshold && !tooltip.startsWith("<qt") && !Qt::mightBeRichText(tooltip))
+        if(tooltip.size() > size_threshold && !tooltip.startsWith("<qt"))
         {
-            // Envelop with <qt></qt> to make sure Qt detects this as rich text
-            // Escape the current message as HTML and replace \n by <br>
-            tooltip = "<qt>" + HtmlEscape(tooltip, true) + "</qt>";
+            // Escape the current message as HTML and replace \n by <br> if it's not rich text
+            if(!Qt::mightBeRichText(tooltip))
+                tooltip = HtmlEscape(tooltip, true);
+            // Envelop with <qt></qt> to make sure Qt detects every tooltip as rich text
+            // and style='white-space:pre' to preserve line composition
+            tooltip = "<qt style='white-space:pre'>" + tooltip + "</qt>";
             widget->setToolTip(tooltip);
             return true;
         }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -57,11 +57,6 @@ private:
     CAmount currentWatchUnconfBalance;
     CAmount currentWatchImmatureBalance;
 
-    qint64 cachedTxLocks;
-    qint64 lastNewBlock;
-
-    int cachedNumBlocks;
-
     TxViewDelegate *txdelegate;
     TransactionFilterProxy *filter;
 


### PR DESCRIPTION
Various DS related fixes for overview page:
- streamline initialization logic for litemode/masternode/ds
- call updateDarksendProgress on setBalance (should recalculate on new balance and unit change)
- format amountAndRounds for 0 balance same way as for normal balance (see c3febd20a8b8d7b558635034c19923e6ae79f22e)
- use _style='white-space:pre'_ to show long strings in tooltips correctly, adapt few strings
- small fixes (cleanup naming, notr, use static and get rid of unneeded class members where it's possible)