### PR TITLE
V0.12.0.x fix ds mn crashes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -120,7 +120,7 @@ void StartShutdown()
 }
 bool ShutdownRequested()
 {
-    return fRequestShutdown;
+    return fRequestShutdown || fRestartRequested;
 }
 
 class CCoinsViewErrorCatcher : public CCoinsViewBacked
@@ -149,6 +149,7 @@ static CCoinsViewErrorCatcher *pcoinscatcher = NULL;
 /** Preparing steps before shutting down or restarting the wallet */
 void PrepareShutdown()
 {
+    fRequestShutdown = true; // Needed when we shutdown the wallet
     fRestartRequested = true; // Needed when we restart the wallet
     LogPrintf("%s: In progress...\n", __func__);
     static CCriticalSection cs_Shutdown;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -191,6 +191,8 @@ uint256 CMasternode::CalculateScore(int mod, int64_t nBlockHeight)
 
 void CMasternode::Check()
 {
+    if(ShutdownRequested()) return;
+
     //TODO: Random segfault with this line removed
     TRY_LOCK(cs_main, lockRecv);
     if(!lockRecv) return;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -306,7 +306,9 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 
 void OverviewPage::updateDarksendProgress()
 {
-    if(IsInitialBlockDownload()) return;
+    if(IsInitialBlockDownload() || ShutdownRequested()) return;
+
+    if(!pwalletMain || !walletModel || !walletModel->getOptionsModel()) return;
 
     int64_t nBalance = pwalletMain->GetBalance();
     QString strAmountAndRounds;


### PR DESCRIPTION
Prevent CMasternode::Check() and OverviewPage::updateDarksendProgress() from being executed on shutdown/restart. Should finally fix those crashes.