### PR TITLE
Remove assertion from ~LockedPageManager

### DIFF
--- a/src/allocators.h
+++ b/src/allocators.h
@@ -40,7 +40,6 @@ public:
 
     ~LockedPageManagerBase()
     {
-        assert(this->GetLockedPageCount() == 0);
     }
 
 


### PR DESCRIPTION
This assertion will occur any time that the client quits without
shutting down properly due to an error condition. As the user will
report this error instead of the error that was the root cause, it is
better to remove it.