### PR TITLE
Persist Date and Type filters in "Transactions" tab + Popup information on first mixing 

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -20,6 +20,7 @@
 
 #include <QAbstractItemDelegate>
 #include <QPainter>
+#include <QSettings>
 #include <QTimer>
 
 #define DECORATION_SIZE 48
@@ -455,6 +456,15 @@ void OverviewPage::darksendReset(){
 }
 
 void OverviewPage::toggleDarksend(){
+    QSettings settings;
+    // Popup some information on first mixing
+    QString hasMixed = settings.value("hasMixed").toString();
+    if(hasMixed.isEmpty()){
+        QMessageBox::information(this, tr("Darksend"),
+                tr("If you don't want to see internal Darksend fees/transactions select \"Most Common\" as Type on the \"Transactions\" tab."),
+                QMessageBox::Ok, QMessageBox::Ok);
+        settings.setValue("hasMixed", "hasMixed");
+    }
     if(!fEnableDarksend){
         int64_t balance = pwalletMain->GetBalance();
         float minAmount = 1.49 * COIN;

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -29,6 +29,7 @@
 #include <QMenu>
 #include <QPoint>
 #include <QScrollBar>
+#include <QSettings>
 #include <QSignalMapper>
 #include <QTableView>
 #include <QUrl>
@@ -38,6 +39,7 @@ TransactionView::TransactionView(QWidget *parent) :
     QWidget(parent), model(0), transactionProxyModel(0),
     transactionView(0)
 {
+    QSettings settings;
     // Build filter row
     setContentsMargins(0,0,0,0);
 
@@ -71,6 +73,7 @@ TransactionView::TransactionView(QWidget *parent) :
     dateWidget->addItem(tr("Last month"), LastMonth);
     dateWidget->addItem(tr("This year"), ThisYear);
     dateWidget->addItem(tr("Range..."), Range);
+    dateWidget->setCurrentIndex(settings.value("transactionDate").toInt());
     hlayout->addWidget(dateWidget);
 
     typeWidget = new QComboBox(this);
@@ -80,8 +83,8 @@ TransactionView::TransactionView(QWidget *parent) :
     typeWidget->setFixedWidth(TYPE_COLUMN_WIDTH);
 #endif
 
-    typeWidget->addItem(tr("Most Common"), TransactionFilterProxy::COMMON_TYPES);
     typeWidget->addItem(tr("All"), TransactionFilterProxy::ALL_TYPES);
+    typeWidget->addItem(tr("Most Common"), TransactionFilterProxy::COMMON_TYPES);
     typeWidget->addItem(tr("Received with"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) |
                                         TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
     typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
@@ -94,6 +97,7 @@ TransactionView::TransactionView(QWidget *parent) :
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
+    typeWidget->setCurrentIndex(settings.value("transactionType").toInt());
 
     hlayout->addWidget(typeWidget);
 
@@ -181,6 +185,7 @@ TransactionView::TransactionView(QWidget *parent) :
 
 void TransactionView::setModel(WalletModel *model)
 {
+    QSettings settings;
     this->model = model;
     if(model)
     {
@@ -236,6 +241,10 @@ void TransactionView::setModel(WalletModel *model)
 
         // Watch-only signal
         connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyColumn(bool)));
+        
+        // Update transaction list with persisted settings
+        chooseType(settings.value("transactionType").toInt());
+        chooseDate(settings.value("transactionDate").toInt());
     }
 }
 
@@ -285,6 +294,11 @@ void TransactionView::chooseDate(int idx)
         dateRangeChanged();
         break;
     }
+    // Persist settings
+    if (dateWidget->itemData(idx).toInt() != Range){
+        QSettings settings;
+        settings.setValue("transactionDate", idx);
+    }
 }
 
 void TransactionView::chooseType(int idx)
@@ -293,6 +307,9 @@ void TransactionView::chooseType(int idx)
         return;
     transactionProxyModel->setTypeFilter(
         typeWidget->itemData(idx).toInt());
+    // Persist settings
+    QSettings settings;
+    settings.setValue("transactionType", idx);
 }
 
 void TransactionView::chooseWatchonly(int idx)


### PR DESCRIPTION
References: 
- https://dashtalk.org/threads/v12-testing-thread.5484/page-49#post-58676
- https://dashtalk.org/threads/v12-testing-thread.5484/page-49#post-58674

Transaction-date and type settings are perstisted now. The other 2 (prefix and amount) are IMO search fields and shouldn't be pre-filled on startup.

On the very first mixing attempt, an information popup explains this to users:
![mixing](https://cloud.githubusercontent.com/assets/10080039/8508088/5ac771ba-2262-11e5-879a-8a393d4c7018.jpg)
