### PR TITLE
User configurable Wallet Window Title

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -356,7 +356,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -upgradewallet           " + _("Upgrade wallet to latest format") + " " + _("on startup") + "\n";
     strUsage += "  -wallet=<file>           " + _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), "wallet.dat") + "\n";
     strUsage += "  -walletnotify=<cmd>      " + _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)") + "\n";
-    strUsage += "  -windowtitle=<name>      " + _("Wallet window title") + "\n";
+    if (mode == HMM_BITCOIN_QT)
+        strUsage += "  -windowtitle=<name>  " + _("Wallet window title") + "\n";
     strUsage += "  -zapwallettxes=<mode>    " + _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") + "\n";
     strUsage += "                           " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)") + "\n";
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -356,6 +356,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -upgradewallet           " + _("Upgrade wallet to latest format") + " " + _("on startup") + "\n";
     strUsage += "  -wallet=<file>           " + _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), "wallet.dat") + "\n";
     strUsage += "  -walletnotify=<cmd>      " + _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)") + "\n";
+    strUsage += "  -windowtitle=<name>      " + _("Wallet window title") + "\n";
     strUsage += "  -zapwallettxes=<mode>    " + _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") + "\n";
     strUsage += "                           " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)") + "\n";
 #endif

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -113,16 +113,12 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle *networkStyle, QWidget *parent) :
 #endif // ENABLE_WALLET
     if(enableWallet)
     {
-        QString userWindowTitle = QString::fromStdString(GetArg("-windowtitle", ""));
-        if(userWindowTitle.isEmpty()){
-            windowTitle += tr("Wallet");
-        }
-        else{
-            windowTitle += userWindowTitle;
-        }
+        windowTitle += tr("Wallet");
     } else {
         windowTitle += tr("Node");
     }
+    QString userWindowTitle = QString::fromStdString(GetArg("-windowtitle", ""));
+    if(!userWindowTitle.isEmpty()) windowTitle += " - " + userWindowTitle;
     windowTitle += " " + networkStyle->getTitleAddText();
 #ifndef Q_OS_MAC
     QApplication::setWindowIcon(networkStyle->getAppIcon());

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -113,7 +113,13 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle *networkStyle, QWidget *parent) :
 #endif // ENABLE_WALLET
     if(enableWallet)
     {
-        windowTitle += tr("Wallet");
+        QString userWindowTitle = QString::fromStdString(GetArg("-windowtitle", ""));
+        if(userWindowTitle.isEmpty()){
+            windowTitle += tr("Wallet");
+        }
+        else{
+            windowTitle += userWindowTitle;
+        }
     } else {
         windowTitle += tr("Node");
     }


### PR DESCRIPTION
Reference: https://dashtalk.org/threads/enhanced-darkcoin-wallet-ui.1705/page-23#post-57474

Funnily enough  I also use the "Show Automatic Backups" browser to find out which wallet I'm using...

With ```-windowtitle=<name>``` you can now set a dedicated name for each of your wallets.

Looks like this:
![walletname](https://cloud.githubusercontent.com/assets/10080039/8509840/0c063672-22be-11e5-86fe-93124747d780.jpg)

