### PR TITLE
Fixed warning from labelCoinControlChangeLabel

### DIFF
--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -1068,7 +1068,6 @@ QDialog#SendCoinsDialog .QFrame#frameCoinControl .QValidatedLineEdit#lineEditCoi
 QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlChangeLabel { /* Custom Change Address Validation Label */
 font-weight:normal;
 qproperty-margin:-6;
-qproperty-padding:0;
 margin-right:112px;
 }
 


### PR DESCRIPTION
Prevents the following warning in debug.log

GUI: QLabel(0xb0049b8, name = "labelCoinControlChangeLabel") does not have a property named "padding"