### PR TITLE
V0.12.0.x Fix GetInputDarksendRounds

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -60,7 +60,9 @@ extern CActiveMasternode activeMasternode;
 bool IsSyncingMasternodeAssets();
 
 // get the Darksend chain depth for a given input
-int GetInputDarksendRounds(CTxIn in, int rounds=0);
+int GetRealInputDarksendRounds(CTxIn in, int rounds);
+// respect current settings
+int GetInputDarksendRounds(CTxIn in);
 
 /** Holds an Darksend input
  */


### PR DESCRIPTION
Fix GetInputDarksendRounds:
- show user and use in external calculations rounds that are calculated respecting current settings while use "real" rounds in internal calulation to store correct results in cache and easily provide user with updated info on settings change
- fix max real rounds limit (16)