### PR TITLE
V0.12.0.x fix min mnpayments proto usage

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -153,6 +153,12 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, int64_t nFe
     }
 }
 
+int CMasternodePayments::GetMinMasternodePaymentsProto() {
+    return IsSporkActive(SPORK_10_MASTERNODE_PAY_NEWEST_NODES)
+            ? MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2
+            : MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1;
+}
+
 void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
     if(IsInitialBlockDownload()) return;
@@ -409,7 +415,7 @@ bool CMasternodePaymentWinner::IsValid()
 {
     if(IsReferenceNode(vinMasternode)) return true;
 
-    int n = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight-100, MIN_MNPAYMENTS_PROTO_VERSION);
+    int n = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight-100, GetMinMasternodePaymentsProto());
 
     if(n == -1)
     {
@@ -435,7 +441,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     //reference node - hybrid mode
 
     if(!IsReferenceNode(activeMasternode.vin)){
-        int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight-100, MIN_MNPAYMENTS_PROTO_VERSION);
+        int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight-100, GetMinMasternodePaymentsProto());
 
         if(n == -1)
         {

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -21,7 +21,6 @@ extern CMasternodePayments masternodePayments;
 extern std::map<uint256, CMasternodePaymentWinner> mapMasternodePayeeVotes;
 extern std::map<uint256, CMasternodeBlockPayees> mapMasternodeBlocks;
 
-static const int MIN_MNPAYMENTS_PROTO_VERSION = 70066;
 #define MNPAYMENTS_SIGNATURES_REQUIRED           6
 #define MNPAYMENTS_SIGNATURES_TOTAL              10
 
@@ -200,6 +199,7 @@ public:
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
     bool IsScheduled(CMasternode& mn, int nNotBlockHeight);
 
+    int GetMinMasternodePaymentsProto();
     void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     std::string GetRequiredPaymentsString(int nBlockHeight);
     void FillBlockPayee(CMutableTransaction& txNew, int64_t nFees);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -385,12 +385,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         if(!mn.IsEnabled()) continue;
 
         // //check protocol version
-        if(IsSporkActive(SPORK_10_MASTERNODE_PAY_NEWEST_NODES)){
-            if(mn.protocolVersion < MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2) continue;
-        } else {
-            //support older versions for a period of time
-            if(mn.protocolVersion < MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1) continue;
-        }
+        if(mn.protocolVersion < masternodePayments.GetMinMasternodePaymentsProto()) continue;
 
         //it's in the list -- so let's skip it
         if(masternodePayments.IsScheduled(mn, nBlockHeight)) continue;


### PR DESCRIPTION
Use spork dependent logic to get the right minimal proto everywhere MIN_MNPAYMENTS_PROTO_VERSION was used previously