### PR TITLE
V0.12.0.x fix alternative units in send dialog

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -363,7 +363,7 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients, QString strFee,
     }
     questionString.append(tr("Total Amount %1 (= %2)")
         .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount))
-        .arg(alternativeUnits.join(" " + tr("or") + " ")));
+        .arg("<br />" + alternativeUnits.join(" " + tr("or") + "<br />")));
 
     QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm send coins"),
         questionString.arg(formatted.join("<br />")),


### PR DESCRIPTION
Fix some weird bug where high amount were not displayed correctly in alternative units in send dialog.

Before:
![screen shot 2015-07-09 at 6 48 10](https://cloud.githubusercontent.com/assets/1935069/8587637/72cd4598-2607-11e5-9ac3-c38bf7e197fd.png)

After:
![screen shot 2015-07-09 at 6 43 32](https://cloud.githubusercontent.com/assets/1935069/8587639/78a32e9c-2607-11e5-86fb-6c67eaa73a59.png)
