### PR TITLE
De-selecting all transactions resets computed sum to 0 now.

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -472,14 +472,12 @@ void TransactionView::computeSum()
         return;
     QModelIndexList selection = transactionView->selectionModel()->selectedRows();
 
-    if(!selection.isEmpty()){
-        foreach (QModelIndex index, selection){
-            amount += index.data(TransactionTableModel::AmountRole).toLongLong();
-        }
-        QString strAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, amount, true, BitcoinUnits::separatorAlways));
-        if (amount < 0) strAmount = "<span style='color:red;'>" + strAmount + "</span>";
-        emit trxAmount(strAmount);
+    foreach (QModelIndex index, selection){
+        amount += index.data(TransactionTableModel::AmountRole).toLongLong();
     }
+    QString strAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, amount, true, BitcoinUnits::separatorAlways));
+    if (amount < 0) strAmount = "<span style='color:red;'>" + strAmount + "</span>";
+    emit trxAmount(strAmount);
 }
 
 void TransactionView::openThirdPartyTxUrl(QString url)


### PR DESCRIPTION
Reference: https://dashtalk.org/threads/enhanced-darkcoin-wallet-ui.1705/page-23#post-56253 (see **Transactions**-line)

I didn't even know how to de-select every line once something was selected...should up my UI-skills :-)

I won't reset the sum when changing to a different tab, though. Way too much work for little gain.