### PR TITLE
V0.12.0.x major (incompatible) masternode broadcast/ping changes

### DIFF
--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -16,6 +16,20 @@
 // Responsible for activating the Masternode and pinging the network
 class CActiveMasternode
 {
+private:
+    // critical section to protect the inner data structures
+    mutable CCriticalSection cs;
+
+    /// Ping Masternode
+    bool SendMasternodePing(std::string& errorMessage);
+
+    /// Register any Masternode
+    bool Register(CTxIn vin, CService service, CKey key, CPubKey pubKey, CKey keyMasternode, CPubKey pubKeyMasternode, std::string &retErrorMessage);
+
+    /// Get 1000DRK input that can be used for the Masternode
+    bool GetMasterNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey, std::string strTxHash, std::string strOutputIndex);
+    bool GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
+
 public:
 	// Initialized by init.cpp
 	// Keys for the main Masternode
@@ -30,29 +44,21 @@ public:
 
     CActiveMasternode()
     {        
-        status = MASTERNODE_NOT_PROCESSED;
+        status = MASTERNODE_INITIAL;
     }
 
     /// Manage status of main Masternode
     void ManageStatus(); 
-
-    /// Ping for main Masternode
-    bool Mnping(std::string& errorMessage); 
-    /// Ping for any Masternode
-    bool Mnping(CTxIn vin, CService service, CKey key, CPubKey pubKey, std::string &retErrorMessage); 
+    std::string GetStatus();
 
     /// Register remote Masternode
     bool Register(std::string strService, std::string strKey, std::string txHash, std::string strOutputIndex, std::string& errorMessage); 
-    /// Register any Masternode
-    bool Register(CTxIn vin, CService service, CKey key, CPubKey pubKey, CKey keyMasternode, CPubKey pubKeyMasternode, std::string &retErrorMessage); 
 
     /// Get 1000DRK input that can be used for the Masternode
     bool GetMasterNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
-    bool GetMasterNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey, std::string strTxHash, std::string strOutputIndex);
     vector<COutput> SelectCoinsMasternode();
-    bool GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
 
-    /// Enable hot wallet mode (run a Masternode with no funds)
+    /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);
 };
 

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -22,8 +22,6 @@
 using namespace std;
 using namespace boost;
 
-CCriticalSection cs_darksend;
-
 // The main object for accessing Darksend
 CDarksendPool darkSendPool;
 // A helper object for signing messages from Masternodes

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -267,6 +267,9 @@ public:
  */
 class CDarksendPool
 {
+private:
+    mutable CCriticalSection cs_darksend;
+
 public:
     enum messages {
         ERR_ALREADY_HAVE,

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -27,7 +27,7 @@ class CConsensusVote;
 class CTransaction;
 class CTransactionLock;
 
-static const int MIN_INSTANTX_PROTO_VERSION = 70089;
+static const int MIN_INSTANTX_PROTO_VERSION = 70090;
 
 extern map<uint256, CTransaction> mapTxLockReq;
 extern map<uint256, CTransaction> mapTxLockReqRejected;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4180,11 +4180,9 @@ void static ProcessGetData(CNode* pfrom)
 
                 if (!pushed && inv.type == MSG_MASTERNODE_ANNOUNCE) {
                     if(mapSeenMasternodeBroadcast.count(inv.hash)){
-                        bool fRequested = false; // Requested full masternode list
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
                         ss << mapSeenMasternodeBroadcast[inv.hash];
-                        ss << fRequested;
                         pfrom->PushMessage("mnb", ss);
                         pushed = true;
                     }
@@ -4192,11 +4190,9 @@ void static ProcessGetData(CNode* pfrom)
 
                 if (!pushed && inv.type == MSG_MASTERNODE_PING) {
                     if(mapSeenMasternodePing.count(inv.hash)){
-                        bool fRequested = false; // Requested full masternode list
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
                         ss << mapSeenMasternodePing[inv.hash];
-                        ss << fRequested;
                         pfrom->PushMessage("mnp", ss);
                         pushed = true;
                     }

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -49,7 +49,7 @@ public:
 
     CMasternodeDB();
     bool Write(const CMasternodeMan &mnodemanToSave);
-    ReadResult Read(CMasternodeMan& mnodemanToLoad);
+    ReadResult Read(CMasternodeMan& mnodemanToLoad, bool fDryRun = false);
 };
 
 class CMasternodeMan
@@ -57,6 +57,9 @@ class CMasternodeMan
 private:
     // critical section to protect the inner data structures
     mutable CCriticalSection cs;
+
+    // critical section to protect the inner data structures specifically on messaging
+    mutable CCriticalSection cs_process_message;
 
     // map to hold all MNs
     std::vector<CMasternode> vMasternodes;
@@ -93,7 +96,7 @@ public:
     void Check();
 
     /// Check all Masternodes and remove inactive
-    void CheckAndRemove();
+    void CheckAndRemove(bool forceExpiredRemoval = false);
 
     /// Clear Masternode vector
     void Clear();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -19,7 +19,6 @@
 #ifdef ENABLE_WALLET
 #include "wallet.h"
 #endif
-#include "masternodeman.h"
 #include "masternode-payments.h"
 
 #include <boost/thread.hpp>

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70089;
+static const int PROTOCOL_VERSION = 70090;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -22,16 +22,16 @@ static const int GETHEADERS_VERSION = 70077;
 static const int MIN_PEER_PROTO_VERSION = 70066;
 
 //! minimum peer version accepted by DarksendPool
-static const int MIN_POOL_PEER_PROTO_VERSION = 70089;
+static const int MIN_POOL_PEER_PROTO_VERSION = 70090;
 
 //! minimum peer version for masternode budgets
-static const int MIN_BUDGET_PEER_PROTO_VERSION = 70089;
+static const int MIN_BUDGET_PEER_PROTO_VERSION = 70090;
 
 //! minimum peer version that can receive masternode payments
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
 static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70066;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70089;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70090;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Major masternode broadcast/ping changes (incompatible with prev version, proto bump required):

- Do not rely on local ```lastTimeSeen``` and requested ```fRequested anymore```. Use last know (signed) ```CMasternodePing``` instead and base all logic on that. Should reduce mn list difference between
 nodes.
- Rework ```CActiveMasternode``` accordingly along with states, errorMessages, rpc etc.
- Clean some related code, move parts from public to private
- Drop ```c_str()``` in ```LogPrintf()``` calls that were related to this functionality (todo: drop it for ```LogPrintf()``` everywhere else)
- proto bump

PS. Rebased on latest commit and works ok for few nodes here. Pls test it too.