### PR TITLE
V0.12.0.x lower MN reuse rate

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2408,9 +2408,13 @@ void ThreadCheckDarkSendPool()
         }
 
         if(c % 60 == 0){
-            //if we've used 1/5 of the Masternode list, then clear the list.
-            if((int)vecMasternodesUsed.size() > (int)mnodeman.size() / 5)
-                vecMasternodesUsed.clear();
+            //if we've used 90% of the Masternode list then drop all the oldest.
+            int nThreshold = (int)(mnodeman.CountEnabled() * 0.9);
+            if(fDebug) LogPrintf("Checking vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
+            while((int)vecMasternodesUsed.size() > nThreshold){
+                vecMasternodesUsed.erase(vecMasternodesUsed.begin());
+                if(fDebug) LogPrintf("  vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
+            }
         }
 
         if(darkSendPool.GetState() == POOL_STATUS_IDLE && c % 6 == 0){


### PR DESCRIPTION
Start dropping MNs out of vecMasternodesUsed vector when its size reached 90% of enabled MN count.

PS. I kept debug output for debug mode just in case, shouldn't be too spammy. Will move it under darksend category in #384 later.