### PR TITLE
V0.12.0.x few sync improvments

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2327,16 +2327,7 @@ void ThreadCheckDarkSendPool()
         MilliSleep(1000);
         //LogPrintf("ThreadCheckDarkSendPool::check timeout\n");
 
-        if(c % 60 == 0){
-            //if we've used 90% of the Masternode list then drop all the oldest.
-            int nThreshold = (int)(mnodeman.CountEnabled() * 0.9);
-            if(fDebug) LogPrintf("Checking vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
-            while((int)vecMasternodesUsed.size() > nThreshold){
-                vecMasternodesUsed.erase(vecMasternodesUsed.begin());
-                if(fDebug) LogPrintf("  vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
-            }
-        }
-
+        // try to sync from all available nodes (up to 3 or until MASTERNODE_SYNC_TIMEOUT) one step at a time
         masternodeSync.Process();
 
         if(masternodeSync.IsSynced()) {
@@ -2354,12 +2345,14 @@ void ThreadCheckDarkSendPool()
                 mnodeman.ProcessMasternodeConnections();
                 masternodePayments.CleanPaymentList();
                 CleanTransactionLocksList();
-            }
 
-            if(c % 60 == 0){
-                //if we've used 1/5 of the Masternode list, then clear the list.
-                if((int)vecMasternodesUsed.size() > (int)mnodeman.size() / 5)
-                    vecMasternodesUsed.clear();
+                //if we've used 90% of the Masternode list then drop all the oldest.
+                int nThreshold = (int)(mnodeman.CountEnabled() * 0.9);
+                if(fDebug) LogPrintf("Checking vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
+                while((int)vecMasternodesUsed.size() > nThreshold){
+                    vecMasternodesUsed.erase(vecMasternodesUsed.begin());
+                    if(fDebug) LogPrintf("  vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
+                }
             }
 
             if(c % MASTERNODES_DUMP_SECONDS == 0) DumpMasternodes();

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -5,22 +5,14 @@
 #ifndef MASTERNODE_SYNC_H
 #define MASTERNODE_SYNC_H
 
-#include "main.h"
-#include "sync.h"
-#include "net.h"
-#include "key.h"
-#include "masternodeman.h"
-#include "util.h"
-#include "base58.h"
-
-using namespace std;
-
 #define MASTERNODE_INITIAL                0
 #define MASTERNODE_SPORK_SETTINGS         1
 #define MASTERNODE_SYNC_LIST              2
 #define MASTERNODE_SYNC_MNW               3
 #define MASTERNODE_SYNC_BUDGET            4
 #define MASTERNODE_LIST_SYNCED            999
+
+#define MASTERNODE_SYNC_TIMEOUT           5
 
 class CMasternodeSync;
 extern CMasternodeSync masternodeSync;
@@ -32,7 +24,6 @@ extern CMasternodeSync masternodeSync;
 class CMasternodeSync
 {
 public:
-    int c;
     int64_t lastMasternodeList;
     int64_t lastMasternodeWinner;
     int64_t lastBudgetItem;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -603,6 +603,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         if(mnb.CheckInputsAndAdd(nDoS)) {
             // use this as a peer
             addrman.Add(CAddress(mnb.addr), pfrom->addr, 2*60*60);
+            masternodeSync.AddedMasternodeList();
         } else {
             LogPrintf("mnb - Rejected Masternode entry %s\n", mnb.addr.ToString());
 


### PR DESCRIPTION
Few sync improvements:
- do not call ```Added....()``` inside ```CMasternodeSync::Process()``` - that was "faking" sync process
- unify ```RequestedMasternodeAttempt <= ...``` logic and define ```MASTERNODE_SYNC_TIMEOUT```
- add missing ```masternodeSync.AddedMasternodeList()``` to ```CMasternodeMan::ProcessMessage()```
- fix "include"s
- don't check ```vecMasternodesUsed``` while not synced