### PR TITLE
V0.12.0.x use specific proto and fix sync issues

### DIFF
--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -85,7 +85,7 @@ bool CDarkSendRelay::VerifyMessage(std::string strSharedKey)
 
 void CDarkSendRelay::Relay()
 {
-    int nCount = std::min(mnodeman.CountEnabled(), 20);
+    int nCount = std::min(mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION), 20);
     int nRank1 = (rand() % nCount)+1; 
     int nRank2 = (rand() % nCount)+1; 
 

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -80,7 +80,7 @@ void CDarksendPool::ProcessMessageDarksend(CNode* pfrom, std::string& strCommand
 
         if(sessionUsers == 0) {
             if(pmn->nLastDsq != 0 &&
-                pmn->nLastDsq + mnodeman.CountMasternodesAboveProtocol(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
+                pmn->nLastDsq + mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
                 LogPrintf("dsa -- last dsq too recent, must wait. %s \n", pfrom->addr.ToString().c_str());
                 errorID = ERR_RECENT;
                 pfrom->PushMessage("dssu", sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
@@ -139,7 +139,7 @@ void CDarksendPool::ProcessMessageDarksend(CNode* pfrom, std::string& strCommand
             if(fDebug) LogPrintf("dsq last %d last2 %d count %d\n", pmn->nLastDsq, pmn->nLastDsq + mnodeman.size()/5, mnodeman.nDsqCount);
             //don't allow a few nodes to dominate the queuing process
             if(pmn->nLastDsq != 0 &&
-                pmn->nLastDsq + mnodeman.CountMasternodesAboveProtocol(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
+                pmn->nLastDsq + mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
                 if(fDebug) LogPrintf("dsq -- Masternode sending too many dsq messages. %s \n", pmn->addr.ToString().c_str());
                 return;
             }
@@ -1679,7 +1679,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
             }
 
             if(pmn->nLastDsq != 0 &&
-                pmn->nLastDsq + mnodeman.CountMasternodesAboveProtocol(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
+                pmn->nLastDsq + mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
                 i++;
                 continue;
             }
@@ -2348,7 +2348,7 @@ void ThreadCheckDarkSendPool()
                 CleanTransactionLocksList();
 
                 //if we've used 90% of the Masternode list then drop all the oldest.
-                int nThreshold = (int)(mnodeman.CountEnabled() * 0.9);
+                int nThreshold = (int)(mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION) * 0.9);
                 if(fDebug) LogPrintf("Checking vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
                 while((int)vecMasternodesUsed.size() > nThreshold){
                     vecMasternodesUsed.erase(vecMasternodesUsed.begin());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -415,7 +415,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -mnconflock=<n>            " + strprintf(_("Lock masternodes from masternode configuration file (default: %u)"), 1) + "\n";
     strUsage += "  -masternodeprivkey=<n>     " + _("Set the masternode private key") + "\n";
     strUsage += "  -masternodeaddr=<n>        " + _("Set external address:port to get to this masternode (example: address:port)") + "\n";
-    strUsage += "  -masternodeminprotocol=<n> " + strprintf(_("Ignore masternodes less than version (example: 70050; default: %u)"), MIN_POOL_PEER_PROTO_VERSION) + "\n";
+    strUsage += "  -masternodeminprotocol=<n> " + strprintf(_("Ignore masternodes less than version (example: 70050; default: %u)"), masternodePayments.GetMinMasternodePaymentsProto()) + "\n";
     strUsage += "  -budgetvotemode=<mode>    " + _("Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)") + "\n";
 
     strUsage += "\n" + _("Darksend options:") + "\n";
@@ -869,7 +869,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     }
 
     //ignore masternodes below protocol version
-    nMasternodeMinProtocol = GetArg("-masternodeminprotocol", MIN_POOL_PEER_PROTO_VERSION);
+    nMasternodeMinProtocol = GetArg("-masternodeminprotocol", masternodePayments.GetMinMasternodePaymentsProto());
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -415,7 +415,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -mnconflock=<n>            " + strprintf(_("Lock masternodes from masternode configuration file (default: %u)"), 1) + "\n";
     strUsage += "  -masternodeprivkey=<n>     " + _("Set the masternode private key") + "\n";
     strUsage += "  -masternodeaddr=<n>        " + _("Set external address:port to get to this masternode (example: address:port)") + "\n";
-    strUsage += "  -masternodeminprotocol=<n> " + strprintf(_("Ignore masternodes less than version (example: 70050; default: %u)"), masternodePayments.GetMinMasternodePaymentsProto()) + "\n";
     strUsage += "  -budgetvotemode=<mode>    " + _("Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)") + "\n";
 
     strUsage += "\n" + _("Darksend options:") + "\n";
@@ -867,9 +866,6 @@ bool AppInit2(boost::thread_group& threadGroup)
         if (!sporkManager.SetPrivKey(GetArg("-sporkkey", "")))
             return InitError(_("Unable to sign spork message, wrong key?"));
     }
-
-    //ignore masternodes below protocol version
-    nMasternodeMinProtocol = GetArg("-masternodeminprotocol", masternodePayments.GetMinMasternodePaymentsProto());
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3261,13 +3261,14 @@ bool ProcessNewBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDis
         return error("%s : ActivateBestChain failed", __func__);
 
     if(!fLiteMode){
-        if (masternodeSync.IsSynced()){
+        if (masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_LIST) {
             CScript payee;
             CTxIn vin;
             coinbasePayee.ReprocessChain();
             darkSendPool.NewBlock();
             masternodePayments.ProcessBlock(GetHeight()+10);
-            budget.NewBlock();
+            if (masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_BUDGET)
+                budget.NewBlock();
         }
     }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -523,7 +523,7 @@ bool CBudgetManager::IsBudgetPaymentBlock(int nBlockHeight){
     /*
         If budget doesn't have 5% of the network votes, then we should pay a masternode instead
     */
-    if(nHighestCount > mnodeman.CountEnabled()/20) return true;
+    if(nHighestCount > mnodeman.CountEnabled(MIN_BUDGET_PEER_PROTO_VERSION)/20) return true;
 
     return false;
 }
@@ -551,7 +551,7 @@ bool CBudgetManager::IsTransactionValid(const CTransaction& txNew, int nBlockHei
     /*
         If budget doesn't have 5% of the network votes, then we should pay a masternode instead
     */
-    if(nHighestCount < mnodeman.CountEnabled()/20) return false;
+    if(nHighestCount < mnodeman.CountEnabled(MIN_BUDGET_PEER_PROTO_VERSION)/20) return false;
 
     // check the highest finalized budgets (+/- 10% to assist in consensus)
 
@@ -560,7 +560,7 @@ bool CBudgetManager::IsTransactionValid(const CTransaction& txNew, int nBlockHei
     {
         CFinalizedBudget* pfinalizedBudget = &((*it).second);
 
-        if(pfinalizedBudget->GetVoteCount() > nHighestCount - mnodeman.CountEnabled()/10){
+        if(pfinalizedBudget->GetVoteCount() > nHighestCount - mnodeman.CountEnabled(MIN_BUDGET_PEER_PROTO_VERSION)/10){
             if(nBlockHeight >= pfinalizedBudget->GetBlockStart() && nBlockHeight <= pfinalizedBudget->GetBlockEnd()){
                 if(pfinalizedBudget->IsTransactionValid(txNew, nBlockHeight)){
                     return true;
@@ -636,7 +636,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
         //prop start/end should be inside this period
         if(pbudgetProposal->fValid && pbudgetProposal->nBlockStart <= nBlockStart &&
                 pbudgetProposal->nBlockEnd >= nBlockEnd &&
-                pbudgetProposal->GetYeas() - pbudgetProposal->GetNays() > mnodeman.CountEnabled()/10)
+                pbudgetProposal->GetYeas() - pbudgetProposal->GetNays() > mnodeman.CountEnabled(MIN_BUDGET_PEER_PROTO_VERSION)/10)
         {
             if(nTotalBudget == nBudgetAllocated){
                 pbudgetProposal->SetAllotted(0);
@@ -1070,7 +1070,7 @@ CBudgetProposal::CBudgetProposal(const CBudgetProposal& other)
 
 bool CBudgetProposal::IsValid(std::string& strError, bool fCheckCollateral)
 {
-    if(GetNays() - GetYeas() > mnodeman.CountEnabled()/10){
+    if(GetNays() - GetYeas() > mnodeman.CountEnabled(MIN_BUDGET_PEER_PROTO_VERSION)/10){
          strError = "Active removal";
          return false;
     }
@@ -1094,7 +1094,7 @@ bool CBudgetProposal::IsValid(std::string& strError, bool fCheckCollateral)
     //if proposal doesn't gain traction within 2 weeks, remove it
     // nTime not being saved correctly
     // if(nTime + (60*60*24*2) < GetAdjustedTime()) {
-    //     if(GetYeas()-GetNays() < (mnodeman.CountEnabled()/10)) {
+    //     if(GetYeas()-GetNays() < (mnodeman.CountEnabled(MIN_BUDGET_PEER_PROTO_VERSION)/10)) {
     //         strError = "Not enough support";
     //         return false;
     //     }

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -97,7 +97,7 @@ void CMasternodeSync::Process()
     {
 
         //set to synced
-        if(Params().NetworkID() == CBaseChainParams::REGTEST && c >= 10) {
+        if(Params().NetworkID() == CBaseChainParams::REGTEST && tick >= 10) {
             LogPrintf("CMasternodeSync::Process - Sync has finished\n");
             RequestedMasternodeAssets = MASTERNODE_SYNC_FINISHED;
             RequestedMasternodeAttempt = 0;
@@ -116,7 +116,7 @@ void CMasternodeSync::Process()
         }
 
         //don't begin syncing until we're almost at a recent block
-        if(pindexPrev->nHeight + 4 < pindexBestHeader->nHeight || pindexPrev->nTime + 600 < GetTime()) return;
+        if(pindexPrev->nHeight + 4 < pindexBestHeader->nHeight && pindexPrev->nTime + 600 < GetTime()) return;
 
         if (pnode->nVersion >= nMasternodeMinProtocol) {
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -4,6 +4,7 @@
 
 #include "main.h"
 #include "masternode-sync.h"
+#include "masternode-payments.h"
 #include "masternode.h"
 #include "masternodeman.h"
 #include "util.h"

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -118,7 +118,7 @@ void CMasternodeSync::Process()
         //don't begin syncing until we're almost at a recent block
         if(pindexPrev->nHeight + 4 < pindexBestHeader->nHeight && pindexPrev->nTime + 600 < GetTime()) return;
 
-        if (pnode->nVersion >= nMasternodeMinProtocol) {
+        if (pnode->nVersion >= masternodePayments.GetMinMasternodePaymentsProto()) {
 
             if(RequestedMasternodeAssets == MASTERNODE_SYNC_LIST) {
                 if(fDebug) LogPrintf("CMasternodeSync::Process() - lastMasternodeList %lld (GetTime() - MASTERNODE_SYNC_TIMEOUT) %lld\n", lastMasternodeList, GetTime() - MASTERNODE_SYNC_TIMEOUT);
@@ -137,9 +137,7 @@ void CMasternodeSync::Process()
                 }
                 return;
             }
-        }
 
-        if (pnode->nVersion >= masternodePayments.GetMinMasternodePaymentsProto()) {
             if(RequestedMasternodeAssets == MASTERNODE_SYNC_MNW) {
                 if(lastMasternodeWinner > 0 && lastMasternodeWinner < GetTime() - MASTERNODE_SYNC_TIMEOUT){ //hasn't received a new item in the last five seconds, so we'll move to the
                     GetNextAsset();

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -302,7 +302,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     std::string vchPubKey2(pubkey2.begin(), pubkey2.end());
     std::string strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(protocolVersion);
 
-    if(protocolVersion < nMasternodeMinProtocol) {
+    if(protocolVersion < masternodePayments.GetMinMasternodePaymentsProto()) {
         LogPrintf("mnb - ignoring outdated Masternode %s protocol version %d\n", vin.ToString().c_str(), protocolVersion);
         return false;
     }
@@ -516,7 +516,7 @@ bool CMasternodePing::CheckAndUpdate(int& nDos)
 
     // see if we have this Masternode
     CMasternode* pmn = mnodeman.Find(vin);
-    if(pmn != NULL && pmn->IsEnabled() && pmn->protocolVersion >= nMasternodeMinProtocol)
+    if(pmn != NULL && pmn->IsEnabled() && pmn->protocolVersion >= masternodePayments.GetMinMasternodePaymentsProto())
     {
         // LogPrintf("mnping - Found corresponding mn for vin: %s\n", vin.ToString().c_str());
         // update only if there is no known ping for this masternode or

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -78,7 +78,7 @@ CMasternode::CMasternode()
     cacheInputAgeBlock = 0;
     unitTest = false;
     allowFreeTx = true;
-    protocolVersion = MIN_PEER_PROTO_VERSION;
+    protocolVersion = PROTOCOL_VERSION;
     nLastDsq = 0;
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
@@ -244,7 +244,7 @@ CMasternodeBroadcast::CMasternodeBroadcast()
     cacheInputAgeBlock = 0;
     unitTest = false;
     allowFreeTx = true;
-    protocolVersion = MIN_PEER_PROTO_VERSION;
+    protocolVersion = PROTOCOL_VERSION;
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
 }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -355,6 +355,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
         pmn->UpdateFromNewBroadcast((*this));
         pmn->Check();
         if(pmn->IsEnabled()) Relay();
+        masternodeSync.AddedMasternodeList();
     }
 
     return true;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -618,10 +618,6 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             return;
         }
 
-        // only ask for missing items after our syncing process is complete -- 
-        //   otherwise we'll think a full sync succeeded when they return a result
-        if(!masternodeSync.IsSynced()) return;
-
         //search existing Masternode list, if it's known -- don't ask for the mnb
         CMasternode* pmn = mnodeman.Find(mnp.vin);
         if(pmn != NULL) return;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -289,19 +289,7 @@ void CMasternodeMan::Clear()
     nDsqCount = 0;
 }
 
-int CMasternodeMan::CountEnabled()
-{
-    int i = 0;
-
-    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
-        mn.Check();
-        if(mn.IsEnabled()) i++;
-    }
-
-    return i;
-}
-
-int CMasternodeMan::CountMasternodesAboveProtocol(int protocolVersion)
+int CMasternodeMan::CountEnabled(int protocolVersion)
 {
     int i = 0;
 
@@ -390,7 +378,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         if(masternodePayments.IsScheduled(mn, nBlockHeight)) continue;
 
         //make sure it has as many confirmations as there are masternodes
-        if(mn.GetMasternodeInputAge() < CountEnabled()) continue;
+        if(mn.GetMasternodeInputAge() < CountEnabled(masternodePayments.GetMinMasternodePaymentsProto())) continue;
 
         if(pOldestMasternode == NULL || pOldestMasternode->SecondsSincePayment() < mn.SecondsSincePayment()){
             pOldestMasternode = &mn;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -239,7 +239,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
         if((*it).activeState == CMasternode::MASTERNODE_REMOVE ||
                 (*it).activeState == CMasternode::MASTERNODE_VIN_SPENT ||
                 (forceExpiredRemoval && (*it).activeState == CMasternode::MASTERNODE_EXPIRED) ||
-                (*it).protocolVersion < nMasternodeMinProtocol) {
+                (*it).protocolVersion < masternodePayments.GetMinMasternodePaymentsProto()) {
             if(fDebug) LogPrintf("CMasternodeMan: Removing inactive Masternode %s - %i now\n", (*it).addr.ToString().c_str(), size() - 1);
             it = vMasternodes.erase(it);
         } else {
@@ -292,6 +292,7 @@ void CMasternodeMan::Clear()
 int CMasternodeMan::CountEnabled(int protocolVersion)
 {
     int i = 0;
+    protocolVersion = protocolVersion == -1 ? masternodePayments.GetMinMasternodePaymentsProto() : protocolVersion;
 
     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
         mn.Check();
@@ -378,7 +379,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         if(masternodePayments.IsScheduled(mn, nBlockHeight)) continue;
 
         //make sure it has as many confirmations as there are masternodes
-        if(mn.GetMasternodeInputAge() < CountEnabled(masternodePayments.GetMinMasternodePaymentsProto())) continue;
+        if(mn.GetMasternodeInputAge() < CountEnabled()) continue;
 
         if(pOldestMasternode == NULL || pOldestMasternode->SecondsSincePayment() < mn.SecondsSincePayment()){
             pOldestMasternode = &mn;

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -101,7 +101,7 @@ public:
     /// Clear Masternode vector
     void Clear();
 
-    int CountEnabled(int protocolVersion = nMasternodeMinProtocol);
+    int CountEnabled(int protocolVersion = -1);
 
     void DsegUpdate(CNode* pnode);
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -101,9 +101,7 @@ public:
     /// Clear Masternode vector
     void Clear();
 
-    int CountEnabled();
-
-    int CountMasternodesAboveProtocol(int protocolVersion);
+    int CountEnabled(int protocolVersion = nMasternodeMinProtocol);
 
     void DsegUpdate(CNode* pnode);
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -69,7 +69,8 @@ int ClientModel::getNumConnections(unsigned int flags) const
 
 QString ClientModel::getMasternodeCountString() const
 {
-    return QString::number((int)mnodeman.CountEnabled()) + " / " + QString::number((int)mnodeman.size());
+    return QString::number((int)mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION)) +
+            " / " + QString::number((int)mnodeman.CountEnabled()) + " / " + QString::number((int)mnodeman.size());
 }
 
 int ClientModel::getNumBlocks() const

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -136,7 +136,7 @@ Value masternode(const Array& params, bool fHelp)
                 "1. \"command\"        (string or set of strings, required) The command to execute\n"
                 "2. \"passphrase\"     (string, optional) The wallet passphrase\n"
                 "\nAvailable commands:\n"
-                "  count        - Print number of all known masternodes (optional: 'enabled', 'both')\n"
+                "  count        - Print number of all known masternodes (optional: 'ds', 'enabled', 'all')\n"
                 "  current      - Print info on current masternode winner\n"
                 "  debug        - Print masternode status\n"
                 "  genkey       - Generate new masternodeprivkey\n"
@@ -190,8 +190,11 @@ Value masternode(const Array& params, bool fHelp)
         }
         if (params.size() == 2)
         {
+            if(params[1] == "ds") return mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION);
             if(params[1] == "enabled") return mnodeman.CountEnabled();
-            if(params[1] == "both") return strprintf("%d / %d", mnodeman.CountEnabled(), mnodeman.size());
+            if(params[1] == "all") return strprintf("%d / %d / %d",
+                                                    mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION),
+                                                    mnodeman.CountEnabled(), mnodeman.size());
         }
         return mnodeman.size();
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -113,7 +113,6 @@ int nAnonymizeDarkcoinAmount = 1000;
 int nLiquidityProvider = 0;
 /** Spork enforcement enabled time */
 int64_t enforceMasternodePaymentsTime = 4085657524;
-int nMasternodeMinProtocol = 0;
 bool fSucessfullyLoaded = false;
 bool fEnableDarksend = false;
 /** All denominations used by darksend */

--- a/src/util.h
+++ b/src/util.h
@@ -39,7 +39,6 @@ extern int nLiquidityProvider;
 extern bool fEnableDarksend;
 extern int64_t enforceMasternodePaymentsTime;
 extern std::string strMasterNodeAddr;
-extern int nMasternodeMinProtocol;
 extern int keysLoaded;
 extern bool fSucessfullyLoaded;
 extern std::vector<int64_t> darkSendDenominations;


### PR DESCRIPTION
- store all MNs that fit min payment proto, use only those who fit specific proto (pool, ix, budget)
- ~~use ```pindexBestHeader``` height to identify recent block instead of _magic_ time~~ <--- doesn't play nice with forks
- reset ```last...``` on sync initial state
- update ```lastMasternodeList``` when we received legit update for MN we already know
- ask for ```mnb``` on ```mnp``` even if not synced yet
- change rpc and "tools -> info" to show "_ds / enabled / all_" for ```count```