### PR TITLE
UI: allow "," in "Min amount" field of Transaction-View

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -332,7 +332,12 @@ void TransactionView::changedAmount(const QString &amount)
     if(!transactionProxyModel)
         return;
     CAmount amount_parsed = 0;
-    if(BitcoinUnits::parse(model->getOptionsModel()->getDisplayUnit(), amount, &amount_parsed))
+
+    // Replace "," by "." so BitcoinUnits::parse will not fail for users entering "," as decimal separator
+    QString newAmount = amount;
+    newAmount.replace(QString(","), QString("."));
+
+    if(BitcoinUnits::parse(model->getOptionsModel()->getDisplayUnit(), newAmount, &amount_parsed))
     {
         transactionProxyModel->setMinAmount(amount_parsed);
     }


### PR DESCRIPTION
Reference: https://dashtalk.org/threads/enhanced-darkcoin-wallet-ui.1705/page-26#post-60298 and follow-ups.

Example:
![928](https://cloud.githubusercontent.com/assets/10080039/8781179/dd17f01a-2f0d-11e5-8399-d6dace914163.jpg)
![929](https://cloud.githubusercontent.com/assets/10080039/8781185/e29f2f44-2f0d-11e5-8762-1d9cdd4bdde9.jpg)

