### PR TITLE
UI: Limit display of Sendcoins-popup to 10 entries.

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -380,6 +380,22 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients, QString strFee,
         .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount))
         .arg("<br />" + alternativeUnits.join(" " + tr("or") + "<br />")));
 
+    // Limit number of displayed entries
+    int messageEntries = formatted.size();
+    int displayedEntries = 0;
+    for(int i = 0; i < formatted.size(); i++){
+        if(i >= MAX_SEND_POPUP_ENTRIES){
+            formatted.removeLast();
+            i--;
+        }
+        else{
+            displayedEntries = i+1;
+        }
+    }
+    questionString.append("<hr />");
+    questionString.append(tr("<b>(%1 of %2 entries displayed)</b>").arg(displayedEntries).arg(messageEntries));
+
+    // Display message box    
     QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm send coins"),
         questionString.arg(formatted.join("<br />")),
         QMessageBox::Yes | QMessageBox::Cancel,

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -10,6 +10,8 @@
 #include <QDialog>
 #include <QString>
 
+static const int MAX_SEND_POPUP_ENTRIES = 10;
+
 class ClientModel;
 class OptionsModel;
 class SendCoinsEntry;


### PR DESCRIPTION
Reference: https://dashtalk.org/threads/enhanced-darkcoin-wallet-ui.1705/page-27#post-60870

Because QMessageBox is VERY limited with formatting options and I didn't want to overwrite it with my own implementation I just hard limited the maximum number of displayed entries to 10 and added this info for the end user.
The computed amount still shows the sum of all transactions of course.

Looks like this:
![popup](https://cloud.githubusercontent.com/assets/10080039/8894892/35dace30-33c7-11e5-8f03-337016324e4c.jpg)

(the example above was for a maximum of 5 entries for my own tests where I sent 9 transactions of 1 DASH each)