### PR TITLE
V0.12.0.x DS Pack

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -173,7 +173,6 @@ libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 # server: shared between dashd and dash-qt
 libbitcoin_server_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS)
 libbitcoin_server_a_SOURCES = \
-  activemasternode.cpp \
   addrman.cpp \
   alert.cpp \
   bloom.cpp \
@@ -208,8 +207,17 @@ libbitcoin_server_a_SOURCES = \
 libbitcoin_wallet_a_CPPFLAGS = $(BITCOIN_INCLUDES)
 libbitcoin_wallet_a_SOURCES = \
   activemasternode.cpp \
+  darksend.cpp \
+  darksend-relay.cpp \
   db.cpp \
   crypter.cpp \
+  instantx.cpp \
+  masternode.cpp \
+  masternode-budget.cpp \
+  masternode-payments.cpp \
+  masternode-sync.cpp \
+  masternodeconfig.cpp \
+  masternodeman.cpp \
   rpcdump.cpp \
   rpcwallet.cpp \
   wallet.cpp \
@@ -273,20 +281,10 @@ univalue_libbitcoin_univalue_a_SOURCES = \
 # common: shared between dashd, and dash-qt and non-server tools
 libbitcoin_common_a_CPPFLAGS = $(BITCOIN_INCLUDES)
 libbitcoin_common_a_SOURCES = \
-  activemasternode.cpp \
   allocators.cpp \
   amount.cpp \
   base58.cpp \
   chainparams.cpp \
-  darksend.cpp \
-  darksend-relay.cpp \
-  masternode.cpp \
-  masternode-budget.cpp \
-  masternode-sync.cpp \
-  masternode-payments.cpp \
-  masternodeman.cpp \
-  masternodeconfig.cpp \
-  instantx.cpp \
   coins.cpp \
   compressor.cpp \
   primitives/block.cpp \

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1544,22 +1544,12 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
         // otherwise, try one randomly
         while(i < 10)
         {
-            CMasternode* pmn = mnodeman.FindRandom();
+            CMasternode* pmn = mnodeman.FindRandomNotInVec(vecMasternodesUsed, MIN_POOL_PEER_PROTO_VERSION);
             if(pmn == NULL)
             {
-                LogPrintf("DoAutomaticDenominating --- Masternode list is empty!\n");
+                LogPrintf("DoAutomaticDenominating --- Can't find random masternode!\n");
+                strAutoDenomResult = _("Can't find random Masternode.");
                 return false;
-            }
-            //don't reuse Masternodes
-            BOOST_FOREACH(CTxIn usedVin, vecMasternodesUsed) {
-                if(pmn->vin == usedVin){
-                    i++;
-                    continue;
-                }
-            }
-            if(pmn->protocolVersion < MIN_POOL_PEER_PROTO_VERSION) {
-                i++;
-                continue;
             }
 
             if(pmn->nLastDsq != 0 &&

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -56,11 +56,6 @@ extern std::string strMasterNodePrivKey;
 extern map<uint256, CDarksendBroadcastTx> mapDarksendBroadcastTxes;
 extern CActiveMasternode activeMasternode;
 
-// get the Darksend chain depth for a given input
-int GetRealInputDarksendRounds(CTxIn in, int rounds);
-// respect current settings
-int GetInputDarksendRounds(CTxIn in);
-
 /** Holds an Darksend input
  */
 class CTxDSIn : public CTxIn

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -116,7 +116,7 @@ public:
     CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime=true);
 
     /// Find a random entry
-    CMasternode* FindRandom();
+    CMasternode* FindRandomNotInVec(std::vector<CTxIn> &vecToExclude, int protocolVersion = -1);
 
     /// Get the current winner for this block
     CMasternode* GetCurrentMasterNode(int mod=1, int64_t nBlockHeight=0, int minProtocol=0);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -406,7 +406,7 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
         else {
             coinControl->Select(outpt);
             CTxIn vin(outpt);
-            int rounds = GetInputDarksendRounds(vin);
+            int rounds = pwalletMain->GetInputDarksendRounds(vin);
             if(coinControl->useDarkSend && rounds < nDarksendRounds) {
                 QMessageBox::warning(this, windowTitle(),
                     tr("Non-anonymized input selected. <b>Darksend will be disabled.</b><br><br>If you still want to use Darksend, please deselect all non-nonymized inputs first and then check Darksend checkbox again."),
@@ -789,7 +789,7 @@ void CoinControlDialog::updateView()
 
             // ds+ rounds
             CTxIn vin = CTxIn(out.tx->GetHash(), out.i);
-            int rounds = GetInputDarksendRounds(vin);
+            int rounds = pwalletMain->GetInputDarksendRounds(vin);
 
             if(rounds >= 0) itemOutput->setText(COLUMN_DARKSEND_ROUNDS, strPad(QString::number(rounds), 11, " "));
             else itemOutput->setText(COLUMN_DARKSEND_ROUNDS, strPad(QString(tr("n/a")), 11, " "));

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -502,6 +502,7 @@ void OverviewPage::toggleDarksend(){
 
     if(!fEnableDarksend){
         ui->toggleDarksend->setText(tr("Start Darksend Mixing"));
+        darkSendPool.UnlockCoins();
     } else {
         ui->toggleDarksend->setText(tr("Stop Darksend Mixing"));
 

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -72,8 +72,7 @@ Value darksend(const Array& params, bool fHelp)
     }
 
     if(params[0].get_str() == "reset"){
-        darkSendPool.SetNull(true);
-        darkSendPool.UnlockCoins();
+        darkSendPool.Reset();
         return "successfully reset darksend";
     }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -919,6 +919,7 @@ int CWallet::GetRealInputDarksendRounds(CTxIn in, int rounds) const
 
 // respect current settings
 int CWallet::GetInputDarksendRounds(CTxIn in) const {
+    LOCK(cs_wallet);
     int realDarksendRounds = GetRealInputDarksendRounds(in, 0);
     return realDarksendRounds > nDarksendRounds ? nDarksendRounds : realDarksendRounds;
 }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2345,7 +2345,7 @@ string CWallet::PrepareDarksendDenominate(int minRounds, int maxRounds)
         return _("Error: Wallet locked, unable to create transaction!");
 
     if(darkSendPool.GetState() != POOL_STATUS_ERROR && darkSendPool.GetState() != POOL_STATUS_SUCCESS)
-        if(darkSendPool.GetMyTransactionCount() > 0)
+        if(darkSendPool.GetEntriesCount() > 0)
             return _("Error: You already have pending entries in the Darksend pool");
 
     // ** find the coins we'll use

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1193,9 +1193,9 @@ CAmount CWallet::GetAnonymizableBalance(bool includeAlreadyAnonymized) const
                 {
                     CTxIn vin = CTxIn(hash, i);
 
-                    if(IsSpent(hash, i) || !IsMine(pcoin->vout[i])) continue;
+                    if(IsSpent(hash, i) || !IsMine(pcoin->vout[i]) || IsLockedCoin(hash, i)) continue;
                     if (pcoin->IsCoinBase() && pcoin->GetBlocksToMaturity() > 0) continue; // do not count immature
-                    if(pcoin->vout[i].nValue == 1000*COIN) continue; // do not count MN-like outputs
+                    if(fMasterNode && pcoin->vout[i].nValue == 1000*COIN) continue; // do not count MN-like outputs
 
                     int rounds = GetInputDarksendRounds(vin);
                     if(rounds >=-2 && (rounds < nDarksendRounds || (includeAlreadyAnonymized && rounds >= nDarksendRounds))) {
@@ -1450,10 +1450,9 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 
                     found = IsDenominatedAmount(pcoin->vout[i].nValue);
                 } else if(coin_type == ONLY_NONDENOMINATED || coin_type == ONLY_NONDENOMINATED_NOTMN) {
-                    found = true;
                     if (IsCollateralAmount(pcoin->vout[i].nValue)) continue; // do not use collateral amounts
                     found = !IsDenominatedAmount(pcoin->vout[i].nValue);
-                    if(found && coin_type == ONLY_NONDENOMINATED_NOTMN) found = (pcoin->vout[i].nValue != 1000*COIN); // do not use MN funds
+                    if(found && fMasterNode && coin_type == ONLY_NONDENOMINATED_NOTMN) found = (pcoin->vout[i].nValue != 1000*COIN); // do not use MN funds
                 } else {
                     found = true;
                 }


### PR DESCRIPTION
- always clear entries, do not try to reuse them
- unlock coins only when needed (do not unlock them every 10 blocks)
- make logic a bit more strightforward in few places
- clear all expired on timeout (not just the first found)
- add 2 additional statuses on doauto
- run DS & checks on blockchain synced, do not wait for full sync
- move most DS class members to private
- do not mix 1000 if it's local MN _OR_ input is locked
- move ds rounds calculation to wallet class
- add cache to / rework anon/denom balance functions (and move them to wallet class)
- fix updates on new blocks for ds status on overview page
- move ds/ix/mn lib to wallet category
- add cs_wallet lock on GetInputDarksendRounds
- FindRandomNotInVec - should give less failures then FindRandom on doauto

rebased and fixed accordingly