### PR TITLE
UI: alignment fix for Overview-page

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -426,7 +426,7 @@
             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
            </property>
            <property name="horizontalSpacing">
-            <number>30</number>
+            <number>11</number>
            </property>
            <property name="verticalSpacing">
             <number>12</number>
@@ -435,13 +435,6 @@
             <widget class="QLabel" name="label_6">
              <property name="text">
               <string>Status:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="darksendEnabled">
-             <property name="text">
-              <string>Enabled/Disabled</string>
              </property>
             </widget>
            </item>
@@ -513,6 +506,13 @@
              </property>
              <property name="text">
               <string>n/a</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="darksendEnabled">
+             <property name="text">
+              <string>Enabled/Disabled</string>
              </property>
             </widget>
            </item>
@@ -1059,7 +1059,7 @@
            <string>Reset</string>
           </property>
          </widget>
-         <widget class="QWidget" name="">
+         <widget class="QWidget" name="layoutWidget">
           <property name="geometry">
            <rect>
             <x>10</x>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -226,8 +226,15 @@ void OverviewPage::updateWatchOnlyLabels(bool showWatchOnly)
     ui->labelWatchPending->setVisible(showWatchOnly);   // show watch-only pending balance
     ui->labelWatchTotal->setVisible(showWatchOnly);     // show watch-only total balance
 
-    if (!showWatchOnly)
+    if (!showWatchOnly){
         ui->labelWatchImmature->hide();
+    }
+    else{
+        ui->labelBalance->setIndent(20);
+        ui->labelUnconfirmed->setIndent(20);
+        ui->labelImmature->setIndent(20);
+        ui->labelTotal->setIndent(20);
+    }
 }
 
 void OverviewPage::setClientModel(ClientModel *model)

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -748,13 +748,13 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelWalletStatus { /* Wallet Sync Status */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-margin-left:20px;
+margin-left:3px;
 }
 
 QWidget .QFrame#frame .QLabel#labelSpendable { /* Spendable Header */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 font-size:12px;
-margin-left:32px;
+margin-left:18px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchonly { /* Watch-only Header */
@@ -780,7 +780,7 @@ qproperty-alignment: 'AlignVCenter | AlignLeft';
 font-size:12px;
 font-weight:bold;
 color:#56ABD8;
-margin-left:32px;
+margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchAvailable { /* Watch-only Balance */
@@ -801,7 +801,7 @@ padding-right:5px;
 QWidget .QFrame#frame .QLabel#labelUnconfirmed { /* Pending Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 font-size:12px;
-margin-left:32px;
+margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchPending { /* Watch-only Pending Balance */
@@ -822,7 +822,7 @@ padding-right:5px;
 QWidget .QFrame#frame .QLabel#labelImmature { /* Immature Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 font-size:12px;
-margin-left:32px;
+margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchImmature { /* Watch-only Immature Balance */
@@ -843,7 +843,7 @@ padding-right:5px;
 QWidget .QFrame#frame .QLabel#labelTotal { /* Total Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 font-size:12px;
-margin-left:32px;
+margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchTotal { /* Watch-only Total Balance */
@@ -877,7 +877,7 @@ min-height:35px;
 /******************************************************************/
 QWidget .QFrame#frameDarksend .QLabel#labelDarksendSyncStatus { /* Darksend Sync Status */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-margin-left:20px;
+margin-left:2px;
 }
 
 QWidget .QFrame#frameDarksend #formLayoutWidget {
@@ -890,12 +890,11 @@ font-weight:normal;
 min-height:25px;
 }
 
-
 QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_6 { /* Darksend Status Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
-margin-right:5px;
+margin-right:0px;
 padding-right:5px;
 }
 

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -894,7 +894,7 @@ QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_6 { /* Darksend St
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
-margin-right:0px;
+margin-right:5px;
 padding-right:5px;
 }
 


### PR DESCRIPTION
Overview tab shows now everything nicely aligned with watch-only labels and without them.

Many thanks to @snogcel for his help :thumbsup:

Tested on all 3 OS without problems.

**Note**: if there's still some non-alignment there delete your Qt-settings (~/.conf/Dash (Ubuntu), HKEY_CURRENT_USER\Software\Dash\Dash-Qt-testnet (Windows))
