### PR TITLE
UI: "Confirm send coins" popup beautified

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -376,9 +376,11 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients, QString strFee,
         if(u != model->getOptionsModel()->getDisplayUnit())
             alternativeUnits.append(BitcoinUnits::formatHtmlWithUnit(u, totalAmount));
     }
-    questionString.append(tr("Total Amount %1 (= %2)")
+
+    // Show total amount + all alternative units
+    questionString.append(tr("Total Amount = <b>%1</b><br />= %2")
         .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount))
-        .arg("<br />" + alternativeUnits.join(" " + tr("or") + "<br />")));
+        .arg(alternativeUnits.join("<br />= ")));
 
     // Limit number of displayed entries
     int messageEntries = formatted.size();


### PR DESCRIPTION
Reference: https://dashtalk.org/threads/enhanced-darkcoin-wallet-ui.1705/page-28#post-61489

Before: see reference above.

After:
![popup](https://cloud.githubusercontent.com/assets/10080039/9023345/72c99f3a-3898-11e5-9c3a-8397737271f9.jpg)

