### PR TITLE
V0.12.0.x use fBlockchainSynced right on IsBlockchainSynced start

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -41,6 +41,9 @@ bool CMasternodeSync::IsSynced()
 
 bool CMasternodeSync::IsBlockchainSynced()
 {
+    static bool fBlockchainSynced = false;
+    if(fBlockchainSynced) return true;
+
     if (fImporting || fReindex) return false;
 
     TRY_LOCK(cs_main, lockMain);
@@ -49,8 +52,6 @@ bool CMasternodeSync::IsBlockchainSynced()
     CBlockIndex* pindex = chainActive.Tip();
     if(pindex == NULL) return false;
 
-    static bool fBlockchainSynced = false;
-    if(fBlockchainSynced) return true;
 
     if(pindex->nTime + 600 < GetTime())
         return false;


### PR DESCRIPTION
Since
- fImporting and fReindex can't change during execution
- chainActive.Tip() can't became NULL once we synced (?)

we can use locked fBlockchainSynced state right from on IsBlockchainSynced start.
This should lower use of cs_main lock also (down to 0 when synced).