### PR TITLE
V0.12.0.x track hashes and update `last...` only twice per hash

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -250,6 +250,7 @@ bool CActiveMasternode::Register(CTxIn vin, CService service, CKey keyCollateral
         return false;
     }
     mnodeman.mapSeenMasternodeBroadcast.insert(make_pair(mnb.GetHash(), mnb));
+    masternodeSync.AddedMasternodeList(mnb.GetHash());
 
     CMasternode* pmn = mnodeman.Find(vin);
     if(pmn == NULL)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3996,37 +3996,37 @@ bool static AlreadyHave(const CInv& inv)
         return mapSporks.count(inv.hash);
     case MSG_MASTERNODE_WINNER:
         if(masternodePayments.mapMasternodePayeeVotes.count(inv.hash)) {
-            masternodeSync.AddedMasternodeWinner();
+            masternodeSync.AddedMasternodeWinner(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_VOTE:
         if(budget.mapSeenMasternodeBudgetVotes.count(inv.hash)) {
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_PROPOSAL:
         if(budget.mapSeenMasternodeBudgetProposals.count(inv.hash)) {
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_FINALIZED_VOTE:
         if(budget.mapSeenFinalizedBudgetVotes.count(inv.hash)) {
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_FINALIZED:
         if(budget.mapSeenFinalizedBudgets.count(inv.hash)) {
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_MASTERNODE_ANNOUNCE:
         if(mnodeman.mapSeenMasternodeBroadcast.count(inv.hash)) {
-            masternodeSync.AddedMasternodeList();
+            masternodeSync.AddedMasternodeList(inv.hash);
             return true;
         }
         return false;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -830,7 +830,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         vRecv >> budgetProposalBroadcast;
 
         if(mapSeenMasternodeBudgetProposals.count(budgetProposalBroadcast.GetHash())){
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(budgetProposalBroadcast.GetHash());
             return;
         }
 
@@ -849,7 +849,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         CBudgetProposal budgetProposal(budgetProposalBroadcast);
         if(AddProposal(budgetProposal)) {budgetProposalBroadcast.Relay();}
-        masternodeSync.AddedBudgetItem();
+        masternodeSync.AddedBudgetItem(budgetProposalBroadcast.GetHash());
 
         LogPrintf("mprop - new budget - %s\n", budgetProposalBroadcast.GetHash().ToString());
 
@@ -863,7 +863,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         vote.fValid = true;
 
         if(mapSeenMasternodeBudgetVotes.count(vote.GetHash())){
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(vote.GetHash());
             return;
         }
 
@@ -884,7 +884,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         std::string strError = "";
         if(UpdateProposal(vote, pfrom, strError)) {
             vote.Relay();
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(vote.GetHash());
         }
 
         LogPrintf("mvote - new budget vote - %s\n", vote.GetHash().ToString());
@@ -895,7 +895,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         vRecv >> finalizedBudgetBroadcast;
 
         if(mapSeenFinalizedBudgets.count(finalizedBudgetBroadcast.GetHash())){
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(finalizedBudgetBroadcast.GetHash());
             return;
         }
 
@@ -916,7 +916,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         CFinalizedBudget finalizedBudget(finalizedBudgetBroadcast);
         if(AddFinalizedBudget(finalizedBudget)) {finalizedBudgetBroadcast.Relay();}
-        masternodeSync.AddedBudgetItem();
+        masternodeSync.AddedBudgetItem(finalizedBudgetBroadcast.GetHash());
 
         //we might have active votes for this budget that are now valid
         CheckOrphanVotes();
@@ -928,7 +928,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         vote.fValid = true;
 
         if(mapSeenFinalizedBudgetVotes.count(vote.GetHash())){
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(vote.GetHash());
             return;
         }
 
@@ -948,7 +948,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         std::string strError = "";
         if(UpdateFinalizedBudget(vote, pfrom, strError)) {
             vote.Relay();
-            masternodeSync.AddedBudgetItem();
+            masternodeSync.AddedBudgetItem(vote.GetHash());
         }
 
         LogPrint("mnbudget", "fbs - new finalized budget vote - %s\n", vote.GetHash().ToString());

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -365,7 +365,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
 
         if(masternodePayments.mapMasternodePayeeVotes.count(winner.GetHash())){
             LogPrint("mnpayments", "mnw - Already seen - %s bestHeight %d\n", winner.GetHash().ToString().c_str(), chainActive.Tip()->nHeight);
-            masternodeSync.AddedMasternodeWinner();
+            masternodeSync.AddedMasternodeWinner(winner.GetHash());
             return;
         }
 
@@ -400,7 +400,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
 
         if(masternodePayments.AddWinningMasternode(winner)){
             winner.Relay();
-            masternodeSync.AddedMasternodeWinner();
+            masternodeSync.AddedMasternodeWinner(winner.GetHash());
         }
     }
 }
@@ -598,6 +598,7 @@ void CMasternodePayments::CleanPaymentList()
 
         if(chainActive.Tip()->nHeight - winner.nBlockHeight > nLimit){
             LogPrint("mnpayments", "CMasternodePayments::CleanPaymentList - Removing old Masternode payment - block %d\n", winner.nBlockHeight);
+            masternodeSync.mapSeenSyncMNW.erase((*it).first);
             mapMasternodePayeeVotes.erase(it++);
         } else {
             ++it;

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -27,6 +27,10 @@ extern CMasternodeSync masternodeSync;
 class CMasternodeSync
 {
 public:
+    std::map<uint256, int> mapSeenSyncMNB;
+    std::map<uint256, int> mapSeenSyncMNW;
+    std::map<uint256, int> mapSeenSyncBudget;
+
     int64_t lastMasternodeList;
     int64_t lastMasternodeWinner;
     int64_t lastBudgetItem;
@@ -50,9 +54,9 @@ public:
 
     CMasternodeSync();
 
-    void AddedMasternodeList();
-    void AddedMasternodeWinner();
-    void AddedBudgetItem();
+    void AddedMasternodeList(uint256 hash);
+    void AddedMasternodeWinner(uint256 hash);
+    void AddedBudgetItem(uint256 hash);
     void GetNextAsset();
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     bool IsBudgetFinEmpty();

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -390,7 +390,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
         pmn->UpdateFromNewBroadcast((*this));
         pmn->Check();
         if(pmn->IsEnabled()) Relay();
-        masternodeSync.AddedMasternodeList();
+        masternodeSync.AddedMasternodeList(GetHash());
     }
 
     return true;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -254,6 +254,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
             map<uint256, CMasternodeBroadcast>::iterator it3 = mapSeenMasternodeBroadcast.begin();
             while(it3 != mapSeenMasternodeBroadcast.end()){
                 if((*it3).second.vin == (*it).vin){
+                    masternodeSync.mapSeenSyncMNB.erase((*it3).first);
                     mapSeenMasternodeBroadcast.erase(it3++);
                 } else {
                     ++it3;
@@ -644,7 +645,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         vRecv >> mnb;
 
         if(mnodeman.mapSeenMasternodeBroadcast.count(mnb.GetHash())) { //seen
-            masternodeSync.AddedMasternodeList();
+            masternodeSync.AddedMasternodeList(mnb.GetHash());
             return;
         }
         mnodeman.mapSeenMasternodeBroadcast.insert(make_pair(mnb.GetHash(), mnb));
@@ -672,7 +673,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         if(mnb.CheckInputsAndAdd(nDoS)) {
             // use this as a peer
             addrman.Add(CAddress(mnb.addr), pfrom->addr, 2*60*60);
-            masternodeSync.AddedMasternodeList();
+            masternodeSync.AddedMasternodeList(mnb.GetHash());
         } else {
             LogPrintf("mnb - Rejected Masternode entry %s\n", mnb.addr.ToString());
 


### PR DESCRIPTION
The idea behind that is that one can send you same `inv` or `ssc` with 0 in `nCount` in less then `MASTERNODE_SYNC_TIMEOUT` intervals and that way he could keep you from syncing forever if he was lucky enough (or intentional) to get you during sync/resync. This should help to stop him.
With 3000 MNs on mainnet attacker still could potentially try to keep you syncing up to 3000 * 2 * 7 = 42000 sec = ~11.67 h but assuming that you also have at least 2 connections to _normal_ peers you should hit 2 hashes limit pretty fast so attacker will fail.
Additionally `if(mapSeenSync...[hash] < 2)` can be tweaked (3,4,5...) to allow more same hashes to be accepted and update `last...`. Having higher same hashes limit should not harm too much and could smooth sync process a bit though I don't really see the need for it since `MASTERNODE_SYNC_TIMEOUT` is also relatively high.