### PR TITLE
V0.12.0.x pre-enabled status from masternodes

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -30,7 +30,8 @@ void CActiveMasternode::ManageStatus()
         pmn = mnodeman.Find(pubKeyMasternode);
         if(pmn != NULL) {
             pmn->Check();
-            if(pmn->IsEnabled() && pmn->protocolVersion == PROTOCOL_VERSION) EnableHotColdMasterNode(pmn->vin, pmn->addr);
+            if((pmn->IsEnabled() || pmn->IsPreEnabled()) && pmn->protocolVersion == PROTOCOL_VERSION)
+                    EnableHotColdMasterNode(pmn->vin, pmn->addr);
         }
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -171,6 +171,10 @@ void CMasternode::Check()
     //once spent, stop doing the checks
     if(activeState == MASTERNODE_VIN_SPENT) return;
 
+    if(lastPing.sigTime - sigTime < MASTERNODE_MIN_MNP_SECONDS){
+        activeState = MASTERNODE_PRE_ENABLED;
+        return;
+    }
 
     if(!IsPingedWithin(MASTERNODE_REMOVAL_SECONDS)){
         activeState = MASTERNODE_REMOVE;
@@ -379,7 +383,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     //search existing Masternode list, this is where we update existing Masternodes with new mnb broadcasts
     CMasternode* pmn = mnodeman.Find(vin);
 
-    // no such masternode or it's not enabled already, nothing to update
+    // no such masternode or it's not enabled yet/already, nothing to update
     if(pmn == NULL || (pmn != NULL && !pmn->IsEnabled())) return true;
 
     // mn.pubkey = pubkey, IsVinAssociatedWithPubkey is validated once below,
@@ -407,8 +411,8 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
     CMasternode* pmn = mnodeman.Find(vin);
 
     if(pmn != NULL) {
-        // nothing to do here if we already know about this masternode and it's enabled
-        if(pmn->IsEnabled()) return true;
+        // nothing to do here if we already know about this masternode and it's (pre)enabled
+        if(pmn->IsEnabled() || pmn->IsPreEnabled()) return true;
         // if it's not enabled, remove old MN first and continue
         else mnodeman.Remove(pmn->vin);
     }
@@ -560,7 +564,7 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled)
     CMasternode* pmn = mnodeman.Find(vin);
     if(pmn != NULL && pmn->protocolVersion >= masternodePayments.GetMinMasternodePaymentsProto())
     {
-        if (fRequireEnabled && !pmn->IsEnabled()) return false;
+        if (fRequireEnabled && !pmn->IsEnabled() && !pmn->IsPreEnabled()) return false;
 
         // LogPrintf("mnping - Found corresponding mn for vin: %s\n", vin.ToString());
         // update only if there is no known ping for this masternode or

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -110,11 +110,12 @@ private:
 
 public:
     enum state {
-        MASTERNODE_ENABLED = 1,
-        MASTERNODE_EXPIRED = 2,
-        MASTERNODE_VIN_SPENT = 3,
-        MASTERNODE_REMOVE = 4,
-        MASTERNODE_POS_ERROR = 5
+        MASTERNODE_PRE_ENABLED,
+        MASTERNODE_ENABLED,
+        MASTERNODE_EXPIRED,
+        MASTERNODE_VIN_SPENT,
+        MASTERNODE_REMOVE,
+        MASTERNODE_POS_ERROR
     };
 
     CTxIn vin;
@@ -243,6 +244,11 @@ public:
         return activeState == MASTERNODE_ENABLED;
     }
 
+    bool IsPreEnabled()
+    {
+        return activeState == MASTERNODE_PRE_ENABLED;
+    }
+
     int GetMasternodeInputAge()
     {
         if(chainActive.Tip() == NULL) return 0;
@@ -256,13 +262,14 @@ public:
     }
 
     std::string Status() {
-        std::string strStatus = "ACTIVE";
+        std::string strStatus = "unknown";
 
-        if(activeState == CMasternode::MASTERNODE_ENABLED) strStatus   = "ENABLED";
-        if(activeState == CMasternode::MASTERNODE_EXPIRED) strStatus   = "EXPIRED";
-        if(activeState == CMasternode::MASTERNODE_VIN_SPENT) strStatus = "VIN_SPENT";
-        if(activeState == CMasternode::MASTERNODE_REMOVE) strStatus    = "REMOVE";
-        if(activeState == CMasternode::MASTERNODE_POS_ERROR) strStatus = "POS_ERROR";
+        if(activeState == CMasternode::MASTERNODE_PRE_ENABLED) strStatus = "PRE_ENABLED";
+        if(activeState == CMasternode::MASTERNODE_ENABLED) strStatus     = "ENABLED";
+        if(activeState == CMasternode::MASTERNODE_EXPIRED) strStatus     = "EXPIRED";
+        if(activeState == CMasternode::MASTERNODE_VIN_SPENT) strStatus   = "VIN_SPENT";
+        if(activeState == CMasternode::MASTERNODE_REMOVE) strStatus      = "REMOVE";
+        if(activeState == CMasternode::MASTERNODE_POS_ERROR) strStatus   = "POS_ERROR";
 
         return strStatus;
     }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -210,7 +210,7 @@ bool CMasternodeMan::Add(CMasternode &mn)
 {
     LOCK(cs);
 
-    if (!mn.IsEnabled())
+    if (!mn.IsEnabled() && !mn.IsPreEnabled())
         return false;
 
     CMasternode *pmn = Find(mn.vin);


### PR DESCRIPTION
Treat MN as pre-enabled while there is no legit ping that differ from initial one (from mnb). Should give MN owners info if remote MN was actually enabled and sending pings as expected or was it not enabled and could be delisted in an hour because of no pings. Currently it is shown as enabled regardless which could be confusing.

_Rebased resurrection of #481_