### PR TITLE
V0.12.0.x implement WaitForLock/WaitForLock2

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -90,8 +90,11 @@ void CActiveMasternode::ManageStatus()
                 return;
             }
 
-            LOCK(pwalletMain->cs_wallet);
-            pwalletMain->LockCoin(vin.prevout);
+            {
+                WaitForLock(pwalletMain->cs_wallet);
+                LOCK(pwalletMain->cs_wallet);
+                pwalletMain->LockCoin(vin.prevout);
+            }
 
             // send to all nodes
             CPubKey pubKeyMasternode;
@@ -344,6 +347,7 @@ vector<COutput> CActiveMasternode::SelectCoinsMasternode()
     vector<COutput> filteredCoins;
     vector<COutPoint> confLockedCoins;
 
+    WaitForLock(pwalletMain->cs_wallet);
     LOCK(pwalletMain->cs_wallet);
     // Temporary unlock MN coins from masternode.conf
     if(GetBoolArg("-mnconflock", true)) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -186,6 +186,7 @@ void PrepareShutdown()
     }
 
     {
+        WaitForLock(cs_main);
         LOCK(cs_main);
         if (pcoinsTip != NULL) {
             FlushStateToDisk();
@@ -1500,6 +1501,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     strBudgetMode = GetArg("-budgetvotemode", "auto");
 
     if(GetBoolArg("-mnconflock", true) && pwalletMain) {
+        WaitForLock(pwalletMain->cs_wallet);
         LOCK(pwalletMain->cs_wallet);
         LogPrintf("Locking Masternodes:\n");
         uint256 mnTxHash;

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -72,6 +72,7 @@ void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& 
 
         bool fAccepted = false;
         {
+            WaitForLock(cs_main);
             LOCK(cs_main);
             fAccepted = AcceptToMemoryPool(mempool, state, tx, true, &fMissingInputs);
         }

--- a/src/main.h
+++ b/src/main.h
@@ -27,6 +27,7 @@
 #include "txmempool.h"
 #include "uint256.h"
 #include "undo.h"
+#include "utiltime.h"
 
 #include <algorithm>
 #include <exception>
@@ -144,6 +145,29 @@ extern CBlockIndex *pindexBestHeader;
 
 /** Minimum disk space required - used in CheckDiskSpace() */
 static const uint64_t nMinDiskSpace = 52428800;
+
+/** Wait for locks - make sure we can get locks before actually locking smth */
+void WaitForLock(CCriticalSection &cs) {
+    while(true){
+        TRY_LOCK(cs, locked);
+        if(!locked) { MilliSleep(100); continue;}
+        break;
+    }
+}
+
+void WaitForLock2(CCriticalSection &cs1, CCriticalSection &cs2) {
+    while(true){
+        TRY_LOCK(cs1, locked1);
+        if(!locked1) { MilliSleep(100); continue;}
+        while(true){
+            TRY_LOCK(cs2, locked2);
+            if(!locked2) { MilliSleep(100); continue;}
+            break;
+        }
+        break;
+    }
+}
+
 
 /** Register a wallet to receive updates from core */
 void RegisterValidationInterface(CValidationInterface* pwalletIn);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -190,6 +190,7 @@ void CMasternode::Check()
         tx.vout.push_back(vout);
 
         {
+            WaitForLock(cs_main);
             TRY_LOCK(cs_main, lockMain);
             if(!lockMain) return;
 
@@ -420,6 +421,7 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
     tx.vout.push_back(vout);
 
     {
+        WaitForLock(cs_main);
         TRY_LOCK(cs_main, lockMain);
         if(!lockMain) return false;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -129,6 +129,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
     CAmount nFees = 0;
 
     {
+        WaitForLock2(cs_main, mempool.cs);
         LOCK2(cs_main, mempool.cs);
 
         CBlockIndex* pindexPrev = chainActive.Tip();
@@ -430,6 +431,7 @@ bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
 
     // Found a solution
     {
+        WaitForLock(cs_main);
         LOCK(cs_main);
         if (pblock->hashPrevBlock != chainActive.Tip()->GetBlockHash())
             return error("DashMiner : generated block is stale");
@@ -440,6 +442,7 @@ bool ProcessBlockFound(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
 
     // Track how many getdata requests this block gets
     {
+        WaitForLock(wallet.cs_wallet);
         LOCK(wallet.cs_wallet);
         wallet.mapRequestCount[pblock->GetHash()] = 0;
     }
@@ -471,6 +474,7 @@ void static BitcoinMiner(CWallet *pwallet)
                 do {
                     bool fvNodesEmpty;
                     {
+                        WaitForLock(cs_vNodes);
                         LOCK(cs_vNodes);
                         fvNodesEmpty = vNodes.empty();
                     }

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -79,6 +79,7 @@ public:
     {
         cachedAddressTable.clear();
         {
+            WaitForLock(wallet->cs_wallet);
             LOCK(wallet->cs_wallet);
             BOOST_FOREACH(const PAIRTYPE(CTxDestination, CAddressBookData)& item, wallet->mapAddressBook)
             {
@@ -245,6 +246,7 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
 
     if(role == Qt::EditRole)
     {
+        WaitForLock(wallet->cs_wallet); /* For SetAddressBook / DelAddressBook */
         LOCK(wallet->cs_wallet); /* For SetAddressBook / DelAddressBook */
         CTxDestination curAddress = CBitcoinAddress(rec->address.toStdString()).Get();
         if(index.column() == Label)
@@ -357,6 +359,7 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
         }
         // Check for duplicate addresses
         {
+            WaitForLock(wallet->cs_wallet);
             LOCK(wallet->cs_wallet);
             if(wallet->mapAddressBook.count(CBitcoinAddress(strAddress).Get()))
             {
@@ -393,6 +396,7 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
 
     // Add entry
     {
+        WaitForLock(wallet->cs_wallet);
         LOCK(wallet->cs_wallet);
         wallet->SetAddressBook(CBitcoinAddress(strAddress).Get(), strLabel,
                                (type == Send ? "send" : "receive"));
@@ -411,6 +415,7 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
         return false;
     }
     {
+        WaitForLock(wallet->cs_wallet);
         LOCK(wallet->cs_wallet);
         wallet->DelAddressBook(CBitcoinAddress(rec->address.toStdString()).Get());
     }
@@ -422,6 +427,7 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
     {
+        WaitForLock(wallet->cs_wallet);
         LOCK(wallet->cs_wallet);
         CBitcoinAddress address_parsed(address.toStdString());
         std::map<CTxDestination, CAddressBookData>::iterator mi = wallet->mapAddressBook.find(address_parsed.Get());

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -55,6 +55,7 @@ ClientModel::~ClientModel()
 
 int ClientModel::getNumConnections(unsigned int flags) const
 {
+    WaitForLock(cs_vNodes);
     LOCK(cs_vNodes);
     if (flags == CONNECTIONS_ALL) // Shortcut if we want total
         return vNodes.size();
@@ -76,6 +77,7 @@ QString ClientModel::getMasternodeCountString() const
 
 int ClientModel::getNumBlocks() const
 {
+    WaitForLock(cs_main);
     LOCK(cs_main);
     return chainActive.Height();
 }
@@ -98,6 +100,7 @@ quint64 ClientModel::getTotalBytesSent() const
 
 QDateTime ClientModel::getLastBlockDate() const
 {
+    WaitForLock(cs_main);
     LOCK(cs_main);
     if (chainActive.Tip())
         return QDateTime::fromTime_t(chainActive.Tip()->GetBlockTime());
@@ -139,12 +142,6 @@ void ClientModel::updateTimer()
 
 void ClientModel::updateMnTimer()
 {
-    // Get required lock upfront. This avoids the GUI from getting stuck on
-    // periodical polls if the core is holding the locks for a longer time -
-    // for example, during a wallet rescan.
-    TRY_LOCK(cs_main, lockMain);
-    if(!lockMain)
-        return;
     QString newMasternodeCountString = getMasternodeCountString();
 
     if (cachedMasternodeCountString != newMasternodeCountString)

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -91,6 +91,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
 {
     QString strHTML;
 
+    WaitForLock2(cs_main, wallet->cs_wallet);
     LOCK2(cs_main, wallet->cs_wallet);
     strHTML.reserve(4000);
     strHTML += "<html><font face='verdana, arial, helvetica, sans-serif'>";

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -77,6 +77,7 @@ public:
         qDebug() << "TransactionTablePriv::refreshWallet";
         cachedWallet.clear();
         {
+            WaitForLock2(cs_main, wallet->cs_wallet);
             LOCK2(cs_main, wallet->cs_wallet);
             for(std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end(); ++it)
             {
@@ -126,6 +127,7 @@ public:
             }
             if(showTransaction)
             {
+                WaitForLock2(cs_main, wallet->cs_wallet);
                 LOCK2(cs_main, wallet->cs_wallet);
                 // Find transaction in wallet
                 std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(hash);
@@ -208,6 +210,7 @@ public:
     QString describe(TransactionRecord *rec, int unit)
     {
         {
+            WaitForLock2(cs_main, wallet->cs_wallet);
             LOCK2(cs_main, wallet->cs_wallet);
             std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
             if(mi != wallet->mapWallet.end())

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -106,6 +106,7 @@ static bool rest_block(AcceptedConnection* conn,
     CBlock block;
     CBlockIndex* pblockindex = NULL;
     {
+        WaitForLock(cs_main);
         LOCK(cs_main);
         if (mapBlockIndex.count(hash) == 0)
             throw RESTERR(HTTP_NOT_FOUND, hashStr + " not found");

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -691,6 +691,7 @@ Value invalidateblock(const Array& params, bool fHelp)
     CValidationState state;
 
     {
+        WaitForLock(cs_main);
         LOCK(cs_main);
         if (mapBlockIndex.count(hash) == 0)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
@@ -730,6 +731,7 @@ Value reconsiderblock(const Array& params, bool fHelp)
     CValidationState state;
 
     {
+        WaitForLock(cs_main);
         LOCK(cs_main);
         if (mapBlockIndex.count(hash) == 0)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -164,6 +164,7 @@ Value setgenerate(const Array& params, bool fHelp)
         CReserveKey reservekey(pwalletMain);
 
         {   // Don't keep cs_main locked
+            WaitForLock(cs_main);
             LOCK(cs_main);
             nHeightStart = chainActive.Height();
             nHeight = nHeightStart;
@@ -178,6 +179,7 @@ Value setgenerate(const Array& params, bool fHelp)
                 throw JSONRPCError(RPC_INTERNAL_ERROR, "Wallet keypool empty");
             CBlock *pblock = &pblocktemplate->block;
             {
+                WaitForLock(cs_main);
                 LOCK(cs_main);
                 IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
             }
@@ -668,6 +670,7 @@ Value submitblock(const Array& params, bool fHelp)
     uint256 hash = block.GetHash();
     bool fBlockPresent = false;
     {
+        WaitForLock(cs_main);
         LOCK(cs_main);
         BlockMap::iterator mi = mapBlockIndex.find(hash);
         if (mi != mapBlockIndex.end()) {

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -35,6 +35,7 @@ Value getconnectioncount(const Array& params, bool fHelp)
             + HelpExampleRpc("getconnectioncount", "")
         );
 
+    WaitForLock(cs_vNodes);
     LOCK(cs_vNodes);
     return (int)vNodes.size();
 }
@@ -53,6 +54,7 @@ Value ping(const Array& params, bool fHelp)
         );
 
     // Request that each node send a ping during next message processing pass
+    WaitForLock(cs_vNodes);
     LOCK(cs_vNodes);
     BOOST_FOREACH(CNode* pNode, vNodes) {
         pNode->fPingQueued = true;
@@ -65,6 +67,7 @@ static void CopyNodeStats(std::vector<CNodeStats>& vstats)
 {
     vstats.clear();
 
+    WaitForLock(cs_vNodes);
     LOCK(cs_vNodes);
     vstats.reserve(vNodes.size());
     BOOST_FOREACH(CNode* pnode, vNodes) {
@@ -294,6 +297,7 @@ Value getaddednodeinfo(const Array& params, bool fHelp)
         }
     }
 
+    WaitForLock(cs_vNodes);
     LOCK(cs_vNodes);
     for (list<pair<string, vector<CService> > >::iterator it = laddedAddreses.begin(); it != laddedAddreses.end(); it++)
     {

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -1014,14 +1014,17 @@ json_spirit::Value CRPCTable::execute(const std::string &strMethod, const json_s
                 result = pcmd->actor(params, false);
 #ifdef ENABLE_WALLET
             else if (!pwalletMain) {
+                WaitForLock(cs_main);
                 LOCK(cs_main);
                 result = pcmd->actor(params, false);
             } else {
+                WaitForLock2(cs_main, pwalletMain->cs_wallet);
                 LOCK2(cs_main, pwalletMain->cs_wallet);
                 result = pcmd->actor(params, false);
             }
 #else // ENABLE_WALLET
             else {
+                WaitForLock(cs_main);
                 LOCK(cs_main);
                 result = pcmd->actor(params, false);
             }

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -469,6 +469,7 @@ Value listaddressgroupings(const Array& params, bool fHelp)
             addressInfo.push_back(CBitcoinAddress(address).ToString());
             addressInfo.push_back(ValueFromAmount(balances[address]));
             {
+                WaitForLock(pwalletMain->cs_wallet);
                 LOCK(pwalletMain->cs_wallet);
                 if (pwalletMain->mapAddressBook.find(CBitcoinAddress(address).Get()) != pwalletMain->mapAddressBook.end())
                     addressInfo.push_back(pwalletMain->mapAddressBook.find(CBitcoinAddress(address).Get())->second.name);

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -147,6 +147,7 @@ void ReprocessBlocks(int nBlocks)
         if((*it).second  > GetTime() - (nBlocks*60*5)) {   
             BlockMap::iterator mi = mapBlockIndex.find((*it).first);
             if (mi != mapBlockIndex.end() && (*mi).second) {
+                WaitForLock(cs_main);
                 LOCK(cs_main);
                 
                 CBlockIndex* pindex = (*mi).second;
@@ -161,6 +162,7 @@ void ReprocessBlocks(int nBlocks)
 
     CValidationState state;
     {
+        WaitForLock(cs_main);
         LOCK(cs_main);
         DisconnectBlocksAndReprocess(nBlocks);
     }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -435,6 +435,7 @@ public:
     void Inventory(const uint256 &hash)
     {
         {
+            WaitForLock(cs_wallet);
             LOCK(cs_wallet);
             std::map<uint256, int>::iterator mi = mapRequestCount.find(hash);
             if (mi != mapRequestCount.end())
@@ -457,7 +458,7 @@ public:
     bool SetMaxVersion(int nVersion);
 
     //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
-    int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
+    int GetVersion() { WaitForLock(cs_wallet); LOCK(cs_wallet); return nWalletVersion; }
 
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -251,6 +251,7 @@ void CWalletDB::ListAccountCreditDebit(const string& strAccount, list<CAccountin
 
 DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
 {
+    WaitForLock(pwallet->cs_wallet);
     LOCK(pwallet->cs_wallet);
     // Old wallets didn't have any defined order for transactions
     // Probably a bad idea to change the output of this
@@ -612,6 +613,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     DBErrors result = DB_LOAD_OK;
 
     try {
+        WaitForLock(pwallet->cs_wallet);
         LOCK(pwallet->cs_wallet);
         int nMinVersion = 0;
         if (Read((string)"minversion", nMinVersion))
@@ -712,6 +714,7 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, vector<uint256>& vTxHash, vec
     DBErrors result = DB_LOAD_OK;
 
     try {
+        WaitForLock(pwallet->cs_wallet);
         LOCK(pwallet->cs_wallet);
         int nMinVersion = 0;
         if (Read((string)"minversion", nMinVersion))


### PR DESCRIPTION
Idea is pretty simple: try to wait for lock if you need it but can't acquire it right now. Solution however is not very elegant, I know... But anyway, this seems to work for me until now: 5h mixing, no locks or new issues so far.

Testing wanted!

Notes:
- currently covers most common locks only - `cs_main`, `cs_wallet`, `cs_vNodes`
- some `TRY_LOCK`-s are not covered intentionally - they are ok to fail
- reverts https://github.com/dashpay/dash/commit/171c0b145a5a5644f2b955b3196c1a66093801f5 and https://github.com/dashpay/dash/commit/c7077dc9d42c7930147e9385e0a883bbf1d4e2fa
- drops `TRY_LOCK` for `updateMnTimer()` - not sure how it got there, could be old copy/paste...