### PR TITLE
(WIP) V0.12.0.x Locks fixes

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -580,6 +580,9 @@ void SendCoinsDialog::setBalance(const CAmount& balance, const CAmount& unconfir
 
 void SendCoinsDialog::updateDisplayUnit()
 {
+    TRY_LOCK(cs_main, lockMain);
+    if(!lockMain) return;
+
     setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(), model->getAnonymizedBalance(),
                    model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
     CoinControlDialog::coinControl->useDarkSend = ui->checkUseDarksend->isChecked();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -146,6 +146,9 @@ void WalletModel::pollBalanceChanged()
 
 void WalletModel::checkBalanceChanged()
 {
+    TRY_LOCK(cs_main, lockMain);
+    if(!lockMain) return;
+
     CAmount newBalance = getBalance();
     CAmount newUnconfirmedBalance = getUnconfirmedBalance();
     CAmount newImmatureBalance = getImmatureBalance();

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2434,9 +2434,11 @@ string CWallet::PrepareDarksendDenominate(int minRounds, int maxRounds)
 
     LogPrintf("PrepareDarksendDenominate - preparing darksend denominate . Got: %d \n", nValueIn);
 
-    LOCK(cs_wallet);
-    BOOST_FOREACH(CTxIn v, vCoins)
-        LockCoin(v.prevout);
+    {
+        LOCK(cs_wallet);
+        BOOST_FOREACH(CTxIn v, vCoins)
+                LockCoin(v.prevout);
+    }
 
     int64_t nValueLeft = nValueIn;
     std::vector<CTxOut> vOut;
@@ -2503,12 +2505,16 @@ string CWallet::PrepareDarksendDenominate(int minRounds, int maxRounds)
         if(nValueLeft == 0) break;
     }
 
-    // unlock unused coins
-    BOOST_FOREACH(CTxIn v, vCoins)
-        UnlockCoin(v.prevout);
+    {
+        // unlock unused coins
+        LOCK(cs_wallet);
+        BOOST_FOREACH(CTxIn v, vCoins)
+                UnlockCoin(v.prevout);
+    }
 
     if(darkSendPool.GetDenominations(vOut) != darkSendPool.sessionDenom) {
         // unlock used coins on failure
+        LOCK(cs_wallet);
         BOOST_FOREACH(CTxIn v, vCoinsResult)
             UnlockCoin(v.prevout);
         return "Error: can't make current denominated outputs";


### PR DESCRIPTION
Another attempt to fix locking issue. Same ideas as #489 but will actually lock right when it can instead of standalone checks so applied directly only in specific places.

- trylock for `updateDarksendProgress`, `checkBalanceChanged`, "block"
- trylock+wait for `UnlockCoins`, `SendDarksendDenominate`, `ProcessNewBlock`, `ActivateBestChain`
- move `cs_darksend ` trylock in `DoAutomaticDenominating` lower, remove explicit lock

Looks good so far...
I think patching in few most common "hung" places with
```
    while(true) {
        TRY_LOCK(cs_main, lockMain);
        if(!lockMain) { MilliSleep(10); continue; }
        ...
        break;
    }
```
is a quite safe way to go.

Testing anyone? :)