### PR TITLE
V0.12.0.x recognize comments in masternode.conf / write initial file

### DIFF
--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -14,19 +14,34 @@ void CMasternodeConfig::add(std::string alias, std::string ip, std::string privK
 
 bool CMasternodeConfig::read(std::string& strErr) {
     int linenumber = 1;
+    boost::filesystem::path pathMasternodeConfigFile = GetMasternodeConfigFile();
+    boost::filesystem::ifstream streamConfig(pathMasternodeConfigFile);
 
-    boost::filesystem::ifstream streamConfig(GetMasternodeConfigFile());
     if (!streamConfig.good()) {
-        return true; // No masternode.conf file is OK
+        FILE* configFile = fopen(pathMasternodeConfigFile.string().c_str(), "a");
+        if (configFile != NULL) {
+            std::string strHeader = "# Masternode config file\n"
+                          "# Format: alias IP:port masternodeprivkey collateral_output_txid collateral_output_index\n"
+                          "# Example: mn1 127.0.0.2:19999 93HaYBVUCYjEMeeH1Y4sBGLALQZE1Yc1K64xiqgX37tGBDQL8Xg 2bcd3c84c84f87eaa86e4e56834c92927a07f9e18718810b92e0d0324456a67c 0\n";
+            fwrite(strHeader.c_str(), std::strlen(strHeader.c_str()), 1, configFile);
+            fclose(configFile);
+        }
+        return true; // Nothing to read, so just return
     }
 
     for(std::string line; std::getline(streamConfig, line); linenumber++)
     {
-        if(line.empty()) {
-            continue;
-        }
+        if(line.empty()) continue;
+
         std::istringstream iss(line);
-        std::string alias, ip, privKey, txHash, outputIndex;
+        std::string comment, alias, ip, privKey, txHash, outputIndex;
+
+        if (iss >> comment) {
+            if(comment.at(0) == '#') continue;
+            iss.str(line);
+            iss.clear();
+        }
+
         if (!(iss >> alias >> ip >> privKey >> txHash >> outputIndex)) {
             iss.str(line);
             iss.clear();


### PR DESCRIPTION
Recognize "#" as a comment line in masternode config file instead of throwing error. Also write initial file contents (some simple format instructions and an example) if no masternode config file was found.