### PR TITLE
V0.12.0.x Use single random denom in new DS session

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -481,14 +481,14 @@ public:
     bool CreateDenominated(int64_t nTotalValue);
 
     /// Get the denominations for a list of outputs (returns a bitshifted integer)
-    int GetDenominations(const std::vector<CTxOut>& vout, bool fRandDenom = false);
+    int GetDenominations(const std::vector<CTxOut>& vout, bool fSingleRandomDenom = false);
     int GetDenominations(const std::vector<CTxDSOut>& vout);
 
     void GetDenominationsToString(int nDenom, std::string& strDenom);
 
     /// Get the denominations for a specific amount of dash.
     int GetDenominationsByAmount(int64_t nAmount, int nDenomTarget=0); // is not used anymore?
-    int GetDenominationsByAmounts(std::vector<int64_t>& vecAmount, bool fRandDenom = false);
+    int GetDenominationsByAmounts(std::vector<int64_t>& vecAmount);
 
     std::string GetMessageByID(int messageID);
 


### PR DESCRIPTION
Create new session to mix only one single denom at a time. Could help to find mixing partners faster.
Still accept new dsq with multiple denoms though which should be fine.
No proto bump needed, should be completely compatible with current one.