### PR TITLE
V0.12.0.x ds fixes

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1356,7 +1356,7 @@ void CDarksendPool::ClearLastMessage()
 //
 // This does NOT run by default for daemons, only for QT.
 //
-bool CDarksendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
+bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
 {
     if(!fEnableDarksend) return false;
     if(fMasterNode) return false;
@@ -1441,6 +1441,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
 
             if(nBalanceNeedsDenominated > nValueIn) nBalanceNeedsDenominated = nValueIn;
 
+            if(nBalanceNeedsDenominated < nLowestDenom) return false; // most likely we just waiting for denoms to confirm
             if(!fDryRun) return CreateDenominated(nBalanceNeedsDenominated);
 
             return true;
@@ -1606,10 +1607,6 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
     }
 
     strAutoDenomResult = _("Mixing in progress...");
-    if(!ready) return true;
-
-    if(sessionDenom == 0) return true;
-
     return false;
 }
 
@@ -2243,7 +2240,7 @@ void ThreadCheckDarkSendPool()
             darkSendPool.CheckTimeout();
             darkSendPool.CheckForCompleteQueue();
 
-            if(darkSendPool.GetState() == POOL_STATUS_IDLE && c % 6 == 0){
+            if(darkSendPool.GetState() == POOL_STATUS_IDLE && c % 15 == 0){
                 darkSendPool.DoAutomaticDenominating();
             }
         }

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -437,7 +437,7 @@ public:
     bool IsCompatibleWithSession(int64_t nAmount, CTransaction txCollateral, int &errorID);
 
     /// Passively run Darksend in the background according to the configuration in settings (only for QT)
-    bool DoAutomaticDenominating(bool fDryRun=false, bool ready=false);
+    bool DoAutomaticDenominating(bool fDryRun=false);
     bool PrepareDarksendDenominate();
 
     /// Check for process in Darksend

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -251,6 +251,7 @@ void OptionsDialog::on_resetButton_clicked()
 void OptionsDialog::on_okButton_clicked()
 {
     mapper->submit();
+    darkSendPool.cachedNumBlocks = 0;
     pwalletMain->MarkDirty();
     accept();
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -545,6 +545,5 @@ void OverviewPage::toggleDarksend(){
             dlg.exec();
         }
 
-        darkSendPool.DoAutomaticDenominating();
     }
 }


### PR DESCRIPTION
- remove unused argument and fix `DoAutomaticDenominating` return when already mixing (should fail)
- prevent wallet from attempts to create denominations for too small (or sometimes even negative) amounts
- run `DoAutomaticDenominating` every 15 seconds (was 6)
- return `darkSendPool.cachedNumBlocks = 0;` back in `OptionsDialog::on_okButton_clicked` (I shouldn't replace it with `pwalletMain->MarkDirty();`, we need both)
- do not call `DoAutomaticDenominating` right on `toggleDarksend`, just toggle, let UI refresh things and leave `DoAutomaticDenominating` call up to `ThreadCheckDarkSendPool`