### PR TITLE
V0.12.0.x fixes for more then 1 ds action per block

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -335,7 +335,7 @@ public:
         cachedNumBlocks = 0;
         unitTest = false;
         txCollateral = CMutableTransaction();
-        minBlockSpacing = 1;
+        minBlockSpacing = 0;
         lastNewBlock = 0;
 
         SetNull();


### PR DESCRIPTION
- should be compatible with liquidity providers now
- try to clear `vecMasternodesUsed` on every doauto (or else you can run out of available MNs pretty quick)