### PR TITLE
V0.12.0.x clear DS connections to masternodes properly

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -634,11 +634,10 @@ void CMasternodeMan::ProcessMasternodeConnections()
     //we don't care about this for regtest
     if(Params().NetworkID() == CBaseChainParams::REGTEST) return;
 
-    if(!darkSendPool.pSubmittedToMasternode) return;
-
-    CNode* pnode = FindNode(darkSendPool.pSubmittedToMasternode->addr);
-    if(pnode != NULL) {
+    LOCK(cs_vNodes);
+    BOOST_FOREACH(CNode* pnode, vNodes) {
         if(pnode->fDarkSendMaster){
+            if(darkSendPool.pSubmittedToMasternode != NULL && pnode->addr == darkSendPool.pSubmittedToMasternode->addr) continue;
             LogPrintf("Closing Masternode connection %s \n", pnode->addr.ToString());
             pnode->fDisconnect = true;
         }


### PR DESCRIPTION
That's an old bug that caused connections not to be cleared properly in case smth in DS went wrong or even just too fast.