### PR TITLE
V0.12.0.x fix bug with wallet-backups

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -900,7 +900,7 @@ bool AppInit2(boost::thread_group& threadGroup)
             if (filesystem::exists(backupDir))
             {
                 // Create backup of the wallet
-                std::string dateTimeStr = DateTimeStrFormat(".%Y-%m-%d-%H.%M", GetTime());
+                std::string dateTimeStr = DateTimeStrFormat(".%Y-%m-%d-%H-%M", GetTime());
                 std::string backupPathStr = backupDir.string();
                 backupPathStr += "/" + strWalletFile;
                 std::string sourcePathStr = GetDataDir().string();
@@ -930,7 +930,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                     {
                         currentFile = dir_iter->path().filename();
                         // Only add the backups for the current wallet, e.g. wallet.dat.*
-                        if(currentFile.string().find(strWalletFile) != string::npos)
+                        if(dir_iter->path().stem().string() == strWalletFile)
                         {
                             folder_set.insert(folder_set_t::value_type(boost::filesystem::last_write_time(dir_iter->path()), *dir_iter));
                         }


### PR DESCRIPTION
Reference: https://github.com/dashpay/dash/issues/504

With this fix old backups only get deleted when their base filename (without extension) **exactly** matches the name of the current wallet, not when it's just a substring.

The generated time stamp extension is slightly modified ("." replaced by "-" in the time substring) to keep it KISS.

Backups made with the original version (with extensions ".YY-MM-DD-HH.MM") are not touched and must be deleted by hand if wanted.