### PR TITLE
V0.12.0.x fix overview page updates on options change and on DS toggle

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -332,7 +332,7 @@ public:
             to behave themselves. If they don't it takes their money. */
 
         cachedLastSuccess = 0;
-        cachedNumBlocks = 0;
+        cachedNumBlocks = std::numeric_limits<int>::max();
         unitTest = false;
         txCollateral = CMutableTransaction();
         minBlockSpacing = 0;

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -251,7 +251,7 @@ void OptionsDialog::on_resetButton_clicked()
 void OptionsDialog::on_okButton_clicked()
 {
     mapper->submit();
-    darkSendPool.cachedNumBlocks = 0;
+    darkSendPool.cachedNumBlocks = std::numeric_limits<int>::max();
     pwalletMain->MarkDirty();
     accept();
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -517,7 +517,7 @@ void OverviewPage::toggleDarksend(){
             if(!ctx.isValid())
             {
                 //unlock was cancelled
-                darkSendPool.cachedNumBlocks = 0;
+                darkSendPool.cachedNumBlocks = std::numeric_limits<int>::max();
                 QMessageBox::warning(this, tr("Darksend"),
                     tr("Wallet is locked and user declined to unlock. Disabling Darksend."),
                     QMessageBox::Ok, QMessageBox::Ok);
@@ -528,8 +528,8 @@ void OverviewPage::toggleDarksend(){
 
     }
 
-    darkSendPool.cachedNumBlocks = 0;
     fEnableDarksend = !fEnableDarksend;
+    darkSendPool.cachedNumBlocks = std::numeric_limits<int>::max();
 
     if(!fEnableDarksend){
         ui->toggleDarksend->setText(tr("Start Darksend Mixing"));


### PR DESCRIPTION
`cachedNumBlocks` needs to be set to max (strictly saying, smth  >= `nBestHeight` would be ok but we can't get it in a constructor for example so for simplicity/consistency I just used `max`)  to get past `if(((nBestHeight - darkSendPool.cachedNumBlocks) / (GetTimeMillis() - nLastDSProgressBlockTime + 1) > 1)) return;`