### PR TITLE
V0.12.1.x pre-enabled status from masternodes

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -32,7 +32,8 @@ void CActiveMasternode::ManageStatus()
         pmn = mnodeman.Find(pubKeyMasternode);
         if(pmn != NULL) {
             pmn->Check();
-            if(pmn->IsEnabled() && pmn->protocolVersion == PROTOCOL_VERSION) EnableHotColdMasterNode(pmn->vin, pmn->addr);
+            if((pmn->IsEnabled() || pmn->IsPreEnabled()) && pmn->protocolVersion == PROTOCOL_VERSION)
+                    EnableHotColdMasterNode(pmn->vin, pmn->addr);
         }
     }
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -111,11 +111,12 @@ private:
     int64_t lastTimeChecked;
 public:
     enum state {
-        MASTERNODE_ENABLED = 1,
-        MASTERNODE_EXPIRED = 2,
-        MASTERNODE_VIN_SPENT = 3,
-        MASTERNODE_REMOVE = 4,
-        MASTERNODE_POS_ERROR = 5
+        MASTERNODE_PRE_ENABLED,
+        MASTERNODE_ENABLED,
+        MASTERNODE_EXPIRED,
+        MASTERNODE_VIN_SPENT,
+        MASTERNODE_REMOVE,
+        MASTERNODE_POS_ERROR
     };
 
     CTxIn vin;
@@ -246,6 +247,11 @@ public:
         return activeState == MASTERNODE_ENABLED;
     }
 
+    bool IsPreEnabled()
+    {
+        return activeState == MASTERNODE_PRE_ENABLED;
+    }
+
     int GetMasternodeInputAge()
     {
         if(chainActive.Tip() == NULL) return 0;
@@ -259,13 +265,14 @@ public:
     }
 
     std::string Status() {
-        std::string strStatus = "ACTIVE";
+        std::string strStatus = "unknown";
 
-        if(activeState == CMasternode::MASTERNODE_ENABLED) strStatus   = "ENABLED";
-        if(activeState == CMasternode::MASTERNODE_EXPIRED) strStatus   = "EXPIRED";
-        if(activeState == CMasternode::MASTERNODE_VIN_SPENT) strStatus = "VIN_SPENT";
-        if(activeState == CMasternode::MASTERNODE_REMOVE) strStatus    = "REMOVE";
-        if(activeState == CMasternode::MASTERNODE_POS_ERROR) strStatus = "POS_ERROR";
+        if(activeState == CMasternode::MASTERNODE_PRE_ENABLED) strStatus = "PRE_ENABLED";
+        if(activeState == CMasternode::MASTERNODE_ENABLED) strStatus     = "ENABLED";
+        if(activeState == CMasternode::MASTERNODE_EXPIRED) strStatus     = "EXPIRED";
+        if(activeState == CMasternode::MASTERNODE_VIN_SPENT) strStatus   = "VIN_SPENT";
+        if(activeState == CMasternode::MASTERNODE_REMOVE) strStatus      = "REMOVE";
+        if(activeState == CMasternode::MASTERNODE_POS_ERROR) strStatus   = "POS_ERROR";
 
         return strStatus;
     }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -210,7 +210,7 @@ bool CMasternodeMan::Add(CMasternode &mn)
 {
     LOCK(cs);
 
-    if (!mn.IsEnabled())
+    if (!mn.IsEnabled() && !mn.IsPreEnabled())
         return false;
 
     CMasternode *pmn = Find(mn.vin);


### PR DESCRIPTION
Treat MN as pre-enabled while there is no legit ping that differ from initial one (from mnb). Should give MN owners info if remote MN was actually enabled and sending pings as expected or was it not enabled and could be delisted in an hour because of no pings. Currently it is shown as enabled regardless which could be confusing.

Rebased #484 
Issue #443 