### PR TITLE
V0.12.1.x DS can (potentially) leak info by number of inputs

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70103;
+static const int PROTOCOL_VERSION = 70104;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -22,7 +22,7 @@ static const int GETHEADERS_VERSION = 70077;
 static const int MIN_PEER_PROTO_VERSION = 70066;
 
 //! minimum peer version accepted by DarksendPool
-static const int MIN_POOL_PEER_PROTO_VERSION = 70103;
+static const int MIN_POOL_PEER_PROTO_VERSION = 70104;
 
 //! minimum peer version for masternode budgets
 static const int MIN_BUDGET_PEER_PROTO_VERSION = 70103;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -149,7 +149,7 @@ private:
 public:
 //    bool SelectCoins(int64_t nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, const CCoinControl *coinControl = NULL, AvailableCoinsType coin_type=ALL_COINS, bool useIX = true) const;
     bool SelectCoinsDark(int64_t nValueMin, int64_t nValueMax, std::vector<CTxIn>& setCoinsRet, int64_t& nValueRet, int nDarksendRoundsMin, int nDarksendRoundsMax) const;
-    bool SelectCoinsByDenominations(int nDenom, int64_t nValueMin, int64_t nValueMax, std::vector<CTxIn>& vCoinsRet, std::vector<COutput>& vCoinsRet2, int64_t& nValueRet, int nDarksendRoundsMin, int nDarksendRoundsMax);
+    bool SelectCoinsByDenominations(int nDenom, int nNumberOfInputs, std::vector<CTxIn>& vCoinsRet, std::vector<COutput>& vCoinsRet2, int nDarksendRoundsMin, int nDarksendRoundsMax);
     bool SelectCoinsDarkDenominated(int64_t nTargetValue, std::vector<CTxIn>& setCoinsRet, int64_t& nValueRet) const;
     bool HasCollateralInputs(bool fOnlyConfirmed = true) const;
     bool IsCollateralAmount(int64_t nInputAmount) const;


### PR DESCRIPTION
When users submit different number of inputs in one mixing session it can potentially leak info by previous txid even if all inputs use the same denomination(s). This is mostly applicable to first few rounds of mixing, the more rounds of mixing is passed the less info is leaked. But anyway, this is still a really bad situation imo.

This PR should fix issue I just described by requiring users to submit not only the same denominations but also exactly the same number of inputs.

Note:

- replaces few value checks (which doesn't make sense together with this PR anymore imo) by "number of inputs" checks.
- bumps `PROTOCOL_VERSION` and `MIN_POOL_PEER_PROTO_VERSION`

Rebase #558 