### PR TITLE
V0.12.x.x translations

### DIFF
--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -49,7 +49,10 @@ def find_format_specifiers(s):
         percent = s.find('%', pos)
         if percent < 0:
             break
-        specifiers.append(s[percent+1])
+        try:
+            specifiers.append(s[percent+1])
+        except:
+            print('Failed to get specifier')
         pos = percent+2
     return specifiers
 

--- a/src/qt/dash_locale.qrc
+++ b/src/qt/dash_locale.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/translations">
         <file alias="bg">locale/dash_bg.qm</file>
         <file alias="de">locale/dash_de.qm</file>
+        <file alias="en">locale/dash_en.qm</file>
         <file alias="es">locale/dash_es.qm</file>
         <file alias="fi">locale/dash_fi.qm</file>
         <file alias="fr">locale/dash_fr.qm</file>

--- a/src/qt/dashstrings.cpp
+++ b/src/qt/dashstrings.cpp
@@ -169,7 +169,8 @@ QT_TRANSLATE_NOOP("dash-core", ""
 "Unable to locate enough Darksend non-denominated funds for this transaction "
 "that are not equal 1000 DASH."),
 QT_TRANSLATE_NOOP("dash-core", ""
-"Unable to locate enough Darksend non-denominated funds for this transaction."),
+"Unable to locate enough funds for this transaction that are not equal 1000 "
+"DASH."),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: "
 "%s)"),
@@ -312,9 +313,6 @@ QT_TRANSLATE_NOOP("dash-core", "Listen for JSON-RPC connections on <port> (defau
 QT_TRANSLATE_NOOP("dash-core", "Listen for connections on <port> (default: %u or testnet: %u)"),
 QT_TRANSLATE_NOOP("dash-core", "Loading addresses..."),
 QT_TRANSLATE_NOOP("dash-core", "Loading block index..."),
-QT_TRANSLATE_NOOP("dash-core", "Loading budget cache..."),
-QT_TRANSLATE_NOOP("dash-core", "Loading masternode cache..."),
-QT_TRANSLATE_NOOP("dash-core", "Loading masternode payment cache..."),
 QT_TRANSLATE_NOOP("dash-core", "Loading wallet... (%3.2f %%)"),
 QT_TRANSLATE_NOOP("dash-core", "Loading wallet..."),
 QT_TRANSLATE_NOOP("dash-core", "Lock is already in place."),
@@ -387,6 +385,13 @@ QT_TRANSLATE_NOOP("dash-core", "Stop running after importing blocks from disk (d
 QT_TRANSLATE_NOOP("dash-core", "Submitted following entries to masternode: %u / %d"),
 QT_TRANSLATE_NOOP("dash-core", "Submitted to masternode, waiting for more entries ( %u / %d ) %s"),
 QT_TRANSLATE_NOOP("dash-core", "Submitted to masternode, waiting in queue %s"),
+QT_TRANSLATE_NOOP("dash-core", "Synchronization doesn't yet started"),
+QT_TRANSLATE_NOOP("dash-core", "Synchronization failed"),
+QT_TRANSLATE_NOOP("dash-core", "Synchronization finished"),
+QT_TRANSLATE_NOOP("dash-core", "Synchronizing budgets..."),
+QT_TRANSLATE_NOOP("dash-core", "Synchronizing masternode winners..."),
+QT_TRANSLATE_NOOP("dash-core", "Synchronizing masternodes..."),
+QT_TRANSLATE_NOOP("dash-core", "Synchronizing sporks..."),
 QT_TRANSLATE_NOOP("dash-core", "This help message"),
 QT_TRANSLATE_NOOP("dash-core", "This is experimental software."),
 QT_TRANSLATE_NOOP("dash-core", "This is intended for regression testing tools and app development."),

--- a/src/qt/locale/dash_bg.ts
+++ b/src/qt/locale/dash_bg.ts
@@ -459,6 +459,10 @@
         <translation><numerusform>Обработени %n блока от историята на транзакциите.</numerusform><numerusform>Обработени %n блока от историята на транзакциите.</numerusform></translation>
     </message>
     <message>
+        <source>Synchronizing additional data: %p%</source>
+        <translation>Синхронизиране на допълнителни данни: %p%</translation>
+    </message>
+    <message>
         <source>Show the Dash Core help message to get a list with possible Dash command-line options</source>
         <translation>Покажи съобщението за помощ на Dash ядрото за да получиш списък на възможните опции за командния ред</translation>
     </message>
@@ -505,22 +509,6 @@
     <message>
         <source>Up to date</source>
         <translation>Синхронизиран</translation>
-    </message>
-    <message>
-        <source>Synchronizing sporks...</source>
-        <translation>Синхронизиране на sporks...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternodes...</source>
-        <translation>Синхронизиране на masternodes ...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternode winners...</source>
-        <translation>Синхронизиране на masternode победителите ...</translation>
-    </message>
-    <message>
-        <source>Synchronizing budgets...</source>
-        <translation>Синхронизиране на бюджетите ...</translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
@@ -3406,10 +3394,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Не са намерени достатъчно Darksend неденоминирани средства за тази транзакция, които не са равни на 1000 DASH.</translation>
     </message>
     <message>
-        <source>Unable to locate enough Darksend non-denominated funds for this transaction.</source>
-        <translation>Не са намерени достатъчно Darksend неденоминирани средства за тази транзакция.</translation>
-    </message>
-    <message>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Внимание: -paytxfee е с много голяма зададена стойност! Това е транзакционната такса, която ще платите ако направите транзакция.</translation>
     </message>
@@ -3739,6 +3723,10 @@ for example: alertnotify=echo %%s | mail -s "Dash Alert" admin@foo.com
 </source>
         <translation>За използване на dashd, или the -server опция към dash-qt, трябва да зададете rpcpassword в конфигурационния файл: %s Препоръчително е да използвате следната произволна парола: rpcuser=dashrpc rpcpassword=%s (не е нужно да запомняте тази парола) Потребителя и паролата НЕ ТРЯБВА да са еднакви. Ако файла не съществува , създайте го с права за само за четене. Препоръчително е да създадете сигнал за уведомяване за да бъдете осведомени при проблем; Пример: alertnotify=echo %%s | mail -s "Dash Alert" admin@foo.com 
 </translation>
+    </message>
+    <message>
+        <source>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</source>
+        <translation>Не са намерени достатъчно  средства за тази транзакция, които не са равни на 1000 DASH.</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
@@ -4103,6 +4091,34 @@ for example: alertnotify=echo %%s | mail -s "Dash Alert" admin@foo.com
         <translation>Изпратено към Мастернода, чака в опашката %s</translation>
     </message>
     <message>
+        <source>Synchronization doesn't yet started</source>
+        <translation>Синхронизацията все още не е започнала</translation>
+    </message>
+    <message>
+        <source>Synchronization failed</source>
+        <translation>Синхронизацията е неуспешна</translation>
+    </message>
+    <message>
+        <source>Synchronization finished</source>
+        <translation>Синхронизацията е завършена</translation>
+    </message>
+    <message>
+        <source>Synchronizing budgets...</source>
+        <translation>Синхронизиране на бюджетите ...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternode winners...</source>
+        <translation>Синхронизиране на masternode победителите ...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternodes...</source>
+        <translation>Синхронизиране на masternodes ...</translation>
+    </message>
+    <message>
+        <source>Synchronizing sporks...</source>
+        <translation>Синхронизиране на sporks...</translation>
+    </message>
+    <message>
         <source>This is not a Masternode.</source>
         <translation>Това не е Masternode.</translation>
     </message>
@@ -4205,18 +4221,6 @@ for example: alertnotify=echo %%s | mail -s "Dash Alert" admin@foo.com
     <message>
         <source>Loading block index...</source>
         <translation>Зареждане на блок индекса...</translation>
-    </message>
-    <message>
-        <source>Loading budget cache...</source>
-        <translation>Зареждане на бюджетния кеш...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Зареждане на masternode кеш...</translation>
-    </message>
-    <message>
-        <source>Loading masternode payment cache...</source>
-        <translation>Зараждане на masternode кеш за плащане</translation>
     </message>
     <message>
         <source>Loading wallet... (%3.2f %%)</source>

--- a/src/qt/locale/dash_de.ts
+++ b/src/qt/locale/dash_de.ts
@@ -459,6 +459,10 @@
         <translation><numerusform>%n Block des Transaktionsverlaufs verarbeitet.</numerusform><numerusform>%n Blöcke des Transaktionsverlaufs verarbeitet.</numerusform></translation>
     </message>
     <message>
+        <source>Synchronizing additional data: %p%</source>
+        <translation>Synchronisiere zusätzliche Daten:  %p%</translation>
+    </message>
+    <message>
         <source>Show the Dash Core help message to get a list with possible Dash command-line options</source>
         <translation>Zeige den "Dash Core"-Hilfetext, um eine Liste mit möglichen Kommandozeilenoptionen zu erhalten</translation>
     </message>
@@ -505,22 +509,6 @@
     <message>
         <source>Up to date</source>
         <translation>Auf aktuellem Stand</translation>
-    </message>
-    <message>
-        <source>Synchronizing sporks...</source>
-        <translation>Synchronisiere Sporks...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternodes...</source>
-        <translation>Synchronisiere Masternodes...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternode winners...</source>
-        <translation>Synchronisiere Masternode Gewinner...</translation>
-    </message>
-    <message>
-        <source>Synchronizing budgets...</source>
-        <translation>Synchronisiere Budgets...</translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
@@ -3406,10 +3394,6 @@ Dies kann passieren, wenn einige Dash aus ihrer Wallet bereits ausgegeben wurden
         <translation>Für diese Transaktion konnten nicht genug nicht mit Darksend gestückelte Beträge gefunden werden, die ungleich 1000 DASH sind.</translation>
     </message>
     <message>
-        <source>Unable to locate enough Darksend non-denominated funds for this transaction.</source>
-        <translation>Für diese Transaktion konnten nicht genug nicht mit Darksend gestückelte Beträge gefunden werden.</translation>
-    </message>
-    <message>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Warnung: -paytxfee ist auf einen sehr hohen Wert festgelegt! Dies ist die Gebühr die beim Senden einer Transaktion fällig wird.</translation>
     </message>
@@ -3747,6 +3731,10 @@ Der Benutzername und das Passwort dürfen NICHT identisch sein.
 Falls die Konfigurationsdatei nicht existiert, erzeugen Sie diese bitte mit Leserechten nur für den Dateibesitzer.
 Es wird ebenfalls empfohlen alertnotify anzugeben, um im Problemfall benachrichtigt zu werden;
 zum Beispiel: alertnotify=echo %%s | mail -s \"Dash Alert\" admin@foo.com</translation>
+    </message>
+    <message>
+        <source>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</source>
+        <translation>Für diese Transaktion konnten nicht genug Beträge gefunden werden, die ungleich 1000 DASH sind.</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
@@ -4112,6 +4100,34 @@ Dash Core wird heruntergefahren.</translation>
         <translation>An Masternode übermittelt, wartet in Warteschlange %s</translation>
     </message>
     <message>
+        <source>Synchronization doesn't yet started</source>
+        <translation>Die Synchronisation hat noch nicht begonnen.</translation>
+    </message>
+    <message>
+        <source>Synchronization failed</source>
+        <translation>Synchronisation fehlgeschlagen</translation>
+    </message>
+    <message>
+        <source>Synchronization finished</source>
+        <translation>Synchronisation beendet</translation>
+    </message>
+    <message>
+        <source>Synchronizing budgets...</source>
+        <translation>Synchronisiere Budgets...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternode winners...</source>
+        <translation>Synchronisiere Masternode Gewinner...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternodes...</source>
+        <translation>Synchronisiere Masternodes...</translation>
+    </message>
+    <message>
+        <source>Synchronizing sporks...</source>
+        <translation>Synchronisiere Sporks...</translation>
+    </message>
+    <message>
         <source>This is not a Masternode.</source>
         <translation>Dies ist kein Masternode.</translation>
     </message>
@@ -4214,18 +4230,6 @@ Dash Core wird heruntergefahren.</translation>
     <message>
         <source>Loading block index...</source>
         <translation>Lade Blockindex...</translation>
-    </message>
-    <message>
-        <source>Loading budget cache...</source>
-        <translation>Lade Budget-Cache...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Lade Masternode-Cache...</translation>
-    </message>
-    <message>
-        <source>Loading masternode payment cache...</source>
-        <translation>Lade Masternode Zahlungs-Cache...</translation>
     </message>
     <message>
         <source>Loading wallet... (%3.2f %%)</source>

--- a/src/qt/locale/dash_en.ts
+++ b/src/qt/locale/dash_en.ts
@@ -295,12 +295,12 @@
     <name>BitcoinGUI</name>
     <message>
         <location filename="../bitcoingui.cpp" line="+107"/>
-        <location line="+759"/>
+        <location line="+752"/>
         <source>Dash Core</source>
         <translation>Dash Core</translation>
     </message>
     <message>
-        <location line="-750"/>
+        <location line="-743"/>
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
@@ -581,7 +581,12 @@
         <translation><numerusform>Processed %n block of transaction history.</numerusform><numerusform>Processed %n blocks of transaction history.</numerusform></translation>
     </message>
     <message>
-        <location line="-376"/>
+        <location line="+32"/>
+        <source>Synchronizing additional data: %p%</source>
+        <translation>Synchronizing additional data: %p%</translation>
+    </message>
+    <message>
+        <location line="-408"/>
         <source>Show the Dash Core help message to get a list with possible Dash command-line options</source>
         <translation>Show the Dash Core help message to get a list with possible Dash command-line options</translation>
     </message>
@@ -636,32 +641,12 @@
         <translation>No block source available...</translation>
     </message>
     <message>
-        <location line="+16"/>
+        <location line="+17"/>
         <source>Up to date</source>
         <translation>Up to date</translation>
     </message>
-    <message>
-        <location line="+19"/>
-        <source>Synchronizing sporks...</source>
-        <translation>Synchronizing sporks...</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Synchronizing masternodes...</source>
-        <translation>Synchronizing masternodes...</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Synchronizing masternode winners...</source>
-        <translation>Synchronizing masternode winners...</translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Synchronizing budgets...</source>
-        <translation>Synchronizing budgets...</translation>
-    </message>
     <message numerus="yes">
-        <location line="+23"/>
+        <location line="+43"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hour</numerusform><numerusform>%n hours</numerusform></translation>
     </message>
@@ -4349,12 +4334,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Unable to locate enough Darksend non-denominated funds for this transaction that are not equal 1000 DASH.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Unable to locate enough Darksend non-denominated funds for this transaction.</source>
-        <translation>Unable to locate enough Darksend non-denominated funds for this transaction.</translation>
-    </message>
-    <message>
-        <location line="+8"/>
+        <location line="+12"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</translation>
     </message>
@@ -4584,7 +4564,7 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>If &lt;category&gt; is not supplied, output all debugging information.</translation>
     </message>
     <message>
-        <location line="-267"/>
+        <location line="-268"/>
         <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
         <translation>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</translation>
     </message>
@@ -4774,7 +4754,12 @@ for example: alertnotify=echo %%s | mail -s &quot;Dash Alert&quot; admin@foo.com
 </translation>
     </message>
     <message>
-        <location line="+22"/>
+        <location line="+20"/>
+        <source>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</source>
+        <translation>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</translation>
+    </message>
+    <message>
+        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
         <translation>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</translation>
     </message>
@@ -5056,7 +5041,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Dash Alert&quot; admin@foo.com
         <translation>Listen for connections on &lt;port&gt; (default: %u or testnet: %u)</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="+5"/>
         <source>Lock is already in place.</source>
         <translation>Lock is already in place.</translation>
     </message>
@@ -5226,6 +5211,41 @@ for example: alertnotify=echo %%s | mail -s &quot;Dash Alert&quot; admin@foo.com
         <translation>Submitted to masternode, waiting in queue %s</translation>
     </message>
     <message>
+        <location line="+1"/>
+        <source>Synchronization doesn&apos;t yet started</source>
+        <translation>Synchronization doesn&apos;t yet started</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronization failed</source>
+        <translation>Synchronization failed</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronization finished</source>
+        <translation>Synchronization finished</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronizing budgets...</source>
+        <translation>Synchronizing budgets...</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronizing masternode winners...</source>
+        <translation>Synchronizing masternode winners...</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronizing masternodes...</source>
+        <translation>Synchronizing masternodes...</translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Synchronizing sporks...</source>
+        <translation>Synchronizing sporks...</translation>
+    </message>
+    <message>
         <location line="+4"/>
         <source>This is not a Masternode.</source>
         <translation>This is not a Masternode.</translation>
@@ -5271,7 +5291,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Dash Alert&quot; admin@foo.com
         <translation>Will retry...</translation>
     </message>
     <message>
-        <location line="-129"/>
+        <location line="-133"/>
         <source>Invalid masternodeprivkey. Please see documenation.</source>
         <translation>Invalid masternodeprivkey. Please see documenation.</translation>
     </message>
@@ -5354,21 +5374,6 @@ for example: alertnotify=echo %%s | mail -s &quot;Dash Alert&quot; admin@foo.com
         <location line="+1"/>
         <source>Loading block index...</source>
         <translation>Loading block index...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Loading budget cache...</source>
-        <translation>Loading budget cache...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Loading masternode cache...</source>
-        <translation>Loading masternode cache...</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Loading masternode payment cache...</source>
-        <translation>Loading masternode payment cache...</translation>
     </message>
     <message>
         <location line="+1"/>
@@ -5561,7 +5566,7 @@ for example: alertnotify=echo %%s | mail -s &quot;Dash Alert&quot; admin@foo.com
         <translation>Specify your own public address</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+13"/>
         <source>This help message</source>
         <translation>This help message</translation>
     </message>

--- a/src/qt/locale/dash_es.ts
+++ b/src/qt/locale/dash_es.ts
@@ -459,6 +459,10 @@
         <translation><numerusform>Procesado %n bloque del historial de transacciones.</numerusform><numerusform>Procesados %n bloques del historial de transacciones.</numerusform></translation>
     </message>
     <message>
+        <source>Synchronizing additional data: %p%</source>
+        <translation>Sincronizando datos adicionales: %p%</translation>
+    </message>
+    <message>
         <source>Show the Dash Core help message to get a list with possible Dash command-line options</source>
         <translation>Mostrar el mensaje de ayuda de Dash Core para obtener una lista con las posibles opciones de la consola de comandos</translation>
     </message>
@@ -506,25 +510,13 @@
         <source>Up to date</source>
         <translation>Actualizado</translation>
     </message>
-    <message>
-        <source>Synchronizing sporks...</source>
-        <translation>Sincronizando sporks...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternodes...</source>
-        <translation>Sincronizando nodos maestros...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternode winners...</source>
-        <translation>Sincronizando ganadores de los nodos maestros...</translation>
-    </message>
-    <message>
-        <source>Synchronizing budgets...</source>
-        <translation>Sincronizando presupuestos...</translation>
-    </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora(s)</numerusform><numerusform>%n hora(s)</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation><numerusform>%n día</numerusform><numerusform>%n días</numerusform></translation>
     </message>
     <message numerus="yes">
         <source>%n week(s)</source>
@@ -1444,7 +1436,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>Submitted Denom:</source>
-        <translation>Denom Enviados:</translation>
+        <translation>Denom Enviadas:</translation>
     </message>
     <message>
         <source>n/a</source>
@@ -1797,7 +1789,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>Using OpenSSL version</source>
-        <translation>Utilizando la versión OpenSSL</translation>
+        <translation>Utilizando versión de OpenSSL</translation>
     </message>
     <message>
         <source>Build date</source>
@@ -3390,16 +3382,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Esta es una versión de pre-prueba - utilícela bajo su propio riesgo. No la utilice para usos comerciales o de minería.</translation>
     </message>
     <message>
+        <source>Unable to bind to %s on this computer. Dash Core is probably already running.</source>
+        <translation>No se puede enlazar a %s en este equipo. Dash Core probablemente ya está en funcionamiento.</translation>
+    </message>
+    <message>
         <source>Unable to locate enough Darksend denominated funds for this transaction.</source>
         <translation>No se pueden localizar fondos denominados de Darksend suficientes para esta transacción.</translation>
     </message>
     <message>
         <source>Unable to locate enough Darksend non-denominated funds for this transaction that are not equal 1000 DASH.</source>
         <translation>No se pueden localizar fondos no denominados de Darksend suficientes para esta transacción que no sean iguales a 1000 DASH.</translation>
-    </message>
-    <message>
-        <source>Unable to locate enough Darksend non-denominated funds for this transaction.</source>
-        <translation>No se pueden localizar fondos no denominados de Darksend suficientes para esta transacción.</translation>
     </message>
     <message>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
@@ -3675,6 +3667,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Registrar prioridad de las transacciones y la comisión por kB al minar bloques (predeterminado: %u)</translation>
     </message>
     <message>
+        <source>Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</source>
+        <translation>Mantener índice de transacciones completo, utilizado por la llamada rpc getrawtransaction (predeterminado: %u)</translation>
+    </message>
+    <message>
         <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
         <translation>Tamaño máximo de datos en las transacciones de portadora de datos que transmitimos y minamos (predeterminado: %u)</translation>
     </message>
@@ -3737,6 +3733,10 @@ Si el archivo no existe, créelo con permisos de sólo lectura para su propietar
 También resulta recomendable establecer alertnotify para que se le notifique de posibles problemas;
 por ejemplo: alertnotify=echo %%s | mail -s "Alerta de Dash" admin@foo.com
 </translation>
+    </message>
+    <message>
+        <source>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</source>
+        <translation>No se pueden localizar fondos suficientes para esta transacción que no sean iguales a 1000 DASH.</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
@@ -3847,6 +3847,10 @@ por ejemplo: alertnotify=echo %%s | mail -s "Alerta de Dash" admin@foo.com
     <message>
         <source>Error: Unsupported argument -tor found, use -onion.</source>
         <translation>Error: Se encontró el argumento no soportado -tor, use -onion.</translation>
+    </message>
+    <message>
+        <source>Fee (in DASH/kB) to add to transactions you send (default: %s)</source>
+        <translation>Comisión (en DASH/kB) a añadir sobre las transacciones que envíe (predeterminado: %s)</translation>
     </message>
     <message>
         <source>Finalizing transaction.</source>
@@ -3967,6 +3971,10 @@ por ejemplo: alertnotify=echo %%s | mail -s "Alerta de Dash" admin@foo.com
     <message>
         <source>Lock masternodes from masternode configuration file (default: %u)</source>
         <translation>Asegurar nodos maestros a partir del archivo de configuración del nodo maestro (predeterminado: %u)</translation>
+    </message>
+    <message>
+        <source>Maintain at most &lt;n&gt; connections to peers (default: %u)</source>
+        <translation>Mantener como máximo &lt;n&gt; conexiones a pares (predeterminado: %u)</translation>
     </message>
     <message>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
@@ -4093,6 +4101,34 @@ por ejemplo: alertnotify=echo %%s | mail -s "Alerta de Dash" admin@foo.com
         <translation>Enviado al nodo maestro, esperando en cola %s</translation>
     </message>
     <message>
+        <source>Synchronization doesn't yet started</source>
+        <translation>La sincronización aún no ha comenzado</translation>
+    </message>
+    <message>
+        <source>Synchronization failed</source>
+        <translation>La sincronización falló</translation>
+    </message>
+    <message>
+        <source>Synchronization finished</source>
+        <translation>La sincronización finalizó</translation>
+    </message>
+    <message>
+        <source>Synchronizing budgets...</source>
+        <translation>Sincronizando presupuestos...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternode winners...</source>
+        <translation>Sincronizando ganadores de los nodos maestros...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternodes...</source>
+        <translation>Sincronizando nodos maestros...</translation>
+    </message>
+    <message>
+        <source>Synchronizing sporks...</source>
+        <translation>Sincronizando sporks...</translation>
+    </message>
+    <message>
         <source>This is not a Masternode.</source>
         <translation>Esto no es un Nodo Maestro.</translation>
     </message>
@@ -4177,6 +4213,10 @@ por ejemplo: alertnotify=echo %%s | mail -s "Alerta de Dash" admin@foo.com
         <translation>Conservar N DASH anónimos (predeterminado: %u)</translation>
     </message>
     <message>
+        <source>Keep at most &lt;n&gt; unconnectable transactions in memory (default: %u)</source>
+        <translation>Mantenga a lo sumo &lt;n&gt; transacciones no conectables en la memoria (por defecto: %u)</translation>
+    </message>
+    <message>
         <source>Last Darksend was too recent.</source>
         <translation>El último Darksend era demasiado reciente.</translation>
     </message>
@@ -4191,18 +4231,6 @@ por ejemplo: alertnotify=echo %%s | mail -s "Alerta de Dash" admin@foo.com
     <message>
         <source>Loading block index...</source>
         <translation>Cargando el índice de bloques...</translation>
-    </message>
-    <message>
-        <source>Loading budget cache...</source>
-        <translation>Cargando caché del presupuesto...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Cargando caché de nodos maestros...</translation>
-    </message>
-    <message>
-        <source>Loading masternode payment cache...</source>
-        <translation>Cargando caché de pago del nodo maestro...</translation>
     </message>
     <message>
         <source>Loading wallet... (%3.2f %%)</source>

--- a/src/qt/locale/dash_fi.ts
+++ b/src/qt/locale/dash_fi.ts
@@ -459,6 +459,10 @@
         <translation><numerusform>Käsitelty %n lohko tapahtumahistoriasta.</numerusform><numerusform>Käsitelty %n lohkoa tapahtumahistoriasta.</numerusform></translation>
     </message>
     <message>
+        <source>Synchronizing additional data: %p%</source>
+        <translation>Synkronoidaan lisätietoja: %p%</translation>
+    </message>
+    <message>
         <source>Show the Dash Core help message to get a list with possible Dash command-line options</source>
         <translation>Näytä Dash Core ohjelista komentorivin valinnoista</translation>
     </message>
@@ -505,22 +509,6 @@
     <message>
         <source>Up to date</source>
         <translation>Tapahtumahistoria on ajan tasalla</translation>
-    </message>
-    <message>
-        <source>Synchronizing sporks...</source>
-        <translation>Synkronoidaan sporkit...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternodes...</source>
-        <translation>Synkronoidaan masternodet...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternode winners...</source>
-        <translation>Synkronoidaan masternode voittajat...</translation>
-    </message>
-    <message>
-        <source>Synchronizing budgets...</source>
-        <translation>Synkronoidaan budjetit...</translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
@@ -3411,10 +3399,6 @@ Näillä toiminnoilla voit korjata korruptoituneen lohkoketjun tai puuttuvat/van
         <translation>Ei tarpeeksi Darksend ei-anonymisoituja varoja tälle siirtotapahtumalle, joka ei ole 1000 DASH.</translation>
     </message>
     <message>
-        <source>Unable to locate enough Darksend non-denominated funds for this transaction.</source>
-        <translation>Ei tarpeeksi Darksend ei-anonymisoituja varoja tälle siirtotapahtumalle.</translation>
-    </message>
-    <message>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Varoitus: Siirtomaksu on asetettu erittäin korkeaksi! Tämä on siirtomaksu jonka tulet maksamaan kun lähetät siirron.</translation>
     </message>
@@ -3730,7 +3714,7 @@ Näillä toiminnoilla voit korjata korruptoituneen lohkoketjun tai puuttuvat/van
         <source>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit &lt;https://www.openssl.org/&gt; and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</source>
         <translation>Tämä ohjelma sisältää OpenSSL projektin OpenSSL työkalupakin &lt;https://www.openssl.org/&gt; sekä Eric Youngin kehittämän salausohjelmiston ja Thomas Bernardin kehittämän UPnP ohjelmiston.
 
-Käännös päivitetty: 12.8.2015 by AjM.</translation>
+Käännös päivitetty: 22.8.2015 by AjM.</translation>
     </message>
     <message>
         <source>To use dashd, or the -server option to dash-qt, you must set an rpcpassword in the configuration file:
@@ -3755,6 +3739,10 @@ Jos tiedostoa ei ole, luo se vain omistajan-luku-oikeudella.
 Suositellaan asetettavaksi alertnotify jotta saat tietoa ongelmista,
 esimerkiksi: alertnotify=echo %%s | mail -s "Dash Hälytys" admin@foo.com
 </translation>
+    </message>
+    <message>
+        <source>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</source>
+        <translation>Ei tarpeeksi varoja tälle siirtotapahtumalle, joka ei ole 1000 DASH.</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
@@ -4119,6 +4107,34 @@ esimerkiksi: alertnotify=echo %%s | mail -s "Dash Hälytys" admin@foo.com
         <translation>Esitetty masternodelle, odotetaan jonossa %s</translation>
     </message>
     <message>
+        <source>Synchronization doesn't yet started</source>
+        <translation>Synkronointia ei ole vielä aloitettu</translation>
+    </message>
+    <message>
+        <source>Synchronization failed</source>
+        <translation>Synkronointi epäonnistui</translation>
+    </message>
+    <message>
+        <source>Synchronization finished</source>
+        <translation>Synkronointi valmis</translation>
+    </message>
+    <message>
+        <source>Synchronizing budgets...</source>
+        <translation>Synkronoidaan budjetit...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternode winners...</source>
+        <translation>Synkronoidaan masternode voittajat...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternodes...</source>
+        <translation>Synkronoidaan masternodet...</translation>
+    </message>
+    <message>
+        <source>Synchronizing sporks...</source>
+        <translation>Synkronoidaan sporkit...</translation>
+    </message>
+    <message>
         <source>This is not a Masternode.</source>
         <translation>Tämä ei ole Masternode.</translation>
     </message>
@@ -4221,18 +4237,6 @@ esimerkiksi: alertnotify=echo %%s | mail -s "Dash Hälytys" admin@foo.com
     <message>
         <source>Loading block index...</source>
         <translation>Ladataan lohkoindeksiä...</translation>
-    </message>
-    <message>
-        <source>Loading budget cache...</source>
-        <translation>Ladataan budjettivälimuistia...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Ladataan masternodevälimuistia...</translation>
-    </message>
-    <message>
-        <source>Loading masternode payment cache...</source>
-        <translation>Ladataan masternode maksuvälimuistia...</translation>
     </message>
     <message>
         <source>Loading wallet... (%3.2f %%)</source>

--- a/src/qt/locale/dash_fr.ts
+++ b/src/qt/locale/dash_fr.ts
@@ -459,6 +459,10 @@
         <translation><numerusform> Traités %n blocs de l'historique des transactions.</numerusform><numerusform> Traités %n blocs de l'historique des transactions.</numerusform></translation>
     </message>
     <message>
+        <source>Synchronizing additional data: %p%</source>
+        <translation>Synchronisation des données additionnelles: %p%</translation>
+    </message>
+    <message>
         <source>Show the Dash Core help message to get a list with possible Dash command-line options</source>
         <translation>Afficher le message d'aide de Dash Core pour obtenir une liste des options de ligne de commande Bitcoin possibles.</translation>
     </message>
@@ -505,22 +509,6 @@
     <message>
         <source>Up to date</source>
         <translation>À jour</translation>
-    </message>
-    <message>
-        <source>Synchronizing sporks...</source>
-        <translation>Synchronisation des sporks...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternodes...</source>
-        <translation>Synchronisation des masternodes...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternode winners...</source>
-        <translation>Synchronisation des masternodes vainqueurs...</translation>
-    </message>
-    <message>
-        <source>Synchronizing budgets...</source>
-        <translation>Synchronisation des budgets...</translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
@@ -3406,10 +3394,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Impossible de localiser suffisamment de fonds non-dénominés Darksend pour cette transaction qui ne sont pas égaux à 1000 DASH.</translation>
     </message>
     <message>
-        <source>Unable to locate enough Darksend non-denominated funds for this transaction.</source>
-        <translation>Impossible de localiser suffisamment de fonds Darksend non-dénominés  pour cette transaction.</translation>
-    </message>
-    <message>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Attention : -paytxfee est réglée sur un montant très élevé ! Il s'agit des frais de transaction que vous payerez si vous envoyez une transaction.</translation>
     </message>
@@ -3750,6 +3734,10 @@ Pour exemple: alertnotify=echo %%s | mail -s "Alerte Dash" admin@foo.com
 </translation>
     </message>
     <message>
+        <source>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</source>
+        <translation>Impossible de localiser suffisamment de fonds pour cette transaction qui ne sont pas égaux à 1000 DASH.</translation>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
         <translation>Utiliser un serveur proxy SOCKS5 séparé pour atteindre les pairs par les services cachés de Tor (par défaut : %s)</translation>
     </message>
@@ -4032,6 +4020,10 @@ Pour exemple: alertnotify=echo %%s | mail -s "Alerte Dash" admin@foo.com
         <translation>Ajouter l'horodatage au début de la sortie de débogage (par défaut : %u)</translation>
     </message>
     <message>
+        <source>Run a thread to flush wallet periodically (default: %u)</source>
+        <translation>Exécuter une tâche pour purger le portefeuille périodiquement (par défaut : %u) </translation>
+    </message>
+    <message>
         <source>Send trace/debug info to debug.log file (default: %u)</source>
         <translation>Envoyer les informations de débogage/trace au fichier debug.log (par défaut: %u)</translation>
     </message>
@@ -4106,6 +4098,34 @@ Pour exemple: alertnotify=echo %%s | mail -s "Alerte Dash" admin@foo.com
     <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Soumis au masternode, dans la file d'attente %s</translation>
+    </message>
+    <message>
+        <source>Synchronization doesn't yet started</source>
+        <translation>La synchronisation n'a pas encore démarrée</translation>
+    </message>
+    <message>
+        <source>Synchronization failed</source>
+        <translation>La synchronisation a échouée</translation>
+    </message>
+    <message>
+        <source>Synchronization finished</source>
+        <translation>La synchronisation est terminée</translation>
+    </message>
+    <message>
+        <source>Synchronizing budgets...</source>
+        <translation>Synchronisation des budgets...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternode winners...</source>
+        <translation>Synchronisation des masternodes vainqueurs...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternodes...</source>
+        <translation>Synchronisation des masternodes...</translation>
+    </message>
+    <message>
+        <source>Synchronizing sporks...</source>
+        <translation>Synchronisation des sporks...</translation>
     </message>
     <message>
         <source>This is not a Masternode.</source>
@@ -4210,18 +4230,6 @@ Pour exemple: alertnotify=echo %%s | mail -s "Alerte Dash" admin@foo.com
     <message>
         <source>Loading block index...</source>
         <translation>Chargement de l’index des blocs...</translation>
-    </message>
-    <message>
-        <source>Loading budget cache...</source>
-        <translation>Chargement du cache de budget...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Chargement du cache de masternode...</translation>
-    </message>
-    <message>
-        <source>Loading masternode payment cache...</source>
-        <translation>Chargement du cache de paiement masternode...</translation>
     </message>
     <message>
         <source>Loading wallet... (%3.2f %%)</source>

--- a/src/qt/locale/dash_pl.ts
+++ b/src/qt/locale/dash_pl.ts
@@ -459,6 +459,10 @@
         <translation><numerusform>Pobrano %n blok z historią transakcji.</numerusform><numerusform>Przetworzony przez %n bloków historii transakcji.</numerusform><numerusform>Pobranych zostało %n bloków z historią transakcji.</numerusform></translation>
     </message>
     <message>
+        <source>Synchronizing additional data: %p%</source>
+        <translation>Synchronizuję dodatkowe dane: %p%</translation>
+    </message>
+    <message>
         <source>Show the Dash Core help message to get a list with possible Dash command-line options</source>
         <translation>Pokaż wiadomość pomocy Dash Core aby otrzymać listę z dostępnymi opcjami linii komend.</translation>
     </message>
@@ -482,6 +486,10 @@
         <source>Tabs toolbar</source>
         <translation>Pasek zakładek</translation>
     </message>
+    <message numerus="yes">
+        <source>%n active connection(s) to Dash network</source>
+        <translation><numerusform>%n aktywne połączenie do sieci Dash</numerusform><numerusform>%n aktywne połączenia do sieci Dash</numerusform><numerusform>%n aktywne połączenia do sieci Dash</numerusform></translation>
+    </message>
     <message>
         <source>Synchronizing with network...</source>
         <translation>Synchronizacja z siecią...</translation>
@@ -502,9 +510,25 @@
         <source>Up to date</source>
         <translation>Aktualny</translation>
     </message>
+    <message numerus="yes">
+        <source>%n hour(s)</source>
+        <translation><numerusform>%n godzina</numerusform><numerusform>%n godzin</numerusform><numerusform>%n godziny</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n day(s)</source>
+        <translation><numerusform>%n dzień</numerusform><numerusform>%n dni</numerusform><numerusform>%n dni</numerusform></translation>
+    </message>
+    <message numerus="yes">
+        <source>%n week(s)</source>
+        <translation><numerusform>%n tydzień</numerusform><numerusform>%n tygodni</numerusform><numerusform>%n tygodnie</numerusform></translation>
+    </message>
     <message>
         <source>%1 and %2</source>
         <translation>%1 i %2</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n year(s)</source>
+        <translation><numerusform>%n rok</numerusform><numerusform>%n lat</numerusform><numerusform>%n lata</numerusform></translation>
     </message>
     <message>
         <source>%1 behind</source>
@@ -569,6 +593,10 @@ Adres: %4
 </context>
 <context>
     <name>ClientModel</name>
+    <message>
+        <source>Total: %1 (DS compatible: %2 / Enabled: %3)</source>
+        <translation>Całość: %1 (zgodne z DS: %2 / włączone: %3)</translation>
+    </message>
     <message>
         <source>Network Alert</source>
         <translation>Sieć Alert</translation>
@@ -1028,6 +1056,10 @@ Adres: %4
         <translation>Ponieważ uruchomiłeś ten program po raz pierwszy, możesz wybrać gdzie Dash Core będzie przechowywał dane.</translation>
     </message>
     <message>
+        <source>Dash Core will download and store a copy of the Dash block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
+        <translation>Dash Core ściągnie i przechowa  kopię blockchain na twoim dysku. Co najmniej %1GB danych zostanie zapisanych w tym katalogu, a wraz z upływem czasu blockchain będzie stopniowo wymagał coraz więcej miejsca. Twój portfel również zostanie zapisany w tym katalogu.</translation>
+    </message>
+    <message>
         <source>Use the default data directory</source>
         <translation>Użyj domyślnego folderu danych</translation>
     </message>
@@ -1466,6 +1498,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>No inputs detected</source>
         <translation>Nie wykryto wejść</translation>
     </message>
+    <message numerus="yes">
+        <source>%n Rounds</source>
+        <translation><numerusform>%n Runda</numerusform><numerusform>%n Rundy</numerusform><numerusform>%n Rundy</numerusform></translation>
+    </message>
     <message>
         <source>Not enough compatible inputs to anonymize &lt;span style='color:red;'&gt;%1&lt;/span&gt;,&lt;br&gt;will anonymize &lt;span style='color:red;'&gt;%2&lt;/span&gt; instead</source>
         <translation>Nie ma wystarczającej ilośći środków aby moć dokonać anonimizacji &lt;span style='color:red;'&gt;%1&lt;/span&gt;,&lt;br&gt;zamiast oryginalnej sumy &lt;spam style='color:red;'&gt;%2&lt;/spam&gt; zostanie zanonimizowanych.</translation>
@@ -1642,6 +1678,22 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Wpisz adres Dash (np. %1)</translation>
     </message>
     <message>
+        <source>%1 d</source>
+        <translation>%1 dzień</translation>
+    </message>
+    <message>
+        <source>%1 h</source>
+        <translation>%1 godz.</translation>
+    </message>
+    <message>
+        <source>%1 m</source>
+        <translation>%1 min.</translation>
+    </message>
+    <message>
+        <source>%1 s</source>
+        <translation>%1 sec.</translation>
+    </message>
+    <message>
         <source>NETWORK</source>
         <translation>SIEĆ</translation>
     </message>
@@ -1657,7 +1709,11 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>N/A</source>
         <translation>Nie ważne</translation>
     </message>
-    </context>
+    <message>
+        <source>%1 ms</source>
+        <translation>%1 milisec.</translation>
+    </message>
+</context>
 <context>
     <name>QRImageWidget</name>
     <message>
@@ -1976,7 +2032,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
-        <translation>O&amp;drzuć istniejący adres odbiorczy (nie zalecane)</translation>
+        <translation>Użyj istniejący adres odbiorczy (nie zalecane)</translation>
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Dash network.</source>
@@ -2360,6 +2416,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>anonimowe środki</translation>
     </message>
     <message>
+        <source>(darksend requires this amount to be rounded up to the nearest %1).</source>
+        <translation>(darksend wymaga aby kwota ta została zaokrąglona do najbliższego %1).</translation>
+    </message>
+    <message>
         <source>any available funds (not recommended)</source>
         <translation>jakiekolwiek dostępne środki (niezalecane)</translation>
     </message>
@@ -2722,6 +2782,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1/offline (zweryfikowane przez instantx)</translation>
     </message>
     <message>
+        <source>%1/confirmed (verified via instantx)</source>
+        <translation>%1/potwierdzony (zweryfikowane przez instantx)</translation>
+    </message>
+    <message>
+        <source>%1 confirmations (verified via instantx)</source>
+        <translation>%1 potwierdzeń (zweryfikowane przez instantx)</translation>
+    </message>
+    <message>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
@@ -2902,6 +2970,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Address</source>
         <translation>Adres</translation>
+    </message>
+    <message numerus="yes">
+        <source>Open for %n more block(s)</source>
+        <translation><numerusform>Otwarty na %n kolejny blok</numerusform><numerusform>Otwarty na %n kolejne bloki</numerusform><numerusform>Otwarty na %n kolejne bloki</numerusform></translation>
     </message>
     <message>
         <source>Open until %1</source>
@@ -3322,10 +3394,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nie znaleziono wystarczającej ilości nie zdenominowanych środków Darksend dla tej transakcji, które nie równają się 1000 DASH</translation>
     </message>
     <message>
-        <source>Unable to locate enough Darksend non-denominated funds for this transaction.</source>
-        <translation>Nie znaleziono wystarczającej ilości zdenominowanych środków Darksend dla tej transakcji.</translation>
-    </message>
-    <message>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Uwaga: -paytxfee jest bardzo wysoka! To jest opłata którą będziesz musiał uiścić jeśli dokonasz transakcji.</translation>
     </message>
@@ -3454,6 +3522,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Błąd podczas inicjowania bazy dancyh bloku</translation>
     </message>
     <message>
+        <source>Error initializing wallet database environment %s!</source>
+        <translation>Błąd podczas inicjowania środowiska bazy danych portfela %s!</translation>
+    </message>
+    <message>
         <source>Error loading block database</source>
         <translation>Błąd wczytywania bloku bazy danych</translation>
     </message>
@@ -3542,12 +3614,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Usuń wszystkie transakcje portfela i odzyskaj tylko te części blockchainu - zeskanuj powonie na starcie.</translation>
     </message>
     <message>
+        <source>Disable all Dash specific functionality (Masternodes, Darksend, InstantX, Budgeting) (0-1, default: %u)</source>
+        <translation>Wyłącz wszystkie dodatkowe funckje Dash (Masternody, Darksend, InstanX, Budżetowanie) (0-1, domyślnie: %u)</translation>
+    </message>
+    <message>
         <source>Distributed under the MIT software license, see the accompanying file COPYING or &lt;http://www.opensource.org/licenses/mit-license.php&gt;.</source>
         <translation>Rozpowszechniane na licencji MIT. Jeśli chcesz się dowiedzieć więcej otwórz towarzyszący plik o nzwie COPYING lub odwiedź &lt;http://www.opensource.org/licenses/mit-license.php&gt;.</translation>
     </message>
     <message>
         <source>Enable instantx, show confirmations for locked transactions (bool, default: %s)</source>
         <translation>Włącz instantx, pokaż potwierdzenia dla zamkniętych transakcji (bool, domyślnie: %s)</translation>
+    </message>
+    <message>
+        <source>Enable use of automated darksend for funds stored in this wallet (0-1, default: %u)</source>
+        <translation>Włącz możliwość automatyzacji Darksend dla środków zgromadzonych w  tym portfelu (0-1, domyślnie: %u)</translation>
     </message>
     <message>
         <source>Error: Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported.</source>
@@ -3606,6 +3686,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Informacje na temat debugowania danych wyjściowych (domyślnie: %u, podanie &lt;category&gt; jest opcjonalne)</translation>
     </message>
     <message>
+        <source>Provide liquidity to Darksend by infrequently mixing coins on a continual basis (0-100, default: %u, 1=very frequent, high fees, 100=very infrequent, low fees)</source>
+        <translation>Dostarcz Darksend płynności przez rzadkie ale ciągłe mieszanie monet (0-100, domyślnie: %u, 1=bardzo często, wysokie opłaty, 100=bardzo rzadko, małe opłaty)</translation>
+    </message>
+    <message>
         <source>Require high priority for relaying free or low-fee transactions (default:%u)</source>
         <translation>Wymagaj wysokiego priorytetu aby retransmitować darmowe transakcje lub te o niskich opłatach (domyślnie: %u)</translation>
     </message>
@@ -3647,6 +3731,10 @@ Twoje hasło NIE MOŻE być takie samo jak twój login.
 Jeśli plik ten nie istnieje, stwórz go z uprawnieniami do odczytu tylko przez właściciela.
 Zaleca się również aby ustawić alarm powiadomień tzw. alertnotify, aby dać ci znać w razie wystąpienia jekiegoś problemu, na przykład: alertnotify=echo %%s I -s "Dash Alert" admin@foo.com
 </translation>
+    </message>
+    <message>
+        <source>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</source>
+        <translation>Niemożliwe jest zlokalizowanie wystarczającej ilości środków dla tej transakcji, które nie są równe 1000 DASH.</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
@@ -3951,6 +4039,10 @@ Zaleca się również aby ustawić alarm powiadomień tzw. alertnotify, aby dać
         <translation>Klucz prywatny serwera (domyślnie: %s)</translation>
     </message>
     <message>
+        <source>Set external address:port to get to this masternode (example: %s)</source>
+        <translation>Ustaw zewnętrzny address:port aby połączyć się z tym masternodem (na przykład: %s)</translation>
+    </message>
+    <message>
         <source>Set key pool size to &lt;n&gt; (default: %u)</source>
         <translation>Ustaw ilość kluczy w key pool na &lt;n&gt; (domyślny: %u)</translation>
     </message>
@@ -4005,6 +4097,34 @@ Zaleca się również aby ustawić alarm powiadomień tzw. alertnotify, aby dać
     <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Przesłano do masterdnoda, czekaj na swoją kolej %s</translation>
+    </message>
+    <message>
+        <source>Synchronization doesn't yet started</source>
+        <translation>Synchronizacja jeszcze się nie zaczęła</translation>
+    </message>
+    <message>
+        <source>Synchronization failed</source>
+        <translation>Synchronizacja nie powiodła się</translation>
+    </message>
+    <message>
+        <source>Synchronization finished</source>
+        <translation>Synchronizacja zakończona</translation>
+    </message>
+    <message>
+        <source>Synchronizing budgets...</source>
+        <translation>Synchronizuję budżet...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternode winners...</source>
+        <translation>Synchronizuję zwycięskie masternody...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternodes...</source>
+        <translation>Synchronizuję masternody...</translation>
+    </message>
+    <message>
+        <source>Synchronizing sporks...</source>
+        <translation>Synchronizuję sporki...</translation>
     </message>
     <message>
         <source>This is not a Masternode.</source>
@@ -4109,18 +4229,6 @@ Zaleca się również aby ustawić alarm powiadomień tzw. alertnotify, aby dać
     <message>
         <source>Loading block index...</source>
         <translation>Wczytuje indeks bloków</translation>
-    </message>
-    <message>
-        <source>Loading budget cache...</source>
-        <translation>Ładuje pamięć podręczną budżetu...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Ładuje pamięć podręczną masternoda...</translation>
-    </message>
-    <message>
-        <source>Loading masternode payment cache...</source>
-        <translation>Ładuję pamięć podręczną płatności masternodów...</translation>
     </message>
     <message>
         <source>Loading wallet... (%3.2f %%)</source>

--- a/src/qt/locale/dash_ru.ts
+++ b/src/qt/locale/dash_ru.ts
@@ -459,6 +459,10 @@
         <translation><numerusform>Обработано %n блок из истории транзакций.</numerusform><numerusform>Обработано %n блока из истории транзакций.</numerusform><numerusform>Обработано %n блоков из истории транзакций.</numerusform><numerusform>Обработано %n блоков из истории транзакций.</numerusform></translation>
     </message>
     <message>
+        <source>Synchronizing additional data: %p%</source>
+        <translation>Синхронизация дополнительных данных: %p%</translation>
+    </message>
+    <message>
         <source>Show the Dash Core help message to get a list with possible Dash command-line options</source>
         <translation>Показать помощь о Dash Core со списком возможных параметров командной строки</translation>
     </message>
@@ -505,22 +509,6 @@
     <message>
         <source>Up to date</source>
         <translation>Синхронизировано</translation>
-    </message>
-    <message>
-        <source>Synchronizing sporks...</source>
-        <translation>Синхронизация спорков...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternodes...</source>
-        <translation>Синхронизация списка мастернод...</translation>
-    </message>
-    <message>
-        <source>Synchronizing masternode winners...</source>
-        <translation>Синхронизация списка мастернод-победителей...</translation>
-    </message>
-    <message>
-        <source>Synchronizing budgets...</source>
-        <translation>Синхронизация бюджетов...</translation>
     </message>
     <message numerus="yes">
         <source>%n hour(s)</source>
@@ -3406,10 +3394,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Не удалось обнаружить достаточных для выполнения этой транзакции неденоминированных средств, отличающихся от 1000DRK.</translation>
     </message>
     <message>
-        <source>Unable to locate enough Darksend non-denominated funds for this transaction.</source>
-        <translation>Не удалось обнаружить достаточных для выполнения этой транзакции неденоминированных средств.</translation>
-    </message>
-    <message>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Внимание: установлено очень большое значение -paytxfee. Это комиссия, которую Вы заплатите при проведении транзакции.</translation>
     </message>
@@ -3748,6 +3732,10 @@ rpcpassword=%s
 Также рекомендуется включить alertnotify для оповещения о проблемах;
 Например: alertnotify=echo %%s | mail -s "Dash Alert" admin@foo.com
 </translation>
+    </message>
+    <message>
+        <source>Unable to locate enough funds for this transaction that are not equal 1000 DASH.</source>
+        <translation>Не удалось обнаружить достаточных для выполнения этой транзакции средств, отличающихся от 1000DRK.</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
@@ -4112,6 +4100,34 @@ rpcpassword=%s
         <translation>Отправлено на мастерноду, ожидаем в очереди %s</translation>
     </message>
     <message>
+        <source>Synchronization doesn't yet started</source>
+        <translation>Синхронизация еще не началась</translation>
+    </message>
+    <message>
+        <source>Synchronization failed</source>
+        <translation>Синхронизация закончилась неудачно</translation>
+    </message>
+    <message>
+        <source>Synchronization finished</source>
+        <translation>Синхронизация завершена</translation>
+    </message>
+    <message>
+        <source>Synchronizing budgets...</source>
+        <translation>Синхронизация бюджетов...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternode winners...</source>
+        <translation>Синхронизация списка мастернод-победителей...</translation>
+    </message>
+    <message>
+        <source>Synchronizing masternodes...</source>
+        <translation>Синхронизация списка мастернод...</translation>
+    </message>
+    <message>
+        <source>Synchronizing sporks...</source>
+        <translation>Синхронизация спорков...</translation>
+    </message>
+    <message>
         <source>This is not a Masternode.</source>
         <translation>Это не мастернода.</translation>
     </message>
@@ -4214,18 +4230,6 @@ rpcpassword=%s
     <message>
         <source>Loading block index...</source>
         <translation>Загрузка индекса блоков...</translation>
-    </message>
-    <message>
-        <source>Loading budget cache...</source>
-        <translation>Загрузка кэша бюджетов...</translation>
-    </message>
-    <message>
-        <source>Loading masternode cache...</source>
-        <translation>Загрузка кэша мастернод...</translation>
-    </message>
-    <message>
-        <source>Loading masternode payment cache...</source>
-        <translation>Загрузка кэша выплат Мастернодам...</translation>
     </message>
     <message>
         <source>Loading wallet... (%3.2f %%)</source>


### PR DESCRIPTION
- fix update-translations.py to work correctly with % at the end of a string
- bring back ability to choose `en` (was removed accidentally)
- add few strings (uploading updated languages only - see screenshot & tnx everyone on transifex once again!)
- fix lots of mismatched specifiers in `pl`, `es` , `fr` translations

![screen shot 2015-08-22 at 22 01 25](https://cloud.githubusercontent.com/assets/1935069/9425466/2949d8c4-491a-11e5-82a6-5dfb4b4df1c8.png)
