### PR TITLE
Window positions not reset

### DIFF
--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -359,6 +359,12 @@ BitcoinApplication::~BitcoinApplication()
     delete paymentServer;
     paymentServer = 0;
 #endif
+    // Delete Qt-settings if user clicked on "Reset Options"
+    QSettings settings;
+    if(optionsModel->resetSettings){
+        settings.clear();
+        settings.sync();
+    }
     delete optionsModel;
     optionsModel = 0;
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -41,6 +41,7 @@ void OptionsModel::addOverriddenOption(const std::string &option)
 // Writes all missing QSettings with their default values
 void OptionsModel::Init()
 {
+    resetSettings = false;
     QSettings settings;
 
     // Ensure restart flag is unset on client startup
@@ -151,6 +152,7 @@ void OptionsModel::Reset()
 
     // Remove all entries from our QSettings object
     settings.clear();
+    resetSettings = true; // Needed in dash.cpp during shotdown to also remove the window positions
 
     // default setting for OptionsModel::StartAtStartup - disabled
     if (GUIUtil::GetStartOnSystemStartup())

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -70,6 +70,7 @@ public:
     /* Restart flag helper */
     void setRestartRequired(bool fRequired);
     bool isRestartRequired();
+    bool resetSettings;
 
 private:
     /* Qt-only settings */


### PR DESCRIPTION
Reference: https://github.com/dashpay/dash/issues/565

Window positions (not only the ones mentioned in the reference) and a couple of other Qt-settings are not removed from the Qt-options when called from within optionsmodel.cpp (actually, they are. But during shutdown they are put back somewhere).

Now settings.clear() is called at the latest possible moment, directly before the optionsModel gets de-instantiated.

Works fine on Win7 64, Linux and OSX.