### PR TITLE
"bin/make-base-vm --lxc --arch i386 --suite precise" added back

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -303,6 +303,7 @@ Execute the following as user `debian`:
 
 ```bash
 cd gitian-builder
+bin/make-base-vm --lxc --arch i386 --suite precise
 bin/make-base-vm --lxc --arch amd64 --suite precise
 ```
 


### PR DESCRIPTION
Didn't need it for v0.12.0.x, but v0.12.1.x doesn't build without it.