### PR TITLE
V0.12.1.x Fixes for sync:

### DIFF
--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -16,7 +16,7 @@
 #define MASTERNODE_SYNC_FINISHED          999
 
 #define MASTERNODE_SYNC_TIMEOUT           5
-#define MASTERNODE_SYNC_THRESHOLD         4
+#define MASTERNODE_SYNC_THRESHOLD         2
 
 class CMasternodeSync;
 extern CMasternodeSync masternodeSync;


### PR DESCRIPTION
Fixes for sync:
- lower `MASTERNODE_SYNC_THRESHOLD` (4->2)
- higher wait `MASTERNODE_SYNC_TIMEOUT*2`  and fail `MASTERNODE_SYNC_TIMEOUT*5` timeouts for each step
- ask at most `MASTERNODE_SYNC_THRESHOLD*3` nodes for sync data
- sync again 1 minute after last fail

So we will ask at most 6 nodes and stop updating lastTime...s when we had data from at least 2 of them but will fail if we had nothing in 25 sec since current step start.
In case of fail resync again faster.

EDIT: updated