### PR TITLE
V0.12.1.x fixes for mapSeenMasternodeBroadcast:

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -180,6 +180,12 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage) {
 
         pmn->lastPing = mnp;
         mnodeman.mapSeenMasternodePing.insert(make_pair(mnp.GetHash(), mnp));
+
+        //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated, so we'll update it
+        CMasternodeBroadcast mnb(*pmn);
+        uint256 hash = mnb.GetHash();
+        if(mnodeman.mapSeenMasternodeBroadcast.count(hash)) mnodeman.mapSeenMasternodeBroadcast[hash].lastPing = mnp;
+
         mnp.Relay();
 
         /*

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -779,8 +779,12 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             if(mn.IsEnabled()) {
                 LogPrint("masnernode", "dseg - Sending Masternode entry - %s \n", mn.addr.ToString());
                 if(vin == CTxIn() || vin == mn.vin){
-                    CInv inv(MSG_MASTERNODE_ANNOUNCE, CMasternodeBroadcast(mn).GetHash());
+                    CMasternodeBroadcast mnb = CMasternodeBroadcast(mn);
+                    uint256 hash = mnb.GetHash();
+                    CInv inv(MSG_MASTERNODE_ANNOUNCE, hash);
                     vInv.push_back(inv);
+
+                    if(!mapSeenMasternodeBroadcast.count(hash)) mapSeenMasternodeBroadcast.insert(make_pair(hash, mnb));
 
                     if(vin == mn.vin) {
                         LogPrintf("dseg - Sent 1 Masternode entries to %s\n", pfrom->addr.ToString());


### PR DESCRIPTION
- active masternode ping should update mapSeenMasternodeBroadcast's lastPing too
- dseg should fill mapSeenMasternodeBroadcast to be able to serve it later on getdata with MSG_MASTERNODE_ANNOUNCE inv

Though it should work (more or less) ok already it still would be nice to cover all possible edge cases imo.