### PR TITLE
UI: Coding and CSS changes for sum of selected transactions

### DIFF
--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -1498,6 +1498,15 @@ margin-bottom:1px;
 margin-right:1px;
 }
 
+QLabel#transactionSumLabel { /* Example of setObjectName for widgets without name */
+color:#333333;
+font-weight:bold;
+}
+ 
+QLabel#transactionSum { /* Example of setObjectName for widgets without name */
+color:#333333;
+}
+
 /* TRANSACTION DETAIL DIALOG */
 
 QDialog#TransactionDescDialog {

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -51,10 +51,12 @@ WalletView::WalletView(QWidget *parent):
 
     // Sum of selected transactions
     QLabel *transactionSumLabel = new QLabel(); // Label
+    transactionSumLabel->setObjectName("transactionSumLabel"); // Label ID as CSS-reference
     transactionSumLabel->setText(tr("Selected amount:"));
     hbox_buttons->addWidget(transactionSumLabel);
 
     transactionSum = new QLabel(); // Amount
+    transactionSum->setObjectName("transactionSum"); // Label ID as CSS-reference
     transactionSum->setMinimumSize(200, 8);
     transactionSum->setTextInteractionFlags(Qt::TextSelectableByMouse);
     hbox_buttons->addWidget(transactionSum);


### PR DESCRIPTION
[ Original PR (https://github.com/dashpay/dash/pull/550) moved to v0.12.1.x ]

@snogcel :thumbsup: found a way to assign a name to programmed labels so we can finally address them via CSS.
Right now it's more or less just a POC, but we'll need this more often in the future.

BTW, looks like this now:
![label](https://cloud.githubusercontent.com/assets/10080039/9340992/7daef3f6-45f3-11e5-9706-55d26301de27.jpg)
