### PR TITLE
Fix: local hot MN can't start if upnp is on

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -391,7 +391,9 @@ CNode* FindNode(const CService& addr)
 CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool darkSendMaster)
 {
     if (pszDest == NULL) {
-        if (IsLocal(addrConnect))
+        // we clean masternode connections in CMasternodeMan::ProcessMasternodeConnections()
+        // so should be safe to skip this and connect to local Hot MN on CActiveMasternode::ManageStatus()
+        if (IsLocal(addrConnect) && !darkSendMaster)
             return NULL;
 
         // Look for an existing connection


### PR DESCRIPTION
UPnP address is recognized as a local one and local hot mn can't start. This should fix it.