### PR TITLE
inv messages vectors should not be pushed directly

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -782,18 +782,17 @@ void CMasternodePayments::Sync(CNode* node, int nCountNeeded)
     int nCount = (mnodeman.CountEnabled()*2);
     if(nCountNeeded > nCount) nCountNeeded = nCount;
 
-    vector<CInv> vInv;
+    int nInvCount = 0;
     std::map<uint256, CMasternodePaymentWinner>::iterator it = mapMasternodePayeeVotes.begin();
     while(it != mapMasternodePayeeVotes.end()) {
         CMasternodePaymentWinner winner = (*it).second;
         if(winner.nBlockHeight >= chainActive.Tip()->nHeight-nCountNeeded && winner.nBlockHeight <= chainActive.Tip()->nHeight + 20) {
-            CInv inv(MSG_MASTERNODE_WINNER, winner.GetHash());
-            vInv.push_back(inv);
+            node->PushInventory(CInv(MSG_MASTERNODE_WINNER, winner.GetHash()));
+            nInvCount++;
         }
         ++it;
     }
-    node->PushMessage("ssc", MASTERNODE_SYNC_MNW, (int)vInv.size());
-    if(vInv.size() > 0) node->PushMessage("inv", vInv);
+    node->PushMessage("ssc", MASTERNODE_SYNC_MNW, nInvCount);
 }
 
 std::string CMasternodePayments::ToString() const


### PR DESCRIPTION
On mainnet inv vectors are getting way too large to be pushed in one step and receiving node will fail to accept such messages (and ban us). We should use internal inv functionality instead.