### PR TITLE
DS: try to use only inputs with the same number of rounds starting from lowest number of rounds possible

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1625,12 +1625,21 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
 
 bool CDarksendPool::PrepareDarksendDenominate()
 {
-    // Submit transaction to the pool if we get here, use sessionDenom so we use the same amount of money
-    std::string strError = pwalletMain->PrepareDarksendDenominate(0, nDarksendRounds);
-    LogPrintf("DoAutomaticDenominating : Running Darksend denominate. Return '%s'\n", strError);
+    std::string strError = "";
+    // Submit transaction to the pool if we get here
+    // Try to use only inputs with the same number of rounds starting from lowest number of rounds possible
+    for(int i = 0; i < nDarksendRounds; i++) {
+        strError = pwalletMain->PrepareDarksendDenominate(i, i+1);
+        LogPrintf("DoAutomaticDenominating : Running Darksend denominate for %d rounds. Return '%s'\n", i, strError);
+        if(strError == "") return true;
+    }
 
+    // We failed? That's strange but let's just make final attempt and try to mix everything
+    strError = pwalletMain->PrepareDarksendDenominate(0, nDarksendRounds);
+    LogPrintf("DoAutomaticDenominating : Running Darksend denominate for all rounds. Return '%s'\n", strError);
     if(strError == "") return true;
 
+    // Should never actually get here but just in case
     strAutoDenomResult = strError;
     LogPrintf("DoAutomaticDenominating : Error running denominate, %s\n", strError);
     return false;


### PR DESCRIPTION
This should make DS progress a bit more predictable by eliminating cases when inputs with different number of rounds were mixed together and we had to artificially lower number of rounds for each of them to the lowest one to be 100% sure of mixing depth. Should also help to avoid reusing the same coins for mixing too often.

One thing I'm not sure about is will this weaken anonymity or not. To me it seems like it's the same level as we already have now but any inputs are welcome of course.

PS. could be incompatible with #564 and also require to update implementation there but 1) it was reverted anyway 2) this one can be applied to 0.12.0.x while #564 is for 0.12.1.x