### PR TITLE
Security: sanitize mnbudget parameters (part 2) DASH-5

### DIFF
--- a/src/rpcmasternode-budget.cpp
+++ b/src/rpcmasternode-budget.cpp
@@ -376,9 +376,8 @@ Value mnbudget(const Array& params, bool fHelp)
     if(strCommand == "show")
     {
         std::string strShow = "valid";
-        if (params.size() == 2)
-            std::string strProposalName = params[1].get_str();
-
+        std::string strProposalName = "";
+        
         Object resultObj;
         int64_t nTotalAllotted = 0;
 
@@ -387,6 +386,12 @@ Value mnbudget(const Array& params, bool fHelp)
         {
             if(strShow == "valid" && !pbudgetProposal->fValid) continue;
 
+            // if a proposal name is submitted only show that one
+            if (params.size() == 2){
+                strProposalName = SanitizeString(params[1].get_str());
+                if (strProposalName != pbudgetProposal->GetName()) continue;
+            }
+            
             nTotalAllotted += pbudgetProposal->GetAllotted();
 
             CTxDestination address1;
@@ -428,7 +433,7 @@ Value mnbudget(const Array& params, bool fHelp)
         if (params.size() != 2)
             throw runtime_error("Correct usage is 'mnbudget getinfo profilename'");
 
-        std::string strProposalName = params[1].get_str();
+        std::string strProposalName = SanitizeString(params[1].get_str());
 
         CBudgetProposal* pbudgetProposal = budget.FindProposal(strProposalName);
 
@@ -469,7 +474,7 @@ Value mnbudget(const Array& params, bool fHelp)
         if (params.size() != 2)
             throw runtime_error("Correct usage is 'mnbudget getvotes profilename'");
 
-        std::string strProposalName = params[1].get_str();
+        std::string strProposalName = SanitizeString(params[1].get_str());
 
         Object obj;
 

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -26,7 +26,7 @@ string SanitizeString(const string& str)
      * safeChars chosen to allow simple messages/URLs/email addresses, but avoid anything
      * even possibly remotely dangerous like & or >
      */
-    static string safeChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890 .,;_/:?@()");
+    static string safeChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890 .,;_-/:?@()");
     string strResult;
     for (std::string::size_type i = 0; i < str.size(); i++)
     {


### PR DESCRIPTION
* Proposals now checked on the receiving end as well (see https://github.com/dashpay/dash/pull/598)
* **Included the character "-" in _"SanitizeString()"_** to be compatible with existing proposal names. If someone feels uncomfortable with this just tell me and I'll implement a different solution.
* Implemented _"mmbudget show \<proposalname\>"_ which was missing/only partly implemented.