### PR TITLE
fix LP inter-mixing by not initiating new queues by them

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1571,6 +1571,9 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
             }
         }
 
+        // do not initiate queue if we are a liquidity proveder to avoid useless inter-mixing
+        if(nLiquidityProvider) return false;
+
         int i = 0;
 
         // otherwise, try one randomly


### PR DESCRIPTION
Basically that means that no matter how many LPs are out there they will be sitting there waiting for clients to initiate new queue. Few of them (LP) will get lucky to get a chance to help this client to mix and enter queue. Others will hit `nPoolMaxTransactions` threshold and will sit there waiting for the next available session.

_PS. I can't believe it's that easy..._