### PR TITLE
add missing maps cleaning in CMasternodeMan::Clear()

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -354,6 +354,8 @@ void CMasternodeMan::Clear()
     mAskedUsForMasternodeList.clear();
     mWeAskedForMasternodeList.clear();
     mWeAskedForMasternodeListEntry.clear();
+    mapSeenMasternodeBroadcast.clear();
+    mapSeenMasternodePing.clear();
     nDsqCount = 0;
 }
 


### PR DESCRIPTION
I think that is was causing sync issues on restart: we clean masternode list vector and maps about who we asked / who asked us but we leave broadcast and ping maps untouched and I guess that's why we skip some steps later instead of actually requesting info.