### PR TITLE
Non-critical CSS-error-messages removed from debug.log

### DIFF
--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -634,7 +634,6 @@ padding-bottom:8px;
 }
 
 QDialog#OptionsDialog QCheckBox {
-qproperty-alignment: 'AlignVCenter';
 min-height:20px;
 }
 


### PR DESCRIPTION
The following log-messages were caused by setting a non-existing property via CSS in the "Options" dialogue.

```
GUI: QCheckBox(0x7fe0214e7fd0, name = "bitcoinAtStartup")  does not have a property named  "alignment" 
GUI: QCheckBox(0x7fe021500540, name = "minimizeToTray")  does not have a property named  "alignment" 
GUI: QCheckBox(0x7fe021502540, name = "minimizeOnClose")  does not have a property named  "alignment" 
GUI: QCheckBox(0x7fe0214f9d20, name = "mapPortUpnp")  does not have a property named  "alignment" 
GUI: QCheckBox(0x7fe0214fa280, name = "allowIncoming")  does not have a property named  "alignment" 
GUI: QCheckBox(0x7fe0214f9de0, name = "connectSocks")  does not have a property named  "alignment" 
GUI: QCheckBox(0x7fe0214f8df0, name = "coinControlFeatures")  does not have a property named  "alignment" 
GUI: QCheckBox(0x7fe0214f9260, name = "spendZeroConfChange")  does not have a property named  "alignment" 
```
It's fixed now.