### PR TITLE
UI: show complete path to wallet.dat on Wallet-Repair tab

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -1068,7 +1068,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>90</y>
+         <y>100</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1087,7 +1087,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>140</y>
+         <y>150</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1106,7 +1106,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>190</y>
+         <y>200</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1125,7 +1125,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>240</y>
+         <y>250</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1144,7 +1144,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>290</y>
+         <y>300</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1185,7 +1185,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>80</y>
+         <y>90</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1201,7 +1201,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>129</y>
+         <y>140</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1217,7 +1217,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>179</y>
+         <y>190</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1233,7 +1233,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>229</y>
+         <y>240</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1249,7 +1249,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>279</y>
+         <y>290</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1288,7 +1288,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>340</y>
+         <y>350</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1301,7 +1301,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>330</y>
+         <y>340</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1311,6 +1311,19 @@
        </property>
        <property name="wordWrap">
         <bool>true</bool>
+       </property>
+      </widget>
+      <widget class="QLabel" name="wallet_path">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>70</y>
+         <width>731</width>
+         <height>21</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Wallet Path</string>
        </property>
       </widget>
      </widget>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -244,6 +244,9 @@ RPCConsole::RPCConsole(QWidget *parent) :
     ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
 #ifdef ENABLE_WALLET
     ui->berkeleyDBVersion->setText(DbEnv::version(0, 0, 0));
+    std::string walletPath = "Wallet in use: " + GetDataDir().string();
+    walletPath += "/" + GetArg("-wallet", "wallet.dat");
+    ui->wallet_path->setText(QString::fromStdString(walletPath));
 #else
     ui->label_berkeleyDBVersion->hide();
     ui->berkeleyDBVersion->hide();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -246,7 +246,7 @@ RPCConsole::RPCConsole(QWidget *parent) :
 #ifdef ENABLE_WALLET
     ui->berkeleyDBVersion->setText(DbEnv::version(0, 0, 0));
     std::string walletPath = GetDataDir().string();
-    walletPath += QDir::separator().toAscii() + GetArg("-wallet", "wallet.dat");
+    walletPath += QDir::separator().toLatin1() + GetArg("-wallet", "wallet.dat");
     ui->wallet_path->setText(QString::fromStdString(walletPath));
 #else
     ui->label_berkeleyDBVersion->hide();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -24,6 +24,7 @@
 #include <db_cxx.h>
 #endif
 
+#include <QDir>
 #include <QKeyEvent>
 #include <QScrollBar>
 #include <QThread>
@@ -244,9 +245,9 @@ RPCConsole::RPCConsole(QWidget *parent) :
     ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
 #ifdef ENABLE_WALLET
     ui->berkeleyDBVersion->setText(DbEnv::version(0, 0, 0));
-    std::string walletPath = "Wallet in use: " + GetDataDir().string();
-    walletPath += "/" + GetArg("-wallet", "wallet.dat");
-    ui->wallet_path->setText(QString::fromStdString(walletPath));
+    std::string walletPath = GetDataDir().string();
+    walletPath += "/" + GetArg("-wallet", "wallet.dat");   
+    ui->wallet_path->setText(QDir::toNativeSeparators(QString::fromStdString(walletPath)));
 #else
     ui->label_berkeleyDBVersion->hide();
     ui->berkeleyDBVersion->hide();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -246,8 +246,8 @@ RPCConsole::RPCConsole(QWidget *parent) :
 #ifdef ENABLE_WALLET
     ui->berkeleyDBVersion->setText(DbEnv::version(0, 0, 0));
     std::string walletPath = GetDataDir().string();
-    walletPath += "/" + GetArg("-wallet", "wallet.dat");   
-    ui->wallet_path->setText(QDir::toNativeSeparators(QString::fromStdString(walletPath)));
+    walletPath += QDir::separator().toAscii() + GetArg("-wallet", "wallet.dat");
+    ui->wallet_path->setText(QString::fromStdString(walletPath));
 #else
     ui->label_berkeleyDBVersion->hide();
     ui->berkeleyDBVersion->hide();


### PR DESCRIPTION
Reference: https://dashtalk.org/threads/can-the-dash-wallet-show-actual-dat-file-names.6469/

I think this is a quite useful idea. I placed it on the Wallet-Repair tab because that's the place you need to know which wallet you're actually repairing,

Tested on all 3 platforms without problems.

Looks like this:
![walletpath](https://cloud.githubusercontent.com/assets/10080039/10717890/4f11797c-7b65-11e5-897e-ce2d7ac9154f.jpg)

Sorry for the commit-fest, but there seems to be some differences between Qt4 and Qt5 on Windows platforms.