### PR TITLE
fix the way anonymizable balance calculated, fix conditions for DS

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -902,7 +902,11 @@ public:
             const CTxIn vin = CTxIn(hashTx, i);
 
             if(pwallet->IsSpent(hashTx, i) || pwallet->IsLockedCoin(hashTx, i)) continue;
-            if(fMasterNode && vout[i].nValue == 1000*COIN) continue; // do not count MN-like outputs
+            // do not count MN-like outputs
+            if(fMasterNode && vout[i].nValue == 1000*COIN) continue;
+            // do not count outputs that are 10 times smaller then the smallest denomination
+            // otherwise they will just lead to higher fee / lower priority
+            if(vout[i].nValue <= darkSendDenominations[darkSendDenominations.size() - 1]/10) continue;
 
             const int rounds = pwallet->GetInputDarksendRounds(vin);
             if(rounds >=-2 && rounds < nDarksendRounds) {


### PR DESCRIPTION
There was a rare edge case when wallet could enter endless loop wasting keys not being able to produce denoms to mix. This should fix it.