### PR TITLE
Do not create denoms if there are DENOMS_COUNT_MAX (100) of them already

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1763,7 +1763,22 @@ bool CDarksendPool::CreateDenominated(int64_t nTotalValue)
     }
 
     // ****** Add denoms ************ /
+
     BOOST_REVERSE_FOREACH(int64_t v, darkSendDenominations){
+
+        // Note: denoms are skipped if there are already DENOMS_COUNT_MAX of them
+
+        // check skipped denoms
+        if(IsDenomSkipped(v)) continue;
+
+        // find new denoms to skip if any (ignore the largest one)
+        if (v != darkSendDenominations[0] && pwalletMain->CountInputsWithAmount(v) > DENOMS_COUNT_MAX){
+            strAutoDenomResult = strprintf(_("Too many %f denominations, removing."), (float)v/COIN);
+            LogPrintf("DoAutomaticDenominating : %s\n", strAutoDenomResult);
+            darkSendDenominationsSkipped.push_back(v);
+            continue;
+        }
+
         int nOutputs = 0;
 
         // add each output up to 10 times until it can't be added again

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -48,6 +48,7 @@ class CActiveMasternode;
 
 static const int64_t DARKSEND_COLLATERAL = (0.01*COIN);
 static const int64_t DARKSEND_POOL_MAX = (999.99*COIN);
+static const int64_t DENOMS_COUNT_MAX = 100;
 
 extern CDarksendPool darkSendPool;
 extern CDarkSendSigner darkSendSigner;
@@ -290,6 +291,8 @@ private:
 
     int64_t lastNewBlock;
 
+    std::vector<int64_t> darkSendDenominationsSkipped;
+
     //debugging data
     std::string strAutoDenomResult;
 
@@ -360,6 +363,19 @@ public:
 
     void InitCollateralAddress(){
         SetCollateralAddress(Params().DarksendPoolDummyAddress());
+    }
+
+    void ClearSkippedDenominations() {
+        darkSendDenominationsSkipped.clear();
+    }
+
+    bool IsDenomSkipped(int64_t denom) {
+        BOOST_FOREACH(int64_t d, darkSendDenominationsSkipped) {
+            if (d == denom) {
+                return true;
+            }
+        }
+        return false;
     }
 
     void SetMinBlockSpacing(int minBlockSpacingIn){

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2178,6 +2178,8 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, CAmount> >& vecSend,
                     nFeeRet += nChange;
                     nChange = 0;
                     wtxNew.mapValue["DS"] = "1";
+                    // recheck skipped denominations during next mixing
+                    darkSendPool.ClearSkippedDenominations();
                 }
 
                 if (nChange > 0)


### PR DESCRIPTION
This should stop wallet from constantly creating smallest denoms only (which leads to unusable DS funds because of huge txes in some cases).