### PR TITLE
Transaction View: LastMonth calculation fixed

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -281,9 +281,16 @@ void TransactionView::chooseDate(int idx)
                 TransactionFilterProxy::MAX_DATE);
         break;
     case LastMonth:
-        transactionProxyModel->setDateRange(
+        if (current.month() == 1){
+            transactionProxyModel->setDateRange(
+                QDateTime(QDate(current.year()-1, 12, 1)),
+                QDateTime(QDate(current.year(), current.month(), 1)));
+        }
+        else {
+            transactionProxyModel->setDateRange(
                 QDateTime(QDate(current.year(), current.month()-1, 1)),
                 QDateTime(QDate(current.year(), current.month(), 1)));
+        }
         break;
     case ThisYear:
         transactionProxyModel->setDateRange(


### PR DESCRIPTION
Reference: https://dashtalk.org/threads/v12-release.5888/page-61#post-78528

In January 2016, last month isn't from 2016-0-1 to 2016-1-1...it's from 2015-12-1 to 2016-1-1 :-)

(I did the same PR for the master-branch)