### PR TITLE
Moves CMinerPolicyEstimator and CBlockAverage class definitions to header.

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -7,14 +7,8 @@
 
 #include "clientversion.h"
 #include "main.h"
-#include "streams.h"
-#include "util.h"
 #include "utilmoneystr.h"
 #include "version.h"
-
-#include <boost/circular_buffer.hpp>
-
-using namespace std;
 
 CTxMemPoolEntry::CTxMemPoolEntry():
     nFee(0), nTxSize(0), nModSize(0), nTime(0), dPriority(0.0)
@@ -535,7 +529,6 @@ void CMinerPolicyEstimator::seenBlock(const std::vector<CTxMemPoolEntry>& entrie
     }
 }
 
-/// Can return CFeeRate(0) if we don't have any data for that many blocks back. nBlocksToConfirm is 1 based.
 CFeeRate CMinerPolicyEstimator::estimateFee(int nBlocksToConfirm)
 {
     nBlocksToConfirm--;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -46,331 +46,6 @@ CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
     return dResult;
 }
 
-/**
- * Keep track of fee/priority for transactions confirmed within N blocks
- */
-class CBlockAverage
-{
-private:
-    boost::circular_buffer<CFeeRate> feeSamples;
-    boost::circular_buffer<double> prioritySamples;
-
-    template<typename T> std::vector<T> buf2vec(boost::circular_buffer<T> buf) const
-    {
-        std::vector<T> vec(buf.begin(), buf.end());
-        return vec;
-    }
-
-public:
-    CBlockAverage() : feeSamples(100), prioritySamples(100) { }
-
-    void RecordFee(const CFeeRate& feeRate) {
-        feeSamples.push_back(feeRate);
-    }
-
-    void RecordPriority(double priority) {
-        prioritySamples.push_back(priority);
-    }
-
-    size_t FeeSamples() const { return feeSamples.size(); }
-    size_t GetFeeSamples(std::vector<CFeeRate>& insertInto) const
-    {
-        BOOST_FOREACH(const CFeeRate& f, feeSamples)
-            insertInto.push_back(f);
-        return feeSamples.size();
-    }
-    size_t PrioritySamples() const { return prioritySamples.size(); }
-    size_t GetPrioritySamples(std::vector<double>& insertInto) const
-    {
-        BOOST_FOREACH(double d, prioritySamples)
-            insertInto.push_back(d);
-        return prioritySamples.size();
-    }
-
-    /**
-     * Used as belt-and-suspenders check when reading to detect
-     * file corruption
-     */
-    static bool AreSane(const CFeeRate fee, const CFeeRate& minRelayFee)
-    {
-        if (fee < CFeeRate(0))
-            return false;
-        if (fee.GetFeePerK() > minRelayFee.GetFeePerK() * 10000)
-            return false;
-        return true;
-    }
-    static bool AreSane(const std::vector<CFeeRate>& vecFee, const CFeeRate& minRelayFee)
-    {
-        BOOST_FOREACH(CFeeRate fee, vecFee)
-        {
-            if (!AreSane(fee, minRelayFee))
-                return false;
-        }
-        return true;
-    }
-    static bool AreSane(const double priority)
-    {
-        return priority >= 0;
-    }
-    static bool AreSane(const std::vector<double> vecPriority)
-    {
-        BOOST_FOREACH(double priority, vecPriority)
-        {
-            if (!AreSane(priority))
-                return false;
-        }
-        return true;
-    }
-
-    void Write(CAutoFile& fileout) const
-    {
-        std::vector<CFeeRate> vecFee = buf2vec(feeSamples);
-        fileout << vecFee;
-        std::vector<double> vecPriority = buf2vec(prioritySamples);
-        fileout << vecPriority;
-    }
-
-    void Read(CAutoFile& filein, const CFeeRate& minRelayFee) {
-        std::vector<CFeeRate> vecFee;
-        filein >> vecFee;
-        if (AreSane(vecFee, minRelayFee))
-            feeSamples.insert(feeSamples.end(), vecFee.begin(), vecFee.end());
-        else
-            throw runtime_error("Corrupt fee value in estimates file.");
-        std::vector<double> vecPriority;
-        filein >> vecPriority;
-        if (AreSane(vecPriority))
-            prioritySamples.insert(prioritySamples.end(), vecPriority.begin(), vecPriority.end());
-        else
-            throw runtime_error("Corrupt priority value in estimates file.");
-        if (feeSamples.size() + prioritySamples.size() > 0)
-            LogPrint("estimatefee", "Read %d fee samples and %d priority samples\n",
-                     feeSamples.size(), prioritySamples.size());
-    }
-};
-
-class CMinerPolicyEstimator
-{
-private:
-    /**
-     * Records observed averages transactions that confirmed within one block, two blocks,
-     * three blocks etc.
-     */
-    std::vector<CBlockAverage> history;
-    std::vector<CFeeRate> sortedFeeSamples;
-    std::vector<double> sortedPrioritySamples;
-
-    int nBestSeenHeight;
-
-    /**
-     * nBlocksAgo is 0 based, i.e. transactions that confirmed in the highest seen block are
-     * nBlocksAgo == 0, transactions in the block before that are nBlocksAgo == 1 etc.
-     */
-    void seenTxConfirm(const CFeeRate& feeRate, const CFeeRate& minRelayFee, double dPriority, int nBlocksAgo)
-    {
-        // Last entry records "everything else".
-        int nBlocksTruncated = min(nBlocksAgo, (int) history.size() - 1);
-        assert(nBlocksTruncated >= 0);
-
-        // We need to guess why the transaction was included in a block-- either
-        // because it is high-priority or because it has sufficient fees.
-        bool sufficientFee = (feeRate > minRelayFee);
-        bool sufficientPriority = AllowFree(dPriority);
-        const char* assignedTo = "unassigned";
-        if (sufficientFee && !sufficientPriority && CBlockAverage::AreSane(feeRate, minRelayFee))
-        {
-            history[nBlocksTruncated].RecordFee(feeRate);
-            assignedTo = "fee";
-        }
-        else if (sufficientPriority && !sufficientFee && CBlockAverage::AreSane(dPriority))
-        {
-            history[nBlocksTruncated].RecordPriority(dPriority);
-            assignedTo = "priority";
-        }
-        else
-        {
-            // Neither or both fee and priority sufficient to get confirmed:
-            // don't know why they got confirmed.
-        }
-        LogPrint("estimatefee", "Seen TX confirm: %s : %s fee/%g priority, took %d blocks\n",
-                 assignedTo, feeRate.ToString(), dPriority, nBlocksAgo);
-    }
-
-public:
-    CMinerPolicyEstimator(int nEntries) : nBestSeenHeight(0)
-    {
-        history.resize(nEntries);
-    }
-
-    void seenBlock(const std::vector<CTxMemPoolEntry>& entries, int nBlockHeight, const CFeeRate minRelayFee)
-    {
-        if (nBlockHeight <= nBestSeenHeight)
-        {
-            // Ignore side chains and re-orgs; assuming they are random
-            // they don't affect the estimate.
-            // And if an attacker can re-org the chain at will, then
-            // you've got much bigger problems than "attacker can influence
-            // transaction fees."
-            return;
-        }
-        nBestSeenHeight = nBlockHeight;
-
-        // Fill up the history buckets based on how long transactions took
-        // to confirm.
-        std::vector<std::vector<const CTxMemPoolEntry*> > entriesByConfirmations;
-        entriesByConfirmations.resize(history.size());
-        BOOST_FOREACH(const CTxMemPoolEntry& entry, entries)
-        {
-            // How many blocks did it take for miners to include this transaction?
-            int delta = nBlockHeight - entry.GetHeight();
-            if (delta <= 0)
-            {
-                // Re-org made us lose height, this should only happen if we happen
-                // to re-org on a difficulty transition point: very rare!
-                continue;
-            }
-            if ((delta-1) >= (int)history.size())
-                delta = history.size(); // Last bucket is catch-all
-            entriesByConfirmations.at(delta-1).push_back(&entry);
-        }
-        for (size_t i = 0; i < entriesByConfirmations.size(); i++)
-        {
-            std::vector<const CTxMemPoolEntry*> &e = entriesByConfirmations.at(i);
-            // Insert at most 10 random entries per bucket, otherwise a single block
-            // can dominate an estimate:
-            if (e.size() > 10) {
-                std::random_shuffle(e.begin(), e.end());
-                e.resize(10);
-            }
-            BOOST_FOREACH(const CTxMemPoolEntry* entry, e)
-            {
-                // Fees are stored and reported as BTC-per-kb:
-                CFeeRate feeRate(entry->GetFee(), entry->GetTxSize());
-                double dPriority = entry->GetPriority(entry->GetHeight()); // Want priority when it went IN
-                seenTxConfirm(feeRate, minRelayFee, dPriority, i);
-            }
-        }
-
-        //After new samples are added, we have to clear the sorted lists,
-        //so they'll be resorted the next time someone asks for an estimate
-        sortedFeeSamples.clear();
-        sortedPrioritySamples.clear();
-
-        for (size_t i = 0; i < history.size(); i++) {
-            if (history[i].FeeSamples() + history[i].PrioritySamples() > 0)
-                LogPrint("estimatefee", "estimates: for confirming within %d blocks based on %d/%d samples, fee=%s, prio=%g\n", 
-                         i,
-                         history[i].FeeSamples(), history[i].PrioritySamples(),
-                         estimateFee(i+1).ToString(), estimatePriority(i+1));
-        }
-    }
-
-    /**
-     * Can return CFeeRate(0) if we don't have any data for that many blocks back. nBlocksToConfirm is 1 based.
-     */
-    CFeeRate estimateFee(int nBlocksToConfirm)
-    {
-        nBlocksToConfirm--;
-
-        if (nBlocksToConfirm < 0 || nBlocksToConfirm >= (int)history.size())
-            return CFeeRate(0);
-
-        if (sortedFeeSamples.size() == 0)
-        {
-            for (size_t i = 0; i < history.size(); i++)
-                history.at(i).GetFeeSamples(sortedFeeSamples);
-            std::sort(sortedFeeSamples.begin(), sortedFeeSamples.end(),
-                      std::greater<CFeeRate>());
-        }
-        if (sortedFeeSamples.size() < 11)
-        {
-            // Eleven is Gavin's Favorite Number
-            // ... but we also take a maximum of 10 samples per block so eleven means
-            // we're getting samples from at least two different blocks
-            return CFeeRate(0);
-        }
-
-        int nBucketSize = history.at(nBlocksToConfirm).FeeSamples();
-
-        // Estimates should not increase as number of confirmations goes up,
-        // but the estimates are noisy because confirmations happen discretely
-        // in blocks. To smooth out the estimates, use all samples in the history
-        // and use the nth highest where n is (number of samples in previous bucket +
-        // half the samples in nBlocksToConfirm bucket):
-        size_t nPrevSize = 0;
-        for (int i = 0; i < nBlocksToConfirm; i++)
-            nPrevSize += history.at(i).FeeSamples();
-        size_t index = min(nPrevSize + nBucketSize/2, sortedFeeSamples.size()-1);
-        return sortedFeeSamples[index];
-    }
-    double estimatePriority(int nBlocksToConfirm)
-    {
-        nBlocksToConfirm--;
-
-        if (nBlocksToConfirm < 0 || nBlocksToConfirm >= (int)history.size())
-            return -1;
-
-        if (sortedPrioritySamples.size() == 0)
-        {
-            for (size_t i = 0; i < history.size(); i++)
-                history.at(i).GetPrioritySamples(sortedPrioritySamples);
-            std::sort(sortedPrioritySamples.begin(), sortedPrioritySamples.end(),
-                      std::greater<double>());
-        }
-        if (sortedPrioritySamples.size() < 11)
-            return -1.0;
-
-        int nBucketSize = history.at(nBlocksToConfirm).PrioritySamples();
-
-        // Estimates should not increase as number of confirmations needed goes up,
-        // but the estimates are noisy because confirmations happen discretely
-        // in blocks. To smooth out the estimates, use all samples in the history
-        // and use the nth highest where n is (number of samples in previous buckets +
-        // half the samples in nBlocksToConfirm bucket).
-        size_t nPrevSize = 0;
-        for (int i = 0; i < nBlocksToConfirm; i++)
-            nPrevSize += history.at(i).PrioritySamples();
-        size_t index = min(nPrevSize + nBucketSize/2, sortedPrioritySamples.size()-1);
-        return sortedPrioritySamples[index];
-    }
-
-    void Write(CAutoFile& fileout) const
-    {
-        fileout << nBestSeenHeight;
-        fileout << history.size();
-        BOOST_FOREACH(const CBlockAverage& entry, history)
-        {
-            entry.Write(fileout);
-        }
-    }
-
-    void Read(CAutoFile& filein, const CFeeRate& minRelayFee)
-    {
-        int nFileBestSeenHeight;
-        filein >> nFileBestSeenHeight;
-        size_t numEntries;
-        filein >> numEntries;
-        if (numEntries <= 0 || numEntries > 10000)
-            throw runtime_error("Corrupt estimates file. Must have between 1 and 10k entries.");
-
-        std::vector<CBlockAverage> fileHistory;
-        
-        for (size_t i = 0; i < numEntries; i++)
-        {
-            CBlockAverage entry;
-            entry.Read(filein, minRelayFee);
-            fileHistory.push_back(entry);
-        }
-
-        // Now that we've processed the entire fee estimate data file and not
-        // thrown any errors, we can copy it to our history
-        nBestSeenHeight = nFileBestSeenHeight;
-        history = fileHistory;
-        assert(history.size() > 0);
-    }
-};
-
-
 CTxMemPool::CTxMemPool(const CFeeRate& _minRelayFee) :
     nTransactionsUpdated(0),
     minRelayFee(_minRelayFee)
@@ -661,8 +336,7 @@ double CTxMemPool::estimatePriority(int nBlocks) const
     return minerPolicyEstimator->estimatePriority(nBlocks);
 }
 
-bool
-CTxMemPool::WriteFeeEstimates(CAutoFile& fileout) const
+bool CTxMemPool::WriteFeeEstimates(CAutoFile& fileout) const
 {
     try {
         LOCK(cs);
@@ -677,8 +351,7 @@ CTxMemPool::WriteFeeEstimates(CAutoFile& fileout) const
     return true;
 }
 
-bool
-CTxMemPool::ReadFeeEstimates(CAutoFile& filein)
+bool CTxMemPool::ReadFeeEstimates(CAutoFile& filein)
 {
     try {
         int nVersionRequired, nVersionThatWrote;
@@ -741,4 +414,226 @@ bool CCoinsViewMemPool::GetCoins(const uint256 &txid, CCoins &coins) const {
 
 bool CCoinsViewMemPool::HaveCoins(const uint256 &txid) const {
     return mempool.exists(txid) || base->HaveCoins(txid);
+}
+
+void CBlockAverage::Write(CAutoFile& fileout) const
+{
+    std::vector<CFeeRate> vecFee = buf2vec(feeSamples);
+    fileout << vecFee;
+    std::vector<double> vecPriority = buf2vec(prioritySamples);
+    fileout << vecPriority;
+}
+
+void CBlockAverage::Read(CAutoFile& filein, const CFeeRate& minRelayFee) {
+    std::vector<CFeeRate> vecFee;
+    filein >> vecFee;
+    if (AreSane(vecFee, minRelayFee))
+        feeSamples.insert(feeSamples.end(), vecFee.begin(), vecFee.end());
+    else
+        throw runtime_error("Corrupt fee value in estimates file.");
+    std::vector<double> vecPriority;
+    filein >> vecPriority;
+    if (AreSane(vecPriority))
+        prioritySamples.insert(prioritySamples.end(), vecPriority.begin(), vecPriority.end());
+    else
+        throw runtime_error("Corrupt priority value in estimates file.");
+    if (feeSamples.size() + prioritySamples.size() > 0)
+        LogPrint("estimatefee", "Read %d fee samples and %d priority samples\n",
+                 feeSamples.size(), prioritySamples.size());
+}
+
+void CMinerPolicyEstimator::seenTxConfirm(const CFeeRate& feeRate, const CFeeRate& minRelayFee, double dPriority, int nBlocksAgo)
+{
+    // Last entry records "everything else".
+    int nBlocksTruncated = min(nBlocksAgo, (int) history.size() - 1);
+    assert(nBlocksTruncated >= 0);
+
+    // We need to guess why the transaction was included in a block-- either
+    // because it is high-priority or because it has sufficient fees.
+    bool sufficientFee = (feeRate > minRelayFee);
+    bool sufficientPriority = AllowFree(dPriority);
+    const char* assignedTo = "unassigned";
+    if (sufficientFee && !sufficientPriority && CBlockAverage::AreSane(feeRate, minRelayFee))
+    {
+        history[nBlocksTruncated].RecordFee(feeRate);
+        assignedTo = "fee";
+    }
+    else if (sufficientPriority && !sufficientFee && CBlockAverage::AreSane(dPriority))
+    {
+        history[nBlocksTruncated].RecordPriority(dPriority);
+        assignedTo = "priority";
+    }
+    else
+    {
+        // Neither or both fee and priority sufficient to get confirmed:
+        // don't know why they got confirmed.
+    }
+    LogPrint("estimatefee", "Seen TX confirm: %s : %s fee/%g priority, took %d blocks\n",
+             assignedTo, feeRate.ToString(), dPriority, nBlocksAgo);
+}
+
+void CMinerPolicyEstimator::seenBlock(const std::vector<CTxMemPoolEntry>& entries, int nBlockHeight, const CFeeRate minRelayFee)
+{
+    if (nBlockHeight <= nBestSeenHeight)
+    {
+        // Ignore side chains and re-orgs; assuming they are random
+        // they don't affect the estimate.
+        // And if an attacker can re-org the chain at will, then
+        // you've got much bigger problems than "attacker can influence
+        // transaction fees."
+        return;
+    }
+    nBestSeenHeight = nBlockHeight;
+
+    // Fill up the history buckets based on how long transactions took
+    // to confirm.
+    std::vector<std::vector<const CTxMemPoolEntry*> > entriesByConfirmations;
+    entriesByConfirmations.resize(history.size());
+    BOOST_FOREACH(const CTxMemPoolEntry& entry, entries)
+    {
+        // How many blocks did it take for miners to include this transaction?
+        int delta = nBlockHeight - entry.GetHeight();
+        if (delta <= 0)
+        {
+            // Re-org made us lose height, this should only happen if we happen
+            // to re-org on a difficulty transition point: very rare!
+            continue;
+        }
+        if ((delta-1) >= (int)history.size())
+            delta = history.size(); // Last bucket is catch-all
+        entriesByConfirmations.at(delta-1).push_back(&entry);
+    }
+    for (size_t i = 0; i < entriesByConfirmations.size(); i++)
+    {
+        std::vector<const CTxMemPoolEntry*> &e = entriesByConfirmations.at(i);
+        // Insert at most 10 random entries per bucket, otherwise a single block
+        // can dominate an estimate:
+        if (e.size() > 10) {
+            std::random_shuffle(e.begin(), e.end());
+            e.resize(10);
+        }
+        BOOST_FOREACH(const CTxMemPoolEntry* entry, e)
+        {
+            // Fees are stored and reported as BTC-per-kb:
+            CFeeRate feeRate(entry->GetFee(), entry->GetTxSize());
+            double dPriority = entry->GetPriority(entry->GetHeight()); // Want priority when it went IN
+            seenTxConfirm(feeRate, minRelayFee, dPriority, i);
+        }
+    }
+
+    //After new samples are added, we have to clear the sorted lists,
+    //so they'll be resorted the next time someone asks for an estimate
+    sortedFeeSamples.clear();
+    sortedPrioritySamples.clear();
+
+    for (size_t i = 0; i < history.size(); i++) {
+        if (history[i].FeeSamples() + history[i].PrioritySamples() > 0)
+            LogPrint("estimatefee", "estimates: for confirming within %d blocks based on %d/%d samples, fee=%s, prio=%g\n",
+                     i,
+                     history[i].FeeSamples(), history[i].PrioritySamples(),
+                     estimateFee(i+1).ToString(), estimatePriority(i+1));
+    }
+}
+
+/// Can return CFeeRate(0) if we don't have any data for that many blocks back. nBlocksToConfirm is 1 based.
+CFeeRate CMinerPolicyEstimator::estimateFee(int nBlocksToConfirm)
+{
+    nBlocksToConfirm--;
+
+    if (nBlocksToConfirm < 0 || nBlocksToConfirm >= (int)history.size())
+        return CFeeRate(0);
+
+    if (sortedFeeSamples.size() == 0)
+    {
+        for (size_t i = 0; i < history.size(); i++)
+            history.at(i).GetFeeSamples(sortedFeeSamples);
+        std::sort(sortedFeeSamples.begin(), sortedFeeSamples.end(),
+                  std::greater<CFeeRate>());
+    }
+    if (sortedFeeSamples.size() < 11)
+    {
+        // Eleven is Gavin's Favorite Number
+        // ... but we also take a maximum of 10 samples per block so eleven means
+        // we're getting samples from at least two different blocks
+        return CFeeRate(0);
+    }
+
+    int nBucketSize = history.at(nBlocksToConfirm).FeeSamples();
+
+    // Estimates should not increase as number of confirmations goes up,
+    // but the estimates are noisy because confirmations happen discretely
+    // in blocks. To smooth out the estimates, use all samples in the history
+    // and use the nth highest where n is (number of samples in previous bucket +
+    // half the samples in nBlocksToConfirm bucket):
+    size_t nPrevSize = 0;
+    for (int i = 0; i < nBlocksToConfirm; i++)
+        nPrevSize += history.at(i).FeeSamples();
+    size_t index = min(nPrevSize + nBucketSize/2, sortedFeeSamples.size()-1);
+    return sortedFeeSamples[index];
+}
+
+double CMinerPolicyEstimator::estimatePriority(int nBlocksToConfirm)
+{
+    nBlocksToConfirm--;
+
+    if (nBlocksToConfirm < 0 || nBlocksToConfirm >= (int)history.size())
+        return -1;
+
+    if (sortedPrioritySamples.size() == 0)
+    {
+        for (size_t i = 0; i < history.size(); i++)
+            history.at(i).GetPrioritySamples(sortedPrioritySamples);
+        std::sort(sortedPrioritySamples.begin(), sortedPrioritySamples.end(),
+                  std::greater<double>());
+    }
+    if (sortedPrioritySamples.size() < 11)
+        return -1.0;
+
+    int nBucketSize = history.at(nBlocksToConfirm).PrioritySamples();
+
+    // Estimates should not increase as number of confirmations needed goes up,
+    // but the estimates are noisy because confirmations happen discretely
+    // in blocks. To smooth out the estimates, use all samples in the history
+    // and use the nth highest where n is (number of samples in previous buckets +
+    // half the samples in nBlocksToConfirm bucket).
+    size_t nPrevSize = 0;
+    for (int i = 0; i < nBlocksToConfirm; i++)
+        nPrevSize += history.at(i).PrioritySamples();
+    size_t index = min(nPrevSize + nBucketSize/2, sortedPrioritySamples.size()-1);
+    return sortedPrioritySamples[index];
+}
+
+void CMinerPolicyEstimator::Write(CAutoFile& fileout) const
+{
+    fileout << nBestSeenHeight;
+    fileout << history.size();
+    BOOST_FOREACH(const CBlockAverage& entry, history)
+    {
+        entry.Write(fileout);
+    }
+}
+
+void CMinerPolicyEstimator::Read(CAutoFile& filein, const CFeeRate& minRelayFee)
+{
+    int nFileBestSeenHeight;
+    filein >> nFileBestSeenHeight;
+    size_t numEntries;
+    filein >> numEntries;
+    if (numEntries <= 0 || numEntries > 10000)
+        throw runtime_error("Corrupt estimates file. Must have between 1 and 10k entries.");
+
+    std::vector<CBlockAverage> fileHistory;
+
+    for (size_t i = 0; i < numEntries; i++)
+    {
+        CBlockAverage entry;
+        entry.Read(filein, minRelayFee);
+        fileHistory.push_back(entry);
+    }
+
+    // Now that we've processed the entire fee estimate data file and not
+    // thrown any errors, we can copy it to our history
+    nBestSeenHeight = nFileBestSeenHeight;
+    history = fileHistory;
+    assert(history.size() > 0);
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -7,11 +7,17 @@
 #define BITCOIN_TXMEMPOOL_H
 
 #include <list>
+#include <stdarg.h>
+#include <boost/circular_buffer.hpp>
 
 #include "amount.h"
 #include "coins.h"
 #include "primitives/transaction.h"
 #include "sync.h"
+#include "util.h"
+#include "streams.h"
+
+using namespace std;
 
 class CAutoFile;
 
@@ -223,7 +229,6 @@ public:
             return false;
         return true;
     }
-
     static bool AreSane(const std::vector<CFeeRate>& vecFee, const CFeeRate& minRelayFee)
     {
         BOOST_FOREACH(CFeeRate fee, vecFee)
@@ -233,12 +238,10 @@ public:
         }
         return true;
     }
-
     static bool AreSane(const double priority)
     {
         return priority >= 0;
     }
-
     static bool AreSane(const std::vector<double> vecPriority)
     {
         BOOST_FOREACH(double priority, vecPriority)
@@ -256,6 +259,7 @@ public:
 class CMinerPolicyEstimator
 {
 private:
+
     /// Records observed averages transactions that confirmed within one block, two blocks,
     /// three blocks etc.
     std::vector<CBlockAverage> history;
@@ -274,13 +278,16 @@ public:
         history.resize(nEntries);
     }
 
+    void seenBlock(const std::vector<CTxMemPoolEntry>& entries, int nBlockHeight, const CFeeRate minRelayFee);
+
     /// Can return CFeeRate(0) if we don't have any data for that many blocks back. nBlocksToConfirm is 1 based.
     CFeeRate estimateFee(int nBlocksToConfirm);
     double estimatePriority(int nBlocksToConfirm);
 
-    void seenBlock(const std::vector<CTxMemPoolEntry>& entries, int nBlockHeight, const CFeeRate minRelayFee);
     void Write(CAutoFile& fileout) const;
+
     void Read(CAutoFile& filein, const CFeeRate& minRelayFee);
+
 };
 
 #endif // BITCOIN_TXMEMPOOL_H

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -174,4 +174,113 @@ public:
     bool HaveCoins(const uint256 &txid) const;
 };
 
+/// Keep track of fee/priority for transactions confirmed within N blocks
+class CBlockAverage
+{
+private:
+    boost::circular_buffer<CFeeRate> feeSamples;
+    boost::circular_buffer<double> prioritySamples;
+
+    template<typename T> std::vector<T> buf2vec(boost::circular_buffer<T> buf) const
+    {
+        std::vector<T> vec(buf.begin(), buf.end());
+        return vec;
+    }
+
+public:
+    CBlockAverage() : feeSamples(100), prioritySamples(100) { }
+
+    void RecordFee(const CFeeRate& feeRate) {
+        feeSamples.push_back(feeRate);
+    }
+
+    void RecordPriority(double priority) {
+        prioritySamples.push_back(priority);
+    }
+
+    size_t FeeSamples() const { return feeSamples.size(); }
+    size_t GetFeeSamples(std::vector<CFeeRate>& insertInto) const
+    {
+        BOOST_FOREACH(const CFeeRate& f, feeSamples)
+            insertInto.push_back(f);
+        return feeSamples.size();
+    }
+    size_t PrioritySamples() const { return prioritySamples.size(); }
+    size_t GetPrioritySamples(std::vector<double>& insertInto) const
+    {
+        BOOST_FOREACH(double d, prioritySamples)
+            insertInto.push_back(d);
+        return prioritySamples.size();
+    }
+
+    /// Used as belt-and-suspenders check when reading to detect
+    /// file corruption
+    static bool AreSane(const CFeeRate fee, const CFeeRate& minRelayFee)
+    {
+        if (fee < CFeeRate(0))
+            return false;
+        if (fee.GetFeePerK() > minRelayFee.GetFeePerK() * 10000)
+            return false;
+        return true;
+    }
+
+    static bool AreSane(const std::vector<CFeeRate>& vecFee, const CFeeRate& minRelayFee)
+    {
+        BOOST_FOREACH(CFeeRate fee, vecFee)
+        {
+            if (!AreSane(fee, minRelayFee))
+                return false;
+        }
+        return true;
+    }
+
+    static bool AreSane(const double priority)
+    {
+        return priority >= 0;
+    }
+
+    static bool AreSane(const std::vector<double> vecPriority)
+    {
+        BOOST_FOREACH(double priority, vecPriority)
+        {
+            if (!AreSane(priority))
+                return false;
+        }
+        return true;
+    }
+
+    void Write(CAutoFile& fileout) const;
+    void Read(CAutoFile& filein, const CFeeRate& minRelayFee);
+};
+
+class CMinerPolicyEstimator
+{
+private:
+    /// Records observed averages transactions that confirmed within one block, two blocks,
+    /// three blocks etc.
+    std::vector<CBlockAverage> history;
+    std::vector<CFeeRate> sortedFeeSamples;
+    std::vector<double> sortedPrioritySamples;
+
+    int nBestSeenHeight;
+
+    /// nBlocksAgo is 0 based, i.e. transactions that confirmed in the highest seen block are
+    /// nBlocksAgo == 0, transactions in the block before that are nBlocksAgo == 1 etc.
+    void seenTxConfirm(const CFeeRate& feeRate, const CFeeRate& minRelayFee, double dPriority, int nBlocksAgo);
+
+public:
+    CMinerPolicyEstimator(int nEntries) : nBestSeenHeight(0)
+    {
+        history.resize(nEntries);
+    }
+
+    /// Can return CFeeRate(0) if we don't have any data for that many blocks back. nBlocksToConfirm is 1 based.
+    CFeeRate estimateFee(int nBlocksToConfirm);
+    double estimatePriority(int nBlocksToConfirm);
+
+    void seenBlock(const std::vector<CTxMemPoolEntry>& entries, int nBlockHeight, const CFeeRate minRelayFee);
+    void Write(CAutoFile& fileout) const;
+    void Read(CAutoFile& filein, const CFeeRate& minRelayFee);
+};
+
 #endif // BITCOIN_TXMEMPOOL_H


### PR DESCRIPTION
Class definitions should not be in the implementation (.cpp) file.