### PR TITLE
[walletdb] Fix syntax error in key parser

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -199,7 +199,7 @@ bool CDBEnv::Salvage(std::string strFile, bool fAggressive, std::vector<CDBEnv::
     std::string keyHex, valueHex;
     while (!strDump.eof() && keyHex != "DATA=END") {
         getline(strDump, keyHex);
-        if (keyHex != "DATA_END") {
+        if (keyHex != "DATA=END") {
             getline(strDump, valueHex);
             vResult.push_back(make_pair(ParseHex(keyHex), ParseHex(valueHex)));
         }


### PR DESCRIPTION
Reference: https://github.com/bitcoin/bitcoin/pull/7381

Didn't cherry-pick because the file location has changed.