### PR TITLE
txmempool: Fix comparison between signed/unsigned int

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -495,7 +495,7 @@ void CTxMemPool::removeCoinbaseSpends(const CCoinsViewCache *pcoins, unsigned in
                 continue;
             const CCoins *coins = pcoins->AccessCoins(txin.prevout.hash);
             if (fSanityCheck) assert(coins);
-            if (!coins || (coins->IsCoinBase() && nMemPoolHeight - coins->nHeight < COINBASE_MATURITY)) {
+            if (!coins || (coins->IsCoinBase() && ((signed long)nMemPoolHeight) - coins->nHeight < COINBASE_MATURITY)) {
                 transactionsToRemove.push_back(tx);
                 break;
             }


### PR DESCRIPTION
Comparison between signed/unsigned int found in removeCoinbaseSpends

This commit is based on commit e617fe25 by Luke Dashjr in bitcoin.

Fixes: Dashpay github issue 540