### PR TITLE
Bump openssl to 1.0.1r

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,8 +1,8 @@
 package=openssl
-$(package)_version=1.0.1k
+$(package)_version=1.0.1r
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
+$(package)_sha256_hash=784bd8d355ed01ce98b812f873f8b2313da61df7c7b5677fcf2e57b0863a3346
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"


### PR DESCRIPTION
Failed compiling openssl 1.0.1k on Alpine Linux (musl based):
`gcc -m64 -I.. -I../.. -I../modes -I../asn1 -I../evp -I../../include  -DOPENSSL_THREADS -D_REENTRANT -pipe -O2 -I/dash/depends/x86_64-pc-linux-gnu/include -fPIC -Wa,--noexecstack -m64 -DL_ENDIAN -DTERMIO -O3 -Wall -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DWHIRLPOOL_ASM -DGHASH_ASM   -c -o ui_openssl.o ui_openssl.c
ui_openssl.c:232:21: fatal error: termio.h: No such file or directory
`
I guess this [openssl commit](https://github.com/openssl/openssl/commit/64e6bf64b36136d487e2fbf907f09612e69ae911) solved this error which is included since openssl 1.0.1m .

So, I propose for 1.0.1r