### PR TITLE
Fix deadlock that could occur sometimes during mixing

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1160,16 +1160,12 @@ void CDarksendPool::SendDarksendDenominate(std::vector<CTxIn>& vin, std::vector<
 
         LogPrintf("Submitting tx %s\n", tx.ToString());
 
-        while(true){
-            TRY_LOCK(cs_main, lockMain);
-            if(!lockMain) { MilliSleep(50); continue;}
-            if(!AcceptToMemoryPool(mempool, state, CTransaction(tx), false, NULL, false, true, true)){
-                LogPrintf("dsi -- transaction not valid! %s \n", tx.ToString());
-                UnlockCoins();
-                SetNull();
-                return;
-            }
-            break;
+        TRY_LOCK(cs_main, lockMain);
+        if(!lockMain || !AcceptToMemoryPool(mempool, state, CTransaction(tx), false, NULL, false, true, true)){
+            LogPrintf("dsi -- transaction failed! %s \n", tx.ToString());
+            UnlockCoins();
+            SetNull();
+            return;
         }
     }
 


### PR DESCRIPTION
I think I found the part that was leading to wallet dead lock. At least now there were no block hangs for me while I got them pretty often running on current code (same for 0.12.0.x). Instead there are few "dsi -- transaction failed" which I believe come from failed lock rather than AcceptToMemoryPool (and it's fine, you could be charged collateral sometimes however but not on every fail, so again it's fine imo). I guess it's better to fail here than to lock wallet completely and stop receiving next blocks because of that.
It's interesting to see how that patch would work for someone else, please give it a test.

PS. That however is yet another dirty temporary solution just to make things running, we would need to implement smth a bit more smarter later.