### PR TITLE
Fix bug that prevented new blocks to update tip during mixing

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -69,8 +69,6 @@ void CActiveMasternode::ManageStatus()
             service = CService(strMasterNodeAddr);
         }
 
-        LogPrintf("CActiveMasternode::ManageStatus() - Checking inbound connection to '%s'\n", service.ToString());
-
         int mainnetDefaultPort = Params(CBaseChainParams::MAIN).GetDefaultPort();
         if(Params().NetworkIDString() == CBaseChainParams::MAIN) {
             if(service.GetPort() != mainnetDefaultPort) {
@@ -84,11 +82,15 @@ void CActiveMasternode::ManageStatus()
             return;
         }
 
-        if(!ConnectNode((CAddress)service, NULL, true)){
+        LogPrintf("CActiveMasternode::ManageStatus() - Checking inbound connection to '%s'\n", service.ToString());
+
+        CNode *pnode = ConnectNode((CAddress)service, NULL, false);
+        if(!pnode){
             notCapableReason = "Could not connect to " + service.ToString();
             LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
             return;
         }
+        pnode->Release();
 
         // Choose coins to use
         CPubKey pubKeyCollateralAddress;

--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -105,10 +105,11 @@ void CDarkSendRelay::RelayThroughNode(int nRank)
 
     if(pmn != NULL){
         //printf("RelayThroughNode %s\n", pmn->addr.ToString().c_str());
-        CNode* pnode = ConnectNode((CAddress)pmn->addr, NULL, true);
+        CNode* pnode = ConnectNode((CAddress)pmn->addr, NULL, false);
         if(pnode){
             //printf("Connected\n");
             pnode->PushMessage("dsr", (*this));
+            pnode->Release();
             return;
         }
     } else {

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1544,20 +1544,23 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
                 std::vector<COutput> vTempCoins2;
                 // Try to match their denominations if possible
                 if (!pwalletMain->SelectCoinsByDenominations(dsq.nDenom, nValueMin, nBalanceNeedsAnonymized, vTempCoins, vTempCoins2, nValueIn, 0, nDarksendRounds)){
-                    LogPrintf("DoAutomaticDenominating - Couldn't match denominations %d\n", dsq.nDenom);
+                    LogPrintf("DoAutomaticDenominating --- Couldn't match denominations %d\n", dsq.nDenom);
                     continue;
                 }
 
+                CMasternode* pmn = mnodeman.Find(dsq.vin);
+                if(pmn == NULL)
+                {
+                    LogPrintf("DoAutomaticDenominating --- dsq vin %s is not in masternode list!", dsq.vin.ToString());
+                    continue;
+                }
+
+                LogPrintf("DoAutomaticDenominating --- attempt to connect to masternode from queue %s\n", pmn->addr.ToString());
+                lastTimeChanged = GetTimeMillis();
                 // connect to Masternode and submit the queue request
                 CNode* pnode = ConnectNode((CAddress)addr, NULL, true);
                 if(pnode != NULL)
                 {
-                    CMasternode* pmn = mnodeman.Find(dsq.vin);
-                    if(pmn == NULL)
-                    {
-                        LogPrintf("DoAutomaticDenominating --- dsq vin %s is not in masternode list!", dsq.vin.ToString());
-                        continue;
-                    }
                     pSubmittedToMasternode = pmn;
                     vecMasternodesUsed.push_back(dsq.vin);
                     sessionDenom = dsq.nDenom;
@@ -1599,7 +1602,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
             }
 
             lastTimeChanged = GetTimeMillis();
-            LogPrintf("DoAutomaticDenominating -- attempt %d connection to Masternode %s\n", i, pmn->addr.ToString());
+            LogPrintf("DoAutomaticDenominating --- attempt %d connection to Masternode %s\n", i, pmn->addr.ToString());
             CNode* pnode = ConnectNode((CAddress)pmn->addr, NULL, true);
             if(pnode != NULL){
                 pSubmittedToMasternode = pmn;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -669,7 +669,8 @@ void CMasternodeMan::ProcessMasternodeConnections()
         if(pnode->fDarkSendMaster){
             if(darkSendPool.pSubmittedToMasternode != NULL && pnode->addr == darkSendPool.pSubmittedToMasternode->addr) continue;
             LogPrintf("Closing Masternode connection %s \n", pnode->addr.ToString());
-            pnode->fDisconnect = true;
+            pnode->fDarkSendMaster = false;
+            pnode->Release();
         }
     }
 }

--- a/src/net.h
+++ b/src/net.h
@@ -355,6 +355,11 @@ public:
     // b) the peer may tell us in its version message that we should not relay tx invs
     //    unless it loads a bloom filter.
     bool fRelayTxes;
+    // Should be 'true' only if we connected to this node to actually mix funds.
+    // In this case node will be released automatically via CMasternodeMan::ProcessMasternodeConnections().
+    // Connecting to verify connectability/status or connecting for sending/relaying single message
+    // (even if it's relative to mixing e.g. for blinding) should NOT set this to 'true'.
+    // For such cases node should be released manually (preferably right after corresponding code).
     bool fDarkSendMaster;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -137,7 +137,9 @@ UniValue masternode(const UniValue& params, bool fHelp)
 
         CService addr = CService(strAddress);
 
-        if(ConnectNode((CAddress)addr, NULL, true)){
+        CNode *pnode = ConnectNode((CAddress)addr, NULL, false);
+        if(pnode){
+            pnode->Release();
             return "successfully connected";
         } else {
             throw runtime_error("error connecting\n");


### PR DESCRIPTION
Ugh.. I think I finally found it (again, but this time it should be the very last time) :)

The issue was caused by `pnode->fDisconnect = true` in `CMasternodeMan::ProcessMasternodeConnections()`. `ConnectNode()` increments reference count and we should just decrease it (via calling `Release()`) at the right time instead of changing flag directly. Otherwise some cleanup code was never triggered and we were stalling forever. To avoid situation when we could decrease it multiple times (which not only doesn't make sense but also that would trigger assert), flag `pnode->fDarkSendMaster` should also be set to `false`.

I also added `Release()` to some other parts of our code and fixed the way `ConnectNode()` is called there (`true` -> `false`, see notes at https://github.com/dashpay/dash/compare/v0.12.1.x...UdjinM6:fixNoNewBlocks?expand=1#diff-1a8b9d1ad0a6fda5e751286c73102fc2R358)