### PR TITLE
Make sure there is only one instance of `dash-darksend` thread

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2200,7 +2200,12 @@ void ThreadCheckDarkSendPool()
 {
     if(fLiteMode) return; //disable all Darksend/Masternode related functionality
 
-    // Make this thread recognisable as the wallet flushing thread
+    static bool fOneThread;
+    if (fOneThread)
+        return;
+    fOneThread = true;
+
+    // Make this thread recognisable as the Darksend/Masternode thread
     RenameThread("dash-darksend");
 
     unsigned int c = 0;


### PR DESCRIPTION
A trivial safety check - there should be no way to run this thread twice.