### PR TITLE
"Fix locks" Pack

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ BITCOIN_CORE_H = \
   consensus/validation.h \
   core_io.h \
   darksend.h \
+  dsnotificationinterface.h \
   darksend-relay.h \
   core_memusage.h \
   hash.h \
@@ -249,6 +250,7 @@ libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
   activemasternode.cpp \
   darksend.cpp \
+  dsnotificationinterface.cpp \
   darksend-relay.cpp \
   instantx.cpp \
   masternode.cpp \

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -289,6 +289,9 @@ private:
 
     int64_t lastNewBlock;
 
+    // Keep track of current block index
+    const CBlockIndex *pCurrentBlockIndex;
+
     std::vector<CAmount> darkSendDenominationsSkipped;
 
     //debugging data
@@ -535,6 +538,8 @@ public:
     void RelayIn(const std::vector<CTxDSIn>& vin, const CAmount& nAmount, const CTransaction& txCollateral, const std::vector<CTxDSOut>& vout);
     void RelayStatus(const int sessionID, const int newState, const int newEntriesCount, const int newAccepted, const int errorID=MSG_NOERR);
     void RelayCompletedTransaction(const int sessionID, const bool error, const int errorID);
+
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
 void ThreadCheckDarkSendPool();

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2015 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "dsnotificationinterface.h"
+#include "darksend.h"
+#include "masternode-budget.h"
+#include "masternode-payments.h"
+#include "masternode-sync.h"
+
+CDSNotificationInterface::CDSNotificationInterface()
+{
+}
+
+CDSNotificationInterface::~CDSNotificationInterface()
+{
+}
+
+void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
+{
+    darkSendPool.UpdatedBlockTip(pindex);
+    mnpayments.UpdatedBlockTip(pindex);
+    budget.UpdatedBlockTip(pindex);
+    masternodeSync.UpdatedBlockTip(pindex);
+}

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_DSNOTIFICATIONINTERFACE_H
+#define BITCOIN_DSNOTIFICATIONINTERFACE_H
+
+#include "validationinterface.h"
+
+class CDSNotificationInterface : public CValidationInterface
+{
+public:
+    // virtual CDSNotificationInterface();
+    CDSNotificationInterface();
+    virtual ~CDSNotificationInterface();
+
+protected:
+    // CValidationInterface
+    void UpdatedBlockTip(const CBlockIndex *pindex);
+
+private:
+};
+
+#endif // BITCOIN_DSNOTIFICATIONINTERFACE_H

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -235,7 +235,13 @@ int64_t CreateNewLock(CTransaction tx)
         This prevents attackers from using transaction mallibility to predict which masternodes
         they'll use.
     */
-    int nBlockHeight = (chainActive.Tip()->nHeight - nTxAge)+4;
+    int nBlockHeight = 0;
+    {
+        LOCK(cs_main);
+        CBlockIndex* tip = chainActive.Tip();
+        if(tip) nBlockHeight = tip->nHeight - nTxAge + 4;
+        else return 0;
+    }
 
     if (!mapTxLocks.count(tx.GetHash())){
         LogPrintf("CreateNewLock - New Transaction Lock %s !\n", tx.GetHash().ToString().c_str());

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -434,8 +434,6 @@ int64_t GetAverageVoteTime()
 
 void CleanTransactionLocksList()
 {
-    if(chainActive.Tip() == NULL) return;
-
     std::map<uint256, CTransactionLock>::iterator it = mapTxLocks.begin();
 
     while(it != mapTxLocks.end()) {
@@ -460,7 +458,6 @@ void CleanTransactionLocksList()
             it++;
         }
     }
-
 }
 
 uint256 CConsensusVote::GetHash() const

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3527,14 +3527,6 @@ bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, c
     if (!ActivateBestChain(state, chainparams, pblock))
         return error("%s: ActivateBestChain failed", __func__);
 
-    if(!fLiteMode){
-        if (masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_LIST) {
-            darkSendPool.NewBlock();
-            mnpayments.ProcessBlock(GetHeight()+10);
-            budget.NewBlock();
-        }
-    }
-
     LogPrintf("%s : ACCEPTED\n", __func__);
     return true;
 }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -57,6 +57,7 @@ bool IsBudgetCollateralValid(uint256 nTxCollateralHash, uint256 nExpectedHash, s
         return false;
     }
 
+    LOCK(cs_main);
     int conf = GetIXConfirmations(nTxCollateralHash);
     if (nBlockHash != uint256()) {
         BlockMap::iterator mi = mapBlockIndex.find(nBlockHash);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -78,6 +78,8 @@ private:
 
     //hold txes until they mature enough to use
     map<uint256, CTransaction> mapCollateral;
+    // Keep track of current block index
+    const CBlockIndex *pCurrentBlockIndex;
 
 public:
     // critical section to protect the inner data structures
@@ -179,6 +181,8 @@ public:
         READWRITE(mapProposals);
         READWRITE(mapFinalizedBudgets);
     }
+
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
 
@@ -235,7 +239,7 @@ public:
     double GetScore();
     bool HasMinimumRequiredSupport();
 
-    bool IsValid(std::string& strError, bool fCheckCollateral=true);
+    bool IsValid(const CBlockIndex* pindex, std::string& strError, bool fCheckCollateral=true);
 
     std::string GetName() {return strBudgetName; }
     std::string GetProposals();
@@ -427,7 +431,7 @@ public:
     bool HasMinimumRequiredSupport();
     std::pair<std::string, std::string> GetVotes();
 
-    bool IsValid(std::string& strError, bool fCheckCollateral=true);
+    bool IsValid(const CBlockIndex* pindex, std::string& strError, bool fCheckCollateral=true);
     bool IsEstablished();
 
     std::string GetName() {return strProposalName; }
@@ -438,7 +442,7 @@ public:
     int GetTotalPaymentCount();
     int GetRemainingPaymentCount();
     int GetBlockStartCycle();
-    int GetBlockCurrentCycle();
+    int GetBlockCurrentCycle(const CBlockIndex* pindex);
     int GetBlockEndCycle();
     double GetRatio();
     int GetAbsoluteYesCount();

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -269,10 +269,9 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight)
 
 void FillBlockPayee(CMutableTransaction& txNew, CAmount nFees)
 {
-    CBlockIndex* pindexPrev = chainActive.Tip();
-    if(!pindexPrev) return;
+    if(!chainActive.Tip()) return;
 
-    if(IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(pindexPrev->nHeight+1)){
+    if(IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(chainActive.Tip()->nHeight+1)){
         budget.FillBlockPayee(txNew, nFees);
     } else {
         mnpayments.FillBlockPayee(txNew, nFees);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -183,19 +183,21 @@ void DumpMasternodePayments()
 }
 
 bool IsBlockValueValid(const CBlock& block, CAmount nExpectedValue){
-    CBlockIndex* pindexPrev = chainActive.Tip();
-    if(pindexPrev == NULL) return true;
-
     int nHeight = 0;
-    if(pindexPrev->GetBlockHash() == block.hashPrevBlock)
-    {
-        nHeight = pindexPrev->nHeight+1;
-    } else { //out of order
-        BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
-        if (mi != mapBlockIndex.end() && (*mi).second)
-            nHeight = (*mi).second->nHeight+1;
-    }
 
+    {
+        LOCK(cs_main);
+        if(!chainActive.Tip()) return true;
+
+        if(chainActive.Tip()->GetBlockHash() == block.hashPrevBlock)
+        {
+            nHeight = chainActive.Tip()->nHeight+1;
+        } else { //out of order
+            BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
+            if (mi != mapBlockIndex.end() && (*mi).second)
+                nHeight = (*mi).second->nHeight+1;
+        }
+    }
     if(nHeight == 0){
         LogPrintf("IsBlockValueValid() : WARNING: Couldn't find previous block");
     }

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -226,6 +226,8 @@ class CMasternodePayments
 private:
     int nSyncedFromPeer;
     int nLastBlockHeight;
+    // Keep track of current block index
+    const CBlockIndex *pCurrentBlockIndex;
 
 public:
     std::map<uint256, CMasternodePaymentWinner> mapMasternodePayeeVotes;
@@ -293,6 +295,8 @@ public:
         READWRITE(mapMasternodePayeeVotes);
         READWRITE(mapMasternodeBlocks);
     }
+
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
 

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -55,6 +55,9 @@ public:
     // Time when current masternode asset sync started
     int64_t nAssetSyncStarted;
 
+    // Keep track of current block index
+    const CBlockIndex *pCurrentBlockIndex;
+
     CMasternodeSync();
 
     void AddedMasternodeList(uint256 hash);
@@ -71,6 +74,8 @@ public:
     bool IsSynced();
     bool IsBlockchainSynced();
     void ClearFulfilledRequest();
+
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
 #endif

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -251,6 +251,7 @@ public:
 
     int GetMasternodeInputAge()
     {
+        LOCK(cs_main);
         if(chainActive.Tip() == NULL) return 0;
 
         if(cacheInputAge == 0){
@@ -258,7 +259,7 @@ public:
             cacheInputAgeBlock = chainActive.Tip()->nHeight;
         }
 
-        return cacheInputAge+(chainActive.Tip()->nHeight-cacheInputAgeBlock);
+        return cacheInputAge + (chainActive.Tip()->nHeight - cacheInputAgeBlock);
     }
 
     std::string Status() {

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -351,9 +351,6 @@ void OverviewPage::updateDarksendProgress()
     double nAverageAnonymizedRounds;
 
     {
-        TRY_LOCK(cs_main, lockMain);
-        if(!lockMain) return;
-
         nDenominatedConfirmedBalance = pwalletMain->GetDenominatedBalance();
         nDenominatedUnconfirmedBalance = pwalletMain->GetDenominatedBalance(true);
         nAnonymizableBalance = pwalletMain->GetAnonymizableBalance();
@@ -434,12 +431,10 @@ void OverviewPage::updateDarksendProgress()
 
 void OverviewPage::darkSendStatus()
 {
-    if (!chainActive.Tip()) return;
     if(!masternodeSync.IsBlockchainSynced() || ShutdownRequested()) return;
 
     static int64_t nLastDSProgressBlockTime = 0;
-
-    int nBestHeight = chainActive.Tip()->nHeight;
+    int nBestHeight = clientModel->getNumBlocks();
 
     // we we're processing more then 1 block per second, we'll just leave
     if(((nBestHeight - darkSendPool.cachedNumBlocks) / (GetTimeMillis() - nLastDSProgressBlockTime + 1) > 1)) return;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -583,9 +583,6 @@ void SendCoinsDialog::setBalance(const CAmount& balance, const CAmount& unconfir
 
 void SendCoinsDialog::updateDisplayUnit()
 {
-    TRY_LOCK(cs_main, lockMain);
-    if(!lockMain) return;
-
     setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(), model->getAnonymizedBalance(),
                    model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
     CoinControlDialog::coinControl->useDarkSend = ui->checkUseDarksend->isChecked();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -146,9 +146,6 @@ void WalletModel::pollBalanceChanged()
 
 void WalletModel::checkBalanceChanged()
 {
-    TRY_LOCK(cs_main, lockMain);
-    if(!lockMain) return;
-
     CAmount newBalance = getBalance();
     CAmount newUnconfirmedBalance = getUnconfirmedBalance();
     CAmount newImmatureBalance = getImmatureBalance();

--- a/src/rpcmasternode-budget.cpp
+++ b/src/rpcmasternode-budget.cpp
@@ -53,6 +53,7 @@ UniValue mnbudget(const UniValue& params, bool fHelp)
 
     if(strCommand == "nextblock")
     {
+        LOCK(cs_main);
         CBlockIndex* pindexPrev = chainActive.Tip();
         if(!pindexPrev) return "unknown";
 
@@ -62,6 +63,7 @@ UniValue mnbudget(const UniValue& params, bool fHelp)
 
     if(strCommand == "nextsuperblocksize")
     {
+        LOCK(cs_main);
         CBlockIndex* pindexPrev = chainActive.Tip();
         if(!pindexPrev) return "unknown";
 
@@ -77,7 +79,8 @@ UniValue mnbudget(const UniValue& params, bool fHelp)
             throw runtime_error("Correct usage is 'mnbudget prepare <proposal-name> <url> <payment-count> <block-start> <dash-address> <monthly-payment-dash>'");
 
         int nBlockMin = 0;
-        CBlockIndex* pindexPrev = chainActive.Tip();
+        LOCK(cs_main);
+        CBlockIndex* pindex = chainActive.Tip();
 
         std::vector<CMasternodeConfig::CMasternodeEntry> mnEntries;
         mnEntries = masternodeConfig.getEntries();
@@ -88,7 +91,7 @@ UniValue mnbudget(const UniValue& params, bool fHelp)
         int nBlockStart = params[4].get_int();
 
         //set block min
-        if(pindexPrev != NULL) nBlockMin = pindexPrev->nHeight;
+        if(pindex != NULL) nBlockMin = pindex->nHeight;
 
         if(nBlockStart < nBlockMin)
             return "Invalid block start, must be more than current height.";
@@ -140,6 +143,7 @@ UniValue mnbudget(const UniValue& params, bool fHelp)
         }
 
         int nBlockMin = 0;
+        LOCK(cs_main);
         CBlockIndex* pindexPrev = chainActive.Tip();
 
         std::vector<CMasternodeConfig::CMasternodeEntry> mnEntries;
@@ -887,7 +891,7 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
             return "Invalid finalized proposal";
         }
 
-
+        LOCK(cs_main);
         CBlockIndex* pindexPrev = chainActive.Tip();
         if(!pindexPrev) return "invalid chaintip";
 
@@ -945,6 +949,7 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
             return "Invalid finalized proposal";
         }
 
+        LOCK(cs_main);
         CBlockIndex* pindexPrev = chainActive.Tip();
         if(!pindexPrev) return "invalid chaintip";
 

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -448,7 +448,7 @@ UniValue masternode(const UniValue& params, bool fHelp)
 
         UniValue obj(UniValue::VOBJ);
 
-        for(int i = nHeight - nLast; i < nHeight + 20; nHeight++)
+        for(int i = nHeight - nLast; i < nHeight + 20; i++)
         {
             obj.push_back(Pair(strprintf("%d", i), GetRequiredPaymentsString(i)));
         }
@@ -465,10 +465,10 @@ UniValue masternode(const UniValue& params, bool fHelp)
         int nHeight;
         {
             LOCK(cs_main);
-            CBlockIndex* pindexPrev = chainActive.Tip();
-            if(!pindexPrev) return NullUniValue;
+            CBlockIndex* pindex = chainActive.Tip();
+            if(!pindex) return NullUniValue;
 
-            nHeight = pindexPrev->nHeight;
+            nHeight = pindex->nHeight;
         }
 
         int nLast = 10;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -39,6 +39,7 @@ void ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
         CSporkMessage spork;
         vRecv >> spork;
 
+        LOCK(cs_main);
         if(chainActive.Tip() == NULL) return;
 
         uint256 hash = spork.GetHash();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -8,6 +8,7 @@
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
 #include "main.h"
+#include "masternode-payments.h"
 #include "miner.h"
 #include "pubkey.h"
 #include "script/standard.h"
@@ -73,6 +74,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     LOCK(cs_main);
     fCheckpointsEnabled = false;
+
+    // force UpdatedBlockTip to initialize pCurrentBlockIndex
+    mnpayments.UpdatedBlockTip(chainActive.Tip());
 
     // Simple block creation, nothing special yet:
     BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));


### PR DESCRIPTION
There are 3 parts:
- remove unnecessary locks and chainActive.Tip() references
- add _some_ locks to protect chainActive.Tip() and mapBlockIndex (why "_some_"? see next point)
- introduce CDSNotificationInterface - validation interface to listen to tip updates and trigger updates in DS, payments and budgets. Should significantly reduce number of references to chainActive.Tip() i.e.we should have less cs_main in dash-darksend thread and potential deadlocks. This could require dash-darksend internal locks though (which still would be much better than inter-thread locking).

Needs some testing ;)