### PR TITLE
Removes forward slashes (/) from user agent in Peers tab UI.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4343,7 +4343,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             vRecv >> addrFrom >> nNonce;
         if (!vRecv.empty()) {
             vRecv >> LIMITED_STRING(pfrom->strSubVer, 256);
-            pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
+            pfrom->cleanSubVer = SanitizeSubVersionString(pfrom->strSubVer);
         }
         if (!vRecv.empty())
             vRecv >> pfrom->nStartingHeight;

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -36,6 +36,17 @@ string SanitizeString(const string& str)
     return strResult;
 }
 
+/// Formats the network peer user agent text (or clean subversion)
+/// by removing the begining and ending charactors(/).
+/// example: /Dash Core:0.12.0.56/ --> Dash Core:0.12.0.56
+string SanitizeSubVersionString(const string& str)
+{
+    string strResult = SanitizeString(str);
+    if ((strResult.length() > 3) && (strResult.substr(0,1) == "/") && (strResult.substr((strResult.length()-1),1) == "/"))
+        strResult = strResult.substr(1, (strResult.length() - 2));
+    return strResult;
+}
+
 const signed char p_util_hexdigit[256] =
 { -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
   -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -24,6 +24,7 @@
 #define PAIRTYPE(t1, t2)    std::pair<t1, t2>
 
 std::string SanitizeString(const std::string& str);
+std::string SanitizeSubVersionString(const std::string& str);
 std::vector<unsigned char> ParseHex(const char* psz);
 std::vector<unsigned char> ParseHex(const std::string& str);
 signed char HexDigit(char c);


### PR DESCRIPTION
user agent is prefixed and suffixed with forward slashes occupying two spaces and seem unnecessary for the Qt wallet UI. Example: /Dash Core:0.12.0.53/ --> Dash Core:0.12.0.53

Before:
![dash_useragent_before](https://cloud.githubusercontent.com/assets/13896934/13520226/334d06e8-e1a4-11e5-856a-ba4ff4cf1c7d.png)
After:
![dash_useragent_after](https://cloud.githubusercontent.com/assets/13896934/13520229/3c435950-e1a4-11e5-8b8a-09770cbfb706.png)
One good side effect the ellipsis is removed using the default window size.

This code is forked from my original pull for Dark Silk:  https://github.com/SCDeveloper/DarkSilk-Release-Candidate/pull/138