### PR TITLE
Fix crash in CheckAndRemove

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -265,7 +265,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
                 (*it).activeState == CMasternode::MASTERNODE_VIN_SPENT ||
                 (forceExpiredRemoval && (*it).activeState == CMasternode::MASTERNODE_EXPIRED) ||
                 (*it).protocolVersion < mnpayments.GetMinMasternodePaymentsProto()) {
-            LogPrint("masternode", "CMasternodeMan: Removing inactive Masternode %s - %i now\n", (*it).addr.ToString(), size() - 1);
+            LogPrint("masternode", "CMasternodeMan::CheckAndRemove - Removing inactive Masternode %s - %i now\n", (*it).addr.ToString(), size() - 1);
 
             //erase all of the broadcasts we've seen from this vin
             // -- if we missed a few pings and the node was removed, this will allow is to get it back without them 
@@ -326,21 +326,23 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
         }
     }
 
-    // remove expired mapSeenMasternodeBroadcast       
-    map<uint256, CMasternodeBroadcast>::iterator it3 = mapSeenMasternodeBroadcast.begin();     
-    while(it3 != mapSeenMasternodeBroadcast.end()){        
-        if((*it3).second.lastPing.sigTime < GetTime()-(MASTERNODE_REMOVAL_SECONDS*2)){     
-            mapSeenMasternodeBroadcast.erase(it3++);       
-            masternodeSync.mapSeenSyncMNB.erase((*it3).second.GetHash());      
-        } else {       
-            ++it3;     
-        }      
-    }      
-    
+    // remove expired mapSeenMasternodeBroadcast
+    map<uint256, CMasternodeBroadcast>::iterator it3 = mapSeenMasternodeBroadcast.begin();
+    while(it3 != mapSeenMasternodeBroadcast.end()){
+        if((*it3).second.lastPing.sigTime < GetTime() - MASTERNODE_REMOVAL_SECONDS*2){
+            LogPrint("masternode", "CMasternodeMan::CheckAndRemove - Removing expired Masternode broadcast %s\n", (*it3).second.GetHash().ToString());
+            masternodeSync.mapSeenSyncMNB.erase((*it3).second.GetHash());
+            mapSeenMasternodeBroadcast.erase(it3++);
+        } else {
+            ++it3;
+        }
+    }
+
     // remove expired mapSeenMasternodePing
     map<uint256, CMasternodePing>::iterator it4 = mapSeenMasternodePing.begin();
     while(it4 != mapSeenMasternodePing.end()){
-        if((*it4).second.sigTime < GetTime()-(MASTERNODE_REMOVAL_SECONDS*2)){
+        if((*it4).second.sigTime < GetTime() - MASTERNODE_REMOVAL_SECONDS*2){
+            LogPrint("masternode", "CMasternodeMan::CheckAndRemove - Removing expired Masternode ping %s\n", (*it3).second.GetHash().ToString());
             mapSeenMasternodePing.erase(it4++);
         } else {
             ++it4;


### PR DESCRIPTION
This part specifically:
```
...erase(it3++)...
...erase((*it3)...
```
is simply incorrect but in rare cases it also leads to crash.

Also added more log output (for debug mode only).

PS. worth backporting to master imo https://github.com/dashpay/dash/blob/master/src/masternodeman.cpp#L331-L332