### PR TITLE
Debug improvements

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -115,13 +115,13 @@ void CActiveMasternode::ManageStatus()
             if(!darkSendSigner.SetKey(strMasterNodePrivKey, errorMessage, keyMasternode, pubKeyMasternode))
             {
                 notCapableReason = "Error upon calling SetKey: " + errorMessage;
-                LogPrintf("Register::ManageStatus() - %s\n", notCapableReason);
+                LogPrintf("CActiveMasternode::ManageStatus() - %s\n", notCapableReason);
                 return;
             }
 
             if(!Register(vin, service, keyCollateralAddress, pubKeyCollateralAddress, keyMasternode, pubKeyMasternode, errorMessage)) {
                 notCapableReason = "Error on Register: " + errorMessage;
-                LogPrintf("Register::ManageStatus() - %s\n", notCapableReason);
+                LogPrintf("CActiveMasternode::ManageStatus() - %s\n", notCapableReason);
                 return;
             }
 

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -37,19 +37,19 @@ private:
     bool GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
 
 public:
-	// Initialized by init.cpp
-	// Keys for the main Masternode
-	CPubKey pubKeyMasternode;
+    // Initialized by init.cpp
+    // Keys for the main Masternode
+    CPubKey pubKeyMasternode;
 
-	// Initialized while registering Masternode
-	CTxIn vin;
+    // Initialized while registering Masternode
+    CTxIn vin;
     CService service;
 
     int status;
     std::string notCapableReason;
 
     CActiveMasternode()
-    {        
+    {
         status = ACTIVE_MASTERNODE_INITIAL;
     }
 

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2148,7 +2148,7 @@ bool CDarksendQueue::CheckSignature()
 
         std::string errorMessage = "";
         if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage)){
-            return error("CDarksendQueue::CheckSignature() - Got bad Masternode address signature %s \n", vin.ToString().c_str());
+            return error("CDarksendQueue::CheckSignature() - Got bad Masternode queue signature %s", vin.ToString().c_str());
         }
 
         return true;

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -215,7 +215,7 @@ static bool InitRPCAuthentication()
             return false;
         }
     } else {
-        LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation.");
+        LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation.\n");
         strRPCUserColonPass = mapArgs["-rpcuser"] + ":" + mapArgs["-rpcpassword"];
     }
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -519,6 +519,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug)
     {
         strUsage += HelpMessageOpt("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS));
+        strUsage += HelpMessageOpt("-logthreadnames", strprintf("Add thread names to debug messages (default: %u)", DEFAULT_LOGTHREADNAMES));
         strUsage += HelpMessageOpt("-mocktime=<n>", "Replace actual time with <n> seconds since epoch (default: 0)");
         strUsage += HelpMessageOpt("-limitfreerelay=<n>", strprintf("Continuously rate-limit free transactions to <n>*1000 bytes per minute (default: %u)", DEFAULT_LIMITFREERELAY));
         strUsage += HelpMessageOpt("-relaypriority", strprintf("Require high priority for relaying free or low-fee transactions (default: %u)", DEFAULT_RELAYPRIORITY));
@@ -870,6 +871,7 @@ void InitLogging()
     fPrintToDebugLog = GetBoolArg("-printtodebuglog", true) && !fPrintToConsole;
     fLogTimestamps = GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     fLogTimeMicros = GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
+    fLogThreadNames = GetBoolArg("-logthreadnames", DEFAULT_LOGTHREADNAMES);
     fLogIPs = GetBoolArg("-logips", DEFAULT_LOGIPS);
 
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
@@ -1700,7 +1702,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             pwalletMain->SetBestChain(chainActive.GetLocator());
         }
 
-        LogPrintf("%s", strErrors.str());
+        if(!strErrors.str().empty()) LogPrintf("%s", strErrors.str());
         LogPrintf(" wallet      %15dms\n", GetTimeMillis() - nStart);
 
         RegisterValidationInterface(pwalletMain);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5190,7 +5190,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
                 std::string errorMessage = "";
                 if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage)){
-                    LogPrintf("dstx: Got bad masternode address signature %s \n", vin.ToString());
+                    LogPrintf("dstx: Got bad Masternode transaction signature %s\n", vin.ToString());
                     //pfrom->Misbehaving(20);
                     return false;
                 }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -512,7 +512,7 @@ public:
         swap(first.nAmount, second.nAmount);
         swap(first.address, second.address);
         swap(first.nTime, second.nTime);
-        swap(first.nFeeTXHash, second.nFeeTXHash);        
+        swap(first.nFeeTXHash, second.nFeeTXHash);
         first.mapVotes.swap(second.mapVotes);
     }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -767,7 +767,7 @@ bool CMasternodePaymentWinner::SignatureValid()
 
         std::string errorMessage = "";
         if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage)){
-            return error("CMasternodePaymentWinner::SignatureValid() - Got bad Masternode address signature %s \n", vinMasternode.ToString().c_str());
+            return error("CMasternodePaymentWinner::SignatureValid() - Got bad Masternode payment signature %s", vinMasternode.ToString().c_str());
         }
 
         return true;

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -242,8 +242,6 @@ void CMasternodeSync::Process()
         } else if (RequestedMasternodeAssets == MASTERNODE_SYNC_FAILED) {
             return;
         }
-    
-        if(fDebug) LogPrintf("CMasternodeSync::Process() - tick %d RequestedMasternodeAssets %d\n", tick, RequestedMasternodeAssets);
     }
 
     double nSyncProgress = double(RequestedMasternodeAttempt + (RequestedMasternodeAssets - 1) * 8) / (8*4);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -123,7 +123,7 @@ public:
     CService addr;
     CPubKey pubkey;
     CPubKey pubkey2;
-    std::vector<unsigned char> sig;
+    std::vector<unsigned char> vchSig;
     int activeState;
     int64_t sigTime; //mnb message time
     int cacheInputAge;
@@ -152,7 +152,7 @@ public:
         swap(first.addr, second.addr);
         swap(first.pubkey, second.pubkey);
         swap(first.pubkey2, second.pubkey2);
-        swap(first.sig, second.sig);
+        swap(first.vchSig, second.vchSig);
         swap(first.activeState, second.activeState);
         swap(first.sigTime, second.sigTime);
         swap(first.lastPing, second.lastPing);
@@ -192,7 +192,7 @@ public:
             READWRITE(addr);
             READWRITE(pubkey);
             READWRITE(pubkey2);
-            READWRITE(sig);
+            READWRITE(vchSig);
             READWRITE(sigTime);
             READWRITE(protocolVersion);
             READWRITE(activeState);
@@ -291,7 +291,7 @@ public:
     CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey newPubkey, CPubKey newPubkey2, int protocolVersionIn);
     CMasternodeBroadcast(const CMasternode& mn);
 
-    bool CheckAndUpdate(int& nDoS);
+    bool CheckAndUpdate(int& nDos);
     bool CheckInputsAndAdd(int& nDos);
     bool Sign(CKey& keyCollateralAddress);
     void Relay();
@@ -304,7 +304,7 @@ public:
         READWRITE(addr);
         READWRITE(pubkey);
         READWRITE(pubkey2);
-        READWRITE(sig);
+        READWRITE(vchSig);
         READWRITE(sigTime);
         READWRITE(protocolVersion);
         READWRITE(lastPing);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -699,11 +699,11 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         LogPrint("masternode", "mnb - Masternode broadcast, vin: %s new\n", mnb.vin.ToString());
 
-        int nDoS = 0;
-        if(!mnb.CheckAndUpdate(nDoS)){
+        int nDos = 0;
+        if(!mnb.CheckAndUpdate(nDos)){
 
-            if(nDoS > 0)
-                Misbehaving(pfrom->GetId(), nDoS);
+            if(nDos > 0)
+                Misbehaving(pfrom->GetId(), nDos);
 
             LogPrint("masternode", "mnb - Masternode broadcast, vin: %s CheckAndUpdate failed\n", mnb.vin.ToString());
 
@@ -721,15 +721,15 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         // make sure it's still unspent
         //  - this is checked later by .check() in many places and by ThreadCheckDarkSendPool()
-        if(mnb.CheckInputsAndAdd(nDoS)) {
+        if(mnb.CheckInputsAndAdd(nDos)) {
             // use this as a peer
             addrman.Add(CAddress(mnb.addr), pfrom->addr, 2*60*60);
             masternodeSync.AddedMasternodeList(mnb.GetHash());
         } else {
             LogPrintf("mnb - Rejected Masternode entry %s\n", mnb.addr.ToString());
 
-            if (nDoS > 0)
-                Misbehaving(pfrom->GetId(), nDoS);
+            if (nDos > 0)
+                Misbehaving(pfrom->GetId(), nDos);
         }
     }
 
@@ -742,14 +742,14 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         if(mapSeenMasternodePing.count(mnp.GetHash())) return; //seen
         mapSeenMasternodePing.insert(make_pair(mnp.GetHash(), mnp));
 
-        LogPrint("masternode", "mnp - Masternode ping, vin: %s\n new", mnp.vin.ToString());
+        LogPrint("masternode", "mnp - Masternode ping, vin: %s new\n", mnp.vin.ToString());
 
-        int nDoS = 0;
-        if(mnp.CheckAndUpdate(nDoS)) return;
+        int nDos = 0;
+        if(mnp.CheckAndUpdate(nDos)) return;
 
-        if(nDoS > 0) {
+        if(nDos > 0) {
             // if anything significant failed, mark that node
-            Misbehaving(pfrom->GetId(), nDoS);
+            Misbehaving(pfrom->GetId(), nDos);
         } else {
             // if nothing significant failed, search existing Masternode list
             CMasternode* pmn = Find(mnp.vin);

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include <boost/assign/list_of.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <univalue.h>
 
@@ -111,6 +112,30 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     return obj;
+}
+
+UniValue debug(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "debug ( 0|1|addrman|alert|bench|coindb|db|lock|rand|rpc|selectcoins|mempool"
+            "|mempoolrej|net|proxy|prune|http|libevent|tor|zmq|"
+            "dash|darksend|instantx|masternode|keepass|mnpayments|mnbudget )\n"
+            "Change debug category on the fly. Specify single category or use comma to specify many.\n"
+            "\nExamples:\n"
+            + HelpExampleCli("debug", "dash")
+            + HelpExampleRpc("debug", "dash,net")
+        );
+
+    std::string strMode = params[0].get_str();
+
+    mapMultiArgs["-debug"].clear();
+    boost::split(mapMultiArgs["-debug"], strMode, boost::is_any_of(","));
+    mapArgs["-debug"] = mapMultiArgs["-debug"][mapMultiArgs["-debug"].size() - 1];
+
+    fDebug = mapArgs["-debug"] != "0";
+
+    return "Debug mode: " + (fDebug ? strMode : "off");
 }
 
 UniValue mnsync(const UniValue& params, bool fHelp)

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -258,6 +258,7 @@ static const CRPCCommand vRPCCommands[] =
   //  --------------------- ------------------------  -----------------------  ----------
     /* Overall control/query calls */
     { "control",            "getinfo",                &getinfo,                true  }, /* uses wallet if enabled */
+    { "control",            "debug",                  &debug,                  true  },
     { "control",            "help",                   &help,                   true  },
     { "control",            "stop",                   &stop,                   true  },
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -232,6 +232,7 @@ extern UniValue walletlock(const UniValue& params, bool fHelp);
 extern UniValue encryptwallet(const UniValue& params, bool fHelp);
 extern UniValue validateaddress(const UniValue& params, bool fHelp);
 extern UniValue getinfo(const UniValue& params, bool fHelp);
+extern UniValue debug(const UniValue& params, bool fHelp);
 extern UniValue getwalletinfo(const UniValue& params, bool fHelp);
 extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);
 extern UniValue getnetworkinfo(const UniValue& params, bool fHelp);

--- a/src/util.h
+++ b/src/util.h
@@ -51,6 +51,7 @@ extern std::string strBudgetMode;
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
+static const bool DEFAULT_LOGTHREADNAMES = false;
 
 /** Signals for translation. */
 class CTranslationInterface
@@ -69,6 +70,7 @@ extern bool fServer;
 extern std::string strMiscWarning;
 extern bool fLogTimestamps;
 extern bool fLogTimeMicros;
+extern bool fLogThreadNames;
 extern bool fLogIPs;
 extern volatile bool fReopenDebugLog;
 extern CTranslationInterface translationInterface;
@@ -239,6 +241,7 @@ int GetNumCores();
 
 void SetThreadPriority(int nPriority);
 void RenameThread(const char* name);
+std::string GetThreadName();
 
 /**
  * .. and a wrapper that just calls func once


### PR DESCRIPTION
Debug helpers:
- Add `-logthreadnames` cmd-line option to add thread names to debug messages
- Add ability to change debug category on the fly from console
 NOTE: Before switching to another debug category you'd need to turn debugging off via `debug 0`
      and wait a bit (each thread (de)activates debug mode on its own)

Few small changes:
- Better log output (a bit more granular for `mnb`, fixing `\n`s and few other small issues)
- Unify variable/class members naming a bit

_PS. pls do not squash these on merge, I already did it for the later two (7c0a858)_ :wink: 