### PR TITLE
Bump DEFAULT_TRANSACTION_MAXFEE 

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -55,7 +55,7 @@ static const CAmount DEFAULT_FALLBACK_FEE = 20000;
  */
 static const CAmount DEFAULT_TRANSACTION_MINFEE = 10000; // was 1000
 //! -maxtxfee default
-static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN;
+static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.2 * COIN; // "smallest denom" + X * "denom tails"
 //! minimum change amount
 static const CAmount MIN_CHANGE = CENT;
 //! Default for -spendzeroconfchange


### PR DESCRIPTION
Should be smth like `"smallest DS denomination (0.10000100)" + X * "denom tails"` to avoid triggering "absurd fee" error. I think that 0.2 i.e. having 100 of 100s "tails" (or 1000 of 10s etc) should be enough.

PS. by _denom tails_ I mean:
0.10000*100*
1.0000*1000*
10.000*10000*
100.00*100000*