### PR TITLE
Fix DS bugs

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -262,7 +262,7 @@ private:
     mutable CCriticalSection cs_darksend;
 
     std::vector<CDarkSendEntry> entries; // Masternode/clients entries
-    CMutableTransaction finalTransaction; // the finalized transaction ready for signing
+    CMutableTransaction finalMutableTransaction; // the finalized transaction ready for signing
 
     int64_t lastTimeChanged; // last time the 'state' changed, in UTC milliseconds
 


### PR DESCRIPTION
- DS stuck once we reached `DENOMS_COUNT_MAX` and can't get any output at all, ignore `DENOMS_COUNT_MAX` if this happens (will produce even more smaller denoms but I guess that's better than "oh, it's broken and not moving anymore" :wink: )
- I think parts of incomplete dstx (from each participant) can't get into mempool because of 0 fee, prioritize them (but only for "dry run" mode) as we do for signed dstxes already
- refactor names to avoid potential conflicts (`state` -> `validationState`) and better readability (`finalTransaction` -> `finalMutableTransaction`)