### PR TITLE
Fix upnp support for new versions (backport from btc 0.12)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1050,10 +1050,14 @@ void ThreadMapPort()
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9.20150730 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
Local build is broken for me after upnp update. Cherry-picking 9f3e48e5219a09b5ddfd6883d1f0498910eff4b6 to fix this.

> Add support for miniupnpc api version 14
> The value of new arg ttl is set to 2 as it's recommended default.