### PR TITLE
Use chainparams instead of standalone func for mn confirms

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -96,7 +96,7 @@ void CActiveMasternode::ManageStatus()
 
         if(GetMasterNodeVin(vin, pubKeyCollateralAddress, keyCollateralAddress)) {
 
-            if(GetInputAge(vin) < GetMasternodeConfirmationsRequired()){
+            if(GetInputAge(vin) < Params().GetConsensus().nMasternodeMinimumConfirmations){
                 status = ACTIVE_MASTERNODE_INPUT_TOO_NEW;
                 notCapableReason = strprintf("%s - %d confirmations", GetStatus(), GetInputAge(vin));
                 LogPrintf("CActiveMasternode::ManageStatus() - %s\n", notCapableReason);
@@ -153,7 +153,7 @@ std::string CActiveMasternode::GetStatus() {
     switch (status) {
     case ACTIVE_MASTERNODE_INITIAL: return "Node just started, not yet activated";
     case ACTIVE_MASTERNODE_SYNC_IN_PROCESS: return "Sync in progress. Must wait until sync is complete to start Masternode";
-    case ACTIVE_MASTERNODE_INPUT_TOO_NEW: return strprintf("Masternode input must have at least %d confirmations", GetMasternodeConfirmationsRequired());
+    case ACTIVE_MASTERNODE_INPUT_TOO_NEW: return strprintf("Masternode input must have at least %d confirmations", Params().GetConsensus().nMasternodeMinimumConfirmations);
     case ACTIVE_MASTERNODE_NOT_CAPABLE: return "Not capable masternode: " + notCapableReason;
     case ACTIVE_MASTERNODE_STARTED: return "Masternode successfully started";
     default: return "unknown";

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -80,6 +80,7 @@ public:
         consensus.nBudgetPaymentsCycleBlocks = 16616; // ~(60*24*30)/2.6, actual number of blocks per month is 200700 / 12 = 16725
         consensus.nBudgetPaymentsWindowBlocks = 100;
         consensus.nBudgetProposalEstablishingTime = 60*60*24;
+        consensus.nMasternodeMinimumConfirmations = 15;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;
@@ -184,6 +185,7 @@ public:
         consensus.nBudgetPaymentsCycleBlocks = 50;
         consensus.nBudgetPaymentsWindowBlocks = 10;
         consensus.nBudgetProposalEstablishingTime = 60*20;
+        consensus.nMasternodeMinimumConfirmations = 1;
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
         consensus.nMajorityWindow = 100;
@@ -273,6 +275,7 @@ public:
         consensus.nBudgetPaymentsCycleBlocks = 50;
         consensus.nBudgetPaymentsWindowBlocks = 100;
         consensus.nBudgetProposalEstablishingTime = 60*20;
+        consensus.nMasternodeMinimumConfirmations = 1;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -22,6 +22,7 @@ struct Params {
     int nBudgetPaymentsCycleBlocks;
     int nBudgetPaymentsWindowBlocks;
     int nBudgetProposalEstablishingTime; // in seconds
+    int nMasternodeMinimumConfirmations;
     /** Used to check majorities for block version upgrade */
     int nMajorityEnforceBlockUpgrade;
     int nMajorityRejectBlockOutdated;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -487,8 +487,8 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDos)
 
     LogPrint("masternode", "CMasternodeBroadcast::CheckInputsAndAdd - Accepted Masternode entry\n");
 
-    if(GetInputAge(vin) < GetMasternodeConfirmationsRequired()){
-        LogPrintf("CMasternodeBroadcast::CheckInputsAndAdd - Input must have at least %d confirmations\n", GetMasternodeConfirmationsRequired());
+    if(GetInputAge(vin) < Params().GetConsensus().nMasternodeMinimumConfirmations){
+        LogPrintf("CMasternodeBroadcast::CheckInputsAndAdd - Input must have at least %d confirmations\n", Params().GetConsensus().nMasternodeMinimumConfirmations);
         // maybe we miss few blocks, let this mnb to be checked again later
         mnodeman.mapSeenMasternodeBroadcast.erase(GetHash());
         masternodeSync.mapSeenSyncMNB.erase(GetHash());
@@ -496,7 +496,7 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDos)
     }
 
     // verify that sig time is legit in past
-    // should be at least not earlier than block when 1000 DASH tx got GetMasternodeConfirmationsRequired()
+    // should be at least not earlier than block when 1000 DASH tx got nMasternodeMinimumConfirmations
     uint256 hashBlock = uint256();
     CTransaction tx2;
     GetTransaction(vin.prevout.hash, tx2, Params().GetConsensus(), hashBlock, true);
@@ -506,11 +506,11 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDos)
         if (mi != mapBlockIndex.end() && (*mi).second)
         {
             CBlockIndex* pMNIndex = (*mi).second; // block for 1000 DASH tx -> 1 confirmation
-            CBlockIndex* pConfIndex = chainActive[pMNIndex->nHeight + GetMasternodeConfirmationsRequired() - 1]; // block where tx got GetMasternodeConfirmationsRequired()
+            CBlockIndex* pConfIndex = chainActive[pMNIndex->nHeight + Params().GetConsensus().nMasternodeMinimumConfirmations - 1]; // block where tx got nMasternodeMinimumConfirmations
             if(pConfIndex->GetBlockTime() > sigTime)
             {
                 LogPrintf("CMasternodeBroadcast::CheckInputsAndAdd - Bad sigTime %d for Masternode %20s %105s (%i conf block is at %d)\n",
-                          sigTime, addr.ToString(), vin.ToString(), GetMasternodeConfirmationsRequired(), pConfIndex->GetBlockTime());
+                          sigTime, addr.ToString(), vin.ToString(), Params().GetConsensus().nMasternodeMinimumConfirmations, pConfIndex->GetBlockTime());
                 return false;
             }
         }

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -13,8 +13,6 @@
 #include "main.h"
 #include "timedata.h"
 
-#define MASTERNODE_MIN_CONFIRMATIONS_TEST           1
-#define MASTERNODE_MIN_CONFIRMATIONS_MAIN           15
 #define MASTERNODE_MIN_MNP_SECONDS             (10*60)
 #define MASTERNODE_MIN_MNB_SECONDS             (5*60)
 #define MASTERNODE_PING_SECONDS                (5*60)
@@ -30,15 +28,6 @@ class CMasternodePing;
 extern map<int64_t, uint256> mapCacheBlockHashes;
 
 bool GetBlockHash(uint256& hash, int nBlockHeight);
-
-int GetMasternodeConfirmationsRequired()
-{
-    if(Params().NetworkIDString() == CBaseChainParams::MAIN)
-        return MASTERNODE_MIN_CONFIRMATIONS_MAIN;
-    else
-        return MASTERNODE_MIN_CONFIRMATIONS_TEST;
-}
-
 
 //
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network


### PR DESCRIPTION
Improve code quality by using chainparams for network specific mn confirm requirements