### PR TITLE
[UI] Fixed missplaced mixing buttons for traditional wallet theme

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -1034,8 +1034,8 @@
          <widget class="QPushButton" name="darksendReset">
           <property name="geometry">
            <rect>
-            <x>220</x>
-            <y>319</y>
+            <x>230</x>
+            <y>320</y>
             <width>221</width>
             <height>28</height>
            </rect>


### PR DESCRIPTION
Reference: https://www.dash.org/forum/threads/v12-1-testnet-launch-thread.9014/#post-94861 (first screenshot)

**Before:**
![mixing-buttons-old](https://cloud.githubusercontent.com/assets/10080039/15532545/9ce32874-2260-11e6-8c53-fb6f2d3f7ad2.jpg)

**After:**
![mixing-buttons-new](https://cloud.githubusercontent.com/assets/10080039/15532562/abb91f02-2260-11e6-873f-492a4f6fccd1.jpg)

All other themes have the button-locations defined via CSS, so this only changes the traditional theme.