### PR TITLE
[Core]: fix restart hanging during wallet-repair

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -209,7 +209,6 @@ void PrepareShutdown()
     /// module was initialized.
     RenameThread("dash-shutoff");
     mempool.AddTransactionsUpdated(1);
-
     StopHTTPRPC();
     StopREST();
     StopRPC();
@@ -222,7 +221,6 @@ void PrepareShutdown()
     StopNode();
 
     // STORE DATA CACHES INTO SERIALIZED DAT FILES
-
     CFlatDB<CMasternodeMan> flatdb1("mncache.dat", "magicMasternodeCache");
     flatdb1.Dump(mnodeman);
     CFlatDB<CMasternodePayments> flatdb2("mnpayments.dat", "magicMasternodePaymentsCache");
@@ -230,7 +228,6 @@ void PrepareShutdown()
     CFlatDB<CGovernanceManager> flatdb3("governance.dat", "magicGovernanceCache");
     flatdb3.Dump(governance);
 
-    StopTorControl();
     UnregisterNodeSignals(GetNodeSignals());
 
     if (fFeeEstimatesInitialized)
@@ -302,8 +299,8 @@ void Shutdown()
     if(!fRestartRequested){
         PrepareShutdown();
     }
-
-   // Shutdown part 2: delete wallet instance
+   // Shutdown part 2: Stop TOR thread and delete wallet instance
+    StopTorControl();
 #ifdef ENABLE_WALLET
     delete pwalletMain;
     pwalletMain = NULL;

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -687,10 +687,15 @@ void InterruptTorControl()
 
 void StopTorControl()
 {
+    // timed_join() avoids the wallet not closing during a repair-restart. For a 'normal' wallet exit
+    // it behaves for our cases exactly like the normal join()
     if (base) {
-        torControlThread.join();
+#if BOOST_VERSION >= 105000
+        torControlThread.try_join_for(boost::chrono::seconds(1));
+#else
+        torControlThread.timed_join(boost::posix_time::seconds(1));
+#endif
         event_base_free(base);
         base = 0;
     }
 }
-


### PR DESCRIPTION
Reference: https://www.dash.org/forum/threads/v12-1-testnet-launch-thread.9014/page-7#post-95137 last section.

There were 2 issues:

1. torControlThread.join() in the TOR thread blocked the main thread from finishing. A timed_join()  fixed all 3 operating systems, but...
2. workQueue->WaitExit() in the HTTP-servers StopHTTPServer() method never comes back on Windows operating systems, and attempts to use timed waits could result in race conditions. I disabled this call for Windows operating systems. Read my comments in the code why this should work.

Tested on several Linux flavors, OSX and both Win32 and Win64.

Since I consider this a hack (and I tried literally several dozens of solutions before settling on this one) I would appreciate feedback/better solutions.

Having to wait all the time for Gitian to build the Windows version really sucks...
