### PR TITLE
fix mnw sync issues

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -606,8 +606,8 @@ void CMasternodePayments::CheckAndRemove()
 
     LOCK2(cs_mapMasternodePayeeVotes, cs_mapMasternodeBlocks);
 
-    // keep a bit more for historical sake but at least 4000
-    int nLimit = std::max(int(mnodeman.size()*1.25), 4000);
+    // keep a bit more for historical sake but at least minBlocksToStore
+    int nLimit = std::max(int(mnodeman.size() * nStorageCoeff), nMinBlocksToStore);
 
     std::map<uint256, CMasternodePaymentWinner>::iterator it = mapMasternodePayeeVotes.begin();
     while(it != mapMasternodePayeeVotes.end()) {
@@ -834,6 +834,18 @@ int CMasternodePayments::GetNewestBlock()
     }
 
     return nNewestBlock;
+}
+
+bool CMasternodePayments::IsEnoughData(int nMnCount) {
+    if(GetBlockCount() > nMnCount * nStorageCoeff || GetBlockCount() > nMinBlocksToStore)
+    {
+        float nAverageVotes = (MNPAYMENTS_SIGNATURES_TOTAL + MNPAYMENTS_SIGNATURES_REQUIRED) / 2;
+        if(GetVoteCount() > nMnCount * nStorageCoeff * nAverageVotes || GetVoteCount() > nMinBlocksToStore * nAverageVotes)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 void CMasternodePayments::UpdatedBlockTip(const CBlockIndex *pindex)

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -224,7 +224,9 @@ public:
 class CMasternodePayments
 {
 private:
-    int nSyncedFromPeer;
+    int nMinBlocksToStore;
+    float nStorageCoeff;
+
     // Keep track of current block index
     const CBlockIndex *pCurrentBlockIndex;
 
@@ -234,7 +236,8 @@ public:
     std::map<uint256, int> mapMasternodesLastVote; //Hash(BEGIN(prevout.hash), END(prevout.n)), nBlockHeight
 
     CMasternodePayments() {
-        nSyncedFromPeer = 0;
+        nMinBlocksToStore = 4000;
+        nStorageCoeff = 1.25;
     }
 
     void Clear() {
@@ -285,6 +288,8 @@ public:
     {
         return mapMasternodePayeeVotes.size();
     }
+
+    bool IsEnoughData(int nMnCount);
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -329,16 +329,10 @@ void CMasternodeSync::Process()
                     return;
                 }
 
-                // target blocks count
-                // we store nMnCount*1.25 payments blocks so nMnCount*1.2 should be enough most of the time
-                if(mnpayments.GetBlockCount() > nMnCount*1.2)
-                {   
-                    // target votes, max ten per item. 6 average should be fine
-                    if(mnpayments.GetVoteCount() > nMnCount*1.2*6)
-                    {
-                        GetNextAsset();
-                        return;
-                    }
+                // if mnpayments already has enough blocks and votes, move to the next asset
+                if(mnpayments.IsEnoughData(nMnCount)) {
+                    GetNextAsset();
+                    return;
                 }
 
                 // requesting is the last thing we do (incase we needed to move to the next asset and we've requested from each peer already)
@@ -346,7 +340,6 @@ void CMasternodeSync::Process()
                 if(pnode->HasFulfilledRequest("masternode-winner-sync")) continue;
                 pnode->FulfilledRequest("masternode-winner-sync");
 
-                int nMnCount = mnodeman.CountEnabled();
                 pnode->PushMessage(NetMsgType::MNWINNERSSYNC, nMnCount); //sync payees
                 RequestedMasternodeAttempt++;
 


### PR DESCRIPTION
This should fix mnw sync issues on testnet.
Changes:
- logic refactored and moved to `CMasternodePayments::IsEnoughData(int nMnCount)`
- magic values moved to private variables `nMinBlocksToStore` and `nStorageCoeff` (we can move them to chainparams actually to have a bit more precise control for different networks but should work as it is)
- calculate average votes from `MNPAYMENTS_SIGNATURES_TOTAL` and `MNPAYMENTS_SIGNATURES_REQUIRED` instead of hardcoding (will be bumped from 6 to 8 for current values though, which I think should actually be better to prevent unintentional forking)