### PR TITLE
remove hardcoded `strDarksendPoolDummyAddress`

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -139,7 +139,6 @@ public:
         nPoolMaxTransactions = 3;
         strSporkKey = "04549ac134f694c0243f503e8c8a9a986f5de6610049c40b07816809b0d1d06a21b07be27b9bb555931773f62ba6cf35a25fd52f694d4e1106ccd237a7bb899fdd";
         strMasternodePaymentsPubKey = "04549ac134f694c0243f503e8c8a9a986f5de6610049c40b07816809b0d1d06a21b07be27b9bb555931773f62ba6cf35a25fd52f694d4e1106ccd237a7bb899fdd";
-        strDarksendPoolDummyAddress = "Xq19GqFvajRrEdDHYRKGYjTsQfpV5jyipF";
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -243,7 +242,6 @@ public:
         nPoolMaxTransactions = 2;
         strSporkKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
         strMasternodePaymentsPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
-        strDarksendPoolDummyAddress = "y1EZuxhhNMAUofTBEeLqGE1bJrpC2TWRNp";
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
             ( 261, uint256S("0x00000c26026d0815a7e2ce4fa270775f61403c040647ff2c3091f99e894a4618"))

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -79,7 +79,6 @@ public:
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
     std::string SporkKey() const { return strSporkKey; }
-    std::string DarksendPoolDummyAddress() const { return strDarksendPoolDummyAddress; }
     std::string MasternodePaymentPubKey() const { return strMasternodePaymentsPubKey; }
 protected:
     CChainParams() {}
@@ -105,7 +104,6 @@ protected:
     int nPoolMaxTransactions;
     std::string strSporkKey;
     std::string strMasternodePaymentsPubKey;
-    std::string strDarksendPoolDummyAddress;
 };
 
 /**

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -426,17 +426,6 @@ void CDarksendPool::SetNull(){
     std::srand(seed);
 }
 
-bool CDarksendPool::SetCollateralAddress(std::string strAddress){
-    CBitcoinAddress address;
-    if (!address.SetString(strAddress))
-    {
-        LogPrintf("CDarksendPool::SetCollateralAddress - Invalid PrivateSend collateral address\n");
-        return false;
-    }
-    collateralPubKey = GetScriptForDestination(address.Get());
-    return true;
-}
-
 //
 // Unlock coins after Darksend fails or succeeds
 //

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -323,9 +323,6 @@ public:
         MSG_ENTRIES_ADDED
     };
 
-    // where collateral should be made out to
-    CScript collateralPubKey;
-
     CMasternode* pSubmittedToMasternode;
     int sessionDenom; //Users must submit an denom matching this
     int cachedNumBlocks; //used for the overview screen
@@ -361,10 +358,6 @@ public:
      * \param vRecv
      */
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
-
-    void InitCollateralAddress(){
-        SetCollateralAddress(Params().DarksendPoolDummyAddress());
-    }
 
     void ClearSkippedDenominations() {
         darkSendDenominationsSkipped.clear();
@@ -404,7 +397,6 @@ public:
         minBlockSpacing = minBlockSpacingIn;
     }
 
-    bool SetCollateralAddress(std::string strAddress);
     void Reset();
     void SetNull();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1823,24 +1823,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             MilliSleep(10);
     }
 
-    // ********************************************************* Step 10: Load cache data
-
-    // LOAD SERIALIZED DAT FILES INTO DATA CACHES FOR INTERNAL USE
-
-    uiInterface.InitMessage(_("Loading masternode cache..."));
-    CFlatDB<CMasternodeMan> flatdb1("mncache.dat", "magicMasternodeCache");
-    flatdb1.Load(mnodeman);
-
-    uiInterface.InitMessage(_("Loading masternode payment cache..."));
-    CFlatDB<CMasternodePayments> flatdb2("mnpayments.dat", "magicMasternodePaymentsCache");
-    flatdb2.Load(mnpayments);
-
-    CFlatDB<CGovernanceManager> flatdb3("governance.dat", "magicGovernanceCache");
-    flatdb3.Load(governance);
-    governance.ClearSeen();
-
-    // ********************************************************* Step 11: setup DarkSend
-
+    // ********************************************************* Step 11a: setup PrivateSend
     fMasterNode = GetBoolArg("-masternode", false);
 
     if((fMasterNode || masternodeConfig.getCount() > -1) && fTxIndex == false) {
@@ -1879,7 +1862,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             return InitError(_("You must specify a masternodeprivkey in the configuration. Please see documentation for help."));
         }
     }
-    
+
     //get the mode of budget voting for this masternode
     strBudgetMode = GetArg("-budgetvotemode", "auto");
 
@@ -1923,7 +1906,25 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("Budget Mode %s\n", strBudgetMode);
 
     darkSendPool.InitDenominations();
-    darkSendPool.InitCollateralAddress();
+    mnodeman.InitDummyScriptPubkey();
+
+    // ********************************************************* Step 11b: Load cache data
+
+    // LOAD SERIALIZED DAT FILES INTO DATA CACHES FOR INTERNAL USE
+
+    uiInterface.InitMessage(_("Loading masternode cache..."));
+    CFlatDB<CMasternodeMan> flatdb1("mncache.dat", "magicMasternodeCache");
+    flatdb1.Load(mnodeman);
+
+    uiInterface.InitMessage(_("Loading masternode payment cache..."));
+    CFlatDB<CMasternodePayments> flatdb2("mnpayments.dat", "magicMasternodePaymentsCache");
+    flatdb2.Load(mnpayments);
+
+    CFlatDB<CGovernanceManager> flatdb3("governance.dat", "magicGovernanceCache");
+    flatdb3.Load(governance);
+    governance.ClearSeen();
+
+    // ********************************************************* Step 11c: update block tip in Dash modules
 
     // force UpdatedBlockTip to initialize pCurrentBlockIndex for DS, MN payments and budgets
     // but don't call it directly to prevent triggering of other listeners like zmq etc.
@@ -1932,10 +1933,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     mnpayments.UpdatedBlockTip(chainActive.Tip());
     masternodeSync.UpdatedBlockTip(chainActive.Tip());
 
-    // start dash-darksend thread
+    // ********************************************************* Step 11d: start dash-darksend thread
+
     threadGroup.create_thread(boost::bind(&ThreadCheckDarkSendPool));
 
-    // ********************************************************* Step 11: start node
+    // ********************************************************* Step 12: start node
 
     if (!CheckDiskSpace())
         return false;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -214,7 +214,7 @@ void CMasternode::Check(bool forceCheck)
     if(!unitTest){
         CValidationState state;
         CMutableTransaction tx = CMutableTransaction();
-        CTxOut vout = CTxOut(999.99*COIN, darkSendPool.collateralPubKey);
+        CTxOut vout = CTxOut(999.99*COIN, mnodeman.dummyScriptPubkey);
         tx.vin.push_back(vin);
         tx.vout.push_back(vout);
 
@@ -479,7 +479,7 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDos)
 
     CValidationState state;
     CMutableTransaction tx = CMutableTransaction();
-    CTxOut vout = CTxOut(999.99*COIN, darkSendPool.collateralPubKey);
+    CTxOut vout = CTxOut(999.99*COIN, mnodeman.dummyScriptPubkey);
     tx.vin.push_back(vin);
     tx.vout.push_back(vout);
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -631,6 +631,22 @@ CMasternode* CMasternodeMan::GetMasternodeByRank(int nRank, int64_t nBlockHeight
     return NULL;
 }
 
+void CMasternodeMan::InitDummyScriptPubkey() {
+    CKey secret;
+    secret.MakeNewKey(true);
+
+    CPubKey pubkey = secret.GetPubKey();
+    assert(secret.VerifyPubKey(pubkey));
+
+    if (pubkey.IsValid()) {
+        CKeyID keyID = pubkey.GetID();
+        LogPrintf("Generated dummyScriptPubkey: address %s privkey %s\n", CBitcoinAddress(keyID).ToString(), CBitcoinSecret(secret).ToString());
+        dummyScriptPubkey = GetScriptForDestination(keyID);
+    } else {
+        LogPrintf("CMasternodeMan::InitDummyScriptPubkey - ERROR: can't assign dummyScriptPubkey\n");
+    }
+}
+
 void CMasternodeMan::ProcessMasternodeConnections()
 {
     //we don't care about this for regtest

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -67,9 +67,12 @@ public:
     map<uint256, CMasternodeBroadcast> mapSeenMasternodeBroadcast;
     // Keep track of all pings I've seen
     map<uint256, CMasternodePing> mapSeenMasternodePing;
-    
+
     // keep track of dsq count to prevent masternodes from gaming darksend queue
     int64_t nDsqCount;
+
+    // dummy script pubkey to test masternodes' vins against mempool
+    CScript dummyScriptPubkey;
 
     ADD_SERIALIZE_METHODS;
 
@@ -127,6 +130,8 @@ public:
     std::vector<pair<int, CMasternode> > GetMasternodeRanks(int64_t nBlockHeight, int minProtocol=0);
     int GetMasternodeRank(const CTxIn &vin, int64_t nBlockHeight, int minProtocol=0, bool fOnlyActive=true);
     CMasternode* GetMasternodeByRank(int nRank, int64_t nBlockHeight, int minProtocol=0, bool fOnlyActive=true);
+
+    void InitDummyScriptPubkey();
 
     void ProcessMasternodeConnections();
 


### PR DESCRIPTION
- use "" account address
- remove `collateralPubKey` and `SetCollateralAddress()` from darksend and create `dummyScriptPubkey` and `InitDummyScriptPubkey()` in masternodeman
- initialize `dummyScriptPubkey` before loading cache otherwise MNs could be removed because of the invalid tx