### PR TITLE
Fix masternode signatures, bump PROTOCOL_VERSION

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70200;
+static const int PROTOCOL_VERSION = 70201;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
strMessage for masternode broadcast (which we sign and verify) looks like this currently:
```
[2001:1608:45:3::242:ac11:6]:199991464464536
                                  ?~}&?Q?S?Ǚ?q	?0??????O?I/Y?(
?f?jJF??m??bssknN??9鲜JXVs?ә?5T?8??????~70200
```
which I believe in some cases leads to "Got bad Masternode ping signature" errors and banning.

I propose to change the way strMessage is composed so that it looks like this:
`[2002:82ff:c04:2:a90f:2261:43c4:2745]:1999514645552319591ec70225aacadfafa4ab5d21e87cdce641fd4030d029485434533c5e481578a9d471089fb5ec170200`

Further more `nDos` for old masternodes is set to 0 to stop false positives (message still gets rejected though).