### PR TITLE
developement process updated in correspondence with .12.1 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,27 +27,15 @@ License
 Dash Core is released under the terms of the MIT license. See [COPYING](COPYING) for more
 information or see http://opensource.org/licenses/MIT.
 
-Development process
+Development Process
 -------------------
 
-Developers work in their own trees, then submit pull requests when they think
-their feature or bug fix is ready.
+The `master` branch is meant to be stable. Development is normally done in separate branches.
+[Tags](https://github.com/bitcoin/bitcoin/tags) are created to indicate new official,
+stable release versions of Dash Core.
 
-If it is a simple/trivial/non-controversial change, then one of the Dash
-development team members simply pulls it.
+The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-If it is a *more complicated or potentially controversial* change, then the patch
-submitter will be asked to start a discussion (if they haven't already) on the
-[mailing list](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev)
-
-The patch will be accepted if there is broad consensus that it is a good thing.
-Developers should expect to rework and resubmit patches if the code doesn't
-match the project's coding conventions (see [doc/coding.md](doc/coding.md)) or are
-controversial.
-
-The `master` branch is regularly built and tested, but is not guaranteed to be
-completely stable. [Tags](https://github.com/dashpay/dash/tags) are created
-regularly to indicate new official, stable release versions of Dash. ***TODO***
 
 Testing
 -------


### PR DESCRIPTION
this one is confusing. dash is not using bitcoin-dev mailing list. when I found Dash github first many months ago I was confused.