### PR TITLE
Yet another fix for rpc autoCompleter

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -339,6 +339,14 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
                 return true;
             }
             break;
+        case Qt::Key_Return:
+        case Qt::Key_Enter:
+            // forward these events to lineEdit
+            if(obj == autoCompleter->popup()) {
+                QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
+                return true;
+            }
+            break;
         default:
             // Typing in messages widget brings focus to line edit, and redirects key there
             // Exclude most combinations and keys that emit no text, except paste shortcuts
@@ -473,9 +481,7 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         autoCompleter = new QCompleter(wordList, this);
         ui->lineEdit->setCompleter(autoCompleter);
-
-        // clear the lineEdit after activating from QCompleter
-        connect(autoCompleter, SIGNAL(activated(const QString&)), ui->lineEdit, SLOT(clear()), Qt::QueuedConnection);
+        autoCompleter->popup()->installEventFilter(this);
     }
 }
 


### PR DESCRIPTION
#752 was not enough, edit field wasn't cleared sometimes

How to reproduce the issue in current build: open Console, close it, open it again, start writing some rpc command and try to pick it from the list using arrow keys, hit Enter. Now edit field is not being cleared as it should be, works on second try only (i.e. same as before).

Using event filter to forward messages from autoCompleter popup to lineEdit instead of using `connect` method solves the issue.

EDIT: hold on, there is smth more

EDIT2: done, should be working now :)

EDIT3: works for me on mac, pls test on windows and linux