### PR TITLE
Disable incorrect MN signature ban

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -387,7 +387,8 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     std::string errorMessage = "";
     if(!darkSendSigner.VerifyMessage(pubkey, sig, strMessage, errorMessage)){
         LogPrintf("mnb - Got bad Masternode address signature\n");
-        nDos = 100;
+        // There is a bug in MN signatures, ignore such MN but do not ban the peer we got this from
+        // nDos = 100;
         return false;
     }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -874,7 +874,8 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         std::string errorMessage = "";
         if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)){
             LogPrintf("dsee - Got bad Masternode address signature\n");
-            Misbehaving(pfrom->GetId(), 100);
+            // There is a bug in MN signatures, ignore such MN but do not ban the peer we got this from
+            // Misbehaving(pfrom->GetId(), 100);
             return;
         }
 


### PR DESCRIPTION
There is a bug in MN signatures, ignore such MN but do not ban the peer we got this signature from. Bug will be fixed in 0.12.1.x via #836 