### PR TITLE
Allow MNANNOUNCE relay to local address on Test network

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -557,10 +557,11 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDos)
     CMasternode mn(*this);
     mnodeman.Add(mn);
 
-    bool isLocal = addr.IsRFC1918() || addr.IsLocal();
-    if(Params().NetworkIDString() == CBaseChainParams::REGTEST) isLocal = false;
+    bool isLocal = (addr.IsRFC1918() || addr.IsLocal());
+    // Not Relay for local address on Main network
+    if(isLocal && Params().NetworkIDString() == CBaseChainParams::MAIN) return true;
 
-    if(!isLocal) Relay();
+    Relay();
 
     return true;
 }


### PR DESCRIPTION
In case of many masternode with different port running on same host and connect to other nodes in same host with local address , the Masternode Broadcast should be able to relay, shouldn't it?