### PR TITLE
[0.12.1.x] More compatibility for old ipv6 format + refactor

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -293,7 +293,7 @@ public:
     bool CheckAndUpdate(int& nDos);
     bool CheckInputsAndAdd(int& nDos);
     bool Sign(CKey& keyCollateralAddress);
-    bool VerifySignature();
+    bool VerifySignature(int& nDos);
     void Relay();
 
     ADD_SERIALIZE_METHODS;

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -778,6 +778,7 @@ UniValue masternodebroadcast(const UniValue& params, bool fHelp)
 
         int successful = 0;
         int failed = 0;
+        int nDos = 0;
 
         std::vector<CMasternodeBroadcast> vecMnb;
         UniValue returnObj(UniValue::VOBJ);
@@ -788,7 +789,7 @@ UniValue masternodebroadcast(const UniValue& params, bool fHelp)
         BOOST_FOREACH(CMasternodeBroadcast& mnb, vecMnb) {
             UniValue resultObj(UniValue::VOBJ);
 
-            if(mnb.VerifySignature()) {
+            if(mnb.VerifySignature(nDos)) {
                 successful++;
                 resultObj.push_back(Pair("vin", mnb.vin.ToString()));
                 resultObj.push_back(Pair("addr", mnb.addr.ToString()));
@@ -846,7 +847,7 @@ UniValue masternodebroadcast(const UniValue& params, bool fHelp)
 
             int nDos = 0;
             bool fResult;
-            if (mnb.VerifySignature()) {
+            if (mnb.VerifySignature(nDos)) {
                 if (fSafe) {
                     fResult = mnodeman.CheckMnbAndUpdateMasternodeList(mnb, nDos);
                 } else {


### PR DESCRIPTION
Changes:
- try old format ipv6 if new format failed to verify
- sanitize log strings
- remove redundant ability to sign `CMasternodeBroadcast` in `protocolVersion < 70201` way
- verify `CMasternodeBroadcast` signature immediately on `Sign`
- move all `CMasternodeBroadcast` sig verification from `CheckAndUpdate` to `VerifySignature`
- initialize `nDos` at the beginning of functions so that we don't accidentally ban or reject legit MN if caller function forgot to reinitialize it