### PR TITLE
[UI] Column alignement of Transaction-Tab adjusted

### DIFF
--- a/src/qt/res/css/crownium.css
+++ b/src/qt/res/css/crownium.css
@@ -1508,10 +1508,24 @@ border:1px solid #d7d7d7;
 
 /* TRANSACTIONS PAGE */
 
-TransactionView QLineEdit { /* Address Filter */
+TransactionView QLineEdit { /* Filters */
 margin-bottom:2px;
 margin-right:1px;
 min-width:111px;
+text-align:center;
+}
+
+TransactionView QLineEdit#addressWidget { /* Address Filter */
+margin-bottom:2px;
+margin-right:1px;
+min-width:405px;
+text-align:center;
+}
+
+TransactionView QLineEdit#amountWidget { /* Amount Filter */
+margin-bottom:2px;
+margin-right:1px;
+max-width:100px;
 text-align:center;
 }
 

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -1491,10 +1491,24 @@ border:1px solid #d7d7d7;
 
 /* TRANSACTIONS PAGE */
 
-TransactionView QLineEdit { /* Address Filter */
+TransactionView QLineEdit { /* Filters */
 margin-bottom:2px;
 margin-right:1px;
 min-width:111px;
+text-align:center;
+}
+
+TransactionView QLineEdit#addressWidget { /* Address Filter */
+margin-bottom:2px;
+margin-right:1px;
+min-width:405px;
+text-align:center;
+}
+
+TransactionView QLineEdit#amountWidget { /* Amount Filter */
+margin-bottom:2px;
+margin-right:1px;
+max-width:100px;
 text-align:center;
 }
 

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -1501,10 +1501,24 @@ border:1px solid #d7d7d7;
 
 /* TRANSACTIONS PAGE */
 
-TransactionView QLineEdit { /* Address Filter */
+TransactionView QLineEdit { /* Filters */
 margin-bottom:2px;
 margin-right:1px;
 min-width:111px;
+text-align:center;
+}
+
+TransactionView QLineEdit#addressWidget { /* Address Filter */
+margin-bottom:2px;
+margin-right:1px;
+min-width:405px;
+text-align:center;
+}
+
+TransactionView QLineEdit#amountWidget { /* Amount Filter */
+margin-bottom:2px;
+margin-right:1px;
+max-width:100px;
 text-align:center;
 }
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -243,7 +243,7 @@ TransactionTableModel::TransactionTableModel(const PlatformStyle *platformStyle,
         fProcessingQueuedTransactions(false),
         platformStyle(platformStyle)
 {
-    columns << QString() << QString() << tr("Date") << tr("Type") << tr("Label") << BitcoinUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
+    columns << QString() << QString() << tr("Date") << tr("Type") << tr("Address / Label") << BitcoinUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
     priv->refreshWallet();
 
     connect(walletModel->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -46,15 +46,13 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
 
     QHBoxLayout *hlayout = new QHBoxLayout();
     hlayout->setContentsMargins(0,0,0,0);
-
     if (platformStyle->getUseExtraSpacing()) {
-        hlayout->setSpacing(5);
-        hlayout->addSpacing(26);
-    } else {
         hlayout->setSpacing(0);
-        hlayout->addSpacing(23);
+        hlayout->addSpacing(6);
+    } else {
+        hlayout->setSpacing(1);
+        hlayout->addSpacing(5);
     }
-
     QString theme = GUIUtil::getThemeName();
     watchOnlyWidget = new QComboBox(this);
     watchOnlyWidget->setFixedWidth(24);
@@ -65,7 +63,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
 
     dateWidget = new QComboBox(this);
     if (platformStyle->getUseExtraSpacing()) {
-        dateWidget->setFixedWidth(121);
+        dateWidget->setFixedWidth(120);
     } else {
         dateWidget->setFixedWidth(120);
     }
@@ -81,9 +79,9 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
 
     typeWidget = new QComboBox(this);
     if (platformStyle->getUseExtraSpacing()) {
-        typeWidget->setFixedWidth(TYPE_COLUMN_WIDTH+1);
-    } else {
         typeWidget->setFixedWidth(TYPE_COLUMN_WIDTH);
+    } else {
+        typeWidget->setFixedWidth(TYPE_COLUMN_WIDTH-1);
     }
 
     typeWidget->addItem(tr("All"), TransactionFilterProxy::ALL_TYPES);
@@ -108,6 +106,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
 #if QT_VERSION >= 0x040700
     addressWidget->setPlaceholderText(tr("Enter address or label to search"));
 #endif
+    addressWidget->setObjectName("addressWidget");
     hlayout->addWidget(addressWidget);
 
     amountWidget = new QLineEdit(this);
@@ -115,11 +114,12 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     amountWidget->setPlaceholderText(tr("Min amount"));
 #endif
     if (platformStyle->getUseExtraSpacing()) {
-        amountWidget->setFixedWidth(97);
+        amountWidget->setFixedWidth(118);
     } else {
-        amountWidget->setFixedWidth(100);
-    }
+        amountWidget->setFixedWidth(125);
+    }  
     amountWidget->setValidator(new QDoubleValidator(0, 1e20, 8, this));
+    amountWidget->setObjectName("amountWidget");
     hlayout->addWidget(amountWidget);
 
     QVBoxLayout *vlayout = new QVBoxLayout(this);
@@ -592,6 +592,6 @@ bool TransactionView::eventFilter(QObject *obj, QEvent *event)
 // show/hide column Watch-only
 void TransactionView::updateWatchOnlyColumn(bool fHaveWatchOnly)
 {
-    watchOnlyWidget->setVisible(fHaveWatchOnly);
+    watchOnlyWidget->setVisible(true);
     transactionView->setColumnHidden(TransactionTableModel::Watchonly, !fHaveWatchOnly);
 }


### PR DESCRIPTION
Reference: https://github.com/dashpay/dash/issues/788

Looks now acceptable (but not perfect) on all 3 operating systems.

- Linux+Win: looks good
- OSX: columns almost all perfectly aligned minus the traditional (Qt-) theme. Will fix this somewhere in the future and ONLY if someone really complains.
- Watched/Unwatched addresses ComboBox (the small one on the left side) is now always visible. It doesn't make sense to implement tons of hard to understand logic to fix the positions of the visible boxes and explain the CSS that this box is not always there.
- I have left some obsolete if/else statement in the code in case the OSX build needs more finetuning. TransactionView::updateWatchOnlyColumn() is actually also not needed anymore, but I've kept it in case we should need it again in the future.

Looks like this:
![transtab](https://cloud.githubusercontent.com/assets/10080039/15807330/88a4ac30-2b5b-11e6-878b-4c494b57e36b.jpg)
