### PR TITLE
Enable/disable advanced PrivateSend UI

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -164,6 +164,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="showAdvancedPSUI">
+            <property name="toolTip">
+             <string>Show additional information and buttons for PrivateSend on overview screen.</string>
+            </property>
+            <property name="text">
+             <string>Enable advanced PrivateSend interface</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="spendZeroConfChange">
             <property name="toolTip">
              <string>If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</string>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -393,13 +393,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QFrame" name="frameDarksend">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>350</height>
-          </size>
-         </property>
+        <widget class="QFrame" name="framePrivateSend">
          <property name="layoutDirection">
           <enum>Qt::LeftToRight</enum>
          </property>
@@ -409,707 +403,227 @@
          <property name="frameShadow">
           <enum>QFrame::Raised</enum>
          </property>
-         <widget class="QWidget" name="formLayoutWidget">
-          <property name="geometry">
-           <rect>
-            <x>10</x>
-            <y>40</y>
-            <width>451</width>
-            <height>161</height>
-           </rect>
-          </property>
-          <layout class="QFormLayout" name="formLayout">
-           <property name="fieldGrowthPolicy">
-            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-           </property>
-           <property name="horizontalSpacing">
-            <number>11</number>
-           </property>
-           <property name="verticalSpacing">
-            <number>12</number>
-           </property>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Status:</string>
+         <layout class="QVBoxLayout" name="VerticalLayout_PS1">
+          <item>
+           <widget class="QWidget" name="layoutWidgetPrivateSendHeader">
+            <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <item>
+              <widget class="QLabel" name="labelPrivateSendHeader">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>PrivateSend</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="labelPrivateSendSyncStatus">
+               <property name="toolTip">
+                <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Dash network after a connection is established, but this process has not completed yet.</string>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">QLabel { color: red; }</string>
+               </property>
+               <property name="text">
+                <string notr="true">(out of sync)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="privateSendFormLayoutWidget">
+            <layout class="QFormLayout" name="privateSendFormLayout">
+             <property name="fieldGrowthPolicy">
+              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
              </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>Completion:</string>
+             <property name="horizontalSpacing">
+              <number>11</number>
              </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QProgressBar" name="darksendProgress">
-             <property name="maximumSize">
-              <size>
-               <width>154</width>
-               <height>16777215</height>
-              </size>
+             <property name="verticalSpacing">
+              <number>12</number>
              </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="labelAnonymizedText">
-             <property name="text">
-              <string>PrivateSend Balance:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QLabel" name="labelAnonymized">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string notr="true">0 DASH</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_8">
-             <property name="text">
-              <string>Amount and Rounds:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QLabel" name="labelAmountRounds">
-             <property name="text">
-              <string>0 DASH / 0 Rounds</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_9">
-             <property name="text">
-              <string>Submitted Denom:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QLabel" name="labelSubmittedDenom">
-             <property name="toolTip">
-              <string>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</string>
-             </property>
-             <property name="text">
-              <string>n/a</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="darksendEnabled">
-             <property name="text">
-              <string>Enabled/Disabled</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QPushButton" name="runAutoDenom">
-          <property name="geometry">
-           <rect>
-            <x>251</x>
-            <y>17</y>
-            <width>1</width>
-            <height>1</height>
-           </rect>
-          </property>
-          <property name="palette">
-           <palette>
-            <active>
-             <colorrole role="WindowText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Button">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>239</red>
-                <green>238</green>
-                <blue>238</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Light">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>255</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Midlight">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>247</red>
-                <green>246</green>
-                <blue>246</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>119</green>
-                <blue>119</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Mid">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>159</red>
-                <green>159</green>
-                <blue>159</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="BrightText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>255</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Base">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>255</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Window">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>239</red>
-                <green>238</green>
-                <blue>238</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Shadow">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="AlternateBase">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>247</red>
-                <green>246</green>
-                <blue>246</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ToolTipBase">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>220</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ToolTipText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </active>
-            <inactive>
-             <colorrole role="WindowText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Button">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>239</red>
-                <green>238</green>
-                <blue>238</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Light">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>255</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Midlight">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>247</red>
-                <green>246</green>
-                <blue>246</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>119</green>
-                <blue>119</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Mid">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>159</red>
-                <green>159</green>
-                <blue>159</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="BrightText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>255</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Base">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>255</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Window">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>239</red>
-                <green>238</green>
-                <blue>238</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Shadow">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="AlternateBase">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>247</red>
-                <green>246</green>
-                <blue>246</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ToolTipBase">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>220</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ToolTipText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </inactive>
-            <disabled>
-             <colorrole role="WindowText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>119</green>
-                <blue>119</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Button">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>239</red>
-                <green>238</green>
-                <blue>238</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Light">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>255</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Midlight">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>247</red>
-                <green>246</green>
-                <blue>246</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Dark">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>119</green>
-                <blue>119</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Mid">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>159</red>
-                <green>159</green>
-                <blue>159</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Text">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>119</green>
-                <blue>119</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="BrightText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>255</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ButtonText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>119</green>
-                <blue>119</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Base">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>239</red>
-                <green>238</green>
-                <blue>238</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Window">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>239</red>
-                <green>238</green>
-                <blue>238</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="Shadow">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="AlternateBase">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>239</red>
-                <green>238</green>
-                <blue>238</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ToolTipBase">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>255</red>
-                <green>255</green>
-                <blue>220</blue>
-               </color>
-              </brush>
-             </colorrole>
-             <colorrole role="ToolTipText">
-              <brush brushstyle="SolidPattern">
-               <color alpha="255">
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </brush>
-             </colorrole>
-            </disabled>
-           </palette>
-          </property>
-          <property name="focusPolicy">
-           <enum>Qt::NoFocus</enum>
-          </property>
-          <property name="autoFillBackground">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-         </widget>
-         <widget class="QPushButton" name="toggleDarksend">
-          <property name="geometry">
-           <rect>
-            <x>10</x>
-            <y>292</y>
-            <width>221</width>
-            <height>56</height>
-           </rect>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Start/Stop Mixing</string>
-          </property>
-         </widget>
-         <widget class="Line" name="lineLastMessage">
-          <property name="geometry">
-           <rect>
-            <x>10</x>
-            <y>200</y>
-            <width>441</width>
-            <height>16</height>
-           </rect>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-         <widget class="QLabel" name="darksendStatus">
-          <property name="geometry">
-           <rect>
-            <x>10</x>
-            <y>220</y>
-            <width>451</width>
-            <height>61</height>
-           </rect>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>288</width>
-            <height>43</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>(Last Message)</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-         <widget class="QPushButton" name="darksendAuto">
-          <property name="geometry">
-           <rect>
-            <x>230</x>
-            <y>292</y>
-            <width>221</width>
-            <height>28</height>
-           </rect>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Try to manually submit a PrivateSend request.</string>
-          </property>
-          <property name="text">
-           <string>Try Mix</string>
-          </property>
-         </widget>
-         <widget class="QPushButton" name="darksendReset">
-          <property name="geometry">
-           <rect>
-            <x>230</x>
-            <y>320</y>
-            <width>221</width>
-            <height>28</height>
-           </rect>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Reset the current status of PrivateSend (can interrupt PrivateSend if it's in the process of Mixing, which can cost you money!)</string>
-          </property>
-          <property name="autoFillBackground">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Reset</string>
-          </property>
-         </widget>
-         <widget class="QWidget" name="layoutWidget">
-          <property name="geometry">
-           <rect>
-            <x>10</x>
-            <y>10</y>
-            <width>431</width>
-            <height>22</height>
-           </rect>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <item>
-            <widget class="QLabel" name="label_2">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>PrivateSend</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="labelDarksendSyncStatus">
-             <property name="toolTip">
-              <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Dash network after a connection is established, but this process has not completed yet.</string>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">QLabel { color: red; }</string>
-             </property>
-             <property name="text">
-              <string notr="true">(out of sync)</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_4">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelPrivateSendEnabledText">
+               <property name="text">
+                <string>Status:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="labelPrivateSendEnabled">
+               <property name="text">
+                <string>Enabled/Disabled</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="labelCompletitionText">
+               <property name="text">
+                <string>Completion:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QProgressBar" name="privateSendProgress">
+               <property name="maximumSize">
+                <size>
+                 <width>154</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="value">
+                <number>0</number>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="labelAnonymizedText">
+               <property name="text">
+                <string>PrivateSend Balance:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="labelAnonymized">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string notr="true">0 DASH</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="labelAmountAndRoundsText">
+               <property name="text">
+                <string>Amount and Rounds:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QLabel" name="labelAmountRounds">
+               <property name="text">
+                <string>0 DASH / 0 Rounds</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="labelSubmittedDenomText">
+               <property name="text">
+                <string>Submitted Denom:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QLabel" name="labelSubmittedDenom">
+               <property name="toolTip">
+                <string>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</string>
+               </property>
+               <property name="text">
+                <string>n/a</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="layoutWidgetLastMessageAndButtons">
+            <layout class="QVBoxLayout" name="VerticalLayout_PS">
+             <item>
+              <widget class="QLabel" name="labelPrivateSendLastMessage">
+               <property name="text">
+                <string>(Last Message)</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="togglePrivateSend">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Start/Stop Mixing</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_debugbuttons">
+               <item>
+                <widget class="QPushButton" name="privateSendAuto">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Try to manually submit a PrivateSend request.</string>
+                 </property>
+                 <property name="text">
+                  <string>Try Mix</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="privateSendReset">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>Reset the current status of PrivateSend (can interrupt PrivateSend if it's in the process of Mixing, which can cost you money!)</string>
+                 </property>
+                 <property name="autoFillBackground">
+                  <bool>false</bool>
+                 </property>
+                 <property name="text">
+                  <string>Reset</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -197,6 +197,7 @@ void OptionsDialog::setMapper()
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
     mapper->addMapping(ui->showMasternodesTab, OptionsModel::ShowMasternodesTab);
+    mapper->addMapping(ui->showAdvancedPSUI, OptionsModel::ShowAdvancedPSUI);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
     mapper->addMapping(ui->privateSendRounds, OptionsModel::PrivateSendRounds);
     mapper->addMapping(ui->anonymizeDash, OptionsModel::AnonymizeDashAmount);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -84,6 +84,10 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fShowMasternodesTab"))
         settings.setValue("fShowMasternodesTab", masternodeConfig.getCount());
 
+    if (!settings.contains("fShowAdvancedPSUI"))
+        settings.setValue("fShowAdvancedPSUI", false);
+    fShowAdvancedPSUI = settings.value("fShowAdvancedPSUI", false).toBool();
+
     // These are shared with the core or have a command-line parameter
     // and we want command-line parameters to overwrite the GUI settings.
     //
@@ -110,7 +114,7 @@ void OptionsModel::Init(bool resetSettings)
     if (!SoftSetBoolArg("-spendzeroconfchange", settings.value("bSpendZeroConfChange").toBool()))
         addOverriddenOption("-spendzeroconfchange");
 
-    // Darksend
+    // PrivateSend
     if (!settings.contains("nPrivateSendRounds"))
         settings.setValue("nPrivateSendRounds", 2);
     if (!SoftSetArg("-privatesendrounds", settings.value("nPrivateSendRounds").toString().toStdString()))
@@ -239,6 +243,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
 #ifdef ENABLE_WALLET
         case SpendZeroConfChange:
             return settings.value("bSpendZeroConfChange");
+        case ShowAdvancedPSUI:
+            return fShowAdvancedPSUI;
         case PrivateSendRounds:
             return settings.value("nPrivateSendRounds");
         case AnonymizeDashAmount:
@@ -367,12 +373,17 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 setRestartRequired(true);
             }
             break;
+        case ShowAdvancedPSUI:
+            fShowAdvancedPSUI = value.toBool();
+            settings.setValue("fShowAdvancedPSUI", fShowAdvancedPSUI);
+            Q_EMIT advancedPSUIChanged(fShowAdvancedPSUI);
+            break;
         case PrivateSendRounds:
             if (settings.value("nPrivateSendRounds") != value)
             {
                 nPrivateSendRounds = value.toInt();
                 settings.setValue("nPrivateSendRounds", nPrivateSendRounds);
-                Q_EMIT darksendRoundsChanged();
+                Q_EMIT privateSendRoundsChanged();
             }
             break;
         case AnonymizeDashAmount:

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -46,6 +46,7 @@ public:
         ThreadsScriptVerif,     // int
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
+        ShowAdvancedPSUI,       // bool
         PrivateSendRounds,      // int
         AnonymizeDashAmount,    // int
         ShowMasternodesTab,     // bool
@@ -69,6 +70,7 @@ public:
     QString getThirdPartyTxUrls() { return strThirdPartyTxUrls; }
     bool getProxySettings(QNetworkProxy& proxy) const;
     bool getCoinControlFeatures() { return fCoinControlFeatures; }
+    bool getShowAdvancedPSUI() { return fShowAdvancedPSUI; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
 
     /* Restart flag helper */
@@ -84,6 +86,7 @@ private:
     int nDisplayUnit;
     QString strThirdPartyTxUrls;
     bool fCoinControlFeatures;
+    bool fShowAdvancedPSUI;
     /* settings that were overriden by command-line */
     QString strOverriddenByCommandLine;
 
@@ -92,8 +95,9 @@ private:
 
 Q_SIGNALS:
     void displayUnitChanged(int unit);
-    void darksendRoundsChanged();
+    void privateSendRoundsChanged();
     void anonymizeDashAmountChanged();
+    void advancedPSUIChanged(bool);
     void coinControlFeaturesChanged(bool);
 };
 

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -37,7 +37,7 @@ public:
     void showOutOfSyncWarning(bool fShow);
 
 public Q_SLOTS:
-    void darkSendStatus();
+    void privateSendStatus();
     void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& anonymizedBalance,
                     const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
 
@@ -62,11 +62,12 @@ private:
     TransactionFilterProxy *filter;
 
 private Q_SLOTS:
-    void toggleDarksend();
-    void darksendAuto();
-    void darksendReset();
+    void togglePrivateSend();
+    void privateSendAuto();
+    void privateSendReset();
     void updateDisplayUnit();
-    void updateDarksendProgress();
+    void updatePrivateSendProgress();
+    void updateAdvancedPSUI(bool fShowAdvancedPSUI);
     void handleTransactionClicked(const QModelIndex &index);
     void updateAlerts(const QString &warnings);
     void updateWatchOnlyLabels(bool showWatchOnly);

--- a/src/qt/res/css/crownium.css
+++ b/src/qt/res/css/crownium.css
@@ -873,18 +873,21 @@ font-size:12px;
 margin-left:16px;
 }
 
-/* DARKSEND WIDGET */
+/* PRIVATESEND WIDGET */
 
-QWidget .QFrame#frameDarksend { /* Darksend Widget */
+QWidget .QFrame#framePrivateSend { /* PrivateSend Widget */
 background-color:transparent;
-qproperty-minimumSize: 451px 343px;
+max-width: 451px;
+min-width: 451px;
+max-height: 350px;
 }
 
-QWidget .QFrame#frameDarksend QWidget {
-qproperty-geometry: rect(10 0 431 35);
+QWidget .QFrame#framePrivateSend .QWidget#layoutWidgetPrivateSendHeader { /* PrivateSend Header */
+max-width: 421px;
+min-width: 421px;
 }
 
-QWidget .QFrame#frameDarksend .QLabel#label_2 { /* Darksend Header */
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendHeader { /* PrivateSend Header */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #000000, stop: .4 #444444, stop: .6 #444444, stop: 1 #000000);
@@ -895,24 +898,26 @@ padding-right:5px;
 font-weight:bold;
 font-size:14px;
 min-height:35px;
+max-height:35px;
 }
 /******************************************************************/
-QWidget .QFrame#frameDarksend .QLabel#labelDarksendSyncStatus { /* Darksend Sync Status */
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendSyncStatus { /* PrivateSend Sync Status */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 margin-left:2px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget {
-qproperty-geometry: rect(10 51 451 175);
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget {
+max-width: 451px;
+max-height: 175px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget > .QLabel {
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget > .QLabel {
 min-width:175px;
 font-weight:normal;
 min-height:25px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_6 { /* Darksend Status Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelPrivateSendEnabledText { /* PrivateSend Status Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F0F0F0;
@@ -920,11 +925,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#darksendEnabled { /* Darksend Status */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelPrivateSendEnabled { /* PrivateSend Status */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_7 { /* Darksend Completion Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelCompletitionText { /* PrivateSend Completion Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F0F0F0;
@@ -933,7 +938,7 @@ padding-right:5px;
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QProgressBar#darksendProgress { /* Darksend Completion */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QProgressBar#privateSendProgress { /* PrivateSend Completion */
 border: 1px solid #333333;
 border-radius: 1px;
 margin-right:43px;
@@ -941,12 +946,12 @@ text-align: right;
 color:#333333;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QProgressBar#darksendProgress::chunk {
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QProgressBar#privateSendProgress::chunk {
 background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #000000, stop: .4 #EEEEEE, stop: .6 #EEEEEE, stop: 1 #000000);
 width:1px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAnonymizedText { /* Darksend Balance Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAnonymizedText { /* PrivateSend Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F0F0F0;
@@ -954,11 +959,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAnonymized { /* Darksend Balance */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAnonymized { /* PrivateSend Balance */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_8 { /* Darksend Amount and Rounds Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAmountAndRoundsText { /* PrivateSend Amount and Rounds Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F0F0F0;
@@ -966,11 +971,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAmountRounds { /* Darksend Amount and Rounds */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAmountRounds { /* PrivateSend Amount and Rounds */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_9 { /* Darksend Submitted Denom Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelSubmittedDenomText { /* PrivateSend Submitted Denom Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F0F0F0;
@@ -978,34 +983,34 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelSubmittedDenom { /* Darksend Submitted Denom */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelSubmittedDenom { /* PrivateSend Submitted Denom */
 
 }
 
-QWidget .QFrame#frameDarksend .QLabel#darksendStatus { /* Darksend Status Notifications */
+QWidget .QFrame#framePrivateSend .QWidget#layoutWidgetLastMessageAndButtons {
+max-width: 451px;
+}
+
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendLastMessage { /* PrivateSend Status Notifications */
 qproperty-alignment: 'AlignVCenter | AlignCenter';
-qproperty-geometry: rect(70 226 395 34);
+min-width: 288px;
+min-height: 43px;
 font-size:11px;
 color:#222222;
 }
 
-/* DARKSEND BUTTONS */
+/* PRIVATESEND BUTTONS */
 
-QWidget .QFrame#frameDarksend .QPushButton { /* Darksend Buttons - General Attributes */
+QWidget .QFrame#framePrivateSend .QPushButton { /* PrivateSend Buttons - General Attributes */
 border:0px solid #ffffff;
 }
 
-QWidget .QFrame#frameDarksend QPushButton:focus {
+QWidget .QFrame#framePrivateSend QPushButton:focus {
 border:none;
 outline:none;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#runAutoDenom { /* No idea why this button is in the .UI file... */
-qproperty-geometry: rect(0 0 0 0);
-}
-
-QWidget .QFrame#frameDarksend .QPushButton#toggleDarksend { /* Start Darksend Mixing */
-qproperty-geometry: rect(115 268 295 40);
+QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend { /* Start PrivateSend Mixing */
 font-size:15px;
 font-weight:bold;
 color:#000000;
@@ -1015,12 +1020,11 @@ padding-top:5px;
 padding-bottom:6px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#toggleDarksend:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend:hover {
 
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto { /* Try Mix Button */
-qproperty-geometry: rect(120 314 140 25);
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto { /* Try Mix Button */
 background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222, stop: .3 #FFFFFF, stop: .7 #FFFFFF, stop: 1 #222222);
 border:1px solid #d2d2d2;
 color:#616161;
@@ -1029,17 +1033,16 @@ font-size:9px;
 padding:0px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto:hover {
 background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222, stop: .2 #FFFFFF, stop: .6 #FFFFFF, stop: 1 #222222);
 color:#000000;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto:pressed {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto:pressed {
 border:1px solid #9e9e9e;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset { /* Reset Button */
-qproperty-geometry: rect(265 314 140 25);
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset { /* Reset Button */
 background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222, stop: .3 #FFFFFF, stop: .7 #FFFFFF, stop: 1 #222222);
 border:1px solid #d2d2d2;
 color:#616161;
@@ -1048,12 +1051,12 @@ font-size:9px;
 padding:0px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:hover {
 background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222, stop: .2 #FFFFFF, stop: .6 #FFFFFF, stop: 1 #222222);
 color:#000000;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset:pressed {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:pressed {
 border:1px solid #9e9e9e;
 }
 
@@ -1174,7 +1177,7 @@ QDialog#SendCoinsDialog .QPushButton#addButton:pressed {
 
 }
 
-QDialog#SendCoinsDialog .QCheckBox#checkUseDarksend { /* Darksend Checkbox */
+QDialog#SendCoinsDialog .QCheckBox#checkUseDarksend { /* PrivateSend Checkbox */
 color:#555555;
 font-weight:bold;
 background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -851,18 +851,21 @@ font-size:12px;
 margin-left:16px;
 }
 
-/* DARKSEND WIDGET */
+/* PRIVATESEND WIDGET */
 
-QWidget .QFrame#frameDarksend { /* Darksend Widget */
+QWidget .QFrame#framePrivateSend { /* PrivateSend Widget */
 background-color:transparent;
-qproperty-minimumSize: 451px 343px;
+max-width: 451px;
+min-width: 451px;
+max-height: 350px;
 }
 
-QWidget .QFrame#frameDarksend QWidget {
-qproperty-geometry: rect(10 0 431 35);
+QWidget .QFrame#framePrivateSend .QWidget#layoutWidgetPrivateSendHeader { /* PrivateSend Header */
+max-width: 421px;
+min-width: 421px;
 }
 
-QWidget .QFrame#frameDarksend .QLabel#label_2 { /* Darksend Header */
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendHeader { /* PrivateSend Header */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#56ABD8;
@@ -872,24 +875,26 @@ padding-right:5px;
 font-weight:bold;
 font-size:14px;
 min-height:35px;
+max-height:35px;
 }
 /******************************************************************/
-QWidget .QFrame#frameDarksend .QLabel#labelDarksendSyncStatus { /* Darksend Sync Status */
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendSyncStatus { /* PrivateSend Sync Status */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 margin-left:2px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget {
-qproperty-geometry: rect(10 51 451 175);
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget {
+max-width: 451px;
+max-height: 175px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget > .QLabel {
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget > .QLabel {
 min-width:175px;
 font-weight:normal;
 min-height:25px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_6 { /* Darksend Status Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelPrivateSendEnabledText { /* PrivateSend Status Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -897,11 +902,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#darksendEnabled { /* Darksend Status */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelPrivateSendEnabled { /* PrivateSend Status */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_7 { /* Darksend Completion Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelCompletitionText { /* PrivateSend Completion Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -910,7 +915,7 @@ padding-right:5px;
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QProgressBar#darksendProgress { /* Darksend Completion */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QProgressBar#privateSendProgress { /* PrivateSend Completion */
 border: 1px solid #818181;
 border-radius: 1px;
 margin-right:43px;
@@ -918,12 +923,12 @@ text-align: right;
 color:#818181;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QProgressBar#darksendProgress::chunk {
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QProgressBar#privateSendProgress::chunk {
 background-color: #3398CC;
 width:1px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAnonymizedText { /* Darksend Balance Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAnonymizedText { /* PrivateSend Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -931,11 +936,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAnonymized { /* Darksend Balance */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAnonymized { /* PrivateSend Balance */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_8 { /* Darksend Amount and Rounds Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAmountAndRoundsText { /* PrivateSend Amount and Rounds Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -943,11 +948,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAmountRounds { /* Darksend Amount and Rounds */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAmountRounds { /* PrivateSend Amount and Rounds */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_9 { /* Darksend Submitted Denom Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelSubmittedDenomText { /* PrivateSend Submitted Denom Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -955,34 +960,34 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelSubmittedDenom { /* Darksend Submitted Denom */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelSubmittedDenom { /* PrivateSend Submitted Denom */
 
 }
 
-QWidget .QFrame#frameDarksend .QLabel#darksendStatus { /* Darksend Status Notifications */
+QWidget .QFrame#framePrivateSend .QWidget#layoutWidgetLastMessageAndButtons {
+max-width: 451px;
+}
+
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendLastMessage { /* PrivateSend Status Notifications */
 qproperty-alignment: 'AlignVCenter | AlignCenter';
-qproperty-geometry: rect(70 226 395 34);
+min-width: 288px;
+min-height: 43px;
 font-size:11px;
 color:#818181;
 }
 
-/* DARKSEND BUTTONS */
+/* PRIVATESEND BUTTONS */
 
-QWidget .QFrame#frameDarksend .QPushButton { /* Darksend Buttons - General Attributes */
+QWidget .QFrame#framePrivateSend .QPushButton { /* PrivateSend Buttons - General Attributes */
 border:0px solid #ffffff;
 }
 
-QWidget .QFrame#frameDarksend QPushButton:focus {
+QWidget .QFrame#framePrivateSend QPushButton:focus {
 border:none;
 outline:none;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#runAutoDenom { /* No idea why this button is in the .UI file... */
-qproperty-geometry: rect(0 0 0 0);
-}
-
-QWidget .QFrame#frameDarksend .QPushButton#toggleDarksend { /* Start Darksend Mixing */
-qproperty-geometry: rect(115 268 295 40);
+QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend { /* Start PrivateSend Mixing */
 font-size:15px;
 font-weight:bold;
 color:#ffffff;
@@ -992,12 +997,11 @@ padding-top:5px;
 padding-bottom:6px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#toggleDarksend:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend:hover {
 
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto { /* Try Mix Button */
-qproperty-geometry: rect(120 314 140 25);
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto { /* Try Mix Button */
 background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
 border:1px solid #d2d2d2;
 color:#616161;
@@ -1006,17 +1010,16 @@ font-size:9px;
 padding:0px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto:hover {
 background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
 color:#333;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto:pressed {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto:pressed {
 border:1px solid #9e9e9e;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset { /* Reset Button */
-qproperty-geometry: rect(265 314 140 25);
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset { /* Reset Button */
 background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
 border:1px solid #d2d2d2;
 color:#616161;
@@ -1025,12 +1028,12 @@ font-size:9px;
 padding:0px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:hover {
 background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
 color:#333;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset:pressed {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:pressed {
 border:1px solid #9e9e9e;
 }
 
@@ -1158,7 +1161,7 @@ QDialog#SendCoinsDialog .QPushButton#addButton:pressed {
 border:1px solid #9e9e9e;
 }
 
-QDialog#SendCoinsDialog .QCheckBox#checkUseDarksend { /* Darksend Checkbox */
+QDialog#SendCoinsDialog .QCheckBox#checkUseDarksend { /* PrivateSend Checkbox */
 color:#616161;
 font-weight:bold;
 background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -856,45 +856,52 @@ font-size:12px;
 margin-left:16px;
 }
 
-/* DARKSEND WIDGET */
+/* PRIVATESEND WIDGET */
 
-QWidget .QFrame#frameDarksend { /* Darksend Widget */
+QWidget .QFrame#framePrivateSend { /* PrivateSend Widget */
 background-color:transparent;
-qproperty-minimumSize: 451px 353px;
+max-width: 451px;
+min-width: 451px;
+max-height: 350px;
 }
 
-QWidget .QFrame#frameDarksend QWidget {
-qproperty-geometry: rect(10 0 431 35);
+QWidget .QFrame#framePrivateSend .QWidget#layoutWidgetPrivateSendHeader { /* PrivateSend Header */
+max-width: 421px;
+min-width: 421px;
 }
 
-QWidget .QFrame#frameDarksend .QLabel#label_2 { /* Darksend Header */
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendHeader { /* PrivateSend Header */
 qproperty-alignment: 'AlignVCenter | AlignCenter';
-min-width:451px;
+max-width: 421px;
+min-width: 421px;
 background-color:#1c75bc;
 color:#fff;
-margin-right:5px;
-padding-right:5px;
+margin-right: 5px;
+padding-right: 5px;
 font-weight:bold;
 font-size:14px;
 min-height:35px;
+max-height:35px;
 }
 /******************************************************************/
-QWidget .QFrame#frameDarksend .QLabel#labelDarksendSyncStatus { /* Darksend Sync Status */
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendSyncStatus { /* PrivateSend Sync Status */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 margin-left:2px;
+padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget {
-qproperty-geometry: rect(10 51 451 175);
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget {
+max-width: 451px;
+max-height: 175px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget > .QLabel {
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget > .QLabel {
 min-width:175px;
 font-weight:normal;
 min-height:25px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_6 { /* Darksend Status Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelPrivateSendEnabledText { /* PrivateSend Enabled Status Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -902,11 +909,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#darksendEnabled { /* Darksend Status */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelPrivateSendEnabled { /* PrivateSend Enabled Status */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_7 { /* Darksend Completion Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelCompletitionText { /* PrivateSend Completion Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -915,7 +922,7 @@ padding-right:5px;
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QProgressBar#darksendProgress { /* Darksend Completion */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QProgressBar#privateSendProgress { /* PrivateSend Completion */
 border: 1px solid #818181;
 border-radius: 1px;
 margin-right:43px;
@@ -923,12 +930,12 @@ text-align: right;
 color:#818181;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QProgressBar#darksendProgress::chunk {
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QProgressBar#privateSendProgress::chunk {
 background-color: #1c75bc;
 width:1px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAnonymizedText { /* Darksend Balance Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAnonymizedText { /* PrivateSend Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -936,11 +943,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAnonymized { /* Darksend Balance */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAnonymized { /* PrivateSend Balance */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_8 { /* Darksend Amount and Rounds Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAmountAndRoundsText { /* PrivateSend Amount and Rounds Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -948,11 +955,11 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelAmountRounds { /* Darksend Amount and Rounds */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelAmountRounds { /* PrivateSend Amount and Rounds */
 
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#label_9 { /* Darksend Submitted Denom Label */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelSubmittedDenomText { /* PrivateSend Submitted Denom Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
 background-color:#F8F6F6;
@@ -960,34 +967,35 @@ margin-right:5px;
 padding-right:5px;
 }
 
-QWidget .QFrame#frameDarksend #formLayoutWidget .QLabel#labelSubmittedDenom { /* Darksend Submitted Denom */
+QWidget .QFrame#framePrivateSend #privateSendFormLayoutWidget .QLabel#labelSubmittedDenom { /* PrivateSend Submitted Denom */
 
 }
 
-QWidget .QFrame#frameDarksend .QLabel#darksendStatus { /* Darksend Status Notifications */
+QWidget .QFrame#framePrivateSend .QWidget#layoutWidgetLastMessageAndButtons {
+max-width: 451px;
+}
+
+QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendLastMessage { /* PrivateSend Status Notifications */
 qproperty-alignment: 'AlignVCenter | AlignCenter';
-qproperty-geometry: rect(9 226 441 34);
+min-width: 288px;
+min-height: 43px;
 font-size:11px;
 color:#818181;
 }
 
-/* DARKSEND BUTTONS */
+/* PRIVATESEND BUTTONS */
 
-QWidget .QFrame#frameDarksend .QPushButton { /* Darksend Buttons - General Attributes */
+QWidget .QFrame#framePrivateSend .QPushButton { /* PrivateSend Buttons - General Attributes */
 border:0px solid #ffffff;
 }
 
-QWidget .QFrame#frameDarksend QPushButton:focus {
+QWidget .QFrame#framePrivateSend QPushButton:focus {
 border:none;
 outline:none;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#runAutoDenom { /* No idea why this button is in the .UI file... */
-qproperty-geometry: rect(0 0 0 0);
-}
-
-QWidget .QFrame#frameDarksend .QPushButton#toggleDarksend { /* Start Darksend Mixing */
-    qproperty-geometry: rect(9 268 441 40);
+QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend { /* Start PrivateSend Mixing */
+min-height: 40px;
 font-size:15px;
 font-weight:normal;
 color:#ffffff;
@@ -997,12 +1005,11 @@ padding-top:5px;
 padding-bottom:6px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#toggleDarksend:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend:hover {
 
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto { /* Try Mix Button */
-    qproperty-geometry: rect(9 314 220 30);
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto { /* Try Mix Button */
 background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
 border:1px solid #d2d2d2;
 color:#616161;
@@ -1011,17 +1018,16 @@ font-size:9px;
 padding:0px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto:hover {
 background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
 color:#333;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendAuto:pressed {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendAuto:pressed {
 border:1px solid #9e9e9e;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset { /* Reset Button */
-    qproperty-geometry: rect(232 314 220 30);
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset { /* Reset Button */
 background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
 border:1px solid #d2d2d2;
 color:#616161;
@@ -1030,12 +1036,12 @@ font-size:9px;
 padding:0px;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset:hover {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:hover {
 background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
 color:#333;
 }
 
-QWidget .QFrame#frameDarksend .QPushButton#darksendReset:pressed {
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:pressed {
 border:1px solid #9e9e9e;
 }
 
@@ -1164,7 +1170,7 @@ QDialog#SendCoinsDialog .QPushButton#addButton:pressed {
 border:1px solid #9e9e9e;
 }
 
-QDialog#SendCoinsDialog .QCheckBox#checkUseDarksend { /* Darksend Checkbox */
+QDialog#SendCoinsDialog .QCheckBox#checkUseDarksend { /* PrivateSend Checkbox */
 color:#616161;
 font-weight:bold;
 background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));


### PR DESCRIPTION
Implement an option to enable/disable advanced PrivateSend UI, hides progress bar and few fields and debug button.
Address #827 in some way - wasn't able to achieve anything reasonable via css, so took that approach instead. Should look like this:

![screen shot 2016-06-06 at 5 30 01](https://cloud.githubusercontent.com/assets/1935069/15815512/9aba73fe-2bde-11e6-8654-bb0a7b0c51e3.png)
![screen shot 2016-06-06 at 5 34 34](https://cloud.githubusercontent.com/assets/1935069/15815515/9e7e2a12-2bde-11e6-9ab4-e91f072473aa.png)

Also refactored overview tab and themes, more DS->PS there.
Tested on Mac only, Win and Linux testers are welcome :)