### PR TITLE
[UI] Dynamically adjust recent tx list item count + fix #789 (probably)

### DIFF
--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -61,6 +61,8 @@ private:
     TxViewDelegate *txdelegate;
     TransactionFilterProxy *filter;
 
+    void SetupTransactionList(int nNumItems);
+
 private Q_SLOTS:
     void togglePrivateSend();
     void privateSendAuto();


### PR DESCRIPTION
Dynamically adjust recent tx list item count (on overview screen) in correspondence with fShowAdvancedPSUI state and litemode. Continuing from https://github.com/dashpay/dash/pull/869#issuecomment-224534936

And it looks like I accidentally found a fix for #789 , also included here :)