### PR TITLE
follow up for #885 - ignore non-spendable in mnconflock

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1867,12 +1867,12 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         BOOST_FOREACH(CMasternodeConfig::CMasternodeEntry mne, masternodeConfig.getEntries()) {
             mnTxHash.SetHex(mne.getTxHash());
             outputIndex = boost::lexical_cast<unsigned int>(mne.getOutputIndex());
-            // don't lock spent
-            if(pwalletMain->IsSpent(mnTxHash, outputIndex)) {
-                LogPrintf("  %s %s - SPENT, not locked\n", mne.getTxHash(), mne.getOutputIndex());
+            COutPoint outpoint = COutPoint(mnTxHash, outputIndex);
+            // don't lock non-spendable outpoint (i.e. it's already spent or it's not from this wallet at all)
+            if(pwalletMain->IsMine(CTxIn(outpoint)) != ISMINE_SPENDABLE) {
+                LogPrintf("  %s %s - IS NOT SPENDABLE, was not locked\n", mne.getTxHash(), mne.getOutputIndex());
                 continue;
             }
-            COutPoint outpoint = COutPoint(mnTxHash, outputIndex);
             pwalletMain->LockCoin(outpoint);
             LogPrintf("  %s %s - locked successfully\n", mne.getTxHash(), mne.getOutputIndex());
         }


### PR DESCRIPTION
Looks like @splawik21 accidentally 😉 found yet another issue with mnconflock: https://www.dash.org/forum/threads/old-darkcoin-wallet-dat-lost-coins.9135/#post-96731

We should ignore not only outpoints which are already spend but also outpoints which are not from currently loaded wallet i.e. we should ignore all non-spendable.