### PR TITLE
Add `getblockheaders` RPC

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -80,6 +80,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listunspent", 2 },
     { "getblock", 1 },
     { "getblockheader", 1 },
+    { "getblockheaders", 1 },
+    { "getblockheaders", 2 },
     { "gettransaction", 1 },
     { "getrawtransaction", 1 },
     { "createrawtransaction", 0 },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -282,6 +282,7 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "getblock",               &getblock,               true  },
     { "blockchain",         "getblockhash",           &getblockhash,           true  },
     { "blockchain",         "getblockheader",         &getblockheader,         true  },
+    { "blockchain",         "getblockheaders",        &getblockheaders,        true  },
     { "blockchain",         "getchaintips",           &getchaintips,           true  },
     { "blockchain",         "getdifficulty",          &getdifficulty,          true  },
     { "blockchain",         "getmempoolinfo",         &getmempoolinfo,         true  },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -276,6 +276,7 @@ extern UniValue getmempoolinfo(const UniValue& params, bool fHelp);
 extern UniValue getrawmempool(const UniValue& params, bool fHelp);
 extern UniValue getblockhash(const UniValue& params, bool fHelp);
 extern UniValue getblockheader(const UniValue& params, bool fHelp);
+extern UniValue getblockheaders(const UniValue& params, bool fHelp);
 extern UniValue getblock(const UniValue& params, bool fHelp);
 extern UniValue gettxoutsetinfo(const UniValue& params, bool fHelp);
 extern UniValue gettxout(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Returns an array of block headers at once (max/default count is the same as for p2p i.e. `MAX_HEADERS_RESULTS` == 2000).

@snogcel