### PR TITLE
Refactor InstantSend to use block count instead of local time

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -76,6 +76,8 @@ public:
         consensus.nMasternodePaymentsStartBlock = 100000; // not true, but it's ok as long as it's less then nMasternodePaymentsIncreaseBlock
         consensus.nMasternodePaymentsIncreaseBlock = 158000; // actual historical value
         consensus.nMasternodePaymentsIncreasePeriod = 576*30; // 17280 - actual historical value
+        consensus.nInstantSendKeepLock = 24;
+        consensus.nInstantSendReprocessBlocks = 15;
         consensus.nBudgetPaymentsStartBlock = 328008; // actual historical value
         consensus.nBudgetPaymentsCycleBlocks = 16616; // ~(60*24*30)/2.6, actual number of blocks per month is 200700 / 12 = 16725
         consensus.nBudgetPaymentsWindowBlocks = 100;
@@ -191,6 +193,8 @@ public:
         consensus.nMasternodePaymentsStartBlock = 10000; // not true, but it's ok as long as it's less then nMasternodePaymentsIncreaseBlock
         consensus.nMasternodePaymentsIncreaseBlock = 46000;
         consensus.nMasternodePaymentsIncreasePeriod = 576;
+        consensus.nInstantSendKeepLock = 6;
+        consensus.nInstantSendReprocessBlocks = 4;
         consensus.nBudgetPaymentsStartBlock = 78476;
         consensus.nBudgetPaymentsCycleBlocks = 50;
         consensus.nBudgetPaymentsWindowBlocks = 10;
@@ -288,6 +292,8 @@ public:
         consensus.nMasternodePaymentsStartBlock = 240;
         consensus.nMasternodePaymentsIncreaseBlock = 350;
         consensus.nMasternodePaymentsIncreasePeriod = 10;
+        consensus.nInstantSendKeepLock = 6;
+        consensus.nInstantSendReprocessBlocks = 4;
         consensus.nBudgetPaymentsStartBlock = 1000;
         consensus.nBudgetPaymentsCycleBlocks = 50;
         consensus.nBudgetPaymentsWindowBlocks = 100;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -40,6 +40,8 @@ struct Params {
     int nMasternodePaymentsStartBlock;
     int nMasternodePaymentsIncreaseBlock;
     int nMasternodePaymentsIncreasePeriod; // in blocks
+    int nInstantSendKeepLock; // in blocks
+    int nInstantSendReprocessBlocks;
     int nBudgetPaymentsStartBlock;
     int nBudgetPaymentsCycleBlocks;
     int nBudgetPaymentsWindowBlocks;

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -108,7 +108,7 @@ public:
     int nBlockHeight;
     uint256 txHash;
     std::vector<CConsensusVote> vecConsensusVotes;
-    int nExpiration;
+    int nLockExpirationBlock;
     int nTimeout;
 
     bool VotesValid();


### PR DESCRIPTION
Refactor InstantSend to use block count instead of local time to set expiration limit - `nInstantSendKeepLock`. Also make it (and number of blocks to reprocess in case of a conflict - `nInstantSendReprocessBlocks`) a part of Consensus params and set it to lower numbers for testnet/regtest to be able to break things easier there.

Bump `MIN_INSTANTX_PROTO_VERSION`

PS. The reason for this is that security is brought by the "work" done in pow and the "time" is a kind of derivative so even though on average they should match I think it might make sense to rely on the "work" itself rather then on a derivative.

@evan82 