### PR TITLE
Change default datadir

### DIFF
--- a/contrib/debian/manpages/dash.conf.5
+++ b/contrib/debian/manpages/dash.conf.5
@@ -8,7 +8,7 @@ The configuration file is a list of 'setting=value' pairs, one per line, with op
 .TP
 The configuration file is not automatically created; you can create it using your favorite plain-text editor. By default, dashd(1) will look for a file named dash.conf(5) in the dash data directory, but both the data directory and the configuration file path may be changed using the '\-datadir' and '\-conf' command-line arguments.
 .SH LOCATION
-dash.conf should be located in $HOME/.dash
+dash.conf should be located in $HOME/.dashcore
 
 .SH "SEE ALSO"
 dashd(1)

--- a/contrib/linearize/example-linearize-testnet.cfg
+++ b/contrib/linearize/example-linearize-testnet.cfg
@@ -10,7 +10,7 @@ max_height=3130000
 
 # bootstrap.dat input/output settings (linearize-data)
 netmagic=cee2caff
-input=/home/example/.dash/testnet3/blocks
+input=/home/example/.dashcore/testnet3/blocks
 output_file=/home/example/Downloads/bootstrap.dat
 hashlist=hashlist.txt
 split_year=1

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -10,7 +10,7 @@ max_height=3130000
 
 # bootstrap.dat input/output settings (linearize-data)
 netmagic=bf0c6bbd
-input=/home/example/.dash/blocks
+input=/home/example/.dashcore/blocks
 output_file=/home/example/Downloads/bootstrap.dat
 hashlist=hashlist.txt
 split_year=1

--- a/contrib/spendfrom/README.md
+++ b/contrib/spendfrom/README.md
@@ -7,7 +7,7 @@ address (or addresses).
 Depends on [jsonrpc](http://json-rpc.org/).
 
 	spendfrom.py --from=FROMADDRESS1[,FROMADDRESS2] --to=TOADDRESS --amount=amount \
-	             --fee=fee --datadir=/path/to/.dash --testnet --dry_run
+	             --fee=fee --datadir=/path/to/.dashcore --testnet --dry_run
 
 With no arguments, outputs a list of amounts associated with addresses.
 

--- a/contrib/spendfrom/spendfrom.py
+++ b/contrib/spendfrom/spendfrom.py
@@ -35,10 +35,10 @@ def check_json_precision():
 def determine_db_dir():
     """Return the default location of the dash data directory"""
     if platform.system() == "Darwin":
-        return os.path.expanduser("~/Library/Application Support/Dash/")
+        return os.path.expanduser("~/Library/Application Support/DashCore/")
     elif platform.system() == "Windows":
-        return os.path.join(os.environ['APPDATA'], "Dash")
-    return os.path.expanduser("~/.dash")
+        return os.path.join(os.environ['APPDATA'], "DashCore")
+    return os.path.expanduser("~/.dashcore")
 
 def read_bitcoin_config(dbdir):
     """Read the dash.conf file from dbdir, returns dictionary of settings"""

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -102,14 +102,14 @@ directory. We have to first create the RPC configuration file, though.
 Run `./dashd` to get the filename where it should be put, or just try these
 commands:
 
-    echo -e "rpcuser=dashrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Dash/dash.conf"
-    chmod 600 "/Users/${USER}/Library/Application Support/Dash/dash.conf"
+    echo -e "rpcuser=dashrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/DashCore/dash.conf"
+    chmod 600 "/Users/${USER}/Library/Application Support/DashCore/dash.conf"
 
 The next time you run it, it will start downloading the blockchain, but it won't
 output anything while it's doing this. This process may take several hours;
 you can monitor its process by looking at the debug.log file, like this:
 
-    tail -f $HOME/Library/Application\ Support/Dash/debug.log
+    tail -f $HOME/Library/Application\ Support/DashCore/debug.log
 
 Other commands:
 -------

--- a/doc/guide-startmany.md
+++ b/doc/guide-startmany.md
@@ -120,7 +120,7 @@ If you generated a new masternode private key, you will need to update the remot
 
 Shut down the daemon and then edit the file.
 
-```nano .dash/dash.conf```
+```nano .dashcore/dash.conf```
 
 ### Edit the masternodeprivkey
 If you generated a new masternode private key, you will need to update the `masternodeprivkey` value in your remote `dash.conf` file.

--- a/doc/init.md
+++ b/doc/init.md
@@ -68,9 +68,9 @@ can then be controlled by group membership.
 3b) Mac OS X
 
 Binary:              `/usr/local/bin/dashd`  
-Configuration file:  `~/Library/Application Support/Dash/dash.conf`  
-Data directory:      `~/Library/Application Support/Dash`
-Lock file:           `~/Library/Application Support/Dash/.lock`
+Configuration file:  `~/Library/Application Support/DashCore/dash.conf`  
+Data directory:      `~/Library/Application Support/DashCore`
+Lock file:           `~/Library/Application Support/DashCore/.lock`
 
 4. Installing Service Configuration
 -----------------------------------

--- a/doc/masternode_conf.md
+++ b/doc/masternode_conf.md
@@ -2,9 +2,9 @@ Multi masternode config
 =======================
 
 The multi masternode config allows to control multiple masternodes from a single wallet. The wallet needs to have a valid collaral output of 1000 coins for each masternode. To use this, place a file named `masternode.conf` in the data directory of your install:
- * Windows: %APPDATA%\Dash\
- * Mac OS: ~/Library/Application Support/Dash/
- * Unix/Linux: ~/.dash/
+ * Windows: %APPDATA%\DashCore\
+ * Mac OS: ~/Library/Application Support/DashCore/
+ * Unix/Linux: ~/.dashcore/
 
 `masternode.conf` format is a space seperated text file. Each line consisting of an alias, IP address followed by port, masternode private key, collateral output transaction id and collateral output index.
 

--- a/qa/pull-tester/run-bitcoind-for-test.sh.in
+++ b/qa/pull-tester/run-bitcoind-for-test.sh.in
@@ -3,7 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
-DATADIR="@abs_top_builddir@/.dash"
+DATADIR="@abs_top_builddir@/.dashcore"
 rm -rf "$DATADIR"
 mkdir -p "$DATADIR"/regtest
 touch "$DATADIR/regtest/debug.log"

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -50,9 +50,9 @@ Var StartMenuGroup
 # Installer attributes
 OutFile @abs_top_srcdir@/dash-${VERSION}-win@WINDOWS_BITS@-setup.exe
 !if "@WINDOWS_BITS@" == "64"
-InstallDir $PROGRAMFILES64\Dash
+InstallDir $PROGRAMFILES64\DashCore
 !else
-InstallDir $PROGRAMFILES\Dash
+InstallDir $PROGRAMFILES\DashCore
 !endif
 CRCCheck on
 XPStyle on

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -528,13 +528,13 @@ void PrintExceptionContinue(const std::exception* pex, const char* pszThread)
 boost::filesystem::path GetDefaultDataDir()
 {
     namespace fs = boost::filesystem;
-    // Windows < Vista: C:\Documents and Settings\Username\Application Data\Dash
-    // Windows >= Vista: C:\Users\Username\AppData\Roaming\Dash
-    // Mac: ~/Library/Application Support/Dash
-    // Unix: ~/.dash
+    // Windows < Vista: C:\Documents and Settings\Username\Application Data\DashCore
+    // Windows >= Vista: C:\Users\Username\AppData\Roaming\DashCore
+    // Mac: ~/Library/Application Support/DashCore
+    // Unix: ~/.dashcore
 #ifdef WIN32
     // Windows
-    return GetSpecialFolderPath(CSIDL_APPDATA) / "Dash";
+    return GetSpecialFolderPath(CSIDL_APPDATA) / "DashCore";
 #else
     fs::path pathRet;
     char* pszHome = getenv("HOME");
@@ -546,10 +546,10 @@ boost::filesystem::path GetDefaultDataDir()
     // Mac
     pathRet /= "Library/Application Support";
     TryCreateDirectory(pathRet);
-    return pathRet / "Dash";
+    return pathRet / "DashCore";
 #else
     // Unix
-    return pathRet / ".dash";
+    return pathRet / ".dashcore";
 #endif
 #endif
 }


### PR DESCRIPTION
Change default datadir from `Dash(Win,Mac)/.dash(Linux)` to `DashCore(Win,Mac)/.dashcore(Linux)` as discussed in #898 
Changing package/dist name/user/settings will probably follow next in another PR (could blow up things, will require a lot more attention imo).