### PR TITLE
Randomize DoAuto timeouts

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2308,6 +2308,7 @@ void ThreadCheckDarkSendPool()
     RenameThread("dash-privatesend");
 
     unsigned int c = 0;
+    unsigned int nDoAutoNextRun = c + DARKSEND_AUTO_TIMEOUT_MIN;
 
     while (true)
     {
@@ -2335,8 +2336,10 @@ void ThreadCheckDarkSendPool()
             darkSendPool.CheckTimeout();
             darkSendPool.CheckForCompleteQueue();
 
-            if(darkSendPool.GetState() == POOL_STATUS_IDLE && c % 15 == 0){
-                darkSendPool.DoAutomaticDenominating();
+            if(nDoAutoNextRun == c) {
+                if(darkSendPool.GetState() == POOL_STATUS_IDLE) darkSendPool.DoAutomaticDenominating();
+
+                nDoAutoNextRun = c + DARKSEND_AUTO_TIMEOUT_MIN + insecure_rand()%(DARKSEND_AUTO_TIMEOUT_MAX - DARKSEND_AUTO_TIMEOUT_MIN);
             }
         }
     }

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -36,6 +36,8 @@ class CActiveMasternode;
 #define MASTERNODE_REJECTED                    0
 #define MASTERNODE_RESET                       -1
 
+#define DARKSEND_AUTO_TIMEOUT_MIN               5
+#define DARKSEND_AUTO_TIMEOUT_MAX              15
 #define DARKSEND_QUEUE_TIMEOUT                 30
 #define DARKSEND_SIGNING_TIMEOUT               15
 


### PR DESCRIPTION
Having fixed timeouts here can create some kind of pattern in long run which (potentially) could be used by malicious participants (to disrupt one's mixing process for example). Shouldn't be an issue if number of mixing users is large enough but we are not there yet ;)