### PR TITLE
Refactor masternode output selection

### DIFF
--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -32,10 +32,6 @@ private:
     /// Create Masternode broadcast, needs to be relayed manually after that
     bool CreateBroadcast(CTxIn vin, CService service, CKey key, CPubKey pubKey, CKey keyMasternode, CPubKey pubKeyMasternode, std::string &errorMessage, CMasternodeBroadcast &mnb);
 
-    /// Get 1000DRK input that can be used for the Masternode
-    bool GetMasterNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey, std::string strTxHash, std::string strOutputIndex);
-    bool GetVinFromOutput(COutput out, CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
-
 public:
     // Initialized by init.cpp
     // Keys for the main Masternode
@@ -59,10 +55,6 @@ public:
 
     /// Create Masternode broadcast, needs to be relayed manually after that
     bool CreateBroadcast(std::string strService, std::string strKey, std::string strTxHash, std::string strOutputIndex, std::string& errorMessage, CMasternodeBroadcast &mnb, bool fOffline = false);
-
-    /// Get 1000DRK input that can be used for the Masternode
-    bool GetMasterNodeVin(CTxIn& vin, CPubKey& pubkey, CKey& secretKey);
-    vector<COutput> SelectCoinsMasternode();
 
     /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -206,12 +206,10 @@ UniValue masternode(const UniValue& params, bool fHelp)
         CTxIn vin = CTxIn();
         CPubKey pubkey = CPubKey();
         CKey key;
-        bool found = activeMasternode.GetMasterNodeVin(vin, pubkey, key);
-        if(!found){
+        if(!pwalletMain || !pwalletMain->GetMasternodeVinAndKeys(vin, pubkey, key))
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Missing masternode input, please look at the documentation for instructions on masternode creation");
-        } else {
-            return activeMasternode.GetStatus();
-        }
+
+        return activeMasternode.GetStatus();
     }
 
     if(strCommand == "enforce")
@@ -402,12 +400,12 @@ UniValue masternode(const UniValue& params, bool fHelp)
 
     if (strCommand == "outputs"){
         // Find possible candidates
-        vector<COutput> possibleCoins = activeMasternode.SelectCoinsMasternode();
+        std::vector<COutput> vPossibleCoins;
+        pwalletMain->AvailableCoins(vPossibleCoins, true, NULL, false, ONLY_1000);
 
         UniValue obj(UniValue::VOBJ);
-        BOOST_FOREACH(COutput& out, possibleCoins) {
+        BOOST_FOREACH(COutput& out, vPossibleCoins)
             obj.push_back(Pair(out.tx->GetHash().ToString(), strprintf("%d", out.i)));
-        }
 
         return obj;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -95,7 +95,8 @@ enum AvailableCoinsType
     ALL_COINS = 1,
     ONLY_DENOMINATED = 2,
     ONLY_NOT1000IFMN = 3,
-    ONLY_NONDENOMINATED_NOT1000IFMN = 4
+    ONLY_NONDENOMINATED_NOT1000IFMN = 4,
+    ONLY_1000 = 5 // find masternode outputs including locked ones (use with caution)
 };
 
 
@@ -632,13 +633,18 @@ public:
      */
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
-    bool SelectCoinsDark(CAmount nValueMin, CAmount nValueMax, std::vector<CTxIn>& setCoinsRet, CAmount& nValueRet, int nPrivateSendRoundsMin, int nPrivateSendRoundsMax) const;
     bool SelectCoinsByDenominations(int nDenom, CAmount nValueMin, CAmount nValueMax, std::vector<CTxIn>& vCoinsRet, std::vector<COutput>& vCoinsRet2, CAmount& nValueRet, int nPrivateSendRoundsMin, int nPrivateSendRoundsMax);
-    bool SelectCoinsDarkDenominated(CAmount nTargetValue, std::vector<CTxIn>& setCoinsRet, CAmount& nValueRet) const;
+    bool SelectCoinsCollateral(std::vector<CTxIn>& setCoinsRet, CAmount& nValueRet) const ;
+    bool SelectCoinsDark(CAmount nValueMin, CAmount nValueMax, std::vector<CTxIn>& setCoinsRet, CAmount& nValueRet, int nPrivateSendRoundsMin, int nPrivateSendRoundsMax) const;
+
+    /// Get 1000DASH input that can be used for the Masternode
+    bool GetMasternodeVinAndKeys(CTxIn& vinRet, CPubKey& pubKeyRet, CKey& keyRet, std::string strTxHash = "", std::string strOutputIndex = "");
+    // Extract vin information from output
+    bool GetVinAndKeysFromOutput(COutput out, CTxIn& vinRet, CPubKey& pubKeyRet, CKey& keyRet);
+
     bool HasCollateralInputs(bool fOnlyConfirmed = true) const;
     bool IsCollateralAmount(CAmount nInputAmount) const;
     int  CountInputsWithAmount(CAmount nInputAmount);
-    bool SelectCoinsCollateral(std::vector<CTxIn>& setCoinsRet, CAmount& nValueRet) const ;
     CAmount GetTotalValue(std::vector<CTxIn> vCoins);
 
     // get the Darksend chain depth for a given input


### PR DESCRIPTION
Changes:
- move wallet related functions GetMasternodeVin and GetVinFromOutput from activemasternode.cpp/h to wallet.cpp/h (renamed, refactored)
- use new ONLY_1000 coin type to avoid unlocking/locking mn outputs and cut down loops count from 2 to 1 (SelectCoinsMasternode removed)