### PR TITLE
Fix sync process

### DIFF
--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -43,7 +43,7 @@ CGovernanceVote::CGovernanceVote(CTxIn vinMasternodeIn, uint256 nParentHashIn, i
 
 void CGovernanceVote::Relay()
 {
-    CInv inv(MSG_GOVERNANCE_VOTE, GetHash());
+    CInv inv(MSG_GOVERNANCE_OBJECT_VOTE, GetHash());
     RelayInv(inv, MSG_GOVERNANCE_PEER_PROTO_VERSION);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4686,12 +4686,6 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     case MSG_MASTERNODE_WINNER:
         return mnpayments.mapMasternodePayeeVotes.count(inv.hash);
 
-    case MSG_GOVERNANCE_VOTE:
-        return governance.mapVotesByHash.count(inv.hash);
-
-    case MSG_GOVERNANCE_OBJECT:
-        return governance.mapObjects.count(inv.hash);
-
     case MSG_MASTERNODE_ANNOUNCE:
         return mnodeman.mapSeenMasternodeBroadcast.count(inv.hash);
 
@@ -4700,7 +4694,14 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
     case MSG_DSTX:
         return mapDarksendBroadcastTxes.count(inv.hash);
+
+    case MSG_GOVERNANCE_OBJECT:
+        return governance.mapObjects.count(inv.hash);
+
+    case MSG_GOVERNANCE_OBJECT_VOTE:
+        return governance.mapVotesByHash.count(inv.hash);
     }
+
     // Don't know what it is, just say we already got one
     return true;
 }
@@ -4861,26 +4862,6 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                         pushed = true;
                     }
                 }
-            
-                if (!pushed && inv.type == MSG_GOVERNANCE_VOTE) {
-                    if(governance.mapVotesByHash.count(inv.hash)) {
-                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                        ss.reserve(1000);
-                        ss << governance.mapVotesByHash[inv.hash];
-                        pfrom->PushMessage(NetMsgType::MNGOVERNANCEVOTE, ss);
-                        pushed = true;
-                    }
-                }
-
-                if (!pushed && inv.type == MSG_GOVERNANCE_OBJECT) {
-                    if(governance.mapObjects.count(inv.hash)) {
-                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                        ss.reserve(1000);
-                        ss << governance.mapObjects[inv.hash];
-                        pfrom->PushMessage(NetMsgType::MNGOVERNANCEOBJECT, ss);
-                        pushed = true;
-                    }
-                }
 
                 if (!pushed && inv.type == MSG_MASTERNODE_ANNOUNCE) {
                     if(mnodeman.mapSeenMasternodeBroadcast.count(inv.hash)){
@@ -4917,6 +4898,25 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     }
                 }
 
+                if (!pushed && inv.type == MSG_GOVERNANCE_OBJECT) {
+                    if(governance.mapObjects.count(inv.hash)) {
+                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+                        ss.reserve(1000);
+                        ss << governance.mapObjects[inv.hash];
+                        pfrom->PushMessage(NetMsgType::MNGOVERNANCEOBJECT, ss);
+                        pushed = true;
+                    }
+                }
+
+                if (!pushed && inv.type == MSG_GOVERNANCE_OBJECT_VOTE) {
+                    if(governance.mapVotesByHash.count(inv.hash)) {
+                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+                        ss.reserve(1000);
+                        ss << governance.mapVotesByHash[inv.hash];
+                        pfrom->PushMessage(NetMsgType::MNGOVERNANCEOBJECTVOTE, ss);
+                        pushed = true;
+                    }
+                }
 
                 if (!pushed)
                     vNotFound.push_back(inv);

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -161,7 +161,7 @@ public:
     }
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool IsValid(CNode* pnode, std::string& strError);
+    bool IsValid(CNode* pnode, int nValidationHeight, std::string& strError);
     bool SignatureValid();
     void Relay();
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -317,9 +317,20 @@ public:
 
     uint256 GetHash(){
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << vin;
-        ss << pubkey;
-        ss << sigTime;
+        //
+        // REMOVE AFTER MIGRATION TO 12.1
+        //
+        if(protocolVersion < 70201) {
+            ss << sigTime;
+            ss << pubkey;
+        } else {
+        //
+        // END REMOVE
+        //
+            ss << vin;
+            ss << pubkey;
+            ss << sigTime;
+        }
         return ss.GetHash();
     }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -586,6 +586,9 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
     } else if (strCommand == NetMsgType::DSEG) { //Get Masternode list or specific entry
 
+        // ignore such request until we are fully synced
+        if (!masternodeSync.IsSynced()) return;
+
         CTxIn vin;
         vRecv >> vin;
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -43,11 +43,11 @@ const char *GETSPORKS="getsporks";
 const char *MNWINNER="mnw";
 const char *MNWINNERSSYNC="mnget";
 const char *MNSCANERROR="mn scan error"; // not implemented
-const char *MNGOVERNANCESYNC="mnvs";
-const char *MNGOVERNANCEVOTE="mvote";
-const char *MNGOVERNANCEOBJECT="mprop";
-const char *MNGOVERNANCEFINAL="fbs";
-const char *MNGOVERNANCEFINALVOTE="fbvote";
+const char *MNBUDGETSYNC="mnvs"; // depreciated since 12.1
+const char *MNBUDGETVOTE="mvote"; // depreciated since 12.1
+const char *MNBUDGETPROPOSAL="mprop"; // depreciated since 12.1
+const char *MNBUDGETFINAL="fbs"; // depreciated since 12.1
+const char *MNBUDGETFINALVOTE="fbvote"; // depreciated since 12.1
 const char *MNQUORUM="mn quorum"; // not implemented
 const char *MNANNOUNCE="mnb";
 const char *MNPING="mnp";
@@ -61,6 +61,9 @@ const char *DSTX="dstx";
 const char *DSQUEUE="dsq";
 const char *DSEG="dseg";
 const char *SYNCSTATUSCOUNT="ssc";
+const char *MNGOVERNANCESYNC="govsync";
+const char *MNGOVERNANCEOBJECT="govobj";
+const char *MNGOVERNANCEOBJECTVOTE="govobjvote";
 };
 
 static const char* ppszTypeName[] =
@@ -69,20 +72,23 @@ static const char* ppszTypeName[] =
     NetMsgType::TX,
     NetMsgType::BLOCK,
     "filtered block", // Should never occur
-// Dash message types
+    // Dash message types
+    // NOTE: include non-implmented here, we must keep this list in sync with enum in protocol.h
     NetMsgType::IX,
     NetMsgType::IXLOCKVOTE,
     NetMsgType::SPORK,
     NetMsgType::MNWINNER,
     NetMsgType::MNSCANERROR, // not implemented
-    NetMsgType::MNGOVERNANCEVOTE,
-    NetMsgType::MNGOVERNANCEOBJECT,
-    NetMsgType::MNGOVERNANCEFINAL,
-    NetMsgType::MNGOVERNANCEFINALVOTE,
+    NetMsgType::MNBUDGETVOTE, // depreciated since 12.1
+    NetMsgType::MNBUDGETPROPOSAL, // depreciated since 12.1
+    NetMsgType::MNBUDGETFINAL, // depreciated since 12.1
+    NetMsgType::MNBUDGETFINALVOTE, // depreciated since 12.1
     NetMsgType::MNQUORUM, // not implemented
     NetMsgType::MNANNOUNCE,
     NetMsgType::MNPING,
-    NetMsgType::DSTX
+    NetMsgType::DSTX,
+    NetMsgType::MNGOVERNANCEOBJECT,
+    NetMsgType::MNGOVERNANCEOBJECTVOTE
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -111,18 +117,14 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::FILTERCLEAR,
     NetMsgType::REJECT,
     NetMsgType::SENDHEADERS,
-// Dash message types
+    // Dash message types
+    // NOTE: do NOT include non-implmented here, we want them to be "Unknown command" in ProcessMessage()
     NetMsgType::IX,
     NetMsgType::IXLOCKVOTE,
     NetMsgType::SPORK,
     NetMsgType::GETSPORKS,
     NetMsgType::MNWINNER,
     NetMsgType::MNWINNERSSYNC,
-    NetMsgType::MNGOVERNANCESYNC,
-    NetMsgType::MNGOVERNANCEVOTE,
-    NetMsgType::MNGOVERNANCEOBJECT,
-    NetMsgType::MNGOVERNANCEFINAL,
-    NetMsgType::MNGOVERNANCEFINALVOTE,
     NetMsgType::MNANNOUNCE,
     NetMsgType::MNPING,
     NetMsgType::DSACCEPT,
@@ -134,7 +136,10 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::DSTX,
     NetMsgType::DSQUEUE,
     NetMsgType::DSEG,
-    NetMsgType::SYNCSTATUSCOUNT
+    NetMsgType::SYNCSTATUSCOUNT,
+    NetMsgType::MNGOVERNANCESYNC,
+    NetMsgType::MNGOVERNANCEOBJECT,
+    NetMsgType::MNGOVERNANCEOBJECTVOTE
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -220,6 +220,7 @@ extern const char *REJECT;
 extern const char *SENDHEADERS;
 
 // Dash message types
+// NOTE: do NOT declare non-implmented here, we don't want them to be exposed to the outside
 // TODO: add description
 extern const char *IX;
 extern const char *IXLOCKVOTE;
@@ -227,11 +228,6 @@ extern const char *SPORK;
 extern const char *GETSPORKS;
 extern const char *MNWINNER;
 extern const char *MNWINNERSSYNC;
-extern const char *MNGOVERNANCESYNC;
-extern const char *MNGOVERNANCEVOTE;
-extern const char *MNGOVERNANCEOBJECT;
-extern const char *MNGOVERNANCEFINAL;
-extern const char *MNGOVERNANCEFINALVOTE;
 extern const char *MNANNOUNCE;
 extern const char *MNPING;
 extern const char *DSACCEPT;
@@ -244,6 +240,9 @@ extern const char *DSTX;
 extern const char *DSQUEUE;
 extern const char *DSEG;
 extern const char *SYNCSTATUSCOUNT;
+extern const char *MNGOVERNANCESYNC;
+extern const char *MNGOVERNANCEOBJECT;
+extern const char *MNGOVERNANCEOBJECTVOTE;
 };
 
 /* Get a vector of all valid message types (see above) */
@@ -343,17 +342,21 @@ enum {
     MSG_FILTERED_BLOCK,
     MSG_TXLOCK_REQUEST,
     MSG_TXLOCK_VOTE,
+    // Dash message types
+    // NOTE: declare non-implmented here, we must keep this enum consistent and backwards compatible
     MSG_SPORK,
     MSG_MASTERNODE_WINNER,
     MSG_MASTERNODE_SCANNING_ERROR, // not implemented
-    MSG_GOVERNANCE_VOTE,
-    MSG_GOVERNANCE_OBJECT,
-    MSG_BUDGET_FINALIZED,
-    MSG_BUDGET_FINALIZED_VOTE,
+    MSG_BUDGET_VOTE, // depreciated since 12.1
+    MSG_BUDGET_PROPOSAL, // depreciated since 12.1
+    MSG_BUDGET_FINALIZED, // depreciated since 12.1
+    MSG_BUDGET_FINALIZED_VOTE, // depreciated since 12.1
     MSG_MASTERNODE_QUORUM, // not implemented
     MSG_MASTERNODE_ANNOUNCE,
     MSG_MASTERNODE_PING,
-    MSG_DSTX
+    MSG_DSTX,
+    MSG_GOVERNANCE_OBJECT,
+    MSG_GOVERNANCE_OBJECT_VOTE
 };
 
 #endif // BITCOIN_PROTOCOL_H


### PR DESCRIPTION
Changes:
- `CMasternodeBroadcast` hash compatibility with 70103
- ignore some requests while syncing
- fix locking/initializing in sync

EDIT:
to test this on mainnet you need to temporary disable `SPORK_10_MASTERNODE_PAY_UPDATED_NODES`
```
diff --git a/src/masternode-payments.cpp b/src/masternode-payments.cpp
index e829392..89bb7ef 100644
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -181,9 +181,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, CAmount nFe
 }
 
 int CMasternodePayments::GetMinMasternodePaymentsProto() {
-    return IsSporkActive(SPORK_10_MASTERNODE_PAY_UPDATED_NODES)
-            ? MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2
-            : MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1;
+    return MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1;
 }
 
 void CMasternodePayments::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
```