### PR TITLE
Store block hash in CDiskBlockIndex

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -284,13 +284,16 @@ public:
 class CDiskBlockIndex : public CBlockIndex
 {
 public:
+    uint256 hash;
     uint256 hashPrev;
 
     CDiskBlockIndex() {
+        hash = uint256();
         hashPrev = uint256();
     }
 
     explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex) {
+        hash = (hash == uint256() ? pindex->GetBlockHash() : hash);
         hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
     }
 
@@ -311,6 +314,8 @@ public:
         if (nStatus & BLOCK_HAVE_UNDO)
             READWRITE(VARINT(nUndoPos));
 
+        // block hash
+        READWRITE(hash);
         // block header
         READWRITE(this->nVersion);
         READWRITE(hashPrev);
@@ -322,6 +327,8 @@ public:
 
     uint256 GetBlockHash() const
     {
+        if(hash != uint256()) return hash;
+        // should never really get here, keeping this as a fallback
         CBlockHeader block;
         block.nVersion        = nVersion;
         block.hashPrevBlock   = hashPrev;


### PR DESCRIPTION
Changes: Avoid recalculating hashes for block indexes every time wallet starts, store them on disk and reuse.

Reason: X11 is slow :)

Results (time to load indexes on wallet start, mainnet):
- Before: ~65 seconds
- After: ~5 seconds

Notes:
1. There is no security issues with this imo because block indexes are calculated locally.
2. This will invalidate `/blocks/index/` and you'll have to reindex (which is the case for 0.12.0->0.12.1 migration anyway) so save you datadir somewhere before testing (reindexing on mainnet takes 1h+).