### PR TITLE
Add a GUI-only option to hide the warning about low keys

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -174,6 +174,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="lowKeysWarning">
+            <property name="toolTip">
+             <string>Show warning dialog when PrivateSend detects that wallet has very low number of keys left.</string>
+            </property>
+            <property name="text">
+             <string>Warn if PrivateSend is running out of keys</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="privateSendMultiSession">
             <property name="toolTip">
              <string>Whether to use experimental PrivateSend mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</string>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -201,6 +201,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
     mapper->addMapping(ui->privateSendRounds, OptionsModel::PrivateSendRounds);
     mapper->addMapping(ui->privateSendAmount, OptionsModel::PrivateSendAmount);
+    mapper->addMapping(ui->lowKeysWarning, OptionsModel::LowKeysWarning);
     mapper->addMapping(ui->privateSendMultiSession, OptionsModel::PrivateSendMultiSession);
 
     /* Network */

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -88,6 +88,9 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("fShowAdvancedPSUI", false);
     fShowAdvancedPSUI = settings.value("fShowAdvancedPSUI", false).toBool();
 
+    if (!settings.contains("fLowKeysWarning"))
+        settings.setValue("fLowKeysWarning", true);
+
     // These are shared with the core or have a command-line parameter
     // and we want command-line parameters to overwrite the GUI settings.
     //
@@ -251,6 +254,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("bSpendZeroConfChange");
         case ShowAdvancedPSUI:
             return fShowAdvancedPSUI;
+        case LowKeysWarning:
+            return settings.value("fLowKeysWarning");
         case PrivateSendRounds:
             return settings.value("nPrivateSendRounds");
         case PrivateSendAmount:
@@ -385,6 +390,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             fShowAdvancedPSUI = value.toBool();
             settings.setValue("fShowAdvancedPSUI", fShowAdvancedPSUI);
             Q_EMIT advancedPSUIChanged(fShowAdvancedPSUI);
+            break;
+        case LowKeysWarning:
+            settings.setValue("fLowKeysWarning", value);
             break;
         case PrivateSendRounds:
             if (settings.value("nPrivateSendRounds") != value)

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -47,6 +47,7 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         ShowAdvancedPSUI,       // bool
+        LowKeysWarning,         // bool
         PrivateSendRounds,      // int
         PrivateSendAmount,      // int
         ShowMasternodesTab,     // bool

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -463,13 +463,18 @@ void OverviewPage::privateSendStatus()
 
     // Warn user that wallet is running out of keys
     if (nWalletBackups > 0 && pwalletMain->nKeysLeftSinceAutoBackup < PS_KEYS_THRESHOLD_WARNING) {
-        QString strWarn =   tr("Very low number of keys left since last automatic backup!") + "<br><br>" +
-                            tr("We are about to create a new automatic backup for you, however "
-                               "<span style='color:red;'> you should always make sure you have backups "
-                               "saved in some safe place</span>!");
-        ui->labelPrivateSendEnabled->setToolTip(strWarn);
-        LogPrintf("OverviewPage::privateSendStatus - Very low number of keys left since last automatic backup, warning user and trying to create new backup...\n");
-        QMessageBox::warning(this, tr("PrivateSend"), strWarn, QMessageBox::Ok, QMessageBox::Ok);
+        QSettings settings;
+        if(settings.value("fLowKeysWarning").toBool()) {
+            QString strWarn =   tr("Very low number of keys left since last automatic backup!") + "<br><br>" +
+                                tr("We are about to create a new automatic backup for you, however "
+                                   "<span style='color:red;'> you should always make sure you have backups "
+                                   "saved in some safe place</span>!") + "<br><br>" +
+                                tr("Note: You turn this message off in options.");
+            ui->labelPrivateSendEnabled->setToolTip(strWarn);
+            LogPrintf("OverviewPage::privateSendStatus -- Very low number of keys left since last automatic backup, warning user and trying to create new backup...\n");
+            QMessageBox::warning(this, tr("PrivateSend"), strWarn, QMessageBox::Ok, QMessageBox::Ok);
+        } else
+            LogPrintf("OverviewPage::privateSendStatus -- Very low number of keys left since last automatic backup, skipping warning and trying to create new backup...\n");
 
         std::string warningString;
         std::string errorString;


### PR DESCRIPTION
Add a GUI-only option to show (hide) the warning about low keys before creating next autobackup (but still warn if backup fails). Default is ON.

Reason: turned out that it's ok to see this dialog few times but it starts to annoy pretty quick if you mix a lot 😉 and it also interrupts mixing even if you have proper backup system in place and there is no option to avoid that kind of issue currently.