### PR TITLE
Slightly refactor FindRandomNotInVec

### DIFF
--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -97,7 +97,7 @@ public:
     CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount);
 
     /// Find a random entry
-    CMasternode* FindRandomNotInVec(std::vector<CTxIn> &vecToExclude, int protocolVersion = -1);
+    CMasternode* FindRandomNotInVec(std::vector<CTxIn> &vecToExclude, int nProtocolVersion = -1);
 
     /// Get the current winner for this block
     CMasternode* GetCurrentMasterNode(int mod=1, int64_t nBlockHeight=0, int minProtocol=0);


### PR DESCRIPTION
Just shuffle vector before looping over it. That's a slightly more straightforward way and should make it easier to understand what is going on here imo.