### PR TITLE
Refactor/fix spork

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -148,7 +148,7 @@ public:
         fTestnetToBeDeprecatedFieldRPC = false;
 
         nPoolMaxTransactions = 3;
-        strSporkKey = "04549ac134f694c0243f503e8c8a9a986f5de6610049c40b07816809b0d1d06a21b07be27b9bb555931773f62ba6cf35a25fd52f694d4e1106ccd237a7bb899fdd";
+        strSporkPubKey = "04549ac134f694c0243f503e8c8a9a986f5de6610049c40b07816809b0d1d06a21b07be27b9bb555931773f62ba6cf35a25fd52f694d4e1106ccd237a7bb899fdd";
         strMasternodePaymentsPubKey = "04549ac134f694c0243f503e8c8a9a986f5de6610049c40b07816809b0d1d06a21b07be27b9bb555931773f62ba6cf35a25fd52f694d4e1106ccd237a7bb899fdd";
 
         checkpointData = (CCheckpointData) {
@@ -257,7 +257,7 @@ public:
         fTestnetToBeDeprecatedFieldRPC = true;
 
         nPoolMaxTransactions = 2;
-        strSporkKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
+        strSporkPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
         strMasternodePaymentsPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -78,7 +78,7 @@ public:
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
-    std::string SporkKey() const { return strSporkKey; }
+    std::string SporkPubKey() const { return strSporkPubKey; }
     std::string MasternodePaymentPubKey() const { return strMasternodePaymentsPubKey; }
 protected:
     CChainParams() {}
@@ -102,7 +102,7 @@ protected:
     bool fTestnetToBeDeprecatedFieldRPC;
     CCheckpointData checkpointData;
     int nPoolMaxTransactions;
-    std::string strSporkKey;
+    std::string strSporkPubKey;
     std::string strMasternodePaymentsPubKey;
 };
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -41,7 +41,7 @@ int nCompleteTXLocks;
 void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
     if(fLiteMode) return; //disable all darksend/masternode related functionality
-    if(!IsSporkActive(SPORK_2_INSTANTX)) return;
+    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTX)) return;
     if(!masternodeSync.IsBlockchainSynced()) return;
 
     if (strCommand == NetMsgType::IX)
@@ -192,8 +192,8 @@ bool IsIXTXValid(const CTransaction& txCollateral){
         }
     }
 
-    if(nValueOut > GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
-        LogPrint("instantsend", "IsIXTXValid - Transaction value too high - %s\n", txCollateral.ToString());
+    if(nValueOut > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
+        LogPrint("instantsend", "IsIXTXValid -- Transaction value too high: nValueOut=%d, txCollateral=%s", nValueOut, txCollateral.ToString());
         return false;
     }
 
@@ -508,7 +508,7 @@ bool IsLockedIXTransaction(uint256 txHash) {
 int GetTransactionLockSignatures(uint256 txHash)
 {
     if(fLargeWorkForkFound || fLargeWorkInvalidChainFound) return -2;
-    if(!IsSporkActive(SPORK_2_INSTANTX)) return -3;
+    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTX)) return -3;
     if(!fEnableInstantSend) return -1;
 
     std::map<uint256, CTransactionLock>::iterator i = mapTxLocks.find(txHash);

--- a/src/main.h
+++ b/src/main.h
@@ -455,7 +455,8 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockIndex* pindex, CCoinsViewCache& coins, bool* pfClean = NULL);
 
 /** Reprocess a number of blocks to try and get on the correct chain again **/
-bool DisconnectBlocksAndReprocess(int blocks);
+bool DisconnectBlocks(int blocks);
+void ReprocessBlocks(int nBlocks);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck = false);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -52,10 +52,10 @@ bool IsBlockValueValid(const CBlock& block, CAmount nExpectedValue){
     } else { // we're synced and have data so check the budget schedule
 
         //are these blocks even enabled
-        if(!IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)){
+        if(!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)){
             return block.vtx[0].GetValueOut() <= nExpectedValue;
         }
-        
+
         // 12.1
         // if(nHeight >= Params().GetConsensus().nBudgetPaymentsStartBlock &&
         //     budget.IsBudgetPaymentBlock(nHeight)){
@@ -77,14 +77,14 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight)
     }
 
     //check if it's a budget block
-    // 12.1 
-    // if(IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)){
+    // 12.1
+    // if(sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)){
     //     if(budget.IsBudgetPaymentBlock(nBlockHeight)){
     //         if(budget.IsTransactionValid(txNew, nBlockHeight)){
     //             return true;
     //         } else {
-    //             LogPrintf("Invalid budget payment detected %s\n", txNew.ToString());
-    //             if(IsSporkActive(SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT)){
+    //             LogPrintf("Invalid budget payment detected %s", txNew.ToString());
+    //             if(sporkManager.IsSporkActive(SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT)){
     //                 return false;
     //             } else {
     //                 LogPrintf("Budget enforcement is disabled, accepting block\n");
@@ -99,8 +99,8 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight)
     {
         return true;
     } else {
-        LogPrintf("Invalid mn payment detected %s\n", txNew.ToString());
-        if(IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)){
+        LogPrintf("Invalid mn payment detected %s", txNew.ToString());
+        if(sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)){
             return false;
         } else {
             LogPrintf("Masternode payment enforcement is disabled, accepting block\n");
@@ -118,7 +118,7 @@ void FillBlockPayee(CMutableTransaction& txNew, CAmount nFees)
     if(!chainActive.Tip()) return;
 
     // 12.1
-    // if(IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(chainActive.Tip()->nHeight+1)){
+    // if(sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(chainActive.Tip()->nHeight+1)){
     //     budget.FillBlockPayee(txNew, nFees);
     // } else {
     //     mnpayments.FillBlockPayee(txNew, nFees);
@@ -130,7 +130,7 @@ std::string GetRequiredPaymentsString(int nBlockHeight)
 {
     // 12.1 -- added triggered payments
 
-    // if(IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(nBlockHeight)){
+    // if(sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(nBlockHeight)){
     //     return budget.GetRequiredPaymentsString(nBlockHeight);
     // } else {
     //     return mnpayments.GetRequiredPaymentsString(nBlockHeight);
@@ -181,7 +181,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, CAmount nFe
 }
 
 int CMasternodePayments::GetMinMasternodePaymentsProto() {
-    return IsSporkActive(SPORK_10_MASTERNODE_PAY_UPDATED_NODES)
+    return sporkManager.IsSporkActive(SPORK_10_MASTERNODE_PAY_UPDATED_NODES)
             ? MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2
             : MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1;
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -293,8 +293,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         CWalletTx *newTx = transaction.getTransaction();
         CReserveKey *keyChange = transaction.getPossibleKeyChange();
 
-        if(recipients[0].useInstantX && total > GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
-            Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH.").arg(GetSporkValue(SPORK_5_MAX_VALUE)),
+        if(recipients[0].useInstantX && total > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
+            Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH.").arg(sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)),
                          CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }
@@ -304,8 +304,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         if (fSubtractFeeFromAmount && fCreated)
             transaction.reassignAmounts(nChangePosRet);
 
-        if(recipients[0].useInstantX && newTx->GetValueOut() > GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
-            Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH.").arg(GetSporkValue(SPORK_5_MAX_VALUE)),
+        if(recipients[0].useInstantX && newTx->GetValueOut() > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
+            Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH.").arg(sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)),
                          CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -610,7 +610,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     }
 
     result.push_back(Pair("masternode_payments", (int64_t)(pindexPrev->nHeight+1) > Params().GetConsensus().nMasternodePaymentsStartBlock));
-    result.push_back(Pair("enforce_masternode_payments", IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
+    result.push_back(Pair("enforce_masternode_payments", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
 
     return result;
 }

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -236,14 +236,14 @@ UniValue spork(const UniValue& params, bool fHelp)
         UniValue ret(UniValue::VOBJ);
         for(int nSporkID = SPORK_START; nSporkID <= SPORK_END; nSporkID++){
             if(sporkManager.GetSporkNameByID(nSporkID) != "Unknown")
-                ret.push_back(Pair(sporkManager.GetSporkNameByID(nSporkID), GetSporkValue(nSporkID)));
+                ret.push_back(Pair(sporkManager.GetSporkNameByID(nSporkID), sporkManager.GetSporkValue(nSporkID)));
         }
         return ret;
     } else if(params.size() == 1 && params[0].get_str() == "active"){
         UniValue ret(UniValue::VOBJ);
         for(int nSporkID = SPORK_START; nSporkID <= SPORK_END; nSporkID++){
             if(sporkManager.GetSporkNameByID(nSporkID) != "Unknown")
-                ret.push_back(Pair(sporkManager.GetSporkNameByID(nSporkID), IsSporkActive(nSporkID)));
+                ret.push_back(Pair(sporkManager.GetSporkNameByID(nSporkID), sporkManager.IsSporkActive(nSporkID)));
         }
         return ret;
     } else if (params.size() == 2){
@@ -257,7 +257,7 @@ UniValue spork(const UniValue& params, bool fHelp)
 
         //broadcast new spork
         if(sporkManager.UpdateSpork(nSporkID, nValue)){
-            ExecuteSpork(nSporkID, nValue);
+            sporkManager.ExecuteSpork(nSporkID, nValue);
             return "success";
         } else {
             return "failure";


### PR DESCRIPTION
Changes:
- move `ProcessSpork`, `GetSporkValue`, `IsSporkActive`, `ExecuteSpork` and `mapSporksActive` to `CSporkManager`
- move `Sign`, `CheckSignature`, `Relay` to `CSporkMessage`
- move `ReprocessBlocks` out of sporks to main.cpp / rename `DisconnectBlocksAndReprocess` to `DisconnectBlocks`
- rename `SporkKey` to `SporkPubKey`
- bugfix: only set `strMasterPrivKey` if spork signature produced by that key was verified successfully
- few log format changes, cleaned up includes

Note: diff looks a bit messy - I moved things around to group functions in .h and .cpp the same way