### PR TITLE
Fix GUI MN list: filter cooldown + performance boost by fixing date strings

### DIFF
--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -10,8 +10,9 @@
 #include <QTimer>
 #include <QWidget>
 
-#define MASTERNODELIST_UPDATE_SECONDS            5
-#define MY_MASTERNODELIST_UPDATE_SECONDS        60
+#define MY_MASTERNODELIST_UPDATE_SECONDS                 60
+#define MASTERNODELIST_UPDATE_SECONDS                    15
+#define MASTERNODELIST_FILTER_COOLDOWN_SECONDS            3
 
 namespace Ui {
     class MasternodeList;
@@ -40,6 +41,8 @@ public:
 
 private:
     QMenu *contextMenu;
+    int64_t nTimeFilterUpdate;
+    bool fFilterUpdated;
 
 public Q_SLOTS:
     void updateMyMasternodeInfo(QString alias, QString addr, QString privkey, QString txHash, QString txIndex, CMasternode *pmn);


### PR DESCRIPTION
To prevent high cpu usage we should update list only once in MASTERNODELIST_UPDATE_SECONDS seconds or MASTERNODELIST_FILTER_COOLDOWN_SECONDS seconds after filter was last changed. Also changing date/time format - QDateTime ToString() is way to slow for a list of thousands items, using DateTimeStrFormat instead. UI should work much smoother on mainnet now.