### PR TITLE
Refactor All The Things - part1

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -2,35 +2,36 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "addrman.h"
-#include "protocol.h"
 #include "activemasternode.h"
 #include "masternode.h"
 #include "masternode-sync.h"
 #include "masternodeman.h"
-#include "spork.h"
+#include "protocol.h"
 
-//
-// Bootup the Masternode, look for a 1000DRK input and register on the network
-//
-void CActiveMasternode::ManageStatus()
-{    
-    std::string errorMessage;
+extern CWallet* pwalletMain;
+
+// Keep track of the active Masternode
+CActiveMasternode activeMasternode;
+
+// Bootup the Masternode, look for a 1000DASH input and register on the network
+void CActiveMasternode::ManageState()
+{
+    std::string strErrorMessage;
 
     if(!fMasterNode) return;
 
-    if (fDebug) LogPrintf("CActiveMasternode::ManageStatus() - Begin\n");
+    if (fDebug) LogPrintf("CActiveMasternode::ManageState -- Begin\n");
 
     //need correct blocks to send ping
     if(Params().NetworkIDString() != CBaseChainParams::REGTEST && !masternodeSync.IsBlockchainSynced()) {
-        status = ACTIVE_MASTERNODE_SYNC_IN_PROCESS;
-        LogPrintf("CActiveMasternode::ManageStatus() - %s\n", GetStatus());
+        nState = ACTIVE_MASTERNODE_SYNC_IN_PROCESS;
+        LogPrintf("CActiveMasternode::ManageState -- %s\n", GetStatus());
         return;
     }
 
-    if(status == ACTIVE_MASTERNODE_SYNC_IN_PROCESS) status = ACTIVE_MASTERNODE_INITIAL;
+    if(nState == ACTIVE_MASTERNODE_SYNC_IN_PROCESS) nState = ACTIVE_MASTERNODE_INITIAL;
 
-    if(status == ACTIVE_MASTERNODE_INITIAL) {
+    if(nState == ACTIVE_MASTERNODE_INITIAL) {
         CMasternode *pmn;
         pmn = mnodeman.Find(pubKeyMasternode);
         if(pmn != NULL) {
@@ -40,28 +41,28 @@ void CActiveMasternode::ManageStatus()
         }
     }
 
-    if(status != ACTIVE_MASTERNODE_STARTED) {
+    if(nState != ACTIVE_MASTERNODE_STARTED) {
 
         // Set defaults
-        status = ACTIVE_MASTERNODE_NOT_CAPABLE;
-        notCapableReason = "";
+        nState = ACTIVE_MASTERNODE_NOT_CAPABLE;
+        strNotCapableReason = "";
 
-        if(pwalletMain->IsLocked()){
-            notCapableReason = "Wallet is locked.";
-            LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
+        if(pwalletMain->IsLocked()) {
+            strNotCapableReason = "Wallet is locked.";
+            LogPrintf("CActiveMasternode::ManageState -- not capable: %s\n", strNotCapableReason);
             return;
         }
 
-        if(pwalletMain->GetBalance() == 0){
-            notCapableReason = "Hot node, waiting for remote activation.";
-            LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
+        if(pwalletMain->GetBalance() == 0) {
+            nState = ACTIVE_MASTERNODE_INITIAL;
+            LogPrintf("CActiveMasternode::ManageState() -- %s\n", GetStatus());
             return;
         }
 
         if(strMasterNodeAddr.empty()) {
             if(!GetLocal(service)) {
-                notCapableReason = "Can't detect external address. Please use the masternodeaddr configuration option.";
-                LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
+                strNotCapableReason = "Can't detect external address. Please use the masternodeaddr configuration option.";
+                LogPrintf("CActiveMasternode::ManageState -- not capable: %s\n", strNotCapableReason);
                 return;
             }
         } else {
@@ -71,126 +72,124 @@ void CActiveMasternode::ManageStatus()
         int mainnetDefaultPort = Params(CBaseChainParams::MAIN).GetDefaultPort();
         if(Params().NetworkIDString() == CBaseChainParams::MAIN) {
             if(service.GetPort() != mainnetDefaultPort) {
-                notCapableReason = strprintf("Invalid port: %u - only %d is supported on mainnet.", service.GetPort(), mainnetDefaultPort);
-                LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
+                strNotCapableReason = strprintf("Invalid port: %u - only %d is supported on mainnet.", service.GetPort(), mainnetDefaultPort);
+                LogPrintf("CActiveMasternode::ManageState -- not capable: %s\n", strNotCapableReason);
                 return;
             }
         } else if(service.GetPort() == mainnetDefaultPort) {
-            notCapableReason = strprintf("Invalid port: %u - %d is only supported on mainnet.", service.GetPort(), mainnetDefaultPort);
-            LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
+            strNotCapableReason = strprintf("Invalid port: %u - %d is only supported on mainnet.", service.GetPort(), mainnetDefaultPort);
+            LogPrintf("CActiveMasternode::ManageState -- not capable: %s\n", strNotCapableReason);
             return;
         }
 
-        LogPrintf("CActiveMasternode::ManageStatus() - Checking inbound connection to '%s'\n", service.ToString());
+        LogPrintf("CActiveMasternode::ManageState -- Checking inbound connection to '%s'\n", service.ToString());
 
-        if(!ConnectNode((CAddress)service, NULL, true)){
-            notCapableReason = "Could not connect to " + service.ToString();
-            LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
+        if(!ConnectNode((CAddress)service, NULL, true)) {
+            strNotCapableReason = "Could not connect to " + service.ToString();
+            LogPrintf("CActiveMasternode::ManageState -- not capable: %s\n", strNotCapableReason);
             return;
         }
 
         // Choose coins to use
-        CPubKey pubKeyCollateralAddress;
-        CKey keyCollateralAddress;
+        CPubKey pubKeyCollateral;
+        CKey keyCollateral;
 
-        if(pwalletMain->GetMasternodeVinAndKeys(vin, pubKeyCollateralAddress, keyCollateralAddress)) {
+        if(pwalletMain->GetMasternodeVinAndKeys(vin, pubKeyCollateral, keyCollateral)) {
 
-            if(GetInputAge(vin) < Params().GetConsensus().nMasternodeMinimumConfirmations){
-                status = ACTIVE_MASTERNODE_INPUT_TOO_NEW;
-                notCapableReason = strprintf("%s - %d confirmations", GetStatus(), GetInputAge(vin));
-                LogPrintf("CActiveMasternode::ManageStatus() - %s\n", notCapableReason);
+            int nInputAge = GetInputAge(vin);
+            if(nInputAge < Params().GetConsensus().nMasternodeMinimumConfirmations){
+                nState = ACTIVE_MASTERNODE_INPUT_TOO_NEW;
+                strNotCapableReason = strprintf("%s - %d confirmations", GetStatus(), nInputAge);
+                LogPrintf("CActiveMasternode::ManageState -- %s\n", strNotCapableReason);
                 return;
             }
 
             LOCK(pwalletMain->cs_wallet);
             pwalletMain->LockCoin(vin.prevout);
 
-            // send to all nodes
             CMasternodeBroadcast mnb;
-            if(!CMasternodeBroadcast::Create(vin, service, keyCollateralAddress, pubKeyCollateralAddress, keyMasternode, pubKeyMasternode, errorMessage, mnb)) {
-                notCapableReason = "Error on CreateBroadcast: " + errorMessage;
-                LogPrintf("CActiveMasternode::ManageStatus() - %s\n", notCapableReason);
+            if(!CMasternodeBroadcast::Create(vin, service, keyCollateral, pubKeyCollateral, keyMasternode, pubKeyMasternode, strErrorMessage, mnb)) {
+                strNotCapableReason = "Error on CMasternodeBroadcast::Create -- " + strErrorMessage;
+                LogPrintf("CActiveMasternode::ManageState -- %s\n", strNotCapableReason);
                 return;
             }
 
             //update to masternode list
-            LogPrintf("CActiveMasternode::ManageStatus() - Update Masternode List\n");
+            LogPrintf("CActiveMasternode::ManageState -- Update Masternode List\n");
             mnodeman.UpdateMasternodeList(mnb);
 
             //send to all peers
-            LogPrintf("CActiveMasternode::ManageStatus() - Relay broadcast vin = %s\n", vin.ToString());
+            LogPrintf("CActiveMasternode::ManageState -- Relay broadcast, vin=%s\n", vin.ToString());
             mnb.Relay();
 
-            LogPrintf("CActiveMasternode::ManageStatus() - Is capable master node!\n");
-            status = ACTIVE_MASTERNODE_STARTED;
+            LogPrintf("CActiveMasternode::ManageState -- Is capable master node!\n");
+            nState = ACTIVE_MASTERNODE_STARTED;
 
             return;
         } else {
-            notCapableReason = "Could not find suitable coins!";
-            LogPrintf("CActiveMasternode::ManageStatus() - %s\n", notCapableReason);
+            strNotCapableReason = "Could not find suitable coins!";
+            LogPrintf("CActiveMasternode::ManageState -- %s\n", strNotCapableReason);
             return;
         }
     }
 
     //send to all peers
-    if(!SendMasternodePing(errorMessage)) {
-        LogPrintf("CActiveMasternode::ManageStatus() - Error on Ping: %s\n", errorMessage);
+    if(!SendMasternodePing(strErrorMessage)) {
+        LogPrintf("CActiveMasternode::ManageState -- Error on SendMasternodePing(): %s\n", strErrorMessage);
     }
 }
 
-std::string CActiveMasternode::GetStatus() {
-    switch (status) {
-    case ACTIVE_MASTERNODE_INITIAL: return "Node just started, not yet activated";
-    case ACTIVE_MASTERNODE_SYNC_IN_PROCESS: return "Sync in progress. Must wait until sync is complete to start Masternode";
-    case ACTIVE_MASTERNODE_INPUT_TOO_NEW: return strprintf("Masternode input must have at least %d confirmations", Params().GetConsensus().nMasternodeMinimumConfirmations);
-    case ACTIVE_MASTERNODE_NOT_CAPABLE: return "Not capable masternode: " + notCapableReason;
-    case ACTIVE_MASTERNODE_STARTED: return "Masternode successfully started";
-    default: return "unknown";
+std::string CActiveMasternode::GetStatus()
+{
+    switch (nState) {
+        case ACTIVE_MASTERNODE_INITIAL: return "Node just started, not yet activated";
+        case ACTIVE_MASTERNODE_SYNC_IN_PROCESS: return "Sync in progress. Must wait until sync is complete to start Masternode";
+        case ACTIVE_MASTERNODE_INPUT_TOO_NEW: return strprintf("Masternode input must have at least %d confirmations", Params().GetConsensus().nMasternodeMinimumConfirmations);
+        case ACTIVE_MASTERNODE_NOT_CAPABLE: return "Not capable masternode: " + strNotCapableReason;
+        case ACTIVE_MASTERNODE_STARTED: return "Masternode successfully started";
+        default: return "unknown";
     }
 }
 
-bool CActiveMasternode::SendMasternodePing(std::string& errorMessage) {
-    if(status != ACTIVE_MASTERNODE_STARTED) {
-        errorMessage = "Masternode is not in a running status";
+bool CActiveMasternode::SendMasternodePing(std::string& strErrorMessage)
+{
+    if(nState != ACTIVE_MASTERNODE_STARTED) {
+        strErrorMessage = "Masternode is not in a running status";
         return false;
     }
 
-    LogPrintf("CActiveMasternode::SendMasternodePing() - Relay Masternode Ping vin = %s\n", vin.ToString());
-    
     CMasternodePing mnp(vin);
-    if(!mnp.Sign(keyMasternode, pubKeyMasternode))
-    {
-        errorMessage = "Couldn't sign Masternode Ping";
+    if(!mnp.Sign(keyMasternode, pubKeyMasternode)) {
+        strErrorMessage = "Couldn't sign Masternode Ping";
         return false;
     }
 
     // Update lastPing for our masternode in Masternode list
     CMasternode* pmn = mnodeman.Find(vin);
-    if(pmn != NULL)
-    {
-        if(pmn->IsPingedWithin(MASTERNODE_PING_SECONDS, mnp.sigTime)){
-            errorMessage = "Too early to send Masternode Ping";
+    if(pmn != NULL) {
+        if(pmn->IsPingedWithin(MASTERNODE_MIN_MNP_SECONDS, mnp.sigTime)) {
+            strErrorMessage = "Too early to send Masternode Ping";
             return false;
         }
 
         pmn->lastPing = mnp;
-        mnodeman.mapSeenMasternodePing.insert(make_pair(mnp.GetHash(), mnp));
+        mnodeman.mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));
 
         //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated, so we'll update it
         CMasternodeBroadcast mnb(*pmn);
         uint256 hash = mnb.GetHash();
-        if(mnodeman.mapSeenMasternodeBroadcast.count(hash)) mnodeman.mapSeenMasternodeBroadcast[hash].lastPing = mnp;
+        if(mnodeman.mapSeenMasternodeBroadcast.count(hash))
+            mnodeman.mapSeenMasternodeBroadcast[hash].lastPing = mnp;
 
+        LogPrintf("CActiveMasternode::SendMasternodePing -- Relaying ping, collateral=%s\n", vin.ToString());
         mnp.Relay();
 
         return true;
-    }
-    else
-    {
+    } else {
         // Seems like we are trying to send a ping while the Masternode is not registered in the network
-        errorMessage = "PrivateSend Masternode List doesn't include our Masternode, shutting down Masternode pinging service! " + vin.ToString();
-        status = ACTIVE_MASTERNODE_NOT_CAPABLE;
-        notCapableReason = errorMessage;
+        strErrorMessage = "PrivateSend Masternode List doesn't include our Masternode, shutting down Masternode pinging service! " + vin.ToString();
+        nState = ACTIVE_MASTERNODE_NOT_CAPABLE;
+        strNotCapableReason = strErrorMessage;
         return false;
     }
 }
@@ -200,13 +199,13 @@ bool CActiveMasternode::EnableHotColdMasterNode(CTxIn& newVin, CService& newServ
 {
     if(!fMasterNode) return false;
 
-    status = ACTIVE_MASTERNODE_STARTED;
+    nState = ACTIVE_MASTERNODE_STARTED;
 
     //The values below are needed for signing mnping messages going forward
     vin = newVin;
     service = newService;
 
-    LogPrintf("CActiveMasternode::EnableHotColdMasterNode() - Enabled! You may shut down the cold daemon.\n");
+    LogPrintf("CActiveMasternode::EnableHotColdMasterNode -- Enabled! You may shut down the cold daemon.\n");
 
     return true;
 }

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -1,23 +1,23 @@
-// Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2014-2016 The Dash Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef ACTIVEMASTERNODE_H
 #define ACTIVEMASTERNODE_H
 
-#include "sync.h"
 #include "net.h"
 #include "key.h"
-#include "init.h"
 #include "wallet/wallet.h"
-#include "darksend.h"
-#include "masternode.h"
 
-#define ACTIVE_MASTERNODE_INITIAL                     0 // initial state
-#define ACTIVE_MASTERNODE_SYNC_IN_PROCESS             1
-#define ACTIVE_MASTERNODE_INPUT_TOO_NEW               2
-#define ACTIVE_MASTERNODE_NOT_CAPABLE                 3
-#define ACTIVE_MASTERNODE_STARTED                     4
+class CActiveMasternode;
+
+static const int ACTIVE_MASTERNODE_INITIAL          = 0; // initial state
+static const int ACTIVE_MASTERNODE_SYNC_IN_PROCESS  = 1;
+static const int ACTIVE_MASTERNODE_INPUT_TOO_NEW    = 2;
+static const int ACTIVE_MASTERNODE_NOT_CAPABLE      = 3;
+static const int ACTIVE_MASTERNODE_STARTED          = 4;
+
+extern CActiveMasternode activeMasternode;
 
 // Responsible for activating the Masternode and pinging the network
 class CActiveMasternode
@@ -27,11 +27,12 @@ private:
     mutable CCriticalSection cs;
 
     /// Ping Masternode
-    bool SendMasternodePing(std::string& errorMessage);
+    bool SendMasternodePing(std::string& strErrorMessage);
 
 public:
     // Initialized by init.cpp
-    // Keys for the main Masternode
+    std::string strMasterNodeAddr;
+    // Keys for the active Masternode
     CPubKey pubKeyMasternode;
     CKey keyMasternode;
 
@@ -39,18 +40,15 @@ public:
     CTxIn vin;
     CService service;
 
-    int status;
-    std::string notCapableReason;
+    int nState; // should be one of ACTIVE_MASTERNODE_XXXX
+    std::string strNotCapableReason;
 
-    CActiveMasternode()
-    {
-        status = ACTIVE_MASTERNODE_INITIAL;
-    }
+    CActiveMasternode() : nState(ACTIVE_MASTERNODE_INITIAL) {}
 
-    /// Manage status of main Masternode
-    void ManageStatus(); 
+    /// Manage state of active Masternode
+    void ManageState();
+
     std::string GetStatus();
-
 
     /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);

--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -1,4 +1,4 @@
-
+#include "darksend.h"
 #include "darksend-relay.h"
 
 

--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -42,7 +42,7 @@ bool CDarkSendRelay::Sign(std::string strSharedKey)
     CPubKey pubkey2;
     std::string errorMessage = "";
 
-    if(!darkSendSigner.SetKey(strSharedKey, errorMessage, key2, pubkey2))
+    if(!darkSendSigner.GetKeysFromSecret(strSharedKey, errorMessage, key2, pubkey2))
     {
         LogPrintf("CDarkSendRelay():Sign - ERROR: Invalid shared key: '%s'\n", errorMessage);
         return false;
@@ -69,7 +69,7 @@ bool CDarkSendRelay::VerifyMessage(std::string strSharedKey)
     CPubKey pubkey2;
     std::string errorMessage = "";
 
-    if(!darkSendSigner.SetKey(strSharedKey, errorMessage, key2, pubkey2))
+    if(!darkSendSigner.GetKeysFromSecret(strSharedKey, errorMessage, key2, pubkey2))
     {
         LogPrintf("CDarkSendRelay()::VerifyMessage - ERROR: Invalid shared key: '%s'\n", errorMessage);
         return false;
@@ -85,7 +85,7 @@ bool CDarkSendRelay::VerifyMessage(std::string strSharedKey)
 
 void CDarkSendRelay::Relay()
 {
-    int nCount = std::min(mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION), 20);
+    int nCount = std::min(mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION), 20);
     int nRank1 = (rand() % nCount)+1; 
     int nRank2 = (rand() % nCount)+1; 
 
@@ -101,7 +101,7 @@ void CDarkSendRelay::Relay()
 
 void CDarkSendRelay::RelayThroughNode(int nRank)
 {
-    CMasternode* pmn = mnodeman.GetMasternodeByRank(nRank, nBlockHeight, MIN_POOL_PEER_PROTO_VERSION);
+    CMasternode* pmn = mnodeman.GetMasternodeByRank(nRank, nBlockHeight, MIN_PRIVATESEND_PEER_PROTO_VERSION);
 
     if(pmn != NULL){
         //printf("RelayThroughNode %s\n", pmn->addr.ToString().c_str());

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -37,8 +37,6 @@ std::vector<CDarksendQueue> vecDarksendQueue;
 std::vector<CTxIn> vecMasternodesUsed;
 // Keep track of the scanning errors I've seen
 map<uint256, CDarksendBroadcastTx> mapDarksendBroadcastTxes;
-// Keep track of the active Masternode
-CActiveMasternode activeMasternode;
 
 /* *** BEGIN DARKSEND MAGIC - DASH **********
     Copyright (c) 2014-2015, Dash Developers
@@ -2356,7 +2354,8 @@ void ThreadCheckDarkSendPool()
 
             // check if we should activate or ping every few minutes,
             // start right after sync is considered to be done
-            if(c % MASTERNODE_PING_SECONDS == 1) activeMasternode.ManageStatus();
+            if(c % MASTERNODE_PING_SECONDS == 1)
+                activeMasternode.ManageState();
 
             if(c % 60 == 0)
             {

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2,70 +2,52 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "activemasternode.h"
+#include "coincontrol.h"
 #include "consensus/validation.h"
 #include "darksend.h"
-#include "main.h"
 #include "init.h"
-#include "util.h"
+#include "instantx.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"
 #include "masternodeman.h"
 #include "script/sign.h"
-#include "instantx.h"
 #include "txmempool.h"
-#include "ui_interface.h"
-#include "coincontrol.h"
-#include <boost/algorithm/string/replace.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
+#include "util.h"
+
 #include <boost/lexical_cast.hpp>
 
-#include <algorithm>
-#include <boost/assign/list_of.hpp>
-#include <openssl/rand.h>
+int nPrivateSendRounds = DEFAULT_PRIVATESEND_ROUNDS;
+int nPrivateSendAmount = DEFAULT_PRIVATESEND_AMOUNT;
+int nLiquidityProvider = 0;
+bool fEnablePrivateSend = false;
+bool fPrivateSendMultiSession = DEFAULT_PRIVATESEND_MULTISESSION;
 
-using namespace std;
-using namespace boost;
-
-// The main object for accessing Darksend
 CDarksendPool darkSendPool;
-// A helper object for signing messages from Masternodes
 CDarkSendSigner darkSendSigner;
-// The current Darksends in progress on the network
-std::vector<CDarksendQueue> vecDarksendQueue;
-// Keep track of the used Masternodes
-std::vector<CTxIn> vecMasternodesUsed;
-// Keep track of the scanning errors I've seen
-map<uint256, CDarksendBroadcastTx> mapDarksendBroadcastTxes;
-
-/* *** BEGIN DARKSEND MAGIC - DASH **********
-    Copyright (c) 2014-2015, Dash Developers
-        eduffield - evan@dash.org
-        udjinm6   - udjinm6@dash.org
-*/
+std::map<uint256, CDarksendBroadcastTx> mapDarksendBroadcastTxes;
+std::vector<CAmount> vecPrivateSendDenominations;
 
 void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
-    if(fLiteMode) return; //disable all Darksend/Masternode related functionality
+    if(fLiteMode) return; // ignore all Dash related functionality
     if(!masternodeSync.IsBlockchainSynced()) return;
 
-    if (strCommand == NetMsgType::DSACCEPT) { //Darksend Accept Into Pool
+    if(strCommand == NetMsgType::DSACCEPT) {
 
-        int errorID;
+        int nErrorID;
 
-        if (pfrom->nVersion < MIN_POOL_PEER_PROTO_VERSION) {
-            errorID = ERR_VERSION;
-            LogPrintf("dsa -- incompatible version! \n");
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
-
+        if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+            nErrorID = ERR_VERSION;
+            LogPrintf("CDarksendPool::ProcessMessage -- DSACCEPT -- incompatible version! nVersion: %d\n", pfrom->nVersion);
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
             return;
         }
 
-        if(!fMasterNode){
-            errorID = ERR_NOT_A_MN;
-            LogPrintf("dsa -- not a Masternode! \n");
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
-
+        if(!fMasterNode) {
+            nErrorID = ERR_NOT_A_MN;
+            LogPrintf("CDarksendPool::ProcessMessage -- DSACCEPT -- not a Masternode!\n");
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
             return;
         }
 
@@ -74,39 +56,37 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
         vRecv >> nDenom >> txCollateral;
 
         CMasternode* pmn = mnodeman.Find(activeMasternode.vin);
-        if(pmn == NULL)
-        {
-            errorID = ERR_MN_LIST;
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+        if(pmn == NULL) {
+            nErrorID = ERR_MN_LIST;
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
             return;
         }
 
-        if(sessionUsers == 0) {
-            if(pmn->nLastDsq != 0 &&
-                pmn->nLastDsq + mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
-                LogPrintf("dsa -- last dsq too recent, must wait. %s \n", pfrom->addr.ToString());
-                errorID = ERR_RECENT;
-                pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
-                return;
-            }
+        if(nSessionUsers == 0 && pmn->nLastDsq != 0 &&
+            pmn->nLastDsq + mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount)
+        {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSACCEPT -- last dsq too recent, must wait: addr=%s\n", pfrom->addr.ToString());
+            nErrorID = ERR_RECENT;
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
+            return;
         }
 
-        if(!IsCompatibleWithSession(nDenom, txCollateral, errorID))
-        {
-            LogPrintf("dsa -- not compatible with existing transactions! \n");
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+        if(IsDenomCompatibleWithSession(nDenom, txCollateral, nErrorID)) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSACCEPT -- is compatible, please submit!\n");
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_ACCEPTED, nErrorID);
             return;
         } else {
-            LogPrintf("dsa -- is compatible, please submit! \n");
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_ACCEPTED, errorID);
+            LogPrintf("CDarksendPool::ProcessMessage -- DSACCEPT -- not compatible with existing transactions!\n");
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
             return;
         }
 
-    } else if (strCommand == NetMsgType::DSQUEUE) { //Darksend Queue
+    } else if(strCommand == NetMsgType::DSQUEUE) {
         TRY_LOCK(cs_darksend, lockRecv);
         if(!lockRecv) return;
 
-        if (pfrom->nVersion < MIN_POOL_PEER_PROTO_VERSION) {
+        if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+            LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSQUEUE -- incompatible version! nVersion: %d\n", pfrom->nVersion);
             return;
         }
 
@@ -114,87 +94,80 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
         vRecv >> dsq;
 
         CService addr;
-        if(!dsq.GetAddress(addr)) return;
-        if(!dsq.CheckSignature()) return;
-
-        if(dsq.IsExpired()) return;
+        if(!dsq.GetAddress(addr) || !dsq.CheckSignature() || dsq.IsExpired()) return;
 
         CMasternode* pmn = mnodeman.Find(dsq.vin);
         if(pmn == NULL) return;
 
         // if the queue is ready, submit if we can
-        if(dsq.ready) {
+        if(dsq.fReady) {
             if(!pSubmittedToMasternode) return;
-            if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)addr){
-                LogPrintf("dsq - message doesn't match current Masternode - %s != %s\n", pSubmittedToMasternode->addr.ToString(), addr.ToString());
+            if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)addr) {
+                LogPrintf("CDarksendPool::ProcessMessage -- DSQUEUE -- message doesn't match current Masternode: pSubmittedToMasternode=%s, addr=%s\n", pSubmittedToMasternode->addr.ToString(), addr.ToString());
                 return;
             }
 
-            if(state == POOL_STATUS_QUEUE){
-                LogPrint("privatesend", "PrivateSend queue is ready - %s\n", addr.ToString());
-                PrepareDarksendDenominate();
+            if(nState == POOL_STATE_QUEUE) {
+                LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSQUEUE -- PrivateSend queue is ready on masternode %s\n", addr.ToString());
+                PrepareDenominate();
             }
         } else {
-            BOOST_FOREACH(CDarksendQueue q, vecDarksendQueue){
+            BOOST_FOREACH(CDarksendQueue q, vecDarksendQueue)
                 if(q.vin == dsq.vin) return;
-            }
 
-            LogPrint("privatesend", "dsq last %d last2 %d count %d\n", pmn->nLastDsq, pmn->nLastDsq + mnodeman.size()/5, mnodeman.nDsqCount);
+            LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSQUEUE -- nLastDsq: %d  threshold: %d  nDsqCount: %d\n", pmn->nLastDsq, pmn->nLastDsq + mnodeman.size()/5, mnodeman.nDsqCount);
             //don't allow a few nodes to dominate the queuing process
             if(pmn->nLastDsq != 0 &&
-                pmn->nLastDsq + mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
-                LogPrint("privatesend", "dsq -- Masternode sending too many dsq messages. %s \n", pmn->addr.ToString());
+                pmn->nLastDsq + mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount) {
+                LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSQUEUE -- Masternode %s is sending too many dsq messages\n", pmn->addr.ToString());
                 return;
             }
             mnodeman.nDsqCount++;
             pmn->nLastDsq = mnodeman.nDsqCount;
             pmn->allowFreeTx = true;
 
-            LogPrint("privatesend", "dsq - new PrivateSend queue object - %s\n", addr.ToString());
+            LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSQUEUE -- new PrivateSend queue object from masternode %s\n", addr.ToString());
             vecDarksendQueue.push_back(dsq);
             dsq.Relay();
-            dsq.time = GetTime();
+            dsq.nTime = GetTime();
         }
 
-    } else if (strCommand == NetMsgType::DSVIN) { //DarkSend vIn
-        int errorID;
+    } else if(strCommand == NetMsgType::DSVIN) {
+        int nErrorID;
 
-        if (pfrom->nVersion < MIN_POOL_PEER_PROTO_VERSION) {
-            LogPrintf("dsi -- incompatible version! \n");
-            errorID = ERR_VERSION;
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
-
+        if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- incompatible version! nVersion: %d\n", pfrom->nVersion);
+            nErrorID = ERR_VERSION;
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
             return;
         }
 
-        if(!fMasterNode){
-            LogPrintf("dsi -- not a Masternode! \n");
-            errorID = ERR_NOT_A_MN;
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
-
+        if(!fMasterNode) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- not a Masternode!\n");
+            nErrorID = ERR_NOT_A_MN;
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
             return;
         }
 
-        std::vector<CTxIn> in;
+        std::vector<CTxIn> vecTxIn;
         CAmount nAmount;
         CTransaction txCollateral;
-        std::vector<CTxOut> out;
-        vRecv >> in >> nAmount >> txCollateral >> out;
+        std::vector<CTxOut> vecTxOut;
+        vRecv >> vecTxIn >> nAmount >> txCollateral >> vecTxOut;
 
         //do we have enough users in the current session?
-        if(!IsSessionReady()){
-            LogPrintf("dsi -- session not complete! \n");
-            errorID = ERR_SESSION;
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+        if(nSessionUsers < GetMaxPoolTransactions()) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- session not complete!\n");
+            nErrorID = ERR_SESSION;
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
             return;
         }
 
         //do we have the same denominations as the current session?
-        if(!IsCompatibleWithEntries(out))
-        {
-            LogPrintf("dsi -- not compatible with existing transactions! \n");
-            errorID = ERR_EXISTING_TX;
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+        if(!IsOutputsCompatibleWithSessionDenom(vecTxOut)) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- not compatible with existing transactions!\n");
+            nErrorID = ERR_EXISTING_TX;
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
             return;
         }
 
@@ -202,62 +175,63 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
         {
             CAmount nValueIn = 0;
             CAmount nValueOut = 0;
-            bool missingTx = false;
+            bool fMissingTx = false;
 
             CMutableTransaction tx;
 
-            BOOST_FOREACH(const CTxOut o, out){
-                nValueOut += o.nValue;
-                tx.vout.push_back(o);
+            BOOST_FOREACH(const CTxOut txout, vecTxOut) {
+                nValueOut += txout.nValue;
+                tx.vout.push_back(txout);
 
-                if(o.scriptPubKey.size() != 25){
-                    LogPrintf("dsi - non-standard pubkey detected! %s\n", ScriptToAsmStr(o.scriptPubKey));
-                    errorID = ERR_NON_STANDARD_PUBKEY;
-                    pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+                if(txout.scriptPubKey.size() != 25) {
+                    LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- non-standard pubkey detected! scriptPubKey=%s\n", ScriptToAsmStr(txout.scriptPubKey));
+                    nErrorID = ERR_NON_STANDARD_PUBKEY;
+                    pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
                     return;
                 }
-                if(!o.scriptPubKey.IsNormalPaymentScript()){
-                    LogPrintf("dsi - invalid script! %s\n", ScriptToAsmStr(o.scriptPubKey));
-                    errorID = ERR_INVALID_SCRIPT;
-                    pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+                if(!txout.scriptPubKey.IsNormalPaymentScript()) {
+                    LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- invalid script! scriptPubKey=%s\n", ScriptToAsmStr(txout.scriptPubKey));
+                    nErrorID = ERR_INVALID_SCRIPT;
+                    pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
                     return;
                 }
             }
 
-            BOOST_FOREACH(const CTxIn i, in){
-                tx.vin.push_back(i);
+            BOOST_FOREACH(const CTxIn txin, vecTxIn) {
+                tx.vin.push_back(txin);
 
-                LogPrint("privatesend", "dsi -- tx in %s\n", i.ToString());
+                LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSVIN -- txin=%s\n", txin.ToString());
 
-                CTransaction tx2;
+                CTransaction txPrev;
                 uint256 hash;
-                if(GetTransaction(i.prevout.hash, tx2, Params().GetConsensus(), hash, true)){
-                    if(tx2.vout.size() > i.prevout.n) {
-                        nValueIn += tx2.vout[i.prevout.n].nValue;
-                    }
-                } else{
-                    missingTx = true;
+                if(GetTransaction(txin.prevout.hash, txPrev, Params().GetConsensus(), hash, true)) {
+                    if(txPrev.vout.size() > txin.prevout.n)
+                        nValueIn += txPrev.vout[txin.prevout.n].nValue;
+                } else {
+                    fMissingTx = true;
                 }
             }
 
-            if (nValueIn > DARKSEND_POOL_MAX) {
-                LogPrintf("dsi -- more than PrivateSend pool max! %s", tx.ToString());
-                errorID = ERR_MAXIMUM;
-                pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+            if(nValueIn > DARKSEND_POOL_MAX) {
+                LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- more than PrivateSend pool max! nValueIn: %lld, tx=%s", nValueIn, tx.ToString());
+                nErrorID = ERR_MAXIMUM;
+                pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
                 return;
             }
 
-            if(!missingTx){
-                if (nValueIn-nValueOut > nValueIn*.01) {
-                    LogPrintf("dsi -- fees are too high! %s", tx.ToString());
-                    errorID = ERR_FEES;
-                    pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
-                    return;
-                }
-            } else {
-                LogPrintf("dsi -- missing input tx! %s", tx.ToString());
-                errorID = ERR_MISSING_TX;
-                pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+            if(fMissingTx) {
+                LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- missing input! tx=%s", tx.ToString());
+                nErrorID = ERR_MISSING_TX;
+                pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
+                return;
+            }
+
+            // Allow lowest denom (at max) as a a fee. Normally shouldn't happen though.
+            // TODO: Or do not allow fees at all?
+            if(nValueIn - nValueOut > vecPrivateSendDenominations.back()) {
+                LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- fees are too high! fees: %lld, tx=%s", nValueIn - nValueOut, tx.ToString());
+                nErrorID = ERR_FEES;
+                pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
                 return;
             }
 
@@ -266,304 +240,320 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
                 CValidationState validationState;
                 mempool.PrioritiseTransaction(tx.GetHash(), tx.GetHash().ToString(), 1000, 0.1*COIN);
                 if(!AcceptToMemoryPool(mempool, validationState, CTransaction(tx), false, NULL, false, true, true)) {
-                    LogPrintf("dsi -- transaction not valid! %s", tx.ToString());
-                    errorID = ERR_INVALID_TX;
-                    pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+                    LogPrintf("CDarksendPool::ProcessMessage -- DSVIN -- transaction not valid! tx=%s", tx.ToString());
+                    nErrorID = ERR_INVALID_TX;
+                    pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
                     return;
                 }
             }
         }
 
-        if(AddEntry(in, nAmount, txCollateral, out, errorID)){
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_ACCEPTED, errorID);
-            Check();
+        if(AddEntry(vecTxIn, nAmount, txCollateral, vecTxOut, nErrorID)) {
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_ACCEPTED, nErrorID);
+            CheckPool();
 
-            RelayStatus(sessionID, GetState(), GetEntriesCount(), MASTERNODE_RESET);
+            RelayStatus(MASTERNODE_RESET);
         } else {
-            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, errorID);
+            pfrom->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, GetState(), GetEntriesCount(), MASTERNODE_REJECTED, nErrorID);
         }
 
-    } else if (strCommand == NetMsgType::DSSTATUSUPDATE) { //Darksend status update
-        if (pfrom->nVersion < MIN_POOL_PEER_PROTO_VERSION) {
+    } else if(strCommand == NetMsgType::DSSTATUSUPDATE) {
+        if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSSTATUSUPDATE -- incompatible version! nVersion: %d\n", pfrom->nVersion);
             return;
         }
 
         if(!pSubmittedToMasternode) return;
-        if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)pfrom->addr){
-            //LogPrintf("dssu - message doesn't match current Masternode - %s != %s\n", pSubmittedToMasternode->addr.ToString(), pfrom->addr.ToString());
+        if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)pfrom->addr) {
+            //LogPrintf("CDarksendPool::ProcessMessage -- DSSTATUSUPDATE -- message doesn't match current Masternode: pSubmittedToMasternode %s addr %s\n", pSubmittedToMasternode->addr.ToString(), pfrom->addr.ToString());
             return;
         }
 
-        int sessionIDMessage;
-        int state;
-        int entriesCount;
-        int accepted;
-        int errorID;
-        vRecv >> sessionIDMessage >> state >> entriesCount >> accepted >> errorID;
+        int nMsgSessionID;
+        int nMsgState;
+        int nMsgEntriesCount;
+        int nMsgAccepted;
+        int nMsgErrorID;
+        vRecv >> nMsgSessionID >> nMsgState >> nMsgEntriesCount >> nMsgAccepted >> nMsgErrorID;
 
-        LogPrint("privatesend", "dssu - state: %i entriesCount: %i accepted: %i error: %s \n", state, entriesCount, accepted, GetMessageByID(errorID));
+        LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSSTATUSUPDATE -- nMsgState: %d  nEntriesCount: %d  nMsgAccepted: %d  error: %s\n", nMsgState, nEntriesCount, nMsgAccepted, GetMessageByID(nMsgErrorID));
 
-        if((accepted != 1 && accepted != 0) && sessionID != sessionIDMessage){
-            LogPrintf("dssu - message doesn't match current PrivateSend session %d %d\n", sessionID, sessionIDMessage);
+        if((nMsgAccepted != 1 && nMsgAccepted != 0) && nSessionID != nMsgSessionID) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSSTATUSUPDATE -- message doesn't match current PrivateSend session: nSessionID: %d nMsgSessionID: %d\n", nSessionID, nMsgSessionID);
             return;
         }
 
-        StatusUpdate(state, entriesCount, accepted, errorID, sessionIDMessage);
+        UpdatePoolStateOnClient(nMsgState, nMsgEntriesCount, nMsgAccepted, nMsgErrorID, nMsgSessionID);
 
-    } else if (strCommand == NetMsgType::DSSIGNFINALTX) { //Darksend Sign Final Tx
+    } else if(strCommand == NetMsgType::DSSIGNFINALTX) {
 
-        if (pfrom->nVersion < MIN_POOL_PEER_PROTO_VERSION) {
+        if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSSIGNFINALTX -- incompatible version! nVersion: %d\n", pfrom->nVersion);
             return;
         }
 
-        vector<CTxIn> sigs;
-        vRecv >> sigs;
+        std::vector<CTxIn> vecTxIn;
+        vRecv >> vecTxIn;
 
-        bool success = true;
-        int nSigIndex = 0;
-        int nSigsCount = (int)sigs.size();
+        bool fSuccess = true;
+        int nTxInIndex = 0;
+        int nTxInsCount = (int)vecTxIn.size();
 
-        BOOST_FOREACH(const CTxIn item, sigs)
-        {
-            nSigIndex++;
-            if(!AddScriptSig(item)) {
-                success = false;
+        BOOST_FOREACH(const CTxIn txin, vecTxIn) {
+            nTxInIndex++;
+            if(!AddScriptSig(txin)) {
+                fSuccess = false;
                 break;
             }
-            LogPrint("privatesend", "DSSIGNFINALTX - AddScriptSig %d/%d - success\n", nSigIndex, nSigsCount);
+            LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSSIGNFINALTX -- AddScriptSig() %d/%d success\n", nTxInIndex, nTxInsCount);
         }
 
-        if(success){
-            Check();
-            RelayStatus(sessionID, GetState(), GetEntriesCount(), MASTERNODE_RESET);
+        if(fSuccess) {
+            CheckPool();
+            RelayStatus(MASTERNODE_RESET);
         } else {
-            LogPrint("privatesend", "DSSIGNFINALTX - AddScriptSig failed at %d/%d, session %d\n", nSigIndex, nSigsCount, sessionID);
+            LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSSIGNFINALTX -- AddScriptSig() failed at %d/%d, session: %d\n", nTxInIndex, nTxInsCount, nSessionID);
         }
-    } else if (strCommand == NetMsgType::DSFINALTX) { //Darksend Final tx
-        if (pfrom->nVersion < MIN_POOL_PEER_PROTO_VERSION) {
+    } else if(strCommand == NetMsgType::DSFINALTX) {
+        if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSFINALTX -- incompatible version! nVersion: %d\n", pfrom->nVersion);
             return;
         }
 
         if(!pSubmittedToMasternode) return;
-        if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)pfrom->addr){
-            //LogPrintf("dsc - message doesn't match current Masternode - %s != %s\n", pSubmittedToMasternode->addr.ToString(), pfrom->addr.ToString());
+        if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)pfrom->addr) {
+            //LogPrintf("CDarksendPool::ProcessMessage -- DSFINALTX -- message doesn't match current Masternode: pSubmittedToMasternode %s addr %s\n", pSubmittedToMasternode->addr.ToString(), pfrom->addr.ToString());
             return;
         }
 
-        int sessionIDMessage;
+        int nMsgSessionID;
         CTransaction txNew;
-        vRecv >> sessionIDMessage >> txNew;
+        vRecv >> nMsgSessionID >> txNew;
 
-        if(sessionID != sessionIDMessage){
-            LogPrint("privatesend", "dsf - message doesn't match current PrivateSend session %d %d\n", sessionID, sessionIDMessage);
+        if(nSessionID != nMsgSessionID) {
+            LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSFINALTX -- message doesn't match current PrivateSend session: nSessionID: %d  nMsgSessionID: %d\n", nSessionID, nMsgSessionID);
             return;
         }
 
         //check to see if input is spent already? (and probably not confirmed)
         SignFinalTransaction(txNew, pfrom);
 
-    } else if (strCommand == NetMsgType::DSCOMPLETE) { //Darksend Complete
+    } else if(strCommand == NetMsgType::DSCOMPLETE) {
 
-        if (pfrom->nVersion < MIN_POOL_PEER_PROTO_VERSION) {
+        if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+            LogPrintf("CDarksendPool::ProcessMessage -- DSCOMPLETE -- incompatible version! nVersion: %d\n", pfrom->nVersion);
             return;
         }
 
         if(!pSubmittedToMasternode) return;
-        if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)pfrom->addr){
-            //LogPrintf("dsc - message doesn't match current Masternode - %s != %s\n", pSubmittedToMasternode->addr.ToString(), pfrom->addr.ToString());
+        if((CNetAddr)pSubmittedToMasternode->addr != (CNetAddr)pfrom->addr) {
+            LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSCOMPLETE -- message doesn't match current Masternode: pSubmittedToMasternode=%s  addr=%s\n", pSubmittedToMasternode->addr.ToString(), pfrom->addr.ToString());
             return;
         }
 
-        int sessionIDMessage;
-        bool error;
-        int errorID;
-        vRecv >> sessionIDMessage >> error >> errorID;
+        int  nMsgSessionID;
+        bool fMsgError;
+        int  nMsgErrorID;
+        vRecv >> nMsgSessionID >> fMsgError >> nMsgErrorID;
 
-        if(sessionID != sessionIDMessage){
-            LogPrint("privatesend", "dsc - message doesn't match current PrivateSend session %d %d\n", darkSendPool.sessionID, sessionIDMessage);
+        if(nSessionID != nMsgSessionID) {
+            LogPrint("privatesend", "CDarksendPool::ProcessMessage -- DSCOMPLETE -- message doesn't match current PrivateSend session: nSessionID: %d  nMsgSessionID: %d\n", darkSendPool.nSessionID, nMsgSessionID);
             return;
         }
 
-        CompletedTransaction(error, errorID);
+        CompletedTransaction(fMsgError, nMsgErrorID);
     }
-
 }
 
-void CDarksendPool::Reset(){
-    cachedLastSuccess = 0;
-    lastNewBlock = 0;
-    txCollateral = CMutableTransaction();
+void CDarksendPool::InitDenominations()
+{
+    vecPrivateSendDenominations.clear();
+    /* Denominations
+
+        A note about convertability. Within mixing pools, each denomination
+        is convertable to another.
+
+        For example:
+        1DRK+1000 == (.1DRK+100)*10
+        10DRK+10000 == (1DRK+1000)*10
+    */
+    vecPrivateSendDenominations.push_back( (100      * COIN)+100000 );
+    vecPrivateSendDenominations.push_back( (10       * COIN)+10000 );
+    vecPrivateSendDenominations.push_back( (1        * COIN)+1000 );
+    vecPrivateSendDenominations.push_back( (.1       * COIN)+100 );
+    /* Disabled till we need them
+    vecPrivateSendDenominations.push_back( (.01      * COIN)+10 );
+    vecPrivateSendDenominations.push_back( (.001     * COIN)+1 );
+    */
+}
+
+void CDarksendPool::ResetPool()
+{
+    nCachedLastSuccessBlock = 0;
+    txMyCollateral = CMutableTransaction();
     vecMasternodesUsed.clear();
     UnlockCoins();
     SetNull();
 }
 
-void CDarksendPool::SetNull(){
-
+void CDarksendPool::SetNull()
+{
     // MN side
-    sessionUsers = 0;
+    nSessionUsers = 0;
     vecSessionCollateral.clear();
 
     // Client side
-    entriesCount = 0;
-    lastEntryAccepted = 0;
-    countEntriesAccepted = 0;
-    sessionFoundMasternode = false;
+    nEntriesCount = 0;
+    fLastEntryAccepted = false;
+    nAcceptedEntriesCount = 0;
+    fSessionFoundMasternode = false;
 
     // Both sides
-    state = POOL_STATUS_IDLE;
-    sessionID = 0;
-    sessionDenom = 0;
-    entries.clear();
+    nState = POOL_STATE_IDLE;
+    nSessionID = 0;
+    nSessionDenom = 0;
+    vecEntries.clear();
     finalMutableTransaction.vin.clear();
     finalMutableTransaction.vout.clear();
-    lastTimeChanged = GetTimeMillis();
-
-    // -- seed random number generator (used for ordering output lists)
-    unsigned int seed = 0;
-    RAND_bytes((unsigned char*)&seed, sizeof(seed));
-    std::srand(seed);
+    nLastTimeChanged = GetTimeMillis();
 }
 
 //
-// Unlock coins after Darksend fails or succeeds
+// Unlock coins after mixing fails or succeeds
 //
-void CDarksendPool::UnlockCoins(){
+void CDarksendPool::UnlockCoins()
+{
     while(true) {
         TRY_LOCK(pwalletMain->cs_wallet, lockWallet);
         if(!lockWallet) {MilliSleep(50); continue;}
-        BOOST_FOREACH(CTxIn v, lockedCoins)
-            pwalletMain->UnlockCoin(v.prevout);
+        BOOST_FOREACH(COutPoint outpoint, vecOutPointLocked)
+            pwalletMain->UnlockCoin(outpoint);
         break;
     }
 
-    lockedCoins.clear();
+    vecOutPointLocked.clear();
 }
 
 std::string CDarksendPool::GetStatus()
 {
-    static int showingDarkSendMessage = 0;
-    showingDarkSendMessage += 10;
-    std::string suffix = "";
+    static int nStatusMessageProgress = 0;
+    nStatusMessageProgress += 10;
+    std::string strSuffix = "";
 
-    if((pCurrentBlockIndex && pCurrentBlockIndex->nHeight - cachedLastSuccess < minBlockSpacing) || !masternodeSync.IsBlockchainSynced()) {
+    if((pCurrentBlockIndex && pCurrentBlockIndex->nHeight - nCachedLastSuccessBlock < nMinBlockSpacing) || !masternodeSync.IsBlockchainSynced())
         return strAutoDenomResult;
-    }
-    switch(state) {
-        case POOL_STATUS_IDLE:
+
+    switch(nState) {
+        case POOL_STATE_IDLE:
             return _("PrivateSend is idle.");
-        case POOL_STATUS_ACCEPTING_ENTRIES:
-            if(entriesCount == 0) {
-                showingDarkSendMessage = 0;
+        case POOL_STATE_ACCEPTING_ENTRIES:
+            if(nEntriesCount == 0) {
+                nStatusMessageProgress = 0;
                 return strAutoDenomResult;
-            } else if (lastEntryAccepted == 1) {
-                if(showingDarkSendMessage % 10 > 8) {
-                    lastEntryAccepted = 0;
-                    showingDarkSendMessage = 0;
+            } else if(fLastEntryAccepted) {
+                if(nStatusMessageProgress % 10 > 8) {
+                    fLastEntryAccepted = false;
+                    nStatusMessageProgress = 0;
                 }
                 return _("PrivateSend request complete:") + " " + _("Your transaction was accepted into the pool!");
             } else {
-                std::string suffix = "";
-                if(     showingDarkSendMessage % 70 <= 40) return strprintf(_("Submitted following entries to masternode: %u / %d"), entriesCount, GetMaxPoolTransactions());
-                else if(showingDarkSendMessage % 70 <= 50) suffix = ".";
-                else if(showingDarkSendMessage % 70 <= 60) suffix = "..";
-                else if(showingDarkSendMessage % 70 <= 70) suffix = "...";
-                return strprintf(_("Submitted to masternode, waiting for more entries ( %u / %d ) %s"), entriesCount, GetMaxPoolTransactions(), suffix);
+                if(     nStatusMessageProgress % 70 <= 40) return strprintf(_("Submitted following entries to masternode: %u / %d"), nEntriesCount, GetMaxPoolTransactions());
+                else if(nStatusMessageProgress % 70 <= 50) strSuffix = ".";
+                else if(nStatusMessageProgress % 70 <= 60) strSuffix = "..";
+                else if(nStatusMessageProgress % 70 <= 70) strSuffix = "...";
+                return strprintf(_("Submitted to masternode, waiting for more entries ( %u / %d ) %s"), nEntriesCount, GetMaxPoolTransactions(), strSuffix);
             }
-        case POOL_STATUS_SIGNING:
-            if(     showingDarkSendMessage % 70 <= 40) return _("Found enough users, signing ...");
-            else if(showingDarkSendMessage % 70 <= 50) suffix = ".";
-            else if(showingDarkSendMessage % 70 <= 60) suffix = "..";
-            else if(showingDarkSendMessage % 70 <= 70) suffix = "...";
-            return strprintf(_("Found enough users, signing ( waiting %s )"), suffix);
-        case POOL_STATUS_TRANSMISSION:
+        case POOL_STATE_SIGNING:
+            if(     nStatusMessageProgress % 70 <= 40) return _("Found enough users, signing ...");
+            else if(nStatusMessageProgress % 70 <= 50) strSuffix = ".";
+            else if(nStatusMessageProgress % 70 <= 60) strSuffix = "..";
+            else if(nStatusMessageProgress % 70 <= 70) strSuffix = "...";
+            return strprintf(_("Found enough users, signing ( waiting %s )"), strSuffix);
+        case POOL_STATE_TRANSMISSION:
             return _("Transmitting final transaction.");
-        case POOL_STATUS_FINALIZE_TRANSACTION:
+        case POOL_STATE_FINALIZE_TRANSACTION:
             return _("Finalizing transaction.");
-        case POOL_STATUS_ERROR:
-            return _("PrivateSend request incomplete:") + " " + lastMessage + " " + _("Will retry...");
-        case POOL_STATUS_SUCCESS:
-            return _("PrivateSend request complete:") + " " + lastMessage;
-        case POOL_STATUS_QUEUE:
-            if(     showingDarkSendMessage % 70 <= 30) suffix = ".";
-            else if(showingDarkSendMessage % 70 <= 50) suffix = "..";
-            else if(showingDarkSendMessage % 70 <= 70) suffix = "...";
-            return strprintf(_("Submitted to masternode, waiting in queue %s"), suffix);;
+        case POOL_STATE_ERROR:
+            return _("PrivateSend request incomplete:") + " " + strLastMessage + " " + _("Will retry...");
+        case POOL_STATE_SUCCESS:
+            return _("PrivateSend request complete:") + " " + strLastMessage;
+        case POOL_STATE_QUEUE:
+            if(     nStatusMessageProgress % 70 <= 30) strSuffix = ".";
+            else if(nStatusMessageProgress % 70 <= 50) strSuffix = "..";
+            else if(nStatusMessageProgress % 70 <= 70) strSuffix = "...";
+            return strprintf(_("Submitted to masternode, waiting in queue %s"), strSuffix);;
        default:
-            return strprintf(_("Unknown state: id = %u"), state);
+            return strprintf(_("Unknown state: id = %u"), nState);
     }
 }
 
 //
-// Check the Darksend progress and send client updates if a Masternode
+// Check the mixing progress and send client updates if a Masternode
 //
-void CDarksendPool::Check()
+void CDarksendPool::CheckPool()
 {
     if(fMasterNode) {
-        LogPrint("privatesend", "CDarksendPool::Check() - entries count %lu\n", entries.size());
+        LogPrint("privatesend", "CDarksendPool::CheckPool -- entries count %lu\n", GetEntriesCount());
 
         // If entries is full, then move on to the next phase
-        if(state == POOL_STATUS_ACCEPTING_ENTRIES && (int)entries.size() >= GetMaxPoolTransactions())
-        {
-            LogPrint("privatesend", "CDarksendPool::Check() -- TRYING TRANSACTION \n");
-            UpdateState(POOL_STATUS_FINALIZE_TRANSACTION);
+        if(nState == POOL_STATE_ACCEPTING_ENTRIES && GetEntriesCount() >= GetMaxPoolTransactions()) {
+            LogPrint("privatesend", "CDarksendPool::CheckPool -- TRYING TRANSACTION\n");
+            SetState(POOL_STATE_FINALIZE_TRANSACTION);
         }
     }
 
     // create the finalized transaction for distribution to the clients
-    if(state == POOL_STATUS_FINALIZE_TRANSACTION) {
-        LogPrint("privatesend", "CDarksendPool::Check() -- FINALIZE TRANSACTIONS\n");
-        UpdateState(POOL_STATUS_SIGNING);
+    if(nState == POOL_STATE_FINALIZE_TRANSACTION) {
+        LogPrint("privatesend", "CDarksendPool::CheckPool -- FINALIZE TRANSACTIONS\n");
+        SetState(POOL_STATE_SIGNING);
 
-        if (fMasterNode) {
-            CMutableTransaction txNew;
+        if(!fMasterNode) return;
 
-            // make our new transaction
-            for(unsigned int i = 0; i < entries.size(); i++){
-                BOOST_FOREACH(const CTxOut& v, entries[i].vout)
-                    txNew.vout.push_back(v);
+        CMutableTransaction txNew;
 
-                BOOST_FOREACH(const CTxDSIn& s, entries[i].sev)
-                    txNew.vin.push_back(s);
-            }
+        // make our new transaction
+        for(int i = 0; i < GetEntriesCount(); i++) {
+            BOOST_FOREACH(const CTxDSOut& txdsout, vecEntries[i].vecTxDSOut)
+                txNew.vout.push_back(txdsout);
 
-            // BIP69 https://github.com/kristovatlas/bips/blob/master/bip-0069.mediawiki
-            sort(txNew.vin.begin(), txNew.vin.end());
-            sort(txNew.vout.begin(), txNew.vout.end());
-
-
-            LogPrint("privatesend", "Transaction 1: %s\n", txNew.ToString());
-            finalMutableTransaction = txNew;
-
-            // request signatures from clients
-            RelayFinalTransaction(sessionID, finalMutableTransaction);
+            BOOST_FOREACH(const CTxDSIn& txdsin, vecEntries[i].vecTxDSIn)
+                txNew.vin.push_back(txdsin);
         }
+
+        // BIP69 https://github.com/kristovatlas/bips/blob/master/bip-0069.mediawiki
+        sort(txNew.vin.begin(), txNew.vin.end());
+        sort(txNew.vout.begin(), txNew.vout.end());
+
+        finalMutableTransaction = txNew;
+        LogPrint("privatesend", "CDarksendPool::CheckPool -- finalMutableTransaction=%s", txNew.ToString());
+
+        // request signatures from clients
+        RelayFinalTransaction(finalMutableTransaction);
     }
 
     // If we have all of the signatures, try to compile the transaction
-    if(fMasterNode && state == POOL_STATUS_SIGNING && SignaturesComplete()) {
-        LogPrint("privatesend", "CDarksendPool::Check() -- SIGNING\n");
-        UpdateState(POOL_STATUS_TRANSMISSION);
-
+    if(fMasterNode && nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
+        LogPrint("privatesend", "CDarksendPool::CheckPool -- SIGNING\n");
+        SetState(POOL_STATE_TRANSMISSION);
         CheckFinalTransaction();
     }
 
     // reset if we're here for 10 seconds
-    if((state == POOL_STATUS_ERROR || state == POOL_STATUS_SUCCESS) && GetTimeMillis()-lastTimeChanged >= 10000) {
-        LogPrint("privatesend", "CDarksendPool::Check() -- timeout, RESETTING\n");
+    if((nState == POOL_STATE_ERROR || nState == POOL_STATE_SUCCESS) && GetTimeMillis() - nLastTimeChanged >= 10000) {
+        LogPrint("privatesend", "CDarksendPool::CheckPool -- timeout, RESETTING\n");
         UnlockCoins();
         SetNull();
-        if(fMasterNode) RelayStatus(sessionID, GetState(), GetEntriesCount(), MASTERNODE_RESET);
+        if(fMasterNode) RelayStatus(MASTERNODE_RESET);
     }
 }
 
 void CDarksendPool::CheckFinalTransaction()
 {
-    if (!fMasterNode) return; // check and relay final tx only on masternode
+    if(!fMasterNode) return; // check and relay final tx only on masternode
 
     CTransaction finalTransaction = CTransaction(finalMutableTransaction);
 
-    LogPrint("privatesend", "Transaction 2: %s\n", finalTransaction.ToString());
+    LogPrint("privatesend", "CDarksendPool::CheckFinalTransaction -- finalTransaction=%s", finalTransaction.ToString());
 
     {
         // See if the transaction is valid
@@ -572,57 +562,40 @@ void CDarksendPool::CheckFinalTransaction()
         mempool.PrioritiseTransaction(finalTransaction.GetHash(), finalTransaction.GetHash().ToString(), 1000, 0.1*COIN);
         if(!lockMain || !AcceptToMemoryPool(mempool, validationState, finalTransaction, false, NULL, false, true, true))
         {
-            LogPrintf("CDarksendPool::Check() - CommitTransaction : Error: Transaction not valid\n");
+            LogPrintf("CDarksendPool::CheckFinalTransaction -- AcceptToMemoryPool() error: Transaction not valid\n");
             SetNull();
 
             // not much we can do in this case
-            UpdateState(POOL_STATUS_ACCEPTING_ENTRIES);
-            RelayCompletedTransaction(sessionID, true, ERR_INVALID_TX);
+            SetState(POOL_STATE_ACCEPTING_ENTRIES);
+            RelayCompletedTransaction(true, ERR_INVALID_TX);
             return;
         }
     }
-    LogPrintf("CDarksendPool::Check() -- IS MASTER -- TRANSMITTING DARKSEND\n");
 
-    // sign a message
+    LogPrintf("CDarksendPool::CheckFinalTransaction -- CREATING DSTX\n");
 
-    int64_t sigTime = GetAdjustedTime();
-    std::string strMessage = finalTransaction.GetHash().ToString() + boost::lexical_cast<std::string>(sigTime);
-    std::string strError = "";
-    std::vector<unsigned char> vchSig;
-
-    if(!darkSendSigner.SignMessage(strMessage, strError, vchSig, activeMasternode.keyMasternode)) {
-        LogPrintf("CDarksendPool::Check() - Sign message failed\n");
-        return;
+    // create and sign masternode dstx transaction
+    if(!mapDarksendBroadcastTxes.count(finalTransaction.GetHash())) {
+        CDarksendBroadcastTx dstx(finalTransaction, activeMasternode.vin, GetAdjustedTime());
+        dstx.Sign();
+        mapDarksendBroadcastTxes.insert(std::make_pair(finalTransaction.GetHash(), dstx));
     }
 
-    if(!darkSendSigner.VerifyMessage(activeMasternode.pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrintf("CDarksendPool::Check() - Verify message failed\n");
-        return;
-    }
-
-    if(!mapDarksendBroadcastTxes.count(finalTransaction.GetHash())){
-        CDarksendBroadcastTx dstx;
-        dstx.tx = finalTransaction;
-        dstx.vin = activeMasternode.vin;
-        dstx.vchSig = vchSig;
-        dstx.sigTime = sigTime;
-
-        mapDarksendBroadcastTxes.insert(make_pair(finalTransaction.GetHash(), dstx));
-    }
+    LogPrintf("CDarksendPool::CheckFinalTransaction -- TRANSMITTING DSTX\n");
 
     CInv inv(MSG_DSTX, finalTransaction.GetHash());
     RelayInv(inv);
 
     // Tell the clients it was successful
-    RelayCompletedTransaction(sessionID, false, MSG_SUCCESS);
+    RelayCompletedTransaction(false, MSG_SUCCESS);
 
     // Randomly charge clients
     ChargeRandomFees();
 
     // Reset
-    LogPrint("privatesend", "CDarksendPool::Check() -- COMPLETED -- RESETTING\n");
+    LogPrint("privatesend", "CDarksendPool::CheckFinalTransaction -- COMPLETED -- RESETTING\n");
     SetNull();
-    RelayStatus(sessionID, GetState(), GetEntriesCount(), MASTERNODE_RESET);
+    RelayStatus(MASTERNODE_RESET);
 }
 
 //
@@ -637,78 +610,73 @@ void CDarksendPool::CheckFinalTransaction()
 // transaction for the client to be able to enter the pool. This transaction is kept by the Masternode
 // until the transaction is either complete or fails.
 //
-void CDarksendPool::ChargeFees(){
+void CDarksendPool::ChargeFees()
+{
     if(!fMasterNode) return;
 
     //we don't need to charge collateral for every offence.
-    int offences = 0;
-    int r = rand()%100;
+    int nOffences = 0;
+    int r = insecure_rand()%100;
     if(r > 33) return;
 
-    if(state == POOL_STATUS_ACCEPTING_ENTRIES){
+    if(nState == POOL_STATE_ACCEPTING_ENTRIES) {
         BOOST_FOREACH(const CTransaction& txCollateral, vecSessionCollateral) {
-            bool found = false;
-            BOOST_FOREACH(const CDarkSendEntry& v, entries) {
-                if(v.collateral == txCollateral) {
-                    found = true;
-                }
-            }
+            bool fFound = false;
+            BOOST_FOREACH(const CDarkSendEntry& entry, vecEntries)
+                if(entry.txCollateral == txCollateral)
+                    fFound = true;
 
             // This queue entry didn't send us the promised transaction
-            if(!found){
+            if(!fFound) {
                 LogPrintf("CDarksendPool::ChargeFees -- found uncooperative node (didn't send transaction). Found offence.\n");
-                offences++;
+                nOffences++;
             }
         }
     }
 
-    if(state == POOL_STATUS_SIGNING) {
+    if(nState == POOL_STATE_SIGNING) {
         // who didn't sign?
-        BOOST_FOREACH(const CDarkSendEntry v, entries) {
-            BOOST_FOREACH(const CTxDSIn s, v.sev) {
-                if(!s.fHasSig){
+        BOOST_FOREACH(const CDarkSendEntry entry, vecEntries) {
+            BOOST_FOREACH(const CTxDSIn txdsin, entry.vecTxDSIn) {
+                if(!txdsin.fHasSig) {
                     LogPrintf("CDarksendPool::ChargeFees -- found uncooperative node (didn't sign). Found offence\n");
-                    offences++;
+                    nOffences++;
                 }
             }
         }
     }
-
-    r = rand()%100;
-    int target = 0;
-
-    //mostly offending?
-    if(offences >= Params().PoolMaxTransactions()-1 && r > 33) return;
-
-    //everyone is an offender? That's not right
-    if(offences >= Params().PoolMaxTransactions()) return;
-
-    //charge one of the offenders randomly
-    if(offences > 1) target = 50;
 
     //pick random client to charge
-    r = rand()%100;
+    r = insecure_rand()%100;
+    int nTarget = 0;
 
-    if(state == POOL_STATUS_ACCEPTING_ENTRIES){
+    //mostly offending?
+    if(nOffences >= Params().PoolMaxTransactions() - 1 && r > 33) return;
+
+    //everyone is an offender? That's not right
+    if(nOffences >= Params().PoolMaxTransactions()) return;
+
+    //charge one of the offenders randomly
+    if(nOffences > 1) nTarget = 50;
+
+    if(nState == POOL_STATE_ACCEPTING_ENTRIES) {
         BOOST_FOREACH(const CTransaction& txCollateral, vecSessionCollateral) {
-            bool found = false;
-            BOOST_FOREACH(const CDarkSendEntry& v, entries) {
-                if(v.collateral == txCollateral) {
-                    found = true;
-                }
-            }
+            bool fFound = false;
+            BOOST_FOREACH(const CDarkSendEntry& entry, vecEntries)
+                if(entry.txCollateral == txCollateral)
+                    fFound = true;
 
             // This queue entry didn't send us the promised transaction
-            if(!found && r > target){
+            if(!fFound && r > nTarget) {
                 LogPrintf("CDarksendPool::ChargeFees -- found uncooperative node (didn't send transaction). charging fees.\n");
 
                 CWalletTx wtxCollateral = CWalletTx(pwalletMain, txCollateral);
 
                 // Broadcast
-                if (!wtxCollateral.AcceptToMemoryPool(true))
-                {
-                    // This must not fail. The transaction has already been signed and recorded.
-                    LogPrintf("CDarksendPool::ChargeFees() : Error: Transaction not valid");
+                // This must not fail. The transaction has already been signed and recorded.
+                if(!wtxCollateral.AcceptToMemoryPool(true)) {
+                    LogPrintf("CDarksendPool::ChargeFees -- Error: Transaction not valid\n");
+                    return;
                 }
                 wtxCollateral.RelayWalletTransaction();
                 return;
@@ -716,20 +684,19 @@ void CDarksendPool::ChargeFees(){
         }
     }
 
-    if(state == POOL_STATUS_SIGNING) {
+    if(nState == POOL_STATE_SIGNING) {
         // who didn't sign?
-        BOOST_FOREACH(const CDarkSendEntry v, entries) {
-            BOOST_FOREACH(const CTxDSIn s, v.sev) {
-                if(!s.fHasSig && r > target){
+        BOOST_FOREACH(const CDarkSendEntry entry, vecEntries) {
+            BOOST_FOREACH(const CTxDSIn txdsin, entry.vecTxDSIn) {
+                if(!txdsin.fHasSig && r > nTarget) {
                     LogPrintf("CDarksendPool::ChargeFees -- found uncooperative node (didn't sign). charging fees.\n");
 
-                    CWalletTx wtxCollateral = CWalletTx(pwalletMain, v.collateral);
+                    CWalletTx wtxCollateral = CWalletTx(pwalletMain, entry.txCollateral);
 
                     // Broadcast
-                    if (!wtxCollateral.AcceptToMemoryPool(false))
-                    {
+                    if(!wtxCollateral.AcceptToMemoryPool(false)) {
                         // This must not fail. The transaction has already been signed and recorded.
-                        LogPrintf("CDarksendPool::ChargeFees() : Error: Transaction not valid");
+                        LogPrintf("CDarksendPool::ChargeFees -- Error: Transaction not valid\n");
                     }
                     wtxCollateral.RelayWalletTransaction();
                     return;
@@ -739,53 +706,53 @@ void CDarksendPool::ChargeFees(){
     }
 }
 
-// charge the collateral randomly
-//  - Darksend is completely free, to pay miners we randomly pay the collateral of users.
-void CDarksendPool::ChargeRandomFees(){
-    if(fMasterNode) {
-        int i = 0;
+/*
+    Charge the collateral randomly.
+    Mixing is completely free, to pay miners we randomly pay the collateral of users.
 
-        BOOST_FOREACH(const CTransaction& txCollateral, vecSessionCollateral) {
-            int r = rand()%100;
+    Collateral Fee Charges:
 
-            /*
-                Collateral Fee Charges:
+    Being that mixing has "no fees" we need to have some kind of cost associated
+    with using it to stop abuse. Otherwise it could serve as an attack vector and
+    allow endless transaction that would bloat Dash and make it unusable. To
+    stop these kinds of attacks 1 in 10 successful transactions are charged. This
+    adds up to a cost of 0.001DRK per transaction on average.
+*/
+void CDarksendPool::ChargeRandomFees()
+{
+    if(!fMasterNode) return;
 
-                Being that Darksend has "no fees" we need to have some kind of cost associated
-                with using it to stop abuse. Otherwise it could serve as an attack vector and
-                allow endless transaction that would bloat Dash and make it unusable. To
-                stop these kinds of attacks 1 in 10 successful transactions are charged. This
-                adds up to a cost of 0.001DRK per transaction on average.
-            */
-            if(r <= 10)
-            {
-                LogPrintf("CDarksendPool::ChargeRandomFees -- charging random fees. %u\n", i);
+    BOOST_FOREACH(const CTransaction& txCollateral, vecSessionCollateral) {
+        int r = insecure_rand()%100;
 
-                CWalletTx wtxCollateral = CWalletTx(pwalletMain, txCollateral);
+        if(r > 10) return;
 
-                // Broadcast
-                if (!wtxCollateral.AcceptToMemoryPool(true))
-                {
-                    // This must not fail. The transaction has already been signed and recorded.
-                    LogPrintf("CDarksendPool::ChargeRandomFees() : Error: Transaction not valid");
-                }
-                wtxCollateral.RelayWalletTransaction();
-            }
+        LogPrintf("CDarksendPool::ChargeRandomFees -- charging random fees, collateral, txCollateral=%s", txCollateral.ToString());
+
+        CWalletTx wtxCollateral = CWalletTx(pwalletMain, txCollateral);
+
+        // This must not fail. The transaction has already been signed and recorded.
+        if(!wtxCollateral.AcceptToMemoryPool(true)) {
+            LogPrintf("CDarksendPool::ChargeRandomFees -- Error: Transaction not valid, txCollateral=%s", txCollateral.ToString());
+            return;
         }
+
+        // Broadcast
+        wtxCollateral.RelayWalletTransaction();
     }
 }
 
 //
-// Check for various timeouts (queue objects, Darksend, etc)
+// Check for various timeouts (queue objects, mixing, etc)
 //
-void CDarksendPool::CheckTimeout(){
-
-    // check Darksend queue objects for timeouts
+void CDarksendPool::CheckTimeout()
+{
+    // check mixing queue objects for timeouts
     int c = 0;
-    vector<CDarksendQueue>::iterator it = vecDarksendQueue.begin();
-    while(it != vecDarksendQueue.end()){
-        if((*it).IsExpired()){
-            LogPrint("privatesend", "CDarksendPool::CheckTimeout() : Removing expired queue entry - %d\n", c);
+    std::vector<CDarksendQueue>::iterator it = vecDarksendQueue.begin();
+    while(it != vecDarksendQueue.end()) {
+        if((*it).IsExpired()) {
+            LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Removing expired queue entry: %d\n", c);
             it = vecDarksendQueue.erase(it);
         } else ++it;
         c++;
@@ -795,180 +762,174 @@ void CDarksendPool::CheckTimeout(){
 
     // catching hanging sessions
     if(!fMasterNode) {
-        switch(state) {
-            case POOL_STATUS_TRANSMISSION:
-                LogPrint("privatesend", "CDarksendPool::CheckTimeout() -- Session complete -- Running Check()\n");
-                Check();
+        switch(nState) {
+            case POOL_STATE_TRANSMISSION:
+                LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Session complete -- Running CheckPool\n");
+                CheckPool();
                 break;
-            case POOL_STATUS_ERROR:
-                LogPrint("privatesend", "CDarksendPool::CheckTimeout() -- Pool error -- Running Check()\n");
-                Check();
+            case POOL_STATE_ERROR:
+                LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Pool error -- Running CheckPool\n");
+                CheckPool();
                 break;
-            case POOL_STATUS_SUCCESS:
-                LogPrint("privatesend", "CDarksendPool::CheckTimeout() -- Pool success -- Running Check()\n");
-                Check();
+            case POOL_STATE_SUCCESS:
+                LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Pool success -- Running CheckPool\n");
+                CheckPool();
                 break;
         }
     }
 
-    int addLagTime = 0;
-    if(!fMasterNode) addLagTime = 10000; //if we're the client, give the server a few extra seconds before resetting.
+    int nLagTime = 0;
+    if(!fMasterNode) nLagTime = 10000; //if we're the client, give the server a few extra seconds before resetting.
 
-    if(state == POOL_STATUS_ACCEPTING_ENTRIES || state == POOL_STATUS_QUEUE){
+    if(nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_QUEUE) {
         c = 0;
 
         // check for a timeout and reset if needed
-        vector<CDarkSendEntry>::iterator it2 = entries.begin();
-        while(it2 != entries.end()){
-            if((*it2).IsExpired()){
-                LogPrint("privatesend", "CDarksendPool::CheckTimeout() : Removing expired entry - %d\n", c);
-                it2 = entries.erase(it2);
-                if(entries.size() == 0){
+        std::vector<CDarkSendEntry>::iterator it2 = vecEntries.begin();
+        while(it2 != vecEntries.end()) {
+            if((*it2).IsExpired()) {
+                LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Removing expired entry: %d\n", c);
+                it2 = vecEntries.erase(it2);
+                if(GetEntriesCount() == 0) {
                     UnlockCoins();
                     SetNull();
                 }
-                if(fMasterNode){
-                    RelayStatus(sessionID, GetState(), GetEntriesCount(), MASTERNODE_RESET);
-                }
+                if(fMasterNode)
+                    RelayStatus(MASTERNODE_RESET);
             } else ++it2;
             c++;
         }
 
-        if(GetTimeMillis()-lastTimeChanged >= (DARKSEND_QUEUE_TIMEOUT*1000)+addLagTime){
+        if(GetTimeMillis() - nLastTimeChanged >= DARKSEND_QUEUE_TIMEOUT*1000 + nLagTime) {
             UnlockCoins();
             SetNull();
         }
-    } else if(GetTimeMillis()-lastTimeChanged >= (DARKSEND_QUEUE_TIMEOUT*1000)+addLagTime){
-        LogPrint("privatesend", "CDarksendPool::CheckTimeout() -- Session timed out (%ds) -- resetting\n", DARKSEND_QUEUE_TIMEOUT);
+    } else if(GetTimeMillis() - nLastTimeChanged >= DARKSEND_QUEUE_TIMEOUT*1000 + nLagTime) {
+        LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Session timed out (%ds) -- resetting\n", DARKSEND_QUEUE_TIMEOUT);
         UnlockCoins();
         SetNull();
 
-        UpdateState(POOL_STATUS_ERROR);
-        lastMessage = _("Session timed out.");
+        SetState(POOL_STATE_ERROR);
+        strLastMessage = _("Session timed out.");
     }
 
-    if(state == POOL_STATUS_SIGNING && GetTimeMillis()-lastTimeChanged >= (DARKSEND_SIGNING_TIMEOUT*1000)+addLagTime ) {
-            LogPrint("privatesend", "CDarksendPool::CheckTimeout() -- Session timed out (%ds) -- restting\n", DARKSEND_SIGNING_TIMEOUT);
-            ChargeFees();
-            UnlockCoins();
-            SetNull();
+    if(nState == POOL_STATE_SIGNING && GetTimeMillis() - nLastTimeChanged >= DARKSEND_SIGNING_TIMEOUT*1000 + nLagTime) {
+        LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Session timed out (%ds) -- restting\n", DARKSEND_SIGNING_TIMEOUT);
+        ChargeFees();
+        UnlockCoins();
+        SetNull();
 
-            UpdateState(POOL_STATUS_ERROR);
-            lastMessage = _("Signing timed out.");
+        SetState(POOL_STATE_ERROR);
+        strLastMessage = _("Signing timed out.");
     }
 }
 
-//
-// Check for complete queue
-//
-void CDarksendPool::CheckForCompleteQueue(){
+/*
+    Check to see if we're ready for submissions from clients
+    After receiving multiple dsa messages, the queue will switch to "accepting entries"
+    which is the active state right before merging the transaction
+*/
+void CDarksendPool::CheckForCompleteQueue()
+{
     if(!fEnablePrivateSend && !fMasterNode) return;
 
-    /* Check to see if we're ready for submissions from clients */
-    //
-    // After receiving multiple dsa messages, the queue will switch to "accepting entries"
-    // which is the active state right before merging the transaction
-    //
-    if(state == POOL_STATUS_QUEUE && sessionUsers == GetMaxPoolTransactions()) {
-        UpdateState(POOL_STATUS_ACCEPTING_ENTRIES);
+    if(nState == POOL_STATE_QUEUE && nSessionUsers == GetMaxPoolTransactions()) {
+        SetState(POOL_STATE_ACCEPTING_ENTRIES);
 
-        CDarksendQueue dsq;
-        dsq.nDenom = sessionDenom;
-        dsq.vin = activeMasternode.vin;
-        dsq.time = GetTime();
-        dsq.ready = true;
+        CDarksendQueue dsq(nSessionDenom, activeMasternode.vin, GetTime(), true);
         dsq.Sign();
         dsq.Relay();
     }
 }
 
 // check to see if the signature is valid
-bool CDarksendPool::SignatureValid(const CScript& newSig, const CTxIn& newVin){
+bool CDarksendPool::IsSignatureValid(const CScript& scriptSig, const CTxIn& txin)
+{
     CMutableTransaction txNew;
     txNew.vin.clear();
     txNew.vout.clear();
 
-    int found = -1;
+    int i = 0;
+    int nTxInIndex = -1;
     CScript sigPubKey = CScript();
-    unsigned int i = 0;
 
-    BOOST_FOREACH(CDarkSendEntry& e, entries) {
-        BOOST_FOREACH(const CTxOut& out, e.vout)
-            txNew.vout.push_back(out);
+    BOOST_FOREACH(CDarkSendEntry& entry, vecEntries) {
 
-        BOOST_FOREACH(const CTxDSIn& s, e.sev){
-            txNew.vin.push_back(s);
+        BOOST_FOREACH(const CTxDSOut& txdsout, entry.vecTxDSOut)
+            txNew.vout.push_back(txdsout);
 
-            if(s == newVin){
-                found = i;
-                sigPubKey = s.prevPubKey;
+        BOOST_FOREACH(const CTxDSIn& txdsin, entry.vecTxDSIn) {
+            txNew.vin.push_back(txdsin);
+
+            if(txdsin == txin) {
+                nTxInIndex = i;
+                sigPubKey = txdsin.prevPubKey;
             }
             i++;
         }
     }
 
-    if(found >= 0){ //might have to do this one input at a time?
-        int n = found;
-        txNew.vin[n].scriptSig = newSig;
-        LogPrint("privatesend", "CDarksendPool::SignatureValid() - Sign with sig %s\n", ScriptToAsmStr(newSig).substr(0,24));
-        if (!VerifyScript(txNew.vin[n].scriptSig, sigPubKey, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC, MutableTransactionSignatureChecker(&txNew, n))){
-            LogPrint("privatesend", "CDarksendPool::SignatureValid() - Signing - Error signing input %u\n", n);
+    if(nTxInIndex >= 0) { //might have to do this one input at a time?
+        txNew.vin[nTxInIndex].scriptSig = scriptSig;
+        LogPrint("privatesend", "CDarksendPool::IsSignatureValid -- Sign with sig %s\n", ScriptToAsmStr(scriptSig).substr(0,24));
+        if(!VerifyScript(txNew.vin[nTxInIndex].scriptSig, sigPubKey, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC, MutableTransactionSignatureChecker(&txNew, nTxInIndex))) {
+            LogPrint("privatesend", "CDarksendPool::IsSignatureValid -- Signing -- Error signing input %d\n", nTxInIndex);
             return false;
         }
     }
 
-    LogPrint("privatesend", "CDarksendPool::SignatureValid() - Signing - Successfully validated input\n");
+    LogPrint("privatesend", "CDarksendPool::IsSignatureValid -- Signing -- Successfully validated input\n");
     return true;
 }
 
 // check to make sure the collateral provided by the client is valid
-bool CDarksendPool::IsCollateralValid(const CTransaction& txCollateral){
+bool CDarksendPool::IsCollateralValid(const CTransaction& txCollateral)
+{
     if(txCollateral.vout.size() < 1) return false;
     if(txCollateral.nLockTime != 0) return false;
 
     CAmount nValueIn = 0;
     CAmount nValueOut = 0;
-    bool missingTx = false;
+    bool fMissingTx = false;
 
-    BOOST_FOREACH(const CTxOut o, txCollateral.vout){
-        nValueOut += o.nValue;
+    BOOST_FOREACH(const CTxOut txout, txCollateral.vout) {
+        nValueOut += txout.nValue;
 
-        if(!o.scriptPubKey.IsNormalPaymentScript()){
-            LogPrintf ("CDarksendPool::IsCollateralValid - Invalid Script %s", txCollateral.ToString());
+        if(!txout.scriptPubKey.IsNormalPaymentScript()) {
+            LogPrintf ("CDarksendPool::IsCollateralValid -- Invalid Script, txCollateral=%s", txCollateral.ToString());
             return false;
         }
     }
 
-    BOOST_FOREACH(const CTxIn i, txCollateral.vin){
-        CTransaction tx2;
+    BOOST_FOREACH(const CTxIn txin, txCollateral.vin) {
+        CTransaction txPrev;
         uint256 hash;
-        if(GetTransaction(i.prevout.hash, tx2, Params().GetConsensus(), hash, true)){
-            if(tx2.vout.size() > i.prevout.n) {
-                nValueIn += tx2.vout[i.prevout.n].nValue;
-            }
-        } else{
-            missingTx = true;
+        if(GetTransaction(txin.prevout.hash, txPrev, Params().GetConsensus(), hash, true)) {
+            if(txPrev.vout.size() > txin.prevout.n)
+                nValueIn += txPrev.vout[txin.prevout.n].nValue;
+        } else {
+            fMissingTx = true;
         }
     }
 
-    if(missingTx){
-        LogPrint("privatesend", "CDarksendPool::IsCollateralValid - Unknown inputs in collateral transaction - %s", txCollateral.ToString());
+    if(fMissingTx) {
+        LogPrint("privatesend", "CDarksendPool::IsCollateralValid -- Unknown inputs in collateral transaction, txCollateral=%s", txCollateral.ToString());
         return false;
     }
 
     //collateral transactions are required to pay out DARKSEND_COLLATERAL as a fee to the miners
     if(nValueIn - nValueOut < DARKSEND_COLLATERAL) {
-        LogPrint("privatesend", "CDarksendPool::IsCollateralValid - did not include enough fees in transaction %d\n%s", nValueOut-nValueIn, txCollateral.ToString());
+        LogPrint("privatesend", "CDarksendPool::IsCollateralValid -- did not include enough fees in transaction: fees: %d, txCollateral=%s", nValueOut - nValueIn, txCollateral.ToString());
         return false;
     }
 
-    LogPrint("privatesend", "CDarksendPool::IsCollateralValid %s", txCollateral.ToString());
+    LogPrint("privatesend", "CDarksendPool::IsCollateralValid -- %s", txCollateral.ToString());
 
     {
         LOCK(cs_main);
         CValidationState validationState;
-        if(!AcceptToMemoryPool(mempool, validationState, txCollateral, false, NULL, false, true, true)){
-            if(fDebug) LogPrintf ("CDarksendPool::IsCollateralValid - didn't pass IsAcceptable\n");
+        if(!AcceptToMemoryPool(mempool, validationState, txCollateral, false, NULL, false, true, true)) {
+            LogPrint("privatesend", "CDarksendPool::IsCollateralValid -- didn't pass AcceptToMemoryPool()\n");
             return false;
         }
     }
@@ -980,86 +941,87 @@ bool CDarksendPool::IsCollateralValid(const CTransaction& txCollateral){
 //
 // Add a clients transaction to the pool
 //
-bool CDarksendPool::AddEntry(const std::vector<CTxIn>& newInput, const CAmount& nAmount, const CTransaction& txCollateral, const std::vector<CTxOut>& newOutput, int& errorID){
-    if (!fMasterNode) return false;
+bool CDarksendPool::AddEntry(const std::vector<CTxIn>& vecTxInNew, const CAmount nAmount, const CTransaction& txCollateral, const std::vector<CTxOut>& vecTxOutNew, int& nErrorID)
+{
+    if(!fMasterNode) return false;
 
-    BOOST_FOREACH(CTxIn in, newInput) {
-        if (in.prevout.IsNull() || nAmount < 0) {
-            LogPrint("privatesend", "CDarksendPool::AddEntry - input not valid!\n");
-            errorID = ERR_INVALID_INPUT;
-            sessionUsers--;
+    BOOST_FOREACH(CTxIn txin, vecTxInNew) {
+        if(txin.prevout.IsNull() || nAmount < 0) {
+            LogPrint("privatesend", "CDarksendPool::AddEntry -- input not valid!\n");
+            nErrorID = ERR_INVALID_INPUT;
+            nSessionUsers--;
             return false;
         }
     }
 
-    if (!IsCollateralValid(txCollateral)){
-        LogPrint("privatesend", "CDarksendPool::AddEntry - collateral not valid!\n");
-        errorID = ERR_INVALID_COLLATERAL;
-        sessionUsers--;
+    if(!IsCollateralValid(txCollateral)) {
+        LogPrint("privatesend", "CDarksendPool::AddEntry -- collateral not valid!\n");
+        nErrorID = ERR_INVALID_COLLATERAL;
+        nSessionUsers--;
         return false;
     }
 
-    if((int)entries.size() >= GetMaxPoolTransactions()){
-        LogPrint("privatesend", "CDarksendPool::AddEntry - entries is full!\n");
-        errorID = ERR_ENTRIES_FULL;
-        sessionUsers--;
+    if(GetEntriesCount() >= GetMaxPoolTransactions()) {
+        LogPrint("privatesend", "CDarksendPool::AddEntry -- entries is full!\n");
+        nErrorID = ERR_ENTRIES_FULL;
+        nSessionUsers--;
         return false;
     }
 
-    BOOST_FOREACH(CTxIn in, newInput) {
-        LogPrint("privatesend", "looking for vin -- %s\n", in.ToString());
-        BOOST_FOREACH(const CDarkSendEntry& v, entries) {
-            BOOST_FOREACH(const CTxDSIn& s, v.sev){
-                if((CTxIn)s == in) {
-                    LogPrint("privatesend", "CDarksendPool::AddEntry - found in vin\n");
-                    errorID = ERR_ALREADY_HAVE;
-                    sessionUsers--;
+    BOOST_FOREACH(CTxIn txin, vecTxInNew) {
+        LogPrint("privatesend", "looking for txin -- %s\n", txin.ToString());
+        BOOST_FOREACH(const CDarkSendEntry& entry, vecEntries) {
+            BOOST_FOREACH(const CTxDSIn& txdsin, entry.vecTxDSIn) {
+                if((CTxIn)txdsin == txin) {
+                    LogPrint("privatesend", "CDarksendPool::AddEntry -- found in txin\n");
+                    nErrorID = ERR_ALREADY_HAVE;
+                    nSessionUsers--;
                     return false;
                 }
             }
         }
     }
 
-    CDarkSendEntry v;
-    v.Add(newInput, nAmount, txCollateral, newOutput);
-    entries.push_back(v);
+    CDarkSendEntry entry;
+    entry.Add(vecTxInNew, nAmount, txCollateral, vecTxOutNew);
+    vecEntries.push_back(entry);
 
-    LogPrint("privatesend", "CDarksendPool::AddEntry -- adding %s\n", newInput[0].ToString());
-    errorID = MSG_ENTRIES_ADDED;
+    LogPrint("privatesend", "CDarksendPool::AddEntry -- adding entry %s\n", vecTxInNew[0].ToString());
+    nErrorID = MSG_ENTRIES_ADDED;
 
     return true;
 }
 
-bool CDarksendPool::AddScriptSig(const CTxIn& newVin){
-    LogPrint("privatesend", "CDarksendPool::AddScriptSig -- new sig  %s\n", ScriptToAsmStr(newVin.scriptSig).substr(0,24));
+bool CDarksendPool::AddScriptSig(const CTxIn& txinNew)
+{
+    LogPrint("privatesend", "CDarksendPool::AddScriptSig -- new sig, scriptSig=%s\n", ScriptToAsmStr(txinNew.scriptSig).substr(0,24));
 
-
-    BOOST_FOREACH(const CDarkSendEntry& v, entries) {
-        BOOST_FOREACH(const CTxDSIn& s, v.sev){
-            if(s.scriptSig == newVin.scriptSig) {
-                LogPrint("privatesend", "CDarksendPool::AddScriptSig - already exists\n");
+    BOOST_FOREACH(const CDarkSendEntry& entry, vecEntries) {
+        BOOST_FOREACH(const CTxDSIn& txdsin, entry.vecTxDSIn) {
+            if(txdsin.scriptSig == txinNew.scriptSig) {
+                LogPrint("privatesend", "CDarksendPool::AddScriptSig -- already exists\n");
                 return false;
             }
         }
     }
 
-    if(!SignatureValid(newVin.scriptSig, newVin)){
-        LogPrint("privatesend", "CDarksendPool::AddScriptSig - Invalid Sig\n");
+    if(!IsSignatureValid(txinNew.scriptSig, txinNew)) {
+        LogPrint("privatesend", "CDarksendPool::AddScriptSig -- Invalid Sig\n");
         return false;
     }
 
-    LogPrint("privatesend", "CDarksendPool::AddScriptSig -- sig %s\n", ScriptToAsmStr(newVin.scriptSig));
+    LogPrint("privatesend", "CDarksendPool::AddScriptSig -- scriptSig=%s\n", ScriptToAsmStr(txinNew.scriptSig));
 
-    BOOST_FOREACH(CTxIn& vin, finalMutableTransaction.vin){
-        if(newVin.prevout == vin.prevout && vin.nSequence == newVin.nSequence){
-            vin.scriptSig = newVin.scriptSig;
-            vin.prevPubKey = newVin.prevPubKey;
-            LogPrint("privatesend", "CDarksendPool::AddScriptSig -- adding to finalMutableTransaction  %s\n", ScriptToAsmStr(newVin.scriptSig).substr(0,24));
+    BOOST_FOREACH(CTxIn& txin, finalMutableTransaction.vin) {
+        if(txinNew.prevout == txin.prevout && txin.nSequence == txinNew.nSequence) {
+            txin.scriptSig = txinNew.scriptSig;
+            txin.prevPubKey = txinNew.prevPubKey;
+            LogPrint("privatesend", "CDarksendPool::AddScriptSig -- adding to finalMutableTransaction, scriptSig=%s\n", ScriptToAsmStr(txinNew.scriptSig).substr(0,24));
         }
     }
-    for(unsigned int i = 0; i < entries.size(); i++){
-        if(entries[i].AddSig(newVin)){
-            LogPrint("privatesend", "CDarksendPool::AddScriptSig -- adding  %s\n", ScriptToAsmStr(newVin.scriptSig).substr(0,24));
+    for(int i = 0; i < GetEntriesCount(); i++) {
+        if(vecEntries[i].AddScriptSig(txinNew)) {
+            LogPrint("privatesend", "CDarksendPool::AddScriptSig -- adding to entries, scriptSig=%s\n", ScriptToAsmStr(txinNew.scriptSig).substr(0,24));
             return true;
         }
     }
@@ -1069,89 +1031,84 @@ bool CDarksendPool::AddScriptSig(const CTxIn& newVin){
 }
 
 // Check to make sure everything is signed
-bool CDarksendPool::SignaturesComplete(){
-    BOOST_FOREACH(const CDarkSendEntry& v, entries) {
-        BOOST_FOREACH(const CTxDSIn& s, v.sev){
-            if(!s.fHasSig) return false;
-        }
-    }
+bool CDarksendPool::IsSignaturesComplete()
+{
+    BOOST_FOREACH(const CDarkSendEntry& entry, vecEntries)
+        BOOST_FOREACH(const CTxDSIn& txdsin, entry.vecTxDSIn)
+            if(!txdsin.fHasSig) return false;
 
     return true;
 }
 
 //
-// Execute a Darksend denomination via a Masternode.
+// Execute a mixing denomination via a Masternode.
 // This is only ran from clients
 //
-void CDarksendPool::SendDarksendDenominate(std::vector<CTxIn>& vin, std::vector<CTxOut>& vout, CAmount amount){
-
+void CDarksendPool::SendDarksendDenominate(const std::vector<CTxIn>& vecTxIn, const std::vector<CTxOut>& vecTxOut, CAmount nAmount)
+{
     if(fMasterNode) {
-        LogPrintf("CDarksendPool::SendDarksendDenominate() - PrivateSend from a Masternode is not supported currently.\n");
+        LogPrintf("CDarksendPool::SendDarksendDenominate -- PrivateSend from a Masternode is not supported currently.\n");
         return;
     }
 
-    if(txCollateral == CMutableTransaction()){
-        LogPrintf ("CDarksendPool:SendDarksendDenominate() - PrivateSend collateral not set");
+    if(txMyCollateral == CMutableTransaction()) {
+        LogPrintf ("CDarksendPool:SendDarksendDenominate -- PrivateSend collateral not set");
         return;
     }
 
     // lock the funds we're going to use
-    BOOST_FOREACH(CTxIn in, txCollateral.vin)
-        lockedCoins.push_back(in);
+    BOOST_FOREACH(CTxIn txin, txMyCollateral.vin)
+        vecOutPointLocked.push_back(txin.prevout);
 
-    BOOST_FOREACH(CTxIn in, vin)
-        lockedCoins.push_back(in);
+    BOOST_FOREACH(CTxIn txin, vecTxIn)
+        vecOutPointLocked.push_back(txin.prevout);
 
-    //BOOST_FOREACH(CTxOut o, vout)
-    //    LogPrintf(" vout - %s\n", o.ToString());
+    //BOOST_FOREACH(CTxOut o, vecTxOut)
+    //    LogPrintf(" vecTxOut - %s\n", o.ToString());
 
 
     // we should already be connected to a Masternode
-    if(!sessionFoundMasternode){
-        LogPrintf("CDarksendPool::SendDarksendDenominate() - No Masternode has been selected yet.\n");
+    if(!fSessionFoundMasternode) {
+        LogPrintf("CDarksendPool::SendDarksendDenominate -- No Masternode has been selected yet.\n");
         UnlockCoins();
         SetNull();
         return;
     }
 
-    if (!CheckDiskSpace()) {
+    if(!CheckDiskSpace()) {
         UnlockCoins();
         SetNull();
         fEnablePrivateSend = false;
-        LogPrintf("CDarksendPool::SendDarksendDenominate() - Not enough disk space, disabling PrivateSend.\n");
+        LogPrintf("CDarksendPool::SendDarksendDenominate -- Not enough disk space, disabling PrivateSend.\n");
         return;
     }
 
-    UpdateState(POOL_STATUS_ACCEPTING_ENTRIES);
+    SetState(POOL_STATE_ACCEPTING_ENTRIES);
+    strLastMessage = "";
 
-    LogPrintf("CDarksendPool::SendDarksendDenominate() - Added transaction to pool.\n");
-
-    ClearLastMessage();
+    LogPrintf("CDarksendPool::SendDarksendDenominate -- Added transaction to pool.\n");
 
     //check it against the memory pool to make sure it's valid
     {
-        CAmount nValueOut = 0;
-
         CValidationState validationState;
         CMutableTransaction tx;
 
-        BOOST_FOREACH(const CTxOut& o, vout){
-            nValueOut += o.nValue;
-            tx.vout.push_back(o);
+        BOOST_FOREACH(const CTxIn& txin, vecTxIn) {
+            LogPrint("privatesend", "CDarksendPool::SendDarksendDenominate -- txin=%s\n", txin.ToString());
+            tx.vin.push_back(txin);
         }
 
-        BOOST_FOREACH(const CTxIn& i, vin){
-            tx.vin.push_back(i);
-
-            LogPrint("privatesend", "CDarksendPool::SendDarksendDenominate() -- tx in %s\n", i.ToString());
+        BOOST_FOREACH(const CTxOut& txout, vecTxOut) {
+            LogPrint("privatesend", "CDarksendPool::SendDarksendDenominate -- txout=%s\n", txout.ToString());
+            tx.vout.push_back(txout);
         }
 
-        LogPrintf("CDarksendPool::SendDarksendDenominate() -- Submitting tx %s", tx.ToString());
+        LogPrintf("CDarksendPool::SendDarksendDenominate -- Submitting partial tx %s", tx.ToString());
 
         mempool.PrioritiseTransaction(tx.GetHash(), tx.GetHash().ToString(), 1000, 0.1*COIN);
         TRY_LOCK(cs_main, lockMain);
-        if(!lockMain || !AcceptToMemoryPool(mempool, validationState, CTransaction(tx), false, NULL, false, true, true)){
-            LogPrintf("CDarksendPool::SendDarksendDenominate() -- transaction failed! %s", tx.ToString());
+        if(!lockMain || !AcceptToMemoryPool(mempool, validationState, CTransaction(tx), false, NULL, false, true, true)) {
+            LogPrintf("CDarksendPool::SendDarksendDenominate -- AcceptToMemoryPool() failed! tx=%s", tx.ToString());
             UnlockCoins();
             SetNull();
             return;
@@ -1159,56 +1116,57 @@ void CDarksendPool::SendDarksendDenominate(std::vector<CTxIn>& vin, std::vector<
     }
 
     // store our entry for later use
-    CDarkSendEntry e;
-    e.Add(vin, amount, txCollateral, vout);
-    entries.push_back(e);
+    CDarkSendEntry entry;
+    entry.Add(vecTxIn, nAmount, txMyCollateral, vecTxOut);
+    vecEntries.push_back(entry);
 
-    RelayIn(entries[0].sev, entries[0].amount, txCollateral, entries[0].vout);
-    Check();
+    RelayIn(vecEntries[0].vecTxDSIn, vecEntries[0].nAmount, txMyCollateral, vecEntries[0].vecTxDSOut);
+    CheckPool();
 }
 
-// Incoming message from Masternode updating the progress of Darksend
-//    newAccepted:  -1 mean's it'n not a "transaction accepted/not accepted" message, just a standard update
-//                  0 means transaction was not accepted
-//                  1 means transaction was accepted
-
-bool CDarksendPool::StatusUpdate(int newState, int newEntriesCount, int newAccepted, int& errorID, int newSessionID){
+// Incoming message from Masternode updating the progress of mixing
+//    nAcceptedEntriesCountNew:
+//        -1 mean's it'n not a "transaction accepted/not accepted" message, just a standard update
+//         0 means transaction was not accepted
+//         1 means transaction was accepted
+bool CDarksendPool::UpdatePoolStateOnClient(int nStateNew, int nEntriesCountNew, int nAcceptedEntriesCountNew, int& nErrorID, int nSessionIDNew)
+{
     if(fMasterNode) return false;
-    if(state == POOL_STATUS_ERROR || state == POOL_STATUS_SUCCESS) return false;
+    if(nState == POOL_STATE_ERROR || nState == POOL_STATE_SUCCESS) return false;
 
-    UpdateState(newState);
-    entriesCount = newEntriesCount;
+    SetState(nStateNew);
+    nEntriesCount = nEntriesCountNew;
 
-    if(errorID != MSG_NOERR) strAutoDenomResult = _("Masternode:") + " " + GetMessageByID(errorID);
+    strAutoDenomResult = _("Masternode:") + " " + GetMessageByID(nErrorID);
 
-    if(newAccepted != -1) {
-        lastEntryAccepted = newAccepted;
-        countEntriesAccepted += newAccepted;
-        if(newAccepted == 0){
-            UpdateState(POOL_STATUS_ERROR);
-            lastMessage = GetMessageByID(errorID);
+    if(nAcceptedEntriesCountNew != -1) {
+        fLastEntryAccepted = nAcceptedEntriesCountNew;
+        nAcceptedEntriesCount += nAcceptedEntriesCountNew;
+        if(nAcceptedEntriesCountNew == 0) {
+            SetState(POOL_STATE_ERROR);
+            strLastMessage = GetMessageByID(nErrorID);
         }
 
-        if(newAccepted == 1 && newSessionID != 0) {
-            sessionID = newSessionID;
-            LogPrintf("CDarksendPool::StatusUpdate - set sessionID to %d\n", sessionID);
-            sessionFoundMasternode = true;
+        if(nAcceptedEntriesCountNew == 1 && nSessionIDNew != 0) {
+            nSessionID = nSessionIDNew;
+            LogPrintf("CDarksendPool::UpdatePoolStateOnClient -- set nSessionID to %d\n", nSessionID);
+            fSessionFoundMasternode = true;
         }
     }
 
-    if(newState == POOL_STATUS_ACCEPTING_ENTRIES){
-        if(newAccepted == 1){
-            LogPrintf("CDarksendPool::StatusUpdate - entry accepted! \n");
-            sessionFoundMasternode = true;
+    if(nStateNew == POOL_STATE_ACCEPTING_ENTRIES) {
+        if(nAcceptedEntriesCountNew == 1) {
+            LogPrintf("CDarksendPool::UpdatePoolStateOnClient -- entry accepted!\n");
+            fSessionFoundMasternode = true;
             //wait for other users. Masternode will report when ready
-            UpdateState(POOL_STATUS_QUEUE);
-        } else if (newAccepted == 0 && sessionID == 0 && !sessionFoundMasternode) {
-            LogPrintf("CDarksendPool::StatusUpdate - entry not accepted by Masternode \n");
+            SetState(POOL_STATE_QUEUE);
+        } else if(nAcceptedEntriesCountNew == 0 && nSessionID == 0 && !fSessionFoundMasternode) {
+            LogPrintf("CDarksendPool::UpdatePoolStateOnClient -- entry not accepted by Masternode\n");
             UnlockCoins();
-            UpdateState(POOL_STATUS_ACCEPTING_ENTRIES);
+            SetState(POOL_STATE_ACCEPTING_ENTRIES);
             DoAutomaticDenominating(); //try another Masternode
         }
-        if(sessionFoundMasternode) return true;
+        if(fSessionFoundMasternode) return true;
     }
 
     return true;
@@ -1219,52 +1177,53 @@ bool CDarksendPool::StatusUpdate(int newState, int newEntriesCount, int newAccep
 // check it to make sure it's what we want, then sign it if we agree.
 // If we refuse to sign, it's possible we'll be charged collateral
 //
-bool CDarksendPool::SignFinalTransaction(CTransaction& finalTransactionNew, CNode* node){
+bool CDarksendPool::SignFinalTransaction(const CTransaction& finalTransactionNew, CNode* node)
+{
     if(fMasterNode) return false;
 
     finalMutableTransaction = finalTransactionNew;
-    LogPrintf("CDarksendPool::SignFinalTransaction %s", finalMutableTransaction.ToString());
+    LogPrintf("CDarksendPool::SignFinalTransaction -- %s", finalMutableTransaction.ToString());
 
-    vector<CTxIn> sigs;
+    std::vector<CTxIn> sigs;
 
     //make sure my inputs/outputs are present, otherwise refuse to sign
-    BOOST_FOREACH(const CDarkSendEntry e, entries) {
-        BOOST_FOREACH(const CTxDSIn s, e.sev) {
+    BOOST_FOREACH(const CDarkSendEntry entry, vecEntries) {
+        BOOST_FOREACH(const CTxDSIn txdsin, entry.vecTxDSIn) {
             /* Sign my transaction and all outputs */
-            int mine = -1;
+            int nMyInputIndex = -1;
             CScript prevPubKey = CScript();
-            CTxIn vin = CTxIn();
+            CTxIn txin = CTxIn();
 
-            for(unsigned int i = 0; i < finalMutableTransaction.vin.size(); i++){
-                if(finalMutableTransaction.vin[i] == s){
-                    mine = i;
-                    prevPubKey = s.prevPubKey;
-                    vin = s;
+            for(unsigned int i = 0; i < finalMutableTransaction.vin.size(); i++) {
+                if(finalMutableTransaction.vin[i] == txdsin) {
+                    nMyInputIndex = i;
+                    prevPubKey = txdsin.prevPubKey;
+                    txin = txdsin;
                 }
             }
 
-            if(mine >= 0){ //might have to do this one input at a time?
-                int foundOutputs = 0;
+            if(nMyInputIndex >= 0) { //might have to do this one input at a time?
+                int nFoundOutputsCount = 0;
                 CAmount nValue1 = 0;
                 CAmount nValue2 = 0;
 
-                for(unsigned int i = 0; i < finalMutableTransaction.vout.size(); i++){
-                    BOOST_FOREACH(const CTxOut& o, e.vout) {
-                        if(finalMutableTransaction.vout[i] == o){
-                            foundOutputs++;
+                for(unsigned int i = 0; i < finalMutableTransaction.vout.size(); i++) {
+                    BOOST_FOREACH(const CTxOut& txout, entry.vecTxDSOut) {
+                        if(finalMutableTransaction.vout[i] == txout) {
+                            nFoundOutputsCount++;
                             nValue1 += finalMutableTransaction.vout[i].nValue;
                         }
                     }
                 }
 
-                BOOST_FOREACH(const CTxOut o, e.vout)
-                    nValue2 += o.nValue;
+                BOOST_FOREACH(const CTxOut txout, entry.vecTxDSOut)
+                    nValue2 += txout.nValue;
 
-                int targetOuputs = e.vout.size();
-                if(foundOutputs < targetOuputs || nValue1 != nValue2) {
+                int nTargetOuputsCount = entry.vecTxDSOut.size();
+                if(nFoundOutputsCount < nTargetOuputsCount || nValue1 != nValue2) {
                     // in this case, something went wrong and we'll refuse to sign. It's possible we'll be charged collateral. But that's
                     // better then signing if the transaction doesn't look like what we wanted.
-                    LogPrintf("CDarksendPool::Sign - My entries are not correct! Refusing to sign. %d entries %d target. \n", foundOutputs, targetOuputs);
+                    LogPrintf("CDarksendPool::SignFinalTransaction -- My entries are not correct! Refusing to sign: nFoundOutputsCount: %d, nTargetOuputsCount: %d\n", nFoundOutputsCount, nTargetOuputsCount);
                     UnlockCoins();
                     SetNull();
 
@@ -1273,130 +1232,122 @@ bool CDarksendPool::SignFinalTransaction(CTransaction& finalTransactionNew, CNod
 
                 const CKeyStore& keystore = *pwalletMain;
 
-                LogPrint("privatesend", "CDarksendPool::Sign - Signing my input %i\n", mine);
-                if(!SignSignature(keystore, prevPubKey, finalMutableTransaction, mine, int(SIGHASH_ALL|SIGHASH_ANYONECANPAY))) { // changes scriptSig
-                    LogPrint("privatesend", "CDarksendPool::Sign - Unable to sign my own transaction! \n");
+                LogPrint("privatesend", "CDarksendPool::SignFinalTransaction -- Signing my input %i\n", nMyInputIndex);
+                if(!SignSignature(keystore, prevPubKey, finalMutableTransaction, nMyInputIndex, int(SIGHASH_ALL|SIGHASH_ANYONECANPAY))) { // changes scriptSig
+                    LogPrint("privatesend", "CDarksendPool::SignFinalTransaction -- Unable to sign my own transaction!\n");
                     // not sure what to do here, it will timeout...?
                 }
 
-                sigs.push_back(finalMutableTransaction.vin[mine]);
-                LogPrint("privatesend", " -- dss %d %d %s\n", mine, (int)sigs.size(), ScriptToAsmStr(finalMutableTransaction.vin[mine].scriptSig));
+                sigs.push_back(finalMutableTransaction.vin[nMyInputIndex]);
+                LogPrint("privatesend", "CDarksendPool::SignFinalTransaction -- nMyInputIndex: %d, sigs.size(): %d, scriptSig=%s\n", nMyInputIndex, (int)sigs.size(), ScriptToAsmStr(finalMutableTransaction.vin[nMyInputIndex].scriptSig));
             }
 
         }
 
-        LogPrint("privatesend", "CDarksendPool::Sign - txNew:\n%s", finalMutableTransaction.ToString());
+        LogPrint("privatesend", "CDarksendPool::SignFinalTransaction -- finalMutableTransaction=%s", finalMutableTransaction.ToString());
     }
 
-	// push all of our signatures to the Masternode
-	if(sigs.size() > 0 && node != NULL)
-	    node->PushMessage(NetMsgType::DSSIGNFINALTX, sigs);
-
+    // push all of our signatures to the Masternode
+    if(sigs.size() > 0 && node != NULL)
+        node->PushMessage(NetMsgType::DSSIGNFINALTX, sigs);
 
     return true;
 }
 
 void CDarksendPool::NewBlock()
 {
-    LogPrint("privatesend", "CDarksendPool::NewBlock \n");
+    static int64_t nTimeNewBlockReceived = 0;
 
     //we we're processing lots of blocks, we'll just leave
-    if(GetTime() - lastNewBlock < 10) return;
-    lastNewBlock = GetTime();
+    if(GetTime() - nTimeNewBlockReceived < 10) return;
+    nTimeNewBlockReceived = GetTime();
+    LogPrint("privatesend", "CDarksendPool::NewBlock\n");
 
     CheckTimeout();
 }
 
-// Darksend transaction was completed (failed or successful)
-void CDarksendPool::CompletedTransaction(bool error, int errorID)
+// mixing transaction was completed (failed or successful)
+void CDarksendPool::CompletedTransaction(bool fError, int nErrorID)
 {
     if(fMasterNode) return;
 
-    if(error){
-        LogPrintf("CompletedTransaction -- error \n");
-        UpdateState(POOL_STATUS_ERROR);
+    if(fError) {
+        LogPrintf("CompletedTransaction -- error\n");
+        SetState(POOL_STATE_ERROR);
 
-        Check();
+        CheckPool();
         UnlockCoins();
         SetNull();
     } else {
-        LogPrintf("CompletedTransaction -- success \n");
-        UpdateState(POOL_STATUS_SUCCESS);
+        LogPrintf("CompletedTransaction -- success\n");
+        SetState(POOL_STATE_SUCCESS);
 
         UnlockCoins();
         SetNull();
 
         // To avoid race conditions, we'll only let DS run once per block
-        cachedLastSuccess = pCurrentBlockIndex->nHeight;
+        nCachedLastSuccessBlock = pCurrentBlockIndex->nHeight;
     }
-    lastMessage = GetMessageByID(errorID);
-}
-
-void CDarksendPool::ClearLastMessage()
-{
-    lastMessage = "";
+    strLastMessage = GetMessageByID(nErrorID);
 }
 
 //
-// Passively run Darksend in the background to anonymize funds based on the given configuration.
+// Passively run mixing in the background to anonymize funds based on the given configuration.
 //
 bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
 {
-    if(!fEnablePrivateSend) return false;
-    if(fMasterNode) return false;
-
-    if(!pCurrentBlockIndex) return false;
+    if(!fEnablePrivateSend || fMasterNode || !pCurrentBlockIndex) return false;
     if(!pwalletMain || pwalletMain->IsLocked()) return false;
+    if(nState == POOL_STATE_ERROR || nState == POOL_STATE_SUCCESS) return false;
 
-    if(state == POOL_STATUS_ERROR || state == POOL_STATUS_SUCCESS) return false;
-
-    if (nWalletBackups == 0) {
-        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating - Automatic backups disabled, no mixing available.\n");
-        strAutoDenomResult = _("Automatic backups disabled") + ", " + _("no mixing available.");
-        fEnablePrivateSend = false; // stop mixing
-        pwalletMain->nKeysLeftSinceAutoBackup = 0; // no backup, no "keys since last backup"
-        return false;
-    } else if (nWalletBackups == -1) {
-        // Automatic backup failed, nothing else we can do until user fixes the issue manually.
-        // There is no way to bring user attention in daemon mode so we just update status and
-        // keep spaming if debug is on.
-        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating - ERROR! Failed to create automatic backup.\n");
-        strAutoDenomResult = _("ERROR! Failed to create automatic backup") + ", " + _("see debug.log for details.");
-        return false;
-    } else if (nWalletBackups == -2) {
-        // We were able to create automatic backup but keypool was not replenished because wallet is locked.
-        // There is no way to bring user attention in daemon mode so we just update status and
-        // keep spaming if debug is on.
-        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating - WARNING! Failed to create replenish keypool, please unlock your wallet to do so.\n");
-        strAutoDenomResult = _("WARNING! Failed to replenish keypool, please unlock your wallet to do so.") + ", " + _("see debug.log for details.");
-        return false;
+    switch(nWalletBackups) {
+        case 0:
+            LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- Automatic backups disabled, no mixing available.\n");
+            strAutoDenomResult = _("Automatic backups disabled") + ", " + _("no mixing available.");
+            fEnablePrivateSend = false; // stop mixing
+            pwalletMain->nKeysLeftSinceAutoBackup = 0; // no backup, no "keys since last backup"
+            return false;
+        case -1:
+            // Automatic backup failed, nothing else we can do until user fixes the issue manually.
+            // There is no way to bring user attention in daemon mode so we just update status and
+            // keep spaming if debug is on.
+            LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- ERROR! Failed to create automatic backup.\n");
+            strAutoDenomResult = _("ERROR! Failed to create automatic backup") + ", " + _("see debug.log for details.");
+            return false;
+        case -2:
+            // We were able to create automatic backup but keypool was not replenished because wallet is locked.
+            // There is no way to bring user attention in daemon mode so we just update status and
+            // keep spaming if debug is on.
+            LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- WARNING! Failed to create replenish keypool, please unlock your wallet to do so.\n");
+            strAutoDenomResult = _("WARNING! Failed to replenish keypool, please unlock your wallet to do so.") + ", " + _("see debug.log for details.");
+            return false;
     }
 
-    if (pwalletMain->nKeysLeftSinceAutoBackup < PS_KEYS_THRESHOLD_STOP) {
+    if(pwalletMain->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_STOP) {
         // We should never get here via mixing itself but probably smth else is still actively using keypool
-        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating - Very low number of keys left: %d, no mixing available.\n", pwalletMain->nKeysLeftSinceAutoBackup);
+        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- Very low number of keys left: %d, no mixing available.\n", pwalletMain->nKeysLeftSinceAutoBackup);
         strAutoDenomResult = strprintf(_("Very low number of keys left: %d") + ", " + _("no mixing available."), pwalletMain->nKeysLeftSinceAutoBackup);
         // It's getting really dangerous, stop mixing
         fEnablePrivateSend = false;
         return false;
-    } else if (pwalletMain->nKeysLeftSinceAutoBackup < PS_KEYS_THRESHOLD_WARNING) {
+    } else if(pwalletMain->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING) {
         // Low number of keys left but it's still more or less safe to continue
-        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating - Very low number of keys left: %d\n", pwalletMain->nKeysLeftSinceAutoBackup);
+        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- Very low number of keys left: %d\n", pwalletMain->nKeysLeftSinceAutoBackup);
         strAutoDenomResult = strprintf(_("Very low number of keys left: %d"), pwalletMain->nKeysLeftSinceAutoBackup);
 
-        if (fCreateAutoBackups) {
-            LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating - Trying to create new backup.\n");
+        if(fCreateAutoBackups) {
+            LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- Trying to create new backup.\n");
             std::string warningString;
             std::string errorString;
 
             if(!AutoBackupWallet(pwalletMain, "", warningString, errorString)) {
-                if (!warningString.empty()) {
+                if(!warningString.empty()) {
                     // There were some issues saving backup but yet more or less safe to continue
-                    LogPrintf("CDarksendPool::DoAutomaticDenominating - WARNING! Something went wrong on automatic backup: %s\n", warningString);
+                    LogPrintf("CDarksendPool::DoAutomaticDenominating -- WARNING! Something went wrong on automatic backup: %s\n", warningString);
                 }
-                if (!errorString.empty()) {
+                if(!errorString.empty()) {
                     // Things are really broken
-                    LogPrintf("CDarksendPool::DoAutomaticDenominating - ERROR! Failed to create automatic backup: %s\n", errorString);
+                    LogPrintf("CDarksendPool::DoAutomaticDenominating -- ERROR! Failed to create automatic backup: %s\n", errorString);
                     strAutoDenomResult = strprintf(_("ERROR! Failed to create automatic backup") + ": %s", errorString);
                     return false;
                 }
@@ -1407,7 +1358,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
         }
     }
 
-    LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating - Keys left since latest backup: %d\n", pwalletMain->nKeysLeftSinceAutoBackup);
+    LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- Keys left since latest backup: %d\n", pwalletMain->nKeysLeftSinceAutoBackup);
 
     if(GetEntriesCount() > 0) {
         strAutoDenomResult = _("Mixing in progress...");
@@ -1425,33 +1376,32 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
         return false;
     }
 
-    if (!fDryRun && pwalletMain->IsLocked()){
+    if(!fDryRun && pwalletMain->IsLocked()) {
         strAutoDenomResult = _("Wallet is locked.");
         return false;
     }
 
-    if(!fPrivateSendMultiSession && pCurrentBlockIndex->nHeight - cachedLastSuccess < minBlockSpacing) {
-        LogPrintf("CDarksendPool::DoAutomaticDenominating - Last successful PrivateSend action was too recent\n");
+    if(!fPrivateSendMultiSession && pCurrentBlockIndex->nHeight - nCachedLastSuccessBlock < nMinBlockSpacing) {
+        LogPrintf("CDarksendPool::DoAutomaticDenominating -- Last successful PrivateSend action was too recent\n");
         strAutoDenomResult = _("Last successful PrivateSend action was too recent.");
         return false;
     }
 
-    if(mnodeman.size() == 0){
-        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating - No Masternodes detected\n");
+    if(mnodeman.size() == 0) {
+        LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- No Masternodes detected\n");
         strAutoDenomResult = _("No Masternodes detected.");
         return false;
     }
 
     // ** find the coins we'll use
-    std::vector<CTxIn> vCoins;
+    std::vector<CTxIn> vecTxIn;
     CAmount nValueMin = CENT;
     CAmount nValueIn = 0;
 
     CAmount nOnlyDenominatedBalance;
     CAmount nBalanceNeedsDenominated;
 
-    CAmount nLowestDenom = darkSendDenominations[darkSendDenominations.size() - 1];
-
+    CAmount nLowestDenom = vecPrivateSendDenominations.back();
     // if there are no confirmed DS collateral inputs yet
     if(!pwalletMain->HasCollateralInputs())
         // should have some additional amount for them
@@ -1460,26 +1410,25 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
     CAmount nBalanceNeedsAnonymized = pwalletMain->GetNeedsToBeAnonymizedBalance(nLowestDenom);
 
     // anonymizable balance is way too small
-    if(nBalanceNeedsAnonymized < nLowestDenom)
-    {
-        LogPrintf("DoAutomaticDenominating : Not enough funds to anonymize\n");
+    if(nBalanceNeedsAnonymized < nLowestDenom) {
+        LogPrintf("CDarksendPool::DoAutomaticDenominating -- Not enough funds to anonymize\n");
         strAutoDenomResult = _("Not enough funds to anonymize.");
         return false;
     }
 
-    LogPrint("privatesend", "DoAutomaticDenominating : nLowestDenom=%d, nBalanceNeedsAnonymized=%d\n", nLowestDenom, nBalanceNeedsAnonymized);
+    LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- nLowestDenom: %f, nBalanceNeedsAnonymized: %f\n", (float)nLowestDenom/COIN, (float)nBalanceNeedsAnonymized/COIN);
 
     // select coins that should be given to the pool
-    if (!pwalletMain->SelectCoinsDark(nValueMin, nBalanceNeedsAnonymized, vCoins, nValueIn, 0, nPrivateSendRounds))
+    if(!pwalletMain->SelectCoinsDark(nValueMin, nBalanceNeedsAnonymized, vecTxIn, nValueIn, 0, nPrivateSendRounds))
     {
-        if (pwalletMain->SelectCoinsDark(nValueMin, 9999999*COIN, vCoins, nValueIn, -2, 0))
+        if(pwalletMain->SelectCoinsDark(nValueMin, 9999999*COIN, vecTxIn, nValueIn, -2, 0))
         {
             nOnlyDenominatedBalance = pwalletMain->GetDenominatedBalance(true) + pwalletMain->GetDenominatedBalance() - pwalletMain->GetAnonymizedBalance();
             nBalanceNeedsDenominated = nBalanceNeedsAnonymized - nOnlyDenominatedBalance;
 
             if(nBalanceNeedsDenominated > nValueIn) nBalanceNeedsDenominated = nValueIn;
 
-            LogPrint("privatesend", "%s -- SelectCoinsDark -- (%f - (%f + %f - %f = %f) ) = %f\n", __func__,
+            LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- `SelectCoinsDark` (%f - (%f + %f - %f = %f) ) = %f\n",
                             (float)nBalanceNeedsAnonymized/COIN,
                             (float)pwalletMain->GetDenominatedBalance(true)/COIN,
                             (float)pwalletMain->GetDenominatedBalance()/COIN,
@@ -1488,7 +1437,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
                             (float)nBalanceNeedsDenominated/COIN);
 
             if(nBalanceNeedsDenominated < nLowestDenom) { // most likely we are just waiting for denoms to confirm
-                LogPrintf("DoAutomaticDenominating : No funds detected in need of denominating\n");
+                LogPrintf("CDarksendPool::DoAutomaticDenominating -- No funds detected in need of denominating\n");
                 strAutoDenomResult = _("No funds detected in need of denominating.");
                 return false;
             }
@@ -1496,7 +1445,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
 
             return true;
         } else {
-            LogPrintf("DoAutomaticDenominating : Can't denominate - no compatible inputs left\n");
+            LogPrintf("CDarksendPool::DoAutomaticDenominating -- Can't denominate (no compatible inputs left)\n");
             strAutoDenomResult = _("Can't denominate: no compatible inputs left.");
             return false;
         }
@@ -1506,7 +1455,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
 
     nOnlyDenominatedBalance = pwalletMain->GetDenominatedBalance(true) + pwalletMain->GetDenominatedBalance() - pwalletMain->GetAnonymizedBalance();
     nBalanceNeedsDenominated = nBalanceNeedsAnonymized - nOnlyDenominatedBalance;
-    LogPrint("privatesend", "%s -- 'nBalanceNeedsDenominated > 0' (%f - (%f + %f - %f = %f) ) = %f\n", __func__,
+    LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- 'nBalanceNeedsDenominated > 0' (%f - (%f + %f - %f = %f) ) = %f\n",
                     (float)nBalanceNeedsAnonymized/COIN,
                     (float)pwalletMain->GetDenominatedBalance(true)/COIN,
                     (float)pwalletMain->GetDenominatedBalance()/COIN,
@@ -1518,194 +1467,193 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
     if(nBalanceNeedsDenominated > 0) return CreateDenominated();
 
     //check if we have the collateral sized inputs
-    if(!pwalletMain->HasCollateralInputs()) return !pwalletMain->HasCollateralInputs(false) && MakeCollateralAmounts();
+    if(!pwalletMain->HasCollateralInputs())
+        return !pwalletMain->HasCollateralInputs(false) && MakeCollateralAmounts();
 
-    std::vector<CTxOut> vOut;
-
-    // initial phase, find a Masternode
-    if(!sessionFoundMasternode){
-        // Clean if there is anything left from previous session
-        UnlockCoins();
-        SetNull();
-
-        int nUseQueue = rand()%100;
-        UpdateState(POOL_STATUS_ACCEPTING_ENTRIES);
-
-        if(!fPrivateSendMultiSession && pwalletMain->GetDenominatedBalance(true) > 0) { //get denominated unconfirmed inputs
-            LogPrintf("DoAutomaticDenominating -- Found unconfirmed denominated outputs, will wait till they confirm to continue.\n");
-            strAutoDenomResult = _("Found unconfirmed denominated outputs, will wait till they confirm to continue.");
-            return false;
-        }
-
-        //check our collateral and create new if needed
-        std::string strReason;
-        if(txCollateral == CMutableTransaction()){
-            if(!pwalletMain->CreateCollateralTransaction(txCollateral, strReason)){
-                LogPrintf("% -- create collateral error:%s\n", __func__, strReason);
-                return false;
-            }
-        } else {
-            if(!IsCollateralValid(txCollateral)) {
-                LogPrintf("%s -- invalid collateral, recreating...\n", __func__);
-                if(!pwalletMain->CreateCollateralTransaction(txCollateral, strReason)){
-                    LogPrintf("%s -- create collateral error: %s\n", __func__, strReason);
-                    return false;
-                }
-            }
-        }
-
-        //if we've used 90% of the Masternode list then drop all the oldest first
-        int nThreshold = (int)(mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION) * 0.9);
-        LogPrint("privatesend", "Checking vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
-        while((int)vecMasternodesUsed.size() > nThreshold){
-            vecMasternodesUsed.erase(vecMasternodesUsed.begin());
-            LogPrint("privatesend", "  vecMasternodesUsed size %d threshold %d\n", (int)vecMasternodesUsed.size(), nThreshold);
-        }
-
-        // don't use the queues all of the time for mixing unless we are a liquidity provider
-        if(nLiquidityProvider || nUseQueue > 33){
-
-            // Look through the queues and see if anything matches
-            BOOST_FOREACH(CDarksendQueue& dsq, vecDarksendQueue){
-                CService addr;
-                if(dsq.time == 0) continue;
-
-                if(!dsq.GetAddress(addr)) continue;
-                if(dsq.IsExpired()) continue;
-
-                int protocolVersion;
-                if(!dsq.GetProtocolVersion(protocolVersion)) continue;
-                if(protocolVersion < MIN_POOL_PEER_PROTO_VERSION) continue;
-
-                //non-denom's are incompatible
-                if((dsq.nDenom & (1 << 4))) continue;
-
-                bool fUsed = false;
-                //don't reuse Masternodes
-                BOOST_FOREACH(CTxIn usedVin, vecMasternodesUsed){
-                    if(dsq.vin == usedVin) {
-                        fUsed = true;
-                        break;
-                    }
-                }
-                if(fUsed) continue;
-
-                std::vector<CTxIn> vTempCoins;
-                std::vector<COutput> vTempCoins2;
-                // Try to match their denominations if possible
-                if (!pwalletMain->SelectCoinsByDenominations(dsq.nDenom, nValueMin, nBalanceNeedsAnonymized, vTempCoins, vTempCoins2, nValueIn, 0, nPrivateSendRounds)){
-                    LogPrintf("DoAutomaticDenominating --- Couldn't match denominations %d\n", dsq.nDenom);
-                    continue;
-                }
-
-                CMasternode* pmn = mnodeman.Find(dsq.vin);
-                if(pmn == NULL)
-                {
-                    LogPrintf("DoAutomaticDenominating --- dsq vin %s is not in masternode list!", dsq.vin.ToString());
-                    continue;
-                }
-
-                LogPrintf("DoAutomaticDenominating --- attempt to connect to masternode from queue %s\n", pmn->addr.ToString());
-                lastTimeChanged = GetTimeMillis();
-                // connect to Masternode and submit the queue request
-                CNode* pnode = ConnectNode((CAddress)addr, NULL, true);
-                if(pnode != NULL)
-                {
-                    pSubmittedToMasternode = pmn;
-                    vecMasternodesUsed.push_back(dsq.vin);
-                    sessionDenom = dsq.nDenom;
-
-                    pnode->PushMessage(NetMsgType::DSACCEPT, sessionDenom, txCollateral);
-                    LogPrintf("DoAutomaticDenominating --- connected (from queue), sending dsa for %d - %s\n", sessionDenom, pnode->addr.ToString());
-                    strAutoDenomResult = _("Mixing in progress...");
-                    dsq.time = 0; //remove node
-                    return true;
-                } else {
-                    LogPrintf("DoAutomaticDenominating --- error connecting \n");
-                    strAutoDenomResult = _("Error connecting to Masternode.");
-                    dsq.time = 0; //remove node
-                    continue;
-                }
-            }
-        }
-
-        // do not initiate queue if we are a liquidity provider to avoid useless inter-mixing
-        if(nLiquidityProvider) return false;
-
-        int i = 0;
-
-        // otherwise, try one randomly
-        while(i < 10)
-        {
-            CMasternode* pmn = mnodeman.FindRandomNotInVec(vecMasternodesUsed, MIN_POOL_PEER_PROTO_VERSION);
-            if(pmn == NULL)
-            {
-                LogPrintf("DoAutomaticDenominating --- Can't find random masternode!\n");
-                strAutoDenomResult = _("Can't find random Masternode.");
-                return false;
-            }
-
-            if(pmn->nLastDsq != 0 &&
-                pmn->nLastDsq + mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount){
-                i++;
-                continue;
-            }
-
-            lastTimeChanged = GetTimeMillis();
-            LogPrintf("DoAutomaticDenominating --- attempt %d connection to Masternode %s\n", i, pmn->addr.ToString());
-            CNode* pnode = ConnectNode((CAddress)pmn->addr, NULL, true);
-            if(pnode != NULL){
-                pSubmittedToMasternode = pmn;
-                vecMasternodesUsed.push_back(pmn->vin);
-
-                std::vector<CAmount> vecAmounts;
-                pwalletMain->ConvertList(vCoins, vecAmounts);
-                // try to get a single random denom out of vecAmounts
-                while(sessionDenom == 0)
-                    sessionDenom = GetDenominationsByAmounts(vecAmounts);
-
-                pnode->PushMessage(NetMsgType::DSACCEPT, sessionDenom, txCollateral);
-                LogPrintf("DoAutomaticDenominating --- connected, sending dsa for %d\n", sessionDenom);
-                strAutoDenomResult = _("Mixing in progress...");
-                return true;
-            } else {
-                vecMasternodesUsed.push_back(pmn->vin); // postpone MN we wasn't able to connect to
-                i++;
-                continue;
-            }
-        }
-
-        strAutoDenomResult = _("No compatible Masternode found.");
+    if(fSessionFoundMasternode) {
+        strAutoDenomResult = _("Mixing in progress...");
         return false;
     }
 
-    strAutoDenomResult = _("Mixing in progress...");
+    // Initial phase, find a Masternode
+    // Clean if there is anything left from previous session
+    UnlockCoins();
+    SetNull();
+
+    SetState(POOL_STATE_ACCEPTING_ENTRIES);
+
+    if(!fPrivateSendMultiSession && pwalletMain->GetDenominatedBalance(true) > 0) { //get denominated unconfirmed inputs
+        LogPrintf("CDarksendPool::DoAutomaticDenominating -- Found unconfirmed denominated outputs, will wait till they confirm to continue.\n");
+        strAutoDenomResult = _("Found unconfirmed denominated outputs, will wait till they confirm to continue.");
+        return false;
+    }
+
+    //check our collateral and create new if needed
+    std::string strReason;
+    if(txMyCollateral == CMutableTransaction()) {
+        if(!pwalletMain->CreateCollateralTransaction(txMyCollateral, strReason)) {
+            LogPrintf("CDarksendPool::DoAutomaticDenominating -- create collateral error:%s\n", strReason);
+            return false;
+        }
+    } else {
+        if(!IsCollateralValid(txMyCollateral)) {
+            LogPrintf("CDarksendPool::DoAutomaticDenominating -- invalid collateral, recreating...\n");
+            if(!pwalletMain->CreateCollateralTransaction(txMyCollateral, strReason)) {
+                LogPrintf("CDarksendPool::DoAutomaticDenominating -- create collateral error: %s\n", strReason);
+                return false;
+            }
+        }
+    }
+
+    //if we've used 90% of the Masternode list then drop all the oldest first
+    int nThreshold = (int)(mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION) * 0.9);
+    LogPrint("privatesend", "Checking vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold);
+    while((int)vecMasternodesUsed.size() > nThreshold) {
+        vecMasternodesUsed.erase(vecMasternodesUsed.begin());
+        LogPrint("privatesend", "  vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold);
+    }
+
+    bool fUseQueue = insecure_rand()%100 > 33;
+    // don't use the queues all of the time for mixing unless we are a liquidity provider
+    if(nLiquidityProvider || fUseQueue) {
+
+        // Look through the queues and see if anything matches
+        BOOST_FOREACH(CDarksendQueue& dsq, vecDarksendQueue) {
+            if(dsq.nTime == 0) continue;
+            if(dsq.IsExpired()) continue;
+
+            CService addr;
+            if(!dsq.GetAddress(addr)) continue;
+
+            int nProtocolVersion;
+            if(!dsq.GetProtocolVersion(nProtocolVersion)) continue;
+            if(nProtocolVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) continue;
+
+            // incompatible denom
+            if(dsq.nDenom >= (1 << vecPrivateSendDenominations.size())) continue;
+
+            bool fUsed = false;
+            //don't reuse Masternodes
+            BOOST_FOREACH(CTxIn txinUsed, vecMasternodesUsed) {
+                if(dsq.vin == txinUsed) {
+                    fUsed = true;
+                    break;
+                }
+            }
+            if(fUsed) continue;
+
+            std::vector<CTxIn> vecTxInTmp;
+            std::vector<COutput> vCoinsTmp;
+            // Try to match their denominations if possible
+            if(!pwalletMain->SelectCoinsByDenominations(dsq.nDenom, nValueMin, nBalanceNeedsAnonymized, vecTxInTmp, vCoinsTmp, nValueIn, 0, nPrivateSendRounds)) {
+                LogPrintf("CDarksendPool::DoAutomaticDenominating -- Couldn't match denominations %d\n", dsq.nDenom);
+                continue;
+            }
+
+            CMasternode* pmn = mnodeman.Find(dsq.vin);
+            if(pmn == NULL) {
+                LogPrintf("CDarksendPool::DoAutomaticDenominating -- dsq vin is not in masternode list! vin=%s\n", dsq.vin.ToString());
+                continue;
+            }
+
+            LogPrintf("CDarksendPool::DoAutomaticDenominating -- attempt to connect to masternode from queue, addr=%s\n", pmn->addr.ToString());
+            nLastTimeChanged = GetTimeMillis();
+            // connect to Masternode and submit the queue request
+            CNode* pnode = ConnectNode((CAddress)addr, NULL, true);
+            if(pnode != NULL) {
+                pSubmittedToMasternode = pmn;
+                vecMasternodesUsed.push_back(dsq.vin);
+                nSessionDenom = dsq.nDenom;
+
+                pnode->PushMessage(NetMsgType::DSACCEPT, nSessionDenom, txMyCollateral);
+                LogPrintf("CDarksendPool::DoAutomaticDenominating -- connected (from queue), sending dsa: nSessionDenom: %d, addr=%s\n", nSessionDenom, pnode->addr.ToString());
+                strAutoDenomResult = _("Mixing in progress...");
+                dsq.nTime = 0; //remove node
+                return true;
+            } else {
+                LogPrintf("CDarksendPool::DoAutomaticDenominating -- error connecting\n");
+                strAutoDenomResult = _("Error connecting to Masternode.");
+                dsq.nTime = 0; //remove node
+                continue;
+            }
+        }
+    }
+
+    // do not initiate queue if we are a liquidity provider to avoid useless inter-mixing
+    if(nLiquidityProvider) return false;
+
+    int nTries = 0;
+
+    // otherwise, try one randomly
+    while(nTries < 10) {
+        CMasternode* pmn = mnodeman.FindRandomNotInVec(vecMasternodesUsed, MIN_PRIVATESEND_PEER_PROTO_VERSION);
+        if(pmn == NULL) {
+            LogPrintf("CDarksendPool::DoAutomaticDenominating -- Can't find random masternode!\n");
+            strAutoDenomResult = _("Can't find random Masternode.");
+            return false;
+        }
+
+        if(pmn->nLastDsq != 0 && pmn->nLastDsq + mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)/5 > mnodeman.nDsqCount) {
+            nTries++;
+            continue;
+        }
+
+        nLastTimeChanged = GetTimeMillis();
+        LogPrintf("CDarksendPool::DoAutomaticDenominating -- attempt %d connection to Masternode %s\n", nTries, pmn->addr.ToString());
+        CNode* pnode = ConnectNode((CAddress)pmn->addr, NULL, true);
+        if(pnode != NULL) {
+            LogPrintf("CDarksendPool::DoAutomaticDenominating -- connected %s\n", pmn->vin.ToString());
+            pSubmittedToMasternode = pmn;
+            vecMasternodesUsed.push_back(pmn->vin);
+
+            std::vector<CAmount> vecAmounts;
+            pwalletMain->ConvertList(vecTxIn, vecAmounts);
+            // try to get a single random denom out of vecAmounts
+            while(nSessionDenom == 0)
+                nSessionDenom = GetDenominationsByAmounts(vecAmounts);
+
+            pnode->PushMessage(NetMsgType::DSACCEPT, nSessionDenom, txMyCollateral);
+            LogPrintf("CDarksendPool::DoAutomaticDenominating -- connected, sending DSACCEPT, nSessionDenom: %d\n", nSessionDenom);
+            strAutoDenomResult = _("Mixing in progress...");
+            return true;
+        } else {
+            LogPrintf("CDarksendPool::DoAutomaticDenominating -- can't connect %s\n", pmn->vin.ToString());
+            vecMasternodesUsed.push_back(pmn->vin); // postpone MN we wasn't able to connect to
+            nTries++;
+            continue;
+        }
+    }
+
+    strAutoDenomResult = _("No compatible Masternode found.");
     return false;
 }
 
-
-bool CDarksendPool::PrepareDarksendDenominate()
+bool CDarksendPool::PrepareDenominate()
 {
-    std::string strError = "";
+    std::string strError;
+
     // Submit transaction to the pool if we get here
     // Try to use only inputs with the same number of rounds starting from lowest number of rounds possible
     for(int i = 0; i < nPrivateSendRounds; i++) {
         strError = pwalletMain->PrepareDarksendDenominate(i, i+1);
         if(strError == "") {
-            LogPrintf("PrepareDenominate : Running PrivateSend denominate for %d rounds, success\n", i);
+            LogPrintf("CDarksendPool::PrepareDenominate -- Running PrivateSend denominate for %d rounds, success\n", i);
             return true;
         }
-        LogPrintf("PrepareDenominate : Running PrivateSend denominate for %d rounds. Return '%s'\n", i, strError);
+        LogPrintf("CDarksendPool::PrepareDenominate -- Running PrivateSend denominate for %d rounds. Return '%s'\n", i, strError);
     }
 
     // We failed? That's strange but let's just make final attempt and try to mix everything
     strError = pwalletMain->PrepareDarksendDenominate(0, nPrivateSendRounds);
-    LogPrintf("DoAutomaticDenominating : Running PrivateSend denominate for all rounds. Return '%s'\n", strError);
-    if(strError == "") return true;
+    if(strError == "") {
+        LogPrintf("CDarksendPool::PrepareDenominate -- Running PrivateSend denominate for all rounds, success\n");
+        return true;
+    }
+    LogPrintf("CDarksendPool::PrepareDenominate -- Running PrivateSend denominate for all rounds. Return '%s'\n", strError);
 
     // Should never actually get here but just in case
     strAutoDenomResult = strError;
-    LogPrintf("DoAutomaticDenominating : Error running denominate, %s\n", strError);
+    LogPrintf("CDarksendPool::PrepareDenominate -- Error running denominate, %s\n", strError);
     return false;
 }
 
@@ -1714,7 +1662,7 @@ bool CDarksendPool::MakeCollateralAmounts()
 {
     std::vector<CompactTallyItem> vecTally;
     if(!pwalletMain->SelectCoinsGrouppedByAddresses(vecTally, false)) {
-        LogPrint("privatesend", "CDarksendPool::MakeCollateralAmounts() - SelectCoinsGrouppedByAddresses can't find any inputs!\n");
+        LogPrint("privatesend", "CDarksendPool::MakeCollateralAmounts -- SelectCoinsGrouppedByAddresses can't find any inputs!\n");
         return false;
     }
 
@@ -1723,7 +1671,7 @@ bool CDarksendPool::MakeCollateralAmounts()
         return true;
     }
 
-    LogPrintf("CDarksendPool::MakeCollateralAmounts() - failed!\n");
+    LogPrintf("CDarksendPool::MakeCollateralAmounts -- failed!\n");
     return false;
 }
 
@@ -1762,12 +1710,12 @@ bool CDarksendPool::MakeCollateralAmounts(const CompactTallyItem& tallyItem)
     if(!fSuccess) {
         // if we failed (most likeky not enough funds), try to use all coins instead -
         // MN-like funds should not be touched in any case and we can't mix denominated without collaterals anyway
-        LogPrintf("MakeCollateralAmounts: ONLY_NONDENOMINATED_NOT1000IFMN Error - %s\n", strFail);
+        LogPrintf("CDarksendPool::MakeCollateralAmounts -- ONLY_NONDENOMINATED_NOT1000IFMN Error: %s\n", strFail);
         CCoinControl *coinControlNull = NULL;
         fSuccess = pwalletMain->CreateTransaction(vecSend, wtx, reservekeyChange,
                 nFeeRet, nChangePosRet, strFail, coinControlNull, true, ONLY_NOT1000IFMN);
         if(!fSuccess) {
-            LogPrintf("MakeCollateralAmounts: ONLY_NOT1000IFMN Error - %s\n", strFail);
+            LogPrintf("CDarksendPool::MakeCollateralAmounts -- ONLY_NOT1000IFMN Error: %s\n", strFail);
             reservekeyCollateral.ReturnKey();
             return false;
         }
@@ -1775,15 +1723,15 @@ bool CDarksendPool::MakeCollateralAmounts(const CompactTallyItem& tallyItem)
 
     reservekeyCollateral.KeepKey();
 
-    LogPrintf("MakeCollateralAmounts: tx %s\n", wtx.GetHash().GetHex());
+    LogPrintf("CDarksendPool::MakeCollateralAmounts -- txid=%s\n", wtx.GetHash().GetHex());
 
-    // use the same cachedLastSuccess as for DS mixinx to prevent race
+    // use the same nCachedLastSuccessBlock as for DS mixinx to prevent race
     if(!pwalletMain->CommitTransaction(wtx, reservekeyChange)) {
-        LogPrintf("MakeCollateralAmounts: CommitTransaction failed!\n");
+        LogPrintf("CDarksendPool::MakeCollateralAmounts -- CommitTransaction failed!\n");
         return false;
     }
 
-    cachedLastSuccess = pCurrentBlockIndex->nHeight;
+    nCachedLastSuccessBlock = pCurrentBlockIndex->nHeight;
 
     return true;
 }
@@ -1793,7 +1741,7 @@ bool CDarksendPool::CreateDenominated()
 {
     std::vector<CompactTallyItem> vecTally;
     if(!pwalletMain->SelectCoinsGrouppedByAddresses(vecTally)) {
-        LogPrint("privatesend", "CDarksendPool::CreateDenominated() - SelectCoinsGrouppedByAddresses can't find any inputs!\n");
+        LogPrint("privatesend", "CDarksendPool::CreateDenominated -- SelectCoinsGrouppedByAddresses can't find any inputs!\n");
         return false;
     }
 
@@ -1802,7 +1750,7 @@ bool CDarksendPool::CreateDenominated()
         return true;
     }
 
-    LogPrintf("CDarksendPool::CreateDenominated() - failed!\n");
+    LogPrintf("CDarksendPool::CreateDenominated -- failed!\n");
     return false;
 }
 
@@ -1813,7 +1761,7 @@ bool CDarksendPool::CreateDenominated(const CompactTallyItem& tallyItem)
     CAmount nValueLeft = tallyItem.nAmount;
     nValueLeft -= DARKSEND_COLLATERAL; // leave some room for fees
 
-    LogPrintf("CreateDenominated0 %d\n", nValueLeft);
+    LogPrintf("CreateDenominated0 nValueLeft: %f\n", (float)nValueLeft/COIN);
     // make our collateral address
     CReserveKey reservekeyCollateral(pwalletMain);
 
@@ -1839,20 +1787,20 @@ bool CDarksendPool::CreateDenominated(const CompactTallyItem& tallyItem)
     bool fSkip = true;
     do {
 
-        BOOST_REVERSE_FOREACH(CAmount v, darkSendDenominations){
+        BOOST_REVERSE_FOREACH(CAmount nDenomValue, vecPrivateSendDenominations) {
 
             if(fSkip) {
                 // Note: denoms are skipped if there are already DENOMS_COUNT_MAX of them
                 // and there are still larger denoms which can be used for mixing
 
                 // check skipped denoms
-                if(IsDenomSkipped(v)) continue;
+                if(IsDenomSkipped(nDenomValue)) continue;
 
                 // find new denoms to skip if any (ignore the largest one)
-                if (v != darkSendDenominations[0] && pwalletMain->CountInputsWithAmount(v) > DENOMS_COUNT_MAX){
-                    strAutoDenomResult = strprintf(_("Too many %f denominations, removing."), (float)v/COIN);
-                    LogPrintf("DoAutomaticDenominating : %s\n", strAutoDenomResult);
-                    darkSendDenominationsSkipped.push_back(v);
+                if(nDenomValue != vecPrivateSendDenominations[0] && pwalletMain->CountInputsWithAmount(nDenomValue) > DENOMS_COUNT_MAX) {
+                    strAutoDenomResult = strprintf(_("Too many %f denominations, removing."), (float)nDenomValue/COIN);
+                    LogPrintf("CDarksendPool::CreateDenominated -- %s\n", strAutoDenomResult);
+                    vecDenominationsSkipped.push_back(nDenomValue);
                     continue;
                 }
             }
@@ -1860,7 +1808,7 @@ bool CDarksendPool::CreateDenominated(const CompactTallyItem& tallyItem)
             int nOutputs = 0;
 
             // add each output up to 10 times until it can't be added again
-            while(nValueLeft - v >= 0 && nOutputs <= 10) {
+            while(nValueLeft - nDenomValue >= 0 && nOutputs <= 10) {
                 CScript scriptDenom;
                 CPubKey vchPubKey;
                 //use a unique change address
@@ -1869,22 +1817,22 @@ bool CDarksendPool::CreateDenominated(const CompactTallyItem& tallyItem)
                 // TODO: do not keep reservekeyDenom here
                 reservekeyDenom.KeepKey();
 
-                vecSend.push_back((CRecipient){scriptDenom, v, false});
+                vecSend.push_back((CRecipient){ scriptDenom, nDenomValue, false });
 
                 //increment outputs and subtract denomination amount
                 nOutputs++;
-                nValueLeft -= v;
-                LogPrintf("CreateDenominated1 %d %d %d\n", nOutputsTotal, nOutputs, nValueLeft);
+                nValueLeft -= nDenomValue;
+                LogPrintf("CreateDenominated1: nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n", nOutputsTotal, nOutputs, (float)nValueLeft/COIN);
             }
 
             nOutputsTotal += nOutputs;
             if(nValueLeft == 0) break;
         }
-        LogPrintf("CreateDenominated2 %d %d\n", nOutputsTotal, nValueLeft);
+        LogPrintf("CreateDenominated2: nOutputsTotal: %d, nValueLeft: %f\n", nOutputsTotal, (float)nValueLeft/COIN);
         // if there were no outputs added, start over without skipping
         fSkip = !fSkip;
     } while (nOutputsTotal == 0 && !fSkip);
-    LogPrintf("CreateDenominated3 %d %d\n", nOutputsTotal, nValueLeft);
+    LogPrintf("CreateDenominated3: nOutputsTotal: %d, nValueLeft: %f\n", nOutputsTotal, (float)nValueLeft/COIN);
 
     // if we have anything left over, it will be automatically send back as change - there is no need to send it manually
 
@@ -1906,7 +1854,7 @@ bool CDarksendPool::CreateDenominated(const CompactTallyItem& tallyItem)
     bool fSuccess = pwalletMain->CreateTransaction(vecSend, wtx, reservekeyChange,
             nFeeRet, nChangePosRet, strFail, &coinControl, true, ONLY_NONDENOMINATED_NOT1000IFMN);
     if(!fSuccess) {
-        LogPrintf("CreateDenominated: Error - %s\n", strFail);
+        LogPrintf("CDarksendPool::CreateDenominated -- Error: %s\n", strFail);
         // TODO: return reservekeyDenom here
         reservekeyCollateral.ReturnKey();
         return false;
@@ -1916,102 +1864,97 @@ bool CDarksendPool::CreateDenominated(const CompactTallyItem& tallyItem)
     reservekeyCollateral.KeepKey();
 
     if(!pwalletMain->CommitTransaction(wtx, reservekeyChange)) {
-        LogPrintf("CreateDenominated: CommitTransaction failed!\n");
+        LogPrintf("CDarksendPool::CreateDenominated -- CommitTransaction failed!\n");
         return false;
     }
 
-    // use the same cachedLastSuccess as for DS mixing to prevent race
-    cachedLastSuccess = pCurrentBlockIndex->nHeight;
-    LogPrintf("CreateDenominated: tx %s\n", wtx.GetHash().GetHex());
+    // use the same nCachedLastSuccessBlock as for DS mixing to prevent race
+    nCachedLastSuccessBlock = pCurrentBlockIndex->nHeight;
+    LogPrintf("CDarksendPool::CreateDenominated -- txid=%s\n", wtx.GetHash().GetHex());
 
     return true;
 }
 
-bool CDarksendPool::IsCompatibleWithEntries(std::vector<CTxOut>& vout)
+bool CDarksendPool::IsOutputsCompatibleWithSessionDenom(const std::vector<CTxOut>& vecTxOut)
 {
-    if(GetDenominations(vout) == 0) return false;
+    if(GetDenominations(vecTxOut) == 0) return false;
 
-    BOOST_FOREACH(const CDarkSendEntry v, entries) {
-        LogPrintf(" IsCompatibleWithEntries %d %d\n", GetDenominations(vout), GetDenominations(v.vout));
-        if(GetDenominations(vout) != GetDenominations(v.vout)) return false;
+    BOOST_FOREACH(const CDarkSendEntry entry, vecEntries) {
+        LogPrintf("CDarksendPool::IsOutputsCompatibleWithSessionDenom -- vecTxOut denom %d, entry.vecTxDSOut denom %d\n", GetDenominations(vecTxOut), GetDenominations(entry.vecTxDSOut));
+        if(GetDenominations(vecTxOut) != GetDenominations(entry.vecTxDSOut)) return false;
     }
 
     return true;
 }
 
-bool CDarksendPool::IsCompatibleWithSession(int nDenom, CTransaction txCollateral, int& errorID)
+bool CDarksendPool::IsDenomCompatibleWithSession(int nDenom, CTransaction txCollateral, int& nErrorID)
 {
     if(nDenom == 0) return false;
 
-    LogPrintf("CDarksendPool::IsCompatibleWithSession - sessionDenom %d sessionUsers %d\n", sessionDenom, sessionUsers);
+    LogPrintf("CDarksendPool::IsDenomCompatibleWithSession -- nSessionDenom: %d nSessionUsers: %d\n", nSessionDenom, nSessionUsers);
 
-    if (!unitTest && !IsCollateralValid(txCollateral)){
-        LogPrint("privatesend", "CDarksendPool::IsCompatibleWithSession - collateral not valid!\n");
-        errorID = ERR_INVALID_COLLATERAL;
+    if(!fUnitTest && !IsCollateralValid(txCollateral)) {
+        LogPrint("privatesend", "CDarksendPool::IsDenomCompatibleWithSession -- collateral not valid!\n");
+        nErrorID = ERR_INVALID_COLLATERAL;
         return false;
     }
 
-    if(sessionUsers < 0) sessionUsers = 0;
+    if(nSessionUsers < 0) nSessionUsers = 0;
 
-    if(sessionUsers == 0) {
-        sessionID = 1 + (rand() % 999999);
-        sessionDenom = nDenom;
-        sessionUsers++;
-        lastTimeChanged = GetTimeMillis();
+    if(nSessionUsers == 0) {
+        nSessionID = 1 + GetRand(999999);
+        nSessionDenom = nDenom;
+        nSessionUsers++;
+        nLastTimeChanged = GetTimeMillis();
 
-        if(!unitTest){
+        if(!fUnitTest) {
             //broadcast that I'm accepting entries, only if it's the first entry through
-            CDarksendQueue dsq;
-            dsq.nDenom = nDenom;
-            dsq.vin = activeMasternode.vin;
-            dsq.time = GetTime();
+            CDarksendQueue dsq(nDenom, activeMasternode.vin, GetTime(), false);
             dsq.Sign();
             dsq.Relay();
         }
 
-        UpdateState(POOL_STATUS_QUEUE);
+        SetState(POOL_STATE_QUEUE);
         vecSessionCollateral.push_back(txCollateral);
         return true;
     }
 
-    if((state != POOL_STATUS_ACCEPTING_ENTRIES && state != POOL_STATUS_QUEUE) || sessionUsers >= GetMaxPoolTransactions()){
-        if((state != POOL_STATUS_ACCEPTING_ENTRIES && state != POOL_STATUS_QUEUE)) errorID = ERR_MODE;
-        if(sessionUsers >= GetMaxPoolTransactions()) errorID = ERR_QUEUE_FULL;
-        LogPrintf("CDarksendPool::IsCompatibleWithSession - incompatible mode, return false %d %d\n", state != POOL_STATUS_ACCEPTING_ENTRIES, sessionUsers >= GetMaxPoolTransactions());
+    if((nState != POOL_STATE_ACCEPTING_ENTRIES && nState != POOL_STATE_QUEUE) || nSessionUsers >= GetMaxPoolTransactions()) {
+        if((nState != POOL_STATE_ACCEPTING_ENTRIES && nState != POOL_STATE_QUEUE)) nErrorID = ERR_MODE;
+        if(nSessionUsers >= GetMaxPoolTransactions()) nErrorID = ERR_QUEUE_FULL;
+        LogPrintf("CDarksendPool::IsDenomCompatibleWithSession -- incompatible mode, return false: nState status %d, nSessionUsers status %d\n", nState != POOL_STATE_ACCEPTING_ENTRIES, nSessionUsers >= GetMaxPoolTransactions());
         return false;
     }
 
-    if(nDenom != sessionDenom) {
-        errorID = ERR_DENOM;
+    if(nDenom != nSessionDenom) {
+        nErrorID = ERR_DENOM;
         return false;
     }
 
-    LogPrintf("CDarksendPool::IsCompatibleWithSession - compatible\n");
+    LogPrintf("CDarksendPool::IsDenomCompatibleWithSession -- compatible\n");
 
-    sessionUsers++;
-    lastTimeChanged = GetTimeMillis();
+    nSessionUsers++;
+    nLastTimeChanged = GetTimeMillis();
     vecSessionCollateral.push_back(txCollateral);
 
     return true;
 }
 
-//create a nice string to show the denominations
-void CDarksendPool::GetDenominationsToString(int nDenom, std::string& strDenom){
-    // Function returns as follows:
-    //
-    // bit 0 - 100DRK+1 ( bit on if present )
-    // bit 1 - 10DRK+1
-    // bit 2 - 1DRK+1
-    // bit 3 - .1DRK+1
-    // bit 3 - non-denom
+/*  Create a nice string to show the denominations
+    Function returns as follows:
+        ( bit on if present )
+        bit 0           - 100
+        bit 1           - 10
+        bit 2           - 1
+        bit 3           - .1
+        none of above   - non-denom
+        bit 4 and so on - non-denom
+*/
+std::string CDarksendPool::GetDenominationsToString(int nDenom)
+{
+    std::string strDenom;
 
-
-    strDenom = "";
-
-    if(nDenom & (1 << 0)) {
-        if(strDenom.size() > 0) strDenom += "+";
-        strDenom += "100";
-    }
+    if(nDenom & (1 << 0)) strDenom += "100";
 
     if(nDenom & (1 << 1)) {
         if(strDenom.size() > 0) strDenom += "+";
@@ -2027,30 +1970,44 @@ void CDarksendPool::GetDenominationsToString(int nDenom, std::string& strDenom){
         if(strDenom.size() > 0) strDenom += "+";
         strDenom += "0.1";
     }
+
+    if(strDenom.size() == 0 && nDenom >= (1 << 4)) strDenom += "non-denom";
+
+    return strDenom;
 }
 
-int CDarksendPool::GetDenominations(const std::vector<CTxDSOut>& vout){
-    std::vector<CTxOut> vout2;
+int CDarksendPool::GetDenominations(const std::vector<CTxDSOut>& vecTxDSOut)
+{
+    std::vector<CTxOut> vecTxOut;
 
-    BOOST_FOREACH(CTxDSOut out, vout)
-        vout2.push_back(out);
+    BOOST_FOREACH(CTxDSOut out, vecTxDSOut)
+        vecTxOut.push_back(out);
 
-    return GetDenominations(vout2);
+    return GetDenominations(vecTxOut);
 }
 
-// return a bitshifted integer representing the denominations in this list
-int CDarksendPool::GetDenominations(const std::vector<CTxOut>& vout, bool fSingleRandomDenom){
-    std::vector<pair<CAmount, int> > denomUsed;
+/*  Return a bitshifted integer representing the denominations in this list
+    Function returns as follows:
+        ( bit on if present )
+        100       - bit 0
+        10        - bit 1
+        1         - bit 2
+        .1        - bit 3
+        non-denom - 0, all bits off
+*/
+int CDarksendPool::GetDenominations(const std::vector<CTxOut>& vecTxOut, bool fSingleRandomDenom)
+{
+    std::vector<std::pair<CAmount, int> > vecDenomUsed;
 
     // make a list of denominations, with zero uses
-    BOOST_FOREACH(CAmount d, darkSendDenominations)
-        denomUsed.push_back(make_pair(d, 0));
+    BOOST_FOREACH(CAmount nDenomValue, vecPrivateSendDenominations)
+        vecDenomUsed.push_back(std::make_pair(nDenomValue, 0));
 
     // look for denominations and update uses to 1
-    BOOST_FOREACH(CTxOut out, vout){
+    BOOST_FOREACH(CTxOut txout, vecTxOut) {
         bool found = false;
-        BOOST_FOREACH (PAIRTYPE(CAmount, int)& s, denomUsed){
-            if (out.nValue == s.first){
+        BOOST_FOREACH (PAIRTYPE(CAmount, int)& s, vecDenomUsed) {
+            if(txout.nValue == s.first) {
                 s.second = 1;
                 found = true;
             }
@@ -2058,162 +2015,120 @@ int CDarksendPool::GetDenominations(const std::vector<CTxOut>& vout, bool fSingl
         if(!found) return 0;
     }
 
-    int denom = 0;
+    int nDenom = 0;
     int c = 0;
-    // if the denomination is used, shift the bit on.
-    // then move to the next
-    BOOST_FOREACH (PAIRTYPE(CAmount, int)& s, denomUsed) {
-        int bit = (fSingleRandomDenom ? rand()%2 : 1) * s.second;
-        denom |= bit << c++;
+    // if the denomination is used, shift the bit on
+    BOOST_FOREACH (PAIRTYPE(CAmount, int)& s, vecDenomUsed) {
+        int bit = (fSingleRandomDenom ? insecure_rand()%2 : 1) & s.second;
+        nDenom |= bit << c++;
         if(fSingleRandomDenom && bit) break; // use just one random denomination
     }
 
-    // Function returns as follows:
-    //
-    // bit 0 - 100DRK+1 ( bit on if present )
-    // bit 1 - 10DRK+1
-    // bit 2 - 1DRK+1
-    // bit 3 - .1DRK+1
-
-    return denom;
+    return nDenom;
 }
 
+int CDarksendPool::GetDenominationsByAmounts(const std::vector<CAmount>& vecAmount)
+{
+    CScript scriptTmp = CScript();
+    std::vector<CTxOut> vecTxOut;
 
-int CDarksendPool::GetDenominationsByAmounts(std::vector<CAmount>& vecAmount){
-    CScript e = CScript();
-    std::vector<CTxOut> vout1;
-
-    // Make outputs by looping through denominations, from small to large
-    BOOST_REVERSE_FOREACH(CAmount v, vecAmount){
-        CTxOut o(v, e);
-        vout1.push_back(o);
+    BOOST_REVERSE_FOREACH(CAmount nAmount, vecAmount) {
+        CTxOut txout(nAmount, scriptTmp);
+        vecTxOut.push_back(txout);
     }
 
-    return GetDenominations(vout1, true);
+    return GetDenominations(vecTxOut, true);
 }
 
-int CDarksendPool::GetDenominationsByAmount(CAmount nAmount, int nDenomTarget){
-    CScript e = CScript();
-    CAmount nValueLeft = nAmount;
-
-    std::vector<CTxOut> vout1;
-
-    // Make outputs by looping through denominations, from small to large
-    BOOST_REVERSE_FOREACH(CAmount v, darkSendDenominations){
-        if(nDenomTarget != 0){
-            bool fAccepted = false;
-            if((nDenomTarget & (1 << 0)) &&      v == ((100*COIN)+100000)) {fAccepted = true;}
-            else if((nDenomTarget & (1 << 1)) && v == ((10*COIN) +10000)) {fAccepted = true;}
-            else if((nDenomTarget & (1 << 2)) && v == ((1*COIN)  +1000)) {fAccepted = true;}
-            else if((nDenomTarget & (1 << 3)) && v == ((.1*COIN) +100)) {fAccepted = true;}
-            if(!fAccepted) continue;
-        }
-
-        int nOutputs = 0;
-
-        // add each output up to 10 times until it can't be added again
-        while(nValueLeft - v >= 0 && nOutputs <= 10) {
-            CTxOut o(v, e);
-            vout1.push_back(o);
-            nValueLeft -= v;
-            nOutputs++;
-        }
-        LogPrintf("GetDenominationsByAmount --- %d nOutputs %d\n", v, nOutputs);
-    }
-
-    return GetDenominations(vout1);
-}
-
-std::string CDarksendPool::GetMessageByID(int messageID) {
-    switch (messageID) {
-    case ERR_ALREADY_HAVE: return _("Already have that input.");
-    case ERR_DENOM: return _("No matching denominations found for mixing.");
-    case ERR_ENTRIES_FULL: return _("Entries are full.");
-    case ERR_EXISTING_TX: return _("Not compatible with existing transactions.");
-    case ERR_FEES: return _("Transaction fees are too high.");
-    case ERR_INVALID_COLLATERAL: return _("Collateral not valid.");
-    case ERR_INVALID_INPUT: return _("Input is not valid.");
-    case ERR_INVALID_SCRIPT: return _("Invalid script detected.");
-    case ERR_INVALID_TX: return _("Transaction not valid.");
-    case ERR_MAXIMUM: return _("Value more than PrivateSend pool maximum allows.");
-    case ERR_MN_LIST: return _("Not in the Masternode list.");
-    case ERR_MODE: return _("Incompatible mode.");
-    case ERR_NON_STANDARD_PUBKEY: return _("Non-standard public key detected.");
-    case ERR_NOT_A_MN: return _("This is not a Masternode.");
-    case ERR_QUEUE_FULL: return _("Masternode queue is full.");
-    case ERR_RECENT: return _("Last PrivateSend was too recent.");
-    case ERR_SESSION: return _("Session not complete!");
-    case ERR_MISSING_TX: return _("Missing input transaction information.");
-    case ERR_VERSION: return _("Incompatible version.");
-    case MSG_SUCCESS: return _("Transaction created successfully.");
-    case MSG_ENTRIES_ADDED: return _("Your entries added successfully.");
-    case MSG_NOERR:
-    default:
-        return "";
+std::string CDarksendPool::GetMessageByID(int nMessageID)
+{
+    switch (nMessageID) {
+        case ERR_ALREADY_HAVE:          return _("Already have that input.");
+        case ERR_DENOM:                 return _("No matching denominations found for mixing.");
+        case ERR_ENTRIES_FULL:          return _("Entries are full.");
+        case ERR_EXISTING_TX:           return _("Not compatible with existing transactions.");
+        case ERR_FEES:                  return _("Transaction fees are too high.");
+        case ERR_INVALID_COLLATERAL:    return _("Collateral not valid.");
+        case ERR_INVALID_INPUT:         return _("Input is not valid.");
+        case ERR_INVALID_SCRIPT:        return _("Invalid script detected.");
+        case ERR_INVALID_TX:            return _("Transaction not valid.");
+        case ERR_MAXIMUM:               return _("Value more than PrivateSend pool maximum allows.");
+        case ERR_MN_LIST:               return _("Not in the Masternode list.");
+        case ERR_MODE:                  return _("Incompatible mode.");
+        case ERR_NON_STANDARD_PUBKEY:   return _("Non-standard public key detected.");
+        case ERR_NOT_A_MN:              return _("This is not a Masternode.");
+        case ERR_QUEUE_FULL:            return _("Masternode queue is full.");
+        case ERR_RECENT:                return _("Last PrivateSend was too recent.");
+        case ERR_SESSION:               return _("Session not complete!");
+        case ERR_MISSING_TX:            return _("Missing input transaction information.");
+        case ERR_VERSION:               return _("Incompatible version.");
+        case MSG_SUCCESS:               return _("Transaction created successfully.");
+        case MSG_ENTRIES_ADDED:         return _("Your entries added successfully.");
+        case MSG_NOERR:                 return _("No errors detected.");
+        default:                        return _("Unknown response.");
     }
 }
 
-bool CDarkSendSigner::IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey){
-    CScript payee2;
-    payee2 = GetScriptForDestination(pubkey.GetID());
+bool CDarkSendSigner::IsVinAssociatedWithPubkey(const CTxIn& txin, const CPubKey& pubkey)
+{
+    CScript payee;
+    payee = GetScriptForDestination(pubkey.GetID());
 
-    CTransaction txVin;
+    CTransaction tx;
     uint256 hash;
-    if(GetTransaction(vin.prevout.hash, txVin, Params().GetConsensus(), hash, true)){
-        BOOST_FOREACH(CTxOut out, txVin.vout){
-            if(out.nValue == 1000*COIN){
-                if(out.scriptPubKey == payee2) return true;
-            }
-        }
+    if(GetTransaction(txin.prevout.hash, tx, Params().GetConsensus(), hash, true)) {
+        BOOST_FOREACH(CTxOut out, tx.vout)
+            if(out.nValue == 1000*COIN && out.scriptPubKey == payee) return true;
     }
 
     return false;
 }
 
-bool CDarkSendSigner::SetKey(std::string strSecret, std::string& errorMessage, CKey& key, CPubKey& pubkey){
+bool CDarkSendSigner::GetKeysFromSecret(std::string strSecret, std::string& strErrorMessageRet, CKey& keyRet, CPubKey& pubkeyRet)
+{
     CBitcoinSecret vchSecret;
     bool fGood = vchSecret.SetString(strSecret);
 
-    if (!fGood) {
-        errorMessage = _("Invalid private key.");
+    if(!fGood) {
+        strErrorMessageRet = _("Invalid secret.");
         return false;
     }
 
-    key = vchSecret.GetKey();
-    pubkey = key.GetPubKey();
+    keyRet = vchSecret.GetKey();
+    pubkeyRet = keyRet.GetPubKey();
 
     return true;
 }
 
-bool CDarkSendSigner::SignMessage(std::string strMessage, std::string& errorMessage, vector<unsigned char>& vchSig, CKey key)
+bool CDarkSendSigner::SignMessage(std::string strMessage, std::string& strErrorMessageRet, std::vector<unsigned char>& vchSigRet, CKey key)
 {
     CHashWriter ss(SER_GETHASH, 0);
     ss << strMessageMagic;
     ss << strMessage;
 
-    if (!key.SignCompact(ss.GetHash(), vchSig)) {
-        errorMessage = _("Signing failed.");
+    if(!key.SignCompact(ss.GetHash(), vchSigRet)) {
+        strErrorMessageRet = _("Signing failed.");
         return false;
     }
 
     return true;
 }
 
-bool CDarkSendSigner::VerifyMessage(CPubKey pubkey, vector<unsigned char>& vchSig, std::string strMessage, std::string& errorMessage)
+bool CDarkSendSigner::VerifyMessage(CPubKey pubkey, const std::vector<unsigned char>& vchSig, std::string strMessage, std::string& strErrorMessageRet)
 {
     CHashWriter ss(SER_GETHASH, 0);
     ss << strMessageMagic;
     ss << strMessage;
 
-    CPubKey pubkey2;
-    if (!pubkey2.RecoverCompact(ss.GetHash(), vchSig)) {
-        errorMessage = _("Error recovering public key.");
+    CPubKey pubkeyFromSig;
+    if(!pubkeyFromSig.RecoverCompact(ss.GetHash(), vchSig)) {
+        strErrorMessageRet = _("Error recovering public key.");
         return false;
     }
 
-    if (pubkey2.GetID() != pubkey.GetID()) {
-        errorMessage = strprintf("keys don't match - input: %s, recovered: %s, message: %s, sig: %s",
-                    pubkey.GetID().ToString(), pubkey2.GetID().ToString(), strMessage,
+    if(pubkeyFromSig.GetID() != pubkey.GetID()) {
+        strErrorMessageRet = strprintf("keys don't match: pubkey=%s, pubkeyFromSig=%s, strMessage=%s, vchSig=%s",
+                    pubkey.GetID().ToString(), pubkeyFromSig.GetID().ToString(), strMessage,
                     EncodeBase64(&vchSig[0], vchSig.size()));
         return false;
     }
@@ -2221,105 +2136,193 @@ bool CDarkSendSigner::VerifyMessage(CPubKey pubkey, vector<unsigned char>& vchSi
     return true;
 }
 
-bool CDarksendQueue::Sign()
+bool CDarkSendEntry::Add(const std::vector<CTxIn> vecTxIn, CAmount nAmount, const CTransaction txCollateral, const std::vector<CTxOut> vecTxOut)
 {
-    if(!fMasterNode) return false;
+    if(isSet) return false;
 
-    std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(time) + boost::lexical_cast<std::string>(ready);
-    std::string errorMessage = "";
+    BOOST_FOREACH(const CTxIn& txin, vecTxIn)
+        vecTxDSIn.push_back(txin);
 
-    if(!darkSendSigner.SignMessage(strMessage, errorMessage, vchSig, activeMasternode.keyMasternode)) {
-        LogPrintf("CDarksendQueue():Sign - Sign message failed");
-        return false;
-    }
+    BOOST_FOREACH(const CTxOut& txout, vecTxOut)
+        vecTxDSOut.push_back(txout);
 
-    if(!darkSendSigner.VerifyMessage(activeMasternode.pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-        LogPrintf("CDarksendQueue():Sign - Verify message failed");
-        return false;
-    }
+    this->nAmount = nAmount;
+    this->txCollateral = txCollateral;
+
+    isSet = true;
+    nTimeAdded = GetTime();
 
     return true;
 }
 
-bool CDarksendQueue::Relay()
+bool CDarkSendEntry::AddScriptSig(const CTxIn& txin)
 {
+    BOOST_FOREACH(CTxDSIn& txdsin, vecTxDSIn) {
+        if(txdsin.prevout == txin.prevout && txdsin.nSequence == txin.nSequence) {
+            if(txdsin.fHasSig) return false;
 
-    LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes){
-        // always relay to everyone
-        pnode->PushMessage(NetMsgType::DSQUEUE, (*this));
-    }
+            txdsin.scriptSig = txin.scriptSig;
+            txdsin.prevPubKey = txin.prevPubKey;
+            txdsin.fHasSig = true;
 
-    return true;
-}
-
-bool CDarksendQueue::CheckSignature()
-{
-    CMasternode* pmn = mnodeman.Find(vin);
-
-    if(pmn != NULL)
-    {
-        std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(time) + boost::lexical_cast<std::string>(ready);
-
-        std::string errorMessage = "";
-        if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage)){
-            return error("CDarksendQueue::CheckSignature() - Got bad Masternode queue signature %s", vin.ToString().c_str());
+            return true;
         }
-
-        return true;
     }
 
     return false;
 }
 
+bool CDarksendQueue::Sign()
+{
+    if(!fMasterNode) return false;
 
-void CDarksendPool::RelayFinalTransaction(const int sessionID, const CTransaction& txNew)
+    std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(nTime) + boost::lexical_cast<std::string>(fReady);
+    std::string strErrorMessage = "";
+
+    if(!darkSendSigner.SignMessage(strMessage, strErrorMessage, vchSig, activeMasternode.keyMasternode)) {
+        LogPrintf("CDarksendQueue::Sign -- SignMessage() failed\n");
+        return false;
+    }
+
+    return CheckSignature();
+}
+
+bool CDarksendQueue::CheckSignature()
+{
+    CMasternode* pmn = mnodeman.Find(vin);
+    if(pmn == NULL) return false;
+
+    std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(nTime) + boost::lexical_cast<std::string>(fReady);
+    std::string strErrorMessage = "";
+
+    if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, strErrorMessage)) {
+        LogPrintf("CDarksendQueue::CheckSignature -- Got bad Masternode queue signature, vin=%s\n", vin.ToString());
+        return false;
+    }
+
+    return true;
+}
+
+bool CDarksendQueue::GetAddress(CService &addrRet)
+{
+    CMasternode* pmn = mnodeman.Find(vin);
+    if(pmn == NULL) return false;
+
+    addrRet = pmn->addr;
+    return true;
+}
+
+bool CDarksendQueue::GetProtocolVersion(int &nProtocolVersionRet)
+{
+    CMasternode* pmn = mnodeman.Find(vin);
+    if(pmn == NULL) return false;
+
+    nProtocolVersionRet = pmn->protocolVersion;
+    return true;
+}
+
+bool CDarksendQueue::Relay()
 {
     LOCK(cs_vNodes);
     BOOST_FOREACH(CNode* pnode, vNodes)
-    {
-        pnode->PushMessage(NetMsgType::DSFINALTX, sessionID, txNew);
-    }
+        pnode->PushMessage(NetMsgType::DSQUEUE, (*this));
+
+    return true;
 }
 
-void CDarksendPool::RelayIn(const std::vector<CTxDSIn>& vin, const CAmount& nAmount, const CTransaction& txCollateral, const std::vector<CTxDSOut>& vout)
+bool CDarksendBroadcastTx::Sign()
+{
+    if(!fMasterNode) return false;
+
+    std::string strMessage = tx.GetHash().ToString() + boost::lexical_cast<std::string>(sigTime);
+    std::string strError = "";
+
+    if(!darkSendSigner.SignMessage(strMessage, strError, vchSig, activeMasternode.keyMasternode)) {
+        LogPrintf("CDarksendBroadcastTx::Sign -- SignMessage() failed\n");
+        return false;
+    }
+
+    return CheckSignature();
+}
+
+bool CDarksendBroadcastTx::CheckSignature()
+{
+    CMasternode* pmn = mnodeman.Find(vin);
+    if(pmn == NULL) return false;
+
+    std::string strMessage = tx.GetHash().ToString() + boost::lexical_cast<std::string>(sigTime);
+    std::string strError = "";
+
+    if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, strError)) {
+        LogPrintf("CDarksendBroadcastTx::CheckSignature -- Got bad dstx signature\n");
+        return false;
+    }
+
+    return true;
+}
+
+void CDarksendPool::RelayFinalTransaction(const CTransaction& txFinal)
+{
+    LOCK(cs_vNodes);
+    BOOST_FOREACH(CNode* pnode, vNodes)
+        pnode->PushMessage(NetMsgType::DSFINALTX, nSessionID, txFinal);
+}
+
+void CDarksendPool::RelayIn(const std::vector<CTxDSIn>& vecTxDSIn, const CAmount& nAmount, const CTransaction& txCollateral, const std::vector<CTxDSOut>& vecTxDSOut)
 {
     if(!pSubmittedToMasternode) return;
 
-    std::vector<CTxIn> vin2;
-    std::vector<CTxOut> vout2;
+    std::vector<CTxIn> vecTxIn;
+    std::vector<CTxOut> vecTxOut;
 
-    BOOST_FOREACH(CTxDSIn in, vin)
-        vin2.push_back(in);
+    BOOST_FOREACH(CTxDSIn in, vecTxDSIn)
+        vecTxIn.push_back(in);
 
-    BOOST_FOREACH(CTxDSOut out, vout)
-        vout2.push_back(out);
+    BOOST_FOREACH(CTxDSOut out, vecTxDSOut)
+        vecTxOut.push_back(out);
 
     CNode* pnode = FindNode(pSubmittedToMasternode->addr);
     if(pnode != NULL) {
-        LogPrintf("RelayIn - found master, relaying message - %s \n", pnode->addr.ToString());
-        pnode->PushMessage(NetMsgType::DSVIN, vin2, nAmount, txCollateral, vout2);
+        LogPrintf("CDarksendPool::RelayIn -- found master, relaying message to %s\n", pnode->addr.ToString());
+        pnode->PushMessage(NetMsgType::DSVIN, vecTxIn, nAmount, txCollateral, vecTxOut);
     }
 }
 
-void CDarksendPool::RelayStatus(const int sessionID, const int newState, const int newEntriesCount, const int newAccepted, const int errorID)
+void CDarksendPool::RelayStatus(int nErrorID)
 {
     LOCK(cs_vNodes);
     BOOST_FOREACH(CNode* pnode, vNodes)
-        pnode->PushMessage(NetMsgType::DSSTATUSUPDATE, sessionID, newState, newEntriesCount, newAccepted, errorID);
+        pnode->PushMessage(NetMsgType::DSSTATUSUPDATE, nSessionID, nState, nEntriesCount, nAcceptedEntriesCount, nErrorID);
 }
 
-void CDarksendPool::RelayCompletedTransaction(const int sessionID, const bool error, const int errorID)
+void CDarksendPool::RelayCompletedTransaction(bool fError, int nErrorID)
 {
     LOCK(cs_vNodes);
     BOOST_FOREACH(CNode* pnode, vNodes)
-        pnode->PushMessage(NetMsgType::DSCOMPLETE, sessionID, error, errorID);
+        pnode->PushMessage(NetMsgType::DSCOMPLETE, nSessionID, fError, nErrorID);
+}
+
+void CDarksendPool::SetState(unsigned int nStateNew)
+{
+    if(fMasterNode && (nStateNew == POOL_STATE_ERROR || nStateNew == POOL_STATE_SUCCESS)) {
+        LogPrint("privatesend", "CDarksendPool::SetState -- Can't set state to ERROR or SUCCESS as a Masternode. \n");
+        return;
+    }
+
+    LogPrintf("CDarksendPool::SetState -- nState: %d, nStateNew: %d\n", nState, nStateNew);
+    if(nState != nStateNew){
+        nLastTimeChanged = GetTimeMillis();
+        if(fMasterNode) {
+            RelayStatus(MASTERNODE_RESET);
+        }
+    }
+    nState = nStateNew;
 }
 
 void CDarksendPool::UpdatedBlockTip(const CBlockIndex *pindex)
 {
     pCurrentBlockIndex = pindex;
-    LogPrint("privatesend", "pCurrentBlockIndex->nHeight: %d\n", pCurrentBlockIndex->nHeight);
+    LogPrint("privatesend", "CDarksendPool::UpdatedBlockTip -- pCurrentBlockIndex->nHeight: %d\n", pCurrentBlockIndex->nHeight);
 
     if(!fLiteMode && masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_LIST)
         NewBlock();
@@ -2331,15 +2334,14 @@ void ThreadCheckDarkSendPool()
     if(fLiteMode) return; // disable all Dash specific functionality
 
     static bool fOneThread;
-    if (fOneThread)
-        return;
+    if(fOneThread) return;
     fOneThread = true;
 
     // Make this thread recognisable as the PrivateSend thread
     RenameThread("dash-privatesend");
 
-    unsigned int c = 0;
-    unsigned int nDoAutoNextRun = c + DARKSEND_AUTO_TIMEOUT_MIN;
+    unsigned int nTick = 0;
+    unsigned int nDoAutoNextRun = nTick + DARKSEND_AUTO_TIMEOUT_MIN;
 
     while (true)
     {
@@ -2348,17 +2350,16 @@ void ThreadCheckDarkSendPool()
         // try to sync from all available nodes, one step at a time
         masternodeSync.Process();
 
-        if(masternodeSync.IsBlockchainSynced()) {
+        if(masternodeSync.IsBlockchainSynced() && !ShutdownRequested()) {
 
-            c++;
+            nTick++;
 
             // check if we should activate or ping every few minutes,
             // start right after sync is considered to be done
-            if(c % MASTERNODE_PING_SECONDS == 1)
+            if(nTick % MASTERNODE_MIN_MNP_SECONDS == 1)
                 activeMasternode.ManageState();
 
-            if(c % 60 == 0)
-            {
+            if(nTick % 60 == 0) {
                 mnodeman.CheckAndRemove();
                 mnodeman.ProcessMasternodeConnections();
                 mnpayments.CheckAndRemove();
@@ -2368,10 +2369,10 @@ void ThreadCheckDarkSendPool()
             darkSendPool.CheckTimeout();
             darkSendPool.CheckForCompleteQueue();
 
-            if(nDoAutoNextRun == c) {
-                if(darkSendPool.GetState() == POOL_STATUS_IDLE) darkSendPool.DoAutomaticDenominating();
-
-                nDoAutoNextRun = c + DARKSEND_AUTO_TIMEOUT_MIN + insecure_rand()%(DARKSEND_AUTO_TIMEOUT_MAX - DARKSEND_AUTO_TIMEOUT_MIN);
+            if(nDoAutoNextRun == nTick) {
+                if(darkSendPool.GetState() == POOL_STATE_IDLE)
+                    darkSendPool.DoAutomaticDenominating();
+                nDoAutoNextRun = nTick + DARKSEND_AUTO_TIMEOUT_MIN + insecure_rand()%(DARKSEND_AUTO_TIMEOUT_MAX - DARKSEND_AUTO_TIMEOUT_MIN);
             }
         }
     }

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -5,62 +5,68 @@
 #ifndef DARKSEND_H
 #define DARKSEND_H
 
-#include "main.h"
-#include "sync.h"
-#include "activemasternode.h"
-#include "masternodeman.h"
-#include "darksend-relay.h"
+#include "masternode.h"
+#include "wallet/wallet.h"
 
-class CTxIn;
 class CDarksendPool;
 class CDarkSendSigner;
-class CMasterNodeVote;
-class CBitcoinAddress;
 class CDarksendQueue;
 class CDarksendBroadcastTx;
-class CActiveMasternode;
 
 // pool states for mixing
-#define POOL_STATUS_UNKNOWN                    0 // waiting for update
-#define POOL_STATUS_IDLE                       1 // waiting for update
-#define POOL_STATUS_QUEUE                      2 // waiting in a queue
-#define POOL_STATUS_ACCEPTING_ENTRIES          3 // accepting entries
-#define POOL_STATUS_FINALIZE_TRANSACTION       4 // master node will broadcast what it accepted
-#define POOL_STATUS_SIGNING                    5 // check inputs/outputs, sign final tx
-#define POOL_STATUS_TRANSMISSION               6 // transmit transaction
-#define POOL_STATUS_ERROR                      7 // error
-#define POOL_STATUS_SUCCESS                    8 // success
+static const int POOL_STATE_UNKNOWN                 = 0; // waiting for initialization
+static const int POOL_STATE_IDLE                    = 1; // waiting for update
+static const int POOL_STATE_QUEUE                   = 2; // waiting in a queue
+static const int POOL_STATE_ACCEPTING_ENTRIES       = 3; // accepting entries
+static const int POOL_STATE_FINALIZE_TRANSACTION    = 4; // master node will broadcast what it accepted
+static const int POOL_STATE_SIGNING                 = 5; // check inputs/outputs, sign final tx
+static const int POOL_STATE_TRANSMISSION            = 6; // transmit transaction
+static const int POOL_STATE_ERROR                   = 7; // error
+static const int POOL_STATE_SUCCESS                 = 8; // success
 
 // status update message constants
-#define MASTERNODE_ACCEPTED                    1
-#define MASTERNODE_REJECTED                    0
-#define MASTERNODE_RESET                       -1
+static const int MASTERNODE_ACCEPTED                = 1;
+static const int MASTERNODE_REJECTED                = 0;
+static const int MASTERNODE_RESET                   = -1;
 
-#define DARKSEND_AUTO_TIMEOUT_MIN               5
-#define DARKSEND_AUTO_TIMEOUT_MAX              15
-#define DARKSEND_QUEUE_TIMEOUT                 30
-#define DARKSEND_SIGNING_TIMEOUT               15
+// timeouts
+static const int DARKSEND_AUTO_TIMEOUT_MIN          = 5;
+static const int DARKSEND_AUTO_TIMEOUT_MAX          = 15;
+static const int DARKSEND_QUEUE_TIMEOUT             = 30;
+static const int DARKSEND_SIGNING_TIMEOUT           = 15;
 
-// used for anonymous relaying of inputs/outputs/sigs
-#define DARKSEND_RELAY_IN                 1
-#define DARKSEND_RELAY_OUT                2
-#define DARKSEND_RELAY_SIG                3
+//! minimum peer version accepted by DarksendPool
+static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70201;
 
-static const CAmount DARKSEND_COLLATERAL = (0.01*COIN);
-static const CAmount DARKSEND_POOL_MAX = (999.99*COIN);
-static const CAmount DENOMS_COUNT_MAX = 100;
+static const CAmount DARKSEND_COLLATERAL            = 0.01 * COIN;
+static const CAmount DARKSEND_POOL_MAX              = 999.99 * COIN;
+static const int DENOMS_COUNT_MAX                   = 100;
+
+static const int DEFAULT_PRIVATESEND_ROUNDS         = 2;
+static const int DEFAULT_PRIVATESEND_AMOUNT         = 1000;
+static const bool DEFAULT_PRIVATESEND_MULTISESSION  = false;
+
 // Warn user if mixing in gui or try to create backup if mixing in daemon mode
 // when we have only this many keys left
-static const int PS_KEYS_THRESHOLD_WARNING = 100;
+static const int PRIVATESEND_KEYS_THRESHOLD_WARNING = 100;
 // Stop mixing completely, it's too dangerous to continue when we have only this many keys left
-static const int PS_KEYS_THRESHOLD_STOP = 50;
+static const int PRIVATESEND_KEYS_THRESHOLD_STOP    = 50;
 
+extern int nPrivateSendRounds;
+extern int nPrivateSendAmount;
+extern int nLiquidityProvider;
+extern bool fEnablePrivateSend;
+extern bool fPrivateSendMultiSession;
+
+// The main object for accessing mixing
 extern CDarksendPool darkSendPool;
+// A helper object for signing messages from Masternodes
 extern CDarkSendSigner darkSendSigner;
-extern std::vector<CDarksendQueue> vecDarksendQueue;
-extern map<uint256, CDarksendBroadcastTx> mapDarksendBroadcastTxes;
 
-/** Holds an Darksend input
+extern std::map<uint256, CDarksendBroadcastTx> mapDarksendBroadcastTxes;
+extern std::vector<CAmount> vecPrivateSendDenominations;
+
+/** Holds an mixing input
  */
 class CTxDSIn : public CTxIn
 {
@@ -68,114 +74,69 @@ public:
     bool fHasSig; // flag to indicate if signed
     int nSentTimes; //times we've sent this anonymously
 
-    CTxDSIn(const CTxIn& in)
-    {
-        prevout = in.prevout;
-        scriptSig = in.scriptSig;
-        prevPubKey = in.prevPubKey;
-        nSequence = in.nSequence;
-        nSentTimes = 0;
-        fHasSig = false;
-    }
+    CTxDSIn(const CTxIn& txin) :
+        CTxIn(txin),
+        fHasSig(false),
+        nSentTimes(0) {}
 };
 
-/** Holds an Darksend output
+/** Holds an mixing output
  */
 class CTxDSOut : public CTxOut
 {
 public:
     int nSentTimes; //times we've sent this anonymously
 
-    CTxDSOut(const CTxOut& out)
-    {
-        nValue = out.nValue;
-        nRounds = out.nRounds;
-        scriptPubKey = out.scriptPubKey;
-        nSentTimes = 0;
-    }
+    CTxDSOut(const CTxOut& out) :
+        CTxOut(out),
+        nSentTimes(0) {}
 };
 
-// A clients transaction in the darksend pool
+// A clients transaction in the mixing pool
 class CDarkSendEntry
 {
 public:
+    std::vector<CTxDSIn> vecTxDSIn;
+    std::vector<CTxDSOut> vecTxDSOut;
+    CTransaction txCollateral;
+    CAmount nAmount;
+    int64_t nTimeAdded; // time in UTC milliseconds
     bool isSet;
-    std::vector<CTxDSIn> sev;
-    std::vector<CTxDSOut> vout;
-    CAmount amount;
-    CTransaction collateral;
-    CTransaction txSupporting;
-    int64_t addedTime; // time in UTC milliseconds
 
-    CDarkSendEntry()
-    {
-        isSet = false;
-        collateral = CTransaction();
-        amount = 0;
-    }
+    CDarkSendEntry() :
+        txCollateral(CTransaction()),
+        nAmount(0),
+        nTimeAdded(0),
+        isSet(false) {}
 
-    /// Add entries to use for Darksend
-    bool Add(const std::vector<CTxIn> vinIn, CAmount amountIn, const CTransaction collateralIn, const std::vector<CTxOut> voutIn)
-    {
-        if(isSet){return false;}
+    /// Add entries to use for mixing
+    bool Add(const std::vector<CTxIn> vecTxIn, CAmount nAmount, const CTransaction txCollateral, const std::vector<CTxOut> vecTxOut);
 
-        BOOST_FOREACH(const CTxIn& in, vinIn)
-            sev.push_back(in);
+    bool AddScriptSig(const CTxIn& txin);
 
-        BOOST_FOREACH(const CTxOut& out, voutIn)
-            vout.push_back(out);
-
-        amount = amountIn;
-        collateral = collateralIn;
-        isSet = true;
-        addedTime = GetTime();
-
-        return true;
-    }
-
-    bool AddSig(const CTxIn& vin)
-    {
-        BOOST_FOREACH(CTxDSIn& s, sev) {
-            if(s.prevout == vin.prevout && s.nSequence == vin.nSequence){
-                if(s.fHasSig){return false;}
-                s.scriptSig = vin.scriptSig;
-                s.prevPubKey = vin.prevPubKey;
-                s.fHasSig = true;
-
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    bool IsExpired()
-    {
-        return (GetTime() - addedTime) > DARKSEND_QUEUE_TIMEOUT;// 30 seconds
-    }
+    bool IsExpired() { return GetTime() - nTimeAdded > DARKSEND_QUEUE_TIMEOUT; }
 };
 
 
 /**
- * A currently inprogress Darksend merge and denomination information
+ * A currently inprogress mixing merge and denomination information
  */
 class CDarksendQueue
 {
 public:
-    CTxIn vin;
-    int64_t time;
     int nDenom;
-    bool ready; //ready for submit
+    CTxIn vin;
+    int64_t nTime;
+    bool fReady; //ready for submit
     std::vector<unsigned char> vchSig;
 
-    CDarksendQueue()
-    {
-        nDenom = 0;
-        vin = CTxIn();
-        time = 0;
-        vchSig.clear();
-        ready = false;
-    }
+    CDarksendQueue() { CDarksendQueue(0, CTxIn(), 0, false); }
+
+    CDarksendQueue(int nDenom, CTxIn vin, int64_t nTime, bool fReady) :
+        nDenom(nDenom),
+        vin(vin),
+        nTime(nTime),
+        fReady(fReady) { vchSig = std::vector<unsigned char>(); }
 
     ADD_SERIALIZE_METHODS;
 
@@ -183,35 +144,15 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(nDenom);
         READWRITE(vin);
-        READWRITE(time);
-        READWRITE(ready);
+        READWRITE(nTime);
+        READWRITE(fReady);
         READWRITE(vchSig);
     }
 
-    bool GetAddress(CService &addr)
-    {
-        CMasternode* pmn = mnodeman.Find(vin);
-        if(pmn != NULL)
-        {
-            addr = pmn->addr;
-            return true;
-        }
-        return false;
-    }
+    bool GetAddress(CService &addrRet);
+    bool GetProtocolVersion(int &nProtocolVersionRet);
 
-    /// Get the protocol version
-    bool GetProtocolVersion(int &protocolVersion)
-    {
-        CMasternode* pmn = mnodeman.Find(vin);
-        if(pmn != NULL)
-        {
-            protocolVersion = pmn->protocolVersion;
-            return true;
-        }
-        return false;
-    }
-
-    /** Sign this Darksend transaction
+    /** Sign this mixing transaction
      *  \return true if all conditions are met:
      *     1) we have an active Masternode,
      *     2) we have a valid Masternode private key,
@@ -219,29 +160,42 @@ public:
      *     4) we verified the message successfully
      */
     bool Sign();
-
-    bool Relay();
-
-    /// Is this Darksend expired?
-    bool IsExpired()
-    {
-        return (GetTime() - time) > DARKSEND_QUEUE_TIMEOUT;// 30 seconds
-    }
-
     /// Check if we have a valid Masternode address
     bool CheckSignature();
 
+    bool Relay();
+
+    /// Is this queue expired?
+    bool IsExpired() { return GetTime() - nTime > DARKSEND_QUEUE_TIMEOUT; }
 };
 
-/** Helper class to store Darksend transaction (tx) information.
+/** Helper class to store mixing transaction (tx) information.
  */
 class CDarksendBroadcastTx
 {
 public:
     CTransaction tx;
     CTxIn vin;
-    vector<unsigned char> vchSig;
+    std::vector<unsigned char> vchSig;
     int64_t sigTime;
+
+    CDarksendBroadcastTx() { CDarksendBroadcastTx(CTransaction(), CTxIn(), 0); }
+
+    CDarksendBroadcastTx(CTransaction tx, CTxIn vin, int64_t sigTime) :
+        tx(tx), vin(vin), sigTime(sigTime) { vchSig = std::vector<unsigned char>(); }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(tx);
+        READWRITE(vin);
+        READWRITE(vchSig);
+        READWRITE(sigTime);
+    }
+
+    bool Sign();
+    bool CheckSignature();
 };
 
 /** Helper object for signing and checking signatures
@@ -250,59 +204,20 @@ class CDarkSendSigner
 {
 public:
     /// Is the inputs associated with this public key? (and there is 1000 DASH - checking if valid masternode)
-    bool IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey);
+    bool IsVinAssociatedWithPubkey(const CTxIn& vin, const CPubKey& pubkey);
     /// Set the private/public key values, returns true if successful
-    bool SetKey(std::string strSecret, std::string& errorMessage, CKey& key, CPubKey& pubkey);
+    bool GetKeysFromSecret(std::string strSecret, std::string& strErrorMessageRet, CKey& keyRet, CPubKey& pubkeyRet);
     /// Sign the message, returns true if successful
-    bool SignMessage(std::string strMessage, std::string& errorMessage, std::vector<unsigned char>& vchSig, CKey key);
+    bool SignMessage(std::string strMessage, std::string& strErrorMessageRet, std::vector<unsigned char>& vchSigRet, CKey key);
     /// Verify the message, returns true if succcessful
-    bool VerifyMessage(CPubKey pubkey, std::vector<unsigned char>& vchSig, std::string strMessage, std::string& errorMessage);
+    bool VerifyMessage(CPubKey pubkey, const std::vector<unsigned char>& vchSig, std::string strMessage, std::string& strErrorMessageRet);
 };
 
-/** Used to keep track of current status of Darksend pool
+/** Used to keep track of current status of mixing pool
  */
 class CDarksendPool
 {
 private:
-    mutable CCriticalSection cs_darksend;
-
-    std::vector<CDarkSendEntry> entries; // Masternode/clients entries
-    CMutableTransaction finalMutableTransaction; // the finalized transaction ready for signing
-
-    int64_t lastTimeChanged; // last time the 'state' changed, in UTC milliseconds
-
-    unsigned int state; // should be one of the POOL_STATUS_XXX values
-    unsigned int entriesCount;
-    unsigned int lastEntryAccepted;
-    unsigned int countEntriesAccepted;
-
-    std::vector<CTxIn> lockedCoins;
-
-    std::string lastMessage;
-    bool unitTest;
-
-    int sessionID;
-
-    int sessionUsers; //N Users have said they'll join
-    bool sessionFoundMasternode; //If we've found a compatible Masternode
-    std::vector<CTransaction> vecSessionCollateral;
-
-    int cachedLastSuccess;
-
-    int minBlockSpacing; //required blocks between mixes
-    CMutableTransaction txCollateral;
-
-    int64_t lastNewBlock;
-
-    // Keep track of current block index
-    const CBlockIndex *pCurrentBlockIndex;
-
-    std::vector<CAmount> darkSendDenominationsSkipped;
-
-    //debugging data
-    std::string strAutoDenomResult;
-
-public:
     enum messages {
         ERR_ALREADY_HAVE,
         ERR_DENOM,
@@ -328,219 +243,177 @@ public:
         MSG_ENTRIES_ADDED
     };
 
-    CMasternode* pSubmittedToMasternode;
-    int sessionDenom; //Users must submit an denom matching this
-    int cachedNumBlocks; //used for the overview screen
-    bool fCreateAutoBackups; //builtin support for automatic backups
+    mutable CCriticalSection cs_darksend;
 
-    CDarksendPool()
-    {
-        /* Darksend uses collateral addresses to trust parties entering the pool
-            to behave themselves. If they don't it takes their money. */
+    // The current mixing sessions in progress on the network
+    std::vector<CDarksendQueue> vecDarksendQueue;
+    // Keep track of the used Masternodes
+    std::vector<CTxIn> vecMasternodesUsed;
 
-        cachedLastSuccess = 0;
-        cachedNumBlocks = std::numeric_limits<int>::max();
-        unitTest = false;
-        txCollateral = CMutableTransaction();
-        minBlockSpacing = 0;
-        lastNewBlock = 0;
-        fCreateAutoBackups = true;
+    std::vector<CAmount> vecDenominationsSkipped;
+    std::vector<COutPoint> vecOutPointLocked;
+    // Mixing uses collateral transactions to trust parties entering the pool
+    // to behave honestly. If they don't it takes their money.
+    std::vector<CTransaction> vecSessionCollateral;
+    std::vector<CDarkSendEntry> vecEntries; // Masternode/clients entries
 
-        SetNull();
-    }
+    unsigned int nState; // should be one of the POOL_STATE_XXX values
+    int64_t nLastTimeChanged; // last time the 'state' changed, in UTC milliseconds
 
-    /** Process a Darksend message using the Darksend protocol
-     * \param pfrom
-     * \param strCommand lower case command string; valid values are:
-     *        Command  | Description
-     *        -------- | -----------------
-     *        dsa      | Darksend Acceptable
-     *        dsc      | Darksend Complete
-     *        dsf      | Darksend Final tx
-     *        dsi      | Darksend vIn
-     *        dsq      | Darksend Queue
-     *        dss      | Darksend Signal Final Tx
-     *        dssu     | Darksend status update
-     *        dssub    | Darksend Subscribe To
-     * \param vRecv
-     */
-    void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+    int nCachedLastSuccessBlock;
+    int nMinBlockSpacing; //required blocks between mixes
+    const CBlockIndex *pCurrentBlockIndex; // Keep track of current block index
 
-    void ClearSkippedDenominations() {
-        darkSendDenominationsSkipped.clear();
-    }
+    int nSessionID;
+    int nSessionUsers; //N Users have said they'll join
+    bool fSessionFoundMasternode; //If we've found a compatible Masternode
 
-    bool IsDenomSkipped(CAmount denom) {
-        BOOST_FOREACH(CAmount d, darkSendDenominationsSkipped) {
-            if (d == denom) {
-                return true;
-            }
-        }
-        return false;
-    }
+    unsigned int nEntriesCount;
+    bool fLastEntryAccepted;
+    unsigned int nAcceptedEntriesCount;
 
-    void InitDenominations() {
-        darkSendDenominations.clear();
-        /* Denominations
+    std::string strLastMessage;
+    std::string strAutoDenomResult;
 
-           A note about convertability. Within Darksend pools, each denomination
-           is convertable to another.
+    bool fUnitTest;
 
-           For example:
-           1DRK+1000 == (.1DRK+100)*10
-           10DRK+10000 == (1DRK+1000)*10
-        */
-        darkSendDenominations.push_back( (100      * COIN)+100000 );
-        darkSendDenominations.push_back( (10       * COIN)+10000 );
-        darkSendDenominations.push_back( (1        * COIN)+1000 );
-        darkSendDenominations.push_back( (.1       * COIN)+100 );
-        /* Disabled till we need them
-        darkSendDenominations.push_back( (.01      * COIN)+10 );
-        darkSendDenominations.push_back( (.001     * COIN)+1 );
-        */
-    }
+    CMutableTransaction txMyCollateral; // client side collateral
+    CMutableTransaction finalMutableTransaction; // the finalized transaction ready for signing
 
-    void SetMinBlockSpacing(int minBlockSpacingIn){
-        minBlockSpacing = minBlockSpacingIn;
-    }
+    /// Add a clients entry to the pool
+    bool AddEntry(const std::vector<CTxIn>& vecTxInNew, const CAmount nAmount, const CTransaction& txCollateral, const std::vector<CTxOut>& vecTxOutNew, int& nErrorID);
+    /// Add signature to a txin
+    bool AddScriptSig(const CTxIn& txin);
 
-    void Reset();
-    void SetNull();
-
-    void UnlockCoins();
-
-    bool IsNull() const
-    {
-        return state == POOL_STATUS_ACCEPTING_ENTRIES && entries.empty();
-    }
-
-    int GetState() const
-    {
-        return state;
-    }
-
-    std::string GetStatus();
-
-    int GetEntriesCount() const
-    {
-        return entries.size();
-    }
-
-    /// Get the time the last entry was accepted (time in UTC milliseconds)
-    int GetLastEntryAccepted() const
-    {
-        return lastEntryAccepted;
-    }
-
-    /// Get the count of the accepted entries
-    int GetCountEntriesAccepted() const
-    {
-        return countEntriesAccepted;
-    }
-
-    // Set the 'state' value, with some logging and capturing when the state changed
-    void UpdateState(unsigned int newState)
-    {
-        if (fMasterNode && (newState == POOL_STATUS_ERROR || newState == POOL_STATUS_SUCCESS)){
-            LogPrint("privatesend", "CDarksendPool::UpdateState() - Can't set state to ERROR or SUCCESS as a Masternode. \n");
-            return;
-        }
-
-        LogPrintf("CDarksendPool::UpdateState() == %d | %d \n", state, newState);
-        if(state != newState){
-            lastTimeChanged = GetTimeMillis();
-            if(fMasterNode) {
-                RelayStatus(darkSendPool.sessionID, darkSendPool.GetState(), darkSendPool.GetEntriesCount(), MASTERNODE_RESET);
-            }
-        }
-        state = newState;
-    }
-
-    /// Get the maximum number of transactions for the pool
-    int GetMaxPoolTransactions()
-    {
-        return Params().PoolMaxTransactions();
-    }
-
-    /// Do we have enough users to take entries?
-    bool IsSessionReady(){
-        return sessionUsers >= GetMaxPoolTransactions();
-    }
-
-    /// Are these outputs compatible with other client in the pool?
-    bool IsCompatibleWithEntries(std::vector<CTxOut>& vout);
-
-    /// Is this amount compatible with other client in the pool?
-    bool IsCompatibleWithSession(int nDenom, CTransaction txCollateral, int &errorID);
-
-    /// Passively run Darksend in the background according to the configuration in settings
-    bool DoAutomaticDenominating(bool fDryRun=false);
-    bool PrepareDarksendDenominate();
-
-    /// Check for process in Darksend
-    void Check();
-    void CheckFinalTransaction();
     /// Charge fees to bad actors (Charge clients a fee if they're abusive)
     void ChargeFees();
     /// Rarely charge fees to pay miners
     void ChargeRandomFees();
-    void CheckTimeout();
-    void CheckForCompleteQueue();
-    /// Check to make sure a signature matches an input in the pool
-    bool SignatureValid(const CScript& newSig, const CTxIn& newVin);
+
+    /// Check for process
+    void CheckPool();
+
+    void CheckFinalTransaction();
+
+    void CompletedTransaction(bool fError, int nErrorID);
+
+    /// Get the denominations for a specific amount of dash.
+    int GetDenominationsByAmounts(const std::vector<CAmount>& vecAmount);
+
+    std::string GetMessageByID(int nMessageID);
+
+    /// Get the maximum number of transactions for the pool
+    int GetMaxPoolTransactions() { return Params().PoolMaxTransactions(); }
+
+    /// Are these outputs compatible with other client in the pool?
+    bool IsOutputsCompatibleWithSessionDenom(const std::vector<CTxOut>& vecTxOut);
+    /// Is this nDenom compatible with other client in the pool?
+    bool IsDenomCompatibleWithSession(int nDenom, CTransaction txCollateral, int &nErrorID);
+
     /// If the collateral is valid given by a client
     bool IsCollateralValid(const CTransaction& txCollateral);
-    /// Add a clients entry to the pool
-    bool AddEntry(const std::vector<CTxIn>& newInput, const CAmount& nAmount, const CTransaction& txCollateral, const std::vector<CTxOut>& newOutput, int& errorID);
-    /// Add signature to a vin
-    bool AddScriptSig(const CTxIn& newVin);
     /// Check that all inputs are signed. (Are all inputs signed?)
-    bool SignaturesComplete();
-    /// As a client, send a transaction to a Masternode to start the denomination process
-    void SendDarksendDenominate(std::vector<CTxIn>& vin, std::vector<CTxOut>& vout, CAmount amount);
-    /// Get Masternode updates about the progress of Darksend
-    bool StatusUpdate(int newState, int newEntriesCount, int newAccepted, int &errorID, int newSessionID=0);
+    bool IsSignaturesComplete();
+    /// Check to make sure a signature matches an input in the pool
+    bool IsSignatureValid(const CScript& scriptSig, const CTxIn& txin);
 
-    /// As a client, check and sign the final transaction
-    bool SignFinalTransaction(CTransaction& finalTransactionNew, CNode* node);
+    bool IsDenomSkipped(CAmount nDenomValue) {
+        return std::find(vecDenominationsSkipped.begin(), vecDenominationsSkipped.end(), nDenomValue) != vecDenominationsSkipped.end();
+    }
 
-    /// Get the last valid block hash for a given modulus
-    bool GetLastValidBlockHash(uint256& hash, int mod=1, int nBlockHeight=0);
-    /// Process a new block
-    void NewBlock();
-    void CompletedTransaction(bool error, int errorID);
-    void ClearLastMessage();
+    bool IsNull() const { return nState == POOL_STATE_ACCEPTING_ENTRIES && vecEntries.empty(); }
 
-    /// Split up large inputs or make fee sized inputs
-    bool MakeCollateralAmounts();
-    bool MakeCollateralAmounts(const CompactTallyItem& tallyItem);
     /// Create denominations
     bool CreateDenominated();
     bool CreateDenominated(const CompactTallyItem& tallyItem);
+    /// Split up large inputs or make fee sized inputs
+    bool MakeCollateralAmounts();
+    bool MakeCollateralAmounts(const CompactTallyItem& tallyItem);
 
+    bool PrepareDenominate();
 
-    /// Get the denominations for a list of outputs (returns a bitshifted integer)
-    int GetDenominations(const std::vector<CTxOut>& vout, bool fSingleRandomDenom = false);
-    int GetDenominations(const std::vector<CTxDSOut>& vout);
+    /// Get Masternode updates about the progress of mixing
+    bool UpdatePoolStateOnClient(int nStateNew, int nEntriesCountNew, int nAcceptedEntriesCountNew, int &nErrorID, int nSessionIDNew=0);
+    // Set the 'state' value, with some logging and capturing when the state changed
+    void SetState(unsigned int nStateNew);
 
-    void GetDenominationsToString(int nDenom, std::string& strDenom);
+    /// As a client, check and sign the final transaction
+    bool SignFinalTransaction(const CTransaction& finalTransactionNew, CNode* node);
 
-    /// Get the denominations for a specific amount of dash.
-    int GetDenominationsByAmount(CAmount nAmount, int nDenomTarget=0); // is not used anymore?
-    int GetDenominationsByAmounts(std::vector<CAmount>& vecAmount);
-
-    std::string GetMessageByID(int messageID);
-
-    //
-    // Relay Darksend Messages
-    //
-
-    void RelayFinalTransaction(const int sessionID, const CTransaction& txNew);
+    /// Relay mixing Messages
+    void RelayFinalTransaction(const CTransaction& txFinal);
     void RelaySignaturesAnon(std::vector<CTxIn>& vin);
     void RelayInAnon(std::vector<CTxIn>& vin, std::vector<CTxOut>& vout);
     void RelayIn(const std::vector<CTxDSIn>& vin, const CAmount& nAmount, const CTransaction& txCollateral, const std::vector<CTxDSOut>& vout);
-    void RelayStatus(const int sessionID, const int newState, const int newEntriesCount, const int newAccepted, const int errorID=MSG_NOERR);
-    void RelayCompletedTransaction(const int sessionID, const bool error, const int errorID);
+    void RelayStatus(int nErrorID=MSG_NOERR);
+    void RelayCompletedTransaction(bool fError, int nErrorID);
+
+public:
+    CMasternode* pSubmittedToMasternode;
+    int nSessionDenom; //Users must submit an denom matching this
+    int nCachedNumBlocks; //used for the overview screen
+    bool fCreateAutoBackups; //builtin support for automatic backups
+
+    CDarksendPool() :
+        nCachedLastSuccessBlock(0),
+        nMinBlockSpacing(0),
+        fUnitTest(false),
+        txMyCollateral(CMutableTransaction()),
+        nCachedNumBlocks(std::numeric_limits<int>::max()),
+        fCreateAutoBackups(true) { SetNull(); }
+
+    /** Process a mixing message using the protocol below
+     * \param pfrom
+     * \param strCommand lower case command string; valid values are:
+     *        Command  | Description
+     *        -------- | -----------------
+     *        dsa      | Acceptable
+     *        dsc      | Complete
+     *        dsf      | Final tx
+     *        dsi      | Vector of CTxIn
+     *        dsq      | Queue
+     *        dss      | Signal Final Tx
+     *        dssu     | status update
+     * \param vRecv
+     */
+    void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+
+    void InitDenominations();
+    void ClearSkippedDenominations() { vecDenominationsSkipped.clear(); }
+
+    /// Get the denominations for a list of outputs (returns a bitshifted integer)
+    int GetDenominations(const std::vector<CTxOut>& vecTxOut, bool fSingleRandomDenom = false);
+    int GetDenominations(const std::vector<CTxDSOut>& vecTxDSOut);
+    std::string GetDenominationsToString(int nDenom);
+
+    void SetMinBlockSpacing(int nMinBlockSpacingIn) { nMinBlockSpacing = nMinBlockSpacingIn; }
+
+    void ResetPool();
+    void SetNull();
+
+    void UnlockCoins();
+
+    int GetQueueSize() const { return vecDarksendQueue.size(); }
+    int GetState() const { return nState; }
+    std::string GetStatus();
+
+    int GetEntriesCount() const { return vecEntries.size(); }
+    /// Get the count of the accepted entries
+    int GetCountEntriesAccepted() const { return nAcceptedEntriesCount; }
+
+    /// Passively run mixing in the background according to the configuration in settings
+    bool DoAutomaticDenominating(bool fDryRun=false);
+
+    void CheckTimeout();
+    void CheckForCompleteQueue();
+    /// Do we have enough users to take entries?
+    bool IsSessionReady(){ return nSessionUsers >= GetMaxPoolTransactions(); }
+
+    /// As a client, send a transaction to a Masternode to start the denomination process
+    void SendDarksendDenominate(const std::vector<CTxIn>& vecTxIn, const std::vector<CTxOut>& vecTxOut, CAmount nAmount);
+
+    /// Process a new block
+    void NewBlock();
 
     void UpdatedBlockTip(const CBlockIndex *pindex);
 };

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -59,7 +59,6 @@ extern CDarksendPool darkSendPool;
 extern CDarkSendSigner darkSendSigner;
 extern std::vector<CDarksendQueue> vecDarksendQueue;
 extern map<uint256, CDarksendBroadcastTx> mapDarksendBroadcastTxes;
-extern CActiveMasternode activeMasternode;
 
 /** Holds an Darksend input
  */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -558,10 +558,10 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-budgetvotemode=<mode>", _("Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)"));
 
     strUsage += HelpMessageGroup(_("PrivateSend options:"));
-    strUsage += HelpMessageOpt("-enableprivatesend=<n>", strprintf(_("Enable use of automated PrivateSend for funds stored in this wallet (0-1, default: %u)"), fEnablePrivateSend));
-    strUsage += HelpMessageOpt("-privatesendmultisession=<n>", strprintf(_("Enable multiple PrivateSend mixing sessions per block, experimental (0-1, default: %u)"), fPrivateSendMultiSession));
-    strUsage += HelpMessageOpt("-privatesendrounds=<n>", strprintf(_("Use N separate masternodes to anonymize funds  (2-8, default: %u)"), nPrivateSendRounds));
-    strUsage += HelpMessageOpt("-privatesendamount=<n>", strprintf(_("Keep N DASH anonymized (default: %u)"), nPrivateSendAmount));
+    strUsage += HelpMessageOpt("-enableprivatesend=<n>", strprintf(_("Enable use of automated PrivateSend for funds stored in this wallet (0-1, default: %u)"), 0));
+    strUsage += HelpMessageOpt("-privatesendmultisession=<n>", strprintf(_("Enable multiple PrivateSend mixing sessions per block, experimental (0-1, default: %u)"), DEFAULT_PRIVATESEND_MULTISESSION));
+    strUsage += HelpMessageOpt("-privatesendrounds=<n>", strprintf(_("Use N separate masternodes to anonymize funds  (2-8, default: %u)"), DEFAULT_PRIVATESEND_ROUNDS));
+    strUsage += HelpMessageOpt("-privatesendamount=<n>", strprintf(_("Keep N DASH anonymized (default: %u)"), DEFAULT_PRIVATESEND_AMOUNT));
     strUsage += HelpMessageOpt("-liquidityprovider=<n>", strprintf(_("Provide liquidity to PrivateSend by infrequently mixing coins on a continual basis (0-100, default: %u, 1=very frequent, high fees, 100=very infrequent, low fees)"), nLiquidityProvider));
 
     strUsage += HelpMessageGroup(_("InstantSend options:"));
@@ -1797,7 +1797,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         if(!strMasterNodePrivKey.empty()) {
             std::string strErrorMessage;
 
-            if(!darkSendSigner.SetKey(strMasterNodePrivKey, strErrorMessage, activeMasternode.keyMasternode, activeMasternode.pubKeyMasternode))
+            if(!darkSendSigner.GetKeysFromSecret(strMasterNodePrivKey, strErrorMessage, activeMasternode.keyMasternode, activeMasternode.pubKeyMasternode))
                 return InitError(_("Invalid masternodeprivkey. Please see documenation."));
 
             LogPrintf("  pubKeyMasternode: %s\n", CBitcoinAddress(activeMasternode.pubKeyMasternode.GetID()).ToString());
@@ -1832,11 +1832,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     nLiquidityProvider = std::min(std::max(nLiquidityProvider, 0), 100);
     darkSendPool.SetMinBlockSpacing(nLiquidityProvider * 15);
 
-    fEnablePrivateSend = GetBoolArg("-enableprivatesend", fEnablePrivateSend);
-    fPrivateSendMultiSession = GetBoolArg("-privatesendmultisession", fPrivateSendMultiSession);
-    nPrivateSendRounds = GetArg("-privatesendrounds", nPrivateSendRounds);
+    fEnablePrivateSend = GetBoolArg("-enableprivatesend", 0);
+    fPrivateSendMultiSession = GetBoolArg("-privatesendmultisession", DEFAULT_PRIVATESEND_MULTISESSION);
+    nPrivateSendRounds = GetArg("-privatesendrounds", DEFAULT_PRIVATESEND_ROUNDS);
     nPrivateSendRounds = std::min(std::max(nPrivateSendRounds, 1), 99999);
-    nPrivateSendAmount = GetArg("-privatesendamount", nPrivateSendAmount);
+    nPrivateSendAmount = GetArg("-privatesendamount", DEFAULT_PRIVATESEND_AMOUNT);
     nPrivateSendAmount = std::min(std::max(nPrivateSendAmount, 2), 999999);
 
     fEnableInstantSend = GetBoolArg("-enableinstantsend", 1);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -34,6 +34,7 @@
 #include "ui_interface.h"
 #include "util.h"
 #include "activemasternode.h"
+#include "instantx.h"
 #include "darksend.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"
@@ -564,8 +565,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-liquidityprovider=<n>", strprintf(_("Provide liquidity to PrivateSend by infrequently mixing coins on a continual basis (0-100, default: %u, 1=very frequent, high fees, 100=very infrequent, low fees)"), nLiquidityProvider));
 
     strUsage += HelpMessageGroup(_("InstantSend options:"));
-    strUsage += HelpMessageOpt("-enableinstantsend=<n>", strprintf(_("Enable InstantSend, show confirmations for locked transactions (0-1, default: %u)"), fEnableInstantSend));
-    strUsage += HelpMessageOpt("-instantsenddepth=<n>", strprintf(_("Show N confirmations for a successfully locked transaction (0-9999, default: %u)"), nInstantSendDepth));
+    strUsage += HelpMessageOpt("-enableinstantsend=<n>", strprintf(_("Enable InstantSend, show confirmations for locked transactions (0-1, default: %u)"), 1));
+    strUsage += HelpMessageOpt("-instantsenddepth=<n>", strprintf(_("Show N confirmations for a successfully locked transaction (0-9999, default: %u)"), DEFAULT_INSTANTSEND_DEPTH));
     strUsage += HelpMessageOpt("-instantsendnotify=<cmd>", _("Execute command when a wallet IS transaction is successfully locked (%s in cmd is replaced by TxID)"));
 
 
@@ -1838,8 +1839,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     nPrivateSendAmount = GetArg("-privatesendamount", nPrivateSendAmount);
     nPrivateSendAmount = std::min(std::max(nPrivateSendAmount, 2), 999999);
 
-    fEnableInstantSend = GetBoolArg("-enableinstantsend", fEnableInstantSend);
-    nInstantSendDepth = GetArg("-instantsenddepth", nInstantSendDepth);
+    fEnableInstantSend = GetBoolArg("-enableinstantsend", 1);
+    nInstantSendDepth = GetArg("-instantsenddepth", DEFAULT_INSTANTSEND_DEPTH);
     nInstantSendDepth = std::min(std::max(nInstantSendDepth, 0), 60);
 
     //lite mode disables all Masternode and Darksend related functionality

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -23,6 +23,8 @@
 using namespace std;
 using namespace boost;
 
+extern CWallet* pwalletMain;
+
 std::map<uint256, CTransaction> mapTxLockReq;
 std::map<uint256, CTransaction> mapTxLockReqRejected;
 std::map<uint256, CConsensusVote> mapTxLockVote;

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -20,35 +20,38 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/thread.hpp>
 
-using namespace std;
-using namespace boost;
-
 extern CWallet* pwalletMain;
+
+bool fEnableInstantSend = true;
+int nInstantSendDepth = DEFAULT_INSTANTSEND_DEPTH;
+int nCompleteTXLocks;
 
 std::map<uint256, CTransaction> mapTxLockReq;
 std::map<uint256, CTransaction> mapTxLockReqRejected;
 std::map<uint256, CConsensusVote> mapTxLockVote;
-std::map<uint256, CTransactionLock> mapTxLocks;
 std::map<COutPoint, uint256> mapLockedInputs;
+
+std::map<uint256, CTransactionLock> mapTxLocks;
 std::map<uint256, int64_t> mapUnknownVotes; //track votes with no tx for DOS
-int nCompleteTXLocks;
+
+CCriticalSection cs_instantsend;
 
 //txlock - Locks transaction
 //
 //step 1.) Broadcast intention to lock transaction inputs, "txlreg", CTransaction
-//step 2.) Top INSTANTX_SIGNATURES_TOTAL masternodes, open connect to top 1 masternode.
+//step 2.) Top INSTANTSEND_SIGNATURES_TOTAL masternodes, open connect to top 1 masternode.
 //         Send "txvote", CTransaction, Signature, Approve
-//step 3.) Top 1 masternode, waits for INSTANTX_SIGNATURES_REQUIRED messages. Upon success, sends "txlock'
+//step 3.) Top 1 masternode, waits for INSTANTSEND_SIGNATURES_REQUIRED messages. Upon success, sends "txlock'
 
-void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
+void ProcessMessageInstantSend(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
-    if(fLiteMode) return; //disable all darksend/masternode related functionality
+    if(fLiteMode) return; // disable all Dash specific functionality
     if(!sporkManager.IsSporkActive(SPORK_2_INSTANTX)) return;
     if(!masternodeSync.IsBlockchainSynced()) return;
 
     if (strCommand == NetMsgType::IX)
     {
-        //LogPrintf("ProcessMessageInstantX::ix\n");
+        //LogPrintf("ProcessMessageInstantSend\n");
         CDataStream vMsg(vRecv);
         CTransaction tx;
         vRecv >> tx;
@@ -62,13 +65,13 @@ void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& 
         // have we seen it already?
         if(mapTxLockReq.count(inv.hash) || mapTxLockReqRejected.count(inv.hash)) return;
         // is it a valid one?
-        if(!IsIXTXValid(tx)) return;
+        if(!IsInstantSendTxValid(tx)) return;
 
-        BOOST_FOREACH(const CTxOut o, tx.vout){
+        BOOST_FOREACH(const CTxOut o, tx.vout) {
             // IX supports normal scripts and unspendable scripts (used in DS collateral and Budget collateral).
             // TODO: Look into other script types that are normal and can be included
-            if(!o.scriptPubKey.IsNormalPaymentScript() && !o.scriptPubKey.IsUnspendable()){
-                LogPrintf("ProcessMessageInstantX::ix - Invalid Script %s", tx.ToString());
+            if(!o.scriptPubKey.IsNormalPaymentScript() && !o.scriptPubKey.IsUnspendable()) {
+                LogPrintf("ProcessMessageInstantSend -- Invalid Script %s", tx.ToString());
                 return;
             }
         }
@@ -83,15 +86,14 @@ void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& 
             LOCK(cs_main);
             fAccepted = AcceptToMemoryPool(mempool, state, tx, true, &fMissingInputs);
         }
-        if (fAccepted)
-        {
+        if(fAccepted) {
             RelayInv(inv);
 
             DoConsensusVote(tx, nBlockHeight);
 
-            mapTxLockReq.insert(make_pair(tx.GetHash(), tx));
+            mapTxLockReq.insert(std::make_pair(tx.GetHash(), tx));
 
-            LogPrintf("ProcessMessageInstantX::ix - Transaction Lock Request: %s %s : accepted %s\n",
+            LogPrintf("ProcessMessageInstantSend -- Transaction Lock Request: %s %s : accepted %s\n",
                 pfrom->addr.ToString(), pfrom->cleanSubVer,
                 tx.GetHash().ToString()
             );
@@ -99,7 +101,7 @@ void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& 
             // Masternodes will sometimes propagate votes before the transaction is known to the client.
             // If this just happened - update transaction status, try forcing external script notification,
             // lock inputs and resolve conflicting locks
-            if(IsLockedIXTransaction(tx.GetHash())) {
+            if(IsLockedInstandSendTransaction(tx.GetHash())) {
                 UpdateLockedTransaction(tx, true);
                 LockTransactionInputs(tx);
                 ResolveConflicts(tx);
@@ -108,11 +110,11 @@ void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& 
             return;
 
         } else {
-            mapTxLockReqRejected.insert(make_pair(tx.GetHash(), tx));
+            mapTxLockReqRejected.insert(std::make_pair(tx.GetHash(), tx));
 
             // can we get the conflicting transaction as proof?
 
-            LogPrintf("ProcessMessageInstantX::ix - Transaction Lock Request: %s %s : rejected %s\n",
+            LogPrintf("ProcessMessageInstantSend -- Transaction Lock Request: %s %s : rejected %s\n",
                 pfrom->addr.ToString(), pfrom->cleanSubVer,
                 tx.GetHash().ToString()
             );
@@ -125,39 +127,35 @@ void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& 
     }
     else if (strCommand == NetMsgType::IXLOCKVOTE) //InstantX Lock Consensus Votes
     {
-        CConsensusVote ctx;
-        vRecv >> ctx;
+        CConsensusVote vote;
+        vRecv >> vote;
 
-        CInv inv(MSG_TXLOCK_VOTE, ctx.GetHash());
+        CInv inv(MSG_TXLOCK_VOTE, vote.GetHash());
         pfrom->AddInventoryKnown(inv);
 
-        if(mapTxLockVote.count(ctx.GetHash())){
-            return;
-        }
+        if(mapTxLockVote.count(vote.GetHash())) return;
+        mapTxLockVote.insert(std::make_pair(vote.GetHash(), vote));
 
-        mapTxLockVote.insert(make_pair(ctx.GetHash(), ctx));
-
-        if(ProcessConsensusVote(pfrom, ctx)){
+        if(ProcessConsensusVote(pfrom, vote)) {
             //Spam/Dos protection
             /*
                 Masternodes will sometimes propagate votes before the transaction is known to the client.
                 This tracks those messages and allows it at the same rate of the rest of the network, if
                 a peer violates it, it will simply be ignored
             */
-            if(!mapTxLockReq.count(ctx.txHash) && !mapTxLockReqRejected.count(ctx.txHash)){
-                if(!mapUnknownVotes.count(ctx.vinMasternode.prevout.hash)){
-                    mapUnknownVotes[ctx.vinMasternode.prevout.hash] = GetTime()+(60*10);
-                }
+            if(!mapTxLockReq.count(vote.txHash) && !mapTxLockReqRejected.count(vote.txHash)) {
+                if(!mapUnknownVotes.count(vote.vinMasternode.prevout.hash))
+                    mapUnknownVotes[vote.vinMasternode.prevout.hash] = GetTime()+(60*10);
 
-                if(mapUnknownVotes[ctx.vinMasternode.prevout.hash] > GetTime() &&
-                    mapUnknownVotes[ctx.vinMasternode.prevout.hash] - GetAverageVoteTime() > 60*10){
-                        LogPrintf("ProcessMessageInstantX::ix - masternode is spamming transaction votes: %s %s\n",
-                            ctx.vinMasternode.ToString(),
-                            ctx.txHash.ToString()
+                if(mapUnknownVotes[vote.vinMasternode.prevout.hash] > GetTime() &&
+                    mapUnknownVotes[vote.vinMasternode.prevout.hash] - GetAverageVoteTime() > 60*10) {
+                        LogPrintf("ProcessMessageInstantSend -- masternode is spamming transaction votes: %s %s\n",
+                            vote.vinMasternode.ToString(),
+                            vote.txHash.ToString()
                         );
                         return;
                 } else {
-                    mapUnknownVotes[ctx.vinMasternode.prevout.hash] = GetTime()+(60*10);
+                    mapUnknownVotes[vote.vinMasternode.prevout.hash] = GetTime()+(60*10);
                 }
             }
             RelayInv(inv);
@@ -167,11 +165,12 @@ void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& 
     }
 }
 
-bool IsIXTXValid(const CTransaction& txCollateral){
+bool IsInstantSendTxValid(const CTransaction& txCollateral)
+{
     if(txCollateral.vout.size() < 1) return false;
 
     if(!CheckFinalTx(txCollateral)) {
-        LogPrint("instantsend", "IsIXTXValid - Transaction is not final - %s\n", txCollateral.ToString());
+        LogPrint("instantsend", "IsInstantSendTxValid -- Transaction is not final: txCollateral=%s", txCollateral.ToString());
         return false;
     }
 
@@ -179,28 +178,27 @@ bool IsIXTXValid(const CTransaction& txCollateral){
     int64_t nValueOut = 0;
     bool missingTx = false;
 
-    BOOST_FOREACH(const CTxOut o, txCollateral.vout)
-        nValueOut += o.nValue;
+    BOOST_FOREACH(const CTxOut txout, txCollateral.vout)
+        nValueOut += txout.nValue;
 
-    BOOST_FOREACH(const CTxIn i, txCollateral.vin){
+    BOOST_FOREACH(const CTxIn txin, txCollateral.vin) {
         CTransaction tx2;
         uint256 hash;
-        if(GetTransaction(i.prevout.hash, tx2, Params().GetConsensus(), hash, true)){
-            if(tx2.vout.size() > i.prevout.n) {
-                nValueIn += tx2.vout[i.prevout.n].nValue;
-            }
-        } else{
+        if(GetTransaction(txin.prevout.hash, tx2, Params().GetConsensus(), hash, true)) {
+            if(tx2.vout.size() > txin.prevout.n)
+                nValueIn += tx2.vout[txin.prevout.n].nValue;
+        } else {
             missingTx = true;
         }
     }
 
-    if(nValueOut > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
-        LogPrint("instantsend", "IsIXTXValid -- Transaction value too high: nValueOut=%d, txCollateral=%s", nValueOut, txCollateral.ToString());
+    if(nValueOut > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)*COIN) {
+        LogPrint("instantsend", "IsInstantSendTxValid -- Transaction value too high: nValueOut=%d, txCollateral=%s", nValueOut, txCollateral.ToString());
         return false;
     }
 
-    if(missingTx){
-        LogPrint("instantsend", "IsIXTXValid - Unknown inputs in IX transaction - %s\n", txCollateral.ToString());
+    if(missingTx) {
+        LogPrint("instantsend", "IsInstantSendTxValid -- Unknown inputs in IX transaction: txCollateral=%s", txCollateral.ToString());
         /*
             This happens sometimes for an unknown reason, so we'll return that it's a valid transaction.
             If someone submits an invalid transaction it will be rejected by the network anyway and this isn't
@@ -210,7 +208,7 @@ bool IsIXTXValid(const CTransaction& txCollateral){
     }
 
     if(nValueIn-nValueOut < INSTANTSEND_MIN_FEE) {
-        LogPrint("instantsend", "IsIXTXValid - did not include enough fees in transaction %d\n%s\n", nValueOut-nValueIn, txCollateral.ToString());
+        LogPrint("instantsend", "IsInstantSendTxValid -- did not include enough fees in transaction: fees=%d, txCollateral=%s", nValueOut-nValueIn, txCollateral.ToString());
         return false;
     }
 
@@ -221,11 +219,10 @@ int64_t CreateNewLock(CTransaction tx)
 {
 
     int64_t nTxAge = 0;
-    BOOST_REVERSE_FOREACH(CTxIn i, tx.vin){
-        nTxAge = GetInputAge(i);
-        if(nTxAge < 5) //1 less than the "send IX" gui requires, incase of a block propagating the network at the time
-        {
-            LogPrintf("CreateNewLock - Transaction not found / too new: %d / %s\n", nTxAge, tx.GetHash().ToString());
+    BOOST_REVERSE_FOREACH(CTxIn txin, tx.vin) {
+        nTxAge = GetInputAge(txin);
+        if(nTxAge < 5) { //1 less than the "send IX" gui requires, incase of a block propagating the network at the time
+            LogPrintf("CreateNewLock -- Transaction not found / too new: nTxAge=%d, txid=%s\n", nTxAge, tx.GetHash().ToString());
             return 0;
         }
     }
@@ -239,22 +236,24 @@ int64_t CreateNewLock(CTransaction tx)
     {
         LOCK(cs_main);
         CBlockIndex* tip = chainActive.Tip();
-        if(tip) nBlockHeight = tip->nHeight - nTxAge + 4;
-        else return 0;
+        if(tip)
+            nBlockHeight = tip->nHeight - nTxAge + 4;
+        else
+            return 0;
     }
 
-    if (!mapTxLocks.count(tx.GetHash())){
-        LogPrintf("CreateNewLock - New Transaction Lock %s !\n", tx.GetHash().ToString());
+    if(!mapTxLocks.count(tx.GetHash())) {
+        LogPrintf("CreateNewLock -- New Transaction Lock! txid=%s\n", tx.GetHash().ToString());
 
         CTransactionLock newLock;
         newLock.nBlockHeight = nBlockHeight;
         newLock.nExpiration = GetTime()+(60*60); //locks expire after 60 minutes (24 confirmations)
         newLock.nTimeout = GetTime()+(60*5);
         newLock.txHash = tx.GetHash();
-        mapTxLocks.insert(make_pair(tx.GetHash(), newLock));
+        mapTxLocks.insert(std::make_pair(tx.GetHash(), newLock));
     } else {
         mapTxLocks[tx.GetHash()].nBlockHeight = nBlockHeight;
-        LogPrint("instantsend", "CreateNewLock - Transaction Lock Exists %s !\n", tx.GetHash().ToString());
+        LogPrint("instantsend", "CreateNewLock -- Transaction Lock Exists! txid=%s\n", tx.GetHash().ToString());
     }
 
 
@@ -267,110 +266,110 @@ void DoConsensusVote(CTransaction& tx, int64_t nBlockHeight)
 {
     if(!fMasterNode) return;
 
-    int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
+    int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight, MIN_INSTANTSEND_PROTO_VERSION);
 
-    if(n == -1)
-    {
-        LogPrint("instantsend", "InstantX::DoConsensusVote - Unknown Masternode %s\n", activeMasternode.vin.ToString());
+    if(n == -1) {
+        LogPrint("instantsend", "DoConsensusVote -- Unknown Masternode %s\n", activeMasternode.vin.ToString());
         return;
     }
 
-    if(n > INSTANTX_SIGNATURES_TOTAL)
-    {
-        LogPrint("instantsend", "InstantX::DoConsensusVote - Masternode not in the top %d (%d)\n", INSTANTX_SIGNATURES_TOTAL, n);
+    if(n > INSTANTSEND_SIGNATURES_TOTAL) {
+        LogPrint("instantsend", "DoConsensusVote -- Masternode not in the top %d (%d)\n", INSTANTSEND_SIGNATURES_TOTAL, n);
         return;
     }
     /*
         nBlockHeight calculated from the transaction is the authoritive source
     */
 
-    LogPrint("instantsend", "InstantX::DoConsensusVote - In the top %d (%d)\n", INSTANTX_SIGNATURES_TOTAL, n);
+    LogPrint("instantsend", "DoConsensusVote -- In the top %d (%d)\n", INSTANTSEND_SIGNATURES_TOTAL, n);
 
-    CConsensusVote ctx;
-    ctx.vinMasternode = activeMasternode.vin;
-    ctx.txHash = tx.GetHash();
-    ctx.nBlockHeight = nBlockHeight;
-    if(!ctx.Sign()){
-        LogPrintf("InstantX::DoConsensusVote - Failed to sign consensus vote\n");
+    CConsensusVote vote;
+    vote.vinMasternode = activeMasternode.vin;
+    vote.txHash = tx.GetHash();
+    vote.nBlockHeight = nBlockHeight;
+    if(!vote.Sign()) {
+        LogPrintf("DoConsensusVote -- Failed to sign consensus vote\n");
         return;
     }
-    if(!ctx.SignatureValid()) {
-        LogPrintf("InstantX::DoConsensusVote - Signature invalid\n");
+    if(!vote.SignatureValid()) {
+        LogPrintf("DoConsensusVote -- Signature invalid\n");
         return;
     }
 
-    mapTxLockVote[ctx.GetHash()] = ctx;
+    {
+        LOCK(cs_instantsend);
+        mapTxLockVote[vote.GetHash()] = vote;
+    }
 
-    CInv inv(MSG_TXLOCK_VOTE, ctx.GetHash());
+    CInv inv(MSG_TXLOCK_VOTE, vote.GetHash());
     RelayInv(inv);
 }
 
 //received a consensus vote
-bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
+bool ProcessConsensusVote(CNode* pnode, CConsensusVote& vote)
 {
-    int n = mnodeman.GetMasternodeRank(ctx.vinMasternode, ctx.nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
+    int n = mnodeman.GetMasternodeRank(vote.vinMasternode, vote.nBlockHeight, MIN_INSTANTSEND_PROTO_VERSION);
 
-    CMasternode* pmn = mnodeman.Find(ctx.vinMasternode);
+    CMasternode* pmn = mnodeman.Find(vote.vinMasternode);
     if(pmn != NULL)
-        LogPrint("instantsend", "InstantX::ProcessConsensusVote - Masternode ADDR %s %d\n", pmn->addr.ToString(), n);
+        LogPrint("instantsend", "ProcessConsensusVote -- Masternode addr=%s, rank: %d\n", pmn->addr.ToString(), n);
 
-    if(n == -1)
-    {
+    if(n == -1) {
         //can be caused by past versions trying to vote with an invalid protocol
-        LogPrint("instantsend", "InstantX::ProcessConsensusVote - Unknown Masternode %s\n", ctx.vinMasternode.ToString());
-        mnodeman.AskForMN(pnode, ctx.vinMasternode);
+        LogPrint("instantsend", "ProcessConsensusVote -- Unknown Masternode: txin=%s\n", vote.vinMasternode.ToString());
+        mnodeman.AskForMN(pnode, vote.vinMasternode);
         return false;
     }
 
-    if(n > INSTANTX_SIGNATURES_TOTAL)
-    {
-        LogPrint("instantsend", "InstantX::ProcessConsensusVote - Masternode not in the top %d (%d) - %s\n", INSTANTX_SIGNATURES_TOTAL, n, ctx.GetHash().ToString());
+    if(n > INSTANTSEND_SIGNATURES_TOTAL) {
+        LogPrint("instantsend", "ProcessConsensusVote -- Masternode not in the top %d (%d): vote hash %s\n", INSTANTSEND_SIGNATURES_TOTAL, n, vote.GetHash().ToString());
         return false;
     }
 
-    if(!ctx.SignatureValid()) {
-        LogPrintf("InstantX::ProcessConsensusVote - Signature invalid\n");
+    if(!vote.SignatureValid()) {
+        LogPrintf("ProcessConsensusVote -- Signature invalid\n");
         // don't ban, it could just be a non-synced masternode
-        mnodeman.AskForMN(pnode, ctx.vinMasternode);
+        mnodeman.AskForMN(pnode, vote.vinMasternode);
         return false;
     }
 
-    if (!mapTxLocks.count(ctx.txHash)){
-        LogPrintf("InstantX::ProcessConsensusVote - New Transaction Lock %s !\n", ctx.txHash.ToString());
+    if (!mapTxLocks.count(vote.txHash)) {
+        LogPrintf("ProcessConsensusVote -- New Transaction Lock! txid=%s\n", vote.txHash.ToString());
 
         CTransactionLock newLock;
         newLock.nBlockHeight = 0;
         newLock.nExpiration = GetTime()+(60*60);
         newLock.nTimeout = GetTime()+(60*5);
-        newLock.txHash = ctx.txHash;
-        mapTxLocks.insert(make_pair(ctx.txHash, newLock));
-    } else
-        LogPrint("instantsend", "InstantX::ProcessConsensusVote - Transaction Lock Exists %s !\n", ctx.txHash.ToString());
+        newLock.txHash = vote.txHash;
+        mapTxLocks.insert(std::make_pair(vote.txHash, newLock));
+    } else {
+        LogPrint("instantsend", "ProcessConsensusVote -- Transaction Lock Exists! txid=%s\n", vote.txHash.ToString());
+    }
 
     //compile consessus vote
-    std::map<uint256, CTransactionLock>::iterator i = mapTxLocks.find(ctx.txHash);
-    if (i != mapTxLocks.end()){
-        (*i).second.AddSignature(ctx);
+    std::map<uint256, CTransactionLock>::iterator i = mapTxLocks.find(vote.txHash);
+    if (i != mapTxLocks.end()) {
+        (*i).second.AddVote(vote);
 
-        int nSignatures = (*i).second.CountSignatures();
-        LogPrint("instantsend", "InstantX::ProcessConsensusVote - Transaction Lock Votes %d - %s !\n", nSignatures, ctx.GetHash().ToString());
+        int nSignatures = (*i).second.CountVotes();
+        LogPrint("instantsend", "ProcessConsensusVote -- Transaction Lock signatures count: %d, vote hash=%s\n", nSignatures, vote.GetHash().ToString());
 
-        if(nSignatures >= INSTANTX_SIGNATURES_REQUIRED){
-            LogPrint("instantsend", "InstantX::ProcessConsensusVote - Transaction Lock Is Complete %s !\n", ctx.txHash.ToString());
+        if(nSignatures >= INSTANTSEND_SIGNATURES_REQUIRED) {
+            LogPrint("instantsend", "ProcessConsensusVote -- Transaction Lock Is Complete! txid=%s\n", vote.txHash.ToString());
 
             // Masternodes will sometimes propagate votes before the transaction is known to the client,
             // will check for conflicting locks and update transaction status on a new vote message
             // only after the lock itself has arrived
-            if(!mapTxLockReq.count(ctx.txHash) && !mapTxLockReqRejected.count(ctx.txHash)) return true;
+            if(!mapTxLockReq.count(vote.txHash) && !mapTxLockReqRejected.count(vote.txHash)) return true;
 
-            if(!FindConflictingLocks(mapTxLockReq[ctx.txHash])) { //?????
-                if(mapTxLockReq.count(ctx.txHash)) {
-                    UpdateLockedTransaction(mapTxLockReq[ctx.txHash]);
-                    LockTransactionInputs(mapTxLockReq[ctx.txHash]);
-                } else if(mapTxLockReqRejected.count(ctx.txHash)) {
-                    ResolveConflicts(mapTxLockReqRejected[ctx.txHash]); ///?????
+            if(!FindConflictingLocks(mapTxLockReq[vote.txHash])) { //?????
+                if(mapTxLockReq.count(vote.txHash)) {
+                    UpdateLockedTransaction(mapTxLockReq[vote.txHash]);
+                    LockTransactionInputs(mapTxLockReq[vote.txHash]);
+                } else if(mapTxLockReqRejected.count(vote.txHash)) {
+                    ResolveConflicts(mapTxLockReqRejected[vote.txHash]); ///?????
                 } else {
-                    LogPrint("instantsend", "InstantX::ProcessConsensusVote - Transaction Lock Request is missing %s ! votes %d\n", ctx.GetHash().ToString(), nSignatures);
+                    LogPrint("instantsend", "ProcessConsensusVote -- Transaction Lock Request is missing! nSignatures=%d, vote hash %s\n", nSignatures, vote.GetHash().ToString());
                 }
             }
         }
@@ -381,25 +380,25 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
     return false;
 }
 
-void UpdateLockedTransaction(CTransaction& tx, bool fForceNotification) {
+void UpdateLockedTransaction(CTransaction& tx, bool fForceNotification)
+{
     // there should be no conflicting locks
     if(FindConflictingLocks(tx)) return;
     uint256 txHash = tx.GetHash();
     // there must be a successfully verified lock request
-    if (!mapTxLockReq.count(txHash)) return;
+    if(!mapTxLockReq.count(txHash)) return;
 
     int nSignatures = GetTransactionLockSignatures(txHash);
 
 #ifdef ENABLE_WALLET
-    if(pwalletMain && pwalletMain->UpdatedTransaction(txHash)){
+    if(pwalletMain && pwalletMain->UpdatedTransaction(txHash)) {
         // bumping this to update UI
         nCompleteTXLocks++;
         // a transaction lock must have enough signatures to trigger this notification
-        if(nSignatures == INSTANTX_SIGNATURES_REQUIRED || (fForceNotification && nSignatures > INSTANTX_SIGNATURES_REQUIRED)) {
+        if(nSignatures == INSTANTSEND_SIGNATURES_REQUIRED || (fForceNotification && nSignatures > INSTANTSEND_SIGNATURES_REQUIRED)) {
             // notify an external script once threshold is reached
             std::string strCmd = GetArg("-instantsendnotify", "");
-            if ( !strCmd.empty())
-            {
+            if(!strCmd.empty()) {
                 boost::replace_all(strCmd, "%s", txHash.GetHex());
                 boost::thread t(runCommand, strCmd); // thread runs free
             }
@@ -407,19 +406,16 @@ void UpdateLockedTransaction(CTransaction& tx, bool fForceNotification) {
     }
 #endif
 
-    if(nSignatures == INSTANTX_SIGNATURES_REQUIRED || (fForceNotification && nSignatures > INSTANTX_SIGNATURES_REQUIRED)) {
+    if(nSignatures == INSTANTSEND_SIGNATURES_REQUIRED || (fForceNotification && nSignatures > INSTANTSEND_SIGNATURES_REQUIRED))
         GetMainSignals().NotifyTransactionLock(tx);
-    }
 }
 
 void LockTransactionInputs(CTransaction& tx) {
-    if(mapTxLockReq.count(tx.GetHash())){
-        BOOST_FOREACH(const CTxIn& in, tx.vin){
-            if(!mapLockedInputs.count(in.prevout)){
-                mapLockedInputs.insert(make_pair(in.prevout, tx.GetHash()));
-            }
-        }
-    }
+    if(!mapTxLockReq.count(tx.GetHash())) return;
+
+    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+        if(!mapLockedInputs.count(txin.prevout))
+            mapLockedInputs.insert(std::make_pair(txin.prevout, tx.GetHash()));
 }
 
 bool FindConflictingLocks(CTransaction& tx)
@@ -431,12 +427,17 @@ bool FindConflictingLocks(CTransaction& tx)
         Blocks could have been rejected during this time, which is OK. After they cancel out, the client will
         rescan the blocks and find they're acceptable and then take the chain with the most work.
     */
-    BOOST_FOREACH(const CTxIn& in, tx.vin){
-        if(mapLockedInputs.count(in.prevout)){
-            if(mapLockedInputs[in.prevout] != tx.GetHash()){
-                LogPrintf("InstantX::FindConflictingLocks - found two complete conflicting locks - removing both. %s %s", tx.GetHash().ToString(), mapLockedInputs[in.prevout].ToString());
-                if(mapTxLocks.count(tx.GetHash())) mapTxLocks[tx.GetHash()].nExpiration = GetTime();
-                if(mapTxLocks.count(mapLockedInputs[in.prevout])) mapTxLocks[mapLockedInputs[in.prevout]].nExpiration = GetTime();
+    BOOST_FOREACH(const CTxIn& txin, tx.vin) {
+        if(mapLockedInputs.count(txin.prevout)) {
+            if(mapLockedInputs[txin.prevout] != tx.GetHash()) {
+                LogPrintf("FindConflictingLocks -- found two complete conflicting locks, removing both: txid=%s, txin=%s", tx.GetHash().ToString(), mapLockedInputs[txin.prevout].ToString());
+
+                if(mapTxLocks.count(tx.GetHash()))
+                    mapTxLocks[tx.GetHash()].nExpiration = GetTime();
+
+                if(mapTxLocks.count(mapLockedInputs[txin.prevout]))
+                    mapTxLocks[mapLockedInputs[txin.prevout]].nExpiration = GetTime();
+
                 return true;
             }
         }
@@ -445,14 +446,16 @@ bool FindConflictingLocks(CTransaction& tx)
     return false;
 }
 
-void ResolveConflicts(CTransaction& tx) {
+void ResolveConflicts(CTransaction& tx)
+{
     // resolve conflicts
-    if (IsLockedIXTransaction(tx.GetHash()) && !FindConflictingLocks(tx)){ //?????
-        LogPrintf("ResolveConflicts - Found Existing Complete IX Lock, resolving...\n");
+    if (IsLockedInstandSendTransaction(tx.GetHash()) && !FindConflictingLocks(tx)) { //?????
+        LogPrintf("ResolveConflicts -- Found Existing Complete IX Lock, resolving...\n");
 
         //reprocess the last 15 blocks
         ReprocessBlocks(15);
-        if(!mapTxLockReq.count(tx.GetHash())) mapTxLockReq.insert(make_pair(tx.GetHash(), tx)); //?????
+        if(!mapTxLockReq.count(tx.GetHash()))
+            mapTxLockReq.insert(std::make_pair(tx.GetHash(), tx)); //?????
     }
 }
 
@@ -473,23 +476,27 @@ int64_t GetAverageVoteTime()
 
 void CleanTransactionLocksList()
 {
+    LOCK(cs_instantsend);
+
     std::map<uint256, CTransactionLock>::iterator it = mapTxLocks.begin();
 
     while(it != mapTxLocks.end()) {
-        if(GetTime() > it->second.nExpiration){ //keep them for an hour
-            LogPrintf("Removing old transaction lock %s\n", it->second.txHash.ToString());
+        CTransactionLock &txLock = it->second;
+        if(GetTime() > txLock.nExpiration){
+            LogPrintf("Removing old transaction lock: txid=%s\n", txLock.txHash.ToString());
 
-            if(mapTxLockReq.count(it->second.txHash)){
-                CTransaction& tx = mapTxLockReq[it->second.txHash];
+            if(mapTxLockReq.count(txLock.txHash)){
+                CTransaction& tx = mapTxLockReq[txLock.txHash];
 
-                BOOST_FOREACH(const CTxIn& in, tx.vin)
-                    mapLockedInputs.erase(in.prevout);
+                BOOST_FOREACH(const CTxIn& txin, tx.vin)
+                    mapLockedInputs.erase(txin.prevout);
 
-                mapTxLockReq.erase(it->second.txHash);
-                mapTxLockReqRejected.erase(it->second.txHash);
+                mapTxLockReq.erase(txLock.txHash);
+                mapTxLockReqRejected.erase(txLock.txHash);
 
-                BOOST_FOREACH(CConsensusVote& v, it->second.vecConsensusVotes)
-                    mapTxLockVote.erase(v.GetHash());
+                BOOST_FOREACH(const CConsensusVote& vote, txLock.vecConsensusVotes)
+                    if(mapTxLockVote.count(vote.GetHash()))
+                        mapTxLockVote.erase(vote.GetHash());
             }
 
             mapTxLocks.erase(it++);
@@ -499,12 +506,13 @@ void CleanTransactionLocksList()
     }
 }
 
-bool IsLockedIXTransaction(uint256 txHash) {
+bool IsLockedInstandSendTransaction(uint256 txHash)
+{
     // there must be a successfully verified lock request...
     if (!mapTxLockReq.count(txHash)) return false;
     // ...and corresponding lock must have enough signatures
     std::map<uint256, CTransactionLock>::iterator i = mapTxLocks.find(txHash);
-    return i != mapTxLocks.end() && (*i).second.CountSignatures() >= INSTANTX_SIGNATURES_REQUIRED;
+    return i != mapTxLocks.end() && (*i).second.CountVotes() >= INSTANTSEND_SIGNATURES_REQUIRED;
 }
 
 int GetTransactionLockSignatures(uint256 txHash)
@@ -513,10 +521,8 @@ int GetTransactionLockSignatures(uint256 txHash)
     if(!sporkManager.IsSporkActive(SPORK_2_INSTANTX)) return -3;
     if(!fEnableInstantSend) return -1;
 
-    std::map<uint256, CTransactionLock>::iterator i = mapTxLocks.find(txHash);
-    if (i != mapTxLocks.end()){
-        return (*i).second.CountSignatures();
-    }
+    std::map<uint256, CTransactionLock>::iterator it = mapTxLocks.find(txHash);
+    if(it != mapTxLocks.end()) return it->second.CountVotes();
 
     return -1;
 }
@@ -526,9 +532,7 @@ bool IsTransactionLockTimedOut(uint256 txHash)
     if(!fEnableInstantSend) return 0;
 
     std::map<uint256, CTransactionLock>::iterator i = mapTxLocks.find(txHash);
-    if (i != mapTxLocks.end()){
-        return GetTime() > (*i).second.nTimeout;
-    }
+    if (i != mapTxLocks.end()) return GetTime() > (*i).second.nTimeout;
 
     return false;
 }
@@ -547,14 +551,13 @@ bool CConsensusVote::SignatureValid()
 
     CMasternode* pmn = mnodeman.Find(vinMasternode);
 
-    if(pmn == NULL)
-    {
-        LogPrintf("InstantX::CConsensusVote::SignatureValid() - Unknown Masternode %s\n", vinMasternode.ToString());
+    if(pmn == NULL) {
+        LogPrintf("CConsensusVote::SignatureValid -- Unknown Masternode: txin=%s\n", vinMasternode.ToString());
         return false;
     }
 
     if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchMasterNodeSignature, strMessage, errorMessage)) {
-        LogPrintf("InstantX::CConsensusVote::SignatureValid() - Verify message failed\n");
+        LogPrintf("CConsensusVote::SignatureValid -- VerifyMessage() failed\n");
         return false;
     }
 
@@ -566,15 +569,14 @@ bool CConsensusVote::Sign()
     std::string errorMessage;
 
     std::string strMessage = txHash.ToString().c_str() + boost::lexical_cast<std::string>(nBlockHeight);
-    //LogPrintf("signing strMessage %s \n", strMessage);
 
     if(!darkSendSigner.SignMessage(strMessage, errorMessage, vchMasterNodeSignature, activeMasternode.keyMasternode)) {
-        LogPrintf("CConsensusVote::Sign() - Sign message failed");
+        LogPrintf("CConsensusVote::Sign -- SignMessage() failed");
         return false;
     }
 
     if(!darkSendSigner.VerifyMessage(activeMasternode.pubKeyMasternode, vchMasterNodeSignature, strMessage, errorMessage)) {
-        LogPrintf("CConsensusVote::Sign() - Verify message failed");
+        LogPrintf("CConsensusVote::Sign -- VerifyMessage() failed");
         return false;
     }
 
@@ -582,27 +584,25 @@ bool CConsensusVote::Sign()
 }
 
 
-bool CTransactionLock::SignaturesValid()
+bool CTransactionLock::VotesValid()
 {
 
     BOOST_FOREACH(CConsensusVote vote, vecConsensusVotes)
     {
-        int n = mnodeman.GetMasternodeRank(vote.vinMasternode, vote.nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
+        int n = mnodeman.GetMasternodeRank(vote.vinMasternode, vote.nBlockHeight, MIN_INSTANTSEND_PROTO_VERSION);
 
-        if(n == -1)
-        {
-            LogPrintf("CTransactionLock::SignaturesValid() - Unknown Masternode %s\n", vote.vinMasternode.ToString());
+        if(n == -1) {
+            LogPrintf("CTransactionLock::VotesValid -- Unknown Masternode, txin=%s\n", vote.vinMasternode.ToString());
             return false;
         }
 
-        if(n > INSTANTX_SIGNATURES_TOTAL)
-        {
-            LogPrintf("CTransactionLock::SignaturesValid() - Masternode not in the top %s\n", INSTANTX_SIGNATURES_TOTAL);
+        if(n > INSTANTSEND_SIGNATURES_TOTAL) {
+            LogPrintf("CTransactionLock::VotesValid -- Masternode not in the top %s\n", INSTANTSEND_SIGNATURES_TOTAL);
             return false;
         }
 
-        if(!vote.SignatureValid()){
-            LogPrintf("CTransactionLock::SignaturesValid() - Signature not valid\n");
+        if(!vote.SignatureValid()) {
+            LogPrintf("CTransactionLock::VotesValid -- Signature not valid\n");
             return false;
         }
     }
@@ -610,12 +610,12 @@ bool CTransactionLock::SignaturesValid()
     return true;
 }
 
-void CTransactionLock::AddSignature(CConsensusVote& cv)
+void CTransactionLock::AddVote(CConsensusVote& vote)
 {
-    vecConsensusVotes.push_back(cv);
+    vecConsensusVotes.push_back(vote);
 }
 
-int CTransactionLock::CountSignatures()
+int CTransactionLock::CountVotes()
 {
     /*
         Only count signatures where the BlockHeight matches the transaction's blockheight.
@@ -624,11 +624,10 @@ int CTransactionLock::CountSignatures()
 
     if(nBlockHeight == 0) return -1;
 
-    int n = 0;
-    BOOST_FOREACH(CConsensusVote v, vecConsensusVotes){
-        if(v.nBlockHeight == nBlockHeight){
-            n++;
-        }
-    }
-    return n;
+    int nCount = 0;
+    BOOST_FOREACH(CConsensusVote vote, vecConsensusVotes)
+        if(vote.nBlockHeight == nBlockHeight)
+            nCount++;
+
+    return nCount;
 }

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -1,5 +1,4 @@
-
-// Copyright (c) 2009-2012 The Dash Core developers
+// Copyright (c) 2009-2016 The Dash Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef INSTANTX_H
@@ -11,7 +10,10 @@
 #include "util.h"
 #include "base58.h"
 #include "main.h"
-#include "spork.h"
+
+class CConsensusVote;
+class CTransaction;
+class CTransactionLock;
 
 /*
     At 15 signatures, 1/2 of the masternode network can be owned by
@@ -22,37 +24,34 @@
     ### getting 5 of 10 signatures w/ 1000 nodes of 2900
     (1000/2900.0)**5 = 0.004875397277841433
 */
-#define INSTANTX_SIGNATURES_REQUIRED           6
-#define INSTANTX_SIGNATURES_TOTAL              10
+static const int INSTANTSEND_SIGNATURES_REQUIRED    = 6;
+static const int INSTANTSEND_SIGNATURES_TOTAL       = 10;
+static const int DEFAULT_INSTANTSEND_DEPTH          = 5;
 
-using namespace std;
-using namespace boost;
+static const int MIN_INSTANTSEND_PROTO_VERSION      = 70201;
+static const CAmount INSTANTSEND_MIN_FEE            = 1 * CENT;
 
-class CConsensusVote;
-class CTransaction;
-class CTransactionLock;
-
-static const int MIN_INSTANTX_PROTO_VERSION = 70103;
-static const CAmount INSTANTSEND_MIN_FEE = 1 * CENT;
-
-extern map<uint256, CTransaction> mapTxLockReq;
-extern map<uint256, CTransaction> mapTxLockReqRejected;
-extern map<uint256, CConsensusVote> mapTxLockVote;
-extern std::map<COutPoint, uint256> mapLockedInputs;
+extern bool fEnableInstantSend;
+extern int nInstantSendDepth;
 extern int nCompleteTXLocks;
+
+extern std::map<uint256, CTransaction> mapTxLockReq;
+extern std::map<uint256, CTransaction> mapTxLockReqRejected;
+extern std::map<uint256, CConsensusVote> mapTxLockVote;
+extern std::map<COutPoint, uint256> mapLockedInputs;
 
 
 int64_t CreateNewLock(CTransaction tx);
 
-bool IsIXTXValid(const CTransaction& txCollateral);
+bool IsInstantSendTxValid(const CTransaction& txCollateral);
 
-void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+void ProcessMessageInstantSend(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
 //check if we need to vote on this transaction
 void DoConsensusVote(CTransaction& tx, int64_t nBlockHeight);
 
 //process consensus vote message
-bool ProcessConsensusVote(CNode *pnode, CConsensusVote& ctx);
+bool ProcessConsensusVote(CNode *pnode, CConsensusVote& vote);
 
 //update UI and notify external script if any
 void UpdateLockedTransaction(CTransaction& tx, bool fForceNotification = false);
@@ -69,7 +68,7 @@ void ResolveConflicts(CTransaction& tx);
 void CleanTransactionLocksList();
 
 // verify if transaction is currently locked
-bool IsLockedIXTransaction(uint256 txHash);
+bool IsLockedInstandSendTransaction(uint256 txHash);
 
 // get the actual uber og accepted lock signatures
 int GetTransactionLockSignatures(uint256 txHash);
@@ -112,9 +111,9 @@ public:
     int nExpiration;
     int nTimeout;
 
-    bool SignaturesValid();
-    int CountSignatures();
-    void AddSignature(CConsensusVote& cv);
+    bool VotesValid();
+    int CountVotes();
+    void AddVote(CConsensusVote& vote);
 
     uint256 GetHash()
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -962,7 +962,7 @@ int GetInputAgeIX(uint256 nTXHash, CTxIn& vin)
     int nResult = GetInputAge(vin);
     if(nResult < 0) return -1;
 
-    if (nResult < 6 && IsLockedIXTransaction(nTXHash))
+    if (nResult < 6 && IsLockedInstandSendTransaction(nTXHash))
         return nInstantSendDepth + nResult;
 
     return nResult;
@@ -970,7 +970,7 @@ int GetInputAgeIX(uint256 nTXHash, CTxIn& vin)
 
 int GetIXConfirmations(uint256 nTXHash)
 {
-    if (IsLockedIXTransaction(nTXHash))
+    if (IsLockedInstandSendTransaction(nTXHash))
         return nInstantSendDepth;
 
     return 0;
@@ -5947,7 +5947,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             darkSendPool.ProcessMessage(pfrom, strCommand, vRecv);
             mnodeman.ProcessMessage(pfrom, strCommand, vRecv);
             mnpayments.ProcessMessage(pfrom, strCommand, vRecv);
-            ProcessMessageInstantX(pfrom, strCommand, vRecv);
+            ProcessMessageInstantSend(pfrom, strCommand, vRecv);
             sporkManager.ProcessSpork(pfrom, strCommand, vRecv);
             masternodeSync.ProcessMessage(pfrom, strCommand, vRecv);
             governance.ProcessMessage(pfrom, strCommand, vRecv);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4887,12 +4887,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     if(mapDarksendBroadcastTxes.count(inv.hash)) {
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
-                        ss <<
-                            mapDarksendBroadcastTxes[inv.hash].tx <<
-                            mapDarksendBroadcastTxes[inv.hash].vin <<
-                            mapDarksendBroadcastTxes[inv.hash].vchSig <<
-                            mapDarksendBroadcastTxes[inv.hash].sigTime;
-
+                        ss << mapDarksendBroadcastTxes[inv.hash];
                         pfrom->PushMessage(NetMsgType::DSTX, ss);
                         pushed = true;
                     }
@@ -5401,46 +5396,30 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         vector<uint256> vEraseQueue;
         CTransaction tx;
 
-        //masternode signed transaction
-        CTxIn vin;
-        vector<unsigned char> vchSig;
-        int64_t sigTime;
-
         if(strCommand == NetMsgType::TX) {
             vRecv >> tx;
         } else if (strCommand == NetMsgType::DSTX) {
             //these allow masternodes to publish a limited amount of free transactions
-            vRecv >> tx >> vin >> vchSig >> sigTime;
+            CDarksendBroadcastTx dstx;
+            vRecv >> dstx;
+            tx = dstx.tx;
 
-            CMasternode* pmn = mnodeman.Find(vin);
+            CMasternode* pmn = mnodeman.Find(dstx.vin);
             if(pmn != NULL)
             {
                 if(!pmn->allowFreeTx){
                     //multiple peers can send us a valid masternode transaction
-                    if(fDebug) LogPrintf("dstx: Masternode sending too many transactions %s\n", tx.GetHash().ToString());
+                    LogPrint("privatesend", "dstx: Masternode sending too many transactions %s\n", tx.GetHash().ToString());
                     return true;
                 }
 
-                std::string strMessage = tx.GetHash().ToString() + boost::lexical_cast<std::string>(sigTime);
-
-                std::string errorMessage = "";
-                if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage)){
-                    LogPrintf("dstx: Got bad Masternode transaction signature %s\n", vin.ToString());
-                    //pfrom->Misbehaving(20);
-                    return false;
-                }
+                if(!dstx.CheckSignature()) return false;
 
                 LogPrintf("dstx: Got Masternode transaction %s\n", tx.GetHash().ToString());
 
                 pmn->allowFreeTx = false;
 
                 if(!mapDarksendBroadcastTxes.count(tx.GetHash())){
-                    CDarksendBroadcastTx dstx;
-                    dstx.tx = tx;
-                    dstx.vin = vin;
-                    dstx.vchSig = vchSig;
-                    dstx.sigTime = sigTime;
-
                     mapDarksendBroadcastTxes.insert(make_pair(tx.GetHash(), dstx));
                 }
             }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -7,6 +7,7 @@
 #include "masternode-sync.h"
 #include "masternodeman.h"
 #include "darksend.h"
+#include "activemasternode.h"
 #include "util.h"
 #include "sync.h"
 #include "spork.h"

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -150,7 +150,7 @@ void CMasternodeSync::GetNextAsset()
             RequestedMasternodeAssets = MASTERNODE_SYNC_FINISHED;
             uiInterface.NotifyAdditionalDataSyncProgressChanged(1);
             //try to activate our masternode if possible
-            activeMasternode.ManageStatus();
+            activeMasternode.ManageState();
             break;
     }
     RequestedMasternodeAttempt = 0;
@@ -402,7 +402,6 @@ void CMasternodeSync::Process()
                 //     }
                 // }
 
-                if (pnode->nVersion < MSG_GOVERNANCE_PEER_PROTO_VERSION) continue;
 
                 // only request once from each peer
                 if(pnode->HasFulfilledRequest("governance-sync")) continue;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -4,6 +4,7 @@
 
 #include "consensus/validation.h"
 #include "darksend.h"
+#include "init.h"
 #include "masternode.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "consensus/validation.h"
+#include "activemasternode.h"
 #include "darksend.h"
 #include "init.h"
 #include "masternode.h"
@@ -370,7 +371,7 @@ bool CMasternodeBroadcast::Create(std::string strService, std::string strKeyMast
         return false;
     }
 
-    if(!darkSendSigner.SetKey(strKeyMasternode, strErrorMessage, keyMasternodeNew, pubKeyMasternodeNew)) {
+    if(!darkSendSigner.GetKeysFromSecret(strKeyMasternode, strErrorMessage, keyMasternodeNew, pubKeyMasternodeNew)) {
         strErrorMessage = strprintf("Can't find keys for masternode %s, error: %s", strService, strErrorMessage);
         LogPrintf("CMasternodeBroadcast::Create -- %s\n", strErrorMessage);
         return false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -394,7 +394,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fConnectToMas
 {
     if (pszDest == NULL) {
         // we clean masternode connections in CMasternodeMan::ProcessMasternodeConnections()
-        // so should be safe to skip this and connect to local Hot MN on CActiveMasternode::ManageStatus()
+        // so should be safe to skip this and connect to local Hot MN on CActiveMasternode::ManageState()
         if (IsLocal(addrConnect) && !fConnectToMasternode)
             return NULL;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2077,11 +2077,7 @@ void RelayTransaction(const CTransaction& tx)
     ss.reserve(10000);
     uint256 hash = tx.GetHash();
     if(mapDarksendBroadcastTxes.count(hash)) { // MSG_DSTX
-        ss <<
-            mapDarksendBroadcastTxes[hash].tx <<
-            mapDarksendBroadcastTxes[hash].vin <<
-            mapDarksendBroadcastTxes[hash].vchSig <<
-            mapDarksendBroadcastTxes[hash].sigTime;
+        ss << mapDarksendBroadcastTxes[hash];
     } else if(mapTxLockReq.count(hash)) { // MSG_TXLOCK_REQUEST
         ss << mapTxLockReq[hash];
     } else { // MSG_TX

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -13,6 +13,7 @@
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "clientversion.h"
+#include "darksend.h"
 #include "net.h"
 #include "txmempool.h"
 #include "ui_interface.h"
@@ -74,7 +75,7 @@ int ClientModel::getNumConnections(unsigned int flags) const
 QString ClientModel::getMasternodeCountString() const
 {
     return tr("Total: %1 (PS compatible: %2 / Enabled: %3)").arg(QString::number((int)mnodeman.size()))
-            .arg(QString::number((int)mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION)))
+            .arg(QString::number((int)mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)))
             .arg(QString::number((int)mnodeman.CountEnabled()));
 }
 

--- a/src/qt/darksendconfig.cpp
+++ b/src/qt/darksendconfig.cpp
@@ -2,10 +2,10 @@
 #include "ui_darksendconfig.h"
 
 #include "bitcoinunits.h"
+#include "darksend.h"
 #include "guiconstants.h"
 #include "optionsmodel.h"
 #include "walletmodel.h"
-#include "init.h"
 
 #include <QMessageBox>
 #include <QPushButton>

--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -661,7 +661,7 @@ int main(int argc, char *argv[])
 
 #ifdef ENABLE_WALLET
     /// 7a. parse masternode.conf
-    string strErr;
+    std::string strErr;
     if(!masternodeConfig.read(strErr)) {
         QMessageBox::critical(0, QObject::tr("Dash Core"),
                               QObject::tr("Error reading masternode configuration file: %1").arg(strErr.c_str()));

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -259,7 +259,7 @@ void OptionsDialog::on_resetButton_clicked()
 void OptionsDialog::on_okButton_clicked()
 {
     mapper->submit();
-    darkSendPool.cachedNumBlocks = std::numeric_limits<int>::max();
+    darkSendPool.nCachedNumBlocks = std::numeric_limits<int>::max();
     pwalletMain->MarkDirty();
     accept();
     updateDefaultProxyNets();

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -31,6 +31,8 @@
 #include <QMessageBox>
 #include <QTimer>
 
+extern CWallet* pwalletMain;
+
 OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     QDialog(parent),
     ui(new Ui::OptionsDialog),

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -13,6 +13,7 @@
 #include "guiutil.h"
 
 #include "amount.h"
+#include "darksend.h"
 #include "init.h"
 #include "main.h" // For DEFAULT_SCRIPTCHECK_THREADS
 #include "net.h"
@@ -119,7 +120,7 @@ void OptionsModel::Init(bool resetSettings)
 
     // PrivateSend
     if (!settings.contains("nPrivateSendRounds"))
-        settings.setValue("nPrivateSendRounds", 2);
+        settings.setValue("nPrivateSendRounds", DEFAULT_PRIVATESEND_ROUNDS);
     if (!SoftSetArg("-privatesendrounds", settings.value("nPrivateSendRounds").toString().toStdString()))
         addOverriddenOption("-privatesendrounds");
     nPrivateSendRounds = settings.value("nPrivateSendRounds").toInt();
@@ -127,7 +128,7 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("nPrivateSendAmount")) {
         // for migration from old settings
         if (!settings.contains("nAnonymizeDashAmount"))
-            settings.setValue("nPrivateSendAmount", 1000);
+            settings.setValue("nPrivateSendAmount", DEFAULT_PRIVATESEND_AMOUNT);
         else
             settings.setValue("nPrivateSendAmount", settings.value("nAnonymizeDashAmount").toInt());
     }
@@ -136,7 +137,7 @@ void OptionsModel::Init(bool resetSettings)
     nPrivateSendAmount = settings.value("nPrivateSendAmount").toInt();
 
     if (!settings.contains("fPrivateSendMultiSession"))
-        settings.setValue("fPrivateSendMultiSession", fPrivateSendMultiSession);
+        settings.setValue("fPrivateSendMultiSession", DEFAULT_PRIVATESEND_MULTISESSION);
     if (!SoftSetBoolArg("-privatesendmultisession", settings.value("fPrivateSendMultiSession").toBool()))
         addOverriddenOption("-privatesendmultisession");
     fPrivateSendMultiSession = settings.value("fPrivateSendMultiSession").toBool();

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -38,7 +38,7 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
         QString strUsingIX = "";
         if(signatures >= 0){
 
-            if(signatures >= INSTANTX_SIGNATURES_REQUIRED){
+            if(signatures >= INSTANTSEND_SIGNATURES_REQUIRED){
                 int nDepth = wtx.GetDepthInMainChain();
                 if (nDepth < 0)
                     return tr("conflicted");
@@ -54,11 +54,11 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
                     if (nDepth < 0)
                         return tr("conflicted");
                     else if (GetAdjustedTime() - wtx.nTimeReceived > 2 * 60 && wtx.GetRequestCount() == 0)
-                        return tr("%1/offline (InstantSend verification in progress - %2 of %3 signatures)").arg(nDepth).arg(signatures).arg(INSTANTX_SIGNATURES_TOTAL);
+                        return tr("%1/offline (InstantSend verification in progress - %2 of %3 signatures)").arg(nDepth).arg(signatures).arg(INSTANTSEND_SIGNATURES_TOTAL);
                     else if (nDepth < 6)
-                        return tr("%1/confirmed (InstantSend verification in progress - %2 of %3 signatures )").arg(nDepth).arg(signatures).arg(INSTANTX_SIGNATURES_TOTAL);
+                        return tr("%1/confirmed (InstantSend verification in progress - %2 of %3 signatures )").arg(nDepth).arg(signatures).arg(INSTANTSEND_SIGNATURES_TOTAL);
                     else
-                        return tr("%1 confirmations (InstantSend verification in progress - %2 of %3 signatures)").arg(nDepth).arg(signatures).arg(INSTANTX_SIGNATURES_TOTAL);
+                        return tr("%1 confirmations (InstantSend verification in progress - %2 of %3 signatures)").arg(nDepth).arg(signatures).arg(INSTANTSEND_SIGNATURES_TOTAL);
                 } else {
                     int nDepth = wtx.GetDepthInMainChain();
                     if (nDepth < 0)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -13,6 +13,7 @@
 #include "transactiontablemodel.h"
 
 #include "base58.h"
+#include "darksend.h"
 #include "keystore.h"
 #include "main.h"
 #include "sync.h"

--- a/src/rpcmasternode-budget.cpp
+++ b/src/rpcmasternode-budget.cpp
@@ -6,6 +6,7 @@
 #include "db.h"
 #include "init.h"
 #include "activemasternode.h"
+#include "darksend.h"
 #include "governance.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"

--- a/src/rpcmasternode-budget.cpp
+++ b/src/rpcmasternode-budget.cpp
@@ -235,7 +235,7 @@ UniValue mngovernance(const UniValue& params, bool fHelp)
 
             UniValue statusObj(UniValue::VOBJ);
 
-            if(!darkSendSigner.SetKey(mne.getPrivKey(), errorMessage, keyMasternode, pubKeyMasternode)){
+            if(!darkSendSigner.GetKeysFromSecret(mne.getPrivKey(), errorMessage, keyMasternode, pubKeyMasternode)){
                 failed++;
                 statusObj.push_back(Pair("result", "failed"));
                 statusObj.push_back(Pair("errorMessage", "Masternode signing error, could not set key correctly: " + errorMessage));

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -7,6 +7,7 @@
 #include "db.h"
 #include "init.h"
 #include "activemasternode.h"
+#include "darksend.h"
 #include "governance.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"
@@ -199,7 +200,7 @@ UniValue masternode(const UniValue& params, bool fHelp)
 
     if (strCommand == "debug")
     {
-        if(activeMasternode.status != ACTIVE_MASTERNODE_INITIAL || !masternodeSync.IsBlockchainSynced())
+        if(activeMasternode.nState != ACTIVE_MASTERNODE_INITIAL || !masternodeSync.IsBlockchainSynced())
             return activeMasternode.GetStatus();
 
         CTxIn vin = CTxIn();
@@ -236,9 +237,9 @@ UniValue masternode(const UniValue& params, bool fHelp)
             }
         }
 
-        if(activeMasternode.status != ACTIVE_MASTERNODE_STARTED){
-            activeMasternode.status = ACTIVE_MASTERNODE_INITIAL; // TODO: consider better way
-            activeMasternode.ManageStatus();
+        if(activeMasternode.nState != ACTIVE_MASTERNODE_STARTED){
+            activeMasternode.nState = ACTIVE_MASTERNODE_INITIAL; // TODO: consider better way
+            activeMasternode.ManageState();
             pwalletMain->Lock();
         }
 

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -52,7 +52,7 @@ UniValue privatesend(const UniValue& params, bool fHelp)
     }
 
     if(params[0].get_str() == "reset"){
-        darkSendPool.Reset();
+        darkSendPool.ResetPool();
         return "Mixing was reset";
     }
 
@@ -60,7 +60,7 @@ UniValue privatesend(const UniValue& params, bool fHelp)
         UniValue obj(UniValue::VOBJ);
         obj.push_back(Pair("status",            darkSendPool.GetStatus()));
         obj.push_back(Pair("keys_left",     pwalletMain->nKeysLeftSinceAutoBackup));
-        obj.push_back(Pair("warnings",      (pwalletMain->nKeysLeftSinceAutoBackup < PS_KEYS_THRESHOLD_WARNING
+        obj.push_back(Pair("warnings",      (pwalletMain->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING
                                                 ? "WARNING: keypool is almost depleted!" : "")));
         return obj;
     }
@@ -78,7 +78,7 @@ UniValue getpoolinfo(const UniValue& params, bool fHelp)
     UniValue obj(UniValue::VOBJ);
     if (darkSendPool.pSubmittedToMasternode)
         obj.push_back(Pair("masternode",        darkSendPool.pSubmittedToMasternode->addr.ToString()));
-    obj.push_back(Pair("queue",                 (int64_t)vecDarksendQueue.size()));
+    obj.push_back(Pair("queue",                 darkSendPool.GetQueueSize()));
     obj.push_back(Pair("state",                 darkSendPool.GetState()));
     obj.push_back(Pair("entries",               darkSendPool.GetEntriesCount()));
     obj.push_back(Pair("entries_accepted",      darkSendPool.GetCountEntriesAccepted()));
@@ -162,12 +162,12 @@ UniValue masternode(const UniValue& params, bool fHelp)
                     mnodeman.GetNextMasternodeInQueueForPayment(chainActive.Tip()->nHeight, true, nCount);
             }
 
-            if(params[1].get_str() == "ps") return mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION);
+            if(params[1].get_str() == "ps") return mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION);
             if(params[1].get_str() == "enabled") return mnodeman.CountEnabled();
             if(params[1].get_str() == "qualify") return nCount;
             if(params[1].get_str() == "all") return strprintf("Total: %d (PS Compatible: %d / Enabled: %d / Qualify: %d)",
                                                     mnodeman.size(),
-                                                    mnodeman.CountEnabled(MIN_POOL_PEER_PROTO_VERSION),
+                                                    mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION),
                                                     mnodeman.CountEnabled(),
                                                     nCount);
         }

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -202,7 +202,7 @@ bool CSporkMessage::Sign(std::string strSignKey)
     CPubKey pubkey;
     std::string errorMessage = "";
 
-    if(!darkSendSigner.SetKey(strSignKey, errorMessage, key, pubkey)) {
+    if(!darkSendSigner.GetKeysFromSecret(strSignKey, errorMessage, key, pubkey)) {
         LogPrintf("CSporkMessage::Sign -- ERROR: '%s'\n", errorMessage);
         return false;
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -105,9 +105,6 @@ using namespace std;
 //Dash only features
 bool fMasterNode = false;
 bool fLiteMode = false;
-int nPrivateSendRounds = 2;
-int nPrivateSendAmount = 1000;
-int nLiquidityProvider = 0;
 /**
     nWalletBackups:
         1..10   - number of automatic backups to keep
@@ -119,10 +116,6 @@ int nWalletBackups = 10;
 /** Spork enforcement enabled time */
 int64_t enforceMasternodePaymentsTime = 4085657524;
 bool fSucessfullyLoaded = false;
-bool fEnablePrivateSend = false;
-bool fPrivateSendMultiSession = false;
-/** All denominations used by darksend */
-std::vector<CAmount> darkSendDenominations;
 string strBudgetMode = "";
 
 const char * const BITCOIN_CONF_FILENAME = "dash.conf";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -104,7 +104,6 @@ using namespace std;
 
 //Dash only features
 bool fMasterNode = false;
-string strMasterNodeAddr = "";
 bool fLiteMode = false;
 bool fEnableInstantSend = true;
 int nInstantSendDepth = 5;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -105,8 +105,6 @@ using namespace std;
 //Dash only features
 bool fMasterNode = false;
 bool fLiteMode = false;
-bool fEnableInstantSend = true;
-int nInstantSendDepth = 5;
 int nPrivateSendRounds = 2;
 int nPrivateSendAmount = 1000;
 int nLiquidityProvider = 0;

--- a/src/util.h
+++ b/src/util.h
@@ -43,7 +43,6 @@ extern int nWalletBackups;
 extern bool fEnablePrivateSend;
 extern bool fPrivateSendMultiSession;
 extern int64_t enforceMasternodePaymentsTime;
-extern std::string strMasterNodeAddr;
 extern int keysLoaded;
 extern bool fSucessfullyLoaded;
 extern std::vector<CAmount> darkSendDenominations;

--- a/src/util.h
+++ b/src/util.h
@@ -34,16 +34,10 @@
 
 extern bool fMasterNode;
 extern bool fLiteMode;
-extern int nPrivateSendRounds;
-extern int nPrivateSendAmount;
-extern int nLiquidityProvider;
 extern int nWalletBackups;
-extern bool fEnablePrivateSend;
-extern bool fPrivateSendMultiSession;
 extern int64_t enforceMasternodePaymentsTime;
 extern int keysLoaded;
 extern bool fSucessfullyLoaded;
-extern std::vector<CAmount> darkSendDenominations;
 extern std::string strBudgetMode;
 
 static const bool DEFAULT_LOGTIMEMICROS = false;

--- a/src/util.h
+++ b/src/util.h
@@ -34,8 +34,6 @@
 
 extern bool fMasterNode;
 extern bool fLiteMode;
-extern bool fEnableInstantSend;
-extern int nInstantSendDepth;
 extern int nPrivateSendRounds;
 extern int nPrivateSendAmount;
 extern int nLiquidityProvider;

--- a/src/version.h
+++ b/src/version.h
@@ -21,9 +21,6 @@ static const int GETHEADERS_VERSION = 70077;
 //! disconnect from peers older than this proto version
 static const int MIN_PEER_PROTO_VERSION = 70103;
 
-//! minimum peer version accepted by DarksendPool
-static const int MIN_POOL_PEER_PROTO_VERSION = 70201;
-
 //! minimum peer version for masternode budgets
 static const int MSG_GOVERNANCE_PEER_PROTO_VERSION = 70201;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4261,7 +4261,7 @@ int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet, bool enableIX)
         }
     }
 
-    if(enableIX && nResult < 6 && IsLockedIXTransaction(GetHash()))
+    if(enableIX && nResult < 6 && IsLockedInstandSendTransaction(GetHash()))
         return nInstantSendDepth + nResult;
 
     return nResult;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -82,7 +82,7 @@ std::string COutput::ToString() const
 
 int COutput::Priority() const
 {
-    BOOST_FOREACH(CAmount d, darkSendDenominations)
+    BOOST_FOREACH(CAmount d, vecPrivateSendDenominations)
         if(tx->vout[i].nValue == d) return 10000;
     if(tx->vout[i].nValue < 1*COIN) return 20000;
 
@@ -1175,7 +1175,7 @@ bool CWallet::IsDenominated(const CTransaction& tx) const
 
 bool CWallet::IsDenominatedAmount(CAmount nInputAmount) const
 {
-    BOOST_FOREACH(CAmount d, darkSendDenominations)
+    BOOST_FOREACH(CAmount d, vecPrivateSendDenominations)
         if(nInputAmount == d)
             return true;
     return false;
@@ -1896,7 +1896,7 @@ CAmount CWallet::GetAnonymizableBalance() const
 
     BOOST_FOREACH(CompactTallyItem& item, vecTally) {
         // try to anonymize all denoms and anything greater than sum of 10 smallest denoms
-        if(IsDenominatedAmount(item.nAmount) || item.nAmount >= darkSendDenominations.back() * 10)
+        if(IsDenominatedAmount(item.nAmount) || item.nAmount >= vecPrivateSendDenominations.back() * 10)
             nTotal += item.nAmount;
     }
 
@@ -2231,7 +2231,7 @@ bool less_then_denom (const COutput& out1, const COutput& out2)
 
     bool found1 = false;
     bool found2 = false;
-    BOOST_FOREACH(CAmount d, darkSendDenominations) // loop through predefined denoms
+    BOOST_FOREACH(CAmount d, vecPrivateSendDenominations) // loop through predefined denoms
     {
         if(pcoin1->vout[out1.i].nValue == d) found1 = true;
         if(pcoin2->vout[out2.i].nValue == d) found2 = true;
@@ -2392,7 +2392,7 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletTx*
     //if we're doing only denominated, we need to round up to the nearest .1DRK
     if(coin_type == ONLY_DENOMINATED) {
         // Make outputs by looping through denominations, from large to small
-        BOOST_FOREACH(CAmount v, darkSendDenominations)
+        BOOST_FOREACH(CAmount v, vecPrivateSendDenominations)
         {
             BOOST_FOREACH(const COutput& out, vCoins)
             {
@@ -2638,7 +2638,7 @@ bool CWallet::SelectCoinsGrouppedByAddresses(std::vector<CompactTallyItem>& vecT
                 if(fMasterNode && wtx.vout[i].nValue == 1000*COIN) continue;
                 // ignore outputs that are 10 times smaller then the smallest denomination
                 // otherwise they will just lead to higher fee / lower priority
-                if(wtx.vout[i].nValue <= darkSendDenominations.back()/10) continue;
+                if(wtx.vout[i].nValue <= vecPrivateSendDenominations.back()/10) continue;
                 // ignore anonymized
                 if(GetInputPrivateSendRounds(CTxIn(wtx.GetHash(), i)) >= nPrivateSendRounds) continue;
             }
@@ -3421,7 +3421,7 @@ string CWallet::PrepareDarksendDenominate(int minRounds, int maxRounds)
     if (IsLocked())
         return _("Error: Wallet locked, unable to create transaction!");
 
-    if(darkSendPool.GetState() != POOL_STATUS_ERROR && darkSendPool.GetState() != POOL_STATUS_SUCCESS)
+    if(darkSendPool.GetState() != POOL_STATE_ERROR && darkSendPool.GetState() != POOL_STATE_SUCCESS)
         if(darkSendPool.GetEntriesCount() > 0)
             return _("Error: You already have pending entries in the PrivateSend pool");
 
@@ -3438,7 +3438,7 @@ string CWallet::PrepareDarksendDenominate(int minRounds, int maxRounds)
         if minRounds >= 0 it means only denominated inputs are going in and coming out
     */
     if(minRounds >= 0){
-        if (!SelectCoinsByDenominations(darkSendPool.sessionDenom, 0.1*COIN, DARKSEND_POOL_MAX, vCoins, vCoins2, nValueIn, minRounds, maxRounds))
+        if (!SelectCoinsByDenominations(darkSendPool.nSessionDenom, 0.1*COIN, DARKSEND_POOL_MAX, vCoins, vCoins2, nValueIn, minRounds, maxRounds))
             return _("Error: Can't select current denominated inputs");
     }
 
@@ -3465,13 +3465,13 @@ string CWallet::PrepareDarksendDenominate(int minRounds, int maxRounds)
     int nStepsMax = 5 + GetRandInt(5);
     while(nStep < nStepsMax) {
 
-        BOOST_FOREACH(CAmount v, darkSendDenominations){
+        BOOST_FOREACH(CAmount v, vecPrivateSendDenominations){
             // only use the ones that are approved
             bool fAccepted = false;
-            if((darkSendPool.sessionDenom & (1 << 0))      && v == ((100*COIN) +100000)) {fAccepted = true;}
-            else if((darkSendPool.sessionDenom & (1 << 1)) && v == ((10*COIN)  +10000)) {fAccepted = true;}
-            else if((darkSendPool.sessionDenom & (1 << 2)) && v == ((1*COIN)   +1000)) {fAccepted = true;}
-            else if((darkSendPool.sessionDenom & (1 << 3)) && v == ((.1*COIN)  +100)) {fAccepted = true;}
+            if((darkSendPool.nSessionDenom & (1 << 0))      && v == ((100*COIN) +100000)) {fAccepted = true;}
+            else if((darkSendPool.nSessionDenom & (1 << 1)) && v == ((10*COIN)  +10000)) {fAccepted = true;}
+            else if((darkSendPool.nSessionDenom & (1 << 2)) && v == ((1*COIN)   +1000)) {fAccepted = true;}
+            else if((darkSendPool.nSessionDenom & (1 << 3)) && v == ((.1*COIN)  +100)) {fAccepted = true;}
             if(!fAccepted) continue;
 
             // try to add it
@@ -3522,7 +3522,7 @@ string CWallet::PrepareDarksendDenominate(int minRounds, int maxRounds)
                 UnlockCoin(v.prevout);
     }
 
-    if(darkSendPool.GetDenominations(vOut) != darkSendPool.sessionDenom) {
+    if(darkSendPool.GetDenominations(vOut) != darkSendPool.nSessionDenom) {
         // unlock used coins on failure
         LOCK(cs_wallet);
         BOOST_FOREACH(CTxIn v, vCoinsResult)


### PR DESCRIPTION
Alright... Time to clean up my diff backlog :)

I apologize in advance for a somewhat huge PR but things are way too interconnected here and also changes are _mostly_ trivial. I tried to break it into 3 more or less separated commits though, so hopefully this will help to make review a bit easier. Also would like to mention that this is the first part of it and there is more to come in following PRs but I need this as a base (together with #911), so please don't put it at the end of your review queue :D

In general all of this is simply trying to:
- move things out of .h (besides obvious one-liners)
- clean up dependency lists a bit
- simplify constructions to avoid "spaghetti code" as much as possible
- name things properly - nSmth for int-s, fSmth or isSmth for bool-s etc.
- follow code convention for braces and stuff (more or less)
- unify log format for modules that were refactored
- decouple from util.h and version.h
- make some small additional fixes along the way, see below

1) Refactor `CActiveMasternode`
- move `strMasterNodeAddr` out of util.h to `CActiveMasternode`

2) Refactor InstantSend
- new lock `cs_instantsend` to protect maps on `CleanTransactionLocksList()`
- new `DEFAULT_INSTANTSEND_DEPTH` constant
- rename `MIN_INSTANTX_PROTO_VERSION` to `MIN_INSTANTSEND_PROTO_VERSION` and bump it
- move `fEnableInstantSend` and `nInstantSendDepth` out of util.h
- fix a bug that caused crash sometimes(?) https://github.com/dashpay/dash/compare/v0.12.1.x...UdjinM6:refactor?expand=1#diff-3f2efe7102777a5f67b9de6bce83eae7R492 - this needs more attention (later?), probably was the result of the way `CConsensusVote::GetHash()` currently works i.e. it doesn't return a hash at all.

3) Refactor Privatesend
- more functions for `CDarksendBroadcastTx`: constructors, signing, serialization
- use `insecure_rand()` instead of rand() in general but `GetRand()` for session id
- new `DEFAULT_...`
- move `nPrivateSendRounds`, `nPrivateSendAmount`, `nLiquidityProvider`, `fEnablePrivateSend`, `fPrivateSendMultiSession`, `darkSendDenominations` out of util.h

Note: `vin` part of some names was changed to `txin` (which is a proper name for an _object_ of `CTxIn` because `vin` stands for _vector_ of `CTxIn`s) where applicable but not everywhere. That's intentional, I'll explain this in (one of?) the next part :)