### PR TITLE
[UI] IPv4, IPv6 and TOR stats added to Information tab

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -218,6 +218,43 @@ int CMasternodeMan::CountEnabled(int protocolVersion)
     return i;
 }
 
+int CMasternodeMan::CountByIP(int nodeType)
+{
+    int nIPv4_nodes = 0;
+    int nIPv6_nodes = 0;
+    int nTOR_nodes = 0;
+    const std::string sIPv6_node ("[");
+    const std::string sTOR_node (".onion");
+
+    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+        if(mn.addr.ToString().find(sIPv6_node) != std::string::npos){
+            nIPv6_nodes++;
+        } else if(mn.addr.ToString().find(sTOR_node) != std::string::npos){
+            nTOR_nodes++;
+        }
+        else{
+            nIPv4_nodes++; // Must be IPv4 if it isn't IPv6 or TOR
+        }
+    }
+
+    switch(nodeType)
+    {
+        case NODE_IPV4:
+            return nIPv4_nodes;
+            break;
+            
+        case NODE_IPV6:
+            return nIPv6_nodes;
+            break;
+            
+        case NODE_TOR:
+            return nTOR_nodes;
+            break;
+    }
+
+    return nIPv4_nodes + nIPv6_nodes + nTOR_nodes; // Default: return all nodes
+}
+
 void CMasternodeMan::DsegUpdate(CNode* pnode)
 {
     LOCK(cs);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -223,13 +223,11 @@ int CMasternodeMan::CountByIP(int nodeType)
     int nIPv4_nodes = 0;
     int nIPv6_nodes = 0;
     int nTOR_nodes = 0;
-    const std::string sIPv6_node ("[");
-    const std::string sTOR_node (".onion");
 
     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
-        if(mn.addr.ToString().find(sIPv6_node) != std::string::npos){
+        if(mn.addr.IsIPv6()){
             nIPv6_nodes++;
-        } else if(mn.addr.ToString().find(sTOR_node) != std::string::npos){
+        } else if(mn.addr.IsTor()){
             nTOR_nodes++;
         }
         else{
@@ -239,20 +237,19 @@ int CMasternodeMan::CountByIP(int nodeType)
 
     switch(nodeType)
     {
-        case NODE_IPV4:
+        case NET_IPV4:
             return nIPv4_nodes;
-            break;
             
-        case NODE_IPV6:
+        case NET_IPV6:
             return nIPv6_nodes;
-            break;
             
-        case NODE_TOR:
+        case NET_TOR:
             return nTOR_nodes;
-            break;
+
+        default:
+            return nIPv4_nodes + nIPv6_nodes + nTOR_nodes; // Default: return all nodes
     }
 
-    return nIPv4_nodes + nIPv6_nodes + nTOR_nodes; // Default: return all nodes
 }
 
 void CMasternodeMan::DsegUpdate(CNode* pnode)

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -16,10 +16,6 @@
 #define MASTERNODES_DUMP_SECONDS               (15*60)
 #define MASTERNODES_DSEG_SECONDS               (3*60*60)
 
-#define NODE_IPV4 1
-#define NODE_IPV6 2
-#define NODE_TOR 3
-
 using namespace std;
 
 class CMasternodeMan;

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -16,6 +16,10 @@
 #define MASTERNODES_DUMP_SECONDS               (15*60)
 #define MASTERNODES_DSEG_SECONDS               (3*60*60)
 
+#define NODE_IPV4 1
+#define NODE_IPV6 2
+#define NODE_TOR 3
+
 using namespace std;
 
 class CMasternodeMan;
@@ -85,6 +89,8 @@ public:
     void Clear();
 
     int CountEnabled(int protocolVersion = -1);
+    
+    int CountByIP(int nodeType);
 
     void DsegUpdate(CNode* pnode);
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -74,9 +74,12 @@ int ClientModel::getNumConnections(unsigned int flags) const
 
 QString ClientModel::getMasternodeCountString() const
 {
-    return tr("Total: %1 (PS compatible: %2 / Enabled: %3)").arg(QString::number((int)mnodeman.size()))
+    return tr("Total: %1 (PS compatible: %2 / Enabled: %3) (IPv4: %4, IPv6: %5, TOR: %6)").arg(QString::number((int)mnodeman.size()))
             .arg(QString::number((int)mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)))
-            .arg(QString::number((int)mnodeman.CountEnabled()));
+            .arg(QString::number((int)mnodeman.CountEnabled()))
+            .arg(QString::number((int)mnodeman.CountByIP(NODE_IPV4)))
+            .arg(QString::number((int)mnodeman.CountByIP(NODE_IPV6)))
+            .arg(QString::number((int)mnodeman.CountByIP(NODE_TOR)));
 }
 
 int ClientModel::getNumBlocks() const

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -77,9 +77,9 @@ QString ClientModel::getMasternodeCountString() const
     return tr("Total: %1 (PS compatible: %2 / Enabled: %3) (IPv4: %4, IPv6: %5, TOR: %6)").arg(QString::number((int)mnodeman.size()))
             .arg(QString::number((int)mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)))
             .arg(QString::number((int)mnodeman.CountEnabled()))
-            .arg(QString::number((int)mnodeman.CountByIP(NODE_IPV4)))
-            .arg(QString::number((int)mnodeman.CountByIP(NODE_IPV6)))
-            .arg(QString::number((int)mnodeman.CountByIP(NODE_TOR)));
+            .arg(QString::number((int)mnodeman.CountByIP(NET_IPV4)))
+            .arg(QString::number((int)mnodeman.CountByIP(NET_IPV6)))
+            .arg(QString::number((int)mnodeman.CountByIP(NET_TOR)));
 }
 
 int ClientModel::getNumBlocks() const


### PR DESCRIPTION
I think it's convenient to have this information inside the wallet instead from some suspicious external websites :-)

Looks like this:
![ip_stats](https://cloud.githubusercontent.com/assets/10080039/17451630/6fdb4ee2-5b68-11e6-9eb0-e8fb91845a6a.jpg)
