### PR TITLE
Fix GetBlockHash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2339,6 +2339,16 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
     return nVersion;
 }
 
+bool GetBlockHash(uint256& hashRet, int nBlockHeight)
+{
+    LOCK(cs_main);
+    if(chainActive.Tip() == NULL) return false;
+    if(nBlockHeight < -1 || nBlockHeight > chainActive.Height()) return false;
+    if(nBlockHeight == -1) nBlockHeight = chainActive.Height();
+    hashRet = chainActive[nBlockHeight]->GetBlockHash();
+    return true;
+}
+
 /**
  * Threshold condition checker that triggers when unknown versionbits are seen on the network.
  */

--- a/src/main.h
+++ b/src/main.h
@@ -565,6 +565,12 @@ int GetSpendHeight(const CCoinsViewCache& inputs);
  */
 int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
+/**
+ * Return true if hash can be found in chainActive at nBlockHeight height.
+ * Fills hashRet with found hash, if no nBlockHeight is specified - chainActive.Height() is used.
+ */
+bool GetBlockHash(uint256& hashRet, int nBlockHeight = -1);
+
 /** Reject codes greater or equal to this can be returned by AcceptToMemPool
  * for transactions, to signal internal conditions. They cannot and should not
  * be sent over the P2P network.

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -333,9 +333,7 @@ bool CMasternodePayments::IsScheduled(CMasternode& mn, int nNotBlockHeight)
 bool CMasternodePayments::AddWinningMasternode(CMasternodePaymentWinner& winnerIn)
 {
     uint256 blockHash = uint256();
-    if(!GetBlockHash(blockHash, winnerIn.nBlockHeight-100)) {
-        return false;
-    }
+    if(!GetBlockHash(blockHash, winnerIn.nBlockHeight - 101)) return false;
 
     {
         LOCK2(cs_mapMasternodePayeeVotes, cs_mapMasternodeBlocks);
@@ -489,7 +487,7 @@ bool CMasternodePaymentWinner::IsValid(CNode* pnode, int nValidationHeight, std:
         return false;
     }
 
-    int nRank = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight - 100, MIN_MNW_PEER_PROTO_VERSION);
+    int nRank = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight - 101, MIN_MNW_PEER_PROTO_VERSION);
 
     if(nRank > MNPAYMENTS_SIGNATURES_TOTAL) {
         // It's common to have masternodes mistakenly think they are in the top 10
@@ -513,7 +511,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
     if(!fMasterNode) return false;
     
-    int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight-100, MIN_MNW_PEER_PROTO_VERSION);        
+    int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight - 101, MIN_MNW_PEER_PROTO_VERSION);
        
     if(n == -1)       
     {     

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -25,9 +25,6 @@ using namespace std;
 class CMasternode;
 class CMasternodeBroadcast;
 class CMasternodePing;
-extern map<int64_t, uint256> mapCacheBlockHashes;
-
-bool GetBlockHash(uint256& hash, int nBlockHeight);
 
 //
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -333,7 +333,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         CMasternode* pmn = Find(s.second);
         if(!pmn) break;
 
-        arith_uint256 n = UintToArith256(pmn->CalculateScore(1, nBlockHeight-100));
+        arith_uint256 n = UintToArith256(pmn->CalculateScore(1, nBlockHeight - 101));
         if(n > nHigh){
             nHigh = n;
             pBestMasternode = pmn;

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -491,7 +491,7 @@ UniValue masternode(const UniValue& params, bool fHelp)
     //         arith_uint256 nHigh = 0;
     //         CMasternode *pBestMasternode = NULL;
     //         BOOST_FOREACH(CMasternode& mn, vMasternodes) {
-    //             arith_uint256 n = UintToArith256(mn.CalculateScore(1, i - 100));
+    //             arith_uint256 n = UintToArith256(mn.CalculateScore(1, i - 101));
     //             if(n > nHigh){
     //                 nHigh = n;
     //                 pBestMasternode = &mn;


### PR DESCRIPTION
Currently it's doing the job already done by `chainActive` and it's off by 1 block. It is also not masternode specific, so should be moved to main.cpp imo.

