### PR TITLE
Bump NO_BLOOM_VERSION and SENDHEADERS_VERSION to match PROTOCOL_VERSION

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -251,16 +251,16 @@ const std::vector<std::string> &getAllNetMessageTypes();
 /** nServices flags */
 enum {
     // NODE_NETWORK means that the node is capable of serving the block chain. It is currently
-    // set by all Bitcoin Core nodes, and is unset by SPV clients or other peers that just want
+    // set by all Dash Core nodes, and is unset by SPV clients or other peers that just want
     // network services but don't provide them.
     NODE_NETWORK = (1 << 0),
     // NODE_GETUTXO means the node is capable of responding to the getutxo protocol request.
-    // Bitcoin Core does not support this but a patch set called Bitcoin XT does.
+    // Dash Core does not support this but a patch set called Bitcoin XT does.
     // See BIP 64 for details on how this is implemented.
     NODE_GETUTXO = (1 << 1),
     // NODE_BLOOM means the node is capable and willing to handle bloom-filtered connections.
-    // Bitcoin Core nodes used to support this by default, without advertising this bit,
-    // but no longer do as of protocol version 70011 (= NO_BLOOM_VERSION)
+    // Dash Core nodes used to support this by default, without advertising this bit,
+    // but no longer do as of protocol version 70201 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that

--- a/src/version.h
+++ b/src/version.h
@@ -48,9 +48,9 @@ static const int BIP0031_VERSION = 60000;
 static const int MEMPOOL_GD_VERSION = 60002;
 
 //! "filter*" commands are disabled without NODE_BLOOM after and including this version
-static const int NO_BLOOM_VERSION = 70011;
+static const int NO_BLOOM_VERSION = 70201;
 
 //! "sendheaders" command and announcing blocks with headers starts with this version
-static const int SENDHEADERS_VERSION = 70012;
+static const int SENDHEADERS_VERSION = 70201;
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
These features were introduced in bitcoin 0.11/0.12 and our 0.12.0.x nodes (which are bitcoin 0.10 based) are already running on higher protocol (70103). Bumping these to avoid banning nodes for misbehavior (bloom) and correctly (not) push sendheaders messages. Fixing related comments too.