### PR TITLE
Simplify CountByIP()

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -218,38 +218,18 @@ int CMasternodeMan::CountEnabled(int protocolVersion)
     return i;
 }
 
-int CMasternodeMan::CountByIP(int nodeType)
+int CMasternodeMan::CountByIP(int nNetworkType)
 {
-    int nIPv4_nodes = 0;
-    int nIPv6_nodes = 0;
-    int nTOR_nodes = 0;
+    int nNodeCount = 0;
 
-    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
-        if(mn.addr.IsIPv6()){
-            nIPv6_nodes++;
-        } else if(mn.addr.IsTor()){
-            nTOR_nodes++;
+    BOOST_FOREACH(CMasternode& mn, vMasternodes)
+        if( (nNetworkType == NET_IPV4 && mn.addr.IsIPv4()) ||
+            (nNetworkType == NET_TOR  && mn.addr.IsTor())  ||
+            (nNetworkType == NET_IPV6 && mn.addr.IsIPv6())) {
+                nNodeCount++;
         }
-        else{
-            nIPv4_nodes++; // Must be IPv4 if it isn't IPv6 or TOR
-        }
-    }
 
-    switch(nodeType)
-    {
-        case NET_IPV4:
-            return nIPv4_nodes;
-            
-        case NET_IPV6:
-            return nIPv6_nodes;
-            
-        case NET_TOR:
-            return nTOR_nodes;
-
-        default:
-            return nIPv4_nodes + nIPv6_nodes + nTOR_nodes; // Default: return all nodes
-    }
-
+    return nNodeCount;
 }
 
 void CMasternodeMan::DsegUpdate(CNode* pnode)

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -85,8 +85,9 @@ public:
     void Clear();
 
     int CountEnabled(int protocolVersion = -1);
-    
-    int CountByIP(int nodeType);
+
+    /// Count Masternodes by network type - NET_IPV4, NET_IPV6, NET_TOR
+    int CountByIP(int nNetworkType);
 
     void DsegUpdate(CNode* pnode);
 


### PR DESCRIPTION
Followup for #930 discussion

Looks like this function can be simplified even further. Also the case for all networks is covered much more effectively by `size()`, so I'm removing this option here.

@crowning-