### PR TITLE
Leave some space for free transactions by defaut (10000)

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -18,7 +18,7 @@ class CCoinsViewCache;
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
-static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;
+static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 10000; // was 50000 in 0.12.0 and it is 0 in Bitcoin since 0.12
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */


### PR DESCRIPTION
Bitcoin goes full "no free txes" by default which could be not the best case for us since PS mixing txes (dstx, which are 0-fee txes) sometimes could fail to be propagated properly (for whatever reason) and so all participants could end up with such tx sitting in their wallet unconfirmed forever. Imo it would be a good idea to have some kind of fallback here so that such txes were finally included in block (even though it will take some time for them to be accepted since free txes have very low priority, but it least this should save users from zapping their wallets every time this happens).