### PR TITLE
Fixed non-deterministic CSporkMessage hash function

### DIFF
--- a/src/spork.h
+++ b/src/spork.h
@@ -62,7 +62,15 @@ public:
     CSporkMessage(int nSporkID, int64_t nValue, int64_t nTimeSigned) : nSporkID(nSporkID), nValue(nValue), nTimeSigned(nTimeSigned) {}
     CSporkMessage() : nSporkID(0), nValue(0), nTimeSigned(0) {}
 
-    uint256 GetHash() { return HashX11(BEGIN(nSporkID), END(nTimeSigned)); }
+    uint256 GetHash()
+    {
+        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+        ss << nSporkID;
+        ss << nValue;
+        ss << nTimeSigned;
+        return ss.GetHash();
+    }
+
     bool Sign(std::string strSignKey);
     bool CheckSignature();
     void Relay();


### PR DESCRIPTION
CSporkMessage::GetHash() was including random data
in the hash due to 4 bytes of structure padding between the 32 bit
nSporkID and the following 64 bit nValue members.

This has been fixed by using CHashWriter which serializes the structure
data properly before hashing rather than relying on compiler defined behavior
such as structure alignment.  The underlying hash function is CHash256 which is
bitcoin's double SHA-256 hash.  HashX11 is not necessary here
because the hash is only used to identify distinct spork messages.