### PR TITLE
Fix extra warning about low keys on wallet encryption

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -461,7 +461,25 @@ void OverviewPage::privateSendStatus()
     }
     ui->labelPrivateSendEnabled->setToolTip(strKeysLeftText);
 
+    if (!fEnablePrivateSend) {
+        if (nBestHeight != darkSendPool.nCachedNumBlocks) {
+            darkSendPool.nCachedNumBlocks = nBestHeight;
+            updatePrivateSendProgress();
+        }
+
+        ui->labelPrivateSendLastMessage->setText("");
+        ui->togglePrivateSend->setText(tr("Start Mixing"));
+
+        QString strEnabled = tr("Disabled");
+        // Show how many keys left in advanced PS UI mode only
+        if (fShowAdvancedPSUI) strEnabled += ", " + strKeysLeftText;
+        ui->labelPrivateSendEnabled->setText(strEnabled);
+
+        return;
+    }
+
     // Warn user that wallet is running out of keys
+    // NOTE: we do NOT warn user and do NOT create autobackups if mixing is not running
     if (nWalletBackups > 0 && pwalletMain->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING) {
         QSettings settings;
         if(settings.value("fLowKeysWarning").toBool()) {
@@ -518,18 +536,6 @@ void OverviewPage::privateSendStatus()
         // We were able to create automatic backup but keypool was not replenished because wallet is locked.
         QString strWarning = tr("WARNING! Failed to replenish keypool, please unlock your wallet to do so.");
         ui->labelPrivateSendEnabled->setToolTip(strWarning);
-    }
-
-    if(!fEnablePrivateSend) {
-        if(nBestHeight != darkSendPool.nCachedNumBlocks) {
-            darkSendPool.nCachedNumBlocks = nBestHeight;
-            updatePrivateSendProgress();
-        }
-
-        ui->labelPrivateSendLastMessage->setText("");
-        ui->togglePrivateSend->setText(tr("Start Mixing"));
-
-        return;
     }
 
     // check darksend status and unlock if needed

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3658,6 +3658,7 @@ bool CWallet::NewKeyPool()
         BOOST_FOREACH(int64_t nIndex, setKeyPool)
             walletdb.ErasePool(nIndex);
         setKeyPool.clear();
+        fEnablePrivateSend = false;
         pwalletMain->nKeysLeftSinceAutoBackup = 0;
 
         if (IsLocked())


### PR DESCRIPTION
When wallet is encrypted keypool is flushed which triggers warnings and autobackup. Since wallet demands user to restart wallet and will not continue any operation this doesn't really make much sense (autobackup should be created on next start anyway) and could confuse user. This commit is kind of workaround for the issue - we'll be warning and creating autobackups only if mixing is in running and we force mixing to be stopped in case of keepool regeneration.