### PR TITLE
Refactor CDarkSendSigner

### DIFF
--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -36,15 +36,14 @@ std::string CDarkSendRelay::ToString()
 
 bool CDarkSendRelay::Sign(std::string strSharedKey)
 {
+    std::string strError = "";
     std::string strMessage = in.ToString() + out.ToString();
 
     CKey key2;
     CPubKey pubkey2;
-    std::string errorMessage = "";
 
-    if(!darkSendSigner.GetKeysFromSecret(strSharedKey, errorMessage, key2, pubkey2))
-    {
-        LogPrintf("CDarkSendRelay():Sign - ERROR: Invalid shared key: '%s'\n", errorMessage);
+    if(!darkSendSigner.GetKeysFromSecret(strSharedKey, key2, pubkey2)) {
+        LogPrintf("CDarkSendRelay::Sign -- GetKeysFromSecret() failed, invalid shared key %s\n", strSharedKey);
         return false;
     }
 
@@ -53,8 +52,8 @@ bool CDarkSendRelay::Sign(std::string strSharedKey)
         return false;
     }
 
-    if(!darkSendSigner.VerifyMessage(pubkey2, vchSig2, strMessage, errorMessage)) {
-        LogPrintf("CDarkSendRelay::Sign -- VerifyMessage() failed, error: %s\n", errorMessage);
+    if(!darkSendSigner.VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
+        LogPrintf("CDarkSendRelay::Sign -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 
@@ -63,20 +62,19 @@ bool CDarkSendRelay::Sign(std::string strSharedKey)
 
 bool CDarkSendRelay::VerifyMessage(std::string strSharedKey)
 {
+    std::string strError = "";
     std::string strMessage = in.ToString() + out.ToString();
 
     CKey key2;
     CPubKey pubkey2;
-    std::string errorMessage = "";
 
-    if(!darkSendSigner.GetKeysFromSecret(strSharedKey, errorMessage, key2, pubkey2))
-    {
-        LogPrintf("CDarkSendRelay()::VerifyMessage - ERROR: Invalid shared key: '%s'\n", errorMessage);
+    if(!darkSendSigner.GetKeysFromSecret(strSharedKey, key2, pubkey2)) {
+        LogPrintf("CDarkSendRelay::VerifyMessage -- GetKeysFromSecret() failed, invalid shared key %s\n", strSharedKey);
         return false;
     }
 
-    if(!darkSendSigner.VerifyMessage(pubkey2, vchSig2, strMessage, errorMessage)) {
-        LogPrintf("CDarkSendRelay::VerifyMessage -- VerifyMessage() failed, error: %s\n", errorMessage);
+    if(!darkSendSigner.VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
+        LogPrintf("CDarkSendRelay::VerifyMessage -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 

--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -54,7 +54,7 @@ bool CDarkSendRelay::Sign(std::string strSharedKey)
     }
 
     if(!darkSendSigner.VerifyMessage(pubkey2, vchSig2, strMessage, errorMessage)) {
-        LogPrintf("CDarkSendRelay():Sign - Verify message failed\n");
+        LogPrintf("CDarkSendRelay::Sign -- VerifyMessage() failed, error: %s\n", errorMessage);
         return false;
     }
 
@@ -76,7 +76,7 @@ bool CDarkSendRelay::VerifyMessage(std::string strSharedKey)
     }
 
     if(!darkSendSigner.VerifyMessage(pubkey2, vchSig2, strMessage, errorMessage)) {
-        LogPrintf("CDarkSendRelay()::VerifyMessage - Verify message failed\n");
+        LogPrintf("CDarkSendRelay::VerifyMessage -- VerifyMessage() failed, error: %s\n", errorMessage);
         return false;
     }
 

--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -48,8 +48,8 @@ bool CDarkSendRelay::Sign(std::string strSharedKey)
         return false;
     }
 
-    if(!darkSendSigner.SignMessage(strMessage, errorMessage, vchSig2, key2)) {
-        LogPrintf("CDarkSendRelay():Sign - Sign message failed\n");
+    if(!darkSendSigner.SignMessage(strMessage, vchSig2, key2)) {
+        LogPrintf("CDarkSendRelay::Sign -- SignMessage() failed\n");
         return false;
     }
 

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2117,12 +2117,12 @@ bool CDarkSendSigner::VerifyMessage(CPubKey pubkey, const std::vector<unsigned c
 
     CPubKey pubkeyFromSig;
     if(!pubkeyFromSig.RecoverCompact(ss.GetHash(), vchSig)) {
-        strErrorRet = _("Error recovering public key.");
+        strErrorRet = "Error recovering public key.";
         return false;
     }
 
     if(pubkeyFromSig.GetID() != pubkey.GetID()) {
-        strErrorRet = strprintf("keys don't match: pubkey=%s, pubkeyFromSig=%s, strMessage=%s, vchSig=%s",
+        strErrorRet = strprintf("Keys don't match: pubkey=%s, pubkeyFromSig=%s, strMessage=%s, vchSig=%s",
                     pubkey.GetID().ToString(), pubkeyFromSig.GetID().ToString(), strMessage,
                     EncodeBase64(&vchSig[0], vchSig.size()));
         return false;
@@ -2190,7 +2190,7 @@ bool CDarksendQueue::CheckSignature()
     std::string strError = "";
 
     if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, strError)) {
-        LogPrintf("CDarksendQueue::CheckSignature -- Got bad Masternode queue signature, vin=%s\n", vin.ToString());
+        LogPrintf("CDarksendQueue::CheckSignature -- Got bad Masternode queue signature, vin=%s, error: %s\n", vin.ToString(), strError);
         return false;
     }
 
@@ -2247,7 +2247,7 @@ bool CDarksendBroadcastTx::CheckSignature()
     std::string strError = "";
 
     if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, strError)) {
-        LogPrintf("CDarksendBroadcastTx::CheckSignature -- Got bad dstx signature\n");
+        LogPrintf("CDarksendBroadcastTx::CheckSignature -- Got bad dstx signature, error: %s\n", strError);
         return false;
     }
 

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2100,18 +2100,13 @@ bool CDarkSendSigner::GetKeysFromSecret(std::string strSecret, std::string& strE
     return true;
 }
 
-bool CDarkSendSigner::SignMessage(std::string strMessage, std::string& strErrorRet, std::vector<unsigned char>& vchSigRet, CKey key)
+bool CDarkSendSigner::SignMessage(std::string strMessage, std::vector<unsigned char>& vchSigRet, CKey key)
 {
     CHashWriter ss(SER_GETHASH, 0);
     ss << strMessageMagic;
     ss << strMessage;
 
-    if(!key.SignCompact(ss.GetHash(), vchSigRet)) {
-        strErrorRet = _("Signing failed.");
-        return false;
-    }
-
-    return true;
+    return key.SignCompact(ss.GetHash(), vchSigRet);
 }
 
 bool CDarkSendSigner::VerifyMessage(CPubKey pubkey, const std::vector<unsigned char>& vchSig, std::string strMessage, std::string& strErrorRet)
@@ -2177,9 +2172,8 @@ bool CDarksendQueue::Sign()
     if(!fMasterNode) return false;
 
     std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(nTime) + boost::lexical_cast<std::string>(fReady);
-    std::string strError = "";
 
-    if(!darkSendSigner.SignMessage(strMessage, strError, vchSig, activeMasternode.keyMasternode)) {
+    if(!darkSendSigner.SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
         LogPrintf("CDarksendQueue::Sign -- SignMessage() failed\n");
         return false;
     }
@@ -2235,9 +2229,8 @@ bool CDarksendBroadcastTx::Sign()
     if(!fMasterNode) return false;
 
     std::string strMessage = tx.GetHash().ToString() + boost::lexical_cast<std::string>(sigTime);
-    std::string strError = "";
 
-    if(!darkSendSigner.SignMessage(strMessage, strError, vchSig, activeMasternode.keyMasternode)) {
+    if(!darkSendSigner.SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
         LogPrintf("CDarksendBroadcastTx::Sign -- SignMessage() failed\n");
         return false;
     }

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2084,15 +2084,11 @@ bool CDarkSendSigner::IsVinAssociatedWithPubkey(const CTxIn& txin, const CPubKey
     return false;
 }
 
-bool CDarkSendSigner::GetKeysFromSecret(std::string strSecret, std::string& strErrorRet, CKey& keyRet, CPubKey& pubkeyRet)
+bool CDarkSendSigner::GetKeysFromSecret(std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet)
 {
     CBitcoinSecret vchSecret;
-    bool fGood = vchSecret.SetString(strSecret);
 
-    if(!fGood) {
-        strErrorRet = _("Invalid secret.");
-        return false;
-    }
+    if(!vchSecret.SetString(strSecret)) return false;
 
     keyRet = vchSecret.GetKey();
     pubkeyRet = keyRet.GetPubKey();

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -228,7 +228,7 @@ public:
     /// Set the private/public key values, returns true if successful
     bool GetKeysFromSecret(std::string strSecret, std::string& strErrorRet, CKey& keyRet, CPubKey& pubkeyRet);
     /// Sign the message, returns true if successful
-    bool SignMessage(std::string strMessage, std::string& strErrorRet, std::vector<unsigned char>& vchSigRet, CKey key);
+    bool SignMessage(std::string strMessage, std::vector<unsigned char>& vchSigRet, CKey key);
     /// Verify the message, returns true if succcessful
     bool VerifyMessage(CPubKey pubkey, const std::vector<unsigned char>& vchSig, std::string strMessage, std::string& strErrorRet);
 };

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -226,7 +226,7 @@ public:
     /// Is the input associated with this public key? (and there is 1000 DASH - checking if valid masternode)
     bool IsVinAssociatedWithPubkey(const CTxIn& vin, const CPubKey& pubkey);
     /// Set the private/public key values, returns true if successful
-    bool GetKeysFromSecret(std::string strSecret, std::string& strErrorRet, CKey& keyRet, CPubKey& pubkeyRet);
+    bool GetKeysFromSecret(std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet);
     /// Sign the message, returns true if successful
     bool SignMessage(std::string strMessage, std::vector<unsigned char>& vchSigRet, CKey key);
     /// Verify the message, returns true if succcessful

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -154,8 +154,8 @@ bool CGovernanceVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
     std::string strMessage = vinMasternode.prevout.ToStringShort() + "|" + nParentHash.ToString() + "|" +
         boost::lexical_cast<std::string>(nVoteSignal) + "|" + boost::lexical_cast<std::string>(nVoteOutcome) + "|" + boost::lexical_cast<std::string>(nTime);
 
-    if(!darkSendSigner.SignMessage(strMessage, errorMessage, vchSig, keyMasternode)) {
-        LogPrintf("CGovernanceVote::Sign - Error upon calling SignMessage");
+    if(!darkSendSigner.SignMessage(strMessage, vchSig, keyMasternode)) {
+        LogPrintf("CGovernanceVote::Sign -- SignMessage() failed\n");
         return false;
     }
 

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -150,7 +150,7 @@ bool CGovernanceVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
     CPubKey pubKeyCollateralAddress;
     CKey keyCollateralAddress;
 
-    std::string errorMessage;
+    std::string strError;
     std::string strMessage = vinMasternode.prevout.ToStringShort() + "|" + nParentHash.ToString() + "|" +
         boost::lexical_cast<std::string>(nVoteSignal) + "|" + boost::lexical_cast<std::string>(nVoteOutcome) + "|" + boost::lexical_cast<std::string>(nTime);
 
@@ -159,8 +159,8 @@ bool CGovernanceVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
         return false;
     }
 
-    if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-        LogPrintf("CGovernanceVote::Sign - Error upon calling VerifyMessage");
+    if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+        LogPrintf("CGovernanceVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 
@@ -197,12 +197,12 @@ bool CGovernanceVote::IsValid(bool fSignatureCheck)
 
     if(!fSignatureCheck) return true;
 
-    std::string errorMessage;
+    std::string strError;
     std::string strMessage = vinMasternode.prevout.ToStringShort() + "|" + nParentHash.ToString() + "|" +
         boost::lexical_cast<std::string>(nVoteSignal) + "|" + boost::lexical_cast<std::string>(nVoteOutcome) + "|" + boost::lexical_cast<std::string>(nTime);
 
-    if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage)) {
-        LogPrintf("CGovernanceVote::IsValid() - Verify message failed - Error: %s\n", errorMessage);
+    if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, strError)) {
+        LogPrintf("CGovernanceVote::IsValid -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1798,9 +1798,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
         std::string strMasterNodePrivKey = GetArg("-masternodeprivkey", "");
         if(!strMasterNodePrivKey.empty()) {
-            std::string strErrorMessage;
-
-            if(!darkSendSigner.GetKeysFromSecret(strMasterNodePrivKey, strErrorMessage, activeMasternode.keyMasternode, activeMasternode.pubKeyMasternode))
+            if(!darkSendSigner.GetKeysFromSecret(strMasterNodePrivKey, activeMasternode.keyMasternode, activeMasternode.pubKeyMasternode))
                 return InitError(_("Invalid masternodeprivkey. Please see documenation."));
 
             LogPrintf("  pubKeyMasternode: %s\n", CBitcoinAddress(activeMasternode.pubKeyMasternode.GetID()).ToString());

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -560,7 +560,7 @@ bool CConsensusVote::CheckSignature()
     }
 
     if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchMasterNodeSignature, strMessage, strError)) {
-        LogPrintf("CConsensusVote::CheckSignature -- VerifyMessage() failed\n");
+        LogPrintf("CConsensusVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 
@@ -579,7 +579,7 @@ bool CConsensusVote::Sign()
     }
 
     if(!darkSendSigner.VerifyMessage(activeMasternode.pubKeyMasternode, vchMasterNodeSignature, strMessage, strError)) {
-        LogPrintf("CConsensusVote::Sign -- VerifyMessage() failed");
+        LogPrintf("CConsensusVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -573,8 +573,8 @@ bool CConsensusVote::Sign()
 
     std::string strMessage = txHash.ToString().c_str() + boost::lexical_cast<std::string>(nBlockHeight);
 
-    if(!darkSendSigner.SignMessage(strMessage, strError, vchMasterNodeSignature, activeMasternode.keyMasternode)) {
-        LogPrintf("CConsensusVote::Sign -- SignMessage() failed");
+    if(!darkSendSigner.SignMessage(strMessage, vchMasterNodeSignature, activeMasternode.keyMasternode)) {
+        LogPrintf("CConsensusVote::Sign -- SignMessage() failed\n");
         return false;
     }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -316,7 +316,7 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, std::string& strCommand, 
 
 bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    std::string errorMessage;
+    std::string strError;
     std::string strMasterNodeSignMessage;
 
     std::string strMessage =  vinMasternode.prevout.ToStringShort() +
@@ -328,8 +328,8 @@ bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasterno
         return false;
     }
 
-    if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-        LogPrintf("CMasternodePing::Sign() - Error: %s\n", errorMessage);
+    if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+        LogPrintf("CMasternodePing::Sign() -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 
@@ -628,13 +628,13 @@ bool CMasternodePaymentWinner::SignatureValid()
 
     if(pmn != NULL)
     {
+        std::string strError = "";
         std::string strMessage =  vinMasternode.prevout.ToStringShort() +
                     boost::lexical_cast<std::string>(nBlockHeight) +
                     ScriptToAsmStr(payee);
 
-        std::string errorMessage = "";
-        if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, errorMessage)){
-            return error("CMasternodePaymentWinner::SignatureValid() - Got bad Masternode payment signature %s", vinMasternode.ToString().c_str());
+        if(!darkSendSigner.VerifyMessage(pmn->pubkey2, vchSig, strMessage, strError)) {
+            return error("CMasternodePaymentWinner::CheckSignature -- Got bad Masternode payment signature: vin=%s, error: %s", vinMasternode.ToString().c_str(), strError);
         }
 
         return true;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -323,8 +323,8 @@ bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasterno
                 boost::lexical_cast<std::string>(nBlockHeight) +
                 ScriptToAsmStr(payee);
 
-    if(!darkSendSigner.SignMessage(strMessage, errorMessage, vchSig, keyMasternode)) {
-        LogPrintf("CMasternodePing::Sign() - Error: %s\n", errorMessage);
+    if(!darkSendSigner.SignMessage(strMessage, vchSig, keyMasternode)) {
+        LogPrintf("CMasternodePaymentWinner::Sign -- SignMessage() failed\n");
         return false;
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -604,8 +604,8 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
                     pubkey.GetID().ToString() + pubkey2.GetID().ToString() +
                     boost::lexical_cast<std::string>(protocolVersion);
 
-    if(!darkSendSigner.SignMessage(strMessage, errorMessage, vchSig, keyCollateralAddress)) {
-        LogPrintf("CMasternodeBroadcast::Sign() - Error: %s\n", errorMessage);
+    if(!darkSendSigner.SignMessage(strMessage, vchSig, keyCollateralAddress)) {
+        LogPrintf("CMasternodeBroadcast::Sign -- SignMessage() failed\n");
         return false;
     }
 
@@ -716,8 +716,8 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
     sigTime = GetAdjustedTime();
     std::string strMessage = vin.ToString() + blockHash.ToString() + boost::lexical_cast<std::string>(sigTime);
 
-    if(!darkSendSigner.SignMessage(strMessage, errorMessage, vchSig, keyMasternode)) {
-        LogPrintf("CMasternodePing::Sign() - Error: %s\n", errorMessage);
+    if(!darkSendSigner.SignMessage(strMessage, vchSig, keyMasternode)) {
+        LogPrintf("CMasternodePing::Sign -- SignMessage() failed\n");
         return false;
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -595,7 +595,7 @@ void CMasternodeBroadcast::Relay()
 
 bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
 {
-    std::string errorMessage;
+    std::string strError;
     std::string strMessage;
 
     sigTime = GetAdjustedTime();
@@ -609,8 +609,8 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
         return false;
     }
 
-    if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)) {
-        LogPrintf("CMasternodeBroadcast::Sign() - Error: %s\n", errorMessage);
+    if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, strError)) {
+        LogPrintf("CMasternodeBroadcast::Sign -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 
@@ -620,7 +620,7 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
 bool CMasternodeBroadcast::VerifySignature(int& nDos)
 {
     std::string strMessage;
-    std::string errorMessage = "";
+    std::string strError = "";
     nDos = 0;
 
     //
@@ -636,7 +636,7 @@ bool CMasternodeBroadcast::VerifySignature(int& nDos)
             SanitizeString(strMessage), CBitcoinAddress(pubkey.GetID()).ToString(),
             EncodeBase64(&vchSig[0], vchSig.size()));
 
-        if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)){
+        if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, strError)) {
             if (addr.ToString() != addr.ToString(false))
             {
                 // maybe it's wrong format, try again with the old one
@@ -647,17 +647,17 @@ bool CMasternodeBroadcast::VerifySignature(int& nDos)
                     SanitizeString(strMessage), CBitcoinAddress(pubkey.GetID()).ToString(),
                     EncodeBase64(&vchSig[0], vchSig.size()));
 
-                if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)){
+                if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, strError)) {
                     // didn't work either
-                    LogPrintf("CMasternodeBroadcast::VerifySignature - Got bad Masternode address signature, second try, sanitized error: %s\n",
-                        SanitizeString(errorMessage));
+                    LogPrintf("CMasternodeBroadcast::VerifySignature -- Got bad Masternode announce signature, second try, sanitized error: %s\n",
+                        SanitizeString(strError));
                     // don't ban for old masternodes, their sigs could be broken because of the bug
                     return false;
                 }
             } else {
                 // nope, sig is actually wrong
-                LogPrintf("CMasternodeBroadcast::VerifySignature - Got bad Masternode address signature, sanitized error: %s\n",
-                    SanitizeString(errorMessage));
+                LogPrintf("CMasternodeBroadcast::VerifySignature -- Got bad Masternode announce signature, sanitized error: %s\n",
+                    SanitizeString(strError));
                 // don't ban for old masternodes, their sigs could be broken because of the bug
                 return false;
             }
@@ -672,8 +672,8 @@ bool CMasternodeBroadcast::VerifySignature(int& nDos)
 
         LogPrint("masternode", "CMasternodeBroadcast::VerifySignature - strMessage: %s, pubkey address: %s, sig: %s\n", strMessage, CBitcoinAddress(pubkey.GetID()).ToString(), EncodeBase64(&vchSig[0], vchSig.size()));
 
-        if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)){
-            LogPrintf("CMasternodeBroadcast::VerifySignature - Got bad Masternode address signature, error: %s\n", errorMessage);
+        if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, strError)){
+            LogPrintf("CMasternodeBroadcast::VerifySignature -- Got bad Masternode announce signature, error: %s\n", strError);
             nDos = 100;
             return false;
         }
@@ -710,7 +710,7 @@ CMasternodePing::CMasternodePing(CTxIn& newVin)
 
 bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    std::string errorMessage;
+    std::string strError;
     std::string strMasterNodeSignMessage;
 
     sigTime = GetAdjustedTime();
@@ -721,8 +721,8 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
         return false;
     }
 
-    if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-        LogPrintf("CMasternodePing::Sign() - Error: %s\n", errorMessage);
+    if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+        LogPrintf("CMasternodePing::Sign -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 
@@ -731,12 +731,11 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 
 bool CMasternodePing::VerifySignature(CPubKey& pubKeyMasternode, int &nDos) {
     std::string strMessage = vin.ToString() + blockHash.ToString() + boost::lexical_cast<std::string>(sigTime);
-    std::string errorMessage = "";
+    std::string strError = "";
     nDos = 0;
 
-    if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage))
-    {
-        LogPrintf("CMasternodePing::VerifySignature - Got bad Masternode ping signature %s Error: %s\n", vin.ToString(), errorMessage);
+    if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+        LogPrintf("CMasternodePing::VerifySignature -- Got bad Masternode ping signature: %s  error: %s\n", vin.ToString(), strError);
         nDos = 33;
         return false;
     }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -337,8 +337,8 @@ bool CMasternodeBroadcast::Create(std::string strService, std::string strKeyMast
         return false;
     }
 
-    if(!darkSendSigner.GetKeysFromSecret(strKeyMasternode, strErrorMessage, keyMasternodeNew, pubKeyMasternodeNew)) {
-        strErrorMessage = strprintf("Can't find keys for masternode %s, error: %s", strService, strErrorMessage);
+    if(!darkSendSigner.GetKeysFromSecret(strKeyMasternode, keyMasternodeNew, pubKeyMasternodeNew)) {
+        strErrorMessage = strprintf("Invalid masternode key %s", strKeyMasternode);
         LogPrintf("CMasternodeBroadcast::Create -- %s\n", strErrorMessage);
         return false;
     }

--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -312,10 +312,10 @@ UniValue gobject(const UniValue& params, bool fHelp)
 
             UniValue statusObj(UniValue::VOBJ);
 
-            if(!darkSendSigner.GetKeysFromSecret(mne.getPrivKey(), errorMessage, keyMasternode, pubKeyMasternode)){
+            if(!darkSendSigner.GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)) {
                 failed++;
                 statusObj.push_back(Pair("result", "failed"));
-                statusObj.push_back(Pair("errorMessage", "Masternode signing error, could not set key correctly: " + errorMessage));
+                statusObj.push_back(Pair("errorMessage", strprintf("Invalid masternode key %s.", mne.getPrivKey())));
                 resultsObj.push_back(Pair(mne.getAlias(), statusObj));
                 continue;
             }

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -201,8 +201,8 @@ bool CSporkMessage::Sign(std::string strSignKey)
     std::string strError = "";
     std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
 
-    if(!darkSendSigner.GetKeysFromSecret(strSignKey, strError, key, pubkey)) {
-        LogPrintf("CSporkMessage::Sign -- GetKeysFromSecret() failed, error: '%s'\n", strError);
+    if(!darkSendSigner.GetKeysFromSecret(strSignKey, key, pubkey)) {
+        LogPrintf("CSporkMessage::Sign -- GetKeysFromSecret() failed, invalid spork key %s\n", strSignKey);
         return false;
     }
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -196,14 +196,13 @@ bool CSporkManager::SetPrivKey(std::string strPrivKey)
 
 bool CSporkMessage::Sign(std::string strSignKey)
 {
-    std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
-
     CKey key;
     CPubKey pubkey;
-    std::string errorMessage = "";
+    std::string strError = "";
+    std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
 
-    if(!darkSendSigner.GetKeysFromSecret(strSignKey, errorMessage, key, pubkey)) {
-        LogPrintf("CSporkMessage::Sign -- ERROR: '%s'\n", errorMessage);
+    if(!darkSendSigner.GetKeysFromSecret(strSignKey, strError, key, pubkey)) {
+        LogPrintf("CSporkMessage::Sign -- GetKeysFromSecret() failed, error: '%s'\n", strError);
         return false;
     }
 
@@ -212,8 +211,8 @@ bool CSporkMessage::Sign(std::string strSignKey)
         return false;
     }
 
-    if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)) {
-        LogPrintf("CSporkMessage::Sign -- VerifyMessage() failed");
+    if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, strError)) {
+        LogPrintf("CSporkMessage::Sign -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 
@@ -223,12 +222,12 @@ bool CSporkMessage::Sign(std::string strSignKey)
 bool CSporkMessage::CheckSignature()
 {
     //note: need to investigate why this is failing
+    std::string strError = "";
     std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
     CPubKey pubkey(ParseHex(Params().SporkPubKey()));
 
-    std::string errorMessage = "";
-    if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)){
-        LogPrintf("CSporkMessage::CheckSignature -- VerifyMessage() failed");
+    if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, strError)) {
+        LogPrintf("CSporkMessage::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -207,8 +207,8 @@ bool CSporkMessage::Sign(std::string strSignKey)
         return false;
     }
 
-    if(!darkSendSigner.SignMessage(strMessage, errorMessage, vchSig, key)) {
-        LogPrintf("CSporkMessage::Sign -- SignMessage() failed");
+    if(!darkSendSigner.SignMessage(strMessage, vchSig, key)) {
+        LogPrintf("CSporkMessage::Sign -- SignMessage() failed\n");
         return false;
     }
 


### PR DESCRIPTION
Error messages in `SignMessage()` and `GetKeysFromSecret()` don't really help too much since there is only one way these functions can ever fail. Having localized error message in `VerifyMessage()` also do not help too much (and actually is annoying) since the only place it can be visible is debug.log. So changing these functions accordingly and also making sure that every caller gets proper debug.log output etc.