### PR TITLE
Refactor (and fix) CKeePassIntegrator

### DIFF
--- a/src/keepass.h
+++ b/src/keepass.h
@@ -9,13 +9,18 @@
 
 #include <univalue.h>
 
-static const int KEEPASS_CRYPTO_KEY_SIZE                = 32;
-static const int KEEPASS_CRYPTO_BLOCK_SIZE              = 16;
-static const int KEEPASS_HTTP_CONNECT_TIMEOUT           = 30;
+class CKeePassIntegrator;
+
 static const unsigned int DEFAULT_KEEPASS_HTTP_PORT     = 19455;
-static const char* KEEPASS_HTTP_HOST                    = "localhost";
+
+extern CKeePassIntegrator keePassInt;
 
 class CKeePassIntegrator {
+private:
+    static const int KEEPASS_CRYPTO_KEY_SIZE            = 32;
+    static const int KEEPASS_CRYPTO_BLOCK_SIZE          = 16;
+    static const int KEEPASS_HTTP_CONNECT_TIMEOUT       = 30;
+    static const char* KEEPASS_HTTP_HOST;
 
     bool bIsActive;
     unsigned int nPort;
@@ -23,27 +28,27 @@ class CKeePassIntegrator {
     SecureString sKey;
     SecureString sUrl;
     //SecureString sSubmitUrl;
-    std::string sKeePassId;
-    std::string sKeePassEntryName;
+    std::string strKeePassId;
+    std::string strKeePassEntryName;
 
     class CKeePassRequest {
 
         UniValue requestObj;
-        std::string sType;
-        std::string sIV;
+        std::string strType;
+        std::string strIV;
         SecureString sKey;
 
         void init();
 
     public:
-        void addStrParameter(std::string sName, std::string sValue); // Regular
-        void addStrParameter(std::string sName, SecureString sValue); // Encrypt
+        void addStrParameter(std::string strName, std::string strValue); // Regular
+        void addStrParameter(std::string strName, SecureString sValue); // Encrypt
         std::string getJson();
 
-        CKeePassRequest(SecureString sKey, std::string sType)
+        CKeePassRequest(SecureString sKey, std::string strType)
         {
             this->sKey = sKey;
-            this->sType = sType;
+            this->strType = strType;
             init();
         };
     };
@@ -51,30 +56,30 @@ class CKeePassIntegrator {
 
     class CKeePassEntry {
 
-        SecureString uuid;
-        SecureString name;
-        SecureString login;
-        SecureString password;
+        SecureString sUuid;
+        SecureString sName;
+        SecureString sLogin;
+        SecureString sPassword;
 
     public:
-        CKeePassEntry(SecureString uuid, SecureString name, SecureString login, SecureString password) :
-            uuid(uuid), name(name), login(login), password(password) {
+        CKeePassEntry(SecureString sUuid, SecureString sName, SecureString sLogin, SecureString sPassword) :
+            sUuid(sUuid), sName(sName), sLogin(sLogin), sPassword(sPassword) {
         }
 
         SecureString getUuid() {
-            return uuid;
+            return sUuid;
         }
 
         SecureString getName() {
-            return name;
+            return sName;
         }
 
         SecureString getLogin() {
-            return login;
+            return sLogin;
         }
 
         SecureString getPassword() {
-            return password;
+            return sPassword;
         }
 
     };
@@ -83,48 +88,46 @@ class CKeePassIntegrator {
     class CKeePassResponse {
 
         bool bSuccess;
-        std::string sType;
-        std::string sIV;
+        std::string strType;
+        std::string strIV;
         SecureString sKey;
 
-        void parseResponse(std::string sResponse);
+        void parseResponse(std::string strResponse);
 
     public:
         UniValue responseObj;
-        CKeePassResponse(SecureString sKey, std::string sResponse) {
+        CKeePassResponse(SecureString sKey, std::string strResponse) {
             this->sKey = sKey;
-            parseResponse(sResponse);
+            parseResponse(strResponse);
         }
 
         bool getSuccess() {
             return bSuccess;
         }
 
-        SecureString getSecureStr(std::string sName);
-        std::string getStr(std::string sName);
+        SecureString getSecureStr(std::string strName);
+        std::string getStr(std::string strName);
         std::vector<CKeePassEntry> getEntries();
 
-        SecureString decrypt(std::string sValue); // DecodeBase64 and decrypt arbitrary string value
+        SecureString decrypt(std::string strValue); // DecodeBase64 and decrypt arbitrary string value
 
     };
 
     static SecureString generateRandomKey(size_t nSize);
     static std::string constructHTTPPost(const std::string& strMsg, const std::map<std::string,std::string>& mapRequestHeaders);
-    void doHTTPPost(const std::string& sRequest, int& nStatus, std::string& sResponse);
+    void doHTTPPost(const std::string& strRequest, int& nStatus, std::string& strResponse);
     void rpcTestAssociation(bool bTriggerUnlock);
     std::vector<CKeePassEntry> rpcGetLogins();
-    void rpcSetLogin(const SecureString& strWalletPass, const SecureString& sEntryId);
+    void rpcSetLogin(const SecureString& sWalletPass, const SecureString& sEntryId);
 
 public:
     CKeePassIntegrator();
     void init();
     static SecureString generateKeePassKey();
-    void rpcAssociate(std::string& sId, SecureString& sKeyBase64);
+    void rpcAssociate(std::string& strId, SecureString& sKeyBase64);
     SecureString retrievePassphrase();
     void updatePassphrase(const SecureString& sWalletPassphrase);
 
 };
-
-extern CKeePassIntegrator keePassInt;
 
 #endif

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2411,28 +2411,25 @@ UniValue keepass(const UniValue& params, bool fHelp) {
 
     if (strCommand == "genkey")
     {
-        SecureString result;
+        SecureString sResult;
         // Generate RSA key
-        //std::string keePassKey = CKeePassIntegrator::generateKey();
-        //return keePassKey;
         SecureString sKey = CKeePassIntegrator::generateKeePassKey();
-        result = "Generated Key: ";
-        result += sKey;
-        return result.c_str();
+        sResult = "Generated Key: ";
+        sResult += sKey;
+        return sResult.c_str();
     }
     else if(strCommand == "init")
     {
         // Generate base64 encoded 256 bit RSA key and associate with KeePassHttp
-        SecureString result;
+        SecureString sResult;
         SecureString sKey;
-        std::string sId;
-        std::string sErrorMessage;
-        keePassInt.rpcAssociate(sId, sKey);
-        result = "Association successful. Id: ";
-        result += sId.c_str();
-        result += " - Key: ";
-        result += sKey.c_str();
-        return result.c_str();
+        std::string strId;
+        keePassInt.rpcAssociate(strId, sKey);
+        sResult = "Association successful. Id: ";
+        sResult += strId.c_str();
+        sResult += " - Key: ";
+        sResult += sKey.c_str();
+        return sResult.c_str();
     }
     else if(strCommand == "setpassphrase")
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -252,7 +252,7 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool anonymizeOnly
     }
 
     // Verify KeePassIntegration
-    if(strWalletPassphrase == "keepass" && GetBoolArg("-keepass", false)) {
+    if (strWalletPassphrase == "keepass" && GetBoolArg("-keepass", false)) {
         try {
             strWalletPassphraseFinal = keePassInt.retrievePassphrase();
         } catch (std::exception& e) {
@@ -270,7 +270,7 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool anonymizeOnly
         LOCK(cs_wallet);
         BOOST_FOREACH(const MasterKeyMap::value_type& pMasterKey, mapMasterKeys)
         {
-            if(!crypter.SetKeyFromPassphrase(strWalletPassphraseFinal, pMasterKey.second.vchSalt, pMasterKey.second.nDeriveIterations, pMasterKey.second.nDerivationMethod))
+            if (!crypter.SetKeyFromPassphrase(strWalletPassphraseFinal, pMasterKey.second.vchSalt, pMasterKey.second.nDeriveIterations, pMasterKey.second.nDerivationMethod))
                 return false;
             if (!crypter.Decrypt(pMasterKey.second.vchCryptedKey, vMasterKey))
                 continue; // try another master key
@@ -302,7 +302,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
         try {
             strOldWalletPassphraseFinal = keePassInt.retrievePassphrase();
         } catch (std::exception& e) {
-            LogPrintf("CWallet::ChangeWalletPassphrase could not retrieve passphrase from KeePass: Error: %s\n", e.what());
+            LogPrintf("CWallet::ChangeWalletPassphrase -- could not retrieve passphrase from KeePass: Error: %s\n", e.what());
             return false;
         }
     } else {
@@ -346,11 +346,11 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
 
                 // Update KeePass if necessary
                 if(bUseKeePass) {
-                    LogPrintf("CWallet::ChangeWalletPassphrase - Updating KeePass with new passphrase");
+                    LogPrintf("CWallet::ChangeWalletPassphrase -- Updating KeePass with new passphrase");
                     try {
                         keePassInt.updatePassphrase(strNewWalletPassphrase);
                     } catch (std::exception& e) {
-                        LogPrintf("CWallet::ChangeWalletPassphrase - could not update passphrase in KeePass: Error: %s\n", e.what());
+                        LogPrintf("CWallet::ChangeWalletPassphrase -- could not update passphrase in KeePass: Error: %s\n", e.what());
                         return false;
                     }
                 }
@@ -653,11 +653,11 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 
         // Update KeePass if necessary
         if(GetBoolArg("-keepass", false)) {
-            LogPrintf("CWallet::EncryptWallet - Updating KeePass with new passphrase");
+            LogPrintf("CWallet::EncryptWallet -- Updating KeePass with new passphrase");
             try {
                 keePassInt.updatePassphrase(strWalletPassphrase);
             } catch (std::exception& e) {
-                LogPrintf("CWallet::EncryptWallet - could not update passphrase in KeePass: Error: %s\n", e.what());
+                LogPrintf("CWallet::EncryptWallet -- could not update passphrase in KeePass: Error: %s\n", e.what());
             }
         }
 


### PR DESCRIPTION
That one was written a long time ago and uses few notations at once which makes it hard to read. Mostly changing to `SecureString sSmth` and `std::string strSmth` to be able easily distinguish between two. Most consts aren't used anywhere else so moved them to private. And finally, fixed the way `KEEPASS_HTTP_HOST` is initialized.