### PR TITLE
Decouple mn payments from version.h, drop MIN_MNW_PEER_PROTO_VERSION

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -292,7 +292,7 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, std::string& strCommand, 
         CMasternodePaymentWinner winner;
         vRecv >> winner;
 
-        if(pfrom->nVersion < MIN_MNW_PEER_PROTO_VERSION) return;
+        if(pfrom->nVersion < GetMinMasternodePaymentsProto()) return;
 
         if(!pCurrentBlockIndex) return;
 
@@ -555,12 +555,13 @@ bool CMasternodePaymentWinner::IsValid(CNode* pnode, int nValidationHeight, std:
         return false;
     }
 
-    if(pmn->protocolVersion < MIN_MNW_PEER_PROTO_VERSION) {
-        strError = strprintf("Masternode protocol is too old: protocolVersion=%d, MIN_MNW_PEER_PROTO_VERSION=%d", pmn->protocolVersion, MIN_MNW_PEER_PROTO_VERSION);
+    int nMinRequiredProtocol = mnpayments.GetMinMasternodePaymentsProto();
+    if(pmn->protocolVersion < nMinRequiredProtocol) {
+        strError = strprintf("Masternode protocol is too old: nProtocolVersion=%d, nMinRequiredProtocol=%d", pmn->protocolVersion, nMinRequiredProtocol);
         return false;
     }
 
-    int nRank = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight - 101, MIN_MNW_PEER_PROTO_VERSION);
+    int nRank = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight - 101, nMinRequiredProtocol);
 
     if(nRank > MNPAYMENTS_SIGNATURES_TOTAL) {
         // It's common to have masternodes mistakenly think they are in the top 10
@@ -588,20 +589,18 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     // but we have no choice, so we'll try. However it doesn't make sense to even try to do so
     // if we have not enough data about masternodes.
     if(!masternodeSync.IsMasternodeListSynced()) return false;
-    
-    int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight - 101, MIN_MNW_PEER_PROTO_VERSION);
-       
-    if(n == -1)       
-    {     
-        LogPrint("mnpayments", "CMasternodePayments::ProcessBlock - Unknown Masternode\n");       
-        return false;     
-    }     
 
-    if(n > MNPAYMENTS_SIGNATURES_TOTAL)       
-    {     
-        LogPrint("mnpayments", "CMasternodePayments::ProcessBlock - Masternode not in the top %d (%d)\n", MNPAYMENTS_SIGNATURES_TOTAL, n);        
-        return false;     
-    }      
+    int nRank = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight - 101, GetMinMasternodePaymentsProto());
+
+    if (nRank == -1) {
+        LogPrint("mnpayments", "CMasternodePayments::ProcessBlock -- Unknown Masternode\n");
+        return false;
+    }
+
+    if (nRank > MNPAYMENTS_SIGNATURES_TOTAL) {
+        LogPrint("mnpayments", "CMasternodePayments::ProcessBlock -- Masternode not in the top %d (%d)\n", MNPAYMENTS_SIGNATURES_TOTAL, nRank);
+        return false;
+    }
 
 
     // LOCATE THE NEXT MASTERNODE WHICH SHOULD BE PAID

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -555,7 +555,15 @@ bool CMasternodePaymentWinner::IsValid(CNode* pnode, int nValidationHeight, std:
         return false;
     }
 
-    int nMinRequiredProtocol = mnpayments.GetMinMasternodePaymentsProto();
+    int nMinRequiredProtocol;
+    if(nBlockHeight > nValidationHeight) {
+        // new winners must comply SPORK_10_MASTERNODE_PAY_UPDATED_NODES rules
+        nMinRequiredProtocol = mnpayments.GetMinMasternodePaymentsProto();
+    } else {
+        // allow non-updated masternodes for old blocks
+        nMinRequiredProtocol = MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1;
+    }
+
     if(pmn->protocolVersion < nMinRequiredProtocol) {
         strError = strprintf("Masternode protocol is too old: nProtocolVersion=%d, nMinRequiredProtocol=%d", pmn->protocolVersion, nMinRequiredProtocol);
         return false;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -17,6 +17,13 @@
 
 using namespace std;
 
+//! minimum peer version that can receive and send masternode payment messages,
+//  vote for masternode winner and be elected as a winner
+// V1 - Last protocol version before update
+// V2 - Newest protocol version
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70103;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70201;
+
 extern CCriticalSection cs_vecPayments;
 extern CCriticalSection cs_mapMasternodeBlocks;
 extern CCriticalSection cs_mapMasternodePayeeVotes;

--- a/src/version.h
+++ b/src/version.h
@@ -24,15 +24,6 @@ static const int MIN_PEER_PROTO_VERSION = 70103;
 //! minimum peer version for masternode budgets
 static const int MSG_GOVERNANCE_PEER_PROTO_VERSION = 70201;
 
-//! minimum peer version for masternode winner broadcasts
-static const int MIN_MNW_PEER_PROTO_VERSION = 70103;
-
-//! minimum peer version that can receive masternode payments
-// V1 - Last protocol version before update
-// V2 - Newest protocol version
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70103;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70201;
-
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this
 static const int CADDR_TIME_VERSION = 31402;


### PR DESCRIPTION
Changes:
- decouple payments from from `version.h`, move `MIN_MASTERNODE_PAYMENT_PROTO_VERSION_*` to `masternode-payments.h`
- drop `MIN_MNW_PEER_PROTO_VERSION` in fav of `GetMinMasternodePaymentsProto()`, imo  when spork10 is switched to "new only" state there is no reason to receive `MNWINNER` from outdated peers or to allow them to vote for new winner

EDIT: Any cases where having separate `MIN_MNW_PEER_PROTO_VERSION` could be helpful but I'm missing it?