### PR TITLE
Masternode sync improvements

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2313,7 +2313,7 @@ void CDarksendPool::UpdatedBlockTip(const CBlockIndex *pindex)
     pCurrentBlockIndex = pindex;
     LogPrint("privatesend", "CDarksendPool::UpdatedBlockTip -- pCurrentBlockIndex->nHeight: %d\n", pCurrentBlockIndex->nHeight);
 
-    if(!fLiteMode && masternodeSync.GetAssetID() > MASTERNODE_SYNC_LIST) {
+    if(!fLiteMode && masternodeSync.IsMasternodeListSynced()) {
         NewBlock();
     }
 }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -281,6 +281,9 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
     // A NEW GOVERNANCE OBJECT VOTE HAS ARRIVED
     else if (strCommand == NetMsgType::MNGOVERNANCEOBJECTVOTE)
     {
+        // Ignore such messages until masternode list is synced
+        if(!masternodeSync.IsMasternodeListSynced()) return;
+
         CGovernanceVote vote;
         vRecv >> vote;
         vote.fValid = true;
@@ -551,12 +554,11 @@ struct sortProposalsByVotes {
 
 void CGovernanceManager::NewBlock()
 {
+    // IF WE'RE NOT SYNCED, EXIT
+    if(!masternodeSync.IsSynced()) return;
+
     TRY_LOCK(cs, fBudgetNewBlock);
     if(!fBudgetNewBlock || !pCurrentBlockIndex) return;
-
-    // IF WE'RE NOT SYNCED, EXIT
-
-    if(!masternodeSync.IsSynced()) return;
 
     // CHECK OBJECTS WE'VE ASKED FOR, REMOVE OLD ENTRIES
 
@@ -1065,7 +1067,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex)
 
     // TO REPROCESS OBJECTS WE SHOULD BE SYNCED
 
-    if(!fLiteMode && masternodeSync.GetAssetID() > MASTERNODE_SYNC_LIST)
+    if(!fLiteMode && masternodeSync.IsSynced())
         NewBlock();
 }
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -47,7 +47,9 @@ void ProcessMessageInstantSend(CNode* pfrom, std::string& strCommand, CDataStrea
 {
     if(fLiteMode) return; // disable all Dash specific functionality
     if(!sporkManager.IsSporkActive(SPORK_2_INSTANTX)) return;
-    if(!masternodeSync.IsBlockchainSynced()) return;
+
+    // Ignore any InstantSend messages until masternode list is synced
+    if(!masternodeSync.IsMasternodeListSynced()) return;
 
     if (strCommand == NetMsgType::IX)
     {

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -11,6 +11,7 @@
 
 class CMasternodeSync;
 
+static const int MASTERNODE_SYNC_FAILED          = -1;
 static const int MASTERNODE_SYNC_INITIAL         = 0;
 static const int MASTERNODE_SYNC_SPORKS          = 1;
 static const int MASTERNODE_SYNC_LIST            = 2;
@@ -18,7 +19,6 @@ static const int MASTERNODE_SYNC_MNW             = 3;
 static const int MASTERNODE_SYNC_GOVERNANCE      = 4;
 static const int MASTERNODE_SYNC_GOVOBJ          = 10;
 static const int MASTERNODE_SYNC_GOVERNANCE_FIN  = 11;
-static const int MASTERNODE_SYNC_FAILED          = 998;
 static const int MASTERNODE_SYNC_FINISHED        = 999;
 
 static const int MASTERNODE_SYNC_TIMEOUT_SECONDS = 30; // our blocks are 2.5 minutes so 30 seconds should be fine
@@ -80,8 +80,10 @@ public:
     void AddedBudgetItem(uint256 hash);
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
-    bool IsSynced() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED; }
     bool IsBlockchainSynced();
+    bool IsMasternodeListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
+    bool IsWinnersListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_MNW; }
+    bool IsSynced() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED; }
 
     int GetAssetID() { return nRequestedMasternodeAssets; }
     int GetAttempt() { return nRequestedMasternodeAttempt; }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -568,9 +568,12 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         } else {
             if(nDos > 0) Misbehaving(pfrom->GetId(), nDos);
         }
-    }
 
-    else if (strCommand == NetMsgType::MNPING) { //Masternode Ping
+    } else if (strCommand == NetMsgType::MNPING) { //Masternode Ping
+
+        // ignore masternode pings until masternode list is synced
+        if (!masternodeSync.IsMasternodeListSynced()) return;
+
         CMasternodePing mnp;
         vRecv >> mnp;
 
@@ -600,7 +603,9 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
     } else if (strCommand == NetMsgType::DSEG) { //Get Masternode list or specific entry
 
-        // ignore such request until we are fully synced
+        // Ignore such requests until we are fully synced.
+        // We could start processing this after masternode list is synced
+        // but this is a heavy one so it's better to finish sync first.
         if (!masternodeSync.IsSynced()) return;
 
         CTxIn vin;

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -363,7 +363,7 @@ void MasternodeList::on_startAllButton_clicked()
 void MasternodeList::on_startMissingButton_clicked()
 {
 
-    if(masternodeSync.GetAssetID() <= MASTERNODE_SYNC_LIST || masternodeSync.IsFailed()) {
+    if(!masternodeSync.IsMasternodeListSynced()) {
         QMessageBox::critical(this, tr("Command is not available right now"),
             tr("You can't use this command until masternode list is synced"));
         return;

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -319,9 +319,8 @@ UniValue masternode(const UniValue& params, bool fHelp)
             }
         }
 
-        if((strCommand == "start-missing" || strCommand == "start-disabled") &&
-            (masternodeSync.GetAssetID() <= MASTERNODE_SYNC_LIST || masternodeSync.IsFailed())) {
-                throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "You can't use this command until masternode list is synced");
+        if((strCommand == "start-missing" || strCommand == "start-disabled") && !masternodeSync.IsMasternodeListSynced()) {
+            throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "You can't use this command until masternode list is synced");
         }
 
         int successful = 0;

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -155,6 +155,8 @@ UniValue mnsync(const UniValue& params, bool fHelp)
         objStatus.push_back(Pair("AssetName", masternodeSync.GetAssetName()));
         objStatus.push_back(Pair("Attempt", masternodeSync.GetAttempt()));
         objStatus.push_back(Pair("IsBlockchainSynced", masternodeSync.IsBlockchainSynced()));
+        objStatus.push_back(Pair("IsMasternodeListSynced", masternodeSync.IsMasternodeListSynced()));
+        objStatus.push_back(Pair("IsWinnersListSynced", masternodeSync.IsWinnersListSynced()));
         objStatus.push_back(Pair("IsSynced", masternodeSync.IsSynced()));
         objStatus.push_back(Pair("IsFailed", masternodeSync.IsFailed()));
         return objStatus;


### PR DESCRIPTION
Masternode sync improvements:
- add simple helpers for few more sync states (use them where appropriate instead of old code + rpc output)
- use new helpers to avoid meaningless message processing
- actually fail if sync shouldn't continue due to lack of info, make sure Reset is used to quit failed state