### PR TITLE
Slightly refactor sporks

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -89,7 +89,7 @@ bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockRewar
         }
 
         // triggered but invalid? that's weird
-        if(sporkManager.IsSporkActive(SPORK_9_MASTERNODE_SUPERBLOCK_ENFORCEMENT)) {
+        if(sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED)) {
             LogPrintf("IsBlockValueValid -- ERROR: Invalid superblock detected at height %d: %s", nBlockHeight, block.vtx[0].ToString());
             // should NOT allow invalid superblocks, when superblock enforcement is enabled
             return false;
@@ -155,7 +155,7 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount bloc
             return true;
         }
 
-        if(sporkManager.IsSporkActive(SPORK_9_MASTERNODE_SUPERBLOCK_ENFORCEMENT)) {
+        if(sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED)) {
             LogPrintf("IsBlockPayeeValid -- ERROR: Invalid superblock detected at height %d: %s", nBlockHeight, txNew.ToString());
             // should NOT allow such superblocks, when superblock enforcement is enabled
             return false;
@@ -187,7 +187,7 @@ void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blo
 {
     // only create superblocks if spork is enabled AND if superblock is actually triggered
     // (height should be validated inside)
-    if(sporkManager.IsSporkActive(SPORK_9_MASTERNODE_SUPERBLOCK_ENFORCEMENT) &&
+    if(sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED) &&
         CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
             LogPrint("gobject", "FillBlockPayments -- triggered superblock creation at height %d\n", nBlockHeight);
             CSuperblockManager::CreateSuperblock(txNew, nBlockHeight, voutSuperblockRet);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -638,7 +638,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     }
     result.push_back(Pair("superblock", superblockObjArray));
     result.push_back(Pair("superblocks_started", pindexPrev->nHeight + 1 > Params().GetConsensus().nSuperblockStartBlock));
-    result.push_back(Pair("superblocks_enabled", sporkManager.IsSporkActive(SPORK_9_MASTERNODE_SUPERBLOCK_ENFORCEMENT)));
+    result.push_back(Pair("superblocks_enabled", sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED)));
 
     return result;
 }

--- a/src/spork.h
+++ b/src/spork.h
@@ -9,37 +9,35 @@
 #include "net.h"
 #include "utilstrencodings.h"
 
+class CSporkMessage;
+class CSporkManager;
+
 /*
     Don't ever reuse these IDs for other sporks
     - This would result in old clients getting confused about which spork is for what
 */
-#define SPORK_START                                           10001
-#define SPORK_END                                             10012
+static const int SPORK_START                                            = 10001;
+static const int SPORK_END                                              = 10012;
 
-#define SPORK_2_INSTANTX                                      10001
-#define SPORK_3_INSTANTX_BLOCK_FILTERING                      10002
-#define SPORK_5_MAX_VALUE                                     10004
-#define SPORK_7_MASTERNODE_SCANNING                           10006
-#define SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT                10007
-#define SPORK_9_MASTERNODE_SUPERBLOCK_ENFORCEMENT             10008
-#define SPORK_10_MASTERNODE_PAY_UPDATED_NODES                 10009
-#define SPORK_11_RESET_BUDGET                                 10010
-#define SPORK_12_RECONSIDER_BLOCKS                            10011
-#define SPORK_13_OLD_SUPERBLOCK_FLAG                          10012
+static const int SPORK_2_INSTANTX                                       = 10001;
+static const int SPORK_3_INSTANTX_BLOCK_FILTERING                       = 10002;
+static const int SPORK_5_MAX_VALUE                                      = 10004;
+static const int SPORK_7_MASTERNODE_SCANNING                            = 10006;
+static const int SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT                 = 10007;
+static const int SPORK_9_SUPERBLOCKS_ENABLED                            = 10008;
+static const int SPORK_10_MASTERNODE_PAY_UPDATED_NODES                  = 10009;
+static const int SPORK_12_RECONSIDER_BLOCKS                             = 10011;
+static const int SPORK_13_OLD_SUPERBLOCK_FLAG                           = 10012;
 
-#define SPORK_2_INSTANTX_DEFAULT                              978307200   //2001-1-1
-#define SPORK_3_INSTANTX_BLOCK_FILTERING_DEFAULT              1424217600  //2015-2-18
-#define SPORK_5_MAX_VALUE_DEFAULT                             1000        //1000 DASH
-#define SPORK_7_MASTERNODE_SCANNING_DEFAULT                   978307200   //2001-1-1
-#define SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT_DEFAULT        4070908800   //OFF
-#define SPORK_9_MASTERNODE_SUPERBLOCK_ENFORCEMENT_DEFAULT     4070908800   //OFF
-#define SPORK_10_MASTERNODE_PAY_UPDATED_NODES_DEFAULT         4070908800   //OFF
-#define SPORK_11_RESET_BUDGET_DEFAULT                         0
-#define SPORK_12_RECONSIDER_BLOCKS_DEFAULT                    0
-#define SPORK_13_OLD_SUPERBLOCK_FLAG_DEFAULT                  4070908800   //OFF
-
-class CSporkMessage;
-class CSporkManager;
+static const int64_t SPORK_2_INSTANTX_DEFAULT                           = 978307200;    //2001-1-1
+static const int64_t SPORK_3_INSTANTX_BLOCK_FILTERING_DEFAULT           = 1424217600;   //2015-2-18
+static const int64_t SPORK_5_MAX_VALUE_DEFAULT                          = 1000;         //1000 DASH
+static const int64_t SPORK_7_MASTERNODE_SCANNING_DEFAULT                = 978307200;    //2001-1-1
+static const int64_t SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT_DEFAULT     = 4070908800;   //OFF
+static const int64_t SPORK_9_SUPERBLOCKS_ENABLED_DEFAULT                = 4070908800;   //OFF
+static const int64_t SPORK_10_MASTERNODE_PAY_UPDATED_NODES_DEFAULT      = 4070908800;   //OFF
+static const int64_t SPORK_12_RECONSIDER_BLOCKS_DEFAULT                 = 0;
+static const int64_t SPORK_13_OLD_SUPERBLOCK_FLAG_DEFAULT               = 4070908800;   //OFF
 
 extern std::map<uint256, CSporkMessage> mapSporks;
 extern CSporkManager sporkManager;
@@ -59,10 +57,30 @@ public:
     int64_t nValue;
     int64_t nTimeSigned;
 
-    CSporkMessage(int nSporkID, int64_t nValue, int64_t nTimeSigned) : nSporkID(nSporkID), nValue(nValue), nTimeSigned(nTimeSigned) {}
-    CSporkMessage() : nSporkID(0), nValue(0), nTimeSigned(0) {}
+    CSporkMessage(int nSporkID, int64_t nValue, int64_t nTimeSigned) :
+        nSporkID(nSporkID),
+        nValue(nValue),
+        nTimeSigned(nTimeSigned)
+        {}
 
-    uint256 GetHash()
+    CSporkMessage() :
+        nSporkID(0),
+        nValue(0),
+        nTimeSigned(0)
+        {}
+
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(nSporkID);
+        READWRITE(nValue);
+        READWRITE(nTimeSigned);
+        READWRITE(vchSig);
+    }
+
+    uint256 GetHash() const
     {
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << nSporkID;
@@ -74,16 +92,6 @@ public:
     bool Sign(std::string strSignKey);
     bool CheckSignature();
     void Relay();
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(nSporkID);
-        READWRITE(nValue);
-        READWRITE(nTimeSigned);
-        READWRITE(vchSig);
-    }
 };
 
 


### PR DESCRIPTION
Slightly refactor sporks:
- rename SPORK_9_MASTERNODE_SUPERBLOCK_ENFORCEMENT to SPORK_9_SUPERBLOCKS_ENABLED
- remove SPORK_11_RESET_BUDGET (not used anymore)
- change multiple `if`-s to `switch` where possible, return early.