### PR TITLE
CONTRIBUTING.md missing at that place

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `master` branch is meant to be stable. Development is normally done in separ
 [Tags](https://github.com/dashpay/dash/tags) are created to indicate new official,
 stable release versions of Dash Core.
 
-The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
+The contribution workflow is described in [CONTRIBUTING.md](https://github.com/dashpay/dash/blob/v0.12.1.1/CONTRIBUTING.md).
 
 
 Testing

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The `master` branch is meant to be stable. Development is normally done in separ
 [Tags](https://github.com/dashpay/dash/tags) are created to indicate new official,
 stable release versions of Dash Core.
 
-The contribution workflow is described in [CONTRIBUTING.md](https://github.com/dashpay/dash/blob/v0.12.1.1/CONTRIBUTING.md).
+The contribution workflow is described in [CONTRIBUTING.md](https://github.com/dashpay/dash/blob/v0.12.1.x/CONTRIBUTING.md).
 
 
 Testing


### PR DESCRIPTION
I'm NOT sure it's best to point to this specific file (and not e.g. copy it to the place that was pointed to). Also problematic if forked (possible to have a relative path?) See here: https://github.com/dashpay/dash/pull/840#issuecomment-222540862
[skip ci]