### PR TITLE
Changes for sporks

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -46,7 +46,7 @@ CCriticalSection cs_instantsend;
 void ProcessMessageInstantSend(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
     if(fLiteMode) return; // disable all Dash specific functionality
-    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTX)) return;
+    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED)) return;
 
     // Ignore any InstantSend messages until masternode list is synced
     if(!masternodeSync.IsMasternodeListSynced()) return;
@@ -194,7 +194,7 @@ bool IsInstantSendTxValid(const CTransaction& txCollateral)
         }
     }
 
-    if(nValueOut > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)*COIN) {
+    if(nValueOut > sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)*COIN) {
         LogPrint("instantsend", "IsInstantSendTxValid -- Transaction value too high: nValueOut=%d, txCollateral=%s", nValueOut, txCollateral.ToString());
         return false;
     }
@@ -523,7 +523,7 @@ bool IsLockedInstandSendTransaction(uint256 txHash)
 int GetTransactionLockSignatures(uint256 txHash)
 {
     if(fLargeWorkForkFound || fLargeWorkInvalidChainFound) return -2;
-    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTX)) return -3;
+    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED)) return -3;
     if(!fEnableInstantSend) return -1;
 
     std::map<uint256, CTransactionLock>::iterator it = mapTxLocks.find(txHash);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3730,7 +3730,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
     // DASH : CHECK TRANSACTIONS FOR INSTANT SEND
 
-    if(sporkManager.IsSporkActive(SPORK_3_INSTANTX_BLOCK_FILTERING)){
+    if(sporkManager.IsSporkActive(SPORK_3_INSTANTSEND_BLOCK_FILTERING)) {
         BOOST_FOREACH(const CTransaction& tx, block.vtx){
             if (!tx.IsCoinBase()){
                 // LOOK FOR TRANSACTION LOCK IN OUR MAP OF INPUTS

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -294,8 +294,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         CWalletTx *newTx = transaction.getTransaction();
         CReserveKey *keyChange = transaction.getPossibleKeyChange();
 
-        if(recipients[0].useInstantX && total > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
-            Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH.").arg(sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)),
+        if(recipients[0].useInstantX && total > sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)*COIN){
+            Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH.").arg(sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)),
                          CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }
@@ -305,8 +305,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         if (fSubtractFeeFromAmount && fCreated)
             transaction.reassignAmounts(nChangePosRet);
 
-        if(recipients[0].useInstantX && newTx->GetValueOut() > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)*COIN){
-            Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH.").arg(sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)),
+        if(recipients[0].useInstantX && newTx->GetValueOut() > sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)*COIN){
+            Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH.").arg(sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)),
                          CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -100,10 +100,9 @@ bool CSporkManager::IsSporkActive(int nSporkID)
         r = mapSporksActive[nSporkID].nValue;
     } else {
         switch (nSporkID) {
-            case SPORK_2_INSTANTX:                          r = SPORK_2_INSTANTX_DEFAULT; break;
-            case SPORK_3_INSTANTX_BLOCK_FILTERING:          r = SPORK_3_INSTANTX_BLOCK_FILTERING_DEFAULT; break;
-            case SPORK_5_MAX_VALUE:                         r = SPORK_5_MAX_VALUE_DEFAULT; break;
-            case SPORK_7_MASTERNODE_SCANNING:               r = SPORK_7_MASTERNODE_SCANNING_DEFAULT; break;
+            case SPORK_2_INSTANTSEND_ENABLED:               r = SPORK_2_INSTANTSEND_ENABLED_DEFAULT; break;
+            case SPORK_3_INSTANTSEND_BLOCK_FILTERING:       r = SPORK_3_INSTANTSEND_BLOCK_FILTERING_DEFAULT; break;
+            case SPORK_5_INSTANTSEND_MAX_VALUE:             r = SPORK_5_INSTANTSEND_MAX_VALUE_DEFAULT; break;
             case SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT:    r = SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT_DEFAULT; break;
             case SPORK_9_SUPERBLOCKS_ENABLED:               r = SPORK_9_SUPERBLOCKS_ENABLED_DEFAULT; break;
             case SPORK_10_MASTERNODE_PAY_UPDATED_NODES:     r = SPORK_10_MASTERNODE_PAY_UPDATED_NODES_DEFAULT; break;
@@ -126,10 +125,9 @@ int64_t CSporkManager::GetSporkValue(int nSporkID)
         return mapSporksActive[nSporkID].nValue;
 
     switch (nSporkID) {
-        case SPORK_2_INSTANTX:                          return SPORK_2_INSTANTX_DEFAULT;
-        case SPORK_3_INSTANTX_BLOCK_FILTERING:          return SPORK_3_INSTANTX_BLOCK_FILTERING_DEFAULT;
-        case SPORK_5_MAX_VALUE:                         return SPORK_5_MAX_VALUE_DEFAULT;
-        case SPORK_7_MASTERNODE_SCANNING:               return SPORK_7_MASTERNODE_SCANNING_DEFAULT;
+        case SPORK_2_INSTANTSEND_ENABLED:               return SPORK_2_INSTANTSEND_ENABLED_DEFAULT;
+        case SPORK_3_INSTANTSEND_BLOCK_FILTERING:       return SPORK_3_INSTANTSEND_BLOCK_FILTERING_DEFAULT;
+        case SPORK_5_INSTANTSEND_MAX_VALUE:             return SPORK_5_INSTANTSEND_MAX_VALUE_DEFAULT;
         case SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT:    return SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT_DEFAULT;
         case SPORK_9_SUPERBLOCKS_ENABLED:               return SPORK_9_SUPERBLOCKS_ENABLED_DEFAULT;
         case SPORK_10_MASTERNODE_PAY_UPDATED_NODES:     return SPORK_10_MASTERNODE_PAY_UPDATED_NODES_DEFAULT;
@@ -144,10 +142,9 @@ int64_t CSporkManager::GetSporkValue(int nSporkID)
 
 int CSporkManager::GetSporkIDByName(std::string strName)
 {
-    if (strName == "SPORK_2_INSTANTX")                          return SPORK_2_INSTANTX;
-    if (strName == "SPORK_3_INSTANTX_BLOCK_FILTERING")          return SPORK_3_INSTANTX_BLOCK_FILTERING;
-    if (strName == "SPORK_5_MAX_VALUE")                         return SPORK_5_MAX_VALUE;
-    if (strName == "SPORK_7_MASTERNODE_SCANNING")               return SPORK_7_MASTERNODE_SCANNING;
+    if (strName == "SPORK_2_INSTANTSEND_ENABLED")               return SPORK_2_INSTANTSEND_ENABLED;
+    if (strName == "SPORK_3_INSTANTSEND_BLOCK_FILTERING")       return SPORK_3_INSTANTSEND_BLOCK_FILTERING;
+    if (strName == "SPORK_5_INSTANTSEND_MAX_VALUE")             return SPORK_5_INSTANTSEND_MAX_VALUE;
     if (strName == "SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT")    return SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT;
     if (strName == "SPORK_9_SUPERBLOCKS_ENABLED")               return SPORK_9_SUPERBLOCKS_ENABLED;
     if (strName == "SPORK_10_MASTERNODE_PAY_UPDATED_NODES")     return SPORK_10_MASTERNODE_PAY_UPDATED_NODES;
@@ -161,14 +158,13 @@ int CSporkManager::GetSporkIDByName(std::string strName)
 std::string CSporkManager::GetSporkNameByID(int nSporkID)
 {
     switch (nSporkID) {
-        case SPORK_2_INSTANTX:                          return "SPORK_2_INSTANTX_DEFAULT";
-        case SPORK_3_INSTANTX_BLOCK_FILTERING:          return "SPORK_3_INSTANTX_BLOCK_FILTERING_DEFAULT";
-        case SPORK_5_MAX_VALUE:                         return "SPORK_5_MAX_VALUE_DEFAULT";
-        case SPORK_7_MASTERNODE_SCANNING:               return "SPORK_7_MASTERNODE_SCANNING_DEFAULT";
-        case SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT:    return "SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT_DEFAULT";
+        case SPORK_2_INSTANTSEND_ENABLED:               return "SPORK_2_INSTANTSEND_ENABLED";
+        case SPORK_3_INSTANTSEND_BLOCK_FILTERING:       return "SPORK_3_INSTANTSEND_BLOCK_FILTERING";
+        case SPORK_5_INSTANTSEND_MAX_VALUE:             return "SPORK_5_INSTANTSEND_MAX_VALUE";
+        case SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT:    return "SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT";
         case SPORK_9_SUPERBLOCKS_ENABLED:               return "SPORK_9_SUPERBLOCKS_ENABLED";
-        case SPORK_10_MASTERNODE_PAY_UPDATED_NODES:     return "SPORK_10_MASTERNODE_PAY_UPDATED_NODES_DEFAULT";
-        case SPORK_12_RECONSIDER_BLOCKS:                return "SPORK_12_RECONSIDER_BLOCKS_DEFAULT";
+        case SPORK_10_MASTERNODE_PAY_UPDATED_NODES:     return "SPORK_10_MASTERNODE_PAY_UPDATED_NODES";
+        case SPORK_12_RECONSIDER_BLOCKS:                return "SPORK_12_RECONSIDER_BLOCKS";
         case SPORK_13_OLD_SUPERBLOCK_FLAG:              return "SPORK_13_OLD_SUPERBLOCK_FLAG";
         default:
             LogPrintf("CSporkManager::GetSporkNameByID -- Unknown Spork ID %d\n", nSporkID);

--- a/src/spork.h
+++ b/src/spork.h
@@ -19,25 +19,23 @@ class CSporkManager;
 static const int SPORK_START                                            = 10001;
 static const int SPORK_END                                              = 10012;
 
-static const int SPORK_2_INSTANTX                                       = 10001;
-static const int SPORK_3_INSTANTX_BLOCK_FILTERING                       = 10002;
-static const int SPORK_5_MAX_VALUE                                      = 10004;
-static const int SPORK_7_MASTERNODE_SCANNING                            = 10006;
+static const int SPORK_2_INSTANTSEND_ENABLED                            = 10001;
+static const int SPORK_3_INSTANTSEND_BLOCK_FILTERING                    = 10002;
+static const int SPORK_5_INSTANTSEND_MAX_VALUE                          = 10004;
 static const int SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT                 = 10007;
 static const int SPORK_9_SUPERBLOCKS_ENABLED                            = 10008;
 static const int SPORK_10_MASTERNODE_PAY_UPDATED_NODES                  = 10009;
 static const int SPORK_12_RECONSIDER_BLOCKS                             = 10011;
 static const int SPORK_13_OLD_SUPERBLOCK_FLAG                           = 10012;
 
-static const int64_t SPORK_2_INSTANTX_DEFAULT                           = 978307200;    //2001-1-1
-static const int64_t SPORK_3_INSTANTX_BLOCK_FILTERING_DEFAULT           = 1424217600;   //2015-2-18
-static const int64_t SPORK_5_MAX_VALUE_DEFAULT                          = 1000;         //1000 DASH
-static const int64_t SPORK_7_MASTERNODE_SCANNING_DEFAULT                = 978307200;    //2001-1-1
-static const int64_t SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT_DEFAULT     = 4070908800;   //OFF
-static const int64_t SPORK_9_SUPERBLOCKS_ENABLED_DEFAULT                = 4070908800;   //OFF
-static const int64_t SPORK_10_MASTERNODE_PAY_UPDATED_NODES_DEFAULT      = 4070908800;   //OFF
-static const int64_t SPORK_12_RECONSIDER_BLOCKS_DEFAULT                 = 0;
-static const int64_t SPORK_13_OLD_SUPERBLOCK_FLAG_DEFAULT               = 4070908800;   //OFF
+static const int64_t SPORK_2_INSTANTSEND_ENABLED_DEFAULT                = 0;            // ON
+static const int64_t SPORK_3_INSTANTSEND_BLOCK_FILTERING_DEFAULT        = 0;            // ON
+static const int64_t SPORK_5_INSTANTSEND_MAX_VALUE_DEFAULT              = 1000;         // 1000 DASH
+static const int64_t SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT_DEFAULT     = 4070908800;   // OFF
+static const int64_t SPORK_9_SUPERBLOCKS_ENABLED_DEFAULT                = 4070908800;   // OFF
+static const int64_t SPORK_10_MASTERNODE_PAY_UPDATED_NODES_DEFAULT      = 4070908800;   // OFF
+static const int64_t SPORK_12_RECONSIDER_BLOCKS_DEFAULT                 = 0;            // 0 BLOCKS
+static const int64_t SPORK_13_OLD_SUPERBLOCK_FLAG_DEFAULT               = 4070908800;   // OFF
 
 extern std::map<uint256, CSporkMessage> mapSporks;
 extern CSporkManager sporkManager;


### PR DESCRIPTION
- rename all 3 instantsend sporks
- remove `SPORK_7_MASTERNODE_SCANNING` (not used anymore)
- change `_DEFAULT` for spork 2 and 3, adjust comments for for them (should NOT change any logic since both default timestamps were in the past anyway)
- fix `GetSporkNameByID()` (should not return smth_DEFAULT - my bad, "broke" it in #974  :/ )