### PR TITLE
Fix SubmitFinalBudget

### DIFF
--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -80,7 +80,7 @@ class CBudgetManager
 private:
 
     //hold txes until they mature enough to use
-    map<uint256, CTransaction> mapCollateral;
+    map<uint256, uint256> mapCollateralTxids;
 
 public:
     // critical section to protect the inner data structures


### PR DESCRIPTION
- fix `SubmitFinalBudget` confirmations calculation
- quickly lock `cs_`main and grab current height at the beginning of the function
- fix `nSubmittedFinalBudget`
    - should be set at the end of the function
    - should use current height to allow another submission in case payment list changed
    - renamed to nSubmittedHeight and made it local and static

@evan82 pls review!