### PR TITLE
0.12.1.x - update testnet checkpoint

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -277,10 +277,11 @@ public:
             (  1999, uint256S("0x00000052e538d27fa53693efe6fb6892a0c1d26c0235f599171c48a3cce553b1"))
             (  2999, uint256S("0x0000024bc3f4f4cb30d29827c13d921ad77d2c6072e586c7f60d83c2722cdcc5"))
             ( 12907, uint256S("0x00000067de20fd6d276ee0839a3187b203accaa5aad04ca5c17c2997e2730e4c"))
-            ( 15590, uint256S("0x00000009df8f2ee9c230aef9dad257d82bde20ca83378a208ce5d95d29a78852")),
+            ( 15590, uint256S("0x00000009df8f2ee9c230aef9dad257d82bde20ca83378a208ce5d95d29a78852"))
+            ( 65900, uint256S("0x00000063e4e94d75d0dc075e93898444c8ef50655990dfff7c32d92a7efff671")),
 
-            1464843268, // * UNIX timestamp of last checkpoint block
-            26567,      // * total number of transactions between genesis and last checkpoint
+            1473331693, // * UNIX timestamp of last checkpoint block
+            88502,      // * total number of transactions between genesis and last checkpoint
                         //   (the tx=... number in the SetBestChain debug.log lines)
             500         // * estimated number of transactions per day after checkpoint
         };


### PR DESCRIPTION
Trying to get rid of the testnet fork