### PR TITLE
Make testnet mixing as hard as on mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -268,7 +268,7 @@ public:
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = true;
 
-        nPoolMaxTransactions = 2;
+        nPoolMaxTransactions = 3;
         strSporkPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
         strMasternodePaymentsPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
         checkpointData = (CCheckpointData) {


### PR DESCRIPTION
Require 3 participants (same as on mainnet) - imo this should give us better corelation in terms of speed comparison and should make participants matching issues (if any) easier to find.