### PR TITLE
Improve mn winners detection

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -272,6 +272,7 @@ public:
     }
 
     bool IsEnoughData(int nMnCount);
+    int GetStorageLimit();
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -352,7 +352,7 @@ void CMasternodeSync::ProcessTick()
                 // check for data
                 // if mnpayments already has enough blocks and votes, switch to the next asset
                 // try to fetch data from at least two peers though
-                if(nRequestedMasternodeAttempt > 1 && mnpayments.IsEnoughData(nMnCount)) {
+                if(nRequestedMasternodeAttempt > 1 && mnpayments.IsEnoughData(mnpayments.GetStorageLimit())) {
                     LogPrintf("CMasternodeSync::Process -- nTick %d nRequestedMasternodeAssets %d -- found enough data\n", nTick, nRequestedMasternodeAssets);
                     SwitchToNextAsset();
                     return;
@@ -365,7 +365,7 @@ void CMasternodeSync::ProcessTick()
                 if(pnode->nVersion < mnpayments.GetMinMasternodePaymentsProto()) continue;
                 nRequestedMasternodeAttempt++;
 
-                pnode->PushMessage(NetMsgType::MNWINNERSSYNC, nMnCount); //sync payees
+                pnode->PushMessage(NetMsgType::MNWINNERSSYNC, mnpayments.GetStorageLimit()); //sync payees
 
 
                 return; //this will cause each peer to get one request each six seconds for the various assets we need

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -205,18 +205,23 @@ void CMasternode::Check(bool forceCheck)
 
 int CMasternode::GetCollateralAge()
 {
-    if (chainActive.Height() < 0) return -1;
+    int nHeight;
+    {
+        TRY_LOCK(cs_main, lockMain);
+        if(!lockMain || !chainActive.Tip()) return -1;
+        nHeight = chainActive.Height();
+    }
 
     if (nCacheCollateralBlock == 0) {
         int nInputAge = GetInputAge(vin);
         if(nInputAge > 0) {
-            nCacheCollateralBlock = chainActive.Height() - nInputAge;
+            nCacheCollateralBlock = nHeight - nInputAge;
         } else {
             return nInputAge;
         }
     }
 
-    return chainActive.Height() - nCacheCollateralBlock;
+    return nHeight - nCacheCollateralBlock;
 }
 
 void CMasternode::UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScanBack)

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -30,8 +30,9 @@ CMasternode::CMasternode()
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
-    cacheInputAge = 0;
-    cacheInputAgeBlock = 0;
+    nTimeLastPaid = 0;
+    nBlockLastPaid = 0;
+    nCacheCollateralBlock = 0;
     unitTest = false;
     allowFreeTx = true;
     protocolVersion = PROTOCOL_VERSION;
@@ -52,8 +53,9 @@ CMasternode::CMasternode(const CMasternode& other)
     activeState = other.activeState;
     sigTime = other.sigTime;
     lastPing = other.lastPing;
-    cacheInputAge = other.cacheInputAge;
-    cacheInputAgeBlock = other.cacheInputAgeBlock;
+    nTimeLastPaid = other.nTimeLastPaid;
+    nBlockLastPaid = other.nBlockLastPaid;
+    nCacheCollateralBlock = other.nCacheCollateralBlock;
     unitTest = other.unitTest;
     allowFreeTx = other.allowFreeTx;
     protocolVersion = other.protocolVersion;
@@ -74,8 +76,9 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb)
     activeState = MASTERNODE_ENABLED;
     sigTime = mnb.sigTime;
     lastPing = mnb.lastPing;
-    cacheInputAge = 0;
-    cacheInputAgeBlock = 0;
+    nTimeLastPaid = 0;
+    nBlockLastPaid = 0;
+    nCacheCollateralBlock = 0;
     unitTest = false;
     allowFreeTx = true;
     protocolVersion = mnb.protocolVersion;
@@ -200,65 +203,59 @@ void CMasternode::Check(bool forceCheck)
     activeState = MASTERNODE_ENABLED; // OK
 }
 
-int64_t CMasternode::SecondsSincePayment() {
-    int64_t sec = (GetAdjustedTime() - GetLastPaid());
-    int64_t month = 60*60*24*30;
-    if(sec < month) return sec; //if it's less than 30 days, give seconds
+int CMasternode::GetCollateralAge()
+{
+    if (chainActive.Height() < 0) return -1;
 
-    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << vin;
-    ss << sigTime;
-    uint256 hash =  ss.GetHash();
-
-    // return some deterministic value for unknown/unpaid but force it to be more than 30 days old
-    return month + UintToArith256(hash).GetCompact(false);
-}
-
-int64_t CMasternode::GetLastPaid() {
-    CBlockIndex *pindexPrev = NULL;
-    {
-        LOCK(cs_main);
-        pindexPrev = chainActive.Tip();
-        if(!pindexPrev) return 0;
+    if (nCacheCollateralBlock == 0) {
+        int nInputAge = GetInputAge(vin);
+        if(nInputAge > 0) {
+            nCacheCollateralBlock = chainActive.Height() - nInputAge;
+        } else {
+            return nInputAge;
+        }
     }
 
+    return chainActive.Height() - nCacheCollateralBlock;
+}
 
-    CScript mnpayee;
-    mnpayee = GetScriptForDestination(pubkey.GetID());
+void CMasternode::UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScanBack)
+{
+    if(!pindex) return;
 
-    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << vin;
-    ss << sigTime;
-    uint256 hash =  ss.GetHash();
+    const CBlockIndex *BlockReading = pindex;
 
-    // use a deterministic offset to break a tie -- 2.5 minutes
-    int64_t nOffset = UintToArith256(hash).GetCompact(false) % 150;
+    CScript mnpayee = GetScriptForDestination(pubkey.GetID());
+    // LogPrint("masternode", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s\n", vin.prevout.ToStringShort());
 
-    const CBlockIndex *BlockReading = pindexPrev;
+    LOCK(cs_mapMasternodeBlocks);
 
-    int nMnCount = mnodeman.CountEnabled()*1.25;
-    int n = 0;
-    for (unsigned int i = 1; BlockReading && BlockReading->nHeight > 0; i++) {
-        if(n >= nMnCount){
-            return 0;
-        }
-        n++;
+    for (int i = 0; BlockReading && BlockReading->nHeight > nBlockLastPaid && i < nMaxBlocksToScanBack; i++) {
+        if(mnpayments.mapMasternodeBlocks.count(BlockReading->nHeight) &&
+            mnpayments.mapMasternodeBlocks[BlockReading->nHeight].HasPayeeWithVotes(mnpayee, 2))
+        {
+            CBlock block;
+            if(!ReadBlockFromDisk(block, BlockReading, Params().GetConsensus())) // shouldn't really happen
+                continue;
 
-        if(mnpayments.mapMasternodeBlocks.count(BlockReading->nHeight)){
-            /*
-                Search for this payee, with at least 2 votes. This will aid in consensus allowing the network 
-                to converge on the same payees quickly, then keep the same schedule.
-            */
-            if(mnpayments.mapMasternodeBlocks[BlockReading->nHeight].HasPayeeWithVotes(mnpayee, 2)){
-                return BlockReading->nTime + nOffset;
-            }
+            CAmount nMasternodePayment = GetMasternodePayment(BlockReading->nHeight, block.vtx[0].GetValueOut());
+
+            BOOST_FOREACH(CTxOut txout, block.vtx[0].vout)
+                if(mnpayee == txout.scriptPubKey && nMasternodePayment == txout.nValue) {
+                    nBlockLastPaid = BlockReading->nHeight;
+                    nTimeLastPaid = BlockReading->nTime;
+                    LogPrint("masternode", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s -- found new %d\n", vin.prevout.ToStringShort(), nBlockLastPaid);
+                    return;
+                }
         }
 
         if (BlockReading->pprev == NULL) { assert(BlockReading); break; }
         BlockReading = BlockReading->pprev;
     }
 
-    return 0;
+    // Last payment for this masternode wasn't found in latest mnpayments blocks
+    // or it was found in mnpayments blocks but wasn't found in the blockchain.
+    // LogPrint("masternode", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s -- keeping old %d\n", vin.prevout.ToStringShort(), nBlockLastPaid);
 }
 
 CMasternodeBroadcast::CMasternodeBroadcast()
@@ -271,8 +268,9 @@ CMasternodeBroadcast::CMasternodeBroadcast()
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
-    cacheInputAge = 0;
-    cacheInputAgeBlock = 0;
+    nTimeLastPaid = 0;
+    nBlockLastPaid = 0;
+    nCacheCollateralBlock = 0;
     unitTest = false;
     allowFreeTx = true;
     protocolVersion = PROTOCOL_VERSION;
@@ -291,8 +289,9 @@ CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubK
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
-    cacheInputAge = 0;
-    cacheInputAgeBlock = 0;
+    nTimeLastPaid = 0;
+    nBlockLastPaid = 0;
+    nCacheCollateralBlock = 0;
     unitTest = false;
     allowFreeTx = true;
     protocolVersion = protocolVersionIn;
@@ -311,8 +310,9 @@ CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn)
     activeState = mn.activeState;
     sigTime = mn.sigTime;
     lastPing = mn.lastPing;
-    cacheInputAge = mn.cacheInputAge;
-    cacheInputAgeBlock = mn.cacheInputAgeBlock;
+    nTimeLastPaid = mn.nTimeLastPaid;
+    nBlockLastPaid = mn.nBlockLastPaid;
+    nCacheCollateralBlock = mn.nCacheCollateralBlock;
     unitTest = mn.unitTest;
     allowFreeTx = mn.allowFreeTx;
     protocolVersion = mn.protocolVersion;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -122,8 +122,9 @@ public:
     std::vector<unsigned char> vchSig;
     int activeState;
     int64_t sigTime; //mnb message time
-    int cacheInputAge;
-    int cacheInputAgeBlock;
+    int64_t nTimeLastPaid;
+    int nBlockLastPaid;
+    int nCacheCollateralBlock;
     bool unitTest;
     bool allowFreeTx;
     int protocolVersion;
@@ -155,8 +156,9 @@ public:
         swap(first.activeState, second.activeState);
         swap(first.sigTime, second.sigTime);
         swap(first.lastPing, second.lastPing);
-        swap(first.cacheInputAge, second.cacheInputAge);
-        swap(first.cacheInputAgeBlock, second.cacheInputAgeBlock);
+        swap(first.nTimeLastPaid, second.nTimeLastPaid);
+        swap(first.nBlockLastPaid, second.nBlockLastPaid);
+        swap(first.nCacheCollateralBlock, second.nCacheCollateralBlock);
         swap(first.unitTest, second.unitTest);
         swap(first.allowFreeTx, second.allowFreeTx);
         swap(first.protocolVersion, second.protocolVersion);
@@ -204,8 +206,9 @@ public:
             READWRITE(protocolVersion);
             READWRITE(activeState);
             READWRITE(lastPing);
-            READWRITE(cacheInputAge);
-            READWRITE(cacheInputAgeBlock);
+            READWRITE(nTimeLastPaid);
+            READWRITE(nBlockLastPaid);
+            READWRITE(nCacheCollateralBlock);
             READWRITE(unitTest);
             READWRITE(allowFreeTx);
             READWRITE(nLastDsq);
@@ -257,19 +260,6 @@ public:
         return activeState == MASTERNODE_PRE_ENABLED;
     }
 
-    int GetMasternodeInputAge()
-    {
-        LOCK(cs_main);
-        if(chainActive.Tip() == NULL) return 0;
-
-        if(cacheInputAge == 0){
-            cacheInputAge = GetInputAge(vin);
-            cacheInputAgeBlock = chainActive.Tip()->nHeight;
-        }
-
-        return cacheInputAge + (chainActive.Tip()->nHeight - cacheInputAgeBlock);
-    }
-
     std::string Status() {
         std::string strStatus = "unknown";
 
@@ -283,7 +273,11 @@ public:
         return strStatus;
     }
 
-    int64_t GetLastPaid();
+    int GetCollateralAge();
+
+    int GetLastPaidTime() { return nTimeLastPaid; }
+    int GetLastPaidBlock() { return nBlockLastPaid; }
+    void UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScanBack);
 
 };
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -778,7 +778,7 @@ void CMasternodeMan::UpdateLastPaid(const CBlockIndex *pindex) {
     static bool IsFirstRun = true;
     // Do full scan on first run or if we are not a masternode
     // (MNs should update this info on every block, so limited scan should be enough for them)
-    int nMaxBlocksToScanBack = (IsFirstRun || !fMasterNode) ? mnpayments.GetStorageLimit() : 100;
+    int nMaxBlocksToScanBack = (IsFirstRun || !fMasterNode) ? mnpayments.GetStorageLimit() : MASTERNODES_LAST_PAID_SCAN_BLOCKS;
 
     // LogPrint("mnpayments", "CMasternodeMan::UpdateLastPaid -- nHeight=%d, nMaxBlocksToScanBack=%d, IsFirstRun=%s\n",
     //                         pindex->nHeight, nMaxBlocksToScanBack, IsFirstRun ? "true" : "false");

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -17,10 +17,10 @@
 /** Masternode manager */
 CMasternodeMan mnodeman;
 
-struct CompareLastPaid
+struct CompareLastPaidBlock
 {
-    bool operator()(const pair<int64_t, CTxIn>& t1,
-                    const pair<int64_t, CTxIn>& t2) const
+    bool operator()(const std::pair<int, CTxIn>& t1,
+                    const std::pair<int, CTxIn>& t2) const
     {
         return t1.first < t2.first;
     }
@@ -313,7 +313,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     LOCK(cs);
 
     CMasternode *pBestMasternode = NULL;
-    std::vector<pair<int64_t, CTxIn> > vecMasternodeLastPaid;
+    std::vector<std::pair<int, CTxIn> > vecMasternodeLastPaid;
 
     /*
         Make a vector with all of the last paid times
@@ -335,9 +335,9 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         if(fFilterSigTime && mn.sigTime + (nMnCount*2.6*60) > GetAdjustedTime()) continue;
 
         //make sure it has as many confirmations as there are masternodes
-        if(mn.GetMasternodeInputAge() < nMnCount) continue;
+        if(mn.GetCollateralAge() < nMnCount) continue;
 
-        vecMasternodeLastPaid.push_back(make_pair(mn.SecondsSincePayment(), mn.vin));
+        vecMasternodeLastPaid.push_back(std::make_pair(mn.GetLastPaidBlock(), mn.vin));
     }
 
     nCount = (int)vecMasternodeLastPaid.size();
@@ -345,17 +345,17 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     //when the network is in the process of upgrading, don't penalize nodes that recently restarted
     if(fFilterSigTime && nCount < nMnCount/3) return GetNextMasternodeInQueueForPayment(nBlockHeight, false, nCount);
 
-    // Sort them high to low
-    sort(vecMasternodeLastPaid.rbegin(), vecMasternodeLastPaid.rend(), CompareLastPaid());
+    // Sort them low to high
+    sort(vecMasternodeLastPaid.begin(), vecMasternodeLastPaid.end(), CompareLastPaidBlock());
 
     // Look at 1/10 of the oldest nodes (by last payment), calculate their scores and pay the best one
     //  -- This doesn't look at who is being paid in the +8-10 blocks, allowing for double payments very rarely
     //  -- 1/100 payments should be a double payment on mainnet - (1/(3000/10))*2
     //  -- (chance per block * chances before IsScheduled will fire)
     int nTenthNetwork = CountEnabled()/10;
-    int nCountTenth = 0; 
+    int nCountTenth = 0;
     arith_uint256 nHigh = 0;
-    BOOST_FOREACH (PAIRTYPE(int64_t, CTxIn)& s, vecMasternodeLastPaid){
+    BOOST_FOREACH (PAIRTYPE(int, CTxIn)& s, vecMasternodeLastPaid){
         CMasternode* pmn = Find(s.second);
         if(!pmn) break;
 
@@ -770,4 +770,23 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CMasternodeBroadcast mnb, i
     }
 
     return true;
+}
+
+void CMasternodeMan::UpdateLastPaid(const CBlockIndex *pindex) {
+    if(fLiteMode) return;
+
+    static bool IsFirstRun = true;
+    // Do full scan on first run or if we are not a masternode
+    // (MNs should update this info on every block, so limited scan should be enough for them)
+    int nMaxBlocksToScanBack = (IsFirstRun || !fMasterNode) ? mnpayments.GetStorageLimit() : 100;
+
+    // LogPrint("mnpayments", "CMasternodeMan::UpdateLastPaid -- nHeight=%d, nMaxBlocksToScanBack=%d, IsFirstRun=%s\n",
+    //                         pindex->nHeight, nMaxBlocksToScanBack, IsFirstRun ? "true" : "false");
+
+    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+        mn.UpdateLastPaid(pindex, nMaxBlocksToScanBack);
+    }
+
+    // every time is like the first time if winners list is not synced
+    IsFirstRun = !masternodeSync.IsWinnersListSynced();
 }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -22,7 +22,7 @@ struct CompareLastPaidBlock
     bool operator()(const std::pair<int, CTxIn>& t1,
                     const std::pair<int, CTxIn>& t2) const
     {
-        return t1.first < t2.first;
+        return (t1.first != t2.first) ? (t1.first < t2.first) : (t1.second < t2.second);
     }
 };
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -134,6 +134,7 @@ public:
     /// Perform complete check and only then update list and maps
     bool CheckMnbAndUpdateMasternodeList(CMasternodeBroadcast mnb, int& nDos);
 
+    void UpdateLastPaid(const CBlockIndex *pindex);
 };
 
 #endif

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -24,6 +24,8 @@ extern CMasternodeMan mnodeman;
 class CMasternodeMan
 {
 private:
+    static const int MASTERNODES_LAST_PAID_SCAN_BLOCKS  = 100;
+
     // critical section to protect the inner data structures
     mutable CCriticalSection cs;
 


### PR DESCRIPTION
Update and store collateral block height and block height at which MN was last paid (scan blockchain to find out who actually was paid). Use storage limit instead of mn count to fetch enough data. Calculate new winner using info about block height at which MNs were paid instead of time.