### PR TITLE
Remove -DDEBUG_LOCKORDER from debug configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,7 @@ AC_ARG_ENABLE([debug],
     [enable_debug=no])
 
 if test "x$enable_debug" = xyes; then
-    CPPFLAGS="$CPPFLAGS -DDEBUG -DDEBUG_LOCKORDER"
+    CPPFLAGS="$CPPFLAGS -DDEBUG"
     if test "x$GCC" = xyes; then
         CFLAGS="$CFLAGS -g3 -O0"
     fi

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -329,8 +329,7 @@ Threads and synchronization
 ----------------------------
 
 - Build and run tests with `-DDEBUG_LOCKORDER` to verify that no potential
-  deadlocks are introduced. As of 0.12, this is defined by default when
-  configuring with `--enable-debug`
+  deadlocks are introduced.
 
 - When using `LOCK`/`TRY_LOCK` be aware that the lock exists in the context of
   the current scope, so surround the statement and the code that needs the lock


### PR DESCRIPTION
This should allow dash to be built in debug mode without constant crashing.

fixes #1002 