### PR TITLE
(trivial) governance cleanup

### DIFF
--- a/src/governance-classes.h
+++ b/src/governance-classes.h
@@ -19,15 +19,14 @@
 #include "init.h"
 #include "governance.h"
 
-using namespace std;
-
-#define TRIGGER_UNKNOWN             -1
-#define TRIGGER_SUPERBLOCK          1000
 
 class CSuperblock;
 class CGovernanceTrigger;
 class CGovernanceTriggerManager;
 class CSuperblockManager;
+
+static const int TRIGGER_UNKNOWN            = -1;
+static const int TRIGGER_SUPERBLOCK         = 1000;
 
 typedef boost::shared_ptr<CSuperblock> CSuperblock_sptr;
 
@@ -44,35 +43,24 @@ std::vector<std::string> SplitBy(std::string strCommand, std::string strDelimit)
 *   - After triggers are activated and executed, they can be removed
 */
 
-CAmount ParsePaymentAmount(const std::string& strAmount);
-
 class CGovernanceTriggerManager
 {
     friend class CSuperblockManager;
     friend class CGovernanceManager;
 
-public: // Typedefs
+private:
     typedef std::map<uint256, CSuperblock_sptr> trigger_m_t;
-
     typedef trigger_m_t::iterator trigger_m_it;
-
     typedef trigger_m_t::const_iterator trigger_m_cit;
 
-private:
     trigger_m_t mapTrigger;
 
-public:
-    CGovernanceTriggerManager()
-        : mapTrigger()
-    {}
-
-private:
     std::vector<CSuperblock_sptr> GetActiveTriggers();
-
     bool AddNewTrigger(uint256 nHash);
-
     void CleanAndRemove();
 
+public:
+    CGovernanceTriggerManager() : mapTrigger() {}
 };
 
 /**
@@ -84,7 +72,7 @@ private:
 class CSuperblockManager
 {
 private:
-    static bool GetBestSuperblock(CSuperblock_sptr& pBlock, int nBlockHeight);
+    static bool GetBestSuperblock(CSuperblock_sptr& pSuperblockRet, int nBlockHeight);
 
 public:
 
@@ -103,26 +91,16 @@ public:
 
 class CGovernancePayment
 {
+private:
+    bool fValid;
+
 public:
     CScript script;
     CAmount nAmount;
-    bool fValid; 
 
     CGovernancePayment()
     {
         SetNull();
-    }
-
-    void SetNull()
-    {
-        script = CScript();
-        nAmount = 0;
-        fValid = false;
-    }
-
-    bool IsValid()
-    {
-        return fValid;
     }
 
     CGovernancePayment(CBitcoinAddress addrIn, CAmount nAmountIn)
@@ -136,6 +114,15 @@ public:
             SetNull(); //set fValid to false
         }
     }
+
+    void SetNull()
+    {
+        script = CScript();
+        nAmount = 0;
+        fValid = false;
+    }
+
+    bool IsValid() { return fValid; }
 };
 
 
@@ -143,25 +130,21 @@ public:
 *   Trigger : Superblock
 *
 *   - Create payments on the network
+*
+*   object structure:
+*   {
+*       "governance_object_id" : last_id,
+*       "type" : govtypes.trigger,
+*       "subtype" : "superblock",
+*       "superblock_name" : superblock_name,
+*       "start_epoch" : start_epoch,
+*       "payment_addresses" : "addr1|addr2|addr3",
+*       "payment_amounts"   : "amount1|amount2|amount3"
+*   }
 */
 
 class CSuperblock : public CGovernanceObject
 {
-
-    /*
-
-        object structure: 
-        {
-            "governance_object_id" : last_id,
-            "type" : govtypes.trigger,
-            "subtype" : "superblock",
-            "superblock_name" : superblock_name,
-            "start_epoch" : start_epoch,
-            "payment_addresses" : "addr1|addr2|addr3",
-            "payment_amounts"   : "amount1|amount2|amount3"
-        }
-    */
-
 private:
     uint256 nGovObjHash;
 

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -193,7 +193,7 @@ vote_signal_enum_t CGovernanceVoting::ConvertVoteSignal(std::string strVoteSigna
 
     // convert custom sentinel outcomes to integer and store
     try {
-        int  i = boost::lexical_cast<int>(strVoteSignal);
+        int i = boost::lexical_cast<int>(strVoteSignal);
         if(i < VOTE_SIGNAL_CUSTOM1 || i > VOTE_SIGNAL_CUSTOM20) {
             eSignal = VOTE_SIGNAL_NONE;
         }
@@ -203,8 +203,8 @@ vote_signal_enum_t CGovernanceVoting::ConvertVoteSignal(std::string strVoteSigna
     }
     catch(std::exception const & e)
     {
-        ostringstream ostr;
-        ostr << "CGovernanceVote::ConvertVoteSignal: error : " << e.what() << endl;
+        std::ostringstream ostr;
+        ostr << "CGovernanceVote::ConvertVoteSignal: error : " << e.what() << std::endl;
         LogPrintf(ostr.str().c_str());
     }
 
@@ -265,28 +265,28 @@ bool CGovernanceVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 bool CGovernanceVote::IsValid(bool fSignatureCheck)
 {
     if(nTime > GetTime() + (60*60)){
-        LogPrint("gobject", "CGovernanceVote::IsValid() - vote is too far ahead of current time - %s - nTime %lli - Max Time %lli\n", GetHash().ToString(), nTime, GetTime() + (60*60));
+        LogPrint("gobject", "CGovernanceVote::IsValid -- vote is too far ahead of current time - %s - nTime %lli - Max Time %lli\n", GetHash().ToString(), nTime, GetTime() + (60*60));
         return false;
     }
 
     // support up to 50 actions (implemented in sentinel)
     if(nVoteSignal > 50)
     {
-        LogPrint("gobject", "CGovernanceVote::IsValid() - Client attempted to vote on invalid action(%d) - %s\n", nVoteSignal, GetHash().ToString());
+        LogPrint("gobject", "CGovernanceVote::IsValid -- Client attempted to vote on invalid signal(%d) - %s\n", nVoteSignal, GetHash().ToString());
         return false;
     }
 
     // 0=none, 1=yes, 2=no, 3=abstain. Beyond that reject votes
     if(nVoteOutcome > 3)
     {
-        LogPrint("gobject", "CGovernanceVote::IsValid() - Client attempted to vote on invalid outcome(%d) - %s\n", nVoteSignal, GetHash().ToString());
-        return false;   
+        LogPrint("gobject", "CGovernanceVote::IsValid -- Client attempted to vote on invalid outcome(%d) - %s\n", nVoteSignal, GetHash().ToString());
+        return false;
     }
 
     CMasternode* pmn = mnodeman.Find(vinMasternode);
     if(pmn == NULL)
     {
-        LogPrint("gobject", "CGovernanceVote::IsValid() - Unknown Masternode - %s\n", vinMasternode.ToString());
+        LogPrint("gobject", "CGovernanceVote::IsValid -- Unknown Masternode - %s\n", vinMasternode.prevout.ToStringShort());
         return false;
     }
 

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -46,7 +46,7 @@ enum vote_signal_enum_t  {
     VOTE_SIGNAL_NOOP9      = 13,
     VOTE_SIGNAL_NOOP10     = 14,
     VOTE_SIGNAL_NOOP11     = 15,
-    VOTE_SIGNAL_CUSTOM1    = 16,  // SENTINEL CUSTOM ACTIONS 
+    VOTE_SIGNAL_CUSTOM1    = 16,  // SENTINEL CUSTOM ACTIONS
     VOTE_SIGNAL_CUSTOM2    = 17,  //        16-35
     VOTE_SIGNAL_CUSTOM3    = 18,
     VOTE_SIGNAL_CUSTOM4    = 19,
@@ -157,25 +157,25 @@ public:
     *
     *   GET HASH WITH DETERMINISTIC VALUE OF MASTERNODE-VIN/PARENT-HASH/VOTE-SIGNAL
     *
-    *   This hash collides with previous masternode votes when they update their votes on governance objects. 
-    *   With 12.1 there's various types of votes (funding, valid, delete, etc), so this is the deterministic hash 
+    *   This hash collides with previous masternode votes when they update their votes on governance objects.
+    *   With 12.1 there's various types of votes (funding, valid, delete, etc), so this is the deterministic hash
     *   that will collide with the previous vote and allow the system to update.
-    *   
+    *
     *   --
     *
     *   We do not include an outcome, because that can change when a masternode updates their vote from yes to no
-    *   on funding a specific project for example. 
+    *   on funding a specific project for example.
     *   We do not include a time because it will be updated each time the vote is updated, changing the hash
     */
     uint256 GetTypeHash() const
-    {       
+    {
         // CALCULATE HOW TO STORE VOTE IN governance.mapVotes
 
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << vinMasternode;
         ss << nParentHash;
         ss << nVoteSignal;
-        //  -- no outcome 
+        //  -- no outcome
         //  -- timeless
         return ss.GetHash();
     }
@@ -195,7 +195,7 @@ public:
 };
 
 
-/** 
+/**
 * 12.1.1 - CGovernanceVoteManager
 * -------------------------------
 *
@@ -206,7 +206,7 @@ public:
         - load serialized files from filesystem if needed
         - calc answer
         - return result
-    
+
     CacheUnused():
         - Cache votes if lastused > 12h/24/48/etc
 

--- a/src/governance.h
+++ b/src/governance.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2016 The Dash Core developers
-
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef GOVERANCE_H
 #define GOVERANCE_H
 
@@ -25,24 +25,18 @@
 #include <stdio.h>
 #include <string.h>
 
-using namespace std;
+class CGovernanceManager;
+class CGovernanceObject;
+class CGovernanceVote;
 
 static const int GOVERNANCE_OBJECT_UNKNOWN = 0;
 static const int GOVERNANCE_OBJECT_PROPOSAL = 1;
 static const int GOVERNANCE_OBJECT_TRIGGER = 2;
 
-class CGovernanceManager;
-class CGovernanceObject;
-class CGovernanceVote;
-class CNode;
-
 static const CAmount GOVERNANCE_PROPOSAL_FEE_TX = (0.33*COIN);
 
 static const int64_t GOVERNANCE_FEE_CONFIRMATIONS = 6;
 static const int64_t GOVERNANCE_UPDATE_MIN = 60*60;
-
-extern std::map<uint256, int64_t> mapAskedForGovernanceObject;
-extern CGovernanceManager governance;
 
 // FOR SEEN MAP ARRAYS - GOVERNANCE OBJECTS AND VOTES
 static const int SEEN_OBJECT_IS_VALID = 0;
@@ -51,6 +45,9 @@ static const int SEEN_OBJECT_ERROR_IMMATURE = 2;
 static const int SEEN_OBJECT_EXECUTED = 3; //used for triggers
 static const int SEEN_OBJECT_UNKNOWN = 4; // the default
 
+extern std::map<uint256, int64_t> mapAskedForGovernanceObject;
+extern CGovernanceManager governance;
+extern CCriticalSection cs_budget;
 
 
 //
@@ -99,7 +96,7 @@ private:
     // keep track of the scanning errors
     object_m_t mapObjects;
 
-    // note: move to private for better encapsulation 
+    // note: move to private for better encapsulation
     count_m_t mapSeenGovernanceObjects;
     count_m_t mapSeenVotes;
     vote_m_t mapOrphanVotes;
@@ -114,10 +111,11 @@ private:
 public:
     // critical section to protect the inner data structures
     mutable CCriticalSection cs;
-    
+
     CGovernanceManager();
 
-    void ClearSeen() {
+    void ClearSeen()
+    {
         LOCK(cs);
         mapSeenGovernanceObjects.clear();
         mapSeenVotes.clear();
@@ -127,8 +125,6 @@ public:
     {
         return mapSeenGovernanceObjects.size() + mapSeenVotes.size();
     }
-
-    int sizeProposals() {return (int)mapObjects.size();}
 
     void Sync(CNode* node, uint256 nProp);
     void SyncParentObjectByVote(CNode* pfrom, const CGovernanceVote& vote);
@@ -155,7 +151,8 @@ public:
 
     void CheckOrphanVotes();
 
-    void Clear(){
+    void Clear()
+    {
         LOCK(cs);
 
         LogPrint("gobject", "Governance object manager was cleared\n");
@@ -167,7 +164,7 @@ public:
         mapVotesByHash.clear();
         mapLastMasternodeTrigger.clear();
     }
-    
+
     std::string ToString() const;
 
     ADD_SERIALIZE_METHODS;
@@ -185,8 +182,8 @@ public:
     }
 
     void UpdatedBlockTip(const CBlockIndex *pindex);
-    int64_t GetLastDiffTime() {return nTimeLastDiff;}
-    void UpdateLastDiffTime(int64_t nTimeIn) {nTimeLastDiff=nTimeIn;}
+    int64_t GetLastDiffTime() { return nTimeLastDiff; }
+    void UpdateLastDiffTime(int64_t nTimeIn) { nTimeLastDiff = nTimeIn; }
 
     int GetCachedBlockHeight() { return nCachedBlockHeight; }
 
@@ -194,8 +191,6 @@ public:
     bool HaveObjectForHash(uint256 nHash);
 
     bool HaveVoteForHash(uint256 nHash);
-
-    // int GetVoteCountByHash(uint256 nHash);
 
     bool SerializeObjectForHash(uint256 nHash, CDataStream& ss);
 
@@ -224,13 +219,13 @@ public:
 
     uint256 nHashParent; //parent object, 0 is root
     int nRevision; //object revision in the system
-    std::string strName; //org name, username, prop name, etc. 
+    std::string strName; //org name, username, prop name, etc.
     int64_t nTime; //time this object was created
     uint256 nCollateralHash; //fee-tx
     std::string strData; // Data field - can be used for anything
     int nObjectType;
 
-    bool fCachedLocalValidity; // is valid by blockchain 
+    bool fCachedLocalValidity; // is valid by blockchain
     std::string strLocalValidityError;
 
     // Masternode info for signed objects
@@ -287,7 +282,7 @@ public:
     int GetNoCount(vote_signal_enum_t eVoteSignalIn);
     int GetAbstainCount(vote_signal_enum_t eVoteSignalIn);
 
-    // FUNCTIONS FOR DEALING WITH DATA STRING 
+    // FUNCTIONS FOR DEALING WITH DATA STRING
 
     std::string GetDataAsHex();
     std::string GetDataAsString();
@@ -316,7 +311,7 @@ public:
     }
 
 private:
-    // FUNCTIONS FOR DEALING WITH DATA STRING 
+    // FUNCTIONS FOR DEALING WITH DATA STRING
 
     void LoadData();
     bool SetData(std::string& strError, std::string strDataIn);

--- a/src/governance.h
+++ b/src/governance.h
@@ -47,8 +47,6 @@ static const int SEEN_OBJECT_UNKNOWN = 4; // the default
 
 extern std::map<uint256, int64_t> mapAskedForGovernanceObject;
 extern CGovernanceManager governance;
-extern CCriticalSection cs_budget;
-
 
 //
 // Governance Manager : Contains all proposals for the budget
@@ -96,7 +94,6 @@ private:
     // keep track of the scanning errors
     object_m_t mapObjects;
 
-    // note: move to private for better encapsulation
     count_m_t mapSeenGovernanceObjects;
     count_m_t mapSeenVotes;
     vote_m_t mapOrphanVotes;


### PR DESCRIPTION
- (trailing) spaces (lots of them)
- names
- no "using namespace std;"
- few log and rpc messages adjusted
- remove unused
- use defined types instead of declaring via std::map etc again
- move few types and class members to private (the only potential logic changes for future code, does not break any current code afaik)