### PR TITLE
rename NetMsgType::IX and NetMsgType::IXLOCKVOTE

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -51,7 +51,7 @@ void ProcessMessageInstantSend(CNode* pfrom, std::string& strCommand, CDataStrea
     // Ignore any InstantSend messages until masternode list is synced
     if(!masternodeSync.IsMasternodeListSynced()) return;
 
-    if (strCommand == NetMsgType::IX) // InstantSend Transaction Lock Request
+    if (strCommand == NetMsgType::TXLOCKREQUEST) // InstantSend Transaction Lock Request
     {
         //LogPrintf("ProcessMessageInstantSend\n");
         CDataStream vMsg(vRecv);
@@ -127,7 +127,7 @@ void ProcessMessageInstantSend(CNode* pfrom, std::string& strCommand, CDataStrea
             return;
         }
     }
-    else if (strCommand == NetMsgType::IXLOCKVOTE) // InstantSend Transaction Lock Consensus Votes
+    else if (strCommand == NetMsgType::TXLOCKVOTE) // InstantSend Transaction Lock Consensus Votes
     {
         CConsensusVote vote;
         vRecv >> vote;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5076,26 +5076,26 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     }
                 }
 
-                if (!pushed && inv.type == MSG_TXLOCK_VOTE) {
-                    if(mapTxLockVote.count(inv.hash)) {
-                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                        ss.reserve(1000);
-                        ss << mapTxLockVote[inv.hash];
-                        pfrom->PushMessage(NetMsgType::IXLOCKVOTE, ss);
-                        pushed = true;
-                    }
-                }
-            
                 if (!pushed && inv.type == MSG_TXLOCK_REQUEST) {
                     if(mapTxLockReq.count(inv.hash)) {
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
                         ss << mapTxLockReq[inv.hash];
-                        pfrom->PushMessage(NetMsgType::IX, ss);
+                        pfrom->PushMessage(NetMsgType::TXLOCKREQUEST, ss);
                         pushed = true;
                     }
                 }
-            
+
+                if (!pushed && inv.type == MSG_TXLOCK_VOTE) {
+                    if(mapTxLockVote.count(inv.hash)) {
+                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+                        ss.reserve(1000);
+                        ss << mapTxLockVote[inv.hash];
+                        pfrom->PushMessage(NetMsgType::TXLOCKVOTE, ss);
+                        pushed = true;
+                    }
+                }
+
                 if (!pushed && inv.type == MSG_SPORK) {
                     if(mapSporks.count(inv.hash)) {
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -36,8 +36,8 @@ const char *FILTERCLEAR="filterclear";
 const char *REJECT="reject";
 const char *SENDHEADERS="sendheaders";
 // Dash message types
-const char *IX="ix";
-const char *IXLOCKVOTE="txlvote";
+const char *TXLOCKREQUEST="ix";
+const char *TXLOCKVOTE="txlvote";
 const char *SPORK="spork";
 const char *GETSPORKS="getsporks";
 const char *MNWINNER="mnw";
@@ -74,8 +74,8 @@ static const char* ppszTypeName[] =
     "filtered block", // Should never occur
     // Dash message types
     // NOTE: include non-implmented here, we must keep this list in sync with enum in protocol.h
-    NetMsgType::IX,
-    NetMsgType::IXLOCKVOTE,
+    NetMsgType::TXLOCKREQUEST,
+    NetMsgType::TXLOCKVOTE,
     NetMsgType::SPORK,
     NetMsgType::MNWINNER,
     NetMsgType::MNSCANERROR, // not implemented
@@ -119,8 +119,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::SENDHEADERS,
     // Dash message types
     // NOTE: do NOT include non-implmented here, we want them to be "Unknown command" in ProcessMessage()
-    NetMsgType::IX,
-    NetMsgType::IXLOCKVOTE,
+    NetMsgType::TXLOCKREQUEST,
+    NetMsgType::TXLOCKVOTE,
     NetMsgType::SPORK,
     NetMsgType::GETSPORKS,
     NetMsgType::MNWINNER,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -222,8 +222,8 @@ extern const char *SENDHEADERS;
 // Dash message types
 // NOTE: do NOT declare non-implmented here, we don't want them to be exposed to the outside
 // TODO: add description
-extern const char *IX;
-extern const char *IXLOCKVOTE;
+extern const char *TXLOCKREQUEST;
+extern const char *TXLOCKVOTE;
 extern const char *SPORK;
 extern const char *GETSPORKS;
 extern const char *MNWINNER;
@@ -340,10 +340,10 @@ enum {
     // Nodes may always request a MSG_FILTERED_BLOCK in a getdata, however,
     // MSG_FILTERED_BLOCK should not appear in any invs except as a part of getdata.
     MSG_FILTERED_BLOCK,
-    MSG_TXLOCK_REQUEST,
-    MSG_TXLOCK_VOTE,
     // Dash message types
     // NOTE: declare non-implmented here, we must keep this enum consistent and backwards compatible
+    MSG_TXLOCK_REQUEST,
+    MSG_TXLOCK_VOTE,
     MSG_SPORK,
     MSG_MASTERNODE_WINNER,
     MSG_MASTERNODE_SCANNING_ERROR, // not implemented

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -364,7 +364,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
 
         CReserveKey *keyChange = transaction.getPossibleKeyChange();
 
-        if(!wallet->CommitTransaction(*newTx, *keyChange, recipients[0].fUseInstantSend ? NetMsgType::IX : NetMsgType::TX))
+        if(!wallet->CommitTransaction(*newTx, *keyChange, recipients[0].fUseInstantSend ? NetMsgType::TXLOCKREQUEST : NetMsgType::TX))
             return TransactionCommitFailed;
 
         CTransaction* t = (CTransaction*)newTx;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -399,7 +399,7 @@ static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtr
             strError = strprintf("Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!", FormatMoney(nFeeRequired));
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
-    if (!pwalletMain->CommitTransaction(wtxNew, reservekey, fUseInstantSend ? NetMsgType::IX : NetMsgType::TX))
+    if (!pwalletMain->CommitTransaction(wtxNew, reservekey, fUseInstantSend ? NetMsgType::TXLOCKREQUEST : NetMsgType::TX))
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.");
 }
 
@@ -1123,7 +1123,7 @@ UniValue sendmany(const UniValue& params, bool fHelp)
                                                    NULL, true, fUsePrivateSend ? ONLY_DENOMINATED : ALL_COINS, fUseInstantSend);
     if (!fCreated)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, strFailReason);
-    if (!pwalletMain->CommitTransaction(wtx, keyChange, fUseInstantSend ? NetMsgType::IX : NetMsgType::TX))
+    if (!pwalletMain->CommitTransaction(wtx, keyChange, fUseInstantSend ? NetMsgType::TXLOCKREQUEST : NetMsgType::TX))
         throw JSONRPCError(RPC_WALLET_ERROR, "Transaction commit failed");
 
     return wtx.GetHash().GetHex();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1471,7 +1471,7 @@ bool CWalletTx::RelayWalletTransaction(std::string strCommand)
             uint256 hash = GetHash();
             LogPrintf("Relaying wtx %s\n", hash.ToString());
 
-            if(strCommand == NetMsgType::IX){
+            if(strCommand == NetMsgType::TXLOCKREQUEST){
                 mapTxLockReq.insert(make_pair(hash, (CTransaction)*this));
                 CreateNewLock(((CTransaction)*this));
             }


### PR DESCRIPTION
NetMsgType::IX -> NetMsgType::TXLOCKREQUEST
NetMsgType::IXLOCKVOTE -> NetMsgType::TXLOCKVOTE

Also sorted blocks of code in ProcessGetData to follow the same order as in protocol.