### PR TITLE
Implement a way to sync only needed winners

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -40,12 +40,25 @@ std::string GetRequiredPaymentsString(int nBlockHeight);
 
 class CMasternodePayee
 {
-public:
+private:
     CScript scriptPubKey;
     int nVotes;
+    std::vector<uint256> vecVoteHashes;
 
-    CMasternodePayee() : scriptPubKey(CScript()), nVotes(0) {}
-    CMasternodePayee(CScript payee, int nVotesIn) : scriptPubKey(payee), nVotes(nVotesIn) {}
+public:
+    CMasternodePayee() :
+        scriptPubKey(),
+        nVotes(0),
+        vecVoteHashes()
+        {}
+
+    CMasternodePayee(CScript payee, uint256 hashIn) :
+        scriptPubKey(payee),
+        nVotes(1),
+        vecVoteHashes(hashIn)
+    {
+        vecVoteHashes.push_back(hashIn);
+    }
 
     ADD_SERIALIZE_METHODS;
 
@@ -53,7 +66,18 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(*(CScriptBase*)(&scriptPubKey));
         READWRITE(nVotes);
-     }
+        READWRITE(vecVoteHashes);
+    }
+
+    CScript GetPayee() { return scriptPubKey; }
+    int GetVoteCount() { return nVotes; }
+
+    void AddVoteHash(uint256 hashIn)
+    {
+        vecVoteHashes.push_back(hashIn);
+        nVotes++;
+    }
+    std::vector<uint256> GetVoteHashes() { return vecVoteHashes; }
 };
 
 // Keep track of votes for payees from masternodes

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -42,19 +42,16 @@ class CMasternodePayee
 {
 private:
     CScript scriptPubKey;
-    int nVotes;
     std::vector<uint256> vecVoteHashes;
 
 public:
     CMasternodePayee() :
         scriptPubKey(),
-        nVotes(0),
         vecVoteHashes()
         {}
 
     CMasternodePayee(CScript payee, uint256 hashIn) :
         scriptPubKey(payee),
-        nVotes(1),
         vecVoteHashes()
     {
         vecVoteHashes.push_back(hashIn);
@@ -65,19 +62,14 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(*(CScriptBase*)(&scriptPubKey));
-        READWRITE(nVotes);
         READWRITE(vecVoteHashes);
     }
 
     CScript GetPayee() { return scriptPubKey; }
-    int GetVoteCount() { return nVotes; }
 
-    void AddVoteHash(uint256 hashIn)
-    {
-        vecVoteHashes.push_back(hashIn);
-        nVotes++;
-    }
+    void AddVoteHash(uint256 hashIn) { vecVoteHashes.push_back(hashIn); }
     std::vector<uint256> GetVoteHashes() { return vecVoteHashes; }
+    int GetVoteCount() { return vecVoteHashes.size(); }
 };
 
 // Keep track of votes for payees from masternodes

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -55,7 +55,7 @@ public:
     CMasternodePayee(CScript payee, uint256 hashIn) :
         scriptPubKey(payee),
         nVotes(1),
-        vecVoteHashes(hashIn)
+        vecVoteHashes()
     {
         vecVoteHashes.push_back(hashIn);
     }
@@ -193,6 +193,7 @@ public:
     bool ProcessBlock(int nBlockHeight);
 
     void Sync(CNode* node, int nCountNeeded);
+    void RequestLowDataPaymentBlocks(CNode* pnode);
     void CheckAndRemove();
 
     bool GetBlockPayee(int nBlockHeight, CScript& payee);

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -309,8 +309,10 @@ void CMasternodeSync::ProcessTick()
                 if(pnode->nVersion < mnpayments.GetMinMasternodePaymentsProto()) continue;
                 nRequestedMasternodeAttempt++;
 
-                pnode->PushMessage(NetMsgType::MNWINNERSSYNC, mnpayments.GetStorageLimit()); //sync payees
-
+                // ask node for all winners it has (new nodes will only return future winners)
+                pnode->PushMessage(NetMsgType::MNWINNERSSYNC, mnpayments.GetStorageLimit());
+                // ask node for missing pieces only (old nodes will not be asked)
+                mnpayments.RequestLowDataPaymentBlocks(pnode);
 
                 return; //this will cause each peer to get one request each six seconds for the various assets we need
             }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -41,6 +41,7 @@ const char *TXLOCKVOTE="txlvote";
 const char *SPORK="spork";
 const char *GETSPORKS="getsporks";
 const char *MNWINNER="mnw";
+const char *MNWINNERBLOCK="mnwb";
 const char *MNWINNERSSYNC="mnget";
 const char *MNSCANERROR="mn scan error"; // not implemented
 const char *MNBUDGETSYNC="mnvs"; // depreciated since 12.1
@@ -78,7 +79,7 @@ static const char* ppszTypeName[] =
     NetMsgType::TXLOCKVOTE,
     NetMsgType::SPORK,
     NetMsgType::MNWINNER,
-    NetMsgType::MNSCANERROR, // not implemented
+    NetMsgType::MNWINNERBLOCK, // reusing, was MNSCANERROR previousely, was NOT used in 12.0, we need this for inv
     NetMsgType::MNBUDGETVOTE, // depreciated since 12.1
     NetMsgType::MNBUDGETPROPOSAL, // depreciated since 12.1
     NetMsgType::MNBUDGETFINAL, // depreciated since 12.1
@@ -124,6 +125,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::SPORK,
     NetMsgType::GETSPORKS,
     NetMsgType::MNWINNER,
+    // NetMsgType::MNWINNERBLOCK, // there is no message for this, only inventory
     NetMsgType::MNWINNERSSYNC,
     NetMsgType::MNANNOUNCE,
     NetMsgType::MNPING,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -346,7 +346,7 @@ enum {
     MSG_TXLOCK_VOTE,
     MSG_SPORK,
     MSG_MASTERNODE_WINNER,
-    MSG_MASTERNODE_SCANNING_ERROR, // not implemented
+    MSG_MASTERNODE_WINNER_BLOCK, // reusing, was MSG_MASTERNODE_SCANNING_ERROR previousely, was NOT used in 12.0
     MSG_BUDGET_VOTE, // depreciated since 12.1
     MSG_BUDGET_PROPOSAL, // depreciated since 12.1
     MSG_BUDGET_FINALIZED, // depreciated since 12.1


### PR DESCRIPTION
The idea is to ask node we are trying to sync from only for future payment blocks and for blocks where payment info is missing/incomplete for us instead of asking for the whole set of winners every time we sync. This (hopefully) should significantly lower cpu/net load if node was offline for not too long. For nodes which were offline for a period of time comparable to nMinBlocksToStore (~1 week on mainnet) there should be (almost) no difference.