### PR TITLE
Rewrite fulfilled requests handling

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -122,6 +122,7 @@ BITCOIN_CORE_H = \
   miner.h \
   net.h \
   netbase.h \
+  netfulfilledman.h \
   noui.h \
   policy/fees.h \
   policy/policy.h \
@@ -205,6 +206,7 @@ libbitcoin_server_a_SOURCES = \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \
+  netfulfilledman.cpp \
   noui.cpp \
   policy/fees.cpp \
   policy/policy.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -154,6 +154,7 @@ public:
         fTestnetToBeDeprecatedFieldRPC = false;
 
         nPoolMaxTransactions = 3;
+        nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
         strSporkPubKey = "04549ac134f694c0243f503e8c8a9a986f5de6610049c40b07816809b0d1d06a21b07be27b9bb555931773f62ba6cf35a25fd52f694d4e1106ccd237a7bb899fdd";
         strMasternodePaymentsPubKey = "04549ac134f694c0243f503e8c8a9a986f5de6610049c40b07816809b0d1d06a21b07be27b9bb555931773f62ba6cf35a25fd52f694d4e1106ccd237a7bb899fdd";
 
@@ -271,8 +272,10 @@ public:
         fTestnetToBeDeprecatedFieldRPC = true;
 
         nPoolMaxTransactions = 3;
+        nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
         strSporkPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
         strMasternodePaymentsPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
+
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
             (   261, uint256S("0x00000c26026d0815a7e2ce4fa270775f61403c040647ff2c3091f99e894a4618"))
@@ -353,6 +356,8 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
         fTestnetToBeDeprecatedFieldRPC = false;
+
+        nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -78,6 +78,7 @@ public:
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
+    int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
     std::string SporkPubKey() const { return strSporkPubKey; }
     std::string MasternodePaymentPubKey() const { return strMasternodePaymentsPubKey; }
 protected:
@@ -102,6 +103,7 @@ protected:
     bool fTestnetToBeDeprecatedFieldRPC;
     CCheckpointData checkpointData;
     int nPoolMaxTransactions;
+    int nFulfilledRequestExpireTime;
     std::string strSporkPubKey;
     std::string strMasternodePaymentsPubKey;
 };

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -54,7 +54,7 @@ private:
     const CBlockIndex *pCurrentBlockIndex;
 
     void Fail();
-    void ClearFulfilledRequest();
+    void ClearFulfilledRequests();
 
 public:
     CMasternodeSync() { Reset(); }

--- a/src/net.h
+++ b/src/net.h
@@ -371,8 +371,6 @@ protected:
     static CCriticalSection cs_setBanned;
     static bool setBannedIsDirty;
 
-    std::vector<std::string> vecRequestsFulfilled; //keep track of what client has asked for
-    
     // Whitelisted ranges. Any node connecting from these is automatically
     // whitelisted (as well as those connecting to whitelisted binds).
     static std::vector<CSubNet> vWhitelistedRange;
@@ -742,33 +740,6 @@ public:
             AbortMessage();
             throw;
         }
-    }
-
-    bool HasFulfilledRequest(std::string strRequest)
-    {
-        BOOST_FOREACH(std::string& type, vecRequestsFulfilled)
-        {
-            if(type == strRequest) return true;
-        }
-        return false;
-    }
-
-    void ClearFulfilledRequest(std::string strRequest)
-    {
-        std::vector<std::string>::iterator it = vecRequestsFulfilled.begin();
-        while(it != vecRequestsFulfilled.end()){
-            if((*it) == strRequest) {
-                vecRequestsFulfilled.erase(it);
-                return;
-            }
-            ++it;
-        }
-    }
-
-    void FulfilledRequest(std::string strRequest)
-    {
-        if(HasFulfilledRequest(strRequest)) return;
-        vecRequestsFulfilled.push_back(strRequest);
     }
 
     void CloseSocketDisconnect();

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chainparams.h"
+#include "netfulfilledman.h"
+#include "util.h"
+
+CNetFulfilledRequestManager netfulfilledman;
+
+void CNetFulfilledRequestManager::AddFulfilledRequest(CAddress addr, std::string strRequest)
+{
+    LOCK(cs_mapFulfilledRequests);
+    mapFulfilledRequests[addr][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
+}
+
+bool CNetFulfilledRequestManager::HasFulfilledRequest(CAddress addr, std::string strRequest)
+{
+    LOCK(cs_mapFulfilledRequests);
+    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
+
+    return  it != mapFulfilledRequests.end() &&
+            it->second.find(strRequest) != it->second.end() &&
+            it->second[strRequest] > GetTime();
+}
+
+void CNetFulfilledRequestManager::RemoveFulfilledRequest(CAddress addr, std::string strRequest)
+{
+    LOCK(cs_mapFulfilledRequests);
+    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
+
+    if (it != mapFulfilledRequests.end()) {
+        it->second.erase(strRequest);
+    }
+}
+
+void CNetFulfilledRequestManager::CheckAndRemove()
+{
+    LOCK(cs_mapFulfilledRequests);
+
+    int64_t now = GetTime();
+    fulfilledreqmap_t::iterator it = mapFulfilledRequests.begin();
+
+    while(it != mapFulfilledRequests.end()) {
+        fulfilledreqmapentry_t::iterator it_entry = it->second.begin();
+        while(it_entry != it->second.end()) {
+            if(now > it_entry->second) {
+                it->second.erase(it_entry++);
+            } else {
+                ++it_entry;
+            }
+        }
+        if(it->second.size() == 0) {
+            mapFulfilledRequests.erase(it++);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void CNetFulfilledRequestManager::Clear()
+{
+    LOCK(cs_mapFulfilledRequests);
+    mapFulfilledRequests.clear();
+}
+
+std::string CNetFulfilledRequestManager::ToString() const
+{
+    std::ostringstream info;
+    info << "Nodes with fulfilled requests: " << (int)mapFulfilledRequests.size();
+    return info.str();
+}

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NETFULFILLEDMAN_H
+#define NETFULFILLEDMAN_H
+
+#include "netbase.h"
+#include "protocol.h"
+#include "serialize.h"
+#include "sync.h"
+
+class CNetFulfilledRequestManager;
+extern CNetFulfilledRequestManager netfulfilledman;
+
+// Fulfilled requests are used to prevent nodes from asking for the same data on sync
+// and from being banned for doing so too often.
+class CNetFulfilledRequestManager
+{
+private:
+    typedef std::map<std::string, int64_t> fulfilledreqmapentry_t;
+    typedef std::map<CNetAddr, fulfilledreqmapentry_t> fulfilledreqmap_t;
+
+    //keep track of what node has/was asked for and when
+    fulfilledreqmap_t mapFulfilledRequests;
+    CCriticalSection cs_mapFulfilledRequests;
+
+public:
+    CNetFulfilledRequestManager() {}
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        LOCK(cs_mapFulfilledRequests);
+        READWRITE(mapFulfilledRequests);
+    }
+
+    void AddFulfilledRequest(CAddress addr, std::string strRequest); // expire after 1 hour by default
+    bool HasFulfilledRequest(CAddress addr, std::string strRequest);
+    void RemoveFulfilledRequest(CAddress addr, std::string strRequest);
+
+    void CheckAndRemove();
+    void Clear();
+
+    std::string ToString() const;
+};
+
+#endif


### PR DESCRIPTION
Turned out that current implementation doesn't really help to mitigate abuse - when connection is closed CNode object is destroyed and removed from nodes vector meaning that all "fulfilled" info is gone too. Such info wasn't preserved on wallet shutdown either so client wasn't able to prevent banning of itself by other nodes. Basically the whole thing wasn't working.

This PR implements a separate manager for fulfilled requests `CNetFulfilledRequestManager` which fixes issues described above. This also removes testnet/mainnet specific logic for such cases by introducing additional chain param `nFulfilledRequestExpireTime` (60 minutes for mainnet, 5 minutes for testnet).