### PR TITLE
[UI] Add Instantsend parameter to QR-code

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>776</width>
-    <height>364</height>
+    <height>387</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
@@ -127,7 +127,7 @@
           </property>
          </widget>
         </item>
-        <item row="8" column="2">
+        <item row="9" column="2">
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
            <widget class="QPushButton" name="receiveButton">
@@ -176,10 +176,20 @@
           </item>
          </layout>
         </item>
-        <item row="8" column="0">
+        <item row="9" column="0">
          <widget class="QLabel" name="label_7">
           <property name="text">
            <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="2">
+         <widget class="QCheckBox" name="checkUseInstantSend">
+          <property name="text">
+           <string>Request InstantSend</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -206,7 +206,7 @@ bool parseBitcoinURI(QString uri, SendCoinsRecipient *out)
     return parseBitcoinURI(uriInstance, out);
 }
 
-QString formatBitcoinURI(const SendCoinsRecipient &info)
+QString formatBitcoinURI(const SendCoinsRecipient &info, bool fUseInstantsend)
 {
     QString ret = QString("dash:%1").arg(info.address);
     int paramCount = 0;
@@ -228,6 +228,12 @@ QString formatBitcoinURI(const SendCoinsRecipient &info)
     {
         QString msg(QUrl::toPercentEncoding(info.message));;
         ret += QString("%1message=%2").arg(paramCount == 0 ? "?" : "&").arg(msg);
+        paramCount++;
+    }
+    
+    if(fUseInstantsend)
+    {
+        ret += QString("%1IS=1").arg(paramCount == 0 ? "?" : "&");
         paramCount++;
     }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -206,7 +206,7 @@ bool parseBitcoinURI(QString uri, SendCoinsRecipient *out)
     return parseBitcoinURI(uriInstance, out);
 }
 
-QString formatBitcoinURI(const SendCoinsRecipient &info, bool fUseInstantsend)
+QString formatBitcoinURI(const SendCoinsRecipient &info)
 {
     QString ret = QString("dash:%1").arg(info.address);
     int paramCount = 0;
@@ -231,7 +231,7 @@ QString formatBitcoinURI(const SendCoinsRecipient &info, bool fUseInstantsend)
         paramCount++;
     }
     
-    if(fUseInstantsend)
+    if(info.fUseInstantSend)
     {
         ret += QString("%1IS=1").arg(paramCount == 0 ? "?" : "&");
         paramCount++;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -151,6 +151,8 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
     QUrlQuery uriQuery(uri);
     QList<QPair<QString, QString> > items = uriQuery.queryItems();
 #endif
+    
+    rv.fUseInstantSend = false;
     for (QList<QPair<QString, QString> >::iterator i = items.begin(); i != items.end(); i++)
     {
         bool fShouldReturnFalse = false;
@@ -163,6 +165,13 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
         if (i->first == "label")
         {
             rv.label = i->second;
+            fShouldReturnFalse = false;
+        }
+        if (i->first == "IS")
+        {
+            if(i->second.compare(QString("1")) == 0)
+                rv.fUseInstantSend = true;
+
             fShouldReturnFalse = false;
         }
         if (i->first == "message")

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -47,7 +47,7 @@ namespace GUIUtil
     // Parse "dash:" URI into recipient object, return true on successful parsing
     bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out);
     bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
-    QString formatBitcoinURI(const SendCoinsRecipient &info, bool fUseInstandsend);
+    QString formatBitcoinURI(const SendCoinsRecipient &info, bool fUseInstantsend);
 
     // Returns true if given address+amount meets "dust" definition
     bool isDust(const QString& address, const CAmount& amount);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -47,7 +47,7 @@ namespace GUIUtil
     // Parse "dash:" URI into recipient object, return true on successful parsing
     bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out);
     bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
-    QString formatBitcoinURI(const SendCoinsRecipient &info, bool fUseInstantsend);
+    QString formatBitcoinURI(const SendCoinsRecipient &info);
 
     // Returns true if given address+amount meets "dust" definition
     bool isDust(const QString& address, const CAmount& amount);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -47,7 +47,7 @@ namespace GUIUtil
     // Parse "dash:" URI into recipient object, return true on successful parsing
     bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out);
     bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
-    QString formatBitcoinURI(const SendCoinsRecipient &info);
+    QString formatBitcoinURI(const SendCoinsRecipient &info, bool fUseInstandsend);
 
     // Returns true if given address+amount meets "dust" definition
     bool isDust(const QString& address, const CAmount& amount);

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -152,6 +152,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     }
     SendCoinsRecipient info(address, label,
         ui->reqAmount->value(), ui->reqMessage->text());
+    info.fUseInstantSend = ui->checkUseInstantSend->isChecked();
     ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setModel(model->getOptionsModel());

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -17,7 +17,6 @@
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPixmap>
-#include <QSettings>
 #if QT_VERSION < 0x050000
 #include <QUrl>
 #endif
@@ -129,9 +128,6 @@ void ReceiveRequestDialog::setInfo(const SendCoinsRecipient &info)
 
 void ReceiveRequestDialog::update()
 {
-    QSettings settings;
-    bool fUseInstantsend = settings.value("bUseInstantX").toBool();
-    
     if(!model)
         return;
     QString target = info.label;
@@ -139,7 +135,7 @@ void ReceiveRequestDialog::update()
         target = info.address;
     setWindowTitle(tr("Request payment to %1").arg(target));
 
-    QString uri = GUIUtil::formatBitcoinURI(info, fUseInstantsend);
+    QString uri = GUIUtil::formatBitcoinURI(info);
     ui->btnSaveAs->setEnabled(false);
     QString html;
     html += "<html><font face='verdana, arial, helvetica, sans-serif'>";
@@ -153,7 +149,7 @@ void ReceiveRequestDialog::update()
         html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";
     if(!info.message.isEmpty())
         html += "<b>"+tr("Message")+"</b>: " + GUIUtil::HtmlEscape(info.message) + "<br>";
-    if(fUseInstantsend)
+    if(info.fUseInstantSend)
         html += "<b>"+tr("InstantSend")+"</b>: Yes<br>";
     else
         html += "<b>"+tr("InstantSend")+"</b>: No<br>";
@@ -196,8 +192,7 @@ void ReceiveRequestDialog::update()
 
 void ReceiveRequestDialog::on_btnCopyURI_clicked()
 {
-    QSettings settings;
-    GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(info, settings.value("bUseInstantX").toBool()));
+    GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(info));
 }
 
 void ReceiveRequestDialog::on_btnCopyAddress_clicked()

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -17,6 +17,7 @@
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPixmap>
+#include <QSettings>
 #if QT_VERSION < 0x050000
 #include <QUrl>
 #endif
@@ -128,6 +129,9 @@ void ReceiveRequestDialog::setInfo(const SendCoinsRecipient &info)
 
 void ReceiveRequestDialog::update()
 {
+    QSettings settings;
+    bool fUseInstantsend = settings.value("bUseInstantX").toBool();
+    
     if(!model)
         return;
     QString target = info.label;
@@ -135,7 +139,7 @@ void ReceiveRequestDialog::update()
         target = info.address;
     setWindowTitle(tr("Request payment to %1").arg(target));
 
-    QString uri = GUIUtil::formatBitcoinURI(info);
+    QString uri = GUIUtil::formatBitcoinURI(info, fUseInstantsend);
     ui->btnSaveAs->setEnabled(false);
     QString html;
     html += "<html><font face='verdana, arial, helvetica, sans-serif'>";
@@ -149,6 +153,10 @@ void ReceiveRequestDialog::update()
         html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";
     if(!info.message.isEmpty())
         html += "<b>"+tr("Message")+"</b>: " + GUIUtil::HtmlEscape(info.message) + "<br>";
+    if(fUseInstantsend)
+        html += "<b>"+tr("InstantSend")+"</b>: Yes<br>";
+    else
+        html += "<b>"+tr("InstantSend")+"</b>: No<br>";
     ui->outUri->setText(html);
 
 #ifdef USE_QRCODE
@@ -188,7 +196,8 @@ void ReceiveRequestDialog::update()
 
 void ReceiveRequestDialog::on_btnCopyURI_clicked()
 {
-    GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(info));
+    QSettings settings;
+    GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(info, settings.value("bUseInstantX").toBool()));
 }
 
 void ReceiveRequestDialog::on_btnCopyAddress_clicked()

--- a/src/qt/test/uritests.cpp
+++ b/src/qt/test/uritests.cpp
@@ -63,4 +63,32 @@ void URITests::uriTests()
 
     uri.setUrl(QString("dash:XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwg?amount=1,000.0&label=Some Example"));
     QVERIFY(!GUIUtil::parseBitcoinURI(uri, &rv));
+
+    uri.setUrl(QString("dash:XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwg?amount=100&label=Some Example&message=Some Example Message&IS=1"));
+    QVERIFY(GUIUtil::parseBitcoinURI(uri, &rv));
+    QVERIFY(rv.address == QString("XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwg"));
+    QVERIFY(rv.amount == 10000000000LL);
+    QVERIFY(rv.label == QString("Some Example"));
+    QVERIFY(rv.message == QString("Some Example Message"));
+    QVERIFY(rv.fUseInstantSend == 1);
+
+    uri.setUrl(QString("dash:XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwg?amount=100&label=Some Example&message=Some Example Message&IS=Something Invalid"));
+    QVERIFY(GUIUtil::parseBitcoinURI(uri, &rv));
+    QVERIFY(rv.address == QString("XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwg"));
+    QVERIFY(rv.amount == 10000000000LL);
+    QVERIFY(rv.label == QString("Some Example"));
+    QVERIFY(rv.message == QString("Some Example Message"));
+    QVERIFY(rv.fUseInstantSend != 1);
+
+    uri.setUrl(QString("dash:XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwg?IS=1"));
+    QVERIFY(GUIUtil::parseBitcoinURI(uri, &rv));
+    QVERIFY(rv.fUseInstantSend == 1);
+
+    uri.setUrl(QString("dash:XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwg?IS=0"));
+    QVERIFY(GUIUtil::parseBitcoinURI(uri, &rv));
+    QVERIFY(rv.fUseInstantSend != 1);
+
+    uri.setUrl(QString("dash:XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwg"));
+    QVERIFY(GUIUtil::parseBitcoinURI(uri, &rv));
+    QVERIFY(rv.fUseInstantSend != 1);
 }


### PR DESCRIPTION
solarminer and afreer asked for an Instantsend tag when the QR-code for a payment request is generated so that clients reading the code are able to automatically switch to Instantsend when requested.

We came to the following consensus:

1. to keep the resulting URI short the tag is `IS=1` when Instantsend is requested. When not the tag is omitted.
2. whether `IS=1` is added to the QR-code or not depends on the Instantsend settings of the payment requester (the checkbox on the Send page).
3. I've appended it so clients which might assume some order of the existing tags won't break.

Looks like this:
![qr_is](https://cloud.githubusercontent.com/assets/10080039/18845685/f1a6365c-8422-11e6-80f8-46ffc32242f0.jpg)


Tests with _real_ mobile clients highly appreciated.