### PR TITLE
Various sync fixes

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -140,7 +140,6 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         if(mapSeenGovernanceObjects.count(govobj.GetHash())){
             // TODO - print error code? what if it's GOVOBJ_ERROR_IMMATURE?
-            masternodeSync.AddedBudgetItem(govobj.GetHash());
             return;
         }
 
@@ -189,10 +188,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         // IF WE'VE SEEN THIS OBJECT THEN SKIP
 
-        if(mapSeenVotes.count(vote.GetHash())){
-            masternodeSync.AddedBudgetItem(vote.GetHash());
-            return;
-        }
+        if(mapSeenVotes.count(vote.GetHash())) return;
 
         // FIND THE MASTERNODE OF THE VOTER
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1817,7 +1817,7 @@ bool IsInitialBlockDownload()
     if (fCheckpointsEnabled && chainActive.Height() < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints()))
         return true;
     bool state = (chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 ||
-            pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge());
+            std::max(chainActive.Tip()->GetBlockTime(), pindexBestHeader->GetBlockTime()) < GetTime() - chainParams.MaxTipAge());
     if (!state)
         lockIBDState = true;
     return state;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -316,7 +316,6 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, std::string& strCommand, 
 
         if(mapMasternodePaymentVotes.count(vote.GetHash())) {
             LogPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- hash=%s, nHeight=%d seen\n", vote.GetHash().ToString(), pCurrentBlockIndex->nHeight);
-            masternodeSync.AddedPaymentVote();
             return;
         }
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -203,7 +203,9 @@ void CMasternodeSync::ProcessTick()
     TRY_LOCK(cs_vNodes, lockRecv);
     if(!lockRecv) return;
 
-    if(nRequestedMasternodeAssets == MASTERNODE_SYNC_INITIAL) {
+    if(nRequestedMasternodeAssets == MASTERNODE_SYNC_INITIAL ||
+        (nRequestedMasternodeAssets == MASTERNODE_SYNC_SPORKS && IsBlockchainSynced()))
+    {
         SwitchToNextAsset();
     }
 
@@ -245,10 +247,6 @@ void CMasternodeSync::ProcessTick()
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "spork-sync");
                 // get current network sporks
                 pnode->PushMessage(NetMsgType::GETSPORKS);
-
-                // we always ask for sporks, so just skip this
-                if(nRequestedMasternodeAssets == MASTERNODE_SYNC_SPORKS) SwitchToNextAsset();
-
                 continue; // always get sporks first, switch to the next node without waiting for the next tick
             }
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -29,15 +29,14 @@ bool CMasternodeSync::IsBlockchainSynced()
     lastProcess = GetTime();
 
     if(fBlockchainSynced) return true;
+    if(!pCurrentBlockIndex || !pindexBestHeader || fImporting || fReindex) return false;
 
-    if (fImporting || fReindex) return false;
+    // same as !IsInitialBlockDownload() but no cs_main needed here
+    int nMaxBlockTime = std::max(pCurrentBlockIndex->GetBlockTime(), pindexBestHeader->GetBlockTime());
+    fBlockchainSynced = pindexBestHeader->nHeight - pCurrentBlockIndex->nHeight < 24 * 6 &&
+                        GetTime() - nMaxBlockTime < Params().MaxTipAge();
 
-    if(!pCurrentBlockIndex) return false;
-    if(pCurrentBlockIndex->nTime + 60*60 < GetTime()) return false;
-
-    fBlockchainSynced = true;
-
-    return true;
+    return fBlockchainSynced;
 }
 
 void CMasternodeSync::Fail()

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -701,7 +701,6 @@ int CMasternodeMan::GetEstimatedMasternodes(int nBlock)
 void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb) {
     mapSeenMasternodePing.insert(make_pair(mnb.lastPing.GetHash(), mnb.lastPing));
     mapSeenMasternodeBroadcast.insert(make_pair(mnb.GetHash(), mnb));
-    masternodeSync.AddedMasternodeList();
 
     LogPrintf("CMasternodeMan::UpdateMasternodeList() - addr: %s\n    vin: %s\n", mnb.addr.ToString(), mnb.vin.ToString());
 
@@ -709,9 +708,11 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb) {
     if(pmn == NULL)
     {
         CMasternode mn(mnb);
-        Add(mn);
-    } else {
-        pmn->UpdateFromNewBroadcast(mnb);
+        if(Add(mn)) {
+            masternodeSync.AddedMasternodeList();
+        }
+    } else if(pmn->UpdateFromNewBroadcast(mnb)) {
+        masternodeSync.AddedMasternodeList();
     }
 }
 
@@ -720,7 +721,6 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CMasternodeBroadcast mnb, i
     LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList - Masternode broadcast, vin: %s\n", mnb.vin.ToString());
 
     if(mapSeenMasternodeBroadcast.count(mnb.GetHash())) { //seen
-        masternodeSync.AddedMasternodeList();
         return true;
     }
     mapSeenMasternodeBroadcast.insert(make_pair(mnb.GetHash(), mnb));


### PR DESCRIPTION
Fixes:
- backport 8aa722609d7e736b3a3763e15b552795b94f0e9b (IBD fix);
- apply IBD-like logic in `IsBlockchainSynced`;
- do not switch from `MASTERNODE_SYNC_SPORKS` to next asset until blockchain is synced;
- only bump `nTimeLast*` when valid new/updated message arrived, do not bump on invalid or 'seen'.