### PR TITLE
Align governance proto logic with logic for similar proto for other modules

### DIFF
--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -236,7 +236,7 @@ CGovernanceVote::CGovernanceVote(CTxIn vinMasternodeIn, uint256 nParentHashIn, v
 void CGovernanceVote::Relay()
 {
     CInv inv(MSG_GOVERNANCE_OBJECT_VOTE, GetHash());
-    RelayInv(inv, MSG_GOVERNANCE_PEER_PROTO_VERSION);
+    RelayInv(inv, PROTOCOL_VERSION);
 }
 
 bool CGovernanceVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -89,13 +89,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
     if(fLiteMode) return;
     if(!masternodeSync.IsBlockchainSynced()) return;
 
-    //
-    // REMOVE AFTER MIGRATION TO 12.1
-    //
-    if(pfrom->nVersion < 70201) return;
-    //
-    // END REMOVE
-    //
+    if(pfrom->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) return;
 
     LOCK(governance.cs);
 
@@ -864,7 +858,7 @@ bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& s
 
     // IF ABSOLUTE NO COUNT (NO-YES VALID VOTES) IS MORE THAN 10% OF THE NETWORK MASTERNODES, OBJ IS INVALID
 
-    if(GetAbsoluteNoCount(VOTE_SIGNAL_VALID) > mnodeman.CountEnabled(MSG_GOVERNANCE_PEER_PROTO_VERSION)/10) {
+    if(GetAbsoluteNoCount(VOTE_SIGNAL_VALID) > mnodeman.CountEnabled(MIN_GOVERNANCE_PEER_PROTO_VERSION)/10) {
         strError = "Automated removal";
         return false;
     }
@@ -1073,7 +1067,7 @@ int CGovernanceObject::GetAbstainCount(vote_signal_enum_t eVoteSignalIn)
 void CGovernanceObject::Relay()
 {
     CInv inv(MSG_GOVERNANCE_OBJECT, GetHash());
-    RelayInv(inv, MSG_GOVERNANCE_PEER_PROTO_VERSION);
+    RelayInv(inv, PROTOCOL_VERSION);
 }
 
 std::string CGovernanceManager::ToString() const

--- a/src/governance.h
+++ b/src/governance.h
@@ -30,6 +30,7 @@ class CGovernanceObject;
 class CGovernanceVote;
 
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
+static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70201;
 
 static const int GOVERNANCE_OBJECT_UNKNOWN = 0;
 static const int GOVERNANCE_OBJECT_PROPOSAL = 1;

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -365,7 +365,7 @@ void CMasternodeSync::ProcessTick()
                 if(netfulfilledman.HasFulfilledRequest(pnode->addr, "governance-sync")) continue;
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "governance-sync");
 
-                if (pnode->nVersion < MSG_GOVERNANCE_PEER_PROTO_VERSION) continue;
+                if (pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
                 nRequestedMasternodeAttempt++;
 
                 pnode->PushMessage(NetMsgType::MNGOVERNANCESYNC, uint256()); //sync masternode votes

--- a/src/version.h
+++ b/src/version.h
@@ -21,9 +21,6 @@ static const int GETHEADERS_VERSION = 70077;
 //! disconnect from peers older than this proto version
 static const int MIN_PEER_PROTO_VERSION = 70103;
 
-//! minimum peer version for masternode budgets
-static const int MSG_GOVERNANCE_PEER_PROTO_VERSION = 70201;
-
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this
 static const int CADDR_TIME_VERSION = 31402;


### PR DESCRIPTION
i.e `MSG_GOVERNANCE_PEER_PROTO_VERSION` -> `MIN_GOVERNANCE_PEER_PROTO_VERSION` (to check other peers) + `PROTOCOL_VERSION` (to announce own version)