### PR TITLE
GetMinCollateralFee should not validate object type

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -856,6 +856,15 @@ bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& s
         return true;
     }
 
+    switch(nObjectType) {
+        case GOVERNANCE_OBJECT_PROPOSAL:
+        case GOVERNANCE_OBJECT_TRIGGER:
+            break;
+        default:
+            strError = strprintf("Invalid object type %d", nObjectType);
+            return false;
+    }
+
     // IF ABSOLUTE NO COUNT (NO-YES VALID VOTES) IS MORE THAN 10% OF THE NETWORK MASTERNODES, OBJ IS INVALID
 
     if(GetAbsoluteNoCount(VOTE_SIGNAL_VALID) > mnodeman.CountEnabled(MIN_GOVERNANCE_PEER_PROTO_VERSION)/10) {
@@ -921,37 +930,17 @@ bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& s
 
 CAmount CGovernanceObject::GetMinCollateralFee()
 {
-    CAmount nMinFee = 0;
     // Only 1 type has a fee for the moment but switch statement allows for future object types
     switch(nObjectType) {
-    case GOVERNANCE_OBJECT_PROPOSAL:
-        nMinFee = GOVERNANCE_PROPOSAL_FEE_TX;
-        break;
-    case GOVERNANCE_OBJECT_TRIGGER:
-        nMinFee = 0;
-        break;
-    default:
-      {
-        std::ostringstream ostr;
-        ostr << "CGovernanceObject::GetMinCollateralFee ERROR: Unknown governance object type: " << nObjectType;
-        throw std::runtime_error(ostr.str());
-      }
+        case GOVERNANCE_OBJECT_PROPOSAL:    return GOVERNANCE_PROPOSAL_FEE_TX;
+        default:                            return 0;
     }
-    return nMinFee;
 }
 
 bool CGovernanceObject::IsCollateralValid(std::string& strError)
 {
-    CAmount nMinFee = 0;
-    try  {
-        nMinFee = GetMinCollateralFee();
-    }
-    catch(std::exception& e) {
-        strError = e.what();
-        LogPrintf("CGovernanceObject::IsCollateralValid ERROR An exception occurred - %s\n", e.what());
-        return false;
-    }
-
+    strError = "";
+    CAmount nMinFee = GetMinCollateralFee();
     uint256 nExpectedHash = GetHash();
 
     CTransaction txCollateral;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -933,7 +933,8 @@ CAmount CGovernanceObject::GetMinCollateralFee()
     // Only 1 type has a fee for the moment but switch statement allows for future object types
     switch(nObjectType) {
         case GOVERNANCE_OBJECT_PROPOSAL:    return GOVERNANCE_PROPOSAL_FEE_TX;
-        default:                            return 0;
+        case GOVERNANCE_OBJECT_TRIGGER:     return 0;
+        default:                            return MAX_MONEY;
     }
 }
 


### PR DESCRIPTION
This should be IsValidLocally's job. If object is not of a valid type there is no way it should be proceed so by the time fee is calculated it must be a valid one (or fee is 0 by default so it won't hurt).