### PR TITLE
bump proto 70202

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -35,8 +35,8 @@ static const int PRIVATESEND_AUTO_TIMEOUT_MAX       = 15;
 static const int PRIVATESEND_QUEUE_TIMEOUT          = 30;
 static const int PRIVATESEND_SIGNING_TIMEOUT        = 15;
 
-//! minimum peer version accepted by DarksendPool
-static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70201;
+//! minimum peer version accepted by mixing pool
+static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70202;
 
 static const CAmount PRIVATESEND_COLLATERAL         = 0.001 * COIN;
 static const CAmount PRIVATESEND_POOL_MAX           = 999.999 * COIN;

--- a/src/governance.h
+++ b/src/governance.h
@@ -30,7 +30,7 @@ class CGovernanceObject;
 class CGovernanceVote;
 
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
-static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70201;
+static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70202;
 
 static const int GOVERNANCE_OBJECT_UNKNOWN = 0;
 static const int GOVERNANCE_OBJECT_PROPOSAL = 1;

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -28,7 +28,7 @@ static const int INSTANTSEND_SIGNATURES_REQUIRED    = 6;
 static const int INSTANTSEND_SIGNATURES_TOTAL       = 10;
 static const int DEFAULT_INSTANTSEND_DEPTH          = 5;
 
-static const int MIN_INSTANTSEND_PROTO_VERSION      = 70201;
+static const int MIN_INSTANTSEND_PROTO_VERSION      = 70202;
 static const CAmount INSTANTSEND_MIN_FEE            = 0.1 * CENT;
 
 extern bool fEnableInstantSend;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -748,7 +748,7 @@ void CMasternodePayments::Sync(CNode* pnode, int nCountNeeded)
 
     if(!pCurrentBlockIndex) return;
 
-    if(pnode->nVersion < 70201) {
+    if(pnode->nVersion < 70202) {
         // Old nodes can only sync via heavy method
         int nLimit = GetStorageLimit();
         if(nCountNeeded > nLimit) nCountNeeded = nLimit;
@@ -779,7 +779,7 @@ void CMasternodePayments::Sync(CNode* pnode, int nCountNeeded)
 void CMasternodePayments::RequestLowDataPaymentBlocks(CNode* pnode)
 {
     // Old nodes can't process this
-    if(pnode->nVersion < 70201) return;
+    if(pnode->nVersion < 70202) return;
 
     LOCK(cs_mapMasternodeBlocks);
 

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -24,7 +24,7 @@ static const int MNPAYMENTS_SIGNATURES_TOTAL            = 10;
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
 static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70103;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70201;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70202;
 
 extern CCriticalSection cs_vecPayees;
 extern CCriticalSection cs_mapMasternodeBlocks;

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70201;
+static const int PROTOCOL_VERSION = 70202;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
note: SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT is off on testnet so bumping MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 should be safe and make no difference

Protocol "if"s in masterode GetHash() and CheckSignature() are unchanged (70201) since these rules are already applied on testnet. Same for NO_BLOOM_VERSION and SENDHEADERS_VERSION.