### PR TITLE
[PrivateSend] Performance tweak for MN-exclusion list

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -385,13 +385,14 @@ CMasternode *CMasternodeMan::FindRandomNotInVec(std::vector<CTxIn> &vecToExclude
             vpMasternodesShuffled.push_back(&mn);
     }
 
-    // Shuffle the resulting vector of Masternodes
-    std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), GetRandInt);
+    if(vpMasternodesShuffled.size() > 0){
+        // Shuffle the resulting vector of Masternodes
+        std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), GetRandInt);
 
-    // If we have non-excluded Masternodes, return the first one from the vector
-    // The shuffling guarantees that it's a random one
-    if(vpMasternodesShuffled.size() > 0)
+        // If we have non-excluded Masternodes, return the first one from the vector
+        // The shuffling guarantees that it's a random one
         return vpMasternodesShuffled.front();
+    }
 
     LogPrint("masternode", "CMasternodeMan::FindRandomNotInVec -- failed\n");
     return NULL;


### PR DESCRIPTION
I think it's inefficient to build a vector with ALL Masternodes, shuffle them and then loop over all to find one not in the exclusion vector.

My change builds a vector with all not-excluded Masternodes and shuffles that vector  instead.
When there's lots of Masternodes and lots of excluded Masternodes this is much more efficient because that vector is much smaller.

Not a dramatic improvement, but IMO one worth trying.

