### PR TITLE
V0.12.1.x governance locking pr

### DIFF
--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -283,9 +283,8 @@ bool CGovernanceVote::IsValid(bool fSignatureCheck)
         return false;
     }
 
-    CMasternode* pmn = mnodeman.Find(vinMasternode);
-    if(pmn == NULL)
-    {
+    CMasternode mn;
+    if(!mnodeman.Get(vinMasternode, mn)) {
         LogPrint("gobject", "CGovernanceVote::IsValid -- Unknown Masternode - %s\n", vinMasternode.prevout.ToStringShort());
         return false;
     }
@@ -296,7 +295,7 @@ bool CGovernanceVote::IsValid(bool fSignatureCheck)
     std::string strMessage = vinMasternode.prevout.ToStringShort() + "|" + nParentHash.ToString() + "|" +
         boost::lexical_cast<std::string>(nVoteSignal) + "|" + boost::lexical_cast<std::string>(nVoteOutcome) + "|" + boost::lexical_cast<std::string>(nTime);
 
-    if(!darkSendSigner.VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
+    if(!darkSendSigner.VerifyMessage(mn.pubKeyMasternode, vchSig, strMessage, strError)) {
         LogPrintf("CGovernanceVote::IsValid -- VerifyMessage() failed, error: %s\n", strError);
         return false;
     }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -132,8 +132,13 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         CGovernanceObject govobj;
         vRecv >> govobj;
 
+        std::string strHash = govobj.GetHash().ToString();
+
+        LogPrint("gobject", "CGovernanceObject::ProcessMessage -- received govobj: %s", strHash);
+
         if(mapSeenGovernanceObjects.count(govobj.GetHash())){
             // TODO - print error code? what if it's GOVOBJ_ERROR_IMMATURE?
+            LogPrint("gobject", "CGovernanceObject::ProcessMessage -- govobj already seen: %s", strHash);
             return;
         }
 
@@ -144,7 +149,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         if(!govobj.IsValidLocally(pCurrentBlockIndex, strError, true)) {
             mapSeenGovernanceObjects.insert(std::make_pair(govobj.GetHash(), SEEN_OBJECT_ERROR_INVALID));
-            LogPrintf("Governance object is invalid - %s\n", strError);
+            LogPrintf("Governance object: %s is invalid - %s\n", strHash, strError);
             return;
         }
 
@@ -163,7 +168,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         mapSeenGovernanceObjects.insert(make_pair(govobj.GetHash(), SEEN_OBJECT_IS_VALID));
         masternodeSync.AddedBudgetItem(govobj.GetHash());
 
-        LogPrintf("MNGOVERNANCEOBJECT -- %s new\n", govobj.GetHash().ToString());
+        LogPrintf("MNGOVERNANCEOBJECT -- %s new\n", strHash);
         
         // WE MIGHT HAVE PENDING/ORPHAN VOTES FOR THIS OBJECT
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -660,7 +660,7 @@ CGovernanceObject::CGovernanceObject(const CGovernanceObject& other)
     strData = other.strData;
     nObjectType = other.nObjectType;
 
-    fUnparsable = true;
+    fUnparsable = other.fUnparsable;
 
     vinMasternode = other.vinMasternode;
     vchSig = other.vchSig;
@@ -802,6 +802,7 @@ void CGovernanceObject::LoadData()
         nObjectType = obj["type"].get_int();
     }
     catch(std::exception& e) {
+        fUnparsable = true;
         std::ostringstream ostr;
         ostr << "CGovernanceObject::LoadData Error parsing JSON"
              << ", e.what() = " << e.what();
@@ -810,6 +811,7 @@ void CGovernanceObject::LoadData()
         return;
     }
     catch(...) {
+        fUnparsable = true;
         std::ostringstream ostr;
         ostr << "CGovernanceObject::LoadData Unknown Error parsing JSON";
         DBG( cout << ostr.str() << endl; );
@@ -865,6 +867,10 @@ bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& s
     if(!pindex) {
         strError = "Tip is NULL";
         return true;
+    }
+
+    if(fUnparsable) {
+        return false;
     }
 
     switch(nObjectType) {

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -191,8 +191,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         // FIND THE MASTERNODE OF THE VOTER
 
-        CMasternode* pmn = mnodeman.Find(vote.GetVinMasternode());
-        if(pmn == NULL) {
+        if(!mnodeman.Has(vote.GetVinMasternode())) {
             LogPrint("gobject", "gobject - unknown masternode - vin: %s\n", vote.GetVinMasternode().ToString());
             mnodeman.AskForMN(pfrom, vote.GetVinMasternode());
             return;
@@ -217,7 +216,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         if(AddOrUpdateVote(vote, pfrom, strError)) {
             vote.Relay();
             masternodeSync.AddedBudgetItem(vote.GetHash());
-            pmn->AddGovernanceVote(vote.GetParentHash());
+            mnodeman.AddGovernanceVote(vote.GetVinMasternode(), vote.GetParentHash());
         }
 
         LogPrint("gobject", "NEW governance vote: %s\n", vote.GetHash().ToString());
@@ -288,6 +287,16 @@ void CGovernanceManager::UpdateCachesAndClean()
 {
     LogPrintf("CGovernanceManager::UpdateCachesAndClean \n");
 
+    std::vector<uint256> vecDirtyHashes = mnodeman.GetAndClearDirtyGovernanceObjectHashes();
+
+    for(size_t i = 0; i < vecDirtyHashes.size(); ++i) {
+        object_m_it it = mapObjects.find(vecDirtyHashes[i]);
+        if(it == mapObjects.end()) {
+            continue;
+        }
+        it->second.fDirtyCache = true;
+    }
+
     LOCK(cs);
 
     // DOUBLE CHECK THAT WE HAVE A VALID POINTER TO TIP
@@ -327,6 +336,7 @@ void CGovernanceManager::UpdateCachesAndClean()
 
         if(pObj->fCachedDelete || pObj->fExpired) {
             LogPrintf("UpdateCachesAndClean --- erase obj %s\n", (*it).first.ToString());
+            mnodeman.RemoveGovernanceObject(pObj->GetHash());
             mapObjects.erase(it++);
         } else {
             ++it;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -799,10 +799,16 @@ void CMasternode::RemoveGovernanceObject(uint256 nGovernanceObjectHash)
 
 void CMasternode::FlagGovernanceItemsAsDirty()
 {
-    LOCK(cs);
-    std::map<uint256, int>::iterator it = mapGovernanceObjectsVotedOn.begin();
-    while(it != mapGovernanceObjectsVotedOn.end()) {
-        mnodeman.AddDirtyGovernanceObjectHash(it->first);
-        ++it;
+    std::vector<uint256> vecDirty;
+    {
+        LOCK(cs);
+        std::map<uint256, int>::iterator it = mapGovernanceObjectsVotedOn.begin();
+        while(it != mapGovernanceObjectsVotedOn.end()) {
+            vecDirty.push_back(it->first);
+            ++it;
+        }
+    }
+    for(size_t i = 0; i < vecDirty.size(); ++i) {
+        mnodeman.AddDirtyGovernanceObjectHash(vecDirty[i]);
     }
 }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -772,11 +772,22 @@ void CMasternodePing::Relay()
 
 void CMasternode::AddGovernanceVote(uint256 nGovernanceObjectHash)
 {
-    if(mapGovernaceObjectsVotedOn.count(nGovernanceObjectHash)) {
-        mapGovernaceObjectsVotedOn[nGovernanceObjectHash]++;
+    LOCK(cs);
+    if(mapGovernanceObjectsVotedOn.count(nGovernanceObjectHash)) {
+        mapGovernanceObjectsVotedOn[nGovernanceObjectHash]++;
     } else {
-        mapGovernaceObjectsVotedOn.insert(std::make_pair(nGovernanceObjectHash, 1));
+        mapGovernanceObjectsVotedOn.insert(std::make_pair(nGovernanceObjectHash, 1));
     }
+}
+
+void CMasternode::RemoveGovernanceObject(uint256 nGovernanceObjectHash)
+{
+    LOCK(cs);
+    std::map<uint256, int>::iterator it = mapGovernanceObjectsVotedOn.find(nGovernanceObjectHash);
+    if(it == mapGovernanceObjectsVotedOn.end()) {
+        return;
+    }
+    mapGovernanceObjectsVotedOn.erase(it);
 }
 
 /**
@@ -788,11 +799,10 @@ void CMasternode::AddGovernanceVote(uint256 nGovernanceObjectHash)
 
 void CMasternode::FlagGovernanceItemsAsDirty()
 {
-    std::map<uint256, int>::iterator it = mapGovernaceObjectsVotedOn.begin();
-    while(it != mapGovernaceObjectsVotedOn.end()){
-        CGovernanceObject *pObj = governance.FindGovernanceObject((*it).first);
-
-        if(pObj) pObj->fDirtyCache = true;
+    LOCK(cs);
+    std::map<uint256, int>::iterator it = mapGovernanceObjectsVotedOn.begin();
+    while(it != mapGovernanceObjectsVotedOn.end()) {
+        mnodeman.AddDirtyGovernanceObjectHash(it->first);
         ++it;
     }
 }

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -133,7 +133,7 @@ public:
     bool fUnitTest;
 
     // KEEP TRACK OF GOVERNANCE ITEMS EACH MASTERNODE HAS VOTE UPON FOR RECALCULATION
-    std::map<uint256, int> mapGovernaceObjectsVotedOn;
+    std::map<uint256, int> mapGovernanceObjectsVotedOn;
 
     CMasternode();
     CMasternode(const CMasternode& other);
@@ -161,7 +161,7 @@ public:
         READWRITE(nProtocolVersion);
         READWRITE(fAllowMixingTx);
         READWRITE(fUnitTest);
-        READWRITE(mapGovernaceObjectsVotedOn);
+        READWRITE(mapGovernanceObjectsVotedOn);
     }
 
     void swap(CMasternode& first, CMasternode& second) // nothrow
@@ -187,7 +187,7 @@ public:
         swap(first.nProtocolVersion, second.nProtocolVersion);
         swap(first.fAllowMixingTx, second.fAllowMixingTx);
         swap(first.fUnitTest, second.fUnitTest);
-        swap(first.mapGovernaceObjectsVotedOn, second.mapGovernaceObjectsVotedOn);
+        swap(first.mapGovernanceObjectsVotedOn, second.mapGovernanceObjectsVotedOn);
     }
 
     // CALCULATE A RANK AGAINST OF GIVEN BLOCK
@@ -224,8 +224,8 @@ public:
     void AddGovernanceVote(uint256 nGovernanceObjectHash);
     // RECALCULATE CACHED STATUS FLAGS FOR ALL AFFECTED OBJECTS
     void FlagGovernanceItemsAsDirty();
-    // TODO: There probably should be some method to clean mapGovernaceObjectsVotedOn map
-    // under some conditions. We shouldn't store everything in memory forever.
+
+    void RemoveGovernanceObject(uint256 nGovernanceObjectHash);
 
     CMasternode& operator=(CMasternode from)
     {

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -12,6 +12,7 @@
 #include "base58.h"
 #include "main.h"
 #include "masternode.h"
+#include "governance.h"
 
 #define MASTERNODES_DUMP_SECONDS               (15*60)
 #define MASTERNODES_DSEG_SECONDS               (3*60*60)
@@ -40,6 +41,8 @@ private:
     std::map<CNetAddr, int64_t> mWeAskedForMasternodeList;
     // which Masternodes we've asked for
     std::map<COutPoint, int64_t> mWeAskedForMasternodeListEntry;
+
+    std::vector<uint256> vecDirtyGovernanceObjectHashes;
 
 public:
     // Keep track of all broadcasts I've seen
@@ -102,6 +105,8 @@ public:
     bool Get(const CPubKey& pubKeyMasternode, CMasternode& masternode);
     bool Get(const CTxIn& vin, CMasternode& masternode);
 
+    bool Has(const CTxIn& vin);
+
     /// Find an entry in the masternode list that is next to be paid
     CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount);
 
@@ -135,6 +140,24 @@ public:
     bool CheckMnbAndUpdateMasternodeList(CMasternodeBroadcast mnb, int& nDos);
 
     void UpdateLastPaid(const CBlockIndex *pindex);
+
+    void AddDirtyGovernanceObjectHash(const uint256& nHash)
+    {
+        LOCK(cs);
+        vecDirtyGovernanceObjectHashes.push_back(nHash);
+    }
+
+    std::vector<uint256> GetAndClearDirtyGovernanceObjectHashes()
+    {
+        LOCK(cs);
+        std::vector<uint256> vecTmp = vecDirtyGovernanceObjectHashes;
+        vecDirtyGovernanceObjectHashes.clear();
+        return vecTmp;;
+    }
+
+    void AddGovernanceVote(const CTxIn& vin, uint256 nGovernanceObjectHash);
+
+    void RemoveGovernanceObject(uint256 nGovernanceObjectHash);
 };
 
 #endif


### PR DESCRIPTION
This PR fixes a locking issue I recently became aware of between CGovernanceManager and CMasternodeMan.  CMasternodeMan maintains a map of governance objects voted on so that they may be updated when masternodes are removed or become invalid.  This was being done without holding the appropriate mutex locks.  This PR ensures that whenever both the CGovernanceManager and CMasternodeMan mutexes are locked this is done in the order:   CGovernanceManager::cs, CMasternodeMan::cs.

Another change is to reject governance objects as invalid if they fail to parse correctly.