### PR TITLE
[PrivateSend] vecMasternodesUsed: remove several nodes at once

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1510,10 +1510,8 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
     LogPrint("privatesend", "Checking vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold_high);
 
     if((int)vecMasternodesUsed.size() > nThreshold_high) {
-        while((int)vecMasternodesUsed.size() > nThreshold_low) {
-            vecMasternodesUsed.erase(vecMasternodesUsed.begin());
-            LogPrint("privatesend", "  vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold_low);
-        }
+        vecMasternodesUsed.erase(vecMasternodesUsed.begin(), vecMasternodesUsed.begin() + vecMasternodesUsed.size() - nThreshold_low);
+        LogPrint("privatesend", "  vecMasternodesUsed: new size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold_high);
     }
 
     bool fUseQueue = insecure_rand()%100 > 33;

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1504,12 +1504,16 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
         }
     }
 
-    //if we've used 90% of the Masternode list then drop all the oldest first
-    int nThreshold = (int)(mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION) * 0.9);
-    LogPrint("privatesend", "Checking vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold);
-    while((int)vecMasternodesUsed.size() > nThreshold) {
-        vecMasternodesUsed.erase(vecMasternodesUsed.begin());
-        LogPrint("privatesend", "  vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold);
+    // If we've used 90% of the Masternode list then drop the oldest first ~30%
+    int nThreshold_high = (int)(mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION) * 0.9);
+    int nThreshold_low = nThreshold_high * 0.7;
+    LogPrint("privatesend", "Checking vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold_high);
+
+    if((int)vecMasternodesUsed.size() > nThreshold_high) {
+        while((int)vecMasternodesUsed.size() > nThreshold_low) {
+            vecMasternodesUsed.erase(vecMasternodesUsed.begin());
+            LogPrint("privatesend", "  vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold_low);
+        }
     }
 
     bool fUseQueue = insecure_rand()%100 > 33;


### PR DESCRIPTION
During some other tests I've noticed that the loop which reduces the size of the used-masternodes vector almost always erases just one single Masternode entry, which keeps the list always at its upper limit and hurts performance.

I've added a lower limit (roughly 30% below the original threshold which works quite nice. Alternative value proposals welcome) and now all entries down to that lower threshold get deleted.

I also thought about @UdjinM6's  idea to limit this vector to (IIRC) 1000 Masternodes. I can add that if wanted (useful values for testnet appreciated).