### PR TITLE
[PrivateSend] Performance tweak: faster shuffling of Masternodes vector

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1151,7 +1151,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "fee") != vstrReplacementModes.end());
     }
 
-    // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
+    // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log, seed insecure_rand()
+
+    // Initialize fast PRNG
+    seed_insecure_rand(false);
 
     // Initialize elliptic curve code
     ECC_Start();

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -373,7 +373,7 @@ CMasternode *CMasternodeMan::FindRandomNotInVec(std::vector<CTxIn> &vecToExclude
     }
 
     // shuffle pointers
-    std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), GetRandInt);
+    std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), insecure_shuffle_rand);
     bool fExclude;
 
     // loop through

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -373,7 +373,7 @@ CMasternode *CMasternodeMan::FindRandomNotInVec(std::vector<CTxIn> &vecToExclude
     }
 
     // shuffle pointers
-    std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), insecure_shuffle_rand);
+    std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), GetInsecureRand);
     bool fExclude;
 
     // loop through

--- a/src/random.h
+++ b/src/random.h
@@ -46,4 +46,11 @@ static inline uint32_t insecure_rand(void)
     return (insecure_rand_Rw << 16) + insecure_rand_Rz;
 }
 
+/**
+ * Function for std::random_shuffle
+ */
+static inline uint32_t insecure_shuffle_rand(uint32_t i){
+    return insecure_rand() % i;
+}
+
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -49,7 +49,7 @@ static inline uint32_t insecure_rand(void)
 /**
  * Function for std::random_shuffle
  */
-static inline uint32_t insecure_shuffle_rand(uint32_t i){
+static inline uint32_t GetInsecureRand(uint32_t i){
     return insecure_rand() % i;
 }
 


### PR DESCRIPTION
This is the result of the investigations here https://github.com/dashpay/dash/pull/1055 and here https://github.com/dashpay/dash/pull/1057 .
Kudos to @UdjinM6 and @tgflynn for all their help.

Summary: to speed up the search for unused Masternodes for mixing the best (and simplest) solution is to just use a faster random number generator, because most time is used there.

I also found a serious faux pas for the existing `insecure_rand()` function: `insecure_rand()` is used all over the place, but it's only properly seeded (with a good random seed) when a new transaction is created, which might be _**after**_ it's already used.

I put the seeding call into init.cpp to fix that.