### PR TITLE
[UI] Change 'Send' warning

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -266,7 +266,7 @@ void SendCoinsDialog::on_sendButton_clicked()
         ).arg(strNearestAmount));
     } else {
         recipients[0].inputType = ALL_COINS;
-        strFunds = tr("using") + " <b>" + tr("any available funds (not recommended)") + "</b>";
+        strFunds = tr("using") + " <b>" + tr("any available funds (not anonymous)") + "</b>";
     }
 
     if(ui->checkUseInstantSend->isChecked()) {


### PR DESCRIPTION
Reference: https://www.dash.org/forum/threads/available-funds-not-recommended.11029/

I always though the "not recommended" warning sounds kinda odd in this context, because no user wants to execute/do something that's not recommended.

Now he sees what's actually important, that it'll not be anonymous.

![na](https://cloud.githubusercontent.com/assets/10080039/19214913/0943d582-8d90-11e6-8ed7-107d3dcdb922.jpg)
