### PR TITLE
new PoSe - MNVERIFY

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1578,6 +1578,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
                 LogPrintf("CDarksendPool::DoAutomaticDenominating -- error connecting\n");
                 strAutoDenomResult = _("Error connecting to Masternode.");
                 dsq.nTime = 0; //remove node
+                pmn->nPoSeBanScore++;
                 continue;
             }
         }
@@ -1624,6 +1625,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
         } else {
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- can't connect %s\n", pmn->vin.ToString());
             nTries++;
+            pmn->nPoSeBanScore++;
             continue;
         }
     }

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -5,6 +5,7 @@
 #include "dsnotificationinterface.h"
 #include "darksend.h"
 #include "governance.h"
+#include "masternodeman.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"
 
@@ -18,6 +19,7 @@ CDSNotificationInterface::~CDSNotificationInterface()
 
 void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
 {
+    mnodeman.UpdatedBlockTip(pindex);
     darkSendPool.UpdatedBlockTip(pindex);
     mnpayments.UpdatedBlockTip(pindex);
     governance.UpdatedBlockTip(pindex);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1880,6 +1880,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // force UpdatedBlockTip to initialize pCurrentBlockIndex for DS, MN payments and budgets
     // but don't call it directly to prevent triggering of other listeners like zmq etc.
     // GetMainSignals().UpdatedBlockTip(chainActive.Tip());
+    mnodeman.UpdatedBlockTip(chainActive.Tip());
     darkSendPool.UpdatedBlockTip(chainActive.Tip());
     mnpayments.UpdatedBlockTip(chainActive.Tip());
     masternodeSync.UpdatedBlockTip(chainActive.Tip());

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -32,6 +32,7 @@ CMasternode::CMasternode() :
     nCacheCollateralBlock(0),
     nBlockLastPaid(0),
     nProtocolVersion(PROTOCOL_VERSION),
+    nPoSeBanScore(0),
     fAllowMixingTx(true),
     fUnitTest(false)
 {}
@@ -52,6 +53,7 @@ CMasternode::CMasternode(CService addrNew, CTxIn vinNew, CPubKey pubKeyCollatera
     nCacheCollateralBlock(0),
     nBlockLastPaid(0),
     nProtocolVersion(nProtocolVersionIn),
+    nPoSeBanScore(0),
     fAllowMixingTx(true),
     fUnitTest(false)
 {}
@@ -72,6 +74,7 @@ CMasternode::CMasternode(const CMasternode& other) :
     nCacheCollateralBlock(other.nCacheCollateralBlock),
     nBlockLastPaid(other.nBlockLastPaid),
     nProtocolVersion(other.nProtocolVersion),
+    nPoSeBanScore(other.nPoSeBanScore),
     fAllowMixingTx(other.fAllowMixingTx),
     fUnitTest(other.fUnitTest)
 {}
@@ -92,6 +95,7 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
     nCacheCollateralBlock(0),
     nBlockLastPaid(0),
     nProtocolVersion(mnb.nProtocolVersion),
+    nPoSeBanScore(0),
     fAllowMixingTx(true),
     fUnitTest(false)
 {}
@@ -101,21 +105,34 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
 //
 bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
 {
-    if(mnb.sigTime > sigTime) {
-        pubKeyMasternode = mnb.pubKeyMasternode;
-        sigTime = mnb.sigTime;
-        vchSig = mnb.vchSig;
-        nProtocolVersion = mnb.nProtocolVersion;
-        addr = mnb.addr;
-        nTimeLastChecked = 0;
-        int nDos = 0;
-        if(mnb.lastPing == CMasternodePing() || (mnb.lastPing != CMasternodePing() && mnb.lastPing.CheckAndUpdate(nDos, false))) {
-            lastPing = mnb.lastPing;
-            mnodeman.mapSeenMasternodePing.insert(std::make_pair(lastPing.GetHash(), lastPing));
-        }
-        return true;
+    if(mnb.sigTime <= sigTime) return false;
+
+    pubKeyMasternode = mnb.pubKeyMasternode;
+    sigTime = mnb.sigTime;
+    vchSig = mnb.vchSig;
+    nProtocolVersion = mnb.nProtocolVersion;
+    addr = mnb.addr;
+    nPoSeBanScore = 0;
+    nTimeLastChecked = 0;
+    int nDos = 0;
+    if(mnb.lastPing == CMasternodePing() || (mnb.lastPing != CMasternodePing() && mnb.lastPing.CheckAndUpdate(nDos, false))) {
+        lastPing = mnb.lastPing;
+        mnodeman.mapSeenMasternodePing.insert(std::make_pair(lastPing.GetHash(), lastPing));
     }
-    return false;
+    // if it matches our Masternode privkey...
+    if(fMasterNode && pubKeyMasternode == activeMasternode.pubKeyMasternode) {
+        nPoSeBanScore = -MASTERNODE_POSE_BAN_MAX_SCORE;
+        if(nProtocolVersion == PROTOCOL_VERSION) {
+            // ... and PROTOCOL_VERSION, then we've been remotely activated ...
+            activeMasternode.ManageState();
+        } else {
+            // ... otherwise we need to reactivate our node, do not add it to the list and do not relay
+            // but also do not ban the node we get this message from
+            LogPrintf("CMasternode::UpdateFromNewBroadcast -- wrong PROTOCOL_VERSION, re-activate your MN: message nProtocolVersion=%d  PROTOCOL_VERSION=%d\n", nProtocolVersion, PROTOCOL_VERSION);
+            return false;
+        }
+    }
+    return true;
 }
 
 //
@@ -143,10 +160,9 @@ void CMasternode::Check(bool fForce)
 {
     LOCK(cs);
 
-    bool fWatchdogActive = mnodeman.IsWatchdogActive();
+    static int64_t nTimeStart;
 
-    LogPrint("masternode", "CMasternode::Check start -- vin = %s\n", 
-             vin.prevout.ToStringShort());
+    LogPrint("masternode", "CMasternode::Check start -- vin %s\n", vin.prevout.ToStringShort());
 
     //once spent, stop doing the checks
     if(nActiveState == MASTERNODE_OUTPOINT_SPENT) return;
@@ -156,15 +172,42 @@ void CMasternode::Check(bool fForce)
     if(!fForce && (GetTime() - nTimeLastChecked < MASTERNODE_CHECK_SECONDS)) return;
     nTimeLastChecked = GetTime();
 
-    if((nActiveState == MASTERNODE_WATCHDOG_EXPIRED) && !fWatchdogActive) {
-        // Redo the checks
-        nActiveState = MASTERNODE_ENABLED;
+    if(!fUnitTest) {
+        TRY_LOCK(cs_main, lockMain);
+        if(!lockMain) return;
+
+        CCoins coins;
+        if(!pcoinsTip->GetCoins(vin.prevout.hash, coins) ||
+           (unsigned int)vin.prevout.n>=coins.vout.size() ||
+           coins.vout[vin.prevout.n].IsNull()) {
+            nActiveState = MASTERNODE_OUTPOINT_SPENT;
+            LogPrint("masternode", "CMasternode::Check -- Failed to find Masternode UTXO, masternode=%s\n", vin.prevout.ToStringShort());
+            return;
+        }
     }
 
                    // masternode doesn't meet payment protocol requirements ...
     bool fRemove = nProtocolVersion < mnpayments.GetMinMasternodePaymentsProto() ||
                    // or it's our own node and we just updated it to the new protocol but we are still waiting for activation ...
                    (pubKeyMasternode == activeMasternode.pubKeyMasternode && nProtocolVersion < PROTOCOL_VERSION);
+
+    // keep old masternodes on start, give them a chance to receive an updated ping without removal/expiry
+    if(!masternodeSync.IsMasternodeListSynced()) nTimeStart = GetTime();
+    bool fWaitForPing = (GetTime() - nTimeStart < MASTERNODE_MIN_MNP_SECONDS);
+
+    if(nActiveState == MASTERNODE_POSE_BAN) {
+        if(IsPingedWithin(MASTERNODE_POSE_BAN_SECONDS)) {
+            // Still alive? Good luck with that.
+            return;
+        } else {
+            // It's finally dead, good...
+            // or did we just start our node and it's too early to decide?
+            fRemove = !fWaitForPing;
+        }
+    } else if(nPoSeBanScore >= MASTERNODE_POSE_BAN_MAX_SCORE) {
+        nActiveState = MASTERNODE_POSE_BAN;
+        return;
+    }
 
     if(fRemove) {
         // it should be removed from the list
@@ -175,47 +218,26 @@ void CMasternode::Check(bool fForce)
         return;
     }
 
-    if(!IsPingedWithin(MASTERNODE_EXPIRATION_SECONDS)) {
-        if(nActiveState != MASTERNODE_WATCHDOG_EXPIRED) {
-            nActiveState = MASTERNODE_EXPIRED;
-        }
+    bool fWatchdogActive = mnodeman.IsWatchdogActive();
+    bool fWatchdogExpired = (fWatchdogActive && ((GetTime() - nTimeLastWatchdogVote) > MASTERNODE_WATCHDOG_MAX_SECONDS));
 
+    LogPrint("masternode", "CMasternode::Check -- vin %s, nTimeLastWatchdogVote %d, GetTime() %d, fWatchdogExpired %d\n",
+            vin.prevout.ToStringShort(), nTimeLastWatchdogVote, GetTime(), fWatchdogExpired);
+
+    if(fWatchdogExpired) {
+        nActiveState = MASTERNODE_WATCHDOG_EXPIRED;
+        return;
+    }
+
+    if(!fWaitForPing && !IsPingedWithin(MASTERNODE_EXPIRATION_SECONDS)) {
+        nActiveState = MASTERNODE_EXPIRED;
         // RESCAN AFFECTED VOTES
         FlagGovernanceItemsAsDirty();
         return;
     }
 
     if(lastPing.sigTime - sigTime < MASTERNODE_MIN_MNP_SECONDS) {
-        if(nActiveState != MASTERNODE_WATCHDOG_EXPIRED) {
-            nActiveState = MASTERNODE_PRE_ENABLED;
-        }
-
-        return;
-    }
-
-    if(!fUnitTest) {
-        CValidationState state;
-        CMutableTransaction tx = CMutableTransaction();
-        CTxOut txout = CTxOut(999.99*COIN, mnodeman.dummyScriptPubkey);
-        tx.vin.push_back(vin);
-        tx.vout.push_back(txout);
-
-        {
-            TRY_LOCK(cs_main, lockMain);
-            if(!lockMain) return;
-
-            if(!AcceptToMemoryPool(mempool, state, CTransaction(tx), false, NULL, false, true, true)) {
-                nActiveState = MASTERNODE_OUTPOINT_SPENT;
-                return;
-            }
-        }
-    }
-
-    bool fWatchdogExpired = (fWatchdogActive && ((GetTime() - nTimeLastWatchdogVote) > MASTERNODE_WATCHDOG_MAX_SECONDS));
-    LogPrint("masternode", "CMasternode::Check -- vin = %s,  nTimeLastWatchdogVote = %d, GetTime() = %d, fWatchdogExpired = %d\n", 
-             vin.prevout.ToStringShort(), nTimeLastWatchdogVote, GetTime(), fWatchdogExpired);
-    if(fWatchdogExpired) {
-        nActiveState = MASTERNODE_WATCHDOG_EXPIRED;
+        nActiveState = MASTERNODE_PRE_ENABLED;
         return;
     }
 
@@ -257,6 +279,7 @@ std::string CMasternode::GetStatus()
         case CMasternode::MASTERNODE_OUTPOINT_SPENT:    return "OUTPOINT_SPENT";
         case CMasternode::MASTERNODE_REMOVE:            return "REMOVE";
         case CMasternode::MASTERNODE_WATCHDOG_EXPIRED:  return "WATCHDOG_EXPIRED";
+        case CMasternode::MASTERNODE_POSE_BAN:          return "POSE_BAN";
         default:                                        return "UNKNOWN";
     }
 }
@@ -398,12 +421,20 @@ bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollater
     return true;
 }
 
-bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
+bool CMasternodeBroadcast::SimpleCheck(int& nDos)
 {
     nDos = 0;
+
+    // make sure addr is valid
+    if(!IsValidNetAddr()) {
+        LogPrintf("CMasternodeBroadcast::SimpleCheck -- Invalid addr, rejected: masternode=%s  addr=%s\n",
+                    vin.prevout.ToStringShort(), addr.ToString());
+        return false;
+    }
+
     // make sure signature isn't in the future (past is OK)
     if (sigTime > GetAdjustedTime() + 60 * 60) {
-        LogPrintf("CMasternodeBroadcast::CheckAndUpdate -- Signature rejected, too far into the future: masternode=%s\n", vin.prevout.ToStringShort());
+        LogPrintf("CMasternodeBroadcast::SimpleCheck -- Signature rejected, too far into the future: masternode=%s\n", vin.prevout.ToStringShort());
         nDos = 1;
         return false;
     }
@@ -414,7 +445,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     }
 
     if(nProtocolVersion < mnpayments.GetMinMasternodePaymentsProto()) {
-        LogPrintf("CMasternodeBroadcast::CheckAndUpdate -- ignoring outdated Masternode: masternode=%s  nProtocolVersion=%d\n", vin.prevout.ToStringShort(), nProtocolVersion);
+        LogPrintf("CMasternodeBroadcast::SimpleCheck -- ignoring outdated Masternode: masternode=%s  nProtocolVersion=%d\n", vin.prevout.ToStringShort(), nProtocolVersion);
         return false;
     }
 
@@ -422,7 +453,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     pubkeyScript = GetScriptForDestination(pubKeyCollateralAddress.GetID());
 
     if(pubkeyScript.size() != 25) {
-        LogPrintf("CMasternodeBroadcast::CheckAndUpdate -- pubKeyCollateralAddress has the wrong size\n");
+        LogPrintf("CMasternodeBroadcast::SimpleCheck -- pubKeyCollateralAddress has the wrong size\n");
         nDos = 100;
         return false;
     }
@@ -431,18 +462,18 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     pubkeyScript2 = GetScriptForDestination(pubKeyMasternode.GetID());
 
     if(pubkeyScript2.size() != 25) {
-        LogPrintf("CMasternodeBroadcast::CheckAndUpdate -- pubKeyMasternode has the wrong size\n");
+        LogPrintf("CMasternodeBroadcast::SimpleCheck -- pubKeyMasternode has the wrong size\n");
         nDos = 100;
         return false;
     }
 
     if(!vin.scriptSig.empty()) {
-        LogPrintf("CMasternodeBroadcast::CheckAndUpdate -- Ignore Not Empty ScriptSig %s\n",vin.ToString());
+        LogPrintf("CMasternodeBroadcast::SimpleCheck -- Ignore Not Empty ScriptSig %s\n",vin.ToString());
         return false;
     }
 
     if (!CheckSignature(nDos)) {
-        LogPrintf("CMasternodeBroadcast::CheckAndUpdate -- CheckSignature() failed, masternode=%s\n", vin.prevout.ToStringShort());
+        LogPrintf("CMasternodeBroadcast::SimpleCheck -- CheckSignature() failed, masternode=%s\n", vin.prevout.ToStringShort());
         return false;
     }
 
@@ -451,28 +482,47 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
         if(addr.GetPort() != mainnetDefaultPort) return false;
     } else if(addr.GetPort() == mainnetDefaultPort) return false;
 
-    //search existing Masternode list, this is where we update existing Masternodes with new mnb broadcasts
-    CMasternode* pmn = mnodeman.Find(vin);
+    return true;
+}
 
-    // no such masternode, nothing to update
-    if(pmn == NULL) return true;
+bool CMasternodeBroadcast::Update(CMasternode* pmn, int& nDos)
+{
+    if(pmn->sigTime == sigTime) {
+        // mapSeenMasternodeBroadcast in CMasternodeMan::CheckMnbAndUpdateMasternodeList should filter legit duplicates
+        // but this still can happen if we just started, which is ok, just do nothing here.
+        return true;
+    }
 
-    // this broadcast is older or equal than the one that we already have - it's bad and should never happen
+    // this broadcast is older than the one that we already have - it's bad and should never happen
     // unless someone is doing something fishy
-    // (mapSeenMasternodeBroadcast in CMasternodeMan::ProcessMessage should filter legit duplicates)
-    if(pmn->sigTime >= sigTime) {
-        LogPrintf("CMasternodeBroadcast::CheckAndUpdate -- Bad sigTime %d (existing broadcast is at %d) for Masternode %s %s\n",
+    if(pmn->sigTime > sigTime) {
+        LogPrintf("CMasternodeBroadcast::Update -- Bad sigTime %d (existing broadcast is at %d) for Masternode %s %s\n",
                       sigTime, pmn->sigTime, vin.prevout.ToStringShort(), addr.ToString());
         return false;
     }
 
-    // masternode is not enabled yet/already, nothing to update
-    if(!pmn->IsEnabled()) return true;
+    pmn->Check();
 
-    // IsVnAssociatedWithPubkey is validated once below, after that they just need to match
-    if(pmn->pubKeyCollateralAddress == pubKeyCollateralAddress && !pmn->IsBroadcastedWithin(MASTERNODE_MIN_MNB_SECONDS)) {
-        //take the newest entry
-        LogPrintf("CMasternodeBroadcast::CheckAndUpdate -- Got UPDATED Masternode entry: addr=%s\n", addr.ToString());
+    // masternode is banned by PoSe
+    if(pmn->IsPoSeBanned()) {
+        LogPrintf("CMasternodeBroadcast::Update -- Banned by PoSe, masternode=%s\n", vin.prevout.ToStringShort());
+        return false;
+    }
+
+    // masternode is not enabled yet/already, nothing to update
+    if(!pmn->IsEnabled()) return false;
+
+    // IsVnAssociatedWithPubkey is validated once in CheckOutpoint, after that they just need to match
+    if(pmn->pubKeyCollateralAddress != pubKeyCollateralAddress) {
+        LogPrintf("CMasternodeMan::Update -- Got mismatched pubKeyCollateralAddress and vin\n");
+        nDos = 33;
+        return false;
+    }
+
+    // if ther was no masternode broadcast recently or if it matches our Masternode privkey...
+    if(!pmn->IsBroadcastedWithin(MASTERNODE_MIN_MNB_SECONDS) || (fMasterNode && pubKeyMasternode == activeMasternode.pubKeyMasternode)) {
+        // take the newest entry
+        LogPrintf("CMasternodeBroadcast::Update -- Got UPDATED Masternode entry: addr=%s\n", addr.ToString());
         if(pmn->UpdateFromNewBroadcast((*this))) {
             pmn->Check();
             // normally masternode should be in pre-enabled status after update, if not - do not relay
@@ -486,66 +536,49 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     return true;
 }
 
-bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDos)
+bool CMasternodeBroadcast::CheckOutpoint(int& nDos)
 {
     // we are a masternode with the same vin (i.e. already activated) and this mnb is ours (matches our Masternode privkey)
     // so nothing to do here for us
     if(fMasterNode && vin.prevout == activeMasternode.vin.prevout && pubKeyMasternode == activeMasternode.pubKeyMasternode) {
-        return true;
-    }
-
-    // incorrect ping or its sigTime
-    if(lastPing == CMasternodePing() || !lastPing.CheckAndUpdate(nDos, false, true)) {
         return false;
     }
-
-    // search existing Masternode list
-    CMasternode* pmn = mnodeman.Find(vin);
-
-    if(pmn != NULL) {
-        // nothing to do here if we already know about this masternode and it's (pre)enabled
-        if(pmn->IsEnabled() || pmn->IsPreEnabled() || pmn->IsWatchdogExpired()) return true;
-        // if it's not (pre)enabled, remove old MN first and continue
-        mnodeman.Remove(pmn->vin);
-    }
-
-    if(GetInputAge(vin) < Params().GetConsensus().nMasternodeMinimumConfirmations) {
-        LogPrintf("CMasternodeBroadcast::CheckInputsAndAdd -- Input must have at least %d confirmations\n", Params().GetConsensus().nMasternodeMinimumConfirmations);
-        // maybe we miss few blocks, let this mnb to be checked again later
-        mnodeman.mapSeenMasternodeBroadcast.erase(GetHash());
-        return false;
-    }
-
-    CValidationState state;
-    CMutableTransaction dummyTx = CMutableTransaction();
-    CTxOut dummyTxOut = CTxOut(999.99*COIN, mnodeman.dummyScriptPubkey);
-    dummyTx.vin.push_back(vin);
-    dummyTx.vout.push_back(dummyTxOut);
 
     {
         TRY_LOCK(cs_main, lockMain);
         if(!lockMain) {
             // not mnb fault, let it to be checked again later
-            LogPrint("masternode", "CMasternodeBroadcast::CheckInputsAndAdd -- Failed to aquire lock, addr=%s", addr.ToString());
+            LogPrint("masternode", "CMasternodeBroadcast::CheckOutpoint -- Failed to aquire lock, addr=%s", addr.ToString());
             mnodeman.mapSeenMasternodeBroadcast.erase(GetHash());
             return false;
         }
 
-        if(!AcceptToMemoryPool(mempool, state, CTransaction(dummyTx), false, NULL, false, true, true)) {
-            //set nDos
-            LogPrint("masternode", "CMasternodeBroadcast::CheckInputsAndAdd -- Failed to accepted Masternode entry to mempool: dummyTx=%s", dummyTx.ToString());
-            state.IsInvalid(nDos);
+        CCoins coins;
+        if(!pcoinsTip->GetCoins(vin.prevout.hash, coins) ||
+           (unsigned int)vin.prevout.n>=coins.vout.size() ||
+           coins.vout[vin.prevout.n].IsNull()) {
+            LogPrint("masternode", "CMasternodeBroadcast::CheckOutpoint -- Failed to find Masternode UTXO, masternode=%s\n", vin.prevout.ToStringShort());
+            return false;
+        }
+        if(coins.vout[vin.prevout.n].nValue != 1000 * COIN) {
+            LogPrint("masternode", "CMasternodeBroadcast::CheckOutpoint -- Masternode UTXO should have 1000 DASH, masternode=%s\n", vin.prevout.ToStringShort());
+            return false;
+        }
+        if(chainActive.Height() - coins.nHeight + 1 < Params().GetConsensus().nMasternodeMinimumConfirmations) {
+            LogPrintf("CMasternodeBroadcast::CheckOutpoint -- Masternode UTXO must have at least %d confirmations, masternode=\n",
+                    Params().GetConsensus().nMasternodeMinimumConfirmations, vin.prevout.ToStringShort());
+            // maybe we miss few blocks, let this mnb to be checked again later
+            mnodeman.mapSeenMasternodeBroadcast.erase(GetHash());
             return false;
         }
     }
 
-    LogPrint("masternode", "CMasternodeBroadcast::CheckInputsAndAdd -- Accepted Masternode entry to mempool (dry-run mode)\n");
-
+    LogPrint("masternode", "CMasternodeBroadcast::CheckOutpoint -- Masternode UTXO verified\n");
 
     // make sure the vout that was signed is related to the transaction that spawned the Masternode
     //  - this is expensive, so it's only done once per Masternode
     if(!darkSendSigner.IsVinAssociatedWithPubkey(vin, pubKeyCollateralAddress)) {
-        LogPrintf("CMasternodeMan::CheckInputsAndAdd -- Got mismatched pubKeyCollateralAddress and vin\n");
+        LogPrintf("CMasternodeMan::CheckOutpoint -- Got mismatched pubKeyCollateralAddress and vin\n");
         nDos = 33;
         return false;
     }
@@ -562,37 +595,11 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDos)
             CBlockIndex* pMNIndex = (*mi).second; // block for 1000 DASH tx -> 1 confirmation
             CBlockIndex* pConfIndex = chainActive[pMNIndex->nHeight + Params().GetConsensus().nMasternodeMinimumConfirmations - 1]; // block where tx got nMasternodeMinimumConfirmations
             if(pConfIndex->GetBlockTime() > sigTime) {
-                LogPrintf("CMasternodeBroadcast::CheckInputsAndAdd -- Bad sigTime %d (%d conf block is at %d) for Masternode %s %s\n",
+                LogPrintf("CMasternodeBroadcast::CheckOutpoint -- Bad sigTime %d (%d conf block is at %d) for Masternode %s %s\n",
                           sigTime, Params().GetConsensus().nMasternodeMinimumConfirmations, pConfIndex->GetBlockTime(), vin.prevout.ToStringShort(), addr.ToString());
                 return false;
             }
         }
-    }
-
-    // if it matches our Masternode privkey...
-    if(fMasterNode && pubKeyMasternode == activeMasternode.pubKeyMasternode) {
-        if(nProtocolVersion == PROTOCOL_VERSION) {
-            // ... and PROTOCOL_VERSION, then we've been remotely activated ...
-            activeMasternode.EnableRemoteMasterNode(vin, addr);
-        } else {
-            // ... otherwise we need to reactivate our node, don not add it to the list and do not relay
-            // but also do not ban the node we get this message from
-            LogPrintf("CMasternodeBroadcast::CheckInputsAndAdd -- wrong PROTOCOL_VERSION, re-activate your MN: message nProtocolVersion=%d  PROTOCOL_VERSION=%d\n", nProtocolVersion, PROTOCOL_VERSION);
-            return false;
-        }
-    }
-
-    LogPrintf("CMasternodeBroadcast::CheckInputsAndAdd -- Got NEW Masternode entry: masternode=%s  sigTime=%lld  addr=%s\n", vin.prevout.ToStringShort(), sigTime, addr.ToString());
-    CMasternode mn(*this);
-    mnodeman.Add(mn);
-
-    bool isLocal = addr.IsRFC1918() || addr.IsLocal();
-    if(Params().NetworkIDString() == CBaseChainParams::REGTEST) {
-        isLocal = false;
-    }
-
-    if(!isLocal) {
-        Relay();
     }
 
     return true;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -160,7 +160,7 @@ void CMasternode::Check(bool fForce)
 {
     LOCK(cs);
 
-    static int64_t nTimeStart;
+    static int64_t nTimeStart = GetTime();
 
     LogPrint("masternode", "CMasternode::Check start -- vin %s\n", vin.prevout.ToStringShort());
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -18,7 +18,6 @@
 /** Masternode manager */
 CMasternodeMan mnodeman;
 
-const int CMasternodeMan::MAX_POSE_RANK;
 const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-1";
 
 struct CompareLastPaidBlock
@@ -768,7 +767,7 @@ void CMasternodeMan::DoFullVerificationStep()
     while(it != vecMasternodeRanks.end()) {
         if(it->first > MAX_POSE_RANK) {
             LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Must be in top %d to send verify request\n",
-                        MAX_POSE_RANK);
+                        (int)MAX_POSE_RANK);
             return;
         }
         if(it->second.vin == activeMasternode.vin) {
@@ -1087,7 +1086,7 @@ void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerif
     int nRank = GetMasternodeRank(mnv.vin2, mnv.nBlockHeight, MIN_POSE_PROTO_VERSION);
     if(nRank < MAX_POSE_RANK) {
         LogPrint("masternode", "MasternodeMan::ProcessVerifyBroadcast -- Mastrernode is not in top %d, current rank %d, peer=%d\n",
-                    MAX_POSE_RANK, nRank, pnode->id);
+                    (int)MAX_POSE_RANK, nRank, pnode->id);
         return;
     }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -8,6 +8,7 @@
 #include "masternode.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"
+#include "netfulfilledman.h"
 #include "util.h"
 #include "addrman.h"
 #include "spork.h"
@@ -16,6 +17,9 @@
 
 /** Masternode manager */
 CMasternodeMan mnodeman;
+
+const int CMasternodeMan::MAX_POSE_RANK;
+const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-1";
 
 struct CompareLastPaidBlock
 {
@@ -35,12 +39,14 @@ struct CompareScoreMN
     }
 };
 
-const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-1";
-
-CMasternodeMan::CMasternodeMan() {
-    nDsqCount = 0;
-    nLastWatchdogVoteTime = 0;
-}
+struct CompareByAddr
+{
+    bool operator()(const CMasternode* t1,
+                    const CMasternode* t2) const
+    {
+        return t1->addr < t2->addr;
+    }
+};
 
 bool CMasternodeMan::Add(CMasternode &mn)
 {
@@ -151,6 +157,15 @@ void CMasternodeMan::CheckAndRemove(bool fForceExpiredRemoval)
         }
     }
 
+    std::map<CNetAddr, CMasternodeVerification>::iterator itv1 = mWeAskedForVerification.begin();
+    while(itv1 != mWeAskedForVerification.end()){
+        if(itv1->second.nBlockHeight < pCurrentBlockIndex->nHeight - MAX_POSE_BLOCKS) {
+            mWeAskedForVerification.erase(itv1++);
+        } else {
+            ++itv1;
+        }
+    }
+
     // remove expired mapSeenMasternodeBroadcast
     map<uint256, CMasternodeBroadcast>::iterator it3 = mapSeenMasternodeBroadcast.begin();
     while(it3 != mapSeenMasternodeBroadcast.end()){
@@ -173,6 +188,16 @@ void CMasternodeMan::CheckAndRemove(bool fForceExpiredRemoval)
         }
     }
 
+    // remove expired mapSeenMasternodeVerification
+    std::map<uint256, CMasternodeVerification>::iterator itv2 = mapSeenMasternodeVerification.begin();
+    while(itv2 != mapSeenMasternodeVerification.end()){
+        if((*itv2).second.nBlockHeight < pCurrentBlockIndex->nHeight - MAX_POSE_BLOCKS){
+            LogPrint("masternode", "CMasternodeMan::CheckAndRemove -- Removing expired Masternode verification: hash=%s\n", (*itv2).first.ToString());
+            mapSeenMasternodeVerification.erase(itv2++);
+        } else {
+            ++itv2;
+        }
+    }
 }
 
 void CMasternodeMan::Clear()
@@ -250,7 +275,7 @@ void CMasternodeMan::DsegUpdate(CNode* pnode)
     }
     
     pnode->PushMessage(NetMsgType::DSEG, CTxIn());
-    int64_t askAgain = GetTime() + MASTERNODES_DSEG_SECONDS;
+    int64_t askAgain = GetTime() + DSEG_UPDATE_SECONDS;
     mWeAskedForMasternodeList[pnode->addr] = askAgain;
 }
 
@@ -670,7 +695,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
                         return;
                     }
                 }
-                int64_t askAgain = GetTime() + MASTERNODES_DSEG_SECONDS;
+                int64_t askAgain = GetTime() + DSEG_UPDATE_SECONDS;
                 mAskedUsForMasternodeList[pfrom->addr] = askAgain;
             }
         } //else, asking for a specific node which is ok
@@ -705,6 +730,420 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         }
         // smth weird happen - someone asked us for vin we have no idea about?
         LogPrint("masternode", "CMasternodeMan::ProcessMessage -- DSEG -- No invs sent to peer %d\n", pfrom->id);
+
+    } else if (strCommand == NetMsgType::MNVERIFY) { // Masternode Verify
+
+        CMasternodeVerification mnv;
+        vRecv >> mnv;
+
+        if(mnv.vchSig1.empty()) {
+            // CASE 1: someone asked me to verify myself /IP we are using/
+            SendVerifyReply(pfrom, mnv);
+        } else if (mnv.vchSig2.empty()) {
+            // CASE 2: we _probably_ got verification we requested from some masternode
+            ProcessVerifyReply(pfrom, mnv);
+        } else {
+            // CASE 3: we _probably_ got verification broadcast signed by some masternode which verified another one
+            ProcessVerifyBroadcast(pfrom, mnv);
+        }
+    }
+}
+
+void CMasternodeMan::DoFullVerificationStep()
+{
+    if(activeMasternode.vin == CTxIn()) return;
+
+    std::vector<std::pair<int, CMasternode> > vecMasternodeRanks = GetMasternodeRanks(pCurrentBlockIndex->nHeight - 1, MIN_POSE_PROTO_VERSION);
+
+    LOCK(cs);
+
+    int nCount = 0;
+    int nCountMax = std::max(10, (int)vMasternodes.size() / 100); // verify at least 10 masternode at once but at most 1% of all known masternodes
+
+    int nMyRank = -1;
+    int nRanksTotal = (int)vecMasternodeRanks.size();
+
+    // send verify requests only if we are in top MAX_POSE_RANK
+    std::vector<std::pair<int, CMasternode> >::iterator it = vecMasternodeRanks.begin();
+    while(it != vecMasternodeRanks.end()) {
+        if(it->first > MAX_POSE_RANK) {
+            LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Must be in top %d to send verify request\n",
+                        MAX_POSE_RANK);
+            return;
+        }
+        if(it->second.vin == activeMasternode.vin) {
+            nMyRank = it->first;
+            LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Found self at rank %d/%d, verifying up to %d masternodes\n",
+                        nMyRank, nRanksTotal, nCountMax);
+            break;
+        }
+        ++it;
+    }
+
+    // edge case: list is too short and this masternode is not enabled
+    if(nMyRank == -1) return;
+
+    // send verify requests to up to nCountMax masternodes starting from
+    // (MAX_POSE_RANK + nCountMax * (nMyRank - 1) + 1)
+    int nOffset = MAX_POSE_RANK + nCountMax * (nMyRank - 1);
+    if(nOffset >= (int)vecMasternodeRanks.size()) return;
+
+    std::vector<CMasternode*> vSortedByAddr;
+    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+        vSortedByAddr.push_back(&mn);
+    }
+
+    sort(vSortedByAddr.begin(), vSortedByAddr.end(), CompareByAddr());
+
+    it = vecMasternodeRanks.begin() + nOffset;
+    while(it != vecMasternodeRanks.end()) {
+        if(it->second.IsPoSeVerified() || it->second.IsPoSeBanned()) {
+            LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Already %s%s%s masternode %s address %s, skipping...\n",
+                        it->second.IsPoSeVerified() ? "verified" : "",
+                        it->second.IsPoSeVerified() && it->second.IsPoSeBanned() ? " and " : "",
+                        it->second.IsPoSeBanned() ? "banned" : "",
+                        it->second.vin.prevout.ToStringShort(), it->second.addr.ToString());
+            ++it;
+            continue;
+        }
+        LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Verifying masternode %s rank %d/%d address %s\n",
+                    it->second.vin.prevout.ToStringShort(), it->first, nRanksTotal, it->second.addr.ToString());
+        if(SendVerifyRequest((CAddress)it->second.addr, vSortedByAddr)) {
+            nCount++;
+            if(nCount >= nCountMax) break;
+        }
+        ++it;
+    }
+
+    LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Sent verification requests to %d masternodes\n", nCount);
+}
+
+void CMasternodeMan::CheckSameAddr()
+{
+    if(!masternodeSync.IsSynced() || vMasternodes.empty()) return;
+
+    std::vector<CMasternode*> vBan;
+    std::vector<CMasternode*> vSortedByAddr;
+
+    {
+        LOCK(cs);
+
+        CMasternode* pprevMasternode = NULL;
+        CMasternode* pverifiedMasternode = NULL;
+
+        BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+            vSortedByAddr.push_back(&mn);
+        }
+
+        sort(vSortedByAddr.begin(), vSortedByAddr.end(), CompareByAddr());
+
+        BOOST_FOREACH(CMasternode* pmn, vSortedByAddr) {
+            // check only (pre)enabled masternodes
+            if(!pmn->IsEnabled() && !pmn->IsPreEnabled()) continue;
+            // initial step
+            if(!pprevMasternode) {
+                pprevMasternode = pmn;
+                continue;
+            }
+            // second+ step
+            if(pmn->addr == pprevMasternode->addr) {
+                if(pverifiedMasternode) {
+                    // another masternode with the same ip is verified, ban this one
+                    vBan.push_back(pmn);
+                } else if(pmn->IsPoSeVerified()) {
+                    // this masternode with the same ip is verified, ban previous one
+                    vBan.push_back(pprevMasternode);
+                    // and keep a reference to be able to ban following masternodes with the same ip
+                    pverifiedMasternode = pmn;
+                }
+            } else {
+                // clear the reference
+                pverifiedMasternode = NULL;
+            }
+            pprevMasternode = pmn;
+        }
+    }
+
+    // ban duplicates
+    BOOST_FOREACH(CMasternode* pmn, vBan) {
+        pmn->nPoSeBanScore++;
+    }
+}
+
+bool CMasternodeMan::SendVerifyRequest(const CAddress& addr, const std::vector<CMasternode*>& vSortedByAddr)
+{
+    if(netfulfilledman.HasFulfilledRequest(addr, strprintf("%s", NetMsgType::MNVERIFY)+"-request")) {
+        // we already asked for verification, not a good idea to do this too often, skip it
+        LogPrint("masternode", "CMasternodeMan::SendVerifyRequest -- too many requests, skipping... addr=%s\n", addr.ToString());
+        return false;
+    }
+
+    CNode* pnode = ConnectNode(addr, NULL, true);
+    if(pnode != NULL) {
+        netfulfilledman.AddFulfilledRequest(addr, strprintf("%s", NetMsgType::MNVERIFY)+"-request");
+        // use random nonce, store it and require node to reply with correct one later
+        CMasternodeVerification mnv(addr, GetInsecureRand(999999), pCurrentBlockIndex->nHeight - 1);
+        mWeAskedForVerification[addr] = mnv;
+        LogPrintf("CMasternodeMan::SendVerifyRequest -- verifying using nonce %d addr=%s\n", mnv.nonce, addr.ToString());
+        pnode->PushMessage(NetMsgType::MNVERIFY, mnv);
+        return true;
+    } else {
+        // can't connect, add some PoSe "ban score" to all masternodes with given addr
+        bool fFound = false;
+        BOOST_FOREACH(CMasternode* pmn, vSortedByAddr) {
+            if(pmn->addr != addr) {
+                if(fFound) break;
+                continue;
+            }
+            fFound = true;
+            pmn->nPoSeBanScore++;
+        }
+        return false;
+    }
+}
+
+void CMasternodeMan::SendVerifyReply(CNode* pnode, CMasternodeVerification& mnv)
+{
+    // only masternodes can sign this, why would someone ask regular node?
+    if(!fMasterNode) {
+        // do not ban, malicious node might be using my IP
+        // and trying to confuse the node which tries to verify it
+        return;
+    }
+
+    if(netfulfilledman.HasFulfilledRequest(pnode->addr, strprintf("%s", NetMsgType::MNVERIFY)+"-reply")) {
+        // peer should not ask us that often
+        LogPrintf("MasternodeMan::SendVerifyReply -- ERROR: peer already asked me recently, peer=%d\n", pnode->id);
+        Misbehaving(pnode->id, 20);
+        return;
+    }
+
+    uint256 blockHash;
+    if(!GetBlockHash(blockHash, mnv.nBlockHeight)) {
+        LogPrintf("MasternodeMan::SendVerifyReply -- can't get block hash for unknown block height %d, peer=%d\n", mnv.nBlockHeight, pnode->id);
+        return;
+    }
+
+    std::string strMessage = strprintf("%s%d%s", activeMasternode.service.ToString(false), mnv.nonce, blockHash.ToString());
+
+    if(!darkSendSigner.SignMessage(strMessage, mnv.vchSig1, activeMasternode.keyMasternode)) {
+        LogPrintf("MasternodeMan::SendVerifyReply -- SignMessage() failed\n");
+        return;
+    }
+
+    std::string strError;
+
+    if(!darkSendSigner.VerifyMessage(activeMasternode.pubKeyMasternode, mnv.vchSig1, strMessage, strError)) {
+        LogPrintf("MasternodeMan::SendVerifyReply -- VerifyMessage() failed, error: %s\n", strError);
+        return;
+    }
+
+    pnode->PushMessage(NetMsgType::MNVERIFY, mnv);
+    netfulfilledman.AddFulfilledRequest(pnode->addr, strprintf("%s", NetMsgType::MNVERIFY)+"-reply");
+}
+
+void CMasternodeMan::ProcessVerifyReply(CNode* pnode, CMasternodeVerification& mnv)
+{
+    std::string strError;
+
+    // did we even ask for it? if that's the case we should have matching fulfilled request
+    if(!netfulfilledman.HasFulfilledRequest(pnode->addr, strprintf("%s", NetMsgType::MNVERIFY)+"-request")) {
+        LogPrintf("CMasternodeMan::ProcessVerifyReply -- ERROR: we didn't ask for verification of %s, peer=%d\n", pnode->addr.ToString(), pnode->id);
+        Misbehaving(pnode->id, 20);
+        return;
+    }
+
+    // Received nonce for a known address must match the one we sent
+    if(mWeAskedForVerification[pnode->addr].nonce != mnv.nonce) {
+        LogPrintf("CMasternodeMan::ProcessVerifyReply -- ERROR: wrong nounce: requested=%d, received=%d, peer=%d\n",
+                    mWeAskedForVerification[pnode->addr].nonce, mnv.nonce, pnode->id);
+        Misbehaving(pnode->id, 20);
+        return;
+    }
+
+    // Received nBlockHeight for a known address must match the one we sent
+    if(mWeAskedForVerification[pnode->addr].nBlockHeight != mnv.nBlockHeight) {
+        LogPrintf("CMasternodeMan::ProcessVerifyReply -- ERROR: wrong nBlockHeight: requested=%d, received=%d, peer=%d\n",
+                    mWeAskedForVerification[pnode->addr].nBlockHeight, mnv.nBlockHeight, pnode->id);
+        Misbehaving(pnode->id, 20);
+        return;
+    }
+
+    uint256 blockHash;
+    if(!GetBlockHash(blockHash, mnv.nBlockHeight)) {
+        // this shouldn't happen...
+        LogPrintf("MasternodeMan::ProcessVerifyReply -- can't get block hash for unknown block height %d, peer=%d\n", mnv.nBlockHeight, pnode->id);
+        return;
+    }
+
+    // we already verified this address, why node is spamming?
+    if(netfulfilledman.HasFulfilledRequest(pnode->addr, strprintf("%s", NetMsgType::MNVERIFY)+"-done")) {
+        LogPrintf("CMasternodeMan::ProcessVerifyReply -- ERROR: already verified %s recently\n", pnode->addr.ToString());
+        Misbehaving(pnode->id, 20);
+        return;
+    }
+
+    {
+        LOCK(cs);
+
+        CMasternode* prealMasternode = NULL;
+        std::vector<CMasternode*> vpMasternodesToBan;
+        std::vector<CMasternode>::iterator it = vMasternodes.begin();
+        std::string strMessage1 = strprintf("%s%d%s", pnode->addr.ToString(false), mnv.nonce, blockHash.ToString());
+        while(it != vMasternodes.end()) {
+            if((CAddress)it->addr == pnode->addr) {
+                if(darkSendSigner.VerifyMessage(it->pubKeyMasternode, mnv.vchSig1, strMessage1, strError)) {
+                    // found it!
+                    prealMasternode = &(*it);
+                    if(!it->IsPoSeVerified()) {
+                            it->nPoSeBanScore--;
+                    }
+                    netfulfilledman.AddFulfilledRequest(pnode->addr, strprintf("%s", NetMsgType::MNVERIFY)+"-done");
+
+                    // we can only broadcast it if we are an activated masternode
+                    if(activeMasternode.vin == CTxIn()) continue;
+                    // update ...
+                    mnv.addr = it->addr;
+                    mnv.vin1 = it->vin;
+                    mnv.vin2 = activeMasternode.vin;
+                    std::string strMessage2 = strprintf("%s%d%s%s%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString(),
+                                            mnv.vin1.prevout.ToStringShort(), mnv.vin2.prevout.ToStringShort());
+                    // ... and sign it
+                    if(!darkSendSigner.SignMessage(strMessage2, mnv.vchSig2, activeMasternode.keyMasternode)) {
+                        LogPrintf("MasternodeMan::ProcessVerifyReply -- SignMessage() failed\n");
+                        return;
+                    }
+
+                    std::string strError;
+
+                    if(!darkSendSigner.VerifyMessage(activeMasternode.pubKeyMasternode, mnv.vchSig2, strMessage2, strError)) {
+                        LogPrintf("MasternodeMan::ProcessVerifyReply -- VerifyMessage() failed, error: %s\n", strError);
+                        return;
+                    }
+
+                    mWeAskedForVerification[pnode->addr] = mnv;
+                    mnv.Relay();
+
+                } else {
+                    vpMasternodesToBan.push_back(&(*it));
+                }
+            }
+            ++it;
+        }
+        // no real masternode found?...
+        if(!prealMasternode) {
+            // this should never be the case normally,
+            // only if someone is trying to game the system in some way or smth like that
+            LogPrintf("CMasternodeMan::ProcessVerifyReply -- ERROR: no real masternode found for addr %s\n", pnode->addr.ToString());
+            Misbehaving(pnode->id, 20);
+            return;
+        }
+        LogPrintf("CMasternodeMan::ProcessVerifyReply -- verified real masternode %s for addr %s\n",
+                    prealMasternode->vin.prevout.ToStringShort(), pnode->addr.ToString());
+        // increase ban score for everyone else
+        BOOST_FOREACH(CMasternode* pmn, vpMasternodesToBan) {
+            pmn->nPoSeBanScore++;
+            LogPrint("masternode", "CMasternodeMan::ProcessVerifyBroadcast -- increased PoSe ban score for %s addr %s, new score %d\n",
+                        prealMasternode->vin.prevout.ToStringShort(), pnode->addr.ToString(), pmn->nPoSeBanScore);
+        }
+        LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- PoSe score incresed for %d fake masternodes, addr %s\n",
+                    (int)vpMasternodesToBan.size(), pnode->addr.ToString());
+    }
+}
+
+void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerification& mnv)
+{
+    std::string strError;
+
+    if(mapSeenMasternodeVerification.find(mnv.GetHash()) != mapSeenMasternodeVerification.end()) {
+        // we already have one
+        return;
+    }
+    mapSeenMasternodeVerification[mnv.GetHash()] = mnv;
+
+    // we don't care about history
+    if(mnv.nBlockHeight < pCurrentBlockIndex->nHeight - MAX_POSE_BLOCKS) {
+        LogPrint("masternode", "MasternodeMan::ProcessVerifyBroadcast -- Outdated: current block %d, verification block %d, peer=%d\n",
+                    pCurrentBlockIndex->nHeight, mnv.nBlockHeight, pnode->id);
+        return;
+    }
+
+    if(mnv.vin1.prevout == mnv.vin2.prevout) {
+        LogPrint("masternode", "MasternodeMan::ProcessVerifyBroadcast -- ERROR: same vins %s, peer=%d\n",
+                    mnv.vin1.prevout.ToStringShort(), pnode->id);
+        // that was NOT a good idea to cheat and verify itself,
+        // ban the node we received such message from
+        Misbehaving(pnode->id, 100);
+        return;
+    }
+
+    uint256 blockHash;
+    if(!GetBlockHash(blockHash, mnv.nBlockHeight)) {
+        // this shouldn't happen...
+        LogPrintf("MasternodeMan::ProcessVerifyBroadcast -- Can't get block hash for unknown block height %d, peer=%d\n", mnv.nBlockHeight, pnode->id);
+        return;
+    }
+
+    int nRank = GetMasternodeRank(mnv.vin2, mnv.nBlockHeight, MIN_POSE_PROTO_VERSION);
+    if(nRank < MAX_POSE_RANK) {
+        LogPrint("masternode", "MasternodeMan::ProcessVerifyBroadcast -- Mastrernode is not in top %d, current rank %d, peer=%d\n",
+                    MAX_POSE_RANK, nRank, pnode->id);
+        return;
+    }
+
+    {
+        LOCK(cs);
+
+        std::string strMessage1 = strprintf("%s%d%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString());
+        std::string strMessage2 = strprintf("%s%d%s%s%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString(),
+                                mnv.vin1.prevout.ToStringShort(), mnv.vin2.prevout.ToStringShort());
+
+        CMasternode* pmn1 = Find(mnv.vin1);
+        if(!pmn1) {
+            LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- can't find masternode1 %s\n", mnv.vin1.prevout.ToStringShort());
+            return;
+        }
+
+        CMasternode* pmn2 = Find(mnv.vin2);
+        if(!pmn2) {
+            LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- can't find masternode2 %s\n", mnv.vin2.prevout.ToStringShort());
+            return;
+        }
+
+        if(pmn1->addr != mnv.addr) {
+            LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- addr %s do not match %s\n", mnv.addr.ToString(), pnode->addr.ToString());
+            return;
+        }
+
+        if(darkSendSigner.VerifyMessage(pmn1->pubKeyMasternode, mnv.vchSig1, strMessage1, strError)) {
+            LogPrintf("MasternodeMan::ProcessVerifyBroadcast -- VerifyMessage() for masternode1 failed, error: %s\n", strError);
+            return;
+        }
+
+        if(darkSendSigner.VerifyMessage(pmn2->pubKeyMasternode, mnv.vchSig2, strMessage2, strError)) {
+            LogPrintf("MasternodeMan::ProcessVerifyBroadcast -- VerifyMessage() for masternode2 failed, error: %s\n", strError);
+            return;
+        }
+
+        if(!pmn1->IsPoSeVerified()) {
+            pmn1->nPoSeBanScore--;
+        }
+        mnv.Relay();
+
+        LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- verified masternode %s for addr %s\n",
+                    pmn1->vin.prevout.ToStringShort(), pnode->addr.ToString());
+
+        // increase ban score for everyone else with the same addr
+        int nCount = 0;
+        BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+            if(mn.addr != mnv.addr || mn.vin.prevout == mnv.vin1.prevout) continue;
+            mn.nPoSeBanScore++;
+            nCount++;
+            LogPrint("masternode", "CMasternodeMan::ProcessVerifyBroadcast -- increased PoSe ban score for %s addr %s, new score %d\n",
+                        mn.vin.prevout.ToStringShort(), mn.addr.ToString(), mn.nPoSeBanScore);
+        }
+        LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- PoSe score incresed for %d fake masternodes, addr %s\n",
+                    nCount, pnode->addr.ToString());
     }
 }
 
@@ -778,49 +1217,71 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb) {
     }
 }
 
-bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CMasternodeBroadcast mnb, int& nDos) {
+bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CMasternodeBroadcast mnb, int& nDos)
+{
     LOCK(cs);
+
     nDos = 0;
-    LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList - Masternode broadcast, vin: %s\n", mnb.vin.ToString());
+    LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s\n", mnb.vin.prevout.ToStringShort());
 
     if(mapSeenMasternodeBroadcast.count(mnb.GetHash())) { //seen
         return true;
     }
-    mapSeenMasternodeBroadcast.insert(make_pair(mnb.GetHash(), mnb));
+    mapSeenMasternodeBroadcast.insert(std::make_pair(mnb.GetHash(), mnb));
 
-    LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList - Masternode broadcast, vin: %s new\n", mnb.vin.ToString());
-    // We check addr before both initial mnb and update
-    if(!mnb.IsValidNetAddr()) {
-        LogPrintf("CMasternodeBroadcast::CheckMnbAndUpdateMasternodeList -- Invalid addr, rejected: masternode=%s  sigTime=%lld  addr=%s\n",
-                    mnb.vin.prevout.ToStringShort(), mnb.sigTime, mnb.addr.ToString());
+    LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s new\n", mnb.vin.prevout.ToStringShort());
+
+    if(!mnb.SimpleCheck(nDos)) {
+        LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- SimpleCheck() failed, masternode=%s\n", mnb.vin.prevout.ToStringShort());
         return false;
     }
 
-    if(!mnb.CheckAndUpdate(nDos)){
-        LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList - Masternode broadcast, vin: %s CheckAndUpdate failed\n", mnb.vin.ToString());
-        return false;
-    }
-
-    // make sure it's still unspent
-    //  - this is checked later by .check() in many places and by ThreadCheckDarkSendPool()
-    if(mnb.CheckInputsAndAdd(nDos)) {
-        masternodeSync.AddedMasternodeList();
+    // search Masternode list
+    CMasternode* pmn = Find(mnb.vin);
+    if(pmn) {
+        if(!mnb.Update(pmn, nDos)) {
+            LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- Update() failed, masternode=%s\n", mnb.vin.prevout.ToStringShort());
+            return false;
+        }
     } else {
-        LogPrintf("CMasternodeMan::CheckMnbAndUpdateMasternodeList - Rejected Masternode entry %s\n", mnb.addr.ToString());
-        return false;
+        if(mnb.CheckOutpoint(nDos)) {
+            Add(mnb);
+            masternodeSync.AddedMasternodeList();
+            // if it matches our Masternode privkey...
+            if(fMasterNode && mnb.pubKeyMasternode == activeMasternode.pubKeyMasternode) {
+                mnb.nPoSeBanScore = -MASTERNODE_POSE_BAN_MAX_SCORE;
+                if(mnb.nProtocolVersion == PROTOCOL_VERSION) {
+                    // ... and PROTOCOL_VERSION, then we've been remotely activated ...
+                    LogPrintf("CMasternodeMan::CheckMnbAndUpdateMasternodeList -- Got NEW Masternode entry: masternode=%s  sigTime=%lld  addr=%s\n",
+                                mnb.vin.prevout.ToStringShort(), mnb.sigTime, mnb.addr.ToString());
+                    activeMasternode.ManageState();
+                } else {
+                    // ... otherwise we need to reactivate our node, do not add it to the list and do not relay
+                    // but also do not ban the node we get this message from
+                    LogPrintf("CMasternodeMan::CheckMnbAndUpdateMasternodeList -- wrong PROTOCOL_VERSION, re-activate your MN: message nProtocolVersion=%d  PROTOCOL_VERSION=%d\n", mnb.nProtocolVersion, PROTOCOL_VERSION);
+                    return false;
+                }
+            }
+            mnb.Relay();
+        } else {
+            LogPrintf("CMasternodeMan::CheckMnbAndUpdateMasternodeList -- Rejected Masternode entry: %s  addr=%s\n", mnb.vin.prevout.ToStringShort(), mnb.addr.ToString());
+            return false;
+        }
     }
 
     return true;
 }
 
-void CMasternodeMan::UpdateLastPaid(const CBlockIndex *pindex) {
+void CMasternodeMan::UpdateLastPaid(const CBlockIndex *pindex)
+{
     LOCK(cs);
+
     if(fLiteMode) return;
 
     static bool IsFirstRun = true;
     // Do full scan on first run or if we are not a masternode
     // (MNs should update this info on every block, so limited scan should be enough for them)
-    int nMaxBlocksToScanBack = (IsFirstRun || !fMasterNode) ? mnpayments.GetStorageLimit() : MASTERNODES_LAST_PAID_SCAN_BLOCKS;
+    int nMaxBlocksToScanBack = (IsFirstRun || !fMasterNode) ? mnpayments.GetStorageLimit() : LAST_PAID_SCAN_BLOCKS;
 
     // LogPrint("mnpayments", "CMasternodeMan::UpdateLastPaid -- nHeight=%d, nMaxBlocksToScanBack=%d, IsFirstRun=%s\n",
     //                         pindex->nHeight, nMaxBlocksToScanBack, IsFirstRun ? "true" : "false");
@@ -933,5 +1394,19 @@ void CMasternodeMan::SetMasternodeLastPing(const CTxIn& vin, const CMasternodePi
     uint256 hash = mnb.GetHash();
     if(mapSeenMasternodeBroadcast.count(hash)) {
         mapSeenMasternodeBroadcast[hash].lastPing = mnp;
+    }
+}
+
+void CMasternodeMan::UpdatedBlockTip(const CBlockIndex *pindex)
+{
+    pCurrentBlockIndex = pindex;
+    LogPrint("masternode", "CMasternodeMan::UpdatedBlockTip -- pCurrentBlockIndex->nHeight=%d\n", pCurrentBlockIndex->nHeight);
+
+    CheckSameAddr();
+
+    if(fMasterNode) {
+        DoFullVerificationStep();
+        // normal wallet does not need to update this every block, doing update on rpc call should be enough
+        UpdateLastPaid(pindex);
     }
 }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -842,6 +842,7 @@ void CMasternodeMan::CheckSameAddr()
             // initial step
             if(!pprevMasternode) {
                 pprevMasternode = pmn;
+                pverifiedMasternode = pmn->IsPoSeVerified() ? pmn : NULL;
                 continue;
             }
             // second+ step
@@ -856,8 +857,7 @@ void CMasternodeMan::CheckSameAddr()
                     pverifiedMasternode = pmn;
                 }
             } else {
-                // clear the reference
-                pverifiedMasternode = NULL;
+                pverifiedMasternode = pmn->IsPoSeVerified() ? pmn : NULL;
             }
             pprevMasternode = pmn;
         }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -65,6 +65,7 @@ const char *SYNCSTATUSCOUNT="ssc";
 const char *MNGOVERNANCESYNC="govsync";
 const char *MNGOVERNANCEOBJECT="govobj";
 const char *MNGOVERNANCEOBJECTVOTE="govobjvote";
+const char *MNVERIFY="mnv";
 };
 
 static const char* ppszTypeName[] =
@@ -89,7 +90,8 @@ static const char* ppszTypeName[] =
     NetMsgType::MNPING,
     NetMsgType::DSTX,
     NetMsgType::MNGOVERNANCEOBJECT,
-    NetMsgType::MNGOVERNANCEOBJECTVOTE
+    NetMsgType::MNGOVERNANCEOBJECTVOTE,
+    NetMsgType::MNVERIFY,
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -141,7 +143,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::SYNCSTATUSCOUNT,
     NetMsgType::MNGOVERNANCESYNC,
     NetMsgType::MNGOVERNANCEOBJECT,
-    NetMsgType::MNGOVERNANCEOBJECTVOTE
+    NetMsgType::MNGOVERNANCEOBJECTVOTE,
+    NetMsgType::MNVERIFY,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -243,6 +243,7 @@ extern const char *SYNCSTATUSCOUNT;
 extern const char *MNGOVERNANCESYNC;
 extern const char *MNGOVERNANCEOBJECT;
 extern const char *MNGOVERNANCEOBJECTVOTE;
+extern const char *MNVERIFY;
 };
 
 /* Get a vector of all valid message types (see above) */
@@ -356,7 +357,8 @@ enum {
     MSG_MASTERNODE_PING,
     MSG_DSTX,
     MSG_GOVERNANCE_OBJECT,
-    MSG_GOVERNANCE_OBJECT_VOTE
+    MSG_GOVERNANCE_OBJECT_VOTE,
+    MSG_MASTERNODE_VERIFY,
 };
 
 #endif // BITCOIN_PROTOCOL_H


### PR DESCRIPTION
So the idea is to use an approach similar to the old PoSe but it's kind of upside-down - instead of relaying "ban" score we relay signed "success" plus it uses randomized nonce to verify that node is not only online but is synced and is capable of signing a message properly. This message is constructed in a kind of ping-pong like manner: it's initially constructed by a verifying node, filled with signature of a verified node and finally filled with additional fields and a signature of a verifying node. And only then it's relayed to the rest of the network but only if a verifying node is a masternode. In this scheme all nodes only know that some legit masternode (or at least a masternode from the top `MAX_POSE_RANK` which was also able to construct a correct signature) verified some another legit/reachable masternode (or at least a masternode that was able to construct a correct signature). So once nodes have quite a few such messages for some masternode they can be pretty sure that announced IP address of that node was OK. In other words, it's not "exclude who was banned first" (like it was in the old version) but "approve the one who was verified first and exclude the others with the same IP". Assuming that majority of masternodes are legit, they should get much faster approval comparing to malicious nodes if someone would try to game the system.

Note that if we can't connect to some masternode (e.g. during mixing), its `nPoSeBanScore` is increased (local only which looks like a bit controversial design but eventually the whole masternode network should arrive at the same decision pretty soon imo). Once some masternode is finally "banned" in that way it would have to stay offline for at least `MASTERNODE_POSE_BAN_SECONDS` (1 day in proposed code) to be removed from the list and be able to enter the list again (or one can move funds to a new outpoint and start from scratch). If it's alive and sending pings, this period of "ban" is extended. This way if your node was offline for a short period of time, it can probably miss few checks from top masternodes and they will set some local "ban" score but getting your node back online should save you from hijacking your ip by some other node and you should get to "approved" state again quite quickly.

TODO: if that scheme proves itself in testing we could probably start paying bock rewards only to masternodes with `IsPoSeVerified()` equal `true`.

NOTE: This requires proto bump to 70203 (not included).