### PR TITLE
Refactor CalculateScore, move GetBlockHash out of it

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -119,28 +119,20 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
 // the proof of work for that block. The further away they are the better, the furthest will win the election
 // and get paid this block
 //
-uint256 CMasternode::CalculateScore(int nBlockHeight)
+arith_uint256 CMasternode::CalculateScore(const uint256& blockHash)
 {
-    uint256 hash;
     uint256 aux = ArithToUint256(UintToArith256(vin.prevout.hash) + vin.prevout.n);
 
-    if(!GetBlockHash(hash, nBlockHeight)) {
-        LogPrintf("CMasternode::CalculateScore -- ERROR: GetBlockHash() failed at nBlockHeight %d\n", nBlockHeight);
-        return uint256();
-    }
-
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << hash;
+    ss << blockHash;
     arith_uint256 hash2 = UintToArith256(ss.GetHash());
 
     CHashWriter ss2(SER_GETHASH, PROTOCOL_VERSION);
-    ss2 << hash;
+    ss2 << blockHash;
     ss2 << aux;
     arith_uint256 hash3 = UintToArith256(ss2.GetHash());
 
-    arith_uint256 r = (hash3 > hash2 ? hash3 - hash2 : hash2 - hash3);
-
-    return ArithToUint256(r);
+    return (hash3 > hash2 ? hash3 - hash2 : hash2 - hash3);
 }
 
 void CMasternode::Check(bool fForce)

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -191,7 +191,7 @@ public:
     }
 
     // CALCULATE A RANK AGAINST OF GIVEN BLOCK
-    uint256 CalculateScore(int nBlockHeight = -1);
+    arith_uint256 CalculateScore(const uint256& blockHash);
 
     bool UpdateFromNewBroadcast(CMasternodeBroadcast& mnb);
 


### PR DESCRIPTION
`CalculateScore` is often called in a loop for the same block height and it doesn't make a lot of sense to call `GetBlockHash` every time. Also given the function `CalculateScore` is meant to perform I think it just feels a bit better to keep it hash-agnostic so to speak.