### PR TITLE
Fix get next Masternode in queue for payment

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -324,7 +324,12 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         //make sure it has as many confirmations as there are masternodes
         if(mn.GetCollateralAge() < nMnCount) continue;
 
-        vecMasternodeLastPaid.push_back(std::make_pair(mn.GetLastPaidBlock(), &mn));
+        //never get paid then assume sigtime is the last paid
+        if(mn.GetLastPaidTime() < mn.sigTime) {
+            vecMasternodeLastPaid.push_back(std::make_pair(mn.sigTime, &mn));
+        } else {
+            vecMasternodeLastPaid.push_back(std::make_pair(mn.GetLastPaidTime(), &mn));
+        }
     }
 
     nCount = (int)vecMasternodeLastPaid.size();
@@ -333,7 +338,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     if(fFilterSigTime && nCount < nMnCount/3) return GetNextMasternodeInQueueForPayment(nBlockHeight, false, nCount);
 
     // Sort them low to high
-    sort(vecMasternodeLastPaid.begin(), vecMasternodeLastPaid.end(), CompareLastPaidBlock());
+    sort(vecMasternodeLastPaid.begin(), vecMasternodeLastPaid.end(), CompareScoreMN());
 
     uint256 blockHash;
     if(!GetBlockHash(blockHash, nBlockHeight - 101)) {


### PR DESCRIPTION
Use LastPaidTime to sort for finding oldest paid masternode and consider never paid node has its masternode broadcast time as last paid time.