### PR TITLE
Revert few parts of #1073

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1564,7 +1564,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
             nLastTimeChanged = GetTimeMillis();
             // connect to Masternode and submit the queue request
             CNode* pnode = ConnectNode((CAddress)addr, NULL, true);
-            if(pnode != NULL && pnode->nVersion >= MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+            if(pnode) {
                 pSubmittedToMasternode = pmn;
                 nSessionDenom = dsq.nDenom;
 
@@ -1605,7 +1605,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
         nLastTimeChanged = GetTimeMillis();
         LogPrintf("CDarksendPool::DoAutomaticDenominating -- attempt %d connection to Masternode %s\n", nTries, pmn->addr.ToString());
         CNode* pnode = ConnectNode((CAddress)pmn->addr, NULL, true);
-        if(pnode != NULL && pnode->nVersion >= MIN_PRIVATESEND_PEER_PROTO_VERSION) {
+        if(pnode) {
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- connected %s\n", pmn->vin.ToString());
             pSubmittedToMasternode = pmn;
 


### PR DESCRIPTION
It's too early for node version check - we don't know node version right after connection is initiated, we get it a bit later. And it's not necessary to do so here anyway since we already only try to connect to nodes with compatible proto version so I just reverted this part, no additional fixes.