### PR TITLE
Hardfork testnet to force upgrade

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -147,7 +147,8 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         else retarget = DIFF_BTC;
     // testnet -- we want a lot of coins in existance early on 
     } else {
-        if (pindexLast->nHeight + 1 >= 3000) retarget = DIFF_DGW;
+        if (pindexLast->nHeight + 1 >= 80000) retarget = DIFF_KGW;
+        else  if (pindexLast->nHeight + 1 >= 3000) retarget = DIFF_DGW;
         else retarget = DIFF_BTC;
     }
 


### PR DESCRIPTION
This should help us to force the network to upgrade and remove all of the old non-compliant nodes from our test group.e Our masternode inputs will still be valid, so it's easy to update. 

Fork initiates at block 80k and is implemented by adding one required KGW block.
