### PR TITLE
Deadlock fixes

### DIFF
--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -83,8 +83,11 @@ UniValue gobject(const UniValue& params, bool fHelp)
 
         // ASSEMBLE NEW GOVERNANCE OBJECT FROM USER PARAMETERS
 
-        LOCK(cs_main);
-        CBlockIndex* pindex = chainActive.Tip();
+        CBlockIndex* pindex = NULL;
+        {
+            LOCK(cs_main);
+            CBlockIndex* pindex = chainActive.Tip();
+        }
 
         std::vector<CMasternodeConfig::CMasternodeEntry> mnEntries;
         mnEntries = masternodeConfig.getEntries();
@@ -157,8 +160,11 @@ UniValue gobject(const UniValue& params, bool fHelp)
 
         // ASSEMBLE NEW GOVERNANCE OBJECT FROM USER PARAMETERS
 
-        LOCK(cs_main);
-        CBlockIndex* pindex = chainActive.Tip();
+        CBlockIndex* pindex = NULL;
+        {
+            LOCK(cs_main);
+            CBlockIndex* pindex = chainActive.Tip();
+        }
 
         uint256 txidFee;
 
@@ -547,7 +553,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
 
         // SETUP BLOCK INDEX VARIABLE / RESULTS VARIABLE
 
-        CBlockIndex* pindex;
+        CBlockIndex* pindex = NULL;
         {
             LOCK(cs_main);
             pindex = chainActive.Tip();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2701,9 +2701,6 @@ bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& 
     if (fImporting || fReindex) return false;
 
     // Find possible candidates
-    TRY_LOCK(cs_wallet, fWallet);
-    if(!fWallet) return false;
-
     std::vector<COutput> vPossibleCoins;
     AvailableCoins(vPossibleCoins, true, NULL, false, ONLY_1000);
     if(vPossibleCoins.empty()) {


### PR DESCRIPTION
These commits fix two distinct observed deadlocks.

Note that the lock in CWallet::GetMasternodeVinAndKeys is unneeded because it calls CWallet::AvailableCoins, which locks cs_main and cs_wallet in the correct order, and then works only on copied data.