### PR TITLE
refactor and fix PS collateral creation

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -647,7 +647,7 @@ public:
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
     bool SelectCoinsByDenominations(int nDenom, CAmount nValueMin, CAmount nValueMax, std::vector<CTxIn>& vecTxInRet, std::vector<COutput>& vCoinsRet, CAmount& nValueRet, int nPrivateSendRoundsMin, int nPrivateSendRoundsMax);
-    bool SelectCoinsCollateral(std::vector<CTxIn>& vecTxInRet, CAmount& nValueRet) const;
+    bool GetCollateralTxIn(CTxIn& txinRet, CAmount& nValueRet) const;
     bool SelectCoinsDark(CAmount nValueMin, CAmount nValueMax, std::vector<CTxIn>& vecTxInRet, CAmount& nValueRet, int nPrivateSendRoundsMin, int nPrivateSendRoundsMax) const;
     bool SelectCoinsGrouppedByAddresses(std::vector<CompactTallyItem>& vecTallyRet, bool fSkipDenominated = true, bool fAnonymizable = true) const;
 


### PR DESCRIPTION
Refactor: code here is quite outdated and overcomplicated - we don't use multiple PS collateral inputs since quite a long time already (since "zombie change bug" fix I believe). Made it more explicit that we only get single CTxIn here.
Fix: issue https://www.dash.org/forum/threads/12-1-testnet-testing-phase-two-ignition.10818/page-4#post-106363 This issue is due to the fact that reduced `PRIVATESEND_COLLATERAL` matches `nFeeRet` now. But `nFeeRet` itself doesn't actually make much sense anymore since collateral inputs are at least 2x of `PRIVATESEND_COLLATERAL` (note: we can't let tx to have 0 outputs so 2x is the lower limit: 1x fee + (min)1x change).