### PR TITLE
fix fCheckSigTimeOnly in CMasternodePing::CheckAndUpdate

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -439,7 +439,7 @@ bool CMasternodeBroadcast::SimpleCheck(int& nDos)
         return false;
     }
 
-    // incorrect ping or its sigTime
+    // empty ping or incorrect sigTime/blockhash
     if(lastPing == CMasternodePing() || !lastPing.CheckAndUpdate(nDos, false, true)) {
         return false;
     }
@@ -745,7 +745,7 @@ bool CMasternodePing::CheckSignature(CPubKey& pubKeyMasternode, int &nDos)
     return true;
 }
 
-bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fCheckSigTimeOnly)
+bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fSimpleCheck)
 {
     if (sigTime > GetAdjustedTime() + 60 * 60) {
         LogPrintf("CMasternodePing::CheckAndUpdate -- Signature rejected, too far into the future, masternode=%s\n", vin.prevout.ToStringShort());
@@ -776,9 +776,8 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
         }
     }
 
-    if (fCheckSigTimeOnly) {
-        CMasternode* pmn = mnodeman.Find(vin);
-        if (pmn) return CheckSignature(pmn->pubKeyMasternode, nDos);
+    if (fSimpleCheck) {
+        LogPrint("masternode", "CMasternodePing::CheckAndUpdate -- ping verified in fSimpleCheck mode: masternode=%s  blockHash=%s  sigTime=%d\n", vin.prevout.ToStringShort(), blockHash.ToString(), sigTime);
         return true;
     }
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -78,7 +78,7 @@ public:
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
     bool CheckSignature(CPubKey& pubKeyMasternode, int &nDos);
-    bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fCheckSigTimeOnly = false);
+    bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fSimpleCheck = false);
     void Relay();
 
     CMasternodePing& operator=(CMasternodePing from)


### PR DESCRIPTION
Not sure why we have this code here at all but it's preventing mns from updating their info from new mnb when masternodeprivkey changes. As a result nodes start banning each other (keys from sig and stored one do not match). Removed excessive logic and renamed `fCheckSigTimeOnly` to `fSimpleCheck` to better match actual check mode it's used in.