### PR TITLE
Allow masternode broadcasts to update masternode information regardless of state

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -118,8 +118,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& strErrorRet)
 
 void CActiveMasternode::ManageStateInitial()
 {
-    LogPrint("masternode", "CActiveMasternode::ManageStateInitial -- Start status = %s, type = %s, pinger enabled = %d\n", GetStatus(), GetType(), fPingerEnabled);
-
+    LogPrint("masternode", "CActiveMasternode::ManageStateInitial -- status = %s, type = %s, pinger enabled = %d\n", GetStatus(), GetType(), fPingerEnabled);
     // Check that our local network configuration is correct
     if(!GetLocal(service)) {
         strNotCapableReason = "Can't detect external address. Please consider using the externalip configuration option if problem persists.";
@@ -184,7 +183,12 @@ void CActiveMasternode::ManageStateInitial()
 
 void CActiveMasternode::ManageStateRemote()
 {
-    LogPrint("masternode", "CActiveMasternode::ManageStateRemote -- status = %s, type = %s, pinger enabled = %d\n", GetStatus(), GetType(), fPingerEnabled);
+    LogPrint("masternode", "CActiveMasternode::ManageStateRemote -- Start status = %s, type = %s, pinger enabled = %d, pubKeyMasternode.GetID() = %s\n", 
+             GetStatus(),
+             GetType(),
+             fPingerEnabled,
+             pubKeyMasternode.GetID().ToString());
+
     mnodeman.CheckMasternode(pubKeyMasternode);
     masternode_info_t infoMn = mnodeman.GetMasternodeInfo(pubKeyMasternode);
     if(infoMn.fInfoValid) {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -393,6 +393,11 @@ bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollater
     // wait for reindex and/or import to finish
     if (fImporting || fReindex) return false;
 
+    LogPrint("masternode", "CMasternodeBroadcast::Create -- pubKeyCollateralAddressNew = %s, keyMasternodeNew.GetID() = %s\n",
+             CBitcoinAddress(pubKeyCollateralAddressNew.GetID()).ToString(),
+             pubKeyMasternodeNew.GetID().ToString());
+
+
     CMasternodePing mnp(txin);
     if(!mnp.Sign(keyMasternodeNew, pubKeyMasternodeNew)) {
         strErrorRet = strprintf("Failed to sign ping, masternode=%s", txin.prevout.ToStringShort());

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -393,7 +393,7 @@ bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollater
     // wait for reindex and/or import to finish
     if (fImporting || fReindex) return false;
 
-    LogPrint("masternode", "CMasternodeBroadcast::Create -- pubKeyCollateralAddressNew = %s, keyMasternodeNew.GetID() = %s\n",
+    LogPrint("masternode", "CMasternodeBroadcast::Create -- pubKeyCollateralAddressNew = %s, pubKeyMasternodeNew.GetID() = %s\n",
              CBitcoinAddress(pubKeyCollateralAddressNew.GetID()).ToString(),
              pubKeyMasternodeNew.GetID().ToString());
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -509,9 +509,6 @@ bool CMasternodeBroadcast::Update(CMasternode* pmn, int& nDos)
         return false;
     }
 
-    // masternode is not enabled yet/already, nothing to update
-    if(!pmn->IsEnabled()) return false;
-
     // IsVnAssociatedWithPubkey is validated once in CheckOutpoint, after that they just need to match
     if(pmn->pubKeyCollateralAddress != pubKeyCollateralAddress) {
         LogPrintf("CMasternodeMan::Update -- Got mismatched pubKeyCollateralAddress and vin\n");
@@ -525,10 +522,7 @@ bool CMasternodeBroadcast::Update(CMasternode* pmn, int& nDos)
         LogPrintf("CMasternodeBroadcast::Update -- Got UPDATED Masternode entry: addr=%s\n", addr.ToString());
         if(pmn->UpdateFromNewBroadcast((*this))) {
             pmn->Check();
-            // normally masternode should be in pre-enabled status after update, if not - do not relay
-            if(pmn->IsPreEnabled()) {
-                Relay();
-            }
+            Relay();
         }
         masternodeSync.AddedMasternodeList();
     }

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -265,6 +265,19 @@ UniValue masternode(const UniValue& params, bool fHelp)
 
                 bool fResult = CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), strError, mnb);
 
+                CPubKey pubKeyMasternode;
+                CKey keyMasternode;
+                if(darkSendSigner.GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)) {
+                    LogPrint("masternode", "masternode start-alias -- alias = %s, pubKeyMasternode.GetID() = %s\n",
+                             mne.getAlias(),
+                             pubKeyMasternode.GetID().ToString());
+                }
+                else {
+                    LogPrint("masternode", "masternode start-alias -- alias = %s, failed to extract public key\n",
+                             mne.getAlias());
+                }
+
+
                 statusObj.push_back(Pair("result", fResult ? "successful" : "failed"));
                 if(fResult) {
                     mnodeman.UpdateMasternodeList(mnb);

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -265,19 +265,6 @@ UniValue masternode(const UniValue& params, bool fHelp)
 
                 bool fResult = CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), strError, mnb);
 
-                CPubKey pubKeyMasternode;
-                CKey keyMasternode;
-                if(darkSendSigner.GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)) {
-                    LogPrint("masternode", "masternode start-alias -- alias = %s, pubKeyMasternode.GetID() = %s\n",
-                             mne.getAlias(),
-                             pubKeyMasternode.GetID().ToString());
-                }
-                else {
-                    LogPrint("masternode", "masternode start-alias -- alias = %s, failed to extract public key\n",
-                             mne.getAlias());
-                }
-
-
                 statusObj.push_back(Pair("result", fResult ? "successful" : "failed"));
                 if(fResult) {
                     mnodeman.UpdateMasternodeList(mnb);


### PR DESCRIPTION
Without this it's currently not possible to move a masternode to a different IP address or key without moving the collateral if the masternode is not in the enabled state.

Note that the only logic changes are in this commit:
https://github.com/dashpay/dash/commit/e93a52e7a7b49f4d52dff49ba446faa475011d26

The others are only to improve logging, notably by dumping the masternode public key when debug logging is enabled. Otherwise this information, which is quite important because it is what ties broadcasts generated by start-alias to a specific masternode.

Note: This will also require PR 1093 to be effective.