### PR TITLE
Set initial masternode last watchdog time to mnb.sigTime

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -90,7 +90,7 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
     nLastDsq(mnb.nLastDsq),
     nTimeLastChecked(0),
     nTimeLastPaid(0),
-    nTimeLastWatchdogVote(GetTime()),
+    nTimeLastWatchdogVote(mnb.sigTime),
     nActiveState(MASTERNODE_ENABLED),
     nCacheCollateralBlock(0),
     nBlockLastPaid(0),
@@ -114,7 +114,7 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
     addr = mnb.addr;
     nPoSeBanScore = 0;
     nTimeLastChecked = 0;
-    nTimeLastWatchdogVote = GetTime();
+    nTimeLastWatchdogVote = mnb.sigTime;
     int nDos = 0;
     if(mnb.lastPing == CMasternodePing() || (mnb.lastPing != CMasternodePing() && mnb.lastPing.CheckAndUpdate(nDos, false))) {
         lastPing = mnb.lastPing;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -90,7 +90,7 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
     nLastDsq(mnb.nLastDsq),
     nTimeLastChecked(0),
     nTimeLastPaid(0),
-    nTimeLastWatchdogVote(0),
+    nTimeLastWatchdogVote(GetTime()),
     nActiveState(MASTERNODE_ENABLED),
     nCacheCollateralBlock(0),
     nBlockLastPaid(0),
@@ -114,6 +114,7 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
     addr = mnb.addr;
     nPoSeBanScore = 0;
     nTimeLastChecked = 0;
+    nTimeLastWatchdogVote = GetTime();
     int nDos = 0;
     if(mnb.lastPing == CMasternodePing() || (mnb.lastPing != CMasternodePing() && mnb.lastPing.CheckAndUpdate(nDos, false))) {
         lastPing = mnb.lastPing;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -57,6 +57,7 @@ bool CMasternodeMan::Add(CMasternode &mn)
     CMasternode *pmn = Find(mn.vin);
     if (pmn == NULL) {
         LogPrint("masternode", "CMasternodeMan::Add -- Adding new Masternode: addr=%s, %i now\n", mn.addr.ToString(), size() + 1);
+        mn.nTimeLastWatchdogVote = GetTime();
         vMasternodes.push_back(mn);
         return true;
     }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -57,7 +57,7 @@ bool CMasternodeMan::Add(CMasternode &mn)
     CMasternode *pmn = Find(mn.vin);
     if (pmn == NULL) {
         LogPrint("masternode", "CMasternodeMan::Add -- Adding new Masternode: addr=%s, %i now\n", mn.addr.ToString(), size() + 1);
-        mn.nTimeLastWatchdogVote = GetTime();
+        mn.nTimeLastWatchdogVote = mn.sigTime;
         vMasternodes.push_back(mn);
         return true;
     }


### PR DESCRIPTION
Following @UdjinM6 's suggestion, this fixes the issue of new masternodes initially appearing in the WATCHDOG_EXPIRED state.

The last watchdog time is also reset by masternode broadcasts.  This could be used to artificially keep an MN from expiring but it would be at the cost of that MN never being paid since it's sigTime would also get reset by each new broadcast.