### PR TITLE
fix deadlock on masternode list sync

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -210,8 +210,7 @@ void CMasternodeSync::ProcessTick()
         return;
     }
 
-    TRY_LOCK(cs_vNodes, lockRecv);
-    if(!lockRecv) return;
+    LOCK2(mnodeman.cs, cs_vNodes);
 
     if(nRequestedMasternodeAssets == MASTERNODE_SYNC_INITIAL ||
         (nRequestedMasternodeAssets == MASTERNODE_SYNC_SPORKS && IsBlockchainSynced()))

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -608,8 +608,6 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
     if(fLiteMode) return; // disable all Dash specific functionality
     if(!masternodeSync.IsBlockchainSynced()) return;
 
-    LOCK(cs);
-
     if (strCommand == NetMsgType::MNANNOUNCE) { //Masternode Broadcast
 
         CMasternodeBroadcast mnb;
@@ -633,6 +631,8 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         vRecv >> mnp;
 
         LogPrint("masternode", "MNPING -- Masternode ping, masternode=%s\n", mnp.vin.prevout.ToStringShort());
+
+        LOCK(cs);
 
         if(mapSeenMasternodePing.count(mnp.GetHash())) return; //seen
         mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));
@@ -667,6 +667,8 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         vRecv >> vin;
 
         LogPrint("masternode", "DSEG -- Masternode list, masternode=%s\n", vin.prevout.ToStringShort());
+
+        LOCK(cs);
 
         if(vin == CTxIn()) { //only should ask for this once
             //local network

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -49,6 +49,8 @@ private:
 
     int64_t nLastWatchdogVoteTime;
 
+    friend class CMasternodeSync;
+
 public:
     // Keep track of all broadcasts I've seen
     std::map<uint256, CMasternodeBroadcast> mapSeenMasternodeBroadcast;


### PR DESCRIPTION
While syncing we lock `cs_vNodes` and then call `DsegUpdate` which locks `cs` in `mnodeman` in the `privatesend` thread (the one sync works from). At the same time `net` thread starts to receive new `mnb` and locks `cs` in `mnodeman` first and `cs_vNodes` in `RelayInv` second. Because of the small masternode list these two events almost never intersect on testnet, however on mainnet the issue can be reproduced quite often (remove `mncache.dat` to force clean sync).

This PR fixes the issue by locking both `cs_vNodes` and ~~`cs` in `CheckMnbAndUpdateMasternodeList`~~ _`mnodeman.cs` in `ProcessTick`_ (and making `cs` lock usage in `ProcessMessage` a bit more granular).

EDIT: fixed description