### PR TITLE
PoSe changes:

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1597,7 +1597,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
                 LogPrintf("CDarksendPool::DoAutomaticDenominating -- can't connect, addr=%s\n", pmn->addr.ToString());
                 strAutoDenomResult = _("Error connecting to Masternode.");
                 dsq.nTime = 0; //remove node
-                pmn->nPoSeBanScore++;
+                pmn->IncreasePoSeBanScore();
                 continue;
             }
         }
@@ -1650,7 +1650,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
         } else {
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- can't connect, addr=%s\n", pmn->addr.ToString());
             nTries++;
-            pmn->nPoSeBanScore++;
+            pmn->IncreasePoSeBanScore();
             continue;
         }
     }

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -21,7 +21,6 @@ static const int MASTERNODE_REMOVAL_SECONDS         = 75 * 60;
 static const int MASTERNODE_CHECK_SECONDS           = 5;
 static const int MASTERNODE_WATCHDOG_MAX_SECONDS    = 2 * 60 * 60;
 
-static const int MASTERNODE_POSE_BAN_SECONDS        = 24 * 60 * 60;
 static const int MASTERNODE_POSE_BAN_MAX_SCORE      = 5;
 //
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network
@@ -165,6 +164,7 @@ public:
     int nBlockLastPaid;
     int nProtocolVersion;
     int nPoSeBanScore;
+    int nPoSeBanHeight;
     bool fAllowMixingTx;
     bool fUnitTest;
 
@@ -197,6 +197,7 @@ public:
         READWRITE(nBlockLastPaid);
         READWRITE(nProtocolVersion);
         READWRITE(nPoSeBanScore);
+        READWRITE(nPoSeBanHeight);
         READWRITE(fAllowMixingTx);
         READWRITE(fUnitTest);
         READWRITE(mapGovernanceObjectsVotedOn);
@@ -225,6 +226,7 @@ public:
         swap(first.nBlockLastPaid, second.nBlockLastPaid);
         swap(first.nProtocolVersion, second.nProtocolVersion);
         swap(first.nPoSeBanScore, second.nPoSeBanScore);
+        swap(first.nPoSeBanHeight, second.nPoSeBanHeight);
         swap(first.fAllowMixingTx, second.fAllowMixingTx);
         swap(first.fUnitTest, second.fUnitTest);
         swap(first.mapGovernanceObjectsVotedOn, second.mapGovernanceObjectsVotedOn);
@@ -257,6 +259,9 @@ public:
     bool IsWatchdogExpired() { return nActiveState == MASTERNODE_WATCHDOG_EXPIRED; }
 
     bool IsValidNetAddr();
+
+    void IncreasePoSeBanScore() { if(nPoSeBanScore < MASTERNODE_POSE_BAN_MAX_SCORE) nPoSeBanScore++; }
+    void DecreasePoSeBanScore() { if(nPoSeBanScore > -MASTERNODE_POSE_BAN_MAX_SCORE) nPoSeBanScore--; }
 
     masternode_info_t GetInfo();
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -860,7 +860,7 @@ void CMasternodeMan::CheckSameAddr()
 
     // ban duplicates
     BOOST_FOREACH(CMasternode* pmn, vBan) {
-        pmn->nPoSeBanScore++;
+        pmn->IncreasePoSeBanScore();
     }
 }
 
@@ -890,7 +890,7 @@ bool CMasternodeMan::SendVerifyRequest(const CAddress& addr, const std::vector<C
                 continue;
             }
             fFound = true;
-            pmn->nPoSeBanScore++;
+            pmn->IncreasePoSeBanScore();
         }
         return false;
     }
@@ -990,7 +990,7 @@ void CMasternodeMan::ProcessVerifyReply(CNode* pnode, CMasternodeVerification& m
                     // found it!
                     prealMasternode = &(*it);
                     if(!it->IsPoSeVerified()) {
-                            it->nPoSeBanScore--;
+                        it->DecreasePoSeBanScore();
                     }
                     netfulfilledman.AddFulfilledRequest(pnode->addr, strprintf("%s", NetMsgType::MNVERIFY)+"-done");
 
@@ -1036,7 +1036,7 @@ void CMasternodeMan::ProcessVerifyReply(CNode* pnode, CMasternodeVerification& m
                     prealMasternode->vin.prevout.ToStringShort(), pnode->addr.ToString());
         // increase ban score for everyone else
         BOOST_FOREACH(CMasternode* pmn, vpMasternodesToBan) {
-            pmn->nPoSeBanScore++;
+            pmn->IncreasePoSeBanScore();
             LogPrint("masternode", "CMasternodeMan::ProcessVerifyBroadcast -- increased PoSe ban score for %s addr %s, new score %d\n",
                         prealMasternode->vin.prevout.ToStringShort(), pnode->addr.ToString(), pmn->nPoSeBanScore);
         }
@@ -1120,7 +1120,7 @@ void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerif
         }
 
         if(!pmn1->IsPoSeVerified()) {
-            pmn1->nPoSeBanScore--;
+            pmn1->DecreasePoSeBanScore();
         }
         mnv.Relay();
 
@@ -1131,7 +1131,7 @@ void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerif
         int nCount = 0;
         BOOST_FOREACH(CMasternode& mn, vMasternodes) {
             if(mn.addr != mnv.addr || mn.vin.prevout == mnv.vin1.prevout) continue;
-            mn.nPoSeBanScore++;
+            mn.IncreasePoSeBanScore();
             nCount++;
             LogPrint("masternode", "CMasternodeMan::ProcessVerifyBroadcast -- increased PoSe ban score for %s addr %s, new score %d\n",
                         mn.vin.prevout.ToStringShort(), mn.addr.ToString(), mn.nPoSeBanScore);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -860,6 +860,7 @@ void CMasternodeMan::CheckSameAddr()
 
     // ban duplicates
     BOOST_FOREACH(CMasternode* pmn, vBan) {
+        LogPrintf("CMasternodeMan::CheckSameAddr -- increasing PoSe ban score for masternode %s\n", pmn->vin.prevout.ToStringShort());
         pmn->IncreasePoSeBanScore();
     }
 }


### PR DESCRIPTION
- use helpers to alter `nPoSeBanScore` within predefined range only
- use `nPoSeBanHeight` instead of timeout of inactivity to ban masternodes till some block in the future (currently should block for the whole payment cycle)