### PR TITLE
[UI] Fix for empty Masternode list when mncache.dat exists

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -60,6 +60,7 @@ MasternodeList::MasternodeList(const PlatformStyle *platformStyle, QWidget *pare
     connect(timer, SIGNAL(timeout()), this, SLOT(updateMyNodeList()));
     timer->start(1000);
 
+    fFilterUpdated = false;
     updateNodeList();
 }
 
@@ -232,7 +233,7 @@ void MasternodeList::updateNodeList()
                             : nTimeListUpdated - GetTime() + MASTERNODELIST_UPDATE_SECONDS;
 
     if(fFilterUpdated) ui->countLabel->setText(QString::fromStdString(strprintf("Please wait... %d", nSecondsToWait)));
-    if(nSecondsToWait > 0 && nSecondsToWait < 600) return;
+    if(nSecondsToWait > 0) return;
 
     nTimeListUpdated = GetTime();
     fFilterUpdated = false;

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -232,7 +232,7 @@ void MasternodeList::updateNodeList()
                             : nTimeListUpdated - GetTime() + MASTERNODELIST_UPDATE_SECONDS;
 
     if(fFilterUpdated) ui->countLabel->setText(QString::fromStdString(strprintf("Please wait... %d", nSecondsToWait)));
-    if(nSecondsToWait > 0) return;
+    if(nSecondsToWait > 0 && nSecondsToWait < 600) return;
 
     nTimeListUpdated = GetTime();
     fFilterUpdated = false;

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -61,6 +61,7 @@ MasternodeList::MasternodeList(const PlatformStyle *platformStyle, QWidget *pare
     timer->start(1000);
 
     fFilterUpdated = false;
+    nTimeFilterUpdated = GetTime();
     updateNodeList();
 }
 


### PR DESCRIPTION
I have one Ubuntu system where, when mncache.dat already exists, the counter for the list-update starts with: 
![counter](https://cloud.githubusercontent.com/assets/10080039/19833888/15f930b8-9e4a-11e6-9546-21b10fdddecd.jpg)

That's a loooong time to wait for the next (here: first) update of the list, so it just stays empty.
When you delete mncache.dat everything works as designed, but when you close and re-open the wallet this happens again each time.

Since this happens only on one of my test-systems and is not reproducible on the other systems I just added a quick fix instead of investigating more time to find out why this actually happens.

Hope that's okay.