### PR TITLE
Fix Governance Object's Expiration calculation

### DIFF
--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -211,10 +211,9 @@ void CGovernanceTriggerManager::CleanAndRemove()
                 break;
             case SEEN_OBJECT_IS_VALID:
                 {
-                    // Rough approximation: 30 days per month * 576 blocks per day
-                    static const int nMonthlyBlocks = 30*576;
                     int nTriggerBlock = pSuperblock->GetBlockStart();
-                    int nExpirationBlock = nTriggerBlock + nMonthlyBlocks;
+                    // Rough approximation: a cycle of superblock ++
+                    int nExpirationBlock = nTriggerBlock + Params().GetConsensus().nSuperblockCycle + GOVERNANCE_FEE_CONFIRMATIONS; 
                     if(governance.GetCachedBlockHeight() > nExpirationBlock) {
                         remove = true;
                         CGovernanceObject* pgovobj = pSuperblock->GetGovernanceObject();


### PR DESCRIPTION
Since testnet's superblock cycle is not monthly, it's better to base on a number of cycle blocks than the rough estimation of a month to be expired, I guess.
