### PR TITLE
Trivial: Add NetBeans project folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,10 +118,12 @@ share/BitcoindComparisonTool.jar
 
 !src/leveldb*/Makefile
 
+# IDE project files/folders
 .cproject
 .project
 .autotools
 /doc/doxygen/
+/nbproject/
 
 libbitcoinconsensus.pc
 src/qt/dash-qt.bash


### PR DESCRIPTION
NetBeans is a _really_ nice IDE, but you don't want to push its project folder to Github.

(BTW, NetBeans does take care of this automatically, but when you (like me) often use the git command line tools it's only a matter of time until you accidentally push this folder as well).