### PR TITLE
fix dsq rate limit bug in DoAuto

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1552,15 +1552,9 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
             // incompatible denom
             if(dsq.nDenom >= (1 << vecPrivateSendDenominations.size())) continue;
 
-            bool fUsed = false;
-            //don't reuse Masternodes
-            BOOST_FOREACH(CTxIn txinUsed, vecMasternodesUsed) {
-                if(dsq.vin == txinUsed) {
-                    fUsed = true;
-                    break;
-                }
-            }
-            if(fUsed) continue;
+            // mixing rate limit i.e. nLastDsq check should already pass in DSQUEUE ProcessMessage
+            // in order for dsq to get into vecDarksendQueue, so we should be safe to mix already,
+            // no need for additional verification here
 
             LogPrint("privatesend", "CDarksendPool::DoAutomaticDenominating -- found valid queue: %s\n", dsq.ToString());
 


### PR DESCRIPTION
Should not check `vecMasternodesUsed` when connecting from queue, should check `nLastDsq` only - they serve completely different purposes. (And `nLastDsq` verification is already done when dsq is received, so no need for additional check in DoAuto).
(part of #1120)