### PR TITLE
remove excessive bool arg in dscomplete

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -360,10 +360,9 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
             return;
         }
 
-        int  nMsgSessionID;
-        bool fMsgError;
-        int  nMsgMessageID;
-        vRecv >> nMsgSessionID >> fMsgError >> nMsgMessageID;
+        int nMsgSessionID;
+        int nMsgMessageID;
+        vRecv >> nMsgSessionID >> nMsgMessageID;
 
         if(nMsgMessageID < MSG_POOL_MIN || nMsgMessageID > MSG_POOL_MAX) {
             LogPrint("privatesend", "DSCOMPLETE -- nMsgMessageID is out of bounds: %d\n", nMsgMessageID);
@@ -377,7 +376,7 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
 
         LogPrint("privatesend", "DSCOMPLETE -- nMsgSessionID %d  nMsgMessageID %d (%s)\n", nMsgSessionID, nMsgMessageID, GetMessageByID(PoolMessage(nMsgMessageID)));
 
-        CompletedTransaction(fMsgError, PoolMessage(nMsgMessageID));
+        CompletedTransaction(PoolMessage(nMsgMessageID));
     }
 }
 
@@ -588,7 +587,7 @@ void CDarksendPool::CommitFinalTransaction()
 
             // not much we can do in this case
             SetState(POOL_STATE_ACCEPTING_ENTRIES);
-            RelayCompletedTransaction(true, ERR_INVALID_TX);
+            RelayCompletedTransaction(ERR_INVALID_TX);
             return;
         }
     }
@@ -608,7 +607,7 @@ void CDarksendPool::CommitFinalTransaction()
     RelayInv(inv);
 
     // Tell the clients it was successful
-    RelayCompletedTransaction(false, MSG_SUCCESS);
+    RelayCompletedTransaction(MSG_SUCCESS);
 
     // Randomly charge clients
     ChargeRandomFees();
@@ -1282,27 +1281,18 @@ void CDarksendPool::NewBlock()
 }
 
 // mixing transaction was completed (failed or successful)
-void CDarksendPool::CompletedTransaction(bool fError, PoolMessage nMessageID)
+void CDarksendPool::CompletedTransaction(PoolMessage nMessageID)
 {
     if(fMasterNode) return;
 
-    if(fError) {
-        LogPrintf("CompletedTransaction -- error\n");
-        SetState(POOL_STATE_ERROR);
-
-        CheckPool();
-        UnlockCoins();
-        SetNull();
-    } else {
+    if(nMessageID == MSG_SUCCESS) {
         LogPrintf("CompletedTransaction -- success\n");
-        SetState(POOL_STATE_SUCCESS);
-
-        UnlockCoins();
-        SetNull();
-
-        // To avoid race conditions, we'll only let DS run once per block
         nCachedLastSuccessBlock = pCurrentBlockIndex->nHeight;
+    } else {
+        LogPrintf("CompletedTransaction -- error\n");
     }
+    UnlockCoins();
+    SetNull();
     strLastMessage = GetMessageByID(nMessageID);
 }
 
@@ -2411,12 +2401,12 @@ void CDarksendPool::RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nMes
             PushStatus(pnode, nStatusUpdate, nMessageID);
 }
 
-void CDarksendPool::RelayCompletedTransaction(bool fError, PoolMessage nMessageID)
+void CDarksendPool::RelayCompletedTransaction(PoolMessage nMessageID)
 {
     LOCK(cs_vNodes);
     BOOST_FOREACH(CNode* pnode, vNodes)
         if(pnode->nVersion >= MIN_PRIVATESEND_PEER_PROTO_VERSION)
-            pnode->PushMessage(NetMsgType::DSCOMPLETE, nSessionID, fError, (int)nMessageID);
+            pnode->PushMessage(NetMsgType::DSCOMPLETE, nSessionID, (int)nMessageID);
 }
 
 void CDarksendPool::SetState(PoolState nStateNew)

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -355,7 +355,7 @@ private:
     void CreateFinalTransaction();
     void CommitFinalTransaction();
 
-    void CompletedTransaction(bool fError, PoolMessage nMessageID);
+    void CompletedTransaction(PoolMessage nMessageID);
 
     /// Get the denominations for a specific amount of dash.
     int GetDenominationsByAmounts(const std::vector<CAmount>& vecAmount);
@@ -413,7 +413,7 @@ private:
     void RelayIn(const CDarkSendEntry& entry);
     void PushStatus(CNode* pnode, PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID);
     void RelayStatus(PoolStatusUpdate nStatusUpdate = STATUS_SET_STATE, PoolMessage nMessageID = MSG_NOERR);
-    void RelayCompletedTransaction(bool fError, PoolMessage nMessageID);
+    void RelayCompletedTransaction(PoolMessage nMessageID);
 
 public:
     CMasternode* pSubmittedToMasternode;


### PR DESCRIPTION
We can rely on message id here since it's an enum (was not and id but a message itself (string) long time ago iirc, that's when this bool was useful but it's not the case anymore).

Requires proto bump (will be done later).

(part of #1120)