### PR TITLE
Fix qt crash

### DIFF
--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -372,7 +372,7 @@ BitcoinApplication::~BitcoinApplication()
 #endif
     // Delete Qt-settings if user clicked on "Reset Options"
     QSettings settings;
-    if(optionsModel->resetSettings){
+    if(optionsModel && optionsModel->resetSettings){
         settings.clear();
         settings.sync();
     }


### PR DESCRIPTION
Fixes `dash-qt --version` (`--help` etc) crash (`Segmentation fault: 11`)