### PR TITLE
[UI] In-wallet PrivateSend help

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -405,223 +405,233 @@
          </property>
          <layout class="QVBoxLayout" name="VerticalLayout_PS1">
           <item>
-           <widget class="QWidget" name="layoutWidgetPrivateSendHeader">
-            <layout class="QHBoxLayout" name="horizontalLayout_5">
-             <item>
-              <widget class="QLabel" name="labelPrivateSendHeader">
-               <property name="font">
-                <font>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string>PrivateSend</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="labelPrivateSendSyncStatus">
-               <property name="toolTip">
-                <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Dash network after a connection is established, but this process has not completed yet.</string>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">QLabel { color: red; }</string>
-               </property>
-               <property name="text">
-                <string notr="true">(out of sync)</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_4">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QLabel" name="labelPrivateSendHeader">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>PrivateSend</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="labelPrivateSendSyncStatus">
+              <property name="toolTip">
+               <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Dash network after a connection is established, but this process has not completed yet.</string>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">QLabel { color: red; }</string>
+              </property>
+              <property name="text">
+               <string notr="true">(out of sync)</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
           <item>
-           <widget class="QWidget" name="privateSendFormLayoutWidget">
-            <layout class="QFormLayout" name="privateSendFormLayout">
-             <property name="fieldGrowthPolicy">
-              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-             </property>
-             <property name="horizontalSpacing">
-              <number>11</number>
-             </property>
-             <property name="verticalSpacing">
-              <number>12</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="labelPrivateSendEnabledText">
-               <property name="text">
-                <string>Status:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelPrivateSendEnabled">
-               <property name="text">
-                <string>Enabled/Disabled</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="labelCompletitionText">
-               <property name="text">
-                <string>Completion:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QProgressBar" name="privateSendProgress">
-               <property name="maximumSize">
-                <size>
-                 <width>154</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="value">
-                <number>0</number>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="labelAnonymizedText">
-               <property name="text">
-                <string>PrivateSend Balance:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QLabel" name="labelAnonymized">
-               <property name="font">
-                <font>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="text">
-                <string notr="true">0 DASH</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="labelAmountAndRoundsText">
-               <property name="text">
-                <string>Amount and Rounds:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QLabel" name="labelAmountRounds">
-               <property name="text">
-                <string>0 DASH / 0 Rounds</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="labelSubmittedDenomText">
-               <property name="text">
-                <string>Submitted Denom:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="QLabel" name="labelSubmittedDenom">
-               <property name="toolTip">
-                <string>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</string>
-               </property>
-               <property name="text">
-                <string>n/a</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
+           <layout class="QFormLayout" name="privateSendFormLayout">
+            <property name="fieldGrowthPolicy">
+             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+            </property>
+            <property name="horizontalSpacing">
+             <number>11</number>
+            </property>
+            <property name="verticalSpacing">
+             <number>12</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="labelPrivateSendEnabledText">
+              <property name="text">
+               <string>Status:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="labelPrivateSendEnabled">
+              <property name="text">
+               <string>Enabled/Disabled</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="labelCompletitionText">
+              <property name="text">
+               <string>Completion:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QProgressBar" name="privateSendProgress">
+              <property name="maximumSize">
+               <size>
+                <width>154</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="labelAnonymizedText">
+              <property name="text">
+               <string>PrivateSend Balance:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="labelAnonymized">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string notr="true">0 DASH</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="labelAmountAndRoundsText">
+              <property name="text">
+               <string>Amount and Rounds:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="labelAmountRounds">
+              <property name="text">
+               <string>0 DASH / 0 Rounds</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="labelSubmittedDenomText">
+              <property name="text">
+               <string>Submitted Denom:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLabel" name="labelSubmittedDenom">
+              <property name="toolTip">
+               <string>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</string>
+              </property>
+              <property name="text">
+               <string>n/a</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
-           <widget class="QWidget" name="layoutWidgetLastMessageAndButtons">
-            <layout class="QVBoxLayout" name="VerticalLayout_PS">
-             <item>
-              <widget class="QLabel" name="labelPrivateSendLastMessage">
-               <property name="text">
-                <string>(Last Message)</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-               </property>
-               <property name="wordWrap">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="togglePrivateSend">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Start/Stop Mixing</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_debugbuttons">
-               <item>
-                <widget class="QPushButton" name="privateSendAuto">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Try to manually submit a PrivateSend request.</string>
-                 </property>
-                 <property name="text">
-                  <string>Try Mix</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="privateSendReset">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="toolTip">
-                  <string>Reset the current status of PrivateSend (can interrupt PrivateSend if it's in the process of Mixing, which can cost you money!)</string>
-                 </property>
-                 <property name="autoFillBackground">
-                  <bool>false</bool>
-                 </property>
-                 <property name="text">
-                  <string>Reset</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
+           <layout class="QVBoxLayout" name="VerticalLayout_PS">
+            <item>
+             <widget class="QLabel" name="labelPrivateSendLastMessage">
+              <property name="text">
+               <string>(Last Message)</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="togglePrivateSend">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Start/Stop Mixing</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_debugbuttons">
+              <item>
+               <widget class="QPushButton" name="privateSendAuto">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Try to manually submit a PrivateSend request.</string>
+                </property>
+                <property name="text">
+                 <string>Try Mix</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="privateSendReset">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Reset the current status of PrivateSend (can interrupt PrivateSend if it's in the process of Mixing, which can cost you money!)</string>
+                </property>
+                <property name="autoFillBackground">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Reset</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="privateSendInfo">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Information about PrivateSend and Mixing</string>
+                </property>
+                <property name="text">
+                 <string>Info</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -282,6 +282,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         connect(ui->privateSendAuto, SIGNAL(clicked()), this, SLOT(privateSendAuto()));
         connect(ui->privateSendReset, SIGNAL(clicked()), this, SLOT(privateSendReset()));
+        connect(ui->privateSendInfo, SIGNAL(clicked()), this, SLOT(privateSendInfo()));
         connect(ui->togglePrivateSend, SIGNAL(clicked()), this, SLOT(togglePrivateSend()));
         updateWatchOnlyLabels(model->haveWatchOnly());
         connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyLabels(bool)));
@@ -441,6 +442,7 @@ void OverviewPage::updateAdvancedPSUI(bool fShowAdvancedPSUI) {
     ui->labelSubmittedDenom->setVisible(fShowAdvancedPSUI);
     ui->privateSendAuto->setVisible(fShowAdvancedPSUI);
     ui->privateSendReset->setVisible(fShowAdvancedPSUI);
+    ui->privateSendInfo->setVisible(true);
     ui->labelPrivateSendLastMessage->setVisible(fShowAdvancedPSUI);
 }
 
@@ -574,6 +576,41 @@ void OverviewPage::privateSendReset(){
     QMessageBox::warning(this, tr("PrivateSend"),
         tr("PrivateSend was successfully reset."),
         QMessageBox::Ok, QMessageBox::Ok);
+}
+
+void OverviewPage::privateSendInfo(){
+
+    // Artificial long boxtitle to ensure minimum width without overwriting the global CSS styles
+    QString placeHolder = "                                                                                                                                                                                    ";
+    QString infoBoxTitle = tr("PrivateSend") + placeHolder;
+    
+    QMessageBox::information(this, infoBoxTitle,
+        tr("\
+In order to utilize PrivateSend coins needs to be 'mixed' before they can be used.<hr> \
+<b>Mixing in a nutshell:</b>\
+<ol type=\"1\"> \
+<li>PrivateSend uses the fact that a transaction can be formed by multiple parties and made out to multiple parties to merge funds together ('Mixing') in a way where they can’t be uncoupled thereafter.</li> \
+<li>All PrivateSend transactions are setup for users to pay themselves, so the system is highly secure against theft and users coins always remain safe.</li> \
+<li>PrivateSend requires at least 3 participants to mix funds.</li> \
+<li>To improve privacy, the funds to be mixed will be denominated into 0.1DASH, 1DASH, 10DASH AND 100DASH payments. \
+Therefore in each mixing session, all users submit the same denominations as inputs and outputs.</li> \
+<li>PrivateSend is limited to 1000 DASH per user per session and requires multiple sessions to thoroughly anonymize significant amounts of money.</li> \
+<li>At set intervals, a user’s client will request to join with other clients via a Masternode.<br> \
+Upon entry into the Masternode, a queue object is propagated throughout the network detailing the denominations the user is looking to anonymize, but no information that can be used to identify the user.</li> \
+<li>Each PrivateSend session ('Round') can be thought of as an independent event increasing the anonymity of user’s funds. Each round of mixing utilizes multiple randomly chosen Masternodes, one after another. </li> \
+<li>At the end of the anonymization phase, the user’s coins are returned to their client at randomly generated change addresses.</li> \
+<li>When the user wishes to make a private transaction, the client forwards the intended amount from these anonymous change addresses directly to the intended receiver’s address.<br> \
+There is no direct involvement of of Masternodes in the final person-to-person transaction.</li> \
+</ol> \
+Step 8 above needs some extra attention: the Dash-wallet starts with with a pool (called keypool) of 1000 randomly generated change addresses.<br><br> \
+With every round of mixing, some of those addresses are used, reducing the number of unused keypool addresses.<br> \
+When the keypool is down to 100 addresses, the wallet tries to replenish the keypool. When replenishment has finished, the wallet MUST create a new backup of your newly generated Dash addresses.<br> \
+That's why mixing is disabled when you disable automatic wallet backups in the settings.<br><br> \
+Without this (automatic) backup you wouldn't be able to access this newly created addresses from old wallet backups, and thus losing coins!<hr> \
+For more info see <a href=\"https://dashpay.atlassian.net/wiki/display/DOC/PrivateSend\">https://dashpay.atlassian.net/wiki/display/DOC/PrivateSend</a> \
+        "),
+        QMessageBox::Ok, QMessageBox::Ok);
+
 }
 
 void OverviewPage::togglePrivateSend(){

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -586,27 +586,29 @@ void OverviewPage::privateSendInfo(){
     
     QMessageBox::information(this, infoBoxTitle,
         tr("\
-In order to utilize PrivateSend coins needs to be 'mixed' before they can be used.<hr> \
-<b>Mixing in a nutshell:</b>\
+<h3>PrivateSend Basics</h3> \
+PrivateSend gives you true financial privacy by obscuring the origins of your funds. \
+All the Dash in your wallet is comprised of different \"inputs\" which you can think of as separate, discrete coins.<br> \
+PrivateSend uses an innovative process to mix your inputs with the inputs of two other people, without having your coins ever leave your wallet. \
+You retain control of your money at all times..<hr> \
+<b>The PrivateSend process works like this:</b>\
 <ol type=\"1\"> \
-<li>PrivateSend uses the fact that a transaction can be formed by multiple parties and made out to multiple parties to merge funds together ('Mixing') in a way where they can’t be uncoupled thereafter.</li> \
-<li>All PrivateSend transactions are setup for users to pay themselves, so the system is highly secure against theft and users coins always remain safe.</li> \
-<li>PrivateSend requires at least 3 participants to mix funds.</li> \
-<li>To improve privacy, the funds to be mixed will be denominated into 0.1DASH, 1DASH, 10DASH AND 100DASH payments. \
-Therefore in each mixing session, all users submit the same denominations as inputs and outputs.</li> \
-<li>PrivateSend is limited to 1000 DASH per user per session and requires multiple sessions to thoroughly anonymize significant amounts of money.</li> \
-<li>At set intervals, a user’s client will request to join with other clients via a Masternode.<br> \
-Upon entry into the Masternode, a queue object is propagated throughout the network detailing the denominations the user is looking to anonymize, but no information that can be used to identify the user.</li> \
-<li>Each PrivateSend session ('Round') can be thought of as an independent event increasing the anonymity of user’s funds. Each round of mixing utilizes multiple randomly chosen Masternodes, one after another. </li> \
-<li>At the end of the anonymization phase, the user’s coins are returned to their client at randomly generated change addresses.</li> \
-<li>When the user wishes to make a private transaction, the client forwards the intended amount from these anonymous change addresses directly to the intended receiver’s address.<br> \
-There is no direct involvement of of Masternodes in the final person-to-person transaction.</li> \
-</ol> \
-Step 8 above needs some extra attention: the Dash-wallet starts with a pool (called keypool) of 1000 randomly generated change addresses.<br><br> \
-With every round of mixing, some of those addresses are used, reducing the number of unused keypool addresses.<br> \
-When the keypool is down to 100 addresses, the wallet tries to replenish the keypool. When replenishment has finished, the wallet MUST create a new backup of your newly generated Dash addresses.<br> \
-That's why mixing is disabled when you disable automatic wallet backups in the settings.<br><br> \
-Without this (automatic) backup you wouldn't be able to access this newly created addresses from old wallet backups, and thus losing coins!<hr> \
+<li>PrivateSend begins by breaking your transaction inputs down into standard denominations. \
+These denominations are 0.1 DASH, 1 DASH, 10 DASH, and 100 DASH--sort of like the paper money you use every day.</li> \
+<li>Your wallet then sends requests to specially configured software nodes on the network, called \"Masternodes.\" \
+These Masternodes are informed then that you are interested in mixing a certain denomination. \
+No identifiable information is sent to the masternodes, so they never know \"who\" you are.</li> \
+<li>When two other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. \
+The Masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. \
+Your wallet pays that denomination directly to itself, but in a different address (called a change address).</li> \
+<li>In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. \
+Each time the process is completed, it's called a \"round.\" Each round of PrivateSend makes it exponentially more difficult to determine where your funds originated.</li> \
+<li>This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, \
+your funds will already be anonymized. No additional waiting is required.</li> \
+</ol> <hr>\
+<b>IMPORTANT:</b> Your wallet only contains 1000 of these \"change addresses.\" Every time a mixing event happens, one of your addresses is used up. \
+Once enough of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.<br> \
+Consequently, users who have backups disabled will also have PrivateSend disabled. <hr>\
 For more info see <a href=\"https://dashpay.atlassian.net/wiki/display/DOC/PrivateSend\">https://dashpay.atlassian.net/wiki/display/DOC/PrivateSend</a> \
         "),
         QMessageBox::Ok, QMessageBox::Ok);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -606,8 +606,9 @@ Each time the process is completed, it's called a \"round.\" Each round of Priva
 <li>This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, \
 your funds will already be anonymized. No additional waiting is required.</li> \
 </ol> <hr>\
-<b>IMPORTANT:</b> Your wallet only contains 1000 of these \"change addresses.\" Every time a mixing event happens, one of your addresses is used up. \
-Once enough of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.<br> \
+<b>IMPORTANT:</b> Your wallet only contains 1000 of these \"change addresses.\" Every time a mixing event happens, up to 9 of your addresses are used up. \
+This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. \
+It can only do this, however, if you have automatic backups enabled.<br> \
 Consequently, users who have backups disabled will also have PrivateSend disabled. <hr>\
 For more info see <a href=\"https://dashpay.atlassian.net/wiki/display/DOC/PrivateSend\">https://dashpay.atlassian.net/wiki/display/DOC/PrivateSend</a> \
         "),

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -595,11 +595,11 @@ You retain control of your money at all times..<hr> \
 <ol type=\"1\"> \
 <li>PrivateSend begins by breaking your transaction inputs down into standard denominations. \
 These denominations are 0.1 DASH, 1 DASH, 10 DASH, and 100 DASH--sort of like the paper money you use every day.</li> \
-<li>Your wallet then sends requests to specially configured software nodes on the network, called \"Masternodes.\" \
-These Masternodes are informed then that you are interested in mixing a certain denomination. \
+<li>Your wallet then sends requests to specially configured software nodes on the network, called \"masternodes.\" \
+These masternodes are informed then that you are interested in mixing a certain denomination. \
 No identifiable information is sent to the masternodes, so they never know \"who\" you are.</li> \
 <li>When two other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. \
-The Masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. \
+The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. \
 Your wallet pays that denomination directly to itself, but in a different address (called a change address).</li> \
 <li>In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. \
 Each time the process is completed, it's called a \"round.\" Each round of PrivateSend makes it exponentially more difficult to determine where your funds originated.</li> \

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -602,7 +602,7 @@ Upon entry into the Masternode, a queue object is propagated throughout the netw
 <li>When the user wishes to make a private transaction, the client forwards the intended amount from these anonymous change addresses directly to the intended receiver’s address.<br> \
 There is no direct involvement of of Masternodes in the final person-to-person transaction.</li> \
 </ol> \
-Step 8 above needs some extra attention: the Dash-wallet starts with with a pool (called keypool) of 1000 randomly generated change addresses.<br><br> \
+Step 8 above needs some extra attention: the Dash-wallet starts with a pool (called keypool) of 1000 randomly generated change addresses.<br><br> \
 With every round of mixing, some of those addresses are used, reducing the number of unused keypool addresses.<br> \
 When the keypool is down to 100 addresses, the wallet tries to replenish the keypool. When replenishment has finished, the wallet MUST create a new backup of your newly generated Dash addresses.<br> \
 That's why mixing is disabled when you disable automatic wallet backups in the settings.<br><br> \

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -69,6 +69,7 @@ private Q_SLOTS:
     void togglePrivateSend();
     void privateSendAuto();
     void privateSendReset();
+    void privateSendInfo();
     void updateDisplayUnit();
     void updatePrivateSendProgress();
     void updateAdvancedPSUI(bool fShowAdvancedPSUI);

--- a/src/qt/res/css/crownium.css
+++ b/src/qt/res/css/crownium.css
@@ -1101,6 +1101,24 @@ QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:pressed {
 border:1px solid #9e9e9e;
 }
 
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo { /* Info Button */
+background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222, stop: .3 #FFFFFF, stop: .7 #FFFFFF, stop: 1 #222222);
+border:1px solid #d2d2d2;
+color:#616161;
+min-height:25px;
+font-size:9px;
+padding:0px;
+}
+
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo:hover {
+background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222, stop: .2 #FFFFFF, stop: .6 #FFFFFF, stop: 1 #222222);
+color:#000000;
+}
+
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo:pressed {
+border:1px solid #9e9e9e;
+}
+
 /* RECENT TRANSACTIONS */
 
 QWidget .QFrame#frame_2 { /* Transactions Widget */

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -1078,6 +1078,24 @@ QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:pressed {
 border:1px solid #9e9e9e;
 }
 
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo { /* Info Button */
+background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
+border:1px solid #d2d2d2;
+color:#616161;
+min-height:25px;
+font-size:9px;
+padding:0px;
+}
+
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo:hover {
+background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
+color:#333;
+}
+
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo:pressed {
+border:1px solid #9e9e9e;
+}
+
 /* RECENT TRANSACTIONS */
 
 QWidget .QFrame#frame_2 { /* Transactions Widget */

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -1085,6 +1085,24 @@ QWidget .QFrame#framePrivateSend .QPushButton#privateSendReset:pressed {
 border:1px solid #9e9e9e;
 }
 
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo { /* Info Button */
+background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
+border:1px solid #d2d2d2;
+color:#616161;
+min-height:25px;
+font-size:9px;
+padding:0px;
+}
+
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo:hover {
+background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(240, 240, 240, 255), stop: .95 rgba(240, 240, 240, 255), stop: 1 #ebebeb);
+color:#333;
+}
+
+QWidget .QFrame#framePrivateSend .QPushButton#privateSendInfo:pressed {
+border:1px solid #9e9e9e;
+}
+
 /* RECENT TRANSACTIONS */
 
 QWidget .QFrame#frame_2 { /* Transactions Widget */


### PR DESCRIPTION
Reference: https://www.dash.org/forum/threads/q3-core-team-report-call.11085/#post-106703 and https://www.dash.org/forum/threads/in-wallet-privatesend-help.11324/

Final text by ddlink7 (thanks a lot :+1: ).

Advanced PrivateSend interface with complete help text:
![advanced_ps](https://cloud.githubusercontent.com/assets/10080039/19983703/505d67e6-a20b-11e6-8071-9404a0eceb96.jpg)

Simple PrivateSend interface:
![simple_ps](https://cloud.githubusercontent.com/assets/10080039/19983718/629fbf80-a20b-11e6-9b29-a8db8169ddb8.jpg)

The link at the end is clickable and goes to our Wiki.