### PR TITLE
WIP: fix travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
 # - sudo/dist/group are set so as to get Blue Box VMs, necessary for [loopback]
 #   IPv6 support
 
-sudo: false
+sudo: required
 dist: trusty
 
 os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,10 @@ matrix:
       addons:
         apt:
           packages:
+            - python3
             - nsis
-            - gcc-mingw-w64-i686
             - g++-mingw-w64-i686
-            - binutils-mingw-w64-i686
-            - mingw-w64-dev
-            - wine
+            - wine1.6
             - bc
     - compiler: ": 32-bit + dash"
       env: HOST=i686-pc-linux-gnu RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash" PYZMQ=true


### PR DESCRIPTION
Travis-CI separated their whitelist to distribution specific lists, which causes our builds to fail. Switching to `sudo: required` to fix it.