### PR TITLE
Governance fixes

### DIFF
--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -198,12 +198,15 @@ void CGovernanceTriggerManager::CleanAndRemove()
             switch(pSuperblock->GetStatus()) {
             case SEEN_OBJECT_ERROR_INVALID:
             case SEEN_OBJECT_UNKNOWN:
+                LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Unknown or invalid trigger found\n");
                 remove = true;
                 break;
             case SEEN_OBJECT_EXECUTED:
                 {
+                    LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Executed trigger found\n");
                     CGovernanceObject* pgovobj = pSuperblock->GetGovernanceObject();
                     if(pgovobj) {
+                        LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Expiring executed object: %s\n", pgovobj->GetHash().ToString());
                         pgovobj->fExpired = true;
                     }
                 }
@@ -215,9 +218,11 @@ void CGovernanceTriggerManager::CleanAndRemove()
                     // Rough approximation: a cycle of superblock ++
                     int nExpirationBlock = nTriggerBlock + Params().GetConsensus().nSuperblockCycle + GOVERNANCE_FEE_CONFIRMATIONS; 
                     if(governance.GetCachedBlockHeight() > nExpirationBlock) {
+                        LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Outdated trigger found\n");
                         remove = true;
                         CGovernanceObject* pgovobj = pSuperblock->GetGovernanceObject();
                         if(pgovobj) {
+                            LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Expiring outdated object: %s\n", pgovobj->GetHash().ToString());
                             pgovobj->fExpired = true;
                         }
                     }
@@ -239,6 +244,7 @@ void CGovernanceTriggerManager::CleanAndRemove()
                      << strdata
                      << endl;
                );
+            LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Removing trigger object\n");
             mapTrigger.erase(it++);
         }
         else  {

--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -164,6 +164,7 @@ bool CGovernanceTriggerManager::AddNewTrigger(uint256 nHash)
 
 void CGovernanceTriggerManager::CleanAndRemove()
 {
+    LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Start\n");
     DBG( cout << "CGovernanceTriggerManager::CleanAndRemove: Start" << endl; );
     AssertLockHeld(governance.cs);
 
@@ -186,15 +187,18 @@ void CGovernanceTriggerManager::CleanAndRemove()
 
     // Remove triggers that are invalid or already executed
     DBG( cout << "CGovernanceTriggerManager::CleanAndRemove: mapTrigger.size() = " << mapTrigger.size() << endl; );
+    LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- mapTrigger.size() = %d\n", mapTrigger.size());
     trigger_m_it it = mapTrigger.begin();
     while(it != mapTrigger.end()) {
         bool remove = false;
         CSuperblock_sptr& pSuperblock = it->second;
         if(!pSuperblock) {
             DBG( cout << "CGovernanceTriggerManager::CleanAndRemove: NULL superblock marked for removal " << endl; );
+            LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- NULL superblock marked for removal\n");
             remove = true;
         } else {
             DBG( cout << "CGovernanceTriggerManager::CleanAndRemove: superblock status = " << pSuperblock->GetStatus() << endl; );
+            LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- superblock status = %d\n", pSuperblock->GetStatus());
             switch(pSuperblock->GetStatus()) {
             case SEEN_OBJECT_ERROR_INVALID:
             case SEEN_OBJECT_UNKNOWN:
@@ -217,6 +221,7 @@ void CGovernanceTriggerManager::CleanAndRemove()
                     int nTriggerBlock = pSuperblock->GetBlockStart();
                     // Rough approximation: a cycle of superblock ++
                     int nExpirationBlock = nTriggerBlock + Params().GetConsensus().nSuperblockCycle + GOVERNANCE_FEE_CONFIRMATIONS; 
+                    LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- nTriggerBlock = %d, nExpriartionBlock = %d\n");
                     if(governance.GetCachedBlockHeight() > nExpirationBlock) {
                         LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Outdated trigger found\n");
                         remove = true;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -481,9 +481,14 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
 
        vote_m_it it2 = mapVotesByHash.begin();
        while(it2 != mapVotesByHash.end()) {
-          pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT_VOTE, (*it2).first));
-          nInvCount++;
-          ++it2;
+           CGovernanceVote& vote = it2->second;
+           if(!vote.IsValid(true)) {
+               // Don't relay votes that are now invalid (ie. missing MN) to avoid being banned
+               continue;
+           }
+           pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT_VOTE, (*it2).first));
+           nInvCount++;
+           ++it2;
        }
     }
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -620,6 +620,21 @@ bool CGovernanceManager::MasternodeRateCheck(const CTxIn& vin, int nObjectType)
     return false;
 }
 
+void CGovernanceManager::AddCachedTriggers()
+{
+    LOCK(cs);
+
+    for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
+        CGovernanceObject& govobj = it->second;
+        
+        if(govobj.nObjectType != GOVERNANCE_OBJECT_TRIGGER) {
+            continue;
+        }
+
+        triggerman.AddNewTrigger(govobj.GetHash());
+    }    
+}
+
 CGovernanceObject::CGovernanceObject()
     : cs(),
       nHashParent(),

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -300,6 +300,8 @@ void CGovernanceManager::UpdateCachesAndClean()
 
     if(!pCurrentBlockIndex) return;
 
+    LogPrint("gobject", "CGovernanceManager::UpdateCachesAndClean -- After pCurrentBlockIndex (not NULL)\n");
+
     // UPDATE CACHE FOR EACH OBJECT THAT IS FLAGGED DIRTYCACHE=TRUE
 
     object_m_it it = mapObjects.begin();
@@ -332,7 +334,7 @@ void CGovernanceManager::UpdateCachesAndClean()
         // IF DELETE=TRUE, THEN CLEAN THE MESS UP!
 
         if(pObj->fCachedDelete || pObj->fExpired) {
-            LogPrintf("UpdateCachesAndClean -- erase obj %s\n", (*it).first.ToString());
+            LogPrintf("CGovernanceManager::UpdateCachesAndClean -- erase obj %s\n", (*it).first.ToString());
             mnodeman.RemoveGovernanceObject(pObj->GetHash());
             mapObjects.erase(it++);
         } else {

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1106,7 +1106,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex)
     LOCK(cs);
     pCurrentBlockIndex = pindex;
     nCachedBlockHeight = pCurrentBlockIndex->nHeight;
-    LogPrint("gobject", "pCurrentBlockIndex->nHeight: %d\n", pCurrentBlockIndex->nHeight);
+    LogPrint("gobject", "CGovernanceManager::UpdatedBlockTip pCurrentBlockIndex->nHeight: %d\n", pCurrentBlockIndex->nHeight);
 
     // TO REPROCESS OBJECTS WE SHOULD BE SYNCED
 

--- a/src/governance.h
+++ b/src/governance.h
@@ -185,6 +185,9 @@ public:
         READWRITE(mapVotesByHash);
         READWRITE(mapVotesByType);
         READWRITE(mapLastMasternodeTrigger);
+        if(ser_action.ForRead()) {
+            AddCachedTriggers();
+        }
     }
 
     void UpdatedBlockTip(const CBlockIndex *pindex);
@@ -207,6 +210,9 @@ public:
     void AddSeenVote(uint256 nHash, int status);
 
     bool MasternodeRateCheck(const CTxIn& vin, int nObjectType);
+
+private:
+    void AddCachedTriggers();
 
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4976,6 +4976,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
             break;
 
         const CInv &inv = *it;
+        LogPrint("net", "ProcessGetData -- inv = %s\n", inv.ToString());
         {
             boost::this_thread::interruption_point();
             it++;
@@ -5169,6 +5170,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                 }
 
                 if (!pushed && inv.type == MSG_GOVERNANCE_OBJECT) {
+                    LogPrint("net", "ProcessGetData -- MSG_GOVERNANCE_OBJECT: inv = %s\n", inv.ToString());
                     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                     bool topush = false;
                     {
@@ -5179,6 +5181,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                             }
                         }
                     }
+                    LogPrint("net", "ProcessGetData -- MSG_GOVERNANCE_OBJECT: topush = %d, inv = %s\n", topush, inv.ToString());
                     if(topush) {
                         pfrom->PushMessage(NetMsgType::MNGOVERNANCEOBJECT, ss);
                         pushed = true;
@@ -5197,6 +5200,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                         }
                     }
                     if(topush) {
+                        LogPrint("net", "ProcessGetData -- pushing: inv = %s\n", inv.ToString());
                         pfrom->PushMessage(NetMsgType::MNGOVERNANCEOBJECTVOTE, ss);
                         pushed = true;
                     }


### PR DESCRIPTION
This PR fixes two issues seen on testnet.

Governance votes were being relayed without rechecking their validity.  Votes that were once valid can become invalid if the masternode that created them is removed from the list.  This can lead to banning.

The second issue is that superblocks (ie. triggers) loaded from disk were not being added to the trigger map, preventing them from being expired.

Some additional non-default logging statements have also been added to facilitate debugging of the inventory relaying process.