### PR TITLE
New vote tallying implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ script:
     - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
     - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
     - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
-    - if [ -n "$OSX_SDK" -a -e depends/$HOST/native/bin/clang++ ]; then depends/$HOST/native/bin/clang++ --version; fi
     - depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE
     - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
     - ./configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ script:
     - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
     - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
     - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
+    - if [ -n "$OSX_SDK" -a -e depends/$HOST/native/bin/clang++ ]; then depends/$HOST/native/bin/clang++ --version; fi
     - depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE
     - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
     - ./configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,6 +74,8 @@ BITCOIN_CORE_H = \
   arith_uint256.h \
   base58.h \
   bloom.h \
+  cachemap.h \
+  cachemultimap.h \
   chain.h \
   chainparams.h \
   chainparamsbase.h \
@@ -99,6 +101,7 @@ BITCOIN_CORE_H = \
   darksend-relay.h \
   governance.h \
   governance-classes.h \
+  governance-exceptions.h \
   governance-vote.h \
   governance-votedb.h \
   flat-database.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -100,6 +100,7 @@ BITCOIN_CORE_H = \
   governance.h \
   governance-classes.h \
   governance-vote.h \
+  governance-votedb.h \
   flat-database.h \
   hash.h \
   httprpc.h \
@@ -202,6 +203,7 @@ libbitcoin_server_a_SOURCES = \
   governance.cpp \
   governance-classes.cpp \
   governance-vote.cpp \
+  governance-votedb.cpp \
   main.cpp \
   merkleblock.cpp \
   miner.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -43,6 +43,8 @@ BITCOIN_TESTS =\
   test/base64_tests.cpp \
   test/bip32_tests.cpp \
   test/bloom_tests.cpp \
+  test/cachemap_tests.cpp \
+  test/cachemultimap_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \
   test/coins_tests.cpp \

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -271,6 +271,7 @@ void CActiveMasternode::ManageStateLocal()
         //update to masternode list
         LogPrintf("CActiveMasternode::ManageStateLocal -- Update Masternode List\n");
         mnodeman.UpdateMasternodeList(mnb);
+        mnodeman.NotifyMasternodeUpdates();
 
         //send to all peers
         LogPrintf("CActiveMasternode::ManageStateLocal -- Relay broadcast, vin=%s\n", vin.ToString());

--- a/src/cachemap.h
+++ b/src/cachemap.h
@@ -1,0 +1,200 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef CACHEMAP_H_
+#define CACHEMAP_H_
+
+#include <map>
+#include <list>
+#include <cstddef>
+
+#include "serialize.h"
+
+/**
+ * Serializable structure for key/value items
+ */
+template<typename K, typename V>
+struct CacheItem
+{
+    CacheItem()
+    {}
+
+    CacheItem(const K& keyIn, const V& valueIn)
+    : key(keyIn),
+      value(valueIn)
+    {}
+
+    K key;
+    V value;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(key);
+        READWRITE(value);
+    }
+};
+
+
+/**
+ * Map like container that keeps the N most recently added items
+ */
+template<typename K, typename V>
+class CacheMap
+{
+public:
+    typedef CacheItem<K,V> item_t;
+
+    typedef std::list<item_t> list_t;
+
+    typedef typename list_t::iterator list_it;
+
+    typedef typename list_t::const_iterator list_cit;
+
+    typedef std::map<K, list_it> map_t;
+
+    typedef typename map_t::iterator map_it;
+
+    typedef typename map_t::const_iterator map_cit;
+
+private:
+    std::size_t nMaxSize;
+
+    std::size_t nCurrentSize;
+
+    list_t listItems;
+
+    map_t mapIndex;
+
+public:
+    CacheMap(std::size_t nMaxSizeIn = 0)
+        : nMaxSize(nMaxSizeIn),
+          nCurrentSize(0),
+          listItems(),
+          mapIndex()
+    {}
+
+    CacheMap(const CacheMap<K,V>& other)
+        : nMaxSize(other.nMaxSize),
+          nCurrentSize(other.nCurrentSize),
+          listItems(other.listItems),
+          mapIndex()
+    {
+        RebuildIndex();
+    }
+
+    void Clear()
+    {
+        mapIndex.clear();
+        listItems.clear();
+        nCurrentSize = 0;
+    }
+
+    void SetMaxSize(std::size_t nMaxSizeIn)
+    {
+        nMaxSize = nMaxSizeIn;
+    }
+
+    std::size_t GetMaxSize() const {
+        return nMaxSize;
+    }
+
+    std::size_t GetSize() const {
+        return nCurrentSize;
+    }
+
+    void Insert(const K& key, const V& value)
+    {
+        map_it it = mapIndex.find(key);
+        if(it != mapIndex.end()) {
+            item_t& item = *(it->second);
+            item.value = value;
+            return;
+        }
+        if(nCurrentSize == nMaxSize) {
+            PruneLast();
+        }
+        listItems.push_front(item_t(key, value));
+        mapIndex[key] = listItems.begin();
+        ++nCurrentSize;
+    }
+
+    bool HasKey(const K& key) const
+    {
+        map_cit it = mapIndex.find(key);
+        return (it != mapIndex.end());
+    }
+
+    bool Get(const K& key, V& value) const
+    {
+        map_cit it = mapIndex.find(key);
+        if(it == mapIndex.end()) {
+            return false;
+        }
+        item_t& item = *(it->second);
+        value = item.value;
+        return true;
+    }
+
+    void Erase(const K& key)
+    {
+        map_it it = mapIndex.find(key);
+        if(it == mapIndex.end()) {
+            return;
+        }
+        listItems.erase(it->second);
+        mapIndex.erase(it);
+        --nCurrentSize;
+    }
+
+    const list_t& GetItemList() const {
+        return listItems;
+    }
+
+    CacheMap<K,V>& operator=(const CacheMap<K,V>& other)
+    {
+        nMaxSize = other.nMaxSize;
+        nCurrentSize = other.nCurrentSize;
+        listItems = other.listItems;
+        RebuildIndex();
+        return *this;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(nMaxSize);
+        READWRITE(nCurrentSize);
+        READWRITE(listItems);
+        if(ser_action.ForRead()) {
+            RebuildIndex();
+        }
+    }
+
+private:
+    void PruneLast()
+    {
+        if(nCurrentSize < 1) {
+            return;
+        }
+        item_t& item = listItems.back();
+        mapIndex.erase(item.key);
+        listItems.pop_back();
+        --nCurrentSize;
+    }
+
+    void RebuildIndex()
+    {
+        mapIndex.clear();
+        for(list_it it = listItems.begin(); it != listItems.end(); ++it) {
+            mapIndex[it->key] = it;
+        }
+    }
+};
+
+#endif /* CACHEMAP_H_ */

--- a/src/cachemap.h
+++ b/src/cachemap.h
@@ -42,10 +42,12 @@ struct CacheItem
 /**
  * Map like container that keeps the N most recently added items
  */
-template<typename K, typename V>
+template<typename K, typename V, typename Size = uint32_t>
 class CacheMap
 {
 public:
+    typedef Size size_type;
+
     typedef CacheItem<K,V> item_t;
 
     typedef std::list<item_t> list_t;
@@ -61,16 +63,16 @@ public:
     typedef typename map_t::const_iterator map_cit;
 
 private:
-    std::size_t nMaxSize;
+    size_type nMaxSize;
 
-    std::size_t nCurrentSize;
+    size_type nCurrentSize;
 
     list_t listItems;
 
     map_t mapIndex;
 
 public:
-    CacheMap(std::size_t nMaxSizeIn = 0)
+    CacheMap(size_type nMaxSizeIn = 0)
         : nMaxSize(nMaxSizeIn),
           nCurrentSize(0),
           listItems(),
@@ -93,16 +95,16 @@ public:
         nCurrentSize = 0;
     }
 
-    void SetMaxSize(std::size_t nMaxSizeIn)
+    void SetMaxSize(size_type nMaxSizeIn)
     {
         nMaxSize = nMaxSizeIn;
     }
 
-    std::size_t GetMaxSize() const {
+    size_type GetMaxSize() const {
         return nMaxSize;
     }
 
-    std::size_t GetSize() const {
+    size_type GetSize() const {
         return nCurrentSize;
     }
 

--- a/src/cachemultimap.h
+++ b/src/cachemultimap.h
@@ -98,7 +98,6 @@ public:
         }
         it_map_t& mapIt = mit->second;
 
-        it_map_it it = mapIt.find(value);
         if(mapIt.count(value) > 0) {
             // Don't insert duplicates
             return;

--- a/src/cachemultimap.h
+++ b/src/cachemultimap.h
@@ -1,0 +1,253 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef CACHEMULTIMAP_H_
+#define CACHEMULTIMAP_H_
+
+#include <cstddef>
+#include <map>
+#include <list>
+#include <set>
+
+#include "serialize.h"
+
+#include "cachemap.h"
+
+/**
+ * Map like container that keeps the N most recently added items
+ */
+template<typename K, typename V>
+class CacheMultiMap
+{
+public:
+    typedef CacheItem<K,V> item_t;
+
+    typedef std::list<item_t> list_t;
+
+    typedef typename list_t::iterator list_it;
+
+    typedef typename list_t::const_iterator list_cit;
+
+    typedef std::map<V,list_it> it_map_t;
+
+    typedef typename it_map_t::iterator it_map_it;
+
+    typedef typename it_map_t::const_iterator it_map_cit;
+
+    typedef std::map<K, it_map_t> map_t;
+
+    typedef typename map_t::iterator map_it;
+
+    typedef typename map_t::const_iterator map_cit;
+
+private:
+    std::size_t nMaxSize;
+
+    std::size_t nCurrentSize;
+
+    list_t listItems;
+
+    map_t mapIndex;
+
+public:
+    CacheMultiMap(std::size_t nMaxSizeIn = 0)
+        : nMaxSize(nMaxSizeIn),
+          nCurrentSize(0),
+          listItems(),
+          mapIndex()
+    {}
+
+    CacheMultiMap(const CacheMap<K,V>& other)
+        : nMaxSize(other.nMaxSize),
+          nCurrentSize(other.nCurrentSize),
+          listItems(other.listItems),
+          mapIndex()
+    {
+        RebuildIndex();
+    }
+
+    void Clear()
+    {
+        mapIndex.clear();
+        listItems.clear();
+        nCurrentSize = 0;
+    }
+
+    void SetMaxSize(std::size_t nMaxSizeIn)
+    {
+        nMaxSize = nMaxSizeIn;
+    }
+
+    std::size_t GetMaxSize() const {
+        return nMaxSize;
+    }
+
+    std::size_t GetSize() const {
+        return nCurrentSize;
+    }
+
+    void Insert(const K& key, const V& value)
+    {
+        if(nCurrentSize == nMaxSize) {
+            PruneLast();
+        }
+        map_it mit = mapIndex.find(key);
+        if(mit == mapIndex.end()) {
+            mit = mapIndex.insert(std::pair<K,it_map_t>(key, it_map_t())).first;
+        }
+        it_map_t& mapIt = mit->second;
+
+        it_map_it it = mapIt.find(value);
+        if(mapIt.count(value) > 0) {
+            // Don't insert duplicates
+            return;
+        }
+
+        listItems.push_front(item_t(key, value));
+        list_it lit = listItems.begin();
+
+        mapIt[value] = lit;
+        ++nCurrentSize;
+    }
+
+    bool HasKey(const K& key) const
+    {
+        map_cit it = mapIndex.find(key);
+        return (it != mapIndex.end());
+    }
+
+    bool Get(const K& key, V& value) const
+    {
+        map_cit it = mapIndex.find(key);
+        if(it == mapIndex.end()) {
+            return false;
+        }
+        const it_map_t& mapIt = it->second;
+        const item_t& item = *(mapIt.begin()->second);
+        value = item.value;
+        return true;
+    }
+
+    bool GetAll(const K& key, std::vector<V>& vecValues)
+    {
+        map_cit mit = mapIndex.find(key);
+        if(mit == mapIndex.end()) {
+            return false;
+        }
+        const it_map_t& mapIt = mit->second;
+
+        for(it_map_cit it = mapIt.begin(); it != mapIt.end(); ++it) {
+            const item_t& item = *(it->second);
+            vecValues.push_back(item.value);
+        }
+        return true;
+    }
+
+    void Erase(const K& key)
+    {
+        map_it mit = mapIndex.find(key);
+        if(mit == mapIndex.end()) {
+            return;
+        }
+        it_map_t& mapIt = mit->second;
+
+        for(it_map_it it = mapIt.begin(); it != mapIt.end(); ++it) {
+            listItems.erase(it->second);
+            --nCurrentSize;
+        }
+
+        mapIndex.erase(mit);
+    }
+
+    void Erase(const K& key, const V& value)
+    {
+        map_it mit = mapIndex.find(key);
+        if(mit == mapIndex.end()) {
+            return;
+        }
+        it_map_t& mapIt = mit->second;
+
+        it_map_it it = mapIt.find(value);
+        if(it == mapIt.end()) {
+            return;
+        }
+
+        listItems.erase(it->second);
+        --nCurrentSize;
+        mapIt.erase(it);
+
+        if(mapIt.size() < 1) {
+            mapIndex.erase(mit);
+        }
+    }
+
+    const list_t& GetItemList() const {
+        return listItems;
+    }
+
+    CacheMap<K,V>& operator=(const CacheMap<K,V>& other)
+    {
+        nMaxSize = other.nMaxSize;
+        nCurrentSize = other.nCurrentSize;
+        listItems = other.listItems;
+        RebuildIndex();
+        return *this;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(nMaxSize);
+        READWRITE(nCurrentSize);
+        READWRITE(listItems);
+        if(ser_action.ForRead()) {
+            RebuildIndex();
+        }
+    }
+
+private:
+    void PruneLast()
+    {
+        if(nCurrentSize < 1) {
+            return;
+        }
+
+        list_it lit = listItems.end();
+        --lit;
+        item_t& item = *lit;
+
+        map_it mit = mapIndex.find(item.key);
+
+        if(mit != mapIndex.end()) {
+            it_map_t& mapIt = mit->second;
+
+            mapIt.erase(item.value);
+
+            if(mapIt.size() < 1) {
+                mapIndex.erase(item.key);
+            }
+        }
+
+        listItems.pop_back();
+        --nCurrentSize;
+    }
+
+    void RebuildIndex()
+    {
+        mapIndex.clear();
+        for(list_it lit = listItems.begin(); lit != listItems.end(); ++lit) {
+            item_t& item = *lit;
+            map_it mit = mapIndex.find(item.key);
+            if(mit == mapIndex.end()) {
+                mit = mapIndex.insert(std::pair<K,it_map_t>(item.key, it_map_t())).first;
+            }
+            it_map_t& mapIt = mit->second;
+            mapIt[item.value] = lit;
+        }
+    }
+};
+
+#endif /* CACHEMAP_H_ */

--- a/src/cachemultimap.h
+++ b/src/cachemultimap.h
@@ -251,4 +251,4 @@ private:
     }
 };
 
-#endif /* CACHEMAP_H_ */
+#endif /* CACHEMULTIMAP_H_ */

--- a/src/cachemultimap.h
+++ b/src/cachemultimap.h
@@ -17,10 +17,12 @@
 /**
  * Map like container that keeps the N most recently added items
  */
-template<typename K, typename V>
+template<typename K, typename V, typename Size = uint32_t>
 class CacheMultiMap
 {
 public:
+    typedef Size size_type;
+
     typedef CacheItem<K,V> item_t;
 
     typedef std::list<item_t> list_t;
@@ -42,16 +44,16 @@ public:
     typedef typename map_t::const_iterator map_cit;
 
 private:
-    std::size_t nMaxSize;
+    size_type nMaxSize;
 
-    std::size_t nCurrentSize;
+    size_type nCurrentSize;
 
     list_t listItems;
 
     map_t mapIndex;
 
 public:
-    CacheMultiMap(std::size_t nMaxSizeIn = 0)
+    CacheMultiMap(size_type nMaxSizeIn = 0)
         : nMaxSize(nMaxSizeIn),
           nCurrentSize(0),
           listItems(),
@@ -74,16 +76,16 @@ public:
         nCurrentSize = 0;
     }
 
-    void SetMaxSize(std::size_t nMaxSizeIn)
+    void SetMaxSize(size_type nMaxSizeIn)
     {
         nMaxSize = nMaxSizeIn;
     }
 
-    std::size_t GetMaxSize() const {
+    size_type GetMaxSize() const {
         return nMaxSize;
     }
 
-    std::size_t GetSize() const {
+    size_type GetSize() const {
         return nCurrentSize;
     }
 

--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -346,7 +346,7 @@ bool CSuperblockManager::IsSuperblockTriggered(int nBlockHeight)
 
         // MAKE SURE THIS TRIGGER IS ACTIVE VIA FUNDING CACHE FLAG
 
-        if(pObj->fCachedFunding) {
+        if(pObj->IsSetCachedFunding()) {
             LogPrint("gobject", "CSuperblockManager::IsSuperblockTriggered -- fCacheFunding = true, returning true\n");
             DBG( cout << "IsSuperblockTriggered returning true" << endl; );
             return true;
@@ -678,7 +678,7 @@ bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, CAmount b
     int nMinerPayments = nOutputs - nPayments;
 
     LogPrint("gobject", "CSuperblock::IsValid nOutputs = %d, nPayments = %d, strData = %s\n",
-             nOutputs, nPayments, GetGovernanceObject()->strData);
+             nOutputs, nPayments, GetGovernanceObject()->GetDataAsHex());
 
     // We require an exact match (including order) between the expected
     // superblock payments and the payments actually in the block, after

--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -506,7 +506,7 @@ CSuperblock(uint256& nHash)
 
     DBG( cout << "CSuperblock Constructor pGovObj : "
          << pGovObj->GetDataAsString()
-         << ", nObjectType = " << pGovObj->nObjectType
+         << ", nObjectType = " << pGovObj->GetObjectType()
          << endl; );
 
     if (pGovObj->GetObjectType() != GOVERNANCE_OBJECT_TRIGGER) {

--- a/src/governance-classes.h
+++ b/src/governance-classes.h
@@ -1,8 +1,8 @@
 // Copyright (c) 2014-2016 The Dash Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef GOVERANCE_CLASSES_H
-#define GOVERANCE_CLASSES_H
+#ifndef GOVERNANCE_CLASSES_H
+#define GOVERNANCE_CLASSES_H
 
 //#define ENABLE_DASH_DEBUG
 

--- a/src/governance-exceptions.h
+++ b/src/governance-exceptions.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GOVERNANCE_EXCEPTIONS_H
+#define GOVERNANCE_EXCEPTIONS_H
+
+#include <exception>
+#include <string>
+#include <iostream>
+
+enum governance_exception_type_enum_t {
+    /// Default value, normally indicates no exception condition occurred
+    GOVERNANCE_EXCEPTION_NONE = 0,
+    /// Unusual condition requiring no caller action
+    GOVERNANCE_EXCEPTION_WARNING = 1,
+    /// Requested operation cannot be performed
+    GOVERNANCE_EXCEPTION_PERMANENT_ERROR = 2,
+    /// Requested operation not currently possible, may resubmit later
+    GOVERNANCE_EXCEPTION_TEMPORARY_ERROR = 3,
+    /// Unexpected error (ie. should not happen unless there is a bug in the code)
+    GOVERNANCE_EXCEPTION_INTERNAL_ERROR = 4
+};
+
+inline std::ostream& operator<<(std::ostream& os, governance_exception_type_enum_t eType)
+{
+    switch(eType) {
+    case GOVERNANCE_EXCEPTION_NONE:
+        os << "GOVERNANCE_EXCEPTION_NONE";
+        break;
+    case GOVERNANCE_EXCEPTION_WARNING:
+        os << "GOVERNANCE_EXCEPTION_WARNING";
+        break;
+    case GOVERNANCE_EXCEPTION_PERMANENT_ERROR:
+        os << "GOVERNANCE_EXCEPTION_PERMANENT_ERROR";
+        break;
+    case GOVERNANCE_EXCEPTION_TEMPORARY_ERROR:
+        os << "GOVERNANCE_EXCEPTION_TEMPORARY_ERROR";
+        break;
+    case GOVERNANCE_EXCEPTION_INTERNAL_ERROR:
+        os << "GOVERNANCE_EXCEPTION_INTERNAL_ERROR";
+        break;
+    }
+    return os;
+}
+
+/**
+ * A class which encapsulates information about a governance exception condition
+ *
+ * Derives from std::exception so is suitable for throwing
+ * (ie. will be caught by a std::exception handler) but may also be used as a
+ * normal object.
+ */
+class CGovernanceException : public std::exception
+{
+private:
+    std::string strMessage;
+
+    governance_exception_type_enum_t eType;
+
+    int nNodePenalty;
+
+public:
+    CGovernanceException(const std::string& strMessageIn = "",
+                         governance_exception_type_enum_t eTypeIn = GOVERNANCE_EXCEPTION_NONE,
+                         int nNodePenaltyIn = 0)
+        : strMessage(),
+          eType(eTypeIn),
+          nNodePenalty(nNodePenaltyIn)
+    {
+        std::ostringstream ostr;
+        ostr << eType << ":" << strMessageIn;
+        strMessage = ostr.str();
+    }
+
+    virtual ~CGovernanceException() throw() {}
+
+    virtual const char* what() const throw()
+    {
+        return strMessage.c_str();
+    }
+
+    const std::string& GetMessage() const
+    {
+        return strMessage;
+    }
+
+    governance_exception_type_enum_t GetType() const
+    {
+        return eType;
+    }
+
+    int GetNodePenalty() const {
+        return nNodePenalty;
+    }
+};
+
+#endif

--- a/src/governance-misc.h
+++ b/src/governance-misc.h
@@ -2,8 +2,8 @@
 
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef GOVERANCE_MISC_H
-#define GOVERANCE_MISC_H
+#ifndef GOVERNANCE_MISC_H
+#define GOVERNANCE_MISC_H
 
 #include "main.h"
 #include "governance.h"

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -2,8 +2,8 @@
 
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef GOVERANCE_VOTE_H
-#define GOVERANCE_VOTE_H
+#ifndef GOVERNANCE_VOTE_H
+#define GOVERNANCE_VOTE_H
 
 #include "main.h"
 #include "sync.h"
@@ -68,6 +68,8 @@ enum vote_signal_enum_t  {
     VOTE_SIGNAL_CUSTOM20   = 35
 };
 
+static const int MAX_SUPPORTED_VOTE_SIGNAL = 4;
+
 /**
 * Governance Voting
 *
@@ -89,6 +91,10 @@ public:
 
 class CGovernanceVote
 {
+    friend bool operator==(const CGovernanceVote& vote1, const CGovernanceVote& vote2);
+
+    friend bool operator<(const CGovernanceVote& vote1, const CGovernanceVote& vote2);
+
 private:
     bool fValid; //if the vote is currently valid / counted
     bool fSynced; //if we've sent this to our peers
@@ -120,8 +126,12 @@ public:
     void SetSignature(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool IsValid(bool fSignatureCheck);
-    void Relay();
+    bool IsValid(bool fSignatureCheck) const;
+    void Relay() const;
+
+    std::string GetVoteString() const {
+        return CGovernanceVoting::ConvertOutcomeToString(GetOutcome());
+    }
 
     CTxIn& GetVinMasternode() { return vinMasternode; }
 
@@ -144,7 +154,7 @@ public:
         return ss.GetHash();
     }
 
-    std::string ToString()
+    std::string ToString() const
     {
         std::ostringstream ostr;
         ostr << vinMasternode.ToString() << ":"
@@ -196,6 +206,8 @@ public:
 
 };
 
+
+bool operator==(const CGovernanceVote& vote1, const CGovernanceVote& vote2);
 
 /**
 * 12.1.1 - CGovernanceVoteManager

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -68,7 +68,7 @@ enum vote_signal_enum_t  {
     VOTE_SIGNAL_CUSTOM20   = 35
 };
 
-static const int MAX_SUPPORTED_VOTE_SIGNAL = 4;
+static const int MAX_SUPPORTED_VOTE_SIGNAL = VOTE_SIGNAL_ENDORSED;
 
 /**
 * Governance Voting

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -207,7 +207,6 @@ public:
 };
 
 
-bool operator==(const CGovernanceVote& vote1, const CGovernanceVote& vote2);
 
 /**
 * 12.1.1 - CGovernanceVoteManager

--- a/src/governance-votedb.cpp
+++ b/src/governance-votedb.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "governance-votedb.h"
+
+CGovernanceObjectVoteFile::CGovernanceObjectVoteFile()
+    : nMemoryVotes(0),
+      listVotes(),
+      mapVoteIndex()
+{}
+
+CGovernanceObjectVoteFile::CGovernanceObjectVoteFile(const CGovernanceObjectVoteFile& other)
+    : nMemoryVotes(other.nMemoryVotes),
+      listVotes(other.listVotes),
+      mapVoteIndex()
+{
+    RebuildIndex();
+}
+
+void CGovernanceObjectVoteFile::AddVote(const CGovernanceVote& vote)
+{
+    listVotes.push_front(vote);
+    mapVoteIndex[vote.GetHash()] = listVotes.begin();
+    ++nMemoryVotes;
+}
+
+bool CGovernanceObjectVoteFile::HasVote(const uint256& nHash) const
+{
+    vote_m_cit it = mapVoteIndex.find(nHash);
+    if(it == mapVoteIndex.end()) {
+        return false;
+    }
+    return true;
+}
+
+bool CGovernanceObjectVoteFile::GetVote(const uint256& nHash, CGovernanceVote& vote) const
+{
+    vote_m_cit it = mapVoteIndex.find(nHash);
+    if(it == mapVoteIndex.end()) {
+        return false;
+    }
+    vote = *(it->second);
+    return true;
+}
+
+std::vector<CGovernanceVote> CGovernanceObjectVoteFile::GetVotes() const
+{
+    std::vector<CGovernanceVote> vecResult;
+    for(vote_l_cit it = listVotes.begin(); it != listVotes.end(); ++it) {
+        vecResult.push_back(*it);
+    }
+    return vecResult;
+}
+
+void CGovernanceObjectVoteFile::RemoveVotesFromMasternode(const CTxIn& vinMasternode)
+{
+    vote_l_it it = listVotes.begin();
+    while(it != listVotes.end()) {
+        if(it->GetVinMasternode() == vinMasternode) {
+            listVotes.erase(it++);
+        }
+        else {
+            ++it;
+        }
+    }
+}
+
+CGovernanceObjectVoteFile& CGovernanceObjectVoteFile::operator=(const CGovernanceObjectVoteFile& other)
+{
+    nMemoryVotes = other.nMemoryVotes;
+    listVotes = other.listVotes;
+    RebuildIndex();
+    return *this;
+}
+
+void CGovernanceObjectVoteFile::RebuildIndex()
+{
+    mapVoteIndex.clear();
+    for(vote_l_it it = listVotes.begin(); it != listVotes.end(); ++it) {
+        CGovernanceVote& vote = *it;
+        mapVoteIndex[vote.GetHash()] = it;
+    }
+}

--- a/src/governance-votedb.h
+++ b/src/governance-votedb.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GOVERNANCE_VOTEDB_H
+#define GOVERNANCE_VOTEDB_H
+
+#include <list>
+#include <map>
+
+#include "governance-vote.h"
+#include "serialize.h"
+#include "uint256.h"
+
+/**
+ * Represents the collection of votes associated with a given CGovernanceObject
+ * Recently received votes are held in memory until a maximum size is reached after
+ * which older votes a flushed to a disk file.
+ *
+ * Note: This is a stub implementation that doesn't limit the number of votes held
+ * in memory and doesn't flush to disk.
+ */
+class CGovernanceObjectVoteFile
+{
+public: // Types
+    typedef std::list<CGovernanceVote> vote_l_t;
+
+    typedef vote_l_t::iterator vote_l_it;
+
+    typedef vote_l_t::const_iterator vote_l_cit;
+
+    typedef std::map<uint256,vote_l_it> vote_m_t;
+
+    typedef vote_m_t::iterator vote_m_it;
+
+    typedef vote_m_t::const_iterator vote_m_cit;
+
+private:
+    static const int MAX_MEMORY_VOTES = -1;
+
+    int nMemoryVotes;
+
+    vote_l_t listVotes;
+
+    vote_m_t mapVoteIndex;
+
+public:
+    CGovernanceObjectVoteFile();
+
+    CGovernanceObjectVoteFile(const CGovernanceObjectVoteFile& other);
+
+    /**
+     * Add a vote to the file
+     */
+    void AddVote(const CGovernanceVote& vote);
+
+    /**
+     * Return true if the vote with this hash is currently cached in memory
+     */
+    bool HasVote(const uint256& nHash) const;
+
+    /**
+     * Retrieve a vote cached in memory
+     */
+    bool GetVote(const uint256& nHash, CGovernanceVote& vote) const;
+
+    int GetVoteCount() {
+        return nMemoryVotes;
+    }
+
+    std::vector<CGovernanceVote> GetVotes() const;
+
+    CGovernanceObjectVoteFile& operator=(const CGovernanceObjectVoteFile& other);
+
+    void RemoveVotesFromMasternode(const CTxIn& vinMasternode);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(nMemoryVotes);
+        READWRITE(listVotes);
+        if(ser_action.ForRead()) {
+            RebuildIndex();
+        }
+    }
+private:
+    void RebuildIndex();
+
+};
+
+#endif

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -27,18 +27,19 @@ std::map<uint256, int64_t> mapAskedForGovernanceObject;
 
 int nSubmittedFinalBudget;
 
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-1";
+
 CGovernanceManager::CGovernanceManager()
-    : mapCollateral(),
-      pCurrentBlockIndex(NULL),
+    : pCurrentBlockIndex(NULL),
       nTimeLastDiff(0),
       nCachedBlockHeight(0),
       mapObjects(),
       mapSeenGovernanceObjects(),
-      mapSeenVotes(),
-      mapOrphanVotes(),
-      mapVotesByHash(),
-      mapVotesByType(),
+      mapVoteToObject(MAX_CACHE_SIZE),
+      mapInvalidVotes(MAX_CACHE_SIZE),
+      mapOrphanVotes(MAX_CACHE_SIZE),
       mapLastMasternodeTrigger(),
+      setRequestedObjects(),
       cs()
 {}
 
@@ -48,12 +49,8 @@ bool CGovernanceManager::HaveObjectForHash(uint256 nHash) {
     return (mapObjects.count(nHash) == 1);
 }
 
-bool CGovernanceManager::HaveVoteForHash(uint256 nHash) {
-    LOCK(cs);
-    return (mapVotesByHash.count(nHash) == 1);
-}
-
-bool CGovernanceManager::SerializeObjectForHash(uint256 nHash, CDataStream& ss) {
+bool CGovernanceManager::SerializeObjectForHash(uint256 nHash, CDataStream& ss)
+{
     LOCK(cs);
     object_m_it it = mapObjects.find(nHash);
     if (it == mapObjects.end()) {
@@ -63,13 +60,36 @@ bool CGovernanceManager::SerializeObjectForHash(uint256 nHash, CDataStream& ss) 
     return true;
 }
 
-bool CGovernanceManager::SerializeVoteForHash(uint256 nHash, CDataStream& ss) {
+bool CGovernanceManager::HaveVoteForHash(uint256 nHash)
+{
     LOCK(cs);
-    vote_m_it it = mapVotesByHash.find(nHash);
-    if (it == mapVotesByHash.end()) {
+
+    CGovernanceObject* pGovobj = NULL;
+    if(!mapVoteToObject.Get(nHash,pGovobj)) {
         return false;
     }
-    ss << it->second;
+
+    if(!pGovobj->GetVoteFile().HasVote(nHash)) {
+        return false;
+    }
+    return true;
+}
+
+bool CGovernanceManager::SerializeVoteForHash(uint256 nHash, CDataStream& ss)
+{
+    LOCK(cs);
+
+    CGovernanceObject* pGovobj = NULL;
+    if(!mapVoteToObject.Get(nHash,pGovobj)) {
+        return false;
+    }
+
+    CGovernanceVote vote;
+    if(!pGovobj->GetVoteFile().GetVote(nHash, vote)) {
+        return false;
+    }
+
+    ss << vote;
     return true;
 }
 
@@ -77,12 +97,6 @@ void CGovernanceManager::AddSeenGovernanceObject(uint256 nHash, int status)
 {
     LOCK(cs);
     mapSeenGovernanceObjects[nHash] = status;
-}
-
-void CGovernanceManager::AddSeenVote(uint256 nHash, int status)
-{
-    LOCK(cs);
-    mapSeenVotes[nHash] = status;
 }
 
 void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
@@ -93,7 +107,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
     if(pfrom->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) return;
 
-    LOCK(governance.cs);
+    LOCK(cs);
 
     // ANOTHER USER IS ASKING US TO HELP THEM SYNC GOVERNANCE OBJECT DATA
     if (strCommand == NetMsgType::MNGOVERNANCESYNC)
@@ -126,7 +140,6 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
     else if (strCommand == NetMsgType::MNGOVERNANCEOBJECT)
 
     {
-        LOCK(cs);
         // MAKE SURE WE HAVE A VALID REFERENCE TO THE TIP BEFORE CONTINUING
 
         if(!pCurrentBlockIndex) return;
@@ -134,8 +147,20 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         CGovernanceObject govobj;
         vRecv >> govobj;
 
-        if(mapSeenGovernanceObjects.count(govobj.GetHash())){
+        uint256 nHash = govobj.GetHash();
+        std::string strHash = nHash.ToString();
+
+        LogPrint("gobject", "CGovernanceManager -- Received object: %s\n", strHash);
+
+        if(!AcceptObjectMessage(nHash)) {
+            LogPrintf("CGovernanceManager -- Received unrequested object: %s\n", strHash);
+            Misbehaving(pfrom->GetId(), 20);
+            return;
+        }
+
+        if(mapSeenGovernanceObjects.count(nHash)) {
             // TODO - print error code? what if it's GOVOBJ_ERROR_IMMATURE?
+            LogPrint("gobject", "CGovernanceManager -- Received already seen object: %s\n", strHash);
             return;
         }
 
@@ -143,7 +168,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         // CHECK OBJECT AGAINST LOCAL BLOCKCHAIN
 
         if(!govobj.IsValidLocally(pCurrentBlockIndex, strError, true)) {
-            mapSeenGovernanceObjects.insert(std::make_pair(govobj.GetHash(), SEEN_OBJECT_ERROR_INVALID));
+            mapSeenGovernanceObjects.insert(std::make_pair(nHash, SEEN_OBJECT_ERROR_INVALID));
             LogPrintf("MNGOVERNANCEOBJECT -- Governance object is invalid - %s\n", strError);
             return;
         }
@@ -154,7 +179,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         if(AddGovernanceObject(govobj))
         {
-            LogPrintf("MNGOVERNANCEOBJECT -- %s new\n", govobj.GetHash().ToString());
+            LogPrintf("MNGOVERNANCEOBJECT -- %s new\n", strHash);
             govobj.Relay();
         }
 
@@ -165,7 +190,8 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         // WE MIGHT HAVE PENDING/ORPHAN VOTES FOR THIS OBJECT
 
-        CheckOrphanVotes();
+        CGovernanceException exception;
+        CheckOrphanVotes(pfrom, govobj, exception);
     }
 
     // A NEW GOVERNANCE OBJECT VOTE HAS ARRIVED
@@ -176,59 +202,51 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         CGovernanceVote vote;
         vRecv >> vote;
-        //vote.fValid = true;
 
-        // IF WE'VE SEEN THIS OBJECT THEN SKIP
+        LogPrint("gobject", "CGovernanceManager -- Received vote: %s\n", vote.ToString());
 
-        if(mapSeenVotes.count(vote.GetHash())) return;
-
-        // FIND THE MASTERNODE OF THE VOTER
-
-        if(!mnodeman.Has(vote.GetVinMasternode())) {
-            LogPrint("gobject", "MNGOVERNANCEOBJECTVOTE -- unknown masternode - vin: %s\n", vote.GetVinMasternode().ToString());
-            mnodeman.AskForMN(pfrom, vote.GetVinMasternode());
+        if(!AcceptVoteMessage(vote.GetHash())) {
+            LogPrintf("CGovernanceManager -- Received unrequested vote object: %s, hash: %s, peer = %d\n",
+                      vote.ToString(),
+                      vote.GetHash().ToString(),
+                      pfrom->GetId());
+            //Misbehaving(pfrom->GetId(), 20);
             return;
         }
 
-        // CHECK LOCAL VALIDITY AGAINST BLOCKCHAIN, TIME DATA, ETC
-
-        if(!vote.IsValid(true)){
-            LogPrintf("MNGOVERNANCEOBJECTVOTE -- signature invalid\n");
-            if(masternodeSync.IsSynced()) Misbehaving(pfrom->GetId(), 20);
-            // it could just be a non-synced masternode
-            mnodeman.AskForMN(pfrom, vote.GetVinMasternode());
-            mapSeenVotes.insert(std::make_pair(vote.GetHash(), SEEN_OBJECT_ERROR_INVALID));
-            return;
-        } else {
-            mapSeenVotes.insert(std::make_pair(vote.GetHash(), SEEN_OBJECT_IS_VALID));
-        }
-
-        // IF EVERYTHING CHECKS OUT, UPDATE THE GOVERNANCE MANAGER
-
-        std::string strError = "";
-        if(AddOrUpdateVote(vote, pfrom, strError)) {
-            LogPrint("gobject", "MNGOVERNANCEOBJECTVOTE -- %s new\n", vote.GetHash().ToString());
+        CGovernanceException exception;
+        if(ProcessVote(pfrom, vote, exception)) {
+            LogPrint("gobject", "CGovernanceManager -- Accepted vote\n");
             vote.Relay();
-            masternodeSync.AddedBudgetItem(vote.GetHash());
-            mnodeman.AddGovernanceVote(vote.GetVinMasternode(), vote.GetParentHash());
+        }
+        else {
+            LogPrint("gobject", "CGovernanceManager -- Rejected vote, error = %s\n", exception.what());
+            if((exception.GetNodePenalty() != 0) && masternodeSync.IsSynced()) {
+                Misbehaving(pfrom->GetId(), exception.GetNodePenalty());
+            }
+            return;
         }
 
     }
-
 }
 
-void CGovernanceManager::CheckOrphanVotes()
+void CGovernanceManager::CheckOrphanVotes(CNode* pfrom, CGovernanceObject& govobj, CGovernanceException& exception)
 {
-    LOCK(cs);
+    uint256 nHash = govobj.GetHash();
+    std::vector<CGovernanceVote> vecVotes;
+    mapOrphanVotes.GetAll(nHash, vecVotes);
 
-    std::string strError = "";
-    vote_m_it it1 = mapOrphanVotes.begin();
-    while(it1 != mapOrphanVotes.end()){
-        if(AddOrUpdateVote(((*it1).second), NULL, strError)){
-            LogPrintf("CGovernanceManager::CheckOrphanVotes -- Governance object is known, activating and removing orphan vote\n");
-            mapOrphanVotes.erase(it1++);
-        } else {
-            ++it1;
+    for(size_t i = 0; i < vecVotes.size(); ++i) {
+        CGovernanceVote& vote = vecVotes[i];
+        CGovernanceException exception;
+        if(govobj.ProcessVote(pfrom, vote, exception)) {
+            vecVotes[i].Relay();
+            mapOrphanVotes.Erase(nHash, vote);
+        }
+        else {
+            if((exception.GetNodePenalty() != 0) && masternodeSync.IsSynced()) {
+                Misbehaving(pfrom->GetId(), exception.GetNodePenalty());
+            }
         }
     }
 }
@@ -264,6 +282,10 @@ bool CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj)
               << ", nObjectType = " << govobj.nObjectType
               << endl; );
 
+    if(govobj.GetObjectType() == GOVERNANCE_OBJECT_TRIGGER) {
+        mapLastMasternodeTrigger[govobj.GetMasternodeVin().prevout] = nCachedBlockHeight;
+    }
+
     switch(govobj.nObjectType) {
     case GOVERNANCE_OBJECT_TRIGGER:
         mapLastMasternodeTrigger[govobj.vinMasternode.prevout] = nCachedBlockHeight;
@@ -293,6 +315,7 @@ void CGovernanceManager::UpdateCachesAndClean()
         if(it == mapObjects.end()) {
             continue;
         }
+        it->second.ClearMasternodeVotes();
         it->second.fDirtyCache = true;
     }
 
@@ -305,8 +328,6 @@ void CGovernanceManager::UpdateCachesAndClean()
     // UPDATE CACHE FOR EACH OBJECT THAT IS FLAGGED DIRTYCACHE=TRUE
 
     object_m_it it = mapObjects.begin();
-
-    count_m_t mapDirtyObjects;
 
     // Clean up any expired or invalid triggers
     triggerman.CleanAndRemove();
@@ -321,9 +342,7 @@ void CGovernanceManager::UpdateCachesAndClean()
         }
 
         // IF CACHE IS NOT DIRTY, WHY DO THIS?
-        if(pObj->fDirtyCache) {
-            mapDirtyObjects.insert(std::make_pair((*it).first, 1));
-
+        if(pObj->IsSetDirtyCache()) {
             // UPDATE LOCAL VALIDITY AGAINST CRYPTO DATA
             pObj->UpdateLocalValidity(pCurrentBlockIndex);
 
@@ -333,31 +352,29 @@ void CGovernanceManager::UpdateCachesAndClean()
 
         // IF DELETE=TRUE, THEN CLEAN THE MESS UP!
 
-        if(pObj->fCachedDelete || pObj->fExpired) {
+        if(pObj->IsSetCachedDelete() || pObj->IsSetExpired()) {
             LogPrintf("CGovernanceManager::UpdateCachesAndClean -- erase obj %s\n", (*it).first.ToString());
             mnodeman.RemoveGovernanceObject(pObj->GetHash());
+
+            // Remove vote references
+            const object_ref_cache_t::list_t& listItems = mapVoteToObject.GetItemList();
+            object_ref_cache_t::list_cit lit = listItems.begin();
+            while(lit != listItems.end()) {
+                if(lit->value == pObj) {
+                    uint256 nKey = lit->key;
+                    ++lit;
+                    mapVoteToObject.Erase(nKey);
+                }
+                else {
+                    ++lit;
+                }
+            }
+
             mapObjects.erase(it++);
         } else {
             ++it;
         }
     }
-
-    // CHECK EACH GOVERNANCE OBJECTS VALIDITY (CPU HEAVY)
-
-    // 12.1 todo - compile issues
-
-    // std::map<uint256, CBudgetVote>::iterator it = mapVotesByHash.begin();
-    // while(it != mapVotes.end()) {
-
-    //     // ONLY UPDATE THE DIRTY OBJECTS!
-
-    //     if(mapDirtyObjects.count((*it).first))
-    //     {
-    //         (*it).second.fValid = (*it).second.IsValid(true);
-    //         ++it;
-    //     }
-    // }
-
 }
 
 CGovernanceObject *CGovernanceManager::FindGovernanceObject(const uint256& nHash)
@@ -370,21 +387,18 @@ CGovernanceObject *CGovernanceManager::FindGovernanceObject(const uint256& nHash
     return NULL;
 }
 
-std::vector<CGovernanceVote*> CGovernanceManager::GetMatchingVotes(const uint256& nParentHash)
+std::vector<CGovernanceVote> CGovernanceManager::GetMatchingVotes(const uint256& nParentHash)
 {
-    std::vector<CGovernanceVote*> vecResult;
+    LOCK(cs);
+    std::vector<CGovernanceVote> vecResult;
 
-    // LOOP THROUGH ALL VOTES AND FIND THOSE MATCHING USER HASH
-
-    vote_m_it it2 = mapVotesByType.begin();
-    while(it2 != mapVotesByType.end()) {
-        if((*it2).second.GetParentHash() == nParentHash) {
-            vecResult.push_back(&(*it2).second);
-        }
-        ++it2;
+    object_m_it it = mapObjects.find(nParentHash);
+    if(it == mapObjects.end()) {
+        return vecResult;
     }
+    CGovernanceObject& govobj = it->second;
 
-    return vecResult;
+    return govobj.GetVoteFile().GetVotes();
 }
 
 std::vector<CGovernanceObject*> CGovernanceManager::GetAllNewerThan(int64_t nMoreThanTime)
@@ -398,7 +412,7 @@ std::vector<CGovernanceObject*> CGovernanceManager::GetAllNewerThan(int64_t nMor
     {
         // IF THIS OBJECT IS OLDER THAN TIME, CONTINUE
 
-        if((*it).second.nTime < nMoreThanTime) {
+        if((*it).second.GetCreationTime() < nMoreThanTime) {
             ++it;
             continue;
         }
@@ -423,7 +437,7 @@ struct sortProposalsByVotes {
     bool operator()(const std::pair<CGovernanceObject*, int> &left, const std::pair<CGovernanceObject*, int> &right) {
         if (left.second != right.second)
             return (left.second > right.second);
-        return (UintToArith256(left.first->nCollateralHash) > UintToArith256(right.first->nCollateralHash));
+        return (UintToArith256(left.first->GetCollateralHash()) > UintToArith256(right.first->GetCollateralHash()));
     }
 };
 
@@ -438,8 +452,8 @@ void CGovernanceManager::NewBlock()
     // CHECK OBJECTS WE'VE ASKED FOR, REMOVE OLD ENTRIES
 
     std::map<uint256, int64_t>::iterator it = mapAskedForGovernanceObject.begin();
-    while(it != mapAskedForGovernanceObject.end()){
-        if((*it).second > GetTime() - (60*60*24)){
+    while(it != mapAskedForGovernanceObject.end()) {
+        if((*it).second > GetTime() - (60*60*24)) {
             ++it;
         } else {
             mapAskedForGovernanceObject.erase(it++);
@@ -449,6 +463,59 @@ void CGovernanceManager::NewBlock()
     // CHECK AND REMOVE - REPROCESS GOVERNANCE OBJECTS
 
     UpdateCachesAndClean();
+}
+
+bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
+{
+    LOCK(cs);
+
+    LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest inv = %s\n", inv.ToString());
+
+    // First check if we've already recorded this object
+    switch(inv.type) {
+    case MSG_GOVERNANCE_OBJECT:
+    {
+        object_m_it it = mapObjects.find(inv.hash);
+        if(it != mapObjects.end()) {
+            LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest already have governance object, returning false\n");
+            return false;
+        }
+    }
+    break;
+    case MSG_GOVERNANCE_OBJECT_VOTE:
+    {
+        if(mapVoteToObject.HasKey(inv.hash)) {
+            LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest already have governance vote, returning false\n");
+            return false;
+        }
+    }
+    break;
+    default:
+        LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest unknown type, returning false\n");
+        return false;
+    }
+
+
+    hash_s_t* setHash = NULL;
+    switch(inv.type) {
+    case MSG_GOVERNANCE_OBJECT:
+        setHash = &setRequestedObjects;
+        break;
+    case MSG_GOVERNANCE_OBJECT_VOTE:
+        setHash = &setRequestedVotes;
+        break;
+    default:
+        return false;
+    }
+
+    hash_s_cit it = setHash->find(inv.hash);
+    if(it == setHash->end()) {
+        setHash->insert(inv.hash);
+        LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest added inv to requested set\n");
+    }
+
+    LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest reached end, returning true\n");
+    return true;
 }
 
 void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
@@ -464,32 +531,27 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
     // SYNC GOVERNANCE OBJECTS WITH OTHER CLIENT
 
     {
-       LOCK(cs);
-       object_m_it it1 = mapObjects.begin();
-       while(it1 != mapObjects.end()) {
-          uint256 h = (*it1).first;
+        LOCK(cs);
+        for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
+            uint256 h = it->first;
 
-           if((*it1).second.fCachedValid && (nProp == uint256() || h == nProp)) {
-              // Push the inventory budget proposal message over to the other client
-              pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT, h));
-              nInvCount++;
-           }
-           ++it1;
-       }
+            CGovernanceObject& govobj = it->second;
 
-       // SYNC OUR GOVERNANCE OBJECT VOTES WITH THEIR GOVERNANCE OBJECT VOTES
+            if(govobj.IsSetCachedValid() && (nProp == uint256() || h == nProp)) {
+                // Push the inventory budget proposal message over to the other client
+                pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT, h));
+                ++nInvCount;
 
-       vote_m_it it2 = mapVotesByHash.begin();
-       while(it2 != mapVotesByHash.end()) {
-           CGovernanceVote& vote = it2->second;
-           if(!vote.IsValid(true)) {
-               // Don't relay votes that are now invalid (ie. missing MN) to avoid being banned
-               continue;
-           }
-           pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT_VOTE, (*it2).first));
-           nInvCount++;
-           ++it2;
-       }
+                std::vector<CGovernanceVote> vecVotes = govobj.GetVoteFile().GetVotes();
+                for(size_t i = 0; i < vecVotes.size(); ++i) {
+                    if(!vecVotes[i].IsValid(true)) {
+                        continue;
+                    }
+                    pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT_VOTE, vecVotes[i].GetHash()));
+                    ++nInvCount;
+                }
+            }
+        }
     }
 
     pfrom->PushMessage(NetMsgType::SYNCSTATUSCOUNT, MASTERNODE_SYNC_GOVOBJ, nInvCount);
@@ -502,92 +564,6 @@ void CGovernanceManager::SyncParentObjectByVote(CNode* pfrom, const CGovernanceV
         pfrom->PushMessage(NetMsgType::MNGOVERNANCESYNC, vote.GetParentHash());
         mapAskedForGovernanceObject[vote.GetParentHash()] = GetTime();
     }
-}
-
-bool CGovernanceManager::AddOrUpdateVote(const CGovernanceVote& vote, CNode* pfrom, std::string& strError)
-{
-    // MAKE SURE WE HAVE THE PARENT OBJECT THE VOTE IS FOR
-
-    bool syncparent = false;
-    uint256 votehash;
-    {
-        LOCK(cs);
-        if(!mapObjects.count(vote.GetParentHash()))  {
-            if(pfrom)  {
-                // only ask for missing items after our syncing process is complete --
-                //   otherwise we'll think a full sync succeeded when they return a result
-                if(!masternodeSync.IsSynced()) return false;
-
-                // ADD THE VOTE AS AN ORPHAN, TO BE USED UPON RECEIVAL OF THE PARENT OBJECT
-
-                LogPrintf("CGovernanceManager::AddOrUpdateVote -- Unknown object %s, asking for source\n", vote.GetParentHash().ToString());
-                mapOrphanVotes[vote.GetParentHash()] = vote;
-
-                // ASK FOR THIS VOTES PARENT SPECIFICALLY FROM THIS USER (THEY SHOULD HAVE IT, NO?)
-
-                if(!mapAskedForGovernanceObject.count(vote.GetParentHash())){
-                    syncparent = true;
-                    votehash = vote.GetParentHash();
-                    mapAskedForGovernanceObject[vote.GetParentHash()] = GetTime();
-                } else {
-                    strError = "Governance object not found! Sync message has been already pushed.";
-                    return false;
-                }
-            }
-        }
-    }
-
-    // Need to keep this out of the locked section
-    if(syncparent) {
-        pfrom->PushMessage(NetMsgType::MNGOVERNANCESYNC, votehash);
-        strError = "Governance object not found! Sync message was pushed.";
-        return false;
-    }
-
-    // Reestablish lock
-    LOCK(cs);
-    // GET DETERMINISTIC HASH WHICH COLLIDES ON MASTERNODE-VIN/GOVOBJ-HASH/VOTE-SIGNAL
-
-    uint256 nTypeHash = vote.GetTypeHash();
-    uint256 nHash = vote.GetHash();
-
-    // LOOK FOR PREVIOUS VOTES BY THIS SPECIFIC MASTERNODE FOR THIS SPECIFIC SIGNAL
-
-    vote_m_it it = mapVotesByType.find(nTypeHash);
-    if(it != mapVotesByType.end()) {
-        if(it->second.GetTimestamp() > vote.GetTimestamp()) {
-            strError = strprintf("new vote older than existing vote - %s", nTypeHash.ToString());
-            LogPrint("gobject", "CGovernanceObject::AddOrUpdateVote -- %s\n", strError);
-            return false;
-        }
-        if(vote.GetTimestamp() - it->second.GetTimestamp() < GOVERNANCE_UPDATE_MIN) {
-            strError = strprintf("time between votes is too soon - %s - %lli", nTypeHash.ToString(), vote.GetTimestamp() - it->second.GetTimestamp());
-            LogPrint("gobject", "CGovernanceObject::AddOrUpdateVote -- %s\n", strError);
-            return false;
-        }
-    }
-
-    // UPDATE TO NEWEST VOTE
-    {
-        mapVotesByHash[nHash] = vote;
-        mapVotesByType[nTypeHash] = vote;
-    }
-
-    // SET CACHE AS DIRTY / WILL BE UPDATED NEXT BLOCK
-
-    CGovernanceObject* pGovObj = FindGovernanceObject(vote.GetParentHash());
-    if(pGovObj)
-    {
-        pGovObj->fDirtyCache = true;
-        UpdateCachesAndClean();
-        if(pGovObj->GetObjectType() == GOVERNANCE_OBJECT_WATCHDOG) {
-            mnodeman.UpdateWatchdogVoteTime(vote.GetVinMasternode());
-        }
-    } else {
-        LogPrintf("CGovernanceObject::AddOrUpdateVote -- Governance object not found! Can't update fDirtyCache - %s\n", vote.GetParentHash().ToString());
-    }
-
-    return true;
 }
 
 bool CGovernanceManager::MasternodeRateCheck(const CTxIn& vin, int nObjectType)
@@ -620,6 +596,118 @@ bool CGovernanceManager::MasternodeRateCheck(const CTxIn& vin, int nObjectType)
     return false;
 }
 
+bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, CGovernanceException& exception)
+{
+    LOCK(cs);
+    uint256 nHashVote = vote.GetHash();
+    if(mapInvalidVotes.HasKey(nHashVote)) {
+        std::ostringstream ostr;
+        ostr << "CGovernanceManager::ProcessVote -- Old invalid vote "
+                << ", MN outpoint = " << vote.GetVinMasternode().prevout.ToStringShort()
+                << ", governance object hash = " << vote.GetParentHash().ToString() << "\n";
+        LogPrintf(ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
+        return false;
+    }
+
+    uint256 nHashGovobj = vote.GetParentHash();
+    object_m_it it = mapObjects.find(nHashGovobj);
+    if(it == mapObjects.end()) {
+        mapOrphanVotes.Insert(nHashGovobj, vote);
+        RequestGovernanceObject(pfrom, nHashGovobj);
+        std::ostringstream ostr;
+        ostr << "CGovernanceManager::ProcessVote -- Unknown parent object "
+                << ", MN outpoint = " << vote.GetVinMasternode().prevout.ToStringShort()
+                << ", governance object hash = " << vote.GetParentHash().ToString() << "\n";
+        LogPrintf(ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
+        return false;
+    }
+
+    CGovernanceObject& govobj = it->second;
+    bool fOk = govobj.ProcessVote(pfrom, vote, exception);
+    if(fOk) {
+        mapVoteToObject.Insert(vote.GetHash(), &govobj);
+
+        if(govobj.GetObjectType() == GOVERNANCE_OBJECT_WATCHDOG) {
+            mnodeman.UpdateWatchdogVoteTime(vote.GetVinMasternode());
+        }
+    }
+    return fOk;
+}
+
+void CGovernanceManager::CheckMasternodeOrphanVotes()
+{
+    LOCK(cs);
+    for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
+        it->second.CheckOrphanVotes();
+    }
+}
+
+void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nHash)
+{
+    if(!pfrom) {
+        return;
+    }
+
+    pfrom->PushMessage(NetMsgType::MNGOVERNANCESYNC, nHash);
+}
+
+bool CGovernanceManager::AcceptObjectMessage(const uint256& nHash)
+{
+    LOCK(cs);
+    return AcceptMessage(nHash, setRequestedObjects);
+}
+
+bool CGovernanceManager::AcceptVoteMessage(const uint256& nHash)
+{
+    LOCK(cs);
+    return AcceptMessage(nHash, setRequestedVotes);
+}
+
+bool CGovernanceManager::AcceptMessage(const uint256& nHash, hash_s_t& setHash)
+{
+    hash_s_it it = setHash.find(nHash);
+    if(it == setHash.end()) {
+        // We never requested this
+        return false;
+    }
+    // Only accept one response
+    setHash.erase(it);
+    return true;
+}
+
+void CGovernanceManager::RebuildIndexes()
+{
+    mapVoteToObject.Clear();
+    for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
+        CGovernanceObject& govobj = it->second;
+        std::vector<CGovernanceVote> vecVotes = govobj.GetVoteFile().GetVotes();
+        for(size_t i = 0; i < vecVotes.size(); ++i) {
+            mapVoteToObject.Insert(vecVotes[i].GetHash(), &govobj);
+        }
+    }
+}
+
+int CGovernanceManager::GetMasternodeIndex(const CTxIn& masternodeVin)
+{
+    LOCK(cs);
+    bool fIndexRebuilt = false;
+    int nMNIndex = mnodeman.GetMasternodeIndex(masternodeVin, fIndexRebuilt);
+    while(fIndexRebuilt) {
+        RebuildVoteMaps();
+        nMNIndex = mnodeman.GetMasternodeIndex(masternodeVin, fIndexRebuilt);
+    }
+    return nMNIndex;
+}
+
+void CGovernanceManager::RebuildVoteMaps()
+{
+    for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
+        it->second.RebuildVoteMap();
+    }
+}
+
 void CGovernanceManager::AddCachedTriggers()
 {
     LOCK(cs);
@@ -636,73 +724,194 @@ void CGovernanceManager::AddCachedTriggers()
 }
 
 CGovernanceObject::CGovernanceObject()
-    : cs(),
-      nHashParent(),
-      nRevision(0),
-      nTime(0),
-      nCollateralHash(),
-      strData(),
-      nObjectType(GOVERNANCE_OBJECT_UNKNOWN),
-      vinMasternode(),
-      vchSig(),
-      fCachedLocalValidity(false),
-      strLocalValidityError(),
-      fCachedFunding(false),
-      fCachedValid(true),
-      fCachedDelete(false),
-      fCachedEndorsed(false),
-      fDirtyCache(true),
-      fUnparsable(false),
-      fExpired(false)
+: cs(),
+  nObjectType(GOVERNANCE_OBJECT_UNKNOWN),
+  nHashParent(),
+  nRevision(0),
+  nTime(0),
+  nCollateralHash(),
+  strData(),
+  vinMasternode(),
+  vchSig(),
+  fCachedLocalValidity(false),
+  strLocalValidityError(),
+  fCachedFunding(false),
+  fCachedValid(true),
+  fCachedDelete(false),
+  fCachedEndorsed(false),
+  fDirtyCache(true),
+  fExpired(false),
+  fUnparsable(false),
+  mapCurrentMNVotes(),
+  mapOrphanVotes(),
+  fileVotes()
 {
     // PARSE JSON DATA STORAGE (STRDATA)
     LoadData();
 }
 
 CGovernanceObject::CGovernanceObject(uint256 nHashParentIn, int nRevisionIn, int64_t nTimeIn, uint256 nCollateralHashIn, std::string strDataIn)
-    : cs(),
-      nHashParent(nHashParentIn),
-      nRevision(nRevisionIn),
-      nTime(nTimeIn),
-      nCollateralHash(nCollateralHashIn),
-      strData(strDataIn),
-      nObjectType(GOVERNANCE_OBJECT_UNKNOWN),
-      vinMasternode(),
-      vchSig(),
-      fCachedLocalValidity(false),
-      strLocalValidityError(),
-      fCachedFunding(false),
-      fCachedValid(true),
-      fCachedDelete(false),
-      fCachedEndorsed(false),
-      fDirtyCache(true),
-      fUnparsable(false),
-      fExpired(false)
+: cs(),
+  nObjectType(GOVERNANCE_OBJECT_UNKNOWN),
+  nHashParent(nHashParentIn),
+  nRevision(nRevisionIn),
+  nTime(nTimeIn),
+  nCollateralHash(nCollateralHashIn),
+  strData(strDataIn),
+  vinMasternode(),
+  vchSig(),
+  fCachedLocalValidity(false),
+  strLocalValidityError(),
+  fCachedFunding(false),
+  fCachedValid(true),
+  fCachedDelete(false),
+  fCachedEndorsed(false),
+  fDirtyCache(true),
+  fExpired(false),
+  fUnparsable(false),
+  mapCurrentMNVotes(),
+  mapOrphanVotes(),
+  fileVotes()
 {
     // PARSE JSON DATA STORAGE (STRDATA)
     LoadData();
 }
 
 CGovernanceObject::CGovernanceObject(const CGovernanceObject& other)
-    : cs(),
-      nHashParent(other.nHashParent),
-      nRevision(other.nRevision),
-      nTime(other.nTime),
-      nCollateralHash(other.nCollateralHash),
-      strData(other.strData),
-      nObjectType(other.nObjectType),
-      vinMasternode(other.vinMasternode),
-      vchSig(other.vchSig),
-      fCachedLocalValidity(other.fCachedLocalValidity),
-      strLocalValidityError(other.strLocalValidityError),
-      fCachedFunding(other.fCachedFunding),
-      fCachedValid(other.fCachedValid),
-      fCachedDelete(other.fCachedDelete),
-      fCachedEndorsed(other.fCachedEndorsed),
-      fDirtyCache(other.fDirtyCache),
-      fUnparsable(other.fUnparsable),
-      fExpired(other.fExpired)
+: cs(),
+  nObjectType(other.nObjectType),
+  nHashParent(other.nHashParent),
+  nRevision(other.nRevision),
+  nTime(other.nTime),
+  nCollateralHash(other.nCollateralHash),
+  strData(other.strData),
+  vinMasternode(other.vinMasternode),
+  vchSig(other.vchSig),
+  fCachedLocalValidity(other.fCachedLocalValidity),
+  strLocalValidityError(other.strLocalValidityError),
+  fCachedFunding(other.fCachedFunding),
+  fCachedValid(other.fCachedValid),
+  fCachedDelete(other.fCachedDelete),
+  fCachedEndorsed(other.fCachedEndorsed),
+  fDirtyCache(other.fDirtyCache),
+  fExpired(other.fExpired),
+  fUnparsable(other.fUnparsable),
+  mapCurrentMNVotes(other.mapCurrentMNVotes),
+  mapOrphanVotes(other.mapOrphanVotes),
+  fileVotes(other.fileVotes)
 {}
+
+bool CGovernanceObject::ProcessVote(CNode* pfrom,
+                                    const CGovernanceVote& vote,
+                                    CGovernanceException& exception)
+{
+    int nMNIndex = governance.GetMasternodeIndex(vote.GetVinMasternode());
+    if(nMNIndex < 0) {
+        mapOrphanVotes.Insert(vote.GetVinMasternode(), vote);
+        if(pfrom) {
+            mnodeman.AskForMN(pfrom, vote.GetVinMasternode());
+        }
+        std::ostringstream ostr;
+        ostr << "CGovernanceObject::UpdateVote -- Masternode index not found\n";
+        LogPrintf(ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
+        return false;
+    }
+
+    vote_m_it it = mapCurrentMNVotes.find(nMNIndex);
+    if(it == mapCurrentMNVotes.end()) {
+        it = mapCurrentMNVotes.insert(vote_m_t::value_type(nMNIndex,vote_rec_t())).first;
+    }
+    vote_rec_t& recVote = it->second;
+    vote_signal_enum_t eSignal = vote.GetSignal();
+    if(eSignal == VOTE_SIGNAL_NONE) {
+        std::ostringstream ostr;
+        ostr << "CGovernanceObject::UpdateVote -- Vote signal: none" << "\n";
+        LogPrint("gobject", ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
+        return false;
+    }
+    if(eSignal > MAX_SUPPORTED_VOTE_SIGNAL) {
+        std::ostringstream ostr;
+        ostr << "CGovernanceObject::UpdateVote -- Unsupported vote signal:" << CGovernanceVoting::ConvertSignalToString(vote.GetSignal()) << "\n";
+        LogPrintf(ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
+        return false;
+    }
+    vote_instance_m_it it2 = recVote.mapInstances.find(int(eSignal));
+    if(it2 == recVote.mapInstances.end()) {
+        it2 = recVote.mapInstances.insert(vote_instance_m_t::value_type(int(eSignal), vote_instance_t())).first;
+    }
+    vote_instance_t& voteInstance = it2->second;
+    int64_t nNow = GetTime();
+    int64_t nTimeDelta = nNow - voteInstance.nTime;
+    if(nTimeDelta < GOVERNANCE_UPDATE_MIN) {
+        std::ostringstream ostr;
+        ostr << "CGovernanceObject::UpdateVote -- Masternode voting too often "
+                << ", MN outpoint = " << vote.GetVinMasternode().prevout.ToStringShort()
+                << ", governance object hash = " << GetHash().ToString()
+                << ", time delta = " << nTimeDelta << "\n";
+        LogPrint("gobject", ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_TEMPORARY_ERROR);
+        return false;
+    }
+    // Finally check that the vote is actually valid (done last because of cost of signature verification)
+    if(!vote.IsValid(true)) {
+        std::ostringstream ostr;
+        ostr << "CGovernanceObject::UpdateVote -- Invalid vote "
+                << ", MN outpoint = " << vote.GetVinMasternode().prevout.ToStringShort()
+                << ", governance object hash = " << GetHash().ToString()
+                << ", vote hash = " << vote.GetHash().ToString() << "\n";
+        LogPrintf(ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
+        governance.AddInvalidVote(vote);
+        return false;
+    }
+    voteInstance = vote_instance_t(vote.GetOutcome(), nNow);
+    fileVotes.AddVote(vote);
+    fDirtyCache = true;
+    return true;
+}
+
+void CGovernanceObject::RebuildVoteMap()
+{
+    vote_m_t mapMNVotesNew;
+    for(vote_m_it it = mapCurrentMNVotes.begin(); it != mapCurrentMNVotes.end(); ++it) {
+        CTxIn vinMasternode;
+        if(mnodeman.GetMasternodeVinForIndexOld(it->first, vinMasternode)) {
+            int nNewIndex = mnodeman.GetMasternodeIndex(vinMasternode);
+            if((nNewIndex >= 0)) {
+                mapMNVotesNew[nNewIndex] = it->second;
+            }
+        }
+    }
+    mapCurrentMNVotes = mapMNVotesNew;
+}
+
+void CGovernanceObject::ClearMasternodeVotes()
+{
+    vote_m_it it = mapCurrentMNVotes.begin();
+    while(it != mapCurrentMNVotes.end()) {
+        bool fIndexRebuilt = false;
+        CTxIn vinMasternode;
+        bool fRemove = true;
+        if(mnodeman.Get(it->first, vinMasternode, fIndexRebuilt)) {
+            if(mnodeman.Has(vinMasternode)) {
+                fRemove = false;
+            }
+            else {
+                fileVotes.RemoveVotesFromMasternode(vinMasternode);
+            }
+        }
+
+        if(fRemove) {
+            mapCurrentMNVotes.erase(it++);
+        }
+        else {
+            ++it;
+        }
+    }
+}
 
 void CGovernanceObject::SetMasternodeInfo(const CTxIn& vin)
 {
@@ -747,11 +956,6 @@ bool CGovernanceObject::CheckSignature(CPubKey& pubKeyMasternode)
     }
 
     return true;
-}
-
-int CGovernanceObject::GetObjectType()
-{
-    return nObjectType;
 }
 
 int CGovernanceObject::GetObjectSubtype()
@@ -1070,33 +1274,50 @@ bool CGovernanceObject::IsCollateralValid(std::string& strError)
     return true;
 }
 
+int CGovernanceObject::CountMatchingVotes(vote_signal_enum_t eVoteSignalIn, vote_outcome_enum_t eVoteOutcomeIn) const
+{
+    int nCount = 0;
+    for(vote_m_cit it = mapCurrentMNVotes.begin(); it != mapCurrentMNVotes.end(); ++it) {
+        const vote_rec_t& recVote = it->second;
+        vote_instance_m_cit it2 = recVote.mapInstances.find(eVoteSignalIn);
+        if(it2 == recVote.mapInstances.end()) {
+            continue;
+        }
+        const vote_instance_t& voteInstance = it2->second;
+        if(voteInstance.eOutcome == eVoteOutcomeIn) {
+            ++nCount;
+        }
+    }
+    return nCount;
+}
+
 /**
 *   Get specific vote counts for each outcome (funding, validity, etc)
 */
 
-int CGovernanceObject::GetAbsoluteYesCount(vote_signal_enum_t eVoteSignalIn)
+int CGovernanceObject::GetAbsoluteYesCount(vote_signal_enum_t eVoteSignalIn) const
 {
     return GetYesCount(eVoteSignalIn) - GetNoCount(eVoteSignalIn);
 }
 
-int CGovernanceObject::GetAbsoluteNoCount(vote_signal_enum_t eVoteSignalIn)
+int CGovernanceObject::GetAbsoluteNoCount(vote_signal_enum_t eVoteSignalIn) const
 {
     return GetNoCount(eVoteSignalIn) - GetYesCount(eVoteSignalIn);
 }
 
-int CGovernanceObject::GetYesCount(vote_signal_enum_t eVoteSignalIn)
+int CGovernanceObject::GetYesCount(vote_signal_enum_t eVoteSignalIn) const
 {
-    return governance.CountMatchingVotes((*this), eVoteSignalIn, VOTE_OUTCOME_YES);
+    return CountMatchingVotes(eVoteSignalIn, VOTE_OUTCOME_YES);
 }
 
-int CGovernanceObject::GetNoCount(vote_signal_enum_t eVoteSignalIn)
+int CGovernanceObject::GetNoCount(vote_signal_enum_t eVoteSignalIn) const
 {
-    return governance.CountMatchingVotes((*this), eVoteSignalIn, VOTE_OUTCOME_NO);
+    return CountMatchingVotes(eVoteSignalIn, VOTE_OUTCOME_NO);
 }
 
-int CGovernanceObject::GetAbstainCount(vote_signal_enum_t eVoteSignalIn)
+int CGovernanceObject::GetAbstainCount(vote_signal_enum_t eVoteSignalIn) const
 {
-    return governance.CountMatchingVotes((*this), eVoteSignalIn, VOTE_OUTCOME_ABSTAIN);
+    return CountMatchingVotes(eVoteSignalIn, VOTE_OUTCOME_ABSTAIN);
 }
 
 void CGovernanceObject::Relay()
@@ -1110,10 +1331,8 @@ std::string CGovernanceManager::ToString() const
     std::ostringstream info;
 
     info << "Governance Objects: " << (int)mapObjects.size() <<
-            ", Seen Budgets: " << (int)mapSeenGovernanceObjects.size() <<
-            ", Seen Budget Votes: " << (int)mapSeenVotes.size() <<
-            ", VoteByHash Count: " << (int)mapVotesByHash.size() <<
-            ", VoteByType Count: " << (int)mapVotesByType.size();
+            ", Seen Budgets : " << (int)mapSeenGovernanceObjects.size() <<
+            ", Vote Count   : " << (int)mapVoteToObject.GetSize();
 
     return info.str();
 }
@@ -1134,32 +1353,6 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex)
 
     if(!fLiteMode && masternodeSync.IsSynced())
         NewBlock();
-}
-
-int CGovernanceManager::CountMatchingVotes(CGovernanceObject& govobj, vote_signal_enum_t eVoteSignalIn, vote_outcome_enum_t eVoteOutcomeIn)
-{
-    /*
-    *
-    *   Count matching votes and return
-    *
-    */
-
-    LOCK(cs);
-    int nCount = 0;
-
-    uint256 hash = govobj.GetHash();
-    std::map<uint256, CGovernanceVote>::iterator it = mapVotesByType.begin();
-    while(it != mapVotesByType.end())  {
-        if(it->second.IsValid() &&
-           it->second.GetSignal() == eVoteSignalIn &&
-           it->second.GetOutcome() == eVoteOutcomeIn &&
-           it->second.GetParentHash() == hash) {
-            ++nCount;
-        }
-        ++it;
-    }
-
-    return nCount;
 }
 
 void CGovernanceObject::UpdateSentinelVariables(const CBlockIndex *pCurrentBlockIndex)
@@ -1222,4 +1415,19 @@ void CGovernanceObject::swap(CGovernanceObject& first, CGovernanceObject& second
     swap(first.fCachedEndorsed, second.fCachedEndorsed);
     swap(first.fDirtyCache, second.fDirtyCache);
     swap(first.fExpired, second.fExpired);
+}
+
+void CGovernanceObject::CheckOrphanVotes()
+{
+    const vote_mcache_t::list_t& listVotes = mapOrphanVotes.GetItemList();
+    for(vote_mcache_t::list_cit it = listVotes.begin(); it != listVotes.end(); ++it) {
+        const CGovernanceVote& vote = it->value;
+        if(!mnodeman.Has(vote.GetVinMasternode())) {
+            continue;
+        }
+        CGovernanceException exception;
+        if(!ProcessVote(NULL, vote, exception)) {
+            LogPrintf("CGovernanceObject::CheckOrphanVotes -- Failed to add orphan vote: %s\n", exception.what());
+        }
+    }
 }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -882,6 +882,14 @@ void CMasternode::UpdateWatchdogVoteTime()
 */
 void CMasternode::FlagGovernanceItemsAsDirty()
 {
+    std::map<uint256, int>::iterator it = mapGovernanceObjectsVotedOn.begin();
+    while(it != mapGovernanceObjectsVotedOn.end()){
+        CGovernanceObject *pObj = governance.FindGovernanceObject((*it).first);
+
+        if(pObj) pObj->InvalidateVoteCache();
+        ++it;
+    }
+
     std::vector<uint256> vecDirty;
     {
         std::map<uint256, int>::iterator it = mapGovernanceObjectsVotedOn.begin();

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -14,9 +14,85 @@ class CMasternodeMan;
 
 extern CMasternodeMan mnodeman;
 
+/**
+ * Provides a forward and reverse index between MN vin's and integers.
+ *
+ * This mapping is normally add-only and is expected to be permanent
+ * It is only rebuilt if the size of the index exceeds the expected maximum number
+ * of MN's and the current number of known MN's.
+ *
+ * The external interface to this index is provided via delegation by CMasternodeMan
+ */
+class CMasternodeIndex
+{
+public: // Types
+    typedef std::map<CTxIn,int> index_m_t;
+
+    typedef index_m_t::iterator index_m_it;
+
+    typedef index_m_t::const_iterator index_m_cit;
+
+    typedef std::map<int,CTxIn> rindex_m_t;
+
+    typedef rindex_m_t::iterator rindex_m_it;
+
+    typedef rindex_m_t::const_iterator rindex_m_cit;
+
+private:
+    int                  nSize;
+
+    index_m_t            mapIndex;
+
+    rindex_m_t           mapReverseIndex;
+
+public:
+    CMasternodeIndex();
+
+    int GetSize() const {
+        return nSize;
+    }
+
+    /// Retrieve masternode vin by index
+    bool Get(int nIndex, CTxIn& vinMasternode) const;
+
+    /// Get index of a masternode vin
+    int GetMasternodeIndex(const CTxIn& vinMasternode) const;
+
+    void AddMasternodeVIN(const CTxIn& vinMasternode);
+
+    void Clear();
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(mapIndex);
+        if(ser_action.ForRead()) {
+            RebuildIndex();
+        }
+    }
+
+private:
+    void RebuildIndex();
+
+};
+
 class CMasternodeMan
 {
+public:
+    typedef std::map<CTxIn,int> index_m_t;
+
+    typedef index_m_t::iterator index_m_it;
+
+    typedef index_m_t::const_iterator index_m_cit;
+
 private:
+    static const int MAX_EXPECTED_INDEX_SIZE = 30000;
+
+    /// Only allow 1 index rebuild per hour
+    static const int64_t MIN_INDEX_REBUILD_TIME = 3600;
+
     static const std::string SERIALIZATION_VERSION_STRING;
 
     static const int DSEG_UPDATE_SECONDS        = 3 * 60 * 60;
@@ -45,6 +121,21 @@ private:
     // who we asked for the masternode verification
     std::map<CNetAddr, CMasternodeVerification> mWeAskedForVerification;
 
+    int64_t nLastIndexRebuildTime;
+
+    CMasternodeIndex indexMasternodes;
+
+    CMasternodeIndex indexMasternodesOld;
+
+    /// Set when index has been rebuilt, clear when read
+    bool fIndexRebuilt;
+
+    /// Set when masternodes are added, cleared when CGovernanceManager is notified
+    bool fMasternodesAdded;
+
+    /// Set when masternodes are removed, cleared when CGovernanceManager is notified
+    bool fMasternodesRemoved;
+
     std::vector<uint256> vecDirtyGovernanceObjectHashes;
 
     int64_t nLastWatchdogVoteTime;
@@ -61,8 +152,6 @@ public:
     // keep track of dsq count to prevent masternodes from gaming darksend queue
     int64_t nDsqCount;
 
-
-    CMasternodeMan() : nLastWatchdogVoteTime(0), nDsqCount(0) {}
 
     ADD_SERIALIZE_METHODS;
 
@@ -87,16 +176,19 @@ public:
 
         READWRITE(mapSeenMasternodeBroadcast);
         READWRITE(mapSeenMasternodePing);
+        READWRITE(indexMasternodes);
         if(ser_action.ForRead() && (strVersion != SERIALIZATION_VERSION_STRING)) {
             Clear();
         }
     }
 
+    CMasternodeMan();
+
     /// Add an entry
     bool Add(CMasternode &mn);
 
     /// Ask (source) node for mnb
-    void AskForMN(CNode *pnode, CTxIn &vin);
+    void AskForMN(CNode *pnode, const CTxIn &vin);
 
     /// Check all Masternodes
     void Check();
@@ -127,6 +219,49 @@ public:
     /// Versions of Find that are safe to use from outside the class
     bool Get(const CPubKey& pubKeyMasternode, CMasternode& masternode);
     bool Get(const CTxIn& vin, CMasternode& masternode);
+
+    /// Retrieve masternode vin by index
+    bool Get(int nIndex, CTxIn& vinMasternode, bool& fIndexRebuiltOut) {
+        LOCK(cs);
+        fIndexRebuiltOut = fIndexRebuilt;
+        return indexMasternodes.Get(nIndex, vinMasternode);
+    }
+
+    bool GetIndexRebuiltFlag() {
+        LOCK(cs);
+        return fIndexRebuilt;
+    }
+
+    /// Get index of a masternode vin
+    int GetMasternodeIndex(const CTxIn& vinMasternode) {
+        LOCK(cs);
+        return indexMasternodes.GetMasternodeIndex(vinMasternode);
+    }
+
+    /// Get old index of a masternode vin
+    int GetMasternodeIndexOld(const CTxIn& vinMasternode) {
+        LOCK(cs);
+        return indexMasternodesOld.GetMasternodeIndex(vinMasternode);
+    }
+
+    /// Get masternode VIN for an old index value
+    bool GetMasternodeVinForIndexOld(int nMasternodeIndex, CTxIn& vinMasternodeOut) {
+        LOCK(cs);
+        return indexMasternodesOld.Get(nMasternodeIndex, vinMasternodeOut);
+    }
+
+    /// Get index of a masternode vin, returning rebuild flag
+    int GetMasternodeIndex(const CTxIn& vinMasternode, bool& fIndexRebuiltOut) {
+        LOCK(cs);
+        fIndexRebuiltOut = fIndexRebuilt;
+        return indexMasternodes.GetMasternodeIndex(vinMasternode);
+    }
+
+    void ClearOldMasternodeIndex() {
+        LOCK(cs);
+        indexMasternodesOld.Clear();
+        fIndexRebuilt = false;
+    }
 
     bool Has(const CTxIn& vin);
 
@@ -173,6 +308,8 @@ public:
 
     void UpdateLastPaid(const CBlockIndex *pindex);
 
+    void CheckAndRebuildMasternodeIndex();
+
     void AddDirtyGovernanceObjectHash(const uint256& nHash)
     {
         LOCK(cs);
@@ -202,6 +339,13 @@ public:
     void SetMasternodeLastPing(const CTxIn& vin, const CMasternodePing& mnp);
 
     void UpdatedBlockTip(const CBlockIndex *pindex);
+
+    /**
+     * Called to notify CGovernanceManager that the masternode index has been updated.
+     * Must be called while not holding the CMasternodeMan::cs mutex
+     */
+    void NotifyMasternodeUpdates();
+
 };
 
 #endif

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -106,6 +106,7 @@ void MasternodeList::StartAlias(std::string strAlias)
                 strStatusHtml += "<br>Successfully started masternode.";
                 mnodeman.UpdateMasternodeList(mnb);
                 mnb.Relay();
+                mnodeman.NotifyMasternodeUpdates();
             } else {
                 strStatusHtml += "<br>Failed to start masternode.<br>Error: " + strError;
             }
@@ -142,6 +143,7 @@ void MasternodeList::StartAll(std::string strCommand)
             nCountSuccessful++;
             mnodeman.UpdateMasternodeList(mnb);
             mnb.Relay();
+            mnodeman.NotifyMasternodeUpdates();
         } else {
             nCountFailed++;
             strFailedHtml += "\nFailed to start " + mne.getAlias() + ". Error: " + strError;

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -329,6 +329,7 @@ UniValue masternode(const UniValue& params, bool fHelp)
 
             resultsObj.push_back(Pair("status", statusObj));
         }
+        mnodeman.NotifyMasternodeUpdates();
 
         UniValue returnObj(UniValue::VOBJ);
         returnObj.push_back(Pair("overall", strprintf("Successfully started %d masternodes, failed to start %d, total %d", nSuccessful, nFailed, nSuccessful + nFailed)));

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -272,6 +272,7 @@ UniValue masternode(const UniValue& params, bool fHelp)
                 } else {
                     statusObj.push_back(Pair("errorMessage", strError));
                 }
+                mnodeman.NotifyMasternodeUpdates();
                 break;
             }
         }
@@ -781,6 +782,7 @@ UniValue masternodebroadcast(const UniValue& params, bool fHelp)
                     mnb.Relay();
                     fResult = true;
                 }
+                mnodeman.NotifyMasternodeUpdates();
             } else fResult = false;
 
             if(fResult) {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <ios>
 #include <limits>
+#include <list>
 #include <map>
 #include <set>
 #include <stdint.h>
@@ -883,6 +884,39 @@ void Unserialize(Stream& is, std::set<K, Pred, A>& m, int nType, int nVersion)
         K key;
         Unserialize(is, key, nType, nVersion);
         it = m.insert(it, key);
+    }
+}
+
+/**
+ * list
+ */
+template<typename T, typename A>
+unsigned int GetSerializeSize(const std::list<T, A>& l, int nType, int nVersion)
+{
+    unsigned int nSize = GetSizeOfCompactSize(l.size());
+    for (typename std::list<T, A>::const_iterator it = l.begin(); it != l.end(); ++it)
+        nSize += GetSerializeSize((*it), nType, nVersion);
+    return nSize;
+}
+
+template<typename Stream, typename T, typename A>
+void Serialize(Stream& os, const std::list<T, A>& l, int nType, int nVersion)
+{
+    WriteCompactSize(os, l.size());
+    for (typename std::list<T, A>::const_iterator it = l.begin(); it != l.end(); ++it)
+        Serialize(os, (*it), nType, nVersion);
+}
+
+template<typename Stream, typename T, typename A>
+void Unserialize(Stream& is, std::list<T, A>& l, int nType, int nVersion)
+{
+    l.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    for (unsigned int i = 0; i < nSize; i++)
+    {
+        T val;
+        Unserialize(is, val, nType, nVersion);
+        l.push_back(val);
     }
 }
 

--- a/src/test/cachemap_tests.cpp
+++ b/src/test/cachemap_tests.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+
+#include "cachemap.h"
+
+#include "test/test_dash.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(cachemap_tests, BasicTestingSetup)
+
+bool Compare(const CacheMap<int,int>& map1, const CacheMap<int,int>& map2 )
+{
+    if(map1.GetMaxSize() != map2.GetMaxSize()) {
+        return false;
+    }
+
+    if(map1.GetSize() != map2.GetSize()) {
+        return false;
+    }
+
+    const CacheMap<int,int>::list_t& items1 = map1.GetItemList();
+    for(CacheMap<int,int>::list_cit it = items1.begin(); it != items1.end(); ++it) {
+        if(!map2.HasKey(it->key)) {
+            return false;
+        }
+        int val = 0;
+        if(!map2.Get(it->key, val)) {
+            return false;
+        }
+        if(it->value != val) {
+            return false;
+        }
+    }
+
+    const CacheMap<int,int>::list_t& items2 = map2.GetItemList();
+    for(CacheMap<int,int>::list_cit it = items2.begin(); it != items2.end(); ++it) {
+        if(!map1.HasKey(it->key)) {
+            return false;
+        }
+        int val = 0;
+        if(!map1.Get(it->key, val)) {
+            return false;
+        }
+        if(it->value != val) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE(cachemap_test)
+{
+    // create a CacheMap limited to 10 items
+    CacheMap<int,int> mapTest1(10);
+
+    // check that the max size is 10
+    BOOST_CHECK(mapTest1.GetMaxSize() == 10);
+
+    // check that the size is 0
+    BOOST_CHECK(mapTest1.GetSize() == 0);
+
+    // insert (-1, -1)
+    mapTest1.Insert(-1, -1);
+
+    // make sure that the size is updated
+    BOOST_CHECK(mapTest1.GetSize() == 1);
+
+    // make sure the map contains the key
+    BOOST_CHECK(mapTest1.HasKey(-1) == true);
+
+    // add 10 items
+    for(int i = 0; i < 10; ++i) {
+        mapTest1.Insert(i, i);
+    }
+
+    // check that the size is 10
+    BOOST_CHECK(mapTest1.GetSize() == 10);
+
+    // check that the map contains the expected items
+    for(int i = 0; i < 10; ++i) {
+        int nVal = 0;
+        BOOST_CHECK(mapTest1.Get(i, nVal) == true);
+        BOOST_CHECK(nVal == i);
+    }
+
+    // check that the map no longer contains the first item
+    BOOST_CHECK(mapTest1.HasKey(-1) == false);
+
+    // erase an item
+    mapTest1.Erase(5);
+
+    // check the size
+    BOOST_CHECK(mapTest1.GetSize() == 9);
+
+    // check that the map no longer contains the item
+    BOOST_CHECK(mapTest1.HasKey(5) == false);
+
+    // check that the map contains the expected items
+    int expected[] = { 0, 1, 2, 3, 4, 6, 7, 8, 9 };
+    for(size_t i = 0; i < 9; ++i) {
+        int nVal = 0;
+        int eVal = expected[i];
+        BOOST_CHECK(mapTest1.Get(eVal, nVal) == true);
+        BOOST_CHECK(nVal == eVal);
+    }
+
+    // test serialization
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << mapTest1;
+
+    CacheMap<int,int> mapTest2;
+    ss >> mapTest2;
+
+    BOOST_CHECK(Compare(mapTest1, mapTest2));
+
+    // test copy constructor
+    CacheMap<int,int> mapTest3(mapTest1);
+    BOOST_CHECK(Compare(mapTest1, mapTest3));
+
+    // test assignment operator
+    CacheMap<int,int> mapTest4;
+    mapTest4 = mapTest1;
+    BOOST_CHECK(Compare(mapTest1, mapTest4));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/cachemultimap_tests.cpp
+++ b/src/test/cachemultimap_tests.cpp
@@ -1,0 +1,176 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+
+#include "cachemultimap.h"
+
+#include "test/test_dash.h"
+
+#include <algorithm>
+#include <iostream>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(cachemultimap_tests, BasicTestingSetup)
+
+void DumpMap(const CacheMultiMap<int,int>& map)
+{
+    const CacheMultiMap<int,int>::list_t& listItems = map.GetItemList();
+    for(CacheMultiMap<int,int>::list_cit it = listItems.begin(); it != listItems.end(); ++it) {
+        const CacheItem<int,int>& item = *it;
+        std::cout << item.key << " : " << item.value << std::endl;
+    }
+}
+
+bool Compare(const CacheMultiMap<int,int>& map1, const CacheMultiMap<int,int>& map2 )
+{
+    if(map1.GetMaxSize() != map2.GetMaxSize()) {
+        std::cout << "Compare returning false: max size mismatch" << std::endl;
+        return false;
+    }
+
+    if(map1.GetSize() != map2.GetSize()) {
+        std::cout << "Compare returning false: size mismatch" << std::endl;
+        return false;
+    }
+
+    const CacheMultiMap<int,int>::list_t& items1 = map1.GetItemList();
+    const CacheMultiMap<int,int>::list_t& items2 = map2.GetItemList();
+    CacheMultiMap<int,int>::list_cit it2 = items2.begin();
+    for(CacheMultiMap<int,int>::list_cit it1 = items1.begin(); it1 != items1.end(); ++it1) {
+        const CacheItem<int,int>& item1 = *it1;
+        const CacheItem<int,int>& item2 = *it2;
+        if(item1.key != item2.key) {
+            return false;
+        }
+        if(item1.value != item2.value) {
+            return false;
+        }
+        ++it2;
+    }
+
+    return true;
+}
+
+bool CheckExpected(const CacheMultiMap<int,int>& map, int* expected, size_t nSize)
+{
+    if(map.GetSize() != nSize) {
+        return false;
+    }
+    for(size_t i = 0; i < nSize; ++i) {
+        int nVal = 0;
+        int eVal = expected[i];
+        if(!map.Get(eVal, nVal)) {
+            return false;
+        }
+        if(nVal != eVal) {
+            return false;
+        }
+    }
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE(cachemultimap_test)
+{
+    // create a CacheMultiMap limited to 10 items
+    CacheMultiMap<int,int> mapTest1(10);
+
+    // check that the max size is 10
+    BOOST_CHECK(mapTest1.GetMaxSize() == 10);
+
+    // check that the size is 0
+    BOOST_CHECK(mapTest1.GetSize() == 0);
+
+    // insert (-1, -1)
+    mapTest1.Insert(-1, -1);
+
+    // make sure that the size is updated
+    BOOST_CHECK(mapTest1.GetSize() == 1);
+
+    // make sure the map contains the key
+    BOOST_CHECK(mapTest1.HasKey(-1) == true);
+
+    // add 10 items
+    for(int i = 0; i < 10; ++i) {
+        mapTest1.Insert(i, i);
+    }
+
+    // check that the size is 10
+    BOOST_CHECK(mapTest1.GetSize() == 10);
+
+    // check that the map contains the expected items
+    for(int i = 0; i < 10; ++i) {
+        int nVal = 0;
+        BOOST_CHECK(mapTest1.Get(i, nVal) == true);
+        BOOST_CHECK(nVal == i);
+    }
+
+    // check that the map no longer contains the first item
+    BOOST_CHECK(mapTest1.HasKey(-1) == false);
+
+    // erase an item
+    mapTest1.Erase(5);
+
+    // check the size
+    BOOST_CHECK(mapTest1.GetSize() == 9);
+
+    // check that the map no longer contains the item
+    BOOST_CHECK(mapTest1.HasKey(5) == false);
+
+    // check that the map contains the expected items
+    int expected[] = { 0, 1, 2, 3, 4, 6, 7, 8, 9 };
+    BOOST_CHECK(CheckExpected(mapTest1, expected, 9 ) == true);
+
+    // add multiple items for the same key
+    mapTest1.Insert(5, 2);
+    mapTest1.Insert(5, 1);
+    mapTest1.Insert(5, 4);
+
+    // check the size
+    BOOST_CHECK(mapTest1.GetSize() == 10);
+
+    // check that 2 keys have been removed
+    BOOST_CHECK(mapTest1.HasKey(0) == false);
+    BOOST_CHECK(mapTest1.HasKey(1) == false);
+    BOOST_CHECK(mapTest1.HasKey(2) == true);
+
+    // check multiple values
+    std::vector<int> vecVals;
+    BOOST_CHECK(mapTest1.GetAll(5, vecVals) == true);
+    BOOST_CHECK(vecVals.size() == 3);
+    BOOST_CHECK(vecVals[0] == 1);
+    BOOST_CHECK(vecVals[1] == 2);
+    BOOST_CHECK(vecVals[2] == 4);
+
+//    std::cout << "mapTest1 dump:" << std::endl;
+//    DumpMap(mapTest1);
+
+    // test serialization
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << mapTest1;
+
+    CacheMultiMap<int,int> mapTest2;
+    ss >> mapTest2;
+
+//    std::cout << "mapTest2 dump:" << std::endl;
+//    DumpMap(mapTest2);
+
+    // check multiple values
+    std::vector<int> vecVals2;
+    BOOST_CHECK(mapTest2.GetAll(5, vecVals2) == true);
+    BOOST_CHECK(vecVals2.size() == 3);
+    BOOST_CHECK(vecVals2[0] == 1);
+    BOOST_CHECK(vecVals2[1] == 2);
+    BOOST_CHECK(vecVals2[2] == 4);
+
+    BOOST_CHECK(Compare(mapTest1, mapTest2));
+
+    // test copy constructor
+    CacheMultiMap<int,int> mapTest3(mapTest1);
+    BOOST_CHECK(Compare(mapTest1, mapTest3));
+
+    // test assignment operator
+    CacheMultiMap<int,int> mapTest4;
+    mapTest4 = mapTest1;
+    BOOST_CHECK(Compare(mapTest1, mapTest4));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/cachemultimap_tests.cpp
+++ b/src/test/cachemultimap_tests.cpp
@@ -50,12 +50,12 @@ bool Compare(const CacheMultiMap<int,int>& map1, const CacheMultiMap<int,int>& m
     return true;
 }
 
-bool CheckExpected(const CacheMultiMap<int,int>& map, int* expected, size_t nSize)
+bool CheckExpected(const CacheMultiMap<int,int>& map, int* expected, CacheMultiMap<int,int>::size_type nSize)
 {
     if(map.GetSize() != nSize) {
         return false;
     }
-    for(size_t i = 0; i < nSize; ++i) {
+    for(CacheMultiMap<int,int>::size_type i = 0; i < nSize; ++i) {
         int nVal = 0;
         int eVal = expected[i];
         if(!map.Get(eVal, nVal)) {


### PR DESCRIPTION
This replaces the vote maps in CGovernanceManager with maps in each CGovernanceObject.

This is the first of three subtasks for the voting changes, the others involve syncing and on disk vote storage.

For purposes of relaying requested votes each CGovernanceObject contains a CGovernanceObjectVoteFile object containing all votes for that object.  In the current PR this is implemented in memory only with no file storage.  The in memory votes are serialized on startup and shutdown like other governance data.  In a future PR they will be moved to disk files which will be read and written to as needed.

Note that a major change in this PR is that instead of using 32 byte hashes to identify masternodes internally, a masternode index is mainatained which maps these to 4 byte ints.