### PR TITLE
CGovernanceManager initialization fix

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1131,6 +1131,10 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex)
     // On the other hand it should be safe for us to access pindex without holding a lock
     // on cs_main because the CBlockIndex objects are dynamically allocated and
     // presumably never deleted.
+    if(!pindex) {
+        return;
+    }
+
     LOCK(cs);
     pCurrentBlockIndex = pindex;
     nCachedBlockHeight = pCurrentBlockIndex->nHeight;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -176,7 +176,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
     {
         // Ignore such messages until masternode list is synced
         if(!masternodeSync.IsMasternodeListSynced()) {
-            LogPrintf("CGovernanceManager::ProcessMessage MNGOVERNANCEOBJECTVOTE -- masternode list not synced\n");
+            LogPrint("gobject", "CGovernanceManager::ProcessMessage MNGOVERNANCEOBJECTVOTE -- masternode list not synced\n");
             return;
         }
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -129,7 +129,10 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         LOCK(cs);
         // MAKE SURE WE HAVE A VALID REFERENCE TO THE TIP BEFORE CONTINUING
 
-        if(!pCurrentBlockIndex) return;
+        if(!pCurrentBlockIndex) {
+            LogPrintf("CGovernanceManager::ProcessMessage MNGOVERNANCEOBJECT -- pCurrentBlockIndex is NULL\n");
+            return;
+        }
 
         CGovernanceObject govobj;
         vRecv >> govobj;
@@ -172,7 +175,10 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
     else if (strCommand == NetMsgType::MNGOVERNANCEOBJECTVOTE)
     {
         // Ignore such messages until masternode list is synced
-        if(!masternodeSync.IsMasternodeListSynced()) return;
+        if(!masternodeSync.IsMasternodeListSynced()) {
+            LogPrintf("CGovernanceManager::ProcessMessage MNGOVERNANCEOBJECTVOTE -- masternode list not synced\n");
+            return;
+        }
 
         CGovernanceVote vote;
         vRecv >> vote;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1883,6 +1883,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     darkSendPool.UpdatedBlockTip(chainActive.Tip());
     mnpayments.UpdatedBlockTip(chainActive.Tip());
     masternodeSync.UpdatedBlockTip(chainActive.Tip());
+    governance.UpdatedBlockTip(chainActive.Tip());
 
     // ********************************************************* Step 11d: start dash-privatesend thread
 


### PR DESCRIPTION
This fixes a problem with the initialiation of CGovernanceManager that caused non-reproducible failure of governance object syncing.

The code was relying on UpdatedBlockTip to be called by new blocks but sometimes a node is restarted before any new blocks have been generated and hence this function was not called in time.

This adds a call to UpdatedBlockTip to init.cpp that should ensure that pCurrentBlockIndex is initialized.