### PR TITLE
Fix PR1135 bugs

### DIFF
--- a/src/cachemultimap.h
+++ b/src/cachemultimap.h
@@ -89,7 +89,7 @@ public:
         return nCurrentSize;
     }
 
-    void Insert(const K& key, const V& value)
+    bool Insert(const K& key, const V& value)
     {
         if(nCurrentSize == nMaxSize) {
             PruneLast();
@@ -102,7 +102,7 @@ public:
 
         if(mapIt.count(value) > 0) {
             // Don't insert duplicates
-            return;
+            return false;
         }
 
         listItems.push_front(item_t(key, value));
@@ -110,6 +110,7 @@ public:
 
         mapIt[value] = lit;
         ++nCurrentSize;
+        return true;
     }
 
     bool HasKey(const K& key) const

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -223,7 +223,6 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         CGovernanceException exception;
         if(ProcessVote(pfrom, vote, exception)) {
             LogPrint("gobject", "CGovernanceManager -- Accepted vote\n");
-            vote.Relay();
         }
         else {
             LogPrint("gobject", "CGovernanceManager -- Rejected vote, error = %s\n", exception.what());
@@ -638,6 +637,8 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
         if(govobj.GetObjectType() == GOVERNANCE_OBJECT_WATCHDOG) {
             mnodeman.UpdateWatchdogVoteTime(vote.GetVinMasternode());
         }
+
+        vote.Relay();
     }
     return fOk;
 }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -819,7 +819,7 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
     int nMNIndex = governance.GetMasternodeIndex(vote.GetVinMasternode());
     if(nMNIndex < 0) {
         std::ostringstream ostr;
-        ostr << "CGovernanceObject::UpdateVote -- Masternode index not found\n";
+        ostr << "CGovernanceObject::ProcessVote -- Masternode index not found\n";
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
         if(mapOrphanVotes.Insert(vote.GetVinMasternode(), vote)) {
             if(pfrom) {
@@ -841,14 +841,14 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
     vote_signal_enum_t eSignal = vote.GetSignal();
     if(eSignal == VOTE_SIGNAL_NONE) {
         std::ostringstream ostr;
-        ostr << "CGovernanceObject::UpdateVote -- Vote signal: none" << "\n";
+        ostr << "CGovernanceObject::ProcessVote -- Vote signal: none" << "\n";
         LogPrint("gobject", ostr.str().c_str());
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
         return false;
     }
     if(eSignal > MAX_SUPPORTED_VOTE_SIGNAL) {
         std::ostringstream ostr;
-        ostr << "CGovernanceObject::UpdateVote -- Unsupported vote signal:" << CGovernanceVoting::ConvertSignalToString(vote.GetSignal()) << "\n";
+        ostr << "CGovernanceObject::ProcessVote -- Unsupported vote signal:" << CGovernanceVoting::ConvertSignalToString(vote.GetSignal()) << "\n";
         LogPrintf(ostr.str().c_str());
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
         return false;
@@ -862,7 +862,7 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
     int64_t nTimeDelta = nNow - voteInstance.nTime;
     if(nTimeDelta < GOVERNANCE_UPDATE_MIN) {
         std::ostringstream ostr;
-        ostr << "CGovernanceObject::UpdateVote -- Masternode voting too often "
+        ostr << "CGovernanceObject::ProcessVote -- Masternode voting too often "
                 << ", MN outpoint = " << vote.GetVinMasternode().prevout.ToStringShort()
                 << ", governance object hash = " << GetHash().ToString()
                 << ", time delta = " << nTimeDelta << "\n";
@@ -873,7 +873,7 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
     // Finally check that the vote is actually valid (done last because of cost of signature verification)
     if(!vote.IsValid(true)) {
         std::ostringstream ostr;
-        ostr << "CGovernanceObject::UpdateVote -- Invalid vote "
+        ostr << "CGovernanceObject::ProcessVote -- Invalid vote "
                 << ", MN outpoint = " << vote.GetVinMasternode().prevout.ToStringShort()
                 << ", governance object hash = " << GetHash().ToString()
                 << ", vote hash = " << vote.GetHash().ToString() << "\n";


### PR DESCRIPTION
This fixes 2 major bugs in PR1135:

1) Votes submitted locally are not being relayed.

2) Orphan votes are being reprocessed multiple times leading to excessive log messages, object requests and cpu usage.

The basic idea for the orphan vote fix is due to @thelazier's PR1139, but this is a cleaner implementation of that idea.