### PR TITLE
Masternode syncing fix

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -551,7 +551,10 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
 
             CGovernanceObject& govobj = it->second;
 
-            if(govobj.IsSetCachedValid() && (nProp == uint256() || h == nProp)) {
+            std::string strError;
+            if(govobj.IsSetCachedValid() &&
+               (nProp == uint256() || h == nProp) &&
+               govobj.IsValidLocally(pCurrentBlockIndex, strError, true)) {
                 // Push the inventory budget proposal message over to the other client
                 pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT, h));
                 ++nInvCount;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -572,7 +572,7 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
     }
 
     pfrom->PushMessage(NetMsgType::SYNCSTATUSCOUNT, MASTERNODE_SYNC_GOVOBJ, nInvCount);
-    LogPrintf("CGovernanceManager::Sync -- sent %d items\n", nInvCount);
+    LogPrintf("CGovernanceManager::Sync -- sent %d items, peer=%d\n", nInvCount, pfrom->id);
 }
 
 void CGovernanceManager::SyncParentObjectByVote(CNode* pfrom, const CGovernanceVote& vote)

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1113,6 +1113,14 @@ void CGovernanceObject::UpdateLocalValidity(const CBlockIndex *pCurrentBlockInde
 
 bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& strError, bool fCheckCollateral)
 {
+    bool fMissingMasternode = false;
+
+    return IsValidLocally(pindex, strError, fMissingMasternode, fCheckCollateral);
+}
+
+bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& strError, bool& fMissingMasternode, bool fCheckCollateral)
+{
+    fMissingMasternode = false;
     if(!pindex) {
         strError = "Tip is NULL";
         return true;
@@ -1147,6 +1155,7 @@ bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& s
             std::string strOutpoint = vinMasternode.prevout.ToStringShort();
             masternode_info_t infoMn = mnodeman.GetMasternodeInfo(vinMasternode);
             if(!infoMn.fInfoValid) {
+                fMissingMasternode = true;
                 strError = "Masternode not found: " + strOutpoint;
                 return false;
             }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1119,6 +1119,7 @@ bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& s
     }
 
     if(fUnparsable) {
+        strError = "Object data unparseable";
         return false;
     }
 

--- a/src/governance.h
+++ b/src/governance.h
@@ -120,6 +120,8 @@ private:
 
     count_m_t mapSeenGovernanceObjects;
 
+    object_m_t mapMasternodeOrphanObjects;
+
     object_ref_cache_t mapVoteToObject;
 
     vote_cache_t mapInvalidVotes;
@@ -251,6 +253,8 @@ public:
     }
 
     void CheckMasternodeOrphanVotes();
+
+    void CheckMasternodeOrphanObjects();
 
 private:
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash);

--- a/src/governance.h
+++ b/src/governance.h
@@ -481,6 +481,8 @@ public:
 
     bool IsValidLocally(const CBlockIndex* pindex, std::string& strError, bool fCheckCollateral);
 
+    bool IsValidLocally(const CBlockIndex* pindex, std::string& strError, bool& fMissingMasternode, bool fCheckCollateral);
+
     /// Check the collateral transaction for the budget proposal/finalized budget
     bool IsCollateralValid(std::string& strError);
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1536,6 +1536,7 @@ void CMasternodeMan::NotifyMasternodeUpdates()
     }
 
     if(fMasternodesAddedLocal) {
+        governance.CheckMasternodeOrphanObjects();
         governance.CheckMasternodeOrphanVotes();
     }
     if(fMasternodesRemovedLocal) {


### PR DESCRIPTION
This should fix a masternode syncing failure which leads to governance object syncing failures.

Watchdog and superblock objects must be signed by a valid masternode.  If the signing masternode is not found in the masternode list the object is rejected.

This maintains an orphan map of governance objects and requests the signing masternode from the peer which sent the governance object.

Note that though the mechanism used here is similar to the one used for votes, the problem of excessive requests that was fixed in PR1140 does not occur here because a map of seen governance objects is also maintained and the masternode request code only runs if the governance object was not previously seen.

Commits a3277ea and c00fdb5 are two very small unrelated changes.  The later is to obtain more information about the large number of CGovernanceManager::Sync messages seen in the logs.