### PR TITLE
CMasternodeMan cleanup

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -167,7 +167,7 @@ void CMasternodeMan::Check()
     }
 }
 
-void CMasternodeMan::CheckAndRemove(bool fForceExpiredRemoval)
+void CMasternodeMan::CheckAndRemove()
 {
     LogPrintf("CMasternodeMan::CheckAndRemove\n");
 
@@ -182,9 +182,7 @@ void CMasternodeMan::CheckAndRemove(bool fForceExpiredRemoval)
             bool fRemove =  // If it's marked to be removed from the list by CMasternode::Check for whatever reason ...
                     (*it).nActiveState == CMasternode::MASTERNODE_REMOVE ||
                     // or collateral was spent ...
-                    (*it).nActiveState == CMasternode::MASTERNODE_OUTPOINT_SPENT ||
-                    // or we were asked to remove exired entries ...
-                    (fForceExpiredRemoval && (*it).nActiveState == CMasternode::MASTERNODE_EXPIRED);
+                    (*it).nActiveState == CMasternode::MASTERNODE_OUTPOINT_SPENT;
 
             if (fRemove) {
                 LogPrint("masternode", "CMasternodeMan::CheckAndRemove -- Removing Masternode: %s  addr=%s  %i now\n", (*it).GetStatus(), (*it).addr.ToString(), size() - 1);
@@ -1232,21 +1230,6 @@ void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerif
         }
         LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- PoSe score incresed for %d fake masternodes, addr %s\n",
                     nCount, pnode->addr.ToString());
-    }
-}
-
-void CMasternodeMan::Remove(CTxIn vin)
-{
-    LOCK(cs);
-
-    std::vector<CMasternode>::iterator it = vMasternodes.begin();
-    while(it != vMasternodes.end()) {
-        if((*it).vin == vin) {
-            LogPrint("masternode", "CMasternodeMan::Remove -- Removing Masternode: %s  addr=%s, %i now\n", vin.prevout.ToStringShort(), (*it).addr.ToString(), size() - 1);
-            vMasternodes.erase(it);
-            break;
-        }
-        ++it;
     }
 }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -295,6 +295,8 @@ void CMasternodeMan::Clear()
     mapSeenMasternodePing.clear();
     nDsqCount = 0;
     nLastWatchdogVoteTime = 0;
+    indexMasternodes.Clear();
+    indexMasternodesOld.Clear();
 }
 
 int CMasternodeMan::CountMasternodes(int nProtocolVersion)

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -194,7 +194,7 @@ public:
     void Check();
 
     /// Check all Masternodes and remove inactive
-    void CheckAndRemove(bool fForceExpiredRemoval = false);
+    void CheckAndRemove();
 
     /// Clear Masternode vector
     void Clear();
@@ -296,8 +296,6 @@ public:
     int size() { return vMasternodes.size(); }
 
     std::string ToString() const;
-
-    void Remove(CTxIn vin);
 
     int GetEstimatedMasternodes(int nBlock);
 


### PR DESCRIPTION
This is a small code cleanup for CMasternodeMan that removes an unused method and an unused argument.

The second commit is a fix for CMasternodeMan::Clear() that probably will have very little effect because that method is only called after loading from the disk cache if the serialization version is incorrect.