### PR TITLE
Fix CheckMasternodeOrphanObjects iterator

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -683,8 +683,8 @@ void CGovernanceManager::CheckMasternodeOrphanObjects()
             }
             else {
                 ++it;
-                continue;
             }
+            continue;
         }
 
         if(AddGovernanceObject(govobj)) {


### PR DESCRIPTION
Fix CheckMasternodeOrphanObjects to ensure that iterator is increemented exactly once per passage through the loop.