### PR TITLE
Masternode syncing changes

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -41,6 +41,7 @@ CGovernanceManager::CGovernanceManager()
       mapOrphanVotes(MAX_CACHE_SIZE),
       mapLastMasternodeTrigger(),
       setRequestedObjects(),
+      fRateChecksEnabled(true),
       cs()
 {}
 
@@ -579,6 +580,10 @@ bool CGovernanceManager::MasternodeRateCheck(const CTxIn& vin, int nObjectType)
 {
     LOCK(cs);
 
+    if(!fRateChecksEnabled) {
+        return true;
+    }
+
     int mindiff = 0;
     switch(nObjectType) {
     case GOVERNANCE_OBJECT_TRIGGER:
@@ -662,6 +667,7 @@ void CGovernanceManager::CheckMasternodeOrphanVotes()
 void CGovernanceManager::CheckMasternodeOrphanObjects()
 {
     LOCK(cs);
+    fRateChecksEnabled = false;
     object_m_it it = mapMasternodeOrphanObjects.begin();
     while(it != mapMasternodeOrphanObjects.end()) {
         CGovernanceObject& govobj = it->second;
@@ -688,6 +694,7 @@ void CGovernanceManager::CheckMasternodeOrphanObjects()
             ++it;
         }
     }
+    fRateChecksEnabled = true;
 }
 
 void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nHash)

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -575,14 +575,6 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
     LogPrintf("CGovernanceManager::Sync -- sent %d items, peer=%d\n", nInvCount, pfrom->id);
 }
 
-void CGovernanceManager::SyncParentObjectByVote(CNode* pfrom, const CGovernanceVote& vote)
-{
-    if(!mapAskedForGovernanceObject.count(vote.GetParentHash())){
-        pfrom->PushMessage(NetMsgType::MNGOVERNANCESYNC, vote.GetParentHash());
-        mapAskedForGovernanceObject[vote.GetParentHash()] = GetTime();
-    }
-}
-
 bool CGovernanceManager::MasternodeRateCheck(const CTxIn& vin, int nObjectType)
 {
     LOCK(cs);

--- a/src/governance.h
+++ b/src/governance.h
@@ -164,8 +164,6 @@ public:
 
     void Sync(CNode* node, uint256 nProp);
 
-    void SyncParentObjectByVote(CNode* pfrom, const CGovernanceVote& vote);
-
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
     void NewBlock();

--- a/src/governance.h
+++ b/src/governance.h
@@ -134,6 +134,8 @@ private:
 
     hash_s_t setRequestedVotes;
 
+    bool fRateChecksEnabled;
+
 public:
     // critical section to protect the inner data structures
     mutable CCriticalSection cs;
@@ -253,6 +255,11 @@ public:
     void CheckMasternodeOrphanVotes();
 
     void CheckMasternodeOrphanObjects();
+
+    bool AreRateChecksEnabled() const {
+        LOCK(cs);
+        return fRateChecksEnabled;
+    }
 
 private:
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -783,7 +783,6 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         BOOST_FOREACH(CMasternode& mn, vMasternodes) {
             if (vin != CTxIn() && vin != mn.vin) continue; // asked for specific vin but we are not there yet
             if (mn.addr.IsRFC1918() || mn.addr.IsLocal()) continue; // do not send local network masternode
-            if (!mn.IsEnabled()) continue;
 
             LogPrint("masternode", "DSEG -- Sending Masternode entry: masternode=%s  addr=%s\n", mn.vin.prevout.ToStringShort(), mn.addr.ToString());
             CMasternodeBroadcast mnb = CMasternodeBroadcast(mn);


### PR DESCRIPTION
This PR includes several changes to masternode syncing.

These are needed because masternode list discrepancies continue to cause issues for governance object and vote syncing.

The most significant change is to allow mnb's to be sent regardless of the state of the masternode.

The other changes disable rate limits during masternode orphan object and vote processing, since during these operations it is expected that multiple objects or votes from a single masternode may be seen during a short period of time.

Commit e87f903 is just to remove an unused function from governance.cpp.