### PR TITLE
Implemented delay for governance object deletion

### DIFF
--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -212,6 +212,7 @@ void CGovernanceTriggerManager::CleanAndRemove()
                     if(pgovobj) {
                         LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Expiring executed object: %s\n", pgovobj->GetHash().ToString());
                         pgovobj->fExpired = true;
+                        pgovobj->nDeletionTime = GetAdjustedTime();
                     }
                 }
                 remove = true;
@@ -229,6 +230,7 @@ void CGovernanceTriggerManager::CleanAndRemove()
                         if(pgovobj) {
                             LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Expiring outdated object: %s\n", pgovobj->GetHash().ToString());
                             pgovobj->fExpired = true;
+                            pgovobj->nDeletionTime = GetAdjustedTime();
                         }
                     }
                 }

--- a/src/governance.h
+++ b/src/governance.h
@@ -46,6 +46,8 @@ static const CAmount GOVERNANCE_PROPOSAL_FEE_TX = (0.33*COIN);
 
 static const int64_t GOVERNANCE_FEE_CONFIRMATIONS = 6;
 static const int64_t GOVERNANCE_UPDATE_MIN = 60*60;
+static const int64_t GOVERNANCE_DELETION_DELAY = 10*60;
+
 
 // FOR SEEN MAP ARRAYS - GOVERNANCE OBJECTS AND VOTES
 static const int SEEN_OBJECT_IS_VALID = 0;
@@ -370,6 +372,9 @@ private:
     /// time this object was created
     int64_t nTime;
 
+    /// time this object was marked for deletion
+    int64_t nDeletionTime;
+
     /// fee-tx
     uint256 nCollateralHash;
 
@@ -429,6 +434,10 @@ public:
 
     int64_t GetCreationTime() const {
         return nTime;
+    }
+
+    int64_t GetDeletionTime() const {
+        return nDeletionTime;
     }
 
     int GetObjectType() const {


### PR DESCRIPTION
When governance objects are deleted their votes are no longer available to be relayed.  This can lead to vote and object discrepancies.

This PR fixes this by implementing a 10 minute delay between the time when an object is marked for deletion and the time when it is actually deleted.