### PR TITLE
Deadlocks

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -90,8 +90,6 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
         }
 
     } else if(strCommand == NetMsgType::DSQUEUE) {
-        TRY_LOCK(cs_darksend, lockRecv);
-        if(!lockRecv) return;
 
         if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
             LogPrint("privatesend", "DSQUEUE -- incompatible version! nVersion: %d\n", pfrom->nVersion);
@@ -101,11 +99,14 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
         CDarksendQueue dsq;
         vRecv >> dsq;
 
-        // process every dsq only once
-        BOOST_FOREACH(CDarksendQueue q, vecDarksendQueue) {
-            if(q == dsq) {
-                // LogPrint("privatesend", "DSQUEUE -- %s seen\n", dsq.ToString());
-                return;
+        {
+            LOCK(cs_darksend);
+            // process every dsq only once
+            BOOST_FOREACH(CDarksendQueue q, vecDarksendQueue) {
+                if(q == dsq) {
+                    // LogPrint("privatesend", "DSQUEUE -- %s seen\n", dsq.ToString());
+                    return;
+                }
             }
         }
 
@@ -135,11 +136,15 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
                 SubmitDenominate();
             }
         } else {
-            BOOST_FOREACH(CDarksendQueue q, vecDarksendQueue) {
-                if(q.vin == dsq.vin) {
-                    // no way same mn can send another "not yet ready" dsq this soon
-                    LogPrint("privatesend", "DSQUEUE -- Masternode %s is sending WAY too many dsq messages\n", pmn->addr.ToString());
-                    return;
+
+            {
+                LOCK(cs_darksend);
+                BOOST_FOREACH(CDarksendQueue q, vecDarksendQueue) {
+                    if(q.vin == dsq.vin) {
+                        // no way same mn can send another "not yet ready" dsq this soon
+                        LogPrint("privatesend", "DSQUEUE -- Masternode %s is sending WAY too many dsq messages\n", pmn->addr.ToString());
+                        return;
+                    }
                 }
             }
 
@@ -724,6 +729,8 @@ void CDarksendPool::ChargeFees()
         LogPrintf("CDarksendPool::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s\n",
                 (nState == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0].ToString());
 
+        LOCK(cs_main);
+
         CValidationState state;
         bool fMissingInputs;
         if(!AcceptToMemoryPool(mempool, state, vecOffendersCollaterals[0], false, &fMissingInputs, false, true)) {
@@ -751,6 +758,8 @@ void CDarksendPool::ChargeRandomFees()
 {
     if(!fMasterNode) return;
 
+    LOCK(cs_main);
+
     BOOST_FOREACH(const CTransaction& txCollateral, vecSessionCollaterals) {
 
         if(GetRandInt(100) > 10) return;
@@ -773,13 +782,17 @@ void CDarksendPool::ChargeRandomFees()
 //
 void CDarksendPool::CheckTimeout()
 {
-    // check mixing queue objects for timeouts
-    std::vector<CDarksendQueue>::iterator it = vecDarksendQueue.begin();
-    while(it != vecDarksendQueue.end()) {
-        if((*it).IsExpired()) {
-            LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Removing expired queue (%s)\n", (*it).ToString());
-            it = vecDarksendQueue.erase(it);
-        } else ++it;
+    {
+        LOCK(cs_darksend);
+
+        // check mixing queue objects for timeouts
+        std::vector<CDarksendQueue>::iterator it = vecDarksendQueue.begin();
+        while(it != vecDarksendQueue.end()) {
+            if((*it).IsExpired()) {
+                LogPrint("privatesend", "CDarksendPool::CheckTimeout -- Removing expired queue (%s)\n", (*it).ToString());
+                it = vecDarksendQueue.erase(it);
+            } else ++it;
+        }
     }
 
     if(!fEnablePrivateSend && !fMasterNode) return;
@@ -1347,11 +1360,7 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
         return false;
     }
 
-    TRY_LOCK(cs_darksend, lockDS);
-    if(!lockDS) {
-        strAutoDenomResult = _("Lock is already in place.");
-        return false;
-    }
+    LOCK2(cs_main, cs_darksend);
 
     if(!fDryRun && pwalletMain->IsLocked(true)) {
         strAutoDenomResult = _("Wallet is locked.");
@@ -2335,11 +2344,22 @@ bool CDarksendQueue::CheckSignature(const CPubKey& pubKeyMasternode)
 
 bool CDarksendQueue::Relay()
 {
-    LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    std::vector<CNode*> vNodesCopy;
+    {
+        LOCK(cs_vNodes);
+        vNodesCopy = vNodes;
+        BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            pnode->AddRef();
+    }
+    BOOST_FOREACH(CNode* pnode, vNodesCopy)
         if(pnode->nVersion >= MIN_PRIVATESEND_PEER_PROTO_VERSION)
             pnode->PushMessage(NetMsgType::DSQUEUE, (*this));
 
+    {
+        LOCK(cs_vNodes);
+        BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            pnode->Release();
+    }
     return true;
 }
 

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2483,6 +2483,8 @@ void ThreadCheckDarkSendPool()
             if(nTick % MASTERNODE_MIN_MNP_SECONDS == 1)
                 activeMasternode.ManageState();
 
+            mnodeman.Check();
+
             if(nTick % 60 == 0) {
                 mnodeman.CheckAndRemove();
                 mnodeman.ProcessMasternodeConnections();

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -542,8 +542,7 @@ void CGovernanceManager::NewBlock()
 
 bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
 {
-    // FIXME:
-    // LOCK(cs);
+    LOCK(cs);
 
     LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest inv = %s\n", inv.ToString());
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -278,7 +278,7 @@ void CGovernanceManager::CheckOrphanVotes(CNode* pfrom, CGovernanceObject& govob
 
 bool CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj)
 {
-    LOCK2(cs_main, cs);
+    LOCK(cs);
     std::string strError = "";
 
     DBG( cout << "CGovernanceManager::AddGovernanceObject START" << endl; );
@@ -333,7 +333,7 @@ void CGovernanceManager::UpdateCachesAndClean()
 
     std::vector<uint256> vecDirtyHashes = mnodeman.GetAndClearDirtyGovernanceObjectHashes();
 
-    LOCK2(cs_main, cs);
+    LOCK(cs);
 
     for(size_t i = 0; i < vecDirtyHashes.size(); ++i) {
         object_m_it it = mapObjects.find(vecDirtyHashes[i]);
@@ -607,7 +607,7 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
     // SYNC GOVERNANCE OBJECTS WITH OTHER CLIENT
 
     {
-        LOCK2(cs_main, cs);
+        LOCK(cs);
         for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
             uint256 h = it->first;
 
@@ -868,7 +868,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex)
         return;
     }
 
-    LOCK2(cs_main, cs);
+    LOCK(cs);
     pCurrentBlockIndex = pindex;
     nCachedBlockHeight = pCurrentBlockIndex->nHeight;
     LogPrint("gobject", "CGovernanceManager::UpdatedBlockTip pCurrentBlockIndex->nHeight: %d\n", pCurrentBlockIndex->nHeight);

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -110,8 +110,6 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
     if(pfrom->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) return;
 
-    LOCK(cs);
-
     // ANOTHER USER IS ASKING US TO HELP THEM SYNC GOVERNANCE OBJECT DATA
     if (strCommand == NetMsgType::MNGOVERNANCESYNC)
     {
@@ -163,6 +161,8 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
             Misbehaving(pfrom->GetId(), 20);
             return;
         }
+
+        LOCK2(cs_main, cs);
 
         if(mapSeenGovernanceObjects.count(nHash)) {
             // TODO - print error code? what if it's GOVOBJ_ERROR_IMMATURE?
@@ -278,7 +278,7 @@ void CGovernanceManager::CheckOrphanVotes(CNode* pfrom, CGovernanceObject& govob
 
 bool CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj)
 {
-    LOCK(cs);
+    LOCK2(cs_main, cs);
     std::string strError = "";
 
     DBG( cout << "CGovernanceManager::AddGovernanceObject START" << endl; );
@@ -333,7 +333,7 @@ void CGovernanceManager::UpdateCachesAndClean()
 
     std::vector<uint256> vecDirtyHashes = mnodeman.GetAndClearDirtyGovernanceObjectHashes();
 
-    LOCK(cs);
+    LOCK2(cs_main, cs);
 
     for(size_t i = 0; i < vecDirtyHashes.size(); ++i) {
         object_m_it it = mapObjects.find(vecDirtyHashes[i]);
@@ -542,7 +542,8 @@ void CGovernanceManager::NewBlock()
 
 bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
 {
-    LOCK(cs);
+    // FIXME:
+    // LOCK(cs);
 
     LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest inv = %s\n", inv.ToString());
 
@@ -606,7 +607,7 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
     // SYNC GOVERNANCE OBJECTS WITH OTHER CLIENT
 
     {
-        LOCK(cs);
+        LOCK2(cs_main, cs);
         for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
             uint256 h = it->first;
 
@@ -867,7 +868,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex)
         return;
     }
 
-    LOCK(cs);
+    LOCK2(cs_main, cs);
     pCurrentBlockIndex = pindex;
     nCachedBlockHeight = pCurrentBlockIndex->nHeight;
     LogPrint("gobject", "CGovernanceManager::UpdatedBlockTip pCurrentBlockIndex->nHeight: %d\n", pCurrentBlockIndex->nHeight);

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -72,9 +72,12 @@ bool IsInstantSendTxValid(const CTransaction& txCandidate)
 {
     if(txCandidate.vout.size() < 1) return false;
 
-    if(!CheckFinalTx(txCandidate)) {
-        LogPrint("instantsend", "IsInstantSendTxValid -- Transaction is not final: txCandidate=%s", txCandidate.ToString());
-        return false;
+    {
+        LOCK(cs_main);
+        if(!CheckFinalTx(txCandidate)) {
+            LogPrint("instantsend", "IsInstantSendTxValid -- Transaction is not final: txCandidate=%s", txCandidate.ToString());
+            return false;
+        }
     }
 
     int64_t nValueIn = 0;
@@ -460,15 +463,15 @@ int64_t GetAverageMasternodeOrphanVoteTime()
 
 void CleanTxLockCandidates()
 {
-    LOCK(cs_instantsend);
-
-    std::map<uint256, CTxLockCandidate>::iterator it = mapTxLockCandidates.begin();
-
     int nHeight;
     {
         LOCK(cs_main);
         nHeight = chainActive.Height();
     }
+
+    LOCK(cs_instantsend);
+
+    std::map<uint256, CTxLockCandidate>::iterator it = mapTxLockCandidates.begin();
 
     while(it != mapTxLockCandidates.end()) {
         CTxLockCandidate &txLockCandidate = it->second;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5057,14 +5057,16 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
             {
                 // Send stream from relay memory
                 bool pushed = false;
+                map<CInv, CDataStream>::iterator mi;
                 {
                     LOCK(cs_mapRelay);
-                    map<CInv, CDataStream>::iterator mi = mapRelay.find(inv);
+                    mi = mapRelay.find(inv);
                     if (mi != mapRelay.end()) {
-                        pfrom->PushMessage(inv.GetCommand(), (*mi).second);
                         pushed = true;
                     }
                 }
+                if(pushed)
+                    pfrom->PushMessage(inv.GetCommand(), (*mi).second);
 
                 if (!pushed && inv.type == MSG_TX) {
                     CTransaction tx;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -416,7 +416,7 @@ bool CMasternodePayments::AddPaymentVote(const CMasternodePaymentVote& vote)
     uint256 blockHash = uint256();
     if(!GetBlockHash(blockHash, vote.nBlockHeight - 101)) return false;
 
-    LOCK2(cs_mapMasternodePaymentVotes, cs_mapMasternodeBlocks);
+    LOCK2(cs_mapMasternodeBlocks, cs_mapMasternodePaymentVotes);
 
     if(mapMasternodePaymentVotes.count(vote.GetHash())) return false;
 
@@ -573,7 +573,7 @@ void CMasternodePayments::CheckAndRemove()
 {
     if(!pCurrentBlockIndex) return;
 
-    LOCK2(cs_mapMasternodePaymentVotes, cs_mapMasternodeBlocks);
+    LOCK2(cs_mapMasternodeBlocks, cs_mapMasternodePaymentVotes);
 
     int nLimit = GetStorageLimit();
 
@@ -781,7 +781,7 @@ void CMasternodePayments::RequestLowDataPaymentBlocks(CNode* pnode)
     // Old nodes can't process this
     if(pnode->nVersion < 70202) return;
 
-    LOCK(cs_mapMasternodeBlocks);
+    LOCK2(cs_main, cs_mapMasternodeBlocks);
 
     std::vector<CInv> vToFetch;
     std::map<int, CMasternodeBlockPayees>::iterator it = mapMasternodeBlocks.begin();

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -158,7 +158,7 @@ void CMasternodeMan::AskForMN(CNode* pnode, const CTxIn &vin)
 
 void CMasternodeMan::Check()
 {
-    LOCK(cs);
+    LOCK2(cs_main, cs);
 
     LogPrint("masternode", "CMasternodeMan::Check nLastWatchdogVoteTime = %d, IsWatchdogActive() = %d\n", nLastWatchdogVoteTime, IsWatchdogActive());
 
@@ -315,7 +315,7 @@ int CMasternodeMan::CountMasternodes(int nProtocolVersion)
 
 int CMasternodeMan::CountEnabled(int nProtocolVersion)
 {
-    LOCK(cs);
+    LOCK2(cs_main, cs);
     int nCount = 0;
     nProtocolVersion = nProtocolVersion == -1 ? mnpayments.GetMinMasternodePaymentsProto() : nProtocolVersion;
 
@@ -460,10 +460,19 @@ bool CMasternodeMan::Has(const CTxIn& vin)
 //
 // Deterministically select the oldest/best masternode to pay on the network
 //
+CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(bool fFilterSigTime, int& nCount)
+{
+    if(!pCurrentBlockIndex) {
+        nCount = 0;
+        return NULL;
+    }
+    return GetNextMasternodeInQueueForPayment(pCurrentBlockIndex->nHeight, fFilterSigTime, nCount);
+}
+
 CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount)
 {
     // Need LOCK2 here to ensure consistent locking order because the GetBlockHash call below locks cs_main
-    LOCK2(cs_main,cs);
+    LOCK2(cs_main, cs);
 
     CMasternode *pBestMasternode = NULL;
     std::vector<std::pair<int, CMasternode*> > vecMasternodeLastPaid;
@@ -510,7 +519,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     //  -- This doesn't look at who is being paid in the +8-10 blocks, allowing for double payments very rarely
     //  -- 1/100 payments should be a double payment on mainnet - (1/(3000/10))*2
     //  -- (chance per block * chances before IsScheduled will fire)
-    int nTenthNetwork = CountEnabled()/10;
+    int nTenthNetwork = nMnCount/10;
     int nCountTenth = 0;
     arith_uint256 nHighest = 0;
     BOOST_FOREACH (PAIRTYPE(int, CMasternode*)& s, vecMasternodeLastPaid){
@@ -527,7 +536,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
 
 CMasternode* CMasternodeMan::FindRandomNotInVec(const std::vector<CTxIn> &vecToExclude, int nProtocolVersion)
 {
-    LOCK(cs);
+    LOCK2(cs_main, cs);
 
     nProtocolVersion = nProtocolVersion == -1 ? mnpayments.GetMinMasternodePaymentsProto() : nProtocolVersion;
 
@@ -576,7 +585,7 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int nBlockHeight, int nM
     uint256 blockHash = uint256();
     if(!GetBlockHash(blockHash, nBlockHeight)) return -1;
 
-    LOCK(cs);
+    LOCK2(cs_main, cs);
 
     // scan for winner
     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
@@ -613,7 +622,7 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
     uint256 blockHash = uint256();
     if(!GetBlockHash(blockHash, nBlockHeight)) return vecMasternodeRanks;
 
-    LOCK(cs);
+    LOCK2(cs_main, cs);
 
     // scan for winner
     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
@@ -642,7 +651,7 @@ CMasternode* CMasternodeMan::GetMasternodeByRank(int nRank, int nBlockHeight, in
 {
     std::vector<std::pair<int64_t, CMasternode*> > vecMasternodeScores;
 
-    LOCK(cs);
+    LOCK2(cs_main, cs);
 
     uint256 blockHash;
     if(!GetBlockHash(blockHash, nBlockHeight)) {
@@ -700,7 +709,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
     if (strCommand == NetMsgType::MNANNOUNCE) { //Masternode Broadcast
 
         {
-            LOCK(cs);
+            LOCK2(cs_main, cs);
 
             CMasternodeBroadcast mnb;
             vRecv >> mnb;
@@ -726,7 +735,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         LogPrint("masternode", "MNPING -- Masternode ping, masternode=%s\n", mnp.vin.prevout.ToStringShort());
 
-        LOCK(cs);
+        LOCK2(cs_main, cs);
 
         if(mapSeenMasternodePing.count(mnp.GetHash())) return; //seen
         mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));
@@ -814,7 +823,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
     } else if (strCommand == NetMsgType::MNVERIFY) { // Masternode Verify
 
-        LOCK(cs);
+        LOCK2(cs_main, cs);
 
         CMasternodeVerification mnv;
         vRecv >> mnv;
@@ -840,7 +849,7 @@ void CMasternodeMan::DoFullVerificationStep()
 
     std::vector<std::pair<int, CMasternode> > vecMasternodeRanks = GetMasternodeRanks(pCurrentBlockIndex->nHeight - 1, MIN_POSE_PROTO_VERSION);
 
-    LOCK(cs);
+    LOCK2(cs_main, cs);
 
     int nCount = 0;
     int nCountMax = std::max(10, (int)vMasternodes.size() / 100); // verify at least 10 masternode at once but at most 1% of all known masternodes
@@ -968,6 +977,9 @@ bool CMasternodeMan::SendVerifyRequest(const CAddress& addr, const std::vector<C
         LogPrint("masternode", "CMasternodeMan::SendVerifyRequest -- too many requests, skipping... addr=%s\n", addr.ToString());
         return false;
     }
+
+    AssertLockHeld(cs_main);
+    AssertLockHeld(cs);
 
     CNode* pnode = ConnectNode(addr, NULL, true);
     if(pnode != NULL) {
@@ -1275,7 +1287,7 @@ int CMasternodeMan::GetEstimatedMasternodes(int nBlock)
 
 void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb)
 {
-    LOCK(cs);
+    LOCK2(cs_main, cs);
     mapSeenMasternodePing.insert(std::make_pair(mnb.lastPing.GetHash(), mnb.lastPing));
     mapSeenMasternodeBroadcast.insert(std::make_pair(mnb.GetHash(), mnb));
 
@@ -1347,11 +1359,12 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CMasternodeBroadcast mnb, i
     return true;
 }
 
-void CMasternodeMan::UpdateLastPaid(const CBlockIndex *pindex)
+void CMasternodeMan::UpdateLastPaid()
 {
     LOCK(cs);
 
     if(fLiteMode) return;
+    if(!pCurrentBlockIndex) return;
 
     static bool IsFirstRun = true;
     // Do full scan on first run or if we are not a masternode
@@ -1359,10 +1372,10 @@ void CMasternodeMan::UpdateLastPaid(const CBlockIndex *pindex)
     int nMaxBlocksToScanBack = (IsFirstRun || !fMasterNode) ? mnpayments.GetStorageLimit() : LAST_PAID_SCAN_BLOCKS;
 
     // LogPrint("mnpayments", "CMasternodeMan::UpdateLastPaid -- nHeight=%d, nMaxBlocksToScanBack=%d, IsFirstRun=%s\n",
-    //                         pindex->nHeight, nMaxBlocksToScanBack, IsFirstRun ? "true" : "false");
+    //                         pCurrentBlockIndex->nHeight, nMaxBlocksToScanBack, IsFirstRun ? "true" : "false");
 
     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
-        mn.UpdateLastPaid(pindex, nMaxBlocksToScanBack);
+        mn.UpdateLastPaid(pCurrentBlockIndex, nMaxBlocksToScanBack);
     }
 
     // every time is like the first time if winners list is not synced
@@ -1508,7 +1521,7 @@ void CMasternodeMan::UpdatedBlockTip(const CBlockIndex *pindex)
     if(fMasterNode) {
         DoFullVerificationStep();
         // normal wallet does not need to update this every block, doing update on rpc call should be enough
-        UpdateLastPaid(pindex);
+        UpdateLastPaid();
     }
 }
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -271,6 +271,8 @@ public:
 
     /// Find an entry in the masternode list that is next to be paid
     CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount);
+    /// Same as above but use current block height
+    CMasternode* GetNextMasternodeInQueueForPayment(bool fFilterSigTime, int& nCount);
 
     /// Find a random entry
     CMasternode* FindRandomNotInVec(const std::vector<CTxIn> &vecToExclude, int nProtocolVersion = -1);
@@ -304,7 +306,7 @@ public:
     /// Perform complete check and only then update list and maps
     bool CheckMnbAndUpdateMasternodeList(CMasternodeBroadcast mnb, int& nDos);
 
-    void UpdateLastPaid(const CBlockIndex *pindex);
+    void UpdateLastPaid();
 
     void CheckAndRebuildMasternodeIndex();
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -277,7 +277,7 @@ public:
     /// Find a random entry
     CMasternode* FindRandomNotInVec(const std::vector<CTxIn> &vecToExclude, int nProtocolVersion = -1);
 
-    std::vector<CMasternode> GetFullMasternodeVector() { Check(); return vMasternodes; }
+    std::vector<CMasternode> GetFullMasternodeVector() { return vMasternodes; }
 
     std::vector<std::pair<int, CMasternode> > GetMasternodeRanks(int nBlockHeight = -1, int nMinProtocol=0);
     int GetMasternodeRank(const CTxIn &vin, int nBlockHeight, int nMinProtocol=0, bool fOnlyActive=true);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -74,7 +74,7 @@ int ClientModel::getNumConnections(unsigned int flags) const
 
 QString ClientModel::getMasternodeCountString() const
 {
-    // return tr("Total: %1 (PS compatible: %2 / Enabled: %3) (IPv4: %4, IPv6: %5, TOR: %6)").arg(QString::number((int)mnodeman.size()))
+    LOCK(cs_main);
     return tr("Total: %1 (PS compatible: %2 / Enabled: %3)")
             .arg(QString::number((int)mnodeman.size()))
             .arg(QString::number((int)mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)))

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -74,7 +74,6 @@ int ClientModel::getNumConnections(unsigned int flags) const
 
 QString ClientModel::getMasternodeCountString() const
 {
-    LOCK(cs_main);
     return tr("Total: %1 (PS compatible: %2 / Enabled: %3)")
             .arg(QString::number((int)mnodeman.size()))
             .arg(QString::number((int)mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)))

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -167,9 +167,8 @@ UniValue masternode(const UniValue& params, bool fHelp)
         if (strMode == "enabled")
             return mnodeman.CountEnabled();
 
-        LOCK(cs_main);
         int nCount;
-        mnodeman.GetNextMasternodeInQueueForPayment(chainActive.Height(), true, nCount);
+        mnodeman.GetNextMasternodeInQueueForPayment(true, nCount);
 
         if (strMode == "qualify")
             return nCount;
@@ -184,14 +183,12 @@ UniValue masternode(const UniValue& params, bool fHelp)
     {
         int nCount;
         int nHeight;
-        CBlockIndex* pindex;
         CMasternode* winner = NULL;
         {
             LOCK(cs_main);
             nHeight = chainActive.Height() + (strCommand == "current" ? 1 : 10);
-            pindex = chainActive.Tip();
         }
-        mnodeman.UpdateLastPaid(pindex);
+        mnodeman.UpdateLastPaid();
         winner = mnodeman.GetNextMasternodeInQueueForPayment(nHeight, true, nCount);
         if(!winner) return "unknown";
 
@@ -482,22 +479,12 @@ UniValue masternodelist(const UniValue& params, bool fHelp)
     }
 
     if (strMode == "full" || strMode == "lastpaidtime" || strMode == "lastpaidblock") {
-        CBlockIndex* pindex;
-        {
-            LOCK(cs_main);
-            pindex = chainActive.Tip();
-        }
-        mnodeman.UpdateLastPaid(pindex);
+        mnodeman.UpdateLastPaid();
     }
 
     UniValue obj(UniValue::VOBJ);
     if (strMode == "rank") {
-        int nHeight;
-        {
-            LOCK(cs_main);
-            nHeight = chainActive.Height();
-        }
-        std::vector<std::pair<int, CMasternode> > vMasternodeRanks = mnodeman.GetMasternodeRanks(nHeight);
+        std::vector<std::pair<int, CMasternode> > vMasternodeRanks = mnodeman.GetMasternodeRanks();
         BOOST_FOREACH(PAIRTYPE(int, CMasternode)& s, vMasternodeRanks) {
             std::string strOutpoint = s.second.vin.prevout.ToStringShort();
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2754,7 +2754,7 @@ int CWallet::CountInputsWithAmount(CAmount nInputAmount)
 {
     CAmount nTotal = 0;
     {
-        LOCK(cs_wallet);
+        LOCK2(cs_main, cs_wallet);
         for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
         {
             const CWalletTx* pcoin = &(*it).second;


### PR DESCRIPTION
- [x] moving `cs_main` lock from masternodes to upper lever i.e. mnodeman etc to make sure it's locked first
- [x] fixing all kind of other (potential) deadlocks reported in `DEBUG_LOCKORDER` mode
- [x] less locks for some rpc commands
- [ ] `CGovernanceManager::ConfirmInventoryRequest` `cs` deadlock - not really fixed, lock is disabled for now
- [ ] `CGovernanceTriggerManager::AddNewTrigger` `governance.cs` assert fails in `Read` on `Dump`, can potentially lead to governance data corruption but chances are low imo - not fixed, no changes