### PR TITLE
Removed CGovernanceManager::ClearSeen()

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -875,7 +875,6 @@ void CGovernanceManager::InitOnLoad()
     LOCK(cs);
     RebuildIndexes();
     AddCachedTriggers();
-    ClearSeen();
 }
 
 std::string CGovernanceManager::ToString() const

--- a/src/governance.h
+++ b/src/governance.h
@@ -140,12 +140,6 @@ public:
 
     virtual ~CGovernanceManager() {}
 
-    void ClearSeen()
-    {
-        LOCK(cs);
-        mapSeenGovernanceObjects.clear();
-    }
-
     int CountProposalInventoryItems()
     {
         // TODO What is this for ?


### PR DESCRIPTION
Calling of this function is apparently an oversight from early testing.

It is important that seen governance objects are remembered, otherwise deleted objects could be resurrected and lead to forks.