### PR TITLE
fix excessive banning, remove some redundant logic

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -78,7 +78,7 @@ public:
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
     bool CheckSignature(CPubKey& pubKeyMasternode, int &nDos);
-    bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fSimpleCheck = false);
+    bool CheckAndUpdate(int& nDos, bool fSimpleCheck = false);
     void Relay();
 
     CMasternodePing& operator=(CMasternodePing from)

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -123,9 +123,6 @@ bool CMasternodeMan::Add(CMasternode &mn)
 {
     LOCK(cs);
 
-    if (!mn.IsEnabled() && !mn.IsPreEnabled())
-        return false;
-
     CMasternode *pmn = Find(mn.vin);
     if (pmn == NULL) {
         LogPrint("masternode", "CMasternodeMan::Add -- Adding new Masternode: addr=%s, %i now\n", mn.addr.ToString(), size() + 1);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -733,7 +733,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         LogPrint("masternode", "MNPING -- Masternode ping, masternode=%s new\n", mnp.vin.prevout.ToStringShort());
 
         int nDos = 0;
-        if(mnp.CheckAndUpdate(nDos, false)) return;
+        if(mnp.CheckAndUpdate(nDos)) return;
 
         if(nDos > 0) {
             // if anything significant failed, mark that node


### PR DESCRIPTION
Since we send all mnb's now regardless of mn state ( #1149 ), ping check for `sigTime` being too old is obsolete (and wrong). Removing it should fix excessive banning.

Also removing `fRequireEnabled`, this logic seems to be deprecated too.

NOTE: it looks like non-(pre-)enabled MNs still won't be added to the list on receiving node. If that was the goal of #1149 - `CMasternodeMan::Add()` should be fixed in some way too because it still has this:
```
    if (!mn.IsEnabled() && !mn.IsPreEnabled())
        return false;
```
and therefore actual "add" logic never executes for such MNs if I get it right.

Correct me if I'm wrong pls :)