### PR TITLE
Split CMasternodePing::CheckAndUpdate, fix mnb acceptance in CMasternodeBroadcast::SimpleCheck

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -78,7 +78,8 @@ public:
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
     bool CheckSignature(CPubKey& pubKeyMasternode, int &nDos);
-    bool CheckAndUpdate(int& nDos, bool fSimpleCheck = false);
+    bool SimpleCheck(int& nDos);
+    bool CheckAndUpdate(int& nDos);
     void Relay();
 
     CMasternodePing& operator=(CMasternodePing from)


### PR DESCRIPTION
This is a followup for #1149 and #1172 - looks like we are still not adding mns to the list, but now because ping block hash verification fails.

Moved that ping block hash "too old" check to "full" route and split code into two functions:
- `CMasternodePing::SimpleCheck` - to verify only for future sigTime and for unknown blockhash (used in CMasternodeBroadcast::SimpleCheck)
- `CMasternodePing::CheckAndUpdate` - to verify everything (used everywhere else)