### PR TITLE
Fix masternode rate checks

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -368,6 +368,8 @@ void CGovernanceManager::UpdateCachesAndClean()
 
     if(!pCurrentBlockIndex) return;
 
+    fRateChecksEnabled = false;
+
     LogPrint("gobject", "CGovernanceManager::UpdateCachesAndClean -- After pCurrentBlockIndex (not NULL)\n");
 
     // UPDATE CACHE FOR EACH OBJECT THAT IS FLAGGED DIRTYCACHE=TRUE
@@ -423,6 +425,8 @@ void CGovernanceManager::UpdateCachesAndClean()
             ++it;
         }
     }
+
+    fRateChecksEnabled = true;
 }
 
 CGovernanceObject *CGovernanceManager::FindGovernanceObject(const uint256& nHash)

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -625,6 +625,8 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
 
     // SYNC GOVERNANCE OBJECTS WITH OTHER CLIENT
 
+    LogPrint("gobject", "CGovernanceManager::Sync -- syncing to peer=%d, nProp = %s\n", pfrom->id, nProp.ToString());
+
     {
         LOCK(cs);
         for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
@@ -632,22 +634,38 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
 
             CGovernanceObject& govobj = it->second;
 
-            std::string strError;
-            if(govobj.IsSetCachedValid() &&
-               (nProp == uint256() || h == nProp) &&
-               govobj.IsValidLocally(pCurrentBlockIndex, strError, true)) {
-                // Push the inventory budget proposal message over to the other client
-                pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT, h));
-                ++nInvCount;
+            if((nProp != uint256()) && (h != nProp)) {
+                continue;
+            }
 
-                std::vector<CGovernanceVote> vecVotes = govobj.GetVoteFile().GetVotes();
-                for(size_t i = 0; i < vecVotes.size(); ++i) {
-                    if(!vecVotes[i].IsValid(true)) {
-                        continue;
-                    }
-                    pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT_VOTE, vecVotes[i].GetHash()));
-                    ++nInvCount;
+            LogPrint("gobject", "CGovernanceManager::Sync -- attempting to sync govobj: %s, peer=%d\n", govobj.GetHash().ToString(), pfrom->id);
+
+            std::string strError;
+            bool fIsValid = govobj.IsValidLocally(pCurrentBlockIndex, strError, true); 
+            if(!fIsValid) {
+                LogPrintf("CGovernanceManager::Sync -- not syncing invalid govobj: %s, strError = %s, fCachedValid = %d, peer=%d\n", 
+                         govobj.GetHash().ToString(), strError, govobj.IsSetCachedValid(), pfrom->id);
+                continue;
+            }
+
+            if(!govobj.IsSetCachedValid()) {
+                LogPrintf("CGovernanceManager::Sync -- invalid flag cached, not syncing govobj: %s, fCachedValid = %d, peer=%d\n", 
+                          govobj.GetHash().ToString(), govobj.IsSetCachedValid(), pfrom->id);
+                continue;
+            }
+
+            // Push the inventory budget proposal message over to the other client
+            LogPrint("gobject", "CGovernanceManager::Sync -- syncing govobj: %s, peer=%d\n", govobj.GetHash().ToString(), pfrom->id);
+            pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT, h));
+            ++nInvCount;
+
+            std::vector<CGovernanceVote> vecVotes = govobj.GetVoteFile().GetVotes();
+            for(size_t i = 0; i < vecVotes.size(); ++i) {
+                if(!vecVotes[i].IsValid(true)) {
+                    continue;
                 }
+                pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT_VOTE, vecVotes[i].GetHash()));
+                ++nInvCount;
             }
         }
     }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -629,6 +629,7 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
 
     {
         LOCK(cs);
+        fRateChecksEnabled = false;
         for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
             uint256 h = it->first;
 
@@ -668,6 +669,7 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
                 ++nInvCount;
             }
         }
+        fRateChecksEnabled = true;
     }
 
     pfrom->PushMessage(NetMsgType::SYNCSTATUSCOUNT, MASTERNODE_SYNC_GOVOBJ, nInvCount);

--- a/src/net.h
+++ b/src/net.h
@@ -15,6 +15,7 @@
 #include "streams.h"
 #include "sync.h"
 #include "uint256.h"
+#include "util.h"
 
 #include <deque>
 #include <stdint.h>
@@ -510,8 +511,11 @@ public:
     {
         {
             LOCK(cs_inventory);
-            if (inv.type == MSG_TX && filterInventoryKnown.contains(inv.hash))
+            if (inv.type == MSG_TX && filterInventoryKnown.contains(inv.hash)) {
+                LogPrint("net", "PushInventory --  filtered inv: %s  %s peer=%d\n", inv.ToString(), id);
                 return;
+            }
+            LogPrint("net", "PushInventory --  inv: %s  %s peer=%d\n", inv.ToString(), id);
             vInventoryToSend.push_back(inv);
         }
     }

--- a/src/net.h
+++ b/src/net.h
@@ -512,10 +512,10 @@ public:
         {
             LOCK(cs_inventory);
             if (inv.type == MSG_TX && filterInventoryKnown.contains(inv.hash)) {
-                LogPrint("net", "PushInventory --  filtered inv: %s  %s peer=%d\n", inv.ToString(), id);
+                LogPrint("net", "PushInventory --  filtered inv: %s peer=%d\n", inv.ToString(), id);
                 return;
             }
-            LogPrint("net", "PushInventory --  inv: %s  %s peer=%d\n", inv.ToString(), id);
+            LogPrint("net", "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
             vInventoryToSend.push_back(inv);
         }
     }


### PR DESCRIPTION
This PR should fix one major issue that has been causing governance object syncing failures.

The masternode rate check was on during syncing potentially causing governance objects to be invalidated incorrectly.

This may not be the only syncing bug but I suspect it contributes to many of the problems currently being seen.

Also added logging of errors seen during governance object syncing.