### PR TITLE
bug: release nodes after loop in CMasternodeSync::ProcessTick()

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -412,6 +412,8 @@ void CMasternodeSync::ProcessTick()
             }
         }
     }
+    // looped through all nodes, release them
+    ReleaseNodes(vNodesCopy);
 }
 
 void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindex)


### PR DESCRIPTION
Missed it in #1169 , should fix rare issue ("Timeout downloading block" and no more blocks processed after that until node restart).