### PR TITLE
Update superblock valid checking to allow block creation by p2pool

### DIFF
--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -670,8 +670,7 @@ bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, CAmount b
              nOutputs, nPayments, GetGovernanceObject()->GetDataAsHex());
 
     // We require an exact match (including order) between the expected
-    // superblock payments and the payments actually in the block, after
-    // skipping any initial miner payments.
+    // superblock payments and the payments actually in the block.
 
     if(nMinerPayments < 0) {
         // This means the block cannot have all the superblock payments

--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -719,7 +719,7 @@ bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, CAmount b
         }
 
         if(!fPaymentMatch) {
-            // MISMATCHED SUPERBLOCK OUTPUT!
+            // Superblock payment not found!
 
             CTxDestination address1;
             ExtractDestination(payment.script, address1);


### PR DESCRIPTION
By checking the superblock payment to be in order at the end of Outputs , p2pool could not create this because the end of output is being used by p2pool for its own checking as well.
So, I think it's better to check superblock by finding payment with more loop.