### PR TITLE
Fix some gov sync issues

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -651,6 +651,7 @@ bool CGovernanceObject::GetCurrentMNVotes(const CTxIn& mnCollateralOutpoint, vot
 
 void CGovernanceObject::Relay()
 {
+    if(!masternodeSync.IsSynced()) return;
     CInv inv(MSG_GOVERNANCE_OBJECT, GetHash());
     RelayInv(inv, PROTOCOL_VERSION);
 }

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -235,6 +235,7 @@ CGovernanceVote::CGovernanceVote(CTxIn vinMasternodeIn, uint256 nParentHashIn, v
 
 void CGovernanceVote::Relay() const
 {
+    if(!masternodeSync.IsSynced()) return;
     CInv inv(MSG_GOVERNANCE_OBJECT_VOTE, GetHash());
     RelayInv(inv, PROTOCOL_VERSION);
 }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -199,8 +199,8 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         }
 
         // UPDATE THAT WE'VE SEEN THIS OBJECT
-        mapSeenGovernanceObjects.insert(std::make_pair(govobj.GetHash(), SEEN_OBJECT_IS_VALID));
-        masternodeSync.AddedBudgetItem(govobj.GetHash());
+        mapSeenGovernanceObjects.insert(std::make_pair(nHash, SEEN_OBJECT_IS_VALID));
+        masternodeSync.AddedGovernanceItem();
 
 
         // WE MIGHT HAVE PENDING/ORPHAN VOTES FOR THIS OBJECT
@@ -235,6 +235,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         CGovernanceException exception;
         if(ProcessVote(pfrom, vote, exception)) {
             LogPrint("gobject", "CGovernanceManager -- Accepted vote\n");
+            masternodeSync.AddedGovernanceItem();
         }
         else {
             LogPrint("gobject", "CGovernanceManager -- Rejected vote, error = %s\n", exception.what());

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -55,7 +55,7 @@ void CMasternodeSync::Reset()
     nTimeAssetSyncStarted = GetTime();
     nTimeLastMasternodeList = GetTime();
     nTimeLastPaymentVote = GetTime();
-    nTimeLastBudgetItem = GetTime();
+    nTimeLastGovernanceItem = GetTime();
     nTimeLastFailure = 0;
     nCountFailures = 0;
 }
@@ -95,7 +95,7 @@ void CMasternodeSync::SwitchToNextAsset()
             nRequestedMasternodeAssets = MASTERNODE_SYNC_MNW;
             break;
         case(MASTERNODE_SYNC_MNW):
-            nTimeLastBudgetItem = GetTime();
+            nTimeLastGovernanceItem = GetTime();
             nRequestedMasternodeAssets = MASTERNODE_SYNC_GOVERNANCE;
             break;
         case(MASTERNODE_SYNC_GOVERNANCE):
@@ -374,7 +374,7 @@ void CMasternodeSync::ProcessTick()
                 LogPrint("mnpayments", "CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d nTimeLastPaymentVote %lld GetTime() %lld diff %lld\n", nTick, nRequestedMasternodeAssets, nTimeLastPaymentVote, GetTime(), GetTime() - nTimeLastPaymentVote);
 
                 // check for timeout first
-                if(nTimeLastBudgetItem < GetTime() - MASTERNODE_SYNC_TIMEOUT_SECONDS){
+                if(GetTime() - nTimeLastGovernanceItem > MASTERNODE_SYNC_TIMEOUT_SECONDS) {
                     LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- timeout\n", nTick, nRequestedMasternodeAssets);
                     if(nRequestedMasternodeAttempt == 0) {
                         LogPrintf("CMasternodeSync::ProcessTick -- WARNING: failed to sync %s\n", GetAssetName());
@@ -419,11 +419,4 @@ void CMasternodeSync::ProcessTick()
 void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindex)
 {
     pCurrentBlockIndex = pindex;
-}
-
-
-void CMasternodeSync::AddedBudgetItem(uint256 hash)
-{
-    // skip this for now
-    return;
 }

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -18,7 +18,7 @@ static const int MASTERNODE_SYNC_LIST            = 2;
 static const int MASTERNODE_SYNC_MNW             = 3;
 static const int MASTERNODE_SYNC_GOVERNANCE      = 4;
 static const int MASTERNODE_SYNC_GOVOBJ          = 10;
-static const int MASTERNODE_SYNC_GOVERNANCE_FIN  = 11;
+static const int MASTERNODE_SYNC_GOVOBJ_VOTE     = 11;
 static const int MASTERNODE_SYNC_FINISHED        = 999;
 
 static const int MASTERNODE_SYNC_TIMEOUT_SECONDS = 30; // our blocks are 2.5 minutes so 30 seconds should be fine

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -43,7 +43,7 @@ private:
     // Last time when we received some masternode asset ...
     int64_t nTimeLastMasternodeList;
     int64_t nTimeLastPaymentVote;
-    int64_t nTimeLastBudgetItem;
+    int64_t nTimeLastGovernanceItem;
     // ... or failed
     int64_t nTimeLastFailure;
 
@@ -61,7 +61,7 @@ public:
 
     void AddedMasternodeList() { nTimeLastMasternodeList = GetTime(); }
     void AddedPaymentVote() { nTimeLastPaymentVote = GetTime(); }
-    void AddedBudgetItem(uint256 hash);
+    void AddedGovernanceItem() { nTimeLastGovernanceItem = GetTime(); };
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
     bool IsBlockchainSynced();


### PR DESCRIPTION
- "Don't relay objects and votes until synced" 5c3503c and "reuse GetHash() value, adjust log messages" dc033e2 - should free some bandwidth/cpu for faster processing of received objs/votes, logs adjusted to match same pattern as other ProcessMessage-s (should be easier to grep now imo)
- "fix sync timeout for govobjs" f4b444a - sync wasn't really aware about received objs/votes, this should fix it
- "count objs and votes separately" a7200fd - just to have a better idea on receiving side how many objs/votes (not objs+votes) sending side is claiming to have