### PR TITLE
small IS fixes

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2931,8 +2931,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
     // now we ensure code won't be written that makes assumptions about
     // nLockTime that preclude a fix later.
 
-    // FIXME: "compatibility mode" for 12.0 IX, make it "txNew.nLockTime = chainActive.Height();" again in 12.2
-    txNew.nLockTime = fUseInstantSend ? 0 : chainActive.Height();
+    txNew.nLockTime = chainActive.Height();
 
     // Secondly occasionally randomly pick a nLockTime even further back, so
     // that transactions that are delayed after signing for whatever reason,


### PR DESCRIPTION
- make script verification a part of IsInstantSendTxValid()
- relax nLockTime for IS txes since we don't have compatibility with 12.0 IS txes anyway now (fee is lower in 12.1)
