### PR TITLE
Governance relaying fixes

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -804,7 +804,6 @@ void CGovernanceManager::CheckMasternodeOrphanObjects()
 
         if(AddGovernanceObject(govobj)) {
             LogPrintf("CGovernanceManager::CheckMasternodeOrphanObjects -- %s new\n", govobj.GetHash().ToString());
-            govobj.Relay();
             mapMasternodeOrphanObjects.erase(it++);
         }
         else {

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -237,6 +237,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         if(ProcessVote(pfrom, vote, exception)) {
             LogPrint("gobject", "MNGOVERNANCEOBJECTVOTE -- %s new\n", strHash);
             masternodeSync.AddedGovernanceItem();
+            vote.Relay();
         }
         else {
             LogPrint("gobject", "MNGOVERNANCEOBJECTVOTE -- Rejected vote, error = %s\n", exception.what());
@@ -265,7 +266,6 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, CGovernance
             fRemove = true;
         }
         else if(govobj.ProcessVote(NULL, vote, exception)) {
-            vote.Relay();
             fRemove = true;
         }
         if(fRemove) {
@@ -760,8 +760,6 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
         if(govobj.GetObjectType() == GOVERNANCE_OBJECT_WATCHDOG) {
             mnodeman.UpdateWatchdogVoteTime(vote.GetVinMasternode());
         }
-
-        vote.Relay();
     }
     return fOk;
 }

--- a/src/governance.h
+++ b/src/governance.h
@@ -238,7 +238,11 @@ public:
     bool MasternodeRateCheck(const CTxIn& vin, int nObjectType);
 
     bool ProcessVote(const CGovernanceVote& vote, CGovernanceException& exception) {
-        return ProcessVote(NULL, vote, exception);
+        bool fOK = ProcessVote(NULL, vote, exception);
+        if(fOK) {
+            vote.Relay();
+        }
+        return fOK;
     }
 
     void CheckMasternodeOrphanVotes();

--- a/src/governance.h
+++ b/src/governance.h
@@ -237,7 +237,7 @@ public:
 
     bool MasternodeRateCheck(const CTxIn& vin, int nObjectType);
 
-    bool ProcessVote(const CGovernanceVote& vote, CGovernanceException& exception) {
+    bool ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception) {
         bool fOK = ProcessVote(NULL, vote, exception);
         if(fOK) {
             vote.Relay();

--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -284,7 +284,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
         }
 
         CGovernanceException exception;
-        if(governance.ProcessVote(vote, exception)) {
+        if(governance.ProcessVoteAndRelay(vote, exception)) {
             success++;
             statusObj.push_back(Pair("result", "success"));
         }
@@ -386,7 +386,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
             }
 
             CGovernanceException exception;
-            if(governance.ProcessVote(vote, exception)) {
+            if(governance.ProcessVoteAndRelay(vote, exception)) {
                 success++;
                 statusObj.push_back(Pair("result", "success"));
             }
@@ -511,7 +511,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
             // UPDATE LOCAL DATABASE WITH NEW OBJECT SETTINGS
 
             CGovernanceException exception;
-            if(governance.ProcessVote(vote, exception)) {
+            if(governance.ProcessVoteAndRelay(vote, exception)) {
                 success++;
                 statusObj.push_back(Pair("result", "success"));
             }
@@ -807,7 +807,7 @@ UniValue voteraw(const UniValue& params, bool fHelp)
     }
 
     CGovernanceException exception;
-    if(governance.ProcessVote(vote, exception)) {
+    if(governance.ProcessVoteAndRelay(vote, exception)) {
         return "Voted successfully";
     }
     else {


### PR DESCRIPTION
The main effect of these changes is to avoid relaying objects and votes during orphan processing, which could cause rate check failures and banning.