### PR TITLE
Rate check fixes

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -150,6 +150,7 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
     }
     vote_instance_t& voteInstance = it2->second;
     int64_t nNow = GetTime();
+    int64_t nVoteTimeUpdate = voteInstance.nTime;
     if(governance.AreRateChecksEnabled()) {
         int64_t nTimeDelta = nNow - voteInstance.nTime;
         if(nTimeDelta < GOVERNANCE_UPDATE_MIN) {
@@ -160,6 +161,7 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
                  << ", time delta = " << nTimeDelta << "\n";
             LogPrint("gobject", ostr.str().c_str());
             exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_TEMPORARY_ERROR);
+            nVoteTimeUpdate = nNow;
             return false;
         }
     }
@@ -175,7 +177,7 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
         governance.AddInvalidVote(vote);
         return false;
     }
-    voteInstance = vote_instance_t(vote.GetOutcome(), nNow);
+    voteInstance = vote_instance_t(vote.GetOutcome(), nVoteTimeUpdate);
     fileVotes.AddVote(vote);
     fDirtyCache = true;
     return true;

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -459,15 +459,6 @@ bool CGovernanceObject::IsValidLocally(const CBlockIndex* pindex, std::string& s
                 return false;
             }
 
-            // Only perform rate check if we are synced because during syncing it is expected
-            // that objects will be seen in rapid succession
-            if(masternodeSync.IsSynced()) {
-                if(!governance.MasternodeRateCheck(vinMasternode, nObjectType)) {
-                    strError = "Masternode attempting to create too many objects: " + strOutpoint;
-                    return false;
-                }
-            }
-
             return true;
         }
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -261,6 +261,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, CGovernance
     std::vector<vote_time_pair_t> vecVotePairs;
     mapOrphanVotes.GetAll(nHash, vecVotePairs);
 
+    fRateChecksEnabled = false;
     int64_t nNow = GetAdjustedTime();
     for(size_t i = 0; i < vecVotePairs.size(); ++i) {
         bool fRemove = false;
@@ -277,6 +278,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, CGovernance
             mapOrphanVotes.Erase(nHash, pairVote);
         }
     }
+    fRateChecksEnabled = true;
 }
 
 bool CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj)

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -28,7 +28,7 @@ std::map<uint256, int64_t> mapAskedForGovernanceObject;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-2";
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-3";
 
 CGovernanceManager::CGovernanceManager()
     : pCurrentBlockIndex(NULL),

--- a/src/governance.h
+++ b/src/governance.h
@@ -48,6 +48,26 @@ class CGovernanceManager
     friend class CGovernanceObject;
 
 public: // Types
+    struct last_object_rec {
+        last_object_rec(int nLastTriggerBlockHeightIn = 0, int nLastWatchdogBlockHeightIn = 0)
+            : nLastTriggerBlockHeight(nLastTriggerBlockHeightIn),
+              nLastWatchdogBlockHeight(nLastWatchdogBlockHeightIn)
+            {}
+
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+        {
+            READWRITE(nLastTriggerBlockHeight);
+            READWRITE(nLastWatchdogBlockHeight);
+        }
+
+        int nLastTriggerBlockHeight;
+        int nLastWatchdogBlockHeight;
+    };
+
+
     typedef std::map<uint256, CGovernanceObject> object_m_t;
 
     typedef object_m_t::iterator object_m_it;
@@ -74,7 +94,7 @@ public: // Types
 
     typedef object_m_t::size_type size_type;
 
-    typedef std::map<COutPoint, int> txout_m_t;
+    typedef std::map<COutPoint, last_object_rec > txout_m_t;
 
     typedef txout_m_t::iterator txout_m_it;
 
@@ -124,7 +144,7 @@ private:
 
     vote_mcache_t mapOrphanVotes;
 
-    txout_m_t mapLastMasternodeTrigger;
+    txout_m_t mapLastMasternodeObject;
 
     hash_s_t setRequestedObjects;
 
@@ -186,7 +206,7 @@ public:
         mapVoteToObject.Clear();
         mapInvalidVotes.Clear();
         mapOrphanVotes.Clear();
-        mapLastMasternodeTrigger.clear();
+        mapLastMasternodeObject.clear();
     }
 
     std::string ToString() const;
@@ -209,7 +229,7 @@ public:
         READWRITE(mapOrphanVotes);
         READWRITE(mapObjects);
         READWRITE(mapWatchdogObjects);
-        READWRITE(mapLastMasternodeTrigger);
+        READWRITE(mapLastMasternodeObject);
         if(ser_action.ForRead() && (strVersion != SERIALIZATION_VERSION_STRING)) {
             Clear();
             return;
@@ -235,7 +255,7 @@ public:
 
     void AddSeenVote(uint256 nHash, int status);
 
-    bool MasternodeRateCheck(const CTxIn& vin, int nObjectType);
+    bool MasternodeRateCheck(const CGovernanceObject& govobj, bool fUpdateLast = false);
 
     bool ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception) {
         bool fOK = ProcessVote(NULL, vote, exception);

--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -217,6 +217,9 @@ UniValue gobject(const UniValue& params, bool fHelp)
         }
 
         // RELAY THIS OBJECT
+        if(!governance.MasternodeRateCheck(govobj)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Object creation rate limit exceeded");
+        }
         governance.AddSeenGovernanceObject(govobj.GetHash(), SEEN_OBJECT_IS_VALID);
         govobj.Relay();
         governance.AddGovernanceObject(govobj);


### PR DESCRIPTION
The main change here is to avoid updating the last block height when rate checks are disabled and during masternode sync.

Also fixed the rate check for watchdogs which wasn't working previously.

Moved the rate check into ProcessMessage and rpcgovernance so as to avoid adding rate check failed objects to the seen objects map.  That will allow these objects to be added later if the rate check later passes.