### PR TITLE
Don't increase PoSe ban score when can't connect

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1558,7 +1558,6 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
             } else {
                 LogPrintf("CDarksendPool::DoAutomaticDenominating -- can't connect, addr=%s\n", pmn->addr.ToString());
                 strAutoDenomResult = _("Error connecting to Masternode.");
-                pmn->IncreasePoSeBanScore();
                 continue;
             }
         }
@@ -1611,7 +1610,6 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
         } else {
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- can't connect, addr=%s\n", pmn->addr.ToString());
             nTries++;
-            pmn->IncreasePoSeBanScore();
             continue;
         }
     }


### PR DESCRIPTION
Such behavior can be used as an attack vector to fork the network by filling nodes connection slots using malicious daemon and making such nodes not being able to answer verification requests, so I'm removing it. Also it was kind of ruining the original idea of new PoSe which is to find "good" nodes rather than "bad" ones as we previously did in old PoSe, so this behavior was already a controversial one anyway.

Thanks @ivansib for code review and outlining potential attack 👍 