### PR TITLE
Convert masternode rate checks to use object timestamp

### DIFF
--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -336,6 +336,8 @@ bool CSuperblockManager::IsSuperblockTriggered(int nBlockHeight)
 
         // MAKE SURE THIS TRIGGER IS ACTIVE VIA FUNDING CACHE FLAG
 
+        pObj->UpdateSentinelVariables();
+
         if(pObj->IsSetCachedFunding()) {
             LogPrint("gobject", "CSuperblockManager::IsSuperblockTriggered -- fCacheFunding = true, returning true\n");
             DBG( cout << "IsSuperblockTriggered returning true" << endl; );

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -277,7 +277,7 @@ int CGovernanceObject::GetObjectSubtype()
     return -1;
 }
 
-uint256 CGovernanceObject::GetHash()
+uint256 CGovernanceObject::GetHash() const
 {
     // CREATE HASH OF ALL IMPORTANT PIECES OF DATA
 

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -649,7 +649,7 @@ void CGovernanceObject::Relay()
     RelayInv(inv, PROTOCOL_VERSION);
 }
 
-void CGovernanceObject::UpdateSentinelVariables(const CBlockIndex *pCurrentBlockIndex)
+void CGovernanceObject::UpdateSentinelVariables()
 {
     // CALCULATE MINIMUM SUPPORT LEVELS REQUIRED
 

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -273,7 +273,7 @@ public:
 
     void UpdateLocalValidity(const CBlockIndex *pCurrentBlockIndex);
 
-    void UpdateSentinelVariables(const CBlockIndex *pCurrentBlockIndex);
+    void UpdateSentinelVariables();
 
     int GetObjectSubtype();
 

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -283,7 +283,7 @@ public:
 
     void Relay();
 
-    uint256 GetHash();
+    uint256 GetHash() const;
 
     // GET VOTE COUNT FOR SIGNAL
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -28,7 +28,7 @@ std::map<uint256, int64_t> mapAskedForGovernanceObject;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-3";
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-4";
 
 CGovernanceManager::CGovernanceManager()
     : pCurrentBlockIndex(NULL),

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -734,10 +734,10 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
             it = mapLastMasternodeObject.insert(txout_m_t::value_type(vin.prevout, last_object_rec(0, 0, true))).first;
             switch(nObjectType) {
             case GOVERNANCE_OBJECT_TRIGGER:
-                it->second.nLastTriggerTime = nTimestamp;
+                it->second.nLastTriggerTime = std::max(it->second.nLastTriggerTime, nTimestamp);
                 break;
             case GOVERNANCE_OBJECT_WATCHDOG:
-                it->second.nLastWatchdogTime = nTimestamp;
+                it->second.nLastWatchdogTime = std::max(it->second.nLastWatchdogTime, nTimestamp);
                 break;
             default:
                 break;
@@ -773,14 +773,14 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
         nMinDiff = int64_t(0.9 * nSuperblockCycleSeconds);
         nLastObjectTime = it->second.nLastTriggerTime;
         if(fUpdateLast) {
-            it->second.nLastTriggerTime = nTimestamp;
+            it->second.nLastTriggerTime = std::max(it->second.nLastTriggerTime, nTimestamp);
         }
         break;
     case GOVERNANCE_OBJECT_WATCHDOG:
         nMinDiff = Params().GetConsensus().nPowTargetSpacing;
         nLastObjectTime = it->second.nLastWatchdogTime;
         if(fUpdateLast) {
-            it->second.nLastWatchdogTime = nTimestamp;
+            it->second.nLastWatchdogTime = std::max(it->second.nLastWatchdogTime, nTimestamp);
         }
         break;
     default:

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -203,7 +203,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         // UPDATE CACHED VARIABLES FOR THIS OBJECT AND ADD IT TO OUR MANANGED DATA
 
-        govobj.UpdateSentinelVariables(pCurrentBlockIndex); //this sets local vars in object
+        govobj.UpdateSentinelVariables(); //this sets local vars in object
 
         if(AddGovernanceObject(govobj))
         {
@@ -406,7 +406,7 @@ void CGovernanceManager::UpdateCachesAndClean()
             pObj->UpdateLocalValidity(pCurrentBlockIndex);
 
             // UPDATE SENTINEL SIGNALING VARIABLES
-            pObj->UpdateSentinelVariables(pCurrentBlockIndex);
+            pObj->UpdateSentinelVariables();
         }
 
         // IF DELETE=TRUE, THEN CLEAN THE MESS UP!

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -754,13 +754,13 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
     std::string strHash = govobj.GetHash().ToString();
 
     if(nTimestamp < nNow - 2 * nSuperblockCycleSeconds) {
-        LogPrint("gobject", "CGovernanceManager::MasternodeRateCheck -- object %s rejected due to too old timestamp, masternode vin = %s, timestamp = %d, current time = %d\n",
+        LogPrintf("CGovernanceManager::MasternodeRateCheck -- object %s rejected due to too old timestamp, masternode vin = %s, timestamp = %d, current time = %d\n",
                  strHash, vin.prevout.ToStringShort(), nTimestamp, nNow);
         return false;
     }
 
     if(nTimestamp > nNow - 2 * nSuperblockCycleSeconds) {
-        LogPrint("gobject", "CGovernanceManager::MasternodeRateCheck -- object %s rejected due to too new (future) timestamp, masternode vin = %s, timestamp = %d, current time = %d\n",
+        LogPrintf("CGovernanceManager::MasternodeRateCheck -- object %s rejected due to too new (future) timestamp, masternode vin = %s, timestamp = %d, current time = %d\n",
                  strHash, vin.prevout.ToStringShort(), nTimestamp, nNow);
         return false;
     }
@@ -799,7 +799,7 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
         }
     }
 
-    LogPrintf("CGovernanceManager::MasternodeRateCheck -- Rate too high: object hash = %s, vin = %s, object timestamp = %d, last timestamp = %d, minimum difference = %d\n",
+    LogPrintf("CGovernanceManager::MasternodeRateCheck -- Rate too high: object hash = %s, masternode vin = %s, object timestamp = %d, last timestamp = %d, minimum difference = %d\n",
               strHash, vin.prevout.ToStringShort(), nTimestamp, nLastObjectTime, nMinDiff);
     return false;
 }

--- a/src/governance.h
+++ b/src/governance.h
@@ -49,9 +49,10 @@ class CGovernanceManager
 
 public: // Types
     struct last_object_rec {
-        last_object_rec(int nLastTriggerBlockHeightIn = 0, int nLastWatchdogBlockHeightIn = 0)
+        last_object_rec(int nLastTriggerBlockHeightIn = 0, int nLastWatchdogBlockHeightIn = 0, bool fStatusOKIn = true)
             : nLastTriggerBlockHeight(nLastTriggerBlockHeightIn),
-              nLastWatchdogBlockHeight(nLastWatchdogBlockHeightIn)
+              nLastWatchdogBlockHeight(nLastWatchdogBlockHeightIn),
+              fStatusOK(fStatusOKIn)
             {}
 
         ADD_SERIALIZE_METHODS;
@@ -61,10 +62,12 @@ public: // Types
         {
             READWRITE(nLastTriggerBlockHeight);
             READWRITE(nLastWatchdogBlockHeight);
+            READWRITE(fStatusOK);
         }
 
         int nLastTriggerBlockHeight;
         int nLastWatchdogBlockHeight;
+        bool fStatusOK;
     };
 
 
@@ -256,6 +259,8 @@ public:
     void AddSeenVote(uint256 nHash, int status);
 
     bool MasternodeRateCheck(const CGovernanceObject& govobj, bool fUpdateLast = false);
+
+    bool MasternodeRateCheck(const CGovernanceObject& govobj, bool fUpdateLast, bool fForce, bool& fRateCheckBypassed);
 
     bool ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception) {
         bool fOK = ProcessVote(NULL, vote, exception);

--- a/src/governance.h
+++ b/src/governance.h
@@ -49,9 +49,9 @@ class CGovernanceManager
 
 public: // Types
     struct last_object_rec {
-        last_object_rec(int nLastTriggerBlockHeightIn = 0, int nLastWatchdogBlockHeightIn = 0, bool fStatusOKIn = true)
-            : nLastTriggerBlockHeight(nLastTriggerBlockHeightIn),
-              nLastWatchdogBlockHeight(nLastWatchdogBlockHeightIn),
+        last_object_rec(int64_t nLastTriggerTimeIn = 0, int64_t nLastWatchdogTimeIn = 0, bool fStatusOKIn = true)
+            : nLastTriggerTime(nLastTriggerTimeIn),
+              nLastWatchdogTime(nLastWatchdogTimeIn),
               fStatusOK(fStatusOKIn)
             {}
 
@@ -60,13 +60,13 @@ public: // Types
         template <typename Stream, typename Operation>
         inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
         {
-            READWRITE(nLastTriggerBlockHeight);
-            READWRITE(nLastWatchdogBlockHeight);
+            READWRITE(nLastTriggerTime);
+            READWRITE(nLastWatchdogTime);
             READWRITE(fStatusOK);
         }
 
-        int nLastTriggerBlockHeight;
-        int nLastWatchdogBlockHeight;
+        int64_t nLastTriggerTime;
+        int64_t nLastWatchdogTime;
         bool fStatusOK;
     };
 


### PR DESCRIPTION
The main change in this PR is to use object timestamps instead of arrival times in the masternode rate checks for triggers and watchdogs.  In order for this to be an effective constraint it is necessary to reject triggers that are older or newer than a certain time delta relative to the current time.  This delta is chosen to be twice the superblock period.  

Changes were also made in the way the rate check function is called to prevent possible DoS attacks.  It is generally necessary to verify the object signature before rejecting an object due to the rate check because an attacker could otherwise forge the masternode vin and block objects from that masternode.  However if we always check the signature first, which is cpu intensive, an attacker could overload machines by creating huge numbers of objects.  What we do then is to maintain a status flag for each masternode along with the last seen object times.  If the status is OK we check the signature before performing the rate check.  However if the masternode has previously violated the rate check we immediately reject future objects from that masternode which continue to violate the rate check.

Finally there is one small unrelated change which ensures that the cached funding variable is updated before blocks are checked for validity relative to superblocks.

Note that for the DoS protections above to be effective it is necessary to change the governance object hash function (which is used for signing) to include the masternode vin.  Since this requires a protocol bump it has been left out of this PR to simplify testing.