### PR TITLE
Implement rate check using buffer

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -66,6 +66,7 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
+  test/ratecheck_tests.cpp \
   test/reverselock_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -759,7 +759,7 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
         return false;
     }
 
-    if(nTimestamp > nNow + 2 * nSuperblockCycleSeconds) {
+    if(nTimestamp > nNow + 60*60) {
         LogPrintf("CGovernanceManager::MasternodeRateCheck -- object %s rejected due to too new (future) timestamp, masternode vin = %s, timestamp = %d, current time = %d\n",
                  strHash, vin.prevout.ToStringShort(), nTimestamp, nNow);
         return false;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -28,7 +28,7 @@ std::map<uint256, int64_t> mapAskedForGovernanceObject;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-4";
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-5";
 
 CGovernanceManager::CGovernanceManager()
     : pCurrentBlockIndex(NULL),
@@ -731,13 +731,13 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
 
     if(it == mapLastMasternodeObject.end()) {
         if(fUpdateLast) {
-            it = mapLastMasternodeObject.insert(txout_m_t::value_type(vin.prevout, last_object_rec(0, 0, true))).first;
+            it = mapLastMasternodeObject.insert(txout_m_t::value_type(vin.prevout, last_object_rec(true))).first;
             switch(nObjectType) {
             case GOVERNANCE_OBJECT_TRIGGER:
-                it->second.nLastTriggerTime = std::max(it->second.nLastTriggerTime, nTimestamp);
+                it->second.triggerBuffer.AddTimestamp(nTimestamp);
                 break;
             case GOVERNANCE_OBJECT_WATCHDOG:
-                it->second.nLastWatchdogTime = std::max(it->second.nLastWatchdogTime, nTimestamp);
+                it->second.watchdogBuffer.AddTimestamp(nTimestamp);
                 break;
             default:
                 break;
@@ -764,30 +764,35 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
                  strHash, vin.prevout.ToStringShort(), nTimestamp, nNow);
         return false;
     }
-
-    int64_t nMinDiff = 0;
-    int64_t nLastObjectTime = 0;
+    
+    double dMaxRate = 1.1 / nSuperblockCycleSeconds;
+    double dRate = 0.0;
+    CRateCheckBuffer buffer;
     switch(nObjectType) {
     case GOVERNANCE_OBJECT_TRIGGER:
         // Allow 1 trigger per mn per cycle, with a small fudge factor
-        nMinDiff = int64_t(0.9 * nSuperblockCycleSeconds);
-        nLastObjectTime = it->second.nLastTriggerTime;
+        dMaxRate = 1.1 / nSuperblockCycleSeconds;
+        buffer = it->second.triggerBuffer;
+        buffer.AddTimestamp(nTimestamp);
+        dRate = buffer.GetRate();
         if(fUpdateLast) {
-            it->second.nLastTriggerTime = std::max(it->second.nLastTriggerTime, nTimestamp);
+            it->second.triggerBuffer.AddTimestamp(nTimestamp);
         }
         break;
     case GOVERNANCE_OBJECT_WATCHDOG:
-        nMinDiff = Params().GetConsensus().nPowTargetSpacing;
-        nLastObjectTime = it->second.nLastWatchdogTime;
+        dMaxRate = 1.1 / 3600.;
+        buffer = it->second.watchdogBuffer;
+        buffer.AddTimestamp(nTimestamp);
+        dRate = buffer.GetRate();
         if(fUpdateLast) {
-            it->second.nLastWatchdogTime = std::max(it->second.nLastWatchdogTime, nTimestamp);
+            it->second.watchdogBuffer.AddTimestamp(nTimestamp);
         }
         break;
     default:
         break;
     }
 
-    if((nTimestamp - nLastObjectTime) > nMinDiff) {
+    if(dRate < dMaxRate) {
         if(fUpdateLast) {
             it->second.fStatusOK = true;
         }
@@ -799,8 +804,8 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
         }
     }
 
-    LogPrintf("CGovernanceManager::MasternodeRateCheck -- Rate too high: object hash = %s, masternode vin = %s, object timestamp = %d, last timestamp = %d, minimum difference = %d\n",
-              strHash, vin.prevout.ToStringShort(), nTimestamp, nLastObjectTime, nMinDiff);
+    LogPrintf("CGovernanceManager::MasternodeRateCheck -- Rate too high: object hash = %s, masternode vin = %s, object timestamp = %d, rate = %f, max rate = %f\n",
+              strHash, vin.prevout.ToStringShort(), nTimestamp, dRate, dMaxRate);
     return false;
 }
 

--- a/src/test/ratecheck_tests.cpp
+++ b/src/test/ratecheck_tests.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2014-2016 The Dash Core developers
+
+#include "governance.h"
+
+#include "test/test_dash.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(ratecheck_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(ratecheck_test)
+{
+    CRateCheckBuffer buffer;
+
+    BOOST_CHECK(buffer.GetCount() == 0);
+    BOOST_CHECK(buffer.GetMinTimestamp() == numeric_limits<int64_t>::max());
+    BOOST_CHECK(buffer.GetMaxTimestamp() == 0);
+    BOOST_CHECK(buffer.GetRate() == 0.0);
+
+    buffer.AddTimestamp(1);
+
+    std::cout << "buffer.GetMinTimestamp() = " << buffer.GetMinTimestamp() << std::endl;
+
+    BOOST_CHECK(buffer.GetCount() == 1);
+    BOOST_CHECK(buffer.GetMinTimestamp() == 1);
+    BOOST_CHECK(buffer.GetMaxTimestamp() == 1);
+    BOOST_CHECK(buffer.GetRate() == 0.0);
+
+    buffer.AddTimestamp(2);
+    BOOST_CHECK(buffer.GetCount() == 2);
+    BOOST_CHECK(buffer.GetMinTimestamp() == 1);
+    BOOST_CHECK(buffer.GetMaxTimestamp() == 2);
+    BOOST_CHECK(fabs(buffer.GetRate() - 2.0) < 1.0e-9);
+
+    buffer.AddTimestamp(3);
+    BOOST_CHECK(buffer.GetCount() == 3);
+    BOOST_CHECK(buffer.GetMinTimestamp() == 1);
+    BOOST_CHECK(buffer.GetMaxTimestamp() == 3);
+
+    int64_t nMin = buffer.GetMinTimestamp();
+    int64_t nMax = buffer.GetMaxTimestamp();
+    double dRate = buffer.GetRate();
+
+    std::cout << "buffer.GetCount() = " << buffer.GetCount() << std::endl;
+    std::cout << "nMin = " << nMin << std::endl;
+    std::cout << "nMax = " << nMax << std::endl;
+    std::cout << "buffer.GetRate() = " << dRate << std::endl;
+
+    BOOST_CHECK(fabs(buffer.GetRate() - (3.0/2.0)) < 1.0e-9);
+
+    buffer.AddTimestamp(4);
+    BOOST_CHECK(buffer.GetCount() == 4);
+    BOOST_CHECK(buffer.GetMinTimestamp() == 1);
+    BOOST_CHECK(buffer.GetMaxTimestamp() == 4);
+    BOOST_CHECK(fabs(buffer.GetRate() - (4.0/3.0)) < 1.0e-9);
+
+    buffer.AddTimestamp(5);
+    BOOST_CHECK(buffer.GetCount() == 5);
+    BOOST_CHECK(buffer.GetMinTimestamp() == 1);
+    BOOST_CHECK(buffer.GetMaxTimestamp() == 5);
+    BOOST_CHECK(fabs(buffer.GetRate() - (5.0/4.0)) < 1.0e-9);
+
+    buffer.AddTimestamp(6);
+    BOOST_CHECK(buffer.GetCount() == 5);
+    BOOST_CHECK(buffer.GetMinTimestamp() == 2);
+    BOOST_CHECK(buffer.GetMaxTimestamp() == 6);
+    BOOST_CHECK(fabs(buffer.GetRate() - (5.0/4.0)) < 1.0e-9);
+
+    CRateCheckBuffer buffer2;
+
+    std::cout << "Before loop tests" << std::endl;
+    for(int64_t i = 1; i < 11; ++i)  {
+        std::cout << "In loop: i = " << i << std::endl;
+        buffer2.AddTimestamp(i);
+        BOOST_CHECK(buffer2.GetCount() == (i <= 5 ? i : 5));
+        BOOST_CHECK(buffer2.GetMinTimestamp() == max(int64_t(1), i - 4));
+        BOOST_CHECK(buffer2.GetMaxTimestamp() == i);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes a potential bug in the masternode rate check for objects due the fact that the time delta is dependent on the order of arrival of objects.

The rate is now computed using a buffer containing the timestamps of up to the 5 most recently received objects.  This eliminates the order dependence.

In addition the upper limit on timestamps has been reduced to 1 hour in the future.