### PR TITLE
Restore relaying and fix rate threshold

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -732,6 +732,7 @@ void CGovernanceObject::CheckOrphanVotes()
             LogPrintf("CGovernanceObject::CheckOrphanVotes -- Failed to add orphan vote: %s\n", exception.what());
         }
         else {
+            vote.Relay();
             fRemove = true;
         }
         ++it;

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -644,7 +644,6 @@ bool CGovernanceObject::GetCurrentMNVotes(const CTxIn& mnCollateralOutpoint, vot
 
 void CGovernanceObject::Relay()
 {
-    if(!masternodeSync.IsSynced()) return;
     CInv inv(MSG_GOVERNANCE_OBJECT, GetHash());
     RelayInv(inv, PROTOCOL_VERSION);
 }

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -235,7 +235,6 @@ CGovernanceVote::CGovernanceVote(CTxIn vinMasternodeIn, uint256 nParentHashIn, v
 
 void CGovernanceVote::Relay() const
 {
-    if(!masternodeSync.IsSynced()) return;
     CInv inv(MSG_GOVERNANCE_OBJECT_VOTE, GetHash());
     RelayInv(inv, PROTOCOL_VERSION);
 }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -786,7 +786,7 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
     switch(nObjectType) {
     case GOVERNANCE_OBJECT_TRIGGER:
         // Allow 1 trigger per mn per cycle, with a small fudge factor
-        dMaxRate = 1.1 / nSuperblockCycleSeconds;
+        dMaxRate = 2 * 1.1 / double(nSuperblockCycleSeconds);
         buffer = it->second.triggerBuffer;
         buffer.AddTimestamp(nTimestamp);
         dRate = buffer.GetRate();
@@ -795,7 +795,7 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
         }
         break;
     case GOVERNANCE_OBJECT_WATCHDOG:
-        dMaxRate = 1.1 / 3600.;
+        dMaxRate = 2 * 1.1 / 3600.;
         buffer = it->second.watchdogBuffer;
         buffer.AddTimestamp(nTimestamp);
         dRate = buffer.GetRate();

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -280,6 +280,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, CGovernance
             fRemove = true;
         }
         else if(govobj.ProcessVote(NULL, vote, exception)) {
+            vote.Relay();
             fRemove = true;
         }
         if(fRemove) {

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -907,6 +907,7 @@ void CGovernanceManager::CheckMasternodeOrphanObjects()
 
         if(AddGovernanceObject(govobj)) {
             LogPrintf("CGovernanceManager::CheckMasternodeOrphanObjects -- %s new\n", govobj.GetHash().ToString());
+            govobj.Relay();
             mapMasternodeOrphanObjects.erase(it++);
         }
         else {


### PR DESCRIPTION
This PR restores relaying of objects and votes during syncing and orphan processing.  These were turned off in earlier PR's due to problems with the rate check but now that the object rate check has been changed to not use arrival time it should be possible to restore these relaying mechanisms.  Leaving these disabled may cause problems for object propagation in certain situations.

In addition the rate check threshold has been doubled to account for the fact that 2 objects with the minimum acceptable spacing could lead to a calculated rate double the correct rate.