### PR TITLE
Fix governance hash

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -19,7 +19,7 @@ static const int PRIVATESEND_QUEUE_TIMEOUT          = 30;
 static const int PRIVATESEND_SIGNING_TIMEOUT        = 15;
 
 //! minimum peer version accepted by mixing pool
-static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70203;
+static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70204;
 
 static const CAmount PRIVATESEND_COLLATERAL         = 0.001 * COIN;
 static const CAmount PRIVATESEND_POOL_MAX           = 999.999 * COIN;

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -223,6 +223,19 @@ void CGovernanceObject::ClearMasternodeVotes()
     }
 }
 
+std::string CGovernanceObject::GetSignatureMessage() const
+{
+    LOCK(cs);
+    std::string strMessage = nHashParent.ToString() + "|" +
+        boost::lexical_cast<std::string>(nRevision) + "|" +
+        boost::lexical_cast<std::string>(nTime) + "|" +
+        strData + "|" +
+        vinMasternode.prevout.ToStringShort() + "|" +
+        nCollateralHash.ToString();
+
+    return strMessage;
+}
+
 void CGovernanceObject::SetMasternodeInfo(const CTxIn& vin)
 {
     vinMasternode = vin;
@@ -230,11 +243,10 @@ void CGovernanceObject::SetMasternodeInfo(const CTxIn& vin)
 
 bool CGovernanceObject::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    LOCK(cs);
-
     std::string strError;
-    uint256 nHash = GetHash();
-    std::string strMessage = nHash.ToString();
+    std::string strMessage = GetSignatureMessage();
+
+    LOCK(cs);
 
     if(!darkSendSigner.SignMessage(strMessage, vchSig, keyMasternode)) {
         LogPrintf("CGovernanceObject::Sign -- SignMessage() failed\n");
@@ -255,11 +267,11 @@ bool CGovernanceObject::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 
 bool CGovernanceObject::CheckSignature(CPubKey& pubKeyMasternode)
 {
-    LOCK(cs);
     std::string strError;
-    uint256 nHash = GetHash();
-    std::string strMessage = nHash.ToString();
 
+    std::string strMessage = GetSignatureMessage();
+
+    LOCK(cs);
     if(!darkSendSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
         LogPrintf("CGovernance::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
         return false;
@@ -288,6 +300,7 @@ uint256 CGovernanceObject::GetHash() const
     ss << strData;
     ss << vinMasternode;
     ss << nCollateralHash;
+    ss << vchSig;
     // fee_tx is left out on purpose
     uint256 h1 = ss.GetHash();
 

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -287,6 +287,7 @@ uint256 CGovernanceObject::GetHash() const
     ss << nTime;
     ss << strData;
     ss << vinMasternode;
+    ss << nCollateralHash;
     // fee_tx is left out on purpose
     uint256 h1 = ss.GetHash();
 

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -286,6 +286,7 @@ uint256 CGovernanceObject::GetHash() const
     ss << nRevision;
     ss << nTime;
     ss << strData;
+    ss << vinMasternode;
     // fee_tx is left out on purpose
     uint256 h1 = ss.GetHash();
 

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -299,7 +299,6 @@ uint256 CGovernanceObject::GetHash() const
     ss << nTime;
     ss << strData;
     ss << vinMasternode;
-    ss << nCollateralHash;
     ss << vchSig;
     // fee_tx is left out on purpose
     uint256 h1 = ss.GetHash();

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -35,7 +35,7 @@ class CGovernanceObject;
 class CGovernanceVote;
 
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
-static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70203;
+static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70204;
 
 static const int GOVERNANCE_OBJECT_UNKNOWN = 0;
 static const int GOVERNANCE_OBJECT_PROPOSAL = 1;

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -262,6 +262,8 @@ public:
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
     bool CheckSignature(CPubKey& pubKeyMasternode);
 
+    std::string GetSignatureMessage() const;
+
     // CORE OBJECT FUNCTIONS
 
     bool IsValidLocally(const CBlockIndex* pindex, std::string& strError, bool fCheckCollateral);

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -28,7 +28,7 @@ std::map<uint256, int64_t> mapAskedForGovernanceObject;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-5";
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-6";
 
 CGovernanceManager::CGovernanceManager()
     : pCurrentBlockIndex(NULL),

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -28,7 +28,7 @@ static const int INSTANTSEND_SIGNATURES_REQUIRED    = 6;
 static const int INSTANTSEND_SIGNATURES_TOTAL       = 10;
 static const int DEFAULT_INSTANTSEND_DEPTH          = 5;
 
-static const int MIN_INSTANTSEND_PROTO_VERSION      = 70203;
+static const int MIN_INSTANTSEND_PROTO_VERSION      = 70204;
 static const CAmount INSTANTSEND_MIN_FEE            = 0.001 * COIN;
 
 extern bool fEnableInstantSend;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -24,7 +24,7 @@ static const int MNPAYMENTS_SIGNATURES_TOTAL            = 10;
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
 static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70103;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70203;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70204;
 
 extern CCriticalSection cs_vecPayees;
 extern CCriticalSection cs_mapMasternodeBlocks;

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70203;
+static const int PROTOCOL_VERSION = 70204;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
This adds vinMasternode to the governance object hash and signature to protect against a DoS vulnerability in the rate check.

Network protocol and serialization format bumped to avoid having hashes changed for existing objects.  This will flush all old governance objects from dashd.