### PR TITLE
local nLastDsq

### DIFF
--- a/dash-docs/protocol-documentation.md
+++ b/dash-docs/protocol-documentation.md
@@ -67,7 +67,7 @@ Whenever a masternode comes online or a client is syncing, they will send this m
 | 8 | sigTime | int64_t | Time which the signature was created
 | 4 | nProtocolVersion | int | The protocol version of the masternode
 | # | lastPing | CMasternodePing | The last known ping of the masternode
-| 8 | nLastDsq | int64_t | The last time the masternode sent a DSQ message (for mixing)
+| 8 | nLastDsq | int64_t | The last time the masternode sent a DSQ message (for mixing) (DEPRECATED)
 
 ### MNPING - "mnp"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5145,6 +5145,10 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
                         ss << mnodeman.mapSeenMasternodeBroadcast[inv.hash];
+                        // backward compatibility patch
+                        if(pfrom->nVersion < 70204) {
+                            ss << (int64_t)0;
+                        }
                         pfrom->PushMessage(NetMsgType::MNANNOUNCE, ss);
                         pushed = true;
                     }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -90,7 +90,7 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
     lastPing(mnb.lastPing),
     vchSig(mnb.vchSig),
     sigTime(mnb.sigTime),
-    nLastDsq(mnb.nLastDsq),
+    nLastDsq(0),
     nTimeLastChecked(0),
     nTimeLastPaid(0),
     nTimeLastWatchdogVote(mnb.sigTime),

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -342,7 +342,6 @@ public:
         READWRITE(sigTime);
         READWRITE(nProtocolVersion);
         READWRITE(lastPing);
-        READWRITE(nLastDsq);
     }
 
     uint256 GetHash() const

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -19,7 +19,7 @@
 /** Masternode manager */
 CMasternodeMan mnodeman;
 
-const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-1";
+const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-2";
 
 struct CompareLastPaidBlock
 {
@@ -699,6 +699,12 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         CMasternodeBroadcast mnb;
         vRecv >> mnb;
+
+        // backward compatibility patch
+        if(pfrom->nVersion < 70204) {
+            int64_t nLastDsqDummy;
+            vRecv >> nLastDsqDummy;
+        }
 
         int nDos = 0;
 


### PR DESCRIPTION
Revert behaviour introduced in 5e1a6afe7f42bb8aac55417f0ab37681ecbb6a91, make `nLastDsq` local variable again instead of being network-wide one. Should fix mixing for new clients and for those who was offline for too long.

Implemented with backward compatibility so that we were able to talk to old nodes and get/send mn list (these patches can be removed after migration on mainnet is done).

Bumped `CMasternodeMan::SERIALIZATION_VERSION_STRING` to clean mncache.dat and repopulate it with MNs records containing initial `nLastDsq` value (0).