### PR TITLE
Implement superblock offset

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -82,7 +82,7 @@ public:
         consensus.nBudgetPaymentsCycleBlocks = 16616; // ~(60*24*30)/2.6, actual number of blocks per month is 200700 / 12 = 16725
         consensus.nBudgetPaymentsWindowBlocks = 100;
         consensus.nBudgetProposalEstablishingTime = 60*60*24;
-        consensus.nSuperblockStartBlock = 600000; // TODO, the block at which 12.1 goes live.
+        consensus.nSuperblockStartBlock = 764336; // TODO, the block at which 12.1 goes live.
         consensus.nSuperblockCycle = 16616; // ~(60*24*30)/2.6, actual number of blocks per month is 200700 / 12 = 16725
         consensus.nGovernanceMinQuorum = 10;
         consensus.nMasternodeMinimumConfirmations = 15;
@@ -206,7 +206,7 @@ public:
         consensus.nBudgetPaymentsCycleBlocks = 50;
         consensus.nBudgetPaymentsWindowBlocks = 10;
         consensus.nBudgetProposalEstablishingTime = 60*20;
-        consensus.nSuperblockStartBlock = 61000; // NOTE: Should satisfy nSuperblockStartBlock > nBudgetPeymentsStartBlock
+        consensus.nSuperblockStartBlock = 61008; // NOTE: Should satisfy nSuperblockStartBlock > nBudgetPeymentsStartBlock
         consensus.nSuperblockCycle = 24; // Superblocks can be issued hourly on testnet
         consensus.nGovernanceMinQuorum = 1;
         consensus.nMasternodeMinimumConfirmations = 1;
@@ -312,7 +312,7 @@ public:
         consensus.nBudgetPaymentsCycleBlocks = 50;
         consensus.nBudgetPaymentsWindowBlocks = 10;
         consensus.nBudgetProposalEstablishingTime = 60*20;
-        consensus.nSuperblockStartBlock = 1500;
+        consensus.nSuperblockStartBlock = 1512;
         consensus.nSuperblockCycle = 10;
         consensus.nGovernanceMinQuorum = 1;
         consensus.nMasternodeMinimumConfirmations = 1;

--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -521,7 +521,7 @@ bool CSuperblock::IsValidBlockHeight(int nBlockHeight)
 {
     // SUPERBLOCKS CAN HAPPEN ONLY after hardfork and only ONCE PER CYCLE
     return nBlockHeight >= Params().GetConsensus().nSuperblockStartBlock &&
-            ((nBlockHeight % Params().GetConsensus().nSuperblockCycle) == 0);
+        (((nBlockHeight - Params().GetConsensus().nSuperblockStartBlock)  % Params().GetConsensus().nSuperblockCycle) == 0);
 }
 
 CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)

--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -840,6 +840,7 @@ UniValue getgovernanceinfo(const UniValue& params, bool fHelp)
             "  \"masternodewatchdogmaxseconds\": xxxxx,  (numeric) sentinel watchdog expiration time in seconds\n"
             "  \"proposalfee\": xxx.xx,                  (numeric) the collateral transaction fee which must be paid to create a proposal in " + CURRENCY_UNIT + "\n"
             "  \"superblockcycle\": xxxxx,               (numeric) the number of blocks between superblocks\n"
+            "  \"superstartblock\": xxxxx,               (numeric) the block number of the first superblock\n"
             "  \"lastsuperblock\": xxxxx,                (numeric) the block number of the last superblock\n"
             "  \"nextsuperblock\": xxxxx,                (numeric) the block number of the next superblock\n"
             "}\n"
@@ -863,15 +864,11 @@ UniValue getgovernanceinfo(const UniValue& params, bool fHelp)
     int nSuperblockStartBlock = Params().GetConsensus().nSuperblockStartBlock;
     int nSuperblockCycle = Params().GetConsensus().nSuperblockCycle;
 
-    // Get first superblock
-    int nFirstSuperblockOffset = (nSuperblockCycle - nSuperblockStartBlock % nSuperblockCycle) % nSuperblockCycle;
-    int nFirstSuperblock = nSuperblockStartBlock + nFirstSuperblockOffset;
-
-    if(nBlockHeight < nFirstSuperblock){
+    if(nBlockHeight < nSuperblockStartBlock) {
         nLastSuperblock = 0;
-        nNextSuperblock = nFirstSuperblock;
+        nNextSuperblock = nSuperblockStartBlock;
     } else {
-        nLastSuperblock = nBlockHeight - nBlockHeight % nSuperblockCycle;
+        nLastSuperblock = nBlockHeight - (nBlockHeight - nSuperblockStartBlock) % nSuperblockCycle;
         nNextSuperblock = nLastSuperblock + nSuperblockCycle;
     }
 
@@ -879,7 +876,8 @@ UniValue getgovernanceinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("governanceminquorum", Params().GetConsensus().nGovernanceMinQuorum));
     obj.push_back(Pair("masternodewatchdogmaxseconds", MASTERNODE_WATCHDOG_MAX_SECONDS));
     obj.push_back(Pair("proposalfee", ValueFromAmount(GOVERNANCE_PROPOSAL_FEE_TX)));
-    obj.push_back(Pair("superblockcycle", Params().GetConsensus().nSuperblockCycle));
+    obj.push_back(Pair("superblockcycle", nSuperblockCycle));
+    obj.push_back(Pair("superblockstartblock", nSuperblockStartBlock));
     obj.push_back(Pair("lastsuperblock", nLastSuperblock));
     obj.push_back(Pair("nextsuperblock", nNextSuperblock));
 


### PR DESCRIPTION
The existing formula for superblock heights did not align with superblocks on mainnet.

This PR changes the way nSuperblockStartBlock is used so that it now acts as an offset allowing the superblock cycle to be set to start at any arbitrary block.

nSuperblockStartBlock for testnet was changed to maintain the same cycle as we currently have on testnet.

For mainnet it has been set to a value that aligns with the current mainnet superblock cycle but remains in the future until a decision is made on the deployment date.