### PR TITLE
V0.12.0.x [build] fix deprecated download paths

### DIFF
--- a/depends/packages/native_protobuf.mk
+++ b/depends/packages/native_protobuf.mk
@@ -1,6 +1,6 @@
 package=native_protobuf
 $(package)_version=2.5.0
-$(package)_download_path=https://protobuf.googlecode.com/files
+$(package)_download_path=https://github.com/google/protobuf/releases/download/v$($(package)_version)
 $(package)_file_name=protobuf-$($(package)_version).tar.bz2
 $(package)_sha256_hash=13bfc5ae543cf3aa180ac2485c0bc89495e3ae711fc6fab4f8ffe90dfb4bb677
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.2.1
-$(package)_download_path=http://download.qt-project.org/official_releases/qt/5.2/$($(package)_version)/single
+$(package)_download_path=http://download.qt-project.org/archive/qt/5.2/$($(package)_version)/single
 $(package)_file_name=$(package)-everywhere-opensource-src-$($(package)_version).tar.gz
 $(package)_sha256_hash=84e924181d4ad6db00239d87250cc89868484a14841f77fb85ab1f1dbdcd7da1
 $(package)_dependencies=openssl


### PR DESCRIPTION
Some download paths have changed for (old) dependencies - fixed
- googlecode is deprecated, moved to github
- Qt5.2 moved to download archive