### PR TITLE
Fix sync issues

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -20,7 +20,7 @@ std::map<uint256, int64_t> mapAskedForGovernanceObject;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-6";
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-7";
 
 CGovernanceManager::CGovernanceManager()
     : pCurrentBlockIndex(NULL),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5145,7 +5145,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     if(mnodeman.mapSeenMasternodeBroadcast.count(inv.hash)){
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
-                        ss << mnodeman.mapSeenMasternodeBroadcast[inv.hash];
+                        ss << mnodeman.mapSeenMasternodeBroadcast[inv.hash].second;
                         // backward compatibility patch
                         if(pfrom->nVersion < 70204) {
                             ss << (int64_t)0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4013,6 +4013,8 @@ bool ProcessNewBlock(CValidationState& state, const CChainParams& chainparams, c
     if (!ActivateBestChain(state, chainparams, pblock))
         return error("%s: ActivateBestChain failed", __func__);
 
+    masternodeSync.IsBlockchainSynced(true);
+
     LogPrintf("%s : ACCEPTED\n", __func__);
     return true;
 }

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -65,7 +65,7 @@ public:
     void AddedGovernanceItem() { nTimeLastGovernanceItem = GetTime(); };
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
-    bool IsBlockchainSynced(bool fReset = false);
+    bool IsBlockchainSynced(bool fBlockAccepted = false);
     bool IsMasternodeListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
     bool IsWinnersListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_MNW; }
     bool IsSynced() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED; }

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -21,6 +21,7 @@ static const int MASTERNODE_SYNC_GOVOBJ          = 10;
 static const int MASTERNODE_SYNC_GOVOBJ_VOTE     = 11;
 static const int MASTERNODE_SYNC_FINISHED        = 999;
 
+static const int MASTERNODE_SYNC_TICK_SECONDS    = 6;
 static const int MASTERNODE_SYNC_TIMEOUT_SECONDS = 30; // our blocks are 2.5 minutes so 30 seconds should be fine
 
 extern CMasternodeSync masternodeSync;
@@ -64,7 +65,7 @@ public:
     void AddedGovernanceItem() { nTimeLastGovernanceItem = GetTime(); };
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
-    bool IsBlockchainSynced();
+    bool IsBlockchainSynced(bool fReset = false);
     bool IsMasternodeListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
     bool IsWinnersListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_MNW; }
     bool IsSynced() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED; }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -911,7 +911,7 @@ bool CMasternodePing::CheckAndUpdate(CMasternode* pmn, int& nDos)
     CMasternodeBroadcast mnb(*pmn);
     uint256 hash = mnb.GetHash();
     if (mnodeman.mapSeenMasternodeBroadcast.count(hash)) {
-        mnodeman.mapSeenMasternodeBroadcast[hash].lastPing = *this;
+        mnodeman.mapSeenMasternodeBroadcast[hash].second.lastPing = *this;
     }
 
     pmn->Check(true); // force update, ignoring cache

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -144,7 +144,7 @@ private:
 
 public:
     // Keep track of all broadcasts I've seen
-    std::map<uint256, CMasternodeBroadcast> mapSeenMasternodeBroadcast;
+    std::map<uint256, std::pair<int64_t, CMasternodeBroadcast> > mapSeenMasternodeBroadcast;
     // Keep track of all pings I've seen
     std::map<uint256, CMasternodePing> mapSeenMasternodePing;
     // Keep track of all verifications I've seen


### PR DESCRIPTION
Changes:
- Store time we saw mnb last time, bump sync timeout if we received seen mnb but we are too close to MASTERNODE_NEW_START_REQUIRED_SECONDS;
- Reset blockchain sync status if new blocks were accepted during sync, add some log output.

This should (hopefully) solve additional data sync issues.