### PR TITLE
Ignore payments and governance cache when mncache is empty

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1874,18 +1874,22 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         return InitError("Failed to load masternode cache from mncache.dat");
     }
 
-    uiInterface.InitMessage(_("Loading masternode payment cache..."));
-    CFlatDB<CMasternodePayments> flatdb2("mnpayments.dat", "magicMasternodePaymentsCache");
-    if(!flatdb2.Load(mnpayments)) {
-        return InitError("Failed to load masternode payments cache from mnpayments.dat");
-    }
+    if(mnodeman.size()) {
+        uiInterface.InitMessage(_("Loading masternode payment cache..."));
+        CFlatDB<CMasternodePayments> flatdb2("mnpayments.dat", "magicMasternodePaymentsCache");
+        if(!flatdb2.Load(mnpayments)) {
+            return InitError("Failed to load masternode payments cache from mnpayments.dat");
+        }
 
-    uiInterface.InitMessage(_("Loading governance cache..."));
-    CFlatDB<CGovernanceManager> flatdb3("governance.dat", "magicGovernanceCache");
-    if(!flatdb3.Load(governance)) {
-        return InitError("Failed to load governance cache from governance.dat");
+        uiInterface.InitMessage(_("Loading governance cache..."));
+        CFlatDB<CGovernanceManager> flatdb3("governance.dat", "magicGovernanceCache");
+        if(!flatdb3.Load(governance)) {
+            return InitError("Failed to load governance cache from governance.dat");
+        }
+        governance.InitOnLoad();
+    } else {
+        uiInterface.InitMessage(_("Masternode cache is empty, skipping payments and governance cache..."));
     }
-    governance.InitOnLoad();
 
     uiInterface.InitMessage(_("Loading fullfiled requests cache..."));
     CFlatDB<CNetFulfilledRequestManager> flatdb4("netfulfilled.dat", "magicFulfilledCache");


### PR DESCRIPTION
This should help to keep things consistent when we bump mnodeman version and/or when user deletes mncache.dat manually for whatever reason.

EDIT: most diffs here are because of whitespaces, actual changes - https://github.com/dashpay/dash/pull/1227/files?w=1