### PR TITLE
Add more checking in CheckForkWarningConditions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1857,7 +1857,10 @@ void CheckForkWarningConditions()
         }
         else
         {
-            LogPrintf("%s: Warning: Found invalid chain at least ~6 blocks longer than our best chain.\nChain state database corruption likely.\n", __func__);
+            if(pindexBestInvalid->nHeight > chainActive.Height() + 6)
+                LogPrintf("%s: Warning: Found invalid chain at least ~6 blocks longer than our best chain.\nChain state database corruption likely.\n", __func__);
+            else
+                LogPrintf("%s: Warning: Found invalid chain which has higher work (at least ~6 blocks worth of work) than our best chain.\nChain state database corruption likely.\n", __func__);
             fLargeWorkInvalidChainFound = true;
         }
     }


### PR DESCRIPTION
Regarding to my situation, the chain is needed to be invalid by **invalidblock** but that chain has higher difficulties than the correct chain. 
After invalidate block and staying on correct chain, this warning is in debug.log:
**CheckForkWarningConditions: Warning: Found invalid chain at least ~6 blocks longer than our best chain.**
So, this modification would possibly make this warning not shown in my case but do correctly checking regarding to the warning sentence.
BTW, I do understand that the bitcoin core has same validation (https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp#L1177) so I'm not sure if we need to modify it this way or not.