### PR TITLE
[UI] Command line option to reset the wallet-UI added

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -486,6 +486,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-keepasskey=<key>", _("KeePassHttp key for AES encrypted communication with KeePass"));
     strUsage += HelpMessageOpt("-keepassid=<name>", _("KeePassHttp id for the established association"));
     strUsage += HelpMessageOpt("-keepassname=<name>", _("Name to construct url for KeePass entry that stores the wallet passphrase"));
+    strUsage += HelpMessageOpt("-resetui", _("Reset GUI options if the 'Reset Options' button is not accessible any more. Wallet will be closed after this"));
     if (mode == HMM_BITCOIN_QT)
         strUsage += HelpMessageOpt("-windowtitle=<name>", _("Wallet window title"));
 #endif

--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -522,6 +522,15 @@ void BitcoinApplication::initializeResult(int retval)
         connect(paymentServer, SIGNAL(message(QString,QString,unsigned int)),
                          window, SLOT(message(QString,QString,unsigned int)));
         QTimer::singleShot(100, paymentServer, SLOT(uiReady()));
+
+        // Reset GUI options if the 'Reset Options' button is not accessible any more
+        if(GetBoolArg("-resetui", false))
+        {
+            if(clientModel->getOptionsModel()){
+                clientModel->getOptionsModel()->Reset();
+                QApplication::quit();
+            }
+        }
 #endif
     } else {
         quit(); // Exit main loop


### PR DESCRIPTION
Reference: https://bitcointalk.org/index.php?topic=421615.msg17362363#msg17362363 (and some more I can't find any more)

Sometimes (settings corrupt, change to a smaller screen resolution, other end-user-error, ...) parts of the UI are not visible/accessible anymore, and if that includes the ```Reset Options``` button the user has a problem.

Instead of explaining the user how to navigate to the folder/registry-entry where the Qt-settings are persisted it's much more convenient to just tell him _"Start the wallet with the option ```-resetui```"_.
