### PR TITLE
mix inputs with highest number of rounds first

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1625,13 +1625,13 @@ bool CDarksendPool::SubmitDenominate()
     std::vector<CTxOut> vecTxOutRet;
 
     // Submit transaction to the pool if we get here
-    // Try to use only inputs with the same number of rounds starting from lowest number of rounds possible
-    for(int i = 0; i < nPrivateSendRounds; i++) {
-        if(PrepareDenominate(i, i+1, strError, vecTxInRet, vecTxOutRet)) {
+    // Try to use only inputs with the same number of rounds starting from the highest number of rounds possible
+    for(int i = nPrivateSendRounds; i > 0; i--) {
+        if(PrepareDenominate(i - 1, i, strError, vecTxInRet, vecTxOutRet)) {
             LogPrintf("CDarksendPool::SubmitDenominate -- Running PrivateSend denominate for %d rounds, success\n", i);
             return SendDenominate(vecTxInRet, vecTxOutRet);
         }
-        LogPrintf("CDarksendPool::SubmitDenominate -- Running PrivateSend denominate for %d rounds, error: %s\n", i, strError);
+        LogPrint("privatesend", "CDarksendPool::SubmitDenominate -- Running PrivateSend denominate for %d rounds, error: %s\n", i, strError);
     }
 
     // We failed? That's strange but let's just make final attempt and try to mix everything


### PR DESCRIPTION
Currently we are mixing like this (imagine columns are number of rounds and we mix simple input, for simplicity sake, and inputs are selected in some order (which is not the case, we randomize them and even drop some to break possible patterns)):
```
1st session: 100000000
2nd session: 110000000
3rd session: 111000000
...
nth sesssion: 111111111
nth+1 session: 211111111
```
and so on until finally we get to `nPrivateSendRounds` round (N, M=N-1):
```NMMMMMMMM```

This is the first time user will finally see smth in his Private balance (input with N rounds).

What I'm proposing is changing this scheme to:
```
1st session: 100000000
2nd session: 200000000
...
Nth session: N00000000
Nth+1 session: N10000000
Nth+2 session: N20000000
```
and so on.
This way user will see (and will be able to use) mixed funds much earlier.

One thing to note is that together with multi-session option this scheme actually morphs into a mixed one because we don't use non-confirmed inputs for mixing. Smth like this:
```
1st session: 100000000
2nd session: 110000000
_block accepted_
3nd session: 210000000
4th session: 220000000
5th session: 221000000
...
```
and so on. This way user will be able to get even more private funds faster.

I was thinking about it for a while and wasn't able to find any reasonable arguments why this could not work or why this would defeat/leak some privacy. Suggestions and possible attack vector ideas are highly welcome.