### PR TITLE
Change lock order

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4970,8 +4970,6 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
 
     vector<CInv> vNotFound;
 
-    LOCK(cs_main);
-
     while (it != pfrom->vRecvGetData.end()) {
         // Don't bother if send buffer is too full to respond anyway
         if (pfrom->nSendSize >= SendBufferSize())
@@ -4985,6 +4983,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
 
             if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK)
             {
+                LOCK(cs_main);
                 bool send = false;
                 BlockMap::iterator mi = mapBlockIndex.find(inv.hash);
                 if (mi != mapBlockIndex.end())
@@ -5128,8 +5127,8 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                 }
 
                 if (!pushed && inv.type == MSG_MASTERNODE_PAYMENT_BLOCK) {
+                    LOCK2(cs_main, cs_mapMasternodeBlocks);
                     BlockMap::iterator mi = mapBlockIndex.find(inv.hash);
-                    LOCK(cs_mapMasternodeBlocks);
                     if (mi != mapBlockIndex.end() && mnpayments.mapMasternodeBlocks.count(mi->second->nHeight)) {
                         BOOST_FOREACH(CMasternodePayee& payee, mnpayments.mapMasternodeBlocks[mi->second->nHeight].vecPayees) {
                             std::vector<uint256> vecVoteHashes = payee.GetVoteHashes();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4476,7 +4476,7 @@ bool LoadBlockIndex()
 
 bool InitBlockIndex(const CChainParams& chainparams) 
 {
-    LOCK(cs_main);
+    LOCK2(governance.cs, cs_main);
 
     // Initialize global variables that cannot be constructed at startup.
     recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3358,6 +3358,7 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
         const CBlockIndex *pindexFork;
         bool fInitialDownload;
         {
+            LOCK2(governance.cs, mnodeman.cs);
             LOCK(cs_main);
             CBlockIndex *pindexOldTip = chainActive.Tip();
             pindexMostWork = FindMostWorkChain();
@@ -4354,6 +4355,7 @@ CVerifyDB::~CVerifyDB()
 
 bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview, int nCheckLevel, int nCheckDepth)
 {
+    LOCK2(governance.cs, mnodeman.cs);
     LOCK(cs_main);
     if (chainActive.Tip() == NULL || chainActive.Tip()->pprev == NULL)
         return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6454,12 +6454,15 @@ bool SendMessages(CNode* pto)
             }
         }
 
+        int64_t nNow = 0;
+        vector<CInv> vGetData;
+        {
         TRY_LOCK(cs_main, lockMain); // Acquire cs_main for IsInitialBlockDownload() and CNodeState()
         if (!lockMain)
             return true;
 
         // Address refresh broadcast
-        int64_t nNow = GetTimeMicros();
+        nNow = GetTimeMicros();
         if (!IsInitialBlockDownload() && pto->nNextLocalAddrSend < nNow) {
             AdvertiseLocal(pto);
             pto->nNextLocalAddrSend = PoissonNextSend(nNow, AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL);
@@ -6733,7 +6736,6 @@ bool SendMessages(CNode* pto)
         //
         // Message: getdata (blocks)
         //
-        vector<CInv> vGetData;
         if (!pto->fDisconnect && !pto->fClient && (fFetch || !IsInitialBlockDownload()) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             vector<CBlockIndex*> vToDownload;
             NodeId staller = -1;
@@ -6752,6 +6754,7 @@ bool SendMessages(CNode* pto)
             }
         }
 
+        }
         //
         // Message: getdata (non-blocks)
         //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4476,7 +4476,8 @@ bool LoadBlockIndex()
 
 bool InitBlockIndex(const CChainParams& chainparams) 
 {
-    LOCK2(governance.cs, cs_main);
+    LOCK2(governance.cs, mnodeman.cs);
+    LOCK(cs_main);
 
     // Initialize global variables that cannot be constructed at startup.
     recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -177,9 +177,7 @@ void CMasternodeMan::CheckAndRemove()
 
 
     {
-        // Need LOCK2 here to ensure consistent locking order because code below locks cs_main
-        // through GetHeight() signal in ConnectNode and in CheckMnbAndUpdateMasternodeList()
-        LOCK2(cs_main, cs);
+        LOCK(cs);
 
         Check();
 
@@ -541,8 +539,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(bool fFilterSigT
 
 CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount)
 {
-    // Need LOCK2 here to ensure consistent locking order because the GetBlockHash call below locks cs_main
-    LOCK2(cs_main,cs);
+    LOCK(cs);
 
     CMasternode *pBestMasternode = NULL;
     std::vector<std::pair<int, CMasternode*> > vecMasternodeLastPaid;
@@ -801,8 +798,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         LogPrint("masternode", "MNPING -- Masternode ping, masternode=%s\n", mnp.vin.prevout.ToStringShort());
 
-        // Need LOCK2 here to ensure consistent locking order because the CheckAndUpdate call below locks cs_main
-        LOCK2(cs_main, cs);
+        LOCK(cs);
 
         if(mapSeenMasternodePing.count(mnp.GetHash())) return; //seen
         mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));
@@ -895,8 +891,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
     } else if (strCommand == NetMsgType::MNVERIFY) { // Masternode Verify
 
-        // Need LOCK2 here to ensure consistent locking order because the all functions below call GetBlockHash which locks cs_main
-        LOCK2(cs_main, cs);
+        LOCK(cs);
 
         CMasternodeVerification mnv;
         vRecv >> mnv;
@@ -922,9 +917,7 @@ void CMasternodeMan::DoFullVerificationStep()
 
     std::vector<std::pair<int, CMasternode> > vecMasternodeRanks = GetMasternodeRanks(pCurrentBlockIndex->nHeight - 1, MIN_POSE_PROTO_VERSION);
 
-    // Need LOCK2 here to ensure consistent locking order because the SendVerifyRequest call below locks cs_main
-    // through GetHeight() signal in ConnectNode
-    LOCK2(cs_main, cs);
+    LOCK(cs);
 
     int nCount = 0;
     int nCountMax = std::max(10, (int)vMasternodes.size() / 100); // verify at least 10 masternode at once but at most 1% of all known masternodes
@@ -1374,8 +1367,7 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb)
 
 bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBroadcast mnb, int& nDos)
 {
-    // Need LOCK2 here to ensure consistent locking order because the SimpleCheck call below locks cs_main
-    LOCK2(cs_main, cs);
+    LOCK(cs);
 
     nDos = 0;
     LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s\n", mnb.vin.prevout.ToStringShort());

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -109,9 +109,6 @@ private:
     static const int MNB_RECOVERY_RETRY_SECONDS     = 3 * 60 * 60;
 
 
-    // critical section to protect the inner data structures
-    mutable CCriticalSection cs;
-
     // Keep track of current block index
     const CBlockIndex *pCurrentBlockIndex;
 
@@ -152,6 +149,9 @@ private:
     friend class CMasternodeSync;
 
 public:
+    // critical section to protect the inner data structures
+    mutable CCriticalSection cs;
+
     // Keep track of all broadcasts I've seen
     std::map<uint256, std::pair<int64_t, CMasternodeBroadcast> > mapSeenMasternodeBroadcast;
     // Keep track of all pings I've seen

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -24,9 +24,12 @@
 #include "txmempool.h"
 #include "util.h"
 #include "utilmoneystr.h"
+#include "validationinterface.h"
+
+#include "governance.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"
-#include "validationinterface.h"
+#include "masternodeman.h"
 
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple.hpp>
@@ -124,6 +127,8 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
     CAmount nFees = 0;
 
     {
+        CCriticalBlock criticalblockGov(governance.cs, "governance.cs", __FILE__, __LINE__);
+        CCriticalBlock criticalblockMnman(mnodeman.cs, "mnodeman.cs", __FILE__, __LINE__);
         LOCK2(cs_main, mempool.cs);
         CBlockIndex* pindexPrev = chainActive.Tip();
         const int nHeight = pindexPrev->nHeight + 1;

--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -564,7 +564,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
 
         // GET MATCHING GOVERNANCE OBJECTS
 
-        LOCK2(cs_main, governance.cs);
+        LOCK(governance.cs);
 
         std::vector<CGovernanceObject*> objs = governance.GetAllNewerThan(nStartTime);
         governance.UpdateLastDiffTime(GetTime());
@@ -620,7 +620,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
         // COLLECT VARIABLES FROM OUR USER
         uint256 hash = ParseHashV(params[1], "GovObj hash");
 
-        LOCK2(cs_main, governance.cs);
+        LOCK(governance.cs);
 
         // FIND THE GOVERNANCE OBJECT THE USER IS LOOKING FOR
         CGovernanceObject* pGovObj = governance.FindGovernanceObject(hash);

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -21,11 +21,14 @@
 #include "spork.h"
 #include "txmempool.h"
 #include "util.h"
-#ifdef ENABLE_WALLET
-#include "masternode-sync.h"
-#endif
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+
+#ifdef ENABLE_WALLET
+#include "governance.h"
+#include "masternode-sync.h"
+#include "masternodeman.h"
+#endif
 
 #include <stdint.h>
 
@@ -405,6 +408,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             + HelpExampleRpc("getblocktemplate", "")
          );
 
+    LOCK2(governance.cs, mnodeman.cs);
     LOCK(cs_main);
 
     std::string strMode = "template";

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -8,7 +8,6 @@
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
 #include "main.h"
-#include "masternode-payments.h"
 #include "miner.h"
 #include "pubkey.h"
 #include "script/standard.h"
@@ -16,6 +15,10 @@
 #include "uint256.h"
 #include "util.h"
 #include "utilstrencodings.h"
+
+#include "governance.h"
+#include "masternode-payments.h"
+#include "masternodeman.h"
 
 #include "test/test_dash.h"
 
@@ -86,6 +89,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     entry.dPriority = 111.0;
     entry.nHeight = 11;
 
+    LOCK2(governance.cs, mnodeman.cs);
     LOCK(cs_main);
     fCheckpointsEnabled = false;
 


### PR DESCRIPTION
We have been enforcing the lock order: cs_main, governance.cs, mnodeman.cs.

However this is suboptimal because the cs_main lock is required for a number of low level calls in various places that access the blockchain database.  Therefore with this lock order virtually all dash operations require the cs_main to lock to be acquired first, which make multi-threading largely ineffective.

This PR changes the lock order to: governance.cs, mnodeman.cs, cs_main.