### PR TITLE
Fix locking order

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1047,7 +1047,6 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex)
         return;
     }
 
-    // Need to lock cs_main here because NewBlock 
     LOCK(cs);
     pCurrentBlockIndex = pindex;
     nCachedBlockHeight = pCurrentBlockIndex->nHeight;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -155,7 +155,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
             return;
         }
 
-        LOCK(cs);
+        LOCK2(cs_main, cs);
 
         if(mapSeenGovernanceObjects.count(nHash)) {
             // TODO - print error code? what if it's GOVOBJ_ERROR_IMMATURE?
@@ -284,7 +284,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, CGovernance
 
 bool CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj)
 {
-    LOCK(cs);
+    LOCK2(cs_main, cs);
     std::string strError = "";
 
     DBG( cout << "CGovernanceManager::AddGovernanceObject START" << endl; );
@@ -564,8 +564,9 @@ void CGovernanceManager::NewBlock()
     // IF WE'RE NOT SYNCED, EXIT
     if(!masternodeSync.IsSynced()) return;
 
-    TRY_LOCK(cs, fBudgetNewBlock);
-    if(!fBudgetNewBlock || !pCurrentBlockIndex) return;
+    if(!pCurrentBlockIndex) return;
+    LOCK(cs);
+
 
     // CHECK OBJECTS WE'VE ASKED FOR, REMOVE OLD ENTRIES
 
@@ -652,7 +653,7 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
     LogPrint("gobject", "CGovernanceManager::Sync -- syncing to peer=%d, nProp = %s\n", pfrom->id, nProp.ToString());
 
     {
-        LOCK(cs);
+        LOCK2(cs_main, cs);
         fRateChecksEnabled = false;
         for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
             uint256 h = it->first;
@@ -1046,6 +1047,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex)
         return;
     }
 
+    // Need to lock cs_main here because NewBlock 
     LOCK(cs);
     pCurrentBlockIndex = pindex;
     nCachedBlockHeight = pCurrentBlockIndex->nHeight;


### PR DESCRIPTION
This adds cs_main locks to ensure that locks are acquired in the order: cs_main, governance.cs, mnodeman.cs.