### PR TITLE
Use peer info to make decision if blockchain is synced or not

### DIFF
--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -24,6 +24,8 @@ static const int MASTERNODE_SYNC_FINISHED        = 999;
 static const int MASTERNODE_SYNC_TICK_SECONDS    = 6;
 static const int MASTERNODE_SYNC_TIMEOUT_SECONDS = 30; // our blocks are 2.5 minutes so 30 seconds should be fine
 
+static const int MASTERNODE_SYNC_ENOUGH_PEERS    = 6;
+
 extern CMasternodeSync masternodeSync;
 
 //
@@ -54,6 +56,7 @@ private:
     // Keep track of current block index
     const CBlockIndex *pCurrentBlockIndex;
 
+    bool CheckNodeHeight(CNode* pnode, bool fDisconnectStuckNodes = false);
     void Fail();
     void ClearFulfilledRequests();
 


### PR DESCRIPTION
Assuming that we synced blockchain already if we have at least `MASTERNODE_SYNC_ENOUGH_PEERS` (6 currently) peers at the same height as we are.