### PR TITLE
Remove hashes from setAskFor

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -147,6 +147,8 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         uint256 nHash = govobj.GetHash();
         std::string strHash = nHash.ToString();
 
+        pfrom->setAskFor.erase(nHash);
+
         LogPrint("gobject", "MNGOVERNANCEOBJECT -- Received object: %s\n", strHash);
 
         if(!AcceptObjectMessage(nHash)) {
@@ -230,6 +232,8 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         uint256 nHash = vote.GetHash();
         std::string strHash = nHash.ToString();
+
+        pfrom->setAskFor.erase(nHash);
 
         if(!AcceptVoteMessage(nHash)) {
             LogPrint("gobject", "MNGOVERNANCEOBJECTVOTE -- Received unrequested vote object: %s, hash: %s, peer = %d\n",

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -340,18 +340,22 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, std::string& strCommand, 
 
         if(!pCurrentBlockIndex) return;
 
+        uint256 nHash = vote.GetHash();
+
+        pfrom->setAskFor.erase(nHash);
+
         {
             LOCK(cs_mapMasternodePaymentVotes);
-            if(mapMasternodePaymentVotes.count(vote.GetHash())) {
-                LogPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- hash=%s, nHeight=%d seen\n", vote.GetHash().ToString(), pCurrentBlockIndex->nHeight);
+            if(mapMasternodePaymentVotes.count(nHash)) {
+                LogPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- hash=%s, nHeight=%d seen\n", nHash.ToString(), pCurrentBlockIndex->nHeight);
                 return;
             }
 
             // Avoid processing same vote multiple times
-            mapMasternodePaymentVotes[vote.GetHash()] = vote;
+            mapMasternodePaymentVotes[nHash] = vote;
             // but first mark vote as non-verified,
             // AddPaymentVote() below should take care of it if vote is actually ok
-            mapMasternodePaymentVotes[vote.GetHash()].MarkAsNotVerified();
+            mapMasternodePaymentVotes[nHash].MarkAsNotVerified();
         }
 
         int nFirstBlock = pCurrentBlockIndex->nHeight - GetStorageLimit();

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -774,6 +774,8 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         CMasternodeBroadcast mnb;
         vRecv >> mnb;
 
+        pfrom->setAskFor.erase(mnb.GetHash());
+
         LogPrint("masternode", "MNANNOUNCE -- Masternode announce, masternode=%s\n", mnb.vin.prevout.ToStringShort());
 
         // backward compatibility patch
@@ -799,13 +801,17 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         CMasternodePing mnp;
         vRecv >> mnp;
 
+        uint256 nHash = mnp.GetHash();
+
+        pfrom->setAskFor.erase(nHash);
+
         LogPrint("masternode", "MNPING -- Masternode ping, masternode=%s\n", mnp.vin.prevout.ToStringShort());
 
         // Need LOCK2 here to ensure consistent locking order because the CheckAndUpdate call below locks cs_main
         LOCK2(cs_main, cs);
 
-        if(mapSeenMasternodePing.count(mnp.GetHash())) return; //seen
-        mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));
+        if(mapSeenMasternodePing.count(nHash)) return; //seen
+        mapSeenMasternodePing.insert(std::make_pair(nHash, mnp));
 
         LogPrint("masternode", "MNPING -- Masternode ping, masternode=%s new\n", mnp.vin.prevout.ToStringShort());
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -30,6 +30,7 @@ void CSporkManager::ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStr
         std::string strLogMsg;
         {
             LOCK(cs_main);
+            pfrom->setAskFor.erase(hash);
             if(!chainActive.Tip()) return;
             strLogMsg = strprintf("SPORK -- hash: %s id: %d value: %10d bestHeight: %d peer=%d", hash.ToString(), spork.nSporkID, spork.nValue, chainActive.Height(), pfrom->id);
         }


### PR DESCRIPTION
We should remove hash from these tables when the message corresponding to previous inv arrives, otherwise it's stays there forever and tables overflow (i.e. AskFor returns immediately).