### PR TITLE
Change governance sync process

### DIFF
--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -321,6 +321,12 @@ public:
         // AFTER DESERIALIZATION OCCURS, CACHED VARIABLES MUST BE CALCULATED MANUALLY
     }
 
+    CGovernanceObject& operator=(CGovernanceObject from)
+    {
+        swap(*this, from);
+        return *this;
+    }
+
 private:
     // FUNCTIONS FOR DEALING WITH DATA STRING
     void LoadData();

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -936,12 +936,13 @@ void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nH
 
 void CGovernanceManager::RequestGovernanceObjectVotes(CNode* pnode)
 {
+    if(pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) return;
     std::vector<CNode*> vNodesCopy;
     vNodesCopy.push_back(pnode);
     RequestGovernanceObjectVotes(vNodesCopy);
 }
 
-void CGovernanceManager::RequestGovernanceObjectVotes(std::vector<CNode*> vNodesCopy)
+void CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy)
 {
     static std::map<uint256, int64_t> mapAskedRecently;
     LOCK2(cs_main, cs);
@@ -959,6 +960,9 @@ void CGovernanceManager::RequestGovernanceObjectVotes(std::vector<CNode*> vNodes
         // only use reqular peers, don't try to ask from temporary nodes we connected to -
         // they stay connected for a short period of time and it's possible that we won't get everything we should
         if(pnode->fMasternode) continue;
+        // only use up to date peers
+        if(pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
+        // stop early to prevent setAskFor overflow
         if(pnode->setAskFor.size() > SETASKFOR_MAX_SZ/2) continue;
         uint256 nHashGovobj;
         // ask for triggers first

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -936,31 +936,46 @@ void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nH
 
 void CGovernanceManager::RequestGovernanceObjectVotes(CNode* pnode)
 {
+    std::vector<CNode*> vNodesCopy;
+    vNodesCopy.push_back(pnode);
+    RequestGovernanceObjectVotes(vNodesCopy);
+}
+
+void CGovernanceManager::RequestGovernanceObjectVotes(std::vector<CNode*> vNodesCopy)
+{
     static std::map<uint256, int64_t> mapAskedRecently;
     LOCK2(cs_main, cs);
-    if(pnode->setAskFor.size() > SETASKFOR_MAX_SZ/2) return;
-    std::vector<CGovernanceObject> vGovObjsTmp;
-    std::vector<CGovernanceObject> vGovObjsTriggersTmp;
+    std::vector<CGovernanceObject*> vpGovObjsTmp;
+    std::vector<CGovernanceObject*> vpGovObjsTriggersTmp;
     int64_t nNow = GetTime();
-    // request votes on per-obj basis while syncing
     for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
         if(mapAskedRecently.count(it->first) && mapAskedRecently[it->first] > nNow) continue;
         if(it->second.nObjectType == GOVERNANCE_OBJECT_TRIGGER)
-            vGovObjsTriggersTmp.push_back(it->second);
+            vpGovObjsTriggersTmp.push_back(&(it->second));
         else
-            vGovObjsTmp.push_back(it->second);
+            vpGovObjsTmp.push_back(&(it->second));
     }
-    uint256 nHashGovobj;
-    // ask for triggers first
-    if(vGovObjsTriggersTmp.size()) {
-        nHashGovobj = vGovObjsTriggersTmp[GetRandInt(vGovObjsTriggersTmp.size())].GetHash();
-    } else {
-        if(vGovObjsTmp.empty()) return;
-        nHashGovobj = vGovObjsTmp[GetRandInt(vGovObjsTmp.size())].GetHash();
+    BOOST_FOREACH(CNode* pnode, vNodesCopy) {
+        // only use reqular peers, don't try to ask from temporary nodes we connected to -
+        // they stay connected for a short period of time and it's possible that we won't get everything we should
+        if(pnode->fMasternode) continue;
+        if(pnode->setAskFor.size() > SETASKFOR_MAX_SZ/2) continue;
+        uint256 nHashGovobj;
+        // ask for triggers first
+        if(vpGovObjsTriggersTmp.size()) {
+            int r = GetRandInt(vpGovObjsTriggersTmp.size());
+            nHashGovobj = vpGovObjsTriggersTmp[r]->GetHash();
+            vpGovObjsTriggersTmp.erase(vpGovObjsTriggersTmp.begin() + r);
+        } else {
+            if(vpGovObjsTmp.empty()) return;
+            int r = GetRandInt(vpGovObjsTmp.size());
+            nHashGovobj = vpGovObjsTmp[r]->GetHash();
+            vpGovObjsTmp.erase(vpGovObjsTmp.begin() + r);
+        }
+        LogPrintf("CGovernanceManager::RequestGovernanceObjectVotes -- Requesting votes for %s, peer=%d\n", nHashGovobj.ToString(), pnode->id);
+        RequestGovernanceObject(pnode, nHashGovobj);
+        mapAskedRecently[nHashGovobj] = nNow + mapObjects.size() * 60; // ask again after full cycle
     }
-    LogPrintf("CGovernanceManager::RequestGovernanceObjectVotes -- Requesting votes for %s, peer=%d\n", nHashGovobj.ToString(), pnode->id);
-    RequestGovernanceObject(pnode, nHashGovobj);
-    mapAskedRecently[nHashGovobj] = nNow + mapObjects.size() * 60;
 }
 
 bool CGovernanceManager::AcceptObjectMessage(const uint256& nHash)

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -934,12 +934,10 @@ void CGovernanceManager::RequestGovernanceObjectVotes(CNode* pnode)
     // request votes on per-obj basis while syncing
     for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
         if(mapAskedRecently.count(it->first) && mapAskedRecently[it->first] > nNow) continue;
-        if((int)it->second.mapCurrentMNVotes.size() < mnodeman.CountEnabled()/2) {
-            if(it->second.nObjectType == GOVERNANCE_OBJECT_TRIGGER)
-                vGovObjsTriggersTmp.push_back(it->second);
-            else
-                vGovObjsTmp.push_back(it->second);
-        }
+        if(it->second.nObjectType == GOVERNANCE_OBJECT_TRIGGER)
+            vGovObjsTriggersTmp.push_back(it->second);
+        else
+            vGovObjsTmp.push_back(it->second);
     }
     uint256 nHashGovobj;
     // ask for triggers first
@@ -951,7 +949,7 @@ void CGovernanceManager::RequestGovernanceObjectVotes(CNode* pnode)
     }
     LogPrintf("CGovernanceManager::RequestGovernanceObjectVotes -- Requesting votes for %s, peer=%d\n", nHashGovobj.ToString(), pnode->id);
     RequestGovernanceObject(pnode, nHashGovobj);
-    mapAskedRecently[nHashGovobj] = nNow + 2 * 60; // ask again in 2 minutes
+    mapAskedRecently[nHashGovobj] = nNow + mapObjects.size() * 60;
 }
 
 bool CGovernanceManager::AcceptObjectMessage(const uint256& nHash)

--- a/src/governance.h
+++ b/src/governance.h
@@ -375,6 +375,8 @@ public:
 
     void InitOnLoad();
 
+    void RequestGovernanceObjectVotes(CNode* pnode);
+
 private:
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash);
 

--- a/src/governance.h
+++ b/src/governance.h
@@ -376,7 +376,7 @@ public:
     void InitOnLoad();
 
     void RequestGovernanceObjectVotes(CNode* pnode);
-    void RequestGovernanceObjectVotes(std::vector<CNode*> vNodesCopy);
+    void RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy);
 
 private:
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash);

--- a/src/governance.h
+++ b/src/governance.h
@@ -376,6 +376,7 @@ public:
     void InitOnLoad();
 
     void RequestGovernanceObjectVotes(CNode* pnode);
+    void RequestGovernanceObjectVotes(std::vector<CNode*> vNodesCopy);
 
 private:
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash);

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -283,10 +283,7 @@ void CMasternodeSync::ProcessTick()
                     BOOST_FOREACH(CNode* pnode, vNodesCopy)
                         pnode->AddRef();
                 }
-
-                BOOST_FOREACH(CNode* pnode, vNodesCopy)
-                    governance.RequestGovernanceObjectVotes(pnode);
-
+                governance.RequestGovernanceObjectVotes(vNodesCopy);
                 ReleaseNodes(vNodesCopy);
                 return;
             }


### PR DESCRIPTION
On gov sync first sync objs, then ask for votes on per-obj basis from different peers.

This should help to sync obj list initially and split the load among many peers. Also adds ability to catch up votes later after the sync.