### PR TITLE
Voting related syncing changes

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -439,11 +439,6 @@ bool CGovernanceObject::IsValidLocally(std::string& strError, bool& fMissingMast
 
     // IF ABSOLUTE NO COUNT (NO-YES VALID VOTES) IS MORE THAN 10% OF THE NETWORK MASTERNODES, OBJ IS INVALID
 
-    if(GetAbsoluteNoCount(VOTE_SIGNAL_VALID) > mnodeman.CountEnabled(MIN_GOVERNANCE_PEER_PROTO_VERSION)/10) {
-        strError = "Voted invalid";
-        return false;
-    }
-
     // CHECK COLLATERAL IF REQUIRED (HIGH CPU USAGE)
 
     if(fCheckCollateral) { 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -158,7 +158,6 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         if(!AcceptObjectMessage(nHash)) {
             LogPrintf("MNGOVERNANCEOBJECT -- Received unrequested object: %s\n", strHash);
-            Misbehaving(pfrom->GetId(), 20);
             return;
         }
 
@@ -243,7 +242,6 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         if(!AcceptVoteMessage(nHash)) {
             LogPrint("gobject", "MNGOVERNANCEOBJECTVOTE -- Received unrequested vote object: %s, hash: %s, peer = %d\n",
                       vote.ToString(), strHash, pfrom->GetId());
-            //Misbehaving(pfrom->GetId(), 20);
             return;
         }
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -672,12 +672,6 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
 
                 LogPrint("gobject", "CGovernanceManager::Sync -- attempting to sync govobj: %s, peer=%d\n", strHash, pfrom->id);
 
-                if(!govobj.IsSetCachedValid()) {
-                    LogPrintf("CGovernanceManager::Sync -- invalid flag cached, not syncing govobj: %s, fCachedValid = %d, peer=%d\n",
-                              strHash, govobj.IsSetCachedValid(), pfrom->id);
-                    continue;
-                }
-
                 // Push the inventory budget proposal message over to the other client
                 LogPrint("gobject", "CGovernanceManager::Sync -- syncing govobj: %s, peer=%d\n", strHash, pfrom->id);
                 pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT, it->first));
@@ -694,12 +688,6 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
             std::string strHash = it->first.ToString();
 
             LogPrint("gobject", "CGovernanceManager::Sync -- attempting to sync govobj: %s, peer=%d\n", strHash, pfrom->id);
-
-            if(!govobj.IsSetCachedValid()) {
-                LogPrintf("CGovernanceManager::Sync -- invalid flag cached, not syncing govobj: %s, fCachedValid = %d, peer=%d\n",
-                          strHash, govobj.IsSetCachedValid(), pfrom->id);
-                return;
-            }
 
             // Push the inventory budget proposal message over to the other client
             LogPrint("gobject", "CGovernanceManager::Sync -- syncing govobj: %s, peer=%d\n", strHash, pfrom->id);

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -672,6 +672,12 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
 
                 LogPrint("gobject", "CGovernanceManager::Sync -- attempting to sync govobj: %s, peer=%d\n", strHash, pfrom->id);
 
+                if(govobj.IsSetCachedDelete()) {
+                    LogPrintf("CGovernanceManager::Sync -- not syncing deleted govobj: %s, peer=%d\n",
+                              strHash, pfrom->id);
+                    continue;
+                }
+
                 // Push the inventory budget proposal message over to the other client
                 LogPrint("gobject", "CGovernanceManager::Sync -- syncing govobj: %s, peer=%d\n", strHash, pfrom->id);
                 pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT, it->first));
@@ -688,6 +694,12 @@ void CGovernanceManager::Sync(CNode* pfrom, uint256 nProp)
             std::string strHash = it->first.ToString();
 
             LogPrint("gobject", "CGovernanceManager::Sync -- attempting to sync govobj: %s, peer=%d\n", strHash, pfrom->id);
+
+            if(govobj.IsSetCachedDelete()) {
+                LogPrintf("CGovernanceManager::Sync -- not syncing deleted govobj: %s, peer=%d\n",
+                          strHash, pfrom->id);
+                return;
+            }
 
             // Push the inventory budget proposal message over to the other client
             LogPrint("gobject", "CGovernanceManager::Sync -- syncing govobj: %s, peer=%d\n", strHash, pfrom->id);


### PR DESCRIPTION
Ignore the voted validity flag for purposes of syncing objects.  Not syncing objects being voted on is likely to lead to consensus problems.

Don't sync objects marked for deletion.

Remove penalty for unrequested objects (this occurs occasionally and should not lead to banning).