### PR TITLE
Do not call CloseSocketDisconnect from non-socket handler threads

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -788,7 +788,7 @@ void SocketSendData(CNode *pnode)
                 if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                 {
                     LogPrintf("socket send error %s\n", NetworkErrorString(nErr));
-                    pnode->CloseSocketDisconnect();
+                    pnode->fDisconnect = true;
                 }
             }
             // couldn't send anything at all
@@ -1749,7 +1749,7 @@ void ThreadMessageHandler()
                 if (lockRecv)
                 {
                     if (!g_signals.ProcessMessages(pnode))
-                        pnode->CloseSocketDisconnect();
+                        pnode->fDisconnect = true;
 
                     if (pnode->nSendSize < SendBufferSize())
                     {


### PR DESCRIPTION
This should fix an observed crash due to lack of locking of CNode data fields in net.cpp.

The crash was caused by hSocket being set to INVALID_SOCKET from another thread after the value had been checked in the socket handler thread.

This PR removes the two places where CloseSocketDisconnect (which invalidates the socket handle) can be called from another thread, replacing them with setting the disconnect flag.

With this change the actual disconnection is handled only by the socket handler thread and this bug should not occur.