### PR TITLE
Shift PS denoms

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -436,12 +436,14 @@ void CDarksendPool::InitDenominations()
         1DRK+1000 == (.1DRK+100)*10
         10DRK+10000 == (1DRK+1000)*10
     */
+    /* Disabled
     vecPrivateSendDenominations.push_back( (100      * COIN)+100000 );
+    */
     vecPrivateSendDenominations.push_back( (10       * COIN)+10000 );
     vecPrivateSendDenominations.push_back( (1        * COIN)+1000 );
     vecPrivateSendDenominations.push_back( (.1       * COIN)+100 );
-    /* Disabled till we need them
     vecPrivateSendDenominations.push_back( (.01      * COIN)+10 );
+    /* Disabled till we need them
     vecPrivateSendDenominations.push_back( (.001     * COIN)+1 );
     */
 }

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -19,7 +19,7 @@ static const int PRIVATESEND_QUEUE_TIMEOUT          = 30;
 static const int PRIVATESEND_SIGNING_TIMEOUT        = 15;
 
 //! minimum peer version accepted by mixing pool
-static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70204;
+static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70206;
 
 static const CAmount PRIVATESEND_COLLATERAL         = 0.001 * COIN;
 static const CAmount PRIVATESEND_POOL_MAX           = 999.999 * COIN;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -597,10 +597,9 @@ void OverviewPage::togglePrivateSend(){
         settings.setValue("hasMixed", "hasMixed");
     }
     if(!fEnablePrivateSend){
-        int64_t balance = currentBalance;
-        float minAmount = 1.49 * COIN;
-        if(balance < minAmount){
-            QString strMinAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, minAmount));
+        CAmount nMinAmount = vecPrivateSendDenominations.back() + PRIVATESEND_COLLATERAL*4;
+        if(currentBalance < nMinAmount){
+            QString strMinAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, nMinAmount));
             QMessageBox::warning(this, tr("PrivateSend"),
                 tr("PrivateSend requires at least %1 to use.").arg(strMinAmount),
                 QMessageBox::Ok, QMessageBox::Ok);

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70205;
+static const int PROTOCOL_VERSION = 70206;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Remove 100s, add 0.01s, partial protobump.

NOTE: Previously mixed 100s won't be recognized as mixed anymore.