### PR TITLE
Fix mnbcon open connection.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1711,7 +1711,7 @@ void ThreadMnbRequestConnections()
 
         std::pair<CService, uint256> p = mnodeman.PopScheduledMnbRequestConnection();
         if(p.first == CService()) continue;
-        CNode* pnode = ConnectNode(CAddress(p.first), NULL, true);
+        CNode* pnode = ConnectNode(CAddress(p.first), NULL, false);
         if(pnode) {
             grant.MoveTo(pnode->grantMasternodeOutbound);
             if(p.second != uint256())


### PR DESCRIPTION
I'm not sure if this is correct behavior for this ThreadMnbRequestConnections.
At least this change will stop the behavior on Testnet that occurred on every new block found. 
The behavior is node closes Masternodes connections and then open new connections to Masternodes again.