### PR TITLE
simulate mainnet gov obj sync conditions on testnet

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -943,14 +943,17 @@ void CGovernanceManager::CheckMasternodeOrphanObjects()
     fRateChecksEnabled = true;
 }
 
-void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nHash, bool fUseFilter)
+void CGovernanceManager::RequestGovernanceObject(CNode* pnode, const uint256& nHash, bool fUseFilter)
 {
-    if(!pfrom) {
+    if(!pnode) {
         return;
     }
 
-    if(pfrom->nVersion < GOVERNANCE_FILTER_PROTO_VERSION) {
-        pfrom->PushMessage(NetMsgType::MNGOVERNANCESYNC, nHash);
+    if(nHash != uint256())
+        LogPrintf("CGovernanceManager::RequestGovernanceObject -- Requesting votes for %s, peer=%d\n", nHash.ToString(), pnode->id);
+
+    if(pnode->nVersion < GOVERNANCE_FILTER_PROTO_VERSION) {
+        pnode->PushMessage(NetMsgType::MNGOVERNANCESYNC, nHash);
         return;
     }
 
@@ -969,7 +972,7 @@ void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nH
         }
     }
 
-    pfrom->PushMessage(NetMsgType::MNGOVERNANCESYNC, nHash, filter);
+    pnode->PushMessage(NetMsgType::MNGOVERNANCESYNC, nHash, filter);
 }
 
 void CGovernanceManager::RequestGovernanceObjectVotes(CNode* pnode)
@@ -982,11 +985,16 @@ void CGovernanceManager::RequestGovernanceObjectVotes(CNode* pnode)
 
 void CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy)
 {
-    static std::map<uint256, int64_t> mapAskedRecently;
+    if(vNodesCopy.empty()) return;
+
     LOCK2(cs_main, cs);
+
+    static std::map<uint256, int64_t> mapAskedRecently;
     std::vector<CGovernanceObject*> vpGovObjsTmp;
     std::vector<CGovernanceObject*> vpGovObjsTriggersTmp;
+
     int64_t nNow = GetTime();
+
     for(object_m_it it = mapObjects.begin(); it != mapObjects.end(); ++it) {
         if(mapAskedRecently.count(it->first) && mapAskedRecently[it->first] > nNow) continue;
         if(it->second.nObjectType == GOVERNANCE_OBJECT_TRIGGER)
@@ -994,29 +1002,48 @@ void CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>&
         else
             vpGovObjsTmp.push_back(&(it->second));
     }
-    BOOST_FOREACH(CNode* pnode, vNodesCopy) {
+
+    InsecureRand insecureRand;
+    // shuffle pointers
+    std::random_shuffle(vpGovObjsTriggersTmp.begin(), vpGovObjsTriggersTmp.end(), insecureRand);
+    std::random_shuffle(vpGovObjsTmp.begin(), vpGovObjsTmp.end(), insecureRand);
+
+    // This should help to get some idea about an impact this can bring once deployed.
+    // Testnet is ~40 times smaller in masternode count, but only ~1000 masternodes usually vote,
+    // so 1 obj on mainnet == ~10 objs or ~1000 votes on testnet. However we want to test a higher
+    // number of votes to make sure it's robust enough, so aim at 2000 votes per node per request.
+    // On mainnet we have 4K+ nodes, so nMaxObjsRequestsPerNode always evaluates to `1`.
+    size_t nProjectedVotes = 2000;
+    int nMaxObjsRequestsPerNode = std::max(1, int(nProjectedVotes / mnodeman.size()));
+    std::vector<CNode*>::const_iterator it = vNodesCopy.begin();
+
+    while(it != vNodesCopy.end()) {
+        CNode* pnode = (*it);
         // only use reqular peers, don't try to ask from temporary nodes we connected to -
         // they stay connected for a short period of time and it's possible that we won't get everything we should
-        if(pnode->fMasternode) continue;
+        if(pnode->fMasternode) { ++it; continue; }
         // only use up to date peers
-        if(pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
+        if(pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) { ++it; continue; }
+
         // stop early to prevent setAskFor overflow
-        if(pnode->setAskFor.size() > SETASKFOR_MAX_SZ/2) continue;
-        uint256 nHashGovobj;
-        // ask for triggers first
-        if(vpGovObjsTriggersTmp.size()) {
-            int r = GetRandInt(vpGovObjsTriggersTmp.size());
-            nHashGovobj = vpGovObjsTriggersTmp[r]->GetHash();
-            vpGovObjsTriggersTmp.erase(vpGovObjsTriggersTmp.begin() + r);
-        } else {
-            if(vpGovObjsTmp.empty()) return;
-            int r = GetRandInt(vpGovObjsTmp.size());
-            nHashGovobj = vpGovObjsTmp[r]->GetHash();
-            vpGovObjsTmp.erase(vpGovObjsTmp.begin() + r);
+        size_t nProjectedSize = pnode->setAskFor.size() + nProjectedVotes;
+        if(nProjectedSize > SETASKFOR_MAX_SZ/2) { ++it; continue; }
+
+        for (int i = 0; i < nMaxObjsRequestsPerNode; ++i) {
+            uint256 nHashGovobj;
+            // ask for triggers first
+            if(vpGovObjsTriggersTmp.size()) {
+                nHashGovobj = vpGovObjsTriggersTmp.back()->GetHash();
+                vpGovObjsTriggersTmp.pop_back();
+            } else {
+                if(vpGovObjsTmp.empty()) return;
+                nHashGovobj = vpGovObjsTmp.back()->GetHash();
+                vpGovObjsTmp.pop_back();
+            }
+            RequestGovernanceObject(pnode, nHashGovobj, true);
+            mapAskedRecently[nHashGovobj] = nNow + mapObjects.size() * 60; // ask again after full cycle
         }
-        LogPrintf("CGovernanceManager::RequestGovernanceObjectVotes -- Requesting votes for %s, peer=%d\n", nHashGovobj.ToString(), pnode->id);
-        RequestGovernanceObject(pnode, nHashGovobj, true);
-        mapAskedRecently[nHashGovobj] = nNow + mapObjects.size() * 60; // ask again after full cycle
+        ++it;
     }
 }
 

--- a/src/governance.h
+++ b/src/governance.h
@@ -380,7 +380,7 @@ public:
     void RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy);
 
 private:
-    void RequestGovernanceObject(CNode* pfrom, const uint256& nHash, bool fUseFilter = false);
+    void RequestGovernanceObject(CNode* pnode, const uint256& nHash, bool fUseFilter = false);
 
     void AddInvalidVote(const CGovernanceVote& vote)
     {


### PR DESCRIPTION
This should change `RequestGovernanceObjectVotes` to fetch ~5000 votes per node per request (which is number of masternodes on mainnet + some margin). Should give us some idea about the load this will produce on mainnet.