### PR TITLE
Improve governance syncing efficiency with bloom filter

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -84,7 +84,6 @@ public:
         consensus.nSuperblockStartBlock = 600000; // TODO, the block at which 12.1 goes live.
         consensus.nSuperblockCycle = 16616; // ~(60*24*30)/2.6, actual number of blocks per month is 200700 / 12 = 16725
         consensus.nGovernanceMinQuorum = 10;
-        consensus.nGovernanceFilterElements = 100;
         consensus.nGovernanceFilterElements = 20000;
         consensus.nMasternodeMinimumConfirmations = 15;
         consensus.nMajorityEnforceBlockUpgrade = 750;
@@ -209,6 +208,7 @@ public:
         consensus.nSuperblockStartBlock = 61000; // NOTE: Should satisfy nSuperblockStartBlock > nBudgetPeymentsStartBlock
         consensus.nSuperblockCycle = 24; // Superblocks can be issued hourly on testnet
         consensus.nGovernanceMinQuorum = 1;
+        consensus.nGovernanceFilterElements = 500;
         consensus.nMasternodeMinimumConfirmations = 1;
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
@@ -315,7 +315,7 @@ public:
         consensus.nSuperblockStartBlock = 1500;
         consensus.nSuperblockCycle = 10;
         consensus.nGovernanceMinQuorum = 1;
-        consensus.nGovernanceFilterElements = 500;
+        consensus.nGovernanceFilterElements = 100;
         consensus.nMasternodeMinimumConfirmations = 1;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -84,6 +84,8 @@ public:
         consensus.nSuperblockStartBlock = 600000; // TODO, the block at which 12.1 goes live.
         consensus.nSuperblockCycle = 16616; // ~(60*24*30)/2.6, actual number of blocks per month is 200700 / 12 = 16725
         consensus.nGovernanceMinQuorum = 10;
+        consensus.nGovernanceFilterElements = 100;
+        consensus.nGovernanceFilterElements = 20000;
         consensus.nMasternodeMinimumConfirmations = 15;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
@@ -313,6 +315,7 @@ public:
         consensus.nSuperblockStartBlock = 1500;
         consensus.nSuperblockCycle = 10;
         consensus.nGovernanceMinQuorum = 1;
+        consensus.nGovernanceFilterElements = 500;
         consensus.nMasternodeMinimumConfirmations = 1;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -47,7 +47,8 @@ struct Params {
     int nBudgetProposalEstablishingTime; // in seconds
     int nSuperblockStartBlock;
     int nSuperblockCycle; // in blocks
-    int nGovernanceMinQuorum; // Min absolute vote count to trigger an action 
+    int nGovernanceMinQuorum; // Min absolute vote count to trigger an action
+    int nGovernanceFilterElements;
     int nMasternodeMinimumConfirmations;
     /** Used to check majorities for block version upgrade */
     int nMajorityEnforceBlockUpgrade;

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -26,6 +26,7 @@ class CGovernanceVote;
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
 static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70204;
 static const int GOVERNANCE_FILTER_PROTO_VERSION = 70206;
+static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 
 static const int GOVERNANCE_OBJECT_UNKNOWN = 0;
 static const int GOVERNANCE_OBJECT_PROPOSAL = 1;
@@ -48,8 +49,6 @@ static const int SEEN_OBJECT_ERROR_INVALID = 1;
 static const int SEEN_OBJECT_ERROR_IMMATURE = 2;
 static const int SEEN_OBJECT_EXECUTED = 3; //used for triggers
 static const int SEEN_OBJECT_UNKNOWN = 4; // the default
-
-static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 
 typedef std::pair<CGovernanceVote, int64_t> vote_time_pair_t;
 

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -25,6 +25,7 @@ class CGovernanceVote;
 
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
 static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70204;
+static const int GOVERNANCE_FILTER_PROTO_VERSION = 70206;
 
 static const int GOVERNANCE_OBJECT_UNKNOWN = 0;
 static const int GOVERNANCE_OBJECT_PROPOSAL = 1;
@@ -47,6 +48,9 @@ static const int SEEN_OBJECT_ERROR_INVALID = 1;
 static const int SEEN_OBJECT_ERROR_IMMATURE = 2;
 static const int SEEN_OBJECT_EXECUTED = 3; //used for triggers
 static const int SEEN_OBJECT_UNKNOWN = 4; // the default
+
+static const int GOVERNANCE_FILTER_ELEMENTS = 20000;
+static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 
 typedef std::pair<CGovernanceVote, int64_t> vote_time_pair_t;
 

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -26,6 +26,7 @@ class CGovernanceVote;
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
 static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70204;
 static const int GOVERNANCE_FILTER_PROTO_VERSION = 70206;
+
 static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 
 static const int GOVERNANCE_OBJECT_UNKNOWN = 0;

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -49,7 +49,7 @@ static const int SEEN_OBJECT_ERROR_IMMATURE = 2;
 static const int SEEN_OBJECT_EXECUTED = 3; //used for triggers
 static const int SEEN_OBJECT_UNKNOWN = 4; // the default
 
-static const int GOVERNANCE_FILTER_ELEMENTS = 20000;
+static const int GOVERNANCE_FILTER_MAX_ELEMENTS = 20000;
 static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 
 typedef std::pair<CGovernanceVote, int64_t> vote_time_pair_t;

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -49,7 +49,6 @@ static const int SEEN_OBJECT_ERROR_IMMATURE = 2;
 static const int SEEN_OBJECT_EXECUTED = 3; //used for triggers
 static const int SEEN_OBJECT_UNKNOWN = 4; // the default
 
-static const int GOVERNANCE_FILTER_MAX_ELEMENTS = 20000;
 static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 
 typedef std::pair<CGovernanceVote, int64_t> vote_time_pair_t;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -961,8 +961,7 @@ void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nH
         CGovernanceObject* pObj = FindGovernanceObject(nHash);
 
         if(pObj) {
-            int nFilterElements = min(3*mnodeman.CountMasternodes(), GOVERNANCE_FILTER_MAX_ELEMENTS); 
-            filter = CBloomFilter(nFilterElements, GOVERNANCE_FILTER_FP_RATE, GetRandInt(999999), BLOOM_UPDATE_ALL);
+            filter = CBloomFilter(Params().GetConsensus().nGovernanceFilterElements, GOVERNANCE_FILTER_FP_RATE, GetRandInt(999999), BLOOM_UPDATE_ALL);
             std::vector<CGovernanceVote> vecVotes = pObj->GetVoteFile().GetVotes();
             for(size_t i = 0; i < vecVotes.size(); ++i) {
                 filter.insert(vecVotes[i].GetHash());

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -650,6 +650,9 @@ bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
         LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest added inv to requested set\n");
     }
 
+    // Keep sync alive
+    masternodeSync.AddedGovernanceItem();
+
     LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest reached end, returning true\n");
     return true;
 }

--- a/src/governance.h
+++ b/src/governance.h
@@ -272,7 +272,7 @@ public:
      */
     bool ConfirmInventoryRequest(const CInv& inv);
 
-    void Sync(CNode* node, uint256 nProp, CBloomFilter& filter);
+    void Sync(CNode* node, const uint256& nProp, const CBloomFilter& filter);
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 

--- a/src/governance.h
+++ b/src/governance.h
@@ -7,6 +7,7 @@
 
 //#define ENABLE_DASH_DEBUG
 
+#include "bloom.h"
 #include "cachemap.h"
 #include "cachemultimap.h"
 #include "chain.h"
@@ -271,7 +272,7 @@ public:
      */
     bool ConfirmInventoryRequest(const CInv& inv);
 
-    void Sync(CNode* node, uint256 nProp);
+    void Sync(CNode* node, uint256 nProp, CBloomFilter& filter);
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
@@ -379,7 +380,7 @@ public:
     void RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy);
 
 private:
-    void RequestGovernanceObject(CNode* pfrom, const uint256& nHash);
+    void RequestGovernanceObject(CNode* pfrom, const uint256& nHash, bool fUseFilter = false);
 
     void AddInvalidVote(const CGovernanceVote& vote)
     {

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -67,6 +67,8 @@ public:
     void AddedPaymentVote() { nTimeLastPaymentVote = GetTime(); }
     void AddedGovernanceItem() { nTimeLastGovernanceItem = GetTime(); };
 
+    void SendGovernanceSyncRequest(CNode* pnode, const char* strMessage, uint256 nHash);
+
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
     bool IsBlockchainSynced(bool fBlockAccepted = false);
     bool IsMasternodeListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -67,7 +67,7 @@ public:
     void AddedPaymentVote() { nTimeLastPaymentVote = GetTime(); }
     void AddedGovernanceItem() { nTimeLastGovernanceItem = GetTime(); };
 
-    void SendGovernanceSyncRequest(CNode* pnode, const char* strMessage, uint256 nHash);
+    void SendGovernanceSyncRequest(CNode* pnode);
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
     bool IsBlockchainSynced(bool fBlockAccepted = false);

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70205;
+static const int PROTOCOL_VERSION = 70206;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
 - Use bloom filter for governance vote syncing
 - Bump protocol to 70206 (backward compatible with 70205)
 - Update sync time on governance inv's to avoid premature sync timeout which can lead to forked nodes