### PR TITLE
Restore 5 Dash fee for proposal creation

### DIFF
--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -31,7 +31,7 @@ static const int GOVERNANCE_OBJECT_PROPOSAL = 1;
 static const int GOVERNANCE_OBJECT_TRIGGER = 2;
 static const int GOVERNANCE_OBJECT_WATCHDOG = 3;
 
-static const CAmount GOVERNANCE_PROPOSAL_FEE_TX = (0.33*COIN);
+static const CAmount GOVERNANCE_PROPOSAL_FEE_TX = (5.0*COIN);
 
 static const int64_t GOVERNANCE_FEE_CONFIRMATIONS = 6;
 static const int64_t GOVERNANCE_UPDATE_MIN = 60*60;


### PR DESCRIPTION
This restores the 12.0 5 Dash fee for budget proposal creation in order to reduce the risk of spam attacks on the governance system.