### PR TITLE
bump gov cache version

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -20,7 +20,7 @@ std::map<uint256, int64_t> mapAskedForGovernanceObject;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-7";
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-8";
 
 CGovernanceManager::CGovernanceManager()
     : pCurrentBlockIndex(NULL),


### PR DESCRIPTION
This should drop cache for all clients and invalidate old proposal after recent fee change.