### PR TITLE
Few fixes for PrivateSend

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -188,6 +188,18 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
 
         LogPrint("privatesend", "DSVIN -- txCollateral %s", entry.txCollateral.ToString());
 
+        if(entry.vecTxDSIn.size() > PRIVATESEND_ENTRY_MAX_SIZE) {
+            LogPrintf("DSVIN -- ERROR: too many inputs! %d/%d\n", entry.vecTxDSIn.size(), PRIVATESEND_ENTRY_MAX_SIZE);
+            PushStatus(pfrom, STATUS_REJECTED, ERR_MAXIMUM);
+            return;
+        }
+
+        if(entry.vecTxDSOut.size() > PRIVATESEND_ENTRY_MAX_SIZE) {
+            LogPrintf("DSVIN -- ERROR: too many outputs! %d/%d\n", entry.vecTxDSOut.size(), PRIVATESEND_ENTRY_MAX_SIZE);
+            PushStatus(pfrom, STATUS_REJECTED, ERR_MAXIMUM);
+            return;
+        }
+
         //do we have the same denominations as the current session?
         if(!IsOutputsCompatibleWithSessionDenom(entry.vecTxDSOut)) {
             LogPrintf("DSVIN -- not compatible with existing transactions!\n");
@@ -233,12 +245,6 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
                     PushStatus(pfrom, STATUS_REJECTED, ERR_MISSING_TX);
                     return;
                 }
-            }
-
-            if(nValueIn > PRIVATESEND_POOL_MAX) {
-                LogPrintf("DSVIN -- more than PrivateSend pool max! nValueIn: %lld, tx=%s", nValueIn, tx.ToString());
-                PushStatus(pfrom, STATUS_REJECTED, ERR_MAXIMUM);
-                return;
             }
 
             // Allow lowest denom (at max) as a a fee. Normally shouldn't happen though.
@@ -1675,7 +1681,7 @@ bool CDarksendPool::PrepareDenominate(int nMinRounds, int nMaxRounds, std::strin
 
         if nMinRounds >= 0 it means only denominated inputs are going in and coming out
     */
-    bool fSelected = pwalletMain->SelectCoinsByDenominations(nSessionDenom, vecPrivateSendDenominations.back(), PRIVATESEND_POOL_MAX, vecTxIn, vCoins, nValueIn, nMinRounds, nMaxRounds);
+    bool fSelected = pwalletMain->SelectCoinsByDenominations(nSessionDenom, vecPrivateSendDenominations.back(), GetMaxPoolAmount(), vecTxIn, vCoins, nValueIn, nMinRounds, nMaxRounds);
     if (nMinRounds >= 0 && !fSelected) {
         strErrorRet = "Can't select current denominated inputs";
         return false;
@@ -1692,11 +1698,11 @@ bool CDarksendPool::PrepareDenominate(int nMinRounds, int nMaxRounds, std::strin
 
     CAmount nValueLeft = nValueIn;
 
-    // Try to add every needed denomination, repeat up to 5-9 times.
+    // Try to add every needed denomination, repeat up to 5-PRIVATESEND_ENTRY_MAX_SIZE times.
     // NOTE: No need to randomize order of inputs because they were
     // initially shuffled in CWallet::SelectCoinsByDenominations already.
     int nStep = 0;
-    int nStepsMax = 5 + GetRandInt(5);
+    int nStepsMax = 5 + GetRandInt(PRIVATESEND_ENTRY_MAX_SIZE-5+1);
     std::vector<int> vecBits;
     if (!GetDenominationsBits(nSessionDenom, vecBits)) {
         strErrorRet = "Incorrect session denom";
@@ -2225,7 +2231,7 @@ std::string CDarksendPool::GetMessageByID(PoolMessage nMessageID)
         case ERR_INVALID_INPUT:         return _("Input is not valid.");
         case ERR_INVALID_SCRIPT:        return _("Invalid script detected.");
         case ERR_INVALID_TX:            return _("Transaction not valid.");
-        case ERR_MAXIMUM:               return _("Value more than PrivateSend pool maximum allows.");
+        case ERR_MAXIMUM:               return _("Entry exceeds PrivateSend pool maximum size.");
         case ERR_MN_LIST:               return _("Not in the Masternode list.");
         case ERR_MODE:                  return _("Incompatible mode.");
         case ERR_NON_STANDARD_PUBKEY:   return _("Non-standard public key detected.");

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2233,7 +2233,7 @@ std::string CDarksendPool::GetMessageByID(PoolMessage nMessageID)
         case ERR_INVALID_INPUT:         return _("Input is not valid.");
         case ERR_INVALID_SCRIPT:        return _("Invalid script detected.");
         case ERR_INVALID_TX:            return _("Transaction not valid.");
-        case ERR_MAXIMUM:               return _("Entry exceeds PrivateSend pool maximum size.");
+        case ERR_MAXIMUM:               return _("Entry exceeds maximum size.");
         case ERR_MN_LIST:               return _("Not in the Masternode list.");
         case ERR_MODE:                  return _("Incompatible mode.");
         case ERR_NON_STANDARD_PUBKEY:   return _("Non-standard public key detected.");

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -247,10 +247,10 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
                 }
             }
 
-            // Allow lowest denom (at max) as a a fee. Normally shouldn't happen though.
-            // TODO: Or do not allow fees at all?
-            if(nValueIn - nValueOut > vecPrivateSendDenominations.back()) {
-                LogPrintf("DSVIN -- fees are too high! fees: %lld, tx=%s", nValueIn - nValueOut, tx.ToString());
+            // There should be no fee in mixing tx
+            CAmount nFee = nValueIn - nValueOut;
+            if(nFee != 0) {
+                LogPrintf("DSVIN -- there should be no fee in mixing tx! fees: %lld, tx=%s", nFee, tx.ToString());
                 PushStatus(pfrom, STATUS_REJECTED, ERR_FEES);
                 return;
             }

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1656,6 +1656,8 @@ bool CDarksendPool::SubmitDenominate()
 
 bool CDarksendPool::PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, std::vector<CTxIn>& vecTxInRet, std::vector<CTxOut>& vecTxOutRet)
 {
+    if(!pwalletMain) return false;
+
     if (pwalletMain->IsLocked(true)) {
         strErrorRet = "Wallet locked, unable to create transaction!";
         return false;

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -21,7 +21,8 @@ static const int PRIVATESEND_SIGNING_TIMEOUT        = 15;
 //! minimum peer version accepted by mixing pool
 static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70206;
 
-static const CAmount PRIVATESEND_COLLATERAL         = 0.001 * COIN;
+//! 1/10 of min denom, should not collide with other values to avoid confusion
+static const CAmount PRIVATESEND_COLLATERAL         = 0.001 * COIN + 1;
 static const CAmount PRIVATESEND_ENTRY_MAX_SIZE     = 9;
 static const int DENOMS_COUNT_MAX                   = 100;
 

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -22,7 +22,7 @@ static const int PRIVATESEND_SIGNING_TIMEOUT        = 15;
 static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70206;
 
 static const CAmount PRIVATESEND_COLLATERAL         = 0.001 * COIN;
-static const CAmount PRIVATESEND_POOL_MAX           = 999.999 * COIN;
+static const CAmount PRIVATESEND_ENTRY_MAX_SIZE     = 9;
 static const int DENOMS_COUNT_MAX                   = 100;
 
 static const int DEFAULT_PRIVATESEND_ROUNDS         = 2;
@@ -452,6 +452,8 @@ public:
     int GetDenominations(const std::vector<CTxDSOut>& vecTxDSOut);
     std::string GetDenominationsToString(int nDenom);
     bool GetDenominationsBits(int nDenom, std::vector<int> &vecBitsRet);
+
+    CAmount GetMaxPoolAmount() { return vecPrivateSendDenominations.empty() ? 0 : PRIVATESEND_ENTRY_MAX_SIZE * vecPrivateSendDenominations.front(); }
 
     void SetMinBlockSpacing(int nMinBlockSpacingIn) { nMinBlockSpacing = nMinBlockSpacingIn; }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -351,7 +351,7 @@ void OverviewPage::updatePrivateSendProgress()
     CAmount nDenominatedUnconfirmedBalance;
     CAmount nAnonymizableBalance;
     CAmount nNormalizedAnonymizedBalance;
-    double nAverageAnonymizedRounds;
+    float nAverageAnonymizedRounds;
 
     {
         nDenominatedConfirmedBalance = pwalletMain->GetDenominatedBalance();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -23,6 +23,8 @@
 #include "txmempool.h"
 #include "wallet/wallet.h"
 
+#include "darksend.h"
+
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QSettings>
@@ -260,7 +262,7 @@ void SendCoinsDialog::on_sendButton_clicked()
         strFunds = tr("using") + " <b>" + tr("anonymous funds") + "</b>";
         QString strNearestAmount(
             BitcoinUnits::formatWithUnit(
-                model->getOptionsModel()->getDisplayUnit(), 0.1 * COIN));
+                model->getOptionsModel()->getDisplayUnit(), vecPrivateSendDenominations.back()));
         strFee = QString(tr(
             "(privatesend requires this amount to be rounded up to the nearest %1)."
         ).arg(strNearestAmount));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1895,12 +1895,12 @@ CAmount CWallet::GetAnonymizedBalance() const
 
 // Note: calculated including unconfirmed,
 // that's ok as long as we use it for informational purposes only
-double CWallet::GetAverageAnonymizedRounds() const
+float CWallet::GetAverageAnonymizedRounds() const
 {
     if(fLiteMode) return 0;
 
-    double fTotal = 0;
-    double fCount = 0;
+    int nTotal = 0;
+    int nCount = 0;
 
     {
         LOCK2(cs_main, cs_wallet);
@@ -1912,20 +1912,19 @@ double CWallet::GetAverageAnonymizedRounds() const
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
 
-                CTxIn vin = CTxIn(hash, i);
+                CTxIn txin = CTxIn(hash, i);
 
-                if(IsSpent(hash, i) || IsMine(pcoin->vout[i]) != ISMINE_SPENDABLE || !IsDenominated(vin)) continue;
+                if(IsSpent(hash, i) || IsMine(pcoin->vout[i]) != ISMINE_SPENDABLE || !IsDenominated(txin)) continue;
 
-                int rounds = GetInputPrivateSendRounds(vin);
-                fTotal += (float)rounds;
-                fCount += 1;
+                nTotal += GetInputPrivateSendRounds(txin);
+                nCount++;
             }
         }
     }
 
-    if(fCount == 0) return 0;
+    if(nCount == 0) return 0;
 
-    return fTotal/fCount;
+    return (float)nTotal/nCount;
 }
 
 // Note: calculated including unconfirmed,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1979,7 +1979,7 @@ CAmount CWallet::GetNeedsToBeAnonymizedBalance(CAmount nMinBalance) const
     if(nNeedsToAnonymizeBalance > nAnonymizableBalance) nNeedsToAnonymizeBalance = nAnonymizableBalance;
 
     // we should never exceed the pool max
-    if (nNeedsToAnonymizeBalance > PRIVATESEND_POOL_MAX) nNeedsToAnonymizeBalance = PRIVATESEND_POOL_MAX;
+    if (nNeedsToAnonymizeBalance > darkSendPool.GetMaxPoolAmount()) nNeedsToAnonymizeBalance = darkSendPool.GetMaxPoolAmount();
 
     return nNeedsToAnonymizeBalance;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -743,7 +743,7 @@ public:
 
     CAmount GetAnonymizableBalance() const;
     CAmount GetAnonymizedBalance() const;
-    double GetAverageAnonymizedRounds() const;
+    float GetAverageAnonymizedRounds() const;
     CAmount GetNormalizedAnonymizedBalance() const;
     CAmount GetNeedsToBeAnonymizedBalance(CAmount nMinBalance = 0) const;
     CAmount GetDenominatedBalance(bool unconfirmed=false) const;


### PR DESCRIPTION
Fixes:
- PS should limit entry size, not mixing amount (_legacy issue_)
- there should be no fee in mixing tx (_legacy issue_)
- make sure `pwalletMain` is not null in `PrepareDenominate` (_shouldn't really happen but just in case_)
- slightly adjust `PRIVATESEND_COLLATERAL` to avoid collision with `CTxLockRequest::MIN_FEE` (_otherwise Transactions tab info could be inaccurate if IS to yourself_)
- ~send confirmation dialog box should display correct smallest denom (_missed this one when refactored PrivateSend to use actual denoms instead of magic numbers_)~ fixed in #1329 
- no need for "double" in GetAverageAnonymizedRounds, "float" should be enough

~No protocol bump is needed.~