### PR TITLE
remove IS limit for number of inputs, add warning instead

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -815,9 +815,8 @@ bool CTxLockRequest::IsValid(bool fRequireUnspent) const
 {
     if(vout.size() < 1) return false;
 
-    if(vin.size() > MAX_INPUTS) {
-        LogPrint("instantsend", "CTxLockRequest::IsValid -- Too many inputs: tx=%s", ToString());
-        return false;
+    if(vin.size() > WARN_MANY_INPUTS) {
+        LogPrint("instantsend", "CTxLockRequest::IsValid -- WARNING: Too many inputs: tx=%s", ToString());
     }
 
     LOCK(cs_main);

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -116,7 +116,7 @@ private:
     int64_t nTimeCreated;
 
 public:
-    static const int MAX_INPUTS             = 10;
+    static const int WARN_MANY_INPUTS       = 100;
 
     CTxLockRequest() :
         CTransaction(),

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -313,10 +313,9 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                              CClientUIInterface::MSG_ERROR);
                 return TransactionCreationFailed;
             }
-            if(newTx->vin.size() > CTxLockRequest::MAX_INPUTS) {
-                Q_EMIT message(tr("Send Coins"), tr("InstantSend doesn't support transactions with more than %1 inputs.").arg(CTxLockRequest::MAX_INPUTS),
-                             CClientUIInterface::MSG_ERROR);
-                return TransactionCreationFailed;
+            if(newTx->vin.size() > CTxLockRequest::WARN_MANY_INPUTS) {
+                Q_EMIT message(tr("Send Coins"), tr("Used way too many inputs (>%1) for this InstantSend transaction, fees could be huge.").arg(CTxLockRequest::WARN_MANY_INPUTS),
+                             CClientUIInterface::MSG_WARNING);
             }
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2358,9 +2358,6 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletTx*
             setCoinsRet.insert(make_pair(out.tx, out.i));
         }
 
-        if(fUseInstantSend && setCoinsRet.size() > CTxLockRequest::MAX_INPUTS)
-            return false;
-
         return (nValueRet >= nTargetValue);
     }
 
@@ -3014,10 +3011,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                         strFailReason = _("Insufficient funds.");
                     }
                     if (fUseInstantSend) {
-                        size_t nMaxInputs = CTxLockRequest::MAX_INPUTS;
-                        if(setCoins.size() > nMaxInputs) {
-                            strFailReason += " " + strprintf(_("InstantSend doesn't support transactions with more than %d inputs."), nMaxInputs);
-                        } else if (nValueIn > sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)*COIN) {
+                        if (nValueIn > sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)*COIN) {
                             strFailReason += " " + strprintf(_("InstantSend doesn't support sending values that high yet. Transactions are currently limited to %1 DASH."), sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE));
                         } else {
                             // could be not true but most likely that's the reason


### PR DESCRIPTION
As discussed in Slack, fees are probably already high enough to prevent abuse, plus it turned out that way too low limit conflicts with PS transactions (which can have a lot of inputs in general).
EDIT: Also limiting number of inputs doesn't really help because you can always create multiple txes instead.