### PR TITLE
put some reasonable limits on SPORK_12_RECONSIDER_BLOCKS

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -75,9 +75,28 @@ void CSporkManager::ExecuteSpork(int nSporkID, int nValue)
 {
     //correct fork via spork technology
     if(nSporkID == SPORK_12_RECONSIDER_BLOCKS && nValue > 0) {
+        // allow to reprocess 6h of blocks max which is 2x fork detection time, should be enough to resolve any issues
+        int64_t nMaxBlocks = 144;
+        // this potentially can be a heavy operation, so only allow this to be executed once per 10 minutes
+        int64_t nTimeout = 10 * 60;
+
+        static int64_t nTimeExecuted = 0; // i.e. it was never executed before
+
+        if(GetTime() - nTimeExecuted < nTimeout) {
+            LogPrint("spork", "CSporkManager::ExecuteSpork -- ERROR: Trying to reconsider blocks, too soon - %d/%d\n", GetTime() - nTimeExecuted, nTimeout);
+            return;
+        }
+
+        if(nValue > nMaxBlocks) {
+            LogPrintf("CSporkManager::ExecuteSpork -- ERROR: Trying to reconsider too many blocks %d/%d\n", nValue, nMaxBlocks);
+            return;
+        }
+
+
         LogPrintf("CSporkManager::ExecuteSpork -- Reconsider Last %d Blocks\n", nValue);
 
         ReprocessBlocks(nValue);
+        nTimeExecuted = GetTime();
     }
 }
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -75,8 +75,8 @@ void CSporkManager::ExecuteSpork(int nSporkID, int nValue)
 {
     //correct fork via spork technology
     if(nSporkID == SPORK_12_RECONSIDER_BLOCKS && nValue > 0) {
-        // allow to reprocess 6h of blocks max which is 2x fork detection time, should be enough to resolve any issues
-        int64_t nMaxBlocks = 144;
+        // allow to reprocess 24h of blocks max, which should be enough to resolve any issues
+        int64_t nMaxBlocks = 576;
         // this potentially can be a heavy operation, so only allow this to be executed once per 10 minutes
         int64_t nTimeout = 10 * 60;
 


### PR DESCRIPTION
Humans are prone to errors and this feature is way too powerful to be executed "AS IS". Put some limits on it: we don't want to reprocess way too many blocks and we don't want to be able to do that way too often.