### PR TITLE
Fix IS vote expiration/cleanup

### DIFF
--- a/src/instantx.h
+++ b/src/instantx.h
@@ -208,7 +208,8 @@ public:
     COutPoint GetOutpoint() const { return outpoint; }
 
     bool AddVote(const CTxLockVote& vote);
-    bool HasMasternodeVoted(const COutPoint& outpointMasternodeIn);
+    std::vector<CTxLockVote> GetVotes() const;
+    bool HasMasternodeVoted(const COutPoint& outpointMasternodeIn) const;
     int CountVotes() const { return mapMasternodeVotes.size(); }
     bool IsReady() const { return CountVotes() >= SIGNATURES_REQUIRED; }
 


### PR DESCRIPTION
- vote should be removed when corresponding orphan vote expires
- fix CInstantSend::SyncTransaction: mapTxLockVotes is indexed by vote hash, not by tx hash (use votes from candidates and from orhpan vote map to avoid looping through the whole vote map)