### PR TITLE
Allow updating masternode list entries during sync

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4964,7 +4964,7 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         }
 
     case MSG_MASTERNODE_ANNOUNCE:
-        return mnodeman.mapSeenMasternodeBroadcast.count(inv.hash) && !mnodeman.IsMnbRecoveryRequested(inv.hash);
+        return mnodeman.mapSeenMasternodeBroadcast.count(inv.hash) && !mnodeman.IsMnbRecoveryRequested(inv.hash) && masternodeSync.IsMasternodeListSynced();
 
     case MSG_MASTERNODE_PING:
         return mnodeman.mapSeenMasternodePing.count(inv.hash);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1432,6 +1432,10 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
     }
     mapSeenMasternodeBroadcast.insert(std::make_pair(hash, std::make_pair(GetTime(), mnb)));
 
+    if(!masternodeSync.IsBlockchainSynced()) {
+        mnb.fRecovery = true;
+    }
+
     LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s new\n", mnb.vin.prevout.ToStringShort());
 
     if(!mnb.SimpleCheck(nDos)) {

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1399,7 +1399,7 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
     LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s\n", mnb.vin.prevout.ToStringShort());
 
     uint256 hash = mnb.GetHash();
-    if(masternodeSync.IsBlockchainSynced() && mapSeenMasternodeBroadcast.count(hash) && !mnb.fRecovery) { //seen
+    if(masternodeSync.IsMasternodeListSynced() && mapSeenMasternodeBroadcast.count(hash) && !mnb.fRecovery) { //seen
         LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s seen\n", mnb.vin.prevout.ToStringShort());
         // less then 2 pings left before this MN goes into non-recoverable state, bump sync timeout
         if(GetTime() - mapSeenMasternodeBroadcast[hash].first > MASTERNODE_NEW_START_REQUIRED_SECONDS - MASTERNODE_MIN_MNP_SECONDS * 2) {
@@ -1432,7 +1432,7 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
     }
     mapSeenMasternodeBroadcast.insert(std::make_pair(hash, std::make_pair(GetTime(), mnb)));
 
-    if(!masternodeSync.IsBlockchainSynced()) {
+    if(!masternodeSync.IsMasternodeListSynced()) {
         mnb.fRecovery = true;
     }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1399,7 +1399,7 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
     LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s\n", mnb.vin.prevout.ToStringShort());
 
     uint256 hash = mnb.GetHash();
-    if(mapSeenMasternodeBroadcast.count(hash) && !mnb.fRecovery) { //seen
+    if(masternodeSync.IsBlockchainSynced() && mapSeenMasternodeBroadcast.count(hash) && !mnb.fRecovery) { //seen
         LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s seen\n", mnb.vin.prevout.ToStringShort());
         // less then 2 pings left before this MN goes into non-recoverable state, bump sync timeout
         if(GetTime() - mapSeenMasternodeBroadcast[hash].first > MASTERNODE_NEW_START_REQUIRED_SECONDS - MASTERNODE_MIN_MNP_SECONDS * 2) {


### PR DESCRIPTION
Nodes that have been offline may incorrectly see masternodes in the NEW_START_REQUIRED state.

If no MN's are seen in the ENABLED state, masternode recovery will not work.

This allows masternode states to be updated during syncing.