### PR TITLE
Fix CMasternodeConfig::read

### DIFF
--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -1,8 +1,7 @@
 
-#include "net.h"
+#include "netbase.h"
 #include "masternodeconfig.h"
 #include "util.h"
-#include "ui_interface.h"
 #include "chainparams.h"
 
 #include <boost/filesystem.hpp>
@@ -56,16 +55,26 @@ bool CMasternodeConfig::read(std::string& strErr) {
             }
         }
 
+        int port = 0;
+        std::string hostname = "";
+        SplitHostPort(ip, port, hostname);
+        if(port == 0 || hostname == "") {
+            strErr = _("Failed to parse host:port string") + "\n"+
+                    strprintf(_("Line: %d"), linenumber) + "\n\"" + line + "\"";
+            streamConfig.close();
+            return false;
+        }
         int mainnetDefaultPort = Params(CBaseChainParams::MAIN).GetDefaultPort();
         if(Params().NetworkIDString() == CBaseChainParams::MAIN) {
-            if(CService(ip).GetPort() != mainnetDefaultPort) {
+            if(port != mainnetDefaultPort) {
                 strErr = _("Invalid port detected in masternode.conf") + "\n" +
+                        strprintf(_("Port: %d"), port) + "\n" +
                         strprintf(_("Line: %d"), linenumber) + "\n\"" + line + "\"" + "\n" +
                         strprintf(_("(must be %d for mainnet)"), mainnetDefaultPort);
                 streamConfig.close();
                 return false;
             }
-        } else if(CService(ip).GetPort() == mainnetDefaultPort) {
+        } else if(port == mainnetDefaultPort) {
             strErr = _("Invalid port detected in masternode.conf") + "\n" +
                     strprintf(_("Line: %d"), linenumber) + "\n\"" + line + "\"" + "\n" +
                     strprintf(_("(%d could be used only on mainnet)"), mainnetDefaultPort);


### PR DESCRIPTION
CService fails to initialize correctly on Windows for whatever reason, replacing this functionality with SplitHostPort call.