### PR TITLE
Fix alerts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -228,6 +228,7 @@ libbitcoin_server_a_SOURCES = \
   rpcrawtransaction.cpp \
   rpcserver.cpp \
   script/sigcache.cpp \
+  sendalert.cpp \
   timedata.cpp \
   torcontrol.cpp \
   txdb.cpp \

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -5,6 +5,7 @@
 
 #include "alert.h"
 
+#include "base58.h"
 #include "clientversion.h"
 #include "net.h"
 #include "pubkey.h"
@@ -143,6 +144,27 @@ bool CAlert::RelayTo(CNode* pnode) const
         }
     }
     return false;
+}
+
+bool CAlert::Sign()
+{
+    CDataStream sMsg(SER_NETWORK, CLIENT_VERSION);
+    sMsg << *(CUnsignedAlert*)this;
+    vchMsg = std::vector<unsigned char>(sMsg.begin(), sMsg.end());
+    CBitcoinSecret vchSecret;
+    if (!vchSecret.SetString(GetArg("-alertkey", "")))
+    {
+        printf("CAlert::SignAlert() : vchSecret.SetString failed\n");
+        return false;
+    }
+    CKey key = vchSecret.GetKey();
+    if (!key.Sign(Hash(vchMsg.begin(), vchMsg.end()), vchSig))
+    {
+        printf("CAlert::SignAlert() : key.Sign failed\n");
+        return false;
+    }
+
+    return true;
 }
 
 bool CAlert::CheckSignature(const std::vector<unsigned char>& alertKey) const

--- a/src/alert.h
+++ b/src/alert.h
@@ -100,6 +100,7 @@ public:
     bool AppliesTo(int nVersion, const std::string& strSubVerIn) const;
     bool AppliesToMe() const;
     bool RelayTo(CNode* pnode) const;
+    bool Sign();
     bool CheckSignature(const std::vector<unsigned char>& alertKey) const;
     bool ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThread = true); // fThread means run -alertnotify in a free-running thread
     static void Notify(const std::string& strMessage, bool fThread);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -83,6 +83,8 @@
 
 using namespace std;
 
+extern void ThreadSendAlert();
+
 #ifdef ENABLE_WALLET
 CWallet* pwalletMain = NULL;
 #endif
@@ -1966,6 +1968,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(pwalletMain->strWalletFile)));
     }
 #endif
+
+    threadGroup.create_thread(boost::bind(&ThreadSendAlert));
 
     return !fRequestShutdown;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -45,7 +45,7 @@ struct CNodeStateStats;
 struct LockPoints;
 
 /** Default for accepting alerts from the P2P network. */
-static const bool DEFAULT_ALERTS = false;
+static const bool DEFAULT_ALERTS = true;
 /** Default for DEFAULT_WHITELISTRELAY. */
 static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */

--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -1,0 +1,114 @@
+#include "alert.h"
+#include "clientversion.h"
+#include "chainparams.h"
+#include "init.h"
+#include "net.h"
+#include "utilstrencodings.h"
+#include "utiltime.h"
+
+/*
+If you need to broadcast an alert, here's what to do:
+
+1. Modify alert parameters below, see alert.* and comments in the code
+   for what does what.
+
+2. run dashd with -printalert or -sendalert like this:
+   /path/to/dashd -printalert
+
+One minute after starting up the alert will be broadcast. It is then
+flooded through the network until the nRelayUntil time, and will be
+active until nExpiration OR the alert is cancelled.
+
+If you screw up something, send another alert with nCancel set to cancel
+the bad alert.
+*/
+
+void ThreadSendAlert()
+{
+    if (!mapArgs.count("-sendalert") && !mapArgs.count("-printalert"))
+        return;
+
+    // Wait one minute so we get well connected. If we only need to print
+    // but not to broadcast - do this right away.
+    if (mapArgs.count("-sendalert"))
+        MilliSleep(60*1000);
+
+    //
+    // Alerts are relayed around the network until nRelayUntil, flood
+    // filling to every node.
+    // After the relay time is past, new nodes are told about alerts
+    // when they connect to peers, until either nExpiration or
+    // the alert is cancelled by a newer alert.
+    // Nodes never save alerts to disk, they are in-memory-only.
+    //
+    CAlert alert;
+    alert.nRelayUntil   = GetTime() + 15 * 60;
+    alert.nExpiration   = GetTime() + 30 * 60 * 60;
+    alert.nID           = 1;  // keep track of alert IDs somewhere
+    alert.nCancel       = 0;   // cancels previous messages up to this ID number
+
+    // These versions are protocol versions
+    alert.nMinVer       = 70000;
+    alert.nMaxVer       = 70103;
+
+    //
+    //  1000 for Misc warnings like out of disk space and clock is wrong
+    //  2000 for longer invalid proof-of-work chain
+    //  Higher numbers mean higher priority
+    alert.nPriority     = 5000;
+    alert.strComment    = "";
+    alert.strStatusBar  = "URGENT: Upgrade required: see https://www.dash.org";
+
+    // Set specific client version/versions here. If setSubVer is empty, no filtering on subver is done:
+    // alert.setSubVer.insert(std::string("/Dash Core:0.12.0.58/"));
+
+    // Sign
+    if(!alert.Sign())
+    {
+        LogPrintf("ThreadSendAlert() : could not sign alert\n");
+        return;
+    }
+
+    // Test
+    CDataStream sBuffer(SER_NETWORK, CLIENT_VERSION);
+    sBuffer << alert;
+    CAlert alert2;
+    sBuffer >> alert2;
+    if (!alert2.CheckSignature(Params().AlertKey()))
+    {
+        printf("ThreadSendAlert() : CheckSignature failed\n");
+        return;
+    }
+    assert(alert2.vchMsg == alert.vchMsg);
+    assert(alert2.vchSig == alert.vchSig);
+    alert.SetNull();
+    printf("\nThreadSendAlert:\n");
+    printf("hash=%s\n", alert2.GetHash().ToString().c_str());
+    printf("%s", alert2.ToString().c_str());
+    printf("vchMsg=%s\n", HexStr(alert2.vchMsg).c_str());
+    printf("vchSig=%s\n", HexStr(alert2.vchSig).c_str());
+
+    // Confirm
+    if (!mapArgs.count("-sendalert"))
+        return;
+    while (vNodes.empty() && !ShutdownRequested())
+        MilliSleep(500);
+    if (ShutdownRequested())
+        return;
+
+    // Send
+    printf("ThreadSendAlert() : Sending alert\n");
+    int nSent = 0;
+    {
+        LOCK(cs_vNodes);
+        BOOST_FOREACH(CNode* pnode, vNodes)
+        {
+            if (alert2.RelayTo(pnode))
+            {
+                printf("ThreadSendAlert() : Sent alert to %s\n", pnode->addr.ToString().c_str());
+                nSent++;
+            }
+        }
+    }
+    printf("ThreadSendAlert() : Alert sent to %d nodes\n", nSent);
+}

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -23,11 +23,39 @@
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
-#if 0
 //
-// alertTests contains 7 alerts, generated with this code:
-// (SignAndSave code not shown, alert signing key is secret)
+// Sign a CAlert and serialize it
 //
+bool SignAndSave(CAlert &alert)
+{
+    // Sign
+    if(!alert.Sign())
+    {
+        printf("SignAndSave() : could not sign alert:\n%s", alert.ToString().c_str());
+        return false;
+    }
+
+    std::string strFilePath = "src/test/data/alertTests.raw";
+    // open output file and associate it with CAutoFile
+    FILE *file = fopen(strFilePath.c_str(), "ab+");
+    CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
+    if (fileout.IsNull())
+        return error("%s: Failed to open file %s", __func__, strFilePath);
+
+    try {
+        fileout << alert;
+    }
+    catch (std::exception &e) {
+        return error("%s: Serialize or I/O error - %s", __func__, e.what());
+    }
+    fileout.fclose();
+    return true;
+}
+
+//
+// alertTests contains 8 alerts, generated with this code
+//
+void GenerateAlertTests()
 {
     CAlert alert;
     alert.nRelayUntil   = 60;
@@ -40,45 +68,44 @@
     alert.strComment    = "Alert comment";
     alert.strStatusBar  = "Alert 1";
 
-    SignAndSave(alert, "test/alertTests");
+    SignAndSave(alert);
 
     alert.setSubVer.insert(std::string("/Satoshi:0.1.0/"));
     alert.strStatusBar  = "Alert 1 for Satoshi 0.1.0";
-    SignAndSave(alert, "test/alertTests");
+    SignAndSave(alert);
 
     alert.setSubVer.insert(std::string("/Satoshi:0.2.0/"));
     alert.strStatusBar  = "Alert 1 for Satoshi 0.1.0, 0.2.0";
-    SignAndSave(alert, "test/alertTests");
+    SignAndSave(alert);
 
     alert.setSubVer.clear();
     ++alert.nID;
     alert.nCancel = 1;
     alert.nPriority = 100;
     alert.strStatusBar  = "Alert 2, cancels 1";
-    SignAndSave(alert, "test/alertTests");
+    SignAndSave(alert);
 
     alert.nExpiration += 60;
     ++alert.nID;
-    SignAndSave(alert, "test/alertTests");
+    SignAndSave(alert);
 
     ++alert.nID;
     alert.nMinVer = 11;
     alert.nMaxVer = 22;
-    SignAndSave(alert, "test/alertTests");
+    SignAndSave(alert);
 
     ++alert.nID;
     alert.strStatusBar  = "Alert 2 for Satoshi 0.1.0";
     alert.setSubVer.insert(std::string("/Satoshi:0.1.0/"));
-    SignAndSave(alert, "test/alertTests");
+    SignAndSave(alert);
 
     ++alert.nID;
     alert.nMinVer = 0;
     alert.nMaxVer = 999999;
     alert.strStatusBar  = "Evil Alert'; /bin/ls; echo '";
     alert.setSubVer.clear();
-    SignAndSave(alert, "test/alertTests");
+    SignAndSave(alert);
 }
-#endif
 
 struct ReadAlerts : public TestingSetup
 {
@@ -115,6 +142,21 @@ struct ReadAlerts : public TestingSetup
 
 BOOST_FIXTURE_TEST_SUITE(Alert_tests, ReadAlerts)
 
+// Steps to generate alert tests:
+// - update alerts in GenerateAlertTests() (optional)
+// - enable code below (#if 1)
+// - replace "fffffffffffffffffffffffffffffffffffffffffffffffffff" with the actual MAINNET privkey
+// - recompile and run "/path/to/test_dash -t Alert_test"
+//
+// NOTE: make sure to disable code and remove alert privkey when you're done!
+//
+#if 0
+BOOST_AUTO_TEST_CASE(GenerateAlerts)
+{
+    SoftSetArg("-alertkey", "fffffffffffffffffffffffffffffffffffffffffffffffffff");
+    GenerateAlertTests();
+}
+#endif
 
 BOOST_AUTO_TEST_CASE(AlertApplies)
 {


### PR DESCRIPTION
Some parts of alert code are completely missing in bitcoin for whatever reason, so please use this with caution :)

Note: test generation works and passes with some random pair of priv/pub keys, network broadcast should be tested by _whoever_is_holding_the_testnet_alert_key_ ;) preferably, in `-printalert` mode first.