### PR TITLE
Privatesend denominations

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -141,7 +141,7 @@ You retain control of your money at all times..<hr> \
 <b>The PrivateSend process works like this:</b>\
 <ol type=\"1\"> \
 <li>PrivateSend begins by breaking your transaction inputs down into standard denominations. \
-These denominations are 0.1 DASH, 1 DASH, 10 DASH, and 100 DASH--sort of like the paper money you use every day.</li> \
+These denominations are 0.01 DASH, 0.1 DASH, 1 DASH, and 10 DASH--sort of like the paper money you use every day.</li> \
 <li>Your wallet then sends requests to specially configured software nodes on the network, called \"masternodes.\" \
 These masternodes are informed then that you are interested in mixing a certain denomination. \
 No identifiable information is sent to the masternodes, so they never know \"who\" you are.</li> \


### PR DESCRIPTION
It was stated that the privateSend denominations for 12.1 changed from 0.1, 1, 10, 100 to 0.01, 0.1, 1, 10. This was not reflected in the help text: Help > PrivateSend Information (in the GUI menus).

This fixes that.