### PR TITLE
Fix crash on initial mixing step:

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1549,18 +1549,16 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
                 pnodeFound = FindNode(pmn->addr);
                 if(pnodeFound) {
                     if(pnodeFound->fDisconnect) {
-                        nTries++;
                         continue;
                     } else {
                         pnodeFound->AddRef();
-                        pnodeFound->fMasternode = true;
                     }
                 }
             }
 
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- attempt to connect to masternode from queue, addr=%s\n", pmn->addr.ToString());
             // connect to Masternode and submit the queue request
-            CNode* pnode = pnodeFound ? pnodeFound : ConnectNode((CAddress)pmn->addr, NULL, true);
+            CNode* pnode = (pnodeFound && pnodeFound->fMasternode) ? pnodeFound : ConnectNode((CAddress)pmn->addr, NULL, true);
             if(pnode) {
                 pSubmittedToMasternode = pmn;
                 nSessionDenom = dsq.nDenom;
@@ -1617,13 +1615,12 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
                     continue;
                 } else {
                     pnodeFound->AddRef();
-                    pnodeFound->fMasternode = true;
                 }
             }
         }
 
         LogPrintf("CDarksendPool::DoAutomaticDenominating -- attempt %d connection to Masternode %s\n", nTries, pmn->addr.ToString());
-        CNode* pnode = pnodeFound ? pnodeFound : ConnectNode((CAddress)pmn->addr, NULL, true);
+        CNode* pnode = (pnodeFound && pnodeFound->fMasternode) ? pnodeFound : ConnectNode((CAddress)pmn->addr, NULL, true);
         if(pnode) {
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- connected, addr=%s\n", pmn->addr.ToString());
             pSubmittedToMasternode = pmn;

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1543,9 +1543,24 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
 
             vecMasternodesUsed.push_back(dsq.vin);
 
+            CNode* pnodeFound = NULL;
+            {
+                LOCK(cs_vNodes);
+                pnodeFound = FindNode(pmn->addr);
+                if(pnodeFound) {
+                    if(pnodeFound->fDisconnect) {
+                        nTries++;
+                        continue;
+                    } else {
+                        pnodeFound->AddRef();
+                        pnodeFound->fMasternode = true;
+                    }
+                }
+            }
+
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- attempt to connect to masternode from queue, addr=%s\n", pmn->addr.ToString());
             // connect to Masternode and submit the queue request
-            CNode* pnode = ConnectNode((CAddress)pmn->addr, NULL, true);
+            CNode* pnode = pnodeFound ? pnodeFound : ConnectNode((CAddress)pmn->addr, NULL, true);
             if(pnode) {
                 pSubmittedToMasternode = pmn;
                 nSessionDenom = dsq.nDenom;
@@ -1556,6 +1571,9 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
                 strAutoDenomResult = _("Mixing in progress...");
                 SetState(POOL_STATE_QUEUE);
                 nTimeLastSuccessfulStep = GetTimeMillis();
+                if(pnodeFound) {
+                    pnodeFound->Release();
+                }
                 return true;
             } else {
                 LogPrintf("CDarksendPool::DoAutomaticDenominating -- can't connect, addr=%s\n", pmn->addr.ToString());
@@ -1589,8 +1607,23 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
             continue;
         }
 
+        CNode* pnodeFound = NULL;
+        {
+            LOCK(cs_vNodes);
+            pnodeFound = FindNode(pmn->addr);
+            if(pnodeFound) {
+                if(pnodeFound->fDisconnect) {
+                    nTries++;
+                    continue;
+                } else {
+                    pnodeFound->AddRef();
+                    pnodeFound->fMasternode = true;
+                }
+            }
+        }
+
         LogPrintf("CDarksendPool::DoAutomaticDenominating -- attempt %d connection to Masternode %s\n", nTries, pmn->addr.ToString());
-        CNode* pnode = ConnectNode((CAddress)pmn->addr, NULL, true);
+        CNode* pnode = pnodeFound ? pnodeFound : ConnectNode((CAddress)pmn->addr, NULL, true);
         if(pnode) {
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- connected, addr=%s\n", pmn->addr.ToString());
             pSubmittedToMasternode = pmn;
@@ -1608,6 +1641,9 @@ bool CDarksendPool::DoAutomaticDenominating(bool fDryRun)
             strAutoDenomResult = _("Mixing in progress...");
             SetState(POOL_STATE_QUEUE);
             nTimeLastSuccessfulStep = GetTimeMillis();
+            if(pnodeFound) {
+                pnodeFound->Release();
+            }
             return true;
         } else {
             LogPrintf("CDarksendPool::DoAutomaticDenominating -- can't connect, addr=%s\n", pmn->addr.ToString());


### PR DESCRIPTION
- skip nodes marked to be disconnected
- add/release ref to make sure pnode is not deleted in the middle of the process

Should hopefully fix the crash reported there https://www.dash.org/forum/threads/tail-of-debug-log-after-12-1-crash-during-mixing.13051/