### PR TITLE
Few networking fixes

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -666,7 +666,7 @@ void CGovernanceManager::Sync(CNode* pfrom, const uint256& nProp, const CBloomFi
     */
 
     // do not provide any data until our node is synced
-    if(!masternodeSync.IsSynced()) return;
+    if(fMasterNode && !masternodeSync.IsSynced()) return;
 
     int nObjCount = 0;
     int nVoteCount = 0;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1052,7 +1052,7 @@ void CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>&
             // they stay connected for a short period of time and it's possible that we won't get everything we should.
             // Only use outbound connections - inbound connection could be a "masternode" connection
             // initialted from another node, so skip it too.
-            if(pnode->fMasternode || pnode->fInbound) continue;
+            if(pnode->fMasternode || (fMasterNode && pnode->fInbound)) continue;
             // only use up to date peers
             if(pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
             // stop early to prevent setAskFor overflow

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -665,6 +665,9 @@ void CGovernanceManager::Sync(CNode* pfrom, const uint256& nProp, const CBloomFi
         budget object to see if they're OK. If all checks pass, we'll send it to the peer.
     */
 
+    // do not provide any data until our node is synced
+    if(!masternodeSync.IsSynced()) return;
+
     int nObjCount = 0;
     int nVoteCount = 0;
 
@@ -1045,9 +1048,11 @@ void CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>&
         }
         bool fAsked = false;
         BOOST_FOREACH(CNode* pnode, vNodesCopy) {
-            // only use reqular peers, don't try to ask from temporary nodes we connected to -
-            // they stay connected for a short period of time and it's possible that we won't get everything we should
-            if(pnode->fMasternode) continue;
+            // Only use reqular peers, don't try to ask from outbound "masternode" connections -
+            // they stay connected for a short period of time and it's possible that we won't get everything we should.
+            // Only use outbound connections - inbound connection could be a "masternode" connection
+            // initialted from another node, so skip it too.
+            if(pnode->fMasternode || pnode->fInbound) continue;
             // only use up to date peers
             if(pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
             // stop early to prevent setAskFor overflow

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -334,6 +334,12 @@ void CMasternodeSync::ProcessTick()
 
     BOOST_FOREACH(CNode* pnode, vNodesCopy)
     {
+        // Don't try to sync any data from outbound "masternode" connections -
+        // they are temporary and should be considered unreliable for a sync process.
+        // Inbound connection this early is most likely a "masternode" connection
+        // initialted from another node, so skip it too.
+        if(pnode->fMasternode || pnode->fInbound) continue;
+
         // QUICK MODE (REGTEST ONLY!)
         if(Params().NetworkIDString() == CBaseChainParams::REGTEST)
         {

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -338,7 +338,7 @@ void CMasternodeSync::ProcessTick()
         // they are temporary and should be considered unreliable for a sync process.
         // Inbound connection this early is most likely a "masternode" connection
         // initialted from another node, so skip it too.
-        if(pnode->fMasternode || pnode->fInbound) continue;
+        if(pnode->fMasternode || (fMasterNode && pnode->fInbound)) continue;
 
         // QUICK MODE (REGTEST ONLY!)
         if(Params().NetworkIDString() == CBaseChainParams::REGTEST)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -964,8 +964,8 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
 
 static void AcceptConnection(const ListenSocket& hListenSocket) {
     // don't accept incoming connections until fully synced
-    if(!masternodeSync.IsSynced()) {
-        LogPrintf("AcceptConnection -- node is not synced yet, skipping\n");
+    if(fMasterNode && !masternodeSync.IsSynced()) {
+        LogPrintf("AcceptConnection -- masternode is not synced yet, skipping inbound connection attempt\n");
         return;
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -24,6 +24,7 @@
 
 #include "darksend.h"
 #include "instantx.h"
+#include "masternode-sync.h"
 #include "masternodeman.h"
 
 #ifdef WIN32
@@ -962,6 +963,12 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
 }
 
 static void AcceptConnection(const ListenSocket& hListenSocket) {
+    // don't accept incoming connections until fully synced
+    if(!masternodeSync.IsSynced()) {
+        LogPrintf("AcceptConnection -- node is not synced yet, skipping\n");
+        return;
+    }
+
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
     SOCKET hSocket = accept(hListenSocket.socket, (struct sockaddr*)&sockaddr, &len);


### PR DESCRIPTION
- skip "masternode"/inbound connections for sync related processes
- do not sync gov data to other nodes until fully synced ourselves
- do not accept incoming connections until fully synced