### PR TITLE
Add "enough data" stop conditions for gov sync

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -71,6 +71,12 @@ bool CGovernanceManager::HaveVoteForHash(uint256 nHash)
     return true;
 }
 
+int CGovernanceManager::GetVoteCount() const
+{
+    LOCK(cs);
+    return (int)mapVoteToObject.GetSize();
+}
+
 bool CGovernanceManager::SerializeVoteForHash(uint256 nHash, CDataStream& ss)
 {
     LOCK(cs);
@@ -987,21 +993,23 @@ void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nH
     pfrom->PushMessage(NetMsgType::MNGOVERNANCESYNC, nHash, filter);
 }
 
-void CGovernanceManager::RequestGovernanceObjectVotes(CNode* pnode)
+int CGovernanceManager::RequestGovernanceObjectVotes(CNode* pnode)
 {
-    if(pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) return;
+    if(pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) return -3;
     std::vector<CNode*> vNodesCopy;
     vNodesCopy.push_back(pnode);
-    RequestGovernanceObjectVotes(vNodesCopy);
+    return RequestGovernanceObjectVotes(vNodesCopy);
 }
 
-void CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy)
+int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy)
 {
     static std::map<uint256, std::map<CService, int64_t> > mapAskedRecently;
 
-    if(vNodesCopy.empty()) return;
+    if(vNodesCopy.empty()) return -1;
 
     LOCK2(cs_main, cs);
+
+    if(mapObjects.empty()) return -2;
 
     int64_t nNow = GetTime();
     int nTimeout = 60 * 60;
@@ -1040,7 +1048,7 @@ void CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>&
         }
     }
 
-    LogPrint("governance", "CGovernanceManager::RequestGovernanceObjectVotes -- start: vpGovObjsTriggersTmp %d vpGovObjsTmp %d mapAskedRecently %d\n",
+    LogPrint("gobject", "CGovernanceManager::RequestGovernanceObjectVotes -- start: vpGovObjsTriggersTmp %d vpGovObjsTmp %d mapAskedRecently %d\n",
                 vpGovObjsTriggersTmp.size(), vpGovObjsTmp.size(), mapAskedRecently.size());
 
     InsecureRand insecureRand;
@@ -1087,8 +1095,10 @@ void CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>&
         }
         if(!fAsked) i--;
     }
-    LogPrint("governance", "CGovernanceManager::RequestGovernanceObjectVotes -- end: vpGovObjsTriggersTmp %d vpGovObjsTmp %d mapAskedRecently %d\n",
+    LogPrint("gobject", "CGovernanceManager::RequestGovernanceObjectVotes -- end: vpGovObjsTriggersTmp %d vpGovObjsTmp %d mapAskedRecently %d\n",
                 vpGovObjsTriggersTmp.size(), vpGovObjsTmp.size(), mapAskedRecently.size());
+
+    return int(vpGovObjsTriggersTmp.size() + vpGovObjsTmp.size());
 }
 
 bool CGovernanceManager::AcceptObjectMessage(const uint256& nHash)

--- a/src/governance.h
+++ b/src/governance.h
@@ -345,6 +345,8 @@ public:
 
     bool HaveVoteForHash(uint256 nHash);
 
+    int GetVoteCount() const;
+
     bool SerializeObjectForHash(uint256 nHash, CDataStream& ss);
 
     bool SerializeVoteForHash(uint256 nHash, CDataStream& ss);
@@ -376,8 +378,8 @@ public:
 
     void InitOnLoad();
 
-    void RequestGovernanceObjectVotes(CNode* pnode);
-    void RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy);
+    int RequestGovernanceObjectVotes(CNode* pnode);
+    int RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy);
 
 private:
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash, bool fUseFilter = false);

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -465,7 +465,7 @@ void CMasternodeSync::ProcessTick()
             // GOVOBJ : SYNC GOVERNANCE ITEMS FROM OUR PEERS
 
             if(nRequestedMasternodeAssets == MASTERNODE_SYNC_GOVERNANCE) {
-                LogPrint("mnpayments", "CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d nTimeLastPaymentVote %lld GetTime() %lld diff %lld\n", nTick, nRequestedMasternodeAssets, nTimeLastPaymentVote, GetTime(), GetTime() - nTimeLastPaymentVote);
+                LogPrint("gobject", "CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d nTimeLastGovernanceItem %lld GetTime() %lld diff %lld\n", nTick, nRequestedMasternodeAssets, nTimeLastGovernanceItem, GetTime(), GetTime() - nTimeLastGovernanceItem);
 
                 // check for timeout first
                 if(GetTime() - nTimeLastGovernanceItem > MASTERNODE_SYNC_TIMEOUT_SECONDS) {
@@ -479,22 +479,27 @@ void CMasternodeSync::ProcessTick()
                     return;
                 }
 
-                // check for data
-                // if(nCountBudgetItemProp > 0 && nCountBudgetItemFin)
-                // {
-                //     if(governance.CountProposalInventoryItems() >= (nSumBudgetItemProp / nCountBudgetItemProp)*0.9)
-                //     {
-                //         if(governance.CountFinalizedInventoryItems() >= (nSumBudgetItemFin / nCountBudgetItemFin)*0.9)
-                //         {
-                //             SwitchToNextAsset();
-                //             return;
-                //         }
-                //     }
-                // }
-
                 // only request obj sync once from each peer, then request votes on per-obj basis
                 if(netfulfilledman.HasFulfilledRequest(pnode->addr, "governance-sync")) {
-                    governance.RequestGovernanceObjectVotes(pnode);
+                    int nObjsLeftToAsk = governance.RequestGovernanceObjectVotes(pnode);
+                    // check for data
+                    if(nObjsLeftToAsk == 0) {
+                        static int64_t nTimeNoObjectsLeft = GetTime();
+                        static int nLastVotes = 0;
+                        if(GetTime() - nTimeNoObjectsLeft > MASTERNODE_SYNC_TIMEOUT_SECONDS &&
+                            governance.GetVoteCount() - nLastVotes < std::max(int(0.0001 * nLastVotes), MASTERNODE_SYNC_TICK_SECONDS)
+                        ) {
+                            // We already asked for all objects, waited for MASTERNODE_SYNC_TIMEOUT_SECONDS
+                            // after that and less then 0.01% or MASTERNODE_SYNC_TICK_SECONDS
+                            // (i.e. 1 per second) votes were recieved during the last tick.
+                            // We can be pretty sure that we are done syncing.
+                            LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- asked for all objects, nothing to do\n", nTick, nRequestedMasternodeAssets);
+                            SwitchToNextAsset();
+                            ReleaseNodes(vNodesCopy);
+                            return;
+                        }
+                        nLastVotes = governance.GetVoteCount();
+                    }
                     continue;
                 }
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "governance-sync");


### PR DESCRIPTION
Trying both not to miss some data and not to wait forever for gov sync to finish - considering <0.01% increase in vote count or vote rate less then 1 vote per sec after votes for all objects were requested to be the "end of the tail".

Works quite well for me.

(also fixed few related LogPrint(f)-s)