### PR TITLE
[RFC] add ObjectType to first-level JSON result

### DIFF
--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -584,6 +584,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
             bObj.push_back(Pair("DataString",  pGovObj->GetDataAsString()));
             bObj.push_back(Pair("Hash",  pGovObj->GetHash().ToString()));
             bObj.push_back(Pair("CollateralHash",  pGovObj->GetCollateralHash().ToString()));
+            bObj.push_back(Pair("ObjectType", pGovObj->GetObjectType()));
             bObj.push_back(Pair("CreationTime", pGovObj->GetCreationTime()));
             const CTxIn& masternodeVin = pGovObj->GetMasternodeVin();
             if(masternodeVin != CTxIn()) {
@@ -635,6 +636,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
         objResult.push_back(Pair("DataString",  pGovObj->GetDataAsString()));
         objResult.push_back(Pair("Hash",  pGovObj->GetHash().ToString()));
         objResult.push_back(Pair("CollateralHash",  pGovObj->GetCollateralHash().ToString()));
+        objResult.push_back(Pair("ObjectType", pGovObj->GetObjectType()));
         objResult.push_back(Pair("CreationTime", pGovObj->GetCreationTime()));
         const CTxIn& masternodeVin = pGovObj->GetMasternodeVin();
         if(masternodeVin != CTxIn()) {


### PR DESCRIPTION
I think for Governance objects the type-attribute should be a first level attribute and not buried deeply in "DataString".
This makes it much easier for external applications/scripts to parse the results.

I've left the type attribute in "DataStrings" for backward compatibility, it's not much data anyway. If you think it should remove it from there I'll do that of course.

This PR covers both `gobject list` and `gobject get` RPC commands.

Example RPC-result:
![objecttype](https://cloud.githubusercontent.com/assets/10080039/23102747/42e1377a-f6af-11e6-8d31-c8cee5767a21.png)

