### PR TITLE
fix gov list filtering bug

### DIFF
--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -544,7 +544,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
         // GET MAIN PARAMETER FOR THIS MODE, VALID OR ALL?
 
         std::string strShow = "valid";
-        if (params.size() == 2) strShow = params[1].get_str();
+        if (params.size() >= 2) strShow = params[1].get_str();
         if (strShow != "valid" && strShow != "all")
             return "Invalid mode, should be 'valid' or 'all'";
 


### PR DESCRIPTION
`gobject list all <type>` actually returns result of `gobject list valid <type>` currently. This should fix it.