### PR TITLE
Define current votes by creation time instead of arrival time

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -140,6 +140,16 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
         it2 = recVote.mapInstances.insert(vote_instance_m_t::value_type(int(eSignal), vote_instance_t())).first;
     }
     vote_instance_t& voteInstance = it2->second;
+
+    // Reject obsolete votes
+    if(vote.GetTimestamp() < voteInstance.nCreationTime) {
+        std::ostringstream ostr;
+        ostr << "CGovernanceObject::ProcessVote -- Obsolete vote" << "\n";
+        LogPrint("gobject", ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_NONE);
+        return false;
+    }
+
     int64_t nNow = GetTime();
     int64_t nVoteTimeUpdate = voteInstance.nTime;
     if(governance.AreRateChecksEnabled()) {
@@ -168,7 +178,7 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
         governance.AddInvalidVote(vote);
         return false;
     }
-    voteInstance = vote_instance_t(vote.GetOutcome(), nVoteTimeUpdate);
+    voteInstance = vote_instance_t(vote.GetOutcome(), nVoteTimeUpdate, vote.GetTimestamp());
     fileVotes.AddVote(vote);
     mnodeman.AddGovernanceVote(vote.GetVinMasternode(), vote.GetParentHash());
     fDirtyCache = true;

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -62,10 +62,12 @@ struct vote_instance_t {
 
     vote_outcome_enum_t eOutcome;
     int64_t nTime;
+    int64_t nCreationTime;
 
-    vote_instance_t(vote_outcome_enum_t eOutcomeIn = VOTE_OUTCOME_NONE, int64_t nTimeIn = 0)
+    vote_instance_t(vote_outcome_enum_t eOutcomeIn = VOTE_OUTCOME_NONE, int64_t nTimeIn = 0, int64_t nCreationTimeIn = 0)
         : eOutcome(eOutcomeIn),
-          nTime(nTimeIn)
+          nTime(nTimeIn),
+          nCreationTime(nCreationTimeIn)
     {}
 
     ADD_SERIALIZE_METHODS;
@@ -76,6 +78,7 @@ struct vote_instance_t {
         int nOutcome = int(eOutcome);
         READWRITE(nOutcome);
         READWRITE(nTime);
+        READWRITE(nCreationTime);
         if(ser_action.ForRead()) {
             eOutcome = vote_outcome_enum_t(nOutcome);
         }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -20,7 +20,7 @@ std::map<uint256, int64_t> mapAskedForGovernanceObject;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-10";
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-11";
 
 CGovernanceManager::CGovernanceManager()
     : pCurrentBlockIndex(NULL),
@@ -593,10 +593,10 @@ std::vector<CGovernanceVote> CGovernanceManager::GetCurrentVotes(const uint256& 
         for (vote_instance_m_it it3 = voteRecord.mapInstances.begin(); it3 != voteRecord.mapInstances.end(); ++it3) {
             int signal = (it3->first);
             int outcome = ((it3->second).eOutcome);
-            int64_t nTime = ((it3->second).nTime);
+            int64_t nCreationTime = ((it3->second).nCreationTime);
 
             CGovernanceVote vote = CGovernanceVote(mnCollateralOutpoint, nParentHash, (vote_signal_enum_t)signal, (vote_outcome_enum_t)outcome);
-            vote.SetTime(nTime);
+            vote.SetTime(nCreationTime);
 
             vecResult.push_back(vote);
         }


### PR DESCRIPTION
The current vote for a given mn/governance object/signal has up until now been defined as the vote most recently seen.   This works well for nodes that are online but not for offline nodes since vote syncing does not preserve arrival time.

This PR changes the definition of the current vote to the vote seen with the largest creation time.

It also rejects older votes since these can no longer have any effect.