### PR TITLE
Reverse order for sending bulk winner list

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -830,7 +830,7 @@ void CMasternodePayments::Sync(CNode* pnode, int nCountNeeded)
 
     int nInvCount = 0;
 
-    for(int h = pCurrentBlockIndex->nHeight - nCountNeeded; h < pCurrentBlockIndex->nHeight + 20; h++) {
+    for(int h = pCurrentBlockIndex->nHeight + 20; h > pCurrentBlockIndex->nHeight - nCountNeeded; h--) {
         if(mapMasternodeBlocks.count(h)) {
             BOOST_FOREACH(CMasternodePayee& payee, mapMasternodeBlocks[h].vecPayees) {
                 std::vector<uint256> vecVoteHashes = payee.GetVoteHashes();


### PR DESCRIPTION
I think the winner list for new blocks is more important than the old blocks so we should send the latest first.