### PR TITLE
fixed protobuf 3.0 (byteswap) issue on macOS

### DIFF
--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -1,13 +1,16 @@
 bin_PROGRAMS += qt/test/test_dash-qt
 TESTS += qt/test/test_dash-qt
 
-TEST_QT_MOC_CPP = qt/test/moc_uritests.cpp
+TEST_QT_MOC_CPP = \
+  qt/test/moc_compattests.cpp \
+  qt/test/moc_uritests.cpp
 
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += qt/test/moc_paymentservertests.cpp
 endif
 
 TEST_QT_H = \
+  qt/test/compattests.h \
   qt/test/uritests.h \
   qt/test/paymentrequestdata.h \
   qt/test/paymentservertests.h
@@ -16,6 +19,7 @@ qt_test_test_dash_qt_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_QT_
   $(QT_INCLUDES) $(QT_TEST_INCLUDES) $(PROTOBUF_CFLAGS)
 
 qt_test_test_dash_qt_SOURCES = \
+  qt/test/compattests.cpp \
   qt/test/test_main.cpp \
   qt/test/uritests.cpp \
   $(TEST_QT_H)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -43,6 +43,7 @@ BITCOIN_TESTS =\
   test/base64_tests.cpp \
   test/bip32_tests.cpp \
   test/bloom_tests.cpp \
+  test/bswap_tests.cpp \
   test/cachemap_tests.cpp \
   test/cachemultimap_tests.cpp \
   test/checkblock_tests.cpp \

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -15,6 +15,23 @@
 #include <byteswap.h>
 #endif
 
+#if defined(__APPLE__)
+
+#if !defined(bswap_16)
+
+// Mac OS X / Darwin features; we include a check for bswap_16 because if it is already defined, protobuf has
+// defined these macros for us already; if it isn't, we do it ourselves. In either case, we get the exact same
+// result regardless which path was taken
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+
+#endif // !defined(bswap_16)
+
+#else
+// Non-Mac OS X / non-Darwin
+
 #if HAVE_DECL_BSWAP_16 == 0
 inline uint16_t bswap_16(uint16_t x)
 {
@@ -43,5 +60,7 @@ inline uint64_t bswap_64(uint64_t x)
           | ((x & 0x00000000000000ffull) << 56));
 }
 #endif // HAVE_DECL_BSWAP64
+
+#endif // defined(__APPLE__)
 
 #endif // BITCOIN_COMPAT_BYTESWAP_H

--- a/src/qt/test/compattests.cpp
+++ b/src/qt/test/compattests.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "paymentrequestplus.h" // this includes protobuf's port.h which defines its own bswap macos
+
+#include "compattests.h"
+
+#include "compat/byteswap.h"
+
+void CompatTests::bswapTests()
+{
+	// Sibling in bitcoin/src/test/bswap_tests.cpp
+	uint16_t u1 = 0x1234;
+	uint32_t u2 = 0x56789abc;
+	uint64_t u3 = 0xdef0123456789abc;
+	uint16_t e1 = 0x3412;
+	uint32_t e2 = 0xbc9a7856;
+	uint64_t e3 = 0xbc9a78563412f0de;
+	QVERIFY(bswap_16(u1) == e1);
+	QVERIFY(bswap_32(u2) == e2);
+	QVERIFY(bswap_64(u3) == e3);
+}

--- a/src/qt/test/compattests.h
+++ b/src/qt/test/compattests.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_COMPATTESTS_H
+#define BITCOIN_QT_TEST_COMPATTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+class CompatTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void bswapTests();
+};
+
+#endif // BITCOIN_QT_TEST_COMPATTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -9,6 +9,7 @@
 
 #include "util.h"
 #include "uritests.h"
+#include "compattests.h"
 
 #ifdef ENABLE_WALLET
 #include "paymentservertests.h"
@@ -49,6 +50,9 @@ int main(int argc, char *argv[])
     if (QTest::qExec(&test2) != 0)
         fInvalid = true;
 #endif
+    CompatTests test4;
+    if (QTest::qExec(&test4) != 0)
+        fInvalid = true;
 
     return fInvalid;
 }

--- a/src/test/bswap_tests.cpp
+++ b/src/test/bswap_tests.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "compat/byteswap.h"
+#include "test/test_dash.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(bswap_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(bswap_tests)
+{
+	// Sibling in bitcoin/src/qt/test/compattests.cpp
+	uint16_t u1 = 0x1234;
+	uint32_t u2 = 0x56789abc;
+	uint64_t u3 = 0xdef0123456789abc;
+	uint16_t e1 = 0x3412;
+	uint32_t e2 = 0xbc9a7856;
+	uint64_t e3 = 0xbc9a78563412f0de;
+	BOOST_CHECK(bswap_16(u1) == e1);
+	BOOST_CHECK(bswap_32(u2) == e2);
+	BOOST_CHECK(bswap_64(u3) == e3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This resolves an issue during compilation on MacOS.

Protobuf v 3.0 had some issues and this fixes them.

Merged from bitcoincore https://github.com/bitcoin/bitcoin/commit/79da3979b7cc0d1f93f918983c47af22f551ac63

Discussion can be found here
https://github.com/bitcoin/bitcoin/pull/9366