### PR TITLE
Do not force disconnect for stalled nodes on sync

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -369,9 +369,6 @@ void CMasternodeSync::ProcessTick()
                 continue;
             }
 
-            // Make sure this peer is presumably at the same height
-            if(!CheckNodeHeight(pnode, true)) continue;
-
             // SPORK : ALWAYS ASK FOR SPORKS AS WE SYNC (we skip this mode now)
 
             if(!netfulfilledman.HasFulfilledRequest(pnode->addr, "spork-sync")) {


### PR DESCRIPTION
Looks like this was not such a good idea. They might be simply busy serving us another data (i.e. headers are in the tail of that queue).