### PR TITLE
Periodicially request orphan objects

### DIFF
--- a/src/cachemultimap.h
+++ b/src/cachemultimap.h
@@ -146,6 +146,13 @@ public:
         return true;
     }
 
+    void GetKeys(std::vector<K>& vecKeys)
+    {
+        for(map_cit it = mapIndex.begin(); it != mapIndex.end(); ++it) {
+            vecKeys.push_back(it->first);
+        }
+    }
+
     void Erase(const K& key)
     {
         map_it mit = mapIndex.find(key);

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -6,6 +6,7 @@
 #include "coincontrol.h"
 #include "consensus/validation.h"
 #include "darksend.h"
+#include "governance.h"
 #include "init.h"
 #include "instantx.h"
 #include "masternode-payments.h"
@@ -2519,6 +2520,10 @@ void ThreadCheckDarkSendPool()
             }
             if(fMasterNode && (nTick % (60 * 5) == 0)) {
                 mnodeman.DoFullVerificationStep();
+            }
+
+            if(nTick % (60 * 5) == 0) {
+                governance.DoMaintenance();
             }
 
             darkSendPool.CheckTimeout();

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -668,6 +668,8 @@ void CGovernanceManager::NewBlock()
         }
     }
 
+    CleanOrphanObjects();
+
     RequestOrphanObjects();
 
     // CHECK AND REMOVE - REPROCESS GOVERNANCE OBJECTS
@@ -1336,4 +1338,22 @@ void CGovernanceManager::RequestOrphanObjects()
     }
 
     ReleaseNodeVector(vNodesCopy);
+}
+
+void CGovernanceManager::CleanOrphanObjects()
+{
+    LOCK(cs);
+    const vote_mcache_t::list_t& items = mapOrphanVotes.GetItemList();
+
+    int64_t nNow = GetAdjustedTime();
+
+    vote_mcache_t::list_cit it = items.begin();
+    while(it != items.end()) {
+        vote_mcache_t::list_cit prevIt = it;
+        ++it;
+        const vote_time_pair_t& pairVote = prevIt->value;
+        if(pairVote.second < nNow) {
+            mapOrphanVotes.Erase(prevIt->key, prevIt->value);
+        }
+    }
 }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1032,6 +1032,8 @@ void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nH
         return;
     }
 
+    LogPrint("gobject", "CGovernanceObject::RequestGovernanceObject -- hash = %s (peer=%d)\n", nHash.ToString(), pfrom->GetId());
+
     if(pfrom->nVersion < GOVERNANCE_FILTER_PROTO_VERSION) {
         pfrom->PushMessage(NetMsgType::MNGOVERNANCESYNC, nHash);
         return;
@@ -1317,6 +1319,7 @@ void CGovernanceManager::RequestOrphanObjects()
         std::vector<uint256> vecHashes;
         mapOrphanVotes.GetKeys(vecHashes);
 
+        LogPrint("gobject", "CGovernanceObject::RequestOrphanObjects -- number objects = %d\n", vecHashes.size());
         for(size_t i = 0; i < vecHashes.size(); ++i) {
             const uint256& nHash = vecHashes[i];
             if(mapObjects.find(nHash) != mapObjects.end()) {
@@ -1324,6 +1327,9 @@ void CGovernanceManager::RequestOrphanObjects()
             }
             for(size_t j = 0; j < vNodesCopy.size(); ++j) {
                 CNode* pnode = vNodesCopy[j];
+                if(pnode->fMasternode) {
+                    continue;
+                }
                 RequestGovernanceObject(pnode, nHash);
             }
         }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1314,15 +1314,16 @@ void CGovernanceManager::RequestOrphanObjects()
 
     {
         LOCK(cs);
-        const vote_mcache_t::list_t& items = mapOrphanVotes.GetItemList();
+        std::vector<uint256> vecHashes;
+        mapOrphanVotes.GetKeys(vecHashes);
 
-        for(vote_mcache_t::list_cit it = items.begin(); it != items.end(); ++it) {
-            const uint256& nHash = it->key;
+        for(size_t i = 0; i < vecHashes.size(); ++i) {
+            const uint256& nHash = vecHashes[i];
             if(mapObjects.find(nHash) != mapObjects.end()) {
                 continue;
             }
-            for(size_t i = 0; i < vNodesCopy.size(); ++i) {
-                CNode* pnode = vNodesCopy[i];
+            for(size_t j = 0; j < vNodesCopy.size(); ++j) {
+                CNode* pnode = vNodesCopy[j];
                 RequestGovernanceObject(pnode, nHash);
             }
         }

--- a/src/governance.h
+++ b/src/governance.h
@@ -280,7 +280,7 @@ public:
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
-    void NewBlock();
+    void DoMaintenance();
 
     CGovernanceObject *FindGovernanceObject(const uint256& nHash);
 

--- a/src/governance.h
+++ b/src/governance.h
@@ -425,6 +425,8 @@ private:
 
     bool UpdateCurrentWatchdog(CGovernanceObject& watchdogNew);
 
+    void RequestOrphanObjects();
+
 };
 
 #endif

--- a/src/governance.h
+++ b/src/governance.h
@@ -427,6 +427,8 @@ private:
 
     void RequestOrphanObjects();
 
+    void CleanOrphanObjects();
+
 };
 
 #endif

--- a/src/governance.h
+++ b/src/governance.h
@@ -24,7 +24,6 @@ class CGovernanceTriggerManager;
 class CGovernanceObject;
 class CGovernanceVote;
 
-extern std::map<uint256, int64_t> mapAskedForGovernanceObject;
 extern CGovernanceManager governance;
 
 typedef std::pair<CGovernanceObject, int64_t> object_time_pair_t;


### PR DESCRIPTION
It happens that nodes see votes for objects they do not have. Currently when this occurs the node requests the missing object once from the peer that sent the vote. This doesn't always suffice to obtain the missing object, perhaps because of network congestion at the time the vote is received.

This PR re-requests missing objects from all peers once every 5 minutes until the orphan record expires (increased from 10 minutes to 20 minutes).