### PR TITLE
Locking fix for UpdatePreferredDownload

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5362,8 +5362,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         pfrom->fClient = !(pfrom->nServices & NODE_NETWORK);
 
+        CNodeState* pNodeState = NULL;
+        {
+            LOCK(cs_main);
+            pNodeState = State(pfrom->GetId());
+            assert(pNodeState);
+        }
+
         // Potentially mark this peer as a preferred download peer.
-        UpdatePreferredDownload(pfrom, State(pfrom->GetId()));
+        UpdatePreferredDownload(pfrom, pNodeState);
 
         // Change version
         pfrom->PushMessage(NetMsgType::VERACK);


### PR DESCRIPTION
This should fix an observed crash in UpdatePreferredDownload believed to be caused by a non-threadsafe access to mapNodeState.