### PR TITLE
Node eviction fix

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -420,7 +420,7 @@ public:
     // Whether a ping is requested.
     bool fPingQueued;
 
-    std::vector<unsigned char> vchKeyedNetgroup;
+    std::vector<unsigned char> vchKeyedNetGroup;
 
     CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false, bool fNetworkNodeIn = false);
     ~CNode();
@@ -828,7 +828,7 @@ public:
     // in case of no limit, it will always response 0
     static uint64_t GetMaxOutboundTimeLeftInCycle();
 
-    static std::vector<unsigned char> CalculateKeyedNetgroup(CAddress& address);
+    static std::vector<unsigned char> CalculateKeyedNetGroup(CAddress& address);
 };
 
 class CExplicitNetCleanup

--- a/src/net.h
+++ b/src/net.h
@@ -420,6 +420,8 @@ public:
     // Whether a ping is requested.
     bool fPingQueued;
 
+    std::vector<unsigned char> vchKeyedNetgroup;
+
     CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false, bool fNetworkNodeIn = false);
     ~CNode();
 
@@ -435,6 +437,9 @@ private:
     static uint64_t nMaxOutboundCycleStartTime;
     static uint64_t nMaxOutboundLimit;
     static uint64_t nMaxOutboundTimeframe;
+
+    // Secret key for computing keyed net groups
+    static std::vector<unsigned char> vchSecretKey;
 
     CCriticalSection cs_nRefCount;
 
@@ -822,6 +827,8 @@ public:
     //!response the time in second left in the current max outbound cycle
     // in case of no limit, it will always response 0
     static uint64_t GetMaxOutboundTimeLeftInCycle();
+
+    static std::vector<unsigned char> CalculateKeyedNetgroup(CAddress& address);
 };
 
 class CExplicitNetCleanup


### PR DESCRIPTION
This fixes two issues with node eviction.

The first is that CNode fields used for sorting can be changed by another thread while this function is running which can cause sort to segfault.

The second problem is that SHA256 hases were computed in a comparison function resulting in unnecessary recalculations.

These problems have been fixed by adding a keyed net group field to CNode which is computed in the constructor and by copying data used for sorting into a temporary structure.