### PR TITLE
Fail to proceed in listsinceblock if provided blockhash can't be found

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1767,6 +1767,8 @@ UniValue listsinceblock(const UniValue& params, bool fHelp)
         BlockMap::iterator it = mapBlockIndex.find(blockId);
         if (it != mapBlockIndex.end())
             pindex = it->second;
+        else
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid blockhash");
     }
 
     if (params.size() > 1)


### PR DESCRIPTION
If daemon crashes, it can't save latest block sometimes, so querying daemon
for presumably best/last hash would result in a list of all txes recognized by
this wallet as its own since genesis block which could be confusing,
to say at least. Same applies for typos etc. This should fix it.

Not sure why but such weird behaviour was the case since listsinceblock rpc was
initially introduced in Bitcoin 0.5 (Oct 5, 2011)
https://github.com/bitcoin/bitcoin/commit/3a6e468d9a0caceea80f274967bb0cf6aecdc8f1