### PR TITLE
Drop support for pre-12.1 nodes

### DIFF
--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -35,7 +35,7 @@ import copy
 import dash_hash
 
 BIP0031_VERSION = 60000
-MY_VERSION = 70103  # past bip-31 for ping/pong
+MY_VERSION = 70206  # current MIN_PEER_PROTO_VERSION
 MY_SUBVERSION = b"/python-mininode-tester:0.0.2/"
 
 MAX_INV_SZ = 50000

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -313,7 +313,6 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
 
         if(nMsgMessageID < MSG_POOL_MIN || nMsgMessageID > MSG_POOL_MAX) {
             LogPrint("privatesend", "DSSTATUSUPDATE -- nMsgMessageID is out of bounds: %d\n", nMsgMessageID);
-            if(pfrom->nVersion < 70203) nMsgMessageID = MSG_NOERR;
             return;
         }
 

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -24,7 +24,7 @@ class CGovernanceObject;
 class CGovernanceVote;
 
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
-static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70204;
+static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70206;
 static const int GOVERNANCE_FILTER_PROTO_VERSION = 70206;
 
 static const double GOVERNANCE_FILTER_FP_RATE = 0.001;

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -27,7 +27,7 @@ extern CInstantSend instantsend;
 static const int INSTANTSEND_CONFIRMATIONS_REQUIRED = 6;
 static const int DEFAULT_INSTANTSEND_DEPTH          = 5;
 
-static const int MIN_INSTANTSEND_PROTO_VERSION      = 70205;
+static const int MIN_INSTANTSEND_PROTO_VERSION      = 70206;
 
 extern bool fEnableInstantSend;
 extern int nInstantSendDepth;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5173,10 +5173,6 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
                         ss << mnodeman.mapSeenMasternodeBroadcast[inv.hash].second;
-                        // backward compatibility patch
-                        if(pfrom->nVersion < 70204) {
-                            ss << (int64_t)0;
-                        }
                         pfrom->PushMessage(NetMsgType::MNANNOUNCE, ss);
                         pushed = true;
                     }

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -23,8 +23,8 @@ static const int MNPAYMENTS_SIGNATURES_TOTAL            = 10;
 //  vote for masternode and be elected as a payment winner
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70103;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70204;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70206;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70206;
 
 extern CCriticalSection cs_vecPayees;
 extern CCriticalSection cs_mapMasternodeBlocks;
@@ -196,7 +196,7 @@ public:
     bool HasVerifiedPaymentVote(uint256 hashIn);
     bool ProcessBlock(int nBlockHeight);
 
-    void Sync(CNode* node, int nCountNeeded);
+    void Sync(CNode* node);
     void RequestLowDataPaymentBlocks(CNode* pnode);
     void CheckAndRemove();
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -226,22 +226,6 @@ void CMasternode::Check(bool fForce)
     // keep old masternodes on start, give them a chance to receive updates...
     bool fWaitForPing = !masternodeSync.IsMasternodeListSynced() && !IsPingedWithin(MASTERNODE_MIN_MNP_SECONDS);
 
-    //
-    // REMOVE AFTER MIGRATION TO 12.1
-    //
-    // Old nodes don't send pings on dseg, so they could switch to one of the expired states
-    // if we were offline for too long even if they are actually enabled for the rest
-    // of the network. Postpone their check for MASTERNODE_MIN_MNP_SECONDS seconds.
-    // This could be usefull for 12.1 migration, can be removed after it's done.
-    static int64_t nTimeStart = GetTime();
-    if(nProtocolVersion < 70204) {
-        if(!masternodeSync.IsMasternodeListSynced()) nTimeStart = GetTime();
-        fWaitForPing = GetTime() - nTimeStart < MASTERNODE_MIN_MNP_SECONDS;
-    }
-    //
-    // END REMOVE
-    //
-
     if(fWaitForPing && !fOurMasternode) {
         // ...but if it was already expired before the initial check - return right away
         if(IsExpired() || IsWatchdogExpired() || IsNewStartRequired()) {
@@ -715,59 +699,16 @@ bool CMasternodeBroadcast::CheckSignature(int& nDos)
     std::string strError = "";
     nDos = 0;
 
-    //
-    // REMOVE AFTER MIGRATION TO 12.1
-    //
-    if(nProtocolVersion < 70201) {
-        std::string vchPubkeyCollateralAddress(pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end());
-        std::string vchPubkeyMasternode(pubKeyMasternode.begin(), pubKeyMasternode.end());
-        strMessage = addr.ToString(false) + boost::lexical_cast<std::string>(sigTime) +
-                        vchPubkeyCollateralAddress + vchPubkeyMasternode + boost::lexical_cast<std::string>(nProtocolVersion);
+    strMessage = addr.ToString(false) + boost::lexical_cast<std::string>(sigTime) +
+                    pubKeyCollateralAddress.GetID().ToString() + pubKeyMasternode.GetID().ToString() +
+                    boost::lexical_cast<std::string>(nProtocolVersion);
 
-        LogPrint("masternode", "CMasternodeBroadcast::CheckSignature -- sanitized strMessage: %s  pubKeyCollateralAddress address: %s  sig: %s\n",
-            SanitizeString(strMessage), CBitcoinAddress(pubKeyCollateralAddress.GetID()).ToString(),
-            EncodeBase64(&vchSig[0], vchSig.size()));
+    LogPrint("masternode", "CMasternodeBroadcast::CheckSignature -- strMessage: %s  pubKeyCollateralAddress address: %s  sig: %s\n", strMessage, CBitcoinAddress(pubKeyCollateralAddress.GetID()).ToString(), EncodeBase64(&vchSig[0], vchSig.size()));
 
-        if(!darkSendSigner.VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)) {
-            if(addr.ToString() != addr.ToString(false)) {
-                // maybe it's wrong format, try again with the old one
-                strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) +
-                                vchPubkeyCollateralAddress + vchPubkeyMasternode + boost::lexical_cast<std::string>(nProtocolVersion);
-
-                LogPrint("masternode", "CMasternodeBroadcast::CheckSignature -- second try, sanitized strMessage: %s  pubKeyCollateralAddress address: %s  sig: %s\n",
-                    SanitizeString(strMessage), CBitcoinAddress(pubKeyCollateralAddress.GetID()).ToString(),
-                    EncodeBase64(&vchSig[0], vchSig.size()));
-
-                if(!darkSendSigner.VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)) {
-                    // didn't work either
-                    LogPrintf("CMasternodeBroadcast::CheckSignature -- Got bad Masternode announce signature, second try, sanitized error: %s\n",
-                        SanitizeString(strError));
-                    // don't ban for old masternodes, their sigs could be broken because of the bug
-                    return false;
-                }
-            } else {
-                // nope, sig is actually wrong
-                LogPrintf("CMasternodeBroadcast::CheckSignature -- Got bad Masternode announce signature, sanitized error: %s\n",
-                    SanitizeString(strError));
-                // don't ban for old masternodes, their sigs could be broken because of the bug
-                return false;
-            }
-        }
-    } else {
-    //
-    // END REMOVE
-    //
-        strMessage = addr.ToString(false) + boost::lexical_cast<std::string>(sigTime) +
-                        pubKeyCollateralAddress.GetID().ToString() + pubKeyMasternode.GetID().ToString() +
-                        boost::lexical_cast<std::string>(nProtocolVersion);
-
-        LogPrint("masternode", "CMasternodeBroadcast::CheckSignature -- strMessage: %s  pubKeyCollateralAddress address: %s  sig: %s\n", strMessage, CBitcoinAddress(pubKeyCollateralAddress.GetID()).ToString(), EncodeBase64(&vchSig[0], vchSig.size()));
-
-        if(!darkSendSigner.VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)){
-            LogPrintf("CMasternodeBroadcast::CheckSignature -- Got bad Masternode announce signature, error: %s\n", strError);
-            nDos = 100;
-            return false;
-        }
+    if(!darkSendSigner.VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)){
+        LogPrintf("CMasternodeBroadcast::CheckSignature -- Got bad Masternode announce signature, error: %s\n", strError);
+        nDos = 100;
+        return false;
     }
 
     return true;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -366,20 +366,9 @@ public:
     uint256 GetHash() const
     {
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        //
-        // REMOVE AFTER MIGRATION TO 12.1
-        //
-        if(nProtocolVersion < 70201) {
-            ss << sigTime;
-            ss << pubKeyCollateralAddress;
-        } else {
-        //
-        // END REMOVE
-        //
-            ss << vin;
-            ss << pubKeyCollateralAddress;
-            ss << sigTime;
-        }
+        ss << vin;
+        ss << pubKeyCollateralAddress;
+        ss << sigTime;
         return ss.GetHash();
     }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -814,12 +814,6 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         LogPrint("masternode", "MNANNOUNCE -- Masternode announce, masternode=%s\n", mnb.vin.prevout.ToStringShort());
 
-        // backward compatibility patch
-        if(pfrom->nVersion < 70204) {
-            int64_t nLastDsqDummy;
-            vRecv >> nLastDsqDummy;
-        }
-
         int nDos = 0;
 
         if (CheckMnbAndUpdateMasternodeList(pfrom, mnb, nDos)) {

--- a/src/version.h
+++ b/src/version.h
@@ -19,7 +19,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70103;
+static const int MIN_PEER_PROTO_VERSION = 70206;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Migration to 12.1 is done, no more support for pre-12.1 nodes (`PROTOCOL_VERSION` < 70206):
- remove deprecated code
- bump min_proto-s to 70206

IMO this should be done as a preliminary action before next migration to clean network and code ahead of time.