### PR TITLE
Fix mn list sync

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -844,7 +844,7 @@ bool CMasternodePing::CheckAndUpdate(CMasternode* pmn, bool fFromNewBroadcast, i
 
     // if we are still syncing and there was no known ping for this mn for quite a while
     // (NOTE: assuming that MASTERNODE_EXPIRATION_SECONDS/2 should be enough to finish mn list sync)
-    if(!masternodeSync.IsMasternodeListSynced() && !pmn->IsPingedWithin(MASTERNODE_EXPIRATION_SECONDS/2, sigTime)) {
+    if(!masternodeSync.IsMasternodeListSynced() && !pmn->IsPingedWithin(MASTERNODE_EXPIRATION_SECONDS/2)) {
         // let's bump sync timeout
         LogPrint("masternode", "CMasternodePing::CheckAndUpdate -- bumping sync timeout, masternode=%s\n", vin.prevout.ToStringShort());
         masternodeSync.AddedMasternodeList();

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -840,7 +840,17 @@ bool CMasternodePing::CheckAndUpdate(CMasternode* pmn, bool fFromNewBroadcast, i
 
     if (!CheckSignature(pmn->pubKeyMasternode, nDos)) return false;
 
-    // so, ping seems to be ok, let's store it
+    // so, ping seems to be ok
+
+    // if we are still syncing and there was no known ping for this mn for quite a while
+    // (NOTE: assuming that MASTERNODE_EXPIRATION_SECONDS/2 should be enough to finish mn list sync)
+    if(!masternodeSync.IsMasternodeListSynced() && !pmn->IsPingedWithin(MASTERNODE_EXPIRATION_SECONDS/2, sigTime)) {
+        // let's bump sync timeout
+        LogPrint("masternode", "CMasternodePing::CheckAndUpdate -- bumping sync timeout, masternode=%s\n", vin.prevout.ToStringShort());
+        masternodeSync.AddedMasternodeList();
+    }
+
+    // let's store this ping as the last one
     LogPrint("masternode", "CMasternodePing::CheckAndUpdate -- Masternode ping accepted, masternode=%s\n", vin.prevout.ToStringShort());
     pmn->lastPing = *this;
 


### PR DESCRIPTION
Bump sync timeout on new ping if masternode is "initially valid" and last ping was quite a long time ago. This should fix the issue when MNs were switching to `MASTERNODE_NEW_START_REQUIRED` shortly after mnsync was finished when they really shouldn't.