### PR TITLE
Few fixes for PrivateSend

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1672,6 +1672,8 @@ bool CDarksendPool::SubmitDenominate()
 
 bool CDarksendPool::PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, std::vector<CTxIn>& vecTxInRet, std::vector<CTxOut>& vecTxOutRet)
 {
+    if(!pwalletMain) return false;
+
     if (pwalletMain->IsLocked(true)) {
         strErrorRet = "Wallet locked, unable to create transaction!";
         return false;

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -248,10 +248,10 @@ void CDarksendPool::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataS
                 }
             }
 
-            // Allow lowest denom (at max) as a a fee. Normally shouldn't happen though.
-            // TODO: Or do not allow fees at all?
-            if(nValueIn - nValueOut > vecPrivateSendDenominations.back()) {
-                LogPrintf("DSVIN -- fees are too high! fees: %lld, tx=%s", nValueIn - nValueOut, tx.ToString());
+            // There should be no fee in mixing tx
+            CAmount nFee = nValueIn - nValueOut;
+            if(nFee != 0) {
+                LogPrintf("DSVIN -- there should be no fee in mixing tx! fees: %lld, tx=%s", nFee, tx.ToString());
                 PushStatus(pfrom, STATUS_REJECTED, ERR_FEES);
                 return;
             }

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1672,7 +1672,10 @@ bool CDarksendPool::SubmitDenominate()
 
 bool CDarksendPool::PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, std::vector<CTxIn>& vecTxInRet, std::vector<CTxOut>& vecTxOutRet)
 {
-    if(!pwalletMain) return false;
+    if(!pwalletMain) {
+        strErrorRet = "Wallet is not initialized";
+        return false;
+    }
 
     if (pwalletMain->IsLocked(true)) {
         strErrorRet = "Wallet locked, unable to create transaction!";

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -22,7 +22,7 @@ static const int PRIVATESEND_SIGNING_TIMEOUT        = 15;
 static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70206;
 
 static const CAmount PRIVATESEND_COLLATERAL         = 0.001 * COIN;
-static const CAmount PRIVATESEND_POOL_MAX           = 999.999 * COIN;
+static const CAmount PRIVATESEND_ENTRY_MAX_SIZE     = 9;
 static const int DENOMS_COUNT_MAX                   = 100;
 
 static const int DEFAULT_PRIVATESEND_ROUNDS         = 2;
@@ -452,6 +452,8 @@ public:
     int GetDenominations(const std::vector<CTxDSOut>& vecTxDSOut);
     std::string GetDenominationsToString(int nDenom);
     bool GetDenominationsBits(int nDenom, std::vector<int> &vecBitsRet);
+
+    CAmount GetMaxPoolAmount() { return vecPrivateSendDenominations.empty() ? 0 : PRIVATESEND_ENTRY_MAX_SIZE * vecPrivateSendDenominations.front(); }
 
     void SetMinBlockSpacing(int nMinBlockSpacingIn) { nMinBlockSpacing = nMinBlockSpacingIn; }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -350,7 +350,7 @@ void OverviewPage::updatePrivateSendProgress()
     CAmount nDenominatedUnconfirmedBalance;
     CAmount nAnonymizableBalance;
     CAmount nNormalizedAnonymizedBalance;
-    double nAverageAnonymizedRounds;
+    float nAverageAnonymizedRounds;
 
     {
         nDenominatedConfirmedBalance = pwalletMain->GetDenominatedBalance();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1897,12 +1897,12 @@ CAmount CWallet::GetAnonymizedBalance() const
 
 // Note: calculated including unconfirmed,
 // that's ok as long as we use it for informational purposes only
-double CWallet::GetAverageAnonymizedRounds() const
+float CWallet::GetAverageAnonymizedRounds() const
 {
     if(fLiteMode) return 0;
 
-    double fTotal = 0;
-    double fCount = 0;
+    int nTotal = 0;
+    int nCount = 0;
 
     {
         LOCK2(cs_main, cs_wallet);
@@ -1914,20 +1914,19 @@ double CWallet::GetAverageAnonymizedRounds() const
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
 
-                CTxIn vin = CTxIn(hash, i);
+                CTxIn txin = CTxIn(hash, i);
 
-                if(IsSpent(hash, i) || IsMine(pcoin->vout[i]) != ISMINE_SPENDABLE || !IsDenominated(vin)) continue;
+                if(IsSpent(hash, i) || IsMine(pcoin->vout[i]) != ISMINE_SPENDABLE || !IsDenominated(txin)) continue;
 
-                int rounds = GetInputPrivateSendRounds(vin);
-                fTotal += (float)rounds;
-                fCount += 1;
+                nTotal += GetInputPrivateSendRounds(txin);
+                nCount++;
             }
         }
     }
 
-    if(fCount == 0) return 0;
+    if(nCount == 0) return 0;
 
-    return fTotal/fCount;
+    return (float)nTotal/nCount;
 }
 
 // Note: calculated including unconfirmed,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1981,7 +1981,7 @@ CAmount CWallet::GetNeedsToBeAnonymizedBalance(CAmount nMinBalance) const
     if(nNeedsToAnonymizeBalance > nAnonymizableBalance) nNeedsToAnonymizeBalance = nAnonymizableBalance;
 
     // we should never exceed the pool max
-    if (nNeedsToAnonymizeBalance > PRIVATESEND_POOL_MAX) nNeedsToAnonymizeBalance = PRIVATESEND_POOL_MAX;
+    if (nNeedsToAnonymizeBalance > darkSendPool.GetMaxPoolAmount()) nNeedsToAnonymizeBalance = darkSendPool.GetMaxPoolAmount();
 
     return nNeedsToAnonymizeBalance;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -743,7 +743,7 @@ public:
 
     CAmount GetAnonymizableBalance(bool fSkipDenominated = false) const;
     CAmount GetAnonymizedBalance() const;
-    double GetAverageAnonymizedRounds() const;
+    float GetAverageAnonymizedRounds() const;
     CAmount GetNormalizedAnonymizedBalance() const;
     CAmount GetNeedsToBeAnonymizedBalance(CAmount nMinBalance = 0) const;
     CAmount GetDenominatedBalance(bool unconfirmed=false) const;


### PR DESCRIPTION
Cleaner version of #1307 (rebased, fixed conflicts, squashed 2 commits, removed already merged commit, postponed collateral adjustment for later)

Fixes:
- PS should limit entry size, not mixing amount (_legacy issue_)
- there should be no fee in mixing tx (_legacy issue_)
- make sure `pwalletMain` is not null in `PrepareDenominate` (_shouldn't really happen but just in case_)
- no need for "double" in GetAverageAnonymizedRounds, "float" should be enough