### PR TITLE
Don't add non-current wd's to seen map

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -219,14 +219,18 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
         govobj.UpdateSentinelVariables(); //this sets local vars in object
 
-        if(AddGovernanceObject(govobj, pfrom))
+        bool fAddToSeen = true;
+        if(AddGovernanceObject(govobj, fAddToSeen, pfrom))
         {
             LogPrintf("MNGOVERNANCEOBJECT -- %s new\n", strHash);
             govobj.Relay();
         }
 
-        // UPDATE THAT WE'VE SEEN THIS OBJECT
-        mapSeenGovernanceObjects.insert(std::make_pair(nHash, SEEN_OBJECT_IS_VALID));
+        if(fAddToSeen) {
+            // UPDATE THAT WE'VE SEEN THIS OBJECT
+            mapSeenGovernanceObjects.insert(std::make_pair(nHash, SEEN_OBJECT_IS_VALID));
+        }
+
         masternodeSync.AddedGovernanceItem();
 
 
@@ -305,12 +309,14 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, CGovernance
     fRateChecksEnabled = true;
 }
 
-bool CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CNode* pfrom)
+bool CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, bool& fAddToSeen, CNode* pfrom)
 {
     LOCK2(cs_main, cs);
     std::string strError = "";
 
     DBG( cout << "CGovernanceManager::AddGovernanceObject START" << endl; );
+
+    fAddToSeen = true;
 
     uint256 nHash = govobj.GetHash();
 
@@ -341,6 +347,8 @@ bool CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CNode* p
         }
 
         if(!UpdateCurrentWatchdog(govobj)) {
+            // Allow wd's which are not current to be reprocessed
+            fAddToSeen = false;
             if(pfrom && (nHashWatchdogCurrent != uint256())) {
                 pfrom->PushInventory(CInv(MSG_GOVERNANCE_OBJECT, nHashWatchdogCurrent));
             }
@@ -1007,7 +1015,8 @@ void CGovernanceManager::CheckMasternodeOrphanObjects()
             continue;
         }
 
-        if(AddGovernanceObject(govobj)) {
+        bool fAddToSeen = true;
+        if(AddGovernanceObject(govobj, fAddToSeen)) {
             LogPrintf("CGovernanceManager::CheckMasternodeOrphanObjects -- %s new\n", govobj.GetHash().ToString());
             govobj.Relay();
             mapMasternodeOrphanObjects.erase(it++);

--- a/src/governance.h
+++ b/src/governance.h
@@ -288,7 +288,7 @@ public:
     std::vector<CGovernanceObject*> GetAllNewerThan(int64_t nMoreThanTime);
 
     bool IsBudgetPaymentBlock(int nBlockHeight);
-    bool AddGovernanceObject(CGovernanceObject& govobj, CNode* pfrom = NULL);
+    bool AddGovernanceObject(CGovernanceObject& govobj, bool& fAddToSeen, CNode* pfrom = NULL);
 
     std::string GetRequiredPaymentsString(int nBlockHeight);
 

--- a/src/rpcgovernance.cpp
+++ b/src/rpcgovernance.cpp
@@ -221,7 +221,8 @@ UniValue gobject(const UniValue& params, bool fHelp)
         governance.AddSeenGovernanceObject(govobj.GetHash(), SEEN_OBJECT_IS_VALID);
         govobj.Relay();
         LogPrintf("gobject(submit) -- Adding locally created governance object - %s\n", strHash);
-        governance.AddGovernanceObject(govobj);
+        bool fAddToSeen = true;
+        governance.AddGovernanceObject(govobj, fAddToSeen);
 
         return govobj.GetHash().ToString();
     }


### PR DESCRIPTION
Due to differences in network propagation delays the current watchdog can become inconsistent between nodes.  Nodes which receive a new wd earlier than others may reject it because their current wd is not yet considered expired and has a larger hash.

This change allows nodes to continue to receive a wd that was previously rejected due to not being better than the current wd.