### PR TITLE
c++11: Backport from bitcoin-core: don't throw from the reverselock destructor

### DIFF
--- a/src/reverselock.h
+++ b/src/reverselock.h
@@ -15,10 +15,12 @@ public:
 
     explicit reverse_lock(Lock& lock) : lock(lock) {
         lock.unlock();
+        lock.swap(templock);
     }
 
     ~reverse_lock() {
-        lock.lock();
+        templock.lock();
+        templock.swap(lock);
     }
 
 private:
@@ -26,6 +28,7 @@ private:
     reverse_lock& operator=(reverse_lock const&);
 
     Lock& lock;
+    Lock templock;
 };
 
 #endif // BITCOIN_REVERSELOCK_H

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -42,22 +42,18 @@ BOOST_AUTO_TEST_CASE(reverselock_errors)
     BOOST_CHECK(failed);
     BOOST_CHECK(!lock.owns_lock());
 
-    // Make sure trying to lock a lock after it has been reverse locked fails
-    failed = false;
-    bool locked = false;
+    // Locking the original lock after it has been taken by a reverse lock
+    // makes no sense. Ensure that the original lock no longer owns the lock
+    // after giving it to a reverse one.
 
     lock.lock();
     BOOST_CHECK(lock.owns_lock());
-
-    try {
+    {
         reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
-        lock.lock();
-        locked = true;
-    } catch(...) {
-        failed = true;
+        BOOST_CHECK(!lock.owns_lock());
     }
 
-    BOOST_CHECK(locked && failed);
+    BOOST_CHECK(failed);
     BOOST_CHECK(lock.owns_lock());
 }
 


### PR DESCRIPTION
This is a backport of a fix for `reverselock` from bitcoin-core. Undefined behaviour causes cascading test failure when compiled with gcc 6.3.1 in C++11 mode without this fix.

The original commit message follows.

----
## c++11: don't throw from the `reverselock` destructor

`noexcept` is default for destructors as of c++11. By throwing in `reverselock`'s destructor if it's lock has been tampered with, the likely result is `std::terminate` being called. Indeed that happened before this change.

Once `reverselock` has taken another lock (its ctor didn't throw), it makes no sense to try to grab or lock the parent lock. That is be broken/undefined behavior depending on the parent lock's implementation, but it shouldn't cause the `reverselock` to fail to re-lock when destroyed.

To avoid those problems, simply swap the parent lock's contents with a dummy for the duration of the lock. That will ensure that any undefined behavior is caught at the call-site rather than the reverse lock's destruction.

Barring a failed mutex unlock which would be indicative of a larger problem, the destructor should now never throw.