### PR TITLE
Fix potential race condition in vote processing

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -178,9 +178,17 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
         governance.AddInvalidVote(vote);
         return false;
     }
+    if(!mnodeman.AddGovernanceVote(vote.GetVinMasternode(), vote.GetParentHash())) {
+        std::ostringstream ostr;
+        ostr << "CGovernanceObject::ProcessVote -- Unable to add governance vote "
+             << ", MN outpoint = " << vote.GetVinMasternode().prevout.ToStringShort()
+             << ", governance object hash = " << GetHash().ToString() << "\n";
+        LogPrint("gobject", ostr.str().c_str());
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR);
+        return false;
+    }
     voteInstance = vote_instance_t(vote.GetOutcome(), nVoteTimeUpdate, vote.GetTimestamp());
     fileVotes.AddVote(vote);
-    mnodeman.AddGovernanceVote(vote.GetVinMasternode(), vote.GetParentHash());
     fDirtyCache = true;
     return true;
 }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1555,14 +1555,15 @@ bool CMasternodeMan::IsWatchdogActive()
     return (GetTime() - nLastWatchdogVoteTime) <= MASTERNODE_WATCHDOG_MAX_SECONDS;
 }
 
-void CMasternodeMan::AddGovernanceVote(const CTxIn& vin, uint256 nGovernanceObjectHash)
+bool CMasternodeMan::AddGovernanceVote(const CTxIn& vin, uint256 nGovernanceObjectHash)
 {
     LOCK(cs);
     CMasternode* pMN = Find(vin);
     if(!pMN)  {
-        return;
+        return false;
     }
     pMN->AddGovernanceVote(nGovernanceObjectHash);
+    return true;
 }
 
 void CMasternodeMan::RemoveGovernanceObject(uint256 nGovernanceObjectHash)

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -341,7 +341,7 @@ public:
 
     bool IsWatchdogActive();
     void UpdateWatchdogVoteTime(const CTxIn& vin);
-    void AddGovernanceVote(const CTxIn& vin, uint256 nGovernanceObjectHash);
+    bool AddGovernanceVote(const CTxIn& vin, uint256 nGovernanceObjectHash);
     void RemoveGovernanceObject(uint256 nGovernanceObjectHash);
 
     void CheckMasternode(const CTxIn& vin, bool fForce = false);


### PR DESCRIPTION
This fixes the following race condition:

t1: vote received from mn
t2: vote checked for valid mn
t3: mn removed from list (2nd thread)
t4: vote added to current votes map
t5: masternode.AddGovernanceVote fails silently due to missing mn

If this happens the vote remains in the current votes map even though the voting mn has been removed.