### PR TITLE
V0.12.1.x multiple vote fix

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -188,7 +188,9 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
         return false;
     }
     voteInstance = vote_instance_t(vote.GetOutcome(), nVoteTimeUpdate, vote.GetTimestamp());
-    fileVotes.AddVote(vote);
+    if(!fileVotes.HasVote(vote.GetHash())) {
+        fileVotes.AddVote(vote);
+    }
     fDirtyCache = true;
     return true;
 }

--- a/src/governance-votedb.cpp
+++ b/src/governance-votedb.cpp
@@ -58,6 +58,7 @@ void CGovernanceObjectVoteFile::RemoveVotesFromMasternode(const CTxIn& vinMaster
     vote_l_it it = listVotes.begin();
     while(it != listVotes.end()) {
         if(it->GetVinMasternode() == vinMasternode) {
+            --nMemoryVotes;
             mapVoteIndex.erase(it->GetHash());
             listVotes.erase(it++);
         }
@@ -78,8 +79,18 @@ CGovernanceObjectVoteFile& CGovernanceObjectVoteFile::operator=(const CGovernanc
 void CGovernanceObjectVoteFile::RebuildIndex()
 {
     mapVoteIndex.clear();
-    for(vote_l_it it = listVotes.begin(); it != listVotes.end(); ++it) {
+    nMemoryVotes = 0;
+    vote_l_it it = listVotes.begin();
+    while(it != listVotes.end()) {
         CGovernanceVote& vote = *it;
-        mapVoteIndex[vote.GetHash()] = it;
+        uint256 nHash = vote.GetHash();
+        if(mapVoteIndex.find(nHash) == mapVoteIndex.end()) {
+            mapVoteIndex[nHash] = it;
+            ++nMemoryVotes;
+            ++it;
+        }
+        else {
+            listVotes.erase(it++);
+        }
     }
 }


### PR DESCRIPTION
This fixes a bug which allows the same vote to be added to the vote file more than once.  Normally the inventory system prevents this but there are race conditions which can allow it to occur.

The bug doesn't affect functionality but can lead to unnecessary memory usage.