### PR TITLE
Force self-recheck on CActiveMasternode::ManageStateRemote()

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -231,7 +231,7 @@ void CActiveMasternode::ManageStateRemote()
     LogPrint("masternode", "CActiveMasternode::ManageStateRemote -- Start status = %s, type = %s, pinger enabled = %d, pubKeyMasternode.GetID() = %s\n", 
              GetStatus(), GetTypeString(), fPingerEnabled, pubKeyMasternode.GetID().ToString());
 
-    mnodeman.CheckMasternode(pubKeyMasternode);
+    mnodeman.CheckMasternode(pubKeyMasternode, true);
     masternode_info_t infoMn = mnodeman.GetMasternodeInfo(pubKeyMasternode);
     if(infoMn.fInfoValid) {
         if(infoMn.nProtocolVersion != PROTOCOL_VERSION) {


### PR DESCRIPTION
Reason: otherwise code below could fail if we received new mnb right after latest check and thus our MN will not start.

~NOTE: this is a bug-fix for the stable release (12.1)~