### PR TITLE
Access WorkQueue::running only within the cs lock.

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -126,7 +126,7 @@ public:
     void Run()
     {
         ThreadCounter count(*this);
-        while (running) {
+        while (true) {
             WorkItem* i = 0;
             {
                 boost::unique_lock<boost::mutex> lock(cs);


### PR DESCRIPTION
This removes a race between Interrupt() and Run()