### PR TITLE
PrivateSend:  dont waste keys from keypool on failure in CreateDenominated

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1199,6 +1199,8 @@ bool CPrivateSendClient::MakeCollateralAmounts(const CompactTallyItem& tallyItem
 // Create denominations by looping through inputs grouped by addresses
 bool CPrivateSendClient::CreateDenominated()
 {
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
     std::vector<CompactTallyItem> vecTally;
     if(!pwalletMain->SelectCoinsGrouppedByAddresses(vecTally)) {
         LogPrint("privatesend", "CPrivateSendClient::CreateDenominated -- SelectCoinsGrouppedByAddresses can't find any inputs!\n");

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1285,7 +1285,7 @@ bool CPrivateSendClient::CreateDenominated(const CompactTallyItem& tallyItem, bo
                 //increment outputs and subtract denomination amount
                 nOutputs++;
                 nValueLeft -= nDenomValue;
-                LogPrintf("CreateDenominated1: nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n", nOutputsTotal + nOutputs, nOutputs, (float)nValueLeft/COIN);
+                LogPrintf("CreateDenominated1: totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n", nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float)nValueLeft/COIN);
             }
 
             nOutputsTotal += nOutputs;

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1269,7 +1269,7 @@ bool CPrivateSendClient::CreateDenominated(const CompactTallyItem& tallyItem, bo
 
             int nOutputs = 0;
 
-            // add each output up to 10 times until it can't be added again
+            // add each output up to 11 times until it can't be added again
             while(nValueLeft - nDenomValue >= 0 && nOutputs <= 10) {
                 CScript scriptDenom;
                 CPubKey vchPubKey;
@@ -1285,7 +1285,7 @@ bool CPrivateSendClient::CreateDenominated(const CompactTallyItem& tallyItem, bo
                 //increment outputs and subtract denomination amount
                 nOutputs++;
                 nValueLeft -= nDenomValue;
-                LogPrintf("CreateDenominated1: nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n", nOutputsTotal, nOutputs, (float)nValueLeft/COIN);
+                LogPrintf("CreateDenominated1: nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n", nOutputsTotal + nOutputs, nOutputs, (float)nValueLeft/COIN);
             }
 
             nOutputsTotal += nOutputs;


### PR DESCRIPTION
Changes:
- store keys for denominations in vector
- on success run keep on all keys
- on failure run return of all keys
- log current number of created outputs
- can be up to 11 outputs per denomination not 10
- add lock at the start of CPrivateSendClient::CreateDenominated() so no one can spend outputs used for denominations

connected with track#19.