### PR TITLE
Fix the same header included twice

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -4,7 +4,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "rpcserver.h"
 #include "base58.h"
 #include "amount.h"
 #include "chain.h"


### PR DESCRIPTION
The rpcserver.h header file is included twice as a result of changes merged from Bitcoin 2 years ago (commit 64eebc3316547e4799b8aa2f0573f0b6d38f6042).
Include this file just once.