### PR TITLE
Icon Cutoff Fix

### DIFF
--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -114,7 +114,6 @@ padding-left:25px;
 padding-right:25px;
 padding-top:5px;
 padding-bottom:5px;
-margin-right: 10px;
 }
 
 QPushButton:hover {


### PR DESCRIPTION
This will prevent the cutoff of the connections icon when using the light theme.