### PR TITLE
Validate proposals on prepare and submit

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ BITCOIN_CORE_H = \
   governance-classes.h \
   governance-exceptions.h \
   governance-object.h \
+  governance-validators.h \
   governance-vote.h \
   governance-votedb.h \
   flat-database.h \
@@ -212,6 +213,7 @@ libbitcoin_server_a_SOURCES = \
   governance.cpp \
   governance-classes.cpp \
   governance-object.cpp \
+  governance-validators.cpp \
   governance-vote.cpp \
   governance-votedb.cpp \
   main.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -55,6 +55,7 @@ BITCOIN_TESTS =\
   test/crypto_tests.cpp \
   test/DoS_tests.cpp \
   test/getarg_tests.cpp \
+  test/governance_validators_tests.cpp \
   test/hash_tests.cpp \
   test/key_tests.cpp \
   test/limitedmap_tests.cpp \

--- a/src/governance-validators.cpp
+++ b/src/governance-validators.cpp
@@ -38,6 +38,7 @@ void CProposalValidator::SetHexData(const std::string& strDataHexIn)
 bool CProposalValidator::Validate()
 {
     if(!ValidateJSON()) {
+        strErrorMessages += "JSON parsing error;";
         return false;
     }
     if(!ValidateName()) {
@@ -111,7 +112,7 @@ bool CProposalValidator::ValidateStartEndEpoch()
     }
 
     if(nEndEpoch <= nStartEpoch) {
-        strErrorMessages += "end_epoch <= start_epoch field not found;";
+        strErrorMessages += "end_epoch <= start_epoch;";
         return false;
     }
 
@@ -128,9 +129,13 @@ bool CProposalValidator::ValidatePaymentAmount()
     }
 
     if(dValue <= 0.0) {
-        strErrorMessages += "payment_amount invalid;";
+        strErrorMessages += "payment_amount is negative;";
         return false;
     }
+
+    // TODO: Should check for an amount which exceeds the budget but this is
+    // currently difficult because start and end epochs are defined in terms of
+    // clock time instead of block height.
 
     return true;
 }
@@ -177,7 +182,7 @@ bool CProposalValidator::ValidateURL()
 
     std::string strURLStripped = StripWhitespace(strURL);
 
-    if(int(strURLStripped.size()) < 4) {
+    if(strURLStripped.size() < 4U) {
         strErrorMessages += "url too short;";
         return false;
     }

--- a/src/governance-validators.cpp
+++ b/src/governance-validators.cpp
@@ -85,9 +85,9 @@ bool CProposalValidator::ValidateName()
 
     static const std::string strAllowedChars = "-_abcdefghijklmnopqrstuvwxyz012345789";
 
-    std::transform(strNameStripped.begin(), strNameStripped.end(), strNameStripped.begin(), ::tolower);
+    std::transform(strName.begin(), strName.end(), strName.begin(), ::tolower);
 
-    if(strNameStripped.find_first_not_of(strAllowedChars) != std::string::npos) {
+    if(strName.find_first_not_of(strAllowedChars) != std::string::npos) {
         strErrorMessages += "name contains invalid characters;";
         return false;
     }

--- a/src/governance-validators.cpp
+++ b/src/governance-validators.cpp
@@ -1,0 +1,349 @@
+// Copyright (c) 2014-2017 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "governance-validators.h"
+
+#include "base58.h"
+#include "utilstrencodings.h"
+
+#include <algorithm>
+
+CProposalValidator::CProposalValidator(const std::string& strDataHexIn)
+    : strData(),
+      objJSON(UniValue::VOBJ),
+      fJSONValid(false),
+      strErrorMessages()
+{
+    if(!strDataHexIn.empty()) {
+        SetHexData(strDataHexIn);
+    }
+}
+
+void CProposalValidator::Clear()
+{
+    strData = std::string();
+    objJSON = UniValue(UniValue::VOBJ);
+    fJSONValid = false;
+    strErrorMessages = std::string();
+}
+
+void CProposalValidator::SetHexData(const std::string& strDataHexIn)
+{
+    std::vector<unsigned char> v = ParseHex(strDataHexIn);
+    strData = std::string(v.begin(), v.end());
+    ParseJSONData();
+}
+
+bool CProposalValidator::Validate()
+{
+    if(!ValidateJSON()) {
+        return false;
+    }
+    if(!ValidateName()) {
+        strErrorMessages += "Invalid name;";
+        return false;
+    }
+    if(!ValidateStartEndEpoch()) {
+        strErrorMessages += "Invalid start:end range;";
+        return false;
+    }
+    if(!ValidatePaymentAmount()) {
+        strErrorMessages += "Invalid payment amount;";
+        return false;
+    }
+    if(!ValidatePaymentAddress()) {
+        strErrorMessages += "Invalid payment address;";
+        return false;
+    }
+    if(!ValidateURL()) {
+        strErrorMessages += "Invalid URL;";
+        return false;
+    }
+    return true;
+}
+
+bool CProposalValidator::ValidateJSON()
+{
+    return fJSONValid;
+}
+
+bool CProposalValidator::ValidateName()
+{
+    std::string strName;
+    if(!GetDataValue("name", strName)) {
+        strErrorMessages += "name field not found;";
+        return false;
+    }
+
+    std::string strNameStripped = StripWhitespace(strName);
+
+    if(strNameStripped.empty()) {
+        strErrorMessages += "name is empty;";
+        return false;
+    }
+
+    static const std::string strAllowedChars = "-_abcdefghijklmnopqrstuvwxyz012345789";
+
+    std::transform(strNameStripped.begin(), strNameStripped.end(), strNameStripped.begin(), ::tolower);
+
+    if(strNameStripped.find_first_not_of(strAllowedChars) != std::string::npos) {
+        strErrorMessages += "name contains invalid characters;";
+        return false;
+    }
+
+    return true;
+}
+
+bool CProposalValidator::ValidateStartEndEpoch()
+{
+    int64_t nStartEpoch = 0;
+    int64_t nEndEpoch = 0;
+
+    if(!GetDataValue("start_epoch", nStartEpoch)) {
+        strErrorMessages += "start_epoch field not found;";
+        return false;
+    }
+
+    if(!GetDataValue("end_epoch", nEndEpoch)) {
+        strErrorMessages += "end_epoch field not found;";
+        return false;
+    }
+
+    if(nEndEpoch <= nStartEpoch) {
+        strErrorMessages += "end_epoch <= start_epoch field not found;";
+        return false;
+    }
+
+    return true;
+}
+
+bool CProposalValidator::ValidatePaymentAmount()
+{
+    double dValue = 0.0;
+
+    if(!GetDataValue("payment_amount", dValue)) {
+        strErrorMessages += "payment_amount field not found;";
+        return false;
+    }
+
+    if(dValue <= 0.0) {
+        strErrorMessages += "payment_amount invalid;";
+        return false;
+    }
+
+    return true;
+}
+
+bool CProposalValidator::ValidatePaymentAddress()
+{
+    std::string strPaymentAddress;
+
+    if(!GetDataValue("payment_address", strPaymentAddress)) {
+        strErrorMessages += "payment_address field not found;";
+        return false;
+    }
+
+    static const std::string base58chars = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+    size_t nLength = strPaymentAddress.size();
+
+    if((nLength < 26) || (nLength > 35)) {
+        strErrorMessages += "incorrect payment_address length;";
+        return false;
+    }
+
+    if(strPaymentAddress.find_first_not_of(base58chars) != std::string::npos) {
+        strErrorMessages += "payment_address contains invalid characters;";
+        return false;
+    }
+
+    CBitcoinAddress address(strPaymentAddress);
+    if(!address.IsValid()) {
+        strErrorMessages += "payment_address is invalid;";
+        return false;
+    }
+
+    return true;
+}
+
+bool CProposalValidator::ValidateURL()
+{
+    std::string strURL;
+    if(!GetDataValue("url", strURL)) {
+        strErrorMessages += "url field not found;";
+        return false;
+    }
+
+    std::string strURLStripped = StripWhitespace(strURL);
+
+    if(int(strURLStripped.size()) < 4) {
+        strErrorMessages += "url too short;";
+        return false;
+    }
+
+    if(!CheckURL(strURL)) {
+        strErrorMessages += "url invalid;";
+        return false;
+    }
+
+    return true;
+}
+
+void CProposalValidator::ParseJSONData()
+{
+    fJSONValid = false;
+
+    if(strData.empty()) {
+        return;
+    }
+
+    try {
+        UniValue obj(UniValue::VOBJ);
+        obj.read(strData);
+        std::vector<UniValue> arr1 = obj.getValues();
+        std::vector<UniValue> arr2 = arr1.at(0).getValues();
+        objJSON = arr2.at(1);
+        fJSONValid = true;
+    }
+    catch(std::exception& e) {
+        strErrorMessages += std::string(e.what()) + std::string(";");
+    }
+    catch(...) {
+        strErrorMessages += "Unknown exception;";
+    }
+}
+
+bool CProposalValidator::GetDataValue(const std::string& strKey, std::string& strValue)
+{
+    bool fOK = false;
+    try  {
+        strValue = objJSON[strKey].get_str();
+        fOK = true;
+    }
+    catch(std::exception& e) {
+        strErrorMessages += std::string(e.what()) + std::string(";");
+    }
+    catch(...) {
+        strErrorMessages += "Unknown exception;";
+    }
+    return fOK;
+}
+
+bool CProposalValidator::GetDataValue(const std::string& strKey, int64_t& nValue)
+{
+    bool fOK = false;
+    try  {
+        const UniValue uValue = objJSON[strKey];
+        switch(uValue.getType()) {
+        case UniValue::VNUM:
+            nValue = uValue.get_int64();
+            fOK = true;
+            break;
+        case UniValue::VSTR:
+        {
+            std::istringstream istr(uValue.get_str());
+            istr >> nValue;
+            fOK = ! istr.fail();
+        }
+        break;
+        default:
+            break;
+        }
+    }
+    catch(std::exception& e) {
+        strErrorMessages += std::string(e.what()) + std::string(";");
+    }
+    catch(...) {
+        strErrorMessages += "Unknown exception;";
+    }
+    return fOK;
+}
+
+bool CProposalValidator::GetDataValue(const std::string& strKey, double& dValue)
+{
+    bool fOK = false;
+    try  {
+        const UniValue uValue = objJSON[strKey];
+        switch(uValue.getType()) {
+        case UniValue::VNUM:
+            dValue = uValue.get_real();
+            fOK = true;
+            break;
+        case UniValue::VSTR:
+        {
+            std::istringstream istr(uValue.get_str());
+            istr >> dValue;
+            fOK = ! istr.fail();
+        }
+        break;
+        default:
+            break;
+        }
+    }
+    catch(std::exception& e) {
+        strErrorMessages += std::string(e.what()) + std::string(";");
+    }
+    catch(...) {
+        strErrorMessages += "Unknown exception;";
+    }
+    return fOK;
+}
+
+std::string CProposalValidator::StripWhitespace(const std::string& strIn)
+{
+    static const std::string strWhitespace = " \f\n\r\t\v";
+
+    std::string::size_type nStart = strIn.find_first_not_of(strWhitespace);
+    std::string::size_type nEnd = strIn.find_last_not_of(strWhitespace);
+
+    if((nStart == std::string::npos) || (nEnd == std::string::npos)) {
+        return std::string();
+    }
+
+    return strIn.substr(nStart, nEnd - nStart + 1);
+}
+
+/*
+  The purpose of this function is to replicate the behavior of the
+  Python urlparse function used by sentinel (urlparse.py).  This function
+  should return false whenever urlparse raises an exception and true
+  otherwise.
+ */
+bool CProposalValidator::CheckURL(const std::string& strURLIn)
+{
+    std::string strRest(strURLIn);
+    std::string::size_type nPos = strRest.find(':');
+
+    if(nPos != std::string::npos) {
+        //std::string strSchema = strRest.substr(0,nPos);
+
+        if(nPos < strRest.size()) {
+            strRest = strRest.substr(nPos + 1);
+        }
+        else {
+            strRest = "";
+        }
+    }
+
+    // Process netloc
+    if((strRest.size() > 2) && (strRest.substr(0,2) == "//")) {
+        static const std::string strNetlocDelimiters = "/?#";
+
+        strRest = strRest.substr(2);
+
+        std::string::size_type nPos2 = strRest.find_first_of(strNetlocDelimiters);
+
+        std::string strNetloc = strRest.substr(0,nPos2);
+
+        if((strNetloc.find('[') != std::string::npos) && (strNetloc.find(']') == std::string::npos)) {
+            return false;
+        }
+
+        if((strNetloc.find(']') != std::string::npos) && (strNetloc.find('[') == std::string::npos)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/governance-validators.h
+++ b/src/governance-validators.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2014-2017 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef GOVERNANCE_VALIDATORS_H
+#define GOVERNANCE_VALIDATORS_H
+
+#include <string>
+
+#include <univalue.h>
+
+class CProposalValidator  {
+public:
+    CProposalValidator(const std::string& strDataHexIn = std::string());
+
+    void Clear();
+
+    void SetHexData(const std::string& strDataHexIn);
+
+    bool Validate();
+
+    bool ValidateJSON();
+
+    bool ValidateName();
+
+    bool ValidateStartEndEpoch();
+
+    bool ValidatePaymentAmount();
+
+    bool ValidatePaymentAddress();
+
+    bool ValidateURL();
+
+    const std::string& GetErrorMessages()
+    {
+        return strErrorMessages;
+    }
+
+private:
+    void ParseJSONData();
+
+    bool GetDataValue(const std::string& strKey, std::string& strValue);
+
+    bool GetDataValue(const std::string& strKey, int64_t& nValue);
+
+    bool GetDataValue(const std::string& strKey, double& dValue);
+
+    static std::string StripWhitespace(const std::string& strIn);
+
+    static bool CheckURL(const std::string& strURLIn);
+
+private:
+    std::string            strData;
+
+    UniValue               objJSON;
+
+    bool                   fJSONValid;
+
+    std::string            strErrorMessages;
+
+};
+
+#endif

--- a/src/test/data/proposals-invalid.json
+++ b/src/test/data/proposals-invalid.json
@@ -1,0 +1,6 @@
+[
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "yYe8KwyaUu5YswSYmB3q3ryx8XTUu9y7Ui", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": " XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": "25.75", "start_epoch": 1474261086, "type": 1, "url": "http://[::1/foo/bad]/bad"},
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": "25.75", "start_epoch": 1474261086, "type": 1, "url": "http://::12.34.56.78]/"}
+]

--- a/src/test/data/proposals-valid.json
+++ b/src/test/data/proposals-valid.json
@@ -1,0 +1,5 @@
+[
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": "25.75", "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": "25.75", "start_epoch": 1474261086, "type": 1, "url": "http://[dead:beef:cafe:5417:affe:8FA3:deaf:feed]:/foo/"}
+]

--- a/src/test/governance_validators_tests.cpp
+++ b/src/test/governance_validators_tests.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2014-2017 The Dash Core developers
+
+#include "governance-validators.h"
+#include "univalue.h"
+#include "utilstrencodings.h"
+
+#include "test/test_dash.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+BOOST_FIXTURE_TEST_SUITE(governance_validators_tests, BasicTestingSetup)
+
+UniValue LoadJSON(const std::string& strFilename)
+{
+    UniValue obj(UniValue::VOBJ);
+    std::ifstream istr(strFilename.c_str());
+
+    std::string strData;
+    std::string strLine;
+    bool fFirstLine = true;
+    while(std::getline(istr, strLine)) {
+        if(!fFirstLine) {
+            strData += "\n";
+        }
+        strData += strLine;
+        fFirstLine = false;
+    }
+    obj.read(strData);
+
+    return obj;
+}
+
+std::string CreateEncodedProposalObject(const UniValue& objJSON)
+{
+    UniValue innerArray(UniValue::VARR);
+    innerArray.push_back(UniValue("proposal"));
+    innerArray.push_back(objJSON);
+
+    UniValue outerArray(UniValue::VARR);
+    outerArray.push_back(innerArray);
+    
+    std::string strData = outerArray.write();
+    std::string strHex = HexStr(strData);
+    return strHex;
+}
+
+BOOST_AUTO_TEST_CASE(valid_proposals_test)
+{
+    CProposalValidator validator;
+    UniValue obj = LoadJSON("src/test/data/proposals-valid.json");
+    for(size_t i = 0; i < obj.size(); ++i) {
+        const UniValue& objProposal = obj[i];
+        std::string strHexData = CreateEncodedProposalObject(objProposal);
+        validator.SetHexData(strHexData);
+        BOOST_CHECK(validator.ValidateJSON());
+        BOOST_CHECK(validator.ValidateName());
+        BOOST_CHECK(validator.ValidateURL());
+        BOOST_CHECK(validator.ValidateStartEndEpoch());
+        BOOST_CHECK(validator.ValidatePaymentAmount());
+        BOOST_CHECK(validator.ValidatePaymentAddress());
+        BOOST_CHECK(validator.Validate());
+        validator.Clear();
+    }
+}
+
+BOOST_AUTO_TEST_CASE(invalid_proposals_test)
+{
+    CProposalValidator validator;
+    UniValue obj = LoadJSON("src/test/data/proposals-invalid.json");
+    for(size_t i = 0; i < obj.size(); ++i) {
+        const UniValue& objProposal = obj[i];
+        std::string strHexData = CreateEncodedProposalObject(objProposal);
+        validator.SetHexData(strHexData);
+        BOOST_CHECK(!validator.Validate());
+        validator.Clear();
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
There have been some issues with the submission of invalid proposals.  Currently these are detected only by sentinel and can thus result in the loss of the collateral fee for the submitter.

This PR replicates sentinel's proposal validation in dashcore and will reject invalid proposals from being prepared or submitted.

It also provides a new RPC command: "gobject check" which allows proposal data to be validated without attempting to create a proposal.