### PR TITLE
Fix MasternodeRateCheck

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -557,8 +557,9 @@ void CGovernanceManager::UpdateCachesAndClean()
 
     // forget about expired deleted objects
     hash_time_m_it s_it = mapErasedGovernanceObjects.begin();
+    nNow = GetTime();
     while(s_it != mapErasedGovernanceObjects.end()) {
-        if(s_it->second < GetTime())
+        if(s_it->second < nNow)
             mapErasedGovernanceObjects.erase(s_it++);
         else
             ++s_it;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -146,7 +146,6 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
 
     // A NEW GOVERNANCE OBJECT HAS ARRIVED
     else if (strCommand == NetMsgType::MNGOVERNANCEOBJECT)
-
     {
         // MAKE SURE WE HAVE A VALID REFERENCE TO THE TIP BEFORE CONTINUING
 
@@ -885,6 +884,8 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, up
             default:
                 break;
             }
+
+            it->second.fStatusOK = true;
         }
         return true;
     }
@@ -947,14 +948,18 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, up
 
     switch(eUpdateLast) {
     case UPDATE_TRUE:
+        // we should update the buffer only if object has accepted
+        if (!fRateOK)
+            LogPrintf("CGovernanceManager::MasternodeRateCheck -- WARNING !!! Rate too high but eUpdateLast = UPDATE_TRUE : object hash = %s, masternode vin = %s, object timestamp = %d, rate = %f, max rate = %f\n",
+                        strHash, vin.prevout.ToStringShort(), nTimestamp, dRate, dMaxRate);
         pBuffer->AddTimestamp(nTimestamp);
         it->second.fStatusOK = fRateOK;
-        break;
+        return true;
     case UPDATE_FAIL_ONLY:
-        if(!fRateOK) {
-            pBuffer->AddTimestamp(nTimestamp);
+        if(!fRateOK)
             it->second.fStatusOK = false;
-        }
+    case UPDATE_FALSE:
+        break;
     default:
         return true;
     }

--- a/src/governance.h
+++ b/src/governance.h
@@ -141,12 +141,6 @@ public:
     }
 };
 
-enum update_mode_enum_t {
-    UPDATE_FALSE,
-    UPDATE_TRUE,
-    UPDATE_FAIL_ONLY
-};
-
 //
 // Governance Manager : Contains all proposals for the budget
 //
@@ -401,9 +395,11 @@ public:
 
     void AddSeenVote(uint256 nHash, int status);
 
-    bool MasternodeRateCheck(const CGovernanceObject& govobj, update_mode_enum_t eUpdateLast = UPDATE_FALSE);
+    void MasternodeRateUpdate(const CGovernanceObject& govobj);
 
-    bool MasternodeRateCheck(const CGovernanceObject& govobj, update_mode_enum_t eUpdateLast, bool fForce, bool& fRateCheckBypassed);
+    bool MasternodeRateCheck(const CGovernanceObject& govobj, bool fUpdateFailStatus = false);
+
+    bool MasternodeRateCheck(const CGovernanceObject& govobj, bool fUpdateFailStatus, bool fForce, bool& fRateCheckBypassed);
 
     bool ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception) {
         bool fOK = ProcessVote(NULL, vote, exception);

--- a/src/governance.h
+++ b/src/governance.h
@@ -117,7 +117,7 @@ public:
     double GetRate()
     {
         int nCount = GetCount();
-        if(nCount < 2) {
+        if(nCount < RATE_BUFFER_SIZE) {
             return 0.0;
         }
         int64_t nMin = GetMinTimestamp();

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -273,11 +273,6 @@ UniValue gobject(const UniValue& params, bool fHelp)
             LogPrintf("gobject(submit) -- Object submission rejected because of rate check failure - hash = %s\n", strHash);
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Object creation rate limit exceeded");
         }
-        // This check should always pass, update buffer
-        if(!governance.MasternodeRateCheck(govobj, UPDATE_TRUE)) {
-            LogPrintf("gobject(submit) -- Object submission rejected because of rate check failure (buffer updated) - hash = %s\n", strHash);
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Object creation rate limit exceeded");
-        }
 
         LogPrintf("gobject(submit) -- Adding locally created governance object - %s\n", strHash);
 

--- a/src/test/ratecheck_tests.cpp
+++ b/src/test/ratecheck_tests.cpp
@@ -30,7 +30,8 @@ BOOST_AUTO_TEST_CASE(ratecheck_test)
     BOOST_CHECK(buffer.GetCount() == 2);
     BOOST_CHECK(buffer.GetMinTimestamp() == 1);
     BOOST_CHECK(buffer.GetMaxTimestamp() == 2);
-    BOOST_CHECK(fabs(buffer.GetRate() - 2.0) < 1.0e-9);
+    //BOOST_CHECK(fabs(buffer.GetRate() - 2.0) < 1.0e-9);
+    BOOST_CHECK(buffer.GetRate() == 0.0);
 
     buffer.AddTimestamp(3);
     BOOST_CHECK(buffer.GetCount() == 3);
@@ -46,13 +47,15 @@ BOOST_AUTO_TEST_CASE(ratecheck_test)
     std::cout << "nMax = " << nMax << std::endl;
     std::cout << "buffer.GetRate() = " << dRate << std::endl;
 
-    BOOST_CHECK(fabs(buffer.GetRate() - (3.0/2.0)) < 1.0e-9);
+    //BOOST_CHECK(fabs(buffer.GetRate() - (3.0/2.0)) < 1.0e-9);
+    BOOST_CHECK(buffer.GetRate() == 0.0);
 
     buffer.AddTimestamp(4);
     BOOST_CHECK(buffer.GetCount() == 4);
     BOOST_CHECK(buffer.GetMinTimestamp() == 1);
     BOOST_CHECK(buffer.GetMaxTimestamp() == 4);
-    BOOST_CHECK(fabs(buffer.GetRate() - (4.0/3.0)) < 1.0e-9);
+    //BOOST_CHECK(fabs(buffer.GetRate() - (4.0/3.0)) < 1.0e-9);
+    BOOST_CHECK(buffer.GetRate() == 0.0);
 
     buffer.AddTimestamp(5);
     BOOST_CHECK(buffer.GetCount() == 5);


### PR DESCRIPTION
Rationale:
1. `MasternodeRateCheck` is working only for watchdog's/trigger's owner when he is creating the object initially. In all other cases, the method always returns `true` for all the objects with correct timestamp.
2. The method updates MN's `CRateCheckBuffer` even if check has failed. Bearing in mind (1) it is not a big problem, but we still can drop this object in some cases (object is invalid, we have this object already or watchdog object doesn't fit required time bounds)

---

Explanation of the commits:

[fixed an issue with MasternodeRateCheck always returns true](https://github.com/dashpay/dash/pull/1490/commits/a2a9ec63d5f2cddecc9faa5c9cdff4dfe1c37b81)

This is simple fix for the issue.

Consequences:

Initial call to `MasternodeRateCheck` is no longer updating the buffer when the rate check fails.
Taking into account another problem discovered in processing of `MNGOVERNANCEOBJECT` we don't need to update buffer because it won't help to counter spam. But it could cause another problems with governance objects propagation.

We shouldn't update buffer unless we accept the object. Otherwise if we reject some object, update the buffer for it's masternode, but other nodes won't update this (because we didn't relay the object), and then this MN can create another valid object which will be accepted by most of nodes, but rejected by us.

`UPDATE_TRUE` in `MasternodeRateCheck` is always returns true, just because we always use this flag when object has accepted and this value doesn't matter. In next commit this part of code changed to "return void".

[additioanal fixes and refactoring](https://github.com/dashpay/dash/pull/1490/commits/aaeed1c46ecf127a4afe26de9b5589dce49c23c5)

This commit is basically refactoring of the code. It's purposed to make buffer updating outside of `MasternodeRateCheck`.

---

Some test results for the PR: https://github.com/the-schnibble/dash-tests/blob/master/results/mn_rate_check.txt

The test itself: https://github.com/the-schnibble/dash-tests/blob/master/mn_rate_check.py

Here node1 is a slightly modified masternode which can create triggers with an arbitrary rate to check that the constraint works for others. The test also checks (counts records in the log) that all objects are relayed, accepted and rejected by nodes as expected (I'm using a private testnet with a reduced interval of superblocks, so the test was waiting for 8.46 minutes to check the "rate limit").