### PR TITLE
Backport Bitcoin PR#7458 : [Net] peers.dat, banlist.dat recreated when missing

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1962,8 +1962,10 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
         CAddrDB adb;
         if (adb.Read(addrman))
             LogPrintf("Loaded %i addresses from peers.dat  %dms\n", addrman.size(), GetTimeMillis() - nStart);
-        else
+        else {
             LogPrintf("Invalid or missing peers.dat; recreating\n");
+            DumpAddresses();
+        }
     }
 
     uiInterface.InitMessage(_("Loading banlist..."));
@@ -1978,8 +1980,11 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
 
         LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
             banmap.size(), GetTimeMillis() - nStart);
-    } else
+    } else {
         LogPrintf("Invalid or missing banlist.dat; recreating\n");
+        CNode::SetBannedSetDirty(true); // force write
+        DumpBanlist();
+    }
 
     fAddressesInitialized = true;
 


### PR DESCRIPTION
This is backport of Bitcoin PR bitcoin/bitcoin#7458.

Again, this PR is needed because it makes changes in places affected by subsequent changes of big networking refactoring.

Original description follows.
---
In response to issue bitcoin/bitcoin#7452. Still leaves an error message for the missing file in the logs though.

My first PR, so be nice please :)