### PR TITLE
Backport Bitcoin PR#7749: Enforce expected outbound services

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -199,7 +199,7 @@ void CActiveMasternode::ManageStateInitial()
 
     LogPrintf("CActiveMasternode::ManageStateInitial -- Checking inbound connection to '%s'\n", service.ToString());
 
-    if(!ConnectNode((CAddress)service, NULL, true)) {
+    if(!ConnectNode(CAddress(service, NODE_NETWORK), NULL, true)) {
         nState = ACTIVE_MASTERNODE_NOT_CAPABLE;
         strNotCapableReason = "Could not connect to " + service.ToString();
         LogPrintf("CActiveMasternode::ManageStateInitial -- %s: %s\n", GetStateString(), strNotCapableReason);

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -495,6 +495,24 @@ void CAddrMan::Connected_(const CService& addr, int64_t nTime)
         info.nTime = nTime;
 }
 
+void CAddrMan::SetServices_(const CService& addr, uint64_t nServices)
+{
+    CAddrInfo* pinfo = Find(addr);
+
+    // if not found, bail out
+    if (!pinfo)
+        return;
+
+    CAddrInfo& info = *pinfo;
+
+    // check whether we are talking about the exact same CService (including same port)
+    if (info != addr)
+        return;
+
+    // update info
+    info.nServices = nServices;
+}
+
 int CAddrMan::RandomInt(int nMax){
     return GetRandInt(nMax);
 }

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -259,7 +259,7 @@ bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimeP
             pinfo->nTime = std::max((int64_t)0, addr.nTime - nTimePenalty);
 
         // add services
-        pinfo->nServices |= addr.nServices;
+        pinfo->nServices = ServiceFlags(pinfo->nServices | addr.nServices);
 
         // do not update if no new information is present
         if (!addr.nTime || (pinfo->nTime && addr.nTime <= pinfo->nTime))
@@ -495,7 +495,7 @@ void CAddrMan::Connected_(const CService& addr, int64_t nTime)
         info.nTime = nTime;
 }
 
-void CAddrMan::SetServices_(const CService& addr, uint64_t nServices)
+void CAddrMan::SetServices_(const CService& addr, ServiceFlags nServices)
 {
     CAddrInfo* pinfo = Find(addr);
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -249,7 +249,7 @@ protected:
     void Connected_(const CService &addr, int64_t nTime);
 
     //! Update an entry's service bits.
-    void SetServices_(const CService &addr, uint64_t nServices);
+    void SetServices_(const CService &addr, ServiceFlags nServices);
 
 public:
     /**
@@ -575,7 +575,7 @@ public:
         }
     }
 
-    void SetServices(const CService &addr, uint64_t nServices)
+    void SetServices(const CService &addr, ServiceFlags nServices)
     {
         LOCK(cs);
         Check();

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -248,6 +248,9 @@ protected:
     //! Mark an entry as currently-connected-to.
     void Connected_(const CService &addr, int64_t nTime);
 
+    //! Update an entry's service bits.
+    void SetServices_(const CService &addr, uint64_t nServices);
+
 public:
     /**
      * serialized format:
@@ -570,6 +573,14 @@ public:
             Connected_(addr, nTime);
             Check();
         }
+    }
+
+    void SetServices(const CService &addr, uint64_t nServices)
+    {
+        LOCK(cs);
+        Check();
+        SetServices_(addr, nServices);
+        Check();
     }
 
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1163,7 +1163,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op
 
     if (GetBoolArg("-peerbloomfilters", true))
-        nLocalServices |= NODE_BLOOM;
+        nLocalServices = ServiceFlags(nLocalServices | NODE_BLOOM);
 
     fEnableReplacement = GetBoolArg("-mempoolreplacement", DEFAULT_ENABLE_REPLACEMENT);
     if ((!fEnableReplacement) && mapArgs.count("-mempoolreplacement")) {
@@ -1791,7 +1791,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // after any wallet rescanning has taken place.
     if (fPruneMode) {
         LogPrintf("Unsetting NODE_NETWORK on prune mode\n");
-        nLocalServices &= ~NODE_NETWORK;
+        nLocalServices = ServiceFlags(nLocalServices & ~NODE_NETWORK);
         if (!fReindex) {
             uiInterface.InitMessage(_("Pruning blockstore..."));
             PruneAndFlush();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5491,7 +5491,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             boost::this_thread::interruption_point();
 
-            if (!(addr.nServices & NODE_NETWORK))
+            if ((addr.nServices & REQUIRED_SERVICES) != REQUIRED_SERVICES)
                 continue;
 
             if (addr.nTime <= 100000000 || addr.nTime > nNow + 10 * 60)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5310,7 +5310,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CAddress addrMe;
         CAddress addrFrom;
         uint64_t nNonce = 1;
-        vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
+        uint64_t nServiceInt;
+        vRecv >> pfrom->nVersion >> nServiceInt >> nTime >> addrMe;
+        pfrom->nServices = ServiceFlags(nServiceInt);
         if (!pfrom->fInbound)
         {
             addrman.SetServices(pfrom->addr, pfrom->nServices);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5315,6 +5315,15 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             addrman.SetServices(pfrom->addr, pfrom->nServices);
         }
+        if (pfrom->nServicesExpected & ~pfrom->nServices)
+        {
+            LogPrint("net", "peer=%d does not offer the expected services (%08x offered, %08x expected); disconnecting\n", pfrom->id, pfrom->nServices, pfrom->nServicesExpected);
+            pfrom->PushMessage(NetMsgType::REJECT, strCommand, REJECT_NONSTANDARD,
+                               strprintf("Expected to offer services %08x", pfrom->nServicesExpected));
+            pfrom->fDisconnect = true;
+            return false;
+        }
+
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
             // disconnect from peers older than this proto version

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5489,6 +5489,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         {
             boost::this_thread::interruption_point();
 
+            if (!(addr.nServices & NODE_NETWORK))
+                continue;
+
             if (addr.nTime <= 100000000 || addr.nTime > nNow + 10 * 60)
                 addr.nTime = nNow - 5 * 24 * 60 * 60;
             pfrom->AddAddressKnown(addr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5311,6 +5311,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CAddress addrFrom;
         uint64_t nNonce = 1;
         vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
+        if (!pfrom->fInbound)
+        {
+            addrman.SetServices(pfrom->addr, pfrom->nServices);
+        }
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
             // disconnect from peers older than this proto version

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -819,7 +819,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         if (CheckMnbAndUpdateMasternodeList(pfrom, mnb, nDos)) {
             // use announced Masternode as a peer
-            addrman.Add(CAddress(mnb.addr), pfrom->addr, 2*60*60);
+            addrman.Add(CAddress(mnb.addr, NODE_NETWORK), pfrom->addr, 2*60*60);
         } else if(nDos > 0) {
             Misbehaving(pfrom->GetId(), nDos);
         }
@@ -1020,7 +1020,7 @@ void CMasternodeMan::DoFullVerificationStep()
         }
         LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Verifying masternode %s rank %d/%d address %s\n",
                     it->second.vin.prevout.ToStringShort(), it->first, nRanksTotal, it->second.addr.ToString());
-        if(SendVerifyRequest((CAddress)it->second.addr, vSortedByAddr)) {
+        if(SendVerifyRequest(CAddress(it->second.addr, NODE_NETWORK), vSortedByAddr)) {
             nCount++;
             if(nCount >= MAX_POSE_CONNECTIONS) break;
         }
@@ -1203,7 +1203,7 @@ void CMasternodeMan::ProcessVerifyReply(CNode* pnode, CMasternodeVerification& m
         std::vector<CMasternode>::iterator it = vMasternodes.begin();
         std::string strMessage1 = strprintf("%s%d%s", pnode->addr.ToString(false), mnv.nonce, blockHash.ToString());
         while(it != vMasternodes.end()) {
-            if((CAddress)it->addr == pnode->addr) {
+            if(CAddress(it->addr, NODE_NETWORK) == pnode->addr) {
                 if(CMessageSigner::VerifyMessage(it->pubKeyMasternode, mnv.vchSig1, strMessage1, strError)) {
                     // found it!
                     prealMasternode = &(*it);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1590,7 +1590,7 @@ void ThreadOpenConnections()
                 continue;
 
             // only connect to full nodes
-            if (!(addr.nServices & NODE_NETWORK))
+            if ((addr.nServices & REQUIRED_SERVICES) != REQUIRED_SERVICES)
                 continue;
 
             // only consider very recently tried nodes after 30 failed attempts

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1590,6 +1590,10 @@ void ThreadOpenConnections()
             if (IsLimited(addr))
                 continue;
 
+            // only connect to full nodes
+            if (!(addr.nServices & NODE_NETWORK))
+                continue;
+
             // only consider very recently tried nodes after 30 failed attempts
             if (nANow - addr.nLastTry < 600 && nTries < 30)
                 continue;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -80,14 +80,14 @@ namespace {
 const static std::string NET_MESSAGE_COMMAND_OTHER = "*other*";
 
 /** Services this node implementation cares about */
-static const uint64_t nRelevantServices = NODE_NETWORK;
+static const ServiceFlags nRelevantServices = NODE_NETWORK;
 
 //
 // Global state variables
 //
 bool fDiscover = true;
 bool fListen = true;
-uint64_t nLocalServices = NODE_NETWORK;
+ServiceFlags nLocalServices = NODE_NETWORK;
 CCriticalSection cs_mapLocalHost;
 map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};
@@ -189,7 +189,7 @@ static std::vector<CAddress> convertSeed6(const std::vector<SeedSpec6> &vSeedsIn
 // one by discovery.
 CAddress GetLocalAddress(const CNetAddr *paddrPeer)
 {
-    CAddress ret(CService("0.0.0.0",GetListenPort()),0);
+    CAddress ret(CService("0.0.0.0",GetListenPort()), NODE_NONE);
     CService addr;
     if (GetLocal(addr, paddrPeer))
     {
@@ -444,7 +444,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fConnectToMas
 
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
-        pnode->nServicesExpected = addrConnect.nServices & nRelevantServices;
+        pnode->nServicesExpected = ServiceFlags(addrConnect.nServices & nRelevantServices);
 
         return pnode;
     } else if (!proxyConnectionFailed) {
@@ -476,14 +476,14 @@ void CNode::PushVersion()
     int nBestHeight = g_signals.GetHeight().get_value_or(0);
 
     int64_t nTime = (fInbound ? GetAdjustedTime() : GetTime());
-    CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService("0.0.0.0",0), addr.nServices));
+    CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService("0.0.0.0", 0), addr.nServices));
     CAddress addrMe = GetLocalAddress(&addr);
     GetRandBytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
     if (fLogIPs)
         LogPrint("net", "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), id);
     else
         LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), id);
-    PushMessage(NetMsgType::VERSION, PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
+    PushMessage(NetMsgType::VERSION, PROTOCOL_VERSION, (uint64_t)nLocalServices, nTime, addrYou, addrMe,
                 nLocalHostNonce, strSubVersion, nBestHeight, !GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY));
 }
 
@@ -1517,7 +1517,7 @@ void ThreadOpenConnections()
             ProcessOneShot();
             BOOST_FOREACH(const std::string& strAddr, mapMultiArgs["-connect"])
             {
-                CAddress addr(CService(), 0);
+                CAddress addr(CService(), NODE_NONE);
                 OpenNetworkConnection(addr, NULL, strAddr.c_str());
                 for (int i = 0; i < 10 && i < nLoop; i++)
                 {
@@ -1675,8 +1675,8 @@ void ThreadOpenAddedConnections()
         {
             CSemaphoreGrant grant(*semOutbound);
             /* We want -addnode to work even for nodes that don't provide all
-             * wanted services, so pass in nServices=0 to CAddress. */
-            OpenNetworkConnection(CAddress(vserv[i % vserv.size()], 0), &grant);
+             * wanted services, so pass in nServices=NODE_NONE to CAddress. */
+            OpenNetworkConnection(CAddress(vserv[i % vserv.size()], NODE_NONE), &grant);
             MilliSleep(500);
         }
         MilliSleep(120000); // Retry every 2 minutes
@@ -2434,8 +2434,8 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     addrKnown(5000, 0.001),
     filterInventoryKnown(50000, 0.000001)
 {
-    nServices = 0;
-    nServicesExpected = 0;
+    nServices = NODE_NONE;
+    nServicesExpected = NODE_NONE;
     hSocket = hSocketIn;
     nRecvVersion = INIT_PROTO_VERSION;
     nLastSend = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -79,6 +79,9 @@ namespace {
 
 const static std::string NET_MESSAGE_COMMAND_OTHER = "*other*";
 
+/** Services this node implementation cares about */
+static const uint64_t nRelevantServices = NODE_NETWORK;
+
 //
 // Global state variables
 //
@@ -442,6 +445,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fConnectToMas
 
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
+        pnode->nServicesExpected = addrConnect.nServices & nRelevantServices;
 
         return pnode;
     } else if (!proxyConnectionFailed) {
@@ -2426,6 +2430,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     filterInventoryKnown(50000, 0.000001)
 {
     nServices = 0;
+    nServicesExpected = 0;
     hSocket = hSocketIn;
     nRecvVersion = INIT_PROTO_VERSION;
     nLastSend = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -323,6 +323,7 @@ class CNode
 public:
     // socket
     uint64_t nServices;
+    uint64_t nServicesExpected;
     SOCKET hSocket;
     CDataStream ssSend;
     size_t nSendSize; // total size of all vSendMsg entries

--- a/src/net.h
+++ b/src/net.h
@@ -73,6 +73,8 @@ static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
+static const ServiceFlags REQUIRED_SERVICES = NODE_NETWORK;
+
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
 static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
 

--- a/src/net.h
+++ b/src/net.h
@@ -156,7 +156,7 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
 
 extern bool fDiscover;
 extern bool fListen;
-extern uint64_t nLocalServices;
+extern ServiceFlags nLocalServices;
 extern uint64_t nLocalHostNonce;
 extern CAddrMan addrman;
 
@@ -192,7 +192,7 @@ class CNodeStats
 {
 public:
     NodeId nodeid;
-    uint64_t nServices;
+    ServiceFlags nServices;
     bool fRelayTxes;
     int64_t nLastSend;
     int64_t nLastRecv;
@@ -322,8 +322,8 @@ class CNode
 {
 public:
     // socket
-    uint64_t nServices;
-    uint64_t nServicesExpected;
+    ServiceFlags nServices;
+    ServiceFlags nServicesExpected;
     SOCKET hSocket;
     CDataStream ssSend;
     size_t nSendSize; // total size of all vSendMsg entries

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -863,7 +863,7 @@ bool CPrivateSendClient::JoinExistingQueue(CAmount nBalanceNeedsAnonymized)
 
         LogPrintf("CPrivateSendClient::JoinExistingQueue -- attempt to connect to masternode from queue, addr=%s\n", infoMn.addr.ToString());
         // connect to Masternode and submit the queue request
-        CNode* pnode = (pnodeFound && pnodeFound->fMasternode) ? pnodeFound : ConnectNode((CAddress)infoMn.addr, NULL, true);
+        CNode* pnode = (pnodeFound && pnodeFound->fMasternode) ? pnodeFound : ConnectNode(CAddress(infoMn.addr, NODE_NETWORK), NULL, true);
         if(pnode) {
             infoMixingMasternode = infoMn;
             nSessionDenom = dsq.nDenom;
@@ -936,7 +936,7 @@ bool CPrivateSendClient::StartNewQueue(CAmount nValueMin, CAmount nBalanceNeedsA
         }
 
         LogPrintf("CPrivateSendClient::StartNewQueue -- attempt %d connection to Masternode %s\n", nTries, infoMn.addr.ToString());
-        CNode* pnode = (pnodeFound && pnodeFound->fMasternode) ? pnodeFound : ConnectNode((CAddress)infoMn.addr, NULL, true);
+        CNode* pnode = (pnodeFound && pnodeFound->fMasternode) ? pnodeFound : ConnectNode(CAddress(infoMn.addr, NODE_NETWORK), NULL, true);
         if(pnode) {
             LogPrintf("CPrivateSendClient::StartNewQueue -- connected, addr=%s\n", infoMn.addr.ToString());
             infoMixingMasternode = infoMn;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -206,7 +206,7 @@ CAddress::CAddress() : CService()
     Init();
 }
 
-CAddress::CAddress(CService ipIn, uint64_t nServicesIn) : CService(ipIn)
+CAddress::CAddress(CService ipIn, ServiceFlags nServicesIn) : CService(ipIn)
 {
     Init();
     nServices = nServicesIn;
@@ -214,7 +214,7 @@ CAddress::CAddress(CService ipIn, uint64_t nServicesIn) : CService(ipIn)
 
 void CAddress::Init()
 {
-    nServices = 0;
+    nServices = NODE_NONE;
     nTime = 100000000;
 }
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -214,7 +214,7 @@ CAddress::CAddress(CService ipIn, uint64_t nServicesIn) : CService(ipIn)
 
 void CAddress::Init()
 {
-    nServices = NODE_NETWORK;
+    nServices = 0;
     nTime = 100000000;
 }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -278,7 +278,7 @@ class CAddress : public CService
 {
 public:
     CAddress();
-    explicit CAddress(CService ipIn, uint64_t nServicesIn = NODE_NETWORK);
+    explicit CAddress(CService ipIn, uint64_t nServicesIn);
 
     void Init();
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -250,7 +250,9 @@ extern const char *MNVERIFY;
 const std::vector<std::string> &getAllNetMessageTypes();
 
 /** nServices flags */
-enum {
+enum ServiceFlags : uint64_t {
+    // Nothing
+    NODE_NONE = 0,
     // NODE_NETWORK means that the node is capable of serving the block chain. It is currently
     // set by all Dash Core nodes, and is unset by SPV clients or other peers that just want
     // network services but don't provide them.
@@ -278,7 +280,7 @@ class CAddress : public CService
 {
 public:
     CAddress();
-    explicit CAddress(CService ipIn, uint64_t nServicesIn);
+    explicit CAddress(CService ipIn, ServiceFlags nServicesIn);
 
     void Init();
 
@@ -294,13 +296,15 @@ public:
         if ((nType & SER_DISK) ||
             (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
             READWRITE(nTime);
-        READWRITE(nServices);
+        uint64_t nServicesInt = nServices;
+        READWRITE(nServicesInt);
+        nServices = (ServiceFlags)nServicesInt;
         READWRITE(*(CService*)this);
     }
 
     // TODO: make private (improves encapsulation)
 public:
-    uint64_t nServices;
+    ServiceFlags nServices;
 
     // disk and network only
     unsigned int nTime;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -147,7 +147,7 @@ UniValue masternode(const UniValue& params, bool fHelp)
 
         CService addr = CService(strAddress);
 
-        CNode *pnode = ConnectNode((CAddress)addr, NULL);
+        CNode *pnode = ConnectNode(CAddress(addr, NODE_NETWORK), NULL);
         if(!pnode)
             throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Couldn't connect to masternode %s", strAddress));
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -45,7 +45,7 @@ BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
     CNode::ClearBanned();
-    CAddress addr1(ip(0xa0b0c001), 0);
+    CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     BOOST_CHECK(CNode::IsBanned(addr1));
     BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
-    CAddress addr2(ip(0xa0b0c002), 0);
+    CAddress addr2(ip(0xa0b0c002), NODE_NONE);
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
     CNode::ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
-    CAddress addr1(ip(0xa0b0c001), 0);
+    CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     int64_t nStartTime = GetTime();
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
 
-    CAddress addr(ip(0xa0b0c001), 0);
+    CAddress addr(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode(INVALID_SOCKET, addr, "", true);
     dummyNode.nVersion = 1;
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -45,7 +45,7 @@ BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
     CNode::ClearBanned();
-    CAddress addr1(ip(0xa0b0c001));
+    CAddress addr1(ip(0xa0b0c001), 0);
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     BOOST_CHECK(CNode::IsBanned(addr1));
     BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
-    CAddress addr2(ip(0xa0b0c002));
+    CAddress addr2(ip(0xa0b0c002), 0);
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
     CNode::ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
-    CAddress addr1(ip(0xa0b0c001));
+    CAddress addr1(ip(0xa0b0c001), 0);
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     int64_t nStartTime = GetTime();
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
 
-    CAddress addr(ip(0xa0b0c001));
+    CAddress addr(ip(0xa0b0c001), 0);
     CNode dummyNode(INVALID_SOCKET, addr, "", true);
     dummyNode.nVersion = 1;
 

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
 
     // Test 2: Does Addrman::Add work as expected.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret1 = addrman.Select();
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
@@ -76,14 +76,14 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     // Test 3: Does IP address deduplication work correctly.
     //  Expected dup IP should not be added.
     CService addr1_dup = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1_dup), source);
+    addrman.Add(CAddress(addr1_dup, 0), source);
     BOOST_CHECK(addrman.size() == 1);
 
 
     // Test 5: New table has one addr and we add a diff addr we should
     //  have two addrs.
     CService addr2 = CService("250.1.1.2", 8333);
-    addrman.Add(CAddress(addr2), source);
+    addrman.Add(CAddress(addr2, 0), source);
     BOOST_CHECK(addrman.size() == 2);
 
     // Test 6: AddrMan::Clear() should empty the new table.
@@ -106,18 +106,18 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
 
     // Test 7; Addr with same IP but diff port does not replace existing addr.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 1);
 
     CService addr1_port = CService("250.1.1.1", 8334);
-    addrman.Add(CAddress(addr1_port), source);
+    addrman.Add(CAddress(addr1_port, 0), source);
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select();
     BOOST_CHECK(addr_ret2.ToString() == "250.1.1.1:8333");
 
     // Test 8: Add same IP but diff port to tried table, it doesn't get added.
     //  Perhaps this is not ideal behavior but it is the current behavior.
-    addrman.Good(CAddress(addr1_port));
+    addrman.Good(CAddress(addr1_port, 0));
     BOOST_CHECK(addrman.size() == 1);
     bool newOnly = true;
     CAddrInfo addr_ret3 = addrman.Select(newOnly);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
 
     // Test 9: Select from new with 1 addr in new.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 1);
 
     bool newOnly = true;
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
 
     // Test 10: move addr to tried, select from new expected nothing returned.
-    addrman.Good(CAddress(addr1));
+    addrman.Good(CAddress(addr1, 0));
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select(newOnly);
     BOOST_CHECK(addr_ret2.ToString() == "[::]:0");
@@ -160,21 +160,21 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     CService addr3 = CService("250.3.2.2", 9999);
     CService addr4 = CService("250.3.3.3", 9999);
 
-    addrman.Add(CAddress(addr2), CService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr3), CService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr4), CService("250.4.1.1", 8333));
+    addrman.Add(CAddress(addr2, 0), CService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr3, 0), CService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr4, 0), CService("250.4.1.1", 8333));
 
     // Add three addresses to tried table.
     CService addr5 = CService("250.4.4.4", 8333);
     CService addr6 = CService("250.4.5.5", 7777);
     CService addr7 = CService("250.4.6.6", 8333);
 
-    addrman.Add(CAddress(addr5), CService("250.3.1.1", 8333));
-    addrman.Good(CAddress(addr5));
-    addrman.Add(CAddress(addr6), CService("250.3.1.1", 8333));
-    addrman.Good(CAddress(addr6));
-    addrman.Add(CAddress(addr7), CService("250.1.1.3", 8333));
-    addrman.Good(CAddress(addr7));
+    addrman.Add(CAddress(addr5, 0), CService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr5, 0));
+    addrman.Add(CAddress(addr6, 0), CService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr6, 0));
+    addrman.Add(CAddress(addr7, 0), CService("250.1.1.3", 8333));
+    addrman.Good(CAddress(addr7, 0));
 
     // Test 11: 6 addrs + 1 addr from last test = 7.
     BOOST_CHECK(addrman.size() == 7);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     for (unsigned int i = 1; i < 18; i++) {
         CService addr = CService("250.1.1." + boost::to_string(i));
-        addrman.Add(CAddress(addr), source);
+        addrman.Add(CAddress(addr, 0), source);
 
         //Test 13: No collision in new table yet.
         BOOST_CHECK(addrman.size() == i);
@@ -207,11 +207,11 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     //Test 14: new table collision!
     CService addr1 = CService("250.1.1.18");
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 17);
 
     CService addr2 = CService("250.1.1.19");
-    addrman.Add(CAddress(addr2), source);
+    addrman.Add(CAddress(addr2, 0), source);
     BOOST_CHECK(addrman.size() == 18);
 }
 
@@ -228,8 +228,8 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     for (unsigned int i = 1; i < 80; i++) {
         CService addr = CService("250.1.1." + boost::to_string(i));
-        addrman.Add(CAddress(addr), source);
-        addrman.Good(CAddress(addr));
+        addrman.Add(CAddress(addr, 0), source);
+        addrman.Good(CAddress(addr, 0));
 
         //Test 15: No collision in tried table yet.
         BOOST_TEST_MESSAGE(addrman.size());
@@ -238,11 +238,11 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     //Test 16: tried table collision!
     CService addr1 = CService("250.1.1.80");
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 79);
 
     CService addr2 = CService("250.1.1.81");
-    addrman.Add(CAddress(addr2), source);
+    addrman.Add(CAddress(addr2, 0), source);
     BOOST_CHECK(addrman.size() == 80);
 }
 
@@ -255,9 +255,9 @@ BOOST_AUTO_TEST_CASE(addrman_find)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333));
-    CAddress addr2 = CAddress(CService("250.1.2.1", 9999));
-    CAddress addr3 = CAddress(CService("251.255.2.1", 8333));
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
+    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), 0);
+    CAddress addr3 = CAddress(CService("251.255.2.1", 8333), 0);
 
     CNetAddr source1 = CNetAddr("250.1.2.1");
     CNetAddr source2 = CNetAddr("250.1.2.2");
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(addrman_create)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333));
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
     int nId;
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(addrman_delete)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333));
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
     int nId;
@@ -344,15 +344,15 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     vector<CAddress> vAddr1 = addrman.GetAddr();
     BOOST_CHECK(vAddr1.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.250.2.1", 8333));
+    CAddress addr1 = CAddress(CService("250.250.2.1", 8333), 0);
     addr1.nTime = GetAdjustedTime(); // Set time so isTerrible = false
-    CAddress addr2 = CAddress(CService("250.251.2.2", 9999));
+    CAddress addr2 = CAddress(CService("250.251.2.2", 9999), 0);
     addr2.nTime = GetAdjustedTime();
-    CAddress addr3 = CAddress(CService("251.252.2.3", 8333));
+    CAddress addr3 = CAddress(CService("251.252.2.3", 8333), 0);
     addr3.nTime = GetAdjustedTime();
-    CAddress addr4 = CAddress(CService("252.253.3.4", 8333));
+    CAddress addr4 = CAddress(CService("252.253.3.4", 8333), 0);
     addr4.nTime = GetAdjustedTime();
-    CAddress addr5 = CAddress(CService("252.254.4.5", 8333));
+    CAddress addr5 = CAddress(CService("252.254.4.5", 8333), 0);
     addr5.nTime = GetAdjustedTime();
     CNetAddr source1 = CNetAddr("250.1.2.1");
     CNetAddr source2 = CNetAddr("250.2.3.3");
@@ -368,8 +368,8 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     BOOST_CHECK(addrman.GetAddr().size() == 1); 
 
     // Test 24: Ensure GetAddr works with new and tried addresses.
-    addrman.Good(CAddress(addr1));
-    addrman.Good(CAddress(addr2));
+    addrman.Good(CAddress(addr1, 0));
+    addrman.Good(CAddress(addr2, 0));
     BOOST_CHECK(addrman.GetAddr().size() == 1);
 
     // Test 25: Ensure GetAddr still returns 23% when addrman has many addrs.
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
         int octet2 = (i / 256) % 256;
         int octet3 = (i / (256 * 2)) % 256;
         string strAddr = boost::to_string(octet1) + "." + boost::to_string(octet2) + "." + boost::to_string(octet3) + ".23";
-        CAddress addr = CAddress(CService(strAddr));
+        CAddress addr = CAddress(CService(strAddr), 0);
         
         // Ensure that for all addrs in addrman, isTerrible == false.
         addr.nTime = GetAdjustedTime();
@@ -403,8 +403,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    CAddress addr1 = CAddress(CService("250.1.1.1", 8333));
-    CAddress addr2 = CAddress(CService("250.1.1.1", 9999));
+    CAddress addr1 = CAddress(CService("250.1.1.1", 8333), 0);
+    CAddress addr2 = CAddress(CService("250.1.1.1", 9999), 0);
 
     CNetAddr source1 = CNetAddr("250.1.1.1");
 
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
         CAddrInfo infoi = CAddrInfo(
-            CAddress(CService("250.1.1." + boost::to_string(i))),
+            CAddress(CService("250.1.1." + boost::to_string(i)), 0),
             CNetAddr("250.1.1." + boost::to_string(i)));
         int bucket = infoi.GetTriedBucket(nKey1);
         buckets.insert(bucket);
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     buckets.clear();
     for (int j = 0; j < 255; j++) {
         CAddrInfo infoj = CAddrInfo(
-            CAddress(CService("250." + boost::to_string(j) + ".1.1")),
+            CAddress(CService("250." + boost::to_string(j) + ".1.1"), 0),
             CNetAddr("250." + boost::to_string(j) + ".1.1"));
         int bucket = infoj.GetTriedBucket(nKey1);
         buckets.insert(bucket);
@@ -460,8 +460,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333));
-    CAddress addr2 = CAddress(CService("250.1.2.1", 9999));
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
+    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), 0);
 
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
         CAddrInfo infoi = CAddrInfo(
-            CAddress(CService("250.1.1." + boost::to_string(i))),
+            CAddress(CService("250.1.1." + boost::to_string(i)), 0),
             CNetAddr("250.1.1." + boost::to_string(i)));
         int bucket = infoi.GetNewBucket(nKey1);
         buckets.insert(bucket);
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     for (int j = 0; j < 4 * 255; j++) {
         CAddrInfo infoj = CAddrInfo(CAddress(
                                         CService(
-                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1")),
+                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1"), 0),
             CNetAddr("251.4.1.1"));
         int bucket = infoj.GetNewBucket(nKey1);
         buckets.insert(bucket);
@@ -509,7 +509,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     buckets.clear();
     for (int p = 0; p < 255; p++) {
         CAddrInfo infoj = CAddrInfo(
-            CAddress(CService("250.1.1.1")),
+            CAddress(CService("250.1.1.1"), 0),
             CNetAddr("250." + boost::to_string(p) + ".1.1"));
         int bucket = infoj.GetNewBucket(nKey1);
         buckets.insert(bucket);

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
 
     // Test 2: Does Addrman::Add work as expected.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret1 = addrman.Select();
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
@@ -76,14 +76,14 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     // Test 3: Does IP address deduplication work correctly.
     //  Expected dup IP should not be added.
     CService addr1_dup = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1_dup, 0), source);
+    addrman.Add(CAddress(addr1_dup, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
 
 
     // Test 5: New table has one addr and we add a diff addr we should
     //  have two addrs.
     CService addr2 = CService("250.1.1.2", 8333);
-    addrman.Add(CAddress(addr2, 0), source);
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 2);
 
     // Test 6: AddrMan::Clear() should empty the new table.
@@ -106,18 +106,18 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
 
     // Test 7; Addr with same IP but diff port does not replace existing addr.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
 
     CService addr1_port = CService("250.1.1.1", 8334);
-    addrman.Add(CAddress(addr1_port, 0), source);
+    addrman.Add(CAddress(addr1_port, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select();
     BOOST_CHECK(addr_ret2.ToString() == "250.1.1.1:8333");
 
     // Test 8: Add same IP but diff port to tried table, it doesn't get added.
     //  Perhaps this is not ideal behavior but it is the current behavior.
-    addrman.Good(CAddress(addr1_port, 0));
+    addrman.Good(CAddress(addr1_port, NODE_NONE));
     BOOST_CHECK(addrman.size() == 1);
     bool newOnly = true;
     CAddrInfo addr_ret3 = addrman.Select(newOnly);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
 
     // Test 9: Select from new with 1 addr in new.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
 
     bool newOnly = true;
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
 
     // Test 10: move addr to tried, select from new expected nothing returned.
-    addrman.Good(CAddress(addr1, 0));
+    addrman.Good(CAddress(addr1, NODE_NONE));
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select(newOnly);
     BOOST_CHECK(addr_ret2.ToString() == "[::]:0");
@@ -160,21 +160,21 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     CService addr3 = CService("250.3.2.2", 9999);
     CService addr4 = CService("250.3.3.3", 9999);
 
-    addrman.Add(CAddress(addr2, 0), CService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr3, 0), CService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr4, 0), CService("250.4.1.1", 8333));
+    addrman.Add(CAddress(addr2, NODE_NONE), CService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr3, NODE_NONE), CService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr4, NODE_NONE), CService("250.4.1.1", 8333));
 
     // Add three addresses to tried table.
     CService addr5 = CService("250.4.4.4", 8333);
     CService addr6 = CService("250.4.5.5", 7777);
     CService addr7 = CService("250.4.6.6", 8333);
 
-    addrman.Add(CAddress(addr5, 0), CService("250.3.1.1", 8333));
-    addrman.Good(CAddress(addr5, 0));
-    addrman.Add(CAddress(addr6, 0), CService("250.3.1.1", 8333));
-    addrman.Good(CAddress(addr6, 0));
-    addrman.Add(CAddress(addr7, 0), CService("250.1.1.3", 8333));
-    addrman.Good(CAddress(addr7, 0));
+    addrman.Add(CAddress(addr5, NODE_NONE), CService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr5, NODE_NONE));
+    addrman.Add(CAddress(addr6, NODE_NONE), CService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr6, NODE_NONE));
+    addrman.Add(CAddress(addr7, NODE_NONE), CService("250.1.1.3", 8333));
+    addrman.Good(CAddress(addr7, NODE_NONE));
 
     // Test 11: 6 addrs + 1 addr from last test = 7.
     BOOST_CHECK(addrman.size() == 7);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     for (unsigned int i = 1; i < 18; i++) {
         CService addr = CService("250.1.1." + boost::to_string(i));
-        addrman.Add(CAddress(addr, 0), source);
+        addrman.Add(CAddress(addr, NODE_NONE), source);
 
         //Test 13: No collision in new table yet.
         BOOST_CHECK(addrman.size() == i);
@@ -207,11 +207,11 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     //Test 14: new table collision!
     CService addr1 = CService("250.1.1.18");
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 17);
 
     CService addr2 = CService("250.1.1.19");
-    addrman.Add(CAddress(addr2, 0), source);
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 18);
 }
 
@@ -228,8 +228,8 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     for (unsigned int i = 1; i < 80; i++) {
         CService addr = CService("250.1.1." + boost::to_string(i));
-        addrman.Add(CAddress(addr, 0), source);
-        addrman.Good(CAddress(addr, 0));
+        addrman.Add(CAddress(addr, NODE_NONE), source);
+        addrman.Good(CAddress(addr, NODE_NONE));
 
         //Test 15: No collision in tried table yet.
         BOOST_TEST_MESSAGE(addrman.size());
@@ -238,11 +238,11 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     //Test 16: tried table collision!
     CService addr1 = CService("250.1.1.80");
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 79);
 
     CService addr2 = CService("250.1.1.81");
-    addrman.Add(CAddress(addr2, 0), source);
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 80);
 }
 
@@ -255,9 +255,9 @@ BOOST_AUTO_TEST_CASE(addrman_find)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
-    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), 0);
-    CAddress addr3 = CAddress(CService("251.255.2.1", 8333), 0);
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), NODE_NONE);
+    CAddress addr3 = CAddress(CService("251.255.2.1", 8333), NODE_NONE);
 
     CNetAddr source1 = CNetAddr("250.1.2.1");
     CNetAddr source2 = CNetAddr("250.1.2.2");
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(addrman_create)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), NODE_NONE);
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
     int nId;
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(addrman_delete)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), NODE_NONE);
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
     int nId;
@@ -344,15 +344,15 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     vector<CAddress> vAddr1 = addrman.GetAddr();
     BOOST_CHECK(vAddr1.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.250.2.1", 8333), 0);
+    CAddress addr1 = CAddress(CService("250.250.2.1", 8333), NODE_NONE);
     addr1.nTime = GetAdjustedTime(); // Set time so isTerrible = false
-    CAddress addr2 = CAddress(CService("250.251.2.2", 9999), 0);
+    CAddress addr2 = CAddress(CService("250.251.2.2", 9999), NODE_NONE);
     addr2.nTime = GetAdjustedTime();
-    CAddress addr3 = CAddress(CService("251.252.2.3", 8333), 0);
+    CAddress addr3 = CAddress(CService("251.252.2.3", 8333), NODE_NONE);
     addr3.nTime = GetAdjustedTime();
-    CAddress addr4 = CAddress(CService("252.253.3.4", 8333), 0);
+    CAddress addr4 = CAddress(CService("252.253.3.4", 8333), NODE_NONE);
     addr4.nTime = GetAdjustedTime();
-    CAddress addr5 = CAddress(CService("252.254.4.5", 8333), 0);
+    CAddress addr5 = CAddress(CService("252.254.4.5", 8333), NODE_NONE);
     addr5.nTime = GetAdjustedTime();
     CNetAddr source1 = CNetAddr("250.1.2.1");
     CNetAddr source2 = CNetAddr("250.2.3.3");
@@ -368,8 +368,8 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     BOOST_CHECK(addrman.GetAddr().size() == 1); 
 
     // Test 24: Ensure GetAddr works with new and tried addresses.
-    addrman.Good(CAddress(addr1, 0));
-    addrman.Good(CAddress(addr2, 0));
+    addrman.Good(CAddress(addr1, NODE_NONE));
+    addrman.Good(CAddress(addr2, NODE_NONE));
     BOOST_CHECK(addrman.GetAddr().size() == 1);
 
     // Test 25: Ensure GetAddr still returns 23% when addrman has many addrs.
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
         int octet2 = (i / 256) % 256;
         int octet3 = (i / (256 * 2)) % 256;
         string strAddr = boost::to_string(octet1) + "." + boost::to_string(octet2) + "." + boost::to_string(octet3) + ".23";
-        CAddress addr = CAddress(CService(strAddr), 0);
+        CAddress addr = CAddress(CService(strAddr), NODE_NONE);
         
         // Ensure that for all addrs in addrman, isTerrible == false.
         addr.nTime = GetAdjustedTime();
@@ -403,8 +403,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    CAddress addr1 = CAddress(CService("250.1.1.1", 8333), 0);
-    CAddress addr2 = CAddress(CService("250.1.1.1", 9999), 0);
+    CAddress addr1 = CAddress(CService("250.1.1.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(CService("250.1.1.1", 9999), NODE_NONE);
 
     CNetAddr source1 = CNetAddr("250.1.1.1");
 
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
         CAddrInfo infoi = CAddrInfo(
-            CAddress(CService("250.1.1." + boost::to_string(i)), 0),
+            CAddress(CService("250.1.1." + boost::to_string(i)), NODE_NONE),
             CNetAddr("250.1.1." + boost::to_string(i)));
         int bucket = infoi.GetTriedBucket(nKey1);
         buckets.insert(bucket);
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     buckets.clear();
     for (int j = 0; j < 255; j++) {
         CAddrInfo infoj = CAddrInfo(
-            CAddress(CService("250." + boost::to_string(j) + ".1.1"), 0),
+            CAddress(CService("250." + boost::to_string(j) + ".1.1"), NODE_NONE),
             CNetAddr("250." + boost::to_string(j) + ".1.1"));
         int bucket = infoj.GetTriedBucket(nKey1);
         buckets.insert(bucket);
@@ -460,8 +460,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
-    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), 0);
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), NODE_NONE);
 
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
@@ -484,7 +484,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
         CAddrInfo infoi = CAddrInfo(
-            CAddress(CService("250.1.1." + boost::to_string(i)), 0),
+            CAddress(CService("250.1.1." + boost::to_string(i)), NODE_NONE),
             CNetAddr("250.1.1." + boost::to_string(i)));
         int bucket = infoi.GetNewBucket(nKey1);
         buckets.insert(bucket);
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     for (int j = 0; j < 4 * 255; j++) {
         CAddrInfo infoj = CAddrInfo(CAddress(
                                         CService(
-                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1"), 0),
+                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1"), NODE_NONE),
             CNetAddr("251.4.1.1"));
         int bucket = infoj.GetNewBucket(nKey1);
         buckets.insert(bucket);
@@ -509,7 +509,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     buckets.clear();
     for (int p = 0; p < 255; p++) {
         CAddrInfo infoj = CAddrInfo(
-            CAddress(CService("250.1.1.1"), 0),
+            CAddress(CService("250.1.1.1"), NODE_NONE),
             CNetAddr("250." + boost::to_string(p) + ".1.1"));
         int bucket = infoj.GetNewBucket(nKey1);
         buckets.insert(bucket);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -44,7 +44,7 @@ public:
         int nUBuckets = ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30);
         s << nUBuckets;
 
-        CAddress addr = CAddress(CService("252.1.1.1", 7777), 0);
+        CAddress addr = CAddress(CService("252.1.1.1", 7777), NODE_NONE);
         CAddrInfo info = CAddrInfo(addr, CNetAddr("252.2.2.2"));
         s << info;
     }
@@ -71,9 +71,9 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     CService addr3 = CService("250.7.3.3", 9999);
 
     // Add three addresses to new table.
-    addrmanUncorrupted.Add(CAddress(addr1, 0), CService("252.5.1.1", 8333));
-    addrmanUncorrupted.Add(CAddress(addr2, 0), CService("252.5.1.1", 8333));
-    addrmanUncorrupted.Add(CAddress(addr3, 0), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr1, NODE_NONE), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr2, NODE_NONE), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr3, NODE_NONE), CService("252.5.1.1", 8333));
 
     // Test that the de-serialization does not throw an exception.
     CDataStream ssPeers1 = AddrmanToStream(addrmanUncorrupted);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -44,7 +44,7 @@ public:
         int nUBuckets = ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30);
         s << nUBuckets;
 
-        CAddress addr = CAddress(CService("252.1.1.1", 7777));
+        CAddress addr = CAddress(CService("252.1.1.1", 7777), 0);
         CAddrInfo info = CAddrInfo(addr, CNetAddr("252.2.2.2"));
         s << info;
     }
@@ -71,9 +71,9 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     CService addr3 = CService("250.7.3.3", 9999);
 
     // Add three addresses to new table.
-    addrmanUncorrupted.Add(CAddress(addr1), CService("252.5.1.1", 8333));
-    addrmanUncorrupted.Add(CAddress(addr2), CService("252.5.1.1", 8333));
-    addrmanUncorrupted.Add(CAddress(addr3), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr1, 0), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr2, 0), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr3, 0), CService("252.5.1.1", 8333));
 
     // Test that the de-serialization does not throw an exception.
     CDataStream ssPeers1 = AddrmanToStream(addrmanUncorrupted);


### PR DESCRIPTION
This is backport of Bitcoin PR bitcoin/bitcoin#7749.

It's needed because:
* although Dash nodes use only `NODE_NETWORK` flag, this allows further extensibility;
* service flags are changed to have `ServiceFlags` type that is not only good for type safety, but is also used in many places affected by further changes;

Dash-specific code is also adapted to changes in `CAddress::CAddress()` constructor signature change.

The original PR description follows.
---
At this point, we do not:

* check that relayed/stored addr messages have the NODE_NETWORK bit set.
* check that nodes selected for outbound connection have NODE_NETWORK advertized.
* check that the nServices flag in the "version" message by a node corresponds to what we expected when deciding to connect to it.
* store the updated nServices flag from the "version" message in addrman.

Fix this.