### PR TITLE
New rpc call "masternodelist info"

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -737,7 +737,7 @@ void CMasternodeBroadcast::Relay()
 
 CMasternodePing::CMasternodePing(CTxIn& vinNew) :
     fSentinelIsCurrent(false),
-    nSentinelVersion(0)
+    nSentinelVersion(DEFAULT_SENTINEL_VERSION)
 {
     LOCK(cs_main);
     if (!chainActive.Tip() || chainActive.Height() < 12) return;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -28,7 +28,7 @@ static const int MASTERNODE_POSE_BAN_MAX_SCORE          = 5;
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network
 //
 
-// sentinel version defore sentinel ping implementation
+// sentinel version before sentinel ping implementation
 #define DEFAULT_SENTINEL_VERSION 0x010001
 
 class CMasternodePing

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -28,6 +28,9 @@ static const int MASTERNODE_POSE_BAN_MAX_SCORE          = 5;
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network
 //
 
+// sentinel version defore sentinel ping implementation
+#define DEFAULT_SENTINEL_VERSION 0x010001
+
 class CMasternodePing
 {
 public:
@@ -45,7 +48,7 @@ public:
         sigTime(0),
         vchSig(),
         fSentinelIsCurrent(false),
-        nSentinelVersion(0)
+        nSentinelVersion(DEFAULT_SENTINEL_VERSION)
         {}
 
     CMasternodePing(CTxIn& vinNew);
@@ -59,7 +62,11 @@ public:
         READWRITE(sigTime);
         READWRITE(vchSig);
         if(ser_action.ForRead() && (s.size() == 0))
+        {
+            fSentinelIsCurrent = false;
+            nSentinelVersion = DEFAULT_SENTINEL_VERSION;
             return;
+        }
         READWRITE(fSentinelIsCurrent);
         READWRITE(nSentinelVersion);
     }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -452,7 +452,7 @@ UniValue masternodelist(const UniValue& params, bool fHelp)
     if (params.size() == 2) strFilter = params[1].get_str();
 
     if (fHelp || (
-                strMode != "activeseconds" && strMode != "addr" && strMode != "full" &&strMode != "info" &&
+                strMode != "activeseconds" && strMode != "addr" && strMode != "full" && strMode != "info" &&
                 strMode != "lastseen" && strMode != "lastpaidtime" && strMode != "lastpaidblock" &&
                 strMode != "protocol" && strMode != "payee" && strMode != "rank" && strMode != "status"))
     {
@@ -469,7 +469,7 @@ UniValue masternodelist(const UniValue& params, bool fHelp)
                 "  addr           - Print ip address associated with a masternode (can be additionally filtered, partial match)\n"
                 "  full           - Print info in format 'status protocol payee lastseen activeseconds lastpaidtime lastpaidblock IP'\n"
                 "                   (can be additionally filtered, partial match)\n"
-                "  info           - Print info in format 'status protocol payee lastseen activeseconds sentinelversion IP'\n"
+                "  info           - Print info in format 'status protocol payee lastseen activeseconds sentinelversion sentinelstate IP'\n"
                 "                   (can be additionally filtered, partial match)\n"
                 "  lastpaidblock  - Print the last block height a node was paid on the network\n"
                 "  lastpaidtime   - Print the last time a node was paid on the network\n"
@@ -531,7 +531,8 @@ UniValue masternodelist(const UniValue& params, bool fHelp)
                                (int64_t)mn.lastPing.sigTime << " " << std::setw(8) <<
                                (int64_t)(mn.lastPing.sigTime - mn.sigTime) << " " <<
                                SafeIntVersionToString(mn.lastPing.nSentinelVersion) << " "  <<
-                               std::setw(6) << mn.addr.ToString();
+                               (mn.lastPing.fSentinelIsCurrent ? "current" : "expired") << " " <<
+                               mn.addr.ToString();
                 std::string strInfo = streamInfo.str();
                 if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
                     strOutpoint.find(strFilter) == std::string::npos) continue;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -452,7 +452,7 @@ UniValue masternodelist(const UniValue& params, bool fHelp)
     if (params.size() == 2) strFilter = params[1].get_str();
 
     if (fHelp || (
-                strMode != "activeseconds" && strMode != "addr" && strMode != "full" &&
+                strMode != "activeseconds" && strMode != "addr" && strMode != "full" &&strMode != "info" &&
                 strMode != "lastseen" && strMode != "lastpaidtime" && strMode != "lastpaidblock" &&
                 strMode != "protocol" && strMode != "payee" && strMode != "rank" && strMode != "status"))
     {
@@ -468,6 +468,8 @@ UniValue masternodelist(const UniValue& params, bool fHelp)
                 "                   (since latest issued \"masternode start/start-many/start-alias\")\n"
                 "  addr           - Print ip address associated with a masternode (can be additionally filtered, partial match)\n"
                 "  full           - Print info in format 'status protocol payee lastseen activeseconds lastpaidtime lastpaidblock IP'\n"
+                "                   (can be additionally filtered, partial match)\n"
+                "  info           - Print info in format 'status protocol payee lastseen activeseconds sentinelversion IP'\n"
                 "                   (can be additionally filtered, partial match)\n"
                 "  lastpaidblock  - Print the last block height a node was paid on the network\n"
                 "  lastpaidtime   - Print the last time a node was paid on the network\n"
@@ -520,6 +522,20 @@ UniValue masternodelist(const UniValue& params, bool fHelp)
                 if (strFilter !="" && strFull.find(strFilter) == std::string::npos &&
                     strOutpoint.find(strFilter) == std::string::npos) continue;
                 obj.push_back(Pair(strOutpoint, strFull));
+            } else if (strMode == "info") {
+                std::ostringstream streamInfo;
+                streamInfo << std::setw(18) <<
+                               mn.GetStatus() << " " <<
+                               mn.nProtocolVersion << " " <<
+                               CBitcoinAddress(mn.pubKeyCollateralAddress.GetID()).ToString() << " " <<
+                               (int64_t)mn.lastPing.sigTime << " " << std::setw(8) <<
+                               (int64_t)(mn.lastPing.sigTime - mn.sigTime) << " " <<
+                               SafeIntVersionToString(mn.lastPing.nSentinelVersion) << " "  <<
+                               std::setw(6) << mn.addr.ToString();
+                std::string strInfo = streamInfo.str();
+                if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
+                    strOutpoint.find(strFilter) == std::string::npos) continue;
+                obj.push_back(Pair(strOutpoint, strInfo));
             } else if (strMode == "lastpaidblock") {
                 if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) continue;
                 obj.push_back(Pair(strOutpoint, mn.GetLastPaidBlock()));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -990,3 +990,16 @@ std::string IntVersionToString(uint32_t nVersion)
     }
     return boost::join(tokens, ".");
 }
+
+std::string SafeIntVersionToString(uint32_t nVersion)
+{
+    try
+    {
+        return IntVersionToString(nVersion);
+    }
+    catch(const std::bad_cast&)
+    {
+        return "Invalid version";
+    }
+}
+

--- a/src/util.h
+++ b/src/util.h
@@ -290,4 +290,14 @@ uint32_t StringVersionToInt(const std::string& strVersion);
 std::string IntVersionToString(uint32_t nVersion);
 
 
+/**
+ * @brief Copy of the IntVersionToString, that returns "Invalid version" string
+ * instead of throwing std::bad_cast
+ * @param nVersion 4-byte unsigned integer, most significant byte is always 0
+ * @return version string in "x.x.x" format (last 3 bytes as version parts)
+ * or "Invalid version" if can't cast the given value
+ */
+std::string SafeIntVersionToString(uint32_t nVersion);
+
+
 #endif // BITCOIN_UTIL_H


### PR DESCRIPTION
Rationale: Allows to view sentinel version and state for all masternodes in query that is lighter than "masternodelist full" call. "masternodelist info" returns all info from "masternodelist full" without lastpaidtime and lastpaidblock values but with  sentinel version and state instead. Default sentinel version for old nodes is changed to 1.0.1.