### PR TITLE
Implement BIP69 outside of CTxIn/CTxOut

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -199,11 +199,6 @@ public:
         return !(a == b);
     }
 
-    friend bool operator<(const CTxOut& a, const CTxOut& b)
-    {
-        return a.nValue < b.nValue || (a.nValue == b.nValue && a.scriptPubKey < b.scriptPubKey);
-    }
-
     std::string ToString() const;
 };
 
@@ -336,6 +331,34 @@ struct CMutableTransaction
         return !(a == b);
     }
 
+};
+
+/** Implementation of BIP69
+ * https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki
+ */
+struct CompareInputBIP69
+{
+    inline bool operator()(const CTxIn& a, const CTxIn& b) const
+    {
+        if (a.prevout.hash == b.prevout.hash) return a.prevout.n < b.prevout.n;
+
+        uint256 hasha = a.prevout.hash;
+        uint256 hashb = b.prevout.hash;
+
+        typedef std::reverse_iterator<const unsigned char*> rev_it;
+        rev_it rita = rev_it(hasha.end());
+        rev_it ritb = rev_it(hashb.end());
+
+        return std::lexicographical_compare(rita, rita + hasha.size(), ritb, ritb + hashb.size());
+    }
+};
+
+struct CompareOutputBIP69
+{
+    inline bool operator()(const CTxOut& a, const CTxOut& b) const
+    {
+        return a.nValue < b.nValue || (a.nValue == b.nValue && a.scriptPubKey < b.scriptPubKey);
+    }
 };
 
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -320,9 +320,8 @@ void CPrivateSendServer::CreateFinalTransaction()
             txNew.vin.push_back(txdsin);
     }
 
-    // BIP69 https://github.com/kristovatlas/bips/blob/master/bip-0069.mediawiki
-    sort(txNew.vin.begin(), txNew.vin.end());
-    sort(txNew.vout.begin(), txNew.vout.end());
+    sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());
+    sort(txNew.vout.begin(), txNew.vout.end(), CompareOutputBIP69());
 
     finalMutableTransaction = txNew;
     LogPrint("privatesend", "CPrivateSendServer::CreateFinalTransaction -- finalMutableTransaction=%s", txNew.ToString());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3425,9 +3425,8 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     txNew.vin.push_back(txin);
                 }
 
-                // BIP69 https://github.com/kristovatlas/bips/blob/master/bip-0069.mediawiki
-                sort(txNew.vin.begin(), txNew.vin.end());
-                sort(txNew.vout.begin(), txNew.vout.end());
+                sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());
+                sort(txNew.vout.begin(), txNew.vout.end(), CompareOutputBIP69());
 
                 // If there was change output added before, we must update its position now
                 if (nChangePosRet != -1) {


### PR DESCRIPTION
Apply BIP69 on transaction creation only, fix inputs order to match the BIP.

Replaces #1509