### PR TITLE
Update transaction fee relay

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -53,8 +53,10 @@ static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions
  * We are ~100 times smaller then bitcoin now (2016-03-01), set minRelayTxFee only 10 times higher
  * so it's still 10 times lower comparing to bitcoin.
+ * (2017-07-10) with the price rise in dash change it back to 1000
+ * DEFAULT_TRANSACTION_MINFEE would be changed in another relase
  */
-static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 10000; // was 1000
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000; // was 1000
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */


### PR DESCRIPTION
To successfully lower the transaction fee, nodes need to first relay transactions with the lower fee.  Then, in a future release, the fee broadcast on transactions can safely be lowered without getting dropped from the network.  

I have not tested this Pull Request.  

I do NOT recommend lowering DEFAULT_TRANSACTION_MINFEE until the change of this pull request is live on the network supported by most nodes.  