### PR TITLE
Backport Bitcoin PR#8070: Remove non-determinism which is breaking net_tests

### DIFF
--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -17,6 +17,13 @@ class CAddrManSerializationMock : public CAddrMan
 {
 public:
     virtual void Serialize(CDataStream& s, int nType, int nVersionDummy) const = 0;
+
+    //! Ensure that bucket placement is always the same for testing purposes.
+    void MakeDeterministic()
+    {
+        nKey.SetNull();
+        seed_insecure_rand(true);
+    }
 };
 
 class CAddrManUncorrupted : public CAddrManSerializationMock
@@ -65,6 +72,7 @@ BOOST_FIXTURE_TEST_SUITE(net_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(caddrdb_read)
 {
     CAddrManUncorrupted addrmanUncorrupted;
+    addrmanUncorrupted.MakeDeterministic();
 
     CService addr1 = CService("250.7.1.1", 8333);
     CService addr2 = CService("250.7.2.2", 9999);
@@ -106,6 +114,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
 BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
 {
     CAddrManCorrupted addrmanCorrupted;
+    addrmanCorrupted.MakeDeterministic();
 
     // Test that the de-serialization of corrupted addrman throws an exception.
     CDataStream ssPeers1 = AddrmanToStream(addrmanCorrupted);


### PR DESCRIPTION
This is backport of Bitcoin PR bitcoin/bitcoin#8070.

Pretty trivial, affects only tests, fixes this error in `test_dash` that happens randomly:
```
test/net_tests.cpp(92): error: in "net_tests/caddrdb_read": check addrman1.size() == 3 has failed
test/net_tests.cpp(102): error: in "net_tests/caddrdb_read": check addrman2.size() == 3 has failed
```

Original PR description follows.
---
If addrmanUncorrupted does not have the same nKey every time it will map addrs to different bucket positions and occasionally cause a collision between two addrs, breaking the test.