### PR TITLE
Revert "fixed regtest+ds issues"

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -374,16 +374,9 @@ CNode* FindNode(const std::string& addrName)
 CNode* FindNode(const CService& addr)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes){
-        if(Params().NetworkIDString() == CBaseChainParams::REGTEST){
-            //if using regtest, just check the IP
-            if((CNetAddr)pnode->addr == (CNetAddr)addr)
-                return (pnode);
-        } else {
-            if((CService)pnode->addr == addr)
-                return (pnode);
-        }
-    }
+    BOOST_FOREACH(CNode* pnode, vNodes)
+        if((CService)pnode->addr == addr)
+            return (pnode);
     return NULL;
 }
 


### PR DESCRIPTION
This reverts commit 1f828f45ecaafa69195dd0fd9d9b7418d6dd795f.

The commit being reverted changed `FindNode(const CService& addr)` to make no difference between nodes with the same IP address, but different ports, but only for `regtest` network.
As functional tests run several nodes on different ports or the same IP address (127.0.0.1), this eventually started breaking functional tests.
The only use for `regtest` network I know is for functional tests, so it's time to revert that commit.