### PR TITLE
Workaround for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@
 
 sudo: required
 dist: trusty
+group: deprecated-2017Q3
 
 os: linux
 language: generic


### PR DESCRIPTION
Travis updated its trusty images which is probably causing us some issues
>This job ran on our Trusty environment, which was updated on Wednesday, July 12th. Read all about it in the [docs](https://docs.travis-ci.com/user/build-environment-updates/2017-07-12) and take note that you can add `group: deprecated-2017Q3` in your .travis.yml file to use the previous version.

Switching to the previous version of trusty images for now (as advised in the message above).