### PR TITLE
Trivial: Change invalid version string constant

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -999,7 +999,7 @@ std::string SafeIntVersionToString(uint32_t nVersion)
     }
     catch(const std::bad_cast&)
     {
-        return "Invalid version";
+        return "invalid_version";
     }
 }
 


### PR DESCRIPTION
Rationale: String constant for invalid version value was changed to single token for easier rpc "masternodelist info" call results parsing. 