### PR TITLE
Update fee relay

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -53,8 +53,9 @@ static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions
  * We are ~100 times smaller then bitcoin now (2016-03-01), set minRelayTxFee only 10 times higher
  * so it's still 10 times lower comparing to bitcoin.
+ * 2017-07-14 change it back to 1000 as the price of dash has gone up.
  */
-static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 10000; // was 1000
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000; // was 1000
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     // Check dust with default relay fee:
     CAmount nDustThreshold = 182 * minRelayTxFee.GetFeePerK()/1000 * 3;
-    BOOST_CHECK_EQUAL(nDustThreshold, 5460);
+    BOOST_CHECK_EQUAL(nDustThreshold, 546);
     // dust:
     t.vout[0].nValue = nDustThreshold - 1;
     BOOST_CHECK(!IsStandardTx(t, reason));


### PR DESCRIPTION
This is stage one of two at lowering the fee.  This PR will lower a fee required to relay a transaction.  After this change is live on the network with (around 66%) sufficient coverage then the fee broadcast can be lowered.  The expectation that a second release of 12.2.x could include this lower fee broadcast.  