### PR TITLE
Fix potential deadlock in CGovernanceManager::ProcessVote

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -971,7 +971,7 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, up
 
 bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, CGovernanceException& exception)
 {
-    LOCK(cs);
+    ENTER_CRITICAL_SECTION(cs);
     uint256 nHashVote = vote.GetHash();
     if(mapInvalidVotes.HasKey(nHashVote)) {
         std::ostringstream ostr;
@@ -980,6 +980,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
                 << ", governance object hash = " << vote.GetParentHash().ToString();
         LogPrintf("%s\n", ostr.str());
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
+        LEAVE_CRITICAL_SECTION(cs);
         return false;
     }
 
@@ -992,12 +993,14 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
              << ", governance object hash = " << vote.GetParentHash().ToString();
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
         if(mapOrphanVotes.Insert(nHashGovobj, vote_time_pair_t(vote, GetAdjustedTime() + GOVERNANCE_ORPHAN_EXPIRATION_TIME))) {
+            LEAVE_CRITICAL_SECTION(cs);
             RequestGovernanceObject(pfrom, nHashGovobj);
             LogPrintf("%s\n", ostr.str());
+            return false;
         }
-        else {
-            LogPrint("gobject", "%s\n", ostr.str());
-        }
+
+        LogPrint("gobject", "%s\n", ostr.str());
+        LEAVE_CRITICAL_SECTION(cs);
         return false;
     }
 
@@ -1005,6 +1008,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
 
     if(govobj.IsSetCachedDelete() || govobj.IsSetExpired()) {
         LogPrint("gobject", "CGovernanceObject::ProcessVote -- ignoring vote for expired or deleted object, hash = %s\n", nHashGovobj.ToString());
+        LEAVE_CRITICAL_SECTION(cs);
         return false;
     }
 
@@ -1017,6 +1021,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
             LogPrint("gobject", "CGovernanceObject::ProcessVote -- GOVERNANCE_OBJECT_WATCHDOG vote for %s\n", vote.GetParentHash().ToString());
         }
     }
+    LEAVE_CRITICAL_SECTION(cs);
     return fOk;
 }
 


### PR DESCRIPTION
govman.cs -> cs_vSend:
`CGovernanceManager::ProcessVote - LOCK(govman.cs) -> RequestGovernanceObject -> PushMessage -> BeginMessage - LOCK(cs_vSend)`

cs_vSend -> govman.cs:
`ThreadMessageHandler - TRY_LOCK(pnode->cs_vSend, lockSend) -> SendMessages -> AlreadyHave -> ConfirmInventoryRequest - LOCK(govman.cs)`