### PR TITLE
Make sure mixing messages are relayed/accepted properly

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -60,7 +60,7 @@ void CPrivateSendClient::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         // if the queue is ready, submit if we can
         if(dsq.fReady) {
             if(!infoMixingMasternode.fInfoValid) return;
-            if((CNetAddr)infoMixingMasternode.addr != (CNetAddr)infoMn.addr) {
+            if(infoMixingMasternode.addr != infoMn.addr) {
                 LogPrintf("DSQUEUE -- message doesn't match current Masternode: infoMixingMasternode=%s, addr=%s\n", infoMixingMasternode.addr.ToString(), infoMn.addr.ToString());
                 return;
             }
@@ -105,7 +105,7 @@ void CPrivateSendClient::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         }
 
         if(!infoMixingMasternode.fInfoValid) return;
-        if((CNetAddr)infoMixingMasternode.addr != (CNetAddr)pfrom->addr) {
+        if(infoMixingMasternode.addr != pfrom->addr) {
             //LogPrintf("DSSTATUSUPDATE -- message doesn't match current Masternode: infoMixingMasternode %s addr %s\n", infoMixingMasternode.addr.ToString(), pfrom->addr.ToString());
             return;
         }
@@ -149,7 +149,7 @@ void CPrivateSendClient::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         }
 
         if(!infoMixingMasternode.fInfoValid) return;
-        if((CNetAddr)infoMixingMasternode.addr != (CNetAddr)pfrom->addr) {
+        if(infoMixingMasternode.addr != pfrom->addr) {
             //LogPrintf("DSFINALTX -- message doesn't match current Masternode: infoMixingMasternode %s addr %s\n", infoMixingMasternode.addr.ToString(), pfrom->addr.ToString());
             return;
         }
@@ -176,7 +176,7 @@ void CPrivateSendClient::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         }
 
         if(!infoMixingMasternode.fInfoValid) return;
-        if((CNetAddr)infoMixingMasternode.addr != (CNetAddr)pfrom->addr) {
+        if(infoMixingMasternode.addr != pfrom->addr) {
             LogPrint("privatesend", "DSCOMPLETE -- message doesn't match current Masternode: infoMixingMasternode=%s  addr=%s\n", infoMixingMasternode.addr.ToString(), pfrom->addr.ToString());
             return;
         }

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -20,7 +20,7 @@
 #include <boost/lexical_cast.hpp>
 
 CDarkSendEntry::CDarkSendEntry(const std::vector<CTxIn>& vecTxIn, const std::vector<CTxOut>& vecTxOut, const CTransaction& txCollateral) :
-    txCollateral(txCollateral)
+    txCollateral(txCollateral), addr(CService())
 {
     BOOST_FOREACH(CTxIn txin, vecTxIn)
         vecTxDSIn.push_back(txin);

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -117,11 +117,14 @@ public:
     std::vector<CTxDSIn> vecTxDSIn;
     std::vector<CTxDSOut> vecTxDSOut;
     CTransaction txCollateral;
+    // memory only
+    CService addr;
 
     CDarkSendEntry() :
         vecTxDSIn(std::vector<CTxDSIn>()),
         vecTxDSOut(std::vector<CTxDSOut>()),
-        txCollateral(CTransaction())
+        txCollateral(CTransaction()),
+        addr(CService())
         {}
 
     CDarkSendEntry(const std::vector<CTxIn>& vecTxIn, const std::vector<CTxOut>& vecTxOut, const CTransaction& txCollateral);


### PR DESCRIPTION
Currently masternodes are trying to relay mixing messages to every connected node even though most of them should simply ignore such messages if they are not mixing on this mn atm. On the other hand on client side only IP is verified which can potentially lead to a situation where messages are mistakenly accepted from different masternode (only possible on testnet where port can be anything but 9999). This PR should fix both issues.