### PR TITLE
Fix windows installer script, should handle `dash:` uri correctly now

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -106,10 +106,10 @@ Section -post SEC0001
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
-    WriteRegStr HKCR "dashcore" "URL Protocol" ""
-    WriteRegStr HKCR "dashcore" "" "URL:Dash"
-    WriteRegStr HKCR "dashcore\DefaultIcon" "" $INSTDIR\dash-qt.exe
-    WriteRegStr HKCR "dashcore\shell\open\command" "" '"$INSTDIR\dash-qt.exe" "%1"'
+    WriteRegStr HKCR "dash" "URL Protocol" ""
+    WriteRegStr HKCR "dash" "" "URL:Dash"
+    WriteRegStr HKCR "dash\DefaultIcon" "" $INSTDIR\dash-qt.exe
+    WriteRegStr HKCR "dash\shell\open\command" "" '"$INSTDIR\dash-qt.exe" "%1"'
 SectionEnd
 
 # Macro for selecting uninstaller sections
@@ -147,7 +147,7 @@ Section -un.post UNSEC0001
     DeleteRegValue HKCU "${REGKEY}" Path
     DeleteRegKey /IfEmpty HKCU "${REGKEY}\Components"
     DeleteRegKey /IfEmpty HKCU "${REGKEY}"
-    DeleteRegKey HKCR "dashcore"
+    DeleteRegKey HKCR "dash"
     RmDir /REBOOTOK $SMPROGRAMS\$StartMenuGroup
     RmDir /REBOOTOK $INSTDIR
     Push $R0


### PR DESCRIPTION
Basically, I messed up - HKCR key should have the exact name of the expected uri protocol, not the package name. Find&Replace is not the best option sometimes...