### PR TITLE
Backport Bitcoin PR#8715: net: only delete CConnman if it's been created

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -228,7 +228,6 @@ void PrepareShutdown()
 #endif
     GenerateBitcoins(false, 0, Params(), *g_connman);
     MapPort(false);
-    g_connman->Stop();
     g_connman.reset();
 
     // STORE DATA CACHES INTO SERIALIZED DAT FILES

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2252,6 +2252,7 @@ void CConnman::DeleteNode(CNode* pnode)
 
 CConnman::~CConnman()
 {
+    Stop();
 }
 
 size_t CConnman::GetAddressCount() const


### PR DESCRIPTION
This is backport of Bitcoin PR bitcoin/bitcoin#8715.

The original PR description follows.
---
This fixes a possible shutdown crash. Thanks to @morcos for reporting.

In the case of (for example) an already-running bitcoind, the shutdown sequence begins before CConnman has been created, leading to a null-pointer dereference when g_connman->Stop() is called.