### PR TITLE
fix CDSNotificationInterface::UpdatedBlockTip signature

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -18,14 +18,14 @@ CDSNotificationInterface::~CDSNotificationInterface()
 {
 }
 
-void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
+void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
-    mnodeman.UpdatedBlockTip(pindex);
-    privateSendClient.UpdatedBlockTip(pindex);
-    instantsend.UpdatedBlockTip(pindex);
-    mnpayments.UpdatedBlockTip(pindex);
-    governance.UpdatedBlockTip(pindex);
-    masternodeSync.UpdatedBlockTip(pindex);
+    mnodeman.UpdatedBlockTip(pindexNew);
+    privateSendClient.UpdatedBlockTip(pindexNew);
+    instantsend.UpdatedBlockTip(pindexNew);
+    mnpayments.UpdatedBlockTip(pindexNew);
+    governance.UpdatedBlockTip(pindexNew);
+    masternodeSync.UpdatedBlockTip(pindexNew);
 }
 
 void CDSNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlock *pblock)

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -16,7 +16,7 @@ public:
 
 protected:
     // CValidationInterface
-    void UpdatedBlockTip(const CBlockIndex *pindex);
+    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
     void SyncTransaction(const CTransaction &tx, const CBlock *pblock);
 
 private:


### PR DESCRIPTION
Fix it to match the one in `CValidationInterface`.

Thanks @chaeplin for reporting/digging/testing 👍 