### PR TITLE
Sync overhaul

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -25,7 +25,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     instantsend.UpdatedBlockTip(pindexNew);
     mnpayments.UpdatedBlockTip(pindexNew);
     governance.UpdatedBlockTip(pindexNew);
-    masternodeSync.UpdatedBlockTip(pindexNew);
+    masternodeSync.UpdatedBlockTip(pindexNew, fInitialDownload);
 }
 
 void CDSNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlock *pblock)

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -704,6 +704,9 @@ void CGovernanceManager::DoMaintenance()
 
 bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
 {
+    // do not request objects until it's time to sync
+    if(!masternodeSync.IsWinnersListSynced()) return false;
+
     LOCK(cs);
 
     LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest inv = %s\n", inv.ToString());
@@ -749,9 +752,6 @@ bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
         setHash->insert(inv.hash);
         LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest added inv to requested set\n");
     }
-
-    // Keep sync alive
-    masternodeSync.AddedGovernanceItem();
 
     LogPrint("gobject", "CGovernanceManager::ConfirmInventoryRequest reached end, returning true\n");
     return true;
@@ -1073,6 +1073,8 @@ void CGovernanceManager::CheckMasternodeOrphanObjects()
 
 void CGovernanceManager::CheckPostponedObjects()
 {
+    if(!masternodeSync.IsSynced()) return;
+
     LOCK2(cs_main, cs);
 
     // Check postponed proposals

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -263,7 +263,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, std::string& strCommand, C
         CGovernanceException exception;
         if(ProcessVote(pfrom, vote, exception)) {
             LogPrint("gobject", "MNGOVERNANCEOBJECTVOTE -- %s new\n", strHash);
-            masternodeSync.AddedGovernanceItem();
+            masternodeSync.BumpAssetLastTime("MNGOVERNANCEOBJECTVOTE");
             vote.Relay();
         }
         else {
@@ -384,7 +384,7 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CNode* p
     // Update the rate buffer
     MasternodeRateCheck(govobj, UPDATE_TRUE);
 
-    masternodeSync.AddedGovernanceItem();
+    masternodeSync.BumpAssetLastTime("CGovernanceManager::AddGovernanceObject");
 
     // WE MIGHT HAVE PENDING/ORPHAN VOTES FOR THIS OBJECT
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1969,8 +1969,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     mnodeman.UpdatedBlockTip(chainActive.Tip());
     privateSendClient.UpdatedBlockTip(chainActive.Tip());
     mnpayments.UpdatedBlockTip(chainActive.Tip());
-    masternodeSync.UpdatedBlockTip(chainActive.Tip());
+    masternodeSync.UpdatedBlockTip(chainActive.Tip(), true);
     governance.UpdatedBlockTip(chainActive.Tip());
+    // make sure to skip IBD state in sync if we are already up to date
+    masternodeSync.UpdatedBlockTip(chainActive.Tip(), IsInitialBlockDownload());
 
     // ********************************************************* Step 11d: start dash-ps-<smth> threads
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1969,10 +1969,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     mnodeman.UpdatedBlockTip(chainActive.Tip());
     privateSendClient.UpdatedBlockTip(chainActive.Tip());
     mnpayments.UpdatedBlockTip(chainActive.Tip());
-    masternodeSync.UpdatedBlockTip(chainActive.Tip(), true);
-    governance.UpdatedBlockTip(chainActive.Tip());
-    // make sure to skip IBD state in sync if we are already up to date
     masternodeSync.UpdatedBlockTip(chainActive.Tip(), IsInitialBlockDownload());
+    governance.UpdatedBlockTip(chainActive.Tip());
 
     // ********************************************************* Step 11d: start dash-ps-<smth> threads
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -410,7 +410,7 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, std::string& strCommand, 
 
         if(AddPaymentVote(vote)){
             vote.Relay();
-            masternodeSync.AddedPaymentVote();
+            masternodeSync.BumpAssetLastTime("MASTERNODEPAYMENTVOTE");
         }
     }
 }

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -223,15 +223,14 @@ void CMasternodeSync::ProcessTick()
                 continue;
             }
 
-            // SPORK : ALWAYS ASK FOR SPORKS AS WE SYNC (we skip this mode now)
+            // SPORK : ALWAYS ASK FOR SPORKS AS WE SYNC
 
             if(!netfulfilledman.HasFulfilledRequest(pnode->addr, "spork-sync")) {
-                // only request once from each peer
+                // always get sporks first, only request once from each peer
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "spork-sync");
                 // get current network sporks
                 g_connman->PushMessageWithVersion(pnode, INIT_PROTO_VERSION, NetMsgType::GETSPORKS);
                 LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- requesting sporks from peer %d\n", nTick, nRequestedMasternodeAssets, pnode->id);
-                continue; // always get sporks first, switch to the next node without waiting for the next tick
             }
 
             // MNLIST : SYNC MASTERNODE LIST FROM OTHER CONNECTED CLIENTS

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -67,22 +67,22 @@ void CMasternodeSync::SwitchToNextAsset()
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Starting %s\n", GetAssetName());
             break;
         case(MASTERNODE_SYNC_IBD):
-            LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %ss\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
+            LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %llds\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
             nRequestedMasternodeAssets = MASTERNODE_SYNC_LIST;
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Starting %s\n", GetAssetName());
             break;
         case(MASTERNODE_SYNC_LIST):
-            LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %ss\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
+            LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %llds\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
             nRequestedMasternodeAssets = MASTERNODE_SYNC_MNW;
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Starting %s\n", GetAssetName());
             break;
         case(MASTERNODE_SYNC_MNW):
-            LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %ss\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
+            LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %llds\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
             nRequestedMasternodeAssets = MASTERNODE_SYNC_GOVERNANCE;
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Starting %s\n", GetAssetName());
             break;
         case(MASTERNODE_SYNC_GOVERNANCE):
-            LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %ss\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
+            LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %llds\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
             nRequestedMasternodeAssets = MASTERNODE_SYNC_FINISHED;
             uiInterface.NotifyAdditionalDataSyncProgressChanged(1);
             //try to activate our masternode if possible
@@ -273,7 +273,7 @@ void CMasternodeSync::ProcessTick()
             if(nRequestedMasternodeAssets == MASTERNODE_SYNC_MNW) {
                 LogPrint("mnpayments", "CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d nTimeLastBumped %lld GetTime() %lld diff %lld\n", nTick, nRequestedMasternodeAssets, nTimeLastBumped, GetTime(), GetTime() - nTimeLastBumped);
                 // check for timeout first
-                // This might take a lot longer than MASTERNODE_SYNC_TIMEOUT_SECONDS minutes due to new blocks,
+                // This might take a lot longer than MASTERNODE_SYNC_TIMEOUT_SECONDS due to new blocks,
                 // but that should be OK and it should timeout eventually.
                 if(GetTime() - nTimeLastBumped > MASTERNODE_SYNC_TIMEOUT_SECONDS) {
                     LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- timeout\n", nTick, nRequestedMasternodeAssets);

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -42,11 +42,8 @@ private:
 
     // Time when current masternode asset sync started
     int64_t nTimeAssetSyncStarted;
-
-    // Last time when we received some masternode asset ...
-    int64_t nTimeLastMasternodeList;
-    int64_t nTimeLastPaymentVote;
-    int64_t nTimeLastGovernanceItem;
+    // ... last bumped
+    int64_t nTimeLastBumped;
     // ... or failed
     int64_t nTimeLastFailure;
 
@@ -59,9 +56,6 @@ private:
 public:
     CMasternodeSync() { Reset(); }
 
-    void AddedMasternodeList() { nTimeLastMasternodeList = GetTime(); }
-    void AddedPaymentVote() { nTimeLastPaymentVote = GetTime(); }
-    void AddedGovernanceItem() { nTimeLastGovernanceItem = GetTime(); };
 
     void SendGovernanceSyncRequest(CNode* pnode);
 
@@ -73,6 +67,7 @@ public:
 
     int GetAssetID() { return nRequestedMasternodeAssets; }
     int GetAttempt() { return nRequestedMasternodeAttempt; }
+    void BumpAssetLastTime(std::string strFuncName);
     int64_t GetAssetStartTime() { return nTimeAssetSyncStarted; }
     std::string GetAssetName();
     std::string GetSyncStatus();

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -13,7 +13,7 @@ class CMasternodeSync;
 
 static const int MASTERNODE_SYNC_FAILED          = -1;
 static const int MASTERNODE_SYNC_INITIAL         = 0;
-static const int MASTERNODE_SYNC_SPORKS          = 1;
+static const int MASTERNODE_SYNC_IBD             = 1;
 static const int MASTERNODE_SYNC_LIST            = 2;
 static const int MASTERNODE_SYNC_MNW             = 3;
 static const int MASTERNODE_SYNC_GOVERNANCE      = 4;
@@ -53,7 +53,6 @@ private:
     // Keep track of current block index
     const CBlockIndex *pCurrentBlockIndex;
 
-    bool CheckNodeHeight(CNode* pnode, bool fDisconnectStuckNodes = false);
     void Fail();
     void ClearFulfilledRequests();
 
@@ -67,7 +66,7 @@ public:
     void SendGovernanceSyncRequest(CNode* pnode);
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
-    bool IsBlockchainSynced(bool fBlockAccepted = false);
+    bool IsBlockchainSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_IBD; }
     bool IsMasternodeListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
     bool IsWinnersListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_MNW; }
     bool IsSynced() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED; }
@@ -84,7 +83,7 @@ public:
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     void ProcessTick();
 
-    void UpdatedBlockTip(const CBlockIndex *pindex);
+    void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload);
 };
 
 #endif

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -12,8 +12,7 @@
 class CMasternodeSync;
 
 static const int MASTERNODE_SYNC_FAILED          = -1;
-static const int MASTERNODE_SYNC_INITIAL         = 0;
-static const int MASTERNODE_SYNC_IBD             = 1;
+static const int MASTERNODE_SYNC_INITIAL         = 0; // sync just started, was reset recently or still in IDB
 static const int MASTERNODE_SYNC_LIST            = 2;
 static const int MASTERNODE_SYNC_MNW             = 3;
 static const int MASTERNODE_SYNC_GOVERNANCE      = 4;
@@ -60,7 +59,7 @@ public:
     void SendGovernanceSyncRequest(CNode* pnode);
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
-    bool IsBlockchainSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_IBD; }
+    bool IsBlockchainSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_INITIAL; }
     bool IsMasternodeListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
     bool IsWinnersListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_MNW; }
     bool IsSynced() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED; }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -627,7 +627,7 @@ bool CMasternodeBroadcast::Update(CMasternode* pmn, int& nDos)
             pmn->Check();
             Relay();
         }
-        masternodeSync.AddedMasternodeList();
+        masternodeSync.BumpAssetLastTime("CMasternodeBroadcast::Update");
     }
 
     return true;
@@ -890,7 +890,7 @@ bool CMasternodePing::CheckAndUpdate(CMasternode* pmn, bool fFromNewBroadcast, i
     if(!masternodeSync.IsMasternodeListSynced() && !pmn->IsPingedWithin(MASTERNODE_EXPIRATION_SECONDS/2)) {
         // let's bump sync timeout
         LogPrint("masternode", "CMasternodePing::CheckAndUpdate -- bumping sync timeout, masternode=%s\n", vin.prevout.ToStringShort());
-        masternodeSync.AddedMasternodeList();
+        masternodeSync.BumpAssetLastTime("CMasternodePing::CheckAndUpdate");
     }
 
     // let's store this ping as the last one

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1391,12 +1391,12 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb)
     CMasternode* pmn = Find(mnb.vin);
     if(pmn == NULL) {
         if(Add(mnb)) {
-            masternodeSync.BumpAssetLastTime("CMasternodeMan::UpdateMasternodeList 1");
+            masternodeSync.BumpAssetLastTime("CMasternodeMan::UpdateMasternodeList - new");
         }
     } else {
         CMasternodeBroadcast mnbOld = mapSeenMasternodeBroadcast[CMasternodeBroadcast(*pmn).GetHash()].second;
         if(pmn->UpdateFromNewBroadcast(mnb)) {
-            masternodeSync.BumpAssetLastTime("CMasternodeMan::UpdateMasternodeList 2");
+            masternodeSync.BumpAssetLastTime("CMasternodeMan::UpdateMasternodeList - seen");
             mapSeenMasternodeBroadcast.erase(mnbOld.GetHash());
         }
     }
@@ -1419,7 +1419,7 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
             if(GetTime() - mapSeenMasternodeBroadcast[hash].first > MASTERNODE_NEW_START_REQUIRED_SECONDS - MASTERNODE_MIN_MNP_SECONDS * 2) {
                 LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s seen update\n", mnb.vin.prevout.ToStringShort());
                 mapSeenMasternodeBroadcast[hash].first = GetTime();
-                masternodeSync.BumpAssetLastTime("CMasternodeMan::CheckMnbAndUpdateMasternodeList 1");
+                masternodeSync.BumpAssetLastTime("CMasternodeMan::CheckMnbAndUpdateMasternodeList - seen");
             }
             // did we ask this node for it?
             if(pfrom && IsMnbRecoveryRequested(hash) && GetTime() < mMnbRecoveryRequests[hash].first) {
@@ -1470,7 +1470,7 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
 
     if(mnb.CheckOutpoint(nDos)) {
         Add(mnb);
-        masternodeSync.BumpAssetLastTime("CMasternodeMan::CheckMnbAndUpdateMasternodeList 2");
+        masternodeSync.BumpAssetLastTime("CMasternodeMan::CheckMnbAndUpdateMasternodeList - new");
         // if it matches our Masternode privkey...
         if(fMasterNode && mnb.pubKeyMasternode == activeMasternode.pubKeyMasternode) {
             mnb.nPoSeBanScore = -MASTERNODE_POSE_BAN_MAX_SCORE;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1390,14 +1390,13 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb)
 
     CMasternode* pmn = Find(mnb.vin);
     if(pmn == NULL) {
-        CMasternode mn(mnb);
-        if(Add(mn)) {
-            masternodeSync.AddedMasternodeList();
+        if(Add(mnb)) {
+            masternodeSync.BumpAssetLastTime("CMasternodeMan::UpdateMasternodeList 1");
         }
     } else {
         CMasternodeBroadcast mnbOld = mapSeenMasternodeBroadcast[CMasternodeBroadcast(*pmn).GetHash()].second;
         if(pmn->UpdateFromNewBroadcast(mnb)) {
-            masternodeSync.AddedMasternodeList();
+            masternodeSync.BumpAssetLastTime("CMasternodeMan::UpdateMasternodeList 2");
             mapSeenMasternodeBroadcast.erase(mnbOld.GetHash());
         }
     }
@@ -1420,7 +1419,7 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
             if(GetTime() - mapSeenMasternodeBroadcast[hash].first > MASTERNODE_NEW_START_REQUIRED_SECONDS - MASTERNODE_MIN_MNP_SECONDS * 2) {
                 LogPrint("masternode", "CMasternodeMan::CheckMnbAndUpdateMasternodeList -- masternode=%s seen update\n", mnb.vin.prevout.ToStringShort());
                 mapSeenMasternodeBroadcast[hash].first = GetTime();
-                masternodeSync.AddedMasternodeList();
+                masternodeSync.BumpAssetLastTime("CMasternodeMan::CheckMnbAndUpdateMasternodeList 1");
             }
             // did we ask this node for it?
             if(pfrom && IsMnbRecoveryRequested(hash) && GetTime() < mMnbRecoveryRequests[hash].first) {
@@ -1471,7 +1470,7 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
 
     if(mnb.CheckOutpoint(nDos)) {
         Add(mnb);
-        masternodeSync.AddedMasternodeList();
+        masternodeSync.BumpAssetLastTime("CMasternodeMan::CheckMnbAndUpdateMasternodeList 2");
         // if it matches our Masternode privkey...
         if(fMasterNode && mnb.pubKeyMasternode == activeMasternode.pubKeyMasternode) {
             mnb.nPoSeBanScore = -MASTERNODE_POSE_BAN_MAX_SCORE;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1500,8 +1500,8 @@ void CMasternodeMan::UpdateLastPaid()
 {
     LOCK(cs);
 
-    if(fLiteMode) return;
-    if(!pCurrentBlockIndex) return;
+    if(fLiteMode || !pCurrentBlockIndex) return;
+    if(!masternodeSync.IsWinnersListSynced() || vMasternodes.empty()) return;
 
     static bool IsFirstRun = true;
     // Do full scan on first run or if we are not a masternode
@@ -1515,8 +1515,7 @@ void CMasternodeMan::UpdateLastPaid()
         mn.UpdateLastPaid(pCurrentBlockIndex, nMaxBlocksToScanBack);
     }
 
-    // every time is like the first time if winners list is not synced
-    IsFirstRun = !masternodeSync.IsWinnersListSynced();
+    IsFirstRun = false;
 }
 
 bool CMasternodeMan::UpdateLastDsq(const CTxIn& vin)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -173,6 +173,7 @@ UniValue mnsync(const UniValue& params, bool fHelp)
     if(strMode == "reset")
     {
         masternodeSync.Reset();
+        masternodeSync.SwitchToNextAsset();
         return "success";
     }
     return "failure";

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -38,7 +38,6 @@
 
 #include "instantx.h"
 #include "masternode-payments.h"
-#include "masternode-sync.h"
 
 #include <sstream>
 
@@ -3455,8 +3454,6 @@ bool ProcessNewBlock(const CChainParams& chainparams, const CBlock* pblock, bool
     CValidationState state; // Only used to report errors, not invalidity - ignore it
     if (!ActivateBestChain(state, chainparams, pblock))
         return error("%s: ActivateBestChain failed", __func__);
-
-    masternodeSync.IsBlockchainSynced(true);
 
     LogPrintf("%s : ACCEPTED\n", __func__);
     return true;


### PR DESCRIPTION
Change sync process:
- drop `CheckNodeHeight()` and all complicated code, use `fInitialDownload` in `UpdatedBlockTip()` to switch initial states
- detect sleep mode in `ProcessTick()` like it was in `IsBlockchainSynced()`, not by number of masternodes
- do not keep sync alive on `ConfirmInventoryRequest()`
- skip some governance actions until we are synced to some level
- do not run `CMasternodeMan::UpdateLastPaid()` until winners list is synced
- start syncing mn list on the same node right after requesting sporks
- replace `nTimeLast<Asset>` with the unified `nTimeLastBumped`, bump on `UpdatedBlockTip`
- fix comments and `LogPrintf`-s