### PR TITLE
Fix losing keys on PrivateSend

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ BITCOIN_CORE_H = \
   privatesend.h \
   privatesend-client.h \
   privatesend-server.h \
+  privatesend-util.h \
   dsnotificationinterface.h \
   governance.h \
   governance-classes.h \
@@ -279,6 +280,7 @@ libbitcoin_wallet_a_SOURCES = \
   masternodeman.cpp \
   keepass.cpp \
   privatesend-client.cpp \
+  privatesend-util.cpp \
   wallet/crypter.cpp \
   wallet/db.cpp \
   wallet/rpcdump.cpp \

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -207,6 +207,7 @@ void CPrivateSendClient::ResetPool()
     txMyCollateral = CMutableTransaction();
     vecMasternodesUsed.clear();
     UnlockCoins();
+    keyHolderStorage.ClearWhenNotSure();
     SetNull();
 }
 
@@ -294,6 +295,7 @@ void CPrivateSendClient::CheckPool()
     if((nState == POOL_STATE_ERROR || nState == POOL_STATE_SUCCESS) && GetTimeMillis() - nTimeLastSuccessfulStep >= 10000) {
         LogPrint("privatesend", "CPrivateSendClient::CheckPool -- timeout, RESETTING\n");
         UnlockCoins();
+        keyHolderStorage.ClearOnFailure();
         SetNull();
     }
 }
@@ -343,6 +345,7 @@ void CPrivateSendClient::CheckTimeout()
         LogPrint("privatesend", "CPrivateSendClient::CheckTimeout -- %s timed out (%ds) -- restting\n",
                 (nState == POOL_STATE_SIGNING) ? "Signing" : "Session", nTimeout);
         UnlockCoins();
+        keyHolderStorage.ClearOnFailure();
         SetNull();
         SetState(POOL_STATE_ERROR);
         strLastMessage = _("Session timed out.");
@@ -376,12 +379,14 @@ bool CPrivateSendClient::SendDenominate(const std::vector<CTxIn>& vecTxIn, const
     if(!nSessionID) {
         LogPrintf("CPrivateSendClient::SendDenominate -- No Masternode has been selected yet.\n");
         UnlockCoins();
+        keyHolderStorage.ClearOnFailure();
         SetNull();
         return false;
     }
 
     if(!CheckDiskSpace()) {
         UnlockCoins();
+        keyHolderStorage.ClearOnFailure();
         SetNull();
         fEnablePrivateSend = false;
         LogPrintf("CPrivateSendClient::SendDenominate -- Not enough disk space, disabling PrivateSend.\n");
@@ -415,6 +420,7 @@ bool CPrivateSendClient::SendDenominate(const std::vector<CTxIn>& vecTxIn, const
         if(!lockMain || !AcceptToMemoryPool(mempool, validationState, CTransaction(tx), false, NULL, false, true, true)) {
             LogPrintf("CPrivateSendClient::SendDenominate -- AcceptToMemoryPool() failed! tx=%s", tx.ToString());
             UnlockCoins();
+            keyHolderStorage.ClearOnFailure();
             SetNull();
             return false;
         }
@@ -443,6 +449,7 @@ bool CPrivateSendClient::CheckPoolStateUpdate(PoolState nStateNew, int nEntriesC
     if(nStatusUpdate == STATUS_REJECTED) {
         LogPrintf("CPrivateSendClient::CheckPoolStateUpdate -- entry is rejected by Masternode\n");
         UnlockCoins();
+        keyHolderStorage.ClearOnFailure();
         SetNull();
         SetState(POOL_STATE_ERROR);
         strLastMessage = CPrivateSend::GetMessageByID(nMessageID);
@@ -523,6 +530,7 @@ bool CPrivateSendClient::SignFinalTransaction(const CTransaction& finalTransacti
                     // better then signing if the transaction doesn't look like what we wanted.
                     LogPrintf("CPrivateSendClient::SignFinalTransaction -- My entries are not correct! Refusing to sign: nFoundOutputsCount: %d, nTargetOuputsCount: %d\n", nFoundOutputsCount, nTargetOuputsCount);
                     UnlockCoins();
+                    keyHolderStorage.ClearOnFailure();
                     SetNull();
 
                     return false;
@@ -545,6 +553,7 @@ bool CPrivateSendClient::SignFinalTransaction(const CTransaction& finalTransacti
     if(sigs.empty()) {
         LogPrintf("CPrivateSendClient::SignFinalTransaction -- can't sign anything!\n");
         UnlockCoins();
+        keyHolderStorage.ClearOnFailure();
         SetNull();
 
         return false;
@@ -579,8 +588,10 @@ void CPrivateSendClient::CompletedTransaction(PoolMessage nMessageID)
     if(nMessageID == MSG_SUCCESS) {
         LogPrintf("CompletedTransaction -- success\n");
         nCachedLastSuccessBlock = pCurrentBlockIndex->nHeight;
+        keyHolderStorage.ClearOnSuccess();
     } else {
         LogPrintf("CompletedTransaction -- error\n");
+        keyHolderStorage.ClearOnFailure();
     }
     UnlockCoins();
     SetNull();
@@ -751,6 +762,7 @@ bool CPrivateSendClient::DoAutomaticDenominating(bool fDryRun)
     // Initial phase, find a Masternode
     // Clean if there is anything left from previous session
     UnlockCoins();
+    keyHolderStorage.ClearWhenNotSure();
     SetNull();
 
     // should be no unconfirmed denoms in non-multi-session mode
@@ -1020,7 +1032,6 @@ bool CPrivateSendClient::PrepareDenominate(int nMinRounds, int nMaxRounds, std::
     std::vector<CTxIn> vecTxIn;
     std::vector<COutput> vCoins;
     CAmount nValueIn = 0;
-    CReserveKey reservekey(pwalletMain);
 
     /*
         Select the coins we'll use
@@ -1073,12 +1084,7 @@ bool CPrivateSendClient::PrepareDenominate(int nMinRounds, int nMaxRounds, std::
                     vecTxIn.erase(it);
                     vCoins.erase(it2);
 
-                    CScript scriptDenom;
-                    CPubKey vchPubKey;
-                    // use unique address
-                    assert(reservekey.GetReservedKey(vchPubKey, false)); // should never fail, as we just unlocked
-                    scriptDenom = GetScriptForDestination(vchPubKey.GetID());
-                    reservekey.KeepKey();
+                    CScript scriptDenom = keyHolderStorage.AddKey(pwalletMain)->GetScriptForDestination();
 
                     // add new output
                     CTxOut txout(nValueDenom, scriptDenom);
@@ -1112,6 +1118,7 @@ bool CPrivateSendClient::PrepareDenominate(int nMinRounds, int nMaxRounds, std::
         BOOST_FOREACH(CTxIn txin, vecTxInRet) {
             pwalletMain->UnlockCoin(txin.prevout);
         }
+        keyHolderStorage.ClearOnFailure();
         strErrorRet = "Can't make current denominated outputs";
         return false;
     }

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1084,7 +1084,7 @@ bool CPrivateSendClient::PrepareDenominate(int nMinRounds, int nMaxRounds, std::
                     vecTxIn.erase(it);
                     vCoins.erase(it2);
 
-                    CScript scriptDenom = keyHolderStorage.AddKey(pwalletMain)->GetScriptForDestination();
+                    CScript scriptDenom = keyHolderStorage.AddKey(pwalletMain).GetScriptForDestination();
 
                     // add new output
                     CTxOut txout(nValueDenom, scriptDenom);

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1230,16 +1230,15 @@ bool CPrivateSendClient::CreateDenominated(const CompactTallyItem& tallyItem, bo
 
     LogPrintf("CreateDenominated0 nValueLeft: %f\n", (float)nValueLeft/COIN);
     // make our collateral address
-    CReserveKey reservekeyCollateral(pwalletMain);
-
-    CScript scriptCollateral;
-    CPubKey vchPubKey;
-    assert(reservekeyCollateral.GetReservedKey(vchPubKey, false)); // should never fail, as we just unlocked
-    scriptCollateral = GetScriptForDestination(vchPubKey.GetID());
-
-    // ****** Add collateral outputs ************ /
+    CReserveKey reservekeyCollateral(pwalletMain);    
 
     if(fCreateMixingCollaterals) {
+        CScript scriptCollateral;
+        CPubKey vchPubKey;
+        assert(reservekeyCollateral.GetReservedKey(vchPubKey, false)); // should never fail, as we just unlocked
+        scriptCollateral = GetScriptForDestination(vchPubKey.GetID());
+
+        // ****** Add collateral outputs ************ /
         vecSend.push_back((CRecipient){scriptCollateral, CPrivateSend::GetMaxCollateralAmount(), false});
         nValueLeft -= CPrivateSend::GetMaxCollateralAmount();
     }
@@ -1326,14 +1325,16 @@ bool CPrivateSendClient::CreateDenominated(const CompactTallyItem& tallyItem, bo
         LogPrintf("CPrivateSendClient::CreateDenominated -- Error: %s\n", strFail);
         for(auto key : reservekeyDenomVec)
             key->ReturnKey();
-        reservekeyCollateral.ReturnKey();
+        if (fCreateMixingCollaterals)
+            reservekeyCollateral.ReturnKey();
         LogPrintf("CPrivateSendClient::CreateDenominated -- %d keys returned\n", reservekeyDenomVec.size() + 1);
         return false;
     }
 
     for(auto key : reservekeyDenomVec)
         key->KeepKey();
-    reservekeyCollateral.KeepKey();
+    if (fCreateMixingCollaterals)
+        reservekeyCollateral.KeepKey();
     LogPrintf("CPrivateSendClient::CreateDenominated -- %d keys keeped\n", reservekeyDenomVec.size() + 1);
 
     if(!pwalletMain->CommitTransaction(wtx, reservekeyChange)) {

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -8,6 +8,7 @@
 #include "masternode.h"
 #include "privatesend.h"
 #include "wallet/wallet.h"
+#include "privatesend-util.h"
 
 class CPrivateSendClient;
 
@@ -51,6 +52,8 @@ private:
     std::string strAutoDenomResult;
 
     CMutableTransaction txMyCollateral; // client side collateral
+
+    KeyHolderStorage keyHolderStorage; // storage for keys used in PrepereDenominate
 
     /// Check for process
     void CheckPool();

--- a/src/privatesend-util.cpp
+++ b/src/privatesend-util.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2014-2017 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "privatesend-util.h"
+
+KeyHolder::KeyHolder(CWallet* pwallet)
+        :reserveKey(pwallet)
+{
+        reserveKey.GetReservedKey(pubKey, false);
+}
+
+void KeyHolder::KeepKey()
+{
+    reserveKey.KeepKey();
+}
+
+void KeyHolder::ReturnKey()
+{
+    reserveKey.ReturnKey();
+}
+
+CScript KeyHolder::GetScriptForDestination()
+{
+    return ::GetScriptForDestination(pubKey.GetID());
+}
+
+
+KeyHolderPtr KeyHolderStorage::AddKey(CWallet* pwallet)
+{
+    LogPrintf("PrivateSend - KeyHolderStorage -- AddKey\n");
+    auto key = std::make_shared<KeyHolder>(pwallet);
+    storage.push_back(key);
+    return key;
+}
+
+void KeyHolderStorage::KeepAll(){
+    for(auto key : storage) {
+        key->KeepKey();
+    }
+    storage.clear();
+}
+
+void KeyHolderStorage::ReturnAll()
+{
+    for(auto key : storage) {
+        key->ReturnKey();
+    }
+    storage.clear();
+}
+
+void KeyHolderStorage::ClearOnFailure()
+{
+    if (storage.size() > 0) {
+        LogPrintf("PrivateSend - KeyHolderStorage -- returning keys on privatesend failure\n");
+        ReturnAll();
+    }
+
+}
+
+void KeyHolderStorage::ClearOnSuccess()
+{
+    if (storage.size() > 0) {
+        LogPrintf("PrivateSend - KeyHolderStorage -- keeping keys on privatesend success\n");
+        KeepAll();
+    }
+}
+
+void KeyHolderStorage::ClearWhenNotSure()
+{
+    if (storage.size() > 0) {
+        LogPrintf("PrivateSend - KeyHolderStorage --  keeping keys in - ClearWhenNotSure - some could get lost\n");
+        KeepAll(); // better to loose key than reuse it in private send
+    }
+}
+

--- a/src/privatesend-util.cpp
+++ b/src/privatesend-util.cpp
@@ -34,42 +34,22 @@ KeyHolderPtr KeyHolderStorage::AddKey(CWallet* pwallet)
 }
 
 void KeyHolderStorage::KeepAll(){
-    for(auto key : storage) {
-        key->KeepKey();
+    if (storage.size() > 0) {
+        LogPrintf("PrivateSend - KeyHolderStorage -- KeepAll\n");
+        for (auto key : storage) {
+            key->KeepKey();
+        }
+        storage.clear();
     }
-    storage.clear();
 }
 
 void KeyHolderStorage::ReturnAll()
 {
-    for(auto key : storage) {
-        key->ReturnKey();
-    }
-    storage.clear();
-}
-
-void KeyHolderStorage::ClearOnFailure()
-{
     if (storage.size() > 0) {
-        LogPrintf("PrivateSend - KeyHolderStorage -- returning keys on privatesend failure\n");
-        ReturnAll();
-    }
-
-}
-
-void KeyHolderStorage::ClearOnSuccess()
-{
-    if (storage.size() > 0) {
-        LogPrintf("PrivateSend - KeyHolderStorage -- keeping keys on privatesend success\n");
-        KeepAll();
+        LogPrintf("PrivateSend - KeyHolderStorage -- ReturnAll\n");
+        for (auto key : storage) {
+            key->ReturnKey();
+        }
+        storage.clear();
     }
 }
-
-void KeyHolderStorage::ClearWhenNotSure()
-{
-    if (storage.size() > 0) {
-        LogPrintf("PrivateSend - KeyHolderStorage --  keeping keys in - ClearWhenNotSure - some could get lost\n");
-        KeepAll(); // better to loose key than reuse it in private send
-    }
-}
-

--- a/src/privatesend-util.cpp
+++ b/src/privatesend-util.cpp
@@ -19,25 +19,24 @@ void KeyHolder::ReturnKey()
     reserveKey.ReturnKey();
 }
 
-CScript KeyHolder::GetScriptForDestination()
+CScript KeyHolder::GetScriptForDestination() const
 {
     return ::GetScriptForDestination(pubKey.GetID());
 }
 
 
-KeyHolderPtr KeyHolderStorage::AddKey(CWallet* pwallet)
+const KeyHolder& KeyHolderStorage::AddKey(CWallet* pwallet)
 {
     LogPrintf("PrivateSend - KeyHolderStorage -- AddKey\n");
-    auto key = std::make_shared<KeyHolder>(pwallet);
-    storage.push_back(key);
-    return key;
+    storage.emplace_back(KeyHolder(pwallet));
+    return storage.back();
 }
 
 void KeyHolderStorage::KeepAll(){
     if (storage.size() > 0) {
         LogPrintf("PrivateSend - KeyHolderStorage -- KeepAll\n");
-        for (auto key : storage) {
-            key->KeepKey();
+        for (auto &key : storage) {
+            key.KeepKey();
         }
         storage.clear();
     }
@@ -47,8 +46,8 @@ void KeyHolderStorage::ReturnAll()
 {
     if (storage.size() > 0) {
         LogPrintf("PrivateSend - KeyHolderStorage -- ReturnAll\n");
-        for (auto key : storage) {
-            key->ReturnKey();
+        for (auto &key : storage) {
+            key.ReturnKey();
         }
         storage.clear();
     }

--- a/src/privatesend-util.h
+++ b/src/privatesend-util.h
@@ -17,19 +17,17 @@ public:
     void KeepKey();
     void ReturnKey();
 
-    CScript GetScriptForDestination();
+    CScript GetScriptForDestination() const;
 
 };
-
-typedef std::shared_ptr<KeyHolder> KeyHolderPtr;
 
 class KeyHolderStorage
 {
 private:
-    std::vector<KeyHolderPtr> storage;
+    std::vector<KeyHolder> storage;
 
 public:
-    KeyHolderPtr AddKey(CWallet* pwalletIn);
+    const KeyHolder& AddKey(CWallet* pwalletIn);
     void KeepAll();
     void ReturnAll();
 

--- a/src/privatesend-util.h
+++ b/src/privatesend-util.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2014-2017 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PRIVATESENDUTIL_H
+#define PRIVATESENDUTIL_H
+
+#include "wallet/wallet.h"
+
+class KeyHolder
+{
+private:
+    CReserveKey reserveKey;
+    CPubKey pubKey;
+public:
+    KeyHolder(CWallet* pwalletIn);
+    void KeepKey();
+    void ReturnKey();
+
+    CScript GetScriptForDestination();
+
+};
+
+typedef std::shared_ptr<KeyHolder> KeyHolderPtr;
+
+class KeyHolderStorage
+{
+private:
+    std::vector<KeyHolderPtr> storage;
+
+    void KeepAll();
+    void ReturnAll();
+
+public:
+    KeyHolderPtr AddKey(CWallet* pwalletIn);
+    void ClearOnFailure();
+    void ClearOnSuccess();
+    void ClearWhenNotSure();
+
+};
+#endif //PRIVATESENDUTIL_H

--- a/src/privatesend-util.h
+++ b/src/privatesend-util.h
@@ -28,14 +28,10 @@ class KeyHolderStorage
 private:
     std::vector<KeyHolderPtr> storage;
 
-    void KeepAll();
-    void ReturnAll();
-
 public:
     KeyHolderPtr AddKey(CWallet* pwalletIn);
-    void ClearOnFailure();
-    void ClearOnSuccess();
-    void ClearWhenNotSure();
+    void KeepAll();
+    void ReturnAll();
 
 };
 #endif //PRIVATESENDUTIL_H


### PR DESCRIPTION
PrivateSend has been losing keys in following situations:
1) One key gets lost during creation of denominations
2) After mixing failure all keys used for outTX get lost

Unfortunately, this change doesn't fix all the cases when PrivateSend is still losing keys (Datails were described in trac 33).
However, with this change PrivateSend losses key much less frequently.