### PR TITLE
Pass reference when calling HasPayeeWithVotes

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -528,7 +528,7 @@ bool CMasternodeBlockPayees::GetBestPayee(CScript& payeeRet)
     return (nVotes > -1);
 }
 
-bool CMasternodeBlockPayees::HasPayeeWithVotes(CScript payeeIn, int nVotesReq)
+bool CMasternodeBlockPayees::HasPayeeWithVotes(const CScript& payeeIn, int nVotesReq)
 {
     LOCK(cs_vecPayees);
 

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -98,7 +98,7 @@ public:
 
     void AddPayee(const CMasternodePaymentVote& vote);
     bool GetBestPayee(CScript& payeeRet);
-    bool HasPayeeWithVotes(CScript payeeIn, int nVotesReq);
+    bool HasPayeeWithVotes(const CScript& payeeIn, int nVotesReq);
 
     bool IsTransactionValid(const CTransaction& txNew);
 


### PR DESCRIPTION
Should help with trac#41 (i.e. speedup `UpdateLastPaid`).
On my machine:
before: 1m15s
after: 0m45s