### PR TITLE
fix instantsendtoaddress param convertion

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -37,6 +37,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendtoaddress", 5 },
     { "sendtoaddress", 6 },
     { "instantsendtoaddress", 1 },
+    { "instantsendtoaddress", 4 },
     { "settxfee", 0 },
     { "getreceivedbyaddress", 1 },
     { "getreceivedbyaccount", 1 },


### PR DESCRIPTION
`subtractfeefromamount` is bool but `true`/`false` are not recognized in rpc atm. This should fix it.