### PR TITLE
Partially backport Bitcoin PR#9626: Clean up a few CConnman cs_vNodes/CNode things

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -388,6 +388,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
             // In that case, drop the connection that was just created, and return the existing CNode instead.
             // Also store the name we used to connect in that CNode, so that future FindNode() calls to that
             // name catch this early.
+            LOCK(cs_vNodes);
             CNode* pnode = FindNode((CService)addrConnect);
             if (pnode)
             {
@@ -397,11 +398,8 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
                     pnode->AddRef();
                     pnode->fMasternode = true;
                 }
-                {
-                    LOCK(cs_vNodes);
-                    if (pnode->addrName.empty()) {
-                        pnode->addrName = std::string(pszDest);
-                    }
+                if (pnode->addrName.empty()) {
+                    pnode->addrName = std::string(pszDest);
                 }
                 CloseSocket(hSocket);
                 return pnode;
@@ -2402,6 +2400,7 @@ void CConnman::GetNodeStats(std::vector<CNodeStats>& vstats)
 
 bool CConnman::DisconnectNode(const std::string& strNode)
 {
+    LOCK(cs_vNodes);
     if (CNode* pnode = FindNode(strNode)) {
         pnode->fDisconnect = true;
         return true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2400,24 +2400,6 @@ void CConnman::GetNodeStats(std::vector<CNodeStats>& vstats)
     }
 }
 
-bool CConnman::DisconnectAddress(const CNetAddr& netAddr)
-{
-    if (CNode* pnode = FindNode(netAddr)) {
-        pnode->fDisconnect = true;
-        return true;
-    }
-    return false;
-}
-
-bool CConnman::DisconnectSubnet(const CSubNet& subNet)
-{
-    if (CNode* pnode = FindNode(subNet)) {
-        pnode->fDisconnect = true;
-        return true;
-    }
-    return false;
-}
-
 bool CConnman::DisconnectNode(const std::string& strNode)
 {
     if (CNode* pnode = FindNode(strNode)) {

--- a/src/net.h
+++ b/src/net.h
@@ -347,10 +347,8 @@ public:
 
     size_t GetNodeCount(NumConnections num);
     void GetNodeStats(std::vector<CNodeStats>& vstats);
-    bool DisconnectAddress(const CNetAddr& addr);
     bool DisconnectNode(const std::string& node);
     bool DisconnectNode(NodeId id);
-    bool DisconnectSubnet(const CSubNet& subnet);
 
     unsigned int GetSendBufferSize() const;
 


### PR DESCRIPTION
This is partial backport of Bitcoin PR bitcoin/bitcoin#9626.

The main purpose of this backport is to fix locking issues introduced by earlier backported PR.

This backport includes only 2 of 3 original commits. Last commit is omitted because it moves important code from `CConnman::ConnectNode()` method to `CConnman::OpenNetworkConnection()`. This code adds newly created `CNode` to `CConnman::vNodes` vector and emits `InitializeNode` signal. Moving this code is OK for Bitcoin because `CConnman::ConnectNode()` is private there and the only caller of this method is `CConnman::OpenNetworkConnection()`. Unfortunately, this is not the case in Dash: `CConnman::ConnectNode()` is called in some places of Dash-specific code, so moving important functionality out if this method will break that code.

Hence, the last commit is not included in this backport. It can be backported separately later after we decide how to refactor Dash-specific code that uses `CConnman::ConnectNode()`.

The original PR description follows.
---
This should fix the long-standing (read: satoshi-era) bug where we may not delete a node if we try to connect to it (via RPC) after its already connected as we'll have duplicate refs.

This also removes some unused functions (some of which miss a lock, some of which should otherwise be cleaned up for bitcoin/bitcoin#9609).

This also ensures that if we return a CNode* from FindNode, we are still holding cs_vNodes if we use it for anything aside from existance-checking, fixing a stupid-unlikely race where it might be deleted out from under us.