### PR TITLE
InstandSend overhaul

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -82,16 +82,13 @@ bool CInstantSend::ProcessTxLockRequest(const CTxLockRequest& txLockRequest)
 
     uint256 txHash = txLockRequest.GetHash();
 
-    // Check to see if we conflict with existing completed lock,
-    // fail if so, there can't be 2 completed locks for the same outpoint
+    // Check to see if we conflict with existing completed lock
     BOOST_FOREACH(const CTxIn& txin, txLockRequest.vin) {
         std::map<COutPoint, uint256>::iterator it = mapLockedOutpoints.find(txin.prevout);
-        if(it != mapLockedOutpoints.end()) {
-            // Conflicting with complete lock, ignore this one
-            // (this could be the one we have but we don't want to try to lock it twice anyway)
-            LogPrintf("CInstantSend::ProcessTxLockRequest -- WARNING: Found conflicting completed Transaction Lock, skipping current one, txid=%s, completed lock txid=%s\n",
+        if(it != mapLockedOutpoints.end() && it->second != txLockRequest.GetHash()) {
+            // Conflicting with complete lock, proceed to see if we should cancel them both
+            LogPrintf("CInstantSend::ProcessTxLockRequest -- WARNING: Found conflicting completed Transaction Lock, txid=%s, completed lock txid=%s\n",
                     txLockRequest.GetHash().ToString(), it->second.ToString());
-            return false;
         }
     }
 
@@ -104,6 +101,7 @@ bool CInstantSend::ProcessTxLockRequest(const CTxLockRequest& txLockRequest)
                 if(hash != txLockRequest.GetHash()) {
                     LogPrint("instantsend", "CInstantSend::ProcessTxLockRequest -- Double spend attempt! %s\n", txin.prevout.ToStringShort());
                     // do not fail here, let it go and see which one will get the votes to be locked
+                    // TODO: notify zmq+script
                 }
             }
         }
@@ -131,12 +129,11 @@ bool CInstantSend::ProcessTxLockRequest(const CTxLockRequest& txLockRequest)
 
 bool CInstantSend::CreateTxLockCandidate(const CTxLockRequest& txLockRequest)
 {
-    // Normally we should require all outpoints to be unspent, but in case we are reprocessing
-    // because of a lot of legit orphan votes we should also check already spent outpoints.
-    uint256 txHash = txLockRequest.GetHash();
-    if(!txLockRequest.IsValid(!IsEnoughOrphanVotesForTx(txLockRequest))) return false;
+    if(!txLockRequest.IsValid()) return false;
 
     LOCK(cs_instantsend);
+
+    uint256 txHash = txLockRequest.GetHash();
 
     std::map<uint256, CTxLockCandidate>::iterator itLockCandidate = mapTxLockCandidates.find(txHash);
     if(itLockCandidate == mapTxLockCandidates.end()) {
@@ -148,6 +145,19 @@ bool CInstantSend::CreateTxLockCandidate(const CTxLockRequest& txLockRequest)
             txLockCandidate.AddOutPointLock(txin.prevout);
         }
         mapTxLockCandidates.insert(std::make_pair(txHash, txLockCandidate));
+    } else if (!itLockCandidate->second.txLockRequest) {
+        // i.e. empty Transaction Lock Candidate was created earlier, let's update it with actual data
+        itLockCandidate->second.txLockRequest = txLockRequest;
+        if (itLockCandidate->second.IsTimedOut()) {
+            LogPrintf("CInstantSend::CreateTxLockCandidate -- timed out, txid=%s\n", txHash.ToString());
+            return false;
+        }
+        LogPrintf("CInstantSend::CreateTxLockCandidate -- update empty, txid=%s\n", txHash.ToString());
+
+        // all inputs should already be checked by txLockRequest.IsValid() above, just use them now
+        BOOST_REVERSE_FOREACH(const CTxIn& txin, txLockRequest.vin) {
+            itLockCandidate->second.AddOutPointLock(txin.prevout);
+        }
     } else {
         LogPrint("instantsend", "CInstantSend::CreateTxLockCandidate -- seen, txid=%s\n", txHash.ToString());
     }
@@ -155,9 +165,19 @@ bool CInstantSend::CreateTxLockCandidate(const CTxLockRequest& txLockRequest)
     return true;
 }
 
+void CInstantSend::CreateEmptyTxLockCandidate(const uint256& txHash)
+{
+    if (mapTxLockCandidates.find(txHash) != mapTxLockCandidates.end())
+        return;
+    LogPrintf("CInstantSend::CreateEmptyTxLockCandidate -- new, txid=%s\n", txHash.ToString());
+    const CTxLockRequest txLockRequest = CTxLockRequest();
+    mapTxLockCandidates.insert(std::make_pair(txHash, CTxLockCandidate(txLockRequest)));
+}
+
 void CInstantSend::Vote(CTxLockCandidate& txLockCandidate)
 {
     if(!fMasterNode) return;
+    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED)) return;
 
     LOCK2(cs_main, cs_instantsend);
 
@@ -277,8 +297,10 @@ bool CInstantSend::ProcessTxLockVote(CNode* pfrom, CTxLockVote& vote)
     // will actually process only after the lock request itself has arrived
 
     std::map<uint256, CTxLockCandidate>::iterator it = mapTxLockCandidates.find(txHash);
-    if(it == mapTxLockCandidates.end()) {
+    if(it == mapTxLockCandidates.end() || !it->second.txLockRequest) {
         if(!mapTxLockVotesOrphan.count(vote.GetHash())) {
+            // start timeout countdown after the very first vote
+            CreateEmptyTxLockCandidate(txHash);
             mapTxLockVotesOrphan[vote.GetHash()] = vote;
             LogPrint("instantsend", "CInstantSend::ProcessTxLockVote -- Orphan vote: txid=%s  masternode=%s new\n",
                     txHash.ToString(), vote.GetMasternodeOutpoint().ToStringShort());
@@ -324,6 +346,13 @@ bool CInstantSend::ProcessTxLockVote(CNode* pfrom, CTxLockVote& vote)
         return true;
     }
 
+    CTxLockCandidate& txLockCandidate = it->second;
+
+    if (txLockCandidate.IsTimedOut()) {
+        LogPrint("instantsend", "CInstantSend::ProcessTxLockVote -- too late, Transaction Lock timed out, txid=%s\n", txHash.ToString());
+        return false;
+    }
+
     LogPrint("instantsend", "CInstantSend::ProcessTxLockVote -- Transaction Lock Vote, txid=%s\n", txHash.ToString());
 
     std::map<COutPoint, std::set<uint256> >::iterator it1 = mapVotedOutpoints.find(vote.GetOutpoint());
@@ -331,29 +360,32 @@ bool CInstantSend::ProcessTxLockVote(CNode* pfrom, CTxLockVote& vote)
         BOOST_FOREACH(const uint256& hash, it1->second) {
             if(hash != txHash) {
                 // same outpoint was already voted to be locked by another tx lock request,
-                // find out if the same mn voted on this outpoint before
+                // let's see if it was the same masternode who voted on this outpoint
+                // for another tx lock request
                 std::map<uint256, CTxLockCandidate>::iterator it2 = mapTxLockCandidates.find(hash);
-                if(it2->second.HasMasternodeVoted(vote.GetOutpoint(), vote.GetMasternodeOutpoint())) {
-                    // yes, it did, refuse to accept a vote to include the same outpoint in another tx
-                    // from the same masternode.
-                    // TODO: apply pose ban score to this masternode?
-                    // NOTE: if we decide to apply pose ban score here, this vote must be relayed further
-                    // to let all other nodes know about this node's misbehaviour and let them apply
-                    // pose ban score too.
+                if(it2 !=mapTxLockCandidates.end() && it2->second.HasMasternodeVoted(vote.GetOutpoint(), vote.GetMasternodeOutpoint())) {
+                    // yes, it was the same masternode
                     LogPrintf("CInstantSend::ProcessTxLockVote -- masternode sent conflicting votes! %s\n", vote.GetMasternodeOutpoint().ToStringShort());
-                    return false;
+                    // mark both Lock Candidates as attacked, none of them should complete,
+                    // or at least the new (current) one shouldn't even
+                    // if the second one was already completed earlier
+                    txLockCandidate.MarkOutpointAsAttacked(vote.GetOutpoint());
+                    it2->second.MarkOutpointAsAttacked(vote.GetOutpoint());
+                    // apply maximum PoSe ban score to this masternode i.e. PoSe-ban it instantly
+                    mnodeman.PoSeBan(vote.GetMasternodeOutpoint());
+                    // NOTE: This vote must be relayed further to let all other nodes know about such
+                    // misbehaviour of this masternode. This way they should also be able to construct
+                    // conflicting lock and PoSe-ban this masternode.
                 }
             }
         }
-        // we have votes by other masternodes only (so far), let's continue and see who will win
+        // store all votes, regardless of them being sent by malicious masternode or not
         it1->second.insert(txHash);
     } else {
         std::set<uint256> setHashes;
         setHashes.insert(txHash);
         mapVotedOutpoints.insert(std::make_pair(vote.GetOutpoint(), setHashes));
     }
-
-    CTxLockCandidate& txLockCandidate = it->second;
 
     if(!txLockCandidate.AddVote(vote)) {
         // this should never happen
@@ -424,6 +456,8 @@ bool CInstantSend::IsEnoughOrphanVotesForTxAndOutPoint(const uint256& txHash, co
 
 void CInstantSend::TryToFinalizeLockCandidate(const CTxLockCandidate& txLockCandidate)
 {
+    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED)) return;
+
     LOCK(cs_main);
 #ifdef ENABLE_WALLET
     if (pwalletMain)
@@ -435,7 +469,7 @@ void CInstantSend::TryToFinalizeLockCandidate(const CTxLockCandidate& txLockCand
     if(txLockCandidate.IsAllOutPointsReady() && !IsLockedInstantSendTransaction(txHash)) {
         // we have enough votes now
         LogPrint("instantsend", "CInstantSend::TryToFinalizeLockCandidate -- Transaction Lock is ready to complete, txid=%s\n", txHash.ToString());
-        if(ResolveConflicts(txLockCandidate, Params().GetConsensus().nInstantSendKeepLock)) {
+        if(ResolveConflicts(txLockCandidate)) {
             LockTransactionInputs(txLockCandidate);
             UpdateLockedTransaction(txLockCandidate);
         }
@@ -475,6 +509,8 @@ void CInstantSend::UpdateLockedTransaction(const CTxLockCandidate& txLockCandida
 
 void CInstantSend::LockTransactionInputs(const CTxLockCandidate& txLockCandidate)
 {
+    if(!sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED)) return;
+
     LOCK(cs_instantsend);
 
     uint256 txHash = txLockCandidate.GetHash();
@@ -499,59 +535,60 @@ bool CInstantSend::GetLockedOutPointTxHash(const COutPoint& outpoint, uint256& h
     return true;
 }
 
-bool CInstantSend::ResolveConflicts(const CTxLockCandidate& txLockCandidate, int nMaxBlocks)
+bool CInstantSend::ResolveConflicts(const CTxLockCandidate& txLockCandidate)
 {
-    if(nMaxBlocks < 1) return false;
-
     LOCK2(cs_main, cs_instantsend);
 
     uint256 txHash = txLockCandidate.GetHash();
 
     // make sure the lock is ready
-    if(!txLockCandidate.IsAllOutPointsReady()) return true; // not an error
+    if(!txLockCandidate.IsAllOutPointsReady()) return false;
 
-    LOCK(mempool.cs); // protect mempool.mapNextTx, mempool.mapTx
-
-    bool fMempoolConflict = false;
+    LOCK(mempool.cs); // protect mempool.mapNextTx
 
     BOOST_FOREACH(const CTxIn& txin, txLockCandidate.txLockRequest.vin) {
         uint256 hashConflicting;
         if(GetLockedOutPointTxHash(txin.prevout, hashConflicting) && txHash != hashConflicting) {
-            // conflicting with complete lock, ignore current one
-            LogPrintf("CInstantSend::ResolveConflicts -- WARNING: Found conflicting completed Transaction Lock, skipping current one, txid=%s, conflicting txid=%s\n",
+            // completed lock which conflicts with another completed one?
+            // this means that majority of MNs in the quorum for this specific tx input are malicious!
+            std::map<uint256, CTxLockCandidate>::iterator itLockCandidate = mapTxLockCandidates.find(txHash);
+            std::map<uint256, CTxLockCandidate>::iterator itLockCandidateConflicting = mapTxLockCandidates.find(hashConflicting);
+            if(itLockCandidate == mapTxLockCandidates.end() || itLockCandidateConflicting == mapTxLockCandidates.end()) {
+                // safety check, should never really happen
+                LogPrintf("CInstantSend::ResolveConflicts -- ERROR: Found conflicting completed Transaction Lock, but one of txLockCandidate-s is missing, txid=%s, conflicting txid=%s\n",
+                        txHash.ToString(), hashConflicting.ToString());
+                return false;
+            }
+            LogPrintf("CInstantSend::ResolveConflicts -- WARNING: Found conflicting completed Transaction Lock, dropping both, txid=%s, conflicting txid=%s\n",
                     txHash.ToString(), hashConflicting.ToString());
-            return false; // can't/shouldn't do anything
+            CTxLockRequest txLockRequest = itLockCandidate->second.txLockRequest;
+            CTxLockRequest txLockRequestConflicting = itLockCandidateConflicting->second.txLockRequest;
+            itLockCandidate->second.SetConfirmedHeight(0); // expired
+            itLockCandidateConflicting->second.SetConfirmedHeight(0); // expired
+            CheckAndRemove(); // clean up
+            // AlreadyHave should still return "true" for both of them
+            mapLockRequestRejected.insert(make_pair(txHash, txLockRequest));
+            mapLockRequestRejected.insert(make_pair(hashConflicting, txLockRequestConflicting));
+
+            // TODO: clean up mapLockRequestRejected later somehow
+            //       (not a big issue since we already PoSe ban malicious masternodes
+            //        and they won't be able to spam)
+            // TODO: ban all malicious masternodes permanently, do not accept anything from them, ever
+
+            // TODO: notify zmq+script about this double-spend attempt
+            //       and let merchant cancel/hold the order if it's not too late...
+
+            // can't do anything else, fallback to regular txes
+            return false;
         } else if (mempool.mapNextTx.count(txin.prevout)) {
             // check if it's in mempool
             hashConflicting = mempool.mapNextTx[txin.prevout].ptx->GetHash();
             if(txHash == hashConflicting) continue; // matches current, not a conflict, skip to next txin
-            // conflicting with tx in mempool
-            fMempoolConflict = true;
-            if(HasTxLockRequest(hashConflicting)) {
-                // There can be only one completed lock, the other lock request should never complete
-                LogPrintf("CInstantSend::ResolveConflicts -- WARNING: Found conflicting Transaction Lock Request, replacing by completed Transaction Lock, txid=%s, conflicting txid=%s\n",
-                        txHash.ToString(), hashConflicting.ToString());
-            } else {
-                // If this lock is completed, we don't really care about normal conflicting txes.
-                LogPrintf("CInstantSend::ResolveConflicts -- WARNING: Found conflicting transaction, replacing by completed Transaction Lock, txid=%s, conflicting txid=%s\n",
-                        txHash.ToString(), hashConflicting.ToString());
-            }
-        }
-    } // FOREACH
-    if(fMempoolConflict) {
-        std::list<CTransaction> removed;
-        // remove every tx conflicting with current Transaction Lock Request
-        mempool.removeConflicts(txLockCandidate.txLockRequest, removed);
-        // and try to accept it in mempool again
-        CValidationState state;
-        bool fMissingInputs = false;
-        if(!AcceptToMemoryPool(mempool, state, txLockCandidate.txLockRequest, true, &fMissingInputs)) {
-            LogPrintf("CInstantSend::ResolveConflicts -- ERROR: Failed to accept completed Transaction Lock to mempool, txid=%s\n", txHash.ToString());
+            // conflicts with tx in mempool
+            LogPrintf("CInstantSend::ResolveConflicts -- ERROR: Failed to complete Transaction Lock, conflicts with mempool, txid=%s\n", txHash.ToString());
             return false;
         }
-        LogPrintf("CInstantSend::ResolveConflicts -- Accepted completed Transaction Lock, txid=%s\n", txHash.ToString());
-        return true;
-    }
+    } // FOREACH
     // No conflicts were found so far, check to see if it was already included in block
     CTransaction txTmp;
     uint256 hashBlock;
@@ -564,21 +601,8 @@ bool CInstantSend::ResolveConflicts(const CTxLockCandidate& txLockCandidate, int
         CCoins coins;
         if(!GetUTXOCoins(txin.prevout, coins)) {
             // Not in UTXO anymore? A conflicting tx was mined while we were waiting for votes.
-            // Reprocess tip to make sure tx for this lock is included.
-            LogPrintf("CTxLockRequest::ResolveConflicts -- Failed to find UTXO %s - disconnecting tip...\n", txin.prevout.ToStringShort());
-            if(!DisconnectBlocks(1)) {
-                return false;
-            }
-            // Recursively check at "new" old height. Conflicting tx should be rejected by AcceptToMemoryPool.
-            ResolveConflicts(txLockCandidate, nMaxBlocks - 1);
-            LogPrintf("CTxLockRequest::ResolveConflicts -- Failed to find UTXO %s - activating best chain...\n", txin.prevout.ToStringShort());
-            // Activate best chain, block which includes conflicting tx should be rejected by ConnectBlock.
-            CValidationState state;
-            if(!ActivateBestChain(state, Params()) || !state.IsValid()) {
-                LogPrintf("CTxLockRequest::ResolveConflicts -- ActivateBestChain failed, txid=%s\n", txin.prevout.ToStringShort());
-                return false;
-            }
-            LogPrintf("CTxLockRequest::ResolveConflicts -- Failed to find UTXO %s - fixed!\n", txin.prevout.ToStringShort());
+            LogPrintf("CInstantSend::ResolveConflicts -- ERROR: Failed to find UTXO %s, can't complete Transaction Lock\n", txin.prevout.ToStringShort());
+            return false;
         }
     }
     LogPrint("instantsend", "CInstantSend::ResolveConflicts -- Done, txid=%s\n", txHash.ToString());
@@ -646,8 +670,8 @@ void CInstantSend::CheckAndRemove()
     // remove expired orphan votes
     std::map<uint256, CTxLockVote>::iterator itOrphanVote = mapTxLockVotesOrphan.begin();
     while(itOrphanVote != mapTxLockVotesOrphan.end()) {
-        if(GetTime() - itOrphanVote->second.GetTimeCreated() > ORPHAN_VOTE_SECONDS) {
-            LogPrint("instantsend", "CInstantSend::CheckAndRemove -- Removing expired orphan vote: txid=%s  masternode=%s\n",
+        if(itOrphanVote->second.IsTimedOut()) {
+            LogPrint("instantsend", "CInstantSend::CheckAndRemove -- Removing timed out orphan vote: txid=%s  masternode=%s\n",
                     itOrphanVote->second.GetTxHash().ToString(), itOrphanVote->second.GetMasternodeOutpoint().ToStringShort());
             mapTxLockVotes.erase(itOrphanVote->first);
             mapTxLockVotesOrphan.erase(itOrphanVote++);
@@ -733,7 +757,7 @@ bool CInstantSend::IsInstantSendReadyToLock(const uint256& txHash)
 bool CInstantSend::IsLockedInstantSendTransaction(const uint256& txHash)
 {
     if(!fEnableInstantSend || fLargeWorkForkFound || fLargeWorkInvalidChainFound ||
-        !sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED)) return false;
+        !sporkManager.IsSporkActive(SPORK_3_INSTANTSEND_BLOCK_FILTERING)) return false;
 
     LOCK(cs_instantsend);
 
@@ -776,7 +800,7 @@ int CInstantSend::GetConfirmations(const uint256 &nTXHash)
     return IsLockedInstantSendTransaction(nTXHash) ? nInstantSendDepth : 0;
 }
 
-bool CInstantSend::IsTxLockRequestTimedOut(const uint256& txHash)
+bool CInstantSend::IsTxLockCandidateTimedOut(const uint256& txHash)
 {
     if(!fEnableInstantSend) return false;
 
@@ -785,7 +809,7 @@ bool CInstantSend::IsTxLockRequestTimedOut(const uint256& txHash)
     std::map<uint256, CTxLockCandidate>::iterator itLockCandidate = mapTxLockCandidates.find(txHash);
     if (itLockCandidate != mapTxLockCandidates.end()) {
         return !itLockCandidate->second.IsAllOutPointsReady() &&
-                itLockCandidate->second.txLockRequest.IsTimedOut();
+                itLockCandidate->second.IsTimedOut();
     }
 
     return false;
@@ -882,7 +906,7 @@ std::string CInstantSend::ToString()
 // CTxLockRequest
 //
 
-bool CTxLockRequest::IsValid(bool fRequireUnspent) const
+bool CTxLockRequest::IsValid() const
 {
     if(vout.size() < 1) return false;
 
@@ -912,40 +936,13 @@ bool CTxLockRequest::IsValid(bool fRequireUnspent) const
     BOOST_FOREACH(const CTxIn& txin, vin) {
 
         CCoins coins;
-        int nPrevoutHeight = 0;
-        CAmount nValue = 0;
 
         if(!GetUTXOCoins(txin.prevout, coins)) {
             LogPrint("instantsend", "CTxLockRequest::IsValid -- Failed to find UTXO %s\n", txin.prevout.ToStringShort());
-            // Normally above sould be enough, but in case we are reprocessing this because of
-            // a lot of legit orphan votes we should also check already spent outpoints.
-            if(fRequireUnspent) return false;
-            CTransaction txOutpointCreated;
-            uint256 nHashOutpointConfirmed;
-            if(!GetTransaction(txin.prevout.hash, txOutpointCreated, Params().GetConsensus(), nHashOutpointConfirmed, true) || nHashOutpointConfirmed == uint256()) {
-                LogPrint("instantsend", "CTxLockRequest::IsValid -- Failed to find outpoint %s\n", txin.prevout.ToStringShort());
-                return false;
-            }
-            if(txin.prevout.n >= txOutpointCreated.vout.size()) {
-                LogPrint("instantsend", "CTxLockRequest::IsValid -- Outpoint %s is out of bounds, size() = %lld\n",
-                        txin.prevout.ToStringShort(), txOutpointCreated.vout.size());
-                return false;
-            }
-            BlockMap::iterator mi = mapBlockIndex.find(nHashOutpointConfirmed);
-            if(mi == mapBlockIndex.end() || !mi->second) {
-                // shouldn't happen
-                LogPrint("instantsend", "CTxLockRequest::IsValid -- Failed to find block %s for outpoint %s\n",
-                        nHashOutpointConfirmed.ToString(), txin.prevout.ToStringShort());
-                return false;
-            }
-            nPrevoutHeight = mi->second->nHeight;
-            nValue = txOutpointCreated.vout[txin.prevout.n].nValue;
-        } else {
-            nPrevoutHeight = coins.nHeight;
-            nValue = coins.vout[txin.prevout.n].nValue;
+            return false;
         }
 
-        int nTxAge = chainActive.Height() - nPrevoutHeight + 1;
+        int nTxAge = chainActive.Height() - coins.nHeight + 1;
         // 1 less than the "send IX" gui requires, in case of a block propagating the network at the time
         int nConfirmationsRequired = INSTANTSEND_CONFIRMATIONS_REQUIRED - 1;
 
@@ -955,7 +952,7 @@ bool CTxLockRequest::IsValid(bool fRequireUnspent) const
             return false;
         }
 
-        nValueIn += nValue;
+        nValueIn += coins.vout[txin.prevout.n].nValue;
     }
 
     if(nValueOut > sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)*COIN) {
@@ -980,11 +977,6 @@ CAmount CTxLockRequest::GetMinFee() const
 int CTxLockRequest::GetMaxSignatures() const
 {
     return vin.size() * COutPointLock::SIGNATURES_TOTAL;
-}
-
-bool CTxLockRequest::IsTimedOut() const
-{
-    return GetTime() - nTimeCreated > TIMEOUT_SECONDS;
 }
 
 //
@@ -1105,6 +1097,11 @@ bool CTxLockVote::IsExpired(int nHeight) const
     return (nConfirmedHeight != -1) && (nHeight - nConfirmedHeight > Params().GetConsensus().nInstantSendKeepLock);
 }
 
+bool CTxLockVote::IsTimedOut() const
+{
+    return GetTime() - nTimeCreated > INSTANTSEND_TIMEOUT_SECONDS;
+}
+
 //
 // COutPointLock
 //
@@ -1151,6 +1148,12 @@ void CTxLockCandidate::AddOutPointLock(const COutPoint& outpoint)
     mapOutPointLocks.insert(make_pair(outpoint, COutPointLock(outpoint)));
 }
 
+void CTxLockCandidate::MarkOutpointAsAttacked(const COutPoint& outpoint)
+{
+    std::map<COutPoint, COutPointLock>::iterator it = mapOutPointLocks.find(outpoint);
+    if(it != mapOutPointLocks.end())
+        it->second.MarkAsAttacked();
+}
 
 bool CTxLockCandidate::AddVote(const CTxLockVote& vote)
 {
@@ -1193,6 +1196,11 @@ bool CTxLockCandidate::IsExpired(int nHeight) const
 {
     // Locks and votes expire nInstantSendKeepLock blocks after the block corresponding tx was included into.
     return (nConfirmedHeight != -1) && (nHeight - nConfirmedHeight > Params().GetConsensus().nInstantSendKeepLock);
+}
+
+bool CTxLockCandidate::IsTimedOut() const
+{
+    return GetTime() - nTimeCreated > INSTANTSEND_TIMEOUT_SECONDS;
 }
 
 void CTxLockCandidate::Relay() const

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -955,8 +955,8 @@ bool CTxLockRequest::IsValid() const
         nValueIn += coins.vout[txin.prevout.n].nValue;
     }
 
-    if(nValueOut > sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)*COIN) {
-        LogPrint("instantsend", "CTxLockRequest::IsValid -- Transaction value too high: nValueOut=%d, tx=%s", nValueOut, ToString());
+    if(nValueIn > sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE)*COIN) {
+        LogPrint("instantsend", "CTxLockRequest::IsValid -- Transaction value too high: nValueIn=%d, tx=%s", nValueIn, ToString());
         return false;
     }
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -293,6 +293,9 @@ bool CInstantSend::ProcessTxLockVote(CNode* pfrom, CTxLockVote& vote)
         return false;
     }
 
+    // relay valid vote asap
+    vote.Relay();
+
     // Masternodes will sometimes propagate votes before the transaction is known to the client,
     // will actually process only after the lock request itself has arrived
 
@@ -398,8 +401,6 @@ bool CInstantSend::ProcessTxLockVote(CNode* pfrom, CTxLockVote& vote)
             nSignatures, nSignaturesMax, vote.GetHash().ToString());
 
     TryToFinalizeLockCandidate(txLockCandidate);
-
-    vote.Relay();
 
     return true;
 }

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -28,6 +28,8 @@ extern CInstantSend instantsend;
 static const int INSTANTSEND_CONFIRMATIONS_REQUIRED = 6;
 static const int DEFAULT_INSTANTSEND_DEPTH          = 5;
 
+static const int INSTANTSEND_TIMEOUT_SECONDS        = 15;
+
 static const int MIN_INSTANTSEND_PROTO_VERSION      = 70206;
 
 extern bool fEnableInstantSend;
@@ -37,8 +39,6 @@ extern int nCompleteTXLocks;
 class CInstantSend
 {
 private:
-    static const int ORPHAN_VOTE_SECONDS            = 60;
-
     // Keep track of current block height
     int nCachedBlockHeight;
 
@@ -57,6 +57,7 @@ private:
     std::map<COutPoint, int64_t> mapMasternodeOrphanVotes; // mn outpoint - time
 
     bool CreateTxLockCandidate(const CTxLockRequest& txLockRequest);
+    void CreateEmptyTxLockCandidate(const uint256& txHash);
     void Vote(CTxLockCandidate& txLockCandidate);
 
     //process consensus vote message
@@ -70,7 +71,7 @@ private:
     void LockTransactionInputs(const CTxLockCandidate& txLockCandidate);
     //update UI and notify external script if any
     void UpdateLockedTransaction(const CTxLockCandidate& txLockCandidate);
-    bool ResolveConflicts(const CTxLockCandidate& txLockCandidate, int nMaxBlocks);
+    bool ResolveConflicts(const CTxLockCandidate& txLockCandidate);
 
     bool IsInstantSendReadyToLock(const uint256 &txHash);
 
@@ -94,7 +95,7 @@ public:
 
     // verify if transaction is currently locked
     bool IsLockedInstantSendTransaction(const uint256& txHash);
-    // get the actual uber og accepted lock signatures
+    // get the actual number of accepted lock signatures
     int GetTransactionLockSignatures(const uint256& txHash);
     // get instantsend confirmations (only)
     int GetConfirmations(const uint256 &nTXHash);
@@ -102,7 +103,7 @@ public:
     // remove expired entries from maps
     void CheckAndRemove();
     // verify if transaction lock timed out
-    bool IsTxLockRequestTimedOut(const uint256& txHash);
+    bool IsTxLockCandidateTimedOut(const uint256& txHash);
 
     void Relay(const uint256& txHash);
 
@@ -115,27 +116,22 @@ public:
 class CTxLockRequest : public CTransaction
 {
 private:
-    static const int TIMEOUT_SECONDS        = 5 * 60;
     static const CAmount MIN_FEE            = 0.001 * COIN;
-
-    int64_t nTimeCreated;
 
 public:
     static const int WARN_MANY_INPUTS       = 100;
 
-    CTxLockRequest() :
-        CTransaction(),
-        nTimeCreated(GetTime())
-        {}
-    CTxLockRequest(const CTransaction& tx) :
-        CTransaction(tx),
-        nTimeCreated(GetTime())
-        {}
+    CTxLockRequest() = default;
+    CTxLockRequest(const CTransaction& tx) : CTransaction(tx) {};
 
-    bool IsValid(bool fRequireUnspent = true) const;
+    bool IsValid() const;
     CAmount GetMinFee() const;
     int GetMaxSignatures() const;
-    bool IsTimedOut() const;
+
+    explicit operator bool() const
+    {
+        return *this != CTxLockRequest();
+    }
 };
 
 class CTxLockVote
@@ -183,11 +179,11 @@ public:
     uint256 GetTxHash() const { return txHash; }
     COutPoint GetOutpoint() const { return outpoint; }
     COutPoint GetMasternodeOutpoint() const { return outpointMasternode; }
-    int64_t GetTimeCreated() const { return nTimeCreated; }
 
     bool IsValid(CNode* pnode) const;
     void SetConfirmedHeight(int nConfirmedHeightIn) { nConfirmedHeight = nConfirmedHeightIn; }
     bool IsExpired(int nHeight) const;
+    bool IsTimedOut() const;
 
     bool Sign();
     bool CheckSignature() const;
@@ -200,6 +196,7 @@ class COutPointLock
 private:
     COutPoint outpoint; // utxo
     std::map<COutPoint, CTxLockVote> mapMasternodeVotes; // masternode outpoint - vote
+    bool fAttacked = false;
 
 public:
     static const int SIGNATURES_REQUIRED        = 6;
@@ -215,8 +212,9 @@ public:
     bool AddVote(const CTxLockVote& vote);
     std::vector<CTxLockVote> GetVotes() const;
     bool HasMasternodeVoted(const COutPoint& outpointMasternodeIn) const;
-    int CountVotes() const { return mapMasternodeVotes.size(); }
-    bool IsReady() const { return CountVotes() >= SIGNATURES_REQUIRED; }
+    int CountVotes() const { return fAttacked ? 0 : mapMasternodeVotes.size(); }
+    bool IsReady() const { return !fAttacked && CountVotes() >= SIGNATURES_REQUIRED; }
+    void MarkAsAttacked() { fAttacked = true; }
 
     void Relay() const;
 };
@@ -225,10 +223,12 @@ class CTxLockCandidate
 {
 private:
     int nConfirmedHeight; // when corresponding tx is 0-confirmed or conflicted, nConfirmedHeight is -1
+    int64_t nTimeCreated;
 
 public:
     CTxLockCandidate(const CTxLockRequest& txLockRequestIn) :
         nConfirmedHeight(-1),
+        nTimeCreated(GetTime()),
         txLockRequest(txLockRequestIn),
         mapOutPointLocks()
         {}
@@ -239,6 +239,7 @@ public:
     uint256 GetHash() const { return txLockRequest.GetHash(); }
 
     void AddOutPointLock(const COutPoint& outpoint);
+    void MarkOutpointAsAttacked(const COutPoint& outpoint);
     bool AddVote(const CTxLockVote& vote);
     bool IsAllOutPointsReady() const;
 
@@ -247,6 +248,7 @@ public:
 
     void SetConfirmedHeight(int nConfirmedHeightIn) { nConfirmedHeight = nConfirmedHeightIn; }
     bool IsExpired(int nHeight) const;
+    bool IsTimedOut() const;
 
     void Relay() const;
 };

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -258,6 +258,7 @@ public:
 
     void IncreasePoSeBanScore() { if(nPoSeBanScore < MASTERNODE_POSE_BAN_MAX_SCORE) nPoSeBanScore++; }
     void DecreasePoSeBanScore() { if(nPoSeBanScore > -MASTERNODE_POSE_BAN_MAX_SCORE) nPoSeBanScore--; }
+    void PoSeBan() { nPoSeBanScore = MASTERNODE_POSE_BAN_MAX_SCORE; }
 
     masternode_info_t GetInfo();
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -132,6 +132,18 @@ bool CMasternodeMan::DisallowMixing(const COutPoint &outpoint)
     return true;
 }
 
+bool CMasternodeMan::PoSeBan(const COutPoint &outpoint)
+{
+    LOCK(cs);
+    CMasternode* pmn = Find(outpoint);
+    if (!pmn) {
+        return false;
+    }
+    pmn->PoSeBan();
+
+    return true;
+}
+
 void CMasternodeMan::Check()
 {
     LOCK(cs);

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -60,7 +60,7 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
         strTxStatus += " (";
         if(instantsend.IsLockedInstantSendTransaction(wtx.GetHash())) {
             strTxStatus += tr("verified via InstantSend");
-        } else if(!instantsend.IsTxLockRequestTimedOut(wtx.GetHash())) {
+        } else if(!instantsend.IsTxLockCandidateTimedOut(wtx.GetHash())) {
             strTxStatus += tr("InstantSend verification in progress - %1 of %2 signatures").arg(nSignatures).arg(nSignaturesMax);
         } else {
             strTxStatus += tr("InstantSend verification failed");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3168,11 +3168,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
             BOOST_FOREACH(const CTxIn& txin, tx.vin) {
                 uint256 hashLocked;
                 if(instantsend.GetLockedOutPointTxHash(txin.prevout, hashLocked) && hashLocked != tx.GetHash()) {
-                    // Every node which relayed this block to us must invalidate it
-                    // but they probably need more data.
-                    // Relay corresponding transaction lock request and all its votes
-                    // to let other nodes complete the lock.
-                    instantsend.Relay(hashLocked);
+                    // The node which relayed this will have to swtich later,
+                    // relaying instantsend data won't help it.
                     LOCK(cs_main);
                     mapRejectedBlocks.insert(make_pair(block.GetHash(), GetTime()));
                     return state.DoS(0, error("CheckBlock(DASH): transaction %s conflicts with transaction lock %s",


### PR DESCRIPTION
IS is trying to do way to much, yet it's not doing what it should...

- relay conflicting votes to detect attack earlier and PoSe-ban attacking masternode(s)
- cancel conflicting completed locks
- do not overwrite mempool or reprocess blocks
- 15 sec timeout/window to lock tx

Possible TODOs:
- notify about attack (attempts) via zmq+script
- some cleanup