### PR TITLE
Backport Bitcoin PR#8594: Do not add random inbound peers to addrman.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1231,12 +1231,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 pfrom->fGetAddr = true;
             }
             connman.MarkAddressGood(pfrom->addr);
-        } else {
-            if (((CNetAddr)pfrom->addr) == (CNetAddr)addrFrom)
-            {
-                connman.AddNewAddress(addrFrom, addrFrom);
-                connman.MarkAddressGood(addrFrom);
-            }
         }
 
         // Relay alerts


### PR DESCRIPTION
This is backport of Bitcoin PR bitcoin/bitcoin#8594.

The original PR description follows.
---
We should learn about new peers via address messages.

An inbound peer connecting to us tells us nothing about
its ability to accept incoming connections from us, so
we shouldn't assume that we can connect to it based on
this.

The vast majority of nodes on the network do not accept
incoming connections, adding them will only slow down
the process of making a successful connection in the
future.

Nodes which have configured themselves to not announce would prefer we
not violate their privacy by announcing them in GETADDR responses.