### PR TITLE
Fix sync issues

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -16,6 +16,16 @@ void CDSNotificationInterface::InitializeCurrentBlockTip()
     UpdatedBlockTip(chainActive.Tip(), NULL, IsInitialBlockDownload());
 }
 
+void CDSNotificationInterface::AcceptedBlockHeader(const CBlockIndex *pindexNew)
+{
+    masternodeSync.AcceptedBlockHeader(pindexNew);
+}
+
+void CDSNotificationInterface::NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload)
+{
+    masternodeSync.NotifyHeaderTip(pindexNew, fInitialDownload);
+}
+
 void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
     if (fInitialDownload || pindexNew == pindexFork) // In IBD or blocks were disconnected without any new ones
@@ -26,7 +36,6 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     instantsend.UpdatedBlockTip(pindexNew);
     mnpayments.UpdatedBlockTip(pindexNew);
     governance.UpdatedBlockTip(pindexNew);
-    masternodeSync.UpdatedBlockTip(pindexNew, fInitialDownload);
 }
 
 void CDSNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlock *pblock)

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -18,6 +18,8 @@ public:
 
 protected:
     // CValidationInterface
+    void AcceptedBlockHeader(const CBlockIndex *pindexNew) override;
+    void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void SyncTransaction(const CTransaction &tx, const CBlock *pblock) override;
 

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -13,6 +13,7 @@ class CMasternodeSync;
 
 static const int MASTERNODE_SYNC_FAILED          = -1;
 static const int MASTERNODE_SYNC_INITIAL         = 0; // sync just started, was reset recently or still in IDB
+static const int MASTERNODE_SYNC_WAITING         = 1; // waiting after initial to see if we can get more headers/blocks
 static const int MASTERNODE_SYNC_LIST            = 2;
 static const int MASTERNODE_SYNC_MNW             = 3;
 static const int MASTERNODE_SYNC_GOVERNANCE      = 4;
@@ -56,7 +57,7 @@ public:
     void SendGovernanceSyncRequest(CNode* pnode);
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
-    bool IsBlockchainSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_INITIAL; }
+    bool IsBlockchainSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_WAITING; }
     bool IsMasternodeListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
     bool IsWinnersListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_MNW; }
     bool IsSynced() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED; }
@@ -74,7 +75,8 @@ public:
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     void ProcessTick();
 
-    void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload);
+    void AcceptedBlockHeader(const CBlockIndex *pindexNew);
+    void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload);
 };
 
 #endif

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2762,6 +2762,7 @@ static void NotifyHeaderTip() {
     // Send block tip changed notifications without cs_main
     if (fNotify) {
         uiInterface.NotifyHeaderTip(fInitialBlockDownload, pindexHeader);
+        GetMainSignals().NotifyHeaderTip(pindexHeader, fInitialBlockDownload);
     }
 }
 
@@ -3322,6 +3323,9 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
         *ppindex = pindex;
 
     CheckBlockIndex(chainparams.GetConsensus());
+
+    // Notify external listeners about accepted block header
+    GetMainSignals().AcceptedBlockHeader(pindex);
 
     return true;
 }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -13,6 +13,8 @@ CMainSignals& GetMainSignals()
 }
 
 void RegisterValidationInterface(CValidationInterface* pwalletIn) {
+    g_signals.AcceptedBlockHeader.connect(boost::bind(&CValidationInterface::AcceptedBlockHeader, pwalletIn, _1));
+    g_signals.NotifyHeaderTip.connect(boost::bind(&CValidationInterface::NotifyHeaderTip, pwalletIn, _1, _2));
     g_signals.UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
     g_signals.NotifyTransactionLock.connect(boost::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, _1));
@@ -36,6 +38,8 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.NotifyTransactionLock.disconnect(boost::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, _1));
     g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
+    g_signals.NotifyHeaderTip.disconnect(boost::bind(&CValidationInterface::NotifyHeaderTip, pwalletIn, _1, _2));
+    g_signals.AcceptedBlockHeader.disconnect(boost::bind(&CValidationInterface::AcceptedBlockHeader, pwalletIn, _1));
 }
 
 void UnregisterAllValidationInterfaces() {
@@ -49,4 +53,6 @@ void UnregisterAllValidationInterfaces() {
     g_signals.NotifyTransactionLock.disconnect_all_slots();
     g_signals.SyncTransaction.disconnect_all_slots();
     g_signals.UpdatedBlockTip.disconnect_all_slots();
+    g_signals.NotifyHeaderTip.disconnect_all_slots();
+    g_signals.AcceptedBlockHeader.disconnect_all_slots();
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -30,6 +30,8 @@ void UnregisterAllValidationInterfaces();
 
 class CValidationInterface {
 protected:
+    virtual void AcceptedBlockHeader(const CBlockIndex *pindexNew) {}
+    virtual void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload) {}
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
     virtual void NotifyTransactionLock(const CTransaction &tx) {}
@@ -46,6 +48,10 @@ protected:
 };
 
 struct CMainSignals {
+    /** Notifies listeners of accepted block header */
+    boost::signals2::signal<void (const CBlockIndex *)> AcceptedBlockHeader;
+    /** Notifies listeners of updated block header tip */
+    boost::signals2::signal<void (const CBlockIndex *, bool fInitialDownload)> NotifyHeaderTip;
     /** Notifies listeners of updated block chain tip */
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */


### PR DESCRIPTION
Unlike original bitcoin sync, masternode sync should not start until we are at the tip of the chain. Otherwise there is a chance that we are going to reject recent masternodes (we won't be able to find UTXO, or  there could be not enough confirmations for masternodes) and as a result all objects created by such masternodes are going to be rejected too (e.g. invalid pings/objects due to unknown blockhash). This could lead to masternode list, winners list and gov object list discrepancies which will result in network instability in general due to lack of consensus.

Changes:
- add `MASTERNODE_SYNC_WAITING` sync state/asset and initial timeout
- wait for block headers to be downloaded (new signal `AcceptedBlockHeader`)
- wait for blocks to reach best headers tip before switching to masternode list sync (new signal `NotifyHeaderTip`)
- switched sync from `UpdatedBlockTip` to a combination of `AcceptedBlockHeader` and `NotifyHeaderTip`
- all blockchain-related bumps should take place only while we are still syncing blockchain, should be no such bumps after that
