### PR TITLE
Backport Bitcoin PR#8740: net: No longer send local address in addrMe

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -212,7 +212,7 @@ void PushNodeVersion(CNode *pnode, CConnman& connman, int64_t nTime)
     CAddress addr = pnode->addr;
 
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService("0.0.0.0", 0), addr.nServices));
-    CAddress addrMe = GetLocalAddress(&addr, nLocalNodeServices);
+    CAddress addrMe = CAddress(CService(), nLocalNodeServices);
 
     connman.PushMessageWithVersion(pnode, INIT_PROTO_VERSION, NetMsgType::VERSION, PROTOCOL_VERSION, (uint64_t)nLocalNodeServices, nTime, addrYou, addrMe,
             nonce, strSubVersion, nNodeStartingHeight, ::fRelayTxes);


### PR DESCRIPTION
This is backport of Bitcoin PR bitcoin/bitcoin#8740.

This PR is followup of #1593.

The original PR description follows.
---
After bitcoin/bitcoin#8594 the addrFrom sent by a node is not used anymore at all, so don't bother sending it (it was already not used if it is an invalid address so this doesn't disadvantage older versions either).

Also mitigates the privacy issue in (bitcoin/bitcoin#8616). It doesn't completely solve the issue as GetLocalAddress is also called in AdvertiseLocal, but at least when advertising addresses it stands out less as *our* address.