### PR TITLE
Use connman passed to ThreadSendAlert() instead of g_connman global

### DIFF
--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -100,8 +100,8 @@ void ThreadSendAlert(CConnman& connman)
     printf("ThreadSendAlert() : Sending alert\n");
     int nSent = 0;
     {
-        g_connman->ForEachNode([&alert2, &nSent](CNode* pnode) {
-            if (alert2.RelayTo(pnode, *g_connman))
+        connman.ForEachNode([&alert2, &connman, &nSent](CNode* pnode) {
+            if (alert2.RelayTo(pnode, connman))
             {
                 printf("ThreadSendAlert() : Sent alert to %s\n", pnode->addr.ToString().c_str());
                 nSent++;


### PR DESCRIPTION
There is no reason to use `g_connman` global variable in `ThreadSendAlert()` because reference to `CConnman` instance is already passed to it as argument.

This was overlooked when refactoring `sendalert` module, it's time to fix it.