### PR TITLE
fix TrafficGraphData bandwidth calculation

### DIFF
--- a/src/qt/test/trafficgraphdatatests.cpp
+++ b/src/qt/test/trafficgraphdatatests.cpp
@@ -172,3 +172,52 @@ void TrafficGraphDataTests::clearTests()
     }
     QCOMPARE(trafficGraphData.getCurrentRangeQueue().size(), TrafficGraphData::DESIRED_DATA_SAMPLES);
 }
+
+void TrafficGraphDataTests::averageBandwidthTest()
+{
+    TrafficGraphData trafficGraphData(TrafficGraphData::Range_5m);
+    int step = 384;
+    quint64 totalBytesRecv = 0;
+    quint64 totalBytesSent = 0;
+    for (int i = 1; i <= TrafficGraphData::DESIRED_DATA_SAMPLES; i++){
+        totalBytesRecv += step;
+        totalBytesSent += step;
+        trafficGraphData.update(totalBytesRecv, totalBytesSent);
+    }
+    QCOMPARE(trafficGraphData.getCurrentRangeQueueWithAverageBandwidth().size(), TrafficGraphData::DESIRED_DATA_SAMPLES);
+    for(auto& sample : trafficGraphData.getCurrentRangeQueueWithAverageBandwidth()){
+        QCOMPARE(sample.in, 1.0);
+        QCOMPARE(sample.out, 1.0);
+    }
+
+    trafficGraphData.switchRange(TrafficGraphData::Range_10m);
+
+    QCOMPARE(trafficGraphData.getCurrentRangeQueueWithAverageBandwidth().size(), TrafficGraphData::DESIRED_DATA_SAMPLES / 2);
+    for(auto& sample : trafficGraphData.getCurrentRangeQueueWithAverageBandwidth()){
+        QCOMPARE(sample.in, 1.0);
+        QCOMPARE(sample.out, 1.0);
+    }
+}
+
+void TrafficGraphDataTests::averageBandwidthEvery2EmptyTest()
+{
+    TrafficGraphData trafficGraphData(TrafficGraphData::Range_5m);
+    int step = 384;
+    quint64 totalBytesRecv = 0;
+    quint64 totalBytesSent = 0;
+    for (int i = 1; i <= TrafficGraphData::DESIRED_DATA_SAMPLES; i++){
+        if (i % 2 == 0) {
+            totalBytesRecv += step;
+            totalBytesSent += step;
+        }
+        trafficGraphData.update(totalBytesRecv, totalBytesSent);
+    }
+
+    trafficGraphData.switchRange(TrafficGraphData::Range_10m);
+
+    QCOMPARE(trafficGraphData.getCurrentRangeQueueWithAverageBandwidth().size(), TrafficGraphData::DESIRED_DATA_SAMPLES / 2);
+    for(auto& sample : trafficGraphData.getCurrentRangeQueueWithAverageBandwidth()){
+        QCOMPARE(sample.in, 0.5);
+        QCOMPARE(sample.out, 0.5);
+    }
+}

--- a/src/qt/test/trafficgraphdatatests.h
+++ b/src/qt/test/trafficgraphdatatests.h
@@ -14,6 +14,9 @@ private Q_SLOTS:
     void getRangeTests();
     void switchRangeTests();
     void clearTests();
+    void averageBandwidthTest();
+    void averageBandwidthEvery2EmptyTest();
+
 };
 
 

--- a/src/qt/trafficgraphdata.h
+++ b/src/qt/trafficgraphdata.h
@@ -58,6 +58,7 @@ public:
     void switchRange(GraphRange newRange);
     SampleQueue getRangeQueue(GraphRange range);
     SampleQueue getCurrentRangeQueue();
+    SampleQueue getCurrentRangeQueueWithAverageBandwidth();
     void clear();
     void setLastBytes(quint64 nLastBytesIn, quint64 nLastBytesOut);
 
@@ -82,7 +83,7 @@ private:
     SampleQueue sumEach2Samples(const SampleQueue &rangeQueue);
     SampleQueue sumEach3Samples(const SampleQueue &rangeQueue, GraphRange range);
 
-
+    float converSampletoBandwith(float dataAmount);
     TrafficGraphData(const TrafficGraphData& that);
     TrafficGraphData& operator=(TrafficGraphData const&);
 };

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -115,7 +115,7 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
         }
     }
 
-    const TrafficGraphData::SampleQueue& queue = trafficGraphData.getCurrentRangeQueue();
+    const TrafficGraphData::SampleQueue& queue = trafficGraphData.getCurrentRangeQueueWithAverageBandwidth();
 
     if(!queue.empty()) {
         QPainterPath pIn;
@@ -140,7 +140,7 @@ void TrafficGraphWidget::updateRates()
 
     if (updated){
         float tmax = DEFAULT_SAMPLE_HEIGHT;
-        Q_FOREACH(const TrafficSample& sample, trafficGraphData.getCurrentRangeQueue()) {
+        Q_FOREACH(const TrafficSample& sample, trafficGraphData.getCurrentRangeQueueWithAverageBandwidth()) {
             if(sample.in > tmax) tmax = sample.in;
             if(sample.out > tmax) tmax = sample.out;
         }


### PR DESCRIPTION
After changes from PR1429, TrafficGraphWidget displayed incorrect bandwidth.
This is to fix bandwidth calculation logic in TrafficGraphData.
Now TrafficGraphWidget displays average bandwidth for each sample in given range.

