### PR TITLE
Fix masternode score/rank calculations

### DIFF
--- a/src/darksend-relay.cpp
+++ b/src/darksend-relay.cpp
@@ -101,7 +101,7 @@ void CDarkSendRelay::RelayThroughNode(int nRank)
 {
     masternode_info_t mnInfo;
 
-    if(mnodeman.GetMasternodeByRank(nRank, nBlockHeight, MIN_PRIVATESEND_PEER_PROTO_VERSION, false, mnInfo)){
+    if(mnodeman.GetMasternodeByRank(nRank, mnInfo, nBlockHeight, MIN_PRIVATESEND_PEER_PROTO_VERSION)) {
         //printf("RelayThroughNode %s\n", mnInfo.addr.ToString().c_str());
         // TODO: Pass CConnman instance somehow and don't use global variable.
         CNode* pnode = g_connman->ConnectNode((CAddress)mnInfo.addr, NULL);

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -195,22 +195,21 @@ void CInstantSend::Vote(CTxLockCandidate& txLockCandidate)
 
         int nLockInputHeight = nPrevoutHeight + 4;
 
-        int n = mnodeman.GetMasternodeRank(activeMasternode.outpoint, nLockInputHeight, MIN_INSTANTSEND_PROTO_VERSION);
-
-        if(n == -1) {
+        int nRank;
+        if(!mnodeman.GetMasternodeRank(activeMasternode.outpoint, nRank, nLockInputHeight, MIN_INSTANTSEND_PROTO_VERSION)) {
             LogPrint("instantsend", "CInstantSend::Vote -- Can't calculate rank for masternode %s\n", activeMasternode.outpoint.ToStringShort());
             ++itOutpointLock;
             continue;
         }
 
         int nSignaturesTotal = COutPointLock::SIGNATURES_TOTAL;
-        if(n > nSignaturesTotal) {
-            LogPrint("instantsend", "CInstantSend::Vote -- Masternode not in the top %d (%d)\n", nSignaturesTotal, n);
+        if(nRank > nSignaturesTotal) {
+            LogPrint("instantsend", "CInstantSend::Vote -- Masternode not in the top %d (%d)\n", nSignaturesTotal, nRank);
             ++itOutpointLock;
             continue;
         }
 
-        LogPrint("instantsend", "CInstantSend::Vote -- In the top %d (%d)\n", nSignaturesTotal, n);
+        LogPrint("instantsend", "CInstantSend::Vote -- In the top %d (%d)\n", nSignaturesTotal, nRank);
 
         std::map<COutPoint, std::set<uint256> >::iterator itVoted = mapVotedOutpoints.find(itOutpointLock->first);
 
@@ -1000,19 +999,18 @@ bool CTxLockVote::IsValid(CNode* pnode) const
 
     int nLockInputHeight = coins.nHeight + 4;
 
-    int n = mnodeman.GetMasternodeRank(outpointMasternode, nLockInputHeight, MIN_INSTANTSEND_PROTO_VERSION);
-
-    if(n == -1) {
+    int nRank;
+    if(!mnodeman.GetMasternodeRank(outpointMasternode, nRank, nLockInputHeight, MIN_INSTANTSEND_PROTO_VERSION)) {
         //can be caused by past versions trying to vote with an invalid protocol
         LogPrint("instantsend", "CTxLockVote::IsValid -- Can't calculate rank for masternode %s\n", outpointMasternode.ToStringShort());
         return false;
     }
-    LogPrint("instantsend", "CTxLockVote::IsValid -- Masternode %s, rank=%d\n", outpointMasternode.ToStringShort(), n);
+    LogPrint("instantsend", "CTxLockVote::IsValid -- Masternode %s, rank=%d\n", outpointMasternode.ToStringShort(), nRank);
 
     int nSignaturesTotal = COutPointLock::SIGNATURES_TOTAL;
-    if(n > nSignaturesTotal) {
+    if(nRank > nSignaturesTotal) {
         LogPrint("instantsend", "CTxLockVote::IsValid -- Masternode %s is not in the top %d (%d), vote hash=%s\n",
-                outpointMasternode.ToStringShort(), nSignaturesTotal, n, GetHash().ToString());
+                outpointMasternode.ToStringShort(), nSignaturesTotal, nRank, GetHash().ToString());
         return false;
     }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -684,7 +684,7 @@ bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, std::s
     // Regular clients (miners included) need to verify masternode rank for future block votes only.
     if(!fMasterNode && nBlockHeight < nValidationHeight) return true;
 
-    int nRank = mnodeman.GetMasternodeRank(vinMasternode.prevout, nBlockHeight - 101, nMinRequiredProtocol, false);
+    int nRank = mnodeman.GetMasternodeRank(vinMasternode.prevout, nBlockHeight - 101, nMinRequiredProtocol);
 
     if(nRank == -1) {
         LogPrint("mnpayments", "CMasternodePaymentVote::IsValid -- Can't calculate rank for masternode %s\n",
@@ -723,7 +723,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     // if we have not enough data about masternodes.
     if(!masternodeSync.IsMasternodeListSynced()) return false;
 
-    int nRank = mnodeman.GetMasternodeRank(activeMasternode.outpoint, nBlockHeight - 101, GetMinMasternodePaymentsProto(), false);
+    int nRank = mnodeman.GetMasternodeRank(activeMasternode.outpoint, nBlockHeight - 101, GetMinMasternodePaymentsProto());
 
     if (nRank == -1) {
         LogPrint("mnpayments", "CMasternodePayments::ProcessBlock -- Unknown Masternode\n");

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -684,9 +684,9 @@ bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, std::s
     // Regular clients (miners included) need to verify masternode rank for future block votes only.
     if(!fMasterNode && nBlockHeight < nValidationHeight) return true;
 
-    int nRank = mnodeman.GetMasternodeRank(vinMasternode.prevout, nBlockHeight - 101, nMinRequiredProtocol);
+    int nRank;
 
-    if(nRank == -1) {
+    if(!mnodeman.GetMasternodeRank(vinMasternode.prevout, nRank, nBlockHeight - 101, nMinRequiredProtocol)) {
         LogPrint("mnpayments", "CMasternodePaymentVote::IsValid -- Can't calculate rank for masternode %s\n",
                     vinMasternode.prevout.ToStringShort());
         return false;
@@ -723,9 +723,9 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     // if we have not enough data about masternodes.
     if(!masternodeSync.IsMasternodeListSynced()) return false;
 
-    int nRank = mnodeman.GetMasternodeRank(activeMasternode.outpoint, nBlockHeight - 101, GetMinMasternodePaymentsProto());
+    int nRank;
 
-    if (nRank == -1) {
+    if (!mnodeman.GetMasternodeRank(activeMasternode.outpoint, nRank, nBlockHeight - 101, GetMinMasternodePaymentsProto())) {
         LogPrint("mnpayments", "CMasternodePayments::ProcessBlock -- Unknown Masternode\n");
         return false;
     }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -700,7 +700,10 @@ bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, std::s
         if(nRank > MNPAYMENTS_SIGNATURES_TOTAL*2 && nBlockHeight > nValidationHeight) {
             strError = strprintf("Masternode is not in the top %d (%d)", MNPAYMENTS_SIGNATURES_TOTAL*2, nRank);
             LogPrintf("CMasternodePaymentVote::IsValid -- Error: %s\n", strError);
-            Misbehaving(pnode->GetId(), 20);
+            // do not ban nodes before DIP0001 is locked in to avoid banning majority of (old) masternodes
+            if (fDIP0001LockedInAtTip) {
+                Misbehaving(pnode->GetId(), 20);
+            }
         }
         // Still invalid however
         return false;
@@ -779,7 +782,8 @@ void CMasternodePaymentVote::Relay()
     // do not relay until synced
     if (!masternodeSync.IsWinnersListSynced()) return;
     CInv inv(MSG_MASTERNODE_PAYMENT_VOTE, GetHash());
-    g_connman->RelayInv(inv);
+    // relay votes only strictly to new nodes until DIP0001 is locked in to avoid being banned by majority of (old) masternodes
+    g_connman->RelayInv(inv, fDIP0001LockedInAtTip ? mnpayments.GetMinMasternodePaymentsProto() : MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2);
 }
 
 bool CMasternodePaymentVote::CheckSignature(const CPubKey& pubKeyMasternode, int nValidationHeight, int &nDos)

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -155,7 +155,7 @@ public:
     CMasternodePing lastPing{};
     std::vector<unsigned char> vchSig{};
 
-    int nCacheCollateralBlock{};
+    uint256 nCollateralMinConfBlockHash{};
     int nBlockLastPaid{};
     int nPoSeBanScore{};
     int nPoSeBanHeight{};
@@ -187,7 +187,7 @@ public:
         READWRITE(nTimeLastPaid);
         READWRITE(nTimeLastWatchdogVote);
         READWRITE(nActiveState);
-        READWRITE(nCacheCollateralBlock);
+        READWRITE(nCollateralMinConfBlockHash);
         READWRITE(nBlockLastPaid);
         READWRITE(nProtocolVersion);
         READWRITE(nPoSeBanScore);
@@ -284,7 +284,7 @@ public:
         static_cast<masternode_info_t&>(*this)=from;
         lastPing = from.lastPing;
         vchSig = from.vchSig;
-        nCacheCollateralBlock = from.nCacheCollateralBlock;
+        nCollateralMinConfBlockHash = from.nCollateralMinConfBlockHash;
         nBlockLastPaid = from.nBlockLastPaid;
         nPoSeBanScore = from.nPoSeBanScore;
         nPoSeBanHeight = from.nPoSeBanHeight;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -16,7 +16,7 @@
 /** Masternode manager */
 CMasternodeMan mnodeman;
 
-const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-6";
+const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-7";
 
 struct CompareLastPaidBlock
 {

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -17,6 +17,7 @@ extern CMasternodeMan mnodeman;
 class CMasternodeMan
 {
 public:
+    typedef std::vector<std::pair<arith_uint256, CMasternode*> > score_pair_m_t;
 
 private:
     static const std::string SERIALIZATION_VERSION_STRING;
@@ -72,6 +73,8 @@ private:
     friend class CMasternodeSync;
     /// Find an entry
     CMasternode* Find(const COutPoint& outpoint);
+
+    score_pair_m_t GetMasternodeScores(int nBlockHeight, uint256 blockHash, int nMinProtocol);
 
 public:
     // Keep track of all broadcasts I've seen
@@ -167,8 +170,8 @@ public:
     std::map<COutPoint, CMasternode> GetFullMasternodeMap() { return mapMasternodes; }
 
     std::vector<std::pair<int, CMasternode> > GetMasternodeRanks(int nBlockHeight = -1, int nMinProtocol=0);
-    int GetMasternodeRank(const COutPoint &outpoint, int nBlockHeight, int nMinProtocol=0, bool fOnlyActive=true);
-    bool GetMasternodeByRank(int nRank, int nBlockHeight, int nMinProtocol, bool fOnlyActive, masternode_info_t& mnInfoRet);
+    int GetMasternodeRank(const COutPoint &outpoint, int nBlockHeight, int nMinProtocol=0);
+    bool GetMasternodeByRank(int nRank, int nBlockHeight, int nMinProtocol, masternode_info_t& mnInfoRet);
 
     void ProcessMasternodeConnections();
     std::pair<CService, std::set<uint256> > PopScheduledMnbRequestConnection();

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -17,7 +17,10 @@ extern CMasternodeMan mnodeman;
 class CMasternodeMan
 {
 public:
-    typedef std::vector<std::pair<arith_uint256, CMasternode*> > score_pair_m_t;
+    typedef std::pair<arith_uint256, CMasternode*> score_pair_t;
+    typedef std::vector<score_pair_t> score_pair_vec_t;
+    typedef std::pair<int, CMasternode> rank_pair_t;
+    typedef std::vector<rank_pair_t> rank_pair_vec_t;
 
 private:
     static const std::string SERIALIZATION_VERSION_STRING;
@@ -74,7 +77,7 @@ private:
     /// Find an entry
     CMasternode* Find(const COutPoint& outpoint);
 
-    score_pair_m_t GetMasternodeScores(int nBlockHeight, uint256 blockHash, int nMinProtocol);
+    bool GetMasternodeScores(score_pair_vec_t& vecMasternodeScoresRet, int nBlockHeight = -1, int nMinProtocol = 0);
 
 public:
     // Keep track of all broadcasts I've seen
@@ -169,9 +172,9 @@ public:
 
     std::map<COutPoint, CMasternode> GetFullMasternodeMap() { return mapMasternodes; }
 
-    std::vector<std::pair<int, CMasternode> > GetMasternodeRanks(int nBlockHeight = -1, int nMinProtocol=0);
-    int GetMasternodeRank(const COutPoint &outpoint, int nBlockHeight, int nMinProtocol=0);
-    bool GetMasternodeByRank(int nRank, int nBlockHeight, int nMinProtocol, masternode_info_t& mnInfoRet);
+    bool GetMasternodeRanks(rank_pair_vec_t& vecMasternodeRanksRet, int nBlockHeight = -1, int nMinProtocol = 0);
+    bool GetMasternodeRank(const COutPoint &outpoint, int& nRankRet, int nBlockHeight = -1, int nMinProtocol = 0);
+    bool GetMasternodeByRank(int nRank, masternode_info_t& mnInfoRet, int nBlockHeight = -1, int nMinProtocol = 0);
 
     void ProcessMasternodeConnections();
     std::pair<CService, std::set<uint256> > PopScheduledMnbRequestConnection();

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -77,7 +77,7 @@ private:
     /// Find an entry
     CMasternode* Find(const COutPoint& outpoint);
 
-    bool GetMasternodeScores(score_pair_vec_t& vecMasternodeScoresRet, int nBlockHeight = -1, int nMinProtocol = 0);
+    bool GetMasternodeScores(const uint256& nBlockHash, score_pair_vec_t& vecMasternodeScoresRet, int nMinProtocol = 0);
 
 public:
     // Keep track of all broadcasts I've seen

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -504,7 +504,8 @@ UniValue masternodelist(const UniValue& params, bool fHelp)
 
     UniValue obj(UniValue::VOBJ);
     if (strMode == "rank") {
-        std::vector<std::pair<int, CMasternode> > vMasternodeRanks = mnodeman.GetMasternodeRanks();
+        CMasternodeMan::rank_pair_vec_t vMasternodeRanks;
+        mnodeman.GetMasternodeRanks(vMasternodeRanks);
         BOOST_FOREACH(PAIRTYPE(int, CMasternode)& s, vMasternodeRanks) {
             std::string strOutpoint = s.second.vin.prevout.ToStringShort();
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) continue;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1883,7 +1883,7 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
         const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
         if (vbinfo.check_mn_protocol && state == THRESHOLD_STARTED && !fAssumeMasternodeIsUpgraded) {
             masternode_info_t mnInfo;
-            bool fFound = mnodeman.GetMasternodeByRank(1, pindexPrev->nHeight, 0, false, mnInfo);
+            bool fFound = mnodeman.GetMasternodeByRank(1, pindexPrev->nHeight, 0, mnInfo);
             if (!fFound || mnInfo.nProtocolVersion < PROTOCOL_VERSION) {
                 // no masternodes(?) or masternode is not upgraded yet
                 continue;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1883,7 +1883,7 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
         const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
         if (vbinfo.check_mn_protocol && state == THRESHOLD_STARTED && !fAssumeMasternodeIsUpgraded) {
             masternode_info_t mnInfo;
-            bool fFound = mnodeman.GetMasternodeByRank(1, pindexPrev->nHeight, 0, mnInfo);
+            bool fFound = mnodeman.GetMasternodeByRank(1, mnInfo, pindexPrev->nHeight);
             if (!fFound || mnInfo.nProtocolVersion < PROTOCOL_VERSION) {
                 // no masternodes(?) or masternode is not upgraded yet
                 continue;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2461,7 +2461,8 @@ void static UpdateTip(CBlockIndex *pindexNew) {
         }
     }
 
-    // Update global flag
+    // Update global flags
+    fDIP0001LockedInAtTip = (VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_DIP0001) == THRESHOLD_LOCKED_IN);
     fDIP0001ActiveAtTip = (VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_DIP0001) == THRESHOLD_ACTIVE);
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -47,6 +47,7 @@ class CValidationState;
 
 struct LockPoints;
 
+static std::atomic<bool> fDIP0001LockedInAtTip{false};
 static std::atomic<bool> fDIP0001ActiveAtTip{false};
 
 /** Default for accepting alerts from the P2P network. */


### PR DESCRIPTION
This should fix two issues we have with scores/ranks currently:
- fix `CMasternode::CalculateScore` vulnerability (2ba68b6);
- improve mn list consensus (ae762a6).

Speaking of mn list consensus, selecting non-enabled MNs doesn't degrade quorum quality too much because MNs should have 1000 DASH locked anyway and it's morel likely that they have some problems running MN/propagating pings rather than trying to perform a DoS attack this way. On the other hand, ignoring some live data like pings and wds should help us to stabilize mn list much quicker. Also note, these does NOT change the fact that only valid masternodes are voted for being payed (`GetNextMasternodeInQueueForPayment`), it only affects (extends) the selection of masternodes who are voting.