### PR TITLE
Build: silence gcc7's implicit fallthrough warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,7 @@ fi
 ##       compatibility with the legacy buildsystem.
 ##
 if test "x$CXXFLAGS_overridden" = "xno"; then
-  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -Wno-self-assign"
+  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter -Wno-self-assign -Wno-implicit-fallthrough"
 fi
 CPPFLAGS="$CPPFLAGS -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 


### PR DESCRIPTION
GCC 7 now warns if a `switch` `case` does not end with a `break;` statement.

For reference, bitcoin addressed this with the following PR:
This is a well-intentioned but realistically annoying warning. Unfortunately,
it's too easy for a warning in one header to cause dozens of repeated warnings.
https://github.com/bitcoin/bitcoin/pull/10489