### PR TITLE
Disable HD wallet by default

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -108,6 +108,7 @@ testScripts = [
     'proxy_test.py',
     'merkle_blocks.py',
     'fundrawtransaction.py',
+    'fundrawtransaction-hd.py',
     'signrawtransactions.py',
     'walletbackup.py',
     'nodehandling.py',
@@ -121,6 +122,7 @@ testScripts = [
     'disablewallet.py',
     'sendheaders.py', # NOTE: needs dash_hash to pass
     'keypool.py',
+    'keypool-hd.py',
     'prioritise_transaction.py',
     'invalidblockrequest.py', # NOTE: needs dash_hash to pass
     'invalidtxrequest.py', # NOTE: needs dash_hash to pass

--- a/qa/rpc-tests/fundrawtransaction-hd.py
+++ b/qa/rpc-tests/fundrawtransaction-hd.py
@@ -14,7 +14,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 4)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(4, self.options.tmpdir, [['-usehd=0'], ['-usehd=0'], ['-usehd=0'], ['-usehd=0']])
+        self.nodes = start_nodes(4, self.options.tmpdir, [['-usehd=1'], ['-usehd=1'], ['-usehd=1'], ['-usehd=1']])
 
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
@@ -444,7 +444,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         stop_nodes(self.nodes)
         wait_bitcoinds()
 
-        self.nodes = start_nodes(4, self.options.tmpdir, [['-usehd=0'], ['-usehd=0'], ['-usehd=0'], ['-usehd=0']])
+        self.nodes = start_nodes(4, self.options.tmpdir, [['-usehd=1'], ['-usehd=1'], ['-usehd=1'], ['-usehd=1']])
         # This test is not meant to test fee estimation and we'd like
         # to be sure all txs are sent at a consistent desired feerate
         for node in self.nodes:
@@ -459,6 +459,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # drain the keypool
         self.nodes[1].getnewaddress()
+        self.nodes[1].getrawchangeaddress()
         inputs = []
         outputs = {self.nodes[0].getnewaddress():1.1}
         rawTx = self.nodes[1].createrawtransaction(inputs, outputs)
@@ -472,6 +473,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         #refill the keypool
         self.nodes[1].walletpassphrase("test", 100)
+        self.nodes[1].keypoolrefill(2) #need to refill the keypool to get an internal change address
         self.nodes[1].walletlock()
 
         try:

--- a/qa/rpc-tests/keypool-hd.py
+++ b/qa/rpc-tests/keypool-hd.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Exercise the wallet keypool, and interaction with wallet encryption/locking
+
+# Add python-bitcoinrpc to module search path:
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class KeyPoolTest(BitcoinTestFramework):
+
+    def run_test(self):
+        nodes = self.nodes
+        addr_before_encrypting = nodes[0].getnewaddress()
+        addr_before_encrypting_data = nodes[0].validateaddress(addr_before_encrypting)
+        wallet_info_old = nodes[0].getwalletinfo()
+        assert(addr_before_encrypting_data['hdchainid'] == wallet_info_old['hdchainid'])
+
+        # Encrypt wallet and wait to terminate
+        nodes[0].encryptwallet('test')
+        bitcoind_processes[0].wait()
+        # Restart node 0
+        nodes[0] = start_node(0, self.options.tmpdir, ['-usehd=1'])
+        # Keep creating keys
+        addr = nodes[0].getnewaddress()
+        addr_data = nodes[0].validateaddress(addr)
+        wallet_info = nodes[0].getwalletinfo()
+        assert(addr_before_encrypting_data['hdchainid'] == wallet_info['hdchainid'])
+        assert(addr_data['hdchainid'] == wallet_info['hdchainid'])
+
+        try:
+            addr = nodes[0].getnewaddress()
+            raise AssertionError('Keypool should be exhausted after one address')
+        except JSONRPCException as e:
+            assert(e.error['code']==-12)
+
+        # put six (plus 2) new keys in the keypool (100% external-, +100% internal-keys, 1 in min)
+        nodes[0].walletpassphrase('test', 12000)
+        nodes[0].keypoolrefill(6)
+        nodes[0].walletlock()
+        wi = nodes[0].getwalletinfo()
+        assert_equal(wi['keypoolsize_hd_internal'], 6)
+        assert_equal(wi['keypoolsize'], 6)
+
+        # drain the internal keys
+        nodes[0].getrawchangeaddress()
+        nodes[0].getrawchangeaddress()
+        nodes[0].getrawchangeaddress()
+        nodes[0].getrawchangeaddress()
+        nodes[0].getrawchangeaddress()
+        nodes[0].getrawchangeaddress()
+        # the next one should fail
+        try:
+            nodes[0].getrawchangeaddress()
+            raise AssertionError('Keypool should be exhausted after six addresses')
+        except JSONRPCException as e:
+            assert(e.error['code']==-12)
+
+        addr = set()
+        # drain the external keys
+        addr.add(nodes[0].getnewaddress())
+        addr.add(nodes[0].getnewaddress())
+        addr.add(nodes[0].getnewaddress())
+        addr.add(nodes[0].getnewaddress())
+        addr.add(nodes[0].getnewaddress())
+        addr.add(nodes[0].getnewaddress())
+        assert(len(addr) == 6)
+        # the next one should fail
+        try:
+            addr = nodes[0].getnewaddress()
+            raise AssertionError('Keypool should be exhausted after six addresses')
+        except JSONRPCException as e:
+            assert(e.error['code']==-12)
+
+        # refill keypool with three new addresses
+        nodes[0].walletpassphrase('test', 1)
+        nodes[0].keypoolrefill(3)
+        # test walletpassphrase timeout
+        time.sleep(1.1)
+        assert_equal(nodes[0].getwalletinfo()["unlocked_until"], 0)
+
+        # drain them by mining
+        nodes[0].generate(1)
+        nodes[0].generate(1)
+        nodes[0].generate(1)
+        try:
+            nodes[0].generate(1)
+            raise AssertionError('Keypool should be exhausted after three addesses')
+        except JSONRPCException as e:
+            assert(e.error['code']==-12)
+
+        nodes[0].walletpassphrase('test', 100)
+        nodes[0].keypoolrefill(100)
+        wi = nodes[0].getwalletinfo()
+        assert_equal(wi['keypoolsize_hd_internal'], 100)
+        assert_equal(wi['keypoolsize'], 100)
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 1)
+
+    def setup_network(self):
+        self.nodes = start_nodes(1, self.options.tmpdir, [['-usehd=1']])
+
+if __name__ == '__main__':
+    KeyPoolTest().main()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -488,9 +488,9 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-txconfirmtarget=<n>", strprintf(_("If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)"), DEFAULT_TX_CONFIRM_TARGET));
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees (in %s) to use in a single wallet transaction; setting this too low may abort large transactions (default: %s)"),
         CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)));
-    strUsage += HelpMessageOpt("-usehd", _("Use hierarchical deterministic key generation (HD) after bip32. Only has effect during wallet creation/first start") + " " + strprintf(_("(default: %u)"), DEFAULT_USE_HD_WALLET));
+    strUsage += HelpMessageOpt("-usehd", _("Use hierarchical deterministic key generation (HD) after bip39/bip44. Only has effect during wallet creation/first start") + " " + strprintf(_("(default: %u)"), DEFAULT_USE_HD_WALLET));
     strUsage += HelpMessageOpt("-mnemonic", _("User defined mnemonic for HD wallet (bip39). Only has effect during wallet creation/first start (default: randomly generated)"));
-    strUsage += HelpMessageOpt("-mnemonicpassphrase", _("User defined memonic passphrase for HD wallet (bip39). Only has effect during wallet creation/first start (default: randomly generated)"));
+    strUsage += HelpMessageOpt("-mnemonicpassphrase", _("User defined memonic passphrase for HD wallet (bip39). Only has effect during wallet creation/first start (default: empty string)"));
     strUsage += HelpMessageOpt("-hdseed", _("User defined seed for HD wallet (should be in hex). Only has effect during wallet creation/first start (default: randomly generated)"));
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format on startup"));
     strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), "wallet.dat"));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -71,8 +71,8 @@ static const CAmount nHighTransactionMaxFeeWarning = 100 * nHighTransactionFeeWa
 static const unsigned int MAX_FREE_TRANSACTION_CREATE_SIZE = 1000;
 static const bool DEFAULT_WALLETBROADCAST = true;
 
-//! if set, all keys will be derived by using BIP32
-static const bool DEFAULT_USE_HD_WALLET = true;
+//! if set, all keys will be derived by using BIP39/BIP44
+static const bool DEFAULT_USE_HD_WALLET = false;
 
 class CBlockIndex;
 class CCoinControl;


### PR DESCRIPTION
The feature is still going to be available, just not by default in 12.2

- also fix related comments/help strings
- split tests for HD and non-HD cases (current `fundrawtransaction.py` and `keypool.py` are moved to `fundrawtransaction-hd.py` and `keypool-hd.py` respectively)