### PR TITLE
Speedup MakeCollateralAmounts by skiping denominated inputs early

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1177,6 +1177,10 @@ bool CPrivateSendClient::MakeCollateralAmounts(const CompactTallyItem& tallyItem
 {
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
+    // denominated input is always a single one, so we can check its amount directly and return early
+    if(!fTryDenominated && tallyItem.vecTxIn.size() == 1 && pwalletMain->IsDenominatedAmount(tallyItem.nAmount))
+        return false;
+
     CWalletTx wtx;
     CAmount nFeeRet = 0;
     int nChangePosRet = -1;


### PR DESCRIPTION
In wallets with huge number on inputs we can significantly increase the speed of `MakeCollateralAmounts` by skipping denominated inputs early when we ask to use non-denoms only.