### PR TITLE
bump MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 and PROTOCOL_VERSION to 70208

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -24,7 +24,7 @@ static const int MNPAYMENTS_SIGNATURES_TOTAL            = 10;
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
 static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_1 = 70206;
-static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70206;
+static const int MIN_MASTERNODE_PAYMENT_PROTO_VERSION_2 = 70208;
 
 extern CCriticalSection cs_vecPayees;
 extern CCriticalSection cs_mapMasternodeBlocks;

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70207;
+static const int PROTOCOL_VERSION = 70208;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Note: this means it's no longer going to be compatible with current mainnet while `SPORK_10_MASTERNODE_PAY_UPDATED_NODES` is still on there