### PR TITLE
Ensure Dash wallets < 0.12.2 can't open HD wallets

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1724,6 +1724,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                     return InitError(_("Mnemonic passphrase is too long, must be at most 256 characters"));
                 // generate a new master key
                 pwalletMain->GenerateNewHDChain();
+
+                // ensure this wallet.dat can only be opened by clients supporting HD
+                pwalletMain->SetMinVersion(FEATURE_HD);
             }
 
             CPubKey newDefaultKey;


### PR DESCRIPTION
This does the same as https://github.com/bitcoin/bitcoin/pull/8367

I stumbled across this one while backporting 0.13 changes to Dash. It looked like it should go into the next release independent from my work on other backports.