### PR TITLE
Wait for full sync in functional tests that use getblocktemplate

### DIFF
--- a/qa/rpc-tests/bip9-softforks.py
+++ b/qa/rpc-tests/bip9-softforks.py
@@ -84,6 +84,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
 
 
     def test_BIP(self, bipName, activated_version, invalidate, invalidatePostSignature, bitno):
+        wait_to_sync(self.nodes[0])
         # generate some coins for later
         self.coinbase_blocks = self.nodes[0].generate(2)
         self.height = 3  # height of the next block to build

--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -28,6 +28,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
 
     def run_test(self):
         print "Warning: this test will take about 70 seconds in the best case. Be patient."
+        wait_to_sync(self.nodes[0])
         self.nodes[0].generate(10)
         templat = self.nodes[0].getblocktemplate()
         longpollid = templat['longpollid']

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -72,6 +72,7 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
+        wait_to_sync(node)
         node.generate(1) # Mine a block to leave initial block download
         tmpl = node.getblocktemplate()
         if 'coinbasetxn' not in tmpl:


### PR DESCRIPTION
The `getblocktemplate` RPC call fails if used before node is fully synced.
This change fixes extended functional tests that were failing because of that.