### PR TITLE
[GUI] Change look of modaloverlay

### DIFF
--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>640</width>
-    <height>385</height>
+    <height>401</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -32,9 +32,9 @@
    <item>
     <widget class="QWidget" name="bgWidget" native="true">
      <property name="styleSheet">
-      <string notr="true">#bgWidget { background: rgba(0,0,0,220); }</string>
+      <string notr="true"/>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayoutMain" stretch="1">
+     <layout class="QVBoxLayout" name="verticalLayoutMain" stretch="0">
       <property name="leftMargin">
        <number>60</number>
       </property>
@@ -50,11 +50,9 @@
       <item>
        <widget class="QWidget" name="contentWidget" native="true">
         <property name="styleSheet">
-         <string notr="true">#contentWidget { background: rgba(255,255,255,240); border-radius: 6px; }
-
-QLabel { color: rgb(40,40,40);  }</string>
+         <string notr="true"/>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayoutSub" stretch="1,0,0,0">
+        <layout class="QVBoxLayout" name="verticalLayoutSub" stretch="1,0,0,0,0">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -352,6 +350,23 @@ QLabel { color: rgb(40,40,40);  }</string>
               <string>Hide</string>
              </property>
             </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </item>

--- a/src/qt/res/css/crownium.css
+++ b/src/qt/res/css/crownium.css
@@ -1162,11 +1162,31 @@ margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons 
 
 /* MODAL OVERLAY */
 
+QWidget#bgWidget { /* The 'frame' overlaying the overview-page */
+    background:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
+    color:#616161;
+    padding-left:10px;
+    padding-right:10px;
+}
+
 QWidget#bgWidget .QPushButton#warningIcon {
 width:64px;
 height:64px;
 padding:5px;
 background-color:transparent;
+}
+
+QWidget#contentWidget { /* The actual content with the text/buttons/etc... */
+border-image: url(':/images/crownium/drkblue_walletFrame_bg') 0 0 0 0 stretch stretch;
+border-top:0px solid #000;
+margin:0;
+padding-top:20px;
+padding-bottom: 20px;
+}
+
+QWidget#bgWidget .QPushButton#closeButton {
+
+}color:transparent;
 }
 
 /* SEND DIALOG */

--- a/src/qt/res/css/crownium.css
+++ b/src/qt/res/css/crownium.css
@@ -1186,7 +1186,6 @@ padding-bottom: 20px;
 
 QWidget#bgWidget .QPushButton#closeButton {
 
-}color:transparent;
 }
 
 /* SEND DIALOG */

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -1138,11 +1138,30 @@ margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons 
 
 /* MODAL OVERLAY */
 
+QWidget#bgWidget { /* The 'frame' overlaying the overview-page */
+    background:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
+    color:#616161;
+    padding-left:10px;
+    padding-right:10px;
+}
+
 QWidget#bgWidget .QPushButton#warningIcon {
 width:64px;
 height:64px;
 padding:5px;
 background-color:transparent;
+}
+
+QWidget#contentWidget { /* The actual content with the text/buttons/etc... */
+border-image: url(':/images/drkblue/drkblue_walletFrame_bg') 0 0 0 0 stretch stretch;
+border-top:0px solid #000;
+margin:0;
+padding-top:20px;
+padding-bottom: 20px;
+}
+
+QWidget#bgWidget .QPushButton#closeButton {
+
 }
 
 /* SEND DIALOG */

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -1144,11 +1144,30 @@ margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons 
 
 /* MODAL OVERLAY */
 
+QWidget#bgWidget { /* The 'frame' overlaying the overview-page */
+    background:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, stop: .1 rgba(250, 250, 250, 128), stop: .95 rgba(250, 250, 250, 255), stop: 1 #ebebeb);
+    color:#616161;
+    padding-left:10px;
+    padding-right:10px;
+}
+
 QWidget#bgWidget .QPushButton#warningIcon {
 width:64px;
 height:64px;
 padding:5px;
 background-color:transparent;
+}
+
+QWidget#contentWidget { /* The actual content with the text/buttons/etc... */
+border-image: url(':/images/light/drkblue_walletFrame_bg') 0 0 0 0 stretch stretch;
+border-top:0px solid #000;
+margin:0;
+padding-top:20px;
+padding-bottom: 20px;
+}
+
+QWidget#bgWidget .QPushButton#closeButton {
+
 }
 
 /* SEND DIALOG */


### PR DESCRIPTION
Makes the overlay window which shows up during synchronization more pleasant (I hope) to the human eye.
The content itself is dashyfied, and that ugly black background is gone and replaced by an almost transparent, blurring look.

The different themes now look like this:

**Dash-light**: (default theme)
![dash-light](https://user-images.githubusercontent.com/10080039/30763253-a29ee83a-9fe5-11e7-8bd0-e55b8a42ad66.png)

**Dash-blue**: (old default theme)
![dash-blue](https://user-images.githubusercontent.com/10080039/30763275-c31efcbc-9fe5-11e7-8d1f-a90be6e3a0ab.png)

**Dash-Crownium**: (the REAL theme)
![dash-crownium](https://user-images.githubusercontent.com/10080039/30763300-d5d1acc4-9fe5-11e7-9860-3273bff40085.png)
