### PR TITLE
Fix bug: nCachedBlockHeight was not updated on start

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -55,7 +55,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
         }
     }
 
-    if (fInitialDownload || !masternodeSync.IsBlockchainSynced())
+    if (fInitialDownload)
         return;
 
     mnodeman.UpdatedBlockTip(pindexNew);


### PR DESCRIPTION
`nCachedBlockHeight` was not updated on start in submodules if no new blocks were received since previous shutdown. This was breaking some sync logic e.g. for payment votes.