### PR TITLE
Fix CSS in themes to use points for font sizes, not pixels

### DIFF
--- a/src/qt/res/css/crownium.css
+++ b/src/qt/res/css/crownium.css
@@ -76,7 +76,7 @@ background-color:#F8F6F6;
 /*******************************************************/
 
 QLabel { /* Base Text Size & Color */
-font-size:12px;
+font-size:9pt;
 color:#000000;
 }
 
@@ -91,7 +91,7 @@ background-color:transparent;
 
 .QValidatedLineEdit, .QLineEdit { /* Text Entry Fields */
 border: 1px solid #000000;
-font-size:11px;
+font-size:8pt;
 min-height:25px;
 outline:0;
 padding:3px;
@@ -99,7 +99,7 @@ background-color:#fcfcfc;
 }
 
 .QLineEdit:!focus {
-font-size:12px;
+font-size:9pt;
 }
 
 .QValidatedLineEdit:disabled, .QLineEdit:disabled {
@@ -113,7 +113,7 @@ background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222,
 border:0;
 border-radius:3px;
 color:#000000;
-font-size:12px;
+font-size:9pt;
 font-weight:bold;
 padding-left:25px;
 padding-right:25px;
@@ -288,7 +288,7 @@ background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222,
 color:#000000;
 min-height:25px;
 /* font-weight:bold; */
-font-size:11px;
+font-size:8pt;
 outline:0;
 border:0px solid #fff;
 border-right:1px solid #fff;
@@ -314,7 +314,7 @@ border:0px solid #fff;
 
 QTableView::item { /* Table Item */
 background-color:#fcfcfc;
-font-size:12px;
+font-size:9pt;
 }
 
 QTableView::item:selected { /* Table Item Selected */
@@ -524,7 +524,7 @@ padding-left:15px;
 }
 
 QDialog#SignVerifyMessageDialog QLineEdit:!focus { /* Font Hack */
-font-size:10px;
+font-size:7pt;
 }
 
 QDialog#SignVerifyMessageDialog QPushButton#copySignatureButton_SM { /* Copy Button */
@@ -624,7 +624,7 @@ border:1px solid #9e9e9e;
 }
 
 QWidget#AddressBookPage QTableView { /* Address Listing */
-font-size:12px;
+font-size:9pt;
 }
 
 QWidget#AddressBookPage QHeaderView::section { /* Min width for Windows fix */
@@ -815,13 +815,13 @@ margin-left:3px;
 
 QWidget .QFrame#frame .QLabel#labelSpendable { /* Spendable Header */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:18px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchonly { /* Watch-only Header */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
@@ -833,13 +833,13 @@ color:#ffffff;
 margin-right:5px;
 padding-right:5px;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 min-height:35px;
 }
 
 QWidget .QFrame#frame .QLabel#labelBalance { /* Available Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 font-weight:bold;
 color:#000000;
 margin-left:0px;
@@ -847,14 +847,14 @@ margin-left:0px;
 
 QWidget .QFrame#frame .QLabel#labelWatchAvailable { /* Watch-only Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelPendingText { /* Pending Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F0F0F0;
 margin-right:5px;
 padding-right:5px;
@@ -862,20 +862,20 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelUnconfirmed { /* Pending Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchPending { /* Watch-only Pending Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelImmatureText { /* Immature Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F0F0F0;
 margin-right:5px;
 padding-right:5px;
@@ -883,20 +883,20 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelImmature { /* Immature Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchImmature { /* Watch-only Immature Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelTotalText { /* Total Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F0F0F0;
 margin-right:5px;
 padding-right:5px;
@@ -904,13 +904,13 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelTotal { /* Total Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchTotal { /* Watch-only Total Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
@@ -937,7 +937,7 @@ color:#ffffff;
 margin-right:5px;
 padding-right:5px;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 min-height:35px;
 max-height:35px;
 }
@@ -1036,7 +1036,7 @@ QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendLastMessage { /* Privat
 qproperty-alignment: 'AlignVCenter | AlignCenter';
 min-width: 288px;
 min-height: 43px;
-font-size:11px;
+font-size:8pt;
 color:#222222;
 }
 
@@ -1052,7 +1052,7 @@ outline:none;
 }
 
 QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend { /* Start PrivateSend Mixing */
-font-size:15px;
+font-size:10pt;
 font-weight:bold;
 color:#000000;
 padding-left:10px;
@@ -1070,7 +1070,7 @@ background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222,
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1088,7 +1088,7 @@ background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222,
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1106,7 +1106,7 @@ background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .05 #222222,
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1138,7 +1138,7 @@ margin-top:83px;
 margin-right:5px;
 padding-right:5px;
 font-weight:bold;
-font-size:15px;
+font-size:10pt;
 min-height:24px;
 }
 
@@ -1153,8 +1153,7 @@ min-height:16px;
 
 QWidget .QFrame#frame_2 QListView { /* Transaction List */
 font-weight:normal;
-font-size:12px;
-max-width:369px;
+font-size:9pt;
 color:#333333;
 margin-top:12px;
 margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons */
@@ -1207,7 +1206,7 @@ min-height:25px;
 QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlFeatures { /* Coin Control Header */
 color:#333333;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 }
 
 QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl { /* Coin Control Inputs */
@@ -1292,7 +1291,7 @@ QDialog#SendCoinsDialog QLabel#label {
 margin-right:-2px;
 padding-right:-2px;
 color:#616161;
-font-size:14px;
+font-size:10pt;
 font-weight:bold;
 border-radius:5px;
 padding-top:20px;
@@ -1321,7 +1320,7 @@ QStackedWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry L
 background-color:#F0F0F0;
 min-width:102px;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 color:#000000;
 min-height:25px;
 margin-right:5px;
@@ -1510,7 +1509,7 @@ background-color:#F0F0F0;
 min-width:102px;
 color:#000000;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 padding-right:5px;
 }
 
@@ -1519,7 +1518,7 @@ background-color:#6a6a6a;
 min-width:102px;
 color:#ffffff;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 padding-right:5px;
 }
 
@@ -1528,7 +1527,7 @@ background-color:#6a6a6a;
 min-width:102px;
 color:#000000;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 padding-right:5px;
 }
 
@@ -1586,7 +1585,7 @@ border:1px solid #9e9e9e;
 QWidget#ReceiveCoinsDialog .QFrame#frame .QLabel#label_6 { /* Requested Payments History Label */
 color:#333333;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 }
 
 /* RECEIVE COINS DIALOG */

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -68,7 +68,7 @@ background-color:#F8F6F6;
 /*******************************************************/
 
 QLabel { /* Base Text Size & Color */
-font-size:12px;
+font-size:9pt;
 color:#333333;
 }
 
@@ -83,7 +83,7 @@ background-color:transparent;
 
 .QValidatedLineEdit, .QLineEdit { /* Text Entry Fields */
 border: 1px solid #82C3E6;
-font-size:11px;
+font-size:8pt;
 min-height:25px;
 outline:0;
 padding:3px;
@@ -91,7 +91,7 @@ background-color:#fcfcfc;
 }
 
 .QLineEdit:!focus {
-font-size:12px;
+font-size:9pt;
 }
 
 .QValidatedLineEdit:disabled, .QLineEdit:disabled {
@@ -105,7 +105,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #64ACD2, 
 border:0;
 border-radius:3px;
 color:#ffffff;
-font-size:12px;
+font-size:9pt;
 font-weight:bold;
 padding-left:25px;
 padding-right:25px;
@@ -279,7 +279,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0.25, stop: 0 #4c97bf,
 color:#fff;
 min-height:25px;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 outline:0;
 border:0px solid #fff;
 border-right:1px solid #fff;
@@ -305,7 +305,7 @@ border:0px solid #fff;
 
 QTableView::item { /* Table Item */
 background-color:#fcfcfc;
-font-size:12px;
+font-size:9pt;
 }
 
 QTableView::item:selected { /* Table Item Selected */
@@ -511,7 +511,7 @@ padding-left:15px;
 }
 
 QDialog#SignVerifyMessageDialog QLineEdit:!focus { /* Font Hack */
-font-size:10px;
+font-size:7pt;
 }
 
 QDialog#SignVerifyMessageDialog QPushButton#copySignatureButton_SM { /* Copy Button */
@@ -619,7 +619,7 @@ border:1px solid #9e9e9e;
 }
 
 QWidget#AddressBookPage QTableView { /* Address Listing */
-font-size:12px;
+font-size:9pt;
 }
 
 QWidget#AddressBookPage QHeaderView::section { /* Min width for Windows fix */
@@ -793,13 +793,13 @@ margin-left:3px;
 
 QWidget .QFrame#frame .QLabel#labelSpendable { /* Spendable Header */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:18px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchonly { /* Watch-only Header */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
@@ -811,13 +811,13 @@ color:#ffffff;
 margin-right:5px;
 padding-right:5px;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 min-height:35px;
 }
 
 QWidget .QFrame#frame .QLabel#labelBalance { /* Available Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 font-weight:bold;
 color:#56ABD8;
 margin-left:0px;
@@ -825,14 +825,14 @@ margin-left:0px;
 
 QWidget .QFrame#frame .QLabel#labelWatchAvailable { /* Watch-only Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelPendingText { /* Pending Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F8F6F6;
 margin-right:5px;
 padding-right:5px;
@@ -840,20 +840,20 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelUnconfirmed { /* Pending Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchPending { /* Watch-only Pending Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelImmatureText { /* Immature Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F8F6F6;
 margin-right:5px;
 padding-right:5px;
@@ -861,20 +861,20 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelImmature { /* Immature Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchImmature { /* Watch-only Immature Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelTotalText { /* Total Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F8F6F6;
 margin-right:5px;
 padding-right:5px;
@@ -882,13 +882,13 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelTotal { /* Total Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchTotal { /* Watch-only Total Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
@@ -914,7 +914,7 @@ color:#fff;
 margin-right:5px;
 padding-right:5px;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 min-height:35px;
 max-height:35px;
 }
@@ -1013,7 +1013,7 @@ QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendLastMessage { /* Privat
 qproperty-alignment: 'AlignVCenter | AlignCenter';
 min-width: 288px;
 min-height: 43px;
-font-size:11px;
+font-size:8pt;
 color:#818181;
 }
 
@@ -1029,7 +1029,7 @@ outline:none;
 }
 
 QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend { /* Start PrivateSend Mixing */
-font-size:15px;
+font-size:10pt;
 font-weight:bold;
 color:#ffffff;
 padding-left:10px;
@@ -1047,7 +1047,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, 
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1065,7 +1065,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, 
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1083,7 +1083,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, 
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1115,7 +1115,7 @@ margin-top:83px;
 margin-right:5px;
 padding-right:5px;
 font-weight:bold;
-font-size:15px;
+font-size:10pt;
 min-height:24px;
 }
 
@@ -1130,8 +1130,7 @@ min-height:16px;
 
 QWidget .QFrame#frame_2 QListView { /* Transaction List */
 font-weight:normal;
-font-size:12px;
-max-width:369px;
+font-size:9pt;
 margin-top:12px;
 margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons */
 }
@@ -1183,7 +1182,7 @@ min-height:25px;
 QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlFeatures { /* Coin Control Header */
 color:#3398CC;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 }
 
 QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl { /* Coin Control Inputs */
@@ -1276,7 +1275,7 @@ QDialog#SendCoinsDialog QLabel#label {
 margin-right:-2px;
 padding-right:-2px;
 color:#616161;
-font-size:14px;
+font-size:10pt;
 font-weight:bold;
 border-radius:5px;
 padding-top:20px;
@@ -1305,7 +1304,7 @@ QStackedWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry L
 background-color:#56ABD8;
 min-width:102px;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 color:#ffffff;
 min-height:25px;
 margin-right:5px;
@@ -1493,7 +1492,7 @@ background-color:#56ABD8;
 min-width:102px;
 color:#ffffff;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 padding-right:5px;
 }
 
@@ -1502,7 +1501,7 @@ background-color:#6a6a6a;
 min-width:102px;
 color:#ffffff;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 padding-right:5px;
 }
 
@@ -1511,7 +1510,7 @@ background-color:#56ABD8;
 min-width:102px;
 color:#ffffff;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 padding-right:5px;
 }
 
@@ -1569,7 +1568,7 @@ border:1px solid #9e9e9e;
 QWidget#ReceiveCoinsDialog .QFrame#frame .QLabel#label_6 { /* Requested Payments History Label */
 color:#3398CC;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 }
 
 /* RECEIVE COINS DIALOG */

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -70,7 +70,7 @@ background-color:#F8F6F6;
 /*******************************************************/
 
 QLabel { /* Base Text Size & Color */
-font-size:12px;
+font-size:9pt;
 color:#333333;
 }
 
@@ -85,7 +85,7 @@ background-color:transparent;
 
 .QValidatedLineEdit, .QLineEdit { /* Text Entry Fields */
 border: 1px solid #82C3E6;
-font-size:11px;
+font-size:8pt;
 min-height:25px;
 outline:0;
 padding:3px;
@@ -93,7 +93,7 @@ background-color:#fcfcfc;
 }
 
 .QLineEdit:!focus {
-font-size:12px;
+font-size:9pt;
 }
 
 .QValidatedLineEdit:disabled, .QLineEdit:disabled {
@@ -107,7 +107,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #4ca5dc, 
 border:0;
 border-radius:3px;
 color:#ffffff;
-font-size:12px;
+font-size:9pt;
 font-weight:normal;
 height: 26px;
 padding-left:25px;
@@ -282,7 +282,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0.25, stop: 0 #1070B0,
 color:#fff;
 min-height:25px;
 font-weight:bold;
-font-size:11px;
+font-size:8pt;
 outline:0;
 border:0px solid #fff;
 border-right:1px solid #fff;
@@ -308,7 +308,7 @@ border:0px solid #fff;
 
 QTableView::item { /* Table Item */
 background-color:#fcfcfc;
-font-size:12px;
+font-size:9pt;
 }
 
 QTableView::item:selected { /* Table Item Selected */
@@ -514,7 +514,7 @@ padding-left:15px;
 }
 
 QDialog#SignVerifyMessageDialog QLineEdit:!focus { /* Font Hack */
-font-size:10px;
+font-size:8pt;
 }
 
 QDialog#SignVerifyMessageDialog QPushButton#copySignatureButton_SM { /* Copy Button */
@@ -622,7 +622,7 @@ border:1px solid #9e9e9e;
 }
 
 QWidget#AddressBookPage QTableView { /* Address Listing */
-font-size:12px;
+font-size:9pt;
 }
 
 QWidget#AddressBookPage QHeaderView::section { /* Min width for Windows fix */
@@ -796,13 +796,13 @@ margin-left:3px;
 
 QWidget .QFrame#frame .QLabel#labelSpendable { /* Spendable Header */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:18px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchonly { /* Watch-only Header */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
@@ -813,14 +813,14 @@ background-color:#1c75bc;
 color:#ffffff;
 margin-right:5px;
 padding-right:5px;
-font-size:14px;
+font-size:10pt;
 font-weight: bold;
 min-height:35px;
 }
 
 QWidget .QFrame#frame .QLabel#labelBalance { /* Available Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:16px;
+font-size:12pt;
 color:#1c75bc;
 margin-left:0px;
     font-weight: bold;
@@ -828,14 +828,14 @@ margin-left:0px;
 
 QWidget .QFrame#frame .QLabel#labelWatchAvailable { /* Watch-only Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelPendingText { /* Pending Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F8F6F6;
 margin-right:5px;
 padding-right:5px;
@@ -843,20 +843,20 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelUnconfirmed { /* Pending Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchPending { /* Watch-only Pending Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelImmatureText { /* Immature Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F8F6F6;
 margin-right:5px;
 padding-right:5px;
@@ -864,20 +864,20 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelImmature { /* Immature Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchImmature { /* Watch-only Immature Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
 QWidget .QFrame#frame .QLabel#labelTotalText { /* Total Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignRight';
 min-width:160px;
-font-size:12px;
+font-size:9pt;
 background-color:#F8F6F6;
 margin-right:5px;
 padding-right:5px;
@@ -885,13 +885,13 @@ padding-right:5px;
 
 QWidget .QFrame#frame .QLabel#labelTotal { /* Total Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:0px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWatchTotal { /* Watch-only Total Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
-font-size:12px;
+font-size:9pt;
 margin-left:16px;
 }
 
@@ -918,7 +918,7 @@ color:#fff;
 margin-right: 5px;
 padding-right: 5px;
 font-weight:bold;
-font-size:14px;
+font-size:10pt;
 min-height:35px;
 max-height:35px;
 }
@@ -1018,7 +1018,7 @@ QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendLastMessage { /* Privat
 qproperty-alignment: 'AlignVCenter | AlignCenter';
 min-width: 288px;
 min-height: 43px;
-font-size:11px;
+font-size:8pt;
 color:#818181;
 }
 
@@ -1035,7 +1035,7 @@ outline:none;
 
 QWidget .QFrame#framePrivateSend .QPushButton#togglePrivateSend { /* Start PrivateSend Mixing */
 min-height: 40px;
-font-size:15px;
+font-size:10pt;
 font-weight:normal;
 color:#ffffff;
 padding-left:10px;
@@ -1053,7 +1053,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, 
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1071,7 +1071,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, 
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1089,7 +1089,7 @@ background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: .01 #f6f6f6, 
 border:1px solid #d2d2d2;
 color:#616161;
 min-height:25px;
-font-size:9px;
+font-size:6pt;
 padding:0px;
 }
 
@@ -1121,7 +1121,7 @@ margin-top:83px;
 margin-right:5px;
 padding-right:5px;
 font-weight:normal;
-font-size:15px;
+font-size:10pt;
 min-height:24px;
 }
 
@@ -1136,8 +1136,7 @@ min-height:16px;
 
 QWidget .QFrame#frame_2 QListView { /* Transaction List */
 font-weight:normal;
-font-size:12px;
-max-width:369px;
+font-size:9pt;
 margin-top:12px;
 margin-left:0px; /* CSS Voodoo - set to -66px to hide default transaction icons */
 }
@@ -1190,7 +1189,7 @@ min-height:25px;
 QDialog#SendCoinsDialog .QFrame#frameCoinControl .QLabel#labelCoinControlFeatures { /* Coin Control Header */
 color:#999;
 font-weight:normal;
-font-size:14px;
+font-size:10pt;
 }
 
 QDialog#SendCoinsDialog .QFrame#frameCoinControl .QWidget#widgetCoinControl { /* Coin Control Inputs */
@@ -1283,7 +1282,7 @@ QDialog#SendCoinsDialog QLabel#label {
 margin-right:-2px;
 padding-right:-2px;
 color:#616161;
-font-size:14px;
+font-size:10pt;
 font-weight:bold;
 border-radius:5px;
 padding-top:20px;
@@ -1313,7 +1312,7 @@ QStackedWidget#SendCoinsEntry .QFrame#SendCoins > .QLabel { /* Send Coin Entry L
 background-color:#F8F6F6;
 min-width:102px;
 font-weight:normal;
-/*font-size:11px;*/
+/*font-size:8pt;*/
 color:#333;
 min-height:25px;
 margin-right:5px;
@@ -1503,7 +1502,7 @@ border: 1px solid #fff;
 min-width:102px;
 color:#333;
 /*font-weight:bold;
-font-size:11px;*/
+font-size:8pt;*/
 padding-right:5px;
 }
 
@@ -1513,7 +1512,7 @@ border: 1px solid #fff;
 min-width:102px;
 color:#ffffff;
 /*font-weight:bold;
-font-size:11px;*/
+font-size:8pt;*/
 padding-right:5px;
 }
 
@@ -1523,7 +1522,7 @@ border: 1px solid #fff;
 min-width:102px;
 color:#333;
 /*font-weight:bold;
-font-size:11px;*/
+font-size:8pt;*/
 padding-right:5px;
 }
 
@@ -1581,7 +1580,7 @@ border:1px solid #9e9e9e;
 QWidget#ReceiveCoinsDialog .QFrame#frame .QLabel#label_6 { /* Requested Payments History Label */
 color:#999;
 font-weight:normal;
-font-size:14px;
+font-size:10pt;
 }
 
 /* RECEIVE COINS DIALOG */


### PR DESCRIPTION
Using physical pixels for font sizes is harmful because it leads to unreadable interface on high DPI displays.

This change fixes this problem for all 3 themes that use CSS.

Also, maximum size of recent transactions list view in overview tab has been removed because it was causing this list view to be so narrow on high DPI displays that transaction amount was clashing
with transaction time if fonts are readable.

Interface of `dash-qt` looks good on regular and high DPI display after this change.