### PR TITLE
Update nMinimumChainWork and defaultAssumeValid to more recent values

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -115,10 +115,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DIP0001].nThreshold = 3226; // 80% of 4032
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000006acd76c0e55d52910"); // 721000
+        consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000172210fe351643b3f1"); // 750000
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x0000000000000e869031f3639be333de35d82a16d96c1b8173ad5c4b62554157"); //721000
+        consensus.defaultAssumeValid = uint256S("0x00000000000000b4181bbbdddbae464ce11fede5d0292fb63fdede1e7c8ab21c"); //750000
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -193,11 +193,12 @@ public:
             ( 312645, uint256S("0x0000000000059dcb71ad35a9e40526c44e7aae6c99169a9e7017b7d84b1c2daf"))
             ( 407452, uint256S("0x000000000003c6a87e73623b9d70af7cd908ae22fee466063e4ffc20be1d2dbc"))
             ( 523412, uint256S("0x000000000000e54f036576a10597e0e42cc22a5159ce572f999c33975e121d4d"))
-            ( 523930, uint256S("0x0000000000000bccdb11c2b1cfb0ecab452abf267d89b7f46eaf2d54ce6e652c")),
-            1471809614, // * UNIX timestamp of last checkpoint block
-            1998064,    // * total number of transactions between genesis and last checkpoint
+            ( 523930, uint256S("0x0000000000000bccdb11c2b1cfb0ecab452abf267d89b7f46eaf2d54ce6e652c"))
+            ( 750000, uint256S("0x00000000000000b4181bbbdddbae464ce11fede5d0292fb63fdede1e7c8ab21c")),
+            1507424630, // * UNIX timestamp of last checkpoint block
+            3701128,    // * total number of transactions between genesis and last checkpoint
                         //   (the tx=... number in the SetBestChain debug.log lines)
-            2800        // * estimated number of transactions per day after checkpoint
+            5000        // * estimated number of transactions per day after checkpoint
         };
     }
 };


### PR DESCRIPTION
This updates nMinimumChainWork and defaultAssumeValid to block height 750000 in preparation for the upcoming release. It only updates the value of mainnet, as testnet is still used for fork testing.

You can verify the values in the console with:
```
getblockhash 750000
```
This should give you the same hash found in the PR.

Then:
```
getblock <above-result-hash>
```
This returned json should contain a field "chainwork", which should have the same value as in this PR.