### PR TITLE
Fix Incorrect RPC output for mixing txes

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1444,12 +1444,17 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                 entry.push_back(Pair("involvesWatchonly", true));
             entry.push_back(Pair("account", strSentAccount));
             MaybePushAddress(entry, s.destination);
-            std::map<std::string, std::string>::const_iterator it = wtx.mapValue.find("DS");
-            entry.push_back(Pair("category", (it != wtx.mapValue.end() && it->second == "1") ? "privatesend" : "send"));
+            if (s.vout >= 0) {
+                std::map<std::string, std::string>::const_iterator it = wtx.mapValue.find("DS");
+                entry.push_back(Pair("category", (it != wtx.mapValue.end() && it->second == "1") ? "privatesend" : "send"));
+            } else {
+                entry.push_back(Pair("category", "mixedsend"));
+            }
             entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
             if (pwalletMain->mapAddressBook.count(s.destination))
                 entry.push_back(Pair("label", pwalletMain->mapAddressBook[s.destination].name));
-            entry.push_back(Pair("vout", s.vout));
+            if (s.vout >= 0)
+                entry.push_back(Pair("vout", s.vout));
             if (nFee != 0)
                 entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
             if (fLong)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -30,20 +30,20 @@ BOOST_FIXTURE_TEST_SUITE(wallet_tests, TestingSetup)
 static CWallet wallet;
 static vector<COutput> vCoins;
 
-static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
+static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsRelevantToMe = false, int nInput=0)
 {
     static int nextLockTime = 0;
     CMutableTransaction tx;
     tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
     tx.vout.resize(nInput+1);
     tx.vout[nInput].nValue = nValue;
-    if (fIsFromMe) {
-        // IsFromMe() returns (GetDebit() > 0), and GetDebit() is 0 if vin.empty(),
-        // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
+    if (fIsRelevantToMe) {
+        // IsRelevantToMe() returns (GetDebit() > 0), and GetDebit() is 0 if vin.empty(),
+        // so stop vin being empty, and cache a non-zero Debit to fake out IsRelevantToMe()
         tx.vin.resize(1);
     }
     CWalletTx* wtx = new CWalletTx(&wallet, tx);
-    if (fIsFromMe)
+    if (fIsRelevantToMe)
     {
         wtx->fDebitCached = true;
         wtx->nDebitCached = 1;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -47,6 +47,8 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
     {
         wtx->fDebitCached = true;
         wtx->nDebitCached = 1;
+        wtx->fFromMeCached = true;
+        wtx->fFromMeCachedValue = true;
     }
     COutput output(wtx, nInput, nAge, true, true);
     vCoins.push_back(output);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -30,20 +30,20 @@ BOOST_FIXTURE_TEST_SUITE(wallet_tests, TestingSetup)
 static CWallet wallet;
 static vector<COutput> vCoins;
 
-static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsRelevantToMe = false, int nInput=0)
+static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
 {
     static int nextLockTime = 0;
     CMutableTransaction tx;
     tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
     tx.vout.resize(nInput+1);
     tx.vout[nInput].nValue = nValue;
-    if (fIsRelevantToMe) {
+    if (fIsFromMe) {
         // IsRelevantToMe() returns (GetDebit() > 0), and GetDebit() is 0 if vin.empty(),
         // so stop vin being empty, and cache a non-zero Debit to fake out IsRelevantToMe()
         tx.vin.resize(1);
     }
     CWalletTx* wtx = new CWalletTx(&wallet, tx);
-    if (fIsRelevantToMe)
+    if (fIsFromMe)
     {
         wtx->fDebitCached = true;
         wtx->nDebitCached = 1;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1515,6 +1515,8 @@ bool CWallet::IsFromMe(const CTransaction& tx, const isminefilter& filter) const
             if (!(IsMine(prev.vout[txin.prevout.n]) & filter))
                 return false;
     }
+
+    return true;
 }
 
 CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1610,7 +1610,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
 
     // Compute fee:
     CAmount nDebit = GetDebit(filter);
-    CAmount nReceived = 0;
+    CAmount nCredit = 0;
     bool fFromMe = IsFromMe(filter);
     if (fFromMe) // means we signed/sent this transaction and all inputs are from us
     {
@@ -1654,14 +1654,19 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
 
         // If we are receiving the output, add it as a "received" entry
         if (fIsMine & filter) {
-            nReceived += txout.nValue;
+            nCredit += txout.nValue;
             listReceived.push_back(output);
         }
     }
 
-    if (!fFromMe && nDebit > nReceived) {
-        COutputEntry output = {CNoDestination(), nDebit - nReceived, -1};
-        listSent.push_back(output);
+    if (!fFromMe && nDebit > 0) {
+        if (nCredit == nDebit) {
+            for(const auto& output: listReceived)
+                listSent.push_back(output);
+        } else {
+            COutputEntry output = {CNoDestination(), nDebit, -1};
+            listSent.push_back(output);
+        }
     }
 
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1631,7 +1631,9 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
             // Don't report 'change' txouts
             if (pwallet->IsChange(txout))
                 continue;
-        } if (nDebit == 0 && !(fIsMine & filter))
+        }
+
+        if (nDebit == 0 && !(fIsMine & filter))
             continue;
 
         // In either case, we need to get the destination address

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -288,6 +288,7 @@ public:
     int64_t nOrderPos; //! position in ordered transaction list
 
     // memory only
+    mutable bool fFromMeCached;
     mutable bool fDebitCached;
     mutable bool fCreditCached;
     mutable bool fImmatureCreditCached;
@@ -300,6 +301,8 @@ public:
     mutable bool fImmatureWatchCreditCached;
     mutable bool fAvailableWatchCreditCached;
     mutable bool fChangeCached;
+
+    mutable bool fFromMeCachedValue;
     mutable CAmount nDebitCached;
     mutable CAmount nCreditCached;
     mutable CAmount nImmatureCreditCached;
@@ -343,6 +346,7 @@ public:
         nTimeSmart = 0;
         fFromMe = false;
         strFromAccount.clear();
+        fFromMeCached = false;
         fDebitCached = false;
         fCreditCached = false;
         fImmatureCreditCached = false;
@@ -455,10 +459,12 @@ public:
     void GetAccountAmounts(const std::string& strAccount, CAmount& nReceived,
                            CAmount& nSent, CAmount& nFee, const isminefilter& filter) const;
 
-    bool IsFromMe(const isminefilter& filter) const
+    bool IsRelevantToMe(const isminefilter& filter) const
     {
         return (GetDebit(filter) > 0);
     }
+
+    bool IsFromMe(const isminefilter& filter) const;
 
     // True if only scriptSigs are different
     bool IsEquivalentTo(const CWalletTx& tx) const;
@@ -942,8 +948,8 @@ public:
     bool IsChange(const CTxOut& txout) const;
     CAmount GetChange(const CTxOut& txout) const;
     bool IsMine(const CTransaction& tx) const;
-    /** should probably be renamed to IsRelevantToMe */
-    bool IsFromMe(const CTransaction& tx) const;
+    bool IsRelevantToMe(const CTransaction& tx) const;
+    bool IsFromMe(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;


### PR DESCRIPTION
- `IsFromMe` method has renamed to `IsRelevantToMe` (as suggested in `TODO`)
- added a new method `IsFromMe` that returns `true` only if all tx inputs are from our addresses. So now mixing txes should be outputted without `nFee` field
- added virtual out to the `listtransactions` RPC output with special category "mixedsend" which represents the sum of all our spent inputs