### PR TITLE
Remove InstantSend votes for failed lock attemts after some timeout

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -667,7 +667,7 @@ void CInstantSend::CheckAndRemove()
         }
     }
 
-    // remove expired orphan votes
+    // remove timed out orphan votes
     std::map<uint256, CTxLockVote>::iterator itOrphanVote = mapTxLockVotesOrphan.begin();
     while(itOrphanVote != mapTxLockVotesOrphan.end()) {
         if(itOrphanVote->second.IsTimedOut()) {
@@ -680,11 +680,23 @@ void CInstantSend::CheckAndRemove()
         }
     }
 
-    // remove expired masternode orphan votes (DOS protection)
+    // remove invalid votes and votes for failed lock attempts
+    itVote = mapTxLockVotes.begin();
+    while(itVote != mapTxLockVotes.end()) {
+        if(itVote->second.IsFailed()) {
+            LogPrint("instantsend", "CInstantSend::CheckAndRemove -- Removing vote for failed lock attempt: txid=%s  masternode=%s\n",
+                    itVote->second.GetTxHash().ToString(), itVote->second.GetMasternodeOutpoint().ToStringShort());
+            mapTxLockVotes.erase(itVote++);
+        } else {
+            ++itVote;
+        }
+    }
+
+    // remove timed out masternode orphan votes (DOS protection)
     std::map<COutPoint, int64_t>::iterator itMasternodeOrphan = mapMasternodeOrphanVotes.begin();
     while(itMasternodeOrphan != mapMasternodeOrphanVotes.end()) {
         if(itMasternodeOrphan->second < GetTime()) {
-            LogPrint("instantsend", "CInstantSend::CheckAndRemove -- Removing expired orphan masternode vote: masternode=%s\n",
+            LogPrint("instantsend", "CInstantSend::CheckAndRemove -- Removing timed out orphan masternode vote: masternode=%s\n",
                     itMasternodeOrphan->first.ToStringShort());
             mapMasternodeOrphanVotes.erase(itMasternodeOrphan++);
         } else {
@@ -1083,7 +1095,12 @@ bool CTxLockVote::IsExpired(int nHeight) const
 
 bool CTxLockVote::IsTimedOut() const
 {
-    return GetTime() - nTimeCreated > INSTANTSEND_TIMEOUT_SECONDS;
+    return GetTime() - nTimeCreated > INSTANTSEND_LOCK_TIMEOUT_SECONDS;
+}
+
+bool CTxLockVote::IsFailed() const
+{
+    return (GetTime() - nTimeCreated > INSTANTSEND_FAILED_TIMEOUT_SECONDS) && !instantsend.IsLockedInstantSendTransaction(GetTxHash());
 }
 
 //
@@ -1184,7 +1201,7 @@ bool CTxLockCandidate::IsExpired(int nHeight) const
 
 bool CTxLockCandidate::IsTimedOut() const
 {
-    return GetTime() - nTimeCreated > INSTANTSEND_TIMEOUT_SECONDS;
+    return GetTime() - nTimeCreated > INSTANTSEND_LOCK_TIMEOUT_SECONDS;
 }
 
 void CTxLockCandidate::Relay(CConnman& connman) const

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -28,9 +28,14 @@ extern CInstantSend instantsend;
 static const int INSTANTSEND_CONFIRMATIONS_REQUIRED = 6;
 static const int DEFAULT_INSTANTSEND_DEPTH          = 5;
 
-static const int INSTANTSEND_TIMEOUT_SECONDS        = 15;
-
 static const int MIN_INSTANTSEND_PROTO_VERSION      = 70208;
+
+// For how long we are going to accept votes/locks
+// after we saw the first one for a specific transaction
+static const int INSTANTSEND_LOCK_TIMEOUT_SECONDS   = 15;
+// For how long we are going to keep invalid votes and votes for failed lock attempts,
+// must be greater than INSTANTSEND_LOCK_TIMEOUT_SECONDS
+static const int INSTANTSEND_FAILED_TIMEOUT_SECONDS = 60;
 
 extern bool fEnableInstantSend;
 extern int nInstantSendDepth;
@@ -184,6 +189,7 @@ public:
     void SetConfirmedHeight(int nConfirmedHeightIn) { nConfirmedHeight = nConfirmedHeightIn; }
     bool IsExpired(int nHeight) const;
     bool IsTimedOut() const;
+    bool IsFailed() const;
 
     bool Sign();
     bool CheckSignature() const;


### PR DESCRIPTION
Votes that failed to lock IS or were considered to be invalid for some reason were never removed.
This is how it should work now:
- valid vote, lock failed - removal after `INSTANTSEND_FAILED_TIMEOUT_SECONDS` seconds
- invalid vote, lock succeeded (had enough valid votes) - removal after lock expiration (lock is removed which also switches `IsFailed()` to `true` for corresponding invalid votes)