### PR TITLE
Add missing pieces for PR #1692

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
     - CCACHE_COMPRESS=1
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
-    - SDK_URL=https://bitcoin.jonasschnelli.ch/sdks
+    - SDK_URL=https://bitcoincore.org/depends-sources/sdks
     - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,16 +52,16 @@ env:
 
 before_install:
     - git clone https://github.com/dashpay/dash_hash
-    - travis_retry sudo apt-get install python-dev
+    - travis_retry sudo apt-get install python3-dev python3-pip
     - travis_retry sudo add-apt-repository ppa:ubuntu-wine/ppa -y
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
 install:
-    - if [ "$PYZMQ" = "true" ]; then pip install pyzmq --user ; fi
+    - if [ "$PYZMQ" = "true" ]; then pip3 install pyzmq --user ; fi
     - if [ -n "$PPA" ]; then travis_retry sudo add-apt-repository "$PPA" -y; fi
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
-    - cd dash_hash && python setup.py install --user && cd ..
+    - cd dash_hash && python3 setup.py install --user && cd ..
 before_script:
     - unset CC; unset CXX
     - unset DISPLAY

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -1,8 +1,8 @@
 package=fontconfig
-$(package)_version=2.11.1
+$(package)_version=2.12.1
 $(package)_download_path=http://www.freedesktop.org/software/fontconfig/release/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=dc62447533bca844463a3c3fd4083b57c90f18a70506e7a9f4936b5a1e516a99
+$(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3
 $(package)_dependencies=freetype expat
 
 define $(package)_set_vars

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -1,9 +1,14 @@
 package=fontconfig
-$(package)_version=2.12.1
+$(package)_version=2.12.6
 $(package)_download_path=http://www.freedesktop.org/software/fontconfig/release/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3
+$(package)_sha256_hash=cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017
 $(package)_dependencies=freetype expat
+$(package)_patches=fix_conflicting_types.patch
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/fix_conflicting_types.patch
+endef
 
 define $(package)_set_vars
   $(package)_config_opts=--disable-docs --disable-static

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -147,7 +147,6 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  export PKG_CONFIG_SYSROOT_DIR=/ && \
   export PKG_CONFIG_LIBDIR=$(host_prefix)/lib/pkgconfig && \
   export PKG_CONFIG_PATH=$(host_prefix)/share/pkgconfig  && \
   ./configure $($(package)_config_opts) && \

--- a/depends/patches/fontconfig/fix_conflicting_types.patch
+++ b/depends/patches/fontconfig/fix_conflicting_types.patch
@@ -1,0 +1,15 @@
+--- a/src/fcobjs.c
++++ b/src/fcobjs.c
+@@ -24,12 +24,6 @@
+ 
+ #include "fcint.h"
+ 
+-static unsigned int
+-FcObjectTypeHash (register const char *str, register FC_GPERF_SIZE_T len);
+-
+-static const struct FcObjectTypeInfo *
+-FcObjectTypeLookup (register const char *str, register FC_GPERF_SIZE_T len);
+-
+ #include "fcobjshash.h"
+ 
+ #include <string.h>

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -38,7 +38,7 @@ newer. Typically, it is packaged by distributions as something like
 *libzmq3-dev*. The C++ wrapper for ZeroMQ is *not* needed.
 
 In order to run the example Python client scripts in contrib/ one must
-also install *python-zmq*, though this is not necessary for daemon
+also install *python3-zmq*, though this is not necessary for daemon
 operation.
 
 ## Enabling

--- a/qa/README.md
+++ b/qa/README.md
@@ -11,9 +11,9 @@ Before running the tests, the following must be installed.
 
 Unix
 ----
-The python-zmq library is required. On Ubuntu or Debian it can be installed via: 
+The python3-zmq library is required. On Ubuntu or Debian it can be installed via:
 ```
-sudo apt-get install python-zmq
+sudo apt-get install python3-zmq
 ```
 
 Running tests

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -70,14 +70,14 @@ if "DASHCLI" not in os.environ:
 if EXEEXT == ".exe" and "-win" not in opts:
     # https://github.com/bitcoin/bitcoin/commit/d52802551752140cf41f0d9a225a43e84404d3e9
     # https://github.com/bitcoin/bitcoin/pull/5677#issuecomment-136646964
-    print "Win tests currently disabled by default.  Use -win option to enable"
+    print("Win tests currently disabled by default.  Use -win option to enable")
     sys.exit(0)
 
 if not (ENABLE_WALLET == 1 and ENABLE_UTILS == 1 and ENABLE_BITCOIND == 1):
-    print "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"
+    print("No rpc tests to run. Wallet, utils, and bitcoind must all be enabled")
     sys.exit(0)
 
-# python-zmq may not be installed. Handle this gracefully and with some helpful info
+# python3-zmq may not be installed. Handle this gracefully and with some helpful info
 if ENABLE_ZMQ:
     try:
         import zmq

--- a/qa/pull-tester/tests_config.py.in
+++ b/qa/pull-tester/tests_config.py.in
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2013-2014 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2013-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,5 +11,3 @@ EXEEXT="@EXEEXT@"
 @BUILD_BITCOIN_UTILS_TRUE@ENABLE_UTILS=1
 @BUILD_BITCOIND_TRUE@ENABLE_BITCOIND=1
 @ENABLE_ZMQ_TRUE@ENABLE_ZMQ=1
-
-

--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -1,15 +1,12 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import urllib.parse
 
 class AbandonConflictTest(BitcoinTestFramework):
 
@@ -34,7 +31,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         assert(balance - newbalance < Decimal("0.001")) #no more than fees lost
         balance = newbalance
 
-        url = urlparse.urlparse(self.nodes[1].url)
+        url = urllib.parse.urlparse(self.nodes[1].url)
         self.nodes[0].disconnectnode(url.hostname+":"+str(p2p_port(1)))
 
         # Identify the 10btc outputs
@@ -151,9 +148,9 @@ class AbandonConflictTest(BitcoinTestFramework):
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         newbalance = self.nodes[0].getbalance()
         #assert(newbalance == balance - Decimal("10"))
-        print "If balance has not declined after invalidateblock then out of mempool wallet tx which is no longer"
-        print "conflicted has not resumed causing its inputs to be seen as spent.  See Issue #7315"
-        print balance , " -> " , newbalance , " ?"
+        print("If balance has not declined after invalidateblock then out of mempool wallet tx which is no longer")
+        print("conflicted has not resumed causing its inputs to be seen as spent.  See Issue #7315")
+        print(str(balance) + " -> " + str(newbalance) + " ?")
 
 if __name__ == '__main__':
     AbandonConflictTest().main()

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -36,7 +36,7 @@ class AddressIndexTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(105)
         self.sync_all()
 
@@ -50,7 +50,7 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(balance0["balance"], 0)
 
         # Check p2pkh and p2sh address indexes
-        print "Testing p2pkh and p2sh address index..."
+        print("Testing p2pkh and p2sh address index...")
 
         txid0 = self.nodes[0].sendtoaddress("yMNJePdcKvXtWWQnFYHNeJ5u8TF2v1dfK4", 10)
         self.nodes[0].generate(1)
@@ -85,7 +85,7 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(txidsb[2], txidb2)
 
         # Check that limiting by height works
-        print "Testing querying txids by range of block heights.."
+        print("Testing querying txids by range of block heights..")
         height_txids = self.nodes[1].getaddresstxids({
             "addresses": ["93bVhahvUKmQu8gu9g3QnPPa2cxFK98pMB"],
             "start": 105,
@@ -110,8 +110,8 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(balance0["balance"], 45 * 100000000)
 
         # Check that outputs with the same address will only return one txid
-        print "Testing for txid uniqueness..."
-        addressHash = "FE30B718DCF0BF8A2A686BF1820C073F8B2C3B37".decode("hex")
+        print("Testing for txid uniqueness...")
+        addressHash = bytes.fromhex("FE30B718DCF0BF8A2A686BF1820C073F8B2C3B37")
         scriptPubKey = CScript([OP_HASH160, addressHash, OP_EQUAL])
         unspent = self.nodes[0].listunspent()
         tx = CTransaction()
@@ -130,23 +130,23 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(txidsmany[3], sent_txid)
 
         # Check that balances are correct
-        print "Testing balances..."
+        print("Testing balances...")
         balance0 = self.nodes[1].getaddressbalance("93bVhahvUKmQu8gu9g3QnPPa2cxFK98pMB")
         assert_equal(balance0["balance"], 45 * 100000000 + 21)
 
         # Check that balances are correct after spending
-        print "Testing balances after spending..."
+        print("Testing balances after spending...")
         privkey2 = "cU4zhap7nPJAWeMFu4j6jLrfPmqakDAzy8zn8Fhb3oEevdm4e5Lc"
         address2 = "yeMpGzMj3rhtnz48XsfpB8itPHhHtgxLc3"
-        addressHash2 = "C5E4FB9171C22409809A3E8047A29C83886E325D".decode("hex")
+        addressHash2 = bytes.fromhex("C5E4FB9171C22409809A3E8047A29C83886E325D")
         scriptPubKey2 = CScript([OP_DUP, OP_HASH160, addressHash2, OP_EQUALVERIFY, OP_CHECKSIG])
         self.nodes[0].importprivkey(privkey2)
 
         unspent = self.nodes[0].listunspent()
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
-        amount = unspent[0]["amount"] * 100000000
-        tx.vout = [CTxOut(amount, scriptPubKey2)]
+        amount = unspent[0]["amount"] * COIN
+        tx.vout = [CTxOut(int(amount), scriptPubKey2)]
         tx.rehash()
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
         spending_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
@@ -157,9 +157,9 @@ class AddressIndexTest(BitcoinTestFramework):
 
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(spending_txid, 16), 0))]
-        send_amount = 1 * 100000000 + 12840
+        send_amount = 1 * COIN + 12840
         change_amount = amount - send_amount - 10000
-        tx.vout = [CTxOut(change_amount, scriptPubKey2), CTxOut(send_amount, scriptPubKey)]
+        tx.vout = [CTxOut(int(change_amount), scriptPubKey2), CTxOut(int(send_amount), scriptPubKey)]
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
@@ -188,13 +188,13 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(len(deltas), 1)
 
         # Check that unspent outputs can be queried
-        print "Testing utxos..."
+        print("Testing utxos...")
         utxos = self.nodes[1].getaddressutxos({"addresses": [address2]})
         assert_equal(len(utxos), 1)
         assert_equal(utxos[0]["satoshis"], change_amount)
 
         # Check that indexes will be updated with a reorg
-        print "Testing reorg..."
+        print("Testing reorg...")
 
         best_hash = self.nodes[0].getbestblockhash()
         self.nodes[0].invalidateblock(best_hash)
@@ -228,11 +228,11 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(utxos3[2]["height"], 265)
 
         # Check mempool indexing
-        print "Testing mempool indexing..."
+        print("Testing mempool indexing...")
 
         privKey3 = "cRyrMvvqi1dmpiCmjmmATqjAwo6Wu7QTjKu1ABMYW5aFG4VXW99K"
         address3 = "yWB15aAdpeKuSaQHFVJpBDPbNSLZJSnDLA"
-        addressHash3 = "6C186B3A308A77C779A9BB71C3B5A7EC28232A13".decode("hex")
+        addressHash3 = bytes.fromhex("6C186B3A308A77C779A9BB71C3B5A7EC28232A13")
         scriptPubKey3 = CScript([OP_DUP, OP_HASH160, addressHash3, OP_EQUALVERIFY, OP_CHECKSIG])
         # address4 = "2N8oFVB2vThAKury4vnLquW2zVjsYjjAkYQ"
         scriptPubKey4 = CScript([OP_HASH160, addressHash3, OP_EQUAL])
@@ -240,8 +240,8 @@ class AddressIndexTest(BitcoinTestFramework):
 
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
-        amount = unspent[0]["amount"] * 100000000
-        tx.vout = [CTxOut(amount, scriptPubKey3)]
+        amount = unspent[0]["amount"] * COIN
+        tx.vout = [CTxOut(int(amount), scriptPubKey3)]
         tx.rehash()
         signed_tx = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
         memtxid1 = self.nodes[2].sendrawtransaction(signed_tx["hex"], True)
@@ -249,12 +249,12 @@ class AddressIndexTest(BitcoinTestFramework):
 
         tx2 = CTransaction()
         tx2.vin = [CTxIn(COutPoint(int(unspent[1]["txid"], 16), unspent[1]["vout"]))]
-        amount = unspent[1]["amount"] * 100000000
+        amount = unspent[1]["amount"] * COIN
         tx2.vout = [
-            CTxOut(amount / 4, scriptPubKey3),
-            CTxOut(amount / 4, scriptPubKey3),
-            CTxOut(amount / 4, scriptPubKey4),
-            CTxOut(amount / 4, scriptPubKey4)
+            CTxOut(int(amount / 4), scriptPubKey3),
+            CTxOut(int(amount / 4), scriptPubKey3),
+            CTxOut(int(amount / 4), scriptPubKey4),
+            CTxOut(int(amount / 4), scriptPubKey4)
         ]
         tx2.rehash()
         signed_tx2 = self.nodes[2].signrawtransaction(binascii.hexlify(tx2.serialize()).decode("utf-8"))
@@ -281,7 +281,7 @@ class AddressIndexTest(BitcoinTestFramework):
             CTxIn(COutPoint(int(memtxid2, 16), 0)),
             CTxIn(COutPoint(int(memtxid2, 16), 1))
         ]
-        tx.vout = [CTxOut(amount / 2 - 10000, scriptPubKey2)]
+        tx.vout = [CTxOut(int(amount / 2 - 10000), scriptPubKey2)]
         tx.rehash()
         self.nodes[2].importprivkey(privKey3)
         signed_tx3 = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
@@ -298,7 +298,7 @@ class AddressIndexTest(BitcoinTestFramework):
         # sending and receiving to the same address
         privkey1 = "cMvZn1pVWntTEcsK36ZteGQXRAcZ8CoTbMXF1QasxBLdnTwyVQCc"
         address1 = "yM9Eed1bxjy7tYxD3yZDHxjcVT48WdRoB1"
-        address1hash = "0909C84A817651502E020AAD0FBCAE5F656E7D8A".decode("hex")
+        address1hash = bytes.fromhex("0909C84A817651502E020AAD0FBCAE5F656E7D8A")
         address1script = CScript([OP_DUP, OP_HASH160, address1hash, OP_EQUALVERIFY, OP_CHECKSIG])
 
         self.nodes[0].sendtoaddress(address1, 10)
@@ -313,7 +313,7 @@ class AddressIndexTest(BitcoinTestFramework):
             CTxIn(COutPoint(int(utxos[0]["txid"], 16), utxos[0]["outputIndex"]))
         ]
         amount = utxos[0]["satoshis"] - 10000
-        tx.vout = [CTxOut(amount, address1script)]
+        tx.vout = [CTxOut(int(amount), address1script)]
         tx.rehash()
         self.nodes[0].importprivkey(privkey1)
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
@@ -323,7 +323,7 @@ class AddressIndexTest(BitcoinTestFramework):
         mempool_deltas = self.nodes[2].getaddressmempool({"addresses": [address1]})
         assert_equal(len(mempool_deltas), 2)
 
-        print "Passed\n"
+        print("Passed\n")
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/bip65-cltv-p2p.py
+++ b/qa/rpc-tests/bip65-cltv-p2p.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
@@ -67,13 +66,13 @@ class BIP65Test(ComparisonTestFramework):
 
         self.coinbase_blocks = self.nodes[0].generate(2)
         height = 3  # height of the next block to build
-        self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
         self.nodeaddress = self.nodes[0].getnewaddress()
         self.last_block_time = int(time.time())
 
         ''' 98 more version 3 blocks '''
         test_blocks = []
-        for i in xrange(98):
+        for i in range(98):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 3
             block.rehash()
@@ -86,7 +85,7 @@ class BIP65Test(ComparisonTestFramework):
 
         ''' Mine 749 version 4 blocks '''
         test_blocks = []
-        for i in xrange(749):
+        for i in range(749):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 4
             block.rehash()
@@ -138,7 +137,7 @@ class BIP65Test(ComparisonTestFramework):
 
         ''' Mine 199 new version blocks on last valid tip '''
         test_blocks = []
-        for i in xrange(199):
+        for i in range(199):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 4
             block.rehash()

--- a/qa/rpc-tests/bip65-cltv.py
+++ b/qa/rpc-tests/bip65-cltv.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -32,7 +32,7 @@ class BIP65Test(BitcoinTestFramework):
             raise AssertionError("Failed to mine 100 version=3 blocks")
 
         # Mine 750 new-version blocks
-        for i in xrange(15):
+        for i in range(15):
             self.nodes[2].generate(50)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 850):
@@ -49,7 +49,7 @@ class BIP65Test(BitcoinTestFramework):
         # TODO: check that new CHECKLOCKTIMEVERIFY rules are enforced
 
         # Mine 198 new-version blocks
-        for i in xrange(2):
+        for i in range(2):
             self.nodes[2].generate(99)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 1049):

--- a/qa/rpc-tests/bip68-112-113-p2p.py
+++ b/qa/rpc-tests/bip68-112-113-p2p.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
@@ -63,13 +62,13 @@ seq_random_low_bit = 1<<18
 # b31,b25,b22,b18 represent the 31st, 25th, 22nd and 18th bits respectively in the nSequence field
 # relative_locktimes[b31][b25][b22][b18] is a base_relative_locktime with the indicated bits set if their indices are 1
 relative_locktimes = []
-for b31 in xrange(2):
+for b31 in range(2):
     b25times = []
-    for b25 in xrange(2):
+    for b25 in range(2):
         b22times = []
-        for b22 in xrange(2):
+        for b22 in range(2):
             b18times = []
-            for b18 in xrange(2):
+            for b18 in range(2):
                 rlt = base_relative_locktime
                 if (b31):
                     rlt = rlt | seq_disable_flag
@@ -86,10 +85,10 @@ for b31 in xrange(2):
 
 def all_rlt_txs(txarray):
     txs = []
-    for b31 in xrange(2):
-        for b25 in xrange(2):
-            for b22 in xrange(2):
-                for b18 in xrange(2):
+    for b31 in range(2):
+        for b25 in range(2):
+            for b22 in range(2):
+                for b18 in range(2):
                     txs.append(txarray[b31][b25][b22][b18])
     return txs
 
@@ -131,7 +130,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
         return tx
 
     def generate_blocks(self, number, version, test_blocks = []):
-        for i in xrange(number):
+        for i in range(number):
             block = self.create_test_block([], version)
             test_blocks.append([block, True])
             self.last_block_time += 600
@@ -152,13 +151,13 @@ class BIP68_112_113Test(ComparisonTestFramework):
         txs = []
         assert(len(bip68inputs) >= 16)
         i = 0
-        for b31 in xrange(2):
+        for b31 in range(2):
             b25txs = []
-            for b25 in xrange(2):
+            for b25 in range(2):
                 b22txs = []
-                for b22 in xrange(2):
+                for b22 in range(2):
                     b18txs = []
-                    for b18 in xrange(2):
+                    for b18 in range(2):
                         tx =  self.create_transaction(self.nodes[0], bip68inputs[i], self.nodeaddress, Decimal("499.98"))
                         i += 1
                         tx.nVersion = txversion
@@ -180,13 +179,13 @@ class BIP68_112_113Test(ComparisonTestFramework):
         txs = []
         assert(len(bip112inputs) >= 16)
         i = 0
-        for b31 in xrange(2):
+        for b31 in range(2):
             b25txs = []
-            for b25 in xrange(2):
+            for b25 in range(2):
                 b22txs = []
-                for b22 in xrange(2):
+                for b22 in range(2):
                     b18txs = []
-                    for b18 in xrange(2):
+                    for b18 in range(2):
                         tx =  self.create_transaction(self.nodes[0], bip112inputs[i], self.nodeaddress, Decimal("499.98"))
                         i += 1
                         if (varyOP_CSV): # if varying OP_CSV, nSequence is fixed
@@ -212,7 +211,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
         self.nodes[0].setmocktime(0) # set time back to present so yielded blocks aren't in the future as we advance last_block_time
         self.tipheight = 82 # height of the next block to build
         self.last_block_time = long_past_time
-        self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
         self.nodeaddress = self.nodes[0].getnewaddress()
 
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'defined')
@@ -250,20 +249,20 @@ class BIP68_112_113Test(ComparisonTestFramework):
         # Note we reuse inputs for v1 and v2 txs so must test these separately
         # 16 normal inputs
         bip68inputs = []
-        for i in xrange(16):
+        for i in range(16):
             bip68inputs.append(self.send_generic_input_tx(self.nodes[0], self.coinbase_blocks))
         # 2 sets of 16 inputs with 10 OP_CSV OP_DROP (actually will be prepended to spending scriptSig)
         bip112basicinputs = []
-        for j in xrange(2):
+        for j in range(2):
             inputs = []
-            for i in xrange(16):
+            for i in range(16):
                 inputs.append(self.send_generic_input_tx(self.nodes[0], self.coinbase_blocks))
             bip112basicinputs.append(inputs)
         # 2 sets of 16 varied inputs with (relative_lock_time) OP_CSV OP_DROP (actually will be prepended to spending scriptSig)
         bip112diverseinputs = []
-        for j in xrange(2):
+        for j in range(2):
             inputs = []
-            for i in xrange(16):
+            for i in range(16):
                 inputs.append(self.send_generic_input_tx(self.nodes[0], self.coinbase_blocks))
             bip112diverseinputs.append(inputs)
         # 1 special input with -1 OP_CSV OP_DROP (actually will be prepended to spending scriptSig)
@@ -274,7 +273,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
         self.nodes[0].setmocktime(self.last_block_time + 600)
         inputblockhash = self.nodes[0].generate(1)[0] # 1 block generated for inputs to be in chain at height 572
         self.nodes[0].setmocktime(0)
-        self.tip = int("0x" + inputblockhash + "L", 0)
+        self.tip = int("0x" + inputblockhash, 0)
         self.tipheight += 1
         self.last_block_time += 600
         assert_equal(len(self.nodes[0].getblock(inputblockhash,True)["tx"]), 82+1)
@@ -398,22 +397,22 @@ class BIP68_112_113Test(ComparisonTestFramework):
         ### Version 2 txs ###
         bip68success_txs = []
         # All txs with SEQUENCE_LOCKTIME_DISABLE_FLAG set pass
-        for b25 in xrange(2):
-            for b22 in xrange(2):
-                for b18 in xrange(2):
+        for b25 in range(2):
+            for b22 in range(2):
+                for b18 in range(2):
                     bip68success_txs.append(bip68txs_v2[1][b25][b22][b18])
         yield TestInstance([[self.create_test_block(bip68success_txs), True]]) # 15
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         # All txs without flag fail as we are at delta height = 8 < 10 and delta time = 8 * 600 < 10 * 512
         bip68timetxs = []
-        for b25 in xrange(2):
-            for b18 in xrange(2):
+        for b25 in range(2):
+            for b18 in range(2):
                 bip68timetxs.append(bip68txs_v2[0][b25][1][b18])
         for tx in bip68timetxs:
             yield TestInstance([[self.create_test_block([tx]), False]]) # 16 - 19
         bip68heighttxs = []
-        for b25 in xrange(2):
-            for b18 in xrange(2):
+        for b25 in range(2):
+            for b18 in range(2):
                 bip68heighttxs.append(bip68txs_v2[0][b25][0][b18])
         for tx in bip68heighttxs:
             yield TestInstance([[self.create_test_block([tx]), False]]) # 20 - 23
@@ -445,9 +444,9 @@ class BIP68_112_113Test(ComparisonTestFramework):
         yield TestInstance([[self.create_test_block([bip112tx_special_v1]), False]]) #32
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 1 txs should still pass
         success_txs = []
-        for b25 in xrange(2):
-            for b22 in xrange(2):
-                for b18 in xrange(2):
+        for b25 in range(2):
+            for b22 in range(2):
+                for b18 in range(2):
                     success_txs.append(bip112txs_vary_OP_CSV_v1[1][b25][b22][b18])
                     success_txs.append(bip112txs_vary_OP_CSV_9_v1[1][b25][b22][b18])
         yield TestInstance([[self.create_test_block(success_txs), True]]) # 33
@@ -457,9 +456,9 @@ class BIP68_112_113Test(ComparisonTestFramework):
         fail_txs = []
         fail_txs.extend(all_rlt_txs(bip112txs_vary_nSequence_v1))
         fail_txs.extend(all_rlt_txs(bip112txs_vary_nSequence_9_v1))
-        for b25 in xrange(2):
-            for b22 in xrange(2):
-                for b18 in xrange(2):
+        for b25 in range(2):
+            for b22 in range(2):
+                for b18 in range(2):
                     fail_txs.append(bip112txs_vary_OP_CSV_v1[0][b25][b22][b18])
                     fail_txs.append(bip112txs_vary_OP_CSV_9_v1[0][b25][b22][b18])
 
@@ -472,9 +471,9 @@ class BIP68_112_113Test(ComparisonTestFramework):
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 2 txs should pass (all sequence locks are met)
         success_txs = []
-        for b25 in xrange(2):
-            for b22 in xrange(2):
-                for b18 in xrange(2):
+        for b25 in range(2):
+            for b22 in range(2):
+                for b18 in range(2):
                     success_txs.append(bip112txs_vary_OP_CSV_v2[1][b25][b22][b18]) # 8/16 of vary_OP_CSV
                     success_txs.append(bip112txs_vary_OP_CSV_9_v2[1][b25][b22][b18]) # 8/16 of vary_OP_CSV_9
 
@@ -485,9 +484,9 @@ class BIP68_112_113Test(ComparisonTestFramework):
         # All txs with nSequence 9 should fail either due to earlier mismatch or failing the CSV check
         fail_txs = []
         fail_txs.extend(all_rlt_txs(bip112txs_vary_nSequence_9_v2)) # 16/16 of vary_nSequence_9
-        for b25 in xrange(2):
-            for b22 in xrange(2):
-                for b18 in xrange(2):
+        for b25 in range(2):
+            for b22 in range(2):
+                for b18 in range(2):
                     fail_txs.append(bip112txs_vary_OP_CSV_9_v2[0][b25][b22][b18]) # 16/16 of vary_OP_CSV_9
 
         for tx in fail_txs:
@@ -495,17 +494,17 @@ class BIP68_112_113Test(ComparisonTestFramework):
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in nSequence, tx should fail
         fail_txs = []
-        for b25 in xrange(2):
-            for b22 in xrange(2):
-                for b18 in xrange(2):
+        for b25 in range(2):
+            for b22 in range(2):
+                for b18 in range(2):
                     fail_txs.append(bip112txs_vary_nSequence_v2[1][b25][b22][b18]) # 8/16 of vary_nSequence
         for tx in fail_txs:
             yield TestInstance([[self.create_test_block([tx]), False]]) # 108-115
 
         # If sequencelock types mismatch, tx should fail
         fail_txs = []
-        for b25 in xrange(2):
-            for b18 in xrange(2):
+        for b25 in range(2):
+            for b18 in range(2):
                 fail_txs.append(bip112txs_vary_nSequence_v2[0][b25][1][b18]) # 12/16 of vary_nSequence
                 fail_txs.append(bip112txs_vary_OP_CSV_v2[0][b25][1][b18]) # 12/16 of vary_OP_CSV
         for tx in fail_txs:
@@ -513,8 +512,8 @@ class BIP68_112_113Test(ComparisonTestFramework):
 
         # Remaining txs should pass, just test masking works properly
         success_txs = []
-        for b25 in xrange(2):
-            for b18 in xrange(2):
+        for b25 in range(2):
+            for b18 in range(2):
                 success_txs.append(bip112txs_vary_nSequence_v2[0][b25][0][b18]) # 16/16 of vary_nSequence
                 success_txs.append(bip112txs_vary_OP_CSV_v2[0][b25][0][b18]) # 16/16 of vary_OP_CSV
         yield TestInstance([[self.create_test_block(success_txs), True]]) # 124
@@ -522,8 +521,8 @@ class BIP68_112_113Test(ComparisonTestFramework):
 
         # Additional test, of checking that comparison of two time types works properly
         time_txs = []
-        for b25 in xrange(2):
-            for b18 in xrange(2):
+        for b25 in range(2):
+            for b18 in range(2):
                 tx = bip112txs_vary_OP_CSV_v2[0][b25][1][b18]
                 tx.vin[0].nSequence = base_relative_locktime | seq_type_flag
                 signtx = self.sign_transaction(self.nodes[0], tx)

--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -35,28 +35,28 @@ class BIP68Test(BitcoinTestFramework):
         # Generate some coins
         self.nodes[0].generate(110)
 
-        print "Running test disable flag"
+        print("Running test disable flag")
         self.test_disable_flag()
 
-        print "Running test sequence-lock-confirmed-inputs"
+        print("Running test sequence-lock-confirmed-inputs")
         self.test_sequence_lock_confirmed_inputs()
 
-        print "Running test sequence-lock-unconfirmed-inputs"
+        print("Running test sequence-lock-unconfirmed-inputs")
         self.test_sequence_lock_unconfirmed_inputs()
 
-        print "Running test BIP68 not consensus before versionbits activation"
+        print("Running test BIP68 not consensus before versionbits activation")
         self.test_bip68_not_consensus()
 
-        print "Verifying nVersion=2 transactions aren't standard"
+        print("Verifying nVersion=2 transactions aren't standard")
         self.test_version2_relay(before_activation=True)
 
-        print "Activating BIP68 (and 112/113)"
+        print("Activating BIP68 (and 112/113)")
         self.activateCSV()
 
-        print "Verifying nVersion=2 transactions are now standard"
+        print("Verifying nVersion=2 transactions are now standard")
         self.test_version2_relay(before_activation=False)
 
-        print "Passed\n"
+        print("Passed\n")
 
     # Test that BIP68 is not in effect if tx version is 1, or if
     # the first sequence bit is set.
@@ -125,7 +125,7 @@ class BIP68Test(BitcoinTestFramework):
             random.shuffle(addresses)
             num_outputs = random.randint(1, max_outputs)
             outputs = {}
-            for i in xrange(num_outputs):
+            for i in range(num_outputs):
                 outputs[addresses[i]] = random.randint(1, 20)*0.01
             self.nodes[0].sendmany("", outputs)
             self.nodes[0].generate(1)
@@ -137,7 +137,7 @@ class BIP68Test(BitcoinTestFramework):
         # some of those inputs to be sequence locked (and randomly choose
         # between height/time locking). Small random chance of making the locks
         # all pass.
-        for i in xrange(400):
+        for i in range(400):
             # Randomly choose up to 10 inputs
             num_inputs = random.randint(1, 10)
             random.shuffle(utxos)
@@ -151,7 +151,7 @@ class BIP68Test(BitcoinTestFramework):
             tx = CTransaction()
             tx.nVersion = 2
             value = 0
-            for j in xrange(num_inputs):
+            for j in range(num_inputs):
                 sequence_value = 0xfffffffe # this disables sequence locks
 
                 # 50% chance we enable sequence locks
@@ -259,7 +259,7 @@ class BIP68Test(BitcoinTestFramework):
         # Use prioritisetransaction to lower the effective feerate to 0
         self.nodes[0].prioritisetransaction(tx2.hash, -1e15, int(-self.relayfee*COIN))
         cur_time = int(time.time())
-        for i in xrange(10):
+        for i in range(10):
             self.nodes[0].setmocktime(cur_time + 600)
             self.nodes[0].generate(1)
             cur_time += 600
@@ -324,7 +324,7 @@ class BIP68Test(BitcoinTestFramework):
         # tx3 to be removed.
         tip = int(self.nodes[0].getblockhash(self.nodes[0].getblockcount()-1), 16)
         height = self.nodes[0].getblockcount()
-        for i in xrange(2):
+        for i in range(2):
             block = create_block(tip, create_coinbase(height), cur_time)
             block.nVersion = 3
             block.rehash()

--- a/qa/rpc-tests/bip9-softforks.py
+++ b/qa/rpc-tests/bip9-softforks.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
@@ -64,7 +63,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         return tx
 
     def generate_blocks(self, number, version, test_blocks = []):
-        for i in xrange(number):
+        for i in range(number):
             block = create_block(self.tip, create_coinbase(self.height), self.last_block_time + 1)
             block.nVersion = version
             block.rehash()
@@ -88,7 +87,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         # generate some coins for later
         self.coinbase_blocks = self.nodes[0].generate(2)
         self.height = 3  # height of the next block to build
-        self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
         self.nodeaddress = self.nodes[0].getnewaddress()
         self.last_block_time = int(time.time())
 

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
@@ -75,13 +74,13 @@ class BIP66Test(ComparisonTestFramework):
 
         self.coinbase_blocks = self.nodes[0].generate(2)
         height = 3  # height of the next block to build
-        self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+        self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
         self.nodeaddress = self.nodes[0].getnewaddress()
         self.last_block_time = int(time.time())
 
         ''' 98 more version 2 blocks '''
         test_blocks = []
-        for i in xrange(98):
+        for i in range(98):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 2
             block.rehash()
@@ -94,7 +93,7 @@ class BIP66Test(ComparisonTestFramework):
 
         ''' Mine 749 version 3 blocks '''
         test_blocks = []
-        for i in xrange(749):
+        for i in range(749):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 3
             block.rehash()
@@ -146,7 +145,7 @@ class BIP66Test(ComparisonTestFramework):
 
         ''' Mine 199 new version blocks on last valid tip '''
         test_blocks = []
-        for i in xrange(199):
+        for i in range(199):
             block = create_block(self.tip, create_coinbase(height), self.last_block_time + 1)
             block.nVersion = 3
             block.rehash()

--- a/qa/rpc-tests/bipdersig.py
+++ b/qa/rpc-tests/bipdersig.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -32,7 +32,7 @@ class BIP66Test(BitcoinTestFramework):
             raise AssertionError("Failed to mine 100 version=2 blocks")
 
         # Mine 750 new-version blocks
-        for i in xrange(15):
+        for i in range(15):
             self.nodes[2].generate(50)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 850):
@@ -49,7 +49,7 @@ class BIP66Test(BitcoinTestFramework):
         # TODO: check that new DERSIG rules are enforced
 
         # Mine 198 new-version blocks
-        for i in xrange(2):
+        for i in range(2):
             self.nodes[2].generate(99)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 1049):

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -51,13 +51,13 @@ class BlockchainTest(BitcoinTestFramework):
         node = self.nodes[0]
         res = node.gettxoutsetinfo()
 
-        assert_equal(res[u'total_amount'], Decimal('98214.28571450'))
-        assert_equal(res[u'transactions'], 200)
-        assert_equal(res[u'height'], 200)
-        assert_equal(res[u'txouts'], 200)
-        assert_equal(res[u'bytes_serialized'], 14273),
-        assert_equal(len(res[u'bestblock']), 64)
-        assert_equal(len(res[u'hash_serialized']), 64)
+        assert_equal(res['total_amount'], Decimal('98214.28571450'))
+        assert_equal(res['transactions'], 200)
+        assert_equal(res['height'], 200)
+        assert_equal(res['txouts'], 200)
+        assert_equal(res['bytes_serialized'], 14273),
+        assert_equal(len(res['bestblock']), 64)
+        assert_equal(len(res['hash_serialized']), 64)
 
     def _test_getblockheader(self):
         node = self.nodes[0]

--- a/qa/rpc-tests/decodescript.py
+++ b/qa/rpc-tests/decodescript.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/disablewallet.py
+++ b/qa/rpc-tests/disablewallet.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/forknotify.py
+++ b/qa/rpc-tests/forknotify.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/fundrawtransaction-hd.py
+++ b/qa/rpc-tests/fundrawtransaction-hd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -25,7 +25,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         min_relay_tx_fee = self.nodes[0].getnetworkinfo()['relayfee']
         # This test is not meant to test fee estimation and we'd like

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,7 +10,7 @@ from test_framework.util import *
 class RawTransactionsTest(BitcoinTestFramework):
 
     def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
+        print(("Initializing test directory "+self.options.tmpdir))
         initialize_chain_clean(self.options.tmpdir, 4)
 
     def setup_network(self, split=False):
@@ -25,7 +25,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         min_relay_tx_fee = self.nodes[0].getnetworkinfo()['relayfee']
         # This test is not meant to test fee estimation and we'd like

--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -27,7 +27,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
     '''
 
     def run_test(self):
-        print "Warning: this test will take about 70 seconds in the best case. Be patient."
+        print("Warning: this test will take about 70 seconds in the best case. Be patient.")
         wait_to_sync(self.nodes[0])
         self.nodes[0].generate(10)
         templat = self.nodes[0].getblocktemplate()

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -46,7 +46,7 @@ def genmrklroot(leaflist):
         cur = n
     return cur[0]
 
-def template_to_bytes(tmpl, txlist):
+def template_to_bytearray(tmpl, txlist):
     blkver = pack('<L', tmpl['version'])
     mrklroot = genmrklroot(list(dblsha(a) for a in txlist))
     timestamp = pack('<L', tmpl['curtime'])
@@ -55,10 +55,10 @@ def template_to_bytes(tmpl, txlist):
     blk += varlenEncode(len(txlist))
     for tx in txlist:
         blk += tx
-    return blk
+    return bytearray(blk)
 
 def template_to_hex(tmpl, txlist):
-    return b2x(template_to_bytes(tmpl, txlist))
+    return b2x(template_to_bytearray(tmpl, txlist))
 
 def assert_template(node, tmpl, txlist, expect):
     rsp = node.getblocktemplate({'data':template_to_hex(tmpl, txlist),'mode':'proposal'})
@@ -130,7 +130,7 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
         tmpl['bits'] = realbits
 
         # Test 9: Bad merkle root
-        rawtmpl = template_to_bytes(tmpl, txlist)
+        rawtmpl = template_to_bytearray(tmpl, txlist)
         rawtmpl[4+32] = (rawtmpl[4+32] + 1) % 0x100
         rsp = node.getblocktemplate({'data':b2x(rawtmpl),'mode':'proposal'})
         if rsp != 'bad-txnmrklroot':

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/httpbasics.py
+++ b/qa/rpc-tests/httpbasics.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,14 +10,8 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import http.client
+import urllib.parse
 
 class HTTPBasicsTest (BitcoinTestFramework):
     def setup_nodes(self):
@@ -28,11 +22,11 @@ class HTTPBasicsTest (BitcoinTestFramework):
         #################################################
         # lowlevel check for http persistent connection #
         #################################################
-        url = urlparse.urlparse(self.nodes[0].url)
+        url = urllib.parse.urlparse(self.nodes[0].url)
         authpair = url.username + ':' + url.password
         headers = {"Authorization": "Basic " + str_to_b64str(authpair)}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
@@ -49,7 +43,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         #same should be if we add keep-alive because this should be the std. behaviour
         headers = {"Authorization": "Basic " + str_to_b64str(authpair), "Connection": "keep-alive"}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
@@ -66,7 +60,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         #now do the same with "Connection: close"
         headers = {"Authorization": "Basic " + str_to_b64str(authpair), "Connection":"close"}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
@@ -74,22 +68,22 @@ class HTTPBasicsTest (BitcoinTestFramework):
         assert(conn.sock==None) #now the connection must be closed after the response
 
         #node1 (2nd node) is running with disabled keep-alive option
-        urlNode1 = urlparse.urlparse(self.nodes[1].url)
+        urlNode1 = urllib.parse.urlparse(self.nodes[1].url)
         authpair = urlNode1.username + ':' + urlNode1.password
         headers = {"Authorization": "Basic " + str_to_b64str(authpair)}
 
-        conn = httplib.HTTPConnection(urlNode1.hostname, urlNode1.port)
+        conn = http.client.HTTPConnection(urlNode1.hostname, urlNode1.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
 
         #node2 (third node) is running with standard keep-alive parameters which means keep-alive is on
-        urlNode2 = urlparse.urlparse(self.nodes[2].url)
+        urlNode2 = urllib.parse.urlparse(self.nodes[2].url)
         authpair = urlNode2.username + ':' + urlNode2.password
         headers = {"Authorization": "Basic " + str_to_b64str(authpair)}
 
-        conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)
+        conn = http.client.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
@@ -97,17 +91,17 @@ class HTTPBasicsTest (BitcoinTestFramework):
         assert(conn.sock!=None) #connection must be closed because bitcoind should use keep-alive by default
 
         # Check excessive request size
-        conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)
+        conn = http.client.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
         conn.request('GET', '/' + ('x'*1000), '', headers)
         out1 = conn.getresponse()
-        assert_equal(out1.status, httplib.NOT_FOUND)
+        assert_equal(out1.status, http.client.NOT_FOUND)
 
-        conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)
+        conn = http.client.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
         conn.request('GET', '/' + ('x'*10000), '', headers)
         out1 = conn.getresponse()
-        assert_equal(out1.status, httplib.BAD_REQUEST)
+        assert_equal(out1.status, http.client.BAD_REQUEST)
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -25,46 +25,46 @@ class InvalidateTest(BitcoinTestFramework):
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
         
     def run_test(self):
-        print "Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:"
-        print "Mine 4 blocks on Node 0"
+        print("Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:")
+        print("Mine 4 blocks on Node 0")
         self.nodes[0].generate(4)
         assert(self.nodes[0].getblockcount() == 4)
         besthash = self.nodes[0].getbestblockhash()
 
-        print "Mine competing 6 blocks on Node 1"
+        print("Mine competing 6 blocks on Node 1")
         self.nodes[1].generate(6)
         assert(self.nodes[1].getblockcount() == 6)
 
-        print "Connect nodes to force a reorg"
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes,0,1)
         sync_blocks(self.nodes[0:2])
         assert(self.nodes[0].getblockcount() == 6)
         badhash = self.nodes[1].getblockhash(2)
 
-        print "Invalidate block 2 on node 0 and verify we reorg to node 0's original chain"
+        print("Invalidate block 2 on node 0 and verify we reorg to node 0's original chain")
         self.nodes[0].invalidateblock(badhash)
         newheight = self.nodes[0].getblockcount()
         newhash = self.nodes[0].getbestblockhash()
         if (newheight != 4 or newhash != besthash):
             raise AssertionError("Wrong tip for node0, hash %s, height %d"%(newhash,newheight))
 
-        print "\nMake sure we won't reorg to a lower work chain:"
+        print("\nMake sure we won't reorg to a lower work chain:")
         connect_nodes_bi(self.nodes,1,2)
-        print "Sync node 2 to node 1 so both have 6 blocks"
+        print("Sync node 2 to node 1 so both have 6 blocks")
         sync_blocks(self.nodes[1:3])
         assert(self.nodes[2].getblockcount() == 6)
-        print "Invalidate block 5 on node 1 so its tip is now at 4"
+        print("Invalidate block 5 on node 1 so its tip is now at 4")
         self.nodes[1].invalidateblock(self.nodes[1].getblockhash(5))
         assert(self.nodes[1].getblockcount() == 4)
-        print "Invalidate block 3 on node 2, so its tip is now 2"
+        print("Invalidate block 3 on node 2, so its tip is now 2")
         self.nodes[2].invalidateblock(self.nodes[2].getblockhash(3))
         assert(self.nodes[2].getblockcount() == 2)
-        print "..and then mine a block"
+        print("..and then mine a block")
         self.nodes[2].generate(1)
-        print "Verify all nodes are at the right height"
+        print("Verify all nodes are at the right height")
         time.sleep(5)
-        for i in xrange(3):
-            print i,self.nodes[i].getblockcount()
+        for i in range(3):
+            print(i,self.nodes[i].getblockcount())
         assert(self.nodes[2].getblockcount() == 3)
         assert(self.nodes[0].getblockcount() == 4)
         node1height = self.nodes[1].getblockcount()

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
@@ -39,7 +38,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
 
     def get_tests(self):
         if self.tip is None:
-            self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+            self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
         self.block_time = int(time.time())+1
 
         '''
@@ -59,7 +58,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         Now we need that block to mature so we can spend the coinbase.
         '''
         test = TestInstance(sync_every_block=False)
-        for i in xrange(100):
+        for i in range(100):
             block = create_block(self.tip, create_coinbase(height), self.block_time)
             block.solve()
             self.tip = block.sha256

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.comptool import TestManager, TestInstance, RejectResult
@@ -32,7 +31,7 @@ class InvalidTxRequestTest(ComparisonTestFramework):
 
     def get_tests(self):
         if self.tip is None:
-            self.tip = int ("0x" + self.nodes[0].getbestblockhash() + "L", 0)
+            self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
         self.block_time = int(time.time())+1
 
         '''
@@ -52,7 +51,7 @@ class InvalidTxRequestTest(ComparisonTestFramework):
         Now we need that block to mature so we can spend the coinbase.
         '''
         test = TestInstance(sync_every_block=False)
-        for i in xrange(100):
+        for i in range(100):
             block = create_block(self.tip, create_coinbase(height), self.block_time)
             block.solve()
             self.tip = block.sha256

--- a/qa/rpc-tests/keypool-hd.py
+++ b/qa/rpc-tests/keypool-hd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
@@ -65,7 +64,7 @@ class TestManager(NodeConnCB):
                         raise AssertionError("Error, test failed: block %064x requested more than once" % key)
             if total_requests > MAX_REQUESTS:
                 raise AssertionError("Error, too many blocks (%d) requested" % total_requests)
-            print "Round %d: success (total requests: %d)" % (count, total_requests)
+            print("Round %d: success (total requests: %d)" % (count, total_requests))
 
         self.disconnectOkay = True
         self.connection.disconnect_node()
@@ -78,7 +77,7 @@ class MaxBlocksInFlightTest(BitcoinTestFramework):
                           help="Binary to test max block requests behavior")
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 1)
 
     def setup_network(self):

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
-#
-# Distributed under the MIT/X11 software license, see the accompanying
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
@@ -101,7 +100,7 @@ class MaxUploadTest(BitcoinTestFramework):
     def mine_full_block(self, node, address):
         # Want to create a full block
         # We'll generate a 66k transaction below, and 14 of them is close to the 1MB block limit
-        for j in xrange(14):
+        for j in range(14):
             if len(self.utxo) < 14:
                 self.utxo = node.listunspent()
             inputs=[]
@@ -139,7 +138,7 @@ class MaxUploadTest(BitcoinTestFramework):
         test_nodes = []
         connections = []
 
-        for i in xrange(3):
+        for i in range(3):
             test_nodes.append(TestNode())
             connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_nodes[i]))
             test_nodes[i].add_connection(connections[i])
@@ -181,7 +180,7 @@ class MaxUploadTest(BitcoinTestFramework):
 
         # 144MB will be reserved for relaying new blocks, so expect this to
         # succeed for ~70 tries.
-        for i in xrange(success_count):
+        for i in range(success_count):
             test_nodes[0].send_message(getdata_request)
             test_nodes[0].sync_with_ping()
             assert_equal(test_nodes[0].block_receive_map[big_old_block], i+1)
@@ -189,22 +188,22 @@ class MaxUploadTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[0].getpeerinfo()), 3)
         # At most a couple more tries should succeed (depending on how long 
         # the test has been running so far).
-        for i in xrange(3):
+        for i in range(3):
             test_nodes[0].send_message(getdata_request)
         test_nodes[0].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)
-        print "Peer 0 disconnected after downloading old block too many times"
+        print("Peer 0 disconnected after downloading old block too many times")
 
         # Requesting the current block on test_nodes[1] should succeed indefinitely,
         # even when over the max upload target.
         # We'll try 200 times
         getdata_request.inv = [CInv(2, big_new_block)]
-        for i in xrange(200):
+        for i in range(200):
             test_nodes[1].send_message(getdata_request)
             test_nodes[1].sync_with_ping()
             assert_equal(test_nodes[1].block_receive_map[big_new_block], i+1)
 
-        print "Peer 1 able to repeatedly download new block"
+        print("Peer 1 able to repeatedly download new block")
 
         # But if test_nodes[1] tries for an old block, it gets disconnected too.
         getdata_request.inv = [CInv(2, big_old_block)]
@@ -212,9 +211,9 @@ class MaxUploadTest(BitcoinTestFramework):
         test_nodes[1].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 1)
 
-        print "Peer 1 disconnected after trying to download old block"
+        print("Peer 1 disconnected after trying to download old block")
 
-        print "Advancing system time on node to clear counters..."
+        print("Advancing system time on node to clear counters...")
 
         # If we advance the time by 24 hours, then the counters should reset,
         # and test_nodes[2] should be able to retrieve the old block.
@@ -224,12 +223,12 @@ class MaxUploadTest(BitcoinTestFramework):
         test_nodes[2].sync_with_ping()
         assert_equal(test_nodes[2].block_receive_map[big_old_block], 1)
 
-        print "Peer 2 able to download old block"
+        print("Peer 2 able to download old block")
 
         [c.disconnect_node() for c in connections]
 
         #stop and start node 0 with 1MB maxuploadtarget, whitelist 127.0.0.1
-        print "Restarting nodes with -whitelist=127.0.0.1"
+        print("Restarting nodes with -whitelist=127.0.0.1")
         stop_node(self.nodes[0], 0)
         self.nodes[0] = start_node(0, self.options.tmpdir, ["-debug", "-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000"])
 
@@ -237,7 +236,7 @@ class MaxUploadTest(BitcoinTestFramework):
         test_nodes = []
         connections = []
 
-        for i in xrange(3):
+        for i in range(3):
             test_nodes.append(TestNode())
             connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_nodes[i]))
             test_nodes[i].add_connection(connections[i])
@@ -247,7 +246,7 @@ class MaxUploadTest(BitcoinTestFramework):
 
         #retrieve 20 blocks which should be enough to break the 1MB limit
         getdata_request.inv = [CInv(2, big_new_block)]
-        for i in xrange(20):
+        for i in range(20):
             test_nodes[1].send_message(getdata_request)
             test_nodes[1].sync_with_ping()
             assert_equal(test_nodes[1].block_receive_map[big_new_block], i+1)
@@ -257,7 +256,7 @@ class MaxUploadTest(BitcoinTestFramework):
         test_nodes[1].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 3) #node is still connected because of the whitelist
 
-        print "Peer 1 still connected after trying to download old block (whitelisted)"
+        print("Peer 1 still connected after trying to download old block (whitelisted)")
 
         [c.disconnect_node() for c in connections]
 

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -41,7 +41,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
         relayfee = self.nodes[0].getnetworkinfo()['relayfee']
         base_fee = relayfee*100
-        for i in xrange (4):
+        for i in range (4):
             txids.append([])
             txids[i] = create_lots_of_big_transactions(self.nodes[0], self.txouts, utxos[30*i:30*i+30], (i+1)*base_fee)
 

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -28,7 +28,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         send_value = satoshi_round((value - fee)/num_outputs)
         inputs = [ {'txid' : parent_txid, 'vout' : vout} ]
         outputs = {}
-        for i in xrange(num_outputs):
+        for i in range(num_outputs):
             outputs[node.getnewaddress()] = send_value
         rawtx = node.createrawtransaction(inputs, outputs)
         signedtx = node.signrawtransaction(rawtx)
@@ -48,7 +48,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         fee = Decimal("0.0001")
         # MAX_ANCESTORS transactions off a confirmed tx should be fine
         chain = []
-        for i in xrange(MAX_ANCESTORS):
+        for i in range(MAX_ANCESTORS):
             (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, 0, value, fee, 1)
             value = sent_value
             chain.append(txid)
@@ -84,7 +84,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         try:
             self.chain_transaction(self.nodes[0], txid, vout, value, fee, 1)
         except JSONRPCException as e:
-            print "too-long-ancestor-chain successfully rejected"
+            print("too-long-ancestor-chain successfully rejected")
 
         # Check that prioritising a tx before it's added to the mempool works
         # First clear the mempool by mining a block.
@@ -121,22 +121,22 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # First create one parent tx with 10 children
         (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, vout, value, fee, 10)
         parent_transaction = txid
-        for i in xrange(10):
+        for i in range(10):
             transaction_package.append({'txid': txid, 'vout': i, 'amount': sent_value})
 
-        for i in xrange(MAX_DESCENDANTS):
+        for i in range(MAX_DESCENDANTS):
             utxo = transaction_package.pop(0)
             try:
                 (txid, sent_value) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
-                for j in xrange(10):
+                for j in range(10):
                     transaction_package.append({'txid': txid, 'vout': j, 'amount': sent_value})
                 if i == MAX_DESCENDANTS - 2:
                     mempool = self.nodes[0].getrawmempool(True)
                     assert_equal(mempool[parent_transaction]['descendantcount'], MAX_DESCENDANTS)
             except JSONRPCException as e:
-                print e.error['message']
+                print(e.error['message'])
                 assert_equal(i, MAX_DESCENDANTS - 1)
-                print "tx that would create too large descendant package successfully rejected"
+                print("tx that would create too large descendant package successfully rejected")
 
         # TODO: check that node1's mempool is as expected
 
@@ -171,7 +171,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         send_value = satoshi_round((value - fee)/2)
         inputs = [ {'txid' : txid, 'vout' : vout} ]
         outputs = {}
-        for i in xrange(2):
+        for i in range(2):
             outputs[self.nodes[0].getnewaddress()] = send_value
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         signedtx = self.nodes[0].signrawtransaction(rawtx)
@@ -185,7 +185,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # Create tx2-7
         vout = 1
         txid = tx0_id
-        for i in xrange(6):
+        for i in range(6):
             (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, vout, value, fee, 1)
             vout = 0
             value = sent_value

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -32,7 +32,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(105)
         self.sync_all()
 

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,16 +9,9 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-import base64
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import http.client
+import urllib.parse
 
 class HTTPBasicsTest (BitcoinTestFramework):
     def setup_nodes(self):
@@ -39,7 +32,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         ##################################################
         # Check correctness of the rpcauth config option #
         ##################################################
-        url = urlparse.urlparse(self.nodes[0].url)
+        url = urllib.parse.urlparse(self.nodes[0].url)
 
         #Old authpair
         authpair = url.username + ':' + url.password
@@ -55,7 +48,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
 
         headers = {"Authorization": "Basic " + str_to_b64str(authpair)}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
@@ -65,7 +58,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         #Use new authpair to confirm both work
         headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
@@ -76,7 +69,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         authpairnew = "rtwrong:"+password
         headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
@@ -87,7 +80,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         authpairnew = "rt:"+password+"wrong"
         headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
@@ -98,7 +91,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         authpairnew = "rt2:"+password2
         headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()
@@ -109,7 +102,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         authpairnew = "rt2:"+password2+"wrong"
         headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
 
-        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         resp = conn.getresponse()

--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,14 +10,8 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import http.client
+import urllib.parse
 
 class NodeHandlingTest (BitcoinTestFramework):
     def run_test(self):
@@ -69,7 +63,7 @@ class NodeHandlingTest (BitcoinTestFramework):
         ###########################
         # RPC disconnectnode test #
         ###########################
-        url = urlparse.urlparse(self.nodes[1].url)
+        url = urllib.parse.urlparse(self.nodes[1].url)
         self.nodes[0].disconnectnode(url.hostname+":"+str(p2p_port(1)))
         time.sleep(2) #disconnecting a node needs a little bit of time
         for node in self.nodes[0].getpeerinfo():

--- a/qa/rpc-tests/p2p-acceptblock.py
+++ b/qa/rpc-tests/p2p-acceptblock.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
@@ -145,13 +144,13 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # 1. Have both nodes mine a block (leave IBD)
         [ n.generate(1) for n in self.nodes ]
-        tips = [ int ("0x" + n.getbestblockhash() + "L", 0) for n in self.nodes ]
+        tips = [ int("0x" + n.getbestblockhash(), 0) for n in self.nodes ]
 
         # 2. Send one block that builds on each tip.
         # This should be accepted.
         blocks_h2 = []  # the height 2 blocks on each node's chain
         block_time = int(time.time()) + 1
-        for i in xrange(2):
+        for i in range(2):
             blocks_h2.append(create_block(tips[i], create_coinbase(2), block_time))
             blocks_h2[i].solve()
             block_time += 1
@@ -161,11 +160,11 @@ class AcceptBlockTest(BitcoinTestFramework):
         [ x.sync_with_ping() for x in [test_node, white_node] ]
         assert_equal(self.nodes[0].getblockcount(), 2)
         assert_equal(self.nodes[1].getblockcount(), 2)
-        print "First height 2 block accepted by both nodes"
+        print("First height 2 block accepted by both nodes")
 
         # 3. Send another block that builds on the original tip.
         blocks_h2f = []  # Blocks at height 2 that fork off the main chain
-        for i in xrange(2):
+        for i in range(2):
             blocks_h2f.append(create_block(tips[i], create_coinbase(2), blocks_h2[i].nTime+1))
             blocks_h2f[i].solve()
         test_node.send_message(msg_block(blocks_h2f[0]))
@@ -180,11 +179,11 @@ class AcceptBlockTest(BitcoinTestFramework):
             if x['hash'] == blocks_h2f[1].hash:
                 assert_equal(x['status'], "valid-headers")
 
-        print "Second height 2 block accepted only from whitelisted peer"
+        print("Second height 2 block accepted only from whitelisted peer")
 
         # 4. Now send another block that builds on the forking chain.
         blocks_h3 = []
-        for i in xrange(2):
+        for i in range(2):
             blocks_h3.append(create_block(blocks_h2f[i].sha256, create_coinbase(3), blocks_h2f[i].nTime+1))
             blocks_h3[i].solve()
         test_node.send_message(msg_block(blocks_h3[0]))
@@ -200,13 +199,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         # But this block should be accepted by node0 since it has more work.
         try:
             self.nodes[0].getblock(blocks_h3[0].hash)
-            print "Unrequested more-work block accepted from non-whitelisted peer"
+            print("Unrequested more-work block accepted from non-whitelisted peer")
         except:
             raise AssertionError("Unrequested more work block was not processed")
 
         # Node1 should have accepted and reorged.
         assert_equal(self.nodes[1].getblockcount(), 3)
-        print "Successfully reorged to length 3 chain from whitelisted peer"
+        print("Successfully reorged to length 3 chain from whitelisted peer")
 
         # 4b. Now mine 288 more blocks and deliver; all should be processed but
         # the last (height-too-high) on node0.  Node1 should process the tip if
@@ -214,8 +213,8 @@ class AcceptBlockTest(BitcoinTestFramework):
         tips = blocks_h3
         headers_message = msg_headers()
         all_blocks = []   # node0's blocks
-        for j in xrange(2):
-            for i in xrange(288):
+        for j in range(2):
+            for i in range(288):
                 next_block = create_block(tips[j].sha256, create_coinbase(i + 4), tips[j].nTime+1)
                 next_block.solve()
                 if j==0:
@@ -233,7 +232,7 @@ class AcceptBlockTest(BitcoinTestFramework):
                     raise AssertionError("Unrequested block too far-ahead should have been ignored")
             except:
                 if x == all_blocks[287]:
-                    print "Unrequested block too far-ahead not processed"
+                    print("Unrequested block too far-ahead not processed")
                 else:
                     raise AssertionError("Unrequested block with more work should have been accepted")
 
@@ -243,7 +242,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         try:
             white_node.sync_with_ping()
             self.nodes[1].getblock(tips[1].hash)
-            print "Unrequested block far ahead of tip accepted from whitelisted peer"
+            print("Unrequested block far ahead of tip accepted from whitelisted peer")
         except:
             raise AssertionError("Unrequested block from whitelisted peer not accepted")
 
@@ -259,7 +258,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # a getdata request for this block.
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 2)
-        print "Unrequested block that would complete more-work chain was ignored"
+        print("Unrequested block that would complete more-work chain was ignored")
 
         # 6. Try to get node to request the missing block.
         # Poke the node with an inv for block at height 3 and see if that
@@ -275,14 +274,14 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # Check that the getdata includes the right block
         assert_equal(getdata.inv[0].hash, blocks_h2f[0].sha256)
-        print "Inv at tip triggered getdata for unprocessed block"
+        print("Inv at tip triggered getdata for unprocessed block")
 
         # 7. Send the missing block for the third time (now it is requested)
         test_node.send_message(msg_block(blocks_h2f[0]))
 
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 290)
-        print "Successfully reorged to longer chain from non-whitelisted peer"
+        print("Successfully reorged to longer chain from non-whitelisted peer")
 
         [ c.disconnect_node() for c in connections ]
 

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *

--- a/qa/rpc-tests/p2p-versionbits-warning.py
+++ b/qa/rpc-tests/p2p-versionbits-warning.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2016 The Bitcoin Core developers
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
@@ -82,7 +81,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         block_time = self.nodes[0].getblockheader(tip)["time"]+1
         tip = int(tip, 16)
 
-        for i in xrange(numblocks):
+        for i in range(numblocks):
             block = create_block(tip, create_coinbase(height+1), block_time)
             block.nVersion = nVersionToUse
             block.solve()

--- a/qa/rpc-tests/prioritise_transaction.py
+++ b/qa/rpc-tests/prioritise_transaction.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -35,7 +35,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
 
         # Create 3 batches of transactions at 3 different fee rate levels
         range_size = utxo_count // 3
-        for i in xrange(3):
+        for i in range(3):
             txids.append([])
             start_range = i * range_size
             end_range = start_range + range_size
@@ -46,7 +46,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # more transactions.
         mempool = self.nodes[0].getrawmempool(True)
         sizes = [0, 0, 0]
-        for i in xrange(3):
+        for i in range(3):
             for j in txids[i]:
                 assert(j in mempool)
                 sizes[i] += mempool[j]['size']
@@ -61,7 +61,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
 
         mempool = self.nodes[0].getrawmempool()
-        print "Assert that prioritised transaction was mined"
+        print("Assert that prioritised transaction was mined")
         assert(txids[0][0] not in mempool)
         assert(txids[0][1] in mempool)
 
@@ -93,7 +93,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # High fee transaction should not have been mined, but other high fee rate
         # transactions should have been.
         mempool = self.nodes[0].getrawmempool()
-        print "Assert that de-prioritised transaction is still in mempool"
+        print("Assert that de-prioritised transaction is still in mempool")
         assert(high_fee_tx in mempool)
         for x in txids[2]:
             if (x != high_fee_tx):
@@ -135,7 +135,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # accepted.
         self.nodes[0].prioritisetransaction(tx2_id, 0, int(self.relayfee*COIN))
 
-        print "Assert that prioritised free transaction is accepted to mempool"
+        print("Assert that prioritised free transaction is accepted to mempool")
         assert_equal(self.nodes[0].sendrawtransaction(tx2_hex), tx2_id)
         assert(tx2_id in self.nodes[0].getrawmempool())
 

--- a/qa/rpc-tests/proxy_test.py
+++ b/qa/rpc-tests/proxy_test.py
@@ -1,7 +1,8 @@
-#!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 import socket
 
 from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
@@ -55,7 +56,7 @@ class ProxyTest(BitcoinTestFramework):
             self.conf3.unauth = True
             self.conf3.auth = True
         else:
-            print "Warning: testing without local IPv6 support"
+            print("Warning: testing without local IPv6 support")
 
         self.serv1 = Socks5Server(self.conf1)
         self.serv1.start()

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -57,7 +57,7 @@ class PruneTest(BitcoinTestFramework):
         sync_blocks(self.nodes[0:2])
         self.nodes[0].generate(150)
         # Then mine enough full blocks to create more than 550MiB of data
-        for i in xrange(645):
+        for i in range(645):
             self.mine_full_block(self.nodes[0], self.address[0])
 
         sync_blocks(self.nodes[0:3])
@@ -65,11 +65,11 @@ class PruneTest(BitcoinTestFramework):
     def test_height_min(self):
         if not os.path.isfile(self.prunedir+"blk00000.dat"):
             raise AssertionError("blk00000.dat is missing, pruning too early")
-        print "Success"
-        print "Though we're already using more than 550MiB, current usage:", calc_usage(self.prunedir)
-        print "Mining 25 more blocks should cause the first block file to be pruned"
+        print("Success")
+        print("Though we're already using more than 550MiB, current usage:", calc_usage(self.prunedir))
+        print("Mining 25 more blocks should cause the first block file to be pruned")
         # Pruning doesn't run until we're allocating another chunk, 20 full blocks past the height cutoff will ensure this
-        for i in xrange(25):
+        for i in range(25):
             self.mine_full_block(self.nodes[0],self.address[0])
 
         waitstart = time.time()
@@ -78,17 +78,17 @@ class PruneTest(BitcoinTestFramework):
             if time.time() - waitstart > 10:
                 raise AssertionError("blk00000.dat not pruned when it should be")
 
-        print "Success"
+        print("Success")
         usage = calc_usage(self.prunedir)
-        print "Usage should be below target:", usage
+        print("Usage should be below target:", usage)
         if (usage > 550):
             raise AssertionError("Pruning target not being met")
 
     def create_chain_with_staleblocks(self):
         # Create stale blocks in manageable sized chunks
-        print "Mine 24 (stale) blocks on Node 1, followed by 25 (main chain) block reorg from Node 0, for 12 rounds"
+        print("Mine 24 (stale) blocks on Node 1, followed by 25 (main chain) block reorg from Node 0, for 12 rounds")
 
-        for j in xrange(12):
+        for j in range(12):
             # Disconnect node 0 so it can mine a longer reorg chain without knowing about node 1's soon-to-be-stale chain
             # Node 2 stays connected, so it hears about the stale blocks and then reorg's when node0 reconnects
             # Stopping node 0 also clears its mempool, so it doesn't have node1's transactions to accidentally mine
@@ -96,7 +96,7 @@ class PruneTest(BitcoinTestFramework):
             self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=900)
             # Mine 24 blocks in node 1
             self.utxo = self.nodes[1].listunspent()
-            for i in xrange(24):
+            for i in range(24):
                 if j == 0:
                     self.mine_full_block(self.nodes[1],self.address[1])
                 else:
@@ -104,7 +104,7 @@ class PruneTest(BitcoinTestFramework):
 
             # Reorg back with 25 block chain from node 0
             self.utxo = self.nodes[0].listunspent()
-            for i in xrange(25): 
+            for i in range(25):
                 self.mine_full_block(self.nodes[0],self.address[0])
 
             # Create connections in the order so both nodes can see the reorg at the same time
@@ -112,7 +112,7 @@ class PruneTest(BitcoinTestFramework):
             connect_nodes(self.nodes[2], 0)
             sync_blocks(self.nodes[0:3])
 
-        print "Usage can be over target because of high stale rate:", calc_usage(self.prunedir)
+        print("Usage can be over target because of high stale rate:", calc_usage(self.prunedir))
 
     def reorg_test(self):
         # Node 1 will mine a 300 block chain starting 287 blocks back from Node 0 and Node 2's tip
@@ -123,11 +123,11 @@ class PruneTest(BitcoinTestFramework):
         self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
         height = self.nodes[1].getblockcount()
-        print "Current block height:", height
+        print("Current block height:", height)
 
         invalidheight = height-287
         badhash = self.nodes[1].getblockhash(invalidheight)
-        print "Invalidating block at height:",invalidheight,badhash
+        print("Invalidating block at height:",invalidheight,badhash)
         self.nodes[1].invalidateblock(badhash)
 
         # We've now switched to our previously mined-24 block fork on node 1, but thats not what we want
@@ -139,29 +139,29 @@ class PruneTest(BitcoinTestFramework):
             curhash = self.nodes[1].getblockhash(invalidheight - 1)
 
         assert(self.nodes[1].getblockcount() == invalidheight - 1)
-        print "New best height", self.nodes[1].getblockcount()
+        print("New best height", self.nodes[1].getblockcount())
 
         # Reboot node1 to clear those giant tx's from mempool
         stop_node(self.nodes[1],1)
         self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
-        print "Generating new longer chain of 300 more blocks"
+        print("Generating new longer chain of 300 more blocks")
         self.nodes[1].generate(300)
 
-        print "Reconnect nodes"
+        print("Reconnect nodes")
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[2], 1)
         sync_blocks(self.nodes[0:3])
 
-        print "Verify height on node 2:",self.nodes[2].getblockcount()
-        print "Usage possibly still high bc of stale blocks in block files:", calc_usage(self.prunedir)
+        print("Verify height on node 2:",self.nodes[2].getblockcount())
+        print("Usage possibly still high bc of stale blocks in block files:", calc_usage(self.prunedir))
 
-        print "Mine 220 more blocks so we have requisite history (some blocks will be big and cause pruning of previous chain)"
+        print("Mine 220 more blocks so we have requisite history (some blocks will be big and cause pruning of previous chain)")
         self.nodes[0].generate(220) #node 0 has many large tx's in its mempool from the disconnects
         sync_blocks(self.nodes[0:3])
 
         usage = calc_usage(self.prunedir)
-        print "Usage should be below target:", usage
+        print("Usage should be below target:", usage)
         if (usage > 550):
             raise AssertionError("Pruning target not being met")
 
@@ -173,7 +173,7 @@ class PruneTest(BitcoinTestFramework):
             self.nodes[2].getblock(self.forkhash)
             raise AssertionError("Old block wasn't pruned so can't test redownload")
         except JSONRPCException as e:
-            print "Will need to redownload block",self.forkheight
+            print("Will need to redownload block",self.forkheight)
 
         # Verify that we have enough history to reorg back to the fork point
         # Although this is more than 288 blocks, because this chain was written more recently
@@ -197,14 +197,14 @@ class PruneTest(BitcoinTestFramework):
         # At this point node 2 is within 288 blocks of the fork point so it will preserve its ability to reorg
         if self.nodes[2].getblockcount() < self.mainchainheight:
             blocks_to_mine = first_reorg_height + 1 - self.mainchainheight
-            print "Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed:", blocks_to_mine
+            print("Rewind node 0 to prev main chain to mine longer chain to trigger redownload. Blocks needed:", blocks_to_mine)
             self.nodes[0].invalidateblock(curchainhash)
             assert(self.nodes[0].getblockcount() == self.mainchainheight)
             assert(self.nodes[0].getbestblockhash() == self.mainchainhash2)
             goalbesthash = self.nodes[0].generate(blocks_to_mine)[-1]
             goalbestheight = first_reorg_height + 1
 
-        print "Verify node 2 reorged back to the main chain, some blocks of which it had to redownload"
+        print("Verify node 2 reorged back to the main chain, some blocks of which it had to redownload")
         waitstart = time.time()
         while self.nodes[2].getblockcount() < goalbestheight:
             time.sleep(0.1)
@@ -217,7 +217,7 @@ class PruneTest(BitcoinTestFramework):
     def mine_full_block(self, node, address):
         # Want to create a full block
         # We'll generate a 66k transaction below, and 14 of them is close to the 1MB block limit
-        for j in xrange(14):
+        for j in range(14):
             if len(self.utxo) < 14:
                 self.utxo = node.listunspent()
             inputs=[]
@@ -241,8 +241,8 @@ class PruneTest(BitcoinTestFramework):
 
 
     def run_test(self):
-        print "Warning! This test requires 4GB of disk space and takes over 30 mins (up to 2 hours)"
-        print "Mining a big blockchain of 995 blocks"
+        print("Warning! This test requires 4GB of disk space and takes over 30 mins (up to 2 hours)")
+        print("Mining a big blockchain of 995 blocks")
         self.create_big_chain()
         # Chain diagram key:
         # *   blocks on main chain
@@ -253,12 +253,12 @@ class PruneTest(BitcoinTestFramework):
         # Start by mining a simple chain that all nodes have
         # N0=N1=N2 **...*(995)
 
-        print "Check that we haven't started pruning yet because we're below PruneAfterHeight"
+        print("Check that we haven't started pruning yet because we're below PruneAfterHeight")
         self.test_height_min()
         # Extend this chain past the PruneAfterHeight
         # N0=N1=N2 **...*(1020)
 
-        print "Check that we'll exceed disk space target if we have a very high stale block rate"
+        print("Check that we'll exceed disk space target if we have a very high stale block rate")
         self.create_chain_with_staleblocks()
         # Disconnect N0
         # And mine a 24 block chain on N1 and a separate 25 block chain on N0
@@ -282,7 +282,7 @@ class PruneTest(BitcoinTestFramework):
         self.mainchainheight = self.nodes[2].getblockcount()   #1320
         self.mainchainhash2 = self.nodes[2].getblockhash(self.mainchainheight)
 
-        print "Check that we can survive a 288 block reorg still"
+        print("Check that we can survive a 288 block reorg still")
         (self.forkheight,self.forkhash) = self.reorg_test() #(1033, )
         # Now create a 288 block reorg by mining a longer chain on N1
         # First disconnect N1
@@ -315,7 +315,7 @@ class PruneTest(BitcoinTestFramework):
         #                                 \
         #                                  *...**(1320)
 
-        print "Test that we can rerequest a block we previously pruned if needed for a reorg"
+        print("Test that we can rerequest a block we previously pruned if needed for a reorg")
         self.reorg_back()
         # Verify that N2 still has block 1033 on current chain (@), but not on main chain (*)
         # Invalidate 1033 on current chain (@) on N2 and we should be able to reorg to
@@ -335,7 +335,7 @@ class PruneTest(BitcoinTestFramework):
         #
         # N1 doesn't change because 1033 on main chain (*) is invalid
 
-        print "Done"
+        print("Done")
 
 if __name__ == '__main__':
     PruneTest().main()

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/replace-by-fee.py
+++ b/qa/rpc-tests/replace-by-fee.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -82,34 +82,34 @@ class ReplaceByFeeTest(BitcoinTestFramework):
     def run_test(self):
         make_utxo(self.nodes[0], 1*COIN)
 
-        print "Running test simple doublespend..."
+        print("Running test simple doublespend...")
         self.test_simple_doublespend()
 
-        print "Running test doublespend chain..."
+        print("Running test doublespend chain...")
         self.test_doublespend_chain()
 
-        print "Running test doublespend tree..."
+        print("Running test doublespend tree...")
         self.test_doublespend_tree()
 
-        print "Running test replacement feeperkb..."
+        print("Running test replacement feeperkb...")
         self.test_replacement_feeperkb()
 
-        print "Running test spends of conflicting outputs..."
+        print("Running test spends of conflicting outputs...")
         self.test_spends_of_conflicting_outputs()
 
-        print "Running test new unconfirmed inputs..."
+        print("Running test new unconfirmed inputs...")
         self.test_new_unconfirmed_inputs()
 
-        print "Running test too many replacements..."
+        print("Running test too many replacements...")
         self.test_too_many_replacements()
 
-        print "Running test opt-in..."
+        print("Running test opt-in...")
         self.test_opt_in()
 
-        print "Running test prioritised transactions..."
+        print("Running test prioritised transactions...")
         self.test_prioritised_transactions()
 
-        print "Passed\n"
+        print("Passed\n")
 
     def test_simple_doublespend(self):
         """Simple doublespend"""
@@ -459,7 +459,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         except JSONRPCException as exp:
             assert_equal(exp.error['code'], -26)
         else:
-            print tx1b_txid
+            print(tx1b_txid)
             assert(False)
 
         tx1_outpoint = make_utxo(self.nodes[0], int(1.1*COIN))

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -13,16 +13,9 @@ from test_framework.util import *
 from struct import *
 from io import BytesIO
 from codecs import encode
-import binascii
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import http.client
+import urllib.parse
 
 def deser_uint256(f):
     r = 0
@@ -33,7 +26,7 @@ def deser_uint256(f):
 
 #allows simple http get calls
 def http_get_call(host, port, path, response_object = 0):
-    conn = httplib.HTTPConnection(host, port)
+    conn = http.client.HTTPConnection(host, port)
     conn.request('GET', path)
 
     if response_object:
@@ -43,7 +36,7 @@ def http_get_call(host, port, path, response_object = 0):
 
 #allows simple http post calls with a request body
 def http_post_call(host, port, path, requestdata = '', response_object = 0):
-    conn = httplib.HTTPConnection(host, port)
+    conn = http.client.HTTPConnection(host, port)
     conn.request('POST', path, requestdata)
 
     if response_object:
@@ -67,8 +60,8 @@ class RESTTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        url = urlparse.urlparse(self.nodes[0].url)
-        print "Mining blocks..."
+        url = urllib.parse.urlparse(self.nodes[0].url)
+        print("Mining blocks...")
 
         self.nodes[0].generate(1)
         self.sync_all()
@@ -151,7 +144,7 @@ class RESTTest (BitcoinTestFramework):
         output.write(bin_response)
         output.seek(0)
         chainHeight = unpack("i", output.read(4))[0]
-        hashFromBinResponse = hex(deser_uint256(output))[2:].zfill(65).rstrip("L")
+        hashFromBinResponse = hex(deser_uint256(output))[2:].zfill(64)
 
         assert_equal(bb_hash, hashFromBinResponse) #check if getutxo's chaintip during calculation was fine
         assert_equal(chainHeight, 102) #chain height must be 102

--- a/qa/rpc-tests/rpcbind_test.py
+++ b/qa/rpc-tests/rpcbind_test.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -51,7 +51,7 @@ def run_allowip_test(tmpdir, allow_ips, rpchost, rpcport):
 
 
 def run_test(tmpdir):
-    assert(sys.platform == 'linux2') # due to OS-specific network stats queries, this test works only on Linux
+    assert(sys.platform.startswith('linux')) # due to OS-specific network stats queries, this test works only on Linux
     # find the first non-loopback interface for testing
     non_loopback_ip = None
     for name,ip in all_interfaces():

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
@@ -266,8 +265,8 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # PART 1
         # 1. Mine a block; expect inv announcements each time
-        print "Part 1: headers don't start before sendheaders message..."
-        for i in xrange(4):
+        print("Part 1: headers don't start before sendheaders message...")
+        for i in range(4):
             old_tip = tip
             tip = self.mine_blocks(1)
             assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
@@ -297,14 +296,14 @@ class SendHeadersTest(BitcoinTestFramework):
                 inv_node.clear_last_announcement()
                 test_node.clear_last_announcement()
 
-        print "Part 1: success!"
-        print "Part 2: announce blocks with headers after sendheaders message..."
+        print("Part 1: success!")
+        print("Part 2: announce blocks with headers after sendheaders message...")
         # PART 2
         # 2. Send a sendheaders message and test that headers announcements
         # commence and keep working.
         test_node.send_message(msg_sendheaders())
         prev_tip = int(self.nodes[0].getbestblockhash(), 16)
-        test_node.get_headers(locator=[prev_tip], hashstop=0L)
+        test_node.get_headers(locator=[prev_tip], hashstop=0)
         test_node.sync_with_ping()
 
         # Now that we've synced headers, headers announcements should work
@@ -314,14 +313,14 @@ class SendHeadersTest(BitcoinTestFramework):
 
         height = self.nodes[0].getblockcount()+1
         block_time += 10  # Advance far enough ahead
-        for i in xrange(10):
+        for i in range(10):
             # Mine i blocks, and alternate announcing either via
             # inv (of tip) or via headers. After each, new blocks
             # mined by the node should successfully be announced
             # with block header, even though the blocks are never requested
-            for j in xrange(2):
+            for j in range(2):
                 blocks = []
-                for b in xrange(i+1):
+                for b in range(i+1):
                     blocks.append(create_block(tip, create_coinbase(height), block_time))
                     blocks[-1].solve()
                     tip = blocks[-1].sha256
@@ -360,13 +359,13 @@ class SendHeadersTest(BitcoinTestFramework):
                 height += 1
                 block_time += 1
 
-        print "Part 2: success!"
+        print("Part 2: success!")
 
-        print "Part 3: headers announcements can stop after large reorg, and resume after headers/inv from peer..."
+        print("Part 3: headers announcements can stop after large reorg, and resume after headers/inv from peer...")
 
         # PART 3.  Headers announcements can stop after large reorg, and resume after
         # getheaders or inv from peer.
-        for j in xrange(2):
+        for j in range(2):
             # First try mining a reorg that can propagate with header announcement
             new_block_hashes = self.mine_reorg(length=7)
             tip = new_block_hashes[-1]
@@ -392,7 +391,7 @@ class SendHeadersTest(BitcoinTestFramework):
             test_node.get_data(new_block_hashes)
             test_node.wait_for_block(new_block_hashes[-1])
 
-            for i in xrange(3):
+            for i in range(3):
                 # Mine another block, still should get only an inv
                 tip = self.mine_blocks(1)
                 assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
@@ -414,7 +413,7 @@ class SendHeadersTest(BitcoinTestFramework):
                     # of headers announcements, or mine a new block and inv it, also 
                     # triggering resumption of headers announcements.
                     if j == 0:
-                        test_node.get_headers(locator=[tip], hashstop=0L)
+                        test_node.get_headers(locator=[tip], hashstop=0)
                         test_node.sync_with_ping()
                     else:
                         test_node.send_block_inv(tip)
@@ -424,9 +423,9 @@ class SendHeadersTest(BitcoinTestFramework):
             assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
             assert_equal(test_node.check_last_announcement(headers=[tip]), True)
 
-        print "Part 3: success!"
+        print("Part 3: success!")
 
-        print "Part 4: Testing direct fetch behavior..."
+        print("Part 4: Testing direct fetch behavior...")
         tip = self.mine_blocks(1)
         height = self.nodes[0].getblockcount() + 1
         last_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']
@@ -434,7 +433,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # Create 2 blocks.  Send the blocks, then send the headers.
         blocks = []
-        for b in xrange(2):
+        for b in range(2):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
@@ -452,7 +451,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # This time, direct fetch should work
         blocks = []
-        for b in xrange(3):
+        for b in range(3):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
@@ -473,7 +472,7 @@ class SendHeadersTest(BitcoinTestFramework):
         blocks = []
 
         # Create extra blocks for later
-        for b in xrange(20):
+        for b in range(20):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
@@ -507,7 +506,7 @@ class SendHeadersTest(BitcoinTestFramework):
         with mininode_lock:
             assert_equal(test_node.last_getdata, None)
 
-        print "Part 4: success!"
+        print("Part 4: success!")
 
         # Finally, check that the inv node never received a getdata request,
         # throughout the test

--- a/qa/rpc-tests/signrawtransactions.py
+++ b/qa/rpc-tests/signrawtransactions.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/smartfees.py
+++ b/qa/rpc-tests/smartfees.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -260,7 +260,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.confutxo = self.txouts # Start with the set of confirmed txouts after splitting
         print("Will output estimates for 1/2/3/6/15/25 blocks")
 
-        for i in xrange(2):
+        for i in range(2):
             print("Creating transactions and mining them with a block size that can't keep up")
             # Create transactions and mine 10 small blocks with node 2, but create txs faster than we can mine
             self.transact_and_mine(10, self.nodes[2])

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -36,7 +36,7 @@ class SpentIndexTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(105)
         self.sync_all()
 
@@ -44,17 +44,17 @@ class SpentIndexTest(BitcoinTestFramework):
         assert_equal(chain_height, 105)
 
         # Check that
-        print "Testing spent index..."
+        print("Testing spent index...")
 
         privkey = "cU4zhap7nPJAWeMFu4j6jLrfPmqakDAzy8zn8Fhb3oEevdm4e5Lc"
         address = "yeMpGzMj3rhtnz48XsfpB8itPHhHtgxLc3"
-        addressHash = "C5E4FB9171C22409809A3E8047A29C83886E325D".decode("hex")
+        addressHash = bytes.fromhex("C5E4FB9171C22409809A3E8047A29C83886E325D")
         scriptPubKey = CScript([OP_DUP, OP_HASH160, addressHash, OP_EQUALVERIFY, OP_CHECKSIG])
         unspent = self.nodes[0].listunspent()
         tx = CTransaction()
-        amount = unspent[0]["amount"] * 100000000
+        amount = unspent[0]["amount"] * COIN
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
-        tx.vout = [CTxOut(amount, scriptPubKey)]
+        tx.vout = [CTxOut(int(amount), scriptPubKey)]
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
@@ -62,7 +62,7 @@ class SpentIndexTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        print "Testing getspentinfo method..."
+        print("Testing getspentinfo method...")
 
         # Check that the spentinfo works standalone
         info = self.nodes[1].getspentinfo({"txid": unspent[0]["txid"], "index": unspent[0]["vout"]})
@@ -70,7 +70,7 @@ class SpentIndexTest(BitcoinTestFramework):
         assert_equal(info["index"], 0)
         assert_equal(info["height"], 106)
 
-        print "Testing getrawtransaction method..."
+        print("Testing getrawtransaction method...")
 
         # Check that verbose raw transaction includes spent info
         txVerbose = self.nodes[3].getrawtransaction(unspent[0]["txid"], 1)
@@ -86,11 +86,11 @@ class SpentIndexTest(BitcoinTestFramework):
         # Check that verbose raw transaction includes address values and input values
         privkey2 = "cU4zhap7nPJAWeMFu4j6jLrfPmqakDAzy8zn8Fhb3oEevdm4e5Lc"
         address2 = "yeMpGzMj3rhtnz48XsfpB8itPHhHtgxLc3"
-        addressHash2 = "C5E4FB9171C22409809A3E8047A29C83886E325D".decode("hex")
+        addressHash2 = bytes.fromhex("C5E4FB9171C22409809A3E8047A29C83886E325D")
         scriptPubKey2 = CScript([OP_DUP, OP_HASH160, addressHash2, OP_EQUALVERIFY, OP_CHECKSIG])
         tx2 = CTransaction()
         tx2.vin = [CTxIn(COutPoint(int(txid, 16), 0))]
-        tx2.vout = [CTxOut(amount, scriptPubKey2)]
+        tx2.vout = [CTxOut(int(amount), scriptPubKey2)]
         tx.rehash()
         self.nodes[0].importprivkey(privkey)
         signed_tx2 = self.nodes[0].signrawtransaction(binascii.hexlify(tx2.serialize()).decode("utf-8"))
@@ -112,7 +112,7 @@ class SpentIndexTest(BitcoinTestFramework):
         assert_equal(txVerbose4["vin"][0]["value"], Decimal(unspent[0]["amount"]))
         assert_equal(txVerbose4["vin"][0]["valueSat"], amount)
 
-        print "Passed\n"
+        print("Passed\n")
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -126,8 +126,9 @@ class AuthServiceProxy(object):
                 return self._get_response()
             else:
                 raise
-        except BrokenPipeError:
-            # Python 3.5+ raises this instead of BadStatusLine when the connection was reset
+        except (BrokenPipeError,ConnectionResetError):
+            # Python 3.5+ raises BrokenPipeError instead of BadStatusLine when the connection was reset
+            # ConnectionResetError happens on FreeBSD with Python 3.4
             self.__conn.close()
             self.__conn.request(method, path, postdata, headers)
             return self._get_response()

--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -126,6 +126,11 @@ class AuthServiceProxy(object):
                 return self._get_response()
             else:
                 raise
+        except BrokenPipeError:
+            # Python 3.5+ raises this instead of BadStatusLine when the connection was reset
+            self.__conn.close()
+            self.__conn.request(method, path, postdata, headers)
+            return self._get_response()
 
     def __call__(self, *args):
         AuthServiceProxy.__id_count += 1

--- a/qa/rpc-tests/test_framework/bignum.py
+++ b/qa/rpc-tests/test_framework/bignum.py
@@ -1,16 +1,15 @@
-#
+#!/usr/bin/env python3
 #
 # bignum.py
 #
 # This file is copied from python-bitcoinlib.
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
 """Bignum routines"""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import struct
 

--- a/qa/rpc-tests/test_framework/blockstore.py
+++ b/qa/rpc-tests/test_framework/blockstore.py
@@ -1,16 +1,17 @@
+#!/usr/bin/env python3
 # BlockStore: a helper class that keeps a map of blocks and implements
 #             helper functions for responding to getheaders and getdata,
 #             and for constructing a getheaders message
 #
 
 from .mininode import *
-import dbm
 from io import BytesIO
+import dbm.ndbm
 
 class BlockStore(object):
     def __init__(self, datadir):
-        self.blockDB = dbm.open(datadir + "/blocks", 'c')
-        self.currentBlock = 0L
+        self.blockDB = dbm.ndbm.open(datadir + "/blocks", 'c')
+        self.currentBlock = 0
         self.headers_map = dict()
     
     def close(self):
@@ -67,7 +68,7 @@ class BlockStore(object):
         try:
             self.blockDB[repr(block.sha256)] = bytes(block.serialize())
         except TypeError as e:
-            print "Unexpected error: ", sys.exc_info()[0], e.args
+            print("Unexpected error: ", sys.exc_info()[0], e.args)
         self.currentBlock = block.sha256
         self.headers_map[block.sha256] = CBlockHeader(block)
 
@@ -105,7 +106,7 @@ class BlockStore(object):
 
 class TxStore(object):
     def __init__(self, datadir):
-        self.txDB = dbm.open(datadir + "/transactions", 'c')
+        self.txDB = dbm.ndbm.open(datadir + "/transactions", 'c')
 
     def close(self):
         self.txDB.close()
@@ -127,7 +128,7 @@ class TxStore(object):
         try:
             self.txDB[repr(tx.sha256)] = bytes(tx.serialize())
         except TypeError as e:
-            print "Unexpected error: ", sys.exc_info()[0], e.args
+            print("Unexpected error: ", sys.exc_info()[0], e.args)
 
     def get_transactions(self, inv):
         responses = []

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -1,8 +1,9 @@
+#!/usr/bin/env python3
 # blocktools.py - utilities for manipulating blocks and transactions
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
+
 
 from .mininode import *
 from .script import CScript, OP_TRUE, OP_CHECKSIG

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#
 
 from .mininode import *
 from .blockstore import BlockStore, TxStore
@@ -259,10 +258,10 @@ class TestManager(object):
                     if c.cb.bestblockhash == blockhash:
                         return False
                     if blockhash not in c.cb.block_reject_map:
-                        print 'Block not in reject map: %064x' % (blockhash)
+                        print('Block not in reject map: %064x' % (blockhash))
                         return False
                     if not outcome.match(c.cb.block_reject_map[blockhash]):
-                        print 'Block rejected with %s instead of expected %s: %064x' % (c.cb.block_reject_map[blockhash], outcome, blockhash)
+                        print('Block rejected with %s instead of expected %s: %064x' % (c.cb.block_reject_map[blockhash], outcome, blockhash))
                         return False
                 elif ((c.cb.bestblockhash == blockhash) != outcome):
                     # print c.cb.bestblockhash, blockhash, outcome
@@ -287,10 +286,10 @@ class TestManager(object):
                     if txhash in c.cb.lastInv:
                         return False
                     if txhash not in c.cb.tx_reject_map:
-                        print 'Tx not in reject map: %064x' % (txhash)
+                        print('Tx not in reject map: %064x' % (txhash))
                         return False
                     if not outcome.match(c.cb.tx_reject_map[txhash]):
-                        print 'Tx rejected with %s instead of expected %s: %064x' % (c.cb.tx_reject_map[txhash], outcome, txhash)
+                        print('Tx rejected with %s instead of expected %s: %064x' % (c.cb.tx_reject_map[txhash], outcome, txhash))
                         return False
                 elif ((txhash in c.cb.lastInv) != outcome):
                     # print c.rpc.getrawmempool(), c.cb.lastInv
@@ -393,7 +392,7 @@ class TestManager(object):
                 if (not self.check_mempool(tx.sha256, tx_outcome)):
                     raise AssertionError("Mempool test failed at test %d" % test_number)
 
-            print "Test %d: PASS" % test_number, [ c.rpc.getblockcount() for c in self.connections ]
+            print("Test %d: PASS" % test_number, [ c.rpc.getblockcount() for c in self.connections ])
             test_number += 1
 
         [ c.disconnect_node() for c in self.connections ]

--- a/qa/rpc-tests/test_framework/coverage.py
+++ b/qa/rpc-tests/test_framework/coverage.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """
 This module contains utilities for doing coverage analysis on the RPC
 interface.

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1,7 +1,12 @@
-# mininode.py - Dash P2P network half-a-node
-#
-# Distributed under the MIT/X11 software license, see the accompanying
+#!/usr/bin/env python3
+# Copyright (c) 2010 ArtForz -- public domain half-a-node
+# Copyright (c) 2012 Jeff Garzik
+# Copyright (c) 2010-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# mininode.py - Bitcoin P2P network half-a-node
 #
 # This python code was modified from ArtForz' public domain  half-a-node, as
 # found in the mini-node branch of http://github.com/jgarzik/pynode.
@@ -36,12 +41,12 @@ import dash_hash
 
 BIP0031_VERSION = 60000
 MY_VERSION = 70206  # current MIN_PEER_PROTO_VERSION
-MY_SUBVERSION = b"/python-mininode-tester:0.0.2/"
+MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 
 MAX_INV_SZ = 50000
 MAX_BLOCK_SIZE = 1000000
 
-COIN = 100000000L # 1 btc in satoshis
+COIN = 100000000 # 1 btc in satoshis
 
 # Keep our own socket map for asyncore, so that we can track disconnects
 # ourselves (to workaround an issue with closing an asyncore socket when 
@@ -77,20 +82,18 @@ def deser_string(f):
         nit = struct.unpack("<Q", f.read(8))[0]
     return f.read(nit)
 
-
 def ser_string(s):
     if len(s) < 253:
         return struct.pack("B", len(s)) + s
     elif len(s) < 0x10000:
         return struct.pack("<BH", 253, len(s)) + s
-    elif len(s) < 0x100000000L:
+    elif len(s) < 0x100000000:
         return struct.pack("<BI", 254, len(s)) + s
     return struct.pack("<BQ", 255, len(s)) + s
 
-
 def deser_uint256(f):
-    r = 0L
-    for i in xrange(8):
+    r = 0
+    for i in range(8):
         t = struct.unpack("<I", f.read(4))[0]
         r += t << (i * 32)
     return r
@@ -98,23 +101,23 @@ def deser_uint256(f):
 
 def ser_uint256(u):
     rs = b""
-    for i in xrange(8):
-        rs += struct.pack("<I", u & 0xFFFFFFFFL)
+    for i in range(8):
+        rs += struct.pack("<I", u & 0xFFFFFFFF)
         u >>= 32
     return rs
 
 
 def uint256_from_str(s):
-    r = 0L
+    r = 0
     t = struct.unpack("<IIIIIIII", s[:32])
-    for i in xrange(8):
+    for i in range(8):
         r += t[i] << (i * 32)
     return r
 
 
 def uint256_from_compact(c):
     nbytes = (c >> 24) & 0xFF
-    v = (c & 0xFFFFFFL) << (8 * (nbytes - 3))
+    v = (c & 0xFFFFFF) << (8 * (nbytes - 3))
     return v
 
 
@@ -127,7 +130,7 @@ def deser_vector(f, c):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = c()
         t.deserialize(f)
         r.append(t)
@@ -140,7 +143,7 @@ def ser_vector(l):
         r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
         r = struct.pack("<BH", 253, len(l))
-    elif len(l) < 0x100000000L:
+    elif len(l) < 0x100000000:
         r = struct.pack("<BI", 254, len(l))
     else:
         r = struct.pack("<BQ", 255, len(l))
@@ -158,7 +161,7 @@ def deser_uint256_vector(f):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = deser_uint256(f)
         r.append(t)
     return r
@@ -170,7 +173,7 @@ def ser_uint256_vector(l):
         r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
         r = struct.pack("<BH", 253, len(l))
-    elif len(l) < 0x100000000L:
+    elif len(l) < 0x100000000:
         r = struct.pack("<BI", 254, len(l))
     else:
         r = struct.pack("<BQ", 255, len(l))
@@ -188,7 +191,7 @@ def deser_string_vector(f):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = deser_string(f)
         r.append(t)
     return r
@@ -200,7 +203,7 @@ def ser_string_vector(l):
         r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
         r = struct.pack("<BH", 253, len(l))
-    elif len(l) < 0x100000000L:
+    elif len(l) < 0x100000000:
         r = struct.pack("<BI", 254, len(l))
     else:
         r = struct.pack("<BQ", 255, len(l))
@@ -218,7 +221,7 @@ def deser_int_vector(f):
     elif nit == 255:
         nit = struct.unpack("<Q", f.read(8))[0]
     r = []
-    for i in xrange(nit):
+    for i in range(nit):
         t = struct.unpack("<i", f.read(4))[0]
         r.append(t)
     return r
@@ -230,7 +233,7 @@ def ser_int_vector(l):
         r = struct.pack("B", len(l))
     elif len(l) < 0x10000:
         r = struct.pack("<BH", 253, len(l))
-    elif len(l) < 0x100000000L:
+    elif len(l) < 0x100000000:
         r = struct.pack("<BI", 254, len(l))
     else:
         r = struct.pack("<BQ", 255, len(l))
@@ -281,7 +284,7 @@ class CInv(object):
         1: "TX",
         2: "Block"}
 
-    def __init__(self, t=0, h=0L):
+    def __init__(self, t=0, h=0):
         self.type = t
         self.hash = h
 
@@ -532,7 +535,7 @@ class CBlock(CBlockHeader):
             hashes.append(ser_uint256(tx.sha256))
         while len(hashes) > 1:
             newhashes = []
-            for i in xrange(0, len(hashes), 2):
+            for i in range(0, len(hashes), 2):
                 i2 = min(i+1, len(hashes)-1)
                 newhashes.append(hash256(hashes[i] + hashes[i2]))
             hashes = newhashes
@@ -785,7 +788,7 @@ class msg_getblocks(object):
 
     def __init__(self):
         self.locator = CBlockLocator()
-        self.hashstop = 0L
+        self.hashstop = 0
 
     def deserialize(self, f):
         self.locator = CBlockLocator()
@@ -873,7 +876,7 @@ class msg_ping_prebip31(object):
 class msg_ping(object):
     command = b"ping"
 
-    def __init__(self, nonce=0L):
+    def __init__(self, nonce=0):
         self.nonce = nonce
 
     def deserialize(self, f):
@@ -945,7 +948,7 @@ class msg_getheaders(object):
 
     def __init__(self):
         self.locator = CBlockLocator()
-        self.hashstop = 0L
+        self.hashstop = 0
 
     def deserialize(self, f):
         self.locator = CBlockLocator()
@@ -993,7 +996,7 @@ class msg_reject(object):
         self.message = b""
         self.code = 0
         self.reason = b""
-        self.data = 0L
+        self.data = 0
 
     def deserialize(self, f):
         self.message = deser_string(f)
@@ -1066,10 +1069,10 @@ class NodeConnCB(object):
             time.sleep(deliver_sleep)
         with mininode_lock:
             try:
-                getattr(self, 'on_' + message.command)(conn, message)
+                getattr(self, 'on_' + message.command.decode('ascii'))(conn, message)
             except:
-                print "ERROR delivering %s (%s)" % (repr(message),
-                                                    sys.exc_info()[0])
+                print("ERROR delivering %s (%s)" % (repr(message),
+                                                    sys.exc_info()[0]))
 
     def on_version(self, conn, message):
         if message.nVersion >= 209:
@@ -1185,8 +1188,8 @@ class NodeConn(asyncore.dispatcher):
         vt.addrFrom.ip = "0.0.0.0"
         vt.addrFrom.port = 0
         self.send_message(vt, True)
-        print 'MiniNode: Connecting to Dash Node IP # ' + dstaddr + ':' \
-            + str(dstport)
+        print('MiniNode: Connecting to Dash Node IP # ' + dstaddr + ':' \
+            + str(dstport))
 
         try:
             self.connect((dstaddr, dstport))
@@ -1276,10 +1279,11 @@ class NodeConn(asyncore.dispatcher):
                     t.deserialize(f)
                     self.got_message(t)
                 else:
-                    self.show_debug_msg("Unknown command: '" + command + "' " +
-                                        repr(msg))
+                    self.show_debug_msg("Received unknown command from %s:%d: '%s' %s" % (self.dstaddr, self.dstport, command, repr(msg)))
         except Exception as e:
-            print 'got_data:', repr(e)
+            print('got_data:', repr(e))
+            # import  traceback
+            # traceback.print_tb(sys.exc_info()[2])
 
     def send_message(self, message, pushbuf=False):
         if self.state != "connected" and not pushbuf:

--- a/qa/rpc-tests/test_framework/netutil.py
+++ b/qa/rpc-tests/test_framework/netutil.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -1,10 +1,12 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #
 # script.py
 #
 # This file is modified from python-bitcoinlib.
-#
-# Distributed under the MIT/X11 software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
 """Scripts
@@ -12,7 +14,6 @@
 Functionality to build scripts, as well as SignatureHash().
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .mininode import CTransaction, CTxOut, hash256
 from binascii import hexlify
@@ -658,7 +659,7 @@ class CScript(bytes):
                 other = bchr(CScriptOp(OP_0))
             else:
                 other = CScriptNum.encode(other)
-        elif isinstance(other, (int, long)):
+        elif isinstance(other, int):
             if 0 <= other <= 16:
                 other = bytes(bchr(CScriptOp.encode_op_n(other)))
             elif other == -1:

--- a/qa/rpc-tests/test_framework/socks5.py
+++ b/qa/rpc-tests/test_framework/socks5.py
@@ -1,11 +1,12 @@
-# Copyright (c) 2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
 Dummy Socks5 server for testing.
 '''
-from __future__ import print_function, division, unicode_literals
-import socket, threading, Queue
+
+import socket, threading, queue
 import traceback, sys
 
 ### Protocol constants
@@ -132,7 +133,7 @@ class Socks5Server(object):
         self.s.listen(5)
         self.running = False
         self.thread = None
-        self.queue = Queue.Queue() # report connections and exceptions to client
+        self.queue = queue.Queue() # report connections and exceptions to client
 
     def run(self):
         while self.running:

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -140,7 +140,7 @@ class BitcoinTestFramework(object):
             print("JSONRPC error: "+e.error['message'])
             traceback.print_tb(sys.exc_info()[2])
         except AssertionError as e:
-            print("Assertion failed: "+ str(e))
+            print("Assertion failed: " + str(e))
             traceback.print_tb(sys.exc_info()[2])
         except Exception as e:
             print("Unexpected exception caught during testing: " + repr(e))
@@ -186,7 +186,7 @@ class ComparisonTestFramework(BitcoinTestFramework):
                           help="bitcoind binary to use for reference nodes (if any)")
 
     def setup_chain(self):
-        print "Initializing test directory "+self.options.tmpdir
+        print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, self.num_nodes)
 
     def setup_network(self):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1,6 +1,7 @@
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Copyright (c) 2014-2017 The Dash Core developers
-# Distributed under the MIT/X11 software license, see the accompanying
+# Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 
@@ -210,10 +211,10 @@ def initialize_chain(test_dir):
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
             bitcoind_processes[i] = subprocess.Popen(args)
             if os.getenv("PYTHON_DEBUG", ""):
-                print "initialize_chain: dashd started, waiting for RPC to come up"
+                print("initialize_chain: dashd started, waiting for RPC to come up")
             wait_for_bitcoind_start(bitcoind_processes[i], rpc_url(i), i)
             if os.getenv("PYTHON_DEBUG", ""):
-                print "initialize_chain: RPC succesfully started"
+                print("initialize_chain: RPC succesfully started")
 
         rpcs = []
         for i in range(4):
@@ -295,11 +296,11 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
     if os.getenv("PYTHON_DEBUG", ""):
-        print "start_node: dashd started, waiting for RPC to come up"
+        print("start_node: dashd started, waiting for RPC to come up")
     url = rpc_url(i, rpchost)
     wait_for_bitcoind_start(bitcoind_processes[i], url, i)
     if os.getenv("PYTHON_DEBUG", ""):
-        print "start_node: RPC succesfully started"
+        print("start_node: RPC succesfully started")
     proxy = get_rpc_proxy(url, i, timeout=timewait)
 
     if COVERAGE_DIR:
@@ -489,7 +490,7 @@ def assert_is_hex_string(string):
             "Couldn't interpret %r as hexadecimal; raised: %s" % (string, e))
 
 def assert_is_hash_string(string, length=64):
-    if not isinstance(string, basestring):
+    if not isinstance(string, str):
         raise AssertionError("Expected a string, got type %r" % type(string))
     elif length and len(string) != length:
         raise AssertionError(
@@ -540,7 +541,7 @@ def create_confirmed_utxos(fee, node, count):
     addr2 = node.getnewaddress()
     if iterations <= 0:
         return utxos
-    for i in xrange(iterations):
+    for i in range(iterations):
         t = utxos.pop()
         inputs = []
         inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})
@@ -566,11 +567,11 @@ def gen_return_txouts():
     # So we have big transactions (and therefore can't fit very many into each block)
     # create one script_pubkey
     script_pubkey = "6a4d0200" #OP_RETURN OP_PUSH2 512 bytes
-    for i in xrange (512):
+    for i in range (512):
         script_pubkey = script_pubkey + "01"
     # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
     txouts = "81"
-    for k in xrange(128):
+    for k in range(128):
         # add txout value
         txouts = txouts + "0000000000000000"
         # add length of script_pubkey
@@ -592,7 +593,7 @@ def create_tx(node, coinbase, to_address, amount):
 def create_lots_of_big_transactions(node, txouts, utxos, fee):
     addr = node.getnewaddress()
     txids = []
-    for i in xrange(len(utxos)):
+    for i in range(len(utxos)):
         t = utxos.pop()
         inputs = []
         inputs.append({ "txid" : t["txid"], "vout" : t["vout"]})

--- a/qa/rpc-tests/timestampindex.py
+++ b/qa/rpc-tests/timestampindex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -35,16 +35,16 @@ class TimestampIndexTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining 5 blocks..."
+        print("Mining 5 blocks...")
         blockhashes = self.nodes[0].generate(5)
         low = self.nodes[0].getblock(blockhashes[0])["time"]
         high = self.nodes[0].getblock(blockhashes[4])["time"]
         self.sync_all()
-        print "Checking timestamp index..."
+        print("Checking timestamp index...")
         hashes = self.nodes[1].getblockhashes(high, low)
         assert_equal(len(hashes), 5)
         assert_equal(sorted(blockhashes), sorted(hashes))
-        print "Passed\n"
+        print("Passed\n")
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/txindex.py
+++ b/qa/rpc-tests/txindex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -36,24 +36,24 @@ class TxIndexTest(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(105)
         self.sync_all()
 
         chain_height = self.nodes[1].getblockcount()
         assert_equal(chain_height, 105)
 
-        print "Testing transaction index..."
+        print("Testing transaction index...")
 
         privkey = "cU4zhap7nPJAWeMFu4j6jLrfPmqakDAzy8zn8Fhb3oEevdm4e5Lc"
         address = "yeMpGzMj3rhtnz48XsfpB8itPHhHtgxLc3"
-        addressHash = "C5E4FB9171C22409809A3E8047A29C83886E325D".decode("hex")
+        addressHash = bytes.fromhex("C5E4FB9171C22409809A3E8047A29C83886E325D")
         scriptPubKey = CScript([OP_DUP, OP_HASH160, addressHash, OP_EQUALVERIFY, OP_CHECKSIG])
         unspent = self.nodes[0].listunspent()
         tx = CTransaction()
-        amount = unspent[0]["amount"] * 100000000
+        amount = unspent[0]["amount"] * COIN
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
-        tx.vout = [CTxOut(amount, scriptPubKey)]
+        tx.vout = [CTxOut(int(amount), scriptPubKey)]
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
@@ -63,10 +63,10 @@ class TxIndexTest(BitcoinTestFramework):
 
         # Check verbose raw transaction results
         verbose = self.nodes[3].getrawtransaction(unspent[0]["txid"], 1)
-        assert_equal(verbose["vout"][0]["valueSat"], 5000000000);
-        assert_equal(verbose["vout"][0]["value"], 50);
+        assert_equal(verbose["vout"][0]["valueSat"], 50000000000);
+        assert_equal(verbose["vout"][0]["value"], 500);
 
-        print "Passed\n"
+        print("Passed\n")
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/wallet-hd.py
+++ b/qa/rpc-tests/wallet-hd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # coding=utf-8
 # ^^^^^^^^^^^^ TODO remove when supporting only Python3
 # Copyright (c) 2016 The Bitcoin Core developers

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python2
-# coding=utf-8
-# ^^^^^^^^^^^^ TODO remove when supporting only Python3
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -40,7 +38,7 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(len(self.nodes[1].listunspent()), 0)
         assert_equal(len(self.nodes[2].listunspent()), 0)
 
-        print "Mining blocks..."
+        print("Mining blocks...")
 
         self.nodes[0].generate(1)
 
@@ -329,7 +327,7 @@ class WalletTest (BitcoinTestFramework):
             '-salvagewallet',
         ]
         for m in maintenance:
-            print "check " + m
+            print("check " + m)
             stop_nodes(self.nodes)
             wait_bitcoinds()
             self.nodes = start_nodes(3, self.options.tmpdir, [[m]] * 3)

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2014-2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -22,7 +22,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print("Mining blocks...")
         self.nodes[0].generate(1)
         self.sync_all()
         self.nodes[1].generate(101)

--- a/qa/rpc-tests/zmq_test.py
+++ b/qa/rpc-tests/zmq_test.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-# Copyright (c) 2015 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,16 +10,9 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 import zmq
-import binascii
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import http.client
+import urllib.parse
 
 class ZMQTest (BitcoinTestFramework):
 
@@ -44,7 +37,7 @@ class ZMQTest (BitcoinTestFramework):
         genhashes = self.nodes[0].generate(1)
         self.sync_all()
 
-        print "listen..."
+        print("listen...")
         msg = self.zmqSubSocket.recv_multipart()
         topic = msg[0]
         body = msg[1]


### PR DESCRIPTION
This PR fixes build and test problems for PR #1692.

* Backport of change from Bitcoin upgrading `fontconfig` in `depends` to version 2.12.1.
* Another upgrade of `fontconfig` in `depends` to 2.12.6. This is needed to fix compilation error with `glibc` 2.25.
* Fix for building Qt on systems that use `pkgconf` instead of legacy `pkgconfig`.
* Backport of Bitcoin PR bitcoin/bitcoin#7814: switch to Python 3.
* Backport of Bitcoin PR bitcoin/bitcoin#8139: Fix interrupted HTTP RPC connection in Python 3.5+.
* Backport of Bitcoin PR bitcoin/bitcoin#8839: Avoid ConnectionResetErrors during RPC tests.

See individual commits for more detailed descriptions of changes and why they are needed.

These fixes work when building on modern Fedora 26.
However Travis tests may fail for now, but I know why and working on fix for old Ubuntu that Travis uses.