### PR TITLE
update setAskFor on TXLOCKVOTE

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -64,8 +64,9 @@ void CInstantSend::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataSt
 #endif
         LOCK(cs_instantsend);
 
-
         uint256 nVoteHash = vote.GetHash();
+
+        pfrom->setAskFor.erase(nVoteHash);
 
         if(mapTxLockVotes.count(nVoteHash)) return;
         mapTxLockVotes.insert(std::make_pair(nVoteHash, vote));


### PR DESCRIPTION
We should update `setAskFor` when we receive IS vote we asked node for via `inv`.