### PR TITLE
Fully rely on GetTransaction to find the block for the given TX in gettxoutproof

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -284,17 +284,12 @@ UniValue gettxoutproof(const UniValue& params, bool fHelp)
         if (!mapBlockIndex.count(hashBlock))
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
         pblockindex = mapBlockIndex[hashBlock];
-    } else {
-        const Coin& coin = AccessByTxid(*pcoinsTip, oneTxid);
-        if (!coin.IsSpent() && coin.nHeight > 0 && coin.nHeight <= chainActive.Height()) {
-            pblockindex = chainActive[coin.nHeight];
-        }
     }
 
     if (pblockindex == NULL)
     {
         CTransaction tx;
-        if (!GetTransaction(oneTxid, tx, Params().GetConsensus(), hashBlock, false) || hashBlock.IsNull())
+        if (!GetTransaction(oneTxid, tx, Params().GetConsensus(), hashBlock, true) || hashBlock.IsNull())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
         if (!mapBlockIndex.count(hashBlock))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");


### PR DESCRIPTION
GetTransaction falls back to checking the UTXO set in case the txindex is
not available. This means we don't have to manually check the UTXO set and
can simply delegate this to GetTransaction.

This should fix a similar performance issue as in https://github.com/dashpay/dash/pull/1727. I however was not sure why it was implemented the way it was before, so I'd be happy to see some additional review here. There is a slight possibility that the order in which it was done before had a reasoning behind and that it is important to first check the UTXO set before going to the txindex.