### PR TITLE
Backport bitcoin #11529: Avoid slow transaction search with txindex enabled (João Barbosa)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1112,6 +1112,9 @@ bool GetTransaction(const uint256 &hash, CTransaction &txOut, const Consensus::P
                 return error("%s: txid mismatch", __func__);
             return true;
         }
+
+        // transaction not found in index, nothing more can be done
+        return false;
     }
 
     if (fAllowSlow) { // use coin database to locate block that contains transaction, and scan it


### PR DESCRIPTION
7a5f930 Avoid slow transaction search with txindex enabled (João Barbosa)

Pull request description:

  This is an alternative to #11507 where a slow search is not attempted (in any case) if `txindex` is enabled.

Tree-SHA512: e680621781a9241c0513ddd79d23b0b42f3ccec8a63ed1c926b35c43321c81c39a1028770397dd5070501dcf644d897026a2bd68a161a4b435f19227c1bbca48