### PR TITLE
make CheckDSTXes() private, execute it on both client and server

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -65,6 +65,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
         return;
 
     mnodeman.UpdatedBlockTip(pindexNew);
+    CPrivateSend::UpdatedBlockTip(pindexNew);
 #ifdef ENABLE_WALLET
     privateSendClient.UpdatedBlockTip(pindexNew);
 #endif // ENABLE_WALLET

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1391,13 +1391,13 @@ void CPrivateSendClient::UpdatedBlockTip(const CBlockIndex *pindex)
     nCachedBlockHeight = pindex->nHeight;
     LogPrint("privatesend", "CPrivateSendClient::UpdatedBlockTip -- nCachedBlockHeight: %d\n", nCachedBlockHeight);
 
-    CPrivateSend::CheckDSTXes(pindex->nHeight);
 }
 
 //TODO: Rename/move to core
 void ThreadCheckPrivateSendClient(CConnman& connman)
 {
     if(fLiteMode) return; // disable all Dash specific functionality
+    if(fMasterNode) return; // no client-side mixing on masternodes
 
     static bool fOneThread;
     if(fOneThread) return;

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -403,6 +403,13 @@ void CPrivateSend::CheckDSTXes(int nHeight)
     LogPrint("privatesend", "CPrivateSend::CheckDSTXes -- mapDSTX.size()=%llu\n", mapDSTX.size());
 }
 
+void CPrivateSend::UpdatedBlockTip(const CBlockIndex *pindex)
+{
+    if(pindex && !fLiteMode && masternodeSync.IsMasternodeListSynced()) {
+        CheckDSTXes(pindex->nHeight);
+    }
+}
+
 void CPrivateSend::SyncTransaction(const CTransaction& tx, const CBlock* pblock)
 {
     if (tx.IsCoinBase()) return;

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -5,6 +5,7 @@
 #ifndef PRIVATESEND_H
 #define PRIVATESEND_H
 
+#include "chain.h"
 #include "chainparams.h"
 #include "primitives/transaction.h"
 #include "pubkey.h"
@@ -317,6 +318,8 @@ private:
 
     static CCriticalSection cs_mapdstx;
 
+    static void CheckDSTXes(int nHeight);
+
 public:
     static void InitStandardDenominations();
     static std::vector<CAmount> GetStandardDenominations() { return vecStandardDenominations; }
@@ -348,8 +351,8 @@ public:
 
     static void AddDSTX(const CDarksendBroadcastTx& dstx);
     static CDarksendBroadcastTx GetDSTX(const uint256& hash);
-    static void CheckDSTXes(int nHeight);
 
+    static void UpdatedBlockTip(const CBlockIndex *pindex);
     static void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
 };
 


### PR DESCRIPTION
`mapDSTX` should be cleared on both sides, `CheckDSTXes` should not be exposed.

NOTE: this commit is not included into #1735 because this one actually changes the behavior (fixes the bug).