### PR TITLE
Adjust tests to avoid Travis timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" -a "$WINE" != "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
-    - if [ "$RUN_TESTS" = "true" -a "$WINE" = "true" ]; then wine  src/test/test_dash.exe --show_progress; fi
+    - if [ "$RUN_TESTS" = "true" -a "$WINE" = "true" ]; then wine  src/test/test_dash.exe --log_level=test_suite; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage; fi
 after_script:
     - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then (echo "Upload goes here. Something like: scp -r $BASE_OUTDIR server" || echo "upload failed"); fi

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -190,6 +190,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
 
         // Once every 1000 iterations and at the end, verify the full cache.
         if (insecure_rand() % 1000 == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
+            BOOST_TEST_MESSAGE("coins_cache_simulation_test - verifying full cache");
             for (auto it = result.begin(); it != result.end(); it++) {
                 bool have = stack.back()->HaveCoin(it->first);
                 const Coin& coin = stack.back()->AccessCoin(it->first);
@@ -422,6 +423,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
 
         // Once every 1000 iterations and at the end, verify the full cache.
         if (insecure_rand() % 1000 == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
+            BOOST_TEST_MESSAGE("updatecoins_simulation_test - verifying full cache");
             for (auto it = result.begin(); it != result.end(); it++) {
                 bool have = stack.back()->HaveCoin(it->first);
                 const Coin& coin = stack.back()->AccessCoin(it->first);

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -186,6 +186,7 @@ public:
 BOOST_AUTO_TEST_CASE(PrevectorTestInt)
 {
     for (int j = 0; j < 64; j++) {
+        BOOST_TEST_MESSAGE("PrevectorTestInt " << j);
         prevector_tester<8, int> test;
         for (int i = 0; i < 2048; i++) {
             int r = insecure_rand();

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -136,6 +136,8 @@ BOOST_FIXTURE_TEST_SUITE(versionbits_tests, TestingSetup)
 BOOST_AUTO_TEST_CASE(versionbits_test)
 {
     for (int i = 0; i < 64; i++) {
+        BOOST_TEST_MESSAGE("versionbits_test " << i);
+
         // DEFINED -> FAILED
         VersionBitsTester().TestDefined()
                            .Mine(1, TestTime(1), 0x100).TestDefined()


### PR DESCRIPTION
Travis is acting weird and builds/tests take few times longer than usual on Wine sometimes which causes some relatively heavy tests to timeout. Previous attempt to fix this (#1740) relied on the assumption that no single test should take 10 minutes or more. Turned out that even this assumption is not correct sometimes, so here is an improved version.

Changes:
- add some stdout spam to heavy tests (versionbits_tests, coins_tests and PrevectorTests)
- replace `--show_progress` with `--log_level=test_suite` to print these messages and avoid timeout