### PR TITLE
Fix WarningBitsConditionChecker

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1933,7 +1933,7 @@ public:
     {
         return ((pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS) &&
                ((pindex->nVersion >> bit) & 1) != 0 &&
-               ((ComputeBlockVersion(pindex->pprev, params) >> bit) & 1) == 0;
+               ((ComputeBlockVersion(pindex->pprev, params, true) >> bit) & 1) == 0;
     }
 };
 


### PR DESCRIPTION
Assume that all masternodes are upgraded to avoid false warnings

(another attempt/part to fix #1756 )