### PR TITLE
Bump MIN_PEER_PROTO_VERSION to 70208

### DIFF
--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -35,7 +35,7 @@ import copy
 import dash_hash
 
 BIP0031_VERSION = 60000
-MY_VERSION = 70206  # current MIN_PEER_PROTO_VERSION
+MY_VERSION = 70208  # current MIN_PEER_PROTO_VERSION
 MY_SUBVERSION = b"/python-mininode-tester:0.0.2/"
 
 MAX_INV_SZ = 50000

--- a/src/version.h
+++ b/src/version.h
@@ -19,7 +19,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70206;
+static const int MIN_PEER_PROTO_VERSION = 70208;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
Drop old (pre-v0.12.2.x) peers