### PR TITLE
Fix stale initial sync/mining in devnet

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1407,7 +1407,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             if (inv.type == MSG_BLOCK) {
                 UpdateBlockAvailability(pfrom->GetId(), inv.hash);
                 if (!fAlreadyHave && !fImporting && !fReindex && !mapBlocksInFlight.count(inv.hash)) {
-                    if (chainparams.DelayGetHeadersTime() != 0 && pindexBestHeader->GetBlockTime() < GetAdjustedTime() - chainparams.DelayGetHeadersTime()) {
+                    // Always send GETHEADERS when we are still on the devnet genesis block. Otherwise we'll never sync.
+                    // This is because after startup of the node, we are in IBD mode, which will only be left when recent
+                    // blocks arrive. At the same time, we won't get any blocks from peers because we keep delaying
+                    // GETHEADERS
+                    bool fDevNetGenesis = chainparams.NetworkIDString() == CBaseChainParams::DEVNET && pindexBestHeader->GetBlockHash() == chainparams.DevNetGenesisBlock().GetHash();
+
+                    if (!fDevNetGenesis && chainparams.DelayGetHeadersTime() != 0 && pindexBestHeader->GetBlockTime() < GetAdjustedTime() - chainparams.DelayGetHeadersTime()) {
                         // We are pretty far from being completely synced at the moment. If we would initiate a new
                         // chain of GETHEADERS/HEADERS now, we may end up downnloading the full chain from multiple
                         // peers at the same time, slowing down the initial sync. At the same time, we don't know


### PR DESCRIPTION
With the current rules, we always assume that there is some peer somewhere in the universe that has more recent blocks then we have when the node is started. This is not fully true for devnet, as even the mining nodes start with an empty chain.

See commit descriptions for details on fixes.