### PR TITLE
Fix -prune option which was always failing on start

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1644,7 +1644,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     fMasterNode = GetBoolArg("-masternode", false);
     // TODO: masternode should have no wallet
 
-    if((fMasterNode || masternodeConfig.getCount() > -1) && fTxIndex == false) {
+    if((fMasterNode || masternodeConfig.getCount() > 0) && fTxIndex == false) {
         return InitError("Enabling Masternode support requires turning on transaction indexing."
                   "Please add txindex=1 to your configuration and start with -reindex");
     }


### PR DESCRIPTION
The check of available masternode configuration was wrong. This fix should
allow -prune to be set now.