### PR TITLE
Swap iterations and fUseInstantSend parameters in ApproximateBestSubset

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2491,7 +2491,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 }
 
 static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx*,unsigned int> > >vValue, const CAmount& nTotalLower, const CAmount& nTargetValue,
-                                  vector<char>& vfBest, CAmount& nBest, int iterations = 1000, bool fUseInstantSend = false)
+                                  vector<char>& vfBest, CAmount& nBest, bool fUseInstantSend = false, int iterations = 1000)
 {
     vector<char> vfIncluded;
 


### PR DESCRIPTION
#1695 introduced a fix for a instant send related edge case. Somehow the
parameters got mixed up and fUseInstantSend was passed as "iterations".

I assume this happened while resolving merge conflicts while rebasing after #1770 was merged.