### PR TITLE
Increase travis timeout for "wine src/test/test_dash.exe" call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" -a "$WINE" != "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
-    - if [ "$RUN_TESTS" = "true" -a "$WINE" = "true" ]; then travis_wait 30 wine src/test/test_dash.exe; fi
+    - if [ "$RUN_TESTS" = "true" -a "$WINE" = "true" ]; then travis_wait 60 wine src/test/test_dash.exe; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
There are timeouts happening on Travis now. Increasing travis_wait to 60 minutes.

As of https://travis-ci.org/dashpay/dash/jobs/322244640#L3063, around 40 minutes should also be ok but I'd like to have some buffer here.