### PR TITLE
Vote on IS only if it was accepted to mempool

### DIFF
--- a/src/instantx.h
+++ b/src/instantx.h
@@ -86,6 +86,7 @@ public:
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
     bool ProcessTxLockRequest(const CTxLockRequest& txLockRequest, CConnman& connman);
+    void Vote(const uint256& txHash, CConnman& connman);
 
     bool AlreadyHave(const uint256& hash);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1659,6 +1659,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 LogPrintf("TXLOCKREQUEST -- Transaction Lock Request accepted, txid=%s, peer=%d\n",
                         tx.GetHash().ToString(), pfrom->id);
                 instantsend.AcceptLockRequest(txLockRequest);
+                instantsend.Vote(tx.GetHash(), connman);
             }
 
             mempool.check(pcoinsTip);


### PR DESCRIPTION
Split txlock processing and voting processes - MNs from top10 quorum should only vote if IS was accepted to mempool.