### PR TITLE
[Trivial] RPC Typos / markdown formatting

### DIFF
--- a/dash-docs/protocol-documentation.md
+++ b/dash-docs/protocol-documentation.md
@@ -16,7 +16,7 @@ CScript => uchar[]
 Bitcoin Outpoint https://bitcoin.org/en/glossary/outpoint
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 32 | hash | uint256 | Hash of transactional output which is being referenced
 | 4 | n | uint32_t | Index of transaction which is being referenced
 
@@ -26,7 +26,7 @@ Bitcoin Outpoint https://bitcoin.org/en/glossary/outpoint
 Bitcoin Input https://bitcoin.org/en/glossary/input
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 36 | prevout | [COutPoint](#coutpoint) | The previous output from an existing transaction, in the form of an unspent output
 | 1+ | script length | var_int | The length of the signature script
 | ? | script | CScript | The script which is validated for this input to be spent
@@ -37,14 +37,14 @@ Bitcoin Input https://bitcoin.org/en/glossary/input
 Bitcoin Output https://bitcoin.org/en/glossary/output
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 8 | nValue | int64_t | Transfered value
 | ? | scriptPubKey | CScript | The script for indicating what conditions must be fulfilled for this output to be further spent
 
 ### CTransaction
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 4 | nVersion | int32_t | Transaction data format version
 | 1+ | tx_in count | var_int | Number of Transaction inputs
 | 41+ | vin | [CTxIn](#ctxin) | A list of 1 or more transaction inputs
@@ -57,13 +57,13 @@ Bitcoin Output https://bitcoin.org/en/glossary/output
 Bitcoin Public Key https://bitcoin.org/en/glossary/public-key
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 33-65 | vch | char[] | The public portion of a keypair which can be used to verify signatures made with the private portion of the keypair.
 
 ### CService
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 16 | IP | CNetAddr | IP Address
 | 2 | Port | uint16 | IP Port
 
@@ -76,7 +76,7 @@ CMasternodeBroadcast
 Whenever a masternode comes online or a client is syncing, they will send this message which describes the masternode entry and how to validate messages from it.
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 41 | vin | [CTxIn](#ctxin) | The unspent output which is holding 1000 DASH
 | # | addr | [CService](#cservice) | IPv4 address of the masternode
 | 33-65 | pubKeyCollateralAddress | [CPubKey](#cpubkey) | CPubKey of the main 1000 DASH unspent output
@@ -94,7 +94,7 @@ CMasternodePing
 Every few minutes, masternodes ping the network with a message that propagates the whole network.
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | --------- |
 | 41 | vin | [CTxIn](#ctxin) | The unspent output of the masternode which is signing the message
 | 32 | blockHash | uint256 | Current chaintip blockhash minus 12
 | 8 | sigTime | int64_t | Signature time for this ping
@@ -107,7 +107,7 @@ CMasternodePaymentVote
 When a new block is found on the network, a masternode quorum will be determined and those 10 selected masternodes will issue a masternode payment vote message to pick the next winning node.
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 41 | vinMasternode | [CTxIn](#ctxin) | The unspent output of the masternode which is signing the message
 | 4 | nBlockHeight | int | The blockheight which the payee should be paid
 | ? | payeeAddress | CScript | The address to pay to
@@ -120,7 +120,7 @@ CDarksendBroadcastTx
 Masternodes can broadcast subsidised transactions without fees for the sake of security in mixing. This is done via the DSTX message.
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | # | tx | [CTransaction](#ctransaction) | The transaction
 | 41 | vin | [CTxIn](#ctxin) | Masternode unspent output
 | 71-73 | vchSig | char[] | Signature of this message by masternode (verifiable via pubKeyMasternode)
@@ -131,7 +131,7 @@ Masternodes can broadcast subsidised transactions without fees for the sake of s
 Mixing pool status update
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 4 | nMsgSessionID | int | Session ID
 | 4 | nMsgState | int | Current state of mixing process
 | 4 | nMsgEntriesCount | int | Number of entries in the mixing pool
@@ -145,7 +145,7 @@ CDarksendQueue
 Asks users to sign final mixing tx message.
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 4 | nDenom | int | Which denomination is allowed in this mixing session
 | 41 | vin | [CTxIn](#ctxin) | unspend output from masternode which is hosting this session
 | 8 | nTime | int64_t | the time this DSQ was created
@@ -157,7 +157,7 @@ Asks users to sign final mixing tx message.
 Response to DSQ message which allows the user to join a mixing pool
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 4 | nDenom | int | denomination that will be exclusively used when submitting inputs into the pool
 | 41+ | txCollateral | int | collateral tx that will be charged if this client acts maliciousely
 
@@ -168,7 +168,7 @@ CDarkSendEntry
 When queue is ready user is expected to send his entry to start actual mixing
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | ? | vecTxDSIn | CTxDSIn[] | vector of users inputs (CTxDSIn serialization is equal to [CTxIn](#ctxin) serialization)
 | 8 | nAmount | int64_t | depreciated since 12.1, it's used for backwards compatibility only and can be removed with future protocol bump
 | ? | txCollateral | [CTransaction](#ctransaction) | Collateral transaction which is used to prevent misbehavior and also to charge fees randomly
@@ -179,7 +179,7 @@ When queue is ready user is expected to send his entry to start actual mixing
 User's signed inputs for a group transaction in a mixing session
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | # | inputs | [CTxIn](#ctxin)[] | signed inputs for mixing session
 
 
@@ -196,7 +196,7 @@ CTxLockVote
 Transaction Lock Vote
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 32 | txHash | uint256 | txid of the transaction to lock
 | 36 | outpoint | [COutPoint](#coutpoint) | The utxo to lock in this transaction
 | 36 | outpointMasternode | [COutPoint](#coutpoint) | The utxo of the masternode which is signing the vote
@@ -209,7 +209,7 @@ Governance Object
 A proposal, contract or setting.
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 32 | nHashParent | uint256 | Parent object, 0 is root
 | 4 | nRevision | int | Object revision in the system
 | 8 | nTime | int64_t | Time which this object was created
@@ -226,7 +226,7 @@ Governance Vote
 Masternodes use governance voting in response to new proposals, contracts, settings or finalized budgets.
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 41+ | vinMasternode | [CTxIn](#ctxin) | Unspent output for the masternode which is voting
 | 32 | nParentHash | uint256 | Object which we're voting on (proposal, contract, setting or final budget)
 | 4 | nVoteOutcome | int | ???
@@ -241,11 +241,11 @@ Spork
 Spork
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
-| 4 | nSporkID | int | 
-| 8 | nValue | int64_t | 
-| 8 | nTimeSigned | int64_t | 
-| 66* | vchSig | char[] | Unclear if 66 is the correct size, but this is what it appears to be in most cases
+| ---------- | ----------- | --------- | ---------- |
+| 4 | nSporkID | int | |
+| 8 | nValue | int64_t | |
+| 8 | nTimeSigned | int64_t | |
+| 66* | vchSig | char[] | Unclear if 66 is the correct size, but this is what it appears to be in most cases |
 
 #### Defined Sporks (per src/sporks.h)
  
@@ -257,8 +257,8 @@ Spork
 | 10007 | 8 | MASTERNODE_PAYMENT_ENFORCEMENT | Requires masternodes to be paid by miners when blocks are processed
 | 10008 | 9 | SUPERBLOCKS_ENABLED | Superblocks are enabled (the 10% comes to fund the dash treasury)
 | 10009 | 10 | MASTERNODE_PAY_UPDATED_NODES | Only current protocol version masternode's will be paid (not older nodes)
-| 10011 | 12 | RECONSIDER_BLOCKS |
-| 10012 | 13 | OLD_SUPERBLOCK_FLAG |
+| 10011 | 12 | RECONSIDER_BLOCKS | |
+| 10012 | 13 | OLD_SUPERBLOCK_FLAG | |
 | 10013 | 14 | REQUIRE_SENTINEL_FLAG | Only masternode's running sentinel will be paid 
 
 ## Undocumented messages
@@ -274,7 +274,7 @@ Masternode Payment Block
 Masternode Verify
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 41 | vin1 | [CTxIn](#ctxin) | The unspent output which is holding 1000 DASH for masternode 1
 | 41 | vin2 | [CTxIn](#ctxin) | The unspent output which is holding 1000 DASH for masternode 2
 | # | addr | [CService](#cservice) | IPv4 address / port of the masternode
@@ -288,8 +288,8 @@ Masternode Verify
 Darksend Final Transaction
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
-| 4 | nSessionID | int |
+| ---------- | ----------- | --------- | ---------- |
+| 4 | nSessionID | int | |
 | # | txFinal | [CTransaction](#ctransaction) | Final mixing transaction
 
 ### DSCOMPLETE - "dsc"
@@ -297,18 +297,18 @@ Darksend Final Transaction
 Darksend Complete
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
-| 4 | nSessionID | int |
-| 4 | nMessageID | int |
+| ---------- | ----------- | --------- | ---------- |
+| 4 | nSessionID | int | |
+| 4 | nMessageID | int | |
 
 ### MNGOVERNANCESYNC - "govsync"
 
 Governance Sync
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
-| 32 | nHash | uint256 |
-| # | filter | CBloomFilter |
+| ---------- | ----------- | --------- | ---------- |
+| 32 | nHash | uint256 | |
+| # | filter | CBloomFilter | |
 
 ### DSEG - "dseg"
 
@@ -317,7 +317,7 @@ Masternode List/Entry Sync
 Get Masternode list or specific entry
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 41 | vin | [CTxIn](#ctxin) | The unspent output which is holding 1000 DASH
 
 ### SYNCSTATUSCOUNT - "ssc"
@@ -325,7 +325,7 @@ Get Masternode list or specific entry
 Sync Status Count
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
+| ---------- | ----------- | --------- | ---------- |
 | 4 | nItemID | int | Masternode Sync Item ID
 | 4 | nCount | int | Masternode Sync Count
 
@@ -333,17 +333,17 @@ Sync Status Count
 
 | Item ID | Name | Description |
 | ---------- | ---------- | ----------- |
-| 2 | MASTERNODE_SYNC_LIST |
-| 3 | MASTERNODE_SYNC_MNW |
-| 4 | MASTERNODE_SYNC_GOVERNANCE |
-| 10 | MASTERNODE_SYNC_GOVOBJ |
-| 11 | MASTERNODE_SYNC_GOVOBJ_VOTE |
+| 2 | MASTERNODE_SYNC_LIST | |
+| 3 | MASTERNODE_SYNC_MNW | |
+| 4 | MASTERNODE_SYNC_GOVERNANCE | |
+| 10 | MASTERNODE_SYNC_GOVOBJ | |
+| 11 | MASTERNODE_SYNC_GOVOBJ_VOTE | |
 
 ### MASTERNODEPAYMENTSYNC - "mnget"
 
 Masternode Payment Sync
 
 | Field Size | Field Name | Data type | Description |
-| ---------- | ----------- | --------- | -------- |
-| 4 | nMnCount | int |
+| ---------- | ----------- | --------- | ---------- |
+| 4 | nMnCount | int | |
 

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -18,7 +18,7 @@ extern CInstantSend instantsend;
 
 /*
     At 15 signatures, 1/2 of the masternode network can be owned by
-    one party without comprimising the security of InstantSend
+    one party without compromising the security of InstantSend
     (1000/2150.0)**10 = 0.00047382219560689856
     (1000/2900.0)**10 = 2.3769498616783657e-05
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1026,7 +1026,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
             "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
-            "  \"pruneheight\": xxxxxx,    (numeric) heighest block available\n"
+            "  \"pruneheight\": xxxxxx,    (numeric) highest block available\n"
             "  \"softforks\": [            (array) status of softforks in progress\n"
             "     {\n"
             "        \"id\": \"xxxx\",        (string) name of softfork\n"

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -564,7 +564,7 @@ UniValue gobject(const UniValue& params, bool fHelp)
             if(!fMnFound) {
                 nFailed++;
                 statusObj.push_back(Pair("result", "failed"));
-                statusObj.push_back(Pair("errorMessage", "Masternode must be publically available on network to vote. Masternode not found."));
+                statusObj.push_back(Pair("errorMessage", "Masternode must be publicly available on network to vote. Masternode not found."));
                 resultsObj.push_back(Pair(mne.getAlias(), statusObj));
                 continue;
             }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -265,13 +265,13 @@ UniValue spork(const UniValue& params, bool fHelp)
 
     throw runtime_error(
         "spork <name> [<value>]\n"
-        "<name> is the corresponding spork name, or 'show' to show all current spork settings, active to show which sporks are active\n"
+        "<name> is the corresponding spork name, or 'show' to show all current spork settings, 'active' to show which sporks are active\n"
         "<value> is a epoch datetime to enable or disable spork\n"
         + HelpRequiringPassphrase());
 #else // ENABLE_WALLET
     throw runtime_error(
         "spork <name>\n"
-        "<name> is the corresponding spork name, or 'show' to show all current spork settings, active to show which sporks are active\n");
+        "<name> is the corresponding spork name, or 'show' to show all current spork settings, 'active' to show which sporks are active\n");
 #endif // ENABLE_WALLET
 
 }


### PR DESCRIPTION
- Fix more typos in RPC help
- Make protocol doc table formatting more doxygen friendly