### PR TITLE
Protect CKeyHolderStorage via mutex

### DIFF
--- a/src/privatesend-util.cpp
+++ b/src/privatesend-util.cpp
@@ -27,12 +27,14 @@ CScript CKeyHolder::GetScriptForDestination() const
 
 const CKeyHolder& CKeyHolderStorage::AddKey(CWallet* pwallet)
 {
+    LOCK(cs_storage);
     storage.emplace_back(std::unique_ptr<CKeyHolder>(new CKeyHolder(pwallet)));
     LogPrintf("CKeyHolderStorage::%s -- storage size %lld\n", __func__, storage.size());
     return *storage.back();
 }
 
 void CKeyHolderStorage::KeepAll(){
+    LOCK(cs_storage);
     if (storage.size() > 0) {
         for (auto &key : storage) {
             key->KeepKey();
@@ -44,6 +46,7 @@ void CKeyHolderStorage::KeepAll(){
 
 void CKeyHolderStorage::ReturnAll()
 {
+    LOCK(cs_storage);
     if (storage.size() > 0) {
         for (auto &key : storage) {
             key->ReturnKey();

--- a/src/privatesend-util.h
+++ b/src/privatesend-util.h
@@ -27,6 +27,7 @@ class CKeyHolderStorage
 {
 private:
     std::vector<std::unique_ptr<CKeyHolder> > storage;
+    mutable CCriticalSection cs_storage;
 
 public:
     const CKeyHolder& AddKey(CWallet* pwalletIn);


### PR DESCRIPTION
Sometimes `dsc` arrives at the same time we decide that session is timed out. This leads to a situation when `keyHolderStorage` is accessed from two threads which in its turn leads to a crash. Protecting internal vector via mutex should solve this.