### PR TITLE
Fix logging in PushInventory

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -883,8 +883,10 @@ public:
         LOCK(cs_inventory);
         if (inv.type == MSG_TX) {
             if (!filterInventoryKnown.contains(inv.hash)) {
-                LogPrint("net", "PushInventory --  filtered inv: %s peer=%d\n", inv.ToString(), id);
+                LogPrint("net", "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
                 setInventoryTxToSend.insert(inv.hash);
+            } else {
+                LogPrint("net", "PushInventory --  filtered inv: %s peer=%d\n", inv.ToString(), id);
             }
         } else if (inv.type == MSG_BLOCK) {
             LogPrint("net", "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);


### PR DESCRIPTION
Merge conflict resolution went wrong here. It showed filtered in case it
was pushed and nothing in case it was filtered.