### PR TITLE
shorten MN outpoint output from getvotes

### DIFF
--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -151,7 +151,7 @@ public:
     std::string ToString() const
     {
         std::ostringstream ostr;
-        ostr << vinMasternode.ToString() << ":"
+        ostr << vinMasternode.prevout.ToStringShort() << ":"
              << nTime << ":"
              << CGovernanceVoting::ConvertOutcomeToString(GetOutcome()) << ":"
              << CGovernanceVoting::ConvertSignalToString(GetSignal());


### PR DESCRIPTION
This would change the output of getvotes family of RPC commands from something like (example):

```
"64c9d5a7aed64fddf4f69390b4aec921938238a9efb4e81dab878d74234e1340": "CTxIn(COutPoint(a8b2a88c97682f213d3f71ffa2d0ae2e13220745c7fa7e2b93c2aff0824db4ff, 0), scriptSig=):1511282274:NO:FUNDING"
```

... to this:

```
"64c9d5a7aed64fddf4f69390b4aec921938238a9efb4e81dab878d74234e1340": "a8b2a88c97682f213d3f71ffa2d0ae2e13220745c7fa7e2b93c2aff0824db4ff-0:1511282274:NO:FUNDING"
```

This would make it easier to parse and remove superfluous chars. This has already been done for `masternode status`, so this change is following up on some remaining bits.