### PR TITLE
Switch CNetFulfilledRequestManager from CAddress to CNetAddr

### DIFF
--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -8,13 +8,13 @@
 
 CNetFulfilledRequestManager netfulfilledman;
 
-void CNetFulfilledRequestManager::AddFulfilledRequest(CAddress addr, std::string strRequest)
+void CNetFulfilledRequestManager::AddFulfilledRequest(CNetAddr addr, std::string strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     mapFulfilledRequests[addr][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
 }
 
-bool CNetFulfilledRequestManager::HasFulfilledRequest(CAddress addr, std::string strRequest)
+bool CNetFulfilledRequestManager::HasFulfilledRequest(CNetAddr addr, std::string strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
@@ -24,7 +24,7 @@ bool CNetFulfilledRequestManager::HasFulfilledRequest(CAddress addr, std::string
             it->second[strRequest] > GetTime();
 }
 
-void CNetFulfilledRequestManager::RemoveFulfilledRequest(CAddress addr, std::string strRequest)
+void CNetFulfilledRequestManager::RemoveFulfilledRequest(CNetAddr addr, std::string strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -5,8 +5,7 @@
 #ifndef NETFULFILLEDMAN_H
 #define NETFULFILLEDMAN_H
 
-#include "netbase.h"
-#include "protocol.h"
+#include "netaddress.h"
 #include "serialize.h"
 #include "sync.h"
 
@@ -36,9 +35,9 @@ public:
         READWRITE(mapFulfilledRequests);
     }
 
-    void AddFulfilledRequest(CAddress addr, std::string strRequest); // expire after 1 hour by default
-    bool HasFulfilledRequest(CAddress addr, std::string strRequest);
-    void RemoveFulfilledRequest(CAddress addr, std::string strRequest);
+    void AddFulfilledRequest(CNetAddr addr, std::string strRequest);
+    bool HasFulfilledRequest(CNetAddr addr, std::string strRequest);
+    void RemoveFulfilledRequest(CNetAddr addr, std::string strRequest);
 
     void CheckAndRemove();
     void Clear();


### PR DESCRIPTION
~Ignore ports, skip recent IPs completely when preferring "new" nodes (on sync etc.)~
It's already the case, this just fixes the interface.