### PR TITLE
No need for msgMakerInitProto for sporks

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -195,7 +195,6 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
     BOOST_FOREACH(CNode* pnode, vNodesCopy)
     {
         CNetMsgMaker msgMaker(pnode->GetSendVersion());
-        CNetMsgMaker msgMakerInitProto(INIT_PROTO_VERSION);
 
         // Don't try to sync any data from outbound "masternode" connections -
         // they are temporary and should be considered unreliable for a sync process.
@@ -207,7 +206,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
         if(Params().NetworkIDString() == CBaseChainParams::REGTEST)
         {
             if(nRequestedMasternodeAttempt <= 2) {
-                connman.PushMessage(pnode, msgMakerInitProto.Make(NetMsgType::GETSPORKS)); //get current network sporks
+                connman.PushMessage(pnode, msgMaker.Make(NetMsgType::GETSPORKS)); //get current network sporks
             } else if(nRequestedMasternodeAttempt < 4) {
                 mnodeman.DsegUpdate(pnode, connman);
             } else if(nRequestedMasternodeAttempt < 6) {
@@ -238,7 +237,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 // always get sporks first, only request once from each peer
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "spork-sync");
                 // get current network sporks
-                connman.PushMessage(pnode, msgMakerInitProto.Make(NetMsgType::GETSPORKS));
+                connman.PushMessage(pnode, msgMaker.Make(NetMsgType::GETSPORKS));
                 LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- requesting sporks from peer %d\n", nTick, nRequestedMasternodeAssets, pnode->id);
             }
 


### PR DESCRIPTION
No need for `msgMakerInitProto` for sporks because we loop by fully connected nodes only now