### PR TITLE
Do not send dash-specific requests to masternodes before we are fully connected

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -742,7 +742,7 @@ std::pair<CService, std::set<uint256> > CMasternodeMan::PopScheduledMnbRequestCo
 
 void CMasternodeMan::ProcessQueuedMnbRequests(CConnman& connman)
 {
-    std::pair<CService, std::set<uint256> > p = mnodeman.PopScheduledMnbRequestConnection();
+    std::pair<CService, std::set<uint256> > p = PopScheduledMnbRequestConnection();
     if (!(p.first == CService() || p.second.empty())) {
         if (connman.IsMasternodeOrDisconnectRequested(p.first)) return;
         mnbQueue.push_back(std::make_pair(GetTime(), p));

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -779,8 +779,8 @@ void CMasternodeMan::ProcessPendingMnbRequests(CConnman& connman)
         } else {
             ++itPendingMNB;
         }
-        LogPrint("masternode", "%s -- mapPendingMNB size: %d\n", __func__, mapPendingMNB.size());
     }
+    LogPrint("masternode", "%s -- mapPendingMNB size: %d\n", __func__, mapPendingMNB.size());
 }
 
 void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
@@ -1128,8 +1128,8 @@ void CMasternodeMan::ProcessPendingMnvRequests(CConnman& connman)
         } else {
             ++itPendingMNV;
         }
-        LogPrint("masternode", "%s -- mapPendingMNV size: %d\n", __func__, mapPendingMNV.size());
     }
+    LogPrint("masternode", "%s -- mapPendingMNV size: %d\n", __func__, mapPendingMNV.size());
 }
 
 void CMasternodeMan::SendVerifyReply(CNode* pnode, CMasternodeVerification& mnv, CConnman& connman)

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -63,6 +63,9 @@ private:
     std::map<uint256, std::pair< int64_t, std::set<CNetAddr> > > mMnbRecoveryRequests;
     std::map<uint256, std::vector<CMasternodeBroadcast> > mMnbRecoveryGoodReplies;
     std::list< std::pair<CService, uint256> > listScheduledMnbRequestConnections;
+    std::deque<std::pair<int64_t, std::pair<CService, std::set<uint256> > > > mnbQueue;
+    std::deque<std::pair<int64_t, std::pair<CService, CMasternodeVerification > > > mnvQueue;
+    CCriticalSection cs_mnvQueue;
 
     /// Set when masternodes are added, cleared when CGovernanceManager is notified
     bool fMasternodesAdded;
@@ -180,12 +183,14 @@ public:
 
     void ProcessMasternodeConnections(CConnman& connman);
     std::pair<CService, std::set<uint256> > PopScheduledMnbRequestConnection();
+    void ProcessQueuedMnbRequests(CConnman& connman);
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
     void DoFullVerificationStep(CConnman& connman);
     void CheckSameAddr();
     bool SendVerifyRequest(const CAddress& addr, const std::vector<CMasternode*>& vSortedByAddr, CConnman& connman);
+    void ProcessQueuedMnvRequests(CConnman& connman);
     void SendVerifyReply(CNode* pnode, CMasternodeVerification& mnv, CConnman& connman);
     void ProcessVerifyReply(CNode* pnode, CMasternodeVerification& mnv);
     void ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerification& mnv);

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -63,9 +63,9 @@ private:
     std::map<uint256, std::pair< int64_t, std::set<CNetAddr> > > mMnbRecoveryRequests;
     std::map<uint256, std::vector<CMasternodeBroadcast> > mMnbRecoveryGoodReplies;
     std::list< std::pair<CService, uint256> > listScheduledMnbRequestConnections;
-    std::deque<std::pair<int64_t, std::pair<CService, std::set<uint256> > > > mnbQueue;
-    std::deque<std::pair<int64_t, std::pair<CService, CMasternodeVerification > > > mnvQueue;
-    CCriticalSection cs_mnvQueue;
+    std::map<CService, std::pair<int64_t, std::set<uint256> > > mapPendingMNB;
+    std::map<CService, std::pair<int64_t, CMasternodeVerification> > mapPendingMNV;
+    CCriticalSection cs_mapPendingMNV;
 
     /// Set when masternodes are added, cleared when CGovernanceManager is notified
     bool fMasternodesAdded;
@@ -183,14 +183,14 @@ public:
 
     void ProcessMasternodeConnections(CConnman& connman);
     std::pair<CService, std::set<uint256> > PopScheduledMnbRequestConnection();
-    void ProcessQueuedMnbRequests(CConnman& connman);
+    void ProcessPendingMnbRequests(CConnman& connman);
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
     void DoFullVerificationStep(CConnman& connman);
     void CheckSameAddr();
     bool SendVerifyRequest(const CAddress& addr, const std::vector<CMasternode*>& vSortedByAddr, CConnman& connman);
-    void ProcessQueuedMnvRequests(CConnman& connman);
+    void ProcessPendingMnvRequests(CConnman& connman);
     void SendVerifyReply(CNode* pnode, CMasternodeVerification& mnv, CConnman& connman);
     void ProcessVerifyReply(CNode* pnode, CMasternodeVerification& mnv);
     void ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerification& mnv);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1900,7 +1900,7 @@ void CConnman::ThreadOpenAddedConnections()
     }
 }
 
-void CConnman::ThreadMnbRequestConnections()
+void CConnman::ThreadOpenMasternodeConnections()
 {
     // Connecting to specific addresses, no masternode connections available
     if (IsArgSet("-connect") && mapMultiArgs.at("-connect").size() > 0)
@@ -1915,34 +1915,22 @@ void CConnman::ThreadMnbRequestConnections()
         if (interruptNet)
             return;
 
-        std::pair<CService, std::set<uint256> > p = mnodeman.PopScheduledMnbRequestConnection();
-        if(p.first == CService() || p.second.empty()) continue;
-
-        // compile request vector
-        std::vector<CInv> vToFetch;
-        std::set<uint256>::iterator it = p.second.begin();
-        while(it != p.second.end()) {
-            if(*it != uint256()) {
-                vToFetch.push_back(CInv(MSG_MASTERNODE_ANNOUNCE, *it));
-                LogPrint("masternode", "ThreadMnbRequestConnections -- asking for mnb %s from addr=%s\n", it->ToString(), p.first.ToString());
+        LOCK(cs_vPendingMasternodes);
+        std::vector<CService>::iterator it = vPendingMasternodes.begin();
+        while (it != vPendingMasternodes.end()) {
+            if (!IsMasternodeOrDisconnectRequested(*it)) {
+                OpenMasternodeConnection(CAddress(*it, NODE_NETWORK));
+                // should be in the list now if connection was opened
+                ForNode(*it, CConnman::AllNodes, [&](CNode* pnode) {
+                    if (pnode->fDisconnect) {
+                        return false;
+                    }
+                    grant.MoveTo(pnode->grantMasternodeOutbound);
+                    return true;
+                });
             }
-            ++it;
+            it = vPendingMasternodes.erase(it);
         }
-
-        CAddress addr(p.first, NODE_NETWORK);
-        OpenMasternodeConnection(addr);
-
-        ForNode(addr, CConnman::AllNodes, [&](CNode* pnode) {
-            if (pnode->fDisconnect) return false;
-
-            grant.MoveTo(pnode->grantMasternodeOutbound);
-
-            // ask for data
-            CNetMsgMaker msgMaker(pnode->GetSendVersion());
-            PushMessage(pnode, msgMaker.Make(NetMsgType::GETDATA, vToFetch));
-
-            return true;
-        });
     }
 }
 
@@ -2333,7 +2321,7 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
         threadOpenConnections = std::thread(&TraceThread<std::function<void()> >, "opencon", std::function<void()>(std::bind(&CConnman::ThreadOpenConnections, this)));
 
     // Initiate masternode connections
-    threadMnbRequestConnections = std::thread(&TraceThread<std::function<void()> >, "mnbcon", std::function<void()>(std::bind(&CConnman::ThreadMnbRequestConnections, this)));
+    threadOpenMasternodeConnections = std::thread(&TraceThread<std::function<void()> >, "mncon", std::function<void()>(std::bind(&CConnman::ThreadOpenMasternodeConnections, this)));
 
     // Process messages
     threadMessageHandler = std::thread(&TraceThread<std::function<void()> >, "msghand", std::function<void()>(std::bind(&CConnman::ThreadMessageHandler, this)));
@@ -2387,8 +2375,8 @@ void CConnman::Stop()
 {
     if (threadMessageHandler.joinable())
         threadMessageHandler.join();
-    if (threadMnbRequestConnections.joinable())
-        threadMnbRequestConnections.join();
+    if (threadOpenMasternodeConnections.joinable())
+        threadOpenMasternodeConnections.join();
     if (threadOpenConnections.joinable())
         threadOpenConnections.join();
     if (threadOpenAddedConnections.joinable())
@@ -2506,6 +2494,18 @@ bool CConnman::RemoveAddedNode(const std::string& strNode)
         }
     }
     return false;
+}
+
+bool CConnman::AddPendingMasternode(const CService& service)
+{
+    LOCK(cs_vPendingMasternodes);
+    for(std::vector<CService>::const_iterator it = vPendingMasternodes.begin(); it != vPendingMasternodes.end(); ++it) {
+        if (service == *it)
+            return false;
+    }
+
+    vPendingMasternodes.push_back(service);
+    return true;
 }
 
 size_t CConnman::GetNodeCount(NumConnections flags)

--- a/src/net.h
+++ b/src/net.h
@@ -348,6 +348,7 @@ public:
 
     bool AddNode(const std::string& node);
     bool RemoveAddedNode(const std::string& node);
+    bool AddPendingMasternode(const CService& addr);
     std::vector<AddedNodeInfo> GetAddedNodeInfo();
 
     size_t GetNodeCount(NumConnections num);
@@ -409,7 +410,7 @@ private:
     void AcceptConnection(const ListenSocket& hListenSocket);
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
-    void ThreadMnbRequestConnections();
+    void ThreadOpenMasternodeConnections();
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 
@@ -475,6 +476,8 @@ private:
     CCriticalSection cs_vOneShots;
     std::vector<std::string> vAddedNodes;
     CCriticalSection cs_vAddedNodes;
+    std::vector<CService> vPendingMasternodes;
+    CCriticalSection cs_vPendingMasternodes;
     std::vector<CNode*> vNodes;
     std::list<CNode*> vNodesDisconnected;
     mutable CCriticalSection cs_vNodes;
@@ -512,7 +515,7 @@ private:
     std::thread threadSocketHandler;
     std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;
-    std::thread threadMnbRequestConnections;
+    std::thread threadOpenMasternodeConnections;
     std::thread threadMessageHandler;
 };
 extern std::unique_ptr<CConnman> g_connman;

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -29,6 +29,45 @@ static const int PRIVATESEND_KEYS_THRESHOLD_STOP    = 50;
 // The main object for accessing mixing
 extern CPrivateSendClient privateSendClient;
 
+class CPendingDsaRequest
+{
+private:
+    static const int TIMEOUT = 15;
+
+    CService addr;
+    CDarksendAccept dsa;
+    int64_t nTimeCreated;
+
+public:
+    CPendingDsaRequest():
+        addr(CService()),
+        dsa(CDarksendAccept()),
+        nTimeCreated(0)
+    {};
+
+    CPendingDsaRequest(const CService& addr_, const CDarksendAccept& dsa_):
+        addr(addr_),
+        dsa(dsa_)
+    { nTimeCreated = GetTime(); }
+
+    CService GetAddr() { return addr; }
+    CDarksendAccept GetDSA() { return dsa; }
+    bool IsExpired() { return GetTime() - nTimeCreated > TIMEOUT; }
+
+    friend bool operator==(const CPendingDsaRequest& a, const CPendingDsaRequest& b)
+    {
+        return a.addr == b.addr && a.dsa == b.dsa;
+    }
+    friend bool operator!=(const CPendingDsaRequest& a, const CPendingDsaRequest& b)
+    {
+        return !(a == b);
+    }
+    explicit operator bool() const
+    {
+        return *this != CPendingDsaRequest();
+    }
+};
+
 /** Used to keep track of current status of mixing pool
  */
 class CPrivateSendClient : public CPrivateSendBase
@@ -54,8 +93,7 @@ private:
 
     masternode_info_t infoMixingMasternode;
     CMutableTransaction txMyCollateral; // client side collateral
-    std::map<CService, std::pair<int64_t, CDarksendAccept> > mapPendingDSA;
-    CCriticalSection cs_mapPendingDSA;
+    CPendingDsaRequest pendingDsaRequest;
 
     CKeyHolderStorage keyHolderStorage; // storage for keys used in PrepareDenominate
 
@@ -142,7 +180,7 @@ public:
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun=false);
 
-    void ProcessPendingDsaRequests(CConnman& connman);
+    void ProcessPendingDsaRequest(CConnman& connman);
 
     void CheckTimeout();
 

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -54,6 +54,8 @@ private:
 
     masternode_info_t infoMixingMasternode;
     CMutableTransaction txMyCollateral; // client side collateral
+    CCriticalSection cs_dsaQueue;
+    std::deque<std::pair<int64_t, std::pair<CService, CDarksendAccept> > > dsaQueue;
 
     CKeyHolderStorage keyHolderStorage; // storage for keys used in PrepareDenominate
 
@@ -139,6 +141,8 @@ public:
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun=false);
+
+    void ProcessQueuedDsa(CConnman& connman);
 
     void CheckTimeout();
 

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -54,8 +54,8 @@ private:
 
     masternode_info_t infoMixingMasternode;
     CMutableTransaction txMyCollateral; // client side collateral
-    CCriticalSection cs_dsaQueue;
-    std::deque<std::pair<int64_t, std::pair<CService, CDarksendAccept> > > dsaQueue;
+    std::map<CService, std::pair<int64_t, CDarksendAccept> > mapPendingDSA;
+    CCriticalSection cs_mapPendingDSA;
 
     CKeyHolderStorage keyHolderStorage; // storage for keys used in PrepareDenominate
 
@@ -142,7 +142,7 @@ public:
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun=false);
 
-    void ProcessQueuedDsa(CConnman& connman);
+    void ProcessPendingDsaRequests(CConnman& connman);
 
     void CheckTimeout();
 

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -455,8 +455,8 @@ void ThreadCheckPrivateSend(CConnman& connman)
             // make sure to check all masternodes first
             mnodeman.Check();
 
-            mnodeman.ProcessQueuedMnbRequests(connman);
-            mnodeman.ProcessQueuedMnvRequests(connman);
+            mnodeman.ProcessPendingMnbRequests(connman);
+            mnodeman.ProcessPendingMnvRequests(connman);
 
             // check if we should activate or ping every few minutes,
             // slightly postpone first run to give net thread a chance to connect to some peers

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -455,6 +455,9 @@ void ThreadCheckPrivateSend(CConnman& connman)
             // make sure to check all masternodes first
             mnodeman.Check();
 
+            mnodeman.ProcessQueuedMnbRequests(connman);
+            mnodeman.ProcessQueuedMnvRequests(connman);
+
             // check if we should activate or ping every few minutes,
             // slightly postpone first run to give net thread a chance to connect to some peers
             if(nTick % MASTERNODE_MIN_MNP_SECONDS == 15)

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -121,6 +121,11 @@ public:
         READWRITE(nDenom);
         READWRITE(txCollateral);
     }
+
+    friend bool operator==(const CDarksendAccept& a, const CDarksendAccept& b)
+    {
+        return a.nDenom == b.nDenom && a.txCollateral == b.txCollateral;
+    }
 };
 
 // A clients transaction in the mixing pool


### PR DESCRIPTION
Open all masternode connections via `CConnman::ThreadOpenMasternodeConnections` only. Queue requests and process them after some timeout.