### PR TITLE
Fix qt and fontconfig depends

### DIFF
--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -13,7 +13,13 @@ define $(package)_config_cmds
   $($(package)_autoconf)
 endef
 
+# 2.12.1 uses CHAR_WIDTH which is reserved and clashes with some glibc versions, but newer versions of fontconfig
+# have broken makefiles which needlessly attempt to re-generate headers with gperf.
+# Instead, change all uses of CHAR_WIDTH, and disable the rule that forces header re-generation.
+# This can be removed once the upstream build is fixed.
 define $(package)_build_cmds
+  sed -i 's/CHAR_WIDTH/CHARWIDTH/g' fontconfig/fontconfig.h src/fcobjshash.gperf src/fcobjs.h src/fcobjshash.h && \
+  sed -i 's/fcobjshash.h: fcobjshash.gperf/fcobjshash.h:/' src/Makefile && \
   $(MAKE)
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -150,7 +150,6 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  export PKG_CONFIG_SYSROOT_DIR=/ && \
   export PKG_CONFIG_LIBDIR=$(host_prefix)/lib/pkgconfig && \
   export PKG_CONFIG_PATH=$(host_prefix)/share/pkgconfig  && \
   ./configure $($(package)_config_opts) && \


### PR DESCRIPTION
https://github.com/dashpay/dash/pull/1692 contains two fixes not covered by the previous backports. This PR has these cherry-picked.