### PR TITLE
Return JSON object for masternode count (by default but still support old modes for now)

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -135,7 +135,7 @@ UniValue masternode(const JSONRPCRequest& request)
                 "\nArguments:\n"
                 "1. \"command\"        (string or set of strings, required) The command to execute\n"
                 "\nAvailable commands:\n"
-                "  count        - Print number of all known masternodes (optional: 'ps', 'enabled', 'all', 'qualify')\n"
+                "  count        - Get information about number of masternodes (DEPRECATED options: 'total', 'ps', 'enabled', 'qualify', 'all')\n"
                 "  current      - Print info on current masternode winner to be paid the next block (calculated locally)\n"
                 "  genkey       - Generate new masternodeprivkey\n"
 #ifdef ENABLE_WALLET

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -185,28 +185,18 @@ UniValue masternode(const JSONRPCRequest& request)
         if (request.params.size() > 2)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Too many parameters");
 
-        if (request.params.size() == 1)
-            return mnodeman.size();
-
-        std::string strMode = request.params[1].get_str();
-
-        if (strMode == "ps")
-            return mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION);
-
-        if (strMode == "enabled")
-            return mnodeman.CountEnabled();
-
         int nCount;
         masternode_info_t mnInfo;
         mnodeman.GetNextMasternodeInQueueForPayment(true, nCount, mnInfo);
 
-        if (strMode == "qualify")
-            return nCount;
+        UniValue obj(UniValue::VOBJ);
 
-        if (strMode == "all")
-            return strprintf("Total: %d (PS Compatible: %d / Enabled: %d / Qualify: %d)",
-                mnodeman.size(), mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION),
-                mnodeman.CountEnabled(), nCount);
+        obj.push_back(Pair("total", mnodeman.size()));
+        obj.push_back(Pair("ps_compatible", mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)));
+        obj.push_back(Pair("enabled", mnodeman.CountEnabled()));
+        obj.push_back(Pair("qualify", nCount));
+
+        return obj;
     }
 
     if (strCommand == "current" || strCommand == "winner")

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -189,14 +189,38 @@ UniValue masternode(const JSONRPCRequest& request)
         masternode_info_t mnInfo;
         mnodeman.GetNextMasternodeInQueueForPayment(true, nCount, mnInfo);
 
-        UniValue obj(UniValue::VOBJ);
+        int total = mnodeman.size();
+        int ps = mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION);
+        int enabled = mnodeman.CountEnabled();
 
-        obj.push_back(Pair("total", mnodeman.size()));
-        obj.push_back(Pair("ps_compatible", mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)));
-        obj.push_back(Pair("enabled", mnodeman.CountEnabled()));
-        obj.push_back(Pair("qualify", nCount));
+        if (request.params.size() == 1) {
+            UniValue obj(UniValue::VOBJ);
 
-        return obj;
+            obj.push_back(Pair("total", total));
+            obj.push_back(Pair("ps_compatible", ps));
+            obj.push_back(Pair("enabled", enabled));
+            obj.push_back(Pair("qualify", nCount));
+
+            return obj;
+        }
+
+        std::string strMode = request.params[1].get_str();
+
+        if (strMode == "total")
+            return total;
+
+        if (strMode == "ps")
+            return ps;
+
+        if (strMode == "enabled")
+            return enabled;
+
+        if (strMode == "qualify")
+            return nCount;
+
+        if (strMode == "all")
+            return strprintf("Total: %d (PS Compatible: %d / Enabled: %d / Qualify: %d)",
+                total, ps, enabled, nCount);
     }
 
     if (strCommand == "current" || strCommand == "winner")


### PR DESCRIPTION
The output of the `masternode count` command currently varies by type depending on the mode argument. If the mode is empty, `ps`, `enabled` or `qualify`, the return value is an integer. But if the mode is `all`, the return value is a formatted string intended for human consumption.

I propose to return a JSON object every time. This PR actually returns the output of `masternode count all` as an object regardless of the mode argument, but alternatively it could be modified to return an object with only the requested mode instead.

Example of `masternode count` output with this change compiled in:

```
{
  "total": 139,
  "ps_compatible": 75,
  "enabled": 75,
  "qualify": 68
}
```