### PR TITLE
simplify gobject JSON format, remove unused fields

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -333,9 +333,13 @@ UniValue CGovernanceObject::GetJSONObject()
     UniValue objResult(UniValue::VOBJ);
     GetData(objResult);
 
-    std::vector<UniValue> arr1 = objResult.getValues();
-    std::vector<UniValue> arr2 = arr1.at( 0 ).getValues();
-    obj = arr2.at( 1 );
+    if (objResult.isObject()) {
+        obj = objResult;
+    } else {
+        std::vector<UniValue> arr1 = objResult.getValues();
+        std::vector<UniValue> arr2 = arr1.at( 0 ).getValues();
+        obj = arr2.at( 1 );
+    }
 
     return obj;
 }

--- a/src/governance-validators.cpp
+++ b/src/governance-validators.cpp
@@ -190,10 +190,17 @@ void CProposalValidator::ParseJSONData(const std::string& strJSONData)
 
     try {
         UniValue obj(UniValue::VOBJ);
+
         obj.read(strJSONData);
-        std::vector<UniValue> arr1 = obj.getValues();
-        std::vector<UniValue> arr2 = arr1.at(0).getValues();
-        objJSON = arr2.at(1);
+
+        if (obj.isObject()) {
+            objJSON = obj;
+        } else {
+            std::vector<UniValue> arr1 = obj.getValues();
+            std::vector<UniValue> arr2 = arr1.at(0).getValues();
+            objJSON = arr2.at(1);
+        }
+
         fJSONValid = true;
     }
     catch(std::exception& e) {

--- a/src/test/governance_validators_tests.cpp
+++ b/src/test/governance_validators_tests.cpp
@@ -41,9 +41,16 @@ BOOST_AUTO_TEST_CASE(valid_proposals_test)
     BOOST_CHECK_MESSAGE(tests.size(), "Empty `tests`");
     for(size_t i = 0; i < tests.size(); ++i) {
         const UniValue& objProposal = tests[i];
-        std::string strHexData = CreateEncodedProposalObject(objProposal);
-        CProposalValidator validator(strHexData);
-        BOOST_CHECK_MESSAGE(validator.Validate(), validator.GetErrorMessages());
+
+        // legacy format
+        std::string strHexData1 = CreateEncodedProposalObject(objProposal);
+        CProposalValidator validator1(strHexData1);
+        BOOST_CHECK_MESSAGE(validator1.Validate(), validator1.GetErrorMessages());
+
+        // new format
+        std::string strHexData2 = HexStr(objProposal.write());
+        CProposalValidator validator2(strHexData2);
+        BOOST_CHECK_MESSAGE(validator2.Validate(), validator2.GetErrorMessages());
     }
 }
 


### PR DESCRIPTION
This allows gobject format to change from (for example):

```
[
    [
        "proposal",
        {"object": "data-here"}
    ]
]
```

... to simply:

```
{"object": "data-here"}
```

The outer array isn't needed, and the first value in the 2-item tuple is likewise discarded by DashCore. This change should allow either data format to exist (we can deprecate/remove the older format later) and remove the array of different type elements (string, object).

This will also require some changes to Sentinel, started (but not completed) here: https://github.com/dashpay/sentinel/pull/35