### PR TITLE
Update timeLastMempoolReq when responding to MEMPOOL request

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2783,6 +2783,7 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
                         vInv.clear();
                     }
                 }
+                pto->timeLastMempoolReq = GetTime();
             }
 
             // Determine transactions to relay


### PR DESCRIPTION
This should have been part of the Bitcoin #8080 backporting but was missed
due to manual conflict resolution.