### PR TITLE
Update links and references to current communication channels

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -26,8 +26,8 @@ Drag Dash-Qt to your applications folder, and then run Dash-Qt.
 
 * See the [Dash documentation](https://dashpay.atlassian.net/wiki/display/DOC)
 for help and more information.
-* Ask for help on [#dashpay](http://webchat.freenode.net?channels=dashpay) on Freenode. If you don't have an IRC client use [webchat here](http://webchat.freenode.net?channels=dashpay).
-* Ask for help on the [DashTalk](https://dashtalk.org/) forums.
+* Ask for help on [Dash Nation Discord](http://dashchat.org)
+* Ask for help on the [Dash Forum](https://dash.org/forum)
 
 Building
 ---------------------
@@ -57,8 +57,8 @@ The Dash Core repo's [root README](/README.md) contains relevant information on 
 - [Benchmarking](benchmarking.md)
 
 ### Resources
-* Discuss on the [DashTalk](https://dashtalk.org/) forums, in the Development & Technical Discussion board.
-* Discuss on [#dashpay](http://webchat.freenode.net/?channels=dashpay) on Freenode. If you don't have an IRC client use [webchat here](http://webchat.freenode.net/?channels=dashpay).
+* Discuss on the [Dash Forum](https://dash.org/forum), in the Development & Technical Discussion board.
+* Discuss on [Dash Nation Discord](http://dashchat.org)
 
 ### Miscellaneous
 - [Assets Attribution](assets-attribution.md)

--- a/doc/keepass.md
+++ b/doc/keepass.md
@@ -55,4 +55,4 @@ At this point, the association is made. The next action depends on your particul
 
 At this point, the passphrase is stored in KeePassHttp. When Unlocking the wallet, one can use _keepass_ as the passphrase to trigger retrieval of the password. This works from the RPC commands as well as the GUI.
 
-Extended guide with screenshots is also available: https://dashtalk.org/threads/keepass-integration.3620/
+Extended guide with screenshots is also available: https://www.dash.org/forum/threads/keepass-integration.3620/

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -107,4 +107,4 @@ To create a new language template, you will need to edit the languages manifest 
 **Note:** that the language translation file **must end in `.qm`** (the compiled extension), and not `.ts`.
 
 ### Questions and general assistance
-Check official forum at [https://dashtalk.org/forums/dash-worldwide-collaboration.88/](https://dashtalk.org/forums/dash-worldwide-collaboration.88/).
+Check official forum at [https://www.dash.org/forum/topic/dash-worldwide-collaboration.88/](https://www.dash.org/forum/topic/dash-worldwide-collaboration.88/).


### PR DESCRIPTION
We don't really use freenode anymore. Also, it's dash.org/forum instead of
dashtalk.org today.