### PR TITLE
remove unused method GetObjectSubtype

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -268,15 +268,6 @@ bool CGovernanceObject::CheckSignature(CPubKey& pubKeyMasternode)
     return true;
 }
 
-int CGovernanceObject::GetObjectSubtype()
-{
-    // todo - 12.1
-    //   - detect subtype from strData json, obj["subtype"]
-
-    if(nObjectType == GOVERNANCE_OBJECT_TRIGGER) return TRIGGER_SUPERBLOCK;
-    return -1;
-}
-
 uint256 CGovernanceObject::GetHash() const
 {
     // CREATE HASH OF ALL IMPORTANT PIECES OF DATA

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -273,8 +273,6 @@ public:
 
     void UpdateSentinelVariables();
 
-    int GetObjectSubtype();
-
     CAmount GetMinCollateralFee();
 
     UniValue GetJSONObject();


### PR DESCRIPTION
I believe this was stubbed to eventually read the string in the 1st field of the inner array in the gobject JSON. Currently only Sentinel uses this and I would like to move to just a single JSON object, so don't think this is necessary any longer.