### PR TITLE
Remove excessive custom validation in CProposalValidator::ValidatePaymentAddress

### DIFF
--- a/src/governance-validators.cpp
+++ b/src/governance-validators.cpp
@@ -154,23 +154,14 @@ bool CProposalValidator::ValidatePaymentAddress()
         return false;
     }
 
-    static const std::string base58chars = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-
-    size_t nLength = strPaymentAddress.size();
-
-    if((nLength < 26) || (nLength > 35)) {
-        strErrorMessages += "incorrect payment_address length;";
-        return false;
-    }
-
-    if(strPaymentAddress.find_first_not_of(base58chars) != std::string::npos) {
-        strErrorMessages += "payment_address contains invalid characters;";
-        return false;
-    }
-
     CBitcoinAddress address(strPaymentAddress);
     if(!address.IsValid()) {
         strErrorMessages += "payment_address is invalid;";
+        return false;
+    }
+
+    if(address.IsScript()) {
+        strErrorMessages += "script addresses are not supported;";
         return false;
     }
 


### PR DESCRIPTION
We should already be good with internal validation