### PR TITLE
Add DSHA256 and X11 benchmarks, refactor

### DIFF
--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2016 The Bitcoin Core developers
+// Copyright (c) 2018 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,7 +18,7 @@
 /* Number of bytes to hash per iteration */
 static const uint64_t BUFFER_SIZE = 1000*1000;
 
-static void RIPEMD160(benchmark::State& state)
+static void HASH_RIPEMD160(benchmark::State& state)
 {
     uint8_t hash[CRIPEMD160::OUTPUT_SIZE];
     std::vector<uint8_t> in(BUFFER_SIZE,0);
@@ -25,7 +26,7 @@ static void RIPEMD160(benchmark::State& state)
         CRIPEMD160().Write(in.data(), in.size()).Finalize(hash);
 }
 
-static void SHA1(benchmark::State& state)
+static void HASH_SHA1(benchmark::State& state)
 {
     uint8_t hash[CSHA1::OUTPUT_SIZE];
     std::vector<uint8_t> in(BUFFER_SIZE,0);
@@ -33,7 +34,7 @@ static void SHA1(benchmark::State& state)
         CSHA1().Write(in.data(), in.size()).Finalize(hash);
 }
 
-static void SHA256(benchmark::State& state)
+static void HASH_SHA256(benchmark::State& state)
 {
     uint8_t hash[CSHA256::OUTPUT_SIZE];
     std::vector<uint8_t> in(BUFFER_SIZE,0);
@@ -41,7 +42,7 @@ static void SHA256(benchmark::State& state)
         CSHA256().Write(in.data(), in.size()).Finalize(hash);
 }
 
-static void SHA256_32b(benchmark::State& state)
+static void HASH_SHA256_0032b(benchmark::State& state)
 {
     std::vector<uint8_t> in(32,0);
     while (state.KeepRunning()) {
@@ -51,7 +52,25 @@ static void SHA256_32b(benchmark::State& state)
     }
 }
 
-static void SHA512(benchmark::State& state)
+static void HASH_DSHA256(benchmark::State& state)
+{
+    uint8_t hash[CSHA256::OUTPUT_SIZE];
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        CHash256().Write(in.data(), in.size()).Finalize(hash);
+}
+
+static void HASH_DSHA256_0032b(benchmark::State& state)
+{
+    std::vector<uint8_t> in(32,0);
+    while (state.KeepRunning()) {
+        for (int i = 0; i < 1000000; i++) {
+            CHash256().Write(in.data(), in.size()).Finalize(&in[0]);
+        }
+    }
+}
+
+static void HASH_SHA512(benchmark::State& state)
 {
     uint8_t hash[CSHA512::OUTPUT_SIZE];
     std::vector<uint8_t> in(BUFFER_SIZE,0);
@@ -59,7 +78,7 @@ static void SHA512(benchmark::State& state)
         CSHA512().Write(in.data(), in.size()).Finalize(hash);
 }
 
-static void SipHash_32b(benchmark::State& state)
+static void HASH_SipHash_0032b(benchmark::State& state)
 {
     uint256 x;
     while (state.KeepRunning()) {
@@ -69,10 +88,124 @@ static void SipHash_32b(benchmark::State& state)
     }
 }
 
-BENCHMARK(RIPEMD160);
-BENCHMARK(SHA1);
-BENCHMARK(SHA256);
-BENCHMARK(SHA512);
+static void HASH_DSHA256_0032b_single(benchmark::State& state)
+{
+    std::vector<uint8_t> in(32,0);
+    while (state.KeepRunning())
+        CHash256().Write(in.data(), in.size()).Finalize(&in[0]);
+}
 
-BENCHMARK(SHA256_32b);
-BENCHMARK(SipHash_32b);
+static void HASH_DSHA256_0080b_single(benchmark::State& state)
+{
+    std::vector<uint8_t> in(80,0);
+    while (state.KeepRunning())
+        CHash256().Write(in.data(), in.size()).Finalize(&in[0]);
+}
+
+static void HASH_DSHA256_0128b_single(benchmark::State& state)
+{
+    std::vector<uint8_t> in(128,0);
+    while (state.KeepRunning())
+        CHash256().Write(in.data(), in.size()).Finalize(&in[0]);
+}
+
+static void HASH_DSHA256_0512b_single(benchmark::State& state)
+{
+    std::vector<uint8_t> in(512,0);
+    while (state.KeepRunning())
+        CHash256().Write(in.data(), in.size()).Finalize(&in[0]);
+}
+
+static void HASH_DSHA256_1024b_single(benchmark::State& state)
+{
+    std::vector<uint8_t> in(1024,0);
+    while (state.KeepRunning())
+        CHash256().Write(in.data(), in.size()).Finalize(&in[0]);
+}
+
+static void HASH_DSHA256_2048b_single(benchmark::State& state)
+{
+    std::vector<uint8_t> in(2048,0);
+    while (state.KeepRunning())
+        CHash256().Write(in.data(), in.size()).Finalize(&in[0]);
+}
+
+static void HASH_X11(benchmark::State& state)
+{
+    uint256 hash;
+    std::vector<uint8_t> in(BUFFER_SIZE,0);
+    while (state.KeepRunning())
+        hash = HashX11(in.begin(), in.end());
+}
+
+static void HASH_X11_0032b_single(benchmark::State& state)
+{
+    uint256 hash;
+    std::vector<uint8_t> in(32,0);
+    while (state.KeepRunning())
+        hash = HashX11(in.begin(), in.end());
+}
+
+static void HASH_X11_0080b_single(benchmark::State& state)
+{
+    uint256 hash;
+    std::vector<uint8_t> in(80,0);
+    while (state.KeepRunning())
+        hash = HashX11(in.begin(), in.end());
+}
+
+static void HASH_X11_0128b_single(benchmark::State& state)
+{
+    uint256 hash;
+    std::vector<uint8_t> in(128,0);
+    while (state.KeepRunning())
+        hash = HashX11(in.begin(), in.end());
+}
+
+static void HASH_X11_0512b_single(benchmark::State& state)
+{
+    uint256 hash;
+    std::vector<uint8_t> in(512,0);
+    while (state.KeepRunning())
+        hash = HashX11(in.begin(), in.end());
+}
+
+static void HASH_X11_1024b_single(benchmark::State& state)
+{
+    uint256 hash;
+    std::vector<uint8_t> in(1024,0);
+    while (state.KeepRunning())
+        hash = HashX11(in.begin(), in.end());
+}
+
+static void HASH_X11_2048b_single(benchmark::State& state)
+{
+    uint256 hash;
+    std::vector<uint8_t> in(2048,0);
+    while (state.KeepRunning())
+        hash = HashX11(in.begin(), in.end());
+}
+
+BENCHMARK(HASH_RIPEMD160);
+BENCHMARK(HASH_SHA1);
+BENCHMARK(HASH_SHA256);
+BENCHMARK(HASH_DSHA256);
+BENCHMARK(HASH_SHA512);
+BENCHMARK(HASH_X11);
+
+BENCHMARK(HASH_SHA256_0032b);
+BENCHMARK(HASH_DSHA256_0032b);
+BENCHMARK(HASH_SipHash_0032b);
+
+BENCHMARK(HASH_DSHA256_0032b_single);
+BENCHMARK(HASH_DSHA256_0080b_single);
+BENCHMARK(HASH_DSHA256_0128b_single);
+BENCHMARK(HASH_DSHA256_0512b_single);
+BENCHMARK(HASH_DSHA256_1024b_single);
+BENCHMARK(HASH_DSHA256_2048b_single);
+BENCHMARK(HASH_X11_0032b_single);
+BENCHMARK(HASH_X11_0080b_single);
+BENCHMARK(HASH_X11_0128b_single);
+BENCHMARK(HASH_X11_0512b_single);
+BENCHMARK(HASH_X11_1024b_single);
+BENCHMARK(HASH_X11_2048b_single);


### PR DESCRIPTION
Add DSHA256 and X11 benchmarks. Also refactor names of other algo benchmarks to group them together.

DSHA256 and X11 also have additional tests for data from 32 to 2048 bytes (for comparison, in steps).

Looks like this now:
```
HASH_DSHA256,224,0.004438042640686,0.006658911705017,0.004743687808514,10224691,15343074,10929264
HASH_DSHA256_0032b,2,0.658596992492676,0.658596992492676,0.658596992492676,1517379473,1517379473,1517379473
HASH_DSHA256_0032b_single,1572864,0.000000618980266,0.000000720610842,0.000000653125123,1426,1660,1504
HASH_DSHA256_0080b_single,1048576,0.000000948086381,0.000001071261067,0.000000992204605,2184,2468,2285
HASH_DSHA256_0128b_single,851968,0.000001185868314,0.000001370561222,0.000001246062031,2732,3157,2870
HASH_DSHA256_0512b_single,327680,0.000002957531251,0.000003447115887,0.000003106717486,6814,7942,7157
HASH_DSHA256_1024b_single,196608,0.000005231195246,0.000005721551133,0.000005449997843,12052,13182,12556
HASH_DSHA256_2048b_single,98304,0.000009891489753,0.000011300900951,0.000010374829192,22789,26034,23903
HASH_RIPEMD160,384,0.002567186951637,0.002986758947372,0.002696075787147,5914708,6881347,6211646
HASH_SHA1,576,0.001737110316753,0.002056375145912,0.001831571261088,4002219,4737889,4219863
HASH_SHA256,224,0.004442453384399,0.005187511444092,0.004694205309664,10235832,11951745,10815254
HASH_SHA256_0032b,4,0.328065514564514,0.331060528755188,0.329563021659851,755848191,762750730,759299460
HASH_SHA512,384,0.002631470561028,0.003067433834076,0.002789856866002,6062805,7067288,6427714
HASH_SipHash_0032b,30,0.033042430877686,0.037223458290100,0.034758965174357,76128290,85760828,80083281
HASH_X11,120,0.008013010025024,0.009173631668091,0.008706633249919,18461995,21135490,20059719
HASH_X11_0032b_single,20480,0.000051029841416,0.000058016157709,0.000053492863663,117569,133667,123245
HASH_X11_0080b_single,18432,0.000050947302952,0.000059785670601,0.000054728304450,117380,137742,126091
HASH_X11_0128b_single,18432,0.000053015653975,0.000060724560171,0.000054999991941,122145,139905,126717
HASH_X11_0512b_single,18432,0.000055402866565,0.000063250074163,0.000058378907852,127646,145725,134502
HASH_X11_1024b_single,16384,0.000059022568166,0.000065412139520,0.000061924380134,135985,150708,142671
HASH_X11_2048b_single,14336,0.000067298766226,0.000086345709860,0.000071261510519,155052,198937,164183
```

EDIT: closes #1806 as was reminded below :)