### PR TITLE
Use SPORK_6_NEW_SIGS to switch from signing string messages to hashes

### DIFF
--- a/dash-docs/protocol-documentation.md
+++ b/dash-docs/protocol-documentation.md
@@ -99,6 +99,9 @@ Every few minutes, masternodes ping the network with a message that propagates t
 | 32 | blockHash | uint256 | Current chaintip blockhash minus 12
 | 8 | sigTime | int64_t | Signature time for this ping
 | 71-73 | vchSig | char[] | Signature of this message by masternode (verifiable via pubKeyMasternode)
+| 1 | fSentinelIsCurrent | bool | true if last sentinel ping was actual
+| 4 | nSentinelVersion | uint32_t | The version of Sentinel running on the masternode which is signing the message
+| 4 | nDaemonVersion | uint32_t | The version of dashd of the masternode which is signing the message (i.e. CLIENT_VERSION)
 
 ### MASTERNODEPAYMENTVOTE - "mnw"
 
@@ -254,7 +257,7 @@ Spork
 | 10001 | 2 | INSTANTSEND_ENABLED | Turns on and off InstantSend network wide
 | 10002 | 3 | INSTANTSEND_BLOCK_FILTERING | Turns on and off InstantSend block filtering
 | 10004 | 5 | INSTANTSEND_MAX_VALUE | Controls the max value for an InstantSend transaction (currently 2000 dash)
-| 10005 | 6 | NEW_SIGS | Turns on and off new signature format for some messages (mnp, mnw, dsq)
+| 10005 | 6 | NEW_SIGS | Turns on and off new signature format for Dash-specific messages
 | 10007 | 8 | MASTERNODE_PAYMENT_ENFORCEMENT | Requires masternodes to be paid by miners when blocks are processed
 | 10008 | 9 | SUPERBLOCKS_ENABLED | Superblocks are enabled (the 10% comes to fund the dash treasury)
 | 10009 | 10 | MASTERNODE_PAY_UPDATED_NODES | Only current protocol version masternode's will be paid (not older nodes)

--- a/dash-docs/protocol-documentation.md
+++ b/dash-docs/protocol-documentation.md
@@ -99,7 +99,7 @@ Every few minutes, masternodes ping the network with a message that propagates t
 | 32 | blockHash | uint256 | Current chaintip blockhash minus 12
 | 8 | sigTime | int64_t | Signature time for this ping
 | 71-73 | vchSig | char[] | Signature of this message by masternode (verifiable via pubKeyMasternode)
-| 1 | fSentinelIsCurrent | bool | true if last sentinel ping was actual
+| 1 | fSentinelIsCurrent | bool | true if last sentinel ping was current
 | 4 | nSentinelVersion | uint32_t | The version of Sentinel running on the masternode which is signing the message
 | 4 | nDaemonVersion | uint32_t | The version of dashd of the masternode which is signing the message (i.e. CLIENT_VERSION)
 

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -224,6 +224,18 @@ std::string CGovernanceObject::GetSignatureMessage() const
     return strMessage;
 }
 
+uint256 CGovernanceObject::GetSignatureHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << nHashParent;
+    ss << nRevision;
+    ss << nTime;
+    ss << vchData;
+    ss << masternodeOutpoint;
+    ss << nCollateralHash;
+    return ss.GetHash();
+}
+
 void CGovernanceObject::SetMasternodeOutpoint(const COutPoint& outpoint)
 {
     masternodeOutpoint = outpoint;
@@ -232,23 +244,34 @@ void CGovernanceObject::SetMasternodeOutpoint(const COutPoint& outpoint)
 bool CGovernanceObject::Sign(const CKey& keyMasternode, const CPubKey& pubKeyMasternode)
 {
     std::string strError;
-    std::string strMessage = GetSignatureMessage();
 
-    LOCK(cs);
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetSignatureHash();
 
-    if(!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-        LogPrintf("CGovernanceObject::Sign -- SignMessage() failed\n");
-        return false;
-    }
+        if (!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
+            LogPrintf("CGovernanceObject::Sign -- SignHash() failed\n");
+            return false;
+        }
 
-    if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrintf("CGovernanceObject::Sign -- VerifyMessage() failed, error: %s\n", strError);
-        return false;
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            LogPrintf("CGovernanceObject::Sign -- VerifyHash() failed, error: %s\n", strError);
+            return false;
+        }
+    } else {
+        std::string strMessage = GetSignatureMessage();
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
+            LogPrintf("CGovernanceObject::Sign -- SignMessage() failed\n");
+            return false;
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            LogPrintf("CGovernanceObject::Sign -- VerifyMessage() failed, error: %s\n", strError);
+            return false;
+        }
     }
 
     LogPrint("gobject", "CGovernanceObject::Sign -- pubkey id = %s, masternode = %s\n",
              pubKeyMasternode.GetID().ToString(), masternodeOutpoint.ToStringShort());
-
 
     return true;
 }
@@ -257,12 +280,26 @@ bool CGovernanceObject::CheckSignature(const CPubKey& pubKeyMasternode)
 {
     std::string strError;
 
-    std::string strMessage = GetSignatureMessage();
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetSignatureHash();
 
-    LOCK(cs);
-    if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrintf("CGovernance::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
-        return false;
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            // could be an old object
+            std::string strMessage = GetSignatureMessage();
+
+            if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+                // nope, not in old format either
+                LogPrintf("CGovernance::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
+                return false;
+            }
+        }
+    } else {
+        std::string strMessage = GetSignatureMessage();
+
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            LogPrintf("CGovernance::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
+            return false;
+        }
     }
 
     return true;

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -340,7 +340,9 @@ public:
             // using new format directly
             READWRITE(masternodeOutpoint);
         }
-        READWRITE(vchSig);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
         if(s.GetType() & SER_DISK) {
             // Only include these for the disk file format
             LogPrint("gobject", "CGovernanceObject::SerializationOp Reading/writing votes from/to disk\n");

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -258,6 +258,7 @@ public:
     bool CheckSignature(const CPubKey& pubKeyMasternode);
 
     std::string GetSignatureMessage() const;
+    uint256 GetSignatureHash() const;
 
     // CORE OBJECT FUNCTIONS
 

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -311,7 +311,7 @@ public:
         READWRITE(nRevision);
         READWRITE(nTime);
         READWRITE(nCollateralHash);
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             std::string strDataHex;
             if (ser_action.ForRead()) {
@@ -326,7 +326,7 @@ public:
             READWRITE(vchData);
         }
         READWRITE(nObjectType);
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin;
             if (ser_action.ForRead()) {

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -242,7 +242,7 @@ bool CGovernanceVote::Sign(const CKey& keyMasternode, const CPubKey& pubKeyMaste
     std::string strError;
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
             LogPrintf("CGovernanceVote::Sign -- SignHash() failed\n");
@@ -277,7 +277,7 @@ bool CGovernanceVote::CheckSignature(const CPubKey& pubKeyMasternode) const
     std::string strError;
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
             // could be a signature in old format

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -237,6 +237,24 @@ void CGovernanceVote::Relay(CConnman& connman) const
     connman.RelayInv(inv, MIN_GOVERNANCE_PEER_PROTO_VERSION);
 }
 
+uint256 CGovernanceVote::GetHash() const
+{
+    // Note: doesn't match serialization
+
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << masternodeOutpoint << uint8_t{} << 0xffffffff; // adding dummy values here to match old hashing format
+    ss << nParentHash;
+    ss << nVoteSignal;
+    ss << nVoteOutcome;
+    ss << nTime;
+    return ss.GetHash();
+}
+
+uint256 CGovernanceVote::GetSignatureHash() const
+{
+    return SerializeHash(*this);
+}
+
 bool CGovernanceVote::Sign(const CKey& keyMasternode, const CPubKey& pubKeyMasternode)
 {
     std::string strError;

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -138,18 +138,8 @@ public:
     *   GET UNIQUE HASH WITH DETERMINISTIC VALUE OF THIS SPECIFIC VOTE
     */
 
-    uint256 GetHash() const
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << masternodeOutpoint << uint8_t{} << 0xffffffff;
-        ss << nParentHash;
-        ss << nVoteSignal;
-        ss << nVoteOutcome;
-        ss << nTime;
-        return ss.GetHash();
-    }
-
-    uint256 GetSignatureHash() const { return GetHash(); }
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const;
 
     std::string ToString() const
     {
@@ -212,7 +202,9 @@ public:
         READWRITE(nVoteOutcome);
         READWRITE(nVoteSignal);
         READWRITE(nTime);
-        READWRITE(vchSig);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
     }
 
 };

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -184,7 +184,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         int nVersion = s.GetVersion();
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};
             if (ser_action.ForRead()) {

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -149,6 +149,8 @@ public:
         return ss.GetHash();
     }
 
+    uint256 GetSignatureHash() const { return GetHash(); }
+
     std::string ToString() const
     {
         std::ostringstream ostr;

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -122,6 +122,7 @@ public:
     void SetSignature(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }
 
     bool Sign(const CKey& keyMasternode, const CPubKey& pubKeyMasternode);
+    bool CheckSignature(const CPubKey& pubKeyMasternode) const;
     bool IsValid(bool fSignatureCheck) const;
     void Relay(CConnman& connman) const;
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1045,7 +1045,6 @@ uint256 CTxLockVote::GetHash() const
 bool CTxLockVote::CheckSignature() const
 {
     std::string strError;
-    std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
 
     masternode_info_t infoMn;
 
@@ -1054,9 +1053,24 @@ bool CTxLockVote::CheckSignature() const
         return false;
     }
 
-    if(!CMessageSigner::VerifyMessage(infoMn.pubKeyMasternode, vchMasternodeSignature, strMessage, strError)) {
-        LogPrintf("CTxLockVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
-        return false;
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetHash();
+
+        if (!CHashSigner::VerifyHash(hash, infoMn.pubKeyMasternode, vchMasternodeSignature, strError)) {
+            // could be a signature in old format
+            std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
+            if(!CMessageSigner::VerifyMessage(infoMn.pubKeyMasternode, vchMasternodeSignature, strMessage, strError)) {
+                // nope, not in old format either
+                LogPrintf("CTxLockVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
+                return false;
+            }
+        }
+    } else {
+        std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
+        if(!CMessageSigner::VerifyMessage(infoMn.pubKeyMasternode, vchMasternodeSignature, strMessage, strError)) {
+            LogPrintf("CTxLockVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
+            return false;
+        }
     }
 
     return true;
@@ -1065,16 +1079,31 @@ bool CTxLockVote::CheckSignature() const
 bool CTxLockVote::Sign()
 {
     std::string strError;
-    std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
 
-    if(!CMessageSigner::SignMessage(strMessage, vchMasternodeSignature, activeMasternode.keyMasternode)) {
-        LogPrintf("CTxLockVote::Sign -- SignMessage() failed\n");
-        return false;
-    }
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetHash();
 
-    if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, vchMasternodeSignature, strMessage, strError)) {
-        LogPrintf("CTxLockVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
-        return false;
+        if(!CHashSigner::SignHash(hash, activeMasternode.keyMasternode, vchMasternodeSignature)) {
+            LogPrintf("CTxLockVote::Sign -- SignHash() failed\n");
+            return false;
+        }
+
+        if (!CHashSigner::VerifyHash(hash, activeMasternode.pubKeyMasternode, vchMasternodeSignature, strError)) {
+            LogPrintf("CTxLockVote::Sign -- VerifyHash() failed, error: %s\n", strError);
+            return false;
+        }
+    } else {
+        std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
+
+        if(!CMessageSigner::SignMessage(strMessage, vchMasternodeSignature, activeMasternode.keyMasternode)) {
+            LogPrintf("CTxLockVote::Sign -- SignMessage() failed\n");
+            return false;
+        }
+
+        if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, vchMasternodeSignature, strMessage, strError)) {
+            LogPrintf("CTxLockVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
+            return false;
+        }
     }
 
     return true;

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1054,7 +1054,7 @@ bool CTxLockVote::CheckSignature() const
     }
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, infoMn.pubKeyMasternode, vchMasternodeSignature, strError)) {
             // could be a signature in old format
@@ -1081,7 +1081,7 @@ bool CTxLockVote::Sign()
     std::string strError;
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, activeMasternode.keyMasternode, vchMasternodeSignature)) {
             LogPrintf("CTxLockVote::Sign -- SignHash() failed\n");

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1035,11 +1035,12 @@ bool CTxLockVote::IsValid(CNode* pnode, CConnman& connman) const
 
 uint256 CTxLockVote::GetHash() const
 {
-    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << txHash;
-    ss << outpoint;
-    ss << outpointMasternode;
-    return ss.GetHash();
+    return SerializeHash(*this);
+}
+
+uint256 CTxLockVote::GetSignatureHash() const
+{
+    return GetHash();
 }
 
 bool CTxLockVote::CheckSignature() const

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -211,6 +211,7 @@ public:
     }
 
     uint256 GetHash() const;
+    uint256 GetSignatureHash() const { return GetHash(); }
 
     uint256 GetTxHash() const { return txHash; }
     COutPoint GetOutpoint() const { return outpoint; }

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -207,11 +207,13 @@ public:
         READWRITE(txHash);
         READWRITE(outpoint);
         READWRITE(outpointMasternode);
-        READWRITE(vchMasternodeSignature);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchMasternodeSignature);
+        }
     }
 
     uint256 GetHash() const;
-    uint256 GetSignatureHash() const { return GetHash(); }
+    uint256 GetSignatureHash() const;
 
     uint256 GetTxHash() const { return txHash; }
     COutPoint GetOutpoint() const { return outpoint; }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -399,18 +399,33 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, const std::string& strCom
 bool CMasternodePaymentVote::Sign()
 {
     std::string strError;
-    std::string strMessage = masternodeOutpoint.ToStringShort() +
-                boost::lexical_cast<std::string>(nBlockHeight) +
-                (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS) ? HexStr(payee) : ScriptToAsmStr(payee));
 
-    if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
-        LogPrintf("CMasternodePaymentVote::Sign -- SignMessage() failed\n");
-        return false;
-    }
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetHash();
 
-    if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrintf("CMasternodePaymentVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
-        return false;
+        if(!CHashSigner::SignHash(hash, activeMasternode.keyMasternode, vchSig)) {
+            LogPrintf("CMasternodePaymentVote::Sign -- SignHash() failed\n");
+            return false;
+        }
+
+        if (!CHashSigner::VerifyHash(hash, activeMasternode.pubKeyMasternode, vchSig, strError)) {
+            LogPrintf("CMasternodePaymentVote::Sign -- VerifyHash() failed, error: %s\n", strError);
+            return false;
+        }
+    } else {
+        std::string strMessage = masternodeOutpoint.ToStringShort() +
+                    boost::lexical_cast<std::string>(nBlockHeight) +
+                    ScriptToAsmStr(payee);
+
+        if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
+            LogPrintf("CMasternodePaymentVote::Sign -- SignMessage() failed\n");
+            return false;
+        }
+
+        if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, vchSig, strMessage, strError)) {
+            LogPrintf("CMasternodePaymentVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
+            return false;
+        }
     }
 
     return true;
@@ -831,27 +846,22 @@ void CMasternodePaymentVote::Relay(CConnman& connman)
     connman.RelayInv(inv);
 }
 
-bool CMasternodePaymentVote::CheckSignature(const CPubKey& pubKeyMasternode, int nValidationHeight, int &nDos)
+bool CMasternodePaymentVote::CheckSignature(const CPubKey& pubKeyMasternode, int nValidationHeight, int &nDos) const
 {
     // do not ban by default
     nDos = 0;
-
-    std::string strMessage = masternodeOutpoint.ToStringShort() +
-                boost::lexical_cast<std::string>(nBlockHeight) +
-                (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS) ? HexStr(payee) : ScriptToAsmStr(payee));
-
     std::string strError = "";
-    if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-        if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-            // Try old format even though we activated signing via new one already.
-            // Could be an old vote signed earlier or a vote signed by a non-upgraded MN.
-            std::string strErrorOld = "";
-            strMessage = masternodeOutpoint.ToStringShort() +
+
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetHash();
+
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            // could be a signature in old format
+            std::string strMessage = masternodeOutpoint.ToStringShort() +
                         boost::lexical_cast<std::string>(nBlockHeight) +
                         ScriptToAsmStr(payee);
-
-            if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strErrorOld)) {
-                // Neither format worked, definitely an invalid signature.
+            if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+                // nope, not in old format either
                 // Only ban for future block vote when we are already synced.
                 // Otherwise it could be the case when MN which signed this vote is using another key now
                 // and we have no idea about the old one.
@@ -859,21 +869,24 @@ bool CMasternodePaymentVote::CheckSignature(const CPubKey& pubKeyMasternode, int
                     nDos = 20;
                 }
                 return error("CMasternodePaymentVote::CheckSignature -- Got bad Masternode payment signature, masternode=%s, error: %s",
-                            masternodeOutpoint.ToStringShort(), strErrorOld);
+                            masternodeOutpoint.ToStringShort(), strError);
             }
-            // Was indeed a valid signature in old format
-            LogPrintf("Masternode %s send payment vote in old format, new format \n", masternodeOutpoint.ToStringShort());
-            return true;
         }
-        // Spork is off but message signature is invalid.
-        // Only ban for future block vote when we are already synced.
-        // Otherwise it could be the case when MN which signed this vote is using another key now
-        // and we have no idea about the old one.
-        if(masternodeSync.IsMasternodeListSynced() && nBlockHeight > nValidationHeight) {
-            nDos = 20;
+    } else {
+        std::string strMessage = masternodeOutpoint.ToStringShort() +
+                    boost::lexical_cast<std::string>(nBlockHeight) +
+                    ScriptToAsmStr(payee);
+
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            // Only ban for future block vote when we are already synced.
+            // Otherwise it could be the case when MN which signed this vote is using another key now
+            // and we have no idea about the old one.
+            if(masternodeSync.IsMasternodeListSynced() && nBlockHeight > nValidationHeight) {
+                nDos = 20;
+            }
+            return error("CMasternodePaymentVote::CheckSignature -- Got bad Masternode payment signature, masternode=%s, error: %s",
+                        masternodeOutpoint.ToStringShort(), strError);
         }
-        return error("CMasternodePaymentVote::CheckSignature -- Got bad Masternode payment signature, masternode=%s, error: %s",
-                    masternodeOutpoint.ToStringShort(), strError);
     }
 
     return true;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -401,7 +401,7 @@ bool CMasternodePaymentVote::Sign()
     std::string strError;
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, activeMasternode.keyMasternode, vchSig)) {
             LogPrintf("CMasternodePaymentVote::Sign -- SignHash() failed\n");
@@ -853,7 +853,7 @@ bool CMasternodePaymentVote::CheckSignature(const CPubKey& pubKeyMasternode, int
     std::string strError = "";
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
             // could be a signature in old format

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -396,6 +396,22 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, const std::string& strCom
     }
 }
 
+uint256 CMasternodePaymentVote::GetHash() const
+{
+    // Note: doesn't match serialization
+
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << *(CScriptBase*)(&payee);
+    ss << nBlockHeight;
+    ss << masternodeOutpoint;
+    return ss.GetHash();
+}
+
+uint256 CMasternodePaymentVote::GetSignatureHash() const
+{
+    return SerializeHash(*this);
+}
+
 bool CMasternodePaymentVote::Sign()
 {
     std::string strError;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -161,6 +161,8 @@ public:
         return ss.GetHash();
     }
 
+    uint256 GetSignatureHash() const { return GetHash(); }
+
     bool Sign();
     bool CheckSignature(const CPubKey& pubKeyMasternode, int nValidationHeight, int &nDos) const;
 

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -162,7 +162,7 @@ public:
     }
 
     bool Sign();
-    bool CheckSignature(const CPubKey& pubKeyMasternode, int nValidationHeight, int &nDos);
+    bool CheckSignature(const CPubKey& pubKeyMasternode, int nValidationHeight, int &nDos) const;
 
     bool IsValid(CNode* pnode, int nValidationHeight, std::string& strError, CConnman& connman);
     void Relay(CConnman& connman);

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -150,18 +150,13 @@ public:
         }
         READWRITE(nBlockHeight);
         READWRITE(*(CScriptBase*)(&payee));
-        READWRITE(vchSig);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
     }
 
-    uint256 GetHash() const {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << *(CScriptBase*)(&payee);
-        ss << nBlockHeight;
-        ss << masternodeOutpoint;
-        return ss.GetHash();
-    }
-
-    uint256 GetSignatureHash() const { return GetHash(); }
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const;
 
     bool Sign();
     bool CheckSignature(const CPubKey& pubKeyMasternode, int nValidationHeight, int &nDos) const;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -134,7 +134,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         int nVersion = s.GetVersion();
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};
             if (ser_action.ForRead()) {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -702,7 +702,6 @@ uint256 CMasternodePing::GetHash() const
     } else {
         // Note: doesn't match serialization
 
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << masternodeOutpoint << uint8_t{} << 0xffffffff; // adding dummy values here to match old hashing format
         ss << sigTime;
     }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -581,6 +581,8 @@ bool CMasternodeBroadcast::CheckOutpoint(int& nDos)
 
 uint256 CMasternodeBroadcast::GetHash() const
 {
+    // Note: doesn't match serialization
+
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     ss << outpoint << uint8_t{} << 0xffffffff; // adding dummy values here to match old hashing format
     ss << pubKeyCollateralAddress;
@@ -590,6 +592,7 @@ uint256 CMasternodeBroadcast::GetHash() const
 
 uint256 CMasternodeBroadcast::GetSignatureHash() const
 {
+    // TODO: replace with "return SerializeHash(*this);" after migration to 70209
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     ss << outpoint;
     ss << addr;
@@ -689,6 +692,7 @@ uint256 CMasternodePing::GetHash() const
 {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        // TODO: replace with "return SerializeHash(*this);" after migration to 70209
         ss << masternodeOutpoint;
         ss << blockHash;
         ss << sigTime;
@@ -696,10 +700,18 @@ uint256 CMasternodePing::GetHash() const
         ss << nSentinelVersion;
         ss << nDaemonVersion;
     } else {
+        // Note: doesn't match serialization
+
+        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << masternodeOutpoint << uint8_t{} << 0xffffffff; // adding dummy values here to match old hashing format
         ss << sigTime;
     }
     return ss.GetHash();
+}
+
+uint256 CMasternodePing::GetSignatureHash() const
+{
+    return GetHash();
 }
 
 CMasternodePing::CMasternodePing(const COutPoint& outpoint)

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -720,7 +720,7 @@ bool CMasternodePing::Sign(const CKey& keyMasternode, const CPubKey& pubKeyMaste
     sigTime = GetAdjustedTime();
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
             LogPrintf("CMasternodePing::Sign -- SignHash() failed\n");
@@ -755,7 +755,7 @@ bool CMasternodePing::CheckSignature(const CPubKey& pubKeyMasternode, int &nDos)
     nDos = 0;
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
             std::string strMessage = CTxIn(masternodeOutpoint).ToString() + blockHash.ToString() +

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -457,6 +457,26 @@ public:
         return ss.GetHash();
     }
 
+    uint256 GetSignatureHash1(const uint256& blockHash) const
+    {
+        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+        ss << addr;
+        ss << nonce;
+        ss << blockHash;
+        return ss.GetHash();
+    }
+
+    uint256 GetSignatureHash2(const uint256& blockHash) const
+    {
+        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+        ss << masternodeOutpoint1;
+        ss << masternodeOutpoint2;
+        ss << addr;
+        ss << nonce;
+        ss << blockHash;
+        return ss.GetHash();
+    }
+
     void Relay() const
     {
         CInv inv(MSG_MASTERNODE_VERIFY, GetHash());

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -91,7 +91,7 @@ public:
     bool IsExpired() const { return GetAdjustedTime() - sigTime > MASTERNODE_NEW_START_REQUIRED_SECONDS; }
 
     bool Sign(const CKey& keyMasternode, const CPubKey& pubKeyMasternode);
-    bool CheckSignature(const CPubKey& pubKeyMasternode, int &nDos);
+    bool CheckSignature(const CPubKey& pubKeyMasternode, int &nDos) const;
     bool SimpleCheck(int& nDos);
     bool CheckAndUpdate(CMasternode* pmn, bool fFromNewBroadcast, int& nDos, CConnman& connman);
     void Relay(CConnman& connman);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -68,8 +68,11 @@ public:
         }
         READWRITE(blockHash);
         READWRITE(sigTime);
-        READWRITE(vchSig);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
         if(ser_action.ForRead() && s.size() == 0) {
+            // TODO: drop this after migration to 70209
             fSentinelIsCurrent = false;
             nSentinelVersion = DEFAULT_SENTINEL_VERSION;
             nDaemonVersion = DEFAULT_DAEMON_VERSION;
@@ -78,6 +81,7 @@ public:
         READWRITE(fSentinelIsCurrent);
         READWRITE(nSentinelVersion);
         if(ser_action.ForRead() && s.size() == 0) {
+            // TODO: drop this after migration to 70209
             nDaemonVersion = DEFAULT_DAEMON_VERSION;
             return;
         }
@@ -87,7 +91,7 @@ public:
     }
 
     uint256 GetHash() const;
-    uint256 GetSignatureHash() const { return GetHash(); }
+    uint256 GetSignatureHash() const;
 
     bool IsExpired() const { return GetAdjustedTime() - sigTime > MASTERNODE_NEW_START_REQUIRED_SECONDS; }
 
@@ -374,10 +378,14 @@ public:
         READWRITE(addr);
         READWRITE(pubKeyCollateralAddress);
         READWRITE(pubKeyMasternode);
-        READWRITE(vchSig);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
         READWRITE(sigTime);
         READWRITE(nProtocolVersion);
-        READWRITE(lastPing);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(lastPing);
+        }
     }
 
     uint256 GetHash() const;
@@ -449,6 +457,8 @@ public:
 
     uint256 GetHash() const
     {
+        // Note: doesn't match serialization
+
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << masternodeOutpoint1 << uint8_t{} << 0xffffffff;
         ss << masternodeOutpoint2 << uint8_t{} << 0xffffffff;
@@ -460,6 +470,8 @@ public:
 
     uint256 GetSignatureHash1(const uint256& blockHash) const
     {
+        // Note: doesn't match serialization
+
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << addr;
         ss << nonce;
@@ -469,6 +481,8 @@ public:
 
     uint256 GetSignatureHash2(const uint256& blockHash) const
     {
+        // Note: doesn't match serialization
+
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << masternodeOutpoint1;
         ss << masternodeOutpoint2;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -379,14 +379,8 @@ public:
         READWRITE(lastPing);
     }
 
-    uint256 GetHash() const
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << outpoint << uint8_t{} << 0xffffffff;
-        ss << pubKeyCollateralAddress;
-        ss << sigTime;
-        return ss.GetHash();
-    }
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const;
 
     /// Create Masternode broadcast, needs to be relayed manually after that
     static bool Create(const COutPoint& outpoint, const CService& service, const CKey& keyCollateralAddressNew, const CPubKey& pubKeyCollateralAddressNew, const CKey& keyMasternodeNew, const CPubKey& pubKeyMasternodeNew, std::string &strErrorRet, CMasternodeBroadcast &mnbRet);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -87,6 +87,7 @@ public:
     }
 
     uint256 GetHash() const;
+    uint256 GetSignatureHash() const { return GetHash(); }
 
     bool IsExpired() const { return GetAdjustedTime() - sigTime > MASTERNODE_NEW_START_REQUIRED_SECONDS; }
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -38,7 +38,7 @@ public:
     uint256 blockHash{};
     int64_t sigTime{}; //mnb message times
     std::vector<unsigned char> vchSig{};
-    bool fSentinelIsCurrent = false; // true if last sentinel ping was actual
+    bool fSentinelIsCurrent = false; // true if last sentinel ping was current
     // MSB is always 0, other 3 bits corresponds to x.x.x version scheme
     uint32_t nSentinelVersion{DEFAULT_SENTINEL_VERSION};
     uint32_t nDaemonVersion{DEFAULT_DAEMON_VERSION};

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -52,7 +52,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         int nVersion = s.GetVersion();
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};
             if (ser_action.ForRead()) {
@@ -85,7 +85,7 @@ public:
             nDaemonVersion = DEFAULT_DAEMON_VERSION;
             return;
         }
-        if (nVersion > 70208) {
+        if (!(nVersion == 70208 && (s.GetType() & SER_NETWORK))) {
             READWRITE(nDaemonVersion);
         }
     }
@@ -201,7 +201,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         LOCK(cs);
         int nVersion = s.GetVersion();
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};
             if (ser_action.ForRead()) {
@@ -361,7 +361,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         int nVersion = s.GetVersion();
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};
             if (ser_action.ForRead()) {
@@ -428,7 +428,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         int nVersion = s.GetVersion();
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin1{};
             CTxIn txin2{};

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1194,18 +1194,32 @@ void CMasternodeMan::SendVerifyReply(CNode* pnode, CMasternodeVerification& mnv,
         return;
     }
 
-    std::string strMessage = strprintf("%s%d%s", activeMasternode.service.ToString(false), mnv.nonce, blockHash.ToString());
-
-    if(!CMessageSigner::SignMessage(strMessage, mnv.vchSig1, activeMasternode.keyMasternode)) {
-        LogPrintf("MasternodeMan::SendVerifyReply -- SignMessage() failed\n");
-        return;
-    }
-
     std::string strError;
 
-    if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, mnv.vchSig1, strMessage, strError)) {
-        LogPrintf("MasternodeMan::SendVerifyReply -- VerifyMessage() failed, error: %s\n", strError);
-        return;
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = mnv.GetSignatureHash1(blockHash);
+
+        if(!CHashSigner::SignHash(hash, activeMasternode.keyMasternode, mnv.vchSig1)) {
+            LogPrintf("CMasternodeMan::SendVerifyReply -- SignHash() failed\n");
+            return;
+        }
+
+        if (!CHashSigner::VerifyHash(hash, activeMasternode.pubKeyMasternode, mnv.vchSig1, strError)) {
+            LogPrintf("CMasternodeMan::SendVerifyReply -- VerifyHash() failed, error: %s\n", strError);
+            return;
+        }
+    } else {
+        std::string strMessage = strprintf("%s%d%s", activeMasternode.service.ToString(false), mnv.nonce, blockHash.ToString());
+
+        if(!CMessageSigner::SignMessage(strMessage, mnv.vchSig1, activeMasternode.keyMasternode)) {
+            LogPrintf("MasternodeMan::SendVerifyReply -- SignMessage() failed\n");
+            return;
+        }
+
+        if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, mnv.vchSig1, strMessage, strError)) {
+            LogPrintf("MasternodeMan::SendVerifyReply -- VerifyMessage() failed, error: %s\n", strError);
+            return;
+        }
     }
 
     CNetMsgMaker msgMaker(pnode->GetSendVersion());
@@ -1259,10 +1273,20 @@ void CMasternodeMan::ProcessVerifyReply(CNode* pnode, CMasternodeVerification& m
 
         CMasternode* prealMasternode = NULL;
         std::vector<CMasternode*> vpMasternodesToBan;
+
+        uint256 hash1 = mnv.GetSignatureHash1(blockHash);
         std::string strMessage1 = strprintf("%s%d%s", pnode->addr.ToString(false), mnv.nonce, blockHash.ToString());
+
         for (auto& mnpair : mapMasternodes) {
             if(CAddress(mnpair.second.addr, NODE_NETWORK) == pnode->addr) {
-                if(CMessageSigner::VerifyMessage(mnpair.second.pubKeyMasternode, mnv.vchSig1, strMessage1, strError)) {
+                bool fFound = false;
+                if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+                    fFound = CHashSigner::VerifyHash(hash1, mnpair.second.pubKeyMasternode, mnv.vchSig1, strError);
+                    // we don't care about mnv with signature in old format
+                } else {
+                    fFound = CMessageSigner::VerifyMessage(mnpair.second.pubKeyMasternode, mnv.vchSig1, strMessage1, strError);
+                }
+                if (fFound) {
                     // found it!
                     prealMasternode = &mnpair.second;
                     if(!mnpair.second.IsPoSeVerified()) {
@@ -1276,19 +1300,34 @@ void CMasternodeMan::ProcessVerifyReply(CNode* pnode, CMasternodeVerification& m
                     mnv.addr = mnpair.second.addr;
                     mnv.masternodeOutpoint1 = mnpair.second.outpoint;
                     mnv.masternodeOutpoint2 = activeMasternode.outpoint;
-                    std::string strMessage2 = strprintf("%s%d%s%s%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString(),
-                                            mnv.masternodeOutpoint1.ToStringShort(), mnv.masternodeOutpoint2.ToStringShort());
                     // ... and sign it
-                    if(!CMessageSigner::SignMessage(strMessage2, mnv.vchSig2, activeMasternode.keyMasternode)) {
-                        LogPrintf("MasternodeMan::ProcessVerifyReply -- SignMessage() failed\n");
-                        return;
-                    }
-
                     std::string strError;
 
-                    if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, mnv.vchSig2, strMessage2, strError)) {
-                        LogPrintf("MasternodeMan::ProcessVerifyReply -- VerifyMessage() failed, error: %s\n", strError);
-                        return;
+                    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+                        uint256 hash2 = mnv.GetSignatureHash2(blockHash);
+
+                        if(!CHashSigner::SignHash(hash2, activeMasternode.keyMasternode, mnv.vchSig2)) {
+                            LogPrintf("MasternodeMan::ProcessVerifyReply -- SignHash() failed\n");
+                            return;
+                        }
+
+                        if(!CHashSigner::VerifyHash(hash2, activeMasternode.pubKeyMasternode, mnv.vchSig2, strError)) {
+                            LogPrintf("MasternodeMan::ProcessVerifyReply -- VerifyHash() failed, error: %s\n", strError);
+                            return;
+                        }
+                    } else {
+                        std::string strMessage2 = strprintf("%s%d%s%s%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString(),
+                                                mnv.masternodeOutpoint1.ToStringShort(), mnv.masternodeOutpoint2.ToStringShort());
+
+                        if(!CMessageSigner::SignMessage(strMessage2, mnv.vchSig2, activeMasternode.keyMasternode)) {
+                            LogPrintf("MasternodeMan::ProcessVerifyReply -- SignMessage() failed\n");
+                            return;
+                        }
+
+                        if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, mnv.vchSig2, strMessage2, strError)) {
+                            LogPrintf("MasternodeMan::ProcessVerifyReply -- VerifyMessage() failed, error: %s\n", strError);
+                            return;
+                        }
                     }
 
                     mWeAskedForVerification[pnode->addr] = mnv;
@@ -1372,10 +1411,6 @@ void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerif
     {
         LOCK(cs);
 
-        std::string strMessage1 = strprintf("%s%d%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString());
-        std::string strMessage2 = strprintf("%s%d%s%s%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString(),
-                                mnv.masternodeOutpoint1.ToStringShort(), mnv.masternodeOutpoint2.ToStringShort());
-
         CMasternode* pmn1 = Find(mnv.masternodeOutpoint1);
         if(!pmn1) {
             LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- can't find masternode1 %s\n", mnv.masternodeOutpoint1.ToStringShort());
@@ -1393,14 +1428,33 @@ void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerif
             return;
         }
 
-        if(!CMessageSigner::VerifyMessage(pmn1->pubKeyMasternode, mnv.vchSig1, strMessage1, strError)) {
-            LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- VerifyMessage() for masternode1 failed, error: %s\n", strError);
-            return;
-        }
+        if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+            uint256 hash1 = mnv.GetSignatureHash1(blockHash);
+            uint256 hash2 = mnv.GetSignatureHash2(blockHash);
 
-        if(!CMessageSigner::VerifyMessage(pmn2->pubKeyMasternode, mnv.vchSig2, strMessage2, strError)) {
-            LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- VerifyMessage() for masternode2 failed, error: %s\n", strError);
-            return;
+            if(!CHashSigner::VerifyHash(hash1, pmn1->pubKeyMasternode, mnv.vchSig1, strError)) {
+                LogPrintf("MasternodeMan::ProcessVerifyBroadcast -- VerifyHash() failed, error: %s\n", strError);
+                return;
+            }
+
+            if(!CHashSigner::VerifyHash(hash2, pmn2->pubKeyMasternode, mnv.vchSig2, strError)) {
+                LogPrintf("MasternodeMan::ProcessVerifyBroadcast -- VerifyHash() failed, error: %s\n", strError);
+                return;
+            }
+        } else {
+            std::string strMessage1 = strprintf("%s%d%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString());
+            std::string strMessage2 = strprintf("%s%d%s%s%s", mnv.addr.ToString(false), mnv.nonce, blockHash.ToString(),
+                                    mnv.masternodeOutpoint1.ToStringShort(), mnv.masternodeOutpoint2.ToStringShort());
+
+            if(!CMessageSigner::VerifyMessage(pmn1->pubKeyMasternode, mnv.vchSig1, strMessage1, strError)) {
+                LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- VerifyMessage() for masternode1 failed, error: %s\n", strError);
+                return;
+            }
+
+            if(!CMessageSigner::VerifyMessage(pmn2->pubKeyMasternode, mnv.vchSig2, strMessage2, strError)) {
+                LogPrintf("CMasternodeMan::ProcessVerifyBroadcast -- VerifyMessage() for masternode2 failed, error: %s\n", strError);
+                return;
+            }
         }
 
         if(!pmn1->IsPoSeVerified()) {

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -38,12 +38,7 @@ bool CDarkSendEntry::AddScriptSig(const CTxIn& txin)
 
 uint256 CDarksendQueue::GetSignatureHash() const
 {
-    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << masternodeOutpoint;
-    ss << nDenom;
-    ss << nTime;
-    ss << fReady;
-    return ss.GetHash();
+    return SerializeHash(*this);
 }
 
 bool CDarksendQueue::Sign()
@@ -123,11 +118,7 @@ bool CDarksendQueue::Relay(CConnman& connman)
 
 uint256 CDarksendBroadcastTx::GetSignatureHash() const
 {
-    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << tx->GetHash();
-    ss << masternodeOutpoint;
-    ss << sigTime;
-    return ss.GetHash();
+    return SerializeHash(*this);
 }
 
 bool CDarksendBroadcastTx::Sign()

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -36,50 +36,76 @@ bool CDarkSendEntry::AddScriptSig(const CTxIn& txin)
     return false;
 }
 
+uint256 CDarksendQueue::GetSignatureHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << masternodeOutpoint;
+    ss << nDenom;
+    ss << nTime;
+    ss << fReady;
+    return ss.GetHash();
+}
+
 bool CDarksendQueue::Sign()
 {
     if(!fMasternodeMode) return false;
 
-    std::string strMessage;
+    std::string strError = "";
+
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        strMessage = masternodeOutpoint.ToStringShort() +
-                    boost::lexical_cast<std::string>(nDenom) +
-                    boost::lexical_cast<std::string>(nTime) +
-                    boost::lexical_cast<std::string>(fReady);
+        uint256 hash = GetSignatureHash();
+
+        if (!CHashSigner::SignHash(hash, activeMasternode.keyMasternode, vchSig)) {
+            LogPrintf("CDarksendQueue::Sign -- SignHash() failed\n");
+            return false;
+        }
+
+        if (!CHashSigner::VerifyHash(hash, activeMasternode.pubKeyMasternode, vchSig, strError)) {
+            LogPrintf("CDarksendQueue::Sign -- VerifyHash() failed, error: %s\n", strError);
+            return false;
+        }
     } else {
-        strMessage = CTxIn(masternodeOutpoint).ToString() +
-                    boost::lexical_cast<std::string>(nDenom) +
-                    boost::lexical_cast<std::string>(nTime) +
-                    boost::lexical_cast<std::string>(fReady);
+        std::string strMessage = CTxIn(masternodeOutpoint).ToString() +
+                        boost::lexical_cast<std::string>(nDenom) +
+                        boost::lexical_cast<std::string>(nTime) +
+                        boost::lexical_cast<std::string>(fReady);
+
+        if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
+            LogPrintf("CDarksendQueue::Sign -- SignMessage() failed, %s\n", ToString());
+            return false;
+        }
+
+        if(!CMessageSigner::VerifyMessage(activeMasternode.pubKeyMasternode, vchSig, strMessage, strError)) {
+            LogPrintf("CDarksendQueue::Sign -- VerifyMessage() failed, error: %s\n", strError);
+            return false;
+        }
     }
 
-    if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
-        LogPrintf("CDarksendQueue::Sign -- SignMessage() failed, %s\n", ToString());
-        return false;
-    }
-
-    return CheckSignature(activeMasternode.pubKeyMasternode);
+    return true;
 }
 
-bool CDarksendQueue::CheckSignature(const CPubKey& pubKeyMasternode)
+bool CDarksendQueue::CheckSignature(const CPubKey& pubKeyMasternode) const
 {
     std::string strError = "";
-    std::string strMessage;
-    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        strMessage = masternodeOutpoint.ToStringShort() +
-                    boost::lexical_cast<std::string>(nDenom) +
-                    boost::lexical_cast<std::string>(nTime) +
-                    boost::lexical_cast<std::string>(fReady);
-    } else {
-        strMessage = CTxIn(masternodeOutpoint).ToString() +
-                    boost::lexical_cast<std::string>(nDenom) +
-                    boost::lexical_cast<std::string>(nTime) +
-                    boost::lexical_cast<std::string>(fReady);
-    }
 
-    if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrintf("CDarksendQueue::CheckSignature -- Got bad Masternode queue signature: %s; error: %s\n", ToString(), strError);
-        return false;
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetSignatureHash();
+
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            // we don't care about queues with old signature format
+            LogPrintf("CDarksendQueue::CheckSignature -- VerifyHash() failed, error: %s\n", strError);
+            return false;
+        }
+    } else {
+        std::string strMessage = CTxIn(masternodeOutpoint).ToString() +
+                        boost::lexical_cast<std::string>(nDenom) +
+                        boost::lexical_cast<std::string>(nTime) +
+                        boost::lexical_cast<std::string>(fReady);
+
+        if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            LogPrintf("CDarksendQueue::CheckSignature -- Got bad Masternode queue signature: %s; error: %s\n", ToString(), strError);
+            return false;
+        }
     }
 
     return true;

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -319,8 +319,10 @@ public:
         return *this != CDarksendBroadcastTx();
     }
 
+    uint256 GetSignatureHash() const;
+
     bool Sign();
-    bool CheckSignature(const CPubKey& pubKeyMasternode);
+    bool CheckSignature(const CPubKey& pubKeyMasternode) const;
 
     void SetConfirmedHeight(int nConfirmedHeightIn) { nConfirmedHeight = nConfirmedHeightIn; }
     bool IsExpired(int nHeight);

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -219,7 +219,9 @@ public:
         }
         READWRITE(nTime);
         READWRITE(fReady);
-        READWRITE(vchSig);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
     }
 
     uint256 GetSignatureHash() const;
@@ -302,7 +304,9 @@ public:
             // using new format directly
             READWRITE(masternodeOutpoint);
         }
-        READWRITE(vchSig);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
         READWRITE(sigTime);
     }
 

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -203,7 +203,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(nDenom);
         int nVersion = s.GetVersion();
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};
             if (ser_action.ForRead()) {
@@ -290,7 +290,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(tx);
         int nVersion = s.GetVersion();
-        if (nVersion == 70208) {
+        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};
             if (ser_action.ForRead()) {

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -222,6 +222,7 @@ public:
         READWRITE(vchSig);
     }
 
+    uint256 GetSignatureHash() const;
     /** Sign this mixing transaction
      *  \return true if all conditions are met:
      *     1) we have an active Masternode,
@@ -231,14 +232,14 @@ public:
      */
     bool Sign();
     /// Check if we have a valid Masternode address
-    bool CheckSignature(const CPubKey& pubKeyMasternode);
+    bool CheckSignature(const CPubKey& pubKeyMasternode) const;
 
     bool Relay(CConnman &connman);
 
     /// Is this queue expired?
     bool IsExpired() { return GetAdjustedTime() - nTime > PRIVATESEND_QUEUE_TIMEOUT; }
 
-    std::string ToString()
+    std::string ToString() const
     {
         return strprintf("nDenom=%d, nTime=%lld, fReady=%s, fTried=%s, masternode=%s",
                         nDenom, nTime, fReady ? "true" : "false", fTried ? "true" : "false", masternodeOutpoint.ToStringShort());

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -230,7 +230,7 @@ bool CSporkMessage::Sign(const std::string& strSignKey)
     }
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, key, vchSig)) {
             LogPrintf("CSporkMessage::Sign -- SignHash() failed\n");
@@ -264,7 +264,7 @@ bool CSporkMessage::CheckSignature() const
     CPubKey pubkey(ParseHex(Params().SporkPubKey()));
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetHash();
+        uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
             // Note: unlike for many other messages when SPORK_6_NEW_SIGS is ON sporks in old format

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -267,8 +267,8 @@ bool CSporkMessage::CheckSignature() const
         uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
-            // Note: unlike for many other messages when SPORK_6_NEW_SIGS is ON sporks in old format
-            // with newer timestamps should not be accepted, so if we failed here - that's it
+            // Note: unlike for many other messages when SPORK_6_NEW_SIGS is ON sporks with sigs in old format
+            // and newer timestamps should not be accepted, so if we failed here - that's it
             LogPrintf("CSporkMessage::CheckSignature -- VerifyHash() failed, error: %s\n", strError);
             return false;
         }

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -223,36 +223,62 @@ bool CSporkMessage::Sign(const std::string& strSignKey)
     CKey key;
     CPubKey pubkey;
     std::string strError = "";
-    std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
 
     if(!CMessageSigner::GetKeysFromSecret(strSignKey, key, pubkey)) {
         LogPrintf("CSporkMessage::Sign -- GetKeysFromSecret() failed, invalid spork key %s\n", strSignKey);
         return false;
     }
 
-    if(!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
-        LogPrintf("CSporkMessage::Sign -- SignMessage() failed\n");
-        return false;
-    }
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetHash();
 
-    if(!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
-        LogPrintf("CSporkMessage::Sign -- VerifyMessage() failed, error: %s\n", strError);
-        return false;
+        if(!CHashSigner::SignHash(hash, key, vchSig)) {
+            LogPrintf("CSporkMessage::Sign -- SignHash() failed\n");
+            return false;
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
+            LogPrintf("CSporkMessage::CheckSignature -- VerifyHash() failed, error: %s\n", strError);
+            return false;
+        }
+    } else {
+        std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
+
+        if(!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
+            LogPrintf("CSporkMessage::Sign -- SignMessage() failed\n");
+            return false;
+        }
+
+        if(!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
+            LogPrintf("CSporkMessage::Sign -- VerifyMessage() failed, error: %s\n", strError);
+            return false;
+        }
     }
 
     return true;
 }
 
-bool CSporkMessage::CheckSignature()
+bool CSporkMessage::CheckSignature() const
 {
-    //note: need to investigate why this is failing
     std::string strError = "";
-    std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
     CPubKey pubkey(ParseHex(Params().SporkPubKey()));
 
-    if(!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
-        LogPrintf("CSporkMessage::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
-        return false;
+    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetHash();
+
+        if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
+            // Note: unlike for many other messages when SPORK_6_NEW_SIGS is ON sporks in old format
+            // with newer timestamps should not be accepted, so if we failed here - that's it
+            LogPrintf("CSporkMessage::CheckSignature -- VerifyHash() failed, error: %s\n", strError);
+            return false;
+        }
+    } else {
+        std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
+
+        if (!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)){
+            LogPrintf("CSporkMessage::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
+            return false;
+        }
     }
 
     return true;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -238,7 +238,7 @@ bool CSporkMessage::Sign(const std::string& strSignKey)
         }
 
         if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
-            LogPrintf("CSporkMessage::CheckSignature -- VerifyHash() failed, error: %s\n", strError);
+            LogPrintf("CSporkMessage::Sign -- VerifyHash() failed, error: %s\n", strError);
             return false;
         }
     } else {

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -218,6 +218,16 @@ bool CSporkManager::SetPrivKey(const std::string& strPrivKey)
     }
 }
 
+uint256 CSporkMessage::GetHash() const
+{
+    return SerializeHash(*this);
+}
+
+uint256 CSporkMessage::GetSignatureHash() const
+{
+    return GetHash();
+}
+
 bool CSporkMessage::Sign(const std::string& strSignKey)
 {
     CKey key;

--- a/src/spork.h
+++ b/src/spork.h
@@ -89,6 +89,8 @@ public:
         return ss.GetHash();
     }
 
+    uint256 GetSignatureHash() const { return GetHash(); }
+
     bool Sign(const std::string& strSignKey);
     bool CheckSignature() const;
     void Relay(CConnman& connman);

--- a/src/spork.h
+++ b/src/spork.h
@@ -90,7 +90,7 @@ public:
     }
 
     bool Sign(const std::string& strSignKey);
-    bool CheckSignature();
+    bool CheckSignature() const;
     void Relay(CConnman& connman);
 };
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -77,19 +77,13 @@ public:
         READWRITE(nSporkID);
         READWRITE(nValue);
         READWRITE(nTimeSigned);
-        READWRITE(vchSig);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
     }
 
-    uint256 GetHash() const
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << nSporkID;
-        ss << nValue;
-        ss << nTimeSigned;
-        return ss.GetHash();
-    }
-
-    uint256 GetSignatureHash() const { return GetHash(); }
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const;
 
     bool Sign(const std::string& strSignKey);
     bool CheckSignature() const;


### PR DESCRIPTION
Actually, let's fix all sigs at once while we are at it. Using signature-specific hash (`GetSignatureHash()`) should help avoiding issues on p2p/caching level (which uses `GetHash()`) while being able to cover all required fields at the same time. These changes are grouped into separate commits on a per-message basis.

a721459 also fixes way too aggressive policy for new format of `mnp` signatures introduced in previous PR which could lead to excessive banning. 
3715146 fixes docs by adding missing `mnp` fields and adjusting `SPORK_6_NEW_SIGS` description to match changes proposed here.