### PR TITLE
Store CGovernanceVote hash in memory instead of recalculating it via GetHash() every time

### DIFF
--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -214,7 +214,7 @@ CGovernanceVote::CGovernanceVote()
       vchSig()
 {}
 
-CGovernanceVote::CGovernanceVote(COutPoint outpointMasternodeIn, uint256 nParentHashIn, vote_signal_enum_t eVoteSignalIn, vote_outcome_enum_t eVoteOutcomeIn)
+CGovernanceVote::CGovernanceVote(const COutPoint& outpointMasternodeIn, const uint256& nParentHashIn, vote_signal_enum_t eVoteSignalIn, vote_outcome_enum_t eVoteOutcomeIn)
     : fValid(true),
       fSynced(false),
       nVoteSignal(eVoteSignalIn),
@@ -223,7 +223,9 @@ CGovernanceVote::CGovernanceVote(COutPoint outpointMasternodeIn, uint256 nParent
       nVoteOutcome(eVoteOutcomeIn),
       nTime(GetAdjustedTime()),
       vchSig()
-{}
+{
+    UpdateHash();
+}
 
 void CGovernanceVote::Relay(CConnman& connman) const
 {
@@ -237,7 +239,7 @@ void CGovernanceVote::Relay(CConnman& connman) const
     connman.RelayInv(inv, MIN_GOVERNANCE_PEER_PROTO_VERSION);
 }
 
-uint256 CGovernanceVote::GetHash() const
+void CGovernanceVote::UpdateHash() const
 {
     // Note: doesn't match serialization
 
@@ -247,7 +249,12 @@ uint256 CGovernanceVote::GetHash() const
     ss << nVoteSignal;
     ss << nVoteOutcome;
     ss << nTime;
-    return ss.GetHash();
+    *const_cast<uint256*>(&hash) = ss.GetHash();
+}
+
+uint256 CGovernanceVote::GetHash() const
+{
+    return hash;
 }
 
 uint256 CGovernanceVote::GetSignatureHash() const

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -101,9 +101,13 @@ private:
     int64_t nTime;
     std::vector<unsigned char> vchSig;
 
+    /** Memory only. */
+    const uint256 hash;
+    void UpdateHash() const;
+
 public:
     CGovernanceVote();
-    CGovernanceVote(COutPoint outpointMasternodeIn, uint256 nParentHashIn, vote_signal_enum_t eVoteSignalIn, vote_outcome_enum_t eVoteOutcomeIn);
+    CGovernanceVote(const COutPoint& outpointMasternodeIn, const uint256& nParentHashIn, vote_signal_enum_t eVoteSignalIn, vote_outcome_enum_t eVoteOutcomeIn);
 
     bool IsValid() const { return fValid; }
 
@@ -117,7 +121,7 @@ public:
 
     const uint256& GetParentHash() const { return nParentHash; }
 
-    void SetTime(int64_t nTimeIn) { nTime = nTimeIn; }
+    void SetTime(int64_t nTimeIn) { nTime = nTimeIn; UpdateHash(); }
 
     void SetSignature(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }
 
@@ -205,6 +209,8 @@ public:
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(vchSig);
         }
+        if (ser_action.ForRead())
+            UpdateHash();
     }
 
 };

--- a/src/governance-votedb.cpp
+++ b/src/governance-votedb.cpp
@@ -34,7 +34,7 @@ bool CGovernanceObjectVoteFile::HasVote(const uint256& nHash) const
     return true;
 }
 
-bool CGovernanceObjectVoteFile::GetVoteDataStream(const uint256& nHash, CDataStream& ss) const
+bool CGovernanceObjectVoteFile::SerializeVoteToStream(const uint256& nHash, CDataStream& ss) const
 {
     vote_m_cit it = mapVoteIndex.find(nHash);
     if(it == mapVoteIndex.end()) {

--- a/src/governance-votedb.cpp
+++ b/src/governance-votedb.cpp
@@ -34,13 +34,13 @@ bool CGovernanceObjectVoteFile::HasVote(const uint256& nHash) const
     return true;
 }
 
-bool CGovernanceObjectVoteFile::GetVote(const uint256& nHash, CGovernanceVote& vote) const
+bool CGovernanceObjectVoteFile::GetVoteDataStream(const uint256& nHash, CDataStream& ss) const
 {
     vote_m_cit it = mapVoteIndex.find(nHash);
     if(it == mapVoteIndex.end()) {
         return false;
     }
-    vote = *(it->second);
+    ss << *(it->second);
     return true;
 }
 
@@ -66,14 +66,6 @@ void CGovernanceObjectVoteFile::RemoveVotesFromMasternode(const COutPoint& outpo
             ++it;
         }
     }
-}
-
-CGovernanceObjectVoteFile& CGovernanceObjectVoteFile::operator=(const CGovernanceObjectVoteFile& other)
-{
-    nMemoryVotes = other.nMemoryVotes;
-    listVotes = other.listVotes;
-    RebuildIndex();
-    return *this;
 }
 
 void CGovernanceObjectVoteFile::RebuildIndex()

--- a/src/governance-votedb.h
+++ b/src/governance-votedb.h
@@ -10,6 +10,7 @@
 
 #include "governance-vote.h"
 #include "serialize.h"
+#include "streams.h"
 #include "uint256.h"
 
 /**
@@ -62,15 +63,13 @@ public:
     /**
      * Retrieve a vote cached in memory
      */
-    bool GetVote(const uint256& nHash, CGovernanceVote& vote) const;
+    bool GetVoteDataStream(const uint256& nHash, CDataStream& ss) const;
 
     int GetVoteCount() {
         return nMemoryVotes;
     }
 
     std::vector<CGovernanceVote> GetVotes() const;
-
-    CGovernanceObjectVoteFile& operator=(const CGovernanceObjectVoteFile& other);
 
     void RemoveVotesFromMasternode(const COutPoint& outpointMasternode);
 

--- a/src/governance-votedb.h
+++ b/src/governance-votedb.h
@@ -63,7 +63,7 @@ public:
     /**
      * Retrieve a vote cached in memory
      */
-    bool GetVoteDataStream(const uint256& nHash, CDataStream& ss) const;
+    bool SerializeVoteToStream(const uint256& nHash, CDataStream& ss) const;
 
     int GetVoteCount() {
         return nMemoryVotes;

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -90,7 +90,7 @@ bool CGovernanceManager::SerializeVoteForHash(uint256 nHash, CDataStream& ss)
         return false;
     }
 
-    if(!pGovobj->GetVoteFile().GetVoteDataStream(nHash, ss)) {
+    if(!pGovobj->GetVoteFile().SerializeVoteToStream(nHash, ss)) {
         return false;
     }
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -90,12 +90,10 @@ bool CGovernanceManager::SerializeVoteForHash(uint256 nHash, CDataStream& ss)
         return false;
     }
 
-    CGovernanceVote vote;
-    if(!pGovobj->GetVoteFile().GetVote(nHash, vote)) {
+    if(!pGovobj->GetVoteFile().GetVoteDataStream(nHash, ss)) {
         return false;
     }
 
-    ss << vote;
     return true;
 }
 


### PR DESCRIPTION
We have 70K+ votes and `GetHash()` is used in quite a few places, so I think these changes should lower CPU usage in general. The difference I guess should be most noticeable when node is processing a lot of votes at once like when it's replying to `govsync` message. Note, that calling `UpdateHash()` in `CGovernanceVote::SerializationOp()` should not degrade the time of loading votes from disk because 
we already call `GetHash()` in `CGovernanceObjectVoteFile::RebuildIndex()` (which is called on de-serialization).