### PR TITLE
[RPC] Update getaddednodeinfo help example to remove dummy argument

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -282,9 +282,9 @@ UniValue getaddednodeinfo(const JSONRPCRequest& request)
             "  ,...\n"
             "]\n"
             "\nExamples:\n"
-            + HelpExampleCli("getaddednodeinfo", "true")
-            + HelpExampleCli("getaddednodeinfo", "true \"192.168.0.201\"")
-            + HelpExampleRpc("getaddednodeinfo", "true, \"192.168.0.201\"")
+            + HelpExampleCli("getaddednodeinfo", "")
+            + HelpExampleCli("getaddednodeinfo", "\"192.168.0.201\"")
+            + HelpExampleRpc("getaddednodeinfo", "\"192.168.0.201\"")
         );
 
     if(!g_connman)


### PR DESCRIPTION
- Command fails if true/false used as the example previously showed
- Related to bitcoin #8272 (in PR #1842)