### PR TITLE
Rename CheckPreviousBlockVotes to CheckBlockVotes and adjust its log output a bit

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -207,7 +207,7 @@ public:
     bool AddPaymentVote(const CMasternodePaymentVote& vote);
     bool HasVerifiedPaymentVote(uint256 hashIn);
     bool ProcessBlock(int nBlockHeight, CConnman& connman);
-    void CheckPreviousBlockVotes(int nPrevBlockHeight);
+    void CheckBlockVotes(int nBlockHeight);
 
     void Sync(CNode* node, CConnman& connman);
     void RequestLowDataPaymentBlocks(CNode* pnode, CConnman& connman);


### PR DESCRIPTION
The function (and arg) name is confusing, it has nothing to do with previous block actually. Also, debug output is way too verbose which makes it hard to scan through the log later.