### PR TITLE
 Switch CNetFulfilledRequestManager and CMasternodeMan maps/funcs to CService

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -224,6 +224,7 @@ public:
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
         fAllowMultipleAddressesFromGroup = false;
+        fAllowMultiplePorts = false;
 
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
@@ -369,6 +370,7 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = false;
         fAllowMultipleAddressesFromGroup = false;
+        fAllowMultiplePorts = false;
 
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
@@ -495,6 +497,7 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = false;
         fAllowMultipleAddressesFromGroup = true;
+        fAllowMultiplePorts = false;
 
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
@@ -591,6 +594,7 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
         fAllowMultipleAddressesFromGroup = true;
+        fAllowMultiplePorts = true;
 
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -75,6 +75,8 @@ public:
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** Allow multiple addresses to be selected from the same network group (e.g. 192.168.x.x) */
     bool AllowMultipleAddressesFromGroup() const { return fAllowMultipleAddressesFromGroup; }
+    /** Allow nodes with the same address and multiple ports */
+    bool AllowMultiplePorts() const { return fAllowMultiplePorts; }
     /** Return the BIP70 network string (main, test or regtest) */
     std::string NetworkIDString() const { return strNetworkID; }
     const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
@@ -108,6 +110,7 @@ protected:
     bool fRequireStandard;
     bool fMineBlocksOnDemand;
     bool fAllowMultipleAddressesFromGroup;
+    bool fAllowMultiplePorts;
     CCheckpointData checkpointData;
     ChainTxData chainTxData;
     int nPoolMaxTransactions;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -88,7 +88,7 @@ void CMasternodeMan::AskForMN(CNode* pnode, const COutPoint& outpoint, CConnman&
     CNetMsgMaker msgMaker(pnode->GetSendVersion());
     LOCK(cs);
 
-    CService addrSquashed = IsArgSet("-regtest") ? (CService)pnode->addr : CService(pnode->addr, 0);
+    CService addrSquashed = Params().AllowMultiplePorts() ? (CService)pnode->addr : CService(pnode->addr, 0);
     auto it1 = mWeAskedForMasternodeListEntry.find(outpoint);
     if (it1 != mWeAskedForMasternodeListEntry.end()) {
         auto it2 = it1->second.find(addrSquashed);
@@ -413,7 +413,7 @@ void CMasternodeMan::DsegUpdate(CNode* pnode, CConnman& connman)
     CNetMsgMaker msgMaker(pnode->GetSendVersion());
     LOCK(cs);
 
-    CService addrSquashed = IsArgSet("-regtest") ? (CService)pnode->addr : CService(pnode->addr, 0);
+    CService addrSquashed = Params().AllowMultiplePorts() ? (CService)pnode->addr : CService(pnode->addr, 0);
     if(Params().NetworkIDString() == CBaseChainParams::MAIN) {
         if(!(pnode->addr.IsRFC1918() || pnode->addr.IsLocal())) {
             auto it = mWeAskedForMasternodeList.find(addrSquashed);
@@ -948,7 +948,7 @@ void CMasternodeMan::SyncAll(CNode* pnode, CConnman& connman)
     // local network
     bool isLocal = (pnode->addr.IsRFC1918() || pnode->addr.IsLocal());
 
-    CService addrSquashed = IsArgSet("-regtest") ? (CService)pnode->addr : CService(pnode->addr, 0);
+    CService addrSquashed = Params().AllowMultiplePorts() ? (CService)pnode->addr : CService(pnode->addr, 0);
     // should only ask for this once
     if(!isLocal && Params().NetworkIDString() == CBaseChainParams::MAIN) {
         auto it = mAskedUsForMasternodeList.find(addrSquashed);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -88,25 +88,26 @@ void CMasternodeMan::AskForMN(CNode* pnode, const COutPoint& outpoint, CConnman&
     CNetMsgMaker msgMaker(pnode->GetSendVersion());
     LOCK(cs);
 
-    std::map<COutPoint, std::map<CNetAddr, int64_t> >::iterator it1 = mWeAskedForMasternodeListEntry.find(outpoint);
+    CService addrSquashed = IsArgSet("-regtest") ? (CService)pnode->addr : CService(pnode->addr, 0);
+    auto it1 = mWeAskedForMasternodeListEntry.find(outpoint);
     if (it1 != mWeAskedForMasternodeListEntry.end()) {
-        std::map<CNetAddr, int64_t>::iterator it2 = it1->second.find(pnode->addr);
+        auto it2 = it1->second.find(addrSquashed);
         if (it2 != it1->second.end()) {
             if (GetTime() < it2->second) {
                 // we've asked recently, should not repeat too often or we could get banned
                 return;
             }
             // we asked this node for this outpoint but it's ok to ask again already
-            LogPrintf("CMasternodeMan::AskForMN -- Asking same peer %s for missing masternode entry again: %s\n", pnode->addr.ToString(), outpoint.ToStringShort());
+            LogPrintf("CMasternodeMan::AskForMN -- Asking same peer %s for missing masternode entry again: %s\n", addrSquashed.ToString(), outpoint.ToStringShort());
         } else {
             // we already asked for this outpoint but not this node
-            LogPrintf("CMasternodeMan::AskForMN -- Asking new peer %s for missing masternode entry: %s\n", pnode->addr.ToString(), outpoint.ToStringShort());
+            LogPrintf("CMasternodeMan::AskForMN -- Asking new peer %s for missing masternode entry: %s\n", addrSquashed.ToString(), outpoint.ToStringShort());
         }
     } else {
         // we never asked any node for this outpoint
-        LogPrintf("CMasternodeMan::AskForMN -- Asking peer %s for missing masternode entry for the first time: %s\n", pnode->addr.ToString(), outpoint.ToStringShort());
+        LogPrintf("CMasternodeMan::AskForMN -- Asking peer %s for missing masternode entry for the first time: %s\n", addrSquashed.ToString(), outpoint.ToStringShort());
     }
-    mWeAskedForMasternodeListEntry[outpoint][pnode->addr] = GetTime() + DSEG_UPDATE_SECONDS;
+    mWeAskedForMasternodeListEntry[outpoint][addrSquashed] = GetTime() + DSEG_UPDATE_SECONDS;
 
     if (pnode->GetSendVersion() == 70208) {
         connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, CTxIn(outpoint)));
@@ -206,7 +207,7 @@ void CMasternodeMan::CheckAndRemove(CConnman& connman)
                             !IsMnbRecoveryRequested(hash);
                 if(fAsk) {
                     // this mn is in a non-recoverable state and we haven't asked other nodes yet
-                    std::set<CNetAddr> setRequested;
+                    std::set<CService> setRequested;
                     // calulate only once and only when it's needed
                     if(vecMasternodeRanks.empty()) {
                         int nRandomBlockHeight = GetRandInt(nCachedBlockHeight);
@@ -259,7 +260,7 @@ void CMasternodeMan::CheckAndRemove(CConnman& connman)
         // no need for cm_main below
         LOCK(cs);
 
-        std::map<uint256, std::pair< int64_t, std::set<CNetAddr> > >::iterator itMnbRequest = mMnbRecoveryRequests.begin();
+        auto itMnbRequest = mMnbRecoveryRequests.begin();
         while(itMnbRequest != mMnbRecoveryRequests.end()){
             // Allow this mnb to be re-verified again after MNB_RECOVERY_RETRY_SECONDS seconds
             // if mn is still in MASTERNODE_NEW_START_REQUIRED state.
@@ -271,7 +272,7 @@ void CMasternodeMan::CheckAndRemove(CConnman& connman)
         }
 
         // check who's asked for the Masternode list
-        std::map<CNetAddr, int64_t>::iterator it1 = mAskedUsForMasternodeList.begin();
+        auto it1 = mAskedUsForMasternodeList.begin();
         while(it1 != mAskedUsForMasternodeList.end()){
             if((*it1).second < GetTime()) {
                 mAskedUsForMasternodeList.erase(it1++);
@@ -291,9 +292,9 @@ void CMasternodeMan::CheckAndRemove(CConnman& connman)
         }
 
         // check which Masternodes we've asked for
-        std::map<COutPoint, std::map<CNetAddr, int64_t> >::iterator it2 = mWeAskedForMasternodeListEntry.begin();
+        auto it2 = mWeAskedForMasternodeListEntry.begin();
         while(it2 != mWeAskedForMasternodeListEntry.end()){
-            std::map<CNetAddr, int64_t>::iterator it3 = it2->second.begin();
+            auto it3 = it2->second.begin();
             while(it3 != it2->second.end()){
                 if(it3->second < GetTime()){
                     it2->second.erase(it3++);
@@ -308,7 +309,7 @@ void CMasternodeMan::CheckAndRemove(CConnman& connman)
             }
         }
 
-        std::map<CNetAddr, CMasternodeVerification>::iterator it3 = mWeAskedForVerification.begin();
+        auto it3 = mWeAskedForVerification.begin();
         while(it3 != mWeAskedForVerification.end()){
             if(it3->second.nBlockHeight < nCachedBlockHeight - MAX_POSE_BLOCKS) {
                 mWeAskedForVerification.erase(it3++);
@@ -412,11 +413,12 @@ void CMasternodeMan::DsegUpdate(CNode* pnode, CConnman& connman)
     CNetMsgMaker msgMaker(pnode->GetSendVersion());
     LOCK(cs);
 
+    CService addrSquashed = IsArgSet("-regtest") ? (CService)pnode->addr : CService(pnode->addr, 0);
     if(Params().NetworkIDString() == CBaseChainParams::MAIN) {
         if(!(pnode->addr.IsRFC1918() || pnode->addr.IsLocal())) {
-            std::map<CNetAddr, int64_t>::iterator it = mWeAskedForMasternodeList.find(pnode->addr);
+            auto it = mWeAskedForMasternodeList.find(addrSquashed);
             if(it != mWeAskedForMasternodeList.end() && GetTime() < (*it).second) {
-                LogPrintf("CMasternodeMan::DsegUpdate -- we already asked %s for the list; skipping...\n", pnode->addr.ToString());
+                LogPrintf("CMasternodeMan::DsegUpdate -- we already asked %s for the list; skipping...\n", addrSquashed.ToString());
                 return;
             }
         }
@@ -428,7 +430,7 @@ void CMasternodeMan::DsegUpdate(CNode* pnode, CConnman& connman)
         connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, COutPoint()));
     }
     int64_t askAgain = GetTime() + DSEG_UPDATE_SECONDS;
-    mWeAskedForMasternodeList[pnode->addr] = askAgain;
+    mWeAskedForMasternodeList[addrSquashed] = askAgain;
 
     LogPrint("masternode", "CMasternodeMan::DsegUpdate -- asked %s for the list\n", pnode->addr.ToString());
 }
@@ -946,16 +948,17 @@ void CMasternodeMan::SyncAll(CNode* pnode, CConnman& connman)
     // local network
     bool isLocal = (pnode->addr.IsRFC1918() || pnode->addr.IsLocal());
 
+    CService addrSquashed = IsArgSet("-regtest") ? (CService)pnode->addr : CService(pnode->addr, 0);
     // should only ask for this once
     if(!isLocal && Params().NetworkIDString() == CBaseChainParams::MAIN) {
-        std::map<CNetAddr, int64_t>::iterator it = mAskedUsForMasternodeList.find(pnode->addr);
+        auto it = mAskedUsForMasternodeList.find(addrSquashed);
         if (it != mAskedUsForMasternodeList.end() && it->second > GetTime()) {
             Misbehaving(pnode->GetId(), 34);
             LogPrintf("CMasternodeMan::%s -- peer already asked me for the list, peer=%d\n", __func__, pnode->id);
             return;
         }
         int64_t askAgain = GetTime() + DSEG_UPDATE_SECONDS;
-        mAskedUsForMasternodeList[pnode->addr] = askAgain;
+        mAskedUsForMasternodeList[addrSquashed] = askAgain;
     }
 
     int nInvCount = 0;

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -49,16 +49,17 @@ private:
     // map to hold all MNs
     std::map<COutPoint, CMasternode> mapMasternodes;
     // who's asked for the Masternode list and the last time
-    std::map<CNetAddr, int64_t> mAskedUsForMasternodeList;
+    std::map<CService, int64_t> mAskedUsForMasternodeList;
     // who we asked for the Masternode list and the last time
-    std::map<CNetAddr, int64_t> mWeAskedForMasternodeList;
+    std::map<CService, int64_t> mWeAskedForMasternodeList;
     // which Masternodes we've asked for
-    std::map<COutPoint, std::map<CNetAddr, int64_t> > mWeAskedForMasternodeListEntry;
+    std::map<COutPoint, std::map<CService, int64_t> > mWeAskedForMasternodeListEntry;
+
     // who we asked for the masternode verification
-    std::map<CNetAddr, CMasternodeVerification> mWeAskedForVerification;
+    std::map<CService, CMasternodeVerification> mWeAskedForVerification;
 
     // these maps are used for masternode recovery from MASTERNODE_NEW_START_REQUIRED state
-    std::map<uint256, std::pair< int64_t, std::set<CNetAddr> > > mMnbRecoveryRequests;
+    std::map<uint256, std::pair< int64_t, std::set<CService> > > mMnbRecoveryRequests;
     std::map<uint256, std::vector<CMasternodeBroadcast> > mMnbRecoveryGoodReplies;
     std::list< std::pair<CService, uint256> > listScheduledMnbRequestConnections;
     std::map<CService, std::pair<int64_t, std::set<uint256> > > mapPendingMNB;

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -8,26 +8,29 @@
 
 CNetFulfilledRequestManager netfulfilledman;
 
-void CNetFulfilledRequestManager::AddFulfilledRequest(const CAddress& addr, const std::string& strRequest)
+void CNetFulfilledRequestManager::AddFulfilledRequest(const CService& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    mapFulfilledRequests[addr][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
+    CService addrSquashed = IsArgSet("-regtest") ? addr : CService(addr, 0);
+    mapFulfilledRequests[addrSquashed][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
 }
 
-bool CNetFulfilledRequestManager::HasFulfilledRequest(const CAddress& addr, const std::string& strRequest)
+bool CNetFulfilledRequestManager::HasFulfilledRequest(const CService& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
+    CService addrSquashed = IsArgSet("-regtest") ? addr : CService(addr, 0);
+    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addrSquashed);
 
     return  it != mapFulfilledRequests.end() &&
             it->second.find(strRequest) != it->second.end() &&
             it->second[strRequest] > GetTime();
 }
 
-void CNetFulfilledRequestManager::RemoveFulfilledRequest(const CAddress& addr, const std::string& strRequest)
+void CNetFulfilledRequestManager::RemoveFulfilledRequest(const CService& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
+    CService addrSquashed = IsArgSet("-regtest") ? addr : CService(addr, 0);
+    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addrSquashed);
 
     if (it != mapFulfilledRequests.end()) {
         it->second.erase(strRequest);

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -11,14 +11,14 @@ CNetFulfilledRequestManager netfulfilledman;
 void CNetFulfilledRequestManager::AddFulfilledRequest(const CService& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    CService addrSquashed = IsArgSet("-regtest") ? addr : CService(addr, 0);
+    CService addrSquashed = Params().AllowMultiplePorts() ? addr : CService(addr, 0);
     mapFulfilledRequests[addrSquashed][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
 }
 
 bool CNetFulfilledRequestManager::HasFulfilledRequest(const CService& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    CService addrSquashed = IsArgSet("-regtest") ? addr : CService(addr, 0);
+    CService addrSquashed = Params().AllowMultiplePorts() ? addr : CService(addr, 0);
     fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addrSquashed);
 
     return  it != mapFulfilledRequests.end() &&
@@ -29,7 +29,7 @@ bool CNetFulfilledRequestManager::HasFulfilledRequest(const CService& addr, cons
 void CNetFulfilledRequestManager::RemoveFulfilledRequest(const CService& addr, const std::string& strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    CService addrSquashed = IsArgSet("-regtest") ? addr : CService(addr, 0);
+    CService addrSquashed = Params().AllowMultiplePorts() ? addr : CService(addr, 0);
     fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addrSquashed);
 
     if (it != mapFulfilledRequests.end()) {

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -5,8 +5,7 @@
 #ifndef NETFULFILLEDMAN_H
 #define NETFULFILLEDMAN_H
 
-#include "netbase.h"
-#include "protocol.h"
+#include "netaddress.h"
 #include "serialize.h"
 #include "sync.h"
 
@@ -19,7 +18,7 @@ class CNetFulfilledRequestManager
 {
 private:
     typedef std::map<std::string, int64_t> fulfilledreqmapentry_t;
-    typedef std::map<CNetAddr, fulfilledreqmapentry_t> fulfilledreqmap_t;
+    typedef std::map<CService, fulfilledreqmapentry_t> fulfilledreqmap_t;
 
     //keep track of what node has/was asked for and when
     fulfilledreqmap_t mapFulfilledRequests;
@@ -36,9 +35,9 @@ public:
         READWRITE(mapFulfilledRequests);
     }
 
-    void AddFulfilledRequest(const CAddress& addr, const std::string& strRequest); // expire after 1 hour by default
-    bool HasFulfilledRequest(const CAddress& addr, const std::string& strRequest);
-    void RemoveFulfilledRequest(const CAddress& addr, const std::string& strRequest);
+    void AddFulfilledRequest(const CService& addr, const std::string& strRequest);
+    bool HasFulfilledRequest(const CService& addr, const std::string& strRequest);
+    void RemoveFulfilledRequest(const CService& addr, const std::string& strRequest);
 
     void CheckAndRemove();
     void Clear();


### PR DESCRIPTION
This is to make them work correctly on regtest.
We make sure that behaviour on other networks is not affected though.

Replaces #1876 and similar patch in evo#19