### PR TITLE
Use spork addresses instead of raw keys and allow changing them on startup

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -227,7 +227,8 @@ public:
 
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
-        strSporkPubKey = "04549ac134f694c0243f503e8c8a9a986f5de6610049c40b07816809b0d1d06a21b07be27b9bb555931773f62ba6cf35a25fd52f694d4e1106ccd237a7bb899fdd";
+
+        strSporkAddress = "Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh";
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -371,7 +372,8 @@ public:
 
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
-        strSporkPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
+
+        strSporkAddress = "yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55";
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -500,7 +502,8 @@ public:
 
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
-        strSporkPubKey = "046f78dcf911fbd61910136f7f0f8d90578f68d0b3ac973b5040fb7afb501b5939f39b108b0569dca71488f5bbf498d92e4d1194f6f941307ffd95f75e76869f0e";
+
+        strSporkAddress = "yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55";
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -598,6 +598,9 @@ public:
 
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
+        // privKey: cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK
+        strSporkAddress = "yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW";
+
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of
             ( 0, uint256S("0x000008ca1832a4baf228eb1553c03d3a2c8e02399550dd6ea8d65cec3ef23d2e"))

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -113,7 +113,6 @@ protected:
     int nPoolMaxTransactions;
     int nFulfilledRequestExpireTime;
     std::string strSporkAddress;
-    std::string strMasternodePaymentsPubKey;
 };
 
 /**

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -85,7 +85,7 @@ public:
     const ChainTxData& TxData() const { return chainTxData; }
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
-    std::string SporkPubKey() const { return strSporkPubKey; }
+    const std::string &SporkAddress() const { return strSporkAddress; }
 protected:
     CChainParams() {}
 
@@ -112,7 +112,7 @@ protected:
     ChainTxData chainTxData;
     int nPoolMaxTransactions;
     int nFulfilledRequestExpireTime;
-    std::string strSporkPubKey;
+    std::string strSporkAddress;
     std::string strMasternodePaymentsPubKey;
 };
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -85,7 +85,7 @@ public:
     const ChainTxData& TxData() const { return chainTxData; }
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
-    const std::string &SporkAddress() const { return strSporkAddress; }
+    const std::string& SporkAddress() const { return strSporkAddress; }
 protected:
     CChainParams() {}
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -541,7 +541,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
     AppendParamsHelpMessages(strUsage, showDebug);
     strUsage += HelpMessageOpt("-litemode=<n>", strprintf(_("Disable all Dash specific functionality (Masternodes, PrivateSend, InstantSend, Governance) (0-1, default: %u)"), 0));
-    strUsage += HelpMessageOpt("-sporkaddr=<hex>", strprintf(_("Override spork address. Only useful for regtest and devnet. Using this on mainnet will ban you.")));
+    strUsage += HelpMessageOpt("-sporkaddr=<hex>", strprintf(_("Override spork address. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.")));
 
     strUsage += HelpMessageGroup(_("Masternode options:"));
     strUsage += HelpMessageOpt("-masternode=<n>", strprintf(_("Enable the client to act as a masternode (0-1, default: %u)"), 0));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -541,7 +541,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
     AppendParamsHelpMessages(strUsage, showDebug);
     strUsage += HelpMessageOpt("-litemode=<n>", strprintf(_("Disable all Dash specific functionality (Masternodes, PrivateSend, InstantSend, Governance) (0-1, default: %u)"), 0));
-    strUsage += HelpMessageOpt("-sporkaddr=<hex>", strprintf(_("Override spork address. Only useful for regtest and devnet. Using this on mainnet will ban you")));
+    strUsage += HelpMessageOpt("-sporkaddr=<hex>", strprintf(_("Override spork address. Only useful for regtest and devnet. Using this on mainnet will ban you.")));
 
     strUsage += HelpMessageGroup(_("Masternode options:"));
     strUsage += HelpMessageOpt("-masternode=<n>", strprintf(_("Enable the client to act as a masternode (0-1, default: %u)"), 0));
@@ -1344,12 +1344,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             threadGroup.create_thread(&ThreadScriptCheck);
     }
 
-    sporkManager.InitDefaultSporkAddress();
-
-    if (IsArgSet("-sporkaddr")) {
-        if (!sporkManager.SetSporkAddress(GetArg("-sporkaddr", "")))
-            return InitError(_("Invalid spork address specified with -sporkaddr"));
-    }
+    if (!sporkManager.SetSporkAddress(GetArg("-sporkaddr", Params().SporkAddress())))
+        return InitError(_("Invalid spork address specified with -sporkaddr"));
 
     if (IsArgSet("-sporkkey")) // spork priv key
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -541,6 +541,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-shrinkdebugfile", _("Shrink debug.log file on client startup (default: 1 when no -debug)"));
     AppendParamsHelpMessages(strUsage, showDebug);
     strUsage += HelpMessageOpt("-litemode=<n>", strprintf(_("Disable all Dash specific functionality (Masternodes, PrivateSend, InstantSend, Governance) (0-1, default: %u)"), 0));
+    strUsage += HelpMessageOpt("-sporkaddr=<hex>", strprintf(_("Override spork address. Only useful for regtest and devnet. Using this on mainnet will ban you")));
 
     strUsage += HelpMessageGroup(_("Masternode options:"));
     strUsage += HelpMessageOpt("-masternode=<n>", strprintf(_("Enable the client to act as a masternode (0-1, default: %u)"), 0));
@@ -1344,6 +1345,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     sporkManager.InitDefaultSporkAddress();
+
+    if (IsArgSet("-sporkaddr")) {
+        if (!sporkManager.SetSporkAddress(GetArg("-sporkaddr", "")))
+            return InitError(_("Invalid spork address specified with -sporkaddr"));
+    }
 
     if (IsArgSet("-sporkkey")) // spork priv key
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1343,6 +1343,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             threadGroup.create_thread(&ThreadScriptCheck);
     }
 
+    sporkManager.InitDefaultSporkAddress();
+
     if (IsArgSet("-sporkkey")) // spork priv key
     {
         if (!sporkManager.SetPrivKey(GetArg("-sporkkey", "")))

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -32,11 +32,16 @@ bool CMessageSigner::SignMessage(const std::string& strMessage, std::vector<unsi
 
 bool CMessageSigner::VerifyMessage(const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet)
 {
+    return VerifyMessage(pubkey.GetID(), vchSig, strMessage, strErrorRet);
+}
+
+bool CMessageSigner::VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string &strMessage, std::string& strErrorRet)
+{
     CHashWriter ss(SER_GETHASH, 0);
     ss << strMessageMagic;
     ss << strMessage;
 
-    return CHashSigner::VerifyHash(ss.GetHash(), pubkey, vchSig, strErrorRet);
+    return CHashSigner::VerifyHash(ss.GetHash(), keyID, vchSig, strErrorRet);
 }
 
 bool CHashSigner::SignHash(const uint256& hash, const CKey& key, std::vector<unsigned char>& vchSigRet)
@@ -46,15 +51,20 @@ bool CHashSigner::SignHash(const uint256& hash, const CKey& key, std::vector<uns
 
 bool CHashSigner::VerifyHash(const uint256& hash, const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, std::string& strErrorRet)
 {
+    return VerifyHash(hash, pubkey.GetID(), vchSig, strErrorRet);
+}
+
+bool CHashSigner::VerifyHash(const uint256& hash, const CKeyID& keyID, const std::vector<unsigned char>& vchSig, std::string& strErrorRet)
+{
     CPubKey pubkeyFromSig;
     if(!pubkeyFromSig.RecoverCompact(hash, vchSig)) {
         strErrorRet = "Error recovering public key.";
         return false;
     }
 
-    if(pubkeyFromSig.GetID() != pubkey.GetID()) {
+    if(pubkeyFromSig.GetID() != keyID) {
         strErrorRet = strprintf("Keys don't match: pubkey=%s, pubkeyFromSig=%s, hash=%s, vchSig=%s",
-                    pubkey.GetID().ToString(), pubkeyFromSig.GetID().ToString(), hash.ToString(),
+                    keyID.ToString(), pubkeyFromSig.GetID().ToString(), hash.ToString(),
                     EncodeBase64(&vchSig[0], vchSig.size()));
         return false;
     }

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -35,7 +35,7 @@ bool CMessageSigner::VerifyMessage(const CPubKey& pubkey, const std::vector<unsi
     return VerifyMessage(pubkey.GetID(), vchSig, strMessage, strErrorRet);
 }
 
-bool CMessageSigner::VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string &strMessage, std::string& strErrorRet)
+bool CMessageSigner::VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet)
 {
     CHashWriter ss(SER_GETHASH, 0);
     ss << strMessageMagic;

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -18,6 +18,8 @@ public:
     static bool SignMessage(const std::string& strMessage, std::vector<unsigned char>& vchSigRet, const CKey& key);
     /// Verify the message signature, returns true if succcessful
     static bool VerifyMessage(const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet);
+    /// Verify the message signature, returns true if succcessful
+    static bool VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string &strMessage, std::string& strErrorRet);
 };
 
 /** Helper class for signing hashes and checking their signatures
@@ -29,6 +31,8 @@ public:
     static bool SignHash(const uint256& hash, const CKey& key, std::vector<unsigned char>& vchSigRet);
     /// Verify the hash signature, returns true if succcessful
     static bool VerifyHash(const uint256& hash, const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, std::string& strErrorRet);
+    /// Verify the hash signature, returns true if succcessful
+    static bool VerifyHash(const uint256& hash, const CKeyID& keyID, const std::vector<unsigned char>& vchSig, std::string& strErrorRet);
 };
 
 #endif

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -19,7 +19,7 @@ public:
     /// Verify the message signature, returns true if succcessful
     static bool VerifyMessage(const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet);
     /// Verify the message signature, returns true if succcessful
-    static bool VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string &strMessage, std::string& strErrorRet);
+    static bool VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet);
 };
 
 /** Helper class for signing hashes and checking their signatures

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -2,17 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "spork.h"
+
 #include "chainparams.h"
 #include "validation.h"
 #include "messagesigner.h"
 #include "net_processing.h"
 #include "netmessagemaker.h"
-#include "spork.h"
+#include "base58.h"
 
 #include <boost/lexical_cast.hpp>
-
-class CSporkMessage;
-class CSporkManager;
 
 CSporkManager sporkManager;
 
@@ -48,7 +47,7 @@ void CSporkManager::ProcessSpork(CNode* pfrom, const std::string& strCommand, CD
             LogPrintf("%s new\n", strLogMsg);
         }
 
-        if(!spork.CheckSignature()) {
+        if(!spork.CheckSignature(sporkPubKeyID)) {
             LogPrintf("CSporkManager::ProcessSpork -- ERROR: invalid signature\n");
             Misbehaving(pfrom->GetId(), 100);
             return;
@@ -107,7 +106,7 @@ bool CSporkManager::UpdateSpork(int nSporkID, int64_t nValue, CConnman& connman)
 
     CSporkMessage spork = CSporkMessage(nSporkID, nValue, GetAdjustedTime());
 
-    if(spork.Sign(strMasterPrivKey)) {
+    if(spork.Sign(sporkPrivKey)) {
         spork.Relay(connman);
         mapSporks[spork.GetHash()] = spork;
         mapSporksActive[nSporkID] = spork;
@@ -202,18 +201,38 @@ std::string CSporkManager::GetSporkNameByID(int nSporkID)
     }
 }
 
+void CSporkManager::InitDefaultSporkAddress() {
+    if (!SetSporkAddress(Params().SporkAddress()))
+        assert(false);
+}
+
 bool CSporkManager::SetPrivKey(const std::string& strPrivKey)
 {
+    if (!IsHex(strPrivKey) || strPrivKey.size() != 130) {
+        return false;
+    }
+
+    CKey key;
+    CPubKey pubKey;
+    if(!CMessageSigner::GetKeysFromSecret(strPrivKey, key, pubKey)) {
+        LogPrintf("CSporkManager::SetPrivKey -- Failed to parse private key\n");
+        return false;
+    }
+
+    if (pubKey.GetID() != sporkPubKeyID) {
+        LogPrintf("CSporkManager::SetPrivKey -- New private key does not belong to spork address\n");
+        return false;
+    }
+
     CSporkMessage spork;
-
-    spork.Sign(strPrivKey);
-
-    if(spork.CheckSignature()){
+    if (spork.Sign(key)) {
         // Test signing successful, proceed
         LogPrintf("CSporkManager::SetPrivKey -- Successfully initialized as spork signer\n");
-        strMasterPrivKey = strPrivKey;
+
+        sporkPrivKey = key;
         return true;
     } else {
+        LogPrintf("CSporkManager::SetPrivKey -- Test signing failed\n");
         return false;
     }
 }
@@ -228,16 +247,10 @@ uint256 CSporkMessage::GetSignatureHash() const
     return GetHash();
 }
 
-bool CSporkMessage::Sign(const std::string& strSignKey)
+bool CSporkMessage::Sign(const CKey &key)
 {
-    CKey key;
-    CPubKey pubkey;
+    CKeyID pubKeyId = key.GetPubKey().GetID();
     std::string strError = "";
-
-    if(!CMessageSigner::GetKeysFromSecret(strSignKey, key, pubkey)) {
-        LogPrintf("CSporkMessage::Sign -- GetKeysFromSecret() failed, invalid spork key %s\n", strSignKey);
-        return false;
-    }
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();
@@ -247,7 +260,7 @@ bool CSporkMessage::Sign(const std::string& strSignKey)
             return false;
         }
 
-        if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
+        if (!CHashSigner::VerifyHash(hash, pubKeyId, vchSig, strError)) {
             LogPrintf("CSporkMessage::Sign -- VerifyHash() failed, error: %s\n", strError);
             return false;
         }
@@ -259,7 +272,7 @@ bool CSporkMessage::Sign(const std::string& strSignKey)
             return false;
         }
 
-        if(!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
+        if(!CMessageSigner::VerifyMessage(pubKeyId, vchSig, strMessage, strError)) {
             LogPrintf("CSporkMessage::Sign -- VerifyMessage() failed, error: %s\n", strError);
             return false;
         }
@@ -268,15 +281,14 @@ bool CSporkMessage::Sign(const std::string& strSignKey)
     return true;
 }
 
-bool CSporkMessage::CheckSignature() const
+bool CSporkMessage::CheckSignature(const CKeyID &pubKeyId) const
 {
     std::string strError = "";
-    CPubKey pubkey(ParseHex(Params().SporkPubKey()));
 
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();
 
-        if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
+        if (!CHashSigner::VerifyHash(hash, pubKeyId, vchSig, strError)) {
             // Note: unlike for many other messages when SPORK_6_NEW_SIGS is ON sporks with sigs in old format
             // and newer timestamps should not be accepted, so if we failed here - that's it
             LogPrintf("CSporkMessage::CheckSignature -- VerifyHash() failed, error: %s\n", strError);
@@ -285,7 +297,7 @@ bool CSporkMessage::CheckSignature() const
     } else {
         std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
 
-        if (!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)){
+        if (!CMessageSigner::VerifyMessage(pubKeyId, vchSig, strMessage, strError)){
             LogPrintf("CSporkMessage::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
             return false;
         }

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -206,6 +206,15 @@ void CSporkManager::InitDefaultSporkAddress() {
         assert(false);
 }
 
+bool CSporkManager::SetSporkAddress(const std::string &strAddress) {
+    CBitcoinAddress address(strAddress);
+    if (!address.IsValid() || !address.GetKeyID(sporkPubKeyID)) {
+        LogPrintf("CSporkManager::SetSporkAddress -- Failed to parse spork address\n");
+        return false;
+    }
+    return true;
+}
+
 bool CSporkManager::SetPrivKey(const std::string& strPrivKey)
 {
     if (!IsHex(strPrivKey) || strPrivKey.size() != 130) {

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -201,7 +201,7 @@ std::string CSporkManager::GetSporkNameByID(int nSporkID)
     }
 }
 
-bool CSporkManager::SetSporkAddress(const std::string &strAddress) {
+bool CSporkManager::SetSporkAddress(const std::string& strAddress) {
     CBitcoinAddress address(strAddress);
     if (!address.IsValid() || !address.GetKeyID(sporkPubKeyID)) {
         LogPrintf("CSporkManager::SetSporkAddress -- Failed to parse spork address\n");
@@ -247,7 +247,7 @@ uint256 CSporkMessage::GetSignatureHash() const
     return GetHash();
 }
 
-bool CSporkMessage::Sign(const CKey &key)
+bool CSporkMessage::Sign(const CKey& key)
 {
     CKeyID pubKeyId = key.GetPubKey().GetID();
     std::string strError = "";
@@ -281,7 +281,7 @@ bool CSporkMessage::Sign(const CKey &key)
     return true;
 }
 
-bool CSporkMessage::CheckSignature(const CKeyID &pubKeyId) const
+bool CSporkMessage::CheckSignature(const CKeyID& pubKeyId) const
 {
     std::string strError = "";
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -4,12 +4,12 @@
 
 #include "spork.h"
 
+#include "base58.h"
 #include "chainparams.h"
 #include "validation.h"
 #include "messagesigner.h"
 #include "net_processing.h"
 #include "netmessagemaker.h"
-#include "base58.h"
 
 #include <boost/lexical_cast.hpp>
 
@@ -201,11 +201,6 @@ std::string CSporkManager::GetSporkNameByID(int nSporkID)
     }
 }
 
-void CSporkManager::InitDefaultSporkAddress() {
-    if (!SetSporkAddress(Params().SporkAddress()))
-        assert(false);
-}
-
 bool CSporkManager::SetSporkAddress(const std::string &strAddress) {
     CBitcoinAddress address(strAddress);
     if (!address.IsValid() || !address.GetKeyID(sporkPubKeyID)) {
@@ -217,10 +212,6 @@ bool CSporkManager::SetSporkAddress(const std::string &strAddress) {
 
 bool CSporkManager::SetPrivKey(const std::string& strPrivKey)
 {
-    if (!IsHex(strPrivKey) || strPrivKey.size() != 130) {
-        return false;
-    }
-
     CKey key;
     CPubKey pubKey;
     if(!CMessageSigner::GetKeysFromSecret(strPrivKey, key, pubKey)) {

--- a/src/spork.h
+++ b/src/spork.h
@@ -114,7 +114,6 @@ public:
     int GetSporkIDByName(const std::string& strName);
     std::string GetSporkNameByID(int nSporkID);
 
-    void InitDefaultSporkAddress();
     bool SetSporkAddress(const std::string &strAddress);
     bool SetPrivKey(const std::string& strPrivKey);
 };

--- a/src/spork.h
+++ b/src/spork.h
@@ -115,6 +115,7 @@ public:
     std::string GetSporkNameByID(int nSporkID);
 
     void InitDefaultSporkAddress();
+    bool SetSporkAddress(const std::string &strAddress);
     bool SetPrivKey(const std::string& strPrivKey);
 };
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -8,6 +8,7 @@
 #include "hash.h"
 #include "net.h"
 #include "utilstrencodings.h"
+#include "key.h"
 
 class CSporkMessage;
 class CSporkManager;
@@ -85,8 +86,8 @@ public:
     uint256 GetHash() const;
     uint256 GetSignatureHash() const;
 
-    bool Sign(const std::string& strSignKey);
-    bool CheckSignature() const;
+    bool Sign(const CKey &key);
+    bool CheckSignature(const CKeyID &pubKeyId) const;
     void Relay(CConnman& connman);
 };
 
@@ -95,8 +96,10 @@ class CSporkManager
 {
 private:
     std::vector<unsigned char> vchSig;
-    std::string strMasterPrivKey;
     std::map<int, CSporkMessage> mapSporksActive;
+
+    CKeyID sporkPubKeyID;
+    CKey sporkPrivKey;
 
 public:
 
@@ -111,6 +114,7 @@ public:
     int GetSporkIDByName(const std::string& strName);
     std::string GetSporkNameByID(int nSporkID);
 
+    void InitDefaultSporkAddress();
     bool SetPrivKey(const std::string& strPrivKey);
 };
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -86,8 +86,8 @@ public:
     uint256 GetHash() const;
     uint256 GetSignatureHash() const;
 
-    bool Sign(const CKey &key);
-    bool CheckSignature(const CKeyID &pubKeyId) const;
+    bool Sign(const CKey& key);
+    bool CheckSignature(const CKeyID& pubKeyId) const;
     void Relay(CConnman& connman);
 };
 
@@ -114,7 +114,7 @@ public:
     int GetSporkIDByName(const std::string& strName);
     std::string GetSporkNameByID(int nSporkID);
 
-    bool SetSporkAddress(const std::string &strAddress);
+    bool SetSporkAddress(const std::string& strAddress);
     bool SetPrivKey(const std::string& strPrivKey);
 };
 


### PR DESCRIPTION
This was initially part of https://github.com/dashpay/dash/pull/1960 and splitted out as requested in review.

This PR changes the spork public keys to Dash addresses. These addresses are derived from the previously used public keys. This can/should be verified by reviewers with the help of http://gobittest.appspot.com/Address. To verify, follow this procedure:
1. Look into the code from develop and copy the value that is assigned to `strSporkPubKey` in chainparams.cpp
2. Copy this value into field number 1 of the linked page and press send
3. In field number 4, replace the first 2 characters (which are `00`) with `4C`. This is the "network prefix" for Dash mainnet.
4. Click `Send` next to field 4
5. Compare the Dash address found in field 9 with what this PR uses for the spork address

This has to be done for mainnet and testnet. devnet uses the same key as testnet.

This PR also allows the user to change the spork address on startup via config and command line. This is only useful for devnet and will result in your node being banned if used on mainnet.

This PR also completely skips spork verification in regtest mode. I'm not sure about the usefulness of this one TBH as we could actually also just use `-sporkkey` and `-sporkaddr` in integration tests. If you don't like this change, I'll remove it.