### PR TITLE
[GUI] Create QR-code for Masternode private key

### DIFF
--- a/contrib/dash-qt.pro
+++ b/contrib/dash-qt.pro
@@ -9,6 +9,7 @@ FORMS += \
     ../src/qt/forms/helpmessagedialog.ui \
     ../src/qt/forms/intro.ui \
     ../src/qt/forms/masternodelist.ui \
+    ../src/qt/forms/qrdialog.ui \
     ../src/qt/forms/openuridialog.ui \
     ../src/qt/forms/optionsdialog.ui \
     ../src/qt/forms/overviewpage.ui \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -35,6 +35,7 @@ QT_FORMS_UI = \
   qt/forms/intro.ui \
   qt/forms/modaloverlay.ui \
   qt/forms/masternodelist.ui \
+  qt/forms/qrdialog.ui \
   qt/forms/openuridialog.ui \
   qt/forms/optionsdialog.ui \
   qt/forms/overviewpage.ui \
@@ -74,6 +75,7 @@ QT_MOC_CPP = \
   qt/moc_overviewpage.cpp \
   qt/moc_peertablemodel.cpp \
   qt/moc_paymentserver.cpp \
+  qt/moc_qrdialog.cpp \
   qt/moc_qvalidatedlineedit.cpp \
   qt/moc_qvaluecombobox.cpp \
   qt/moc_receivecoinsdialog.cpp \
@@ -147,6 +149,7 @@ BITCOIN_QT_H = \
   qt/paymentserver.h \
   qt/peertablemodel.h \
   qt/platformstyle.h \
+  qt/qrdialog.h \
   qt/qvalidatedlineedit.h \
   qt/qvaluecombobox.h \
   qt/receivecoinsdialog.h \
@@ -435,6 +438,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/overviewpage.cpp \
   qt/paymentrequestplus.cpp \
   qt/paymentserver.cpp \
+  qt/qrdialog.cpp \
   qt/receivecoinsdialog.cpp \
   qt/receiverequestdialog.cpp \
   qt/recentrequeststablemodel.cpp \

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -69,7 +69,7 @@ const std::string CLIENT_NAME("Dash Core");
 
 const std::string CLIENT_BUILD(BUILD_DESC CLIENT_VERSION_SUFFIX);
 
-static std::string FormatVersion(int nVersion)
+std::string FormatVersion(int nVersion)
 {
     if (nVersion % 100 == 0)
         return strprintf("%d.%d.%d", nVersion / 1000000, (nVersion / 10000) % 100, (nVersion / 100) % 100);

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -60,7 +60,7 @@ static const int CLIENT_VERSION =
 extern const std::string CLIENT_NAME;
 extern const std::string CLIENT_BUILD;
 
-
+std::string FormatVersion(int nVersion);
 std::string FormatFullVersion();
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
 

--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>723</width>
+    <width>762</width>
     <height>457</height>
    </rect>
   </property>
@@ -67,7 +67,7 @@
              <item>
               <widget class="QLabel" name="updateNote">
                <property name="text">
-                <string>Note: Status of your masternodes in local wallet can potentially be slightly incorrect.&lt;br /&gt;Always wait for wallet to sync additional data and then double check from another node&lt;br /&gt;if your masternode should be running but you still do not see "ENABLED" in "Status" field.</string>
+                <string>Note: Status of your masternodes in local wallet can potentially be slightly incorrect.&lt;br /&gt;Always wait for wallet to sync additional data and then double check from another node&lt;br /&gt;if your masternode should be running but you still do not see &quot;ENABLED&quot; in &quot;Status&quot; field.</string>
                </property>
               </widget>
              </item>
@@ -98,9 +98,6 @@
              </property>
              <attribute name="horizontalHeaderStretchLastSection">
               <bool>true</bool>
-             </attribute>
-             <attribute name="ResizeMode">
-              <enum>QHeaderView::Interactive</enum>
              </attribute>
              <column>
               <property name="text">
@@ -173,6 +170,16 @@
               </widget>
              </item>
              <item>
+              <widget class="QPushButton" name="QRButton">
+               <property name="toolTip">
+                <string>Show additional Masternode information</string>
+               </property>
+               <property name="text">
+                <string>Show &amp;Info...</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="QLabel" name="autoupdate_label">
                <property name="text">
                 <string>Status will be updated automatically in (sec):</string>
@@ -226,9 +233,6 @@
            </property>
            <attribute name="horizontalHeaderStretchLastSection">
             <bool>true</bool>
-           </attribute>
-           <attribute name="ResizeMode">
-            <enum>QHeaderView::Interactive</enum>
            </attribute>
            <column>
             <property name="text">

--- a/src/qt/forms/qrdialog.ui
+++ b/src/qt/forms/qrdialog.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QRDialog</class>
+ <widget class="QDialog" name="QRDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>670</width>
+    <height>698</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="QLabel" name="labelQRCodeTitle">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>QR-Code Title</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRGeneralImageWidget" name="lblQRCode">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>300</width>
+       <height>300</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>QR Code</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="outUri">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>50</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="button_saveImage">
+       <property name="text">
+        <string>&amp;Save Image...</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QRGeneralImageWidget</class>
+   <extends>QLabel</extends>
+   <header>qrdialog.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QRDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>452</x>
+     <y>573</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>243</x>
+     <y>298</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QRDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>452</x>
+     <y>573</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>243</x>
+     <y>298</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -3,11 +3,13 @@
 
 #include "activemasternode.h"
 #include "clientmodel.h"
+#include "clientversion.h"
 #include "init.h"
 #include "guiutil.h"
 #include "masternode-sync.h"
 #include "masternodeconfig.h"
 #include "masternodeman.h"
+#include "qrdialog.h"
 #include "sync.h"
 #include "wallet/wallet.h"
 #include "walletmodel.h"
@@ -62,6 +64,7 @@ MasternodeList::MasternodeList(const PlatformStyle *platformStyle, QWidget *pare
     contextMenu = new QMenu();
     contextMenu->addAction(startAliasAction);
     connect(ui->tableWidgetMyMasternodes, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showContextMenu(const QPoint&)));
+    connect(ui->tableWidgetMyMasternodes, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(on_QRButton_clicked()));
     connect(startAliasAction, SIGNAL(triggered()), this, SLOT(on_startButton_clicked()));
 
     timer = new QTimer(this);
@@ -240,7 +243,7 @@ void MasternodeList::updateMyNodeList(bool fForce)
     if(nSecondsTillUpdate > 0 && !fForce) return;
     nTimeMyListUpdated = GetTime();
 
-    ui->tableWidgetMasternodes->setSortingEnabled(false);
+    ui->tableWidgetMyMasternodes->setSortingEnabled(false);
     for (const auto& mne : masternodeConfig.getEntries()) {
         int32_t nOutputIndex = 0;
         if(!ParseInt32(mne.getOutputIndex(), &nOutputIndex)) {
@@ -249,7 +252,8 @@ void MasternodeList::updateMyNodeList(bool fForce)
 
         updateMyMasternodeInfo(QString::fromStdString(mne.getAlias()), QString::fromStdString(mne.getIp()), COutPoint(uint256S(mne.getTxHash()), nOutputIndex));
     }
-    ui->tableWidgetMasternodes->setSortingEnabled(true);
+    ui->tableWidgetMyMasternodes->selectRow(0);
+    ui->tableWidgetMyMasternodes->setSortingEnabled(true);
 
     // reset "timer"
     ui->secondsLabel->setText("0");
@@ -432,4 +436,78 @@ void MasternodeList::on_tableWidgetMyMasternodes_itemSelectionChanged()
 void MasternodeList::on_UpdateButton_clicked()
 {
     updateMyNodeList(true);
+}
+
+void MasternodeList::on_QRButton_clicked()
+{
+    std::string strAlias;
+    {
+        LOCK(cs_mymnlist);
+        // Find selected node alias
+        QItemSelectionModel* selectionModel = ui->tableWidgetMyMasternodes->selectionModel();
+        QModelIndexList selected = selectionModel->selectedRows();
+
+        if(selected.count() == 0) return;
+
+        QModelIndex index = selected.at(0);
+        int nSelectedRow = index.row();
+        strAlias = ui->tableWidgetMyMasternodes->item(nSelectedRow, 0)->text().toStdString();
+    }
+
+    ShowQRCode(strAlias);
+}
+
+void MasternodeList::ShowQRCode(std::string strAlias) {
+
+    if(!walletModel || !walletModel->getOptionsModel())
+        return;
+
+    // Get private key for this alias
+    std::string strMNPrivKey = "";
+    std::string strCollateral = "";
+    std::string strIP = "";
+    CMasternode mn;
+    bool fFound = false;
+
+    BOOST_FOREACH(CMasternodeConfig::CMasternodeEntry mne, masternodeConfig.getEntries()) {
+        if (strAlias != mne.getAlias()) {
+            continue;
+        }
+        else {
+            strMNPrivKey = mne.getPrivKey();
+            strCollateral = mne.getTxHash() + "-" + mne.getOutputIndex();
+            strIP = mne.getIp();
+            fFound = mnodeman.Get(COutPoint(uint256S(mne.getTxHash()), atoi(mne.getOutputIndex())), mn);
+            break;
+        }
+    }
+
+    // Title of popup window
+    QString strWindowtitle = tr("Additional information for Masternode ") + QString::fromStdString(strAlias);
+
+    // Title above QR-Code
+    QString strQRCodeTitle = tr("Masternode Private Key");
+
+    // Create dialog text as HTML
+    QString strHTML = "<html><font face='verdana, arial, helvetica, sans-serif'>";
+    strHTML += "<b>" + tr("Alias") +            ": </b>" + GUIUtil::HtmlEscape(strAlias) + "<br>";
+    strHTML += "<b>" + tr("Private Key") +      ": </b>" + GUIUtil::HtmlEscape(strMNPrivKey) + "<br>";
+    strHTML += "<b>" + tr("Collateral") +       ": </b>" + GUIUtil::HtmlEscape(strCollateral) + "<br>";
+    strHTML += "<b>" + tr("IP") +               ": </b>" + GUIUtil::HtmlEscape(strIP) + "<br>";
+    if (fFound) {
+        strHTML += "<b>" + tr("Protocol") +     ": </b>" + QString::number(mn.nProtocolVersion) + "<br>";
+        strHTML += "<b>" + tr("Version") +      ": </b>" + (mn.lastPing.nDaemonVersion > DEFAULT_DAEMON_VERSION ? GUIUtil::HtmlEscape(FormatVersion(mn.lastPing.nDaemonVersion)) : tr("Unknown")) + "<br>";
+        strHTML += "<b>" + tr("Sentinel") +     ": </b>" + (mn.lastPing.nSentinelVersion > DEFAULT_SENTINEL_VERSION ? GUIUtil::HtmlEscape(SafeIntVersionToString(mn.lastPing.nSentinelVersion)) : tr("Unknown")) + "<br>";
+        strHTML += "<b>" + tr("Status") +       ": </b>" + GUIUtil::HtmlEscape(CMasternode::StateToString(mn.nActiveState)) + "<br>";
+        strHTML += "<b>" + tr("Payee") +        ": </b>" + GUIUtil::HtmlEscape(CBitcoinAddress(mn.pubKeyCollateralAddress.GetID()).ToString()) + "<br>";
+        strHTML += "<b>" + tr("Active") +       ": </b>" + GUIUtil::HtmlEscape(DurationToDHMS(mn.lastPing.sigTime - mn.sigTime)) + "<br>";
+        strHTML += "<b>" + tr("Last Seen") +    ": </b>" + GUIUtil::HtmlEscape(DateTimeStrFormat("%Y-%m-%d %H:%M", mn.lastPing.sigTime + GetOffsetFromUtc())) + "<br>";
+    }
+
+    // Open QR dialog
+    QRDialog *dialog = new QRDialog(this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setModel(walletModel->getOptionsModel());
+    dialog->setInfo(strWindowtitle, QString::fromStdString(strMNPrivKey), strHTML, strQRCodeTitle);
+    dialog->show();
 }

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -36,6 +36,7 @@ public:
 
     void setClientModel(ClientModel *clientModel);
     void setWalletModel(WalletModel *walletModel);
+    void ShowQRCode(std::string strAlias);
     void StartAlias(std::string strAlias);
     void StartAll(std::string strCommand = "start-all");
 
@@ -50,6 +51,7 @@ public Q_SLOTS:
     void updateNodeList();
 
 Q_SIGNALS:
+    void doubleClicked(const QModelIndex&);
 
 private:
     QTimer *timer;
@@ -68,6 +70,7 @@ private:
 private Q_SLOTS:
     void showContextMenu(const QPoint &);
     void on_filterLineEdit_textChanged(const QString &strFilterIn);
+    void on_QRButton_clicked();
     void on_startButton_clicked();
     void on_startAllButton_clicked();
     void on_startMissingButton_clicked();

--- a/src/qt/qrdialog.cpp
+++ b/src/qt/qrdialog.cpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2011-2013 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "qrdialog.h"
+#include "ui_qrdialog.h"
+
+#include "bitcoinunits.h"
+#include "guiconstants.h"
+#include "guiutil.h"
+#include "optionsmodel.h"
+#include "walletmodel.h"
+
+#include <QClipboard>
+#include <QDrag>
+#include <QMenu>
+#include <QMimeData>
+#include <QMouseEvent>
+#include <QPixmap>
+#if QT_VERSION < 0x050000
+#include <QUrl>
+#endif
+
+#if defined(HAVE_CONFIG_H)
+#include "config/dash-config.h" /* for USE_QRCODE */
+#endif
+
+#ifdef USE_QRCODE
+#include <qrencode.h>
+#endif
+
+QRGeneralImageWidget::QRGeneralImageWidget(QWidget *parent):
+    QLabel(parent), contextMenu(0)
+{
+    contextMenu = new QMenu(this);
+    QAction *saveImageAction = new QAction(tr("&Save Image..."), this);
+    connect(saveImageAction, SIGNAL(triggered()), this, SLOT(saveImage()));
+    contextMenu->addAction(saveImageAction);
+    QAction *copyImageAction = new QAction(tr("&Copy Image"), this);
+    connect(copyImageAction, SIGNAL(triggered()), this, SLOT(copyImage()));
+    contextMenu->addAction(copyImageAction);
+}
+
+QImage QRGeneralImageWidget::exportImage()
+{
+    if(!pixmap())
+        return QImage();
+    return pixmap()->toImage();
+}
+
+void QRGeneralImageWidget::mousePressEvent(QMouseEvent *event)
+{
+    if(event->button() == Qt::LeftButton && pixmap())
+    {
+        event->accept();
+        QMimeData *mimeData = new QMimeData;
+        mimeData->setImageData(exportImage());
+
+        QDrag *drag = new QDrag(this);
+        drag->setMimeData(mimeData);
+        drag->exec();
+    } else {
+        QLabel::mousePressEvent(event);
+    }
+}
+
+void QRGeneralImageWidget::saveImage()
+{
+    if(!pixmap())
+        return;
+    QString fn = GUIUtil::getSaveFileName(this, tr("Save QR Code"), QString(), tr("PNG Image (*.png)"), NULL);
+    if (!fn.isEmpty())
+    {
+        exportImage().save(fn);
+    }
+}
+
+void QRGeneralImageWidget::copyImage()
+{
+    if(!pixmap())
+        return;
+    QApplication::clipboard()->setImage(exportImage());
+}
+
+void QRGeneralImageWidget::contextMenuEvent(QContextMenuEvent *event)
+{
+    if(!pixmap())
+        return;
+    contextMenu->exec(event->globalPos());
+}
+
+QRDialog::QRDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::QRDialog),
+    model(0)
+{
+    ui->setupUi(this);
+
+#ifndef USE_QRCODE
+    ui->button_saveImage->setVisible(false);
+    ui->lblQRCode->setVisible(false);
+#endif
+
+    connect(ui->button_saveImage, SIGNAL(clicked()), ui->lblQRCode, SLOT(saveImage()));
+}
+
+QRDialog::~QRDialog()
+{
+    delete ui;
+}
+
+void QRDialog::setModel(OptionsModel *model)
+{
+    this->model = model;
+
+    if (model)
+        connect(model, SIGNAL(displayUnitChanged(int)), this, SLOT(update()));
+
+    // update the display unit if necessary
+    update();
+}
+
+void QRDialog::setInfo(QString strWindowtitle, QString strQRCode, QString strTextInfo, QString strQRCodeTitle)
+{
+    this->strWindowtitle = strWindowtitle;
+    this->strQRCode = strQRCode;
+    this->strTextInfo = strTextInfo;
+    this->strQRCodeTitle = strQRCodeTitle;
+    update();
+}
+
+void QRDialog::update()
+{
+    if(!model)
+        return;
+
+    setWindowTitle(strWindowtitle);
+    ui->button_saveImage->setEnabled(false);
+    ui->outUri->setText(strTextInfo);
+
+#ifdef USE_QRCODE
+    // Create QR-code
+    ui->lblQRCode->setText("");
+    if(!strQRCode.isEmpty())
+    {
+        QRcode *code = QRcode_encodeString(strQRCode.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+        if (!code)
+        {
+            ui->lblQRCode->setText(tr("Error creating QR Code."));
+            return;
+        }
+        ui->lblQRCode->setToolTip(strQRCode);
+        QImage myImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
+        myImage.fill(0xffffff);
+        unsigned char *p = code->data;
+        for (int y = 0; y < code->width; y++)
+        {
+            for (int x = 0; x < code->width; x++)
+            {
+                myImage.setPixel(x + 4, y + 4, ((*p & 1) ? 0x0 : 0xffffff));
+                p++;
+            }
+        }
+        QRcode_free(code);
+
+        ui->labelQRCodeTitle->setText(strQRCodeTitle);
+        ui->lblQRCode->setPixmap(QPixmap::fromImage(myImage).scaled(300, 300));
+        ui->button_saveImage->setEnabled(true);
+    }
+#endif
+}

--- a/src/qt/qrdialog.h
+++ b/src/qt/qrdialog.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_QRDIALOG_H
+#define BITCOIN_QT_QRDIALOG_H
+
+#include "walletmodel.h"
+
+#include <QDialog>
+#include <QImage>
+#include <QLabel>
+
+class OptionsModel;
+
+namespace Ui {
+    class QRDialog;
+}
+
+QT_BEGIN_NAMESPACE
+class QMenu;
+QT_END_NAMESPACE
+
+/* Label widget for QR code. This image can be dragged, dropped, copied and saved
+ * to disk.
+ */
+class QRGeneralImageWidget : public QLabel
+{
+    Q_OBJECT
+
+public:
+    explicit QRGeneralImageWidget(QWidget *parent = 0);
+    QImage exportImage();
+
+public Q_SLOTS:
+    void saveImage();
+    void copyImage();
+
+protected:
+    virtual void mousePressEvent(QMouseEvent *event);
+    virtual void contextMenuEvent(QContextMenuEvent *event);
+
+private:
+    QMenu *contextMenu;
+};
+
+class QRDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit QRDialog(QWidget *parent = 0);
+    ~QRDialog();
+
+    void setModel(OptionsModel *model);
+    void setInfo(QString strWindowtitle, QString strQRCode, QString strTextInfo, QString strQRCodeTitle);
+
+private Q_SLOTS:
+    void update();
+
+private:
+    Ui::QRDialog *ui;
+    OptionsModel *model;
+    QString strWindowtitle;
+    QString strQRCode;
+    QString strTextInfo;
+    QString strQRCodeTitle;
+};
+
+#endif // BITCOIN_QT_QRDIALOG_H

--- a/src/qt/res/css/crownium.css
+++ b/src/qt/res/css/crownium.css
@@ -1599,6 +1599,16 @@ QDialog#ReceiveRequestDialog QTextEdit { /* Contents of Receive Coin Dialog */
 border:1px solid #d7d7d7;
 }
 
+/* General QR-code DIALOG */
+
+QDialog#QRDialog {
+background-color:#F8F6F6;
+}
+
+QDialog#QRDialog QTextEdit { /* Contents of QR-code Dialog */
+border:1px solid #d7d7d7;
+}
+
 /* TRANSACTIONS PAGE */
 
 TransactionView QLineEdit { /* Filters */

--- a/src/qt/res/css/drkblue.css
+++ b/src/qt/res/css/drkblue.css
@@ -1582,6 +1582,16 @@ QDialog#ReceiveRequestDialog QTextEdit { /* Contents of Receive Coin Dialog */
 border:1px solid #d7d7d7;
 }
 
+/* General QR-code DIALOG */
+
+QDialog#QRDialog {
+background-color:#F8F6F6;
+}
+
+QDialog#QRDialog QTextEdit { /* Contents of QR-code Dialog */
+border:1px solid #d7d7d7;
+}
+
 /* TRANSACTIONS PAGE */
 
 TransactionView QLineEdit { /* Filters */

--- a/src/qt/res/css/light-hires.css
+++ b/src/qt/res/css/light-hires.css
@@ -1593,6 +1593,16 @@ QDialog#ReceiveRequestDialog QTextEdit { /* Contents of Receive Coin Dialog */
 border:1px solid #d7d7d7;
 }
 
+/* General QR-code DIALOG */
+
+QDialog#QRDialog {
+background-color:#F8F6F6;
+}
+
+QDialog#QRDialog QTextEdit { /* Contents of QR-code Dialog */
+border:1px solid #d7d7d7;
+}
+
 /* TRANSACTIONS PAGE */
 
 TransactionView QLineEdit { /* Filters */

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -1594,6 +1594,16 @@ QDialog#ReceiveRequestDialog QTextEdit { /* Contents of Receive Coin Dialog */
 border:1px solid #d7d7d7;
 }
 
+/* General QR-code DIALOG */
+
+QDialog#QRDialog {
+background-color:#F8F6F6;
+}
+
+QDialog#QRDialog QTextEdit { /* Contents of QR-code Dialog */
+border:1px solid #d7d7d7;
+}
+
 /* TRANSACTIONS PAGE */
 
 TransactionView QLineEdit { /* Filters */


### PR DESCRIPTION
@QuantumExplorer asked for an enhancement to export the private key of a Masternode to an external device via QR-code.
I've added this to the "My Masternodes" tab where you can select a Masternode and open a screen with the QR-code of its private key.

Looks like this:
![show_key](https://user-images.githubusercontent.com/10080039/36948842-fac07008-1fe0-11e8-96c0-92b65d2788f1.png)

Some additional information:
- I think we will have more and more use cases where it's convenient  to export data via QR-code, that's why I created a dedicated class + UI for it
- the existing QR-export for requesting payments has data processing logic and presentation layer all mixed up, that's very inflexible. My approach has the data processing where it belongs (and where the data actually is, here: masternodelist.cpp), and the QR-UI just gets an appropriate screen title, the data to be converted to QR-code, and a (HTML-) string with the additional text as parameters.
- compared to the payment-request screen I've removed the copy-to-clipboard buttons, they would reduce flexibility (you would have to know which part of the text is what) and the usual mark + copy&paste via mouse does the same job.
- the dialog for payment-requests should be refactored/removed to use the same logic, but that's out of scope for this PR and can be done in a dedicated PR somewhere in the future.
- the screenshot shows an unused private key, so you can't steal my valuable tDASH ;-)

Reviews/feedback welcome.


