### PR TITLE
[RPC] Add `listaddressbalances`

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -47,6 +47,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getreceivedbyaddress", 2, "addlockconf" },
     { "getreceivedbyaccount", 1, "minconf" },
     { "getreceivedbyaccount", 2, "addlockconf" },
+    { "listaddressbalances", 0, "minamount" },
     { "listreceivedbyaddress", 0, "minconf" },
     { "listreceivedbyaddress", 1, "addlockconf" },
     { "listreceivedbyaddress", 2, "include_empty" },


### PR DESCRIPTION
Should be a bit more helpful than `listaddressgroupings` in some use cases (shows real addresses which balances can be verified on the blockchain via explorers instead of some internal accounts).