### PR TITLE
Don't use short version of 'tinyformat/fmt' namespace in util.h

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -1044,6 +1044,6 @@ std::string format(const std::string &fmt, const Args&... args)
 
 } // namespace tinyformat
 
-#define strprintf tfm::format
+#define strprintf tinyformat::format
 
 #endif // TINYFORMAT_H_INCLUDED

--- a/src/util.h
+++ b/src/util.h
@@ -96,18 +96,18 @@ int LogPrintStr(const std::string &str);
 
 #define LogPrint(category, ...) do { \
     if (LogAcceptCategory((category))) { \
-        LogPrintStr(tfm::format(__VA_ARGS__)); \
+        LogPrintStr(tinyformat::format(__VA_ARGS__)); \
     } \
 } while(0)
 
 #define LogPrintf(...) do { \
-    LogPrintStr(tfm::format(__VA_ARGS__)); \
+    LogPrintStr(tinyformat::format(__VA_ARGS__)); \
 } while(0)
 
 template<typename... Args>
 bool error(const char* fmt, const Args&... args)
 {
-    LogPrintStr("ERROR: " + tfm::format(fmt, args...) + "\n");
+    LogPrintStr("ERROR: " + tinyformat::format(fmt, args...) + "\n");
     return false;
 }
 


### PR DESCRIPTION
Clion is not able to parse this correctly and messes up all the syntax
checks, marking large parts of C++ files as syntactically invalid, making
it hard to find real syntax errors without trying compilation.