### PR TITLE
[Init] Avoid segfault when called with -enableinstantsend=0

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -884,7 +884,7 @@ void InitParameterInteraction()
     }
 
     if(!GetBoolArg("-enableinstantsend", fEnableInstantSend)){
-        if (SoftSetArg("-instantsenddepth", 0))
+        if (SoftSetArg("-instantsenddepth", "0"))
             LogPrintf("%s: parameter interaction: -enableinstantsend=false -> setting -nInstantSendDepth=0\n", __func__);
     }
 


### PR DESCRIPTION
Avoids
```
crowning@LMDevbox ~ $ ~/build/dash-master/src/dashd -enableinstantsend=0


************************
EXCEPTION: St11logic_error       
basic_string::_M_construct null not valid       
dash in AppInit()

```


when called with `-enableinstantsend=0`

And I double checked, all other usages of `SoftSetArg()` are correct.
