### PR TITLE
Use operator[] instead of emplace in CMasternodePayments::AddPaymentVote

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -204,7 +204,7 @@ public:
 
     void Clear();
 
-    bool AddPaymentVote(const CMasternodePaymentVote& vote);
+    bool AddOrUpdatePaymentVote(const CMasternodePaymentVote& vote);
     bool HasVerifiedPaymentVote(const uint256& hashIn) const;
     bool ProcessBlock(int nBlockHeight, CConnman& connman);
     void CheckBlockVotes(int nBlockHeight);


### PR DESCRIPTION
Found this when running dip3 integration tests. Votes stopped being
propagated.

When NetMsgType::MASTERNODEPAYMENTVOTE is handled, the payment vote is
already added to mapMasternodePaymentVotes and then marked as not verified.

When AddPaymentVote is then called shortly after that, the emplace does not
update the already added vote.

The real problem here is actually something different. AddPaymentVote is
named badly (should be more like AddOrUpdatePaymentVote) which resulted in
the non-obvious error while refactoring this code (who could have known
that we rely on that side effect?). So I renamed that method as well now.