### PR TITLE
Allow data outputs in PS collaterals

### DIFF
--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -267,7 +267,8 @@ bool CPrivateSend::IsCollateralValid(const CTransaction& txCollateral)
     for (const auto& txout : txCollateral.vout) {
         nValueOut += txout.nValue;
 
-        if(!txout.scriptPubKey.IsPayToPublicKeyHash() && !txout.scriptPubKey.IsUnspendable()) {
+        bool fAllowData = mnpayments.GetMinMasternodePaymentsProto() > 70208;
+        if(!txout.scriptPubKey.IsPayToPublicKeyHash() && !(fAllowData && txout.scriptPubKey.IsUnspendable())) {
             LogPrintf ("CPrivateSend::IsCollateralValid -- Invalid Script, txCollateral=%s", txCollateral.ToString());
             return false;
         }
@@ -305,8 +306,9 @@ bool CPrivateSend::IsCollateralValid(const CTransaction& txCollateral)
 bool CPrivateSend::IsCollateralAmount(CAmount nInputAmount)
 {
     // collateral input should be smth between 1x and 2x OR exactly Nx
-    return (nInputAmount > GetCollateralAmount() && nInputAmount < GetCollateralAmount()*2) ||
-           (nInputAmount >= GetCollateralAmount() && nInputAmount <= GetMaxCollateralAmount() && nInputAmount % GetCollateralAmount() == 0);
+    int nMin = mnpayments.GetMinMasternodePaymentsProto() > 70208 ? 1 : 2;
+    return (nInputAmount > GetCollateralAmount()*nMin && nInputAmount < GetCollateralAmount()*2) ||
+           (nInputAmount >= GetCollateralAmount()*nMin && nInputAmount <= GetMaxCollateralAmount() && nInputAmount % GetCollateralAmount() == 0);
 }
 
 /*  Create a nice string to show the denominations

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -305,10 +305,16 @@ bool CPrivateSend::IsCollateralValid(const CTransaction& txCollateral)
 
 bool CPrivateSend::IsCollateralAmount(CAmount nInputAmount)
 {
-    // collateral input should be smth between 1x and 2x OR exactly Nx
-    int nMin = mnpayments.GetMinMasternodePaymentsProto() > 70208 ? 1 : 2;
-    return (nInputAmount > GetCollateralAmount()*nMin && nInputAmount < GetCollateralAmount()*2) ||
-           (nInputAmount >= GetCollateralAmount()*nMin && nInputAmount <= GetMaxCollateralAmount() && nInputAmount % GetCollateralAmount() == 0);
+    if (mnpayments.GetMinMasternodePaymentsProto() > 70208) {
+        // collateral input should be smth between 1x and 2x OR exactly Nx of mixing collateral (1x..4x)
+        return (nInputAmount > GetCollateralAmount() && nInputAmount < GetCollateralAmount() * 2) ||
+               (nInputAmount >= GetCollateralAmount() && nInputAmount <= GetMaxCollateralAmount() && nInputAmount % GetCollateralAmount() == 0);
+    } else { // <= 70208
+        // collateral input should be exactly Nx of mixing collateral (2x..4x)
+        return (nInputAmount >= GetCollateralAmount() * 2 &&
+                nInputAmount <= GetMaxCollateralAmount() &&
+                nInputAmount % GetCollateralAmount() == 0);
+    }
 }
 
 /*  Create a nice string to show the denominations

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -267,7 +267,7 @@ bool CPrivateSend::IsCollateralValid(const CTransaction& txCollateral)
     for (const auto& txout : txCollateral.vout) {
         nValueOut += txout.nValue;
 
-        if(!txout.scriptPubKey.IsPayToPublicKeyHash()) {
+        if(!txout.scriptPubKey.IsPayToPublicKeyHash() && !txout.scriptPubKey.IsUnspendable()) {
             LogPrintf ("CPrivateSend::IsCollateralValid -- Invalid Script, txCollateral=%s", txCollateral.ToString());
             return false;
         }
@@ -304,10 +304,9 @@ bool CPrivateSend::IsCollateralValid(const CTransaction& txCollateral)
 
 bool CPrivateSend::IsCollateralAmount(CAmount nInputAmount)
 {
-    // collateral inputs should always be a 2x..4x of mixing collateral
-    return  nInputAmount >  GetCollateralAmount() &&
-            nInputAmount <= GetMaxCollateralAmount() &&
-            nInputAmount %  GetCollateralAmount() == 0;
+    // collateral input should be smth between 1x and 2x OR exactly Nx
+    return (nInputAmount > GetCollateralAmount() && nInputAmount < GetCollateralAmount()*2) ||
+           (nInputAmount >= GetCollateralAmount() && nInputAmount <= GetMaxCollateralAmount() && nInputAmount % GetCollateralAmount() == 0);
 }
 
 /*  Create a nice string to show the denominations

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3325,17 +3325,20 @@ bool CWallet::CreateCollateralTransaction(CMutableTransaction& txCollateral, std
 
     txCollateral.vin.push_back(txdsinCollateral);
 
-    //pay collateral charge in fees
-    if (nValue >= CPrivateSend::GetCollateralAmount()*2) {
+    // pay collateral charge in fees
+    // NOTE: no need for protobump patch here,
+    // CPrivateSend::IsCollateralAmount in GetCollateralTxDSIn should already take care of this
+    if (nValue >= CPrivateSend::GetCollateralAmount() * 2) {
         // make our change address
         CScript scriptChange;
         CPubKey vchPubKey;
-        assert(reservekey.GetReservedKey(vchPubKey, true)); // should never fail, as we just unlocked
+        bool success = reservekey.GetReservedKey(vchPubKey, true);
+        assert(success); // should never fail, as we just unlocked
         scriptChange = GetScriptForDestination(vchPubKey.GetID());
         reservekey.KeepKey();
         // return change
         txCollateral.vout.push_back(CTxOut(nValue - CPrivateSend::GetCollateralAmount(), scriptChange));
-    } else { // nValue < CPrivateSend::GetCollateralAmount()*2
+    } else { // nValue < CPrivateSend::GetCollateralAmount() * 2
         // create dummy data output only and pay everything as a fee
         txCollateral.vout.push_back(CTxOut(0, CScript() << OP_RETURN));
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3323,18 +3323,22 @@ bool CWallet::CreateCollateralTransaction(CMutableTransaction& txCollateral, std
         return false;
     }
 
-    // make our change address
-    CScript scriptChange;
-    CPubKey vchPubKey;
-    assert(reservekey.GetReservedKey(vchPubKey, true)); // should never fail, as we just unlocked
-    scriptChange = GetScriptForDestination(vchPubKey.GetID());
-    reservekey.KeepKey();
-
     txCollateral.vin.push_back(txdsinCollateral);
 
     //pay collateral charge in fees
-    CTxOut txout = CTxOut(nValue - CPrivateSend::GetCollateralAmount(), scriptChange);
-    txCollateral.vout.push_back(txout);
+    if (nValue >= CPrivateSend::GetCollateralAmount()*2) {
+        // make our change address
+        CScript scriptChange;
+        CPubKey vchPubKey;
+        assert(reservekey.GetReservedKey(vchPubKey, true)); // should never fail, as we just unlocked
+        scriptChange = GetScriptForDestination(vchPubKey.GetID());
+        reservekey.KeepKey();
+        // return change
+        txCollateral.vout.push_back(CTxOut(nValue - CPrivateSend::GetCollateralAmount(), scriptChange));
+    } else { // nValue < CPrivateSend::GetCollateralAmount()*2
+        // create dummy data output only and pay everything as a fee
+        txCollateral.vout.push_back(CTxOut(0, CScript() << OP_RETURN));
+    }
 
     if(!SignSignature(*this, txdsinCollateral.prevPubKey, txCollateral, 0, int(SIGHASH_ALL|SIGHASH_ANYONECANPAY))) {
         strReason = "Unable to sign collateral transaction!";


### PR DESCRIPTION
This should allow to
- reduce utxo spam caused by 1x collaterals a bit
- use otherwise non-usable small inputs (in the range of 1-2x) as PS collaterals, which should reduce utxo set even further