### PR TITLE
Fix listaddressbalances

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -578,10 +578,12 @@ UniValue listaddressbalances(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    // Whether to include addresses with zero balances
     CAmount nMinAmount = 0;
     if (request.params.size() > 0)
-        nMinAmount = request.params[0].get_int64() * COIN;
+        nMinAmount = AmountFromValue(request.params[0]);
+
+    if (nMinAmount < 0)
+        throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
 
     UniValue jsonBalances(UniValue::VOBJ);
     std::map<CTxDestination, CAmount> balances = pwalletMain->GetAddressBalances();


### PR DESCRIPTION
Fixes bug discovered by @thephez (thanks! 👍 )

Should correctly parse amounts like `10.1` and not only integers now.

Also:
- verifies that specified amount is not negative, just in case :) (makes no sense to have negative balance at some address anyway)
- removes redundant comment which I had there from some older local version and forgot to remove before pushing the original commit...