### PR TITLE
Convert `gobject count` output to json (by default)

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1252,6 +1252,38 @@ std::string CGovernanceManager::ToString() const
                     (int)cmapVoteToObject.GetSize());
 }
 
+UniValue CGovernanceManager::ToJson() const
+{
+    LOCK(cs);
+
+    int nProposalCount = 0;
+    int nTriggerCount = 0;
+    int nOtherCount = 0;
+
+    for (const auto& objpair : mapObjects) {
+        switch(objpair.second.GetObjectType()) {
+            case GOVERNANCE_OBJECT_PROPOSAL:
+                nProposalCount++;
+                break;
+            case GOVERNANCE_OBJECT_TRIGGER:
+                nTriggerCount++;
+                break;
+            default:
+                nOtherCount++;
+                break;
+        }
+    }
+
+    UniValue jsonObj(UniValue::VOBJ);
+    jsonObj.push_back(Pair("objects_total", (int)mapObjects.size()));
+    jsonObj.push_back(Pair("proposals", nProposalCount));
+    jsonObj.push_back(Pair("triggers", nTriggerCount));
+    jsonObj.push_back(Pair("other", nOtherCount));
+    jsonObj.push_back(Pair("erased", (int)mapErasedGovernanceObjects.size()));
+    jsonObj.push_back(Pair("votes", (int)cmapVoteToObject.GetSize()));
+    return jsonObj;
+}
+
 void CGovernanceManager::UpdatedBlockTip(const CBlockIndex *pindex, CConnman& connman)
 {
     // Note this gets called from ActivateBestChain without cs_main being held

--- a/src/governance.h
+++ b/src/governance.h
@@ -19,6 +19,8 @@
 #include "timedata.h"
 #include "util.h"
 
+#include <univalue.h>
+
 class CGovernanceManager;
 class CGovernanceTriggerManager;
 class CGovernanceObject;
@@ -326,6 +328,7 @@ public:
     }
 
     std::string ToString() const;
+    UniValue ToJson() const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -50,7 +50,7 @@ UniValue gobject(const JSONRPCRequest& request)
 #endif // ENABLE_WALLET
                 "  submit             - Submit governance object to network\n"
                 "  deserialize        - Deserialize governance object from hex string to JSON\n"
-                "  count              - Count governance objects and votes\n"
+                "  count              - Count governance objects and votes (additional param: 'json' or 'all', default: 'json')\n"
                 "  get                - Get governance object by hash\n"
                 "  getvotes           - Get all votes for a governance object hash (including old votes)\n"
                 "  getcurrentvotes    - Get only current (tallying) votes for a governance object hash (does not include old votes)\n"
@@ -62,8 +62,19 @@ UniValue gobject(const JSONRPCRequest& request)
                 );
 
 
-    if(strCommand == "count")
-        return governance.ToString();
+    if(strCommand == "count") {
+        std::string strMode{"json"};
+
+        if (request.params.size() == 2) {
+            strMode = request.params[1].get_str();
+        }
+
+        if (request.params.size() > 2 || (strMode != "json" && strMode != "all")) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Correct usage is 'gobject count ( \"json\"|\"all\" )'");
+        }
+
+        return strMode == "json" ? governance.ToJson() : governance.ToString();
+    }
     /*
         ------ Example Governance Item ------
 


### PR DESCRIPTION
Old mode is available via `gobject count all`