### PR TITLE
Drop Nx requirements for PS collaterals

### DIFF
--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -306,14 +306,11 @@ bool CPrivateSend::IsCollateralValid(const CTransaction& txCollateral)
 bool CPrivateSend::IsCollateralAmount(CAmount nInputAmount)
 {
     if (mnpayments.GetMinMasternodePaymentsProto() > 70208) {
-        // collateral input should be smth between 1x and 2x OR exactly Nx of mixing collateral (1x..4x)
-        return (nInputAmount > GetCollateralAmount() && nInputAmount < GetCollateralAmount() * 2) ||
-               (nInputAmount >= GetCollateralAmount() && nInputAmount <= GetMaxCollateralAmount() && nInputAmount % GetCollateralAmount() == 0);
+        // collateral input can be anything between 1x and "max" (including both)
+        return (nInputAmount >= GetCollateralAmount() && nInputAmount <= GetMaxCollateralAmount());
     } else { // <= 70208
-        // collateral input should be exactly Nx of mixing collateral (2x..4x)
-        return (nInputAmount >= GetCollateralAmount() * 2 &&
-                nInputAmount <= GetMaxCollateralAmount() &&
-                nInputAmount % GetCollateralAmount() == 0);
+        // collateral input can be anything between 2x and "max" (including both)
+        return (nInputAmount >= GetCollateralAmount() * 2 && nInputAmount <= GetMaxCollateralAmount());
     }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/dashpay/dash/pull/1984#issuecomment-373308209 we don't really need this legacy thing anymore and moreover removing it is already compatible with current proto (I tested this on mainnet, works as expected). This will let us use more different small inputs as PS collaterals and thus shrink UTXO set. From user perspective it's also a good thing - the less tiny inputs in his wallet the better (faster coin selection, more responsive UI etc.)