### PR TITLE
Fix TransactionRecord::PrivateSendMakeCollaterals tx type

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -151,7 +151,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     const CTxOut& txout = wtx.tx->vout[nOut];
                     sub.idx = parts.size();
 
-                    if(CPrivateSend::IsCollateralAmount(txout.nValue)) sub.type = TransactionRecord::PrivateSendMakeCollaterals;
+                    if(txout.nValue == CPrivateSend::GetMaxCollateralAmount()) sub.type = TransactionRecord::PrivateSendMakeCollaterals;
                     if(CPrivateSend::IsDenominatedAmount(txout.nValue)) sub.type = TransactionRecord::PrivateSendCreateDenominations;
                     if(nDebit - wtx.tx->GetValueOut() == CPrivateSend::GetCollateralAmount()) sub.type = TransactionRecord::PrivateSendCollateralPayment;
                 }


### PR DESCRIPTION
This is a bug that causes some txes to be wrongly marked as `PrivateSendMakeCollaterals` - `CPrivateSendClient::MakeCollateralAmounts()` creates inputs of exactly `CPrivateSend::GetMaxCollateralAmount()` and that's how we should identify them here too.