### PR TITLE
Don't hold cs_storage in CKeyHolderStorage while calling functions which might lock cs_wallet

### DIFF
--- a/src/privatesend-util.cpp
+++ b/src/privatesend-util.cpp
@@ -27,32 +27,45 @@ CScript CKeyHolder::GetScriptForDestination() const
 
 CScript CKeyHolderStorage::AddKey(CWallet* pwallet)
 {
+    auto keyHolder = std::unique_ptr<CKeyHolder>(new CKeyHolder(pwallet));
+    auto script = keyHolder->GetScriptForDestination();
+
     LOCK(cs_storage);
-    storage.emplace_back(std::unique_ptr<CKeyHolder>(new CKeyHolder(pwallet)));
+    storage.emplace_back(std::move(keyHolder));
     LogPrintf("CKeyHolderStorage::%s -- storage size %lld\n", __func__, storage.size());
-    return storage.back()->GetScriptForDestination();
+    return script;
 }
 
 void CKeyHolderStorage::KeepAll()
 {
-    LOCK(cs_storage);
-    if (storage.size() > 0) {
-        for (auto &key : storage) {
+    std::vector<std::unique_ptr<CKeyHolder>> tmp;
+    {
+        // don't hold cs_storage while calling KeepKey(), which might lock cs_wallet
+        LOCK(cs_storage);
+        std::swap(storage, tmp);
+    }
+
+    if (tmp.size() > 0) {
+        for (auto &key : tmp) {
             key->KeepKey();
         }
-        LogPrintf("CKeyHolderStorage::%s -- %lld keys kept\n", __func__, storage.size());
-        storage.clear();
+        LogPrintf("CKeyHolderStorage::%s -- %lld keys kept\n", __func__, tmp.size());
     }
 }
 
 void CKeyHolderStorage::ReturnAll()
 {
-    LOCK(cs_storage);
-    if (storage.size() > 0) {
-        for (auto &key : storage) {
+    std::vector<std::unique_ptr<CKeyHolder>> tmp;
+    {
+        // don't hold cs_storage while calling ReturnKey(), which might lock cs_wallet
+        LOCK(cs_storage);
+        std::swap(storage, tmp);
+    }
+
+    if (tmp.size() > 0) {
+        for (auto &key : tmp) {
             key->ReturnKey();
         }
-        LogPrintf("CKeyHolderStorage::%s -- %lld keys returned\n", __func__, storage.size());
-        storage.clear();
+        LogPrintf("CKeyHolderStorage::%s -- %lld keys returned\n", __func__, tmp.size());
     }
 }


### PR DESCRIPTION
Extracted from https://github.com/dashpay/dash/pull/1997#issuecomment-374197253

The original problem was this deadlock:
```
POTENTIAL DEADLOCK DETECTED
Previous lock order was:
 cs_darksend  privatesend-client.cpp:30 (TRY)
 (1) pwalletMain->cs_wallet  privatesend-client.cpp:1150
 (2) cs_storage  privatesend-util.cpp:50
Current lock order is:
 cs_darksend  privatesend-client.cpp:30 (TRY)
 (2) cs_storage  privatesend-util.cpp:30
 (1) cs_wallet  wallet/wallet.cpp:4215
```
