### PR TITLE
Validate data size for proposals only

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -459,13 +459,6 @@ bool CGovernanceObject::IsValidLocally(std::string& strError, bool& fMissingMast
         return false;
     }
 
-    // TODO: This is redundant and should be removed
-    // TODO: Use size validation for each specific object type (if applicable)
-    if (vchData.size() > MAX_GOVERNANCE_OBJECT_DATA_SIZE) {
-        strError = strprintf("Invalid object size %d", vchData.size());
-        return false;
-    }
-
     switch(nObjectType) {
         case GOVERNANCE_OBJECT_WATCHDOG: {
             // watchdogs are deprecated

--- a/src/governance-validators.cpp
+++ b/src/governance-validators.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 
+const size_t MAX_DATA_SIZE  = 512;
 const size_t MAX_NAME_SIZE  = 40;
 
 CProposalValidator::CProposalValidator(const std::string& strHexData) :
@@ -25,6 +26,10 @@ CProposalValidator::CProposalValidator(const std::string& strHexData) :
 void CProposalValidator::ParseStrHexData(const std::string& strHexData)
 {
     std::vector<unsigned char> v = ParseHex(strHexData);
+    if (v.size() > MAX_DATA_SIZE) {
+        strErrorMessages = strprintf("data exceeds %lu characters;", MAX_DATA_SIZE);
+        return;
+    }
     ParseJSONData(std::string(v.begin(), v.end()));
 }
 


### PR DESCRIPTION
There are no watchdogs and it makes no sense to limit triggers by size (invalid triggers are going to be voted down anyway).
512 bytes should be more than enough for any proposal - the only value we do not check size of is URL and with 512 bytes total limit URL has space for almost 300 bytes.