### PR TITLE
Keep non-expired completed lock requests alive until mined

### DIFF
--- a/src/instantx.h
+++ b/src/instantx.h
@@ -288,6 +288,7 @@ public:
     int CountVotes() const;
 
     void SetConfirmedHeight(int nConfirmedHeightIn) { nConfirmedHeight = nConfirmedHeightIn; }
+    bool IsConfirmed() { return nConfirmedHeight != -1; }
     bool IsExpired(int nHeight) const;
     bool IsTimedOut() const;
 


### PR DESCRIPTION
Even if it was removed from the mempool for some reason (e.g. timeout)