### PR TITLE
Check if in masternode mode first and only then do the job (or not)

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -328,24 +328,24 @@ void CPrivateSendClient::CheckPool()
 //
 void CPrivateSendClient::CheckTimeout()
 {
+    if(fMasternodeMode) return;
+
     CheckQueue();
 
-    if(!fEnablePrivateSend && !fMasternodeMode) return;
+    if(!fEnablePrivateSend) return;
 
     // catching hanging sessions
-    if(!fMasternodeMode) {
-        switch(nState) {
-            case POOL_STATE_ERROR:
-                LogPrint("privatesend", "CPrivateSendClient::CheckTimeout -- Pool error -- Running CheckPool\n");
-                CheckPool();
-                break;
-            case POOL_STATE_SUCCESS:
-                LogPrint("privatesend", "CPrivateSendClient::CheckTimeout -- Pool success -- Running CheckPool\n");
-                CheckPool();
-                break;
-            default:
-                break;
-        }
+    switch(nState) {
+        case POOL_STATE_ERROR:
+            LogPrint("privatesend", "CPrivateSendClient::CheckTimeout -- Pool error -- Running CheckPool\n");
+            CheckPool();
+            break;
+        case POOL_STATE_SUCCESS:
+            LogPrint("privatesend", "CPrivateSendClient::CheckTimeout -- Pool success -- Running CheckPool\n");
+            CheckPool();
+            break;
+        default:
+            break;
     }
 
     int nLagTime = 10; // give the server a few extra seconds before resetting.

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -292,6 +292,12 @@ void CPrivateSendServer::CheckPool(CConnman& connman)
         CommitFinalTransaction(connman);
         return;
     }
+
+    // reset if we're here for 10 seconds
+    if((nState == POOL_STATE_ERROR || nState == POOL_STATE_SUCCESS) && GetTimeMillis() - nTimeLastSuccessfulStep >= 10000) {
+        LogPrint("privatesend", "CPrivateSendServer::CheckPool -- timeout, RESETTING\n");
+        SetNull();
+    }
 }
 
 void CPrivateSendServer::CreateFinalTransaction(CConnman& connman)

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -275,28 +275,22 @@ void CPrivateSendServer::SetNull()
 //
 void CPrivateSendServer::CheckPool(CConnman& connman)
 {
-    if(fMasternodeMode) {
-        LogPrint("privatesend", "CPrivateSendServer::CheckPool -- entries count %lu\n", GetEntriesCount());
+    if (!fMasternodeMode) return;
 
-        // If entries are full, create finalized transaction
-        if(nState == POOL_STATE_ACCEPTING_ENTRIES && GetEntriesCount() >= CPrivateSend::GetMaxPoolTransactions()) {
-            LogPrint("privatesend", "CPrivateSendServer::CheckPool -- FINALIZE TRANSACTIONS\n");
-            CreateFinalTransaction(connman);
-            return;
-        }
+    LogPrint("privatesend", "CPrivateSendServer::CheckPool -- entries count %lu\n", GetEntriesCount());
 
-        // If we have all of the signatures, try to compile the transaction
-        if(nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
-            LogPrint("privatesend", "CPrivateSendServer::CheckPool -- SIGNING\n");
-            CommitFinalTransaction(connman);
-            return;
-        }
+    // If entries are full, create finalized transaction
+    if (nState == POOL_STATE_ACCEPTING_ENTRIES && GetEntriesCount() >= CPrivateSend::GetMaxPoolTransactions()) {
+        LogPrint("privatesend", "CPrivateSendServer::CheckPool -- FINALIZE TRANSACTIONS\n");
+        CreateFinalTransaction(connman);
+        return;
     }
 
-    // reset if we're here for 10 seconds
-    if((nState == POOL_STATE_ERROR || nState == POOL_STATE_SUCCESS) && GetTimeMillis() - nTimeLastSuccessfulStep >= 10000) {
-        LogPrint("privatesend", "CPrivateSendServer::CheckPool -- timeout, RESETTING\n");
-        SetNull();
+    // If we have all of the signatures, try to compile the transaction
+    if (nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
+        LogPrint("privatesend", "CPrivateSendServer::CheckPool -- SIGNING\n");
+        CommitFinalTransaction(connman);
+        return;
     }
 }
 
@@ -471,9 +465,9 @@ void CPrivateSendServer::ChargeRandomFees(CConnman& connman)
 //
 void CPrivateSendServer::CheckTimeout(CConnman& connman)
 {
-    CheckQueue();
-
     if(!fMasternodeMode) return;
+
+    CheckQueue();
 
     int nTimeout = (nState == POOL_STATE_SIGNING) ? PRIVATESEND_SIGNING_TIMEOUT : PRIVATESEND_QUEUE_TIMEOUT;
     bool fTimeout = GetTime() - nTimeLastSuccessfulStep >= nTimeout;
@@ -838,7 +832,9 @@ void CPrivateSendServer::RelayCompletedTransaction(PoolMessage nMessageID, CConn
 
 void CPrivateSendServer::SetState(PoolState nStateNew)
 {
-    if(fMasternodeMode && (nStateNew == POOL_STATE_ERROR || nStateNew == POOL_STATE_SUCCESS)) {
+    if(!fMasternodeMode) return;
+
+    if(nStateNew == POOL_STATE_ERROR || nStateNew == POOL_STATE_SUCCESS) {
         LogPrint("privatesend", "CPrivateSendServer::SetState -- Can't set state to ERROR or SUCCESS as a Masternode. \n");
         return;
     }
@@ -851,6 +847,7 @@ void CPrivateSendServer::SetState(PoolState nStateNew)
 void ThreadCheckPrivateSendServer(CConnman& connman)
 {
     if(fLiteMode) return; // disable all Dash specific functionality
+    if(!fMasternodeMode) return; // only run on masternodes
 
     static bool fOneThread;
     if(fOneThread) return;


### PR DESCRIPTION
Shouldn't change the actual behaviour, mostly to streamline the logic/cleanup the code here.