### PR TITLE
No POOL_STATE_ERROR or POOL_STATE_SUCCESS on masternodes

### DIFF
--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -292,12 +292,6 @@ void CPrivateSendServer::CheckPool(CConnman& connman)
             return;
         }
     }
-
-    // reset if we're here for 10 seconds
-    if((nState == POOL_STATE_ERROR || nState == POOL_STATE_SUCCESS) && GetTimeMillis() - nTimeLastSuccessfulStep >= 10000) {
-        LogPrint("privatesend", "CPrivateSendServer::CheckPool -- timeout, RESETTING\n");
-        SetNull();
-    }
 }
 
 void CPrivateSendServer::CreateFinalTransaction(CConnman& connman)
@@ -483,7 +477,6 @@ void CPrivateSendServer::CheckTimeout(CConnman& connman)
                 (nState == POOL_STATE_SIGNING) ? "Signing" : "Session", nTimeout);
         ChargeFees(connman);
         SetNull();
-        SetState(POOL_STATE_ERROR);
     }
 }
 


### PR DESCRIPTION
The reason for this removal is that this block was a copy/paste when we spit one huge privatesend file into multiple classes/files trying to make as little changes as possible to not to break anything. If you look at CPrivateSendServer::SetState() you'll notice that these states (POOL_STATE_ERROR and POOL_STATE_SUCCESS) are illegal for masternodes anyway, so no reason to have conditions relying on that or trying to set illigal state.