### PR TITLE
Fix instant send in testnet and regtest

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -230,7 +230,7 @@ void CInstantSend::Vote(CTxLockCandidate& txLockCandidate, CConnman& connman)
             return;
         }
 
-        int nLockInputHeight = nPrevoutHeight + 4;
+        int nLockInputHeight = nPrevoutHeight + Params().GetConsensus().nInstantSendConfirmationsRequired - 2;
 
         int nRank;
         if(!mnodeman.GetMasternodeRank(activeMasternode.outpoint, nRank, nLockInputHeight, MIN_INSTANTSEND_PROTO_VERSION)) {
@@ -1038,7 +1038,7 @@ bool CTxLockVote::IsValid(CNode* pnode, CConnman& connman) const
         return false;
     }
 
-    int nLockInputHeight = coin.nHeight + 4;
+    int nLockInputHeight = coin.nHeight + Params().GetConsensus().nInstantSendConfirmationsRequired - 2;
 
     int nRank;
     if(!mnodeman.GetMasternodeRank(outpointMasternode, nRank, nLockInputHeight, MIN_INSTANTSEND_PROTO_VERSION)) {


### PR DESCRIPTION
#1962 changes the minimum required confirmations for InstantSend to 2 when
running in testnet. This resulted in the quorum rank calculation to pick
blocks which are higher then the current chain tip. This commit fixes this
by calculating the added height based on nInstantSendConfirmationsRequired.

This results in the value 4 for mainnet, so no incompatibility is
introduced. On testnet and regtest, this results in 0.