### PR TITLE
Update COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,5 @@
-The MIT License (MIT)
-
 Copyright (c) 2009-2016 The Bitcoin Core developers
-Copyright (c) 2014-2017 The Dash Core developers
+Copyright (c) 2014-2018 The Dash Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
update real license of use.  
update years of license.


according
https://github.com/dashpay/docs/pull/1
the documentation is Closed search, only team:

>Dash translations are managed using Transifex

according:
https://github.com/dashpay/dash/blob/master/COPYING 

> Permission is hereby granted, free of charge, to any person obtaining a copy
> of this software and associated documentation files (the "Software"), to deal
> in the Software without restriction, including without limitation the rights
> to use, copy, modify, merge, publish, distribute, sublicense,
( license of repository Dash - Reinventing Cryptocurrency ) 

Is this being followed if we go to transifex?
Are not the terms the same?

I suggest modifying the Documentation license for MIT.
https://github.com/dashpay/docs/blob/master/README.md


