### PR TITLE
Fix a very ancient bug from mid 2015

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -553,7 +553,7 @@ bool CGovernanceObject::IsCollateralValid(std::string& strError, bool& fMissingC
     // RETRIEVE TRANSACTION IN QUESTION
 
     if(!GetTransaction(nCollateralHash, txCollateral, Params().GetConsensus(), nBlockHash, true)){
-        strError = strprintf("Can't find collateral tx %s", txCollateral->ToString());
+        strError = strprintf("Can't find collateral tx %s", nCollateralHash.ToString());
         LogPrintf("CGovernanceObject::IsCollateralValid -- %s\n", strError);
         return false;
     }


### PR DESCRIPTION
Introduced in https://github.com/dashpay/dash/commit/c701839a43600e0ab2740f3caffa89e90e7ccac5#diff-2e2ff25b7bc057a741bf93c35ae3b624R42 (committed on 10 Jul 2015). Survived all the refactoring for almost 3 years 🙈 and was revealed by https://github.com/dashpay/dash/commit/525c049316a8abb105363fb281e3a673b80c0d6a#diff-49ff8fea774f647034a130c40d4f3c65R519 (as a part of https://github.com/dashpay/dash/pull/1856) by causing silent crashes on multiple nodes (testnet). v0.12.2.x and earlier branches/versions aren't affected (do not crash), they simply print meaningless log entry.