### PR TITLE
Bump testnet checkpoint and nMinimumChainWork/defaultAssumeValid params

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -328,10 +328,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_BIP147].nThreshold = 50; // 50% of 100
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000000924e924a21715"); // 37900
+        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000002951ef46f9553b"); // 100000
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x0000000004f5aef732d572ff514af99a995702c92e4452c7af10858231668b1f"); // 37900
+        consensus.defaultAssumeValid = uint256S("0x0000000003aa53e24b6e60ef97642e4193611f2bcb75ea1fa8105f0b5ffd5242"); // 100000
 
         pchMessageStart[0] = 0xce;
         pchMessageStart[1] = 0xe2;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -386,11 +386,12 @@ public:
             (    261, uint256S("0x00000c26026d0815a7e2ce4fa270775f61403c040647ff2c3091f99e894a4618"))
             (   1999, uint256S("0x00000052e538d27fa53693efe6fb6892a0c1d26c0235f599171c48a3cce553b1"))
             (   2999, uint256S("0x0000024bc3f4f4cb30d29827c13d921ad77d2c6072e586c7f60d83c2722cdcc5"))
+            ( 100000, uint256S("0x0000000003aa53e24b6e60ef97642e4193611f2bcb75ea1fa8105f0b5ffd5242"))
         };
 
         chainTxData = ChainTxData{        
-            1462856598, // * UNIX timestamp of last known number of transactions
-            3094,       // * total number of transactions between genesis and that timestamp
+            1522472609, // * UNIX timestamp of last known number of transactions
+            4897448,    // * total number of transactions between genesis and that timestamp
                         //   (the tx=... number in the SetBestChain debug.log lines)
             0.01        // * estimated number of transactions per second after that timestamp
         };


### PR DESCRIPTION
New checkpoint should help new (or reindexed) nodes to stay on the right chain. `nMinimumChainWork `/`defaultAssumeValid ` should make sync a bit faster by skipping a lot of verifications in 2mb spam blocks.