### PR TITLE
Correctly update pindexBestHeader and pindexBestInvalid in InvalidateBlock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3035,6 +3035,11 @@ bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, C
     setDirtyBlockIndex.insert(pindex);
     setBlockIndexCandidates.erase(pindex);
 
+    if (pindex == pindexBestHeader) {
+        pindexBestInvalid = pindexBestHeader;
+        pindexBestHeader = pindexBestHeader->pprev;
+    }
+
     while (chainActive.Contains(pindex)) {
         CBlockIndex *pindexWalk = chainActive.Tip();
         pindexWalk->nStatus |= BLOCK_FAILED_CHILD;
@@ -3045,6 +3050,10 @@ bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, C
         if (!DisconnectTip(state, chainparams)) {
             mempool.removeForReorg(pcoinsTip, chainActive.Tip()->nHeight + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
             return false;
+        }
+        if (pindexWalk == pindexBestHeader) {
+            pindexBestInvalid = pindexBestHeader;
+            pindexBestHeader = pindexBestHeader->pprev;
         }
     }
 


### PR DESCRIPTION
Stale pindexBestHeader values cause invalid high-work chains to stay as
pindexBestHeader forever and causes initial syncing to fail.

Observed on testnet.