### PR TITLE
clean up governance vote code

### DIFF
--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -47,99 +47,6 @@ std::string CGovernanceVoting::ConvertSignalToString(vote_signal_enum_t nSignal)
         case VOTE_SIGNAL_ENDORSED:
             strReturn = "ENDORSED";
             break;
-        case VOTE_SIGNAL_NOOP1:
-            strReturn = "NOOP1";
-            break;
-        case VOTE_SIGNAL_NOOP2:
-            strReturn = "NOOP2";
-            break;
-        case VOTE_SIGNAL_NOOP3:
-            strReturn = "NOOP3";
-            break;
-        case VOTE_SIGNAL_NOOP4:
-            strReturn = "NOOP4";
-            break;
-        case VOTE_SIGNAL_NOOP5:
-            strReturn = "NOOP5";
-            break;
-        case VOTE_SIGNAL_NOOP6:
-            strReturn = "NOOP6";
-            break;
-        case VOTE_SIGNAL_NOOP7:
-            strReturn = "NOOP7";
-            break;
-        case VOTE_SIGNAL_NOOP8:
-            strReturn = "NOOP8";
-            break;
-        case VOTE_SIGNAL_NOOP9:
-            strReturn = "NOOP9";
-            break;
-        case VOTE_SIGNAL_NOOP10:
-            strReturn = "NOOP10";
-            break;
-        case VOTE_SIGNAL_NOOP11:
-            strReturn = "NOOP11";
-            break;
-        case VOTE_SIGNAL_CUSTOM1:
-            strReturn = "CUSTOM1";
-            break;
-        case VOTE_SIGNAL_CUSTOM2:
-            strReturn = "CUSTOM2";
-            break;
-        case VOTE_SIGNAL_CUSTOM3:
-            strReturn = "CUSTOM3";
-            break;
-        case VOTE_SIGNAL_CUSTOM4:
-            strReturn = "CUSTOM4";
-            break;
-        case VOTE_SIGNAL_CUSTOM5:
-            strReturn = "CUSTOM5";
-            break;
-        case VOTE_SIGNAL_CUSTOM6:
-            strReturn = "CUSTOM6";
-            break;
-        case VOTE_SIGNAL_CUSTOM7:
-            strReturn = "CUSTOM7";
-            break;
-        case VOTE_SIGNAL_CUSTOM8:
-            strReturn = "CUSTOM8";
-            break;
-        case VOTE_SIGNAL_CUSTOM9:
-            strReturn = "CUSTOM9";
-            break;
-        case VOTE_SIGNAL_CUSTOM10:
-            strReturn = "CUSTOM10";
-            break;
-        case VOTE_SIGNAL_CUSTOM11:
-            strReturn = "CUSTOM11";
-            break;
-        case VOTE_SIGNAL_CUSTOM12:
-            strReturn = "CUSTOM12";
-            break;
-        case VOTE_SIGNAL_CUSTOM13:
-            strReturn = "CUSTOM13";
-            break;
-        case VOTE_SIGNAL_CUSTOM14:
-            strReturn = "CUSTOM14";
-            break;
-        case VOTE_SIGNAL_CUSTOM15:
-            strReturn = "CUSTOM15";
-            break;
-        case VOTE_SIGNAL_CUSTOM16:
-            strReturn = "CUSTOM16";
-            break;
-        case VOTE_SIGNAL_CUSTOM17:
-            strReturn = "CUSTOM17";
-            break;
-        case VOTE_SIGNAL_CUSTOM18:
-            strReturn = "CUSTOM18";
-            break;
-        case VOTE_SIGNAL_CUSTOM19:
-            strReturn = "CUSTOM19";
-            break;
-        case VOTE_SIGNAL_CUSTOM20:
-            strReturn = "CUSTOM20";
-            break;
     }
 
     return strReturn;
@@ -163,44 +70,16 @@ vote_outcome_enum_t CGovernanceVoting::ConvertVoteOutcome(const std::string& str
 
 vote_signal_enum_t CGovernanceVoting::ConvertVoteSignal(const std::string& strVoteSignal)
 {
-    vote_signal_enum_t eSignal = VOTE_SIGNAL_NONE;
-    if(strVoteSignal == "funding") {
-        eSignal = VOTE_SIGNAL_FUNDING;
-    }
-    else if(strVoteSignal == "valid") {
-        eSignal = VOTE_SIGNAL_VALID;
-    }
-    if(strVoteSignal == "delete") {
-        eSignal = VOTE_SIGNAL_DELETE;
-    }
-    if(strVoteSignal == "endorsed") {
-        eSignal = VOTE_SIGNAL_ENDORSED;
-    }
+    std::map <std::string, vote_signal_enum_t> mapStrVoteSignals = {
+        {"funding",  VOTE_SIGNAL_FUNDING},
+        {"valid",    VOTE_SIGNAL_VALID},
+        {"delete",   VOTE_SIGNAL_DELETE},
+        {"endorsed", VOTE_SIGNAL_ENDORSED}
+    };
 
-    if(eSignal != VOTE_SIGNAL_NONE)  {
-        return eSignal;
-    }
-
-    // ID FIVE THROUGH CUSTOM_START ARE TO BE USED BY GOVERNANCE ENGINE / TRIGGER SYSTEM
-
-    // convert custom sentinel outcomes to integer and store
-    try {
-        int i = boost::lexical_cast<int>(strVoteSignal);
-        if(i < VOTE_SIGNAL_CUSTOM1 || i > VOTE_SIGNAL_CUSTOM20) {
-            eSignal = VOTE_SIGNAL_NONE;
-        }
-        else  {
-            eSignal = vote_signal_enum_t(i);
-        }
-    }
-    catch(std::exception const & e)
-    {
-        std::ostringstream ostr;
-        ostr << "CGovernanceVote::ConvertVoteSignal: error : " << e.what() << std::endl;
-        LogPrintf(ostr.str().c_str());
-    }
-
-    return eSignal;
+    return mapStrVoteSignals.count(strVoteSignal)
+         ? mapStrVoteSignals[strVoteSignal]
+         : VOTE_SIGNAL_NONE;
 }
 
 CGovernanceVote::CGovernanceVote()
@@ -349,7 +228,7 @@ bool CGovernanceVote::IsValid(bool fSignatureCheck) const
         return false;
     }
 
-    // support up to 50 actions (implemented in sentinel)
+    // support up to MAX_SUPPORTED_VOTE_SIGNAL, can be extended
     if(nVoteSignal > MAX_SUPPORTED_VOTE_SIGNAL)
     {
         LogPrint("gobject", "CGovernanceVote::IsValid -- Client attempted to vote on invalid signal(%d) - %s\n", nVoteSignal, GetHash().ToString());

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -29,37 +29,6 @@ enum vote_signal_enum_t  {
     VOTE_SIGNAL_VALID      = 2, //   -- this object checks out in sentinel engine
     VOTE_SIGNAL_DELETE     = 3, //   -- this object should be deleted from memory entirely
     VOTE_SIGNAL_ENDORSED   = 4, //   -- officially endorsed by the network somehow (delegation)
-    VOTE_SIGNAL_NOOP1      = 5, // FOR FURTHER EXPANSION
-    VOTE_SIGNAL_NOOP2      = 6,
-    VOTE_SIGNAL_NOOP3      = 7,
-    VOTE_SIGNAL_NOOP4      = 8,
-    VOTE_SIGNAL_NOOP5      = 9,
-    VOTE_SIGNAL_NOOP6      = 10,
-    VOTE_SIGNAL_NOOP7      = 11,
-    VOTE_SIGNAL_NOOP8      = 12,
-    VOTE_SIGNAL_NOOP9      = 13,
-    VOTE_SIGNAL_NOOP10     = 14,
-    VOTE_SIGNAL_NOOP11     = 15,
-    VOTE_SIGNAL_CUSTOM1    = 16,  // SENTINEL CUSTOM ACTIONS
-    VOTE_SIGNAL_CUSTOM2    = 17,  //        16-35
-    VOTE_SIGNAL_CUSTOM3    = 18,
-    VOTE_SIGNAL_CUSTOM4    = 19,
-    VOTE_SIGNAL_CUSTOM5    = 20,
-    VOTE_SIGNAL_CUSTOM6    = 21,
-    VOTE_SIGNAL_CUSTOM7    = 22,
-    VOTE_SIGNAL_CUSTOM8    = 23,
-    VOTE_SIGNAL_CUSTOM9    = 24,
-    VOTE_SIGNAL_CUSTOM10   = 25,
-    VOTE_SIGNAL_CUSTOM11   = 26,
-    VOTE_SIGNAL_CUSTOM12   = 27,
-    VOTE_SIGNAL_CUSTOM13   = 28,
-    VOTE_SIGNAL_CUSTOM14   = 29,
-    VOTE_SIGNAL_CUSTOM15   = 30,
-    VOTE_SIGNAL_CUSTOM16   = 31,
-    VOTE_SIGNAL_CUSTOM17   = 32,
-    VOTE_SIGNAL_CUSTOM18   = 33,
-    VOTE_SIGNAL_CUSTOM19   = 34,
-    VOTE_SIGNAL_CUSTOM20   = 35
 };
 
 static const int MAX_SUPPORTED_VOTE_SIGNAL = VOTE_SIGNAL_ENDORSED;

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -337,7 +337,7 @@ UniValue gobject(const JSONRPCRequest& request)
         if(eVoteSignal == VOTE_SIGNAL_NONE) {
             throw JSONRPCError(RPC_INVALID_PARAMETER,
                                "Invalid vote signal. Please using one of the following: "
-                               "(funding|valid|delete|endorsed) OR `custom sentinel code` ");
+                               "(funding|valid|delete|endorsed)");
         }
 
         vote_outcome_enum_t eVoteOutcome = CGovernanceVoting::ConvertVoteOutcome(strVoteOutcome);
@@ -416,7 +416,7 @@ UniValue gobject(const JSONRPCRequest& request)
         if(eVoteSignal == VOTE_SIGNAL_NONE) {
             throw JSONRPCError(RPC_INVALID_PARAMETER,
                                "Invalid vote signal. Please using one of the following: "
-                               "(funding|valid|delete|endorsed) OR `custom sentinel code` ");
+                               "(funding|valid|delete|endorsed)");
         }
 
         vote_outcome_enum_t eVoteOutcome = CGovernanceVoting::ConvertVoteOutcome(strVoteOutcome);
@@ -526,7 +526,7 @@ UniValue gobject(const JSONRPCRequest& request)
         if(eVoteSignal == VOTE_SIGNAL_NONE) {
             throw JSONRPCError(RPC_INVALID_PARAMETER,
                                "Invalid vote signal. Please using one of the following: "
-                               "(funding|valid|delete|endorsed) OR `custom sentinel code` ");
+                               "(funding|valid|delete|endorsed)");
         }
 
         vote_outcome_enum_t eVoteOutcome = CGovernanceVoting::ConvertVoteOutcome(strVoteOutcome);
@@ -887,7 +887,7 @@ UniValue voteraw(const JSONRPCRequest& request)
     if(eVoteSignal == VOTE_SIGNAL_NONE)  {
         throw JSONRPCError(RPC_INVALID_PARAMETER,
                            "Invalid vote signal. Please using one of the following: "
-                           "(funding|valid|delete|endorsed) OR `custom sentinel code` ");
+                           "(funding|valid|delete|endorsed)");
     }
 
     vote_outcome_enum_t eVoteOutcome = CGovernanceVoting::ConvertVoteOutcome(strVoteOutcome);


### PR DESCRIPTION
This PR removes extra unused signals which are defined but not implemented, as well as simplifies the overly complicated method `CGovernanceVoting::ConvertVoteSignal`. If we ever have a need for these signals, we can always add this back, but I would prefer to keep the code base clean & light as possible.

Sentinel custom signals aren't being used and I don't anticipate this being implemented any time in the near future.