### PR TITLE
Replace Dash-specific threads with Dash-specific scheduled tasks

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -189,8 +189,6 @@ Threads
 
 - BitcoinMiner : Generates coins (if wallet is enabled).
 
-- ThreadCheckDarkSendPool : Runs masternode list and sync data update loops
-
 - Shutdown : Does an orderly shutdown of everything.
 
 Ignoring IDE/editor files

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -76,6 +76,8 @@ public:
 
     bool UpdateSentinelPing(int version);
 
+    void DoMaintenance(CConnman &connman) { ManageState(connman); }
+
 private:
     void ManageStateInitial(CConnman& connman);
     void ManageStateRemote();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1941,15 +1941,26 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     // GetMainSignals().UpdatedBlockTip(chainActive.Tip());
     pdsNotificationInterface->InitializeCurrentBlockTip();
 
-    // ********************************************************* Step 11d: start dash-ps-<smth> threads
+    // ********************************************************* Step 11d: schedule Dash-specific tasks
 
-    threadGroup.create_thread(boost::bind(&ThreadCheckPrivateSend, boost::ref(*g_connman)));
-    if (fMasternodeMode)
-        threadGroup.create_thread(boost::bind(&ThreadCheckPrivateSendServer, boost::ref(*g_connman)));
+    if (!fLiteMode) {
+        scheduler.scheduleEvery(boost::bind(&CNetFulfilledRequestManager::DoMaintenance, boost::ref(netfulfilledman)), 60);
+        scheduler.scheduleEvery(boost::bind(&CMasternodeSync::DoMaintenance, boost::ref(masternodeSync), boost::ref(*g_connman)), MASTERNODE_SYNC_TICK_SECONDS);
+        scheduler.scheduleEvery(boost::bind(&CMasternodeMan::DoMaintenance, boost::ref(mnodeman), boost::ref(*g_connman)), 1);
+        scheduler.scheduleEvery(boost::bind(&CActiveMasternode::DoMaintenance, boost::ref(activeMasternode), boost::ref(*g_connman)), 1);
+
+        scheduler.scheduleEvery(boost::bind(&CMasternodePayments::DoMaintenance, boost::ref(mnpayments)), 60);
+        scheduler.scheduleEvery(boost::bind(&CGovernanceManager::DoMaintenance, boost::ref(governance), boost::ref(*g_connman)), 60 * 5);
+
+        scheduler.scheduleEvery(boost::bind(&CInstantSend::DoMaintenance, boost::ref(instantsend)), 60);
+
+        if (fMasternodeMode)
+            scheduler.scheduleEvery(boost::bind(&CPrivateSendServer::DoMaintenance, boost::ref(privateSendServer), boost::ref(*g_connman)), 1);
 #ifdef ENABLE_WALLET
-    else
-        threadGroup.create_thread(boost::bind(&ThreadCheckPrivateSendClient, boost::ref(*g_connman)));
+        else
+            scheduler.scheduleEvery(boost::bind(&CPrivateSendClient::DoMaintenance, boost::ref(privateSendClient), boost::ref(*g_connman)), 1);
 #endif // ENABLE_WALLET
+    }
 
     // ********************************************************* Step 12: start node
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -241,8 +241,11 @@ void PrepareShutdown()
     peerLogic.reset();
     g_connman.reset();
 
-    // STORE DATA CACHES INTO SERIALIZED DAT FILES
     if (!fLiteMode) {
+        // Stop PrivateSend, release keys
+        privateSendClient.fEnablePrivateSend = false;
+        privateSendClient.ResetPool();
+        // STORE DATA CACHES INTO SERIALIZED DAT FILES
         CFlatDB<CMasternodeMan> flatdb1("mncache.dat", "magicMasternodeCache");
         flatdb1.Dump(mnodeman);
         CFlatDB<CMasternodePayments> flatdb2("mnpayments.dat", "magicMasternodePaymentsCache");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -242,9 +242,11 @@ void PrepareShutdown()
     g_connman.reset();
 
     if (!fLiteMode) {
+#ifdef ENABLE_WALLET
         // Stop PrivateSend, release keys
         privateSendClient.fEnablePrivateSend = false;
         privateSendClient.ResetPool();
+#endif
         // STORE DATA CACHES INTO SERIALIZED DAT FILES
         CFlatDB<CMasternodeMan> flatdb1("mncache.dat", "magicMasternodeCache");
         flatdb1.Dump(mnodeman);

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -159,6 +159,8 @@ public:
     void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock);
 
     std::string ToString() const;
+
+    void DoMaintenance() { CheckAndRemove(); }
 };
 
 /**

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -232,6 +232,8 @@ public:
     int GetStorageLimit() const;
 
     void UpdatedBlockTip(const CBlockIndex *pindex, CConnman& connman);
+
+    void DoMaintenance() { CheckAndRemove(); }
 };
 
 #endif

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -133,7 +133,7 @@ void CMasternodeSync::ProcessMessage(CNode* pfrom, const std::string& strCommand
 void CMasternodeSync::ProcessTick(CConnman& connman)
 {
     static int nTick = 0;
-    if(nTick++ % MASTERNODE_SYNC_TICK_SECONDS != 0) return;
+    nTick++;
 
     // reset the sync process if the last call to this function was more than 60 minutes ago (client was in sleep mode)
     static int64_t nTimeLastProcess = GetTime();

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -77,6 +77,8 @@ public:
     void AcceptedBlockHeader(const CBlockIndex *pindexNew);
     void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload, CConnman& connman);
     void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload, CConnman& connman);
+
+    void DoMaintenance(CConnman &connman) { ProcessTick(connman); }
 };
 
 #endif

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -244,6 +244,7 @@ public:
      */
     void NotifyMasternodeUpdates(CConnman& connman);
 
+    void DoMaintenance(CConnman &connman);
 };
 
 #endif

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -44,6 +44,8 @@ public:
     void Clear();
 
     std::string ToString() const;
+
+    void DoMaintenance() { CheckAndRemove(); }
 };
 
 #endif

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1449,34 +1449,22 @@ void CPrivateSendClient::UpdatedBlockTip(const CBlockIndex *pindex)
 
 }
 
-//TODO: Rename/move to core
-void ThreadCheckPrivateSendClient(CConnman& connman)
+void CPrivateSendClient::DoMaintenance(CConnman& connman)
 {
     if(fLiteMode) return; // disable all Dash specific functionality
     if(fMasternodeMode) return; // no client-side mixing on masternodes
 
-    static bool fOneThread;
-    if(fOneThread) return;
-    fOneThread = true;
+    if(!masternodeSync.IsBlockchainSynced() || ShutdownRequested())
+        return;
 
-    // Make this thread recognisable as the PrivateSend thread
-    RenameThread("dash-ps-client");
+    static unsigned int nTick = 0;
+    static unsigned int nDoAutoNextRun = nTick + PRIVATESEND_AUTO_TIMEOUT_MIN;
 
-    unsigned int nTick = 0;
-    unsigned int nDoAutoNextRun = nTick + PRIVATESEND_AUTO_TIMEOUT_MIN;
-
-    while (true)
-    {
-        MilliSleep(1000);
-
-        if(masternodeSync.IsBlockchainSynced() && !ShutdownRequested()) {
-            nTick++;
-            privateSendClient.CheckTimeout();
-            privateSendClient.ProcessPendingDsaRequest(connman);
-            if(nDoAutoNextRun == nTick) {
-                privateSendClient.DoAutomaticDenominating(connman);
-                nDoAutoNextRun = nTick + PRIVATESEND_AUTO_TIMEOUT_MIN + GetRandInt(PRIVATESEND_AUTO_TIMEOUT_MAX - PRIVATESEND_AUTO_TIMEOUT_MIN);
-            }
-        }
+    nTick++;
+    privateSendClient.CheckTimeout();
+    privateSendClient.ProcessPendingDsaRequest(connman);
+    if(nDoAutoNextRun == nTick) {
+        privateSendClient.DoAutomaticDenominating(connman);
+        nDoAutoNextRun = nTick + PRIVATESEND_AUTO_TIMEOUT_MIN + GetRandInt(PRIVATESEND_AUTO_TIMEOUT_MAX - PRIVATESEND_AUTO_TIMEOUT_MIN);
     }
 }

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -190,8 +190,8 @@ public:
     void CheckTimeout();
 
     void UpdatedBlockTip(const CBlockIndex *pindex);
-};
 
-void ThreadCheckPrivateSendClient(CConnman& connman);
+    void DoMaintenance(CConnman& connman);
+};
 
 #endif

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -890,29 +890,14 @@ void CPrivateSendServer::SetState(PoolState nStateNew)
     nState = nStateNew;
 }
 
-//TODO: Rename/move to core
-void ThreadCheckPrivateSendServer(CConnman& connman)
+void CPrivateSendServer::DoMaintenance(CConnman& connman)
 {
     if(fLiteMode) return; // disable all Dash specific functionality
     if(!fMasternodeMode) return; // only run on masternodes
 
-    static bool fOneThread;
-    if(fOneThread) return;
-    fOneThread = true;
+    if(!masternodeSync.IsBlockchainSynced() || ShutdownRequested())
+        return;
 
-    // Make this thread recognisable as the PrivateSend thread
-    RenameThread("dash-ps-server");
-
-    unsigned int nTick = 0;
-
-    while (true)
-    {
-        MilliSleep(1000);
-
-        if(masternodeSync.IsBlockchainSynced() && !ShutdownRequested()) {
-            nTick++;
-            privateSendServer.CheckTimeout(connman);
-            privateSendServer.CheckForCompleteQueue(connman);
-        }
-    }
+    privateSendServer.CheckTimeout(connman);
+    privateSendServer.CheckForCompleteQueue(connman);
 }

--- a/src/privatesend-server.h
+++ b/src/privatesend-server.h
@@ -73,8 +73,8 @@ public:
 
     void CheckTimeout(CConnman& connman);
     void CheckForCompleteQueue(CConnman& connman);
-};
 
-void ThreadCheckPrivateSendServer(CConnman& connman);
+    void DoMaintenance(CConnman& connman);
+};
 
 #endif

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -5,14 +5,10 @@
 
 #include "activemasternode.h"
 #include "consensus/validation.h"
-#include "governance.h"
-#include "init.h"
-#include "instantx.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"
 #include "masternodeman.h"
 #include "messagesigner.h"
-#include "netfulfilledman.h"
 #include "netmessagemaker.h"
 #include "script/sign.h"
 #include "txmempool.h"
@@ -509,59 +505,4 @@ void CPrivateSend::SyncTransaction(const CTransaction& tx, const CBlockIndex *pi
     // When tx is 0-confirmed or conflicted, posInBlock is SYNC_TRANSACTION_NOT_IN_BLOCK and nConfirmedHeight should be set to -1
     mapDSTX[txHash].SetConfirmedHeight(posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK ? -1 : pindex->nHeight);
     LogPrint("privatesend", "CPrivateSendClient::SyncTransaction -- txid=%s\n", txHash.ToString());
-}
-
-//TODO: Rename/move to core
-void ThreadCheckPrivateSend(CConnman& connman)
-{
-    if(fLiteMode) return; // disable all Dash specific functionality
-
-    static bool fOneThread;
-    if(fOneThread) return;
-    fOneThread = true;
-
-    // Make this thread recognisable as the PrivateSend thread
-    RenameThread("dash-ps");
-
-    unsigned int nTick = 0;
-
-    while (true)
-    {
-        MilliSleep(1000);
-
-        // try to sync from all available nodes, one step at a time
-        masternodeSync.ProcessTick(connman);
-
-        if(masternodeSync.IsBlockchainSynced() && !ShutdownRequested()) {
-
-            nTick++;
-
-            // make sure to check all masternodes first
-            mnodeman.Check();
-
-            mnodeman.ProcessPendingMnbRequests(connman);
-            mnodeman.ProcessPendingMnvRequests(connman);
-
-            // check if we should activate or ping every few minutes,
-            // slightly postpone first run to give net thread a chance to connect to some peers
-            if(nTick % MASTERNODE_MIN_MNP_SECONDS == 15)
-                activeMasternode.ManageState(connman);
-
-            if(nTick % 60 == 0) {
-                netfulfilledman.CheckAndRemove();
-                mnodeman.ProcessMasternodeConnections(connman);
-                mnodeman.CheckAndRemove(connman);
-                mnodeman.WarnMasternodeDaemonUpdates();
-                mnpayments.CheckAndRemove();
-                instantsend.CheckAndRemove();
-            }
-            if(fMasternodeMode && (nTick % (60 * 5) == 0)) {
-                mnodeman.DoFullVerificationStep(connman);
-            }
-
-            if(nTick % (60 * 5) == 0) {
-                governance.DoMaintenance(connman);
-            }
-        }
-    }
 }

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -437,6 +437,4 @@ public:
     static void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock);
 };
 
-void ThreadCheckPrivateSend(CConnman& connman);
-
 #endif


### PR DESCRIPTION
As pointed out in #2041, triggering various logic of multiple different submodules in a single (legacy) PrivateSend thread is confusing. Having few separate threads for each of them would probably make things a bit clearer but would be an overkill imo, so I'm proposing to utilise builtin scheduler for this instead - each submodule has `DoMaintenance()` and all of them are scheduled independently in one place in `init.cpp` now.