### PR TITLE
replace boost iterators in dash-specific code

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -153,7 +153,7 @@ bool CInstantSend::CreateTxLockCandidate(const CTxLockRequest& txLockRequest)
 
         CTxLockCandidate txLockCandidate(txLockRequest);
         // all inputs should already be checked by txLockRequest.IsValid() above, just use them now
-        BOOST_REVERSE_FOREACH(const CTxIn& txin, txLockRequest.tx->vin) {
+        for(const auto& txin : txLockRequest.tx->vin) {
             txLockCandidate.AddOutPointLock(txin.prevout);
         }
         mapTxLockCandidates.insert(std::make_pair(txHash, txLockCandidate));
@@ -167,7 +167,7 @@ bool CInstantSend::CreateTxLockCandidate(const CTxLockRequest& txLockRequest)
         LogPrintf("CInstantSend::CreateTxLockCandidate -- update empty, txid=%s\n", txHash.ToString());
 
         // all inputs should already be checked by txLockRequest.IsValid() above, just use them now
-        BOOST_REVERSE_FOREACH(const CTxIn& txin, txLockRequest.tx->vin) {
+        for(const auto& txin : txLockRequest.tx->vin) {
             itLockCandidate->second.AddOutPointLock(txin.prevout);
         }
     } else {

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -469,7 +469,7 @@ void MasternodeList::ShowQRCode(std::string strAlias) {
     CMasternode mn;
     bool fFound = false;
 
-    BOOST_FOREACH(CMasternodeConfig::CMasternodeEntry mne, masternodeConfig.getEntries()) {
+    for (const auto& mne : masternodeConfig.getEntries()) {
         if (strAlias != mne.getAlias()) {
             continue;
         }


### PR DESCRIPTION
Continues from https://github.com/dashpay/dash/pull/1899

In `instantx.cpp`, the reverse iterator is misleading -- if I understand correctly, the order is irrelevant here because `CTxLockCandidate::AddOutPointLock` just adds entries to a map, which aren't ordered. So we should be able to replace this with a forward iterator and swap out this boost foreach at the same time.

We probably should have caught the BOOST_FOREACH in `qt/masternodelist.cpp`, this replacement is straightforward.