### PR TITLE
Save/load InstantSend cache

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -251,8 +251,11 @@ void PrepareShutdown()
         flatdb3.Dump(governance);
         CFlatDB<CNetFulfilledRequestManager> flatdb4("netfulfilled.dat", "magicFulfilledCache");
         flatdb4.Dump(netfulfilledman);
-        CFlatDB<CInstantSend> flatdb5("instantsend.dat", "magicInstantSendCache");
-        flatdb5.Dump(instantsend);
+        if(fEnableInstantSend)
+        {
+            CFlatDB<CInstantSend> flatdb5("instantsend.dat", "magicInstantSendCache");
+            flatdb5.Dump(instantsend);
+        }
     }
 
     UnregisterNodeSignals(GetNodeSignals());
@@ -1917,11 +1920,14 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             return InitError(_("Failed to load fulfilled requests cache from") + "\n" + (pathDB / strDBName).string());
         }
 
-        strDBName = "instantsend.dat";
-        uiInterface.InitMessage(_("Loading InstantSend data cache..."));
-        CFlatDB<CInstantSend> flatdb5(strDBName, "magicInstantSendCache");
-        if(!flatdb5.Load(instantsend)) {
-            return InitError(_("Failed to load InstantSend data cache from") + "\n" + (pathDB / strDBName).string());
+        if(fEnableInstantSend)
+        {
+            strDBName = "instantsend.dat";
+            uiInterface.InitMessage(_("Loading InstantSend data cache..."));
+            CFlatDB<CInstantSend> flatdb5(strDBName, "magicInstantSendCache");
+            if(!flatdb5.Load(instantsend)) {
+                return InitError(_("Failed to load InstantSend data cache from") + "\n" + (pathDB / strDBName).string());
+            }
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -251,6 +251,8 @@ void PrepareShutdown()
         flatdb3.Dump(governance);
         CFlatDB<CNetFulfilledRequestManager> flatdb4("netfulfilled.dat", "magicFulfilledCache");
         flatdb4.Dump(netfulfilledman);
+        CFlatDB<CInstantSend> flatdb5("instantsend.dat", "magicInstantSendCache");
+        flatdb5.Dump(instantsend);
     }
 
     UnregisterNodeSignals(GetNodeSignals());
@@ -1913,6 +1915,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         CFlatDB<CNetFulfilledRequestManager> flatdb4(strDBName, "magicFulfilledCache");
         if(!flatdb4.Load(netfulfilledman)) {
             return InitError(_("Failed to load fulfilled requests cache from") + "\n" + (pathDB / strDBName).string());
+        }
+
+        strDBName = "instantsend.dat";
+        uiInterface.InitMessage(_("Loading InstantSend data cache..."));
+        CFlatDB<CInstantSend> flatdb5(strDBName, "magicInstantSendCache");
+        if(!flatdb5.Load(instantsend)) {
+            return InitError(_("Failed to load InstantSend data cache from") + "\n" + (pathDB / strDBName).string());
         }
     }
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -36,6 +36,7 @@ int nInstantSendDepth = DEFAULT_INSTANTSEND_DEPTH;
 int nCompleteTXLocks;
 
 CInstantSend instantsend;
+const std::string CInstantSend::SERIALIZATION_VERSION_STRING = "CInstantSend-Version-1";
 
 // Transaction Locks
 //
@@ -795,6 +796,21 @@ bool CInstantSend::IsInstantSendReadyToLock(const uint256& txHash)
     return it != mapTxLockCandidates.end() && it->second.IsAllOutPointsReady();
 }
 
+void CInstantSend::Clear()
+{
+    LOCK(cs_instantsend);
+
+    mapLockRequestAccepted.clear();
+    mapLockRequestRejected.clear();
+    mapTxLockVotes.clear();
+    mapTxLockVotesOrphan.clear();
+    mapTxLockCandidates.clear();
+    mapVotedOutpoints.clear();
+    mapLockedOutpoints.clear();
+    mapMasternodeOrphanVotes.clear();
+    nCachedBlockHeight = 0;
+}
+
 bool CInstantSend::IsLockedInstantSendTransaction(const uint256& txHash)
 {
     if(!fEnableInstantSend || GetfLargeWorkForkFound() || GetfLargeWorkInvalidChainFound() ||
@@ -926,7 +942,7 @@ void CInstantSend::SyncTransaction(const CTransaction& tx, const CBlockIndex *pi
     }
 }
 
-std::string CInstantSend::ToString()
+std::string CInstantSend::ToString() const
 {
     LOCK(cs_instantsend);
     return strprintf("Lock Candidates: %llu, Votes %llu", mapTxLockCandidates.size(), mapTxLockVotes.size());

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -277,6 +277,11 @@ private:
     int64_t nTimeCreated;
 
 public:
+    CTxLockCandidate() :
+        nConfirmedHeight(-1),
+        nTimeCreated(GetTime())
+    {}
+
     CTxLockCandidate(const CTxLockRequest& txLockRequestIn) :
         nConfirmedHeight(-1),
         nTimeCreated(GetTime()),
@@ -286,6 +291,16 @@ public:
 
     CTxLockRequest txLockRequest;
     std::map<COutPoint, COutPointLock> mapOutPointLocks;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(txLockRequest);
+        READWRITE(mapOutPointLocks);
+        READWRITE(nTimeCreated);
+        READWRITE(nConfirmedHeight);
+    }
 
     uint256 GetHash() const { return txLockRequest.GetHash(); }
 

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -242,12 +242,23 @@ public:
     static const int SIGNATURES_REQUIRED        = 6;
     static const int SIGNATURES_TOTAL           = 10;
 
+    COutPointLock() {}
+
     COutPointLock(const COutPoint& outpointIn) :
         outpoint(outpointIn),
         mapMasternodeVotes()
         {}
 
     COutPoint GetOutpoint() const { return outpoint; }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(outpoint);
+        READWRITE(mapMasternodeVotes);
+        READWRITE(fAttacked);
+    }
 
     bool AddVote(const CTxLockVote& vote);
     std::vector<CTxLockVote> GetVotes() const;


### PR DESCRIPTION
Save/load data structures needed for InstantSend in cache file (instantsend.dat) just like we already do for masternodes, governance etc.