### PR TITLE
use CLIENT_VERSION as default daemon version instead of hardcoded value

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -303,14 +303,14 @@ void CMasternode::UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScan
 
     const CBlockIndex *BlockReading = pindex;
 
-    CScript mnpayee = GetScriptForDestination(pubKeyCollateralAddress.GetID());
+    const CScript &mnpayee = GetScriptForDestination(pubKeyCollateralAddress.GetID());
     // LogPrint("mnpayments", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s\n", outpoint.ToStringShort());
 
     LOCK(cs_mapMasternodeBlocks);
 
     for (int i = 0; BlockReading && BlockReading->nHeight > nBlockLastPaid && i < nMaxBlocksToScanBack; i++) {
         if(mnpayments.mapMasternodeBlocks.count(BlockReading->nHeight) &&
-            mnpayments.mapMasternodeBlocks[BlockReading->nHeight].HasPayeeWithVotes(mnpayee, 2))
+            mnpayments.mapMasternodeBlocks[BlockReading->nHeight].HasPayeeWithVotes(mnpayee, 2, outpoint.n))
         {
             CBlock block;
             if(!ReadBlockFromDisk(block, BlockReading, Params().GetConsensus()))

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -8,7 +8,7 @@
 #include "key.h"
 #include "validation.h"
 #include "spork.h"
-
+#include "clientversion.h"
 class CMasternode;
 class CMasternodeBroadcast;
 class CConnman;
@@ -29,7 +29,7 @@ static const int MASTERNODE_POSE_BAN_MAX_SCORE          = 5;
 // sentinel version before implementation of nSentinelVersion in CMasternodePing
 #define DEFAULT_SENTINEL_VERSION 0x010001
 // daemon version before implementation of nDaemonVersion in CMasternodePing
-#define DEFAULT_DAEMON_VERSION 120200
+#define DEFAULT_DAEMON_VERSION CLIENT_VERSION
 
 class CMasternodePing
 {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -8,7 +8,7 @@
 #include "key.h"
 #include "validation.h"
 #include "spork.h"
-#include "clientversion.h"
+
 class CMasternode;
 class CMasternodeBroadcast;
 class CConnman;
@@ -29,7 +29,7 @@ static const int MASTERNODE_POSE_BAN_MAX_SCORE          = 5;
 // sentinel version before implementation of nSentinelVersion in CMasternodePing
 #define DEFAULT_SENTINEL_VERSION 0x010001
 // daemon version before implementation of nDaemonVersion in CMasternodePing
-#define DEFAULT_DAEMON_VERSION CLIENT_VERSION
+#define DEFAULT_DAEMON_VERSION 120200
 
 class CMasternodePing
 {


### PR DESCRIPTION
This magic constant was not being used to set the daemon version inside of CMasternodePing's constructor with outpoint. It caused me a 2 hour headache in Syscoin where I figured out the hash of the mnp was different from sender and reciever side and thus signature verification failed because the daemon version's were inadvertently different because on verification it overrides the daemon with the _local_ CLIENT_VERSION where as on the sender it uses the DEFAULT_DAEMON_VERSION and they just so happened to be different for me.

This way when you update your CLIENT_VERSION due to protocol updates in the core you won't have to "remember" to update the default daemon version in masternode.h