### PR TITLE
Trivial: Fix `nl` locale alias

### DIFF
--- a/src/qt/dash_locale.qrc
+++ b/src/qt/dash_locale.qrc
@@ -8,7 +8,7 @@
         <file alias="fr">locale/dash_fr.qm</file>
         <file alias="it">locale/dash_it.qm</file>
         <file alias="ja">locale/dash_ja.qm</file>
-        <file alias="ja">locale/dash_nl.qm</file>
+        <file alias="nl">locale/dash_nl.qm</file>
         <file alias="pl">locale/dash_pl.qm</file>
         <file alias="pt">locale/dash_pt.qm</file>
         <file alias="ru">locale/dash_ru.qm</file>


### PR DESCRIPTION
Copy-paste bug introduced in https://github.com/dashpay/dash/pull/2012/files#diff-370830566248d1de11a591546c049d9cR11