### PR TITLE
remove boost dependency from Dash-specific code

### DIFF
--- a/src/governance-classes.h
+++ b/src/governance-classes.h
@@ -12,8 +12,6 @@
 #include "script/standard.h"
 #include "util.h"
 
-#include <boost/shared_ptr.hpp>
-
 class CSuperblock;
 class CGovernanceTrigger;
 class CGovernanceTriggerManager;
@@ -22,7 +20,7 @@ class CSuperblockManager;
 static const int TRIGGER_UNKNOWN            = -1;
 static const int TRIGGER_SUPERBLOCK         = 1000;
 
-typedef boost::shared_ptr<CSuperblock> CSuperblock_sptr;
+typedef std::shared_ptr<CSuperblock> CSuperblock_sptr;
 
 // DECLARE GLOBAL VARIABLES FOR GOVERNANCE CLASSES
 extern CGovernanceTriggerManager triggerman;

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -15,6 +15,7 @@
 #include "util.h"
 
 #include <univalue.h>
+#include <string>
 
 CGovernanceObject::CGovernanceObject():
     cs(),
@@ -225,8 +226,8 @@ std::string CGovernanceObject::GetSignatureMessage() const
 {
     LOCK(cs);
     std::string strMessage = nHashParent.ToString() + "|" +
-        boost::lexical_cast<std::string>(nRevision) + "|" +
-        boost::lexical_cast<std::string>(nTime) + "|" +
+        std::to_string(nRevision) + "|" +
+        std::to_string(nTime) + "|" +
         GetDataAsHexString() + "|" +
         masternodeOutpoint.ToStringShort() + "|" +
         nCollateralHash.ToString();

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -9,8 +9,6 @@
 #include "messagesigner.h"
 #include "util.h"
 
-#include <boost/lexical_cast.hpp>
-
 std::string CGovernanceVoting::ConvertOutcomeToString(vote_outcome_enum_t nOutcome)
 {
     switch(nOutcome)
@@ -173,7 +171,7 @@ bool CGovernanceVote::Sign(const CKey& keyMasternode, const CPubKey& pubKeyMaste
     } else {
 
         std::string strMessage = masternodeOutpoint.ToStringShort() + "|" + nParentHash.ToString() + "|" +
-            boost::lexical_cast<std::string>(nVoteSignal) + "|" + boost::lexical_cast<std::string>(nVoteOutcome) + "|" + boost::lexical_cast<std::string>(nTime);
+            std::to_string(nVoteSignal) + "|" + std::to_string(nVoteOutcome) + "|" + std::to_string(nTime);
 
         if(!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
             LogPrintf("CGovernanceVote::Sign -- SignMessage() failed\n");
@@ -199,9 +197,9 @@ bool CGovernanceVote::CheckSignature(const CPubKey& pubKeyMasternode) const
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
             // could be a signature in old format
             std::string strMessage = masternodeOutpoint.ToStringShort() + "|" + nParentHash.ToString() + "|" +
-                boost::lexical_cast<std::string>(nVoteSignal) + "|" +
-                boost::lexical_cast<std::string>(nVoteOutcome) + "|" +
-                boost::lexical_cast<std::string>(nTime);
+                std::to_string(nVoteSignal) + "|" +
+                std::to_string(nVoteOutcome) + "|" +
+                std::to_string(nTime);
 
             if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
                 // nope, not in old format either
@@ -211,9 +209,9 @@ bool CGovernanceVote::CheckSignature(const CPubKey& pubKeyMasternode) const
         }
     } else {
         std::string strMessage = masternodeOutpoint.ToStringShort() + "|" + nParentHash.ToString() + "|" +
-            boost::lexical_cast<std::string>(nVoteSignal) + "|" +
-            boost::lexical_cast<std::string>(nVoteOutcome) + "|" +
-            boost::lexical_cast<std::string>(nTime);
+            std::to_string(nVoteSignal) + "|" +
+            std::to_string(nVoteOutcome) + "|" +
+            std::to_string(nTime);
 
         if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
             LogPrint("gobject", "CGovernanceVote::IsValid -- VerifyMessage() failed, error: %s\n", strError);

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -8,8 +8,6 @@
 #include "key.h"
 #include "primitives/transaction.h"
 
-#include <boost/lexical_cast.hpp>
-
 class CGovernanceVote;
 class CConnman;
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -14,7 +14,7 @@
 #include "spork.h"
 #include "util.h"
 
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 /** Object for who's going to get paid on which blocks */
 CMasternodePayments mnpayments;
@@ -455,7 +455,7 @@ bool CMasternodePaymentVote::Sign()
         }
     } else {
         std::string strMessage = masternodeOutpoint.ToStringShort() +
-                    boost::lexical_cast<std::string>(nBlockHeight) +
+                    std::to_string(nBlockHeight) +
                     ScriptToAsmStr(payee);
 
         if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
@@ -905,7 +905,7 @@ bool CMasternodePaymentVote::CheckSignature(const CPubKey& pubKeyMasternode, int
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
             // could be a signature in old format
             std::string strMessage = masternodeOutpoint.ToStringShort() +
-                        boost::lexical_cast<std::string>(nBlockHeight) +
+                        std::to_string(nBlockHeight) +
                         ScriptToAsmStr(payee);
             if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
                 // nope, not in old format either
@@ -921,7 +921,7 @@ bool CMasternodePaymentVote::CheckSignature(const CPubKey& pubKeyMasternode, int
         }
     } else {
         std::string strMessage = masternodeOutpoint.ToStringShort() +
-                    boost::lexical_cast<std::string>(nBlockHeight) +
+                    std::to_string(nBlockHeight) +
                     ScriptToAsmStr(payee);
 
         if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -18,7 +18,7 @@
 #include "wallet/wallet.h"
 #endif // ENABLE_WALLET
 
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 
 CMasternode::CMasternode() :
@@ -640,9 +640,9 @@ bool CMasternodeBroadcast::Sign(const CKey& keyCollateralAddress)
             return false;
         }
     } else {
-        std::string strMessage = addr.ToString(false) + boost::lexical_cast<std::string>(sigTime) +
+        std::string strMessage = addr.ToString(false) + std::to_string(sigTime) +
                         pubKeyCollateralAddress.GetID().ToString() + pubKeyMasternode.GetID().ToString() +
-                        boost::lexical_cast<std::string>(nProtocolVersion);
+                        std::to_string(nProtocolVersion);
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, keyCollateralAddress)) {
             LogPrintf("CMasternodeBroadcast::Sign -- SignMessage() failed\n");
@@ -668,9 +668,9 @@ bool CMasternodeBroadcast::CheckSignature(int& nDos) const
 
         if (!CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, vchSig, strError)) {
             // maybe it's in old format
-            std::string strMessage = addr.ToString(false) + boost::lexical_cast<std::string>(sigTime) +
+            std::string strMessage = addr.ToString(false) + std::to_string(sigTime) +
                             pubKeyCollateralAddress.GetID().ToString() + pubKeyMasternode.GetID().ToString() +
-                            boost::lexical_cast<std::string>(nProtocolVersion);
+                            std::to_string(nProtocolVersion);
 
             if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)){
                 // nope, not in old format either
@@ -680,9 +680,9 @@ bool CMasternodeBroadcast::CheckSignature(int& nDos) const
             }
         }
     } else {
-        std::string strMessage = addr.ToString(false) + boost::lexical_cast<std::string>(sigTime) +
+        std::string strMessage = addr.ToString(false) + std::to_string(sigTime) +
                         pubKeyCollateralAddress.GetID().ToString() + pubKeyMasternode.GetID().ToString() +
-                        boost::lexical_cast<std::string>(nProtocolVersion);
+                        std::to_string(nProtocolVersion);
 
         if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)){
             LogPrintf("CMasternodeBroadcast::CheckSignature -- Got bad Masternode announce signature, error: %s\n", strError);
@@ -762,7 +762,7 @@ bool CMasternodePing::Sign(const CKey& keyMasternode, const CPubKey& pubKeyMaste
         }
     } else {
         std::string strMessage = CTxIn(masternodeOutpoint).ToString() + blockHash.ToString() +
-                    boost::lexical_cast<std::string>(sigTime);
+                    std::to_string(sigTime);
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
             LogPrintf("CMasternodePing::Sign -- SignMessage() failed\n");
@@ -788,7 +788,7 @@ bool CMasternodePing::CheckSignature(const CPubKey& pubKeyMasternode, int &nDos)
 
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
             std::string strMessage = CTxIn(masternodeOutpoint).ToString() + blockHash.ToString() +
-                        boost::lexical_cast<std::string>(sigTime);
+                        std::to_string(sigTime);
 
             if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
                 LogPrintf("CMasternodePing::CheckSignature -- Got bad Masternode ping signature, masternode=%s, error: %s\n", masternodeOutpoint.ToStringShort(), strError);
@@ -798,7 +798,7 @@ bool CMasternodePing::CheckSignature(const CPubKey& pubKeyMasternode, int &nDos)
         }
     } else {
         std::string strMessage = CTxIn(masternodeOutpoint).ToString() + blockHash.ToString() +
-                    boost::lexical_cast<std::string>(sigTime);
+                    std::to_string(sigTime);
 
         if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
             LogPrintf("CMasternodePing::CheckSignature -- Got bad Masternode ping signature, masternode=%s, error: %s\n", masternodeOutpoint.ToStringShort(), strError);

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -19,7 +19,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 bool CDarkSendEntry::AddScriptSig(const CTxIn& txin)
 {
@@ -62,9 +62,9 @@ bool CDarksendQueue::Sign()
         }
     } else {
         std::string strMessage = CTxIn(masternodeOutpoint).ToString() +
-                        boost::lexical_cast<std::string>(nDenom) +
-                        boost::lexical_cast<std::string>(nTime) +
-                        boost::lexical_cast<std::string>(fReady);
+                        std::to_string(nDenom) +
+                        std::to_string(nTime) +
+                        std::to_string(fReady);
 
         if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
             LogPrintf("CDarksendQueue::Sign -- SignMessage() failed, %s\n", ToString());
@@ -94,9 +94,9 @@ bool CDarksendQueue::CheckSignature(const CPubKey& pubKeyMasternode) const
         }
     } else {
         std::string strMessage = CTxIn(masternodeOutpoint).ToString() +
-                        boost::lexical_cast<std::string>(nDenom) +
-                        boost::lexical_cast<std::string>(nTime) +
-                        boost::lexical_cast<std::string>(fReady);
+                        std::to_string(nDenom) +
+                        std::to_string(nTime) +
+                        std::to_string(fReady);
 
         if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
             LogPrintf("CDarksendQueue::CheckSignature -- Got bad Masternode queue signature: %s; error: %s\n", ToString(), strError);
@@ -141,7 +141,7 @@ bool CDarksendBroadcastTx::Sign()
             return false;
         }
     } else {
-        std::string strMessage = tx->GetHash().ToString() + boost::lexical_cast<std::string>(sigTime);
+        std::string strMessage = tx->GetHash().ToString() + std::to_string(sigTime);
 
         if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternode.keyMasternode)) {
             LogPrintf("CDarksendBroadcastTx::Sign -- SignMessage() failed\n");
@@ -170,7 +170,7 @@ bool CDarksendBroadcastTx::CheckSignature(const CPubKey& pubKeyMasternode) const
             return false;
         }
     } else {
-        std::string strMessage = tx->GetHash().ToString() + boost::lexical_cast<std::string>(sigTime);
+        std::string strMessage = tx->GetHash().ToString() + std::to_string(sigTime);
 
         if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
             LogPrintf("CDarksendBroadcastTx::CheckSignature -- Got bad dstx signature, error: %s\n", strError);

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -11,7 +11,7 @@
 #include "net_processing.h"
 #include "netmessagemaker.h"
 
-#include <boost/lexical_cast.hpp>
+#include <string>
 
 CSporkManager sporkManager;
 
@@ -262,7 +262,7 @@ bool CSporkMessage::Sign(const CKey& key)
             return false;
         }
     } else {
-        std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
+        std::string strMessage = std::to_string(nSporkID) + std::to_string(nValue) + std::to_string(nTimeSigned);
 
         if(!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
             LogPrintf("CSporkMessage::Sign -- SignMessage() failed\n");
@@ -292,7 +292,7 @@ bool CSporkMessage::CheckSignature(const CKeyID& pubKeyId) const
             return false;
         }
     } else {
-        std::string strMessage = boost::lexical_cast<std::string>(nSporkID) + boost::lexical_cast<std::string>(nValue) + boost::lexical_cast<std::string>(nTimeSigned);
+        std::string strMessage = std::to_string(nSporkID) + std::to_string(nValue) + std::to_string(nTimeSigned);
 
         if (!CMessageSigner::VerifyMessage(pubKeyId, vchSig, strMessage, strError)){
             // Note: unlike for other messages we have to check for new format even with SPORK_6_NEW_SIGS


### PR DESCRIPTION
This is only a partial replacement, as some of the boost items aren't simple swaps. This PR replaces `lexical_cast` and the boost dependency in CSuperblock `shared_ptr`. The latter should be straightforward, doesn't use anything specific about `boost::shared_ptr` that can't be done with `std::shared_ptr`