### PR TITLE
Add string_cast benchmark

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -25,7 +25,8 @@ bench_bench_dash_SOURCES = \
   bench/base58.cpp \
   bench/lockedpool.cpp \
   bench/perf.cpp \
-  bench/perf.h
+  bench/perf.h \
+  bench/string_cast.cpp
 
 nodist_bench_bench_dash_SOURCES = $(GENERATED_TEST_FILES)
 

--- a/src/bench/string_cast.cpp
+++ b/src/bench/string_cast.cpp
@@ -9,6 +9,13 @@
 #include <boost/lexical_cast.hpp>
 #include <string>
 
+template <typename T>
+std::string NumberToString(T Number){
+    std::ostringstream oss;
+    oss << Number;
+    return oss.str();
+}
+
 static void int_atoi(benchmark::State& state)
 {
     while (state.KeepRunning())
@@ -33,6 +40,13 @@ static void strings_1_lexical_cast(benchmark::State& state)
     int i{0};
     while (state.KeepRunning())
         boost::lexical_cast<std::string>(++i);
+}
+
+static void strings_1_numberToString(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning())
+        NumberToString(++i);
 }
 
 static void strings_1_to_string(benchmark::State& state)
@@ -64,6 +78,15 @@ static void strings_2_multi_lexical_cast(benchmark::State& state)
     }
 }
 
+static void strings_2_multi_numberToString(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning()) {
+        NumberToString(i) + NumberToString(i+1) + NumberToString(i+2) + NumberToString(i+3) + NumberToString(i+4);
+        ++i;
+    }
+}
+
 static void strings_2_multi_to_string(benchmark::State& state)
 {
     int i{0};
@@ -86,8 +109,10 @@ BENCHMARK(int_atoi);
 BENCHMARK(int_lexical_cast);
 BENCHMARK(strings_1_itostr);
 BENCHMARK(strings_1_lexical_cast);
+BENCHMARK(strings_1_numberToString);
 BENCHMARK(strings_1_to_string);
 BENCHMARK(strings_2_multi_itostr);
 BENCHMARK(strings_2_multi_lexical_cast);
+BENCHMARK(strings_2_multi_numberToString);
 BENCHMARK(strings_2_multi_to_string);
 BENCHMARK(strings_2_strptintf);

--- a/src/bench/string_cast.cpp
+++ b/src/bench/string_cast.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "tinyformat.h"
+#include "utilstrencodings.h"
+
+#include <boost/lexical_cast.hpp>
+#include <string>
+
+static void int_atoi(benchmark::State& state)
+{
+    while (state.KeepRunning())
+        atoi("1");
+}
+
+static void int_lexical_cast(benchmark::State& state)
+{
+    while (state.KeepRunning())
+        boost::lexical_cast<int>("1");
+}
+
+static void strings_1_itostr(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning())
+        itostr(++i);
+}
+
+static void strings_1_lexical_cast(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning())
+        boost::lexical_cast<std::string>(++i);
+}
+
+static void strings_1_to_string(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning())
+        std::to_string(++i);
+}
+
+static void strings_2_multi_itostr(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning()) {
+        itostr(i) + itostr(i+1) + itostr(i+2) + itostr(i+3) + itostr(i+4);
+        ++i;
+    }
+}
+
+static void strings_2_multi_lexical_cast(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning()) {
+        boost::lexical_cast<std::string>(i) +
+        boost::lexical_cast<std::string>(i+1) +
+        boost::lexical_cast<std::string>(i+2) +
+        boost::lexical_cast<std::string>(i+3) +
+        boost::lexical_cast<std::string>(i+4);
+        ++i;
+    }
+}
+
+static void strings_2_multi_to_string(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning()) {
+        std::to_string(i) + std::to_string(i+1) + std::to_string(i+2) + std::to_string(i+3) + std::to_string(i+4);
+        ++i;
+    }
+}
+
+static void strings_2_strptintf(benchmark::State& state)
+{
+    int i{0};
+    while (state.KeepRunning()) {
+        strprintf("%d|%d|%d|%d|%d", i, i+1, i+2, i+3, i+4);
+        ++i;
+    }
+}
+
+BENCHMARK(int_atoi);
+BENCHMARK(int_lexical_cast);
+BENCHMARK(strings_1_itostr);
+BENCHMARK(strings_1_lexical_cast);
+BENCHMARK(strings_1_to_string);
+BENCHMARK(strings_2_multi_itostr);
+BENCHMARK(strings_2_multi_lexical_cast);
+BENCHMARK(strings_2_multi_to_string);
+BENCHMARK(strings_2_strptintf);


### PR DESCRIPTION
Benchmark various ways of dealing with `int->string`/`string->int` conversion.

Example output:
```
int_atoi,50331648,0.000000019404922,0.000000022758229,0.000000019926271,44,52,45
int_lexical_cast,11534336,0.000000086763293,0.000000091805305,0.000000088044255,199,211,202
strings_1_itostr,1966080,0.000000513366103,0.000000535408617,0.000000521111118,1182,1233,1200
strings_1_lexical_cast,4718592,0.000000208921847,0.000000232099410,0.000000228008503,481,534,525
strings_1_to_string,10485760,0.000000100358648,0.000000102645799,0.000000100982948,231,236,232
strings_2_multi_itostr,360448,0.000002753280569,0.000003013919923,0.000002918795376,6343,6943,6724
strings_2_multi_lexical_cast,786432,0.000001085310942,0.000001406770025,0.000001326184550,2500,3241,3055
strings_2_multi_to_string,1441792,0.000000722397090,0.000000758904207,0.000000734721074,1664,1748,1692
strings_2_strptintf,589824,0.000001733627869,0.000001917891495,0.000001835428621,3994,4418,4228
```

`atoi` and `to_string` (including concatenation of multiple items) seems to be the fastest option on my machine.

_Somewhat complementary to #2072_