### PR TITLE
Bump GOVERNANCE PROTO_VERSION

### DIFF
--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -25,8 +25,8 @@ class CGovernanceObject;
 class CGovernanceVote;
 
 static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
-static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70206;
-static const int GOVERNANCE_FILTER_PROTO_VERSION = 70206;
+static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70208;
+static const int GOVERNANCE_FILTER_PROTO_VERSION = 70208;
 
 static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 


### PR DESCRIPTION
Since 70206 is obsoleted in this release, these version numbers should be bumped.