### PR TITLE
Bump few consts

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -192,7 +192,7 @@ public:
     std::map<COutPoint, int> mapMasternodesLastVote;
     std::map<COutPoint, int> mapMasternodesDidNotVote;
 
-    CMasternodePayments() : nStorageCoeff(1.25), nMinBlocksToStore(5000) {}
+    CMasternodePayments() : nStorageCoeff(1.25), nMinBlocksToStore(6000) {}
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -24,7 +24,7 @@
 
 static const uint64_t GB_BYTES = 1000000000LL;
 /* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 1;
+static const uint64_t BLOCK_CHAIN_SIZE = 10;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
 static const uint64_t CHAIN_STATE_SIZE = 1;
 /* Total required space (in GB) depending on user choice (prune, not prune) */


### PR DESCRIPTION
Few notes:
- `nMinBlocksToStore` should be close to `N masternodes` x 1.25 (`4800x1.25 = 6000`);
- blockchain size is ~7GB (with txindex only and no additional indexes, otherwise it's ~14GB but since `BLOCK_CHAIN_SIZE` is only used in GUI 10GB should be ok imo).