### PR TITLE
RPC: fix wallet lock check in `privatesend start`

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -53,7 +53,8 @@ UniValue privatesend(const JSONRPCRequest& request)
     if(request.params[0].get_str() == "start") {
         {
             LOCK(pwalletMain->cs_wallet);
-            EnsureWalletIsUnlocked();
+            if (pwalletMain->IsLocked(true))
+                throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please unlock wallet for mixing with walletpassphrase first.");
         }
 
         privateSendClient.fEnablePrivateSend = true;


### PR DESCRIPTION
Should fail only if locked completely, see https://github.com/dashpay/dash/blob/master/src/wallet/crypter.h#L158-L165 for more info about `IsLocked()` logic.

Steps to reproduce the issue:
```
> walletpassphrase "pass" 600 true
> privatesend start
error code: -13
error message:
Error: Please enter the wallet passphrase with walletpassphrase first.
> walletpassphrase "pass" 600 true
error code: -17
error message:
Error: Wallet is already unlocked for mixing only.
```

Kudos to @thephez for finding the issue 👍 