### PR TITLE
Do not create oversized transactions (bad-txns-oversize)

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3703,6 +3703,12 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                 unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
 
+                if (nBytes > MAX_STANDARD_TX_SIZE) {
+                    // Do not create oversized transactions (bad-txns-oversize).
+                    strFailReason = _("Transaction too large");
+                    return false;
+                }
+
                 CTransaction txNewConst(txNew);
                 dPriority = txNewConst.ComputePriority(dPriority, nBytes);
 


### PR DESCRIPTION
Transaction size is limited to 100kb (`MAX_STANDARD_TX_SIZE`) after DIP0001 activation. Wallet should not allow creation of larger txes because they will fail to be accepted to mempool later (and won't be relayed) anyway.