### PR TITLE
Partially revert 1922

### DIFF
--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -448,7 +448,15 @@ void CPrivateSendServer::ChargeFees(CConnman& connman)
         LogPrintf("CPrivateSendServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s\n",
                 (nState == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
 
-        connman.RelayTransaction(*vecOffendersCollaterals[0]);
+        LOCK(cs_main);
+
+        CValidationState state;
+        if(!AcceptToMemoryPool(mempool, state, vecOffendersCollaterals[0], false, NULL, NULL, false, maxTxFee)) {
+            // should never really happen
+            LogPrintf("CPrivateSendServer::ChargeFees -- ERROR: AcceptToMemoryPool failed!\n");
+        } else {
+            connman.RelayTransaction(*vecOffendersCollaterals[0]);
+        }
     }
 }
 
@@ -468,10 +476,19 @@ void CPrivateSendServer::ChargeRandomFees(CConnman& connman)
 {
     if(!fMasternodeMode) return;
 
+    LOCK(cs_main);
+
     for (const auto& txCollateral : vecSessionCollaterals) {
         if(GetRandInt(100) > 10) return;
         LogPrintf("CPrivateSendServer::ChargeRandomFees -- charging random fees, txCollateral=%s", txCollateral->ToString());
-        connman.RelayTransaction(*txCollateral);
+
+        CValidationState state;
+        if(!AcceptToMemoryPool(mempool, state, txCollateral, false, NULL, NULL, false, maxTxFee)) {
+            // should never really happen
+            LogPrintf("CPrivateSendServer::ChargeRandomFees -- ERROR: AcceptToMemoryPool failed!\n");
+        } else {
+            connman.RelayTransaction(*txCollateral);
+        }
     }
 }
 


### PR DESCRIPTION
Turned out we actually need mixing collaterals charged as mixing fees in our mempool for them to be relayed further.

Introduced in #1922 