### PR TITLE
Fix rpc tests broken by 2110

### DIFF
--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -120,7 +120,7 @@ class AddressIndexTest(BitcoinTestFramework):
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        sent_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        sent_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True, False, True)
 
         self.nodes[0].generate(1)
         self.sync_all()
@@ -149,7 +149,7 @@ class AddressIndexTest(BitcoinTestFramework):
         tx.vout = [CTxOut(amount, scriptPubKey2)]
         tx.rehash()
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        spending_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        spending_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True, False, True)
         self.nodes[0].generate(1)
         self.sync_all()
         balance1 = self.nodes[1].getaddressbalance(address2)
@@ -163,7 +163,7 @@ class AddressIndexTest(BitcoinTestFramework):
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        sent_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        sent_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True, False, True)
         self.nodes[0].generate(1)
         self.sync_all()
 
@@ -245,7 +245,7 @@ class AddressIndexTest(BitcoinTestFramework):
         tx.vout = [CTxOut(amount, scriptPubKey3)]
         tx.rehash()
         signed_tx = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        memtxid1 = self.nodes[2].sendrawtransaction(signed_tx["hex"], True)
+        memtxid1 = self.nodes[2].sendrawtransaction(signed_tx["hex"], True, False, True)
         set_mocktime(get_mocktime() + 2)
         set_node_times(self.nodes, get_mocktime())
 
@@ -260,7 +260,7 @@ class AddressIndexTest(BitcoinTestFramework):
         ]
         tx2.rehash()
         signed_tx2 = self.nodes[2].signrawtransaction(binascii.hexlify(tx2.serialize()).decode("utf-8"))
-        memtxid2 = self.nodes[2].sendrawtransaction(signed_tx2["hex"], True)
+        memtxid2 = self.nodes[2].sendrawtransaction(signed_tx2["hex"], True, False, True)
         set_mocktime(get_mocktime() + 2)
         set_node_times(self.nodes, get_mocktime())
 
@@ -288,7 +288,7 @@ class AddressIndexTest(BitcoinTestFramework):
         tx.rehash()
         self.nodes[2].importprivkey(privKey3)
         signed_tx3 = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        memtxid3 = self.nodes[2].sendrawtransaction(signed_tx3["hex"], True)
+        memtxid3 = self.nodes[2].sendrawtransaction(signed_tx3["hex"], True, False, True)
         set_mocktime(get_mocktime() + 2)
         set_node_times(self.nodes, get_mocktime())
 
@@ -321,7 +321,7 @@ class AddressIndexTest(BitcoinTestFramework):
         tx.rehash()
         self.nodes[0].importprivkey(privkey1)
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        mem_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        mem_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True, False, True)
 
         self.sync_all()
         mempool_deltas = self.nodes[2].getaddressmempool({"addresses": [address1]})

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -41,13 +41,13 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         b = [ self.nodes[0].getblockhash(n) for n in range(1, 4) ]
         coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
         spends1_raw = [ create_tx(self.nodes[0], txid, node0_address, 500) for txid in coinbase_txids ]
-        spends1_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends1_raw ]
+        spends1_id = [ self.nodes[0].sendrawtransaction(tx, False, False, True) for tx in spends1_raw ]
 
         blocks = []
         blocks.extend(self.nodes[0].generate(1))
 
         spends2_raw = [ create_tx(self.nodes[0], txid, node0_address, 499.99) for txid in spends1_id ]
-        spends2_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends2_raw ]
+        spends2_id = [ self.nodes[0].sendrawtransaction(tx, False, False, True) for tx in spends2_raw ]
 
         blocks.extend(self.nodes[0].generate(1))
 

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -43,10 +43,10 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
         spends_raw = [ create_tx(self.nodes[0], txid, node0_address, 500) for txid in coinbase_txids ]
 
-        spend_101_id = self.nodes[0].sendrawtransaction(spends_raw[0])
+        spend_101_id = self.nodes[0].sendrawtransaction(spends_raw[0], False, False, True)
 
         # coinbase at height 102 should be too immature to spend
-        assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, spends_raw[1])
+        assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, spends_raw[1], False, False, True)
 
         # mempool should have just spend_101:
         assert_equal(self.nodes[0].getrawmempool(), [ spend_101_id ])
@@ -56,7 +56,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         assert_equal(set(self.nodes[0].getrawmempool()), set())
 
         # ... and now height 102 can be spent:
-        spend_102_id = self.nodes[0].sendrawtransaction(spends_raw[1])
+        spend_102_id = self.nodes[0].sendrawtransaction(spends_raw[1], False, False, True)
         assert_equal(self.nodes[0].getrawmempool(), [ spend_102_id ])
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -44,9 +44,9 @@ class MerkleBlockTest(BitcoinTestFramework):
 
         node0utxos = self.nodes[0].listunspent(1)
         tx1 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 500})
-        txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1)["hex"])
+        txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1)["hex"], False, False, True)
         tx2 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 500})
-        txid2 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx2)["hex"])
+        txid2 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx2)["hex"], False, False, True)
         assert_raises(JSONRPCException, self.nodes[0].gettxoutproof, [txid1])
 
         self.nodes[0].generate(1)
@@ -64,7 +64,7 @@ class MerkleBlockTest(BitcoinTestFramework):
 
         txin_spent = self.nodes[1].listunspent(1).pop()
         tx3 = self.nodes[1].createrawtransaction([txin_spent], {self.nodes[0].getnewaddress(): 500})
-        self.nodes[0].sendrawtransaction(self.nodes[1].signrawtransaction(tx3)["hex"])
+        self.nodes[0].sendrawtransaction(self.nodes[1].signrawtransaction(tx3)["hex"], False, False, True)
         self.nodes[0].generate(1)
         self.sync_all()
 

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -58,7 +58,7 @@ class SpentIndexTest(BitcoinTestFramework):
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True, False, True)
         self.nodes[0].generate(1)
         self.sync_all()
 
@@ -94,7 +94,7 @@ class SpentIndexTest(BitcoinTestFramework):
         tx2.rehash()
         self.nodes[0].importprivkey(privkey)
         signed_tx2 = self.nodes[0].signrawtransaction(binascii.hexlify(tx2.serialize()).decode("utf-8"))
-        txid2 = self.nodes[0].sendrawtransaction(signed_tx2["hex"], True)
+        txid2 = self.nodes[0].sendrawtransaction(signed_tx2["hex"], True, False, True)
 
         # Check the mempool index
         self.sync_all()

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -103,8 +103,8 @@ class WalletTest (BitcoinTestFramework):
             txns_to_send.append(self.nodes[0].signrawtransaction(raw_tx))
 
         # Have node 1 (miner) send the transactions
-        self.nodes[1].sendrawtransaction(txns_to_send[0]["hex"], True)
-        self.nodes[1].sendrawtransaction(txns_to_send[1]["hex"], True)
+        self.nodes[1].sendrawtransaction(txns_to_send[0]["hex"], True, False, True)
+        self.nodes[1].sendrawtransaction(txns_to_send[1]["hex"], True, False, True)
 
         # Have node1 mine a block to confirm transactions:
         self.nodes[1].generate(1)


### PR DESCRIPTION
Fix submission of 0-fee txes via `sendrawtransaction` on mining nodes in rpc tests.

The issue was introduced in #2110 .