### PR TITLE
Do not create mnb until sync is finished

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -352,8 +352,8 @@ bool CMasternodeBroadcast::Create(const std::string& strService, const std::stri
         return false;
     };
 
-    //need correct blocks to send ping
-    if (!fOffline && !masternodeSync.IsBlockchainSynced())
+    // Wait for sync to finish because mnb simply won't be relayed otherwise
+    if (!fOffline && !masternodeSync.IsSynced())
         return Log("Sync in progress. Must wait until sync is complete to start Masternode");
 
     if (!CMessageSigner::GetKeysFromSecret(strKeyMasternode, keyMasternodeNew, pubKeyMasternodeNew))


### PR DESCRIPTION
We don't relay mnb if sync is still in progress. Creating mnb without relaying it only increases inconsistency and leads to user confusion. Unifying conditions for mnb creation and relaying fixes this.