### PR TITLE
Do not send excessive messages in governance sync

### DIFF
--- a/src/governance.h
+++ b/src/governance.h
@@ -301,8 +301,8 @@ public:
      */
     bool ConfirmInventoryRequest(const CInv& inv);
 
-    void SyncSingleObjAndItsVotes(CNode* pnode, const uint256& nProp, const CBloomFilter& filter, CConnman& connman);
-    void SyncAll(CNode* pnode, CConnman& connman) const;
+    void SyncSingleObjVotes(CNode* pnode, const uint256& nProp, const CBloomFilter& filter, CConnman& connman);
+    void SyncObjects(CNode* pnode, CConnman& connman) const;
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 


### PR DESCRIPTION
No need to send gobject inv for a single gobject, the other node already knows it, so send votes only. Also, no need to send "fake" stats like "0 votes" when syncing gobjects and "1 object" when syncing votes. And finally, rename functions accordingly.

EDIT:
PS. Haven't assigned milestone for now - should be safe to merge in 12.3 IMO, but this PR changes the actual behaviour while (strictly saying) it doesn't fix a critical bug or smth, just removes some excessive/redundant parts, so I'm open for other opinions/arguments.