### PR TITLE
Fix CVE-2018-12356 by hardening the regex

### DIFF
--- a/contrib/verify-commits/gpg.sh
+++ b/contrib/verify-commits/gpg.sh
@@ -30,7 +30,7 @@ if ! $VALID; then
 	exit 1
 fi
 if $VALID && $REVSIG; then
-	echo "$INPUT" | gpg --trust-model always "$@" | grep "\[GNUPG:\] \(NEWSIG\|SIG_ID\|VALIDSIG\)" 2>/dev/null
+	echo "$INPUT" | gpg --trust-model always "$@" | grep "^\[GNUPG:\] \(NEWSIG\|SIG_ID\|VALIDSIG\)" 2>/dev/null
 	echo "$GOODREVSIG"
 else
 	echo "$INPUT" | gpg --trust-model always "$@" 2>/dev/null


### PR DESCRIPTION
#2125 for `develop`