### PR TITLE
PrivateSend Enhancement: Up default round count to 4 and allow user to mix up to 16 rounds

### DIFF
--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -21,7 +21,7 @@ static const int MIN_PRIVATESEND_LIQUIDITY          = 0;
 static const int MAX_PRIVATESEND_ROUNDS             = 16;
 static const int MAX_PRIVATESEND_AMOUNT             = MAX_MONEY / COIN;
 static const int MAX_PRIVATESEND_LIQUIDITY          = 100;
-static const int DEFAULT_PRIVATESEND_ROUNDS         = 2;
+static const int DEFAULT_PRIVATESEND_ROUNDS         = 4;
 static const int DEFAULT_PRIVATESEND_AMOUNT         = 1000;
 static const int DEFAULT_PRIVATESEND_LIQUIDITY      = 0;
 

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -224,7 +224,7 @@
             <number>2</number>
            </property>
            <property name="maximum">
-            <number>8</number>
+            <number>16</number>
            </property>
            <property name="value">
             <number>4</number>


### PR DESCRIPTION
This is intended for 12.4
This PR consists of 2 commits
1:
Allows a user to mix up to 16 rounds
It appears the entirety of the codebase supports up to 16 rounds, except for the form where you enter how many rounds you would like it to do. This commit changes that, and allows users to use the core wallet to mix up to 16 rounds. This will potentially increase the upper bound of privacy for users who are highly concerned, and could increase liquidity in general.

2:
Ups the default for PS mixing to 4 rounds. fixes #2055 
Although 2 rounds of private send mixing does have its use case and is fine to use depending on the situation, it does not make a good default. Although the recent improvements to PrivateSend could make 2 rounds more viable and private, 2 rounds is generally accepted as not private to a sufficient degree. As such, myself and many community members believe that the default should be increased to not give users a false sense of security.