### PR TITLE
Don't drop mnb-s for outdated MNs

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -436,8 +436,8 @@ bool CMasternodeBroadcast::SimpleCheck(int& nDos)
     }
 
     if(nProtocolVersion < mnpayments.GetMinMasternodePaymentsProto()) {
-        LogPrintf("CMasternodeBroadcast::SimpleCheck -- ignoring outdated Masternode: masternode=%s  nProtocolVersion=%d\n", outpoint.ToStringShort(), nProtocolVersion);
-        return false;
+        LogPrintf("CMasternodeBroadcast::SimpleCheck -- outdated Masternode: masternode=%s  nProtocolVersion=%d\n", outpoint.ToStringShort(), nProtocolVersion);
+        nActiveState = MASTERNODE_UPDATE_REQUIRED;
     }
 
     CScript pubkeyScript;


### PR DESCRIPTION
Instead just mark them as MASTERNODE_UPDATE_REQUIRED and proceed further. Otherwise we have a bunch of missing MNs in mn list which sometimes leads to a situation when some nodes accept triggers and their votes and some don't (and they stuck).

Fixes the same issue as https://github.com/dashpay/dash/pull/1929/commits/5d658001acded7f38d5f05395e0f143476379d8e in #1929 but on receiving side.