### PR TITLE
RPC: dumphdinfo should throw an error when wallet isn't HD

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -722,6 +722,9 @@ UniValue dumphdinfo(const JSONRPCRequest& request)
         obj.push_back(Pair("mnemonicpassphrase", ssMnemonicPassphrase.c_str()));
 
         return obj;
+    } else 
+	{
+        throw JSONRPCError(RPC_WALLET_ERROR, "This wallet is not a HD (Hierarchical Deterministic) wallet.");
     }
 
     return NullUniValue;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -705,28 +705,23 @@ UniValue dumphdinfo(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked();
 
-    // add the base58check encoded extended master if the wallet uses HD
     CHDChain hdChainCurrent;
-    if (pwalletMain->GetHDChain(hdChainCurrent))
-    {
-        if (!pwalletMain->GetDecryptedHDChain(hdChainCurrent))
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Cannot decrypt HD seed");
+    if (!pwalletMain->GetHDChain(hdChainCurrent))
+        throw JSONRPCError(RPC_WALLET_ERROR, "This wallet is not a HD wallet.");
 
-        SecureString ssMnemonic;
-        SecureString ssMnemonicPassphrase;
-        hdChainCurrent.GetMnemonic(ssMnemonic, ssMnemonicPassphrase);
+    if (!pwalletMain->GetDecryptedHDChain(hdChainCurrent))
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Cannot decrypt HD seed");
 
-        UniValue obj(UniValue::VOBJ);
-        obj.push_back(Pair("hdseed", HexStr(hdChainCurrent.GetSeed())));
-        obj.push_back(Pair("mnemonic", ssMnemonic.c_str()));
-        obj.push_back(Pair("mnemonicpassphrase", ssMnemonicPassphrase.c_str()));
+    SecureString ssMnemonic;
+    SecureString ssMnemonicPassphrase;
+    hdChainCurrent.GetMnemonic(ssMnemonic, ssMnemonicPassphrase);
 
-        return obj;
-    } else {
-        throw JSONRPCError(RPC_WALLET_ERROR, "This wallet is not a HD (Hierarchical Deterministic) wallet.");
-    }
+    UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("hdseed", HexStr(hdChainCurrent.GetSeed())));
+    obj.push_back(Pair("mnemonic", ssMnemonic.c_str()));
+    obj.push_back(Pair("mnemonicpassphrase", ssMnemonicPassphrase.c_str()));
 
-    return NullUniValue;
+    return obj;
 }
 
 UniValue dumpwallet(const JSONRPCRequest& request)


### PR DESCRIPTION
Throws an RPCError `RPC_WALLET_ERROR` (text = "This wallet is not a HD (Hierarchical Deterministic) wallet.") when the command `dumphdinfo` is called and the wallet is not HD. 

This is in response to https://github.com/dashpay/dash/issues/2069