### PR TITLE
Fixes inaccurate round count in CoinControlDialog (Issue #2068)

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -433,7 +433,7 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
             item->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
         else {
             coinControl->Select(outpt);
-            int nRounds = pwalletMain->GetCappedOutpointPrivateSendRounds(outpt);
+            int nRounds = pwalletMain->GetRealOutpointPrivateSendRounds(outpt);
             if (coinControl->fUsePrivateSend && nRounds < privateSendClient.nPrivateSendRounds) {
                 QMessageBox::warning(this, windowTitle(),
                     tr("Non-anonymized input selected. <b>PrivateSend will be disabled.</b><br><br>If you still want to use PrivateSend, please deselect all non-nonymized inputs first and then check PrivateSend checkbox again."),

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -781,7 +781,7 @@ void CoinControlDialog::updateView()
 
             // PrivateSend rounds
             COutPoint outpoint = COutPoint(out.tx->tx->GetHash(), out.i);
-            int nRounds = pwalletMain->GetCappedOutpointPrivateSendRounds(outpoint);
+            int nRounds = pwalletMain->GetRealOutpointPrivateSendRounds(outpoint);
 
             if (nRounds >= 0 || fDebug) itemOutput->setText(COLUMN_PRIVATESEND_ROUNDS, QString::number(nRounds));
             else itemOutput->setText(COLUMN_PRIVATESEND_ROUNDS, tr("n/a"));


### PR DESCRIPTION
The CoinControlDialog previously displayed either the actual round count, or the maxRounds set through the options, whichever is lower (used `GetOutputPrivateSendRounds`). However, there is no reason why the CoinControlDialog should not always display the actual round count of an input (using `GetRealOutputPrivateSendRounds`). Since `GetOutputPrivateSendRounds` is defined as: 
```
    int realPrivateSendRounds = GetRealOutpointPrivateSendRounds(outpoint, 0);
    return realPrivateSendRounds > privateSendClient.nPrivateSendRounds ? privateSendClient.nPrivateSendRounds : realPrivateSendRounds;
```
This should not break anything, while making it a little bit better and more accurate. Fixes #2068 