### PR TITLE
PrepareDenominate fix

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1178,7 +1178,7 @@ bool CPrivateSendClient::PrepareDenominate(int nMinRounds, int nMaxRounds, std::
         }
     }
 
-    if (CPrivateSend::GetDenominations(vecTxOutRet) != nSessionDenom || (nSessionInputCount != 0 && nStep != nStepsMax)) {
+    if (CPrivateSend::GetDenominations(vecTxOutRet) != nSessionDenom || (nSessionInputCount != 0 && vecTxOutRet.size() != nSessionInputCount)) {
         {
             // unlock used coins on failure
             LOCK(pwalletMain->cs_wallet);

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1166,8 +1166,8 @@ bool CPrivateSendClient::PrepareDenominate(int nMinRounds, int nMaxRounds, std::
                 ++it2;
             }
         }
-        if(nValueLeft == 0) break;
         nStep++;
+        if(nValueLeft == 0) break;
     }
 
     {


### PR DESCRIPTION
https://github.com/dashpay/dash/blob/8e6364694f95bf1f675dab1d4027ae3c470a4eeb/src/privatesend-client.cpp#L1181-L1192

This check `(nSessionInputCount != 0 && nStep != nStepsMax)` will fail if amount of selected inputs (from `SelectCoinsByDenominations`) for this round equal to `nSessionInputCount`

Mixing attempt will be failed:
- if `nSessionInputCount` equal to 9 (`PRIVATESEND_ENTRY_MAX_SIZE`) 
- if overall amount of inputs for selected denomination (in all rounds) equal to `nSessionInputCount`

Here is the fix.