### PR TITLE
Fix PrepareDenominate

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1178,7 +1178,7 @@ bool CPrivateSendClient::PrepareDenominate(int nMinRounds, int nMaxRounds, std::
         }
     }
 
-    if (CPrivateSend::GetDenominations(vecTxOutRet) != nSessionDenom || (nSessionInputCount != 0 && nStep != nStepsMax)) {
+    if (CPrivateSend::GetDenominations(vecTxOutRet) != nSessionDenom || (nSessionInputCount != 0 && vecTxOutRet.size() != nSessionInputCount)) {
         {
             // unlock used coins on failure
             LOCK(pwalletMain->cs_wallet);

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1166,8 +1166,8 @@ bool CPrivateSendClient::PrepareDenominate(int nMinRounds, int nMaxRounds, std::
                 ++it2;
             }
         }
-        if(nValueLeft == 0) break;
         nStep++;
+        if(nValueLeft == 0) break;
     }
 
     {


### PR DESCRIPTION
If we have exactly `nSessionInputCount` denoms in our wallet, the mix is going to fail (due to `if(nValueLeft == 0) break;`) while it should succeed instead. This fixes the issue by checking not the steps we made but the actual number of outputs we created during the loop.

Alternative/additional to #2138 