### PR TITLE
Fix p2pkh tests asserts

### DIFF
--- a/src/test/script_P2PKH_tests.cpp
+++ b/src/test/script_P2PKH_tests.cpp
@@ -45,12 +45,12 @@ BOOST_AUTO_TEST_CASE(IsPayToPublicKeyHash)
     static const unsigned char missing2[] = {
         OP_DUP, OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
     };
-    BOOST_CHECK(!CScript(missing2, missing2+sizeof(missing)).IsPayToPublicKeyHash());
+    BOOST_CHECK(!CScript(missing2, missing2+sizeof(missing2)).IsPayToPublicKeyHash());
 
     static const unsigned char tooshort[] = {
         OP_DUP, OP_HASH160, 2, 0,0, OP_EQUALVERIFY, OP_CHECKSIG
     };
-    BOOST_CHECK(!CScript(tooshort, tooshort+sizeof(direct)).IsPayToPublicKeyHash());
+    BOOST_CHECK(!CScript(tooshort, tooshort+sizeof(tooshort)).IsPayToPublicKeyHash());
 
 }
 


### PR DESCRIPTION
Even the results were as expected,
IsPayToPublicKeyHash() breaks at size checking step now, as was intended.
Also removes compile time array-bounds warning.