### PR TITLE
Make PS Buttons not react to spacebar (#1766)

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -300,6 +300,11 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(ui->privateSendReset, SIGNAL(clicked()), this, SLOT(privateSendReset()));
         connect(ui->privateSendInfo, SIGNAL(clicked()), this, SLOT(privateSendInfo()));
         connect(ui->togglePrivateSend, SIGNAL(clicked()), this, SLOT(togglePrivateSend()));
+
+        //PrivateSend buttons never have focus. Need to be clicked on. Space or Enter has no effect.
+        ui->privateSendReset->setFocusPolicy(Qt::NoFocus);
+        ui->privateSendInfo->setFocusPolicy(Qt::NoFocus);
+        ui->togglePrivateSend->setFocusPolicy(Qt::NoFocus);
     }
 }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -302,6 +302,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(ui->togglePrivateSend, SIGNAL(clicked()), this, SLOT(togglePrivateSend()));
 
         // privatesend buttons will not react to spacebar must be clicked on
+        ui->privateSendAuto->setFocusPolicy(Qt::NoFocus);
         ui->privateSendReset->setFocusPolicy(Qt::NoFocus);
         ui->privateSendInfo->setFocusPolicy(Qt::NoFocus);
         ui->togglePrivateSend->setFocusPolicy(Qt::NoFocus);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -301,7 +301,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(ui->privateSendInfo, SIGNAL(clicked()), this, SLOT(privateSendInfo()));
         connect(ui->togglePrivateSend, SIGNAL(clicked()), this, SLOT(togglePrivateSend()));
 
-        //PrivateSend buttons never have focus. Need to be clicked on. Space or Enter has no effect.
+        // privatesend buttons will not react to spacebar must be clicked on
         ui->privateSendReset->setFocusPolicy(Qt::NoFocus);
         ui->privateSendInfo->setFocusPolicy(Qt::NoFocus);
         ui->togglePrivateSend->setFocusPolicy(Qt::NoFocus);


### PR DESCRIPTION
Wow, this one was a lot harder then it looks... I just want to say publicly that I hate qt, so much stuff that based on the documentation should have worked didn't. At least it is a simple fix in the end.

I'd like to call out to @nmarley and point out that there are no tabs in this one, no trailing spaces, etc. I'm getting better 😉 Also, I learned how to squash commits, thanks @UdjinM6 for pointing me in that direction! 

Oh yeah, and this fixes #1766.

Testing it, everything works well. Space bar doesn't seem to do anything. I am slightly worried about `privateSendAuto` only because I can't tell what it does, and don't know if the space might be triggering it now. But it also doesn't actually look to be a button, at least not one that I see anywhere, and I have seen no ill effects from it.