### PR TITLE
Adjust diff for slow testnet/devnet blocks a bit smoother

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -103,19 +103,24 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const CBlockH
         // Special difficulty rule for testnet/devnet:
         // If the new block's timestamp is more than 2* 2.5 minutes
         // then allow mining of a min-difficulty block.
-        if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2) {
-            // start using smoother adjustment on testnet when total work hits
-            // 000000000000000000000000000000000000000000000000003ff00000000000
-            if (pindexLast->nChainWork >= UintToArith256(uint256S("0x000000000000000000000000000000000000000000000000003ff00000000000"))
-                // and immediately on devnet
-                || !params.hashDevnetGenesisBlock.IsNull()) {
+
+        // start using smoother adjustment on testnet when total work hits
+        // 000000000000000000000000000000000000000000000000003ff00000000000
+        if (pindexLast->nChainWork >= UintToArith256(uint256S("0x000000000000000000000000000000000000000000000000003ff00000000000"))
+            // and immediately on devnet
+            || !params.hashDevnetGenesisBlock.IsNull()) {
+            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*4) {
                 arith_uint256 bnNew = arith_uint256().SetCompact(pindexLast->nBits) * 10;
                 if (bnNew > bnPowLimit) {
                     bnNew = bnPowLimit;
                 }
                 return bnNew.GetCompact();
             }
-            return bnPowLimit.GetCompact();
+        } else {
+            // old stuff
+            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2) {
+                return bnPowLimit.GetCompact();
+            }
         }
     }
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -105,8 +105,8 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const CBlockH
         // then allow mining of a min-difficulty block.
         if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2) {
             // start using smoother adjustment on testnet when total work hits
-            // 000000000000000000000000000000000000000000000000003f000000000000
-            if (pindexLast->nChainWork >= UintToArith256(uint256S("0x000000000000000000000000000000000000000000000000003f000000000000"))
+            // 000000000000000000000000000000000000000000000000003ff00000000000
+            if (pindexLast->nChainWork >= UintToArith256(uint256S("0x000000000000000000000000000000000000000000000000003ff00000000000"))
                 // and immediately on devnet
                 || !params.hashDevnetGenesisBlock.IsNull()) {
                 arith_uint256 bnNew = arith_uint256().SetCompact(pindexLast->nBits) * 10;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -103,8 +103,20 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const CBlockH
         // Special difficulty rule for testnet/devnet:
         // If the new block's timestamp is more than 2* 2.5 minutes
         // then allow mining of a min-difficulty block.
-        if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2)
+        if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2) {
+            // start using smoother adjustment on testnet when total work hits
+            // 000000000000000000000000000000000000000000000000003f000000000000
+            if (pindexLast->nChainWork >= UintToArith256(uint256S("0x000000000000000000000000000000000000000000000000003f000000000000"))
+                // and immediately on devnet
+                || !params.hashDevnetGenesisBlock.IsNull()) {
+                arith_uint256 bnNew = arith_uint256().SetCompact(pindexLast->nBits) * 10;
+                if (bnNew > bnPowLimit) {
+                    bnNew = bnPowLimit;
+                }
+                return bnNew.GetCompact();
+            }
             return bnPowLimit.GetCompact();
+        }
     }
 
     const CBlockIndex *pindex = pindexLast;


### PR DESCRIPTION
Unlike for bitcoin where one super-low-diff block changes nothing (diff adjusts every 2016 blocks), in per-block-adjustment algo like DGW it kind of ruins the algo a bit and the expected subsidy (blocks are produced way too fast). We should probably lower diff faster than usual for such cases but not right down to the limit.

Note: this fix is a testnet hard fork at total work `000000000000000000000000000000000000000000000000003f000000000000`.