### PR TITLE
replace map count/insert w/emplace in instantx.cpp

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1153,7 +1153,7 @@ bool CTxLockVote::IsFailed() const
 
 bool COutPointLock::AddVote(const CTxLockVote& vote)
 {
-    return mapMasternodeVotes.emplace(std::make_pair(vote.GetMasternodeOutpoint(), vote)).second;
+    return mapMasternodeVotes.emplace(vote.GetMasternodeOutpoint(), vote).second;
 }
 
 std::vector<CTxLockVote> COutPointLock::GetVotes() const

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1153,10 +1153,7 @@ bool CTxLockVote::IsFailed() const
 
 bool COutPointLock::AddVote(const CTxLockVote& vote)
 {
-    if(mapMasternodeVotes.count(vote.GetMasternodeOutpoint()))
-        return false;
-    mapMasternodeVotes.insert(std::make_pair(vote.GetMasternodeOutpoint(), vote));
-    return true;
+    return mapMasternodeVotes.emplace(std::make_pair(vote.GetMasternodeOutpoint(), vote)).second;
 }
 
 std::vector<CTxLockVote> COutPointLock::GetVotes() const


### PR DESCRIPTION
This feels like an optimization, something about:

```
if map.count(key)
     return false
else
     insert(pair)
     return true
```

... just feels icky. Plus, `vote.GetMasternodeOutpoint()` is only called
once. The previous version might be slightly more readable, however.