### PR TITLE
Sync mn list and mnw list from 3 peers max

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -259,6 +259,12 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                     return;
                 }
 
+                // request from three peers max
+                if (nRequestedMasternodeAttempt > 2) {
+                    connman.ReleaseNodeVector(vNodesCopy);
+                    return;
+                }
+
                 // only request once from each peer
                 if(netfulfilledman.HasFulfilledRequest(pnode->addr, "masternode-list-sync")) continue;
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "masternode-list-sync");
@@ -299,6 +305,12 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 if(nRequestedMasternodeAttempt > 1 && mnpayments.IsEnoughData()) {
                     LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- found enough data\n", nTick, nRequestedMasternodeAssets);
                     SwitchToNextAsset(connman);
+                    connman.ReleaseNodeVector(vNodesCopy);
+                    return;
+                }
+
+                // request from three peers max
+                if (nRequestedMasternodeAttempt > 2) {
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;
                 }


### PR DESCRIPTION
Should solve issues with initial sync and reduce load/bandwidth in general.

EDIT: Some explanation of the issue:
We ask ALL our peers for ALL mnb/mnw when we start with empty or very outdated mn cache. This can be pretty CPU intensive and might take some time. While node is trying to process all these incoming messages from all peers, it can't really see if there are new blocks or txes or anything. So, what happens is that we might miss quite a few blocks and once mnb/mnw sync is over these blocks will finally arrive BUT they arrive all at once, so for us it looks like we were cut off from the longest chain for too long and now finally caught up i.e. we could miss some mnb/mnw, so we reset sync status to try again. However, this time ALL our peers already provided us some mn/mnw and we won't ask them again to avoid being banned by them... and sync fails. What this PR does is it limits number of peers we are trying to sync from and it has few positive effects:
1. all other messages can be received from peers, that do not participate in sync (so no lag and no reset);
2. even if we fail to sync we can use other peers in the second (and 3rd) attempt which is also nice;
3. this should also lower cpu/bandwidth.