### PR TITLE
Allow mining min diff for very slow (2h+) blocks

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -109,7 +109,7 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const CBlockH
         if (pindexLast->nChainWork >= UintToArith256(uint256S("0x000000000000000000000000000000000000000000000000003ff00000000000"))
             // and immediately on devnet
             || !params.hashDevnetGenesisBlock.IsNull()) {
-            // recent block is more than 10 minues old
+            // recent block is more than 10 minutes old
             if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*4) {
                 arith_uint256 bnNew = arith_uint256().SetCompact(pindexLast->nBits) * 10;
                 if (bnNew > bnPowLimit) {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -109,6 +109,10 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const CBlockH
         if (pindexLast->nChainWork >= UintToArith256(uint256S("0x000000000000000000000000000000000000000000000000003ff00000000000"))
             // and immediately on devnet
             || !params.hashDevnetGenesisBlock.IsNull()) {
+            // recent block is more than 2 hours old
+            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + 2 * 60 * 60) {
+                return bnPowLimit.GetCompact();
+            }
             // recent block is more than 10 minutes old
             if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*4) {
                 arith_uint256 bnNew = arith_uint256().SetCompact(pindexLast->nBits) * 10;
@@ -116,10 +120,6 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const CBlockH
                     bnNew = bnPowLimit;
                 }
                 return bnNew.GetCompact();
-            }
-            // recent block is more than 2 hours old
-            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + 2 * 60 * 60) {
-                return bnPowLimit.GetCompact();
             }
         } else {
             // old stuff

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -109,12 +109,17 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const CBlockH
         if (pindexLast->nChainWork >= UintToArith256(uint256S("0x000000000000000000000000000000000000000000000000003ff00000000000"))
             // and immediately on devnet
             || !params.hashDevnetGenesisBlock.IsNull()) {
+            // recent block is more than 10 minues old
             if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*4) {
                 arith_uint256 bnNew = arith_uint256().SetCompact(pindexLast->nBits) * 10;
                 if (bnNew > bnPowLimit) {
                     bnNew = bnPowLimit;
                 }
                 return bnNew.GetCompact();
+            }
+            // recent block is more than 2 hours old
+            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + 2 * 60 * 60) {
+                return bnPowLimit.GetCompact();
             }
         } else {
             // old stuff


### PR DESCRIPTION
Add additional rule for some extreme cases. Testnet/devnet only ofc.