### PR TITLE
remove dashpay.io dns seeder

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -202,7 +202,6 @@ public:
         vSeeds.push_back(CDNSSeedData("dash.org", "dnsseed.dash.org"));
         vSeeds.push_back(CDNSSeedData("dashdot.io", "dnsseed.dashdot.io"));
         vSeeds.push_back(CDNSSeedData("masternode.io", "dnsseed.masternode.io"));
-        vSeeds.push_back(CDNSSeedData("dashpay.io", "dnsseed.dashpay.io"));
 
         // Dash addresses start with 'X'
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,76);


### PR DESCRIPTION
This is redundant as Dash Core Group runs the one at dash.org. It's also non-existent in DNS for a while now.