### PR TITLE
Install python3 in gitian builds

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -27,6 +27,7 @@ packages:
 - "bsdmainutils"
 - "ca-certificates"
 - "python"
+- "python3"
 remotes:
 - "url": "https://github.com/dashpay/dash.git"
   "dir": "dash"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -25,7 +25,9 @@ packages:
 - "libbz2-dev"
 - "python"
 - "python-dev"
-- "python-setuptools"
+- "python3"
+- "python3-dev"
+- "python3-setuptools"
 - "fonts-tuffy"
 remotes:
 - "url": "https://github.com/dashpay/dash.git"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -21,6 +21,7 @@ packages:
 - "zip"
 - "ca-certificates"
 - "python"
+- "python3"
 remotes:
 - "url": "https://github.com/dashpay/dash.git"
   "dir": "dash"


### PR DESCRIPTION
We mostly switched to python3, so we should also install it in gitian
builds. Especially the osx build needs as it otherwise fails due to
missing setuptools.