### PR TITLE
Extend Bloom Filter support to InstantSend related messages

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1121,7 +1121,11 @@ bool CTxLockVote::Sign()
 void CTxLockVote::Relay(CConnman& connman) const
 {
     CInv inv(MSG_TXLOCK_VOTE, GetHash());
-    connman.RelayInv(inv);
+    CTxLockRequest request;
+    if(instantsend.GetTxLockRequest(txHash, request))
+        connman.RelayInvFiltered(inv, *request.tx);
+    else
+        connman.RelayInv(inv);
 }
 
 bool CTxLockVote::IsExpired(int nHeight) const

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2640,6 +2640,23 @@ void CConnman::RelayInv(CInv &inv, const int minProtoVersion) {
             pnode->PushInventory(inv);
 }
 
+void CConnman::RelayInvFiltered(CInv &inv,
+                                const CTransaction& relatedTx,
+                                const int minProtoVersion) {
+    LOCK(cs_vNodes);
+    for (const auto& pnode : vNodes) {
+        if(pnode->nVersion < minProtoVersion)
+            continue;
+        {
+            LOCK(pnode->cs_filter); // TODO: do we need it?
+            if(pnode->pfilter &&
+                    !pnode->pfilter->IsRelevantAndUpdate(relatedTx))
+                continue;
+        }
+        pnode->PushInventory(inv);
+    }
+}
+
 void CConnman::RecordBytesRecv(uint64_t bytes)
 {
     LOCK(cs_totalBytesRecv);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2640,17 +2640,15 @@ void CConnman::RelayInv(CInv &inv, const int minProtoVersion) {
             pnode->PushInventory(inv);
 }
 
-void CConnman::RelayInvFiltered(CInv &inv,
-                                const CTransaction& relatedTx,
-                                const int minProtoVersion) {
+void CConnman::RelayInvFiltered(CInv &inv, const CTransaction& relatedTx, const int minProtoVersion)
+{
     LOCK(cs_vNodes);
     for (const auto& pnode : vNodes) {
         if(pnode->nVersion < minProtoVersion)
             continue;
         {
-            LOCK(pnode->cs_filter); // TODO: do we need it?
-            if(pnode->pfilter &&
-                    !pnode->pfilter->IsRelevantAndUpdate(relatedTx))
+            LOCK(pnode->cs_filter);
+            if(pnode->pfilter && !pnode->pfilter->IsRelevantAndUpdate(relatedTx))
                 continue;
         }
         pnode->PushInventory(inv);

--- a/src/net.h
+++ b/src/net.h
@@ -309,6 +309,7 @@ public:
     void RelayTransaction(const CTransaction& tx);
     void RelayTransaction(const CTransaction& tx, const CDataStream& ss);
     void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
+    void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
 
     // Addrman functions
     size_t GetAddressCount() const;


### PR DESCRIPTION
Implementation for issue https://github.com/dashpay/dash/issues/1677, add filtering during relay for lock votes