### PR TITLE
Switch RequestGovernanceObjectVotes from pointers to hashes

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -735,30 +735,6 @@ void CGovernanceObject::UpdateSentinelVariables()
     if(GetAbsoluteNoCount(VOTE_SIGNAL_VALID) >= nAbsVoteReq) fCachedValid = false;
 }
 
-void CGovernanceObject::swap(CGovernanceObject& first, CGovernanceObject& second) // nothrow
-{
-    // enable ADL (not necessary in our case, but good practice)
-    using std::swap;
-
-    // by swapping the members of two classes,
-    // the two classes are effectively swapped
-    swap(first.nHashParent, second.nHashParent);
-    swap(first.nRevision, second.nRevision);
-    swap(first.nTime, second.nTime);
-    swap(first.nDeletionTime, second.nDeletionTime);
-    swap(first.nCollateralHash, second.nCollateralHash);
-    swap(first.vchData, second.vchData);
-    swap(first.nObjectType, second.nObjectType);
-
-    // swap all cached valid flags
-    swap(first.fCachedFunding, second.fCachedFunding);
-    swap(first.fCachedValid, second.fCachedValid);
-    swap(first.fCachedDelete, second.fCachedDelete);
-    swap(first.fCachedEndorsed, second.fCachedEndorsed);
-    swap(first.fDirtyCache, second.fDirtyCache);
-    swap(first.fExpired, second.fExpired);
-}
-
 void CGovernanceObject::CheckOrphanVotes(CConnman& connman)
 {
     int64_t nNow = GetAdjustedTime();

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -194,8 +194,6 @@ public:
 
     CGovernanceObject(const CGovernanceObject& other);
 
-    void swap(CGovernanceObject& first, CGovernanceObject& second); // nothrow
-
     // Public Getter methods
 
     int64_t GetCreationTime() const {
@@ -353,12 +351,6 @@ public:
         }
 
         // AFTER DESERIALIZATION OCCURS, CACHED VARIABLES MUST BE CALCULATED MANUALLY
-    }
-
-    CGovernanceObject& operator=(CGovernanceObject from)
-    {
-        swap(*this, from);
-        return *this;
     }
 
 private:

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1065,8 +1065,8 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
     int nTimeout = 60 * 60;
     size_t nPeersPerHashMax = 3;
 
-    std::vector<CGovernanceObject*> vpGovObjsTmp;
-    std::vector<CGovernanceObject*> vpGovObjsTriggersTmp;
+    std::vector<uint256> vTriggerObjHashes;
+    std::vector<uint256> vOtherObjHashes;
 
     // This should help us to get some idea about an impact this can bring once deployed on mainnet.
     // Testnet is ~40 times smaller in masternode count, but only ~1000 masternodes usually vote,
@@ -1098,32 +1098,30 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
                 if(mapAskedRecently[nHash].size() >= nPeersPerHashMax) continue;
             }
 
-            auto govObj = objPair.second;
-            if(govObj.nObjectType == GOVERNANCE_OBJECT_TRIGGER) {
-                vpGovObjsTriggersTmp.push_back(&govObj);
+            if(objPair.second.nObjectType == GOVERNANCE_OBJECT_TRIGGER) {
+                vTriggerObjHashes.push_back(nHash);
             } else {
-                vpGovObjsTmp.push_back(&govObj);
+                vOtherObjHashes.push_back(nHash);
             }
         }
     }
 
-    LogPrint("gobject", "CGovernanceManager::RequestGovernanceObjectVotes -- start: vpGovObjsTriggersTmp %d vpGovObjsTmp %d mapAskedRecently %d\n",
-                vpGovObjsTriggersTmp.size(), vpGovObjsTmp.size(), mapAskedRecently.size());
+    LogPrint("gobject", "CGovernanceManager::RequestGovernanceObjectVotes -- start: vTriggerObjHashes %d vOtherObjHashes %d mapAskedRecently %d\n",
+                vTriggerObjHashes.size(), vOtherObjHashes.size(), mapAskedRecently.size());
 
     FastRandomContext insecure_rand;
-    // shuffle pointers
-    std::random_shuffle(vpGovObjsTriggersTmp.begin(), vpGovObjsTriggersTmp.end(), insecure_rand);
-    std::random_shuffle(vpGovObjsTmp.begin(), vpGovObjsTmp.end(), insecure_rand);
+    std::random_shuffle(vTriggerObjHashes.begin(), vTriggerObjHashes.end(), insecure_rand);
+    std::random_shuffle(vOtherObjHashes.begin(), vOtherObjHashes.end(), insecure_rand);
 
     for (int i = 0; i < nMaxObjRequestsPerNode; ++i) {
         uint256 nHashGovobj;
 
         // ask for triggers first
-        if(vpGovObjsTriggersTmp.size()) {
-            nHashGovobj = vpGovObjsTriggersTmp.back()->GetHash();
+        if(vTriggerObjHashes.size()) {
+            nHashGovobj = vTriggerObjHashes.back();
         } else {
-            if(vpGovObjsTmp.empty()) break;
-            nHashGovobj = vpGovObjsTmp.back()->GetHash();
+            if(vOtherObjHashes.empty()) break;
+            nHashGovobj = vOtherObjHashes.back();
         }
         bool fAsked = false;
         for (const auto& pnode : vNodesCopy) {
@@ -1147,17 +1145,17 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
             if(mapAskedRecently[nHashGovobj].size() >= nPeersPerHashMax) break;
         }
         // NOTE: this should match `if` above (the one before `while`)
-        if(vpGovObjsTriggersTmp.size()) {
-            vpGovObjsTriggersTmp.pop_back();
+        if(vTriggerObjHashes.size()) {
+            vTriggerObjHashes.pop_back();
         } else {
-            vpGovObjsTmp.pop_back();
+            vOtherObjHashes.pop_back();
         }
         if(!fAsked) i--;
     }
-    LogPrint("gobject", "CGovernanceManager::RequestGovernanceObjectVotes -- end: vpGovObjsTriggersTmp %d vpGovObjsTmp %d mapAskedRecently %d\n",
-                vpGovObjsTriggersTmp.size(), vpGovObjsTmp.size(), mapAskedRecently.size());
+    LogPrint("gobject", "CGovernanceManager::RequestGovernanceObjectVotes -- end: vTriggerObjHashes %d vOtherObjHashes %d mapAskedRecently %d\n",
+                vTriggerObjHashes.size(), vOtherObjHashes.size(), mapAskedRecently.size());
 
-    return int(vpGovObjsTriggersTmp.size() + vpGovObjsTmp.size());
+    return int(vTriggerObjHashes.size() + vOtherObjHashes.size());
 }
 
 bool CGovernanceManager::AcceptObjectMessage(const uint256& nHash)


### PR DESCRIPTION
While searching for a bug now fixed in #2188, I noticed that we actually use these pointers only for getting hashes later. So here is an alternative (additional?) PR which replaces pointers to gobjects with their hashes and thus solves the same issue in a different way. This one however makes code a little bit less prone to errors imo and also removes some no longer used code (which is nice :)), so I would probably prefer this one over #2188.