### PR TITLE
Make sure pwalletMain is not null whenever it's used in PS client

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -700,12 +700,8 @@ bool CPrivateSendClient::DoAutomaticDenominating(CConnman& connman, bool fDryRun
 {
     if(fMasternodeMode) return false; // no client-side mixing on masternodes
     if(!fEnablePrivateSend) return false;
+    if(!pwalletMain || pwalletMain->IsLocked(true)) return false;
     if(nState != POOL_STATE_IDLE) return false;
-
-    if (!pwalletMain) {
-        strAutoDenomResult = _("Wallet is not initialized");
-        return false;
-    }
 
     if(!masternodeSync.IsMasternodeListSynced()) {
         strAutoDenomResult = _("Can't mix while sync in progress.");


### PR DESCRIPTION
Fixes another crash when wallet is shutdown right after the start and makes code a bit safer in general :)