### PR TITLE
Fix wallet lock check in DoAutomaticDenominating

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -689,11 +689,20 @@ bool CPrivateSendClient::DoAutomaticDenominating(CConnman& connman, bool fDryRun
 {
     if(fMasternodeMode) return false; // no client-side mixing on masternodes
     if(!fEnablePrivateSend) return false;
-    if(!pwalletMain || pwalletMain->IsLocked(true)) return false;
     if(nState != POOL_STATE_IDLE) return false;
 
     if(!masternodeSync.IsMasternodeListSynced()) {
         strAutoDenomResult = _("Can't mix while sync in progress.");
+        return false;
+    }
+
+    if (!pwalletMain) {
+        strAutoDenomResult = _("Wallet is not initialized");
+        return false;
+    }
+
+    if(!fDryRun && pwalletMain->IsLocked(true)) {
+        strAutoDenomResult = _("Wallet is locked.");
         return false;
     }
 
@@ -708,11 +717,6 @@ bool CPrivateSendClient::DoAutomaticDenominating(CConnman& connman, bool fDryRun
     TRY_LOCK(cs_darksend, lockDS);
     if(!lockDS) {
         strAutoDenomResult = _("Lock is already in place.");
-        return false;
-    }
-
-    if(!fDryRun && pwalletMain->IsLocked(true)) {
-        strAutoDenomResult = _("Wallet is locked.");
         return false;
     }
 


### PR DESCRIPTION
Looks like we check if wallet is locked twice here and the one at line 692 is actually doing it wrong (not checking `fDryRun` and not providing any `strAutoDenomResult`). Introduced in https://github.com/dashpay/dash/pull/882/files#diff-568a69d65983b416159f2a6f562c84f4R1360.