### PR TITLE
Add `previousbits` field to `getblocktemplate` output

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -182,6 +182,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
     pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
     pblock->nNonce         = 0;
+    pblocktemplate->nPrevBits = pindexPrev->nBits;
     pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(*pblock->vtx[0]);
 
     CValidationState state;

--- a/src/miner.h
+++ b/src/miner.h
@@ -30,6 +30,7 @@ struct CBlockTemplate
     CBlock block;
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOps;
+    uint32_t nPrevBits;
     CTxOut txoutMasternode; // masternode payment
     std::vector<CTxOut> voutSuperblock; // superblock payment
 };

--- a/src/miner.h
+++ b/src/miner.h
@@ -30,7 +30,7 @@ struct CBlockTemplate
     CBlock block;
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOps;
-    uint32_t nPrevBits;
+    uint32_t nPrevBits; // nBits of previous block (for subsidy calculation)
     CTxOut txoutMasternode; // masternode payment
     std::vector<CTxOut> voutSuperblock; // superblock payment
 };

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -385,6 +385,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             "  \"sizelimit\" : n,                  (numeric) limit of block size\n"
             "  \"curtime\" : ttt,                  (numeric) current timestamp in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"bits\" : \"xxxxxxxx\",              (string) compressed target of next block\n"
+            "  \"previousbits\" : \"xxxxxxxx\",      (string) compressed target of current highest block\n"
             "  \"height\" : n                      (numeric) The height of the next block\n"
             "  \"masternode\" : {                  (json object) required masternode payee that must be included in the next block\n"
             "      \"payee\" : \"xxxx\",             (string) payee address\n"
@@ -696,6 +697,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("sizelimit", (int64_t)MaxBlockSize(fDIP0001ActiveAtTip)));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
+    result.push_back(Pair("previousbits", strprintf("%08x", pblocktemplate->nPrevBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
     UniValue masternodeObj(UniValue::VOBJ);


### PR DESCRIPTION
This should allow calculating block subsidy for the next block to be mined using the info from `getblocktemplate` output outside of Dash Core.