### PR TITLE
Split PS into Manager and Session and allow running multiple mixing sessions in parallel (on client side)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -568,6 +568,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageGroup(_("PrivateSend options:"));
     strUsage += HelpMessageOpt("-enableprivatesend=<n>", strprintf(_("Enable use of automated PrivateSend for funds stored in this wallet (0-1, default: %u)"), 0));
     strUsage += HelpMessageOpt("-privatesendmultisession=<n>", strprintf(_("Enable multiple PrivateSend mixing sessions per block, experimental (0-1, default: %u)"), DEFAULT_PRIVATESEND_MULTISESSION));
+    strUsage += HelpMessageOpt("-privatesendsessions=<n>", strprintf(_("Use N separate masternodes in parallel to mix funds (%u-%u, default: %u)"), MIN_PRIVATESEND_SESSIONS, MAX_PRIVATESEND_SESSIONS, DEFAULT_PRIVATESEND_SESSIONS));
     strUsage += HelpMessageOpt("-privatesendrounds=<n>", strprintf(_("Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)"), MIN_PRIVATESEND_ROUNDS, MAX_PRIVATESEND_ROUNDS, DEFAULT_PRIVATESEND_ROUNDS));
     strUsage += HelpMessageOpt("-privatesendamount=<n>", strprintf(_("Keep N DASH anonymized (%u-%u, default: %u)"), MIN_PRIVATESEND_AMOUNT, MAX_PRIVATESEND_AMOUNT, DEFAULT_PRIVATESEND_AMOUNT));
     strUsage += HelpMessageOpt("-liquidityprovider=<n>", strprintf(_("Provide liquidity to PrivateSend by infrequently mixing coins on a continual basis (%u-%u, default: %u, 1=very frequent, high fees, %u=very infrequent, low fees)"),
@@ -907,6 +908,8 @@ void InitParameterInteraction()
     if (nLiqProvTmp > 0) {
         ForceSetArg("-enableprivatesend", "1");
         LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -enableprivatesend=1\n", __func__, nLiqProvTmp);
+        ForceSetArg("-privatesendsessions", itostr(MIN_PRIVATESEND_SESSIONS));
+        LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -privatesendsessions=%d\n", __func__, nLiqProvTmp, itostr(std::numeric_limits<int>::max()));
         ForceSetArg("-privatesendrounds", itostr(std::numeric_limits<int>::max()));
         LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -privatesendrounds=%d\n", __func__, nLiqProvTmp, itostr(std::numeric_limits<int>::max()));
         ForceSetArg("-privatesendamount", itostr(MAX_PRIVATESEND_AMOUNT));
@@ -1867,6 +1870,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     privateSendClient.fEnablePrivateSend = GetBoolArg("-enableprivatesend", false);
     privateSendClient.fPrivateSendMultiSession = GetBoolArg("-privatesendmultisession", DEFAULT_PRIVATESEND_MULTISESSION);
+    privateSendClient.nPrivateSendSessions = std::min(std::max((int)GetArg("-privatesendsessions", DEFAULT_PRIVATESEND_SESSIONS), MIN_PRIVATESEND_SESSIONS), MAX_PRIVATESEND_SESSIONS);
     privateSendClient.nPrivateSendRounds = std::min(std::max((int)GetArg("-privatesendrounds", DEFAULT_PRIVATESEND_ROUNDS), MIN_PRIVATESEND_ROUNDS), nMaxRounds);
     privateSendClient.nPrivateSendAmount = std::min(std::max((int)GetArg("-privatesendamount", DEFAULT_PRIVATESEND_AMOUNT), MIN_PRIVATESEND_AMOUNT), MAX_PRIVATESEND_AMOUNT);
 #endif // ENABLE_WALLET

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1959,7 +1959,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             scheduler.scheduleEvery(boost::bind(&CPrivateSendServer::DoMaintenance, boost::ref(privateSendServer), boost::ref(*g_connman)), 1);
 #ifdef ENABLE_WALLET
         else
-            scheduler.scheduleEvery(boost::bind(&CPrivateSendClient::DoMaintenance, boost::ref(privateSendClient), boost::ref(*g_connman)), 1);
+            scheduler.scheduleEvery(boost::bind(&CPrivateSendClientManager::DoMaintenance, boost::ref(privateSendClient), boost::ref(*g_connman)), 1);
 #endif // ENABLE_WALLET
     }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -718,11 +718,22 @@ void CMasternodeMan::ProcessMasternodeConnections(CConnman& connman)
     //we don't care about this for regtest
     if(Params().NetworkIDString() == CBaseChainParams::REGTEST) return;
 
-    connman.ForEachNode(CConnman::AllNodes, [](CNode* pnode) {
+    std::vector<masternode_info_t> vecMnInfo; // will be empty when no wallet
 #ifdef ENABLE_WALLET
-        if(pnode->fMasternode && !privateSendClient.IsMixingMasternode(pnode)) {
-#else
-        if(pnode->fMasternode) {
+    privateSendClient.GetMixingMasternodesInfo(vecMnInfo);
+#endif // ENABLE_WALLET
+
+    connman.ForEachNode(CConnman::AllNodes, [&vecMnInfo](CNode* pnode) {
+        if (pnode->fMasternode) {
+#ifdef ENABLE_WALLET
+            bool fFound = false;
+            for (const auto& mnInfo : vecMnInfo) {
+                if (pnode->addr == mnInfo.addr) {
+                    fFound = true;
+                    break;
+                }
+            }
+            if (fFound) return; // do NOT disconnect mixing masternodes
 #endif // ENABLE_WALLET
             LogPrintf("Closing Masternode connection: peer=%d, addr=%s\n", pnode->id, pnode->addr.ToString());
             pnode->fDisconnect = true;

--- a/src/net.h
+++ b/src/net.h
@@ -65,7 +65,7 @@ static const int MAX_OUTBOUND_CONNECTIONS = 8;
 /** Maximum number of addnode outgoing nodes */
 static const int MAX_ADDNODE_CONNECTIONS = 8;
 /** Maximum number if outgoing masternodes */
-static const int MAX_OUTBOUND_MASTERNODE_CONNECTIONS = 20;
+static const int MAX_OUTBOUND_MASTERNODE_CONNECTIONS = 30;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -963,7 +963,7 @@ bool CPrivateSendClientManager::DoAutomaticDenominating(CConnman& connman, bool 
     }
 
     bool fResult = true;
-    if ((int)vecSessions.size() < MAX_PARALLEL_PRIVATESEND_SESSIONS) {
+    if ((int)vecSessions.size() < nPrivateSendSessions) {
         vecSessions.emplace_back();
     }
     for (auto& session : vecSessions) {

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -368,11 +368,6 @@ bool CPrivateSendClientSession::GetMixingMasternodeInfo(masternode_info_t& mnInf
     return infoMixingMasternode.fInfoValid;
 }
 
-bool CPrivateSendClientSession::IsMixingMasternode(const CNode* pnode) const
-{
-    return infoMixingMasternode.fInfoValid && pnode->addr == infoMixingMasternode.addr;
-}
-
 bool CPrivateSendClientManager::GetMixingMasternodesInfo(std::vector<masternode_info_t>& vecMnInfoRet) const
 {
     LOCK(cs_vecsessions);
@@ -383,18 +378,6 @@ bool CPrivateSendClientManager::GetMixingMasternodesInfo(std::vector<masternode_
         }
     }
     return !vecMnInfoRet.empty();
-}
-
-bool CPrivateSendClientManager::IsMixingMasternode(const CNode* pnode) const
-{
-    // TODO: fix deadlock with cs_vNodes in CMasternodeMan::ProcessMasternodeConnections() :/
-    // LOCK(cs_vecsessions);
-    for (const auto& session : vecSessions) {
-        if (session.IsMixingMasternode(pnode)) {
-            return true;
-        }
-    }
-    return false;
 }
 
 //

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -128,7 +128,17 @@ private:
     void SetNull();
 
 public:
-    CPrivateSendClientSession() { SetNull(); }
+    CPrivateSendClientSession() :
+        vecOutPointLocked(),
+        nEntriesCount(0),
+        fLastEntryAccepted(false),
+        strLastMessage(),
+        strAutoDenomResult(),
+        infoMixingMasternode(),
+        txMyCollateral(),
+        pendingDsaRequest(),
+        keyHolderStorage()
+        {}
     CPrivateSendClientSession(const CPrivateSendClientSession& other) { /* dummy copy constructor*/ SetNull(); }
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
@@ -191,6 +201,9 @@ public:
     bool fCreateAutoBackups; //builtin support for automatic backups
 
     CPrivateSendClientManager() :
+        vecMasternodesUsed(),
+        vecDenominationsSkipped(),
+        vecSessions(),
         nCachedLastSuccessBlock(0),
         nMinBlocksToWait(1),
         strAutoDenomResult(),

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -165,6 +165,7 @@ private:
 
     // TODO: or map<denom, CPrivateSendClientSession> ??
     std::vector<CPrivateSendClientSession> vecSessions;
+    mutable CCriticalSection cs_vecsessions;
 
     int nCachedLastSuccessBlock;
     int nMinBlocksToWait; // how many blocks to wait after one successful mixing tx in non-multisession mode

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -10,7 +10,7 @@
 #include "wallet/wallet.h"
 #include "privatesend-util.h"
 
-class CPrivateSendClient;
+class CPrivateSendClientManager;
 class CConnman;
 
 static const int DENOMS_COUNT_MAX                   = 100;
@@ -26,6 +26,7 @@ static const int DEFAULT_PRIVATESEND_AMOUNT         = 1000;
 static const int DEFAULT_PRIVATESEND_LIQUIDITY      = 0;
 
 static const bool DEFAULT_PRIVATESEND_MULTISESSION  = false;
+static const int MAX_PARALLEL_PRIVATESEND_SESSIONS  = 4;
 
 // Warn user if mixing in gui or try to create backup if mixing in daemon mode
 // when we have only this many keys left
@@ -34,7 +35,7 @@ static const int PRIVATESEND_KEYS_THRESHOLD_WARNING = 100;
 static const int PRIVATESEND_KEYS_THRESHOLD_STOP    = 50;
 
 // The main object for accessing mixing
-extern CPrivateSendClient privateSendClient;
+extern CPrivateSendClientManager privateSendClient;
 
 class CPendingDsaRequest
 {
@@ -75,22 +76,10 @@ public:
     }
 };
 
-/** Used to keep track of current status of mixing pool
- */
-class CPrivateSendClient : public CPrivateSendBase
+class CPrivateSendClientSession : public CPrivateSendBaseSession
 {
 private:
-    // Keep track of the used Masternodes
-    std::vector<COutPoint> vecMasternodesUsed;
-
-    std::vector<CAmount> vecDenominationsSkipped;
     std::vector<COutPoint> vecOutPointLocked;
-
-    int nCachedLastSuccessBlock;
-    int nMinBlocksToWait; // how many blocks to wait after one successful mixing tx in non-multisession mode
-
-    // Keep track of current block height
-    int nCachedBlockHeight;
 
     int nEntriesCount;
     bool fLastEntryAccepted;
@@ -104,19 +93,6 @@ private:
 
     CKeyHolderStorage keyHolderStorage; // storage for keys used in PrepareDenominate
 
-    /// Check for process
-    void CheckPool();
-    void CompletedTransaction(PoolMessage nMessageID);
-
-    bool IsDenomSkipped(CAmount nDenomValue);
-
-    bool WaitForAnotherBlock();
-
-    // Make sure we have enough keys since last backup
-    bool CheckAutomaticBackup();
-    bool JoinExistingQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman);
-    bool StartNewQueue(CAmount nValueMin, CAmount nBalanceNeedsAnonymized, CConnman& connman);
-
     /// Create denominations
     bool CreateDenominated(CConnman& connman);
     bool CreateDenominated(const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals, CConnman& connman);
@@ -125,8 +101,9 @@ private:
     bool MakeCollateralAmounts(CConnman& connman);
     bool MakeCollateralAmounts(const CompactTallyItem& tallyItem, bool fTryDenominated, CConnman& connman);
 
-    /// As a client, submit part of a future mixing transaction to a Masternode to start the process
-    bool SubmitDenominate(CConnman& connman);
+    bool JoinExistingQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman);
+    bool StartNewQueue(CAmount nValueMin, CAmount nBalanceNeedsAnonymized, CConnman& connman);
+
     /// step 1: prepare denominated inputs and outputs
     bool PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, std::vector<CTxDSIn>& vecTxDSInRet, std::vector<CTxOut>& vecTxOutRet);
     /// step 2: send denominated inputs and outputs prepared in step 1
@@ -137,12 +114,67 @@ private:
     // Set the 'state' value, with some logging and capturing when the state changed
     void SetState(PoolState nStateNew);
 
+    /// Check for process
+    void CheckPool();
+    void CompletedTransaction(PoolMessage nMessageID);
+
     /// As a client, check and sign the final transaction
     bool SignFinalTransaction(const CTransaction& finalTransactionNew, CNode* pnode, CConnman& connman);
 
     void RelayIn(const CDarkSendEntry& entry, CConnman& connman);
 
     void SetNull();
+
+public:
+    CPrivateSendClientSession() { SetNull(); }
+    CPrivateSendClientSession(const CPrivateSendClientSession& other) { /* dummy copy constructor*/ SetNull(); }
+
+    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
+
+    void UnlockCoins();
+
+    void ResetPool();
+
+    std::string GetStatus(bool fWaitForBlock);
+
+    bool GetMixingMasternodeInfo(masternode_info_t& mnInfoRet) const;
+    bool IsMixingMasternode(const CNode* pnode) const;
+
+    /// Passively run mixing in the background according to the configuration in settings
+    bool DoAutomaticDenominating(CConnman& connman, bool fDryRun=false);
+
+    /// As a client, submit part of a future mixing transaction to a Masternode to start the process
+    bool SubmitDenominate(CConnman& connman);
+
+    bool ProcessPendingDsaRequest(CConnman& connman);
+
+    bool CheckTimeout();
+};
+
+/** Used to keep track of current status of mixing pool
+ */
+class CPrivateSendClientManager : public CPrivateSendBaseManager
+{
+private:
+    // Keep track of the used Masternodes
+    std::vector<COutPoint> vecMasternodesUsed;
+
+    std::vector<CAmount> vecDenominationsSkipped;
+
+    // TODO: or map<denom, CPrivateSendClientSession> ??
+    std::vector<CPrivateSendClientSession> vecSessions;
+
+    int nCachedLastSuccessBlock;
+    int nMinBlocksToWait; // how many blocks to wait after one successful mixing tx in non-multisession mode
+    std::string strAutoDenomResult;
+
+    // Keep track of current block height
+    int nCachedBlockHeight;
+
+    bool WaitForAnotherBlock();
+
+    // Make sure we have enough keys since last backup
+    bool CheckAutomaticBackup();
 
 public:
     int nPrivateSendRounds;
@@ -154,40 +186,47 @@ public:
     int nCachedNumBlocks; //used for the overview screen
     bool fCreateAutoBackups; //builtin support for automatic backups
 
-    CPrivateSendClient() :
+    CPrivateSendClientManager() :
         nCachedLastSuccessBlock(0),
         nMinBlocksToWait(1),
-        txMyCollateral(CMutableTransaction()),
+        strAutoDenomResult(),
+        nCachedBlockHeight(0),
         nPrivateSendRounds(DEFAULT_PRIVATESEND_ROUNDS),
         nPrivateSendAmount(DEFAULT_PRIVATESEND_AMOUNT),
         nLiquidityProvider(DEFAULT_PRIVATESEND_LIQUIDITY),
         fEnablePrivateSend(false),
         fPrivateSendMultiSession(DEFAULT_PRIVATESEND_MULTISESSION),
         nCachedNumBlocks(std::numeric_limits<int>::max()),
-        fCreateAutoBackups(true) { SetNull(); }
+        fCreateAutoBackups(true)
+        {}
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
+    bool IsDenomSkipped(const CAmount& nDenomValue);
+    void AddSkippedDenom(const CAmount& nDenomValue);
     void ClearSkippedDenominations() { vecDenominationsSkipped.clear(); }
 
     void SetMinBlocksToWait(int nMinBlocksToWaitIn) { nMinBlocksToWait = nMinBlocksToWaitIn; }
 
-
     void ResetPool();
 
-    void UnlockCoins();
+    std::string GetStatuses();
+    std::string GetSessionDenoms();
 
-    std::string GetStatus();
-
-    bool GetMixingMasternodeInfo(masternode_info_t& mnInfoRet);
-    bool IsMixingMasternode(const CNode* pnode);
+    bool GetMixingMasternodesInfo(std::vector<masternode_info_t>& vecMnInfoRet) const;
+    bool IsMixingMasternode(const CNode* pnode) const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun=false);
 
+    void CheckTimeout();
+
     void ProcessPendingDsaRequest(CConnman& connman);
 
-    void CheckTimeout();
+    void AddUsedMasternode(const COutPoint& outpointMn);
+    masternode_info_t GetNotUsedMasternode();
+
+    void UpdatedSuccessBlock();
 
     void UpdatedBlockTip(const CBlockIndex *pindex);
 

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -15,18 +15,20 @@ class CConnman;
 
 static const int DENOMS_COUNT_MAX                   = 100;
 
+static const int MIN_PRIVATESEND_SESSIONS           = 1;
 static const int MIN_PRIVATESEND_ROUNDS             = 2;
 static const int MIN_PRIVATESEND_AMOUNT             = 2;
 static const int MIN_PRIVATESEND_LIQUIDITY          = 0;
+static const int MAX_PRIVATESEND_SESSIONS           = 10;
 static const int MAX_PRIVATESEND_ROUNDS             = 16;
 static const int MAX_PRIVATESEND_AMOUNT             = MAX_MONEY / COIN;
 static const int MAX_PRIVATESEND_LIQUIDITY          = 100;
+static const int DEFAULT_PRIVATESEND_SESSIONS       = 4;
 static const int DEFAULT_PRIVATESEND_ROUNDS         = 4;
 static const int DEFAULT_PRIVATESEND_AMOUNT         = 1000;
 static const int DEFAULT_PRIVATESEND_LIQUIDITY      = 0;
 
 static const bool DEFAULT_PRIVATESEND_MULTISESSION  = false;
-static const int MAX_PARALLEL_PRIVATESEND_SESSIONS  = 4;
 
 // Warn user if mixing in gui or try to create backup if mixing in daemon mode
 // when we have only this many keys left
@@ -177,6 +179,7 @@ private:
     bool CheckAutomaticBackup();
 
 public:
+    int nPrivateSendSessions;
     int nPrivateSendRounds;
     int nPrivateSendAmount;
     int nLiquidityProvider;

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -150,7 +150,6 @@ public:
     std::string GetStatus(bool fWaitForBlock);
 
     bool GetMixingMasternodeInfo(masternode_info_t& mnInfoRet) const;
-    bool IsMixingMasternode(const CNode* pnode) const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun=false);
@@ -231,7 +230,6 @@ public:
     std::string GetSessionDenoms();
 
     bool GetMixingMasternodesInfo(std::vector<masternode_info_t>& vecMnInfoRet) const;
-    bool IsMixingMasternode(const CNode* pnode) const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun=false);

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -76,7 +76,7 @@ void CPrivateSendServer::ProcessMessage(CNode* pfrom, const std::string& strComm
         }
 
     } else if(strCommand == NetMsgType::DSQUEUE) {
-        TRY_LOCK(cs_darksend, lockRecv);
+        TRY_LOCK(cs_vecqueue, lockRecv);
         if(!lockRecv) return;
 
         if(pfrom->nVersion < MIN_PRIVATESEND_PEER_PROTO_VERSION) {
@@ -282,7 +282,8 @@ void CPrivateSendServer::SetNull()
     // MN side
     vecSessionCollaterals.clear();
 
-    CPrivateSendBase::SetNull();
+    CPrivateSendBaseSession::SetNull();
+    CPrivateSendBaseManager::SetNull();
 }
 
 //

--- a/src/privatesend-server.h
+++ b/src/privatesend-server.h
@@ -15,7 +15,7 @@ extern CPrivateSendServer privateSendServer;
 
 /** Used to keep track of current status of mixing pool
  */
-class CPrivateSendServer : public CPrivateSendBase
+class CPrivateSendServer : public CPrivateSendBaseSession, public CPrivateSendBaseManager
 {
 private:
     // Mixing uses collateral transactions to trust parties entering the pool
@@ -66,8 +66,7 @@ private:
     void SetNull();
 
 public:
-    CPrivateSendServer() :
-        fUnitTest(false) { SetNull(); }
+    CPrivateSendServer() : fUnitTest(false) {}
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 

--- a/src/privatesend-server.h
+++ b/src/privatesend-server.h
@@ -66,7 +66,7 @@ private:
     void SetNull();
 
 public:
-    CPrivateSendServer() : fUnitTest(false) {}
+    CPrivateSendServer() : vecSessionCollaterals(), fUnitTest(false) {}
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -212,7 +212,7 @@ void CPrivateSendBaseManager::CheckQueue()
     std::vector<CDarksendQueue>::iterator it = vecDarksendQueue.begin();
     while(it != vecDarksendQueue.end()) {
         if((*it).IsExpired()) {
-            LogPrint("privatesend", "CPrivateSendBase::%s -- Removing expired queue (%s)\n", __func__, (*it).ToString());
+            LogPrint("privatesend", "CPrivateSendBaseManager::%s -- Removing expired queue (%s)\n", __func__, (*it).ToString());
             it = vecDarksendQueue.erase(it);
         } else ++it;
     }
@@ -527,5 +527,5 @@ void CPrivateSend::SyncTransaction(const CTransaction& tx, const CBlockIndex *pi
 
     // When tx is 0-confirmed or conflicted, posInBlock is SYNC_TRANSACTION_NOT_IN_BLOCK and nConfirmedHeight should be set to -1
     mapDSTX[txHash].SetConfirmedHeight(posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK ? -1 : pindex->nHeight);
-    LogPrint("privatesend", "CPrivateSendClient::SyncTransaction -- txid=%s\n", txHash.ToString());
+    LogPrint("privatesend", "CPrivateSend::SyncTransaction -- txid=%s\n", txHash.ToString());
 }

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -183,9 +183,10 @@ bool CDarksendBroadcastTx::IsExpired(int nHeight)
     return (nConfirmedHeight != -1) && (nHeight - nConfirmedHeight > 24);
 }
 
-void CPrivateSendBase::SetNull()
+void CPrivateSendBaseSession::SetNull()
 {
     // Both sides
+    LOCK(cs_darksend);
     nState = POOL_STATE_IDLE;
     nSessionID = 0;
     nSessionDenom = 0;
@@ -196,9 +197,15 @@ void CPrivateSendBase::SetNull()
     nTimeLastSuccessfulStep = GetTime();
 }
 
-void CPrivateSendBase::CheckQueue()
+void CPrivateSendBaseManager::SetNull()
 {
-    TRY_LOCK(cs_darksend, lockDS);
+    LOCK(cs_vecqueue);
+    vecDarksendQueue.clear();
+}
+
+void CPrivateSendBaseManager::CheckQueue()
+{
+    TRY_LOCK(cs_vecqueue, lockDS);
     if(!lockDS) return; // it's ok to fail here, we run this quite frequently
 
     // check mixing queue objects for timeouts
@@ -211,7 +218,23 @@ void CPrivateSendBase::CheckQueue()
     }
 }
 
-std::string CPrivateSendBase::GetStateString() const
+bool CPrivateSendBaseManager::GetQueueItemAndTry(CDarksendQueue& dsqRet)
+{
+    TRY_LOCK(cs_vecqueue, lockDS);
+    if(!lockDS) return false; // it's ok to fail here, we run this quite frequently
+
+    for (auto& dsq : vecDarksendQueue) {
+        // only try each queue once
+        if(dsq.fTried || dsq.IsExpired()) continue;
+        dsq.fTried = true;
+        dsqRet = dsq;
+        return true;
+    }
+
+    return false;
+}
+
+std::string CPrivateSendBaseSession::GetStateString() const
 {
     switch(nState) {
         case POOL_STATE_IDLE:                   return "IDLE";

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -348,13 +348,10 @@ public:
 };
 
 // base class
-class CPrivateSendBase
+class CPrivateSendBaseSession
 {
 protected:
     mutable CCriticalSection cs_darksend;
-
-    // The current mixing sessions in progress on the network
-    std::vector<CDarksendQueue> vecDarksendQueue;
 
     std::vector<CDarkSendEntry> vecEntries; // Masternode/clients entries
 
@@ -366,19 +363,43 @@ protected:
     CMutableTransaction finalMutableTransaction; // the finalized transaction ready for signing
 
     void SetNull();
-    void CheckQueue();
 
 public:
-    int nSessionDenom; //Users must submit an denom matching this
+    int nSessionDenom; //Users must submit a denom matching this
     int nSessionInputCount; //Users must submit a count matching this
 
-    CPrivateSendBase() { SetNull(); }
+    CPrivateSendBaseSession() :
+        nState(POOL_STATE_IDLE),
+        nTimeLastSuccessfulStep(0),
+        nSessionID(0),
+        nSessionDenom(0),
+        nSessionInputCount(0)
+        {}
+    CPrivateSendBaseSession(const CPrivateSendBaseSession& other) { /* dummy copy constructor*/ SetNull(); }
 
-    int GetQueueSize() const { return vecDarksendQueue.size(); }
     int GetState() const { return nState; }
     std::string GetStateString() const;
 
     int GetEntriesCount() const { return vecEntries.size(); }
+};
+
+// base class
+class CPrivateSendBaseManager
+{
+protected:
+    mutable CCriticalSection cs_vecqueue;
+
+    // The current mixing sessions in progress on the network
+    std::vector<CDarksendQueue> vecDarksendQueue;
+
+    void SetNull();
+    void CheckQueue();
+
+public:
+    CPrivateSendBaseManager() {}
+
+    int GetQueueSize() const { return vecDarksendQueue.size(); }
+    bool GetQueueItemAndTry(CDarksendQueue& dsqRet);
 };
 
 // helper class

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -369,9 +369,11 @@ public:
     int nSessionInputCount; //Users must submit a count matching this
 
     CPrivateSendBaseSession() :
+        vecEntries(),
         nState(POOL_STATE_IDLE),
         nTimeLastSuccessfulStep(0),
         nSessionID(0),
+        finalMutableTransaction(),
         nSessionDenom(0),
         nSessionInputCount(0)
         {}
@@ -396,7 +398,7 @@ protected:
     void CheckQueue();
 
 public:
-    CPrivateSendBaseManager() {}
+    CPrivateSendBaseManager() : vecDarksendQueue() {}
 
     int GetQueueSize() const { return vecDarksendQueue.size(); }
     bool GetQueueItemAndTry(CDarksendQueue& dsqRet);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -564,7 +564,7 @@ void OverviewPage::privateSendStatus()
         updatePrivateSendProgress();
     }
 
-    QString strStatus = QString(privateSendClient.GetStatus().c_str());
+    QString strStatus = QString(privateSendClient.GetStatuses().c_str());
 
     QString s = tr("Last PrivateSend message:\n") + strStatus;
 
@@ -573,13 +573,7 @@ void OverviewPage::privateSendStatus()
 
     ui->labelPrivateSendLastMessage->setText(s);
 
-    if(privateSendClient.nSessionDenom == 0){
-        ui->labelSubmittedDenom->setText(tr("N/A"));
-    } else {
-        QString strDenom(CPrivateSend::GetDenominationsToString(privateSendClient.nSessionDenom).c_str());
-        ui->labelSubmittedDenom->setText(strDenom);
-    }
-
+    ui->labelSubmittedDenom->setText(QString(privateSendClient.GetSessionDenoms().c_str()));
 }
 
 void OverviewPage::privateSendAuto(){
@@ -642,7 +636,7 @@ void OverviewPage::togglePrivateSend(){
 
     if(!privateSendClient.fEnablePrivateSend){
         ui->togglePrivateSend->setText(tr("Start Mixing"));
-        privateSendClient.UnlockCoins();
+        privateSendClient.ResetPool();
     } else {
         ui->togglePrivateSend->setText(tr("Stop Mixing"));
     }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -59,7 +59,7 @@ UniValue privatesend(const JSONRPCRequest& request)
 
         privateSendClient.fEnablePrivateSend = true;
         bool result = privateSendClient.DoAutomaticDenominating(*g_connman);
-        return "Mixing " + (result ? "started successfully" : ("start failed: " + privateSendClient.GetStatus() + ", will retry"));
+        return "Mixing " + (result ? "started successfully" : ("start failed: " + privateSendClient.GetStatuses() + ", will retry"));
     }
 
     if(request.params[0].get_str() == "stop") {
@@ -84,19 +84,25 @@ UniValue getpoolinfo(const JSONRPCRequest& request)
             "Returns an object containing mixing pool related information.\n");
 
 #ifdef ENABLE_WALLET
-    CPrivateSendBase* pprivateSendBase = fMasternodeMode ? (CPrivateSendBase*)&privateSendServer : (CPrivateSendBase*)&privateSendClient;
+    CPrivateSendBaseManager* pprivateSendBaseManager = fMasternodeMode ? (CPrivateSendBaseManager*)&privateSendServer : (CPrivateSendBaseManager*)&privateSendClient;
 
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("state",             pprivateSendBase->GetStateString()));
-    obj.push_back(Pair("mixing_mode",       (!fMasternodeMode && privateSendClient.fPrivateSendMultiSession) ? "multi-session" : "normal"));
-    obj.push_back(Pair("queue",             pprivateSendBase->GetQueueSize()));
-    obj.push_back(Pair("entries",           pprivateSendBase->GetEntriesCount()));
-    obj.push_back(Pair("status",            privateSendClient.GetStatus()));
+    // TODO:
+    // obj.push_back(Pair("state",             pprivateSendBase->GetStateString()));
+    obj.push_back(Pair("queue",             pprivateSendBaseManager->GetQueueSize()));
+    // obj.push_back(Pair("entries",           pprivateSendBase->GetEntriesCount()));
+    obj.push_back(Pair("status",            privateSendClient.GetStatuses()));
 
-    masternode_info_t mnInfo;
-    if (privateSendClient.GetMixingMasternodeInfo(mnInfo)) {
-        obj.push_back(Pair("outpoint",      mnInfo.outpoint.ToStringShort()));
-        obj.push_back(Pair("addr",          mnInfo.addr.ToString()));
+    std::vector<masternode_info_t> vecMnInfo;
+    if (privateSendClient.GetMixingMasternodesInfo(vecMnInfo)) {
+        UniValue pools(UniValue::VARR);
+        for (const auto& mnInfo : vecMnInfo) {
+            UniValue pool(UniValue::VOBJ);
+            pool.push_back(Pair("outpoint",      mnInfo.outpoint.ToStringShort()));
+            pool.push_back(Pair("addr",          mnInfo.addr.ToString()));
+            pools.push_back(pool);
+        }
+        obj.push_back(Pair("pools", pools));
     }
 
     if (pwalletMain) {


### PR DESCRIPTION
This should considerably speed things up (when there are enough participants ofc). Should also mitigate mixing speed degradation which could happen if we introduce additional mixing denoms (i.e. fix #2198) and keep the rest of it as is.