### PR TITLE
Correction to release date for 0.12.0

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -126,7 +126,7 @@ These release are considered obsolete. Old release notes can be found here:
 - [v0.12.2.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.2.2.md) released Dec/17/2017
 - [v0.12.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.2.md) released Nov/08/2017
 - [v0.12.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.1.md) released Feb/06/2017
-- [v0.12.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.0.md) released Jun/15/2015
+- [v0.12.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.0.md) released Aug/15/2015
 - [v0.11.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.11.2.md) released Mar/04/2015
 - [v0.11.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.11.1.md) released Feb/10/2015
 - [v0.11.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.11.0.md) released Jan/15/2015


### PR DESCRIPTION
Dash 0.12.0 went through several releases for testnet, so the first public release for mainnet was 0.12.0.44 on 15 August 2015.
https://www.dash.org/forum/threads/v12-release.5888/
https://github.com/dashpay/dash/tags?after=v0.12.0.48