### PR TITLE
Use C++14 standard when building

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,8 @@ case $host in
      lt_cv_deplibs_check_method="pass_all"
   ;;
 esac
-dnl Require C++11 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
+dnl Require C++14 compiler (no GNU extensions)
+AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory], [nodefault])
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
 


### PR DESCRIPTION
We have upgraded CI to use a recent compiler already and thus can also
increase the C++ standard now. After this, we'll also have to update
Gitian build to work with C++14 as well, but this is going to happen in
separate commits/PRs.