### PR TITLE
Add support for RPC sub-command help

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -176,7 +176,7 @@ std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey)
  * Note: This interface may still be subject to change.
  */
 
-std::string CRPCTable::help(const std::string& strCommand) const
+std::string CRPCTable::help(const std::string& strCommand, const std::string& strSubCommand) const
 {
     std::string strRet;
     std::string category;
@@ -200,6 +200,10 @@ std::string CRPCTable::help(const std::string& strCommand) const
         {
             JSONRPCRequest jreq;
             jreq.fHelp = true;
+            if (!strSubCommand.empty()) {
+                jreq.params.setArray();
+                jreq.params.push_back(strSubCommand);
+            }
             rpcfn_type pfn = pcmd->actor;
             if (setDone.insert(pfn).second)
                 (*pfn)(jreq);
@@ -234,21 +238,24 @@ std::string CRPCTable::help(const std::string& strCommand) const
 
 UniValue help(const JSONRPCRequest& jsonRequest)
 {
-    if (jsonRequest.fHelp || jsonRequest.params.size() > 1)
+    if (jsonRequest.fHelp || jsonRequest.params.size() > 2)
         throw std::runtime_error(
-            "help ( \"command\" )\n"
+            "help ( \"command\" ) (\"subCommand\")\n"
             "\nList all commands, or get help for a specified command.\n"
             "\nArguments:\n"
             "1. \"command\"     (string, optional) The command to get help on\n"
+            "2. \"subCommand\"  (string, optional) The subcommand to get help on. Please not that not all subcommands support this at the moment\n"
             "\nResult:\n"
             "\"text\"     (string) The help text\n"
         );
 
-    std::string strCommand;
+    std::string strCommand, strSubCommand;
     if (jsonRequest.params.size() > 0)
         strCommand = jsonRequest.params[0].get_str();
+    if (jsonRequest.params.size() > 1)
+        strSubCommand = jsonRequest.params[1].get_str();
 
-    return tableRPC.help(strCommand);
+    return tableRPC.help(strCommand, strSubCommand);
 }
 
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -152,7 +152,7 @@ private:
 public:
     CRPCTable();
     const CRPCCommand* operator[](const std::string& name) const;
-    std::string help(const std::string& name) const;
+    std::string help(const std::string& strCommand, const std::string& strSubCommand) const;
 
     /**
      * Execute a method.


### PR DESCRIPTION
This PR adds support for help queries for sub-commands. We already started to use subcommands like `masternode list`, but are not able to provide proper help queries for such sub-commands, as only `help masternode` is possible. Documenting all sub-commands in the same help query results in hard to read and hard to maintain help strings. With this PR, it's possible to implement `help masternode list` and get a detailed help string for just the sub-command.

An example implementation of such a sub-command help can be found here: https://github.com/dashpay/dash/blob/de04fb88d3e4c281061312c7405471e62857b47c/src/rpc/rpcevo.cpp#L616