### PR TITLE
Add new ParseXXX methods to easily parse UniValue values

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -24,6 +24,7 @@
 #include <boost/thread.hpp>
 #include <boost/algorithm/string/case_conv.hpp> // for to_upper()
 
+#include <algorithm>
 #include <memory> // for unique_ptr
 #include <unordered_map>
 
@@ -170,6 +171,53 @@ std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName)
 std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey)
 {
     return ParseHexV(find_value(o, strKey), strKey);
+}
+
+int32_t ParseInt32V(const UniValue& v, const std::string &strName)
+{
+    std::string strNum = v.getValStr();
+    int32_t num;
+    if (!ParseInt32(strNum, &num))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be a 32bit integer (not '"+strNum+"')");
+    return num;
+}
+
+int64_t ParseInt64V(const UniValue& v, const std::string &strName)
+{
+    std::string strNum = v.getValStr();
+    int64_t num;
+    if (!ParseInt64(strNum, &num))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be a 64bit integer (not '"+strNum+"')");
+    return num;
+}
+
+double ParseDoubleV(const UniValue& v, const std::string &strName)
+{
+    std::string strNum = v.getValStr();
+    double num;
+    if (!ParseDouble(strNum, &num))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be a be number (not '"+strNum+"')");
+    return num;
+}
+
+bool ParseBoolV(const UniValue& v, const std::string &strName)
+{
+    std::string strBool;
+    if (v.isBool())
+        return v.get_bool();
+    else if (v.isNum())
+        strBool = itostr(v.get_int());
+    else if (v.isStr())
+        strBool = v.get_str();
+
+    std::transform(strBool.begin(), strBool.end(), strBool.begin(), ::tolower);
+
+    if (strBool == "true" || strBool == "yes" || strBool == "1") {
+        return true;
+    } else if (strBool == "false" || strBool == "no" || strBool == "0") {
+        return false;
+    }
+    throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be true, false, yes, no, 1 or 0 (not '"+strBool+"')");
 }
 
 /**

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -187,6 +187,11 @@ extern uint256 ParseHashO(const UniValue& o, std::string strKey);
 extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
 extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
 
+extern int32_t ParseInt32V(const UniValue& v, const std::string &strName);
+extern int64_t ParseInt64V(const UniValue& v, const std::string &strName);
+extern double ParseDoubleV(const UniValue& v, const std::string &strName);
+extern bool ParseBoolV(const UniValue& v, const std::string &strName);
+
 extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);


### PR DESCRIPTION
Extracted from the DIP3 PR. These are utility functions which can be used to easily parse RPC sub-command parameters.

For normal RPC commands, we usually use the `vRPCConvertParams` in `client.cpp` to indicate that a parameter is for example an int instead of a string. This however does not work for sub-commands, as the base command has no fixed set of parameters and the parameters are different depending on the actual sub-command.

These functions are not used atm, but will be used in other PRs (e.g. https://github.com/dashpay/dash/pull/2083)