### PR TITLE
Return immediately in MasternodeList::updateNodeList when shutdown is requested

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -269,6 +269,9 @@ void MasternodeList::updateNodeList()
     if(!fLockAcquired) {
         return;
     }
+    if (ShutdownRequested()) {
+        return;
+    }
 
     static int64_t nTimeListUpdated = GetTime();
 


### PR DESCRIPTION
Observed a crash here due to use of freshly destroyed global objects