### PR TITLE
Prepare for DIP3 operator reward payments and switch to array in getblocktemplate

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -205,7 +205,7 @@ bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount bloc
     return true;
 }
 
-void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, CTxOut& txoutMasternodeRet, std::vector<CTxOut>& voutSuperblockRet)
+void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& txoutsMasternodeRet, std::vector<CTxOut>& voutSuperblockRet)
 {
     // only create superblocks if spork is enabled AND if superblock is actually triggered
     // (height should be validated inside)
@@ -226,19 +226,25 @@ void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blo
         return;
     }
 
-    if (!mnpayments.GetMasternodeTxOut(nBlockHeight, blockReward, txoutMasternodeRet)) {
+    if (!mnpayments.GetMasternodeTxOuts(nBlockHeight, blockReward, txoutsMasternodeRet)) {
         // no idea whom to pay (MN list empty?), lets hope for the best
         return;
     }
 
-    txNew.vout.emplace_back(txoutMasternodeRet);
+    txNew.vout.insert(txNew.vout.end(), txoutsMasternodeRet.begin(), txoutsMasternodeRet.end());
     txNew.vout.insert(txNew.vout.end(), voutSuperblockRet.begin(), voutSuperblockRet.end());
 
-    // subtract MN payment from miner reward
-    txNew.vout[0].nValue -= txoutMasternodeRet.nValue;
+    std::string txoutsMasternodeStr;
+    for (const auto& txout : txoutsMasternodeRet) {
+        // subtract MN payment from miner reward
+        txNew.vout[0].nValue -= txout.nValue;
+        if (!txoutsMasternodeStr.empty())
+            txoutsMasternodeStr += ",";
+        txoutsMasternodeStr += txout.ToString();
+    }
 
-    LogPrint("mnpayments", "%s -- nBlockHeight %d blockReward %lld txoutMasternodeRet %s txNew %s", __func__,
-                            nBlockHeight, blockReward, txoutMasternodeRet.ToString(), txNew.ToString());
+    LogPrint("mnpayments", "%s -- nBlockHeight %d blockReward %lld txoutsMasternodeRet \"%s\" txNew %s", __func__,
+                            nBlockHeight, blockReward, txoutsMasternodeStr, txNew.ToString());
 }
 
 std::string GetRequiredPaymentsString(int nBlockHeight)
@@ -277,19 +283,17 @@ bool CMasternodePayments::UpdateLastVote(const CMasternodePaymentVote& vote)
 }
 
 /**
-*   FillBlockPayee
+*   GetMasternodeTxOuts
 *
 *   Get masternode payment tx output
 */
 
-bool CMasternodePayments::GetMasternodeTxOut(int nBlockHeight, CAmount blockReward, CTxOut& txoutMasternodeRet) const
+bool CMasternodePayments::GetMasternodeTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& vecTxOutsMasternodeRet) const
 {
     // make sure it's not filled yet
-    txoutMasternodeRet = CTxOut();
+    vecTxOutsMasternodeRet.clear();
 
-    CScript payee;
-
-    if(!GetBlockPayee(nBlockHeight, payee)) {
+    if(!GetBlockTxOuts(nBlockHeight, blockReward, vecTxOutsMasternodeRet)) {
         // no masternode detected...
         int nCount = 0;
         masternode_info_t mnInfo;
@@ -299,18 +303,18 @@ bool CMasternodePayments::GetMasternodeTxOut(int nBlockHeight, CAmount blockRewa
             return false;
         }
         // fill payee with locally calculated winner and hope for the best
-        payee = GetScriptForDestination(mnInfo.keyIDCollateralAddress);
+        CScript payee = GetScriptForDestination(mnInfo.keyIDCollateralAddress);
+        CAmount masternodePayment = GetMasternodePayment(nBlockHeight, blockReward);
+        vecTxOutsMasternodeRet.emplace_back(masternodePayment, payee);
     }
 
-    // GET MASTERNODE PAYMENT VARIABLES SETUP
-    CAmount masternodePayment = GetMasternodePayment(nBlockHeight, blockReward);
-    txoutMasternodeRet = CTxOut(masternodePayment, payee);
+    for (const auto& txout : vecTxOutsMasternodeRet) {
+        CTxDestination address1;
+        ExtractDestination(txout.scriptPubKey, address1);
+        CBitcoinAddress address2(address1);
 
-    CTxDestination address1;
-    ExtractDestination(payee, address1);
-    CBitcoinAddress address2(address1);
-
-    LogPrintf("CMasternodePayments::%s -- Masternode payment %lld to %s\n", __func__, masternodePayment, address2.ToString());
+        LogPrintf("CMasternodePayments::%s -- Masternode payment %lld to %s\n", __func__, txout.nValue, address2.ToString());
+    }
 
     return true;
 }
@@ -504,12 +508,20 @@ bool CMasternodePaymentVote::Sign()
     return true;
 }
 
-bool CMasternodePayments::GetBlockPayee(int nBlockHeight, CScript& payeeRet) const
+bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& vecTxOutsRet) const
 {
-    LOCK(cs_mapMasternodeBlocks);
+    vecTxOutsRet.clear();
 
+    CAmount masternodeReward = GetMasternodePayment(nBlockHeight, blockReward);
+
+    LOCK(cs_mapMasternodeBlocks);
     auto it = mapMasternodeBlocks.find(nBlockHeight);
-    return it != mapMasternodeBlocks.end() && it->second.GetBestPayee(payeeRet);
+    CScript payee;
+    if (it == mapMasternodeBlocks.end() || !it->second.GetBestPayee(payee)) {
+        return false;
+    }
+    vecTxOutsRet.emplace_back(masternodeReward, payee);
+    return true;
 }
 
 // Is this masternode scheduled to get paid soon?
@@ -523,11 +535,14 @@ bool CMasternodePayments::IsScheduled(const masternode_info_t& mnInfo, int nNotB
     CScript mnpayee;
     mnpayee = GetScriptForDestination(mnInfo.keyIDCollateralAddress);
 
-    CScript payee;
     for(int64_t h = nCachedBlockHeight; h <= nCachedBlockHeight + 8; h++){
         if(h == nNotBlockHeight) continue;
-        if(GetBlockPayee(h, payee) && mnpayee == payee) {
-            return true;
+        std::vector<CTxOut> txOuts;
+        if(GetBlockTxOuts(h, 0, txOuts)) {
+            for (const auto& txout : txOuts) {
+                if (txout.scriptPubKey == mnpayee)
+                    return true;
+            }
         }
     }
 
@@ -691,9 +706,30 @@ std::string CMasternodePayments::GetRequiredPaymentsString(int nBlockHeight) con
 
 bool CMasternodePayments::IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const
 {
-    LOCK(cs_mapMasternodeBlocks);
-    const auto it = mapMasternodeBlocks.find(nBlockHeight);
-    return it == mapMasternodeBlocks.end() ? true : it->second.IsTransactionValid(txNew);
+    std::vector<CTxOut> masternodeTxOuts;
+    if (!GetBlockTxOuts(nBlockHeight, blockReward, masternodeTxOuts)) {
+        LogPrintf("CMasternodePayments::%s -- ERROR failed to get payees for block at height %s\n", __func__, nBlockHeight);
+        return false;
+    }
+
+    for (const auto& txout : masternodeTxOuts) {
+        bool found = false;
+        for (const auto& txout2 : txNew.vout) {
+            if (txout == txout2) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            CTxDestination dest;
+            if (!ExtractDestination(txout.scriptPubKey, dest))
+                assert(false);
+            LogPrintf("CMasternodePayments::%s -- ERROR failed to find expected payee %s in block at height %s\n", __func__, CBitcoinAddress(dest).ToString(), nBlockHeight);
+            return false;
+        }
+    }
+
+    return true;
 }
 
 void CMasternodePayments::CheckAndRemove()

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -35,7 +35,7 @@ extern CMasternodePayments mnpayments;
 /// TODO: all 4 functions do not belong here really, they should be refactored/moved somewhere (main.cpp ?)
 bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet);
 bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
-void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, CTxOut& txoutMasternodeRet, std::vector<CTxOut>& voutSuperblockRet);
+void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& txoutsMasternodeRet, std::vector<CTxOut>& voutSuperblockRet);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 
 class CMasternodePayee
@@ -213,7 +213,7 @@ public:
     void RequestLowDataPaymentBlocks(CNode* pnode, CConnman& connman) const;
     void CheckAndRemove();
 
-    bool GetBlockPayee(int nBlockHeight, CScript& payeeRet) const;
+    bool GetBlockTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& vecTxOutsRet) const;
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const;
     bool IsScheduled(const masternode_info_t& mnInfo, int nNotBlockHeight) const;
 
@@ -222,7 +222,7 @@ public:
     int GetMinMasternodePaymentsProto() const;
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
     std::string GetRequiredPaymentsString(int nBlockHeight) const;
-    bool GetMasternodeTxOut(int nBlockHeight, CAmount blockReward, CTxOut& txoutMasternodeRet) const;
+    bool GetMasternodeTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& vecTxOutsMasternodeRet) const;
     std::string ToString() const;
 
     int GetBlockCount() const { return mapMasternodeBlocks.size(); }

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -35,7 +35,7 @@ extern CMasternodePayments mnpayments;
 /// TODO: all 4 functions do not belong here really, they should be refactored/moved somewhere (main.cpp ?)
 bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet);
 bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
-void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& txoutsMasternodeRet, std::vector<CTxOut>& voutSuperblockRet);
+void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodeRet, std::vector<CTxOut>& voutSuperblockRet);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 
 class CMasternodePayee
@@ -222,7 +222,7 @@ public:
     int GetMinMasternodePaymentsProto() const;
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
     std::string GetRequiredPaymentsString(int nBlockHeight) const;
-    bool GetMasternodeTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& vecTxOutsMasternodeRet) const;
+    bool GetMasternodeTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& vecvoutMasternodeRet) const;
     std::string ToString() const;
 
     int GetBlockCount() const { return mapMasternodeBlocks.size(); }

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -35,7 +35,7 @@ extern CMasternodePayments mnpayments;
 /// TODO: all 4 functions do not belong here really, they should be refactored/moved somewhere (main.cpp ?)
 bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet);
 bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
-void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodeRet, std::vector<CTxOut>& voutSuperblockRet);
+void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 
 class CMasternodePayee
@@ -213,7 +213,7 @@ public:
     void RequestLowDataPaymentBlocks(CNode* pnode, CConnman& connman) const;
     void CheckAndRemove();
 
-    bool GetBlockTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& vecTxOutsRet) const;
+    bool GetBlockTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const;
     bool IsScheduled(const masternode_info_t& mnInfo, int nNotBlockHeight) const;
 
@@ -222,7 +222,7 @@ public:
     int GetMinMasternodePaymentsProto() const;
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
     std::string GetRequiredPaymentsString(int nBlockHeight) const;
-    bool GetMasternodeTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& vecvoutMasternodeRet) const;
+    bool GetMasternodeTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
     std::string ToString() const;
 
     int GetBlockCount() const { return mapMasternodeBlocks.size(); }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Update coinbase transaction with additional info about masternode and governance payments,
     // get some info back to pass to getblocktemplate
-    FillBlockPayments(coinbaseTx, nHeight, blockReward, pblocktemplate->txoutMasternode, pblocktemplate->voutSuperblock);
+    FillBlockPayments(coinbaseTx, nHeight, blockReward, pblocktemplate->txoutsMasternode, pblocktemplate->voutSuperblock);
     // LogPrintf("CreateNewBlock -- nBlockHeight %d blockReward %lld txoutMasternode %s coinbaseTx %s",
     //             nHeight, blockReward, pblocktemplate->txoutMasternode.ToString(), coinbaseTx.ToString());
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Update coinbase transaction with additional info about masternode and governance payments,
     // get some info back to pass to getblocktemplate
-    FillBlockPayments(coinbaseTx, nHeight, blockReward, pblocktemplate->voutMasternode, pblocktemplate->voutSuperblock);
+    FillBlockPayments(coinbaseTx, nHeight, blockReward, pblocktemplate->voutMasternodePayments, pblocktemplate->voutSuperblockPayments);
     // LogPrintf("CreateNewBlock -- nBlockHeight %d blockReward %lld txoutMasternode %s coinbaseTx %s",
     //             nHeight, blockReward, pblocktemplate->txoutsMasternode.ToString(), coinbaseTx.ToString());
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -170,9 +170,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Update coinbase transaction with additional info about masternode and governance payments,
     // get some info back to pass to getblocktemplate
-    FillBlockPayments(coinbaseTx, nHeight, blockReward, pblocktemplate->txoutsMasternode, pblocktemplate->voutSuperblock);
+    FillBlockPayments(coinbaseTx, nHeight, blockReward, pblocktemplate->voutMasternode, pblocktemplate->voutSuperblock);
     // LogPrintf("CreateNewBlock -- nBlockHeight %d blockReward %lld txoutMasternode %s coinbaseTx %s",
-    //             nHeight, blockReward, pblocktemplate->txoutMasternode.ToString(), coinbaseTx.ToString());
+    //             nHeight, blockReward, pblocktemplate->txoutsMasternode.ToString(), coinbaseTx.ToString());
 
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
     pblocktemplate->vTxFees[0] = -nFees;

--- a/src/miner.h
+++ b/src/miner.h
@@ -31,7 +31,7 @@ struct CBlockTemplate
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOps;
     uint32_t nPrevBits; // nBits of previous block (for subsidy calculation)
-    CTxOut txoutMasternode; // masternode payment
+    std::vector<CTxOut> txoutsMasternode; // masternode payment
     std::vector<CTxOut> voutSuperblock; // superblock payment
 };
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -31,8 +31,8 @@ struct CBlockTemplate
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOps;
     uint32_t nPrevBits; // nBits of previous block (for subsidy calculation)
-    std::vector<CTxOut> voutMasternode; // masternode payment
-    std::vector<CTxOut> voutSuperblock; // superblock payment
+    std::vector<CTxOut> voutMasternodePayments; // masternode payment
+    std::vector<CTxOut> voutSuperblockPayments; // superblock payment
 };
 
 // Container for tracking updates to ancestor feerate as we include (parent)

--- a/src/miner.h
+++ b/src/miner.h
@@ -31,7 +31,7 @@ struct CBlockTemplate
     std::vector<CAmount> vTxFees;
     std::vector<int64_t> vTxSigOps;
     uint32_t nPrevBits; // nBits of previous block (for subsidy calculation)
-    std::vector<CTxOut> txoutsMasternode; // masternode payment
+    std::vector<CTxOut> voutMasternode; // masternode payment
     std::vector<CTxOut> voutSuperblock; // superblock payment
 };
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -703,7 +703,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
     UniValue masternodeObj(UniValue::VARR);
-    for (const auto& txout : pblocktemplate->txoutsMasternode) {
+    for (const auto& txout : pblocktemplate->voutMasternode) {
         CTxDestination address1;
         ExtractDestination(txout.scriptPubKey, address1);
         CBitcoinAddress address2(address1);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -493,10 +493,10 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     }
 
     // when enforcement is on we need information about a masternode payee or otherwise our block is going to be orphaned by the network
-    std::vector<CTxOut> payees;
+    std::vector<CTxOut> voutMasternodePayments;
     if (sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)
         && !masternodeSync.IsWinnersListSynced()
-        && !mnpayments.GetBlockTxOuts(chainActive.Height() + 1, 0, payees))
+        && !mnpayments.GetBlockTxOuts(chainActive.Height() + 1, 0, voutMasternodePayments))
             throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Dash Core is downloading masternode winners...");
 
     // next bock is a superblock and we need governance info to correctly construct it
@@ -703,7 +703,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
     UniValue masternodeObj(UniValue::VARR);
-    for (const auto& txout : pblocktemplate->voutMasternode) {
+    for (const auto& txout : pblocktemplate->voutMasternodePayments) {
         CTxDestination address1;
         ExtractDestination(txout.scriptPubKey, address1);
         CBitcoinAddress address2(address1);
@@ -720,8 +720,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("masternode_payments_enforced", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
 
     UniValue superblockObjArray(UniValue::VARR);
-    if(pblocktemplate->voutSuperblock.size()) {
-        for (const auto& txout : pblocktemplate->voutSuperblock) {
+    if(pblocktemplate->voutSuperblockPayments.size()) {
+        for (const auto& txout : pblocktemplate->voutSuperblockPayments) {
             UniValue entry(UniValue::VOBJ);
             CTxDestination address1;
             ExtractDestination(txout.scriptPubKey, address1);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -387,10 +387,12 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             "  \"bits\" : \"xxxxxxxx\",              (string) compressed target of next block\n"
             "  \"previousbits\" : \"xxxxxxxx\",      (string) compressed target of current highest block\n"
             "  \"height\" : n                      (numeric) The height of the next block\n"
-            "  \"masternode\" : {                  (json object) required masternode payee that must be included in the next block\n"
-            "      \"payee\" : \"xxxx\",             (string) payee address\n"
-            "      \"script\" : \"xxxx\",            (string) payee scriptPubKey\n"
-            "      \"amount\": n                   (numeric) required amount to pay\n"
+            "  \"masternode\" : [                  (array) required masternode payments that must be included in the next block\n"
+            "      {\n"
+            "         \"payee\" : \"xxxx\",          (string) payee address\n"
+            "         \"script\" : \"xxxx\",         (string) payee scriptPubKey\n"
+            "         \"amount\": n                (numeric) required amount to pay\n"
+            "      }\n"
             "  },\n"
             "  \"masternode_payments_started\" :  true|false, (boolean) true, if masternode payments started\n"
             "  \"masternode_payments_enforced\" : true|false, (boolean) true, if masternode payments are enforced\n"
@@ -491,10 +493,10 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     }
 
     // when enforcement is on we need information about a masternode payee or otherwise our block is going to be orphaned by the network
-    CScript payee;
+    std::vector<CTxOut> payees;
     if (sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)
         && !masternodeSync.IsWinnersListSynced()
-        && !mnpayments.GetBlockPayee(chainActive.Height() + 1, payee))
+        && !mnpayments.GetBlockTxOuts(chainActive.Height() + 1, 0, payees))
             throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Dash Core is downloading masternode winners...");
 
     // next bock is a superblock and we need governance info to correctly construct it
@@ -700,15 +702,19 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("previousbits", strprintf("%08x", pblocktemplate->nPrevBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
 
-    UniValue masternodeObj(UniValue::VOBJ);
-    if(pblocktemplate->txoutMasternode != CTxOut()) {
+    UniValue masternodeObj(UniValue::VARR);
+    for (const auto& txout : pblocktemplate->txoutsMasternode) {
         CTxDestination address1;
-        ExtractDestination(pblocktemplate->txoutMasternode.scriptPubKey, address1);
+        ExtractDestination(txout.scriptPubKey, address1);
         CBitcoinAddress address2(address1);
-        masternodeObj.push_back(Pair("payee", address2.ToString().c_str()));
-        masternodeObj.push_back(Pair("script", HexStr(pblocktemplate->txoutMasternode.scriptPubKey)));
-        masternodeObj.push_back(Pair("amount", pblocktemplate->txoutMasternode.nValue));
+
+        UniValue obj(UniValue::VOBJ);
+        obj.push_back(Pair("payee", address2.ToString().c_str()));
+        obj.push_back(Pair("script", HexStr(txout.scriptPubKey)));
+        obj.push_back(Pair("amount", txout.nValue));
+        masternodeObj.push_back(obj);
     }
+
     result.push_back(Pair("masternode", masternodeObj));
     result.push_back(Pair("masternode_payments_started", pindexPrev->nHeight + 1 > consensusParams.nMasternodePaymentsStartBlock));
     result.push_back(Pair("masternode_payments_enforced", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1948,13 +1948,13 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
         ThresholdState state = VersionBitsState(pindexPrev, params, pos, versionbitscache);
         const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
         if (vbinfo.check_mn_protocol && state == THRESHOLD_STARTED && !fAssumeMasternodeIsUpgraded) {
-            CScript payee;
+            std::vector<CTxOut> blockTxOuts;;
             masternode_info_t mnInfo;
-            if (!mnpayments.GetBlockPayee(pindexPrev->nHeight + 1, payee)) {
+            if (!mnpayments.GetBlockTxOuts(pindexPrev->nHeight + 1, 0, blockTxOuts)) {
                 // no votes for this block
                 continue;
             }
-            if (!mnodeman.GetMasternodeInfo(payee, mnInfo)) {
+            if (!mnodeman.GetMasternodeInfo(blockTxOuts[0].scriptPubKey, mnInfo)) {
                 // unknown masternode
                 continue;
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1948,13 +1948,13 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
         ThresholdState state = VersionBitsState(pindexPrev, params, pos, versionbitscache);
         const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
         if (vbinfo.check_mn_protocol && state == THRESHOLD_STARTED && !fAssumeMasternodeIsUpgraded) {
-            std::vector<CTxOut> blockTxOuts;;
+            std::vector<CTxOut> voutMasternodePayments;
             masternode_info_t mnInfo;
-            if (!mnpayments.GetBlockTxOuts(pindexPrev->nHeight + 1, 0, blockTxOuts)) {
+            if (!mnpayments.GetBlockTxOuts(pindexPrev->nHeight + 1, 0, voutMasternodePayments)) {
                 // no votes for this block
                 continue;
             }
-            if (!mnodeman.GetMasternodeInfo(blockTxOuts[0].scriptPubKey, mnInfo)) {
+            if (!mnodeman.GetMasternodeInfo(voutMasternodePayments[0].scriptPubKey, mnInfo)) {
                 // unknown masternode
                 continue;
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1954,7 +1954,14 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
                 // no votes for this block
                 continue;
             }
-            if (!mnodeman.GetMasternodeInfo(voutMasternodePayments[0].scriptPubKey, mnInfo)) {
+            bool mnKnown = false;
+            for (const auto& txout : voutMasternodePayments) {
+                if (mnodeman.GetMasternodeInfo(txout.scriptPubKey, mnInfo)) {
+                    mnKnown = true;
+                    break;
+                }
+            }
+            if (!mnKnown) {
                 // unknown masternode
                 continue;
             }


### PR DESCRIPTION
~This PR also includes the commits of #2215. I'll rebase and force-push after that one is merged. Only the last commit is actually part of this PR.~

This refactoring might look useless without the operator rewards from DIP3, but I'd like at least include the getblocktemplate change ASAP so that miners and pools operators can prepare themself for the upcoming changes.