### PR TITLE
adds rpc calls for `setprivatesendrounds` and `setprivatesendamount`

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -139,6 +139,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setban", 3, "absolute" },
     { "setbip69enabled", 0, "enabled" },
     { "setnetworkactive", 0, "state" },
+    { "setprivatesendrounds", 0, "rounds" },
+	{ "setprivatesendamount", 0, "amount" },
     { "getmempoolancestors", 1, "verbose" },
     { "getmempooldescendants", 1, "verbose" },
     { "spork", 1, "value" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -140,7 +140,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setbip69enabled", 0, "enabled" },
     { "setnetworkactive", 0, "state" },
     { "setprivatesendrounds", 0, "rounds" },
-	{ "setprivatesendamount", 0, "amount" },
+    { "setprivatesendamount", 0, "amount" },
     { "getmempoolancestors", 1, "verbose" },
     { "getmempooldescendants", 1, "verbose" },
     { "spork", 1, "value" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2367,60 +2367,60 @@ UniValue settxfee(const JSONRPCRequest& request)
 
 UniValue setprivatesendrounds(const JSONRPCRequest& request)
 {
-	if (!EnsureWalletIsAvailable(request.fHelp))
-		return NullUniValue;
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
 
-	if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
-		throw std::runtime_error(
-			"setprivatesendrounds rounds\n"
-			"\nSet the number of rounds for PrivateSend mixing.\n"
-			"\nArguments:\n"
-			"1. rounds         (numeric, required) The default number of rounds is " + std::to_string(DEFAULT_PRIVATESEND_ROUNDS) + 
-			" Cannot be more than " + std::to_string(MAX_PRIVATESEND_ROUNDS) + " nor less than " + std::to_string(MIN_PRIVATESEND_ROUNDS) +
-			"\nResult:\n"
-			"true|false        (boolean) Returns true if successful\n"
-			"\nExamples:\n"
-			+ HelpExampleCli("setprivatesendrounds", "4")
-			+ HelpExampleRpc("setprivatesendrounds", "16")
-		);
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
+        throw std::runtime_error(
+            "setprivatesendrounds rounds\n"
+            "\nSet the number of rounds for PrivateSend mixing.\n"
+            "\nArguments:\n"
+            "1. rounds         (numeric, required) The default number of rounds is " + std::to_string(DEFAULT_PRIVATESEND_ROUNDS) + 
+            " Cannot be more than " + std::to_string(MAX_PRIVATESEND_ROUNDS) + " nor less than " + std::to_string(MIN_PRIVATESEND_ROUNDS) +
+            "\nResult:\n"
+            "true|false        (boolean) Returns true if successful\n"
+            "\nExamples:\n"
+            + HelpExampleCli("setprivatesendrounds", "4")
+            + HelpExampleRpc("setprivatesendrounds", "16")
+        );
 
-	LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
 
-	// Amount
-	CAmount nRounds = AmountFromValue(request.params[0]);
+    // Amount
+    CAmount nRounds = AmountFromValue(request.params[0]);
 
-	privateSendClient.nPrivateSendRounds = nRounds;
+    privateSendClient.nPrivateSendRounds = nRounds;
 
-	return true;
+    return true;
 }
 
 UniValue setprivatesendamount(const JSONRPCRequest& request)
 {
-	if (!EnsureWalletIsAvailable(request.fHelp))
-		return NullUniValue;
+    if (!EnsureWalletIsAvailable(request.fHelp))
+        return NullUniValue;
 
-	if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
-		throw std::runtime_error(
-			"setprivatesendamount amount\n"
-			"\nSet the goal amount for PrivateSend mixing.\n"
-			"\nArguments:\n"
-			"1. amount         (numeric, required) The default amount is " + std::to_string(DEFAULT_PRIVATESEND_AMOUNT) +
-			" Cannot be more than " + std::to_string(MAX_PRIVATESEND_AMOUNT) + " nor less than " + std::to_string(MIN_PRIVATESEND_AMOUNT) +
-			"\nResult:\n"
-			"true|false        (boolean) Returns true if successful\n"
-			"\nExamples:\n"
-			+ HelpExampleCli("setprivatesendamount", "500")
-			+ HelpExampleRpc("setprivatesendamount", "208")
-		);
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
+        throw std::runtime_error(
+            "setprivatesendamount amount\n"
+            "\nSet the goal amount for PrivateSend mixing.\n"
+            "\nArguments:\n"
+            "1. amount         (numeric, required) The default amount is " + std::to_string(DEFAULT_PRIVATESEND_AMOUNT) +
+            " Cannot be more than " + std::to_string(MAX_PRIVATESEND_AMOUNT) + " nor less than " + std::to_string(MIN_PRIVATESEND_AMOUNT) +
+            "\nResult:\n"
+            "true|false        (boolean) Returns true if successful\n"
+            "\nExamples:\n"
+            + HelpExampleCli("setprivatesendamount", "500")
+            + HelpExampleRpc("setprivatesendamount", "208")
+        );
 
-	LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
 
-	// Amount
-	CAmount nAmount = AmountFromValue(request.params[0]);
+    // Amount
+    CAmount nAmount = AmountFromValue(request.params[0]);
 
-	privateSendClient.nPrivateSendAmount = nAmount;
+    privateSendClient.nPrivateSendAmount = nAmount;
 
-	return true;
+    return true;
 }
 
 UniValue getwalletinfo(const JSONRPCRequest& request)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2370,28 +2370,24 @@ UniValue setprivatesendrounds(const JSONRPCRequest& request)
     if (!EnsureWalletIsAvailable(request.fHelp))
         return NullUniValue;
 
-    if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
+    if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "setprivatesendrounds rounds\n"
             "\nSet the number of rounds for PrivateSend mixing.\n"
             "\nArguments:\n"
             "1. rounds         (numeric, required) The default number of rounds is " + std::to_string(DEFAULT_PRIVATESEND_ROUNDS) + 
             " Cannot be more than " + std::to_string(MAX_PRIVATESEND_ROUNDS) + " nor less than " + std::to_string(MIN_PRIVATESEND_ROUNDS) +
-            "\nResult:\n"
-            "true|false        (boolean) Returns true if successful\n"
             "\nExamples:\n"
             + HelpExampleCli("setprivatesendrounds", "4")
             + HelpExampleRpc("setprivatesendrounds", "16")
         );
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
-    // Amount
+    
     CAmount nRounds = AmountFromValue(request.params[0]);
 
     privateSendClient.nPrivateSendRounds = nRounds;
 
-    return true;
+    return NullUniValue;
 }
 
 UniValue setprivatesendamount(const JSONRPCRequest& request)
@@ -2399,28 +2395,24 @@ UniValue setprivatesendamount(const JSONRPCRequest& request)
     if (!EnsureWalletIsAvailable(request.fHelp))
         return NullUniValue;
 
-    if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
+    if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "setprivatesendamount amount\n"
-            "\nSet the goal amount for PrivateSend mixing.\n"
+            "\nSet the goal amount in " + CURRENCY_UNIT + " for PrivateSend mixing.\n"
             "\nArguments:\n"
             "1. amount         (numeric, required) The default amount is " + std::to_string(DEFAULT_PRIVATESEND_AMOUNT) +
             " Cannot be more than " + std::to_string(MAX_PRIVATESEND_AMOUNT) + " nor less than " + std::to_string(MIN_PRIVATESEND_AMOUNT) +
-            "\nResult:\n"
-            "true|false        (boolean) Returns true if successful\n"
             "\nExamples:\n"
             + HelpExampleCli("setprivatesendamount", "500")
             + HelpExampleRpc("setprivatesendamount", "208")
         );
-
-    LOCK2(cs_main, pwalletMain->cs_wallet);
 
     // Amount
     CAmount nAmount = AmountFromValue(request.params[0]);
 
     privateSendClient.nPrivateSendAmount = nAmount;
 
-    return true;
+    return NullUniValue;
 }
 
 UniValue getwalletinfo(const JSONRPCRequest& request)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2382,8 +2382,10 @@ UniValue setprivatesendrounds(const JSONRPCRequest& request)
             + HelpExampleRpc("setprivatesendrounds", "16")
         );
 
-    
     int nRounds = request.params[0].get_int();
+
+    if (nRounds > MAX_PRIVATESEND_ROUNDS || nRounds < MIN_PRIVATESEND_ROUNDS)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid number of rounds");
 
     privateSendClient.nPrivateSendRounds = nRounds;
 
@@ -2407,8 +2409,10 @@ UniValue setprivatesendamount(const JSONRPCRequest& request)
             + HelpExampleRpc("setprivatesendamount", "208")
         );
 
-    // Amount
     int nAmount = request.params[0].get_int();
+
+    if (nAmount > MAX_PRIVATESEND_AMOUNT || nAmount < MIN_PRIVATESEND_AMOUNT)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid amount of " + CURRENCY_UNIT + " as mixing goal amount");
 
     privateSendClient.nPrivateSendAmount = nAmount;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -21,6 +21,7 @@
 #include "wallet.h"
 #include "walletdb.h"
 #include "keepass.h"
+#include "privatesend-client.h"
 
 #include <stdint.h>
 
@@ -2364,6 +2365,64 @@ UniValue settxfee(const JSONRPCRequest& request)
     return true;
 }
 
+UniValue setprivatesendrounds(const JSONRPCRequest& request)
+{
+	if (!EnsureWalletIsAvailable(request.fHelp))
+		return NullUniValue;
+
+	if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
+		throw std::runtime_error(
+			"setprivatesendrounds rounds\n"
+			"\nSet the number of rounds for PrivateSend mixing.\n"
+			"\nArguments:\n"
+			"1. rounds         (numeric, required) The default number of rounds is " + std::to_string(DEFAULT_PRIVATESEND_ROUNDS) + 
+			" Cannot be more than " + std::to_string(MAX_PRIVATESEND_ROUNDS) + " nor less than " + std::to_string(MIN_PRIVATESEND_ROUNDS) +
+			"\nResult:\n"
+			"true|false        (boolean) Returns true if successful\n"
+			"\nExamples:\n"
+			+ HelpExampleCli("setprivatesendrounds", "4")
+			+ HelpExampleRpc("setprivatesendrounds", "16")
+		);
+
+	LOCK2(cs_main, pwalletMain->cs_wallet);
+
+	// Amount
+	CAmount nRounds = AmountFromValue(request.params[0]);
+
+	privateSendClient.nPrivateSendRounds = nRounds;
+
+	return true;
+}
+
+UniValue setprivatesendamount(const JSONRPCRequest& request)
+{
+	if (!EnsureWalletIsAvailable(request.fHelp))
+		return NullUniValue;
+
+	if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
+		throw std::runtime_error(
+			"setprivatesendamount amount\n"
+			"\nSet the goal amount for PrivateSend mixing.\n"
+			"\nArguments:\n"
+			"1. amount         (numeric, required) The default amount is " + std::to_string(DEFAULT_PRIVATESEND_AMOUNT) +
+			" Cannot be more than " + std::to_string(MAX_PRIVATESEND_AMOUNT) + " nor less than " + std::to_string(MIN_PRIVATESEND_AMOUNT) +
+			"\nResult:\n"
+			"true|false        (boolean) Returns true if successful\n"
+			"\nExamples:\n"
+			+ HelpExampleCli("setprivatesendamount", "500")
+			+ HelpExampleRpc("setprivatesendamount", "208")
+		);
+
+	LOCK2(cs_main, pwalletMain->cs_wallet);
+
+	// Amount
+	CAmount nAmount = AmountFromValue(request.params[0]);
+
+	privateSendClient.nPrivateSendAmount = nAmount;
+
+	return true;
+}
+
 UniValue getwalletinfo(const JSONRPCRequest& request)
 {
     if (!EnsureWalletIsAvailable(request.fHelp))
@@ -2887,6 +2946,8 @@ static const CRPCCommand commands[] =
     { "wallet",             "sendtoaddress",            &sendtoaddress,            false,  {"address","amount","comment","comment_to","subtractfeefromamount"} },
     { "wallet",             "setaccount",               &setaccount,               true,   {"address","account"} },
     { "wallet",             "settxfee",                 &settxfee,                 true,   {"amount"} },
+    { "wallet",             "setprivatesendrounds",     &setprivatesendrounds,     true,   {"rounds"} },
+    { "wallet",             "setprivatesendamount",     &setprivatesendamount,     true,   {"amount"} },
     { "wallet",             "signmessage",              &signmessage,              true,   {"address","message"} },
     { "wallet",             "walletlock",               &walletlock,               true,   {} },
     { "wallet",             "walletpassphrasechange",   &walletpassphrasechange,   true,   {"oldpassphrase","newpassphrase"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2383,7 +2383,7 @@ UniValue setprivatesendrounds(const JSONRPCRequest& request)
         );
 
     
-    CAmount nRounds = AmountFromValue(request.params[0]);
+    int nRounds = request.params[0].get_int();
 
     privateSendClient.nPrivateSendRounds = nRounds;
 
@@ -2408,7 +2408,7 @@ UniValue setprivatesendamount(const JSONRPCRequest& request)
         );
 
     // Amount
-    CAmount nAmount = AmountFromValue(request.params[0]);
+    int nAmount = request.params[0].get_int();
 
     privateSendClient.nPrivateSendAmount = nAmount;
 


### PR DESCRIPTION
Not tested yet. Not positive about help text, but it's probably fine.