### PR TITLE
Don't crash when formatting in logging throws exceptions

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -94,20 +94,31 @@ bool LogAcceptCategory(const char* category);
 /** Send a string to the log output */
 int LogPrintStr(const std::string &str);
 
+/** Formats a string without throwing exceptions. Instead, it'll return an error string instead of formatted string. */
+template<typename... Args>
+std::string SafeStringFormat(const std::string& fmt, const Args&... args)
+{
+    try {
+        return tinyformat::format(fmt, args...);
+    } catch (std::runtime_error& e) {
+        return tinyformat::format("****TINYFORMAT ERROR**** - err=%s, fmt=%s", e.what(), fmt);
+    }
+}
+
 #define LogPrint(category, ...) do { \
     if (LogAcceptCategory((category))) { \
-        LogPrintStr(tinyformat::format(__VA_ARGS__)); \
+        LogPrintStr(SafeStringFormat(__VA_ARGS__)); \
     } \
 } while(0)
 
 #define LogPrintf(...) do { \
-    LogPrintStr(tinyformat::format(__VA_ARGS__)); \
+    LogPrintStr(SafeStringFormat(__VA_ARGS__)); \
 } while(0)
 
 template<typename... Args>
 bool error(const char* fmt, const Args&... args)
 {
-    LogPrintStr("ERROR: " + tinyformat::format(fmt, args...) + "\n");
+    LogPrintStr("ERROR: " + SafeStringFormat(fmt, args...) + "\n");
     return false;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -101,7 +101,9 @@ std::string SafeStringFormat(const std::string& fmt, const Args&... args)
     try {
         return tinyformat::format(fmt, args...);
     } catch (std::runtime_error& e) {
-        return tinyformat::format("****TINYFORMAT ERROR**** - err=%s, fmt=%s", e.what(), fmt);
+        std::string message = tinyformat::format("\n****TINYFORMAT ERROR****\n    err=\"%s\"\n    fmt=\"%s\"\n", e.what(), fmt);
+        fprintf(stderr, "%s", message.c_str());
+        return message;
     }
 }
 


### PR DESCRIPTION
This is something that has annoyed me forever. Always when someone (mainly me as it feels...) forgets to add a parameter in a LogPrintf, the node CRASHES instead of giving a useful hint. IMHO, the tools that are meant to support us while debugging should not cause crashes, never... ;)