### PR TITLE
add compressed option to `masternode genkey`

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -377,7 +377,7 @@ UniValue masternode(const JSONRPCRequest& request)
     {
         bool fCompressed = false;
         if (request.params.size() > 1) {
-            fCompressed = (request.params[1].get_str() == "true");
+            fCompressed = ParseBoolV(request.params[1], "compressed");
         }
 
         CKey secret;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -145,7 +145,7 @@ UniValue masternode(const JSONRPCRequest& request)
                 "  check        - Force check all masternodes and remove invalid ones\n"
                 "  count        - Get information about number of masternodes (DEPRECATED options: 'total', 'ps', 'enabled', 'qualify', 'all')\n"
                 "  current      - Print info on current masternode winner to be paid the next block (calculated locally)\n"
-                "  genkey       - Generate new masternodeprivkey\n"
+                "  genkey       - Generate new masternodeprivkey (optional param: boolean, optional, default=false) generate compressed privkey\n"
 #ifdef ENABLE_WALLET
                 "  outputs      - Print masternode compatible outputs\n"
                 "  start-alias  - Start single remote masternode by assigned alias configured in masternode.conf\n"
@@ -375,8 +375,13 @@ UniValue masternode(const JSONRPCRequest& request)
 
     if (strCommand == "genkey")
     {
+        bool fCompressed = false;
+        if (request.params.size() > 1) {
+            fCompressed = (request.params[1].get_str() == "true");
+        }
+
         CKey secret;
-        secret.MakeNewKey(false);
+        secret.MakeNewKey(fCompressed);
 
         return CBitcoinSecret(secret).ToString();
     }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -145,7 +145,7 @@ UniValue masternode(const JSONRPCRequest& request)
                 "  check        - Force check all masternodes and remove invalid ones\n"
                 "  count        - Get information about number of masternodes (DEPRECATED options: 'total', 'ps', 'enabled', 'qualify', 'all')\n"
                 "  current      - Print info on current masternode winner to be paid the next block (calculated locally)\n"
-                "  genkey       - Generate new masternodeprivkey (optional param: boolean, optional, default=false) generate compressed privkey\n"
+                "  genkey       - Generate new masternodeprivkey, optional param: 'compressed' (boolean, optional, default=false) generate compressed privkey\n"
 #ifdef ENABLE_WALLET
                 "  outputs      - Print masternode compatible outputs\n"
                 "  start-alias  - Start single remote masternode by assigned alias configured in masternode.conf\n"


### PR DESCRIPTION
This allows anyone to generate / display compressed private keys using `masternode genkey`. Prior to this change only the uncompressed format is displayed.

I don't like the "string that looks like bool" option but I've tried and unsure how else to get this to a true bool since `genkey` is a subcommand. Might have to change the help text to reflect this, I'm up for suggestions.