### PR TITLE
Assume MN payments are valid in case we don't have local info about MN payments

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -709,7 +709,7 @@ bool CMasternodePayments::IsTransactionValid(const CTransaction& txNew, int nBlo
     std::vector<CTxOut> voutMasternodePayments;
     if (!GetBlockTxOuts(nBlockHeight, blockReward, voutMasternodePayments)) {
         LogPrintf("CMasternodePayments::%s -- ERROR failed to get payees for block at height %s\n", __func__, nBlockHeight);
-        return false;
+        return true;
     }
 
     for (const auto& txout : voutMasternodePayments) {


### PR DESCRIPTION
This fixes a bug which slipped in while backporting the refactoring commits from the DIP3 branch. This PR fixes it by reverting to the old behavior, which was to accept any MN payments if no local info about correct payments is available.