### PR TITLE
Fix sync in regtest (again)

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -186,8 +186,10 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
         {
             if (nRequestedMasternodeAssets == MASTERNODE_SYNC_WAITING) {
                 connman.PushMessage(pnode, msgMaker.Make(NetMsgType::GETSPORKS)); //get current network sporks
+                SwitchToNextAsset(connman);
             } else if (nRequestedMasternodeAssets == MASTERNODE_SYNC_LIST) {
                 mnodeman.DsegUpdate(pnode, connman);
+                SwitchToNextAsset(connman);
             } else if (nRequestedMasternodeAssets == MASTERNODE_SYNC_MNW) {
                 //sync payment votes
                 if(pnode->nVersion == 70208) {
@@ -195,10 +197,11 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 } else {
                     connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC)); //sync payment votes
                 }
+                SwitchToNextAsset(connman);
             } else if (nRequestedMasternodeAssets == MASTERNODE_SYNC_GOVERNANCE) {
                 SendGovernanceSyncRequest(pnode, connman);
+                SwitchToNextAsset(connman);
             }
-            SwitchToNextAsset(connman);
             connman.ReleaseNodeVector(vNodesCopy);
             return;
         }


### PR DESCRIPTION
Should only call `SwitchToNextAsset()` while being in specific state and not on every tick.

Fixes issues introduced by #2202 

Found it while debugging #2083, corresponding fix for that branch is https://github.com/UdjinM6/dash/commit/f50c3be3941de26a5e86313f1172c917e8000b22