### PR TITLE
Try using cache in GetListForBlock before reading from disk

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -509,6 +509,13 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const uint256& blo
     std::vector<CDeterministicMNListDiff> vecDiff;
 
     while(true) {
+        // try using cache before reading from disk
+        it = mnListsCache.find(blockHashTmp);
+        if (it != mnListsCache.end()) {
+            snapshot = it->second;
+            break;
+        }
+
         if (evoDb.Read(std::make_pair(DB_LIST_SNAPSHOT, blockHashTmp), snapshot)) {
             break;
         }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -506,7 +506,7 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const uint256& blo
 
     uint256 blockHashTmp = blockHash;
     CDeterministicMNList snapshot;
-    std::vector<CDeterministicMNListDiff> vecDiff;
+    std::list<CDeterministicMNListDiff> listDiff;
 
     while(true) {
         // try using cache before reading from disk
@@ -526,11 +526,11 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const uint256& blo
             break;
         }
 
-        vecDiff.emplace(vecDiff.begin(), diff);
+        listDiff.emplace_front(diff);
         blockHashTmp = diff.prevBlockHash;
     }
 
-    for (const auto& diff : vecDiff) {
+    for (const auto& diff : listDiff) {
         if (diff.HasChanges()) {
             snapshot = snapshot.ApplyDiff(diff);
         } else {


### PR DESCRIPTION
This should speed up GetListForBlock calls on the tip. The list for the previous block is very likely already in the cache and it doesn't make sense to go fully back to the snapshot to create the new list.

This was the original intent of the recursive version of GetListForBlock, as it was avoiding many full rebuilds of the list. The recursive implementation was buggy however, so the non-recursive version was proposed.

This solution is a trade-off and should in most cases avoid a full rebuild from an old snapshot.

This PR also changes vecDiff to be a std::list to speed up insertion at the front instead of the back.