### PR TITLE
DIP3 MN reward payment logic

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -14,6 +14,8 @@
 #include "spork.h"
 #include "util.h"
 
+#include "evo/deterministicmns.h"
+
 #include <string>
 
 /** Object for who's going to get paid on which blocks */
@@ -150,7 +152,7 @@ bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockRewar
 
 bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward)
 {
-    if(!masternodeSync.IsSynced() || fLiteMode) {
+    if((!masternodeSync.IsSynced() && !deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight)) || fLiteMode) {
         //there is no budget data to use to check anything, let's just accept the longest chain
         if(fDebug) LogPrintf("%s -- WARNING: Not enough data, skipping block payee checks\n", __func__);
         return true;
@@ -267,6 +269,9 @@ void CMasternodePayments::Clear()
 
 bool CMasternodePayments::UpdateLastVote(const CMasternodePaymentVote& vote)
 {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive())
+        return false;
+
     LOCK(cs_mapMasternodePaymentVotes);
 
     const auto it = mapMasternodesLastVote.find(vote.masternodeOutpoint);
@@ -294,6 +299,8 @@ bool CMasternodePayments::GetMasternodeTxOuts(int nBlockHeight, CAmount blockRew
     voutMasternodePaymentsRet.clear();
 
     if(!GetBlockTxOuts(nBlockHeight, blockReward, voutMasternodePaymentsRet)) {
+        assert(!deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight));
+
         // no masternode detected...
         int nCount = 0;
         masternode_info_t mnInfo;
@@ -327,6 +334,9 @@ int CMasternodePayments::GetMinMasternodePaymentsProto() const {
 
 void CMasternodePayments::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
 {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive())
+        return;
+
     if(fLiteMode) return; // disable all Dash specific functionality
 
     if (strCommand == NetMsgType::MASTERNODEPAYMENTSYNC) { //Masternode Payments Request Sync
@@ -514,14 +524,29 @@ bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, 
 
     CAmount masternodeReward = GetMasternodePayment(nBlockHeight, blockReward);
 
-    LOCK(cs_mapMasternodeBlocks);
-    auto it = mapMasternodeBlocks.find(nBlockHeight);
-    CScript payee;
-    if (it == mapMasternodeBlocks.end() || !it->second.GetBestPayee(payee)) {
-        return false;
+    if (deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight)) {
+        uint256 blockHash;
+        {
+            LOCK(cs_main);
+            blockHash = chainActive[nBlockHeight - 1]->GetBlockHash();
+        }
+        uint256 proTxHash;
+        auto dmnPayee = deterministicMNManager->GetListForBlock(blockHash).GetMNPayee();
+        if (!dmnPayee) {
+            return false;
+        }
+        voutMasternodePaymentsRet.emplace_back(masternodeReward, dmnPayee->pdmnState->scriptPayout);
+        return true;
+    } else {
+        LOCK(cs_mapMasternodeBlocks);
+        auto it = mapMasternodeBlocks.find(nBlockHeight);
+        CScript payee;
+        if (it == mapMasternodeBlocks.end() || !it->second.GetBestPayee(payee)) {
+            return false;
+        }
+        voutMasternodePaymentsRet.emplace_back(masternodeReward, payee);
+        return true;
     }
-    voutMasternodePaymentsRet.emplace_back(masternodeReward, payee);
-    return true;
 }
 
 // Is this masternode scheduled to get paid soon?
@@ -698,10 +723,22 @@ std::string CMasternodeBlockPayees::GetRequiredPaymentsString() const
 
 std::string CMasternodePayments::GetRequiredPaymentsString(int nBlockHeight) const
 {
-    LOCK(cs_mapMasternodeBlocks);
-
-    const auto it = mapMasternodeBlocks.find(nBlockHeight);
-    return it == mapMasternodeBlocks.end() ? "Unknown" : it->second.GetRequiredPaymentsString();
+    if (deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight)) {
+        LOCK(cs_main);
+        auto pindex = chainActive[nBlockHeight - 1];
+        auto payee = deterministicMNManager->GetListForBlock(pindex->GetBlockHash()).GetMNPayee();
+        if (!payee) {
+            return "Unknown";
+        }
+        CTxDestination dest;
+        if (!ExtractDestination(payee->pdmnState->scriptPayout, dest))
+            assert(false);
+        return CBitcoinAddress(dest).ToString();
+    } else {
+        LOCK(cs_mapMasternodeBlocks);
+        const auto it = mapMasternodeBlocks.find(nBlockHeight);
+        return it == mapMasternodeBlocks.end() ? "Unknown" : it->second.GetRequiredPaymentsString();
+    }
 }
 
 bool CMasternodePayments::IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const
@@ -713,6 +750,10 @@ bool CMasternodePayments::IsTransactionValid(const CTransaction& txNew, int nBlo
 
 void CMasternodePayments::CheckAndRemove()
 {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        return;
+    }
+
     if(!masternodeSync.IsBlockchainSynced()) return;
 
     LOCK2(cs_mapMasternodeBlocks, cs_mapMasternodePaymentVotes);
@@ -794,6 +835,10 @@ bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, std::s
 
 bool CMasternodePayments::ProcessBlock(int nBlockHeight, CConnman& connman)
 {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight)) {
+        return true;
+    }
+
     // DETERMINE IF WE SHOULD BE VOTING FOR THE NEXT PAYEE
 
     if(fLiteMode || !fMasternodeMode) return false;
@@ -929,6 +974,10 @@ void CMasternodePayments::CheckBlockVotes(int nBlockHeight)
 
 void CMasternodePaymentVote::Relay(CConnman& connman) const
 {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        return;
+    }
+
     // Do not relay until fully synced
     if(!masternodeSync.IsSynced()) {
         LogPrint("mnpayments", "CMasternodePayments::%s -- won't relay until fully synced\n", __func__);
@@ -1129,6 +1178,10 @@ int CMasternodePayments::GetStorageLimit() const
 void CMasternodePayments::UpdatedBlockTip(const CBlockIndex *pindex, CConnman& connman)
 {
     if(!pindex) return;
+
+    if (deterministicMNManager->IsDeterministicMNsSporkActive(pindex->nHeight)) {
+        return;
+    }
 
     nCachedBlockHeight = pindex->nHeight;
     LogPrint("mnpayments", "CMasternodePayments::%s -- nCachedBlockHeight=%d\n", __func__, nCachedBlockHeight);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -588,7 +588,15 @@ bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, 
         if (!dmnPayee) {
             return false;
         }
-        voutMasternodePaymentsRet.emplace_back(masternodeReward, dmnPayee->pdmnState->scriptPayout);
+
+        if (dmnPayee->nOperatorReward == 0 || dmnPayee->pdmnState->scriptOperatorPayout == CScript()) {
+            voutMasternodePaymentsRet.emplace_back(masternodeReward, dmnPayee->pdmnState->scriptPayout);
+        } else {
+            CAmount operatorReward = (masternodeReward * dmnPayee->nOperatorReward) / 10000;
+            masternodeReward -= operatorReward;
+            voutMasternodePaymentsRet.emplace_back(masternodeReward, dmnPayee->pdmnState->scriptPayout);
+            voutMasternodePaymentsRet.emplace_back(operatorReward, dmnPayee->pdmnState->scriptOperatorPayout);
+        }
         return true;
     } else {
         LOCK(cs_mapMasternodeBlocks);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -608,6 +608,16 @@ bool CMasternodePayments::IsScheduled(const masternode_info_t& mnInfo, int nNotB
 {
     LOCK(cs_mapMasternodeBlocks);
 
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        auto projectedPayees = deterministicMNManager->GetListAtChainTip().GetProjectedMNPayees(8);
+        for (const auto &dmn : projectedPayees) {
+            if (dmn->proTxHash == mnInfo.outpoint.hash) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     if(!masternodeSync.IsMasternodeListSynced()) return false;
 
     CScript mnpayee;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -801,9 +801,35 @@ std::string CMasternodePayments::GetRequiredPaymentsString(int nBlockHeight) con
 
 bool CMasternodePayments::IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const
 {
-    LOCK(cs_mapMasternodeBlocks);
-    const auto it = mapMasternodeBlocks.find(nBlockHeight);
-    return it == mapMasternodeBlocks.end() ? true : it->second.IsTransactionValid(txNew);
+    if (deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight)) {
+        std::vector<CTxOut> voutMasternodePayments;
+        if (!GetBlockTxOuts(nBlockHeight, blockReward, voutMasternodePayments)) {
+            LogPrintf("CMasternodePayments::%s -- ERROR failed to get payees for block at height %s\n", __func__, nBlockHeight);
+            return true;
+        }
+
+        for (const auto& txout : voutMasternodePayments) {
+            bool found = false;
+            for (const auto& txout2 : txNew.vout) {
+                if (txout == txout2) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                CTxDestination dest;
+                if (!ExtractDestination(txout.scriptPubKey, dest))
+                    assert(false);
+                LogPrintf("CMasternodePayments::%s -- ERROR failed to find expected payee %s in block at height %s\n", __func__, CBitcoinAddress(dest).ToString(), nBlockHeight);
+                return false;
+            }
+        }
+        return true;
+    } else {
+        LOCK(cs_mapMasternodeBlocks);
+        const auto it = mapMasternodeBlocks.find(nBlockHeight);
+        return it == mapMasternodeBlocks.end() ? true : it->second.IsTransactionValid(txNew);
+    }
 }
 
 void CMasternodePayments::CheckAndRemove()

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -36,7 +36,7 @@ extern CMasternodePayments mnpayments;
 bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet);
 bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
 void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet);
-std::string GetRequiredPaymentsString(int nBlockHeight);
+std::map<int, std::string> GetRequiredPaymentsStrings(int nStartHeight, int nEndHeight);
 
 class CMasternodePayee
 {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -347,6 +347,8 @@ std::string CMasternode::GetStatus() const
 
 void CMasternode::UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScanBack)
 {
+    AssertLockHeld(cs_main);
+
     if(!pindex) return;
 
     if (deterministicMNManager->IsDeterministicMNsSporkActive(pindex->nHeight)) {
@@ -354,7 +356,6 @@ void CMasternode::UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScan
         if (!dmn || dmn->pdmnState->nLastPaidHeight == -1) {
             LogPrint("masternode", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s -- not found\n", outpoint.ToStringShort());
         } else {
-            LOCK(cs_main);
             nBlockLastPaid = (int)dmn->pdmnState->nLastPaidHeight;
             nTimeLastPaid = chainActive[nBlockLastPaid]->nTime;
             LogPrint("masternode", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s -- found new %d\n", outpoint.ToStringShort(), nBlockLastPaid);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -18,6 +18,8 @@
 #include "wallet/wallet.h"
 #endif // ENABLE_WALLET
 
+#include "evo/deterministicmns.h"
+
 #include <string>
 
 
@@ -346,6 +348,19 @@ std::string CMasternode::GetStatus() const
 void CMasternode::UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScanBack)
 {
     if(!pindex) return;
+
+    if (deterministicMNManager->IsDeterministicMNsSporkActive(pindex->nHeight)) {
+        auto dmn = deterministicMNManager->GetListForBlock(pindex->GetBlockHash()).GetMN(outpoint.hash);
+        if (!dmn || dmn->pdmnState->nLastPaidHeight == -1) {
+            LogPrint("masternode", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s -- not found\n", outpoint.ToStringShort());
+        } else {
+            LOCK(cs_main);
+            nBlockLastPaid = (int)dmn->pdmnState->nLastPaidHeight;
+            nTimeLastPaid = chainActive[nBlockLastPaid]->nTime;
+            LogPrint("masternode", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s -- found new %d\n", outpoint.ToStringShort(), nBlockLastPaid);
+        }
+        return;
+    }
 
     const CBlockIndex *BlockReading = pindex;
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -583,6 +583,14 @@ bool CMasternodeMan::Get(const COutPoint& outpoint, CMasternode& masternodeRet)
     return true;
 }
 
+bool CMasternodeMan::GetMasternodeInfo(const uint256& proTxHash, masternode_info_t& mnInfoRet)
+{
+    auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMN(proTxHash);
+    if (!dmn)
+        return false;
+    return GetMasternodeInfo(COutPoint(proTxHash, dmn->nCollateralIndex), mnInfoRet);
+}
+
 bool CMasternodeMan::GetMasternodeInfo(const COutPoint& outpoint, masternode_info_t& mnInfoRet)
 {
     LOCK(cs);
@@ -654,6 +662,10 @@ bool CMasternodeMan::GetNextMasternodeInQueueForPayment(bool fFilterSigTime, int
 
 bool CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCountRet, masternode_info_t& mnInfoRet)
 {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight)) {
+        return false;
+    }
+
     mnInfoRet = masternode_info_t();
     nCountRet = 0;
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1817,7 +1817,7 @@ bool CMasternodeMan::CheckMnbAndUpdateMasternodeList(CNode* pfrom, CMasternodeBr
 
 void CMasternodeMan::UpdateLastPaid(const CBlockIndex* pindex)
 {
-    LOCK(cs);
+    LOCK2(cs_main, cs);
 
     if(fLiteMode || !masternodeSync.IsWinnersListSynced() || mapMasternodes.empty()) return;
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -171,6 +171,7 @@ public:
     bool Get(const COutPoint& outpoint, CMasternode& masternodeRet);
     bool Has(const COutPoint& outpoint);
 
+    bool GetMasternodeInfo(const uint256& proTxHash, masternode_info_t& mnInfoRet);
     bool GetMasternodeInfo(const COutPoint& outpoint, masternode_info_t& mnInfoRet);
     bool GetMasternodeInfo(const CKeyID& keyIDOperator, masternode_info_t& mnInfoRet);
     bool GetMasternodeInfo(const CPubKey& pubKeyOperator, masternode_info_t& mnInfoRet);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -24,6 +24,8 @@
 #include "evo/specialtx.h"
 #include "evo/deterministicmns.h"
 
+#include "evo/deterministicmns.h"
+
 #include <fstream>
 #include <iomanip>
 #include <univalue.h>
@@ -223,10 +225,15 @@ UniValue masternode_count(const JSONRPCRequest& request)
         masternode_count_help();
 
     int nCount;
-    masternode_info_t mnInfo;
-    mnodeman.GetNextMasternodeInQueueForPayment(true, nCount, mnInfo);
+    int total;
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        nCount = total = mnodeman.CountEnabled();
+    } else {
+        masternode_info_t mnInfo;
+        mnodeman.GetNextMasternodeInQueueForPayment(true, nCount, mnInfo);
+        total = mnodeman.size();
+    }
 
-    int total = mnodeman.size();
     int ps = mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION);
     int enabled = mnodeman.CountEnabled();
 
@@ -272,11 +279,18 @@ UniValue GetNextMasternodeForPayment(int heightShift)
         LOCK(cs_main);
         pindex = chainActive.Tip();
     }
+
     nHeight = pindex->nHeight + heightShift;
     mnodeman.UpdateLastPaid(pindex);
 
-    if (!mnodeman.GetNextMasternodeInQueueForPayment(nHeight, true, nCount, mnInfo))
-        return "unknown";
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        auto payee = deterministicMNManager->GetListAtChainTip().GetMNPayee();
+        if (!payee || !mnodeman.GetMasternodeInfo(payee->proTxHash, mnInfo))
+            return "unknown";
+    } else {
+        if (!mnodeman.GetNextMasternodeInQueueForPayment(nHeight, true, nCount, mnInfo))
+            return "unknown";
+    }
 
     UniValue obj(UniValue::VOBJ);
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -801,11 +801,9 @@ UniValue masternode_winners(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Correct usage is 'masternode winners ( \"count\" \"filter\" )'");
 
     UniValue obj(UniValue::VOBJ);
-
-    for (int i = nHeight - nLast; i < nHeight + 20; i++) {
-        std::string strPayment = GetRequiredPaymentsString(i);
-        if (strFilter !="" && strPayment.find(strFilter) == std::string::npos) continue;
-        obj.push_back(Pair(strprintf("%d", i), strPayment));
+    auto mapPayments = GetRequiredPaymentsStrings(nHeight - nLast, nHeight + 20);
+    for (const auto &p : mapPayments) {
+        obj.push_back(Pair(strprintf("%d", p.first), p.second));
     }
 
     return obj;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -28,6 +28,7 @@
 #include "masternode-payments.h"
 #include "masternode-sync.h"
 
+#include "evo/deterministicmns.h"
 #include "evo/specialtx.h"
 #include "evo/cbtx.h"
 
@@ -720,7 +721,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
 
     result.push_back(Pair("masternode", masternodeObj));
     result.push_back(Pair("masternode_payments_started", pindexPrev->nHeight + 1 > consensusParams.nMasternodePaymentsStartBlock));
-    result.push_back(Pair("masternode_payments_enforced", sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
+    result.push_back(Pair("masternode_payments_enforced", deterministicMNManager->IsDeterministicMNsSporkActive() || sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)));
 
     UniValue superblockObjArray(UniValue::VARR);
     if(pblocktemplate->voutSuperblockPayments.size()) {


### PR DESCRIPTION
This is extracted from #2083. It introduces the new MN reward payment logic for deterministic masternodes.

It also enforces MN reward payments when superblocks are paid out (no more lucky miners getting 100% of the reward). This happens after spork15 activation.