### PR TITLE
Revert 2075

### DIFF
--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -190,7 +190,6 @@ void CPrivateSendBaseSession::SetNull()
     nState = POOL_STATE_IDLE;
     nSessionID = 0;
     nSessionDenom = 0;
-    nSessionInputCount = 0;
     vecEntries.clear();
     finalMutableTransaction.vin.clear();
     finalMutableTransaction.vout.clear();
@@ -477,7 +476,6 @@ std::string CPrivateSend::GetMessageByID(PoolMessage nMessageID)
         case MSG_NOERR:                 return _("No errors detected.");
         case MSG_SUCCESS:               return _("Transaction created successfully.");
         case MSG_ENTRIES_ADDED:         return _("Your entries added successfully.");
-        case ERR_INVALID_INPUT_COUNT:   return _("Invalid input count.");
         default:                        return _("Unknown response.");
     }
 }

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -51,7 +51,6 @@ enum PoolMessage {
     MSG_NOERR,
     MSG_SUCCESS,
     MSG_ENTRIES_ADDED,
-    ERR_INVALID_INPUT_COUNT,
     MSG_POOL_MIN = ERR_ALREADY_HAVE,
     MSG_POOL_MAX = MSG_ENTRIES_ADDED
 };
@@ -100,18 +99,15 @@ class CDarksendAccept
 {
 public:
     int nDenom;
-    int nInputCount;
     CMutableTransaction txCollateral;
 
     CDarksendAccept() :
         nDenom(0),
-        nInputCount(0),
         txCollateral(CMutableTransaction())
         {};
 
-    CDarksendAccept(int nDenom, int nInputCount, const CMutableTransaction& txCollateral) :
+    CDarksendAccept(int nDenom, const CMutableTransaction& txCollateral) :
         nDenom(nDenom),
-        nInputCount(nInputCount),
         txCollateral(txCollateral)
         {};
 
@@ -120,12 +116,6 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(nDenom);
-        int nVersion = s.GetVersion();
-        if (nVersion > 70208) {
-            READWRITE(nInputCount);
-        } else if (ser_action.ForRead()) {
-            nInputCount = 0;
-        }
         READWRITE(txCollateral);
     }
 
@@ -179,7 +169,6 @@ class CDarksendQueue
 {
 public:
     int nDenom;
-    int nInputCount;
     COutPoint masternodeOutpoint;
     int64_t nTime;
     bool fReady; //ready for submit
@@ -189,7 +178,6 @@ public:
 
     CDarksendQueue() :
         nDenom(0),
-        nInputCount(0),
         masternodeOutpoint(COutPoint()),
         nTime(0),
         fReady(false),
@@ -197,9 +185,8 @@ public:
         fTried(false)
         {}
 
-    CDarksendQueue(int nDenom, int nInputCount, COutPoint outpoint, int64_t nTime, bool fReady) :
+    CDarksendQueue(int nDenom, COutPoint outpoint, int64_t nTime, bool fReady) :
         nDenom(nDenom),
-        nInputCount(nInputCount),
         masternodeOutpoint(outpoint),
         nTime(nTime),
         fReady(fReady),
@@ -213,11 +200,6 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(nDenom);
         int nVersion = s.GetVersion();
-        if (nVersion > 70208) {
-            READWRITE(nInputCount);
-        } else if (ser_action.ForRead()) {
-            nInputCount = 0;
-        }
         if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};
@@ -258,13 +240,13 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("nDenom=%d, nInputCount=%d, nTime=%lld, fReady=%s, fTried=%s, masternode=%s",
-                        nDenom, nInputCount, nTime, fReady ? "true" : "false", fTried ? "true" : "false", masternodeOutpoint.ToStringShort());
+        return strprintf("nDenom=%d, nTime=%lld, fReady=%s, fTried=%s, masternode=%s",
+                        nDenom, nTime, fReady ? "true" : "false", fTried ? "true" : "false", masternodeOutpoint.ToStringShort());
     }
 
     friend bool operator==(const CDarksendQueue& a, const CDarksendQueue& b)
     {
-        return a.nDenom == b.nDenom && a.nInputCount == b.nInputCount && a.masternodeOutpoint == b.masternodeOutpoint && a.nTime == b.nTime && a.fReady == b.fReady;
+        return a.nDenom == b.nDenom && a.masternodeOutpoint == b.masternodeOutpoint && a.nTime == b.nTime && a.fReady == b.fReady;
     }
 };
 
@@ -366,7 +348,6 @@ protected:
 
 public:
     int nSessionDenom; //Users must submit a denom matching this
-    int nSessionInputCount; //Users must submit a count matching this
 
     CPrivateSendBaseSession() :
         vecEntries(),
@@ -374,8 +355,7 @@ public:
         nTimeLastSuccessfulStep(0),
         nSessionID(0),
         finalMutableTransaction(),
-        nSessionDenom(0),
-        nSessionInputCount(0)
+        nSessionDenom(0)
         {}
     CPrivateSendBaseSession(const CPrivateSendBaseSession& other) { /* dummy copy constructor*/ SetNull(); }
 

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -116,6 +116,11 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(nDenom);
+        int nVersion = s.GetVersion();
+        if (nVersion > 70208 && nVersion <= 70210) {
+            int nInputCount = 0;
+            READWRITE(nInputCount);
+        }
         READWRITE(txCollateral);
     }
 
@@ -200,6 +205,10 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(nDenom);
         int nVersion = s.GetVersion();
+        if (nVersion > 70208 && nVersion <= 70210) {
+            int nInputCount = 0;
+            READWRITE(nInputCount);
+        }
         if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
             // converting from/to old format
             CTxIn txin{};


### PR DESCRIPTION
Turned out that #2075 wasn't such a good idea after all, so I'd like to revert it. The good news - we've never activated it on mainnet and reverting it this way (with backwards compatibility patch) doesn't hurt mixing on testnet either. I'll push an alternative solution to the issue #2075 was intended to solve after this one is merged.