### PR TITLE
Docs - Update Core version number in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Dash Core staging tree 0.12.3
+Dash Core staging tree 0.12.4
 ===============================
 
 `master:` [![Build Status](https://travis-ci.org/dashpay/dash.svg?branch=master)](https://travis-ci.org/dashpay/dash) `develop:` [![Build Status](https://travis-ci.org/dashpay/dash.svg?branch=develop)](https://travis-ci.org/dashpay/dash/branches)

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-Dash Core 0.12.1
+Dash Core 0.12.4
 =====================
 
 This is the official reference wallet for Dash digital currency and comprises the backbone of the Dash peer-to-peer network. You can [download Dash Core](https://www.dash.org/downloads/) or [build it yourself](#building) using the guides below.

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,4 +1,4 @@
-Dash Core 0.12.1
+Dash Core 0.12.4
 =====================
 
 Intro


### PR DESCRIPTION
I noticed these were out of date. Maybe the version number should just be removed from them entirely?