### PR TITLE
Try to mix more than one input by default

### DIFF
--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -109,7 +109,7 @@ private:
     /// step 0: select denominated inputs and txouts
     bool SelectDenominate(std::string& strErrorRet, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet);
     /// step 1: prepare denominated inputs and outputs
-    bool PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, const std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet);
+    bool PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, const std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet, bool fAvoidSingle);
     /// step 2: send denominated inputs and outputs prepared in step 1
     bool SendDenominate(const std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, CConnman& connman);
 


### PR DESCRIPTION
Turned out that @InhumanPerfection was partially right there https://github.com/dashpay/dash/pull/2261#discussion_r215400925 and wallet indeed tends to mix lower number of inputs in general. Not as bad as predicted ("mostly 1") but still lots of mixing sessions have 1-3 inputs, sometimes 4 but that's really rare. It's not like a huge drawback, considering the fact that privacy is not affected, but it's just going to take more time to mix in general, so still not so good. This situation can be improved by simply trying to skip the worst case (when we found 1 input only) in the first run. From what I observed, this works pretty good and it's much more common to see 3+ inputs per session now. Would be interesting to see if that's the case for someone else, pls test :)

This requires #2274 because otherwise GUI becomes unresponsive due to way too many loops over the heavy coin selection. Will rebase after 2274 is merged. Meaningful changes are pretty trivial here if you ignore commits from previous PRs and whitespaces: https://github.com/dashpay/dash/commit/44f53f1ed6f1f98709af1763152871399b6066a4?w=1