### PR TITLE
Pick rounds with the most inputs available to mix first

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1178,7 +1178,7 @@ bool CPrivateSendClientSession::SubmitDenominate(CConnman& connman)
     }
 
     std::vector< std::pair<int, size_t> > vecInputsByRounds;
-    // Note: liqudity providers are fine whith whatever numner of inputs they've got
+    // Note: liqudity providers are fine with whatever number of inputs they've got
     bool fDryRun = privateSendClient.nLiquidityProvider == 0;
 
     for (int i = 0; i < privateSendClient.nPrivateSendRounds; i++) {

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1289,7 +1289,14 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
             if (vecSteps[nBit] >= nStepsMax) break;
             CAmount nValueDenom = vecStandardDenoms[nBit];
             if (pair.second.nValue == nValueDenom) {
-                CScript scriptDenom = fDryRun ? CScript() : keyHolderStorage.AddKey(pwalletMain);
+                CScript scriptDenom;
+                if (fDryRun) {
+                    scriptDenom = CScript();
+                } else {
+                    // randomly skip some inputs when we have at least one of the same denom already
+                    if (vecSteps[nBit] > 1 && GetRandInt(2)) break;
+                    scriptDenom = keyHolderStorage.AddKey(pwalletMain);
+                }
                 vecPSInOutPairsRet.emplace_back(pair.first, CTxOut(nValueDenom, scriptDenom));
                 fFound = true;
                 nDenomResult |= 1 << nBit;

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1178,7 +1178,7 @@ bool CPrivateSendClientSession::SubmitDenominate(CConnman& connman)
     }
 
     std::vector< std::pair<int, size_t> > vecInputsByRounds;
-    // Note: liqudity providers are fine with whatever number of inputs they've got
+    // Note: liquidity providers are fine with whatever number of inputs they've got
     bool fDryRun = privateSendClient.nLiquidityProvider == 0;
 
     for (int i = 0; i < privateSendClient.nPrivateSendRounds; i++) {

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1167,17 +1167,6 @@ void CPrivateSendClientManager::ProcessPendingDsaRequest(CConnman& connman)
 
 bool CPrivateSendClientSession::SubmitDenominate(CConnman& connman)
 {
-    // This is just a local helper
-    auto GetStartRound = [](bool fMixLowest, bool fScanFromTheMiddle) -> int
-    {
-        if (fScanFromTheMiddle) {
-            return privateSendClient.nPrivateSendRounds / 2;
-        } else if (!fMixLowest) {
-            return privateSendClient.nPrivateSendRounds - 1;
-        }
-        return 0;
-    };
-
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     std::string strError;
@@ -1188,28 +1177,36 @@ bool CPrivateSendClientSession::SubmitDenominate(CConnman& connman)
         return false;
     }
 
-    // lean towards "highest" branch but still mix via "lowest" one someties
-    bool fMixLowest = privateSendClient.nLiquidityProvider || (GetRandInt(4) == 0);
-    // Try to use only inputs with the same number of rounds, from low to high, or vice versa
-    int nLoopStep = fMixLowest ? 1 : -1;
-    // lean towards edges but still mix starting from the middle someties
-    // Note: liqudity providers always start from 0
-    bool fScanFromTheMiddle = (privateSendClient.nLiquidityProvider == 0) && (GetRandInt(4) == 0);
+    std::vector< std::pair<int, size_t> > vecInputsByRounds;
+    // Note: liqudity providers are fine whith whatever numner of inputs they've got
+    bool fDryRun = privateSendClient.nLiquidityProvider == 0;
 
-    int nRoundStart = GetStartRound(fMixLowest, fScanFromTheMiddle);
-    int nRoundEdge = GetStartRound(fMixLowest, false);
-
-    // Submit transaction to the pool if we get here
-    while (true) {
-        for (int i = nRoundStart; i >= 0 && i < privateSendClient.nPrivateSendRounds; i += nLoopStep) {
-            if (PrepareDenominate(i, i, strError, vecPSInOutPairs, vecPSInOutPairsTmp)) {
-                LogPrintf("CPrivateSendClientSession::SubmitDenominate -- Running PrivateSend denominate for %d rounds, success\n", i);
+    for (int i = 0; i < privateSendClient.nPrivateSendRounds; i++) {
+        if (PrepareDenominate(i, i, strError, vecPSInOutPairs, vecPSInOutPairsTmp, fDryRun)) {
+            LogPrintf("CPrivateSendClientSession::SubmitDenominate -- Running PrivateSend denominate for %d rounds, success\n", i);
+            if (!fDryRun) {
                 return SendDenominate(vecPSInOutPairsTmp, connman);
             }
+            vecInputsByRounds.emplace_back(i, vecPSInOutPairsTmp.size());
+        } else {
             LogPrint("privatesend", "CPrivateSendClientSession::SubmitDenominate -- Running PrivateSend denominate for %d rounds, error: %s\n", i, strError);
         }
-        if (nRoundStart == nRoundEdge) break;
-        nRoundStart = nRoundEdge;
+    }
+
+    // more inputs first, for equal input count prefer the one with less rounds
+    std::sort(vecInputsByRounds.begin(), vecInputsByRounds.end(), [](const auto& a, const auto& b) {
+        return a.second > b.second || (a.second == b.second && a.first < b.first);
+    });
+
+    LogPrint("privatesend", "vecInputsByRounds for denom %d\n", nSessionDenom);
+    for (const auto& pair : vecInputsByRounds) {
+        LogPrint("privatesend", "vecInputsByRounds: rounds: %d, inputs: %d\n", pair.first, pair.second);
+    }
+
+    int nRounds = vecInputsByRounds.begin()->first;
+    if (PrepareDenominate(nRounds, nRounds, strError, vecPSInOutPairs, vecPSInOutPairsTmp)) {
+        LogPrintf("CPrivateSendClientSession::SubmitDenominate -- Running PrivateSend denominate for %d rounds, success\n", nRounds);
+        return SendDenominate(vecPSInOutPairsTmp, connman);
     }
 
     // We failed? That's strange but let's just make final attempt and try to mix everything
@@ -1259,7 +1256,7 @@ bool CPrivateSendClientSession::SelectDenominate(std::string& strErrorRet, std::
     return true;
 }
 
-bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, const std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet)
+bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, const std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet, bool fDryRun)
 {
     std::vector<int> vecBits;
     if (!CPrivateSend::GetDenominationsBits(nSessionDenom, vecBits)) {
@@ -1292,7 +1289,7 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
             if (vecSteps[nBit] >= nStepsMax) break;
             CAmount nValueDenom = vecStandardDenoms[nBit];
             if (pair.second.nValue == nValueDenom) {
-                CScript scriptDenom = keyHolderStorage.AddKey(pwalletMain);
+                CScript scriptDenom = fDryRun ? CScript() : keyHolderStorage.AddKey(pwalletMain);
                 vecPSInOutPairsRet.emplace_back(pair.first, CTxOut(nValueDenom, scriptDenom));
                 fFound = true;
                 nDenomResult |= 1 << nBit;
@@ -1301,8 +1298,8 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
                 break;
             }
         }
-        if (!fFound) {
-            // unlock unused coins
+        if (!fFound || fDryRun) {
+            // unlock unused coins and if we are not going to mix right away
             pwalletMain->UnlockCoin(pair.first.prevout);
         }
     }
@@ -1317,7 +1314,6 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
         return false;
     }
 
-    // We also do not care about full amount as long as we have right denominations
     return true;
 }
 

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1293,7 +1293,8 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
                     scriptDenom = CScript();
                 } else {
                     // randomly skip some inputs when we have at least one of the same denom already
-                    if (vecSteps[nBit] > 1 && GetRandInt(2)) {
+                    // TODO: make it adjustable via options/cmd-line params
+                    if (vecSteps[nBit] >= 1 && GetRandInt(5) == 0) {
                         // still count it as a step to randomize number of inputs
                         // if we have more than (or exactly) PRIVATESEND_ENTRY_MAX_SIZE of them
                         ++vecSteps[nBit];

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -109,7 +109,7 @@ private:
     /// step 0: select denominated inputs and txouts
     bool SelectDenominate(std::string& strErrorRet, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet);
     /// step 1: prepare denominated inputs and outputs
-    bool PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, const std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet);
+    bool PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, const std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet, bool fDryRun = false);
     /// step 2: send denominated inputs and outputs prepared in step 1
     bool SendDenominate(const std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, CConnman& connman);
 


### PR DESCRIPTION
After discussion in previous PRs I can't stop thinking that maybe we shouldn't introduce some arbitrary variance and fight the consequences of mixing with "no duplicate txids" rule and instead we could use it to our benefit somehow and the variance will appear naturally. So here is the idea: scan all coins with all rounds first to figure out how many inputs available for each of them and pick the one that has max inputs. For example, let's say that we have `<R, N1>`, `<R+1, N2>` (where R is some number of rounds; N1, N2 is some number of available inputs and N1 > N2). We mix M inputs, so after this we'll have something from `<R, N1-M>` to `<R, N1>` (it depends because previous txes could have more than 1 output) for R and `<R+1, N2+1>` for R+1. Note, that this way we consumed up to M inputs with unique txids for R rounds but we only added 1 input to R+1 rounds (because of "no duplicate txids" rule). What's interesting is that 1) there is already a variance for R which comes from previous txes and 2) if `N2+1` is greater than `N1-M` then we kind of shuffled them and R+1 now has higher mixing priority (hence even more variance).

I wonder if this makes any sense or if I'm missing smth :)

See ~6cebae0~ eddb4d7 for the implementation, ignore all the commits from previous PRs included here, will rebase later.

UPDATE1: we can include inputs from the very next round too if there are some, this should bring more variance I think, see ~541f1f3~ 7c632e7f3. This will however "squash" them into the same single tx which will decrease mixing speed due to "no same txid" rule.

UPDATE2: reverted 7c632e7f3, it tends to have the same issue with lower and lower number of inputs on higher rounds which could probably make cluster analysis easier.

UPDATE3: also randomly skip some inputs and try to add up to PRIVATESEND_ENTRY_MAX_SIZE of every needed denomination to balance out "no duplicate txids" rule and make it harder to analyse.