### PR TITLE
Wait for ThreadImport to finish before we initialize the initial chain tip

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2002,6 +2002,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // ********************************************************* Step 11c: update block tip in Dash modules
 
+    // Wait for importing thread to finish before we continue. Otherwise the current chain tip will not be up-to-date
+    while (fImporting) {
+        MilliSleep(100);
+    }
+
     // force UpdatedBlockTip to initialize nCachedBlockHeight for DS, MN payments and budgets
     // but don't call it directly to prevent triggering of other listeners like zmq etc.
     // GetMainSignals().UpdatedBlockTip(chainActive.Tip());


### PR DESCRIPTION
This should fix the infinite hangs we observe on Jenkins. The reason is that there is a race between ThreadImport finishing and the call to InitializeCurrentBlockTip.

While ThreadImport is running, fImporting is true, which makes IsInitialBlockDownload return true. If InitializeCurrentBlockTip is called while ThreadImport is not finished yet, InitializeCurrentBlockTip will call UpdatedBlockTip with fInitialDownload=true. As UpdatedBlockTip is then never called again (as no block are generated while waiting for mnsync), mnsync will never finish.

This should fix the hangs, but it's not a proper fix for the underlying problem. The underlying problem is the use of mocktime in most of our tests. It results in IsInitialBlockDownload to return false (but only if ThreadImport has finished) even though no block has been generated/received yet, which also means it returns false in a multi-node test BEFORE nodes are connected.

Interestingly, this doesn't cause real problems in the tests...except this one, but this is related to Dash-specific functionality only. The hangs are not happening on Travis as timing seems to be different there. It started to happen on Jenkins after the recent fixes to regtest-mnsync, which implicitely removed calls to SwitchToNextAsset when nRequestedMasternodeAssets is MASTERNODE_SYNC_INIT. This made the mnsync fully dependent on the call to UpdatedBlockTip with fInitialDownload=false. EDIT: Which is actually fine and shouldn't be changed IMHO. UpdatedBlockTip should just be more reliable, which should be the case after this PR.

A possible solution would be to start nodes with a mocktime that is nMaxTipAge seconds after the genesis block.