### PR TITLE
Fix locking issues in DIP3 unit tests

### DIFF
--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -190,11 +190,11 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
 
         // This is a temporary restriction that will be lifted later
         // It is required while we are transitioning from the old MN list to the deterministic list
-        CTransactionRef proRegTx;
-        uint256 tmpHashBlock;
-        if (!GetTransaction(ptx.proTxHash, proRegTx, Params().GetConsensus(), tmpHashBlock))
+        Coin coin;
+        if (!GetUTXOCoin(COutPoint(dmn->proTxHash, dmn->nCollateralIndex), coin) || coin.IsSpent()) {
             return state.DoS(100, false, REJECT_INVALID, "bad-protx-payee-collateral");
-        if (proRegTx->vout[dmn->nCollateralIndex].scriptPubKey != ptx.scriptPayout)
+        }
+        if (coin.out.scriptPubKey != ptx.scriptPayout)
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-collateral");
 
         if (mnList.HasUniqueProperty(ptx.keyIDOperator)) {

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -151,6 +151,7 @@ CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns,
 
     // Manually update CbTx as we modified the block here
     if (block.vtx[0]->nType == TRANSACTION_COINBASE) {
+        LOCK(cs_main);
         CCbTx cbTx;
         if (!GetTxPayload(*block.vtx[0], cbTx)) {
             BOOST_ASSERT(false);


### PR DESCRIPTION
This fixes 2 issues, see individual commits. Without this, builds fail on Jenkins. Builds don't fail on Travis, very likely due to timing differences.