### PR TITLE
Call InitializeCurrentBlockTip and activeMasternodeManager->Init after importing has finished

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -797,6 +797,15 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
         StartShutdown();
     }
     } // End scope of CImportingNow
+
+    // force UpdatedBlockTip to initialize nCachedBlockHeight for DS, MN payments and budgets
+    // but don't call it directly to prevent triggering of other listeners like zmq etc.
+    // GetMainSignals().UpdatedBlockTip(chainActive.Tip());
+    pdsNotificationInterface->InitializeCurrentBlockTip();
+
+    if (activeMasternodeManager && fDIP0003ActiveAtTip)
+        activeMasternodeManager->Init();
+
     LoadMempool();
     fDumpMempoolLater = !fRequestShutdown;
 }
@@ -1999,18 +2008,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         }
     }
 
-
-    // ********************************************************* Step 11c: update block tip in Dash modules
-
-    // force UpdatedBlockTip to initialize nCachedBlockHeight for DS, MN payments and budgets
-    // but don't call it directly to prevent triggering of other listeners like zmq etc.
-    // GetMainSignals().UpdatedBlockTip(chainActive.Tip());
-    pdsNotificationInterface->InitializeCurrentBlockTip();
-
-    if (activeMasternodeManager && fDIP0003ActiveAtTip)
-        activeMasternodeManager->Init();
-
-    // ********************************************************* Step 11d: schedule Dash-specific tasks
+    // ********************************************************* Step 11c: schedule Dash-specific tasks
 
     if (!fLiteMode) {
         scheduler.scheduleEvery(boost::bind(&CNetFulfilledRequestManager::DoMaintenance, boost::ref(netfulfilledman)), 60);


### PR DESCRIPTION
While importing, IsInitialBlockDownload always returns true, meaning that
the call to UpdatedBlockTip will also receive true as fInitialDownload.

UpdatedBlockTip is never called again unless a block is mined.
Mining of new blocks in regtest however only starts after mnsync has
finished, which will never happen as it waits for the next call to
UpdatedBlockTip.

This is an alternative fix to #2283 