### PR TITLE
M-of-N-like sporks

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -124,6 +124,7 @@ testScripts = [
     'wallet-accounts.py',
     'wallet-dump.py',
     'listtransactions.py',
+    'multikeysporks.py',
     # vv Tests less than 60s vv
     'sendheaders.py', # NOTE: needs dash_hash to pass
     'zapwallettxes.py',

--- a/qa/rpc-tests/multikeysporks.py
+++ b/qa/rpc-tests/multikeysporks.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from time import *
+'''
+'''
+
+class MultiKeySporkTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 3
+        self.setup_clean_chain = True
+        self.is_network_split = False
+
+    def setup_network(self):
+        self.nodes = []
+
+        # secret(base58): 931wyuRNVYvhg18Uu9bky5Qg1z4QbxaJ7fefNBzjBPiLRqcd33F
+        # keyid(hex): 60f0f57f71f0081f1aacdd8432340a33a526f91b
+        # address(base58): yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa
+        # secret(base58): 91vbXGMSWKGHom62986XtL1q2mQDA12ngcuUNNe5NfMSj44j7g3
+        # keyid(hex): 43dff2b09de2f904f688ec14ee6899087b889ad0
+        # address(base58): yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h
+        # secret(base58): 92bxUjPT5AhgXuXJwfGGXqhomY2SdQ55MYjXyx9DZNxCABCSsRH
+        # keyid(hex): d9aa5fa00cce99101a4044e65dc544d1579890de
+        # address(base58): ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7
+        # secret(base58): 934yPXiVGf4RCY2qTs2Bt5k3TEtAiAg12sMxCt8yVWbSU7p3fuD
+        # keyid(hex): 0b23935ce0bea3b997a334f6fa276c9fa17687b2
+        # address(base58): ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn
+        # secret(base58): 92Cxwia363Wg2qGF1fE5z4GKi8u7r1nrWQXdtsj2ACZqaDPSihD
+        # keyid(hex): 1d1098b2b1f759b678a0a7a098637a9b898adcac
+        # address(base58): yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui
+        # secret(base58): 92CKXK5dbysc4zQnNsvzgDpiBGgo67VPsRDAFsF4gGwbiZpgLMv
+        # keyid(hex): 0e9b6bdc15dc3afb63d1ffc68cc5534a4caaeaa6
+        # address(base58): ybY28sZzX3Jy3UNcZ72MNubcVEQXcAN3Vh
+        # secret(base58): 91tDdZPR5gfCNfkVN8Pym1YyaaMHhf9MyVS12LRuN2MoAgSeDcE
+        # keyid(hex): 99a001480e0332d1a0d30078bde4d6fe3a178cfa
+        # address(base58): yjADbqTD649DaJnRGZYrXW1fnfQ4ciDcXH
+        # secret(base58): 928dGxqesKbqKpfAJXRnGd4gy3GtbtfM1WHTQBisvWDVJZ1Vxyi
+        # keyid(hex): 3ae21cfc6017c65e80d7ec45310c22f6dc705bdd
+        # address(base58): ygVsj29xcd1B3iMbs6A2CY9mscC8cBXEZX
+        # secret(base58): 91ynY1Q7iaXSbuNq9nQ2u6K2i2ryX3em5wEKEofXTjhsrDL2jY8
+        # keyid(hex): 551a3c676574d355fc3c314955f3b440cf57b245
+        # address(base58): ySfy7vpGjiG27PSr8XKCKr4y3mY1D9U76y
+        # secret(base58): 92ffBcNsSLyEKT5CmqGMEmYHJBUTHoGHjFy9Y3XNPSLbxi4DVWD
+        # keyid(hex): 8df696c8d4e69a898ce7d599559e32268b28ccbb
+        # address(base58): ydSRnFKrboF3L544AWQfG79mcXMC7ZtShL
+        # secret(base58): 92cDaZ9GGSLnJsaEbCDewrXA3RcmDCG9MZAeJZTmMnpgLQAsyHr
+        # keyid(hex): 92af1b1ebe0107dcc648aa150905e1229777225d
+        # address(base58): yUotyrzs4H9DJ7K3Y7ccgeAUh442FEkrKw
+        # secret(base58): 92PGUYidWoq9qBoyEEAeYQ12ZHWBCR5YusLenpa7vUGFXPfgqXx
+        # keyid(hex): 093a9963ac777502251dd98c22ea2c71aaa2fee3
+        # address(base58): yh6yH8LJ4eTFWAWVNdCDaQa53nXpddvmZp
+        # secret(base58): 91tbFNAjdSeUYZAG3QhF91Zh1LGgZcFpq8zrGEH1MHKycFLtDrL
+        # keyid(hex): 5fcfae286651d85e6ad2eff5a38b148d806f9beb
+        # address(base58): yhoDr8n8DzfLR7VQGcLqpmq29WJ5Z2eYNi
+        # secret(base58): 92EMsUxGgk1372edF7iNNzQSN3iLsRkUSmZzQKGwLd4CrC3YUUH
+        # keyid(hex): 4287e28642ebfd3d48e86888a6bb6e7a9af22910
+        # address(base58): yMnuur7LEVgrYFczsNfx8W61eAgGYAmTVG
+        # secret(base58): 92VRomWTLSRRHWR3NwbUAhrPuwfMyciLcDWR9ebJRbSFoEj2RLg
+        # keyid(hex): 6d3fcee4b4b92488ed20171b61c2951ea51cbeb4
+        # address(base58): yco8DwPVN6Wgk1nCmakkLYCGzXy9fgu5zC
+        # secret(base58): 92swaJmVB2c4kLvKt7CihNneE7MxfQnv7eRV248F7t4CmVWsaLe
+        # keyid(hex): ab87f6995077f4bdd6233bc2992611674d7c6594
+        # address(base58): yZr6Rw8GiZwD6GMdC2fuP7c8qkFQPgWVRX
+        # secret(base58): 923NQ12YSeVs4RfaCiCqTE9iNAD4dobSmuEhnV7x6q7styQYfKb
+        # keyid(hex): 2318b0dab38d676aae483ab0f55f2d839a1031b2
+        # address(base58): ycZduSBR8W8Gpb9ec1AocYF1c4Q3E6wjeM
+        # secret(base58): 92tMn4LCFGTthXpdiygJGjQbJYmYY78TiXHFWYTUu9uZiLnHn8W
+        # keyid(hex): ed73329177896a951b0eb30dd962d3e661c0476e
+        # address(base58): yWNZ8gibbLMAyuXX4i1ZNaxmADW59Rz3zJ
+        # secret(base58): 92RgZKa9TYVRJZmj4Nme3jBRn77rD2BmQNJZJkWmN67UVpRXWjW
+        # keyid(hex): a7845c35a6b608c7c3a9a9388e06370fa3f5d32b
+        # address(base58): yQKBpf5bCZ3ctmYKFEPqdeLTg4SwuciMo7
+        # secret(base58): 92mNuCHJ2kWcxGkAus1P6UDPHPFZDPNTzMMf72YujjXtdmbiUCk
+        # keyid(hex): dfe5fcd9bee0b871ad221a4cf3532c2848314701
+        # address(base58): yLSCowJMnKfrmniiX9RD2bxvbHwvzgyKvQ
+        # secret(base58): 92cyrqe2iYqw6ni5MQvBAcSQNAAApmeToeA7qzawEcxLDHufGK3
+        # keyid(hex): 088f9e1ee1a06e0b3fed714beee97e90c035ed76
+        # address(base58): yXAGkUbnEtEeY2cdZnt9zzD4mCnmLeCZfU
+        # secret(base58): 93UMgtWGffnog5yYyyiSwzHCP7FX8wmURQa19f7oT95JQpLu3LN
+        # keyid(hex): 98396e03c6e20e44ce776e07e92cb533cb450e7f
+        # address(base58): yXuFmFBfipN4pDWbiQLLNAaT2HcTGLLAkJ
+
+
+        self.nodes.append(start_node(0, self.options.tmpdir,
+                                     ["-debug", "-sporkkey=931wyuRNVYvhg18Uu9bky5Qg1z4QbxaJ7fefNBzjBPiLRqcd33F",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-minsporkkeys=2"]))
+        self.nodes.append(start_node(1, self.options.tmpdir,
+                                     ["-debug", "-sporkkey=91vbXGMSWKGHom62986XtL1q2mQDA12ngcuUNNe5NfMSj44j7g3",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-minsporkkeys=2"]))
+        self.nodes.append(start_node(2, self.options.tmpdir,
+                                     ["-debug",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-minsporkkeys=2"]))
+        # connect nodes at start
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[1], 2)
+
+    def get_test_spork_state(self, node):
+        info = node.spork('active')
+        # use InstantSend spork for tests
+        return info['SPORK_2_INSTANTSEND_ENABLED']
+
+    def set_test_spork_state(self, node, state):
+        if state:
+            value = 0
+        else:
+            value = 4070908800
+        # use InstantSend spork for tests
+        node.spork('SPORK_2_INSTANTSEND_ENABLED', value)
+
+    def wait_for_test_spork_state(self, node, state):
+        start = time()
+        got_state = False
+        while True:
+            if self.get_test_spork_state(node) == state:
+                got_state = True
+                break
+            if time() > start + 10:
+                break
+            sleep(0.1)
+        return got_state
+
+    def run_test(self):
+        # check test spork default state
+        for node in self.nodes:
+            assert(self.get_test_spork_state(node))
+
+        # first signer turns off spork
+        self.set_test_spork_state(self.nodes[0], False)
+        # spork change requires at least 2 signers
+        for node in self.nodes:
+            assert(not self.wait_for_test_spork_state(node, False))
+
+        # second signer turns off spork
+        self.set_test_spork_state(self.nodes[1], False)
+        # now spork state is changed
+        for node in self.nodes:
+            assert(self.wait_for_test_spork_state(node, False))
+
+
+
+if __name__ == '__main__':
+    MultiKeySporkTest().main()

--- a/qa/rpc-tests/multikeysporks.py
+++ b/qa/rpc-tests/multikeysporks.py
@@ -52,23 +52,43 @@ class MultiKeySporkTest(BitcoinTestFramework):
 
         self.nodes.append(start_node(0, self.options.tmpdir,
                                      ["-debug", "-sporkkey=931wyuRNVYvhg18Uu9bky5Qg1z4QbxaJ7fefNBzjBPiLRqcd33F",
-                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7",
+                                      "-sporkaddr=yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h",
+                                      "-sporkaddr=yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-sporkaddr=ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn",
+                                      "-sporkaddr=yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
                                       "-minsporkkeys=3"]))
         self.nodes.append(start_node(1, self.options.tmpdir,
                                      ["-debug", "-sporkkey=91vbXGMSWKGHom62986XtL1q2mQDA12ngcuUNNe5NfMSj44j7g3",
-                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7",
+                                      "-sporkaddr=yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h",
+                                      "-sporkaddr=yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-sporkaddr=ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn",
+                                      "-sporkaddr=yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
                                       "-minsporkkeys=3"]))
         self.nodes.append(start_node(2, self.options.tmpdir,
                                      ["-debug", "-sporkkey=92bxUjPT5AhgXuXJwfGGXqhomY2SdQ55MYjXyx9DZNxCABCSsRH",
-                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7",
+                                      "-sporkaddr=yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h",
+                                      "-sporkaddr=yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-sporkaddr=ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn",
+                                      "-sporkaddr=yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
                                       "-minsporkkeys=3"]))
         self.nodes.append(start_node(3, self.options.tmpdir,
                                      ["-debug", "-sporkkey=934yPXiVGf4RCY2qTs2Bt5k3TEtAiAg12sMxCt8yVWbSU7p3fuD",
-                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7",
+                                      "-sporkaddr=yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h",
+                                      "-sporkaddr=yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-sporkaddr=ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn",
+                                      "-sporkaddr=yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
                                       "-minsporkkeys=3"]))
         self.nodes.append(start_node(4, self.options.tmpdir,
                                      ["-debug", "-sporkkey=92Cxwia363Wg2qGF1fE5z4GKi8u7r1nrWQXdtsj2ACZqaDPSihD",
-                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7",
+                                      "-sporkaddr=yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h",
+                                      "-sporkaddr=yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-sporkaddr=ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn",
+                                      "-sporkaddr=yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
                                       "-minsporkkeys=3"]))
         # connect nodes at start
         for i in range(0, 5):

--- a/qa/rpc-tests/multikeysporks.py
+++ b/qa/rpc-tests/multikeysporks.py
@@ -76,23 +76,19 @@ class MultiKeySporkTest(BitcoinTestFramework):
                 connect_nodes(self.nodes[i], j)
 
     def get_test_spork_state(self, node):
-        info = node.spork('active')
+        info = node.spork('show')
         # use InstantSend spork for tests
         return info['SPORK_2_INSTANTSEND_ENABLED']
 
-    def set_test_spork_state(self, node, state):
-        if state:
-            value = 0
-        else:
-            value = 4070908800
+    def set_test_spork_state(self, node, value):
         # use InstantSend spork for tests
         node.spork('SPORK_2_INSTANTSEND_ENABLED', value)
 
-    def wait_for_test_spork_state(self, node, state):
+    def wait_for_test_spork_state(self, node, value):
         start = time()
         got_state = False
         while True:
-            if self.get_test_spork_state(node) == state:
+            if self.get_test_spork_state(node) == value:
                 got_state = True
                 break
             if time() > start + 10:
@@ -103,26 +99,26 @@ class MultiKeySporkTest(BitcoinTestFramework):
     def run_test(self):
         # check test spork default state
         for node in self.nodes:
-            assert(self.get_test_spork_state(node))
+            assert(self.get_test_spork_state(node) == 0)
 
-        # first signer turns off spork
-        self.set_test_spork_state(self.nodes[0], False)
+        # first signer set spork value
+        self.set_test_spork_state(self.nodes[0], 1)
         # spork change requires at least 2 signers
         for node in self.nodes:
-            assert(not self.wait_for_test_spork_state(node, False))
+            assert(not self.wait_for_test_spork_state(node, 1))
 
-        # second signer turns off spork
-        self.set_test_spork_state(self.nodes[1], False)
+        # second signer set spork value
+        self.set_test_spork_state(self.nodes[1], 1)
         # now spork state is changed
         for node in self.nodes:
-            assert(self.wait_for_test_spork_state(node, False))
+            assert(self.wait_for_test_spork_state(node, 1))
 
-        # now turn on the spork again with other signers to test
+        # now set the spork again with other signers to test
         # old and new spork messages interaction
-        self.set_test_spork_state(self.nodes[3], True)
-        self.set_test_spork_state(self.nodes[4], True)
+        self.set_test_spork_state(self.nodes[3], 2)
+        self.set_test_spork_state(self.nodes[4], 2)
         for node in self.nodes:
-            assert(self.wait_for_test_spork_state(node, True))
+            assert(self.wait_for_test_spork_state(node, 2))
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/multikeysporks.py
+++ b/qa/rpc-tests/multikeysporks.py
@@ -14,8 +14,8 @@ multikeysporks.py
 Test logic for several signer keys usage for spork broadcast.
 
 We set 5 possible keys for sporks signing and set minimum 
-required signers to 2. We check 1 siger can't set the spork 
-value, any 2 signers can change spork value and other 2 signers
+required signers to 3. We check 1 and 2 signers can't set the spork 
+value, any 3 signers can change spork value and other 3 signers
 can change it again.
 '''
 
@@ -126,7 +126,7 @@ class MultiKeySporkTest(BitcoinTestFramework):
         # first and second signers set spork value
         self.set_test_spork_state(self.nodes[0], 1)
         self.set_test_spork_state(self.nodes[1], 1)
-        # spork change requires at least 2 signers
+        # spork change requires at least 3 signers
         for node in self.nodes:
             assert(not self.wait_for_test_spork_state(node, 1))
 

--- a/qa/rpc-tests/multikeysporks.py
+++ b/qa/rpc-tests/multikeysporks.py
@@ -7,13 +7,23 @@ from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from time import *
+
 '''
+multikeysporks.py
+
+Test logic for several signer keys usage for spork broadcast.
+
+We set 5 possible keys for sporks signing and set minimum 
+required signers to 2. We check 1 siger can't set the spork 
+value, any 2 signers can change spork value and other 2 signers
+can change it again.
 '''
+
 
 class MultiKeySporkTest(BitcoinTestFramework):
     def __init__(self):
         super().__init__()
-        self.num_nodes = 3
+        self.num_nodes = 5
         self.setup_clean_chain = True
         self.is_network_split = False
 
@@ -23,87 +33,47 @@ class MultiKeySporkTest(BitcoinTestFramework):
         # secret(base58): 931wyuRNVYvhg18Uu9bky5Qg1z4QbxaJ7fefNBzjBPiLRqcd33F
         # keyid(hex): 60f0f57f71f0081f1aacdd8432340a33a526f91b
         # address(base58): yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa
+
         # secret(base58): 91vbXGMSWKGHom62986XtL1q2mQDA12ngcuUNNe5NfMSj44j7g3
         # keyid(hex): 43dff2b09de2f904f688ec14ee6899087b889ad0
         # address(base58): yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h
+
         # secret(base58): 92bxUjPT5AhgXuXJwfGGXqhomY2SdQ55MYjXyx9DZNxCABCSsRH
         # keyid(hex): d9aa5fa00cce99101a4044e65dc544d1579890de
         # address(base58): ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7
+
         # secret(base58): 934yPXiVGf4RCY2qTs2Bt5k3TEtAiAg12sMxCt8yVWbSU7p3fuD
         # keyid(hex): 0b23935ce0bea3b997a334f6fa276c9fa17687b2
         # address(base58): ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn
+
         # secret(base58): 92Cxwia363Wg2qGF1fE5z4GKi8u7r1nrWQXdtsj2ACZqaDPSihD
         # keyid(hex): 1d1098b2b1f759b678a0a7a098637a9b898adcac
         # address(base58): yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui
-        # secret(base58): 92CKXK5dbysc4zQnNsvzgDpiBGgo67VPsRDAFsF4gGwbiZpgLMv
-        # keyid(hex): 0e9b6bdc15dc3afb63d1ffc68cc5534a4caaeaa6
-        # address(base58): ybY28sZzX3Jy3UNcZ72MNubcVEQXcAN3Vh
-        # secret(base58): 91tDdZPR5gfCNfkVN8Pym1YyaaMHhf9MyVS12LRuN2MoAgSeDcE
-        # keyid(hex): 99a001480e0332d1a0d30078bde4d6fe3a178cfa
-        # address(base58): yjADbqTD649DaJnRGZYrXW1fnfQ4ciDcXH
-        # secret(base58): 928dGxqesKbqKpfAJXRnGd4gy3GtbtfM1WHTQBisvWDVJZ1Vxyi
-        # keyid(hex): 3ae21cfc6017c65e80d7ec45310c22f6dc705bdd
-        # address(base58): ygVsj29xcd1B3iMbs6A2CY9mscC8cBXEZX
-        # secret(base58): 91ynY1Q7iaXSbuNq9nQ2u6K2i2ryX3em5wEKEofXTjhsrDL2jY8
-        # keyid(hex): 551a3c676574d355fc3c314955f3b440cf57b245
-        # address(base58): ySfy7vpGjiG27PSr8XKCKr4y3mY1D9U76y
-        # secret(base58): 92ffBcNsSLyEKT5CmqGMEmYHJBUTHoGHjFy9Y3XNPSLbxi4DVWD
-        # keyid(hex): 8df696c8d4e69a898ce7d599559e32268b28ccbb
-        # address(base58): ydSRnFKrboF3L544AWQfG79mcXMC7ZtShL
-        # secret(base58): 92cDaZ9GGSLnJsaEbCDewrXA3RcmDCG9MZAeJZTmMnpgLQAsyHr
-        # keyid(hex): 92af1b1ebe0107dcc648aa150905e1229777225d
-        # address(base58): yUotyrzs4H9DJ7K3Y7ccgeAUh442FEkrKw
-        # secret(base58): 92PGUYidWoq9qBoyEEAeYQ12ZHWBCR5YusLenpa7vUGFXPfgqXx
-        # keyid(hex): 093a9963ac777502251dd98c22ea2c71aaa2fee3
-        # address(base58): yh6yH8LJ4eTFWAWVNdCDaQa53nXpddvmZp
-        # secret(base58): 91tbFNAjdSeUYZAG3QhF91Zh1LGgZcFpq8zrGEH1MHKycFLtDrL
-        # keyid(hex): 5fcfae286651d85e6ad2eff5a38b148d806f9beb
-        # address(base58): yhoDr8n8DzfLR7VQGcLqpmq29WJ5Z2eYNi
-        # secret(base58): 92EMsUxGgk1372edF7iNNzQSN3iLsRkUSmZzQKGwLd4CrC3YUUH
-        # keyid(hex): 4287e28642ebfd3d48e86888a6bb6e7a9af22910
-        # address(base58): yMnuur7LEVgrYFczsNfx8W61eAgGYAmTVG
-        # secret(base58): 92VRomWTLSRRHWR3NwbUAhrPuwfMyciLcDWR9ebJRbSFoEj2RLg
-        # keyid(hex): 6d3fcee4b4b92488ed20171b61c2951ea51cbeb4
-        # address(base58): yco8DwPVN6Wgk1nCmakkLYCGzXy9fgu5zC
-        # secret(base58): 92swaJmVB2c4kLvKt7CihNneE7MxfQnv7eRV248F7t4CmVWsaLe
-        # keyid(hex): ab87f6995077f4bdd6233bc2992611674d7c6594
-        # address(base58): yZr6Rw8GiZwD6GMdC2fuP7c8qkFQPgWVRX
-        # secret(base58): 923NQ12YSeVs4RfaCiCqTE9iNAD4dobSmuEhnV7x6q7styQYfKb
-        # keyid(hex): 2318b0dab38d676aae483ab0f55f2d839a1031b2
-        # address(base58): ycZduSBR8W8Gpb9ec1AocYF1c4Q3E6wjeM
-        # secret(base58): 92tMn4LCFGTthXpdiygJGjQbJYmYY78TiXHFWYTUu9uZiLnHn8W
-        # keyid(hex): ed73329177896a951b0eb30dd962d3e661c0476e
-        # address(base58): yWNZ8gibbLMAyuXX4i1ZNaxmADW59Rz3zJ
-        # secret(base58): 92RgZKa9TYVRJZmj4Nme3jBRn77rD2BmQNJZJkWmN67UVpRXWjW
-        # keyid(hex): a7845c35a6b608c7c3a9a9388e06370fa3f5d32b
-        # address(base58): yQKBpf5bCZ3ctmYKFEPqdeLTg4SwuciMo7
-        # secret(base58): 92mNuCHJ2kWcxGkAus1P6UDPHPFZDPNTzMMf72YujjXtdmbiUCk
-        # keyid(hex): dfe5fcd9bee0b871ad221a4cf3532c2848314701
-        # address(base58): yLSCowJMnKfrmniiX9RD2bxvbHwvzgyKvQ
-        # secret(base58): 92cyrqe2iYqw6ni5MQvBAcSQNAAApmeToeA7qzawEcxLDHufGK3
-        # keyid(hex): 088f9e1ee1a06e0b3fed714beee97e90c035ed76
-        # address(base58): yXAGkUbnEtEeY2cdZnt9zzD4mCnmLeCZfU
-        # secret(base58): 93UMgtWGffnog5yYyyiSwzHCP7FX8wmURQa19f7oT95JQpLu3LN
-        # keyid(hex): 98396e03c6e20e44ce776e07e92cb533cb450e7f
-        # address(base58): yXuFmFBfipN4pDWbiQLLNAaT2HcTGLLAkJ
-
 
         self.nodes.append(start_node(0, self.options.tmpdir,
                                      ["-debug", "-sporkkey=931wyuRNVYvhg18Uu9bky5Qg1z4QbxaJ7fefNBzjBPiLRqcd33F",
-                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
                                       "-minsporkkeys=2"]))
         self.nodes.append(start_node(1, self.options.tmpdir,
                                      ["-debug", "-sporkkey=91vbXGMSWKGHom62986XtL1q2mQDA12ngcuUNNe5NfMSj44j7g3",
-                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
                                       "-minsporkkeys=2"]))
         self.nodes.append(start_node(2, self.options.tmpdir,
-                                     ["-debug",
-                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa",
+                                     ["-debug", "-sporkkey=92bxUjPT5AhgXuXJwfGGXqhomY2SdQ55MYjXyx9DZNxCABCSsRH",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
+                                      "-minsporkkeys=2"]))
+        self.nodes.append(start_node(3, self.options.tmpdir,
+                                     ["-debug", "-sporkkey=934yPXiVGf4RCY2qTs2Bt5k3TEtAiAg12sMxCt8yVWbSU7p3fuD",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
+                                      "-minsporkkeys=2"]))
+        self.nodes.append(start_node(4, self.options.tmpdir,
+                                     ["-debug", "-sporkkey=92Cxwia363Wg2qGF1fE5z4GKi8u7r1nrWQXdtsj2ACZqaDPSihD",
+                                      "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
                                       "-minsporkkeys=2"]))
         # connect nodes at start
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[1], 2)
+        for i in range(0, 5):
+            for j in range(i, 5):
+                connect_nodes(self.nodes[i], j)
 
     def get_test_spork_state(self, node):
         info = node.spork('active')
@@ -147,6 +117,12 @@ class MultiKeySporkTest(BitcoinTestFramework):
         for node in self.nodes:
             assert(self.wait_for_test_spork_state(node, False))
 
+        # now turn on the spork again with other signers to test
+        # old and new spork messages interaction
+        self.set_test_spork_state(self.nodes[3], True)
+        self.set_test_spork_state(self.nodes[4], True)
+        for node in self.nodes:
+            assert(self.wait_for_test_spork_state(node, True))
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/multikeysporks.py
+++ b/qa/rpc-tests/multikeysporks.py
@@ -53,23 +53,23 @@ class MultiKeySporkTest(BitcoinTestFramework):
         self.nodes.append(start_node(0, self.options.tmpdir,
                                      ["-debug", "-sporkkey=931wyuRNVYvhg18Uu9bky5Qg1z4QbxaJ7fefNBzjBPiLRqcd33F",
                                       "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
-                                      "-minsporkkeys=2"]))
+                                      "-minsporkkeys=3"]))
         self.nodes.append(start_node(1, self.options.tmpdir,
                                      ["-debug", "-sporkkey=91vbXGMSWKGHom62986XtL1q2mQDA12ngcuUNNe5NfMSj44j7g3",
                                       "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
-                                      "-minsporkkeys=2"]))
+                                      "-minsporkkeys=3"]))
         self.nodes.append(start_node(2, self.options.tmpdir,
                                      ["-debug", "-sporkkey=92bxUjPT5AhgXuXJwfGGXqhomY2SdQ55MYjXyx9DZNxCABCSsRH",
                                       "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
-                                      "-minsporkkeys=2"]))
+                                      "-minsporkkeys=3"]))
         self.nodes.append(start_node(3, self.options.tmpdir,
                                      ["-debug", "-sporkkey=934yPXiVGf4RCY2qTs2Bt5k3TEtAiAg12sMxCt8yVWbSU7p3fuD",
                                       "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
-                                      "-minsporkkeys=2"]))
+                                      "-minsporkkeys=3"]))
         self.nodes.append(start_node(4, self.options.tmpdir,
                                      ["-debug", "-sporkkey=92Cxwia363Wg2qGF1fE5z4GKi8u7r1nrWQXdtsj2ACZqaDPSihD",
                                       "-sporkaddr=ygcG5S2pQz2U1UAaHvU6EznKZW7yapKMA7:yfLSXFfipnkgYioD6L8aUNyfRgEBuJv48h:yNsMZhEhYqv14TgdYb1NS2UmNZjE8FSJxa:ycbRQWbovrhQMTuxg9p4LAuW5SCMAKqPrn:yc5TGfcHYoLCrcbVy4umsiDjsYUn39vLui",
-                                      "-minsporkkeys=2"]))
+                                      "-minsporkkeys=3"]))
         # connect nodes at start
         for i in range(0, 5):
             for j in range(i, 5):
@@ -101,20 +101,22 @@ class MultiKeySporkTest(BitcoinTestFramework):
         for node in self.nodes:
             assert(self.get_test_spork_state(node) == 0)
 
-        # first signer set spork value
+        # first and second signers set spork value
         self.set_test_spork_state(self.nodes[0], 1)
+        self.set_test_spork_state(self.nodes[1], 1)
         # spork change requires at least 2 signers
         for node in self.nodes:
             assert(not self.wait_for_test_spork_state(node, 1))
 
-        # second signer set spork value
-        self.set_test_spork_state(self.nodes[1], 1)
+        # third signer set spork value
+        self.set_test_spork_state(self.nodes[2], 1)
         # now spork state is changed
         for node in self.nodes:
             assert(self.wait_for_test_spork_state(node, 1))
 
         # now set the spork again with other signers to test
         # old and new spork messages interaction
+        self.set_test_spork_state(self.nodes[2], 2)
         self.set_test_spork_state(self.nodes[3], 2)
         self.set_test_spork_state(self.nodes[4], 2)
         for node in self.nodes:

--- a/qa/rpc-tests/multikeysporks.py
+++ b/qa/rpc-tests/multikeysporks.py
@@ -101,6 +101,8 @@ class MultiKeySporkTest(BitcoinTestFramework):
         for node in self.nodes:
             assert(self.get_test_spork_state(node) == 0)
 
+        set_mocktime(get_mocktime() + 1)
+        set_node_times(self.nodes, get_mocktime())
         # first and second signers set spork value
         self.set_test_spork_state(self.nodes[0], 1)
         self.set_test_spork_state(self.nodes[1], 1)
@@ -114,6 +116,8 @@ class MultiKeySporkTest(BitcoinTestFramework):
         for node in self.nodes:
             assert(self.wait_for_test_spork_state(node, 1))
 
+        set_mocktime(get_mocktime() + 1)
+        set_node_times(self.nodes, get_mocktime())
         # now set the spork again with other signers to test
         # old and new spork messages interaction
         self.set_test_spork_state(self.nodes[2], 2)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -237,7 +237,8 @@ public:
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
 
-        strSporkAddress = "Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh";
+        strSporkAddresses = "Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh";
+        nMinSporkKeys = 1;
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -391,7 +392,8 @@ public:
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
-        strSporkAddress = "yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55";
+        strSporkAddresses = "yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55";
+        nMinSporkKeys = 1;
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -535,7 +537,8 @@ public:
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
-        strSporkAddress = "yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55";
+        strSporkAddresses = "yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55";
+        nMinSporkKeys = 1;
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -641,7 +644,8 @@ public:
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         // privKey: cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK
-        strSporkAddress = "yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW";
+        strSporkAddresses = "yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW";
+        nMinSporkKeys = 1;
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -237,7 +237,7 @@ public:
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
 
-        strSporkAddresses = "Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh";
+        vSporkAddresses = {"Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh"};
         nMinSporkKeys = 1;
 
         checkpointData = (CCheckpointData) {
@@ -392,7 +392,7 @@ public:
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
-        strSporkAddresses = "yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55";
+        vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
         nMinSporkKeys = 1;
 
         checkpointData = (CCheckpointData) {
@@ -537,7 +537,7 @@ public:
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
-        strSporkAddresses = "yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55";
+        vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
         nMinSporkKeys = 1;
 
         checkpointData = (CCheckpointData) {
@@ -644,7 +644,7 @@ public:
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         // privKey: cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK
-        strSporkAddresses = "yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW";
+        vSporkAddresses = {"yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW"};
         nMinSporkKeys = 1;
 
         checkpointData = (CCheckpointData){

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -88,7 +88,8 @@ public:
     const ChainTxData& TxData() const { return chainTxData; }
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
-    const std::string& SporkAddress() const { return strSporkAddress; }
+    const std::string& SporkAddresses() const { return strSporkAddresses; }
+    int MinSporkKeys() const { return nMinSporkKeys; }
 protected:
     CChainParams() {}
 
@@ -116,7 +117,8 @@ protected:
     ChainTxData chainTxData;
     int nPoolMaxTransactions;
     int nFulfilledRequestExpireTime;
-    std::string strSporkAddress;
+    std::string strSporkAddresses;
+    int nMinSporkKeys;
 };
 
 /**

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -88,7 +88,7 @@ public:
     const ChainTxData& TxData() const { return chainTxData; }
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
-    const std::string& SporkAddresses() const { return strSporkAddresses; }
+    const std::vector<std::string>& SporkAddresses() const { return vSporkAddresses; }
     int MinSporkKeys() const { return nMinSporkKeys; }
 protected:
     CChainParams() {}
@@ -117,7 +117,7 @@ protected:
     ChainTxData chainTxData;
     int nPoolMaxTransactions;
     int nFulfilledRequestExpireTime;
-    std::string strSporkAddresses;
+    std::vector<std::string> vSporkAddresses;
     int nMinSporkKeys;
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -570,6 +570,7 @@ std::string HelpMessage(HelpMessageMode mode)
     AppendParamsHelpMessages(strUsage, showDebug);
     strUsage += HelpMessageOpt("-litemode=<n>", strprintf(_("Disable all Dash specific functionality (Masternodes, PrivateSend, InstantSend, Governance) (0-1, default: %u)"), 0));
     strUsage += HelpMessageOpt("-sporkaddr=<hex>", strprintf(_("Override spork address. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.")));
+    strUsage += HelpMessageOpt("-minsporkkeys=<n>", strprintf(_("Overrides minimum spork signers to change spork value. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.")));
 
     strUsage += HelpMessageGroup(_("Masternode options:"));
     strUsage += HelpMessageOpt("-masternode=<n>", strprintf(_("Enable the client to act as a masternode (0-1, default: %u)"), 0));
@@ -1398,13 +1399,18 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             threadGroup.create_thread(&ThreadScriptCheck);
     }
 
-    std::string strSporkAddresses = GetArg("-sporkaddr", Params().SporkAddress());
+    std::string strSporkAddresses = GetArg("-sporkaddr", Params().SporkAddresses());
     std::vector<std::string> vSporkAddresses;
     boost::split(vSporkAddresses, strSporkAddresses, boost::is_any_of(":"));
     for(const auto& address: vSporkAddresses) {
         if (!sporkManager.SetSporkAddress(address))
             return InitError(_("Invalid spork address specified with -sporkaddr"));
     }
+
+    int minsporkkeys = GetArg("-minsporkkeys", Params().MinSporkKeys());
+    if(!sporkManager.SetMinSporkKeys(minsporkkeys))
+        return InitError(_("Invalid minimum number of spork signers specified with -minsporkkeys"));
+
 
     if (IsArgSet("-sporkkey")) // spork priv key
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1400,25 +1400,27 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     std::vector<std::string> vSporkAddresses;
-    if(mapMultiArgs.count("-sporkaddr")) {
+    if (mapMultiArgs.count("-sporkaddr")) {
         vSporkAddresses = mapMultiArgs.at("-sporkaddr");
     } else {
         vSporkAddresses = Params().SporkAddresses();
     }
-    for(const auto& address: vSporkAddresses) {
-        if (!sporkManager.SetSporkAddress(address))
+    for (const auto& address: vSporkAddresses) {
+        if (!sporkManager.SetSporkAddress(address)) {
             return InitError(_("Invalid spork address specified with -sporkaddr"));
+        }
     }
 
     int minsporkkeys = GetArg("-minsporkkeys", Params().MinSporkKeys());
-    if(!sporkManager.SetMinSporkKeys(minsporkkeys))
+    if (!sporkManager.SetMinSporkKeys(minsporkkeys)) {
         return InitError(_("Invalid minimum number of spork signers specified with -minsporkkeys"));
+    }
 
 
-    if (IsArgSet("-sporkkey")) // spork priv key
-    {
-        if (!sporkManager.SetPrivKey(GetArg("-sporkkey", "")))
+    if (IsArgSet("-sporkkey")) { // spork priv key
+        if (!sporkManager.SetPrivKey(GetArg("-sporkkey", ""))) {
             return InitError(_("Unable to sign spork message, wrong key?"));
+        }
     }
 
     // Start the lightweight task scheduler thread

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1399,9 +1399,12 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             threadGroup.create_thread(&ThreadScriptCheck);
     }
 
-    std::string strSporkAddresses = GetArg("-sporkaddr", Params().SporkAddresses());
     std::vector<std::string> vSporkAddresses;
-    boost::split(vSporkAddresses, strSporkAddresses, boost::is_any_of(":"));
+    if(mapMultiArgs.count("-sporkaddr")) {
+        vSporkAddresses = mapMultiArgs.at("-sporkaddr");
+    } else {
+        vSporkAddresses = Params().SporkAddresses();
+    }
     for(const auto& address: vSporkAddresses) {
         if (!sporkManager.SetSporkAddress(address))
             return InitError(_("Invalid spork address specified with -sporkaddr"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1398,8 +1398,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             threadGroup.create_thread(&ThreadScriptCheck);
     }
 
-    if (!sporkManager.SetSporkAddress(GetArg("-sporkaddr", Params().SporkAddress())))
-        return InitError(_("Invalid spork address specified with -sporkaddr"));
+    std::string strSporkAddresses = GetArg("-sporkaddr", Params().SporkAddress());
+    std::vector<std::string> vSporkAddresses;
+    boost::split(vSporkAddresses, strSporkAddresses, boost::is_any_of(":"));
+    for(const auto& address: vSporkAddresses) {
+        if (!sporkManager.SetSporkAddress(address))
+            return InitError(_("Invalid spork address specified with -sporkaddr"));
+    }
 
     if (IsArgSet("-sporkkey")) // spork priv key
     {

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -41,20 +41,15 @@ bool CSporkManager::SporkValueIsActive(int nSporkID, int64_t &nActiveValueRet) c
     std::map<int64_t, int> mapValueCounts;
     for (const auto& pair: mapSporksActive.at(nSporkID)) {
         mapValueCounts[pair.second.nValue]++;
-    }
-
-    // check if any value has enough signer votes
-    int max_count = 0;
-    for (const auto& value_data: mapValueCounts) {
-        if (value_data.second >= nMinSporkKeys) {
-            if (value_data.second > max_count) {
-                nActiveValueRet = value_data.first;
-                max_count = value_data.second;
-            }
+        if (mapValueCounts.at(pair.second.nValue) >= nMinSporkKeys) {
+            // nMinSporkKeys is always more than the half of the max spork keys number,
+            // so there is only one such value and we can stop here
+            nActiveValueRet = pair.second.nValue;
+            return true;
         }
     }
 
-    return (max_count > 0);
+    return false;
 }
 
 void CSporkManager::Clear()

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -44,16 +44,17 @@ bool CSporkManager::SporkValueIsActive(int sporkID, int64_t &activeValue) const
     }
 
     // check if any value has enough signer votes
-    bool found = false;
+    int max_count = 0;
     for (const auto& value_data: value_counts) {
         if(value_data.second >= nMinSporkKeys) {
-            if (found) return false; // several active values, no consensus among signers
-            found = true;
-            activeValue = value_data.first;
+            if (value_data.second > max_count) {
+                activeValue = value_data.first;
+                max_count = value_data.second;
+            }
         }
     }
 
-    return found;
+    return (max_count > 0);
 }
 
 void CSporkManager::Clear()

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -275,6 +275,16 @@ bool CSporkManager::SetSporkAddress(const std::string& strAddress) {
     return true;
 }
 
+bool CSporkManager::SetMinSporkKeys(int minSporkKeys)
+{
+    if ((minSporkKeys < 1) || (minSporkKeys > sporkPubKeyIDs.size())) {
+        LogPrintf("CSporkManager::SetSporkAddress -- Invalid min spork signers number: %d\n", minSporkKeys);
+        return false;
+    }
+    nMinSporkKeys = minSporkKeys;
+    return true;
+}
+
 bool CSporkManager::SetPrivKey(const std::string& strPrivKey)
 {
     CKey key;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -330,7 +330,8 @@ bool CSporkManager::SetSporkAddress(const std::string& strAddress) {
 
 bool CSporkManager::SetMinSporkKeys(int minSporkKeys)
 {
-    if ((minSporkKeys < 1) || (minSporkKeys > sporkPubKeyIDs.size())) {
+    int maxKeysNumber = sporkPubKeyIDs.size();
+    if ((minSporkKeys <= maxKeysNumber / 2) || (minSporkKeys > maxKeysNumber)) {
         LogPrintf("CSporkManager::SetSporkAddress -- Invalid min spork signers number: %d\n", minSporkKeys);
         return false;
     }

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -34,8 +34,8 @@ std::map<int, int64_t> mapSporkDefaults = {
 bool CSporkManager::SporkValueIsActive(int sporkID, int64_t &activeValue) const
 {
     LOCK(cs);
-    if (!mapSporksActive.count(sporkID))
-        return false;
+
+    if (!mapSporksActive.count(sporkID)) return false;
 
     // calc how many values we have and how many signers vote for every value
     std::map<int64_t, int> value_counts;
@@ -46,7 +46,7 @@ bool CSporkManager::SporkValueIsActive(int sporkID, int64_t &activeValue) const
     // check if any value has enough signer votes
     int max_count = 0;
     for (const auto& value_data: value_counts) {
-        if(value_data.second >= nMinSporkKeys) {
+        if (value_data.second >= nMinSporkKeys) {
             if (value_data.second > max_count) {
                 activeValue = value_data.first;
                 max_count = value_data.second;
@@ -116,7 +116,7 @@ void CSporkManager::ProcessSpork(CNode* pfrom, const std::string& strCommand, CD
         }
 
         CKeyID signer;
-        if(!(spork.GetSignerKeyID(signer, IsSporkActive(SPORK_6_NEW_SIGS))
+        if (!(spork.GetSignerKeyID(signer, IsSporkActive(SPORK_6_NEW_SIGS))
                                  && sporkPubKeyIDs.count(signer))) {
             LOCK(cs_main);
             LogPrintf("CSporkManager::ProcessSpork -- ERROR: invalid signature\n");
@@ -222,7 +222,7 @@ bool CSporkManager::IsSporkActive(int nSporkID)
     LOCK(cs);
     int64_t r = -1;
 
-    if(SporkValueIsActive(nSporkID, r)){
+    if (SporkValueIsActive(nSporkID, r)){
         return r < GetAdjustedTime();
     }
 
@@ -239,9 +239,10 @@ bool CSporkManager::IsSporkActive(int nSporkID)
 int64_t CSporkManager::GetSporkValue(int nSporkID)
 {
     LOCK(cs);
-    int64_t r = -1;
-    if(SporkValueIsActive(nSporkID, r)){
-        return r;
+
+    int64_t sporkValue = -1;
+    if (SporkValueIsActive(nSporkID, sporkValue)) {
+        return sporkValue;
     }
 
     if (mapSporkDefaults.count(nSporkID)) {

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -15,7 +15,7 @@
 
 CSporkManager sporkManager;
 
-const std::string CSporkManager::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-1";
+const std::string CSporkManager::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-2";
 
 std::map<int, int64_t> mapSporkDefaults = {
     {SPORK_2_INSTANTSEND_ENABLED,            0},             // ON

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -364,7 +364,11 @@ uint256 CSporkMessage::GetHash() const
 
 uint256 CSporkMessage::GetSignatureHash() const
 {
-    return GetHash();
+    CHashWriter s(SER_GETHASH, 0);
+    s << nSporkID;
+    s << nValue;
+    s << nTimeSigned;
+    return s.GetHash();
 }
 
 bool CSporkMessage::Sign(const CKey& key, bool fSporkSixActive)
@@ -441,7 +445,7 @@ bool CSporkMessage::GetSignerKeyID(CKeyID &sporkSignerID, bool fSporkSixActive)
 {
     CPubKey pubkeyFromSig;
     if (fSporkSixActive) {
-        if (!pubkeyFromSig.RecoverCompact(GetHash(), vchSig)) {
+        if (!pubkeyFromSig.RecoverCompact(GetSignatureHash(), vchSig)) {
             return false;
         }
     } else {

--- a/src/spork.h
+++ b/src/spork.h
@@ -78,6 +78,7 @@ public:
 
     bool Sign(const CKey& key, bool fSporkSixActive);
     bool CheckSignature(const CKeyID& pubKeyId, bool fSporkSixActive) const;
+    bool GetSignerKeyID(CKeyID& sporkSignerID, bool fSporkSixActive);
     void Relay(CConnman& connman);
 };
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -78,7 +78,7 @@ public:
 
     bool Sign(const CKey& key, bool fSporkSixActive);
     bool CheckSignature(const CKeyID& pubKeyId, bool fSporkSixActive) const;
-    bool GetSignerKeyID(CKeyID& sporkSignerID, bool fSporkSixActive);
+    bool GetSignerKeyID(CKeyID& retKeyidSporkSigner, bool fSporkSixActive);
     void Relay(CConnman& connman);
 };
 
@@ -92,7 +92,7 @@ private:
     std::map<uint256, CSporkMessage> mapSporksByHash;
     std::map<int, std::map<CKeyID, CSporkMessage> > mapSporksActive;
 
-    std::set<CKeyID> sporkPubKeyIDs;
+    std::set<CKeyID> setSporkPubKeyIDs;
     int nMinSporkKeys;
     CKey sporkPrivKey;
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -115,7 +115,9 @@ public:
             strVersion = SERIALIZATION_VERSION_STRING;
             READWRITE(strVersion);
         }
-        READWRITE(sporkPubKeyIDs);
+        // we don't serialize pubkey ids because pubkeys should be
+        // hardcoded or be setted with cmdline or options, should
+        // not reuse pubkeys from previous dashd run
         READWRITE(mapSporksByHash);
         READWRITE(mapSporksActive);
         // we don't serialize private key to prevent its leakage

--- a/src/spork.h
+++ b/src/spork.h
@@ -93,7 +93,7 @@ private:
     std::map<uint256, CSporkMessage> mapSporksByHash;
     std::map<int, CSporkMessage> mapSporksActive;
 
-    CKeyID sporkPubKeyID;
+    std::set<CKeyID> sporkPubKeyIDs;
     CKey sporkPrivKey;
 
 public:
@@ -114,7 +114,7 @@ public:
             strVersion = SERIALIZATION_VERSION_STRING;
             READWRITE(strVersion);
         }
-        READWRITE(sporkPubKeyID);
+        READWRITE(sporkPubKeyIDs);
         READWRITE(mapSporksByHash);
         READWRITE(mapSporksActive);
         // we don't serialize private key to prevent its leakage

--- a/src/spork.h
+++ b/src/spork.h
@@ -94,6 +94,7 @@ private:
     std::map<int, CSporkMessage> mapSporksActive;
 
     std::set<CKeyID> sporkPubKeyIDs;
+    int nMinSporkKeys;
     CKey sporkPrivKey;
 
 public:
@@ -135,6 +136,7 @@ public:
     bool GetSporkByHash(const uint256& hash, CSporkMessage &sporkRet);
 
     bool SetSporkAddress(const std::string& strAddress);
+    bool SetMinSporkKeys(int minSporkKeys);
     bool SetPrivKey(const std::string& strPrivKey);
 
     std::string ToString() const;

--- a/src/spork.h
+++ b/src/spork.h
@@ -91,12 +91,13 @@ private:
 
     mutable CCriticalSection cs;
     std::map<uint256, CSporkMessage> mapSporksByHash;
-    std::map<int, CSporkMessage> mapSporksActive;
+    std::map<int, std::map<CKeyID, CSporkMessage> > mapSporksActive;
 
     std::set<CKeyID> sporkPubKeyIDs;
     int nMinSporkKeys;
     CKey sporkPrivKey;
 
+    bool SporkValueIsActive(int sporkID, int64_t& activeValue) const;
 public:
 
     CSporkManager() {}

--- a/src/spork.h
+++ b/src/spork.h
@@ -96,7 +96,7 @@ private:
     int nMinSporkKeys;
     CKey sporkPrivKey;
 
-    bool SporkValueIsActive(int sporkID, int64_t& activeValue) const;
+    bool SporkValueIsActive(int nSporkID, int64_t& nActiveValueRet) const;
 public:
 
     CSporkManager() {}

--- a/src/spork.h
+++ b/src/spork.h
@@ -70,9 +70,7 @@ public:
         READWRITE(nSporkID);
         READWRITE(nValue);
         READWRITE(nTimeSigned);
-        if (!(s.GetType() & SER_GETHASH)) {
-            READWRITE(vchSig);
-        }
+        READWRITE(vchSig);
     }
 
     uint256 GetHash() const;


### PR DESCRIPTION
See issue https://github.com/dashpay/dash/issues/2221

- allow multiple hardcoded spork addresses (N) to be specified in chainparams/cmd-line/config (same signers for all sporks);
- allow multiple messages with the same id/value signed by different spork addresses;
- (de)activate any spork only when at least M similar message with the same id/value signed by different signers were received (the same M for all sporks);

    "M-of-N" spork implementation requires spork signers consensus achieved with some external communication and doesn't offer any facilities for such consensus achievement. If this consensus is not achived, the spork is treated as it has default value. For example, if sporks are configured as "at least 2 signers of 5 possible" and some spork has default value `0`, and 2 signers broadcast this spork value `1`, while 2 other signers broadcast value `2` (and `nTimeSigned` field has the same value, see details later), this spork is treated as it has value `0`.

    Also, several possible signers require new logic for `nTimeSigned` field processing. In old implementation this field is used to separate old non-actual spork messages from the new spork messages (spork message with bigger `nTimeSigned` overwrites message with smaller one). We need similar logic in new implementation. For example, we have the same configuration like in previous example, 2-of-5-signers. At moment `t1` signers 1, 2, 3 broadcast spork with value `1` and spork switches to this value. After that at moment `t2` signers 4 and 5 tries to switch this spork to value `2`, and fail to do this, because votes of first 3 signers don't allow any node to calculate current spork value, and spork goes to default value. We can't also simply overwrite all "old" spork messages of other signers because of the fact that in this case just one signer can "rallback" several other signer's messages.

    To resolve this issue we can require all signers to use the same value of the `nTimeSigned` field to treat their messages as a part of the same "spork broadcast" and allow such signer's groups to overwrite messages of other signer's groups with less `nTimeSigned` field value if this group size is bigger or equal to the minimum configured value (M in M-of-N). It is difficult to use current time for this goal as it was before, because signer's clocks are not synchronized and signers can broadcast their messages at slightly different moments of time. I think it is better to use increasing counter instead and allow signers to set its value directly. Also it is better to allow spork signers to use some default way to calculate this counter value for their convenience and I have added such calculation, but this calculation is not a facility for achieving of signers consensus, so it doesn't resolve all possible situations and sometimes signers should set counter value explicitly. Also,  I've renamed `nTimeSigned` field to `nBroadcastID` to reflect its new meaning.
