### PR TITLE
Only use dataDir in CEvoDB when not in-memory

### DIFF
--- a/src/evo/evodb.cpp
+++ b/src/evo/evodb.cpp
@@ -7,7 +7,7 @@
 CEvoDB* evoDb;
 
 CEvoDB::CEvoDB(size_t nCacheSize, bool fMemory, bool fWipe) :
-        db(GetDataDir() / "evodb", nCacheSize, fMemory, fWipe),
+        db(fMemory ? "" : (GetDataDir() / "evodb"), nCacheSize, fMemory, fWipe),
         dbTransaction(db)
 {
 }


### PR DESCRIPTION
GetDataDir() does not give useful results in unit tests and benchmarks