### PR TITLE
Honor filterInventoryKnown for non-tx/non-block items

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -888,9 +888,14 @@ public:
 
     void AddInventoryKnown(const CInv& inv)
     {
+        AddInventoryKnown(inv.hash);
+    }
+
+    void AddInventoryKnown(const uint256& hash)
+    {
         {
             LOCK(cs_inventory);
-            filterInventoryKnown.insert(inv.hash);
+            filterInventoryKnown.insert(hash);
         }
     }
 
@@ -908,8 +913,12 @@ public:
             LogPrint("net", "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
             vInventoryBlockToSend.push_back(inv.hash);
         } else {
-            LogPrint("net", "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
-            vInventoryOtherToSend.push_back(inv);
+            if (!filterInventoryKnown.contains(inv.hash)) {
+                LogPrint("net", "PushInventory --  inv: %s peer=%d\n", inv.ToString(), id);
+                vInventoryOtherToSend.push_back(inv);
+            } else {
+                LogPrint("net", "PushInventory --  filtered inv: %s peer=%d\n", inv.ToString(), id);
+            }
         }
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3431,7 +3431,11 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
 
             // Send non-tx/non-block inventory items
             for (const auto& inv : pto->vInventoryOtherToSend) {
+                if (pto->filterInventoryKnown.contains(inv.hash)) {
+                    continue;
+                }
                 vInv.push_back(inv);
+                pto->filterInventoryKnown.insert(inv.hash);
                 if (vInv.size() == MAX_INV_SZ) {
                     connman.PushMessage(pto, msgMaker.Make(NetMsgType::INV, vInv));
                     vInv.clear();


### PR DESCRIPTION
We were not honoring/updating filterInventoryKnown for non-tx/non-block items, which in some cases resulted in items being sent multiple times. Observes this very often when testing LLMQs, which require some quite large messages to be propagated.