### PR TITLE
A couple of small fixes for mixing collaterals

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1355,7 +1355,7 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(CConnman& connman)
     if (!pwalletMain) return false;
 
     std::vector<CompactTallyItem> vecTally;
-    if(!pwalletMain->SelectCoinsGrouppedByAddresses(vecTally, false)) {
+    if(!pwalletMain->SelectCoinsGrouppedByAddresses(vecTally, false, false)) {
         LogPrint("privatesend", "CPrivateSendClientSession::MakeCollateralAmounts -- SelectCoinsGrouppedByAddresses can't find any inputs!\n");
         return false;
     }

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1550,6 +1550,9 @@ bool CPrivateSendClientSession::CreateDenominated(const CompactTallyItem& tallyI
     } while (nOutputsTotal == 0 && !fSkip);
     LogPrintf("CPrivateSendClientSession::CreateDenominated -- 3 - nOutputsTotal: %d, nValueLeft: %f\n", nOutputsTotal, (float)nValueLeft/COIN);
 
+    // No reasons to create mixing collaterals if we can't create denoms to mix
+    if (nOutputsTotal == 0) return false;
+
     // if we have anything left over, it will be automatically send back as change - there is no need to send it manually
 
     CCoinControl coinControl;


### PR DESCRIPTION
Should slightly reduce utxo and utilise wallet funds a bit better by:
a) not creating mixing collaterals when there is no use for them;
b) by creating mixng collaterals from small inputs (amount > smallest_denom/10 && sum < smallest_denom).