### PR TITLE
Drop (pre-)70208 compatibility code

### DIFF
--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -303,40 +303,13 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         // SERIALIZE DATA FOR SAVING/LOADING OR NETWORK FUNCTIONS
-        int nVersion = s.GetVersion();
         READWRITE(nHashParent);
         READWRITE(nRevision);
         READWRITE(nTime);
         READWRITE(nCollateralHash);
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            std::string strDataHex;
-            if (ser_action.ForRead()) {
-                READWRITE(LIMITED_STRING(strDataHex, MAX_GOVERNANCE_OBJECT_DATA_SIZE));
-                vchData = ParseHex(strDataHex);
-            } else {
-                strDataHex = HexStr(vchData);
-                READWRITE(LIMITED_STRING(strDataHex, MAX_GOVERNANCE_OBJECT_DATA_SIZE));
-            }
-        } else {
-            // using new format directly
-            READWRITE(vchData);
-        }
+        READWRITE(vchData);
         READWRITE(nObjectType);
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin;
-            if (ser_action.ForRead()) {
-                READWRITE(txin);
-                masternodeOutpoint = txin.prevout;
-            } else {
-                txin = CTxIn(masternodeOutpoint);
-                READWRITE(txin);
-            }
-        } else {
-            // using new format directly
-            READWRITE(masternodeOutpoint);
-        }
+        READWRITE(masternodeOutpoint);
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(vchSig);
         }

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -116,21 +116,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        int nVersion = s.GetVersion();
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin{};
-            if (ser_action.ForRead()) {
-                READWRITE(txin);
-                masternodeOutpoint = txin.prevout;
-            } else {
-                txin = CTxIn(masternodeOutpoint);
-                READWRITE(txin);
-            }
-        } else {
-            // using new format directly
-            READWRITE(masternodeOutpoint);
-        }
+        READWRITE(masternodeOutpoint);
         READWRITE(nParentHash);
         READWRITE(nVoteOutcome);
         READWRITE(nVoteSignal);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -420,12 +420,6 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, const std::string& strCom
         // but this is a heavy one so it's better to finish sync first.
         if (!masternodeSync.IsSynced()) return;
 
-        // DEPRECATED, should be removed on next protocol bump
-        if(pfrom->nVersion == 70208) {
-            int nCountNeeded;
-            vRecv >> nCountNeeded;
-        }
-
         if(netfulfilledman.HasFulfilledRequest(pfrom->addr, NetMsgType::MASTERNODEPAYMENTSYNC)) {
             LOCK(cs_main);
             // Asking for the payments list multiple times in a short period of time is no good

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -133,21 +133,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        int nVersion = s.GetVersion();
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin{};
-            if (ser_action.ForRead()) {
-                READWRITE(txin);
-                masternodeOutpoint = txin.prevout;
-            } else {
-                txin = CTxIn(masternodeOutpoint);
-                READWRITE(txin);
-            }
-        } else {
-            // using new format directly
-            READWRITE(masternodeOutpoint);
-        }
+        READWRITE(masternodeOutpoint);
         READWRITE(nBlockHeight);
         READWRITE(*(CScriptBase*)(&payee));
         if (!(s.GetType() & SER_GETHASH)) {

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -203,12 +203,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 SwitchToNextAsset(connman);
             } else if (nRequestedMasternodeAssets == MASTERNODE_SYNC_MNW) {
                 if (!deterministicMNManager->IsDeterministicMNsSporkActive()) {
-                    //sync payment votes
-                    if(pnode->nVersion == 70208) {
-                        connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC, mnpayments.GetStorageLimit())); //sync payment votes
-                    } else {
-                        connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC)); //sync payment votes
-                    }
+                    connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC)); //sync payment votes
                 }
                 SwitchToNextAsset(connman);
             } else if (nRequestedMasternodeAssets == MASTERNODE_SYNC_GOVERNANCE) {
@@ -350,12 +345,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 nRequestedMasternodeAttempt++;
 
                 // ask node for all payment votes it has (new nodes will only return votes for future payments)
-                //sync payment votes
-                if(pnode->nVersion == 70208) {
-                    connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC, mnpayments.GetStorageLimit()));
-                } else {
-                    connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC));
-                }
+                connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC));
                 // ask node for missing pieces only (old nodes will not be asked)
                 mnpayments.RequestLowDataPaymentBlocks(pnode, connman);
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -53,43 +53,15 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        int nVersion = s.GetVersion();
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin{};
-            if (ser_action.ForRead()) {
-                READWRITE(txin);
-                masternodeOutpoint = txin.prevout;
-            } else {
-                txin = CTxIn(masternodeOutpoint);
-                READWRITE(txin);
-            }
-        } else {
-            // using new format directly
-            READWRITE(masternodeOutpoint);
-        }
+        READWRITE(masternodeOutpoint);
         READWRITE(blockHash);
         READWRITE(sigTime);
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(vchSig);
         }
-        if(ser_action.ForRead() && s.size() == 0) {
-            // TODO: drop this after migration to 70209
-            fSentinelIsCurrent = false;
-            nSentinelVersion = DEFAULT_SENTINEL_VERSION;
-            nDaemonVersion = DEFAULT_DAEMON_VERSION;
-            return;
-        }
         READWRITE(fSentinelIsCurrent);
         READWRITE(nSentinelVersion);
-        if(ser_action.ForRead() && s.size() == 0) {
-            // TODO: drop this after migration to 70209
-            nDaemonVersion = DEFAULT_DAEMON_VERSION;
-            return;
-        }
-        if (!(nVersion == 70208 && (s.GetType() & SER_NETWORK))) {
-            READWRITE(nDaemonVersion);
-        }
+        READWRITE(nDaemonVersion);
     }
 
     uint256 GetHash() const;
@@ -223,21 +195,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         LOCK(cs);
-        int nVersion = s.GetVersion();
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin{};
-            if (ser_action.ForRead()) {
-                READWRITE(txin);
-                outpoint = txin.prevout;
-            } else {
-                txin = CTxIn(outpoint);
-                READWRITE(txin);
-            }
-        } else {
-            // using new format directly
-            READWRITE(outpoint);
-        }
+        READWRITE(outpoint);
         READWRITE(addr);
         READWRITE(pubKeyCollateralAddress);
         READWRITE(pubKeyMasternode);
@@ -384,21 +342,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        int nVersion = s.GetVersion();
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin{};
-            if (ser_action.ForRead()) {
-                READWRITE(txin);
-                outpoint = txin.prevout;
-            } else {
-                txin = CTxIn(outpoint);
-                READWRITE(txin);
-            }
-        } else {
-            // using new format directly
-            READWRITE(outpoint);
-        }
+        READWRITE(outpoint);
         READWRITE(addr);
         READWRITE(pubKeyCollateralAddress);
         READWRITE(pubKeyMasternode);
@@ -458,27 +402,8 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        int nVersion = s.GetVersion();
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin1{};
-            CTxIn txin2{};
-            if (ser_action.ForRead()) {
-                READWRITE(txin1);
-                READWRITE(txin2);
-                masternodeOutpoint1 = txin1.prevout;
-                masternodeOutpoint2 = txin2.prevout;
-            } else {
-                txin1 = CTxIn(masternodeOutpoint1);
-                txin2 = CTxIn(masternodeOutpoint2);
-                READWRITE(txin1);
-                READWRITE(txin2);
-            }
-        } else {
-            // using new format directly
-            READWRITE(masternodeOutpoint1);
-            READWRITE(masternodeOutpoint2);
-        }
+        READWRITE(masternodeOutpoint1);
+        READWRITE(masternodeOutpoint2);
         READWRITE(addr);
         READWRITE(nonce);
         READWRITE(nBlockHeight);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -124,11 +124,7 @@ void CMasternodeMan::AskForMN(CNode* pnode, const COutPoint& outpoint, CConnman&
     }
     mWeAskedForMasternodeListEntry[outpoint][addrSquashed] = GetTime() + DSEG_UPDATE_SECONDS;
 
-    if (pnode->GetSendVersion() == 70208) {
-        connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, CTxIn(outpoint)));
-    } else {
-        connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, outpoint));
-    }
+    connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, outpoint));
 }
 
 bool CMasternodeMan::AllowMixing(const COutPoint &outpoint)
@@ -526,11 +522,8 @@ void CMasternodeMan::DsegUpdate(CNode* pnode, CConnman& connman)
         }
     }
 
-    if (pnode->GetSendVersion() == 70208) {
-        connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, CTxIn()));
-    } else {
-        connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, COutPoint()));
-    }
+    connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, COutPoint()));
+
     int64_t askAgain = GetTime() + DSEG_UPDATE_SECONDS;
     mWeAskedForMasternodeList[addrSquashed] = askAgain;
 
@@ -1072,14 +1065,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
         if (!masternodeSync.IsSynced()) return;
 
         COutPoint masternodeOutpoint;
-
-        if (pfrom->nVersion == 70208) {
-            CTxIn vin;
-            vRecv >> vin;
-            masternodeOutpoint = vin.prevout;
-        } else {
-            vRecv >> masternodeOutpoint;
-        }
+        vRecv >> masternodeOutpoint;
 
         LogPrint("masternode", "DSEG -- Masternode list, masternode=%s\n", masternodeOutpoint.ToStringShort());
 

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -209,20 +209,7 @@ public:
             int nInputCount = 0;
             READWRITE(nInputCount);
         }
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin{};
-            if (ser_action.ForRead()) {
-                READWRITE(txin);
-                masternodeOutpoint = txin.prevout;
-            } else {
-                txin = CTxIn(masternodeOutpoint);
-                READWRITE(txin);
-            }
-        } else {
-            // using new format directly
-            READWRITE(masternodeOutpoint);
-        }
+        READWRITE(masternodeOutpoint);
         READWRITE(nTime);
         READWRITE(fReady);
         if (!(s.GetType() & SER_GETHASH)) {
@@ -295,21 +282,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(tx);
-        int nVersion = s.GetVersion();
-        if (nVersion == 70208 && (s.GetType() & SER_NETWORK)) {
-            // converting from/to old format
-            CTxIn txin{};
-            if (ser_action.ForRead()) {
-                READWRITE(txin);
-                masternodeOutpoint = txin.prevout;
-            } else {
-                txin = CTxIn(masternodeOutpoint);
-                READWRITE(txin);
-            }
-        } else {
-            // using new format directly
-            READWRITE(masternodeOutpoint);
-        }
+        READWRITE(masternodeOutpoint);
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(vchSig);
         }


### PR DESCRIPTION
We already bumped `MIN_PEER_PROTO_VERSION` to 70210, so we can safely remove this deprecated code now.