### PR TITLE
Drop MAX_GOVERNANCE_OBJECT_DATA_SIZE (and maxgovobjdatasize in rpc)

### DIFF
--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -24,7 +24,6 @@ class CGovernanceTriggerManager;
 class CGovernanceObject;
 class CGovernanceVote;
 
-static const int MAX_GOVERNANCE_OBJECT_DATA_SIZE = 16 * 1024;
 static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70210;
 static const int GOVERNANCE_FILTER_PROTO_VERSION = 70206;
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -1115,7 +1115,6 @@ UniValue getgovernanceinfo(const JSONRPCRequest& request)
             "  \"superblockcycle\": xxxxx,               (numeric) the number of blocks between superblocks\n"
             "  \"lastsuperblock\": xxxxx,                (numeric) the block number of the last superblock\n"
             "  \"nextsuperblock\": xxxxx,                (numeric) the block number of the next superblock\n"
-            "  \"maxgovobjdatasize\": xxxxx,             (numeric) maximum governance object data size in bytes\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getgovernanceinfo", "")
@@ -1138,7 +1137,6 @@ UniValue getgovernanceinfo(const JSONRPCRequest& request)
     obj.push_back(Pair("superblockcycle", Params().GetConsensus().nSuperblockCycle));
     obj.push_back(Pair("lastsuperblock", nLastSuperblock));
     obj.push_back(Pair("nextsuperblock", nNextSuperblock));
-    obj.push_back(Pair("maxgovobjdatasize", MAX_GOVERNANCE_OBJECT_DATA_SIZE));
 
     return obj;
 }


### PR DESCRIPTION
We no longer communicate to old nodes (#2295 ), so we don't care about this anymore and can finally finish the transition started in #2004 .