### PR TITLE
Update .clang-format to more accurately show the actual style

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -16,6 +16,7 @@ BreakBeforeBinaryOperators: false
 BreakBeforeBraces: Linux
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
 ColumnLimit:     128
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -10,7 +10,6 @@ AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
-AlignConsecutiveAssignments: true
 BinPackArguments: true
 BinPackParameters: false
 BreakBeforeBinaryOperators: false

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -17,7 +17,7 @@ BreakBeforeBraces: Linux
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: AfterColon
-ColumnLimit:     128
+ColumnLimit:     0
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -10,6 +10,7 @@ AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
+AlignConsecutiveAssignments: true
 BinPackArguments: true
 BinPackParameters: false
 BreakBeforeBinaryOperators: false

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -10,12 +10,13 @@ AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
 BinPackParameters: false
 BreakBeforeBinaryOperators: false
 BreakBeforeBraces: Linux
-BreakBeforeTernaryOperators: false
+BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     0
+ColumnLimit:     128
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
@@ -35,8 +36,8 @@ ObjCSpaceBeforeProtocolList: false
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
+PenaltyBreakString: 100
+PenaltyExcessCharacter: 5
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 SpaceBeforeAssignmentOperators: true


### PR DESCRIPTION
There hasn't been enough drama lately, and we all know the quickest way to create dev drama is to talk about style ;)

### Changes explained:

`BinPackArguments: true` allows multiple arguments to be on the same line if needed.
false requires each param to be on a new line if the line needs to be split.
ex:
```
void f() {
  f(aaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaa,
    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
}
```

`BreakBeforeTernaryOperators: true` was prior false. true reads easier imo and is clearer

ex:
true
```
veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription
    ? firstValue
    : SecondValueVeryVeryVeryVeryLong;
```
false
```
veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongDescription ?
    firstValue :
    SecondValueVeryVeryVeryVeryLong;
```

`ColumnLimit:     128`
This means that once a line gets over 128 columns long, it will be likely to be broken in the next couple of chars depending on the situation(will sometimes be a little longer to keep a string together etc based on the penalties below). Based on the current clang file it basically means that single expressions should NEVER get split, which is definitely not the style we actually follow.

**Penalties**
For each column above 128 there is a penalty of 5. That means that single strings and other situations where you don't want a break can be normally held together longer even if it is strictly over the column limit.