### PR TITLE
psclient: initialize base class in copy ctor

### DIFF
--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -141,7 +141,11 @@ public:
         pendingDsaRequest(),
         keyHolderStorage()
         {}
-    CPrivateSendClientSession(const CPrivateSendClientSession& other) { /* dummy copy constructor*/ SetNull(); }
+    CPrivateSendClientSession(const CPrivateSendClientSession& other) : CPrivateSendBaseSession() {
+        /* dummy copy constructor*/
+        SetNull();
+    }
+
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 


### PR DESCRIPTION
This addresses compiler warnings by explicitly initializing base class.