### PR TITLE
refactor connman usage in masternodesync

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -29,7 +29,7 @@ void CDSNotificationInterface::AcceptedBlockHeader(const CBlockIndex *pindexNew)
 
 void CDSNotificationInterface::NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload)
 {
-    masternodeSync.NotifyHeaderTip(pindexNew, fInitialDownload, connman);
+    masternodeSync.NotifyHeaderTip(pindexNew, fInitialDownload);
 }
 
 void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
@@ -39,7 +39,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
     deterministicMNManager->UpdatedBlockTip(pindexNew);
 
-    masternodeSync.UpdatedBlockTip(pindexNew, fInitialDownload, connman);
+    masternodeSync.UpdatedBlockTip(pindexNew, fInitialDownload);
 
     // Update global DIP0001 activation status
     fDIP0001ActiveAtTip = pindexNew->nHeight >= Params().GetConsensus().DIP0001Height;

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -40,6 +40,9 @@ private:
     // Count peers we've requested the asset from
     int nRequestedMasternodeAttempt;
 
+    // keep a connection manager reference instead of passing it around to various methods
+    CConnman* connman;
+
     // Time when current masternode asset sync started
     int64_t nTimeAssetSyncStarted;
     // ... last bumped
@@ -52,8 +55,7 @@ private:
 public:
     CMasternodeSync() { Reset(); }
 
-
-    void SendGovernanceSyncRequest(CNode* pnode, CConnman& connman);
+    void SendGovernanceSyncRequest(CNode* pnode);
 
     bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
     bool IsBlockchainSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_WAITING; }
@@ -69,16 +71,21 @@ public:
     std::string GetSyncStatus();
 
     void Reset();
-    void SwitchToNextAsset(CConnman& connman);
+    void SwitchToNextAsset();
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
-    void ProcessTick(CConnman& connman);
+    void ProcessTick();
 
     void AcceptedBlockHeader(const CBlockIndex *pindexNew);
-    void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload, CConnman& connman);
-    void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload, CConnman& connman);
+    void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload);
+    void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload);
 
-    void DoMaintenance(CConnman &connman) { ProcessTick(connman); }
+    void SetConnectionManager(CConnman *connman);
+
+    void DoMaintenance(CConnman &connman) {
+        SetConnectionManager(&connman);
+        ProcessTick();
+    }
 };
 
 #endif

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -166,14 +166,14 @@ UniValue mnsync(const JSONRPCRequest& request)
 
     if(strMode == "next")
     {
-        masternodeSync.SwitchToNextAsset(*g_connman);
+        masternodeSync.SwitchToNextAsset();
         return "sync updated to " + masternodeSync.GetAssetName();
     }
 
     if(strMode == "reset")
     {
         masternodeSync.Reset();
-        masternodeSync.SwitchToNextAsset(*g_connman);
+        masternodeSync.SwitchToNextAsset();
         return "success";
     }
     return "failure";


### PR DESCRIPTION
Keep a pointer to the connection manager in the class, instead of passing around a reference.

My only concern here is in how to initialize this, although it looks like this doesn't get used until `DoMaintenance` is called (and my testing confirms this). I would still prefer to set the connman ptr in the ctor instead of in DoMaintenance, but `masternodeSync` is declared as a global above of the cpp implementation, which doesn't have the connman in scope at the point (unless via g_connman global).