### PR TITLE
rename vars in mnsync to make more sense

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -19,13 +19,13 @@ CMasternodeSync masternodeSync;
 void CMasternodeSync::Fail()
 {
     nTimeLastFailure = GetTime();
-    nRequestedMasternodeAssets = MASTERNODE_SYNC_FAILED;
+    nCurrentAsset = MASTERNODE_SYNC_FAILED;
 }
 
 void CMasternodeSync::Reset()
 {
-    nRequestedMasternodeAssets = MASTERNODE_SYNC_INITIAL;
-    nRequestedMasternodeAttempt = 0;
+    nCurrentAsset = MASTERNODE_SYNC_INITIAL;
+    nPeerCount = 0;
     nTimeAssetSyncStarted = GetTime();
     nTimeLastBumped = GetTime();
     nTimeLastFailure = 0;
@@ -40,7 +40,7 @@ void CMasternodeSync::BumpAssetLastTime(const std::string& strFuncName)
 
 std::string CMasternodeSync::GetAssetName()
 {
-    switch(nRequestedMasternodeAssets)
+    switch(nCurrentAsset)
     {
         case(MASTERNODE_SYNC_INITIAL):      return "MASTERNODE_SYNC_INITIAL";
         case(MASTERNODE_SYNC_WAITING):      return "MASTERNODE_SYNC_WAITING";
@@ -55,41 +55,41 @@ std::string CMasternodeSync::GetAssetName()
 
 void CMasternodeSync::SwitchToNextAsset(CConnman& connman)
 {
-    switch(nRequestedMasternodeAssets)
+    switch(nCurrentAsset)
     {
         case(MASTERNODE_SYNC_FAILED):
             throw std::runtime_error("Can't switch to next asset from failed, should use Reset() first!");
             break;
         case(MASTERNODE_SYNC_INITIAL):
-            nRequestedMasternodeAssets = MASTERNODE_SYNC_WAITING;
+            nCurrentAsset = MASTERNODE_SYNC_WAITING;
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Starting %s\n", GetAssetName());
             break;
         case(MASTERNODE_SYNC_WAITING):
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %llds\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
             if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-                nRequestedMasternodeAssets = MASTERNODE_SYNC_GOVERNANCE;
+                nCurrentAsset = MASTERNODE_SYNC_GOVERNANCE;
             } else {
-                nRequestedMasternodeAssets = MASTERNODE_SYNC_LIST;
+                nCurrentAsset = MASTERNODE_SYNC_LIST;
             }
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Starting %s\n", GetAssetName());
             break;
         case(MASTERNODE_SYNC_LIST):
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %llds\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
             if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-                nRequestedMasternodeAssets = MASTERNODE_SYNC_GOVERNANCE;
+                nCurrentAsset = MASTERNODE_SYNC_GOVERNANCE;
             } else {
-                nRequestedMasternodeAssets = MASTERNODE_SYNC_MNW;
+                nCurrentAsset = MASTERNODE_SYNC_MNW;
             }
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Starting %s\n", GetAssetName());
             break;
         case(MASTERNODE_SYNC_MNW):
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %llds\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
-            nRequestedMasternodeAssets = MASTERNODE_SYNC_GOVERNANCE;
+            nCurrentAsset = MASTERNODE_SYNC_GOVERNANCE;
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Starting %s\n", GetAssetName());
             break;
         case(MASTERNODE_SYNC_GOVERNANCE):
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Completed %s in %llds\n", GetAssetName(), GetTime() - nTimeAssetSyncStarted);
-            nRequestedMasternodeAssets = MASTERNODE_SYNC_FINISHED;
+            nCurrentAsset = MASTERNODE_SYNC_FINISHED;
             uiInterface.NotifyAdditionalDataSyncProgressChanged(1);
             //try to activate our masternode if possible
             legacyActiveMasternodeManager.ManageState(connman);
@@ -101,14 +101,14 @@ void CMasternodeSync::SwitchToNextAsset(CConnman& connman)
 
             break;
     }
-    nRequestedMasternodeAttempt = 0;
+    nPeerCount = 0;
     nTimeAssetSyncStarted = GetTime();
     BumpAssetLastTime("CMasternodeSync::SwitchToNextAsset");
 }
 
 std::string CMasternodeSync::GetSyncStatus()
 {
-    switch (masternodeSync.nRequestedMasternodeAssets) {
+    switch (masternodeSync.nCurrentAsset) {
         case MASTERNODE_SYNC_INITIAL:       return _("Synchroning blockchain...");
         case MASTERNODE_SYNC_WAITING:       return _("Synchronization pending...");
         case MASTERNODE_SYNC_LIST:          return _("Synchronizing masternodes...");
@@ -170,8 +170,8 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
     }
 
     // Calculate "progress" for LOG reporting / GUI notification
-    double nSyncProgress = double(nRequestedMasternodeAttempt + (nRequestedMasternodeAssets - 1) * 8) / (8*4);
-    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d nRequestedMasternodeAttempt %d nSyncProgress %f\n", nTick, nRequestedMasternodeAssets, nRequestedMasternodeAttempt, nSyncProgress);
+    double nSyncProgress = double(nPeerCount + (nCurrentAsset - 1) * 8) / (8*4);
+    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d nPeerCount %d nSyncProgress %f\n", nTick, nCurrentAsset, nPeerCount, nSyncProgress);
     uiInterface.NotifyAdditionalDataSyncProgressChanged(nSyncProgress);
 
     std::vector<CNode*> vNodesCopy = connman.CopyNodeVector(CConnman::FullyConnectedOnly);
@@ -189,20 +189,20 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
         // QUICK MODE (REGTEST ONLY!)
         if(Params().NetworkIDString() == CBaseChainParams::REGTEST)
         {
-            if (nRequestedMasternodeAssets == MASTERNODE_SYNC_WAITING) {
+            if (nCurrentAsset == MASTERNODE_SYNC_WAITING) {
                 connman.PushMessage(pnode, msgMaker.Make(NetMsgType::GETSPORKS)); //get current network sporks
                 SwitchToNextAsset(connman);
-            } else if (nRequestedMasternodeAssets == MASTERNODE_SYNC_LIST) {
+            } else if (nCurrentAsset == MASTERNODE_SYNC_LIST) {
                 if (!deterministicMNManager->IsDeterministicMNsSporkActive()) {
                     mnodeman.DsegUpdate(pnode, connman);
                 }
                 SwitchToNextAsset(connman);
-            } else if (nRequestedMasternodeAssets == MASTERNODE_SYNC_MNW) {
+            } else if (nCurrentAsset == MASTERNODE_SYNC_MNW) {
                 if (!deterministicMNManager->IsDeterministicMNsSporkActive()) {
                     connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC)); //sync payment votes
                 }
                 SwitchToNextAsset(connman);
-            } else if (nRequestedMasternodeAssets == MASTERNODE_SYNC_GOVERNANCE) {
+            } else if (nCurrentAsset == MASTERNODE_SYNC_GOVERNANCE) {
                 SendGovernanceSyncRequest(pnode, connman);
                 SwitchToNextAsset(connman);
             }
@@ -227,12 +227,12 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "spork-sync");
                 // get current network sporks
                 connman.PushMessage(pnode, msgMaker.Make(NetMsgType::GETSPORKS));
-                LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- requesting sporks from peer=%d\n", nTick, nRequestedMasternodeAssets, pnode->id);
+                LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- requesting sporks from peer=%d\n", nTick, nCurrentAsset, pnode->id);
             }
 
             // INITIAL TIMEOUT
 
-            if(nRequestedMasternodeAssets == MASTERNODE_SYNC_WAITING) {
+            if(nCurrentAsset == MASTERNODE_SYNC_WAITING) {
                 if(GetTime() - nTimeLastBumped > MASTERNODE_SYNC_TIMEOUT_SECONDS) {
                     // At this point we know that:
                     // a) there are peers (because we are looping on at least one of them);
@@ -248,18 +248,18 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
 
             // MNLIST : SYNC MASTERNODE LIST FROM OTHER CONNECTED CLIENTS
 
-            if(nRequestedMasternodeAssets == MASTERNODE_SYNC_LIST) {
+            if(nCurrentAsset == MASTERNODE_SYNC_LIST) {
                 if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
                     SwitchToNextAsset(connman);
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;
                 }
 
-                LogPrint("masternode", "CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d nTimeLastBumped %lld GetTime() %lld diff %lld\n", nTick, nRequestedMasternodeAssets, nTimeLastBumped, GetTime(), GetTime() - nTimeLastBumped);
+                LogPrint("masternode", "CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d nTimeLastBumped %lld GetTime() %lld diff %lld\n", nTick, nCurrentAsset, nTimeLastBumped, GetTime(), GetTime() - nTimeLastBumped);
                 // check for timeout first
                 if(GetTime() - nTimeLastBumped > MASTERNODE_SYNC_TIMEOUT_SECONDS) {
-                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- timeout\n", nTick, nRequestedMasternodeAssets);
-                    if (nRequestedMasternodeAttempt == 0) {
+                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- timeout\n", nTick, nCurrentAsset);
+                    if (nPeerCount == 0) {
                         LogPrintf("CMasternodeSync::ProcessTick -- ERROR: failed to sync %s\n", GetAssetName());
                         // there is no way we can continue without masternode list, fail here and try later
                         Fail();
@@ -272,7 +272,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 }
 
                 // request from three peers max
-                if (nRequestedMasternodeAttempt > 2) {
+                if (nPeerCount > 2) {
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;
                 }
@@ -282,7 +282,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "masternode-list-sync");
 
                 if (pnode->nVersion < mnpayments.GetMinMasternodePaymentsProto()) continue;
-                nRequestedMasternodeAttempt++;
+                nPeerCount++;
 
                 mnodeman.DsegUpdate(pnode, connman);
 
@@ -292,20 +292,20 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
 
             // MNW : SYNC MASTERNODE PAYMENT VOTES FROM OTHER CONNECTED CLIENTS
 
-            if(nRequestedMasternodeAssets == MASTERNODE_SYNC_MNW) {
+            if(nCurrentAsset == MASTERNODE_SYNC_MNW) {
                 if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
                     SwitchToNextAsset(connman);
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;
                 }
 
-                LogPrint("mnpayments", "CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d nTimeLastBumped %lld GetTime() %lld diff %lld\n", nTick, nRequestedMasternodeAssets, nTimeLastBumped, GetTime(), GetTime() - nTimeLastBumped);
+                LogPrint("mnpayments", "CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d nTimeLastBumped %lld GetTime() %lld diff %lld\n", nTick, nCurrentAsset, nTimeLastBumped, GetTime(), GetTime() - nTimeLastBumped);
                 // check for timeout first
                 // This might take a lot longer than MASTERNODE_SYNC_TIMEOUT_SECONDS due to new blocks,
                 // but that should be OK and it should timeout eventually.
                 if(GetTime() - nTimeLastBumped > MASTERNODE_SYNC_TIMEOUT_SECONDS) {
-                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- timeout\n", nTick, nRequestedMasternodeAssets);
-                    if (nRequestedMasternodeAttempt == 0) {
+                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- timeout\n", nTick, nCurrentAsset);
+                    if (nPeerCount == 0) {
                         LogPrintf("CMasternodeSync::ProcessTick -- ERROR: failed to sync %s\n", GetAssetName());
                         // probably not a good idea to proceed without winner list
                         Fail();
@@ -320,15 +320,15 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 // check for data
                 // if mnpayments already has enough blocks and votes, switch to the next asset
                 // try to fetch data from at least two peers though
-                if(nRequestedMasternodeAttempt > 1 && mnpayments.IsEnoughData()) {
-                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- found enough data\n", nTick, nRequestedMasternodeAssets);
+                if(nPeerCount > 1 && mnpayments.IsEnoughData()) {
+                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- found enough data\n", nTick, nCurrentAsset);
                     SwitchToNextAsset(connman);
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;
                 }
 
                 // request from three peers max
-                if (nRequestedMasternodeAttempt > 2) {
+                if (nPeerCount > 2) {
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;
                 }
@@ -338,7 +338,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "masternode-payment-sync");
 
                 if(pnode->nVersion < mnpayments.GetMinMasternodePaymentsProto()) continue;
-                nRequestedMasternodeAttempt++;
+                nPeerCount++;
 
                 // ask node for all payment votes it has (new nodes will only return votes for future payments)
                 connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MASTERNODEPAYMENTSYNC));
@@ -351,13 +351,13 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
 
             // GOVOBJ : SYNC GOVERNANCE ITEMS FROM OUR PEERS
 
-            if(nRequestedMasternodeAssets == MASTERNODE_SYNC_GOVERNANCE) {
-                LogPrint("gobject", "CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d nTimeLastBumped %lld GetTime() %lld diff %lld\n", nTick, nRequestedMasternodeAssets, nTimeLastBumped, GetTime(), GetTime() - nTimeLastBumped);
+            if(nCurrentAsset == MASTERNODE_SYNC_GOVERNANCE) {
+                LogPrint("gobject", "CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d nTimeLastBumped %lld GetTime() %lld diff %lld\n", nTick, nCurrentAsset, nTimeLastBumped, GetTime(), GetTime() - nTimeLastBumped);
 
                 // check for timeout first
                 if(GetTime() - nTimeLastBumped > MASTERNODE_SYNC_TIMEOUT_SECONDS) {
-                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- timeout\n", nTick, nRequestedMasternodeAssets);
-                    if(nRequestedMasternodeAttempt == 0) {
+                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- timeout\n", nTick, nCurrentAsset);
+                    if(nPeerCount == 0) {
                         LogPrintf("CMasternodeSync::ProcessTick -- WARNING: failed to sync %s\n", GetAssetName());
                         // it's kind of ok to skip this for now, hopefully we'll catch up later?
                     }
@@ -387,7 +387,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                             // after that and less then 0.01% or MASTERNODE_SYNC_TICK_SECONDS
                             // (i.e. 1 per second) votes were recieved during the last tick.
                             // We can be pretty sure that we are done syncing.
-                            LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nRequestedMasternodeAssets %d -- asked for all objects, nothing to do\n", nTick, nRequestedMasternodeAssets);
+                            LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- asked for all objects, nothing to do\n", nTick, nCurrentAsset);
                             // reset nTimeNoObjectsLeft to be able to use the same condition on resync
                             nTimeNoObjectsLeft = 0;
                             SwitchToNextAsset(connman);
@@ -402,7 +402,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "governance-sync");
 
                 if (pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
-                nRequestedMasternodeAttempt++;
+                nPeerCount++;
 
                 SendGovernanceSyncRequest(pnode, connman);
 
@@ -496,7 +496,7 @@ void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitia
     if (!IsBlockchainSynced() && fReachedBestHeader) {
         if (fLiteMode) {
             // nothing to do in lite mode, just finish the process immediately
-            nRequestedMasternodeAssets = MASTERNODE_SYNC_FINISHED;
+            nCurrentAsset = MASTERNODE_SYNC_FINISHED;
             return;
         }
         // Reached best header while being in initial mode.

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -32,9 +32,9 @@ class CMasternodeSync
 {
 private:
     // Keep track of current asset
-    int nRequestedMasternodeAssets;
+    int nCurrentAsset;
     // Count peers we've requested the asset from
-    int nRequestedMasternodeAttempt;
+    int nPeerCount;
 
     // Time when current masternode asset sync started
     int64_t nTimeAssetSyncStarted;
@@ -51,14 +51,14 @@ public:
 
     void SendGovernanceSyncRequest(CNode* pnode, CConnman& connman);
 
-    bool IsFailed() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FAILED; }
-    bool IsBlockchainSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_WAITING; }
-    bool IsMasternodeListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
-    bool IsWinnersListSynced() { return nRequestedMasternodeAssets > MASTERNODE_SYNC_MNW; }
-    bool IsSynced() { return nRequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED; }
+    bool IsFailed() { return nCurrentAsset == MASTERNODE_SYNC_FAILED; }
+    bool IsBlockchainSynced() { return nCurrentAsset > MASTERNODE_SYNC_WAITING; }
+    bool IsMasternodeListSynced() { return nCurrentAsset > MASTERNODE_SYNC_LIST; }
+    bool IsWinnersListSynced() { return nCurrentAsset > MASTERNODE_SYNC_MNW; }
+    bool IsSynced() { return nCurrentAsset == MASTERNODE_SYNC_FINISHED; }
 
-    int GetAssetID() { return nRequestedMasternodeAssets; }
-    int GetAttempt() { return nRequestedMasternodeAttempt; }
+    int GetAssetID() { return nCurrentAsset; }
+    int GetAttempt() { return nPeerCount; }
     void BumpAssetLastTime(const std::string& strFuncName);
     int64_t GetAssetStartTime() { return nTimeAssetSyncStarted; }
     std::string GetAssetName();

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -34,7 +34,7 @@ private:
     // Keep track of current asset
     int nCurrentAsset;
     // Count peers we've requested the asset from
-    int nPeerCount;
+    int nTriedPeerCount;
 
     // Time when current masternode asset sync started
     int64_t nTimeAssetSyncStarted;
@@ -58,7 +58,7 @@ public:
     bool IsSynced() { return nCurrentAsset == MASTERNODE_SYNC_FINISHED; }
 
     int GetAssetID() { return nCurrentAsset; }
-    int GetAttempt() { return nPeerCount; }
+    int GetAttempt() { return nTriedPeerCount; }
     void BumpAssetLastTime(const std::string& strFuncName);
     int64_t GetAssetStartTime() { return nTimeAssetSyncStarted; }
     std::string GetAssetName();


### PR DESCRIPTION
`nRequestedMasternodeAssets` -> `nCurrentAsset`
`nRequestedMasternodeAttempt` -> `nTriedPeerCount`