### PR TITLE
CSporkManager::Clear() should not alter sporkPubKeyID and sporkPrivKey

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -33,8 +33,8 @@ void CSporkManager::Clear()
     LOCK(cs);
     mapSporksActive.clear();
     mapSporksByHash.clear();
-    sporkPubKeyID.SetNull();
-    sporkPrivKey = CKey();
+    // sporkPubKeyID and sporkPrivKey should be set in init.cpp,
+    // we should not alter them here.
 }
 
 void CSporkManager::ProcessSpork(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)


### PR DESCRIPTION
If we ever going to call `Clear()` in runtime (e.g. when sporks.dat is corrupted) it's going to result in us banning all other nodes relaying sporks to us. This should fix it.