### PR TITLE
Add 5th denom, drop deprecated logic and bump min PS version

### DIFF
--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -312,9 +312,7 @@ void CPrivateSend::InitStandardDenominations()
     vecStandardDenominations.push_back((1 * COIN) + 1000);
     vecStandardDenominations.push_back((.1 * COIN) + 100);
     vecStandardDenominations.push_back((.01 * COIN) + 10);
-    /* Disabled till we need them
-    vecStandardDenominations.push_back( (.001     * COIN)+1 );
-    */
+    vecStandardDenominations.push_back((.001 * COIN) + 1);
 }
 
 // check to make sure the collateral provided by the client is valid
@@ -329,8 +327,7 @@ bool CPrivateSend::IsCollateralValid(const CTransaction& txCollateral)
     for (const auto& txout : txCollateral.vout) {
         nValueOut += txout.nValue;
 
-        bool fAllowData = mnpayments.GetMinMasternodePaymentsProto() > 70208;
-        if (!txout.scriptPubKey.IsPayToPublicKeyHash() && !(fAllowData && txout.scriptPubKey.IsUnspendable())) {
+        if (!txout.scriptPubKey.IsPayToPublicKeyHash() && !txout.scriptPubKey.IsUnspendable()) {
             LogPrintf("CPrivateSend::IsCollateralValid -- Invalid Script, txCollateral=%s", txCollateral.ToString());
             return false;
         }
@@ -367,13 +364,8 @@ bool CPrivateSend::IsCollateralValid(const CTransaction& txCollateral)
 
 bool CPrivateSend::IsCollateralAmount(CAmount nInputAmount)
 {
-    if (mnpayments.GetMinMasternodePaymentsProto() > 70208) {
-        // collateral input can be anything between 1x and "max" (including both)
-        return (nInputAmount >= GetCollateralAmount() && nInputAmount <= GetMaxCollateralAmount());
-    } else { // <= 70208
-        // collateral input can be anything between 2x and "max" (including both)
-        return (nInputAmount >= GetCollateralAmount() * 2 && nInputAmount <= GetMaxCollateralAmount());
-    }
+    // collateral input can be anything between 1x and "max" (including both)
+    return (nInputAmount >= GetCollateralAmount() && nInputAmount <= GetMaxCollateralAmount());
 }
 
 /*  Create a nice string to show the denominations

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -24,7 +24,7 @@ static const int PRIVATESEND_QUEUE_TIMEOUT = 30;
 static const int PRIVATESEND_SIGNING_TIMEOUT = 15;
 
 //! minimum peer version accepted by mixing pool
-static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70211;
+static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70212;
 
 static const size_t PRIVATESEND_ENTRY_MAX_SIZE = 9;
 

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -410,7 +410,7 @@ public:
 
     /// If the collateral is valid given by a client
     static bool IsCollateralValid(const CTransaction& txCollateral);
-    static CAmount GetCollateralAmount() { return vecStandardDenominations.back() / 10; }
+    static CAmount GetCollateralAmount() { return GetSmallestDenomination() / 10; }
     static CAmount GetMaxCollateralAmount() { return GetCollateralAmount() * 4; }
 
     static bool IsCollateralAmount(CAmount nInputAmount);

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -118,11 +118,6 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(nDenom);
-        int nVersion = s.GetVersion();
-        if (nVersion > 70208 && nVersion <= 70210) {
-            int nInputCount = 0;
-            READWRITE(nInputCount);
-        }
         READWRITE(txCollateral);
     }
 
@@ -179,7 +174,6 @@ class CPrivateSendQueue
 {
 public:
     int nDenom;
-    int nInputCount; // not used for anything but to calculate correct hash, remove after migration to 70211
     COutPoint masternodeOutpoint;
     int64_t nTime;
     bool fReady; //ready for submit
@@ -189,7 +183,6 @@ public:
 
     CPrivateSendQueue() :
         nDenom(0),
-        nInputCount(0),
         masternodeOutpoint(COutPoint()),
         nTime(0),
         fReady(false),
@@ -200,7 +193,6 @@ public:
 
     CPrivateSendQueue(int nDenom, COutPoint outpoint, int64_t nTime, bool fReady) :
         nDenom(nDenom),
-        nInputCount(0),
         masternodeOutpoint(outpoint),
         nTime(nTime),
         fReady(fReady),
@@ -215,10 +207,6 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(nDenom);
-        int nVersion = s.GetVersion();
-        if (nVersion > 70208 && nVersion <= 70210) {
-            READWRITE(nInputCount);
-        }
         READWRITE(masternodeOutpoint);
         READWRITE(nTime);
         READWRITE(fReady);

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -24,7 +24,7 @@ static const int PRIVATESEND_QUEUE_TIMEOUT = 30;
 static const int PRIVATESEND_SIGNING_TIMEOUT = 15;
 
 //! minimum peer version accepted by mixing pool
-static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70210;
+static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70211;
 
 static const size_t PRIVATESEND_ENTRY_MAX_SIZE = 9;
 
@@ -390,8 +390,6 @@ private:
     CPrivateSend(CPrivateSend const&) = delete;
     CPrivateSend& operator=(CPrivateSend const&) = delete;
 
-    static const CAmount COLLATERAL = 0.001 * COIN;
-
     // static members
     static std::vector<CAmount> vecStandardDenominations;
     static std::map<uint256, CPrivateSendBroadcastTx> mapDSTX;
@@ -424,8 +422,8 @@ public:
 
     /// If the collateral is valid given by a client
     static bool IsCollateralValid(const CTransaction& txCollateral);
-    static CAmount GetCollateralAmount() { return COLLATERAL; }
-    static CAmount GetMaxCollateralAmount() { return COLLATERAL * 4; }
+    static CAmount GetCollateralAmount() { return vecStandardDenominations.back() / 10; }
+    static CAmount GetMaxCollateralAmount() { return GetCollateralAmount() * 4; }
 
     static bool IsCollateralAmount(CAmount nInputAmount);
 


### PR DESCRIPTION
- add 5th denom (0.001)
- always allow OP_RETURN in PS collaterals (i.e. drop deprecated logic)
- collateral amount is always 1/10 of the smallest denom (i.e. no need to update it manually if we are going to add yet another denom later)
- bump MIN_PRIVATESEND_PEER_PROTO_VERSION to ~70211~70212 to avoid conflicts with 70210 (esp. during migration)
- drop backward compatibility in dsa/dsq serialization (we won't process messages from nodes below MIN_PRIVATESEND_PEER_PROTO_VERSION anyway)

Note: After merging this `develop` won't be able to mix on current mainnet until migration, you'd have to revert it locally to keep mixing on mainnet.