### PR TITLE
Don't use boost range adaptors in CDeterministicMNList

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -174,10 +174,11 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee() const
         return nullptr;
 
     CDeterministicMNCPtr best;
-    for (const auto& dmn : valid_range()) {
-        if (!best || CompareByLastPaid(dmn, best))
+    ForEachMN(true, [&](const CDeterministicMNCPtr& dmn) {
+        if (!best || CompareByLastPaid(dmn, best)) {
             best = dmn;
-    }
+        }
+    });
 
     return best;
 }
@@ -310,8 +311,8 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
     evoDb.Write(std::make_pair(DB_LIST_DIFF, diff.blockHash), diff);
     if ((nHeight % SNAPSHOT_LIST_PERIOD) == 0) {
         evoDb.Write(std::make_pair(DB_LIST_SNAPSHOT, diff.blockHash), newList);
-        LogPrintf("CDeterministicMNManager::%s -- Wrote snapshot. nHeight=%d, mapCurMNs.size=%d\n",
-                  __func__, nHeight, newList.size());
+        LogPrintf("CDeterministicMNManager::%s -- Wrote snapshot. nHeight=%d, mapCurMNs.allMNsCount=%d\n",
+                  __func__, nHeight, newList.GetAllMNsCount());
     }
 
     if (nHeight == GetSpork15Value()) {
@@ -373,8 +374,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
             if (dmn && dmn->nCollateralIndex == in.prevout.n) {
                 newList.RemoveMN(proTxHash);
 
-                LogPrintf("CDeterministicMNManager::%s -- MN %s removed from list because collateral was spent. nHeight=%d, mapCurMNs.size=%d\n",
-                          __func__, proTxHash.ToString(), nHeight, newList.size());
+                LogPrintf("CDeterministicMNManager::%s -- MN %s removed from list because collateral was spent. nHeight=%d, mapCurMNs.allMNsCount=%d\n",
+                          __func__, proTxHash.ToString(), nHeight, newList.GetAllMNsCount());
             }
         }
 

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -15,9 +15,6 @@
 
 #include <map>
 
-#include <boost/range/adaptors.hpp>
-#include <boost/range/any_range.hpp>
-
 class CBlock;
 class CBlockIndex;
 class CValidationState;
@@ -220,41 +217,18 @@ public:
 
 public:
 
-    size_t size() const
+    size_t GetAllMNsCount() const
     {
         return mnMap.size();
     }
 
-    typedef boost::any_range<const CDeterministicMNCPtr&, boost::forward_traversal_tag> range_type;
-
-    range_type all_range() const
-    {
-        return boost::adaptors::transform(mnMap, [] (const MnMap::value_type& p) -> const CDeterministicMNCPtr& {
-            return p.second;
-        });
-    }
-
-    range_type valid_range() const
-    {
-        return boost::adaptors::filter(all_range(), [&] (const CDeterministicMNCPtr& dmn) -> bool {
-            return IsMNValid(dmn);
-        });
-    }
-
-    size_t all_count() const
-    {
-        return mnMap.size();
-    }
-
-    size_t valid_count() const
-    {
-        size_t c = 0;
+    template<typename Callback>
+    void ForEachMN(bool onlyValid, Callback&& cb) const {
         for (const auto& p : mnMap) {
-            if (IsMNValid(p.second)) {
-                c++;
+            if (!onlyValid || IsMNValid(p.second)) {
+                cb(p.second);
             }
         }
-        return c;
     }
 
 public:

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -56,11 +56,11 @@ CSimplifiedMNList::CSimplifiedMNList(const std::vector<CSimplifiedMNListEntry>& 
 
 CSimplifiedMNList::CSimplifiedMNList(const CDeterministicMNList& dmnList)
 {
-    mnList.reserve(dmnList.all_count());
+    mnList.reserve(dmnList.GetAllMNsCount());
 
-    for (const auto& dmn : dmnList.all_range()) {
+    dmnList.ForEachMN(false, [this](const CDeterministicMNCPtr& dmn) {
         mnList.emplace_back(*dmn);
-    }
+    });
 
     std::sort(mnList.begin(), mnList.end(), [&](const CSimplifiedMNListEntry& a, const CSimplifiedMNListEntry& b) {
         return a.proRegTxHash.Compare(b.proRegTxHash) < 0;

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -199,11 +199,15 @@ static CDeterministicMNCPtr FindPayoutDmn(const CBlock& block)
 {
     auto dmnList = deterministicMNManager->GetListAtChainTip();
 
-    for (auto txout : block.vtx[0]->vout) {
-        for (auto& dmn : dmnList.valid_range()) {
-            if (txout.scriptPubKey == dmn->pdmnState->scriptPayout) {
-                return dmn;
+    for (const auto& txout : block.vtx[0]->vout) {
+        CDeterministicMNCPtr found;
+        dmnList.ForEachMN(true, [&](const CDeterministicMNCPtr& dmn) {
+            if (found == nullptr && txout.scriptPubKey == dmn->pdmnState->scriptPayout) {
+                found = dmn;
             }
+        });
+        if (found != nullptr) {
+            return found;
         }
     }
     return nullptr;


### PR DESCRIPTION
These cause crashes when used in for loops. Reason is very likely that
temporary CDeterministicMNList objects are destroyed before entering the
loop while the adaptors rely on these objects.

Discovered in one of our devnets while calling "protx list"