### PR TITLE
Fix auto-IS and tests

### DIFF
--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -190,6 +190,8 @@ class AutoInstantSendTest(BitcoinTestFramework):
         return info['SPORK_16_INSTANTSEND_AUTOLOCKS']
 
     def set_autoix_spork_state(self, state):
+        set_mocktime(get_mocktime() + 1)
+        set_node_times(self.nodes, get_mocktime())
         if state:
             value = 0
         else:

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -302,5 +302,12 @@ class AutoInstantSendTest(BitcoinTestFramework):
         assert(self.send_simple_tx())
         assert(not self.send_complex_tx())
 
+        self.set_autoix_spork_state(False)
+        assert(not self.get_autoix_spork_state())
+
+        assert(self.send_regular_IX())
+        assert(not self.send_simple_tx())
+        assert(not self.send_complex_tx())
+
 if __name__ == '__main__':
     AutoInstantSendTest().main()

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -262,6 +262,10 @@ class AutoInstantSendTest(BitcoinTestFramework):
     def send_regular_IX(self):
         receiver_addr = self.nodes[self.receiver_idx].getnewaddress()
         txid = self.nodes[0].instantsendtoaddress(receiver_addr, 1.0)
+        MIN_FEE = satoshi_round(-0.0001)
+        fee = self.nodes[0].gettransaction(txid)['fee']
+        expected_fee = MIN_FEE * len(self.nodes[0].getrawtransaction(txid, True)['vin'])
+        assert_equal(fee, expected_fee)
         return self.check_IX_lock(txid)
 
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -989,7 +989,7 @@ bool CTxLockRequest::IsValid() const
 
 CAmount CTxLockRequest::GetMinFee() const
 {
-    if (IsSimple()) {
+    if (CInstantSend::CanAutoLock() && IsSimple()) {
         return CAmount();
     }
     CAmount nMinFee = MIN_FEE;

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -979,7 +979,7 @@ bool CTxLockRequest::IsValid() const
 
     CAmount nValueOut = tx->GetValueOut();
 
-    if (nValueIn - nValueOut < GetMinFee()) {
+    if (nValueIn - nValueOut < GetMinFee(false)) {
         LogPrint("instantsend", "CTxLockRequest::IsValid -- did not include enough fees in transaction: fees=%d, tx=%s", nValueOut - nValueIn, ToString());
         return false;
     }
@@ -987,9 +987,9 @@ bool CTxLockRequest::IsValid() const
     return true;
 }
 
-CAmount CTxLockRequest::GetMinFee() const
+CAmount CTxLockRequest::GetMinFee(bool fForceMinFee) const
 {
-    if (CInstantSend::CanAutoLock() && IsSimple()) {
+    if (!fForceMinFee && CInstantSend::CanAutoLock() && IsSimple()) {
         return CAmount();
     }
     CAmount nMinFee = MIN_FEE;

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -191,7 +191,7 @@ public:
     }
 
     bool IsValid() const;
-    CAmount GetMinFee() const;
+    CAmount GetMinFee(bool fForceMinFee) const;
     int GetMaxSignatures() const;
 
     // checks if related transaction is "simple" to lock it automatically

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -569,7 +569,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
             nPayFee = coinControl->nMinimumTotalFee;
 
         // InstantSend Fee
-        if (coinControl->fUseInstantSend) nPayFee = std::max(nPayFee, CTxLockRequest(txDummy).GetMinFee());
+        if (coinControl->fUseInstantSend) nPayFee = std::max(nPayFee, CTxLockRequest(txDummy).GetMinFee(true));
 
         // Allow free? (require at least hard-coded threshold and default to that if no estimate)
         double mempoolEstimatePriority = mempool.estimateSmartPriority(nTxConfirmTarget);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3408,7 +3408,7 @@ bool CWallet::ConvertList(std::vector<CTxIn> vecTxIn, std::vector<CAmount>& vecA
 bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet,
                                 int& nChangePosInOut, std::string& strFailReason, const CCoinControl* coinControl, bool sign, AvailableCoinsType nCoinType, bool fUseInstantSend, int nExtraPayloadSize)
 {
-    CAmount nFeePay = fUseInstantSend ? CTxLockRequest().GetMinFee() : 0;
+    CAmount nFeePay = fUseInstantSend ? CTxLockRequest().GetMinFee(true) : 0;
 
     CAmount nValue = 0;
     int nChangePosRequest = nChangePosInOut;
@@ -3751,7 +3751,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     nFeeNeeded = coinControl->nMinimumTotalFee;
                 }
                 if(fUseInstantSend) {
-                    nFeeNeeded = std::max(nFeeNeeded, CTxLockRequest(txNew).GetMinFee());
+                    nFeeNeeded = std::max(nFeeNeeded, CTxLockRequest(txNew).GetMinFee(true));
                 }
                 if (coinControl && coinControl->fOverrideFeeRate)
                     nFeeNeeded = coinControl->nFeeRate.GetFee(nBytes);


### PR DESCRIPTION
Missed this in #2140 

Without this we won't be able to create "normal" IS txes if auto-IS is not yet activated or if it's disabled for some reason (too high mempool usage or spork16 is OFF).