### PR TITLE
Remove duplicated check from CWallet::AvailableCoins

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2609,11 +2609,6 @@ void CWallet::AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed, 
             if (nDepth == 0 && !pcoin->InMempool())
                 continue;
 
-            // We should not consider coins which aren't at least in our mempool
-            // It's possible for these to be conflicted via ancestors which we may never be able to detect
-            if (nDepth == 0 && !pcoin->InMempool())
-                continue;
-
             for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
                 bool found = false;
                 if(nCoinType == ONLY_DENOMINATED) {


### PR DESCRIPTION
```
  // We should not consider coins which aren't at least in our mempool
  // It's possible for these to be conflicted via ancestors which we may never be able to detect
  if (nDepth == 0 && !pcoin->InMempool())
      continue;
```