### PR TITLE
depends: Fix qt configure to detect clang version correctly

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -9,7 +9,9 @@ $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib
 $(package)_patches=mac-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch
-$(package)_patches+=fix_qt_pkgconfig.patch fix-cocoahelpers-macos.patch qfixed-coretext.patch
+$(package)_patches+=fix_qt_configure.patch fix_qt_pkgconfig.patch fix-cocoahelpers-macos.patch qfixed-coretext.patch
+# NOTE: fix_qt_configure.patch is only needed for Qt 5.7, newer versions don't have this issue.
+# Remove it after bumping $(package)_version to 5.8+.
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=3a15aebd523c6d89fb97b2d3df866c94149653a26d27a00aac9b6d3020bc5a1d
@@ -140,6 +142,7 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/mingw-uuidof.patch && \
   patch -p1 < $($(package)_patch_dir)/pidlist_absolute.patch && \
   patch -p1 < $($(package)_patch_dir)/fix-xcb-include-order.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_qt_configure.patch && \
   patch -p1 < $($(package)_patch_dir)/fix_qt_pkgconfig.patch && \
   patch -p1 < $($(package)_patch_dir)/fix-cocoahelpers-macos.patch && \
   patch -p1 < $($(package)_patch_dir)/qfixed-coretext.patch && \

--- a/depends/patches/qt/fix_qt_configure.patch
+++ b/depends/patches/qt/fix_qt_configure.patch
@@ -1,0 +1,11 @@
+--- old/qtbase/configure
++++ new/qtbase/configure
+@@ -2846,7 +2846,7 @@
+         # with the system. We use 'xcrun' to check the clang version that's part of
+         # the Xcode installation.
+         XCRUN=`/usr/bin/xcrun -sdk macosx clang -v 2>&1`
+-        CLANGVERSION=`echo "$XCRUN" | sed -n 's/.*version \([0-9]\).*/\1/p'`
++        CLANGVERSION=`echo "$XCRUN" | sed -n 's/.*version \([0-9]*\).*/\1/p'`
+         expr "$CLANGVERSION" : '[0-9]' > /dev/null || { echo "Unable to determine CLANG version from output of xcrun: $XCRUN" ; exit 2 ; }
+         if [ "$CLANGVERSION" -ge 3 ]; then
+             PLATFORM=macx-clang


### PR DESCRIPTION
```
> /usr/bin/xcrun -sdk macosx clang -v
Apple LLVM version 10.0.0 (clang-1000.11.45.2)
Target: x86_64-apple-darwin18.0.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

Before:
```
> XCRUN=`/usr/bin/xcrun -sdk macosx clang -v 2>&1`; echo "$XCRUN" | sed -n 's/.*version \([0-9]\).*/\1/p'
1
```

After:
```
> XCRUN=`/usr/bin/xcrun -sdk macosx clang -v 2>&1`; echo "$XCRUN" | sed -n 's/.*version \([0-9]*\).*/\1/p'
10
```