### PR TITLE
Switched variable type from int to uint64_t in ConsumeDecimalNumber.

### DIFF
--- a/src/leveldb/util/logging.cc
+++ b/src/leveldb/util/logging.cc
@@ -52,7 +52,8 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
     char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
-      const int delta = (c - '0');
+      // |delta| intentionally unit64_t to avoid Android crash (see log).
+      const uint64_t delta = (c - '0');
       static const uint64_t kMaxUint64 = ~static_cast<uint64_t>(0);
       if (v > kMaxUint64/10 ||
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {


### PR DESCRIPTION
An Android test was occasionally crashing with a SEGV in ConsumeDecimalNumber
Switching a local variable from an int to uint64_t eliminated these crashes.
Speculating this is either a compiler, runtime library, or emulator issue.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=166399695
Switching this type to uint64_t also eliminates a compiler warning
about comparing an int with a uint64_t.