### PR TITLE
Fix sign mismatch warnings in GCC.

### DIFF
--- a/src/leveldb/db/memtable.cc
+++ b/src/leveldb/db/memtable.cc
@@ -101,7 +101,7 @@ void MemTable::Add(SequenceNumber s, ValueType type,
   p += 8;
   p = EncodeVarint32(p, val_size);
   memcpy(p, value.data(), val_size);
-  assert((p + val_size) - buf == encoded_len);
+  assert(p + val_size == buf + encoded_len);
   table_.Insert(buf);
 }
 

--- a/src/leveldb/db/version_set.cc
+++ b/src/leveldb/db/version_set.cc
@@ -20,7 +20,7 @@
 
 namespace leveldb {
 
-static const int kTargetFileSize = 2 * 1048576;
+static const size_t kTargetFileSize = 2 * 1048576;
 
 // Maximum bytes of overlaps in grandparent (i.e., level+2) before we
 // stop building a single file in a level->level+1 compaction.


### PR DESCRIPTION
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=193080913