### PR TITLE
Use BLS keys for the DIP3 operator key

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -59,7 +59,7 @@ void CActiveDeterministicMasternodeManager::Init()
 
     CDeterministicMNList mnList = deterministicMNManager->GetListAtChainTip();
 
-    CDeterministicMNCPtr dmn = mnList.GetMNByOperatorKey(activeMasternodeInfo.blsPubKeyOperator);
+    CDeterministicMNCPtr dmn = mnList.GetMNByOperatorKey(*activeMasternodeInfo.blsPubKeyOperator);
     if (!dmn) {
         // MN not appeared on the chain yet
         return;

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -59,7 +59,7 @@ void CActiveDeterministicMasternodeManager::Init()
 
     CDeterministicMNList mnList = deterministicMNManager->GetListAtChainTip();
 
-    CDeterministicMNCPtr dmn = mnList.GetMNByOperatorKey(activeMasternodeInfo.keyIDOperator);
+    CDeterministicMNCPtr dmn = mnList.GetMNByOperatorKey(activeMasternodeInfo.blsPubKeyOperator);
     if (!dmn) {
         // MN not appeared on the chain yet
         return;
@@ -234,7 +234,7 @@ bool CActiveLegacyMasternodeManager::SendMasternodePing(CConnman& connman)
     mnp.nSentinelVersion = nSentinelVersion;
     mnp.fSentinelIsCurrent =
             (abs(GetAdjustedTime() - nSentinelPingTime) < MASTERNODE_SENTINEL_PING_MAX_SECONDS);
-    if(!mnp.Sign(activeMasternodeInfo.keyOperator, activeMasternodeInfo.keyIDOperator)) {
+    if(!mnp.Sign(activeMasternodeInfo.legacyKeyOperator, activeMasternodeInfo.legacyKeyIDOperator)) {
         LogPrintf("CActiveLegacyMasternodeManager::SendMasternodePing -- ERROR: Couldn't sign Masternode Ping\n");
         return false;
     }
@@ -351,11 +351,11 @@ void CActiveLegacyMasternodeManager::ManageStateRemote()
         return;
 
     LogPrint("masternode", "CActiveLegacyMasternodeManager::ManageStateRemote -- Start status = %s, type = %s, pinger enabled = %d, keyIDOperator = %s\n",
-             GetStatus(), GetTypeString(), fPingerEnabled, activeMasternodeInfo.keyIDOperator.ToString());
+             GetStatus(), GetTypeString(), fPingerEnabled, activeMasternodeInfo.legacyKeyIDOperator.ToString());
 
-    mnodeman.CheckMasternode(activeMasternodeInfo.keyIDOperator, true);
+    mnodeman.CheckMasternode(activeMasternodeInfo.legacyKeyIDOperator, true);
     masternode_info_t infoMn;
-    if(mnodeman.GetMasternodeInfo(activeMasternodeInfo.keyIDOperator, infoMn)) {
+    if(mnodeman.GetMasternodeInfo(activeMasternodeInfo.legacyKeyIDOperator, infoMn)) {
         if(infoMn.nProtocolVersion != PROTOCOL_VERSION) {
             nState = ACTIVE_MASTERNODE_NOT_CAPABLE;
             strNotCapableReason = "Invalid protocol version";
@@ -376,12 +376,6 @@ void CActiveLegacyMasternodeManager::ManageStateRemote()
         }
         auto dmn = deterministicMNManager->GetListAtChainTip().GetMN(infoMn.outpoint.hash);
         if (dmn) {
-            if (dmn->pdmnState->keyIDOperator != infoMn.keyIDOperator) {
-                nState = ACTIVE_MASTERNODE_NOT_CAPABLE;
-                strNotCapableReason = strprintf("Masternode collateral is a ProTx and masternode key does not match key from -masternodeprivkey");
-                LogPrintf("CActiveLegacyMasternodeManager::ManageStateRemote -- %s: %s\n", GetStateString(), strNotCapableReason);
-                return;
-            }
             if (dmn->pdmnState->addr != infoMn.addr) {
                 nState = ACTIVE_MASTERNODE_NOT_CAPABLE;
                 strNotCapableReason = strprintf("Masternode collateral is a ProTx and ProTx address does not match local address");

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -30,8 +30,11 @@ extern CActiveDeterministicMasternodeManager* activeMasternodeManager;
 
 struct CActiveMasternodeInfo {
     // Keys for the active Masternode
-    CKeyID keyIDOperator;
-    CKey keyOperator;
+    CKeyID legacyKeyIDOperator;
+    CKey legacyKeyOperator;
+
+    CBLSPublicKey blsPubKeyOperator;
+    CBLSSecretKey blsKeyOperator;
 
     // Initialized while registering Masternode
     COutPoint outpoint;

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -33,8 +33,8 @@ struct CActiveMasternodeInfo {
     CKeyID legacyKeyIDOperator;
     CKey legacyKeyOperator;
 
-    CBLSPublicKey blsPubKeyOperator;
-    CBLSSecretKey blsKeyOperator;
+    std::unique_ptr<CBLSPublicKey> blsPubKeyOperator;
+    std::unique_ptr<CBLSSecretKey> blsKeyOperator;
 
     // Initialized while registering Masternode
     COutPoint outpoint;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -9,6 +9,7 @@
 #include "providertx.h"
 #include "dbwrapper.h"
 #include "sync.h"
+#include "bls/bls.h"
 
 #include "immer/map.hpp"
 #include "immer/map_transient.hpp"
@@ -30,7 +31,7 @@ public:
     uint16_t nRevocationReason{CProUpRevTx::REASON_NOT_SPECIFIED};
 
     CKeyID keyIDOwner;
-    CKeyID keyIDOperator;
+    CBLSPublicKey pubKeyOperator;
     CKeyID keyIDVoting;
     CService addr;
     int32_t nProtocolVersion;
@@ -42,7 +43,7 @@ public:
     CDeterministicMNState(const CProRegTx& proTx)
     {
         keyIDOwner = proTx.keyIDOwner;
-        keyIDOperator = proTx.keyIDOperator;
+        pubKeyOperator = proTx.pubKeyOperator;
         keyIDVoting = proTx.keyIDVoting;
         addr = proTx.addr;
         nProtocolVersion = proTx.nProtocolVersion;
@@ -63,7 +64,7 @@ public:
         READWRITE(nPoSeBanHeight);
         READWRITE(nRevocationReason);
         READWRITE(keyIDOwner);
-        READWRITE(keyIDOperator);
+        READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);
         READWRITE(addr);
         READWRITE(nProtocolVersion);
@@ -73,7 +74,7 @@ public:
 
     void ResetOperatorFields()
     {
-        keyIDOperator.SetNull();
+        pubKeyOperator = CBLSPublicKey();
         addr = CService();
         nProtocolVersion = 0;
         scriptOperatorPayout = CScript();
@@ -95,7 +96,7 @@ public:
                nPoSeBanHeight == rhs.nPoSeBanHeight &&
                nRevocationReason == rhs.nRevocationReason &&
                keyIDOwner == rhs.keyIDOwner &&
-               keyIDOperator == rhs.keyIDOperator &&
+               pubKeyOperator == rhs.pubKeyOperator &&
                keyIDVoting == rhs.keyIDVoting &&
                addr == rhs.addr &&
                nProtocolVersion == rhs.nProtocolVersion &&
@@ -257,7 +258,7 @@ public:
     }
     CDeterministicMNCPtr GetMN(const uint256& proTxHash) const;
     CDeterministicMNCPtr GetValidMN(const uint256& proTxHash) const;
-    CDeterministicMNCPtr GetMNByOperatorKey(const CKeyID& keyID);
+    CDeterministicMNCPtr GetMNByOperatorKey(const CBLSPublicKey& pubKey);
     CDeterministicMNCPtr GetMNPayee() const;
 
     /**

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -7,6 +7,7 @@
 
 #include "primitives/transaction.h"
 #include "consensus/validation.h"
+#include "bls/bls.h"
 
 #include "netaddress.h"
 #include "pubkey.h"
@@ -25,7 +26,7 @@ public:
     uint32_t nCollateralIndex{(uint32_t) - 1};
     CService addr;
     CKeyID keyIDOwner;
-    CKeyID keyIDOperator;
+    CBLSPublicKey pubKeyOperator;
     CKeyID keyIDVoting;
     uint16_t nOperatorReward{0};
     CScript scriptPayout;
@@ -43,7 +44,7 @@ public:
         READWRITE(nCollateralIndex);
         READWRITE(addr);
         READWRITE(keyIDOwner);
-        READWRITE(keyIDOperator);
+        READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);
         READWRITE(*(CScriptBase*)(&scriptPayout));
         READWRITE(nOperatorReward);
@@ -69,7 +70,7 @@ public:
     CService addr;
     CScript scriptOperatorPayout;
     uint256 inputsHash; // replay protection
-    std::vector<unsigned char> vchSig;
+    CBLSSignature sig;
 
 public:
     ADD_SERIALIZE_METHODS;
@@ -84,7 +85,7 @@ public:
         READWRITE(*(CScriptBase*)(&scriptOperatorPayout));
         READWRITE(inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
-            READWRITE(vchSig);
+            READWRITE(sig);
         }
     }
 
@@ -101,7 +102,7 @@ public:
 public:
     uint16_t nVersion{CURRENT_VERSION}; // message version
     uint256 proTxHash;
-    CKeyID keyIDOperator;
+    CBLSPublicKey pubKeyOperator;
     CKeyID keyIDVoting;
     CScript scriptPayout;
     uint256 inputsHash; // replay protection
@@ -115,7 +116,7 @@ public:
     {
         READWRITE(nVersion);
         READWRITE(proTxHash);
-        READWRITE(keyIDOperator);
+        READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);
         READWRITE(*(CScriptBase*)(&scriptPayout));
         READWRITE(inputsHash);
@@ -148,7 +149,7 @@ public:
     uint256 proTxHash;
     uint16_t nReason{REASON_NOT_SPECIFIED};
     uint256 inputsHash; // replay protection
-    std::vector<unsigned char> vchSig;
+    CBLSSignature sig;
 
 public:
     ADD_SERIALIZE_METHODS;
@@ -161,7 +162,7 @@ public:
         READWRITE(nReason);
         READWRITE(inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
-            READWRITE(vchSig);
+            READWRITE(sig);
         }
     }
 

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -15,7 +15,7 @@
 CSimplifiedMNListEntry::CSimplifiedMNListEntry(const CDeterministicMN& dmn) :
     proRegTxHash(dmn.proTxHash),
     service(dmn.pdmnState->addr),
-    keyIDOperator(dmn.pdmnState->keyIDOperator),
+    pubKeyOperator(dmn.pdmnState->pubKeyOperator),
     keyIDVoting(dmn.pdmnState->keyIDVoting),
     isValid(dmn.pdmnState->nPoSeBanHeight == -1)
 {
@@ -30,8 +30,8 @@ uint256 CSimplifiedMNListEntry::CalcHash() const
 
 std::string CSimplifiedMNListEntry::ToString() const
 {
-    return strprintf("CSimplifiedMNListEntry(proRegTxHash=%s, service=%s, keyIDOperator=%s, keyIDVoting=%s, isValie=%d)",
-        proRegTxHash.ToString(), service.ToString(false), keyIDOperator.ToString(), keyIDVoting.ToString(), isValid);
+    return strprintf("CSimplifiedMNListEntry(proRegTxHash=%s, service=%s, pubKeyOperator=%s, keyIDVoting=%s, isValie=%d)",
+        proRegTxHash.ToString(), service.ToString(false), pubKeyOperator.ToString(), keyIDVoting.ToString(), isValid);
 }
 
 void CSimplifiedMNListEntry::ToJson(UniValue& obj) const
@@ -40,8 +40,8 @@ void CSimplifiedMNListEntry::ToJson(UniValue& obj) const
     obj.setObject();
     obj.push_back(Pair("proRegTxHash", proRegTxHash.ToString()));
     obj.push_back(Pair("service", service.ToString(false)));
-    obj.push_back(Pair("keyIDOperator", keyIDOperator.ToString()));
-    obj.push_back(Pair("keyIDVoting", keyIDOperator.ToString()));
+    obj.push_back(Pair("pubKeyOperator", pubKeyOperator.ToString()));
+    obj.push_back(Pair("keyIDVoting", keyIDVoting.ToString()));
     obj.push_back(Pair("isValid", isValid));
 }
 

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -9,6 +9,7 @@
 #include "pubkey.h"
 #include "netaddress.h"
 #include "merkleblock.h"
+#include "bls/bls.h"
 
 class UniValue;
 class CDeterministicMNList;
@@ -19,7 +20,7 @@ class CSimplifiedMNListEntry
 public:
     uint256 proRegTxHash;
     CService service;
-    CKeyID keyIDOperator;
+    CBLSPublicKey pubKeyOperator;
     CKeyID keyIDVoting;
     bool isValid;
 
@@ -35,7 +36,7 @@ public:
     {
         READWRITE(proRegTxHash);
         READWRITE(service);
-        READWRITE(keyIDOperator);
+        READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);
         READWRITE(isValid);
     }

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -16,6 +16,7 @@
 #include "sync.h"
 #include "util.h"
 #include "utilstrencodings.h"
+#include "bls/bls.h"
 
 #include <univalue.h>
 
@@ -260,6 +261,8 @@ public:
     void SetMasternodeOutpoint(const COutPoint& outpoint);
     bool Sign(const CKey& key, const CKeyID& keyID);
     bool CheckSignature(const CKeyID& keyID) const;
+    bool Sign(const CBLSSecretKey& key);
+    bool CheckSignature(const CBLSPublicKey& pubKey) const;
 
     std::string GetSignatureMessage() const;
     uint256 GetSignatureHash() const;

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -214,6 +214,26 @@ bool CGovernanceVote::CheckSignature(const CKeyID& keyID) const
     return true;
 }
 
+bool CGovernanceVote::Sign(const CBLSSecretKey& key)
+{
+    uint256 hash = GetSignatureHash();
+    CBLSSignature sig = key.Sign(hash);
+    sig.GetBuf(vchSig);
+    return true;
+}
+
+bool CGovernanceVote::CheckSignature(const CBLSPublicKey& pubKey) const
+{
+    uint256 hash = GetSignatureHash();
+    CBLSSignature sig;
+    sig.SetBuf(vchSig);
+    if (!sig.VerifyInsecure(pubKey, hash)) {
+        LogPrintf("CGovernanceVote::CheckSignature -- VerifyInsecure() failed\n");
+        return false;
+    }
+    return true;
+}
+
 bool CGovernanceVote::IsValid(bool useVotingKey) const
 {
     if (nTime > GetAdjustedTime() + (60 * 60)) {
@@ -239,7 +259,21 @@ bool CGovernanceVote::IsValid(bool useVotingKey) const
         return false;
     }
 
-    return CheckSignature(useVotingKey ? infoMn.keyIDVoting : infoMn.keyIDOperator);
+    if (useVotingKey) {
+        CheckSignature(infoMn.keyIDVoting);
+    } else {
+        if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+            CheckSignature(infoMn.blsPubKeyOperator);
+        }
+    }
+
+    if (useVotingKey) {
+        return CheckSignature(infoMn.keyIDVoting);
+    } else if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        return CheckSignature(infoMn.blsPubKeyOperator);
+    } else {
+        return CheckSignature(infoMn.legacyKeyIDOperator);
+    }
 }
 
 bool operator==(const CGovernanceVote& vote1, const CGovernanceVote& vote2)

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -260,19 +260,13 @@ bool CGovernanceVote::IsValid(bool useVotingKey) const
     }
 
     if (useVotingKey) {
-        CheckSignature(infoMn.keyIDVoting);
+        return CheckSignature(infoMn.keyIDVoting);
     } else {
         if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-            CheckSignature(infoMn.blsPubKeyOperator);
+            return CheckSignature(infoMn.blsPubKeyOperator);
+        } else {
+            return CheckSignature(infoMn.legacyKeyIDOperator);
         }
-    }
-
-    if (useVotingKey) {
-        return CheckSignature(infoMn.keyIDVoting);
-    } else if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-        return CheckSignature(infoMn.blsPubKeyOperator);
-    } else {
-        return CheckSignature(infoMn.legacyKeyIDOperator);
     }
 }
 

--- a/src/governance-vote.h
+++ b/src/governance-vote.h
@@ -7,6 +7,7 @@
 
 #include "key.h"
 #include "primitives/transaction.h"
+#include "bls/bls.h"
 
 class CGovernanceVote;
 class CConnman;
@@ -96,6 +97,8 @@ public:
 
     bool Sign(const CKey& key, const CKeyID& keyID);
     bool CheckSignature(const CKeyID& keyID) const;
+    bool Sign(const CBLSSecretKey& key);
+    bool CheckSignature(const CBLSPublicKey& pubKey) const;
     bool IsValid(bool useVotingKey) const;
     void Relay(CConnman& connman) const;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1899,14 +1899,30 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         std::string strMasterNodePrivKey = GetArg("-masternodeprivkey", "");
         if(!strMasterNodePrivKey.empty()) {
             CPubKey pubKeyMasternode;
-            if(!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, activeMasternodeInfo.keyOperator, pubKeyMasternode))
+            if(!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, activeMasternodeInfo.legacyKeyOperator, pubKeyMasternode))
                 return InitError(_("Invalid masternodeprivkey. Please see documenation."));
 
-            activeMasternodeInfo.keyIDOperator = pubKeyMasternode.GetID();
+            activeMasternodeInfo.legacyKeyIDOperator = pubKeyMasternode.GetID();
 
-            LogPrintf("  keyIDOperator: %s\n", CBitcoinAddress(activeMasternodeInfo.keyIDOperator).ToString());
+            LogPrintf("  keyIDOperator: %s\n", CBitcoinAddress(activeMasternodeInfo.legacyKeyIDOperator).ToString());
         } else {
             return InitError(_("You must specify a masternodeprivkey in the configuration. Please see documentation for help."));
+        }
+
+        std::string strMasterNodeBLSPrivKey = GetArg("-masternodeblsprivkey", "");
+        if(!strMasterNodeBLSPrivKey.empty()) {
+            auto binKey = ParseHex(strMasterNodeBLSPrivKey);
+            CBLSSecretKey keyOperator;
+            keyOperator.SetBuf(binKey);
+            if (keyOperator.IsValid()) {
+                activeMasternodeInfo.blsKeyOperator = keyOperator;
+                activeMasternodeInfo.blsPubKeyOperator = activeMasternodeInfo.blsKeyOperator.GetPublicKey();
+                LogPrintf("  blsPubKeyOperator: %s\n", keyOperator.GetPublicKey().ToString());
+            } else {
+                return InitError(_("Invalid masternodeblsprivkey. Please see documenation."));
+            }
+        } else {
+            InitWarning(_("You should specify a masternodeblsprivkey in the configuration. Please see documentation for help."));
         }
 
         // init and register activeMasternodeManager

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1915,8 +1915,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             CBLSSecretKey keyOperator;
             keyOperator.SetBuf(binKey);
             if (keyOperator.IsValid()) {
-                activeMasternodeInfo.blsKeyOperator = keyOperator;
-                activeMasternodeInfo.blsPubKeyOperator = activeMasternodeInfo.blsKeyOperator.GetPublicKey();
+                activeMasternodeInfo.blsKeyOperator = std::make_unique<CBLSSecretKey>(keyOperator);
+                activeMasternodeInfo.blsPubKeyOperator = std::make_unique<CBLSPublicKey>(activeMasternodeInfo.blsKeyOperator->GetPublicKey());
                 LogPrintf("  blsPubKeyOperator: %s\n", keyOperator.GetPublicKey().ToString());
             } else {
                 return InitError(_("Invalid masternodeblsprivkey. Please see documenation."));
@@ -1928,6 +1928,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         // init and register activeMasternodeManager
         activeMasternodeManager = new CActiveDeterministicMasternodeManager();
         RegisterValidationInterface(activeMasternodeManager);
+    }
+
+    if (activeMasternodeInfo.blsKeyOperator == nullptr) {
+        activeMasternodeInfo.blsKeyOperator = std::make_unique<CBLSSecretKey>();
+    }
+    if (activeMasternodeInfo.blsPubKeyOperator == nullptr) {
+        activeMasternodeInfo.blsPubKeyOperator = std::make_unique<CBLSPublicKey>();
     }
 
 #ifdef ENABLE_WALLET

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1071,13 +1071,23 @@ bool CTxLockVote::CheckSignature() const
         return false;
     }
 
-    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
         uint256 hash = GetSignatureHash();
 
-        if (!CHashSigner::VerifyHash(hash, infoMn.keyIDOperator, vchMasternodeSignature, strError)) {
+        CBLSSignature sig;
+        sig.SetBuf(vchMasternodeSignature);
+        if (!sig.IsValid() || !sig.VerifyInsecure(infoMn.blsPubKeyOperator,
+                                                  hash)) {
+            LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
+            return false;
+        }
+    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetSignatureHash();
+
+        if (!CHashSigner::VerifyHash(hash, infoMn.legacyKeyIDOperator, vchMasternodeSignature, strError)) {
             // could be a signature in old format
             std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
-        if (!CMessageSigner::VerifyMessage(infoMn.keyIDOperator, vchMasternodeSignature, strMessage, strError)) {
+        if (!CMessageSigner::VerifyMessage(infoMn.legacyKeyIDOperator, vchMasternodeSignature, strMessage, strError)) {
                 // nope, not in old format either
                 LogPrintf("CTxLockVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
                 return false;
@@ -1085,7 +1095,7 @@ bool CTxLockVote::CheckSignature() const
         }
     } else {
         std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
-        if (!CMessageSigner::VerifyMessage(infoMn.keyIDOperator, vchMasternodeSignature, strMessage, strError)) {
+        if (!CMessageSigner::VerifyMessage(infoMn.legacyKeyIDOperator, vchMasternodeSignature, strMessage, strError)) {
             LogPrintf("CTxLockVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
             return false;
         }
@@ -1098,27 +1108,32 @@ bool CTxLockVote::Sign()
 {
     std::string strError;
 
-    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
         uint256 hash = GetSignatureHash();
 
-        if (!CHashSigner::SignHash(hash, activeMasternodeInfo.keyOperator, vchMasternodeSignature)) {
+        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator.Sign(hash);
+        sig.GetBuf(vchMasternodeSignature);
+    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetSignatureHash();
+
+        if (!CHashSigner::SignHash(hash, activeMasternodeInfo.legacyKeyOperator, vchMasternodeSignature)) {
             LogPrintf("CTxLockVote::Sign -- SignHash() failed\n");
             return false;
         }
 
-        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.keyIDOperator, vchMasternodeSignature, strError)) {
+        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.legacyKeyIDOperator, vchMasternodeSignature, strError)) {
             LogPrintf("CTxLockVote::Sign -- VerifyHash() failed, error: %s\n", strError);
             return false;
         }
     } else {
         std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
 
-        if (!CMessageSigner::SignMessage(strMessage, vchMasternodeSignature, activeMasternodeInfo.keyOperator)) {
+        if (!CMessageSigner::SignMessage(strMessage, vchMasternodeSignature, activeMasternodeInfo.legacyKeyOperator)) {
             LogPrintf("CTxLockVote::Sign -- SignMessage() failed\n");
             return false;
         }
 
-        if (!CMessageSigner::VerifyMessage(activeMasternodeInfo.keyIDOperator, vchMasternodeSignature, strMessage, strError)) {
+        if (!CMessageSigner::VerifyMessage(activeMasternodeInfo.legacyKeyIDOperator, vchMasternodeSignature, strMessage, strError)) {
             LogPrintf("CTxLockVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
             return false;
         }

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1111,7 +1111,7 @@ bool CTxLockVote::Sign()
     if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
         uint256 hash = GetSignatureHash();
 
-        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator.Sign(hash);
+        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
         sig.GetBuf(vchMasternodeSignature);
     } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1076,8 +1076,7 @@ bool CTxLockVote::CheckSignature() const
 
         CBLSSignature sig;
         sig.SetBuf(vchMasternodeSignature);
-        if (!sig.IsValid() || !sig.VerifyInsecure(infoMn.blsPubKeyOperator,
-                                                  hash)) {
+        if (!sig.IsValid() || !sig.VerifyInsecure(infoMn.blsPubKeyOperator, hash)) {
             LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
             return false;
         }
@@ -1087,7 +1086,7 @@ bool CTxLockVote::CheckSignature() const
         if (!CHashSigner::VerifyHash(hash, infoMn.legacyKeyIDOperator, vchMasternodeSignature, strError)) {
             // could be a signature in old format
             std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
-        if (!CMessageSigner::VerifyMessage(infoMn.legacyKeyIDOperator, vchMasternodeSignature, strMessage, strError)) {
+            if (!CMessageSigner::VerifyMessage(infoMn.legacyKeyIDOperator, vchMasternodeSignature, strMessage, strError)) {
                 // nope, not in old format either
                 LogPrintf("CTxLockVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
                 return false;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -491,7 +491,7 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, const std::string& strCom
         }
 
         int nDos = 0;
-        if(!vote.CheckSignature(mnInfo.keyIDOperator, nCachedBlockHeight, nDos)) {
+        if(!vote.CheckSignature(mnInfo.legacyKeyIDOperator, nCachedBlockHeight, nDos)) {
             if(nDos) {
                 LOCK(cs_main);
                 LogPrintf("MASTERNODEPAYMENTVOTE -- ERROR: invalid signature\n");
@@ -551,12 +551,12 @@ bool CMasternodePaymentVote::Sign()
     if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();
 
-        if(!CHashSigner::SignHash(hash, activeMasternodeInfo.keyOperator, vchSig)) {
+        if(!CHashSigner::SignHash(hash, activeMasternodeInfo.legacyKeyOperator, vchSig)) {
             LogPrintf("CMasternodePaymentVote::%s -- SignHash() failed\n", __func__);
             return false;
         }
 
-        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.keyIDOperator, vchSig, strError)) {
+        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.legacyKeyIDOperator, vchSig, strError)) {
             LogPrintf("CMasternodePaymentVote::%s -- VerifyHash() failed, error: %s\n", __func__, strError);
             return false;
         }
@@ -565,12 +565,12 @@ bool CMasternodePaymentVote::Sign()
                     std::to_string(nBlockHeight) +
                     ScriptToAsmStr(payee);
 
-        if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternodeInfo.keyOperator)) {
+        if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternodeInfo.legacyKeyOperator)) {
             LogPrintf("CMasternodePaymentVote::%s -- SignMessage() failed\n", __func__);
             return false;
         }
 
-        if(!CMessageSigner::VerifyMessage(activeMasternodeInfo.keyIDOperator, vchSig, strMessage, strError)) {
+        if(!CMessageSigner::VerifyMessage(activeMasternodeInfo.legacyKeyIDOperator, vchSig, strMessage, strError)) {
             LogPrintf("CMasternodePaymentVote::%s -- VerifyMessage() failed, error: %s\n", __func__, strError);
             return false;
         }

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -8,6 +8,7 @@
 #include "key.h"
 #include "validation.h"
 #include "spork.h"
+#include "bls/bls.h"
 
 #include "evo/deterministicmns.h"
 
@@ -110,15 +111,15 @@ struct masternode_info_t
                       CPubKey const& pkCollAddr, CPubKey const& pkMN) :
         nActiveState{activeState}, nProtocolVersion{protoVer}, sigTime{sTime},
         outpoint{outpnt}, addr{addr},
-        pubKeyCollateralAddress{pkCollAddr}, pubKeyMasternode{pkMN}, keyIDCollateralAddress{pkCollAddr.GetID()}, keyIDOwner{pkMN.GetID()}, keyIDOperator{pkMN.GetID()}, keyIDVoting{pkMN.GetID()} {}
+        pubKeyCollateralAddress{pkCollAddr}, pubKeyMasternode{pkMN}, keyIDCollateralAddress{pkCollAddr.GetID()}, keyIDOwner{pkMN.GetID()}, legacyKeyIDOperator{pkMN.GetID()}, keyIDVoting{pkMN.GetID()} {}
 
     // only called when the network is in deterministic MN list mode
     masternode_info_t(int activeState, int protoVer, int64_t sTime,
                       COutPoint const& outpnt, CService const& addr,
-                      CKeyID const& pkCollAddr, CKeyID const& pkOwner, CKeyID const& pkOperator, CKeyID const& pkVoting) :
+                      CKeyID const& pkCollAddr, CKeyID const& pkOwner, CBLSPublicKey const& pkOperator, CKeyID const& pkVoting) :
         nActiveState{activeState}, nProtocolVersion{protoVer}, sigTime{sTime},
         outpoint{outpnt}, addr{addr},
-        pubKeyCollateralAddress{}, pubKeyMasternode{}, keyIDCollateralAddress{pkCollAddr}, keyIDOwner{pkOwner}, keyIDOperator{pkOperator}, keyIDVoting{pkVoting} {}
+        pubKeyCollateralAddress{}, pubKeyMasternode{}, keyIDCollateralAddress{pkCollAddr}, keyIDOwner{pkOwner}, blsPubKeyOperator{pkOperator}, keyIDVoting{pkVoting} {}
 
     int nActiveState = 0;
     int nProtocolVersion = 0;
@@ -130,7 +131,8 @@ struct masternode_info_t
     CPubKey pubKeyMasternode{}; // this will be invalid/unset when the network switches to deterministic MNs (luckely it's only important for the broadcast hash)
     CKeyID keyIDCollateralAddress{};
     CKeyID keyIDOwner{};
-    CKeyID keyIDOperator{};
+    CKeyID legacyKeyIDOperator{};
+    CBLSPublicKey blsPubKeyOperator;
     CKeyID keyIDVoting{};
 
     int64_t nLastDsq = 0; //the dsq count from the last dsq broadcast of this node
@@ -201,7 +203,8 @@ public:
         READWRITE(pubKeyMasternode);
         READWRITE(keyIDCollateralAddress);
         READWRITE(keyIDOwner);
-        READWRITE(keyIDOperator);
+        READWRITE(legacyKeyIDOperator);
+        READWRITE(blsPubKeyOperator);
         READWRITE(keyIDVoting);
         READWRITE(lastPing);
         READWRITE(vchSig);
@@ -358,7 +361,7 @@ public:
         if (ser_action.ForRead()) {
             keyIDCollateralAddress = pubKeyCollateralAddress.GetID();
             keyIDOwner = pubKeyMasternode.GetID();
-            keyIDOperator = pubKeyMasternode.GetID();
+            legacyKeyIDOperator = pubKeyMasternode.GetID();
             keyIDVoting = pubKeyMasternode.GetID();
         }
     }

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -173,7 +173,6 @@ public:
     bool GetMasternodeInfo(const uint256& proTxHash, masternode_info_t& mnInfoRet);
     bool GetMasternodeInfo(const COutPoint& outpoint, masternode_info_t& mnInfoRet);
     bool GetMasternodeInfo(const CKeyID& keyIDOperator, masternode_info_t& mnInfoRet);
-    bool GetMasternodeInfo(const CPubKey& pubKeyOperator, masternode_info_t& mnInfoRet);
     bool GetMasternodeInfo(const CScript& payee, masternode_info_t& mnInfoRet);
 
     /// Find an entry in the masternode list that is next to be paid

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1997,7 +1997,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 // we have no idea about (e.g we were offline)? How to handle them?
             }
 
-            if(!dstx.CheckSignature(mn.keyIDOperator)) {
+            if (!dstx.CheckSignature(mn.legacyKeyIDOperator, mn.blsPubKeyOperator)) {
                 LogPrint("privatesend", "DSTX -- CheckSignature() failed for %s\n", hashTx.ToString());
                 return false;
             }

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -64,7 +64,7 @@ void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& 
         masternode_info_t infoMn;
         if(!mnodeman.GetMasternodeInfo(dsq.masternodeOutpoint, infoMn)) return;
 
-        if(!dsq.CheckSignature(infoMn.keyIDOperator)) {
+        if(!dsq.CheckSignature(infoMn.legacyKeyIDOperator, infoMn.blsPubKeyOperator)) {
             // we probably have outdated info
             mnodeman.AskForMN(pfrom, dsq.masternodeOutpoint, connman);
             return;

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -102,7 +102,7 @@ void CPrivateSendServer::ProcessMessage(CNode* pfrom, const std::string& strComm
         masternode_info_t mnInfo;
         if(!mnodeman.GetMasternodeInfo(dsq.masternodeOutpoint, mnInfo)) return;
 
-        if(!dsq.CheckSignature(mnInfo.keyIDOperator)) {
+        if(!dsq.CheckSignature(mnInfo.legacyKeyIDOperator, mnInfo.blsPubKeyOperator)) {
             // we probably have outdated info
             mnodeman.AskForMN(pfrom, dsq.masternodeOutpoint, connman);
             return;

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -51,15 +51,19 @@ bool CDarksendQueue::Sign()
 
     std::string strError = "";
 
-    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        uint256 hash = GetSignatureHash();
+        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator.Sign(hash);
+        sig.GetBuf(vchSig);
+    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();
 
-        if (!CHashSigner::SignHash(hash, activeMasternodeInfo.keyOperator, vchSig)) {
+        if (!CHashSigner::SignHash(hash, activeMasternodeInfo.legacyKeyOperator, vchSig)) {
             LogPrintf("CDarksendQueue::Sign -- SignHash() failed\n");
             return false;
         }
 
-        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.keyIDOperator, vchSig, strError)) {
+        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.legacyKeyIDOperator, vchSig, strError)) {
             LogPrintf("CDarksendQueue::Sign -- VerifyHash() failed, error: %s\n", strError);
             return false;
         }
@@ -69,12 +73,12 @@ bool CDarksendQueue::Sign()
                         std::to_string(nTime) +
                         std::to_string(fReady);
 
-        if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternodeInfo.keyOperator)) {
+        if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternodeInfo.legacyKeyOperator)) {
             LogPrintf("CDarksendQueue::Sign -- SignMessage() failed, %s\n", ToString());
             return false;
         }
 
-        if(!CMessageSigner::VerifyMessage(activeMasternodeInfo.keyIDOperator, vchSig, strMessage, strError)) {
+        if(!CMessageSigner::VerifyMessage(activeMasternodeInfo.legacyKeyIDOperator, vchSig, strMessage, strError)) {
             LogPrintf("CDarksendQueue::Sign -- VerifyMessage() failed, error: %s\n", strError);
             return false;
         }
@@ -83,11 +87,19 @@ bool CDarksendQueue::Sign()
     return true;
 }
 
-bool CDarksendQueue::CheckSignature(const CKeyID& keyIDOperator) const
+bool CDarksendQueue::CheckSignature(const CKeyID& keyIDOperator, const CBLSPublicKey& blsPubKey) const
 {
     std::string strError = "";
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        uint256 hash = GetSignatureHash();
 
-    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        CBLSSignature sig;
+        sig.SetBuf(vchSig);
+        if (!sig.IsValid() || !sig.VerifyInsecure(blsPubKey, hash)) {
+            LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
+            return false;
+        }
+    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, keyIDOperator, vchSig, strError)) {
@@ -131,27 +143,32 @@ bool CDarksendBroadcastTx::Sign()
 
     std::string strError = "";
 
-    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
         uint256 hash = GetSignatureHash();
 
-        if (!CHashSigner::SignHash(hash, activeMasternodeInfo.keyOperator, vchSig)) {
+        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator.Sign(hash);
+        sig.GetBuf(vchSig);
+    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+        uint256 hash = GetSignatureHash();
+
+        if (!CHashSigner::SignHash(hash, activeMasternodeInfo.legacyKeyOperator, vchSig)) {
             LogPrintf("CDarksendBroadcastTx::Sign -- SignHash() failed\n");
             return false;
         }
 
-        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.keyIDOperator, vchSig, strError)) {
+        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.legacyKeyIDOperator, vchSig, strError)) {
             LogPrintf("CDarksendBroadcastTx::Sign -- VerifyHash() failed, error: %s\n", strError);
             return false;
         }
     } else {
         std::string strMessage = tx->GetHash().ToString() + std::to_string(sigTime);
 
-        if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternodeInfo.keyOperator)) {
+        if(!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternodeInfo.legacyKeyOperator)) {
             LogPrintf("CDarksendBroadcastTx::Sign -- SignMessage() failed\n");
             return false;
         }
 
-        if(!CMessageSigner::VerifyMessage(activeMasternodeInfo.keyIDOperator, vchSig, strMessage, strError)) {
+        if(!CMessageSigner::VerifyMessage(activeMasternodeInfo.legacyKeyIDOperator, vchSig, strMessage, strError)) {
             LogPrintf("CDarksendBroadcastTx::Sign -- VerifyMessage() failed, error: %s\n", strError);
             return false;
         }
@@ -160,11 +177,20 @@ bool CDarksendBroadcastTx::Sign()
     return true;
 }
 
-bool CDarksendBroadcastTx::CheckSignature(const CKeyID& keyIDOperator) const
+bool CDarksendBroadcastTx::CheckSignature(const CKeyID& keyIDOperator, const CBLSPublicKey& blsPubKey) const
 {
     std::string strError = "";
 
-    if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        uint256 hash = GetSignatureHash();
+
+        CBLSSignature sig;
+        sig.SetBuf(vchSig);
+        if (!sig.IsValid() || !sig.VerifyInsecure(blsPubKey, hash)) {
+            LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
+            return false;
+        }
+    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, keyIDOperator, vchSig, strError)) {

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -53,7 +53,7 @@ bool CDarksendQueue::Sign()
 
     if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
         uint256 hash = GetSignatureHash();
-        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator.Sign(hash);
+        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
         sig.GetBuf(vchSig);
     } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();
@@ -146,7 +146,7 @@ bool CDarksendBroadcastTx::Sign()
     if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
         uint256 hash = GetSignatureHash();
 
-        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator.Sign(hash);
+        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
         sig.GetBuf(vchSig);
     } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
         uint256 hash = GetSignatureHash();

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -12,6 +12,7 @@
 #include "sync.h"
 #include "tinyformat.h"
 #include "timedata.h"
+#include "bls/bls.h"
 
 class CPrivateSend;
 class CConnman;
@@ -229,7 +230,7 @@ public:
      */
     bool Sign();
     /// Check if we have a valid Masternode address
-    bool CheckSignature(const CKeyID& keyIDOperator) const;
+    bool CheckSignature(const CKeyID& keyIDOperator, const CBLSPublicKey& blsPubKey) const;
 
     bool Relay(CConnman &connman);
 
@@ -307,7 +308,7 @@ public:
     uint256 GetSignatureHash() const;
 
     bool Sign();
-    bool CheckSignature(const CKeyID& keyIDOperator) const;
+    bool CheckSignature(const CKeyID& keyIDOperator, const CBLSPublicKey& blsPubKey) const;
 
     void SetConfirmedHeight(int nConfirmedHeightIn) { nConfirmedHeight = nConfirmedHeightIn; }
     bool IsExpired(int nHeight);

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -295,7 +295,7 @@ UniValue gobject_submit(const JSONRPCRequest& request)
         if (fMnFound) {
             govobj.SetMasternodeOutpoint(activeMasternodeInfo.outpoint);
             if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-                govobj.Sign(activeMasternodeInfo.blsKeyOperator);
+                govobj.Sign(*activeMasternodeInfo.blsKeyOperator);
             } else {
                 govobj.Sign(activeMasternodeInfo.legacyKeyOperator, activeMasternodeInfo.legacyKeyIDOperator);
             }

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -244,7 +244,7 @@ UniValue gobject_submit(const JSONRPCRequest& request)
 
     bool fMnFound = mnodeman.Has(activeMasternodeInfo.outpoint);
 
-    DBG( std::cout << "gobject: submit activeMasternodeInfo.keyIDOperator = " << activeMasternodeInfo.keyIDOperator.ToString()
+    DBG( std::cout << "gobject: submit activeMasternodeInfo.keyIDOperator = " << activeMasternodeInfo.legacyKeyIDOperator.ToString()
          << ", outpoint = " << activeMasternodeInfo.outpoint.ToStringShort()
          << ", params.size() = " << request.params.size()
          << ", fMnFound = " << fMnFound << std::endl; );
@@ -294,7 +294,11 @@ UniValue gobject_submit(const JSONRPCRequest& request)
     if (govobj.GetObjectType() == GOVERNANCE_OBJECT_TRIGGER) {
         if (fMnFound) {
             govobj.SetMasternodeOutpoint(activeMasternodeInfo.outpoint);
-            govobj.Sign(activeMasternodeInfo.keyOperator, activeMasternodeInfo.keyIDOperator);
+            if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+                govobj.Sign(activeMasternodeInfo.blsKeyOperator);
+            } else {
+                govobj.Sign(activeMasternodeInfo.legacyKeyOperator, activeMasternodeInfo.legacyKeyIDOperator);
+            }
         } else {
             LogPrintf("gobject(submit) -- Object submission rejected because node is not a masternode\n");
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Only valid masternodes can submit this type of object");
@@ -353,6 +357,10 @@ UniValue gobject_vote_conf(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 4)
         gobject_vote_conf_help();
 
+    if(deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Can't use vote-conf when deterministic masternodes are active");
+    }
+
     uint256 hash;
 
     hash = ParseHashV(request.params[1], "Object hash");
@@ -402,20 +410,8 @@ UniValue gobject_vote_conf(const JSONRPCRequest& request)
         return returnObj;
     }
 
-    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-        if (govObjType == GOVERNANCE_OBJECT_PROPOSAL && mn.keyIDVoting != activeMasternodeInfo.keyIDOperator) {
-            nFailed++;
-            statusObj.push_back(Pair("result", "failed"));
-            statusObj.push_back(Pair("errorMessage", "Can't vote on proposal when operator key does not match voting key"));
-            resultsObj.push_back(Pair("dash.conf", statusObj));
-            returnObj.push_back(Pair("overall", strprintf("Voted successfully %d time(s) and failed %d time(s).", nSuccessful, nFailed)));
-            returnObj.push_back(Pair("detail", resultsObj));
-            return returnObj;
-        }
-    }
-
     CGovernanceVote vote(mn.outpoint, hash, eVoteSignal, eVoteOutcome);
-    if (!vote.Sign(activeMasternodeInfo.keyOperator, activeMasternodeInfo.keyIDOperator)) {
+    if (!vote.Sign(activeMasternodeInfo.legacyKeyOperator, activeMasternodeInfo.legacyKeyIDOperator)) {
         nFailed++;
         statusObj.push_back(Pair("result", "failed"));
         statusObj.push_back(Pair("errorMessage", "Failure to sign."));

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -1063,7 +1063,7 @@ UniValue masternodelist(const JSONRPCRequest& request)
                 obj.push_back(Pair(strOutpoint, HexStr(mn.keyIDOwner)));
             } else if (strMode == "keyIDOperator") {
                 if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) continue;
-                obj.push_back(Pair(strOutpoint, HexStr(mn.keyIDOperator)));
+                obj.push_back(Pair(strOutpoint, HexStr(mn.legacyKeyIDOperator)));
             } else if (strMode == "keyIDVoting") {
                 if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) continue;
                 obj.push_back(Pair(strOutpoint, HexStr(mn.keyIDVoting)));
@@ -1248,7 +1248,7 @@ UniValue masternodebroadcast(const JSONRPCRequest& request)
                 resultObj.push_back(Pair("outpoint", mnb.outpoint.ToStringShort()));
                 resultObj.push_back(Pair("addr", mnb.addr.ToString()));
                 resultObj.push_back(Pair("keyIDCollateralAddress", CBitcoinAddress(mnb.keyIDCollateralAddress).ToString()));
-                resultObj.push_back(Pair("keyIDMasternode", CBitcoinAddress(mnb.keyIDOperator).ToString()));
+                resultObj.push_back(Pair("keyIDMasternode", CBitcoinAddress(mnb.legacyKeyIDOperator).ToString()));
                 resultObj.push_back(Pair("vchSig", EncodeBase64(&mnb.vchSig[0], mnb.vchSig.size())));
                 resultObj.push_back(Pair("sigTime", mnb.sigTime));
                 resultObj.push_back(Pair("protocolVersion", mnb.nProtocolVersion));

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -189,7 +189,7 @@ void protx_register_help()
             "9. \"payoutAddress\"       (string, required) The dash address to use for masternode reward payments\n"
             "                         Must match \"collateralAddress\"."
             "\nExamples:\n"
-            + HelpExampleCli("protx", "register \"XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\" 1000 \"1.2.3.4:1234\" 0 \"93Fd7XY2zF4q9YKTZUSFxLgp4Xs7MuaMnvY9kpvH7V8oXWqsCC1\" XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG")
+            + HelpExampleCli("protx", "register \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\" 1000 \"1.2.3.4:1234\" 0 \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" \"Xt9AMWaYSz7tR7Uo7gzXA3m4QmeWgrR3rr\" 0 \"XrVhS9LogauRJGJu2sHuryjhpuex4RNPSb\"")
     );
 }
 
@@ -286,7 +286,7 @@ void protx_update_service_help()
             "5. \"operatorPayoutAddress\"    (string, optional) The address used for operator reward payments.\n"
             "                              Only allowed when the ProRegTx had a non-zero operatorReward value.\n"
             "\nExamples:\n"
-            + HelpExampleCli("protx", "update_service \"0123456701234567012345670123456701234567012345670123456701234567\" \"1.2.3.4:1234\" 0 3rayPEfXPmmsz1xTSPXmvQcL8KdFu1yVXs896Cq3uRxCws44RJB")
+            + HelpExampleCli("protx", "update_service \"0123456701234567012345670123456701234567012345670123456701234567\" \"1.2.3.4:1234\" 0 5a2e15982e62f1e0b7cf9783c64cf7e3af3f90a52d6c40f6f95d624c0b1621cd")
     );
 }
 
@@ -346,7 +346,7 @@ void protx_update_registrar_help()
             "The owner key of the masternode must be known to your wallet.\n"
             "\nArguments:\n"
             "1. \"proTxHash\"           (string, required) The hash of the initial ProRegTx.\n"
-            "2. \"operatorKeyAddr\"     (string, required) The operator key address. The private key does not have to be known by your wallet.\n"
+            "2. \"operatorPubKey\"      (string, required) The operator public key. The private key does not have to be known by you.\n"
             "                         It has to match the private key which is later used when operating the masternode.\n"
             "                         If set to \"0\" or an empty string, the last on-chain operator key of the masternode will be used.\n"
             "3. \"votingKeyAddr\"       (string, required) The voting key address. The private key does not have to be known by your wallet.\n"
@@ -356,7 +356,7 @@ void protx_update_registrar_help()
             "                         Must match \"collateralAddress\" of initial ProRegTx.\n"
             "                         If set to \"0\" or an empty string, the last on-chain payout address of the masternode will be used.\n"
             "\nExamples:\n"
-            + HelpExampleCli("protx", "update_registrar \"0123456701234567012345670123456701234567012345670123456701234567\" \"<operatorKeyAddr>\" \"0\" \"XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\"")
+            + HelpExampleCli("protx", "update_registrar \"0123456701234567012345670123456701234567012345670123456701234567\" \"982eb34b7c7f614f29e5c665bc3605f1beeef85e3395ca12d3be49d2868ecfea5566f11cedfad30c51b2403f2ad95b67\" \"0\" \"XwnLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPwG\"")
     );
 }
 
@@ -420,7 +420,7 @@ void protx_revoke_help()
             "                         registered operator public key.\n"
             "3. reason                  (numeric, optional) The reason for revocation.\n"
             "\nExamples:\n"
-            + HelpExampleCli("protx", "revoke \"0123456701234567012345670123456701234567012345670123456701234567\" \"<operatorKeyAddr>\"")
+            + HelpExampleCli("protx", "revoke \"0123456701234567012345670123456701234567012345670123456701234567\" \"072f36a77261cdd5d64c32d97bac417540eddca1d5612f416feb07ff75a8e240\"")
     );
 }
 

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -22,6 +22,8 @@
 #include "evo/deterministicmns.h"
 #include "evo/simplifiedmns.h"
 
+#include "bls/bls.h"
+
 #ifdef ENABLE_WALLET
 extern UniValue signrawtransaction(const JSONRPCRequest& request);
 extern UniValue sendrawtransaction(const JSONRPCRequest& request);
@@ -646,9 +648,38 @@ UniValue protx(const JSONRPCRequest& request)
 }
 #endif//ENABLE_WALLET
 
+UniValue bls_generate(const JSONRPCRequest& request)
+{
+    CBLSSecretKey sk;
+    sk.MakeNewKey();
+
+    UniValue ret(UniValue::VOBJ);
+    ret.push_back(Pair("secret", sk.ToString()));
+    ret.push_back(Pair("public", sk.GetPublicKey().ToString()));
+    return ret;
+}
+
+UniValue _bls(const JSONRPCRequest& request)
+{
+    if (request.params.empty()) {
+        throw std::runtime_error(
+                "bls \"command\" ...\n"
+        );
+    }
+
+    std::string command = request.params[0].get_str();
+
+    if (command == "generate") {
+        return bls_generate(request);
+    } else {
+        throw std::runtime_error("invalid command: " + command);
+    }
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
+    { "evo",                "bls",                    &_bls,                   false, {}  },
 #ifdef ENABLE_WALLET
     // these require the wallet to be enabled to fund the transactions
     { "evo",                "protx",                  &protx,                  false, {}  },

--- a/src/test/evo_simplifiedmns_tests.cpp
+++ b/src/test/evo_simplifiedmns_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "test/test_dash.h"
 
+#include "bls/bls.h"
 #include "evo/simplifiedmns.h"
 #include "netbase.h"
 
@@ -21,7 +22,13 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
         std::string ip = strprintf("%d.%d.%d.%d", 0, 0, 0, i);
         Lookup(ip.c_str(), smle.service, i, false);
 
-        smle.keyIDOperator.SetHex(strprintf("%040x", i));
+        uint8_t skBuf[CBLSSecretKey::SerSize];
+        memset(skBuf, 0, sizeof(skBuf));
+        skBuf[0] = (uint8_t)i;
+        CBLSSecretKey sk;
+        sk.SetBuf(skBuf, sizeof(skBuf));
+
+        smle.pubKeyOperator = sk.GetPublicKey();
         smle.keyIDVoting.SetHex(strprintf("%040x", i));
         smle.isValid = true;
 
@@ -29,21 +36,21 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
     }
 
     std::vector<std::string> expectedHashes = {
-        "aa8bfb825f433bcd6f1039f27c77ed269386e05577b0fe9afc4e16b1af0076b2",
-        "686a19dba9b515f77f11027cd1e92e6a8c650448bf4616101fd5ddbe6e2629e7",
-        "c2efc1b08daa791c71e1d5887be3eaa136381f783fcc5b7efdc5909db38701bb",
-        "ce394197d6e1684467fbf2e1619f71ae9d1a6cf6548b2235e4289f95d4bccbbd",
-        "aeeaf7b498aa7d5fa92ee0028499b4f165c31662f5e9b0a80e6e13b38fd61f8d",
-        "0c1c8dc9dc82eb5432a557580e5d3d930943ce0d0db5daebc51267afb46b6d48",
-        "1c4add10ea844a46734473e48c2f781059b35382219d0cf67d6432b540e0bbbe",
-        "1ae1ad5ff4dd4c09469d21d569a025d467dca1e407581a2815175528e139b7da",
-        "d59b231cdc80ce7eda3a3f37608abda818659c189d31a7ef42024d496e290cbc",
-        "2d5e6c87e3d4e5b3fdd600f561e8dec1ea720560569398006050480232f1257c",
-        "3d6af35f08efeea22f3c8fcb78038e56dac221f3173ca4e2230ea8ae3cbd3c60",
-        "ecf547077c37b79da954c4ef46a3c4fb136746366bfb81192ed01de96fd66348",
-        "626af5fb8192ead7bbd79ad7bfe2c3ea82714fdfd9ac49b88d7a411aa6956853",
-        "6c84a4485fb2ba35b4dcd4d89cbdd3d813446514bb7a2046b6b1b9813beaac0f",
-        "453ca2a83140da73a37794fe6fddd701ea5066f21c2f1df8a33b6ff6134043c3",
+        "1465924a81df1d0fb46d2571e65296c0fddab30d1b4d104f182f80a6e45362fa",
+        "cb466084403067b699a50bd46e53145ebfd57af9a076a13432f524e41ec2d899",
+        "0f6a720d0119f5b83469d884ec2a7d739c1d653142e5d36b569cddaf735a6149",
+        "8794379559c77d67902a5e894739bd574f25ff6cd48612f7156c5fafaefefd4e",
+        "4738d4f17c76b4e61f028d9426f40242eb56977fe805704d980ff57ad3f60b90",
+        "6342b7ce87a299a0fb070ec040a45613f082b0c99395698a6f712e85be87ad06",
+        "0be7143f4fb357333350a7e28606713933e9819c83c71009b9ea97476d86b78e",
+        "d13dfedc920490a8c6d9b555d740f2944ac83eeb8c3923a51261371a8118ffe0",
+        "c0c4638fcefe09380adff61d59c064be03a18690245b89be20223df737590d46",
+        "4cce41032bb341adb9b9f3f6ba1de3c812f0d1630e3a561c7aae00f39e49c6d4",
+        "3e8c9ad9e2cf0520a96b6bc58aafb7009365a1d8f357047a40430b782142ed69",
+        "bde7a1b61a263a7e0dfe474c850c4f9d642d9a03da501a366800e03093e48cd9",
+        "e221a3e14868251083eea718e698cc81739b016665a9024d798a14c0e9417c35",
+        "b1be038e40bc8ee6a19dbbe70c92d7bc0880ccc54c4bd54eab6b7a30d0650ab1",
+        "0607e1d850e27c336e8d65722fc82eae7ab5331fd88a4fbfcff6c3a1bb6364da",
     };
     std::vector<std::string> calculatedHashes;
 
@@ -56,8 +63,9 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
 
     CSimplifiedMNList sml(entries);
 
-    std::string expectedMerkleRoot = "926efc8dc7b5b060254b102670b918133fea67c5e1bc2703d596e49672878c22";
+    std::string expectedMerkleRoot = "a7fae13820022ddba6cf54ba9b234dfed54ccfa86c2635c5627287f1ffa5497f";
     std::string calculatedMerkleRoot = sml.CalcMerkleRoot(nullptr).ToString();
+    //printf("merkleRoot=\"%s\",\n", calculatedMerkleRoot.c_str());
 
     BOOST_CHECK(expectedMerkleRoot == calculatedMerkleRoot);
 }

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -43,6 +43,7 @@ extern void noui_connect();
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 {
         ECC_Start();
+        BLSInit();
         SetupEnvironment();
         SetupNetworking();
         InitSignatureCache();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -448,7 +448,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
         }
         mapProTxAddresses.emplace(proTx.addr, tx.GetHash());
         mapProTxPubKeyIDs.emplace(proTx.keyIDOwner, tx.GetHash());
-        mapProTxPubKeyIDs.emplace(proTx.keyIDOperator, tx.GetHash());
+        mapProTxBlsPubKeys.emplace(::SerializeHash(proTx.pubKeyOperator), tx.GetHash());
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         CProUpServTx proTx;
         if (!GetTxPayload(tx, proTx)) {
@@ -460,7 +460,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
         if (!GetTxPayload(tx, proTx)) {
             assert(false);
         }
-        mapProTxPubKeyIDs.emplace(proTx.keyIDOperator, tx.GetHash());
+        mapProTxBlsPubKeys.emplace(::SerializeHash(proTx.pubKeyOperator), tx.GetHash());
     }
 
     return true;
@@ -645,7 +645,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         }
         mapProTxAddresses.erase(proTx.addr);
         mapProTxPubKeyIDs.erase(proTx.keyIDOwner);
-        mapProTxPubKeyIDs.erase(proTx.keyIDOperator);
+        mapProTxBlsPubKeys.erase(::SerializeHash(proTx.pubKeyOperator));
     } else if (it->GetTx().nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         CProUpServTx proTx;
         if (!GetTxPayload(it->GetTx(), proTx)) {
@@ -657,7 +657,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         if (!GetTxPayload(it->GetTx(), proTx)) {
             assert(false);
         }
-        mapProTxPubKeyIDs.erase(proTx.keyIDOperator);
+        mapProTxBlsPubKeys.erase(::SerializeHash(proTx.pubKeyOperator));
     }
 
     totalTxSize -= it->GetTxSize();
@@ -796,6 +796,16 @@ void CTxMemPool::removeProTxPubKeyConflicts(const CTransaction &tx, const CKeyID
     }
 }
 
+void CTxMemPool::removeProTxPubKeyConflicts(const CTransaction &tx, const CBLSPublicKey &pubKey)
+{
+    if (mapProTxBlsPubKeys.count(::SerializeHash(pubKey))) {
+        uint256 conflictHash = mapProTxBlsPubKeys[::SerializeHash(pubKey)];
+        if (conflictHash != tx.GetHash() && mapTx.count(conflictHash)) {
+            removeRecursive(mapTx.find(conflictHash)->GetTx(), MemPoolRemovalReason::CONFLICT);
+        }
+    }
+}
+
 void CTxMemPool::removeProTxConflicts(const CTransaction &tx)
 {
     if (tx.nType == TRANSACTION_PROVIDER_REGISTER) {
@@ -811,7 +821,7 @@ void CTxMemPool::removeProTxConflicts(const CTransaction &tx)
             }
         }
         removeProTxPubKeyConflicts(tx, proTx.keyIDOwner);
-        removeProTxPubKeyConflicts(tx, proTx.keyIDOperator);
+        removeProTxPubKeyConflicts(tx, proTx.pubKeyOperator);
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         CProUpServTx proTx;
         if (!GetTxPayload(tx, proTx)) {
@@ -830,7 +840,7 @@ void CTxMemPool::removeProTxConflicts(const CTransaction &tx)
             assert(false);
         }
 
-        removeProTxPubKeyConflicts(tx, proTx.keyIDOperator);
+        removeProTxPubKeyConflicts(tx, proTx.pubKeyOperator);
     }
 }
 
@@ -1117,7 +1127,7 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         CProRegTx proTx;
         if (!GetTxPayload(tx, proTx))
             assert(false);
-        return mapProTxAddresses.count(proTx.addr) || mapProTxPubKeyIDs.count(proTx.keyIDOwner) || mapProTxPubKeyIDs.count(proTx.keyIDOperator);
+        return mapProTxAddresses.count(proTx.addr) || mapProTxPubKeyIDs.count(proTx.keyIDOwner) || mapProTxBlsPubKeys.count(::SerializeHash(proTx.pubKeyOperator));
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         CProUpServTx proTx;
         if (!GetTxPayload(tx, proTx))
@@ -1128,8 +1138,8 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         CProUpRegTx proTx;
         if (!GetTxPayload(tx, proTx))
             assert(false);
-        auto it = mapProTxPubKeyIDs.find(proTx.keyIDOperator);
-        return it != mapProTxPubKeyIDs.end() && it->second != proTx.proTxHash;
+        auto it = mapProTxBlsPubKeys.find(::SerializeHash(proTx.pubKeyOperator));
+        return it != mapProTxBlsPubKeys.end() && it->second != proTx.proTxHash;
     }
     return false;
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -448,7 +448,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
         }
         mapProTxAddresses.emplace(proTx.addr, tx.GetHash());
         mapProTxPubKeyIDs.emplace(proTx.keyIDOwner, tx.GetHash());
-        mapProTxBlsPubKeys.emplace(proTx.pubKeyOperator.GetHash(), tx.GetHash());
+        mapProTxBlsPubKeyHashes.emplace(proTx.pubKeyOperator.GetHash(), tx.GetHash());
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         CProUpServTx proTx;
         if (!GetTxPayload(tx, proTx)) {
@@ -460,7 +460,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
         if (!GetTxPayload(tx, proTx)) {
             assert(false);
         }
-        mapProTxBlsPubKeys.emplace(proTx.pubKeyOperator.GetHash(), tx.GetHash());
+        mapProTxBlsPubKeyHashes.emplace(proTx.pubKeyOperator.GetHash(), tx.GetHash());
     }
 
     return true;
@@ -645,7 +645,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         }
         mapProTxAddresses.erase(proTx.addr);
         mapProTxPubKeyIDs.erase(proTx.keyIDOwner);
-        mapProTxBlsPubKeys.erase(proTx.pubKeyOperator.GetHash());
+        mapProTxBlsPubKeyHashes.erase(proTx.pubKeyOperator.GetHash());
     } else if (it->GetTx().nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         CProUpServTx proTx;
         if (!GetTxPayload(it->GetTx(), proTx)) {
@@ -657,7 +657,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         if (!GetTxPayload(it->GetTx(), proTx)) {
             assert(false);
         }
-        mapProTxBlsPubKeys.erase(proTx.pubKeyOperator.GetHash());
+        mapProTxBlsPubKeyHashes.erase(proTx.pubKeyOperator.GetHash());
     }
 
     totalTxSize -= it->GetTxSize();
@@ -798,8 +798,8 @@ void CTxMemPool::removeProTxPubKeyConflicts(const CTransaction &tx, const CKeyID
 
 void CTxMemPool::removeProTxPubKeyConflicts(const CTransaction &tx, const CBLSPublicKey &pubKey)
 {
-    if (mapProTxBlsPubKeys.count(pubKey.GetHash())) {
-        uint256 conflictHash = mapProTxBlsPubKeys[pubKey.GetHash()];
+    if (mapProTxBlsPubKeyHashes.count(pubKey.GetHash())) {
+        uint256 conflictHash = mapProTxBlsPubKeyHashes[pubKey.GetHash()];
         if (conflictHash != tx.GetHash() && mapTx.count(conflictHash)) {
             removeRecursive(mapTx.find(conflictHash)->GetTx(), MemPoolRemovalReason::CONFLICT);
         }
@@ -1127,7 +1127,7 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         CProRegTx proTx;
         if (!GetTxPayload(tx, proTx))
             assert(false);
-        return mapProTxAddresses.count(proTx.addr) || mapProTxPubKeyIDs.count(proTx.keyIDOwner) || mapProTxBlsPubKeys.count(proTx.pubKeyOperator.GetHash());
+        return mapProTxAddresses.count(proTx.addr) || mapProTxPubKeyIDs.count(proTx.keyIDOwner) || mapProTxBlsPubKeyHashes.count(proTx.pubKeyOperator.GetHash());
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         CProUpServTx proTx;
         if (!GetTxPayload(tx, proTx))
@@ -1138,8 +1138,8 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         CProUpRegTx proTx;
         if (!GetTxPayload(tx, proTx))
             assert(false);
-        auto it = mapProTxBlsPubKeys.find(proTx.pubKeyOperator.GetHash());
-        return it != mapProTxBlsPubKeys.end() && it->second != proTx.proTxHash;
+        auto it = mapProTxBlsPubKeyHashes.find(proTx.pubKeyOperator.GetHash());
+        return it != mapProTxBlsPubKeyHashes.end() && it->second != proTx.proTxHash;
     }
     return false;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -536,7 +536,7 @@ private:
 
     std::map<CService, uint256> mapProTxAddresses;
     std::map<CKeyID, uint256> mapProTxPubKeyIDs;
-    std::map<uint256, uint256> mapProTxBlsPubKeys;
+    std::map<uint256, uint256> mapProTxBlsPubKeyHashes;
 
     void UpdateParent(txiter entry, txiter parent, bool add);
     void UpdateChild(txiter entry, txiter child, bool add);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -22,6 +22,7 @@
 #include "sync.h"
 #include "random.h"
 #include "netaddress.h"
+#include "bls/bls.h"
 
 #undef foreach
 #include "boost/multi_index_container.hpp"
@@ -535,6 +536,7 @@ private:
 
     std::map<CService, uint256> mapProTxAddresses;
     std::map<CKeyID, uint256> mapProTxPubKeyIDs;
+    std::map<uint256, uint256> mapProTxBlsPubKeys;
 
     void UpdateParent(txiter entry, txiter parent, bool add);
     void UpdateChild(txiter entry, txiter child, bool add);
@@ -579,6 +581,7 @@ public:
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);
     void removeConflicts(const CTransaction &tx);
     void removeProTxPubKeyConflicts(const CTransaction &tx, const CKeyID &keyId);
+    void removeProTxPubKeyConflicts(const CTransaction &tx, const CBLSPublicKey &pubKey);
     void removeProTxConflicts(const CTransaction &tx);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight);
 


### PR DESCRIPTION
This changes deterministic masternodes to use BLS for the operator key. It requires to generate a key pair with `bls generate` (which is also part of this PR), use it in `protx register` and then to configure the MN to use `-masternodeblsprivkey` with this secret key.

The ECDSA based keys had the advantage that we could manage the MN key in the wallet as well, which is unfortunately removed for the operator key. But I believe that's ok as MNOs are already used to this.

This PR also changes CBitcoinAddress and CBitcoinSecret to support BLS addresses and secrets. I'm not sure if my choice of prefixes was a good one and I'm open for suggestions.