### PR TITLE
Move handling of `size != SerSize` into SetBuf/GetBuf

### DIFF
--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -16,18 +16,14 @@
 #include <assert.h>
 #include <string.h>
 
-bool CBLSId::InternalSetBuf(const void* buf, size_t size)
+bool CBLSId::InternalSetBuf(const void* buf)
 {
-    assert(size == sizeof(uint256));
     memcpy(impl.begin(), buf, sizeof(uint256));
     return true;
 }
 
-bool CBLSId::InternalGetBuf(void* buf, size_t size) const
+bool CBLSId::InternalGetBuf(void* buf) const
 {
-    if (size != GetSerSize()) {
-        return false;
-    }
     memcpy(buf, impl.begin(), sizeof(uint256));
     return true;
 }
@@ -60,12 +56,8 @@ CBLSId CBLSId::FromHash(const uint256& hash)
     return id;
 }
 
-bool CBLSSecretKey::InternalSetBuf(const void* buf, size_t size)
+bool CBLSSecretKey::InternalSetBuf(const void* buf)
 {
-    if (size != GetSerSize()) {
-        return false;
-    }
-
     try {
         impl = bls::PrivateKey::FromBytes((const uint8_t*)buf);
         return true;
@@ -74,12 +66,8 @@ bool CBLSSecretKey::InternalSetBuf(const void* buf, size_t size)
     }
 }
 
-bool CBLSSecretKey::InternalGetBuf(void* buf, size_t size) const
+bool CBLSSecretKey::InternalGetBuf(void* buf) const
 {
-    if (size != GetSerSize()) {
-        return false;
-    }
-
     impl.Serialize((uint8_t*)buf);
     return true;
 }
@@ -185,12 +173,8 @@ CBLSSignature CBLSSecretKey::Sign(const uint256& hash) const
     return sigRet;
 }
 
-bool CBLSPublicKey::InternalSetBuf(const void* buf, size_t size)
+bool CBLSPublicKey::InternalSetBuf(const void* buf)
 {
-    if (size != GetSerSize()) {
-        return false;
-    }
-
     try {
         impl = bls::PublicKey::FromBytes((const uint8_t*)buf);
         return true;
@@ -199,12 +183,8 @@ bool CBLSPublicKey::InternalSetBuf(const void* buf, size_t size)
     }
 }
 
-bool CBLSPublicKey::InternalGetBuf(void* buf, size_t size) const
+bool CBLSPublicKey::InternalGetBuf(void* buf) const
 {
-    if (size != GetSerSize()) {
-        return false;
-    }
-
     impl.Serialize((uint8_t*)buf);
     return true;
 }
@@ -279,12 +259,8 @@ bool CBLSPublicKey::DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& 
     return true;
 }
 
-bool CBLSSignature::InternalSetBuf(const void* buf, size_t size)
+bool CBLSSignature::InternalSetBuf(const void* buf)
 {
-    if (size != GetSerSize()) {
-        return false;
-    }
-
     try {
         impl = bls::InsecureSignature::FromBytes((const uint8_t*)buf);
         return true;
@@ -293,11 +269,8 @@ bool CBLSSignature::InternalSetBuf(const void* buf, size_t size)
     }
 }
 
-bool CBLSSignature::InternalGetBuf(void* buf, size_t size) const
+bool CBLSSignature::InternalGetBuf(void* buf) const
 {
-    if (size != GetSerSize()) {
-        return false;
-    }
     impl.Serialize((uint8_t*)buf);
     return true;
 }

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -41,8 +41,8 @@ protected:
 
     inline constexpr size_t GetSerSize() const { return SerSize; }
 
-    virtual bool InternalSetBuf(const void* buf, size_t size) = 0;
-    virtual bool InternalGetBuf(void* buf, size_t size) const = 0;
+    virtual bool InternalSetBuf(const void* buf) = 0;
+    virtual bool InternalGetBuf(void* buf) const = 0;
 
 public:
     static const size_t SerSize = _SerSize;
@@ -84,10 +84,15 @@ public:
 
     void SetBuf(const void* buf, size_t size)
     {
-        if (std::all_of((const char*)buf, (const char*)buf + size, [](char c) { return c == 0; })) {
+        if (size != SerSize) {
+            Reset();
+            return;
+        }
+
+        if (std::all_of((const char*)buf, (const char*)buf + SerSize, [](char c) { return c == 0; })) {
             Reset();
         } else {
-            fValid = InternalSetBuf(buf, size);
+            fValid = InternalSetBuf(buf);
             if (!fValid) {
                 Reset();
             }
@@ -102,10 +107,12 @@ public:
 
     void GetBuf(void* buf, size_t size) const
     {
+        assert(size >= SerSize);
+
         if (!fValid) {
-            memset(buf, 0, size);
+            memset(buf, 0, SerSize);
         } else {
-            bool ok = InternalGetBuf(buf, size);
+            bool ok = InternalGetBuf(buf);
             assert(ok);
         }
     }
@@ -201,8 +208,8 @@ public:
     static CBLSId FromHash(const uint256& hash);
 
 protected:
-    bool InternalSetBuf(const void* buf, size_t size);
-    bool InternalGetBuf(void* buf, size_t size) const;
+    bool InternalSetBuf(const void* buf);
+    bool InternalGetBuf(void* buf) const;
 };
 
 class CBLSSecretKey : public CBLSWrapper<bls::PrivateKey, BLS_CURVE_SECKEY_SIZE, CBLSSecretKey>
@@ -224,8 +231,8 @@ public:
     CBLSSignature Sign(const uint256& hash) const;
 
 protected:
-    bool InternalSetBuf(const void* buf, size_t size);
-    bool InternalGetBuf(void* buf, size_t size) const;
+    bool InternalSetBuf(const void* buf);
+    bool InternalGetBuf(void* buf) const;
 };
 
 class CBLSPublicKey : public CBLSWrapper<bls::PublicKey, BLS_CURVE_PUBKEY_SIZE, CBLSPublicKey>
@@ -245,8 +252,8 @@ public:
     bool DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& pk);
 
 protected:
-    bool InternalSetBuf(const void* buf, size_t size);
-    bool InternalGetBuf(void* buf, size_t size) const;
+    bool InternalSetBuf(const void* buf);
+    bool InternalGetBuf(void* buf) const;
 };
 
 class CBLSSignature : public CBLSWrapper<bls::InsecureSignature, BLS_CURVE_SIG_SIZE, CBLSSignature>
@@ -275,8 +282,8 @@ public:
     bool Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids);
 
 protected:
-    bool InternalSetBuf(const void* buf, size_t size);
-    bool InternalGetBuf(void* buf, size_t size) const;
+    bool InternalSetBuf(const void* buf);
+    bool InternalGetBuf(void* buf) const;
 };
 
 typedef std::vector<CBLSId> BLSIdVector;

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -107,7 +107,7 @@ public:
 
     void GetBuf(void* buf, size_t size) const
     {
-        assert(size >= SerSize);
+        assert(size == SerSize);
 
         if (!fValid) {
             memset(buf, 0, SerSize);


### PR DESCRIPTION
Instead of performing this in the individual implementations of
InternalSetBuf and InternalGetBuf