### PR TITLE
 Update Chia BLS libs to latest master

### DIFF
--- a/depends/packages/chia_bls.mk
+++ b/depends/packages/chia_bls.mk
@@ -1,9 +1,9 @@
 package=chia_bls
-$(package)_version=b24c15cef6567a855e901b4774d1d22efb063ea9
+$(package)_version=ef06290c1d92eea79b46af135bcc823b019612a6
 # It's actually from https://github.com/Chia-Network/bls-signatures, but we have so many patches atm that it's forked
 $(package)_download_path=https://github.com/codablock/bls-signatures/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=96b5f9b70179e2e76123fb19b7a00dec9188b571757db15949bf9f1d8dee864f
+$(package)_sha256_hash=1e665359fdb946efce943340a324534f72832ecde97c4ebd4ad189f63e029300
 $(package)_dependencies=gmp
 #$(package)_patches=...TODO (when we switch back to https://github.com/Chia-Network/bls-signatures)
 

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -471,9 +471,9 @@ struct secure_user_allocator {
 // otherwise locking of mutexes slows down the system at places were you'd never expect it
 // downside is that we must make sure that all threads have destroyed their copy of the pool before the global
 // LockedPool is destroyed. This means that all worker threads must finish before static destruction begins
-// we use sizeof(relic::bn_t) as the pool request size as this is what Chia's BLS library will request in most cases
+// we use sizeof(bn_t) as the pool request size as this is what Chia's BLS library will request in most cases
 // In case something larger is requested, we directly call into LockedPool and accept the slowness
-thread_local static boost::pool<secure_user_allocator> securePool(sizeof(relic::bn_t) + sizeof(size_t));
+thread_local static boost::pool<secure_user_allocator> securePool(sizeof(bn_t) + sizeof(size_t));
 
 static void* secure_allocate(size_t n)
 {

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -10,6 +10,7 @@
 #include "uint256.h"
 #include "utilstrencodings.h"
 
+#undef ERROR // chia BLS uses relic, which defines ERROR, which in turn causes win32/win64 builds to print many warnings
 #include <chiabls/bls.hpp>
 #include <chiabls/privatekey.hpp>
 #include <chiabls/publickey.hpp>


### PR DESCRIPTION
This is especially to include https://github.com/Chia-Network/bls-signatures/pull/37 as I was observing strange build errors in https://github.com/dashpay/dash/pull/2352.

`chia_bls.mk` now points to the head of https://github.com/codablock/bls-signatures/tree/dash, which is rebased on https://github.com/Chia-Network/bls-signatures/tree/master