### PR TITLE
mkdir -p to allow re-start of failed chia build

### DIFF
--- a/depends/packages/chia_bls.mk
+++ b/depends/packages/chia_bls.mk
@@ -35,7 +35,7 @@ define $(package)_config_cmds
   export CFLAGS="$($(package)_cflags) $($(package)_cppflags)" && \
   export CXXFLAGS="$($(package)_cxxflags) $($(package)_cppflags)" && \
   export LDFLAGS="$($(package)_ldflags)" && \
-  mkdir build && cd build && \
+  mkdir -p build && cd build && \
   cmake ../ $($(package)_config_opts)
 endef
 


### PR DESCRIPTION
Adds -p option so that `mkdir` does not error if build dir already exists.

Before this change, if chia_bls build failed for some previous reason (e.g. b/c cmake was not installed), the chia_bls build would always fail in the future because the `build` directory already exists. Previous error message:

```
$ make -j4
Configuring chia_bls...
mkdir: cannot create directory ‘build’: File exists
make: *** [/Users/nmarley/projects/dash/depends/work/build/x86_64-apple-darwin18.0.0/chia_bls/b24c15cef6567a855e901b4774d1d22efb063ea9-e5023308c2a/./.stamp_configured] Error 1
```