### PR TITLE
Add cmake to non-mac gitian descriptors

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -23,6 +23,7 @@ packages:
 - "autoconf"
 - "libtool"
 - "automake"
+- "cmake"
 - "faketime"
 - "bsdmainutils"
 - "ca-certificates"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -13,6 +13,7 @@ packages:
 - "autoconf"
 - "libtool"
 - "automake"
+- "cmake"
 - "faketime"
 - "bsdmainutils"
 - "mingw-w64"


### PR DESCRIPTION
Needed since we added Chia bls-signatures.

Gitian builds are currently failing because of this.