### PR TITLE
Fix ' warning: delete called on non-final 'PeerLogicValidation' that has virtual functions but non-virtual destructor'

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -29,7 +29,7 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
 void UnregisterNodeSignals(CNodeSignals& nodeSignals);
 
-class PeerLogicValidation : public CValidationInterface {
+class PeerLogicValidation final : public CValidationInterface {
 private:
     CConnman* connman;
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -33,6 +33,7 @@ void UnregisterAllValidationInterfaces();
 
 class CValidationInterface {
 protected:
+    ~CValidationInterface() = default;
     virtual void AcceptedBlockHeader(const CBlockIndex *pindexNew) {}
     virtual void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload) {}
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}


### PR DESCRIPTION
peerLogic.reset(); in init.cpp calls on delete on PeerLogicValidation in net_processing and PeerLogicValidation is non-final.