### PR TITLE
Clear devNetParams and mimic behavior of other param types

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -715,7 +715,9 @@ CChainParams& Params(const std::string& chain)
 void SelectParams(const std::string& network)
 {
     if (network == CBaseChainParams::DEVNET) {
-        devNetParams = new CDevNetParams();
+        devNetParams = (CDevNetParams*)new uint8_t[sizeof(CDevNetParams)];
+        memset(devNetParams, 0, sizeof(CDevNetParams));
+        new (devNetParams) CDevNetParams();
     }
 
     SelectBaseParams(network);

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -9,6 +9,7 @@
 #include "util.h"
 
 #include <assert.h>
+#include <string.h>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
@@ -109,7 +110,10 @@ void SelectBaseParams(const std::string& chain)
     if (chain == CBaseChainParams::DEVNET) {
         std::string devNetName = GetDevNetName();
         assert(!devNetName.empty());
-        devNetParams = new CBaseDevNetParams(devNetName);
+
+        devNetParams = (CBaseDevNetParams*)new uint8_t[sizeof(CBaseDevNetParams)];
+        memset(devNetParams, 0, sizeof(CBaseDevNetParams));
+        new (devNetParams) CBaseDevNetParams(devNetName);
     }
 
     pCurrentBaseParams = &BaseParams(chain);

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -9,7 +9,6 @@
 #include "util.h"
 
 #include <assert.h>
-#include <string.h>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";


### PR DESCRIPTION
Mainnet, testnet and regtest params are global and thus zero initialized,
we should mimic the same for devnet params.

Not doing so results in all kinds of issues on devnet.