### PR TITLE
Allow to use low difficulty and higher block rewards for devnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -554,6 +554,13 @@ public:
             0.01                          // * estimated number of transactions per second
         };
     }
+
+    void UpdateSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor)
+    {
+        consensus.nMinimumDifficultyBlocks = nMinimumDifficultyBlocks;
+        consensus.nHighSubsidyBlocks = nHighSubsidyBlocks;
+        consensus.nHighSubsidyFactor = nHighSubsidyFactor;
+    }
 };
 static CDevNetParams *devNetParams;
 
@@ -730,4 +737,10 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 void UpdateRegtestBudgetParameters(int nMasternodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock)
 {
     regTestParams.UpdateBudgetParameters(nMasternodePaymentsStartBlock, nBudgetPaymentsStartBlock, nSuperblockStartBlock);
+}
+
+void UpdateDevnetSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor)
+{
+    assert(devNetParams);
+    devNetParams->UpdateSubsidyAndDiffParams(nMinimumDifficultyBlocks, nHighSubsidyBlocks, nHighSubsidyFactor);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -148,4 +148,9 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
  */
 void UpdateRegtestBudgetParameters(int nMasternodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock);
 
+/**
+ * Allows modifying the subsidy and difficulty devnet parameters.
+ */
+void UpdateDevnetSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -91,6 +91,11 @@ struct Params {
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
+
+    /** these parameters are only used on devnet and can be configured from the outside */
+    int nMinimumDifficultyBlocks{0};
+    int nHighSubsidyBlocks{0};
+    int nHighSubsidyFactor{1};
 };
 } // namespace Consensus
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1328,10 +1328,8 @@ bool AppInitParameterInteraction()
         int nHighSubsidyBlocks = GetArg("-highsubsidyblocks", chainparams.GetConsensus().nHighSubsidyBlocks);
         int nHighSubsidyFactor = GetArg("-highsubsidyfactor", chainparams.GetConsensus().nHighSubsidyFactor);
         UpdateDevnetSubsidyAndDiffParams(nMinimumDifficultyBlocks, nHighSubsidyBlocks, nHighSubsidyFactor);
-    } else {
-        if (IsArgSet("-minimumdifficultyblocks") || IsArgSet("-highsubsidyblocks") || IsArgSet("-highsubsidyfactor")) {
-            return InitError("Difficulty and subsidy parameters may only be overridden on devnet.");
-        }
+    } else if (IsArgSet("-minimumdifficultyblocks") || IsArgSet("-highsubsidyblocks") || IsArgSet("-highsubsidyfactor")) {
+        return InitError("Difficulty and subsidy parameters may only be overridden on devnet.");
     }
 
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1323,6 +1323,17 @@ bool AppInitParameterInteraction()
         UpdateRegtestBudgetParameters(nMasternodePaymentsStartBlock, nBudgetPaymentsStartBlock, nSuperblockStartBlock);
     }
 
+    if (chainparams.NetworkIDString() == CBaseChainParams::DEVNET) {
+        int nMinimumDifficultyBlocks = GetArg("-minimumdifficultyblocks", chainparams.GetConsensus().nMinimumDifficultyBlocks);
+        int nHighSubsidyBlocks = GetArg("-highsubsidyblocks", chainparams.GetConsensus().nHighSubsidyBlocks);
+        int nHighSubsidyFactor = GetArg("-highsubsidyfactor", chainparams.GetConsensus().nHighSubsidyFactor);
+        UpdateDevnetSubsidyAndDiffParams(nMinimumDifficultyBlocks, nHighSubsidyBlocks, nHighSubsidyFactor);
+    } else {
+        if (IsArgSet("-minimumdifficultyblocks") || IsArgSet("-highsubsidyblocks") || IsArgSet("-highsubsidyfactor")) {
+            return InitError("Difficulty and subsidy parameters may only be overridden on devnet.");
+        }
+    }
+
     return true;
 }
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -211,7 +211,7 @@ unsigned int GetNextWorkRequiredBTC(const CBlockIndex* pindexLast, const CBlockH
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     // this is only active on devnets
-    if (params.nMinimumDifficultyBlocks != 0 && pindexLast->nHeight < params.nMinimumDifficultyBlocks) {
+    if (pindexLast->nHeight < params.nMinimumDifficultyBlocks) {
         unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
         return nProofOfWorkLimit;
     }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -210,6 +210,12 @@ unsigned int GetNextWorkRequiredBTC(const CBlockIndex* pindexLast, const CBlockH
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
+    // this is only active on devnets
+    if (params.nMinimumDifficultyBlocks != 0 && pindexLast->nHeight < params.nMinimumDifficultyBlocks) {
+        unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
+        return nProofOfWorkLimit;
+    }
+
     // Most recent algo first
     if (pindexLast->nHeight + 1 >= params.nPowDGWHeight) {
         return DarkGravityWave(pindexLast, pblock, params);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1172,7 +1172,7 @@ CAmount GetBlockSubsidy(int nPrevBits, int nPrevHeight, const Consensus::Params&
     }
 
     // this is only active on devnets
-    if (consensusParams.nHighSubsidyBlocks != 0 && nPrevHeight < consensusParams.nHighSubsidyBlocks) {
+    if (nPrevHeight < consensusParams.nHighSubsidyBlocks) {
         nSubsidy *= consensusParams.nHighSubsidyFactor;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1171,6 +1171,11 @@ CAmount GetBlockSubsidy(int nPrevBits, int nPrevHeight, const Consensus::Params&
         nSubsidy -= nSubsidy/14;
     }
 
+    // this is only active on devnets
+    if (consensusParams.nHighSubsidyBlocks != 0 && nPrevHeight < consensusParams.nHighSubsidyBlocks) {
+        nSubsidy *= consensusParams.nHighSubsidyFactor;
+    }
+
     // Hard fork to reduce the block reward by 10 extra percent (allowing budget/superblocks)
     CAmount nSuperblockPart = (nPrevHeight > consensusParams.nBudgetPaymentsStartBlock) ? nSubsidy/10 : 0;
 


### PR DESCRIPTION
Configurable through -minimumdifficultyblocks, -highsubsidyblocks and -highsubsidyfactor

This is very useful in devnets that are created and destroyed very often. For example, when doing my LLMQ tests I create hundrets if not thousands of masternodes in a fresh devnet. If I'd had to wait for enough blocks to fund the collaterals, I'd wait hours for each single test.

These parameters need to be set across all nodes that are part of the devnet.