### PR TITLE
Give tail calls enough time to print errors

### DIFF
--- a/Jenkinsfile.gitian
+++ b/Jenkinsfile.gitian
@@ -102,6 +102,10 @@ for(int i = 0; i < targets.size(); i++) {
                 tail -F var/install.log &
                 tail -F var/build.log &
                 USE_DOCKER=1 ./bin/gbuild -j ${proc} -m ${mem} --commit dash=${commit} --url dash=${repositoryUrl} ../dash/contrib/gitian-descriptors/gitian-${target}.yml
+                RET=$?
+                # give the above tail calls enough time to print everything on failure
+                sleep 2s
+                exit $RET
               """
             } finally {
               // make sure it doesn't run forever


### PR DESCRIPTION
Recent Jenkins failures for the Gitian builds were hard to debug due the actual error not appearing in logs. I hope (but don't know for sure) this helps in the future.