### PR TITLE
Bump CMAKE_CXX_STANDARD to 14 in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.7)
 project(dash)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 include_directories(
         src


### PR DESCRIPTION
We still don't really use this file (it won't even work), but it's good
to have CLion not brable about unknown stuff all the time.