### PR TITLE
Update ProRegTx serialization order

### DIFF
--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -48,8 +48,8 @@ public:
         READWRITE(keyIDOwner);
         READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);
-        READWRITE(*(CScriptBase*)(&scriptPayout));
         READWRITE(nOperatorReward);
+        READWRITE(*(CScriptBase*)(&scriptPayout));
         READWRITE(inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(vchSig);


### PR DESCRIPTION
Operator reward and the payout script were flipped with respect to both DIP-3 and the order [here](https://github.com/dashpay/dash/blob/develop/src/evo/providertx.h#L32-L33)