### PR TITLE
Support fast sync mode in RPC tests (using mnsync next) 

### DIFF
--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -49,7 +49,7 @@ class AutoIXMempoolTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes)
+                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'started':
             set_mocktime(get_mocktime() + 1)
@@ -59,7 +59,7 @@ class AutoIXMempoolTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes)
+                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'locked_in':
             set_mocktime(get_mocktime() + 1)
@@ -69,11 +69,11 @@ class AutoIXMempoolTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes)
+                sync_masternodes(self.nodes, True)
 
         # sync nodes
         self.sync_all()
-        sync_masternodes(self.nodes)
+        sync_masternodes(self.nodes, True)
 
         assert(self.get_autoix_bip9_status() == 'active')
 

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -33,7 +33,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         self.tip = None
         self.block_time = None
         NetworkThread().start() # Start up network handling in another thread
-        sync_masternodes(self.nodes)
+        sync_masternodes(self.nodes, True)
         test.run()
 
     def get_tests(self):

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -51,7 +51,7 @@ class AutoInstantSendTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes)
+                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'started':
             set_mocktime(get_mocktime() + 1)
@@ -61,7 +61,7 @@ class AutoInstantSendTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes)
+                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'locked_in':
             set_mocktime(get_mocktime() + 1)
@@ -71,11 +71,11 @@ class AutoInstantSendTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes)
+                sync_masternodes(self.nodes, True)
 
         # sync nodes
         self.sync_all()
-        sync_masternodes(self.nodes)
+        sync_masternodes(self.nodes, True)
 
         assert(self.get_autoix_bip9_status() == 'active')
 

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -69,7 +69,7 @@ class FullBlockTest(ComparisonTestFramework):
         self.test = TestManager(self, self.options.tmpdir)
         self.test.add_all_connections(self.nodes)
         NetworkThread().start() # Start up network handling in another thread
-        sync_masternodes(self.nodes)
+        sync_masternodes(self.nodes, True)
         self.test.run()
 
     def add_transactions_to_block(self, block, tx_list):

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -298,11 +298,11 @@ class DashTestFramework(BitcoinTestFramework):
         self.sync_all()
         set_mocktime(get_mocktime() + 1)
         set_node_times(self.nodes, get_mocktime())
-        sync_masternodes(self.nodes)
+        sync_masternodes(self.nodes, True)
         for i in range(1, self.mn_count + 1):
             res = self.nodes[0].masternode("start-alias", "mn%d" % i)
             assert (res["result"] == 'successful')
-        sync_masternodes(self.nodes)
+        sync_masternodes(self.nodes, True)
         mn_info = self.nodes[0].masternodelist("status")
         assert (len(mn_info) == self.mn_count)
         for status in mn_info.values():

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -105,11 +105,15 @@ def get_mnsync_status(node):
     result = node.mnsync("status")
     return result['IsSynced']
 
-def wait_to_sync(node):
-    synced = False
-    while not synced:
+def wait_to_sync(node, fast_mnsync=False):
+    while True:
         synced = get_mnsync_status(node)
-        time.sleep(0.5)
+        if synced:
+            break
+        time.sleep(0.2)
+        if fast_mnsync:
+            # skip mnsync states
+            node.mnsync("next")
 
 def p2p_port(n):
     assert(n <= MAX_NODES)
@@ -191,9 +195,9 @@ def sync_mempools(rpc_connections, *, wait=1, timeout=60):
         timeout -= wait
     raise AssertionError("Mempool sync failed")
 
-def sync_masternodes(rpc_connections):
+def sync_masternodes(rpc_connections, fast_mnsync=False):
     for node in rpc_connections:
-        wait_to_sync(node)
+        wait_to_sync(node, fast_mnsync)
 
 bitcoind_processes = {}
 


### PR DESCRIPTION
This should speed up a few of the RPC tests by a few seconds.

