### PR TITLE
Implement RemoveAskFor to indicate that we're not interested in an item anymore

### DIFF
--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -134,7 +134,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
 
         {
             LOCK(cs_main);
-            connman.RemoveAskFor(CInv(MSG_GOVERNANCE_OBJECT, nHash));
+            connman.RemoveAskFor(nHash);
         }
 
         if (pfrom->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) {
@@ -225,7 +225,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
 
         {
             LOCK(cs_main);
-            connman.RemoveAskFor(CInv(MSG_GOVERNANCE_OBJECT_VOTE, nHash));
+            connman.RemoveAskFor(nHash);
         }
 
         if (pfrom->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) {

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -132,7 +132,10 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
 
         uint256 nHash = govobj.GetHash();
 
-        pfrom->setAskFor.erase(nHash);
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(CInv(MSG_GOVERNANCE_OBJECT, nHash));
+        }
 
         if (pfrom->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) {
             LogPrint("gobject", "MNGOVERNANCEOBJECT -- peer=%d using obsolete version %i\n", pfrom->id, pfrom->nVersion);
@@ -220,7 +223,10 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
 
         uint256 nHash = vote.GetHash();
 
-        pfrom->setAskFor.erase(nHash);
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(CInv(MSG_GOVERNANCE_OBJECT_VOTE, nHash));
+        }
 
         if (pfrom->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) {
             LogPrint("gobject", "MNGOVERNANCEOBJECTVOTE -- peer=%d using obsolete version %i\n", pfrom->id, pfrom->nVersion);
@@ -1113,10 +1119,13 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
             // only use up to date peers
             if (pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
             // stop early to prevent setAskFor overflow
-            size_t nProjectedSize = pnode->setAskFor.size() + nProjectedVotes;
-            if (nProjectedSize > SETASKFOR_MAX_SZ / 2) continue;
-            // to early to ask the same node
-            if (mapAskedRecently[nHashGovobj].count(pnode->addr)) continue;
+            {
+                LOCK(cs_main);
+                size_t nProjectedSize = pnode->setAskFor.size() + nProjectedVotes;
+                if (nProjectedSize > SETASKFOR_MAX_SZ / 2) continue;
+                // to early to ask the same node
+                if (mapAskedRecently[nHashGovobj].count(pnode->addr)) continue;
+            }
 
             RequestGovernanceObject(pnode, nHashGovobj, connman, true);
             mapAskedRecently[nHashGovobj][pnode->addr] = nNow + nTimeout;

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -75,7 +75,7 @@ void CInstantSend::ProcessMessage(CNode* pfrom, const std::string& strCommand, C
 
         {
             LOCK(cs_main);
-            connman.RemoveAskFor(CInv(MSG_TXLOCK_VOTE, nVoteHash));
+            connman.RemoveAskFor(nVoteHash);
         }
 
         // Ignore any InstantSend messages until masternode list is synced

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -73,7 +73,10 @@ void CInstantSend::ProcessMessage(CNode* pfrom, const std::string& strCommand, C
 
         uint256 nVoteHash = vote.GetHash();
 
-        pfrom->setAskFor.erase(nVoteHash);
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(CInv(MSG_TXLOCK_VOTE, nVoteHash));
+        }
 
         // Ignore any InstantSend messages until masternode list is synced
         if (!masternodeSync.IsMasternodeListSynced()) return;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -446,7 +446,10 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, const std::string& strCom
 
         uint256 nHash = vote.GetHash();
 
-        pfrom->setAskFor.erase(nHash);
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(CInv(MSG_MASTERNODE_PAYMENT_VOTE, nHash));
+        }
 
         // TODO: clear setAskFor for MSG_MASTERNODE_PAYMENT_BLOCK too
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -448,7 +448,7 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, const std::string& strCom
 
         {
             LOCK(cs_main);
-            connman.RemoveAskFor(CInv(MSG_MASTERNODE_PAYMENT_VOTE, nHash));
+            connman.RemoveAskFor(nHash);
         }
 
         // TODO: clear setAskFor for MSG_MASTERNODE_PAYMENT_BLOCK too

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -977,7 +977,10 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
         CMasternodeBroadcast mnb;
         vRecv >> mnb;
 
-        pfrom->setAskFor.erase(mnb.GetHash());
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(CInv(MSG_MASTERNODE_ANNOUNCE, mnb.GetHash()));
+        }
 
         if(!masternodeSync.IsBlockchainSynced()) return;
 
@@ -1003,7 +1006,10 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
 
         uint256 nHash = mnp.GetHash();
 
-        pfrom->setAskFor.erase(nHash);
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(CInv(MSG_MASTERNODE_PING, nHash));
+        }
 
         if(!masternodeSync.IsBlockchainSynced()) return;
 
@@ -1066,7 +1072,10 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
         CMasternodeVerification mnv;
         vRecv >> mnv;
 
-        pfrom->setAskFor.erase(mnv.GetHash());
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(CInv(MSG_MASTERNODE_VERIFY, mnv.GetHash()));
+        }
 
         if(!masternodeSync.IsMasternodeListSynced()) return;
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -979,7 +979,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
 
         {
             LOCK(cs_main);
-            connman.RemoveAskFor(CInv(MSG_MASTERNODE_ANNOUNCE, mnb.GetHash()));
+            connman.RemoveAskFor(mnb.GetHash());
         }
 
         if(!masternodeSync.IsBlockchainSynced()) return;
@@ -1008,7 +1008,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
 
         {
             LOCK(cs_main);
-            connman.RemoveAskFor(CInv(MSG_MASTERNODE_PING, nHash));
+            connman.RemoveAskFor(nHash);
         }
 
         if(!masternodeSync.IsBlockchainSynced()) return;
@@ -1074,7 +1074,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
 
         {
             LOCK(cs_main);
-            connman.RemoveAskFor(CInv(MSG_MASTERNODE_VERIFY, mnv.GetHash()));
+            connman.RemoveAskFor(mnv.GetHash());
         }
 
         if(!masternodeSync.IsMasternodeListSynced()) return;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2655,13 +2655,13 @@ void CConnman::RelayInvFiltered(CInv &inv, const CTransaction& relatedTx, const 
     }
 }
 
-void CConnman::RemoveAskFor(const CInv& inv)
+void CConnman::RemoveAskFor(const uint256& hash)
 {
-    mapAlreadyAskedFor.erase(inv.hash);
+    mapAlreadyAskedFor.erase(hash);
 
     LOCK(cs_vNodes);
     for (const auto& pnode : vNodes) {
-        pnode->RemoveAskFor(inv);
+        pnode->RemoveAskFor(hash);
     }
 }
 
@@ -2916,11 +2916,11 @@ void CNode::AskFor(const CInv& inv)
     mapAskFor.insert(std::make_pair(nRequestTime, inv));
 }
 
-void CNode::RemoveAskFor(const CInv& inv)
+void CNode::RemoveAskFor(const uint256& hash)
 {
-    setAskFor.erase(inv.hash);
+    setAskFor.erase(hash);
     for (auto it = mapAskFor.begin(); it != mapAskFor.end();) {
-        if (it->second.hash == inv.hash) {
+        if (it->second.hash == hash) {
             it = mapAskFor.erase(it);
         } else {
             ++it;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2655,6 +2655,16 @@ void CConnman::RelayInvFiltered(CInv &inv, const CTransaction& relatedTx, const 
     }
 }
 
+void CConnman::RemoveAskFor(const CInv& inv)
+{
+    mapAlreadyAskedFor.erase(inv.hash);
+
+    LOCK(cs_vNodes);
+    for (const auto& pnode : vNodes) {
+        pnode->RemoveAskFor(inv);
+    }
+}
+
 void CConnman::RecordBytesRecv(uint64_t bytes)
 {
     LOCK(cs_totalBytesRecv);
@@ -2904,6 +2914,18 @@ void CNode::AskFor(const CInv& inv)
     else
         mapAlreadyAskedFor.insert(std::make_pair(inv.hash, nRequestTime));
     mapAskFor.insert(std::make_pair(nRequestTime, inv));
+}
+
+void CNode::RemoveAskFor(const CInv& inv)
+{
+    setAskFor.erase(inv.hash);
+    for (auto it = mapAskFor.begin(); it != mapAskFor.end();) {
+        if (it->second.hash == inv.hash) {
+            it = mapAskFor.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 bool CConnman::NodeFullyConnected(const CNode* pnode)

--- a/src/net.h
+++ b/src/net.h
@@ -310,7 +310,7 @@ public:
     void RelayTransaction(const CTransaction& tx, const CDataStream& ss);
     void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
     void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
-    void RemoveAskFor(const CInv& inv);
+    void RemoveAskFor(const uint256& hash);
 
     // Addrman functions
     size_t GetAddressCount() const;
@@ -930,7 +930,7 @@ public:
     }
 
     void AskFor(const CInv& inv);
-    void RemoveAskFor(const CInv& inv);
+    void RemoveAskFor(const uint256& hash);
 
     void CloseSocketDisconnect();
 

--- a/src/net.h
+++ b/src/net.h
@@ -310,6 +310,7 @@ public:
     void RelayTransaction(const CTransaction& tx, const CDataStream& ss);
     void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
     void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
+    void RemoveAskFor(const CInv& inv);
 
     // Addrman functions
     size_t GetAddressCount() const;
@@ -929,6 +930,7 @@ public:
     }
 
     void AskFor(const CInv& inv);
+    void RemoveAskFor(const CInv& inv);
 
     void CloseSocketDisconnect();
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1962,7 +1962,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         CInv inv(nInvType, tx.GetHash());
         pfrom->AddInventoryKnown(inv);
-        pfrom->setAskFor.erase(inv.hash);
 
         // Process custom logic, no matter if tx will be accepted to mempool later or not
         if (strCommand == NetMsgType::TXLOCKREQUEST || fCanAutoLock) {
@@ -2009,10 +2008,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         LOCK(cs_main);
 
+        connman.RemoveAskFor(inv);
+
         bool fMissingInputs = false;
         CValidationState state;
-
-        mapAlreadyAskedFor.erase(inv.hash);
 
         if (!AlreadyHave(inv) && AcceptToMemoryPool(mempool, state, ptx, true, &fMissingInputs)) {
             // Process custom txes, this changes AlreadyHave to "true"

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2008,7 +2008,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         LOCK(cs_main);
 
-        connman.RemoveAskFor(inv);
+        connman.RemoveAskFor(inv.hash);
 
         bool fMissingInputs = false;
         CValidationState state;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -123,7 +123,7 @@ void CSporkManager::ProcessSpork(CNode* pfrom, const std::string& strCommand, CD
         std::string strLogMsg;
         {
             LOCK(cs_main);
-            pfrom->setAskFor.erase(hash);
+            connman.RemoveAskFor(CInv(MSG_SPORK, hash));
             if(!chainActive.Tip()) return;
             strLogMsg = strprintf("SPORK -- hash: %s id: %d value: %10d bestHeight: %d peer=%d", hash.ToString(), spork.nSporkID, spork.nValue, chainActive.Height(), pfrom->id);
         }

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -123,7 +123,7 @@ void CSporkManager::ProcessSpork(CNode* pfrom, const std::string& strCommand, CD
         std::string strLogMsg;
         {
             LOCK(cs_main);
-            connman.RemoveAskFor(CInv(MSG_SPORK, hash));
+            connman.RemoveAskFor(hash);
             if(!chainActive.Tip()) return;
             strLogMsg = strprintf("SPORK -- hash: %s id: %d value: %10d bestHeight: %d peer=%d", hash.ToString(), spork.nSporkID, spork.nValue, chainActive.Height(), pfrom->id);
         }


### PR DESCRIPTION
When an INV item is received from the first node, the item is requested
immediately. If the same item is received from another node, an entry is
added to mapAskFor which marks the item for re-requesting in case the first
node did not respond. When the item is received from the first node,
the item was previously never removed from mapAskFor. Only the later getdata
loop in SendMessages would then gradually remove items from the map. This
is quite delayed however as the entries in mapAskFor have a timeout value.

RemoveAskFor allows to remove all entries from mapAskFor and setAskFor
when we are not interested in the item anymore (e.g. because we received
it already).