### PR TITLE
Fix crash when deterministic MN list is empty and keep paying superblocks in this case

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -366,7 +366,10 @@ bool CMasternodePayments::GetMasternodeTxOuts(int nBlockHeight, CAmount blockRew
     voutMasternodePaymentsRet.clear();
 
     if(!GetBlockTxOuts(nBlockHeight, blockReward, voutMasternodePaymentsRet)) {
-        assert(!deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight));
+        if (deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight)) {
+            LogPrintf("CMasternodePayments::%s -- deterministic masternode lists enabled and no payee", __func__);
+            return false;
+        }
 
         // no masternode detected...
         int nCount = 0;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -263,7 +263,7 @@ void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blo
         voutMasternodeStr += txout.ToString();
     }
 
-    LogPrint("mnpayments", "%s -- nBlockHeight %d blockReward %lld voutMasternodePaymentsRet \"%s\" txNew %s\n", __func__,
+    LogPrint("mnpayments", "%s -- nBlockHeight %d blockReward %lld voutMasternodePaymentsRet \"%s\" txNew %s", __func__,
                             nBlockHeight, blockReward, voutMasternodeStr, txNew.ToString());
 }
 
@@ -366,7 +366,7 @@ bool CMasternodePayments::GetMasternodeTxOuts(int nBlockHeight, CAmount blockRew
 
     if(!GetBlockTxOuts(nBlockHeight, blockReward, voutMasternodePaymentsRet)) {
         if (deterministicMNManager->IsDeterministicMNsSporkActive(nBlockHeight)) {
-            LogPrintf("CMasternodePayments::%s -- deterministic masternode lists enabled and no payee", __func__);
+            LogPrintf("CMasternodePayments::%s -- deterministic masternode lists enabled and no payee\n", __func__);
             return false;
         }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -248,8 +248,7 @@ void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blo
     }
 
     if (!mnpayments.GetMasternodeTxOuts(nBlockHeight, blockReward, voutMasternodePaymentsRet)) {
-        // no idea whom to pay (MN list empty?), lets hope for the best
-        return;
+        LogPrint("mnpayments", "%s -- no masternode to pay (MN list probably empty)\n", __func__);
     }
 
     txNew.vout.insert(txNew.vout.end(), voutMasternodePaymentsRet.begin(), voutMasternodePaymentsRet.end());

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -263,7 +263,7 @@ void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blo
         voutMasternodeStr += txout.ToString();
     }
 
-    LogPrint("mnpayments", "%s -- nBlockHeight %d blockReward %lld voutMasternodePaymentsRet \"%s\" txNew %s", __func__,
+    LogPrint("mnpayments", "%s -- nBlockHeight %d blockReward %lld voutMasternodePaymentsRet \"%s\" txNew %s\n", __func__,
                             nBlockHeight, blockReward, voutMasternodeStr, txNew.ToString());
 }
 


### PR DESCRIPTION
This was fixed a while ago in the evo branch and should be on develop as well.