### PR TITLE
Don't revert to INV based block announcements when the previous block is the devnet genesis block

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3230,12 +3230,21 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
                         break;
                     }
                     pBestIndex = pindex;
+                    bool isPrevDevnetGenesisBlock = false;
+                    if (!consensusParams.hashDevnetGenesisBlock.IsNull() &&
+                        pindex->pprev != nullptr &&
+                        pindex->pprev->GetBlockHash() == consensusParams.hashDevnetGenesisBlock) {
+                        // even though the devnet genesis block was never transferred through the wire and thus not
+                        // appear anywhere in the node state where we track what other nodes have or not have, we can
+                        // assume that the other node already knows the devnet genesis block
+                        isPrevDevnetGenesisBlock = true;
+                    }
                     if (fFoundStartingHeader) {
                         // add this to the headers message
                         vHeaders.push_back(pindex->GetBlockHeader());
                     } else if (PeerHasHeader(&state, pindex)) {
                         continue; // keep looking for the first new block
-                    } else if (pindex->pprev == NULL || PeerHasHeader(&state, pindex->pprev)) {
+                    } else if (pindex->pprev == NULL || PeerHasHeader(&state, pindex->pprev) || isPrevDevnetGenesisBlock) {
                         // Peer doesn't have this header but they do have the prior one.
                         // Start sending headers.
                         fFoundStartingHeader = true;


### PR DESCRIPTION
Assume that the other node already has the previous block if it matches
the devnet genesis block.

This fixes issues with stuck nodes in devnet. When a devnet is freshly created, nodes might connect too early to other masternodes, resulting in the initial header message to not be sent. This however also leads to the next (freshly generated) headers to not be sent but instead only be announced with INV, which is then ignored by the other node (as it is still in initial sync and expects headers to come).