### PR TITLE
Speed up IX tests and fix test failures

### DIFF
--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -92,7 +92,6 @@ class AutoIXMempoolTest(DashTestFramework):
         self.sync_all()
 
     def run_test(self):
-        self.enforce_masternode_payments()  # required for bip9 activation
         self.activate_autoix_bip9()
         self.set_autoix_spork_state(True)
 

--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -34,43 +34,20 @@ class AutoIXMempoolTest(DashTestFramework):
         return info['bip9_softforks']['dip0003']['status']
 
     def activate_autoix_bip9(self):
-        # sync nodes periodically
-        # if we sync them too often, activation takes too many time
-        # if we sync them too rarely, nodes failed to update its state and
-        # bip9 status is not updated
-        # so, in this code nodes are synced once per 20 blocks
-        counter = 0
-        sync_period = 10
-
         while self.get_autoix_bip9_status() == 'defined':
             set_mocktime(get_mocktime() + 1)
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
-            counter += 1
-            if counter % sync_period == 0:
-                # sync nodes
-                self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'started':
             set_mocktime(get_mocktime() + 1)
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
-            counter += 1
-            if counter % sync_period == 0:
-                # sync nodes
-                self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'locked_in':
             set_mocktime(get_mocktime() + 1)
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
-            counter += 1
-            if counter % sync_period == 0:
-                # sync nodes
-                self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         # sync nodes
         self.sync_all()

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -36,43 +36,20 @@ class AutoInstantSendTest(DashTestFramework):
         return info['bip9_softforks']['dip0003']['status']
 
     def activate_autoix_bip9(self):
-        # sync nodes periodically
-        # if we sync them too often, activation takes too many time
-        # if we sync them too rarely, nodes failed to update its state and
-        # bip9 status is not updated
-        # so, in this code nodes are synced once per 20 blocks
-        counter = 0
-        sync_period = 10
-
         while self.get_autoix_bip9_status() == 'defined':
             set_mocktime(get_mocktime() + 1)
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
-            counter += 1
-            if counter % sync_period == 0:
-                # sync nodes
-                self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'started':
             set_mocktime(get_mocktime() + 1)
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
-            counter += 1
-            if counter % sync_period == 0:
-                # sync nodes
-                self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'locked_in':
             set_mocktime(get_mocktime() + 1)
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
-            counter += 1
-            if counter % sync_period == 0:
-                # sync nodes
-                self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         # sync nodes
         self.sync_all()

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -104,7 +104,6 @@ class AutoInstantSendTest(DashTestFramework):
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
             
-        self.enforce_masternode_payments()  # required for bip9 activation
         assert(self.get_autoix_bip9_status() == 'defined')
         assert(not self.get_autoix_spork_state())
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -945,6 +945,12 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight, CConnman& connman)
     // if we have not enough data about masternodes.
     if(!masternodeSync.IsMasternodeListSynced()) return false;
 
+    // Don't vote when enforcement is disabled. Doesn't make much sense on mainnet and also overloads regtest when
+    // too many blocks are generated
+    if (!sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)) {
+        return false;
+    }
+
     int nRank;
 
     if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, nBlockHeight - 101, GetMinMasternodePaymentsProto())) {


### PR DESCRIPTION
1. Remove periodic sync when activating autoix/DIP3
2. Don't perform masternode payment voting when enforcement is disabled