### PR TITLE
Undefine DOUBLE after include Chia BLS headers

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -15,6 +15,7 @@
 #include <chiabls/privatekey.hpp>
 #include <chiabls/publickey.hpp>
 #include <chiabls/signature.hpp>
+#undef DOUBLE
 
 #include <array>
 #include <unistd.h>


### PR DESCRIPTION
These cause compilation errors on some platforms.
Observed this when I tried to cross compile win32
locally on a Debian Stretch machine.