### PR TITLE
Trivial: Protx RPC operator reward help clarification

### DIFF
--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -191,7 +191,7 @@ void protx_fund_register_help()
             "                         It has to match the private key which is later used when voting on proposals.\n"
             "                         If set to \"0\" or an empty string, ownerAddr will be used.\n"
             "6. \"operatorReward\"      (numeric, required) The fraction in % to share with the operator. If non-zero,\n"
-            "                         \"ipAndPort\" must be zero as well. The value must be between 0 and 100.\n"
+            "                         \"ipAndPort\" must be zero as well. The value must be between 0.00 and 100.00.\n"
             "7. \"payoutAddress\"       (string, required) The dash address to use for masternode reward payments\n"
             "                         Must match \"collateralAddress\"."
             "\nExamples:\n"
@@ -278,7 +278,7 @@ UniValue protx_register(const JSONRPCRequest& request)
 
     double operatorReward = ParseDoubleV(request.params[paramIdx + 4], "operatorReward");
     if (operatorReward < 0 || operatorReward > 100) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorReward must be between 0 and 100");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorReward must be between 0.00 and 100.00");
     }
     ptx.nOperatorReward = (uint16_t)(operatorReward * 100);
 


### PR DESCRIPTION
Add decimal places to clarify:
1. Non-integers are valid (e.g. 3.25)
2. Granularity - anything beyond x.xx is rounded (e.g. 3.259 -> 3.26)

This is due to [DIP3 only allowing values 0-10000](https://github.com/dashpay/dips/blob/master/dip-0003.md#registering-a-masternode-proregtx) for operator reward (1/10000
= 0.01%)