### PR TITLE
Update Chia bls-signature to latest version

### DIFF
--- a/depends/packages/chia_bls.mk
+++ b/depends/packages/chia_bls.mk
@@ -1,9 +1,9 @@
 package=chia_bls
-$(package)_version=ef06290c1d92eea79b46af135bcc823b019612a6
+$(package)_version=v20181101
 # It's actually from https://github.com/Chia-Network/bls-signatures, but we have so many patches atm that it's forked
 $(package)_download_path=https://github.com/codablock/bls-signatures/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=1e665359fdb946efce943340a324534f72832ecde97c4ebd4ad189f63e029300
+$(package)_sha256_hash=b3ec74a77a7b6795f84b05e051a0824ef8d9e05b04b2993f01040f35689aa87c
 $(package)_dependencies=gmp
 #$(package)_patches=...TODO (when we switch back to https://github.com/Chia-Network/bls-signatures)
 

--- a/src/bench/bench_dash.cpp
+++ b/src/bench/bench_dash.cpp
@@ -19,7 +19,6 @@ main(int argc, char** argv)
     ECC_Start();
     ECCVerifyHandle verifyHandle;
 
-    BLSInit();
     SetupEnvironment();
     fPrintToDebugLog = false; // don't want to write to debug.log file
 

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -462,14 +462,3 @@ static void secure_free(void* p)
     return get_secure_allocator().deallocate(ptr, n);
 }
 #endif
-
-bool BLSInit()
-{
-    if (!bls::BLS::Init()) {
-        return false;
-    }
-#ifndef BUILD_BITCOIN_INTERNAL
-    bls::BLS::SetSecureAllocator(secure_allocate, secure_free);
-#endif
-    return true;
-}

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -300,6 +300,4 @@ typedef std::shared_ptr<BLSPublicKeyVector> BLSPublicKeyVectorPtr;
 typedef std::shared_ptr<BLSSecretKeyVector> BLSSecretKeyVectorPtr;
 typedef std::shared_ptr<BLSSignatureVector> BLSSignatureVectorPtr;
 
-bool BLSInit();
-
 #endif // DASH_CRYPTO_BLS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -846,9 +846,6 @@ bool InitSanityCheck(void)
     if (!glibc_sanity_test() || !glibcxx_sanity_test())
         return false;
 
-    if (!BLSInit())
-        return false;
-
     return true;
 }
 

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -43,7 +43,6 @@ extern void noui_connect();
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 {
         ECC_Start();
-        BLSInit();
         SetupEnvironment();
         SetupNetworking();
         InitSignatureCache();


### PR DESCRIPTION
Brings in:
1. https://github.com/Chia-Network/bls-signatures/pull/41
2. https://github.com/Chia-Network/bls-signatures/pull/46
3. A few commits from https://github.com/codablock/bls-signatures are now
   merged into upstream.

This removes the need for manual initialization of the BLS library. This is
now done internally and in a thread-safe way.

Also switch to using tags instead of raw commit hashes. Makes testing
easier and also removes the risk of Github deleting commits due to
cleanup jobs.