### PR TITLE
Explicitly specify which branch of Wine to install

### DIFF
--- a/doc/build-cross.md
+++ b/doc/build-cross.md
@@ -40,7 +40,7 @@ Windows 64bit/32bit Cross-compilation
 Cross-compiling to Windows requires a few additional packages to be installed:
 
 ```bash
-$ sudo apt-get install nsis wine wine64 bc
+$ sudo apt-get install nsis wine-stable wine64 bc
 ```
 
 For Windows 64bit, install :


### PR DESCRIPTION
Specifying only `wine` results in this message under Ubuntu Bionic:

Package wine is a virtual package provided by:
  wine-stable 3.0-1ubuntu1
  wine-development 3.6-1
You should explicitly select one to install.

Compilation is tested working using `wine-stable`.