### PR TITLE
Fix auto-IS tests

### DIFF
--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -50,7 +50,6 @@ class AutoIXMempoolTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'started':
             set_mocktime(get_mocktime() + 1)
@@ -60,7 +59,6 @@ class AutoIXMempoolTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'locked_in':
             set_mocktime(get_mocktime() + 1)
@@ -70,11 +68,9 @@ class AutoIXMempoolTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         # sync nodes
         self.sync_all()
-        sync_masternodes(self.nodes, True)
 
         assert(self.get_autoix_bip9_status() == 'active')
 
@@ -120,6 +116,8 @@ class AutoIXMempoolTest(DashTestFramework):
         self.sync_all()
 
     def run_test(self):
+        # make sure masternodes are synced
+        sync_masternodes(self.nodes)
         self.enforce_masternode_payments()  # required for bip9 activation
         self.activate_autoix_bip9()
         self.set_autoix_spork_state(True)

--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -102,16 +102,21 @@ class AutoIXMempoolTest(DashTestFramework):
         self.sync_all()
         return self.wait_for_instantlock(txid, sender)
 
-    def get_mempool_size(self, node):
+    def get_mempool_usage(self, node):
         info = node.getmempoolinfo()
         return info['usage']
 
     def fill_mempool(self):
-        node = self.nodes[0]
-        rec_address = node.getnewaddress()
-        while self.get_mempool_size(node) < MAX_MEMPOOL_SIZE * MB_SIZE * AUTO_IX_MEM_THRESHOLD + 10000:
-            node.sendtoaddress(rec_address, 1.0)
-            sleep(0.1)
+        # send lots of txes to yourself just to fill the mempool
+        counter = 0
+        sync_period = 10
+        dummy_address = self.nodes[0].getnewaddress()
+        while self.get_mempool_usage(self.nodes[self.sender_idx]) < MAX_MEMPOOL_SIZE * MB_SIZE * AUTO_IX_MEM_THRESHOLD:
+            self.nodes[0].sendtoaddress(dummy_address, 1.0)
+            counter += 1
+            if counter % sync_period == 0:
+                # sync nodes
+                self.sync_all()
         self.sync_all()
 
     def run_test(self):
@@ -123,25 +128,28 @@ class AutoIXMempoolTest(DashTestFramework):
         assert(self.get_autoix_bip9_status() == 'active')
         assert(self.get_autoix_spork_state())
 
-        # autoIX is working
-        assert(self.send_simple_tx(self.nodes[0], self.nodes[self.receiver_idx]))
+        # create 3 inputs for txes on sender node and give them 6 confirmations
+        sender = self.nodes[self.sender_idx]
+        receiver = self.nodes[self.receiver_idx]
+        sender_address = sender.getnewaddress()
+        for i in range(0, 3):
+            self.nodes[0].sendtoaddress(sender_address, 2.0)
+        for i in range(0, 6):
+            set_mocktime(get_mocktime() + 1)
+            set_node_times(self.nodes, get_mocktime())
+            self.nodes[0].generate(1)
+        self.sync_all()
 
-        # send funds for InstantSend  after filling mempool and give them 6 confirmations
-        rec_address = self.nodes[self.receiver_idx].getnewaddress()
-        self.nodes[0].sendtoaddress(rec_address, 500.0)
-        self.nodes[0].sendtoaddress(rec_address, 500.0)
-        self.sync_all()
-        for i in range(0, 2):
-            self.nodes[self.receiver_idx].generate(1)
-        self.sync_all()
+        # autoIX is working
+        assert(self.send_simple_tx(sender, receiver))
 
         # fill mempool with transactions
         self.fill_mempool()
 
         # autoIX is not working now
-        assert(not self.send_simple_tx(self.nodes[self.receiver_idx], self.nodes[0]))
+        assert(not self.send_simple_tx(sender, receiver))
         # regular IX is still working
-        assert(self.send_regular_IX(self.nodes[self.receiver_idx], self.nodes[0]))
+        assert(self.send_regular_IX(sender, receiver))
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -52,7 +52,6 @@ class AutoInstantSendTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'started':
             set_mocktime(get_mocktime() + 1)
@@ -62,7 +61,6 @@ class AutoInstantSendTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         while self.get_autoix_bip9_status() == 'locked_in':
             set_mocktime(get_mocktime() + 1)
@@ -72,11 +70,9 @@ class AutoInstantSendTest(DashTestFramework):
             if counter % sync_period == 0:
                 # sync nodes
                 self.sync_all()
-                sync_masternodes(self.nodes, True)
 
         # sync nodes
         self.sync_all()
-        sync_masternodes(self.nodes, True)
 
         assert(self.get_autoix_bip9_status() == 'active')
 
@@ -118,6 +114,8 @@ class AutoInstantSendTest(DashTestFramework):
         return self.wait_for_instantlock(txid, self.nodes[0])
 
     def run_test(self):
+        # make sure masternodes are synced
+        sync_masternodes(self.nodes)
         # feed the sender with some balance
         sender_addr = self.nodes[self.sender_idx].getnewaddress()
         self.nodes[0].sendtoaddress(sender_addr, 1)

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -304,7 +304,6 @@ class DashTestFramework(BitcoinTestFramework):
         for i in range(1, self.mn_count + 1):
             res = self.nodes[0].masternode("start-alias", "mn%d" % i)
             assert (res["result"] == 'successful')
-        sync_masternodes(self.nodes, True)
         mn_info = self.nodes[0].masternodelist("status")
         assert (len(mn_info) == self.mn_count)
         for status in mn_info.values():

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -227,7 +227,7 @@ class DashTestFramework(BitcoinTestFramework):
 
     def create_simple_node(self):
         idx = len(self.nodes)
-        args = ["-debug"] + self.extra_args
+        args = self.extra_args
         self.nodes.append(start_node(idx, self.options.tmpdir,
                                      args))
         for i in range(0, idx):
@@ -264,7 +264,7 @@ class DashTestFramework(BitcoinTestFramework):
 
     def create_masternodes(self):
         for idx in range(0, self.mn_count):
-            args = ['-debug=masternode', '-externalip=127.0.0.1', '-masternode=1',
+            args = ['-externalip=127.0.0.1', '-masternode=1',
                     '-masternodeprivkey=%s' % self.mninfo[idx].key,
                     '-masternodeblsprivkey=%s' % self.mninfo[idx].blsKey] + self.extra_args
             self.nodes.append(start_node(idx + 1, self.options.tmpdir, args))
@@ -274,7 +274,7 @@ class DashTestFramework(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         # create faucet node for collateral and transactions
-        args = ["-debug"] + self.extra_args
+        args = self.extra_args
         self.nodes.append(start_node(0, self.options.tmpdir, args))
         required_balance = MASTERNODE_COLLATERAL * self.mn_count + 1
         while self.nodes[0].getbalance() < required_balance:
@@ -285,8 +285,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.prepare_masternodes()
         self.write_mn_config()
         stop_node(self.nodes[0], 0)
-        args = ["-debug",
-                "-sporkkey=cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"] + \
+        args = ["-sporkkey=cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"] + \
                self.extra_args
         self.nodes[0] = start_node(0, self.options.tmpdir,
                                    args)


### PR DESCRIPTION
3b84af6 There is a weird issue with `sendtoaddress` vs mempool `usage`: after sending ~200 txes the `usage` on the sending node doesn't match the `usage` on other nodes even though `size` and `bytes` match. Switching the test from using a controller node to using separate sender/receiver nodes instead to send test txes "fixes" it. We should probably investigate the mempool issue itself later (there is probably a bug or maybe I'm missing smth in the way mempool works but I don't see why this happens).

06b01de Dropping `debug` helps to speed things up significantly and helps to avoid mempool sync timeout.

ca2d692 And finally, some cleanup. `setup_network` should already take care of mn sync, calling `sync_masternodes` later in the process does nothing actually. But I think it won't hurt to run it once right at the start of the test to make sure MNs are actually in the `synced` state as expected.