### PR TITLE
Unify help display logic for various "complex" rpc commands

### DIFF
--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -975,15 +975,9 @@ UniValue gobject(const JSONRPCRequest& request)
     if (request.params.size() >= 1)
         strCommand = request.params[0].get_str();
 
-    if ((request.fHelp && strCommand.empty())  ||
-        (
-#ifdef ENABLE_WALLET
-         strCommand != "prepare" &&
-#endif // ENABLE_WALLET
-         strCommand != "vote-many" && strCommand != "vote-conf" && strCommand != "vote-alias" && strCommand != "submit" && strCommand != "count" &&
-         strCommand != "deserialize" && strCommand != "get" && strCommand != "getvotes" && strCommand != "getcurrentvotes" && strCommand != "list" && strCommand != "diff" &&
-         strCommand != "check" ))
-            gobject_help();
+    if (request.fHelp || strCommand.empty()) {
+        gobject_help();
+    }
 
     if (strCommand == "count") {
         return gobject_count(request);
@@ -1026,9 +1020,10 @@ UniValue gobject(const JSONRPCRequest& request)
     } else if (strCommand == "getcurrentvotes") {
         // GETVOTES FOR SPECIFIC GOVERNANCE OBJECT
         return gobject_getcurrentvotes(request);
+    } else {
+        gobject_help();
+        return UniValue::VNULL; // avoid compiler warnings
     }
-
-    throw std::runtime_error("invalid command: " + strCommand);
 }
 
 UniValue voteraw(const JSONRPCRequest& request)

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -945,7 +945,7 @@ UniValue gobject_getcurrentvotes(const JSONRPCRequest& request)
     return bResult;
 }
 
-void gobject_help()
+[[ noreturn ]] void gobject_help()
 {
     throw std::runtime_error(
             "gobject \"command\"...\n"
@@ -1022,7 +1022,6 @@ UniValue gobject(const JSONRPCRequest& request)
         return gobject_getcurrentvotes(request);
     } else {
         gobject_help();
-        return UniValue::VNULL; // avoid compiler warnings
     }
 }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -757,7 +757,7 @@ UniValue masternode_check(const JSONRPCRequest& request)
     return obj;
 }
 
-void masternode_help()
+[[ noreturn ]] void masternode_help()
 {
     throw std::runtime_error(
         "masternode \"command\"...\n"
@@ -834,7 +834,6 @@ UniValue masternode(const JSONRPCRequest& request)
         return masternode_check(request);
     } else {
         masternode_help();
-        return UniValue::VNULL; // avoid compiler warnings
     }
 }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -794,7 +794,7 @@ UniValue masternode(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "DEPRECATED, please use start-all instead");
 #endif // ENABLE_WALLET
 
-    if (request.fHelp && strCommand.empty()) {
+    if (request.fHelp || strCommand.empty()) {
         masternode_help();
     }
 

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -819,7 +819,7 @@ UniValue protx_diff(const JSONRPCRequest& request)
     return ret;
 }
 
-void protx_help()
+[[ noreturn ]] void protx_help()
 {
     throw std::runtime_error(
             "protx \"command\" ...\n"
@@ -867,7 +867,6 @@ UniValue protx(const JSONRPCRequest& request)
         return protx_diff(request);
     } else {
         protx_help();
-        return UniValue::VNULL; // avoid compiler warnings
     }
 }
 #endif//ENABLE_WALLET
@@ -902,7 +901,7 @@ UniValue bls_generate(const JSONRPCRequest& request)
     return ret;
 }
 
-void bls_help()
+[[ noreturn ]] void bls_help()
 {
     throw std::runtime_error(
             "bls \"command\" ...\n"
@@ -927,7 +926,6 @@ UniValue _bls(const JSONRPCRequest& request)
         return bls_generate(request);
     } else {
         bls_help();
-        return UniValue::VNULL; // avoid compiler warnings
     }
 }
 

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -819,28 +819,32 @@ UniValue protx_diff(const JSONRPCRequest& request)
     return ret;
 }
 
+void protx_help()
+{
+    throw std::runtime_error(
+            "protx \"command\" ...\n"
+            "Set of commands to execute ProTx related actions.\n"
+            "To get help on individual commands, use \"help protx command\".\n"
+            "\nArguments:\n"
+            "1. \"command\"        (string, required) The command to execute\n"
+            "\nAvailable commands:\n"
+            "  register          - Create and send ProTx to network\n"
+            "  register_fund     - Fund, create and send ProTx to network\n"
+            "  register_prepare  - Create an unsigned ProTx\n"
+            "  register_submit   - Sign and submit a ProTx\n"
+            "  list              - List ProTxs\n"
+            "  info              - Return information about a ProTx\n"
+            "  update_service    - Create and send ProUpServTx to network\n"
+            "  update_registrar  - Create and send ProUpRegTx to network\n"
+            "  revoke            - Create and send ProUpRevTx to network\n"
+            "  diff              - Calculate a diff and a proof between two masternode lists\n"
+    );
+}
 
 UniValue protx(const JSONRPCRequest& request)
 {
-    if (request.params.empty()) {
-        throw std::runtime_error(
-                "protx \"command\" ...\n"
-                "Set of commands to execute ProTx related actions.\n"
-                "To get help on individual commands, use \"help protx command\".\n"
-                "\nArguments:\n"
-                "1. \"command\"        (string, required) The command to execute\n"
-                "\nAvailable commands:\n"
-                "  register          - Create and send ProTx to network\n"
-                "  register_fund     - Fund, create and send ProTx to network\n"
-                "  register_prepare  - Create an unsigned ProTx\n"
-                "  register_submit   - Sign and submit a ProTx\n"
-                "  list              - List ProTxs\n"
-                "  info              - Return information about a ProTx\n"
-                "  update_service    - Create and send ProUpServTx to network\n"
-                "  update_registrar  - Create and send ProUpRegTx to network\n"
-                "  revoke            - Create and send ProUpRevTx to network\n"
-                "  diff              - Calculate a diff and a proof between two masternode lists\n"
-        );
+    if (request.fHelp || request.params.empty()) {
+        protx_help();
     }
 
     std::string command = request.params[0].get_str();
@@ -862,7 +866,8 @@ UniValue protx(const JSONRPCRequest& request)
     } else if (command == "diff") {
         return protx_diff(request);
     } else {
-        throw std::runtime_error("invalid command: " + command);
+        protx_help();
+        return UniValue::VNULL; // avoid compiler warnings
     }
 }
 #endif//ENABLE_WALLET
@@ -912,7 +917,7 @@ void bls_help()
 
 UniValue _bls(const JSONRPCRequest& request)
 {
-    if (request.params.empty()) {
+    if (request.fHelp || request.params.empty()) {
         bls_help();
     }
 
@@ -922,6 +927,7 @@ UniValue _bls(const JSONRPCRequest& request)
         return bls_generate(request);
     } else {
         bls_help();
+        return UniValue::VNULL; // avoid compiler warnings
     }
 }
 


### PR DESCRIPTION
There is a bit of inconsistency in the behaviour of various rpcs with subcommands, this should fix it.