### PR TITLE
use hd wallets by default

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -75,7 +75,7 @@ static const bool DEFAULT_DISABLE_WALLET = false;
 extern const char * DEFAULT_WALLET_DAT;
 
 //! if set, all keys will be derived by using BIP39/BIP44
-static const bool DEFAULT_USE_HD_WALLET = false;
+static const bool DEFAULT_USE_HD_WALLET = true;
 
 bool AutoBackupWallet (CWallet* wallet, const std::string& strWalletFile_, std::string& strBackupWarningRet, std::string& strBackupErrorRet);
 


### PR DESCRIPTION
I've seen no downsides, this will only change anything on new wallets, upgrading clients will see no changes