### PR TITLE
Fix ps collateral/denom creation tx category confusion

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -155,12 +155,12 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     sub.type = TransactionRecord::PrivateSendCollateralPayment;
                 } else {
                     for (const auto& txout : wtx.tx->vout) {
-                        if(txout.nValue == CPrivateSend::GetMaxCollateralAmount()) {
+                        if (txout.nValue == CPrivateSend::GetMaxCollateralAmount()) {
                             sub.type = TransactionRecord::PrivateSendMakeCollaterals;
-                        }
-                        if(CPrivateSend::IsDenominatedAmount(txout.nValue)) {
+                            continue; // Keep looking, could be a part of PrivateSendCreateDenominations
+                        } else if (CPrivateSend::IsDenominatedAmount(txout.nValue)) {
                             sub.type = TransactionRecord::PrivateSendCreateDenominations;
-                            break;
+                            break; // Done, it's definitely a tx creating mixing denoms, no need to look any further
                         }
                     }
                 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -157,7 +157,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     for (const auto& txout : wtx.tx->vout) {
                         if(txout.nValue == CPrivateSend::GetMaxCollateralAmount()) {
                             sub.type = TransactionRecord::PrivateSendMakeCollaterals;
-                            break;
                         }
                         if(CPrivateSend::IsDenominatedAmount(txout.nValue)) {
                             sub.type = TransactionRecord::PrivateSendCreateDenominations;


### PR DESCRIPTION
Transactions that create mixing denoms also create mixing collateral as an additional output sometimes. Such txes are mistakenly displayed as "Make Collaterals" in GUI atm which is a bit confusing.