### PR TITLE
Display scripts in evo rpc output in a more generic way

### DIFF
--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -407,12 +407,9 @@ void CProRegTx::ToJson(UniValue& obj) const
     obj.push_back(Pair("keyIDOwner", keyIDOwner.ToString()));
     obj.push_back(Pair("pubKeyOperator", pubKeyOperator.ToString()));
     obj.push_back(Pair("keyIDVoting", keyIDVoting.ToString()));
-
-    CTxDestination dest;
-    if (ExtractDestination(scriptPayout, dest)) {
-        CBitcoinAddress bitcoinAddress(dest);
-        obj.push_back(Pair("payoutAddress", bitcoinAddress.ToString()));
-    }
+    UniValue o(UniValue::VOBJ);
+    ScriptPubKeyToUniv(scriptPayout, o, true);
+    obj.push_back(Pair("scriptPayout", o));
     obj.push_back(Pair("operatorReward", (double)nOperatorReward / 100));
 
     obj.push_back(Pair("inputsHash", inputsHash.ToString()));
@@ -437,11 +434,9 @@ void CProUpServTx::ToJson(UniValue& obj) const
     obj.push_back(Pair("version", nVersion));
     obj.push_back(Pair("proTxHash", proTxHash.ToString()));
     obj.push_back(Pair("service", addr.ToString(false)));
-    CTxDestination dest;
-    if (ExtractDestination(scriptOperatorPayout, dest)) {
-        CBitcoinAddress bitcoinAddress(dest);
-        obj.push_back(Pair("operatorPayoutAddress", bitcoinAddress.ToString()));
-    }
+    UniValue o(UniValue::VOBJ);
+    ScriptPubKeyToUniv(scriptOperatorPayout, o, true);
+    obj.push_back(Pair("scriptOperatorPayout", o));
     obj.push_back(Pair("inputsHash", inputsHash.ToString()));
 }
 
@@ -465,11 +460,9 @@ void CProUpRegTx::ToJson(UniValue& obj) const
     obj.push_back(Pair("proTxHash", proTxHash.ToString()));
     obj.push_back(Pair("pubKeyOperator", pubKeyOperator.ToString()));
     obj.push_back(Pair("keyIDVoting", keyIDVoting.ToString()));
-    CTxDestination dest;
-    if (ExtractDestination(scriptPayout, dest)) {
-        CBitcoinAddress bitcoinAddress(dest);
-        obj.push_back(Pair("payoutAddress", bitcoinAddress.ToString()));
-    }
+    UniValue o(UniValue::VOBJ);
+    ScriptPubKeyToUniv(scriptPayout, o, true);
+    obj.push_back(Pair("scriptPayout", o));
     obj.push_back(Pair("inputsHash", inputsHash.ToString()));
 }
 


### PR DESCRIPTION
Basically, display the actual data and do it in a way we already do for raw txes etc. e.g.
```
      "scriptPayout": {
        "asm": "0288325491ab8b60b7a3d4719f48a0d106d4c3f5b06924002f06167eca0f2e9065 OP_CHECKSIG",
        "hex": "210288325491ab8b60b7a3d4719f48a0d106d4c3f5b06924002f06167eca0f2e9065ac",
        "reqSigs": 1,
        "type": "pubkey",
        "addresses": [
          "yU5Wq6uxUKJmcZc8ABgXhBZCEmp4sZMRpL"
        ]
      }
```

This should also help with displaying data later when we decide to allow non-p2pkh scripts in protx-es.