### PR TITLE
Use proTxHash instead of outpoint when calculating masternode scores

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -210,6 +210,54 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int
     return result;
 }
 
+std::vector<CDeterministicMNCPtr> CDeterministicMNList::CalculateQuorum(size_t maxSize, const uint256& modifier) const
+{
+    auto scores = CalculateScores(modifier);
+
+    // sort is descending order
+    std::sort(scores.rbegin(), scores.rend(), [](const std::pair<arith_uint256, CDeterministicMNCPtr>& a, std::pair<arith_uint256, CDeterministicMNCPtr>& b) {
+        if (a.first == b.first) {
+            // this should actually never happen, but we should stay compatible with how the non deterministic MNs did the sorting
+            return a.second->collateralOutpoint < b.second->collateralOutpoint;
+        }
+        return a.first < b.first;
+    });
+
+    // take top maxSize entries and return it
+    std::vector<CDeterministicMNCPtr> result;
+    result.resize(std::min(maxSize, scores.size()));
+    for (size_t i = 0; i < result.size(); i++) {
+        result[i] = std::move(scores[i].second);
+    }
+    return result;
+}
+
+std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CDeterministicMNList::CalculateScores(const uint256& modifier) const
+{
+    std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> scores;
+    scores.reserve(GetAllMNsCount());
+    ForEachMN(true, [&](const CDeterministicMNCPtr& dmn) {
+        if (dmn->pdmnState->confirmedHash.IsNull()) {
+            // we only take confirmed MNs into account to avoid hash grinding on the ProRegTxHash to sneak MNs into a
+            // future quorums
+            return;
+        }
+        // calculate sha256(sha256(proTxHash, confirmedHash), modifier) per MN
+        // Please note that this is not a double-sha256 but a single-sha256
+        // The first part is already precalculated (confirmedHashWithProRegTxHash)
+        // TODO When https://github.com/bitcoin/bitcoin/pull/13191 gets backported, implement something that is similar but for single-sha256
+        uint256 h;
+        CSHA256 sha256;
+        sha256.Write(dmn->pdmnState->confirmedHashWithProRegTxHash.begin(), dmn->pdmnState->confirmedHashWithProRegTxHash.size());
+        sha256.Write(modifier.begin(), modifier.size());
+        sha256.Finalize(h.begin());
+
+        scores.emplace_back(UintToArith256(h), dmn);
+    });
+
+    return scores;
+}
+
 CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNList& to) const
 {
     CDeterministicMNListDiff diffRet;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -5,6 +5,7 @@
 #ifndef DASH_DETERMINISTICMNS_H
 #define DASH_DETERMINISTICMNS_H
 
+#include "arith_uint256.h"
 #include "bls/bls.h"
 #include "dbwrapper.h"
 #include "evodb.h"
@@ -295,6 +296,15 @@ public:
      * @return
      */
     std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(int nCount) const;
+
+    /**
+     * Calculate a quorum based on the modifier. The resulting list is deterministically sorted by score
+     * @param maxSize
+     * @param modifier
+     * @return
+     */
+    std::vector<CDeterministicMNCPtr> CalculateQuorum(size_t maxSize, const uint256& modifier) const;
+    std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CalculateScores(const uint256& modifier) const;
 
     CDeterministicMNListDiff BuildDiff(const CDeterministicMNList& to) const;
     CDeterministicMNList ApplyDiff(const CDeterministicMNListDiff& diff) const;

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -31,8 +31,8 @@ uint256 CSimplifiedMNListEntry::CalcHash() const
 
 std::string CSimplifiedMNListEntry::ToString() const
 {
-    return strprintf("CSimplifiedMNListEntry(proRegTxHash=%s, service=%s, pubKeyOperator=%s, keyIDVoting=%s, isValie=%d)",
-        proRegTxHash.ToString(), service.ToString(false), pubKeyOperator.ToString(), keyIDVoting.ToString(), isValid);
+    return strprintf("CSimplifiedMNListEntry(proRegTxHash=%s, confirmedHash=%s, service=%s, pubKeyOperator=%s, keyIDVoting=%s, isValie=%d)",
+        proRegTxHash.ToString(), confirmedHash.ToString(), service.ToString(false), pubKeyOperator.ToString(), keyIDVoting.ToString(), isValid);
 }
 
 void CSimplifiedMNListEntry::ToJson(UniValue& obj) const
@@ -40,6 +40,7 @@ void CSimplifiedMNListEntry::ToJson(UniValue& obj) const
     obj.clear();
     obj.setObject();
     obj.push_back(Pair("proRegTxHash", proRegTxHash.ToString()));
+    obj.push_back(Pair("confirmedHash", confirmedHash.ToString()));
     obj.push_back(Pair("service", service.ToString(false)));
     obj.push_back(Pair("pubKeyOperator", pubKeyOperator.ToString()));
     obj.push_back(Pair("keyIDVoting", keyIDVoting.ToString()));

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -19,6 +19,7 @@ class CSimplifiedMNListEntry
 {
 public:
     uint256 proRegTxHash;
+    uint256 confirmedHash;
     CService service;
     CBLSPublicKey pubKeyOperator;
     CKeyID keyIDVoting;
@@ -35,6 +36,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(proRegTxHash);
+        READWRITE(confirmedHash);
         READWRITE(service);
         READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -111,6 +111,8 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb, CConnman& co
 //
 arith_uint256 CMasternode::CalculateScore(const uint256& blockHash) const
 {
+    // NOTE not called when deterministic masternodes (spork15) are activated
+
     // Deterministically calculate a "score" for a Masternode based on any given (block)hash
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     ss << outpoint << nCollateralMinConfBlockHash << blockHash;

--- a/src/test/evo_simplifiedmns_tests.cpp
+++ b/src/test/evo_simplifiedmns_tests.cpp
@@ -18,6 +18,7 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
     for (size_t i = 0; i < 15; i++) {
         CSimplifiedMNListEntry smle;
         smle.proRegTxHash.SetHex(strprintf("%064x", i));
+        smle.confirmedHash.SetHex(strprintf("%064x", i));
 
         std::string ip = strprintf("%d.%d.%d.%d", 0, 0, 0, i);
         Lookup(ip.c_str(), smle.service, i, false);
@@ -36,21 +37,21 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
     }
 
     std::vector<std::string> expectedHashes = {
-        "1465924a81df1d0fb46d2571e65296c0fddab30d1b4d104f182f80a6e45362fa",
-        "cb466084403067b699a50bd46e53145ebfd57af9a076a13432f524e41ec2d899",
-        "0f6a720d0119f5b83469d884ec2a7d739c1d653142e5d36b569cddaf735a6149",
-        "8794379559c77d67902a5e894739bd574f25ff6cd48612f7156c5fafaefefd4e",
-        "4738d4f17c76b4e61f028d9426f40242eb56977fe805704d980ff57ad3f60b90",
-        "6342b7ce87a299a0fb070ec040a45613f082b0c99395698a6f712e85be87ad06",
-        "0be7143f4fb357333350a7e28606713933e9819c83c71009b9ea97476d86b78e",
-        "d13dfedc920490a8c6d9b555d740f2944ac83eeb8c3923a51261371a8118ffe0",
-        "c0c4638fcefe09380adff61d59c064be03a18690245b89be20223df737590d46",
-        "4cce41032bb341adb9b9f3f6ba1de3c812f0d1630e3a561c7aae00f39e49c6d4",
-        "3e8c9ad9e2cf0520a96b6bc58aafb7009365a1d8f357047a40430b782142ed69",
-        "bde7a1b61a263a7e0dfe474c850c4f9d642d9a03da501a366800e03093e48cd9",
-        "e221a3e14868251083eea718e698cc81739b016665a9024d798a14c0e9417c35",
-        "b1be038e40bc8ee6a19dbbe70c92d7bc0880ccc54c4bd54eab6b7a30d0650ab1",
-        "0607e1d850e27c336e8d65722fc82eae7ab5331fd88a4fbfcff6c3a1bb6364da",
+        "373b549f6380d8f7b04d7b04d7c58a749c5cbe3bf41536785ba819879c4870f1",
+        "3a1010e28226558560e5296bcee6bf0b9b963b73a1514f5aa2885e270f6b90c1",
+        "85d3d93b28689128daf3a41d706ae5002f447b9b6372776f0ca9d53b31146884",
+        "8930eee6bd2e7971a7090edfb79f74c00a12280e59adfc2cc99d406a01e368f9",
+        "dc2e69caa0ef97e8f5cf40a9530641bd4933dd8c9ad533054537728f7e5f58c2",
+        "3e4a0e0a0d2ed397fa27221de3047de21f50d17d0ba43738cbdb9fee96c7cb46",
+        "eb18476a1496e1cb912b1d4dd93314b78c6a679d83cae8e144a717b967dc4b8c",
+        "6c0d01fa40ac11d7b523facd2bf5632c83f7e4df3f60fd1b364ea90f6c852156",
+        "c9e3e69d54e6e95b280ae102593fe114cf4620fa89dd88da1a146ada08815d68",
+        "1023f67f735e8e9403d5f083e7a17489619b1790feac4f6b133e9dda15999ae6",
+        "5d5fc77944f7c72df236a5baf460c7b9a947144d54d0953521f1494c8a2f7aaa",
+        "ac7db66820de3c7506f8c6415fd352e36ac5f27c6adbdfb74de3e109d0d277df",
+        "cbc25ca965d0fa69a1fdc1d796b8ee2726a0e2137414e92fb9541630e3189901",
+        "ac9934c4049ae952d41fb38e7e9659a558a5ce748bdb7fb613741598d1b16a27",
+        "a61177eb14450bb8c56e5f0547035e0f3a70fe46f36901351cc568b2e48e29d0",
     };
     std::vector<std::string> calculatedHashes;
 
@@ -63,7 +64,7 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
 
     CSimplifiedMNList sml(entries);
 
-    std::string expectedMerkleRoot = "a7fae13820022ddba6cf54ba9b234dfed54ccfa86c2635c5627287f1ffa5497f";
+    std::string expectedMerkleRoot = "b2303aca677ae2091c882e44b58f57869fa88a6db1f4e1a5d71975e5387fa195";
     std::string calculatedMerkleRoot = sml.CalcMerkleRoot(nullptr).ToString();
     //printf("merkleRoot=\"%s\",\n", calculatedMerkleRoot.c_str());
 


### PR DESCRIPTION
See individual commits.

Turned out that SPV clients are currently unable to calculate quorums on their own as the collateral outpoint was not part of DIP4. Instead of adding the outpoint to DIP4, we decided to use the proTxHash for these calculations.

This also required to reimplement the protection against hash grinding of collaterals (which would now be for proTxHash). This means, we track the `confirmedHash` (+15 blocks after registration on mainnet) for each MN now and take this into the score calculation. The `confirmedHash` is also added to DIP4 so that SPV clients have all data necessary to calculate quorums.