### PR TITLE
Restart MNs in DIP3 tests even if collateral has not moved

### DIFF
--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -178,7 +178,7 @@ class DIP3Test(BitcoinTestFramework):
             self.nodes[0].generate(1)
 
             if fund:
-                # collateral has moved, so we need to start it again
+                # collateral has moved, so we need to "masternode start" it again
                 mns_to_restart.append(mns[i])
             else:
                 # collateral has not moved, so it should still be in the masternode list even after upgrade
@@ -195,7 +195,7 @@ class DIP3Test(BitcoinTestFramework):
         print("restarting controller and upgraded MNs")
         self.restart_controller_node()
         self.force_finish_mnsync_list(self.nodes[0])
-        for mn in mns_to_restart:
+        for mn in mns_protx:
             print("restarting MN %s" % mn.alias)
             self.stop_node(mn.idx)
             self.start_mn(mn)


### PR DESCRIPTION
These need to be restarted even in this case as keys are cycled when
upgrade_mn_protx is called. This resulted in invalid IX votes but was not
noticed because only 2 MNs were affected (still 8 of 10 votes succesful)