### PR TITLE
Remove restriction of payeeAddress being the same as collateralAddress

### DIFF
--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -105,7 +105,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
         // should not happen as we checked script types before
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-dest");
     }
-    // don't allow reuse of collateral key for other keys (don't allow people to put the collateral key onto an online server)
+    // don't allow reuse of payout key for other keys (don't allow people to put the payee key onto an online server)
     if (payoutDest == CTxDestination(ptx.keyIDOwner) || payoutDest == CTxDestination(ptx.keyIDVoting)) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-reuse");
     }
@@ -120,6 +120,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-operator-reward");
     }
 
+    CTxDestination collateralTxDest;
     CKeyID keyForPayloadSig;
     COutPoint collateralOutpoint;
 
@@ -129,15 +130,13 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral");
         }
 
-        CTxDestination txDest;
-        if (!ExtractDestination(coin.out.scriptPubKey, txDest)) {
+        if (!ExtractDestination(coin.out.scriptPubKey, collateralTxDest)) {
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-dest");
         }
 
         // Extract key from collateral. This only works for P2PK and P2PKH collaterals and will fail for P2SH.
         // Issuer of this ProRegTx must prove ownership with this key by signing the ProRegTx
-        CBitcoinAddress txAddr(txDest);
-        if (!txAddr.GetKeyID(keyForPayloadSig)) {
+        if (!CBitcoinAddress(collateralTxDest).GetKeyID(keyForPayloadSig)) {
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-pkh");
         }
 
@@ -149,7 +148,18 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
         if (tx.vout[ptx.collateralOutpoint.n].nValue != 1000 * COIN) {
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral");
         }
+
+        if (!ExtractDestination(tx.vout[ptx.collateralOutpoint.n].scriptPubKey, collateralTxDest)) {
+            return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-dest");
+        }
+
         collateralOutpoint = COutPoint(tx.GetHash(), ptx.collateralOutpoint.n);
+    }
+
+    // don't allow reuse of collateral key for other keys (don't allow people to put the collateral key onto an online server)
+    // this check applies to internal and external collateral, but internal collaterals are not necessarely a P2PKH
+    if (collateralTxDest == CTxDestination(ptx.keyIDOwner) || collateralTxDest == CTxDestination(ptx.keyIDVoting)) {
+        return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-reuse");
     }
 
     if (pindexPrev) {
@@ -279,14 +289,24 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
             return state.DoS(100, false, REJECT_INVALID, "bad-protx-hash");
         }
 
-        // don't allow reuse of collateral key for other keys (don't allow people to put the collateral key onto an online server)
+        // don't allow reuse of payee key for other keys (don't allow people to put the payee key onto an online server)
         if (payoutDest == CTxDestination(dmn->pdmnState->keyIDOwner) || payoutDest == CTxDestination(ptx.keyIDVoting)) {
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-reuse");
         }
 
         Coin coin;
         if (!GetUTXOCoin(dmn->collateralOutpoint, coin)) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-protx-payee-collateral");
+            // this should never happen (there would be no dmn otherwise)
+            return state.DoS(100, false, REJECT_INVALID, "bad-protx-collateral");
+        }
+
+        // don't allow reuse of collateral key for other keys (don't allow people to put the collateral key onto an online server)
+        CTxDestination collateralTxDest;
+        if (!ExtractDestination(coin.out.scriptPubKey, collateralTxDest)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-protx-collateral-dest");
+        }
+        if (collateralTxDest == CTxDestination(dmn->pdmnState->keyIDOwner) || collateralTxDest == CTxDestination(ptx.keyIDVoting)) {
+            return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-reuse");
         }
 
         if (mnList.HasUniqueProperty(ptx.pubKeyOperator)) {

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -101,12 +101,6 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
         if (tx.vout[ptx.collateralOutpoint.n].nValue != 1000 * COIN) {
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral");
         }
-
-        // This is a temporary restriction that will be lifted later
-        // It is required while we are transitioning from the old MN list to the deterministic list
-        if (tx.vout[ptx.collateralOutpoint.n].scriptPubKey != ptx.scriptPayout) {
-            return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-collateral");
-        }
     }
     if (ptx.keyIDOwner.IsNull() || !ptx.pubKeyOperator.IsValid() || ptx.keyIDVoting.IsNull()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-null");
@@ -295,14 +289,9 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-reuse");
         }
 
-        // This is a temporary restriction that will be lifted later
-        // It is required while we are transitioning from the old MN list to the deterministic list
         Coin coin;
         if (!GetUTXOCoin(dmn->collateralOutpoint, coin)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-protx-payee-collateral");
-        }
-        if (coin.out.scriptPubKey != ptx.scriptPayout) {
-            return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-collateral");
         }
 
         if (mnList.HasUniqueProperty(ptx.pubKeyOperator)) {

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -105,8 +105,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
     if (ptx.keyIDOwner.IsNull() || !ptx.pubKeyOperator.IsValid() || ptx.keyIDVoting.IsNull()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-null");
     }
-    // we may support P2SH later, but restrict it for now (while in transitioning phase from old MN list to deterministic list)
-    if (!ptx.scriptPayout.IsPayToPublicKeyHash()) {
+    if (!ptx.scriptPayout.IsPayToPublicKeyHash() && !ptx.scriptPayout.IsPayToScriptHash()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee");
     }
 
@@ -266,8 +265,7 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
     if (!ptx.pubKeyOperator.IsValid() || ptx.keyIDVoting.IsNull()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-null");
     }
-    // we may support P2SH later, but restrict it for now (while in transitioning phase from old MN list to deterministic list)
-    if (!ptx.scriptPayout.IsPayToPublicKeyHash()) {
+    if (!ptx.scriptPayout.IsPayToPublicKeyHash() && !ptx.scriptPayout.IsPayToScriptHash()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee");
     }
 

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -93,15 +93,6 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-mode");
     }
 
-    // when collateralOutpoint refers to an external collateral, we check it further down
-    if (ptx.collateralOutpoint.hash.IsNull()) {
-        if (ptx.collateralOutpoint.n >= tx.vout.size()) {
-            return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-index");
-        }
-        if (tx.vout[ptx.collateralOutpoint.n].nValue != 1000 * COIN) {
-            return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral");
-        }
-    }
     if (ptx.keyIDOwner.IsNull() || !ptx.pubKeyOperator.IsValid() || ptx.keyIDVoting.IsNull()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-null");
     }
@@ -152,6 +143,12 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
 
         collateralOutpoint = ptx.collateralOutpoint;
     } else {
+        if (ptx.collateralOutpoint.n >= tx.vout.size()) {
+            return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-index");
+        }
+        if (tx.vout[ptx.collateralOutpoint.n].nValue != 1000 * COIN) {
+            return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral");
+        }
         collateralOutpoint = COutPoint(tx.GetHash(), ptx.collateralOutpoint.n);
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -56,13 +56,9 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
 
 CMasternode::CMasternode(const uint256 &proTxHash, const CDeterministicMNCPtr& dmn) :
     masternode_info_t{ MASTERNODE_ENABLED, DMN_PROTO_VERSION, GetAdjustedTime(),
-                       dmn->collateralOutpoint, dmn->pdmnState->addr, CKeyID(), dmn->pdmnState->keyIDOwner, dmn->pdmnState->pubKeyOperator, dmn->pdmnState->keyIDVoting},
+                       dmn->collateralOutpoint, dmn->pdmnState->addr, CKeyID() /* not valid with DIP3 */, dmn->pdmnState->keyIDOwner, dmn->pdmnState->pubKeyOperator, dmn->pdmnState->keyIDVoting},
     fAllowMixingTx(true)
 {
-    CTxDestination dest;
-    if (!ExtractDestination(dmn->pdmnState->scriptPayout, dest) || !boost::get<CKeyID>(&dest))
-        assert(false); // should not happen (previous verification forbids non p2pkh/p2pk
-    keyIDCollateralAddress = *boost::get<CKeyID>(&dest);
 }
 
 //

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -129,7 +129,7 @@ struct masternode_info_t
     CService addr{};
     CPubKey pubKeyCollateralAddress{}; // this will be invalid/unset when the network switches to deterministic MNs (luckely it's only important for the broadcast hash)
     CPubKey pubKeyMasternode{}; // this will be invalid/unset when the network switches to deterministic MNs (luckely it's only important for the broadcast hash)
-    CKeyID keyIDCollateralAddress{};
+    CKeyID keyIDCollateralAddress{}; // this is only used in compatibility code and won't be used when spork15 gets activated
     CKeyID keyIDOwner{};
     CKeyID legacyKeyIDOperator{};
     CBLSPublicKey blsPubKeyOperator;


### PR DESCRIPTION
This restriction came from one of my early versions of the DIP3 compatibility code. It is not required anymore.

Also, there was a bug introduced by https://github.com/dashpay/dash/pull/2366 that allowed the owner key to be equal to the collateral key. This resulted in at least 2 MNs being registered on testnet which have these invalid keys.

Instead of adding some deployment logic, we will force a reorg on testnet by invalidating the first block on mining pools that has these MNs.