### PR TITLE
Fix integration tests and add P2SH/multisig tests for DIP3 payees

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ script:
     - if [ $SECONDS -gt 1200 ]; then export DEPENDS_TIMEOUT="true"; false; fi # The "false" here ensures that the build is marked as failed even though the whole script returns 0
     - test "$DEPENDS_TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/build_src.sh
     - test "$DEPENDS_TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_unittests.sh
-    - test "$DEPENDS_TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_integrationtests.sh
+    - test "$DEPENDS_TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_integrationtests.sh -parallel=3
     - test "$DEPENDS_TIMEOUT" != "true" && if [ "$DOCKER_BUILD" = "true" ]; then BUILD_DIR=build-ci/dashcore-$BUILD_TARGET ./docker/build-docker.sh; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE

--- a/ci/test_integrationtests.sh
+++ b/ci/test_integrationtests.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+PASS_ARGS="$@"
+
 source ./ci/matrix.sh
 
 if [ "$RUN_TESTS" != "true" ]; then
@@ -15,4 +17,4 @@ export LD_LIBRARY_PATH=$BUILD_DIR/depends/$HOST/lib
 
 cd build-ci/dashcore-$BUILD_TARGET
 
-./qa/pull-tester/rpc-tests.py --coverage
+./qa/pull-tester/rpc-tests.py --coverage $PASS_ARGS

--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -681,7 +681,7 @@ class DIP3Test(BitcoinTestFramework):
         address = node.getnewaddress()
         key = node.getnewaddress()
         blsKey = node.bls('generate')
-        assert_raises_jsonrpc(None, "bad-tx-type-dip3", node.protx, 'register_fund', address, '127.0.0.1:10000', key, blsKey['public'], key, 0, address)
+        assert_raises_jsonrpc(None, "bad-tx-type", node.protx, 'register_fund', address, '127.0.0.1:10000', key, blsKey['public'], key, 0, address)
 
     def test_success_create_protx(self, node):
         address = node.getnewaddress()

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -213,7 +213,7 @@ class TestManager(object):
             )
 
         # --> error if not requested
-        if not wait_until(blocks_requested, attempts=20*num_blocks):
+        if not wait_until(blocks_requested, attempts=20*num_blocks, sleep=0.1):
             # print [ c.cb.block_request_map for c in self.connections ]
             raise AssertionError("Not all nodes requested block")
 

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1226,7 +1226,7 @@ class msg_reject(object):
             % (self.message, self.code, self.reason, self.data)
 
 # Helper function
-def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf')):
+def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), sleep=0.05):
     attempt = 0
     elapsed = 0
 
@@ -1235,8 +1235,8 @@ def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf')):
             if predicate():
                 return True
         attempt += 1
-        elapsed += 0.05
-        time.sleep(0.05)
+        elapsed += sleep
+        time.sleep(sleep)
 
     return False
 

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -553,6 +553,9 @@ UniValue protx_update_registrar(const JSONRPCRequest& request)
     tx.nVersion = 3;
     tx.nType = TRANSACTION_PROVIDER_UPDATE_REGISTRAR;
 
+    // make sure we get anough fees added
+    ptx.vchSig.resize(65);
+
     FundSpecialTx(tx, ptx);
     SignSpecialTxPayloadByHash(tx, ptx, keyOwner);
     SetTxPayload(tx, ptx);


### PR DESCRIPTION
This tries to fix Travis tests:
1. One of the last PRs slipped through a test failure
2. It might be that Travis is generally overloaded when running too many tests in parallel, so this PR reduces the parallelism from 4 to 3.

Implementing the P2SH/multisig tests also uncovered a bug in `update_registrar` which did not add enough fees to the TX. This is also fixed in this PR.