### PR TITLE
Fix "protx diff" and MNLISTDIFF P2P message to not always return all MNs

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -265,20 +265,20 @@ CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNL
     diffRet.blockHash = to.blockHash;
     diffRet.nHeight = to.nHeight;
 
-    for (const auto& p : to.mnMap) {
-        const auto fromPtr = mnMap.find(p.first);
+    to.ForEachMN(false, [&](const CDeterministicMNCPtr& toPtr) {
+        auto fromPtr = GetMN(toPtr->proTxHash);
         if (fromPtr == nullptr) {
-            diffRet.addedMNs.emplace(p.first, p.second);
-        } else if (*p.second->pdmnState != *(*fromPtr)->pdmnState) {
-            diffRet.updatedMNs.emplace(p.first, p.second->pdmnState);
+            diffRet.addedMNs.emplace(toPtr->proTxHash, toPtr);
+        } else if (*toPtr->pdmnState != *fromPtr->pdmnState) {
+            diffRet.updatedMNs.emplace(toPtr->proTxHash, fromPtr->pdmnState);
         }
-    }
-    for (const auto& p : mnMap) {
-        const auto toPtr = to.mnMap.find(p.first);
+    });
+    ForEachMN(false, [&](const CDeterministicMNCPtr& fromPtr) {
+        auto toPtr = to.GetMN(fromPtr->proTxHash);
         if (toPtr == nullptr) {
-            diffRet.removedMns.insert(p.first);
+            diffRet.removedMns.insert(fromPtr->proTxHash);
         }
-    }
+    });
 
     return diffRet;
 }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -270,7 +270,7 @@ CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNL
         if (fromPtr == nullptr) {
             diffRet.addedMNs.emplace(toPtr->proTxHash, toPtr);
         } else if (*toPtr->pdmnState != *fromPtr->pdmnState) {
-            diffRet.updatedMNs.emplace(toPtr->proTxHash, fromPtr->pdmnState);
+            diffRet.updatedMNs.emplace(toPtr->proTxHash, toPtr->pdmnState);
         }
     });
     ForEachMN(false, [&](const CDeterministicMNCPtr& fromPtr) {
@@ -290,19 +290,19 @@ CSimplifiedMNListDiff CDeterministicMNList::BuildSimplifiedDiff(const CDetermini
     diffRet.blockHash = to.blockHash;
 
     to.ForEachMN(false, [&](const CDeterministicMNCPtr& toPtr) {
-        const auto fromPtr = mnMap.find(toPtr->proTxHash);
+        auto fromPtr = GetMN(toPtr->proTxHash);
         if (fromPtr == nullptr) {
             diffRet.mnList.emplace_back(*toPtr);
         } else {
             CSimplifiedMNListEntry sme1(*toPtr);
-            CSimplifiedMNListEntry sme2(**fromPtr);
+            CSimplifiedMNListEntry sme2(*fromPtr);
             if (sme1 != sme2) {
                 diffRet.mnList.emplace_back(*toPtr);
             }
         }
     });
     ForEachMN(false, [&](const CDeterministicMNCPtr& fromPtr) {
-        const auto toPtr = to.mnMap.find(fromPtr->proTxHash);
+        auto toPtr = to.GetMN(fromPtr->proTxHash);
         if (toPtr == nullptr) {
             diffRet.deletedMNs.emplace_back(fromPtr->proTxHash);
         }

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -10,6 +10,7 @@
 #include "dbwrapper.h"
 #include "evodb.h"
 #include "providertx.h"
+#include "simplifiedmns.h"
 #include "sync.h"
 
 #include "immer/map.hpp"
@@ -307,6 +308,7 @@ public:
     std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CalculateScores(const uint256& modifier) const;
 
     CDeterministicMNListDiff BuildDiff(const CDeterministicMNList& to) const;
+    CSimplifiedMNListDiff BuildSimplifiedDiff(const CDeterministicMNList& to) const;
     CDeterministicMNList ApplyDiff(const CDeterministicMNListDiff& diff) const;
 
     void AddMN(const CDeterministicMNCPtr& dmn);

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -144,7 +144,7 @@ bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& bloc
 
     auto baseDmnList = deterministicMNManager->GetListForBlock(baseBlockHash);
     auto dmnList = deterministicMNManager->GetListForBlock(blockHash);
-    auto dmnDiff = baseDmnList.BuildDiff(dmnList);
+    mnListDiffRet = baseDmnList.BuildSimplifiedDiff(dmnList);
 
     // TODO store coinbase TX in CBlockIndex
     CBlock block;
@@ -153,8 +153,6 @@ bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& bloc
         return false;
     }
 
-    mnListDiffRet.baseBlockHash = baseBlockHash;
-    mnListDiffRet.blockHash = blockHash;
     mnListDiffRet.cbTx = block.vtx[0];
 
     std::vector<uint256> vHashes;
@@ -164,17 +162,6 @@ bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& bloc
     }
     vMatch[0] = true; // only coinbase matches
     mnListDiffRet.cbTxMerkleTree = CPartialMerkleTree(vHashes, vMatch);
-    mnListDiffRet.deletedMNs.assign(dmnDiff.removedMns.begin(), dmnDiff.removedMns.end());
-
-    for (const auto& p : dmnDiff.addedMNs) {
-        mnListDiffRet.mnList.emplace_back(*p.second);
-    }
-    for (const auto& p : dmnDiff.updatedMNs) {
-        const auto& dmn = dmnList.GetMN(p.first);
-        CDeterministicMN newDmn(*dmn);
-        newDmn.pdmnState = p.second;
-        mnListDiffRet.mnList.emplace_back(newDmn);
-    }
 
     return true;
 }

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -29,6 +29,21 @@ public:
     CSimplifiedMNListEntry() {}
     CSimplifiedMNListEntry(const CDeterministicMN& dmn);
 
+    bool operator==(const CSimplifiedMNListEntry& rhs) const
+    {
+        return proRegTxHash == rhs.proRegTxHash &&
+               confirmedHash == rhs.confirmedHash &&
+               service == rhs.service &&
+               pubKeyOperator == rhs.pubKeyOperator &&
+               keyIDVoting == rhs.keyIDVoting &&
+               isValid == rhs.isValid;
+    }
+
+    bool operator!=(const CSimplifiedMNListEntry& rhs) const
+    {
+        return !(rhs == *this);
+    }
+
 public:
     ADD_SERIALIZE_METHODS;
 


### PR DESCRIPTION
They reused the same `BuildDiff` method used to store MN list diffs on-disk. That one however takes all fields of the `CDeterministicMNState` into account, even if these are not returned by the RPC and P2P message. This also includes the `nLastPaidHeight`, which changes on a single MN per block, resulting in diffs to grow by at least one entry per block.

`BuildSimplifiedDiff` will now only take fields into account that are part of DIP4.