### PR TITLE
Allow P2SH/multisig addresses for operator rewards

### DIFF
--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -239,8 +239,7 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
                 // don't allow to set operator reward payee in case no operatorReward was set
                 return state.DoS(10, false, REJECT_INVALID, "bad-protx-operator-payee");
             }
-            // we may support P2SH later, but restrict it for now (while in transitioning phase from old MN list to deterministic list)
-            if (!ptx.scriptOperatorPayout.IsPayToPublicKeyHash()) {
+            if (!ptx.scriptOperatorPayout.IsPayToPublicKeyHash() && !ptx.scriptOperatorPayout.IsPayToScriptHash()) {
                 return state.DoS(10, false, REJECT_INVALID, "bad-protx-operator-payee");
             }
         }


### PR DESCRIPTION
There is no reason left to stick with the P2PKH limitation