### PR TITLE
Install libxkbcommon0 in gitian-linux.yml

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -29,6 +29,7 @@ packages:
 - "ca-certificates"
 - "python"
 - "python3"
+- "libxkbcommon0"
 remotes:
 - "url": "https://github.com/dashpay/dash.git"
   "dir": "dash"


### PR DESCRIPTION
This fixes an issue reported by users on Ubuntu 18.04 LTS. They got the
following error message when starting dash-qt:

xkbcommon: ERROR: failed to add default include path auto
Qt: Failed to create XKB context!
Use QT_XKB_CONFIG_ROOT environmental variable to provide an additional search path, add ':' as separator to provide several search paths and/or make sure that XKB configuration data directory contains recent enough contents, to update please see http://cgit.freedesktop.org/xkeyboard-config/ .

Dash-qt starts then, but does not accept any input from the keyboard.
The reason is that qt tries to find the xkb config root in the configure
phase, but fails to find it. To make this detection work, libxkbcommon
has to be installed on the host system, even though it is then never used.