### PR TITLE
Base dsq/dstx thresholold on the total number of up to date masternodes

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -94,7 +94,7 @@ void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& 
                 }
             }
 
-            int nThreshold = infoMn.nLastDsq + mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION) / 5;
+            int nThreshold = infoMn.nLastDsq + mnodeman.CountMasternodes() / 5;
             LogPrint("privatesend", "DSQUEUE -- nLastDsq: %d  threshold: %d  nDsqCount: %d\n", infoMn.nLastDsq, nThreshold, mnodeman.nDsqCount);
             //don't allow a few nodes to dominate the queuing process
             if (infoMn.nLastDsq != 0 && nThreshold > mnodeman.nDsqCount) {

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -114,7 +114,7 @@ void CPrivateSendServer::ProcessMessage(CNode* pfrom, const std::string& strComm
                 }
             }
 
-            int nThreshold = mnInfo.nLastDsq + mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION) / 5;
+            int nThreshold = mnInfo.nLastDsq + mnodeman.CountMasternodes() / 5;
             LogPrint("privatesend", "DSQUEUE -- nLastDsq: %d  threshold: %d  nDsqCount: %d\n", mnInfo.nLastDsq, nThreshold, mnodeman.nDsqCount);
             //don't allow a few nodes to dominate the queuing process
             if (mnInfo.nLastDsq != 0 && nThreshold > mnodeman.nDsqCount) {


### PR DESCRIPTION
Mixing on a newer version with small number of upgraded masternodes causes mixing txes to "stuck" - old nodes refuse to relay dstxes from new ones because they come from the same masternodes too often. Basing threshold on the total number of up to date masternodes and not only on a newer (enabled) ones should solve this. This however will cause mixing to fail if there are not enough masternodes on the needed protocol version (i.e. at least `GetMinMasternodePaymentsProto()`) but it's better to stop mixing than having funds kind of spent yet not confirmed for a long time.