### PR TITLE
Detour Dark Mode on macOS Mojave

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -30,7 +30,7 @@
 
   <key>CFBundleExecutable</key>
   <string>Dash-Qt</string>
-  
+
   <key>CFBundleName</key>
   <string>Dash-Qt</string>
 
@@ -99,7 +99,10 @@
 
   <key>LSAppNapIsDisabled</key>
     <string>True</string>
-  
+
+  <key>NSRequiresAquaSystemAppearance</key>
+    <string>True</string>
+
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>
 </dict>


### PR DESCRIPTION
While theres no `dark mode` support on Qt yet, there is no way to build useable Dash-Qt on current macOS without legacy appearance (no troubles for gitian builds since they using old sdk).