### PR TITLE
Forbid version=0 in special TXs

### DIFF
--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -766,7 +766,7 @@ class DIP3Test(BitcoinTestFramework):
 
         # We can't really use this one as it would result in invalid merkle roots for masternode lists
         if len(bt['coinbase_payload']) != 0:
-            cbtx = FromHex(CCbTx(), bt['coinbase_payload'])
+            cbtx = FromHex(CCbTx(version=1), bt['coinbase_payload'])
             if use_mnmerkleroot_from_tip:
                 if 'cbTx' in tip_block:
                     cbtx.merkleRootMNList = int(tip_block['cbTx']['merkleRootMNList'], 16)

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -25,7 +25,7 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidatio
         return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-payload");
     }
 
-    if (cbTx.nVersion > CCbTx::CURRENT_VERSION) {
+    if (cbTx.nVersion == 0 || cbTx.nVersion > CCbTx::CURRENT_VERSION) {
         return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-version");
     }
 

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -85,7 +85,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-payload");
     }
 
-    if (ptx.nVersion > CProRegTx::CURRENT_VERSION) {
+    if (ptx.nVersion == 0 || ptx.nVersion > CProRegTx::CURRENT_VERSION) {
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-version");
     }
     if (ptx.nType != 0) {
@@ -214,7 +214,7 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-payload");
     }
 
-    if (ptx.nVersion > CProRegTx::CURRENT_VERSION) {
+    if (ptx.nVersion == 0 || ptx.nVersion > CProRegTx::CURRENT_VERSION) {
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-version");
     }
 
@@ -267,7 +267,7 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-payload");
     }
 
-    if (ptx.nVersion > CProRegTx::CURRENT_VERSION) {
+    if (ptx.nVersion == 0 || ptx.nVersion > CProRegTx::CURRENT_VERSION) {
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-version");
     }
     if (ptx.nMode != 0) {
@@ -349,7 +349,7 @@ bool CheckProUpRevTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-payload");
     }
 
-    if (ptx.nVersion > CProRegTx::CURRENT_VERSION) {
+    if (ptx.nVersion == 0 || ptx.nVersion > CProRegTx::CURRENT_VERSION) {
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-version");
     }
 


### PR DESCRIPTION
`nVersion` should not be allowed to be 0 for special TX payloads.