### PR TITLE
Implement and enforce DIP6 commitments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,8 @@ file(GLOB SOURCE_FILES
         src/*.h
         src/evo/*.h
         src/evo/*.cpp
+        src/llmq/*.h
+        src/llmq/*.cpp
         src/rpc/*.cpp
         src/rpc/*.h
         )

--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -780,6 +780,13 @@ class DIP3Test(BitcoinTestFramework):
 
         block = create_block(int(tip_hash, 16), coinbase)
         block.vtx += vtx
+
+        # Add quorum commitments from template
+        for tx in bt['transactions']:
+            tx2 = FromHex(CTransaction(), tx['data'])
+            if tx2.nType == 6:
+                block.vtx.append(tx2)
+
         block.hashMerkleRoot = block.calc_merkle_root()
         block.solve()
         result = node.submitblock(ToHex(block))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,6 +139,8 @@ BITCOIN_CORE_H = \
   keystore.h \
   dbwrapper.h \
   limitedmap.h \
+  llmq/quorums_commitment.h \
+  llmq/quorums_utils.h \
   masternode.h \
   masternode-payments.h \
   masternode-sync.h \
@@ -243,6 +245,8 @@ libdash_server_a_SOURCES = \
   governance-validators.cpp \
   governance-vote.cpp \
   governance-votedb.cpp \
+  llmq/quorums_commitment.cpp \
+  llmq/quorums_utils.cpp \
   masternode.cpp \
   masternode-payments.cpp \
   masternode-sync.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -140,7 +140,9 @@ BITCOIN_CORE_H = \
   dbwrapper.h \
   limitedmap.h \
   llmq/quorums_commitment.h \
+  llmq/quorums_blockprocessor.h \
   llmq/quorums_utils.h \
+  llmq/quorums_init.h \
   masternode.h \
   masternode-payments.h \
   masternode-sync.h \
@@ -246,7 +248,9 @@ libdash_server_a_SOURCES = \
   governance-vote.cpp \
   governance-votedb.cpp \
   llmq/quorums_commitment.cpp \
+  llmq/quorums_blockprocessor.cpp \
   llmq/quorums_utils.cpp \
+  llmq/quorums_init.cpp \
   masternode.cpp \
   masternode-payments.cpp \
   masternode-sync.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -106,6 +106,61 @@ static CBlock FindDevNetGenesisBlock(const Consensus::Params& params, const CBlo
     assert(false);
 }
 
+// this one is for testing only
+static Consensus::LLMQParams llmq10_60 = {
+        .type = Consensus::LLMQ_10_60,
+        .name = "llmq_10",
+        .size = 10,
+        .minSize = 6,
+        .threshold = 6,
+
+        .dkgInterval = 24, // one DKG per hour
+        .dkgPhaseBlocks = 2,
+        .dkgMiningWindowStart = 10, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 18,
+};
+
+static Consensus::LLMQParams llmq50_60 = {
+        .type = Consensus::LLMQ_50_60,
+        .name = "llmq_50_60",
+        .size = 50,
+        .minSize = 40,
+        .threshold = 30,
+
+        .dkgInterval = 24, // one DKG per hour
+        .dkgPhaseBlocks = 2,
+        .dkgMiningWindowStart = 10, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 18,
+};
+
+static Consensus::LLMQParams llmq400_60 = {
+        .type = Consensus::LLMQ_400_60,
+        .name = "llmq_400_51",
+        .size = 400,
+        .minSize = 300,
+        .threshold = 240,
+
+        .dkgInterval = 24 * 12, // one DKG every 12 hours
+        .dkgPhaseBlocks = 4,
+        .dkgMiningWindowStart = 20, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 28,
+};
+
+// Used for deployment and min-proto-version signalling, so it needs a higher threshold
+static Consensus::LLMQParams llmq400_85 = {
+        .type = Consensus::LLMQ_400_85,
+        .name = "llmq_400_85",
+        .size = 400,
+        .minSize = 350,
+        .threshold = 340,
+
+        .dkgInterval = 24 * 24, // one DKG every 24 hours
+        .dkgPhaseBlocks = 4,
+        .dkgMiningWindowStart = 20, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 48, // give it a larger mining window to make sure it is mined
+};
+
+
 /**
  * Main network
  */
@@ -218,6 +273,11 @@ public:
         nExtCoinType = 5;
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
+
+        // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
+        consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
+        consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
 
         fMiningRequiresPeers = true;
         fDefaultConsistencyChecks = false;
@@ -378,6 +438,11 @@ public:
         // Testnet Dash BIP44 coin type is '1' (All coin's testnet default)
         nExtCoinType = 1;
 
+        // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
+        consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
+        consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
+
         // This is temporary until we reset testnet for retesting of the full DIP3 deployment
         consensus.nTemporaryTestnetForkDIP3Height = 264000;
         consensus.nTemporaryTestnetForkHeight = 273000;
@@ -523,6 +588,11 @@ public:
 
         // Testnet Dash BIP44 coin type is '1' (All coin's testnet default)
         nExtCoinType = 1;
+
+        // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
+        consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
+        consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
 
         fMiningRequiresPeers = true;
         fDefaultConsistencyChecks = false;
@@ -675,7 +745,11 @@ public:
 
         // Regtest Dash BIP44 coin type is '1' (All coin's testnet default)
         nExtCoinType = 1;
-   }
+
+        // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_10_60] = llmq10_60;
+        consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
+    }
 
     void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
     {

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -51,17 +51,51 @@ enum LLMQType : uint8_t
     LLMQ_10_60 = 100, // 10 members, 6 (60%) threshold, one per hour
 };
 
+// Configures a LLMQ and its DKG
+// See https://github.com/dashpay/dips/blob/master/dip-0006.md for more details
 struct LLMQParams {
     LLMQType type;
+
+    // not consensus critical, only used in logging, RPC and UI
     std::string name;
 
+    // the size of the quorum, e.g. 50 or 400
     int size;
+
+    // The minimum number of valid members after the DKK. If less members are determined valid, no commitment can be
+    // created. Should be higher then the threshold to allow some room for failing nodes, otherwise quorum might end up
+    // not being able to ever created a recovered signature if more nodes fail after the DKG
     int minSize;
+
+    // The threshold required to recover a final signature. Should be at least 50%+1 of the quorum size. This value
+    // also controls the size of the public key verification vector and has a large influence on the performance of
+    // recovery. It also influences the amount of minimum messages that need to be exchanged for a single signing session.
+    // This value has the most influence on the security of the quorum. The number of total malicious masternodes
+    // required to negatively influence signing sessions highly correlates to the threshold percentage.
     int threshold;
 
+    // The interval in number blocks for DKGs and the creation of LLMQs. If set to 24 for example, a DKG will start
+    // every 24 blocks, which is approximately once every hour.
     int dkgInterval;
+
+    // The number of blocks per phase in a DKG session. There are 6 phases plus the mining phase that need to be processed
+    // per DKG. Set this value to a number of blocks so that each phase has enough time to propagate all required
+    // messages to all members before the next phase starts. If blocks are produced too fast, whole DKG sessions will
+    // fail.
     int dkgPhaseBlocks;
+
+    // The starting block inside the DKG interval for when mining of commitments starts. The value is inclusive.
+    // Starting from this block, the inclusion of (possibly null) commitments is enforced until the first non-null
+    // commitment is mined. The chosen value should be at least 5 * dkgPhaseBlocks so that it starts right after the
+    // finalization phase.
     int dkgMiningWindowStart;
+
+    // The ending block inside the DKG interval for when mining of commitments ends. The value is inclusive.
+    // Choose a value so that miners have enough time to receive the commitment and mine it. Also take into consideration
+    // that miners might omit real commitments and revert to always including null commitments. The mining window should
+    // be large enough so that other miners have a chance to produce a block containing a non-null commitment. The window
+    // should at the same time not be too large so that not too much space is wasted with null commitments in case a DKG
+    // session failed.
     int dkgMiningWindowEnd;
 };
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -39,6 +39,32 @@ struct BIP9Deployment {
     int64_t nThreshold;
 };
 
+enum LLMQType : uint8_t
+{
+    LLMQ_NONE = 0xff,
+
+    LLMQ_50_60 = 1, // 50 members, 30 (60%) threshold, one per hour
+    LLMQ_400_60 = 2, // 400 members, 240 (60%) threshold, one every 12 hours
+    LLMQ_400_85 = 3, // 400 members, 340 (85%) threshold, one every 24 hours
+
+    // for testing only
+    LLMQ_10_60 = 100, // 10 members, 6 (60%) threshold, one per hour
+};
+
+struct LLMQParams {
+    LLMQType type;
+    std::string name;
+
+    int size;
+    int minSize;
+    int threshold;
+
+    int dkgInterval;
+    int dkgPhaseBlocks;
+    int dkgMiningWindowStart;
+    int dkgMiningWindowEnd;
+};
+
 /**
  * Parameters that influence chain consensus.
  */
@@ -96,6 +122,8 @@ struct Params {
     int nHighSubsidyBlocks{0};
     int nHighSubsidyFactor{1};
 
+    std::map<LLMQType, LLMQParams> llmqs;
+	
     // This is temporary until we reset testnet for retesting of the full DIP3 deployment
     int nTemporaryTestnetForkDIP3Height{0};
     uint256 nTemporaryTestnetForkDIP3BlockHash;

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -15,6 +15,7 @@
 #include "specialtx.h"
 
 #include "llmq/quorums_commitment.h"
+#include "llmq/quorums_blockprocessor.h"
 
 bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
 {
@@ -105,6 +106,10 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CV
         return false;
     }
 
+    if (!llmq::quorumBlockProcessor->ProcessBlock(block, pindex->pprev, state)) {
+        return false;
+    }
+
     return true;
 }
 
@@ -115,6 +120,10 @@ bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex)
         if (!UndoSpecialTx(tx, pindex)) {
             return false;
         }
+    }
+
+    if (!llmq::quorumBlockProcessor->UndoBlock(block, pindex)) {
+        return false;
     }
 
     if (!deterministicMNManager->UndoBlock(block, pindex)) {

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -14,6 +14,8 @@
 #include "deterministicmns.h"
 #include "specialtx.h"
 
+#include "llmq/quorums_commitment.h"
+
 bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
 {
     if (tx.nVersion != 3 || tx.nType == TRANSACTION_NORMAL)
@@ -34,6 +36,8 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVali
         return CheckProUpRevTx(tx, pindexPrev, state);
     case TRANSACTION_COINBASE:
         return CheckCbTx(tx, pindexPrev, state);
+    case TRANSACTION_QUORUM_COMMITMENT:
+        return true; // can't really check much here. checks are done in ProcessBlock
     }
 
     return state.DoS(10, false, REJECT_INVALID, "bad-tx-type-check");
@@ -53,6 +57,8 @@ bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, CValida
         return true; // handled in batches per block
     case TRANSACTION_COINBASE:
         return true; // nothing to do
+    case TRANSACTION_QUORUM_COMMITMENT:
+        return true; // handled per block
     }
 
     return state.DoS(100, false, REJECT_INVALID, "bad-tx-type-proc");
@@ -72,6 +78,8 @@ bool UndoSpecialTx(const CTransaction& tx, const CBlockIndex* pindex)
         return true; // handled in batches per block
     case TRANSACTION_COINBASE:
         return true; // nothing to do
+    case TRANSACTION_QUORUM_COMMITMENT:
+        return true; // handled per block
     }
 
     return false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -68,6 +68,8 @@
 
 #include "evo/deterministicmns.h"
 
+#include "llmq/quorums_init.h"
+
 #include <stdint.h>
 #include <stdio.h>
 #include <memory>
@@ -303,6 +305,7 @@ void PrepareShutdown()
         pcoinsdbview = NULL;
         delete pblocktree;
         pblocktree = NULL;
+        llmq::DestroyLLMQSystem();
         delete deterministicMNManager;
         deterministicMNManager = NULL;
         delete evoDb;
@@ -1713,6 +1716,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pcoinsdbview;
                 delete pcoinscatcher;
                 delete pblocktree;
+                llmq::DestroyLLMQSystem();
                 delete deterministicMNManager;
                 delete evoDb;
 
@@ -1722,6 +1726,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex || fReindexChainState);
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);
+                llmq::InitLLMQSystem(*evoDb);
 
                 if (fReindex) {
                     pblocktree->WriteReindexing(true);

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -1,0 +1,318 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "quorums_blockprocessor.h"
+#include "quorums_commitment.h"
+#include "quorums_utils.h"
+
+#include "evo/specialtx.h"
+
+#include "chain.h"
+#include "chainparams.h"
+#include "consensus/validation.h"
+#include "primitives/block.h"
+#include "validation.h"
+
+namespace llmq
+{
+
+CQuorumBlockProcessor* quorumBlockProcessor;
+
+static const std::string DB_MINED_COMMITMENT = "q_mc";
+
+bool CQuorumBlockProcessor::ProcessBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state)
+{
+    AssertLockHeld(cs_main);
+
+    bool fDIP0003Active = VersionBitsState(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0003, versionbitscache) == THRESHOLD_ACTIVE;
+    if (!fDIP0003Active) {
+        return true;
+    }
+
+    int nHeight = pindexPrev->nHeight + 1;
+
+    std::map<Consensus::LLMQType, CFinalCommitment> qcs;
+    if (!GetCommitmentsFromBlock(block, pindexPrev, qcs, state)) {
+        return false;
+    }
+
+    for (const auto& p : Params().GetConsensus().llmqs) {
+        auto type = p.first;
+
+        uint256 quorumHash = GetQuorumBlockHash(type, pindexPrev);
+
+        if (!quorumHash.IsNull() && IsMiningPhase(type, nHeight)) {
+            if (HasMinedCommitment(type, quorumHash)) {
+                if (qcs.count(type)) {
+                    // If in the current mining phase a previous block already mined a non-null commitment and the new
+                    // block contains another (null or non-null) commitment, the block should be rejected.
+                    return state.DoS(100, false, REJECT_INVALID, "bad-qc-already-mined");
+                }
+            } else {
+                if (!qcs.count(type)) {
+                    // If no final commitment was mined for the current DKG yet and the new block does not include
+                    // a (possibly null) commitment, the block should be rejected.
+                    return state.DoS(100, false, REJECT_INVALID, "bad-qc-missing");
+                }
+            }
+        } else {
+            if (qcs.count(type)) {
+                // If the DKG is not in the mining phase and the new block contains a (null or non-null) commitment,
+                // the block should be rejected.
+                return state.DoS(100, false, REJECT_INVALID, "bad-qc-not-mining-phase");
+            }
+        }
+    }
+
+    for (auto& p : qcs) {
+        auto& qc = p.second;
+        if (!ProcessCommitment(pindexPrev, qc, state)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CQuorumBlockProcessor::ProcessCommitment(const CBlockIndex* pindexPrev, const CFinalCommitment& qc, CValidationState& state)
+{
+    auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)qc.llmqType);
+
+    uint256 quorumHash = GetQuorumBlockHash((Consensus::LLMQType)qc.llmqType, pindexPrev);
+    if (quorumHash.IsNull()) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-block");
+    }
+    if (quorumHash != qc.quorumHash) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-block");
+    }
+
+    if (qc.IsNull()) {
+        if (!qc.VerifyNull()) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid-null");
+        }
+        return true;
+    }
+
+    if (HasMinedCommitment(params.type, quorumHash)) {
+        // should not happen as it's already handled in ProcessBlock
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-dup");
+    }
+
+    if (!IsMiningPhase(params.type, pindexPrev->nHeight + 1)) {
+        // should not happen as it's already handled in ProcessBlock
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-height");
+    }
+
+    auto members = CLLMQUtils::GetAllQuorumMembers(params.type, quorumHash);
+
+    if (!qc.Verify(members)) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
+    }
+
+    // Store commitment in DB
+    evoDb.Write(std::make_pair(DB_MINED_COMMITMENT, std::make_pair((uint8_t)params.type, quorumHash)), qc);
+
+    LogPrintf("CQuorumBlockProcessor::%s -- processed commitment from block. type=%d, quorumHash=%s, signers=%s, validMembers=%d, quorumPublicKey=%s\n", __func__,
+              qc.llmqType, quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), qc.quorumPublicKey.ToString());
+
+    return true;
+}
+
+bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, const CBlockIndex* pindex)
+{
+    AssertLockHeld(cs_main);
+
+    std::map<Consensus::LLMQType, CFinalCommitment> qcs;
+    CValidationState dummy;
+    if (!GetCommitmentsFromBlock(block, pindex->pprev, qcs, dummy)) {
+        return false;
+    }
+
+    for (auto& p : qcs) {
+        auto& qc = p.second;
+        if (qc.IsNull()) {
+            continue;
+        }
+
+        evoDb.Erase(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(qc.llmqType, qc.quorumHash)));
+
+        if (!qc.IsNull()) {
+            // if a reorg happened, we should allow to mine this commitment later
+            AddMinableCommitment(qc);
+        }
+    }
+
+    return true;
+}
+
+bool CQuorumBlockProcessor::GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state)
+{
+    AssertLockHeld(cs_main);
+
+    auto& consensus = Params().GetConsensus();
+    bool fDIP0003Active = VersionBitsState(pindexPrev, consensus, Consensus::DEPLOYMENT_DIP0003, versionbitscache) == THRESHOLD_ACTIVE;
+
+    ret.clear();
+
+    for (const auto& tx : block.vtx) {
+        if (tx->nType == TRANSACTION_QUORUM_COMMITMENT) {
+            CFinalCommitment qc;
+            if (!GetTxPayload(*tx, qc)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-tx-payload");
+            }
+
+            if (!consensus.llmqs.count((Consensus::LLMQType)qc.llmqType)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-qc-type");
+            }
+
+            // only allow one commitment per type and per block
+            if (ret.count((Consensus::LLMQType)qc.llmqType)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-qc-dup");
+            }
+
+            ret.emplace((Consensus::LLMQType)qc.llmqType, std::move(qc));
+        }
+    }
+
+    if (!fDIP0003Active && !ret.empty()) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-premature");
+    }
+
+    return true;
+}
+
+bool CQuorumBlockProcessor::IsMiningPhase(Consensus::LLMQType llmqType, int nHeight)
+{
+    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    int phaseIndex = nHeight % params.dkgInterval;
+    if (phaseIndex >= params.dkgMiningWindowStart && phaseIndex <= params.dkgMiningWindowEnd) {
+        return true;
+    }
+    return false;
+}
+
+// WARNING: This method returns uint256() on the first block of the DKG interval (because the block hash is not known yet)
+uint256 CQuorumBlockProcessor::GetQuorumBlockHash(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev)
+{
+    auto& params = Params().GetConsensus().llmqs.at(llmqType);
+
+    int nHeight = pindexPrev->nHeight + 1;
+    int quorumStartHeight = nHeight - (nHeight % params.dkgInterval);
+    if (quorumStartHeight >= pindexPrev->nHeight) {
+        return uint256();
+    }
+    auto quorumIndex = pindexPrev->GetAncestor(quorumStartHeight);
+    assert(quorumIndex);
+    return quorumIndex->GetBlockHash();
+}
+
+bool CQuorumBlockProcessor::HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash)
+{
+    auto key = std::make_pair(DB_MINED_COMMITMENT, std::make_pair((uint8_t)llmqType, quorumHash));
+    return evoDb.Exists(key);
+}
+
+bool CQuorumBlockProcessor::GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, CFinalCommitment& ret)
+{
+    auto key = std::make_pair(DB_MINED_COMMITMENT, std::make_pair((uint8_t)llmqType, quorumHash));
+    return evoDb.Read(key, ret);
+}
+
+bool CQuorumBlockProcessor::HasMinableCommitment(const uint256& hash)
+{
+    LOCK(minableCommitmentsCs);
+    return minableCommitments.count(hash) != 0;
+}
+
+void CQuorumBlockProcessor::AddMinableCommitment(const CFinalCommitment& fqc)
+{
+    uint256 commitmentHash = ::SerializeHash(fqc);
+
+    {
+        LOCK(minableCommitmentsCs);
+
+        auto k = std::make_pair((Consensus::LLMQType) fqc.llmqType, fqc.quorumHash);
+        auto ins = minableCommitmentsByQuorum.emplace(k, commitmentHash);
+        if (ins.second) {
+            minableCommitments.emplace(commitmentHash, fqc);
+        } else {
+            auto& oldFqc = minableCommitments.at(ins.first->second);
+            if (fqc.CountSigners() > oldFqc.CountSigners()) {
+                // new commitment has more signers, so override the known one
+                ins.first->second = commitmentHash;
+                minableCommitments.erase(ins.first->second);
+                minableCommitments.emplace(commitmentHash, fqc);
+            }
+        }
+    }
+}
+
+bool CQuorumBlockProcessor::GetMinableCommitmentByHash(const uint256& commitmentHash, llmq::CFinalCommitment& ret)
+{
+    LOCK(minableCommitmentsCs);
+    auto it = minableCommitments.find(commitmentHash);
+    if (it == minableCommitments.end()) {
+        return false;
+    }
+    ret = it->second;
+    return true;
+}
+
+// Will return false if no commitment should be mined
+// Will return true and a null commitment if no minable commitment is known and none was mined yet
+bool CQuorumBlockProcessor::GetMinableCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev, CFinalCommitment& ret)
+{
+    AssertLockHeld(cs_main);
+
+    int nHeight = pindexPrev->nHeight + 1;
+
+    uint256 quorumHash = GetQuorumBlockHash(llmqType, pindexPrev);
+    if (quorumHash.IsNull()) {
+        return false;
+    }
+
+    if (!IsMiningPhase(llmqType, nHeight)) {
+        // no commitment required for next block
+        return false;
+    }
+
+    if (HasMinedCommitment(llmqType, quorumHash)) {
+        // a non-null commitment has already been mined for a previous block
+        return false;
+    }
+
+    LOCK(minableCommitmentsCs);
+
+    auto k = std::make_pair(llmqType, quorumHash);
+    auto it = minableCommitmentsByQuorum.find(k);
+    if (it == minableCommitmentsByQuorum.end()) {
+        // null commitment required
+        ret = CFinalCommitment(Params().GetConsensus().llmqs.at(llmqType), quorumHash);
+        return true;
+    }
+
+    ret = minableCommitments.at(it->second);
+
+    return true;
+}
+
+bool CQuorumBlockProcessor::GetMinableCommitmentTx(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev, CTransactionRef& ret)
+{
+    AssertLockHeld(cs_main);
+
+    CFinalCommitment qc;
+    if (!GetMinableCommitment(llmqType, pindexPrev, qc)) {
+        return false;
+    }
+
+    CMutableTransaction tx;
+    tx.nVersion = 3;
+    tx.nType = TRANSACTION_QUORUM_COMMITMENT;
+    SetTxPayload(tx, qc);
+
+    ret = MakeTransactionRef(tx);
+
+    return true;
+}
+
+}

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -283,12 +283,11 @@ bool CQuorumBlockProcessor::IsCommitmentRequired(Consensus::LLMQType llmqType, c
         // As we need to fork/revert the chain later to re-test all deployment stages of DIP3, we can
         // remove all this temporary code later.
         LOCK(cs_main);
-        int oldTestnetDIP3ActivationHeight = 264000;
-        int commitmentsActivationHeight = 270500;
-        uint256 oldTestnetDIP3ActivationBlock = uint256S("00000048e6e71d4bd90e7c456dcb94683ae832fcad13e1760d8283f7e89f332f");
-        if (pindexPrev->nHeight + 1 >= oldTestnetDIP3ActivationHeight &&
-            pindexPrev->nHeight + 1 < commitmentsActivationHeight &&
-            chainActive[oldTestnetDIP3ActivationHeight]->GetBlockHash() == oldTestnetDIP3ActivationBlock) {
+        const auto& consensus = Params().GetConsensus();
+        if (consensus.nTemporaryTestnetForkDIP3Height != 0 &&
+            pindexPrev->nHeight + 1 >= consensus.nTemporaryTestnetForkDIP3Height &&
+            pindexPrev->nHeight + 1 < consensus.nTemporaryTestnetForkHeight &&
+            chainActive[consensus.nTemporaryTestnetForkDIP3Height]->GetBlockHash() == consensus.nTemporaryTestnetForkDIP3BlockHash) {
             allowMissingQc = true;
         }
     }

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -191,7 +191,7 @@ bool CQuorumBlockProcessor::ProcessCommitment(const CBlockIndex* pindexPrev, con
     }
 
     if (qc.IsNull()) {
-        if (!qc.VerifyNull()) {
+        if (!qc.VerifyNull(pindexPrev->nHeight + 1)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid-null");
         }
         return true;
@@ -412,6 +412,7 @@ bool CQuorumBlockProcessor::GetMinableCommitment(Consensus::LLMQType llmqType, c
     if (it == minableCommitmentsByQuorum.end()) {
         // null commitment required
         ret = CFinalCommitment(Params().GetConsensus().llmqs.at(llmqType), quorumHash);
+        ret.quorumVvecHash = ::SerializeHash(std::make_pair(quorumHash, nHeight));
         return true;
     }
 

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -32,6 +32,8 @@ private:
 public:
     CQuorumBlockProcessor(CEvoDB& _evoDb) : evoDb(_evoDb) {}
 
+    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
+
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -48,7 +48,6 @@ private:
     bool GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state);
     bool ProcessCommitment(const CBlockIndex* pindexPrev, const CFinalCommitment& qc, CValidationState& state);
     bool IsMiningPhase(Consensus::LLMQType llmqType, int nHeight);
-    bool CheckCommitmentHeight(Consensus::LLMQType llmqType, const uint256& quorumHash, int nHeight);
     uint256 GetQuorumBlockHash(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev);
 };
 

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DASH_QUORUMS_BLOCKPROCESSOR_H
+#define DASH_QUORUMS_BLOCKPROCESSOR_H
+
+#include "llmq/quorums_commitment.h"
+
+#include "consensus/params.h"
+#include "primitives/transaction.h"
+#include "sync.h"
+
+#include <map>
+
+class CNode;
+class CConnman;
+
+namespace llmq
+{
+
+class CQuorumBlockProcessor
+{
+private:
+    CEvoDB& evoDb;
+
+    // TODO cleanup
+    CCriticalSection minableCommitmentsCs;
+    std::map<std::pair<Consensus::LLMQType, uint256>, uint256> minableCommitmentsByQuorum;
+    std::map<uint256, CFinalCommitment> minableCommitments;
+
+public:
+    CQuorumBlockProcessor(CEvoDB& _evoDb) : evoDb(_evoDb) {}
+
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state);
+    bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
+
+    void AddMinableCommitment(const CFinalCommitment& fqc);
+    bool HasMinableCommitment(const uint256& hash);
+    bool GetMinableCommitmentByHash(const uint256& commitmentHash, CFinalCommitment& ret);
+    bool GetMinableCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev, CFinalCommitment& ret);
+    bool GetMinableCommitmentTx(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev, CTransactionRef& ret);
+
+    bool HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash);
+    bool GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, CFinalCommitment& ret);
+
+private:
+    bool GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state);
+    bool ProcessCommitment(const CBlockIndex* pindexPrev, const CFinalCommitment& qc, CValidationState& state);
+    bool IsMiningPhase(Consensus::LLMQType llmqType, int nHeight);
+    bool CheckCommitmentHeight(Consensus::LLMQType llmqType, const uint256& quorumHash, int nHeight);
+    uint256 GetQuorumBlockHash(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev);
+};
+
+extern CQuorumBlockProcessor* quorumBlockProcessor;
+
+}
+
+#endif//DASH_QUORUMS_BLOCKPROCESSOR_H

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -50,6 +50,7 @@ private:
     bool GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state);
     bool ProcessCommitment(const CBlockIndex* pindexPrev, const CFinalCommitment& qc, CValidationState& state);
     bool IsMiningPhase(Consensus::LLMQType llmqType, int nHeight);
+    bool IsCommitmentRequired(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev);
     uint256 GetQuorumBlockHash(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev);
 };
 

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -99,7 +99,7 @@ bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members) 
     return true;
 }
 
-bool CFinalCommitment::VerifyNull() const
+bool CFinalCommitment::VerifyNull(int nHeight) const
 {
     if (!Params().GetConsensus().llmqs.count((Consensus::LLMQType)llmqType)) {
         LogPrintfFinalCommitment("invalid llmqType=%d\n", llmqType);
@@ -107,7 +107,16 @@ bool CFinalCommitment::VerifyNull() const
     }
     const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)llmqType);
 
-    return IsNull() && VerifySizes(params);
+    if (!IsNull() || !VerifySizes(params)) {
+        return false;
+    }
+
+    uint256 expectedQuorumVvecHash = ::SerializeHash(std::make_pair(quorumHash, nHeight));
+    if (quorumVvecHash != expectedQuorumVvecHash) {
+        return false;
+    }
+
+    return true;
 }
 
 bool CFinalCommitment::VerifySizes(const Consensus::LLMQParams& params) const

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "quorums_commitment.h"
+#include "quorums_utils.h"
+
+#include "chainparams.h"
+
+#include <univalue.h>
+
+namespace llmq
+{
+
+CFinalCommitment::CFinalCommitment(const Consensus::LLMQParams& params, const uint256& _quorumHash) :
+        llmqType(params.type),
+        quorumHash(_quorumHash),
+        signers(params.size),
+        validMembers(params.size)
+{
+}
+
+#define LogPrintfFinalCommitment(...) do { \
+    LogPrintStr(strprintf("CFinalCommitment::%s -- %s", __func__, tinyformat::format(__VA_ARGS__))); \
+} while(0)
+
+bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members) const
+{
+    if (nVersion == 0 || nVersion > CURRENT_VERSION) {
+        return false;
+    }
+
+    if (!Params().GetConsensus().llmqs.count((Consensus::LLMQType)llmqType)) {
+        LogPrintfFinalCommitment("invalid llmqType=%d\n", llmqType);
+        return false;
+    }
+    const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)llmqType);
+
+    if (!VerifySizes(params)) {
+        return false;
+    }
+
+    if (CountValidMembers() < params.minSize) {
+        LogPrintfFinalCommitment("invalid validMembers count. validMembersCount=%d\n", CountValidMembers());
+        return false;
+    }
+    if (CountSigners() < params.minSize) {
+        LogPrintfFinalCommitment("invalid signers count. signersCount=%d\n", CountSigners());
+        return false;
+    }
+    if (!quorumPublicKey.IsValid()) {
+        LogPrintfFinalCommitment("invalid quorumPublicKey\n");
+        return false;
+    }
+    if (quorumVvecHash.IsNull()) {
+        LogPrintfFinalCommitment("invalid quorumVvecHash\n");
+        return false;
+    }
+    if (!membersSig.IsValid()) {
+        LogPrintfFinalCommitment("invalid membersSig\n");
+        return false;
+    }
+    if (!quorumSig.IsValid()) {
+        LogPrintfFinalCommitment("invalid vvecSig\n");
+        return false;
+    }
+
+    for (size_t i = members.size(); i < params.size; i++) {
+        if (validMembers[i]) {
+            LogPrintfFinalCommitment("invalid validMembers bitset. bit %d should not be set\n", i);
+            return false;
+        }
+        if (signers[i]) {
+            LogPrintfFinalCommitment("invalid signers bitset. bit %d should not be set\n", i);
+            return false;
+        }
+    }
+
+    uint256 commitmentHash = CLLMQUtils::BuildCommitmentHash((uint8_t)params.type, quorumHash, validMembers, quorumPublicKey, quorumVvecHash);
+
+    std::vector<CBLSPublicKey> memberPubKeys;
+    for (size_t i = 0; i < members.size(); i++) {
+        if (!signers[i]) {
+            continue;
+        }
+        memberPubKeys.emplace_back(members[i]->pdmnState->pubKeyOperator);
+    }
+
+    if (!membersSig.VerifySecureAggregated(memberPubKeys, commitmentHash)) {
+        LogPrintfFinalCommitment("invalid aggregated members signature\n");
+        return false;
+    }
+
+    if (!quorumSig.VerifyInsecure(quorumPublicKey, commitmentHash)) {
+        LogPrintfFinalCommitment("invalid quorum signature\n");
+        return false;
+    }
+
+    return true;
+}
+
+bool CFinalCommitment::VerifyNull() const
+{
+    if (!Params().GetConsensus().llmqs.count((Consensus::LLMQType)llmqType)) {
+        LogPrintfFinalCommitment("invalid llmqType=%d\n", llmqType);
+        return false;
+    }
+    const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)llmqType);
+
+    return IsNull() && VerifySizes(params);
+}
+
+bool CFinalCommitment::VerifySizes(const Consensus::LLMQParams& params) const
+{
+    if (signers.size() != params.size) {
+        LogPrintfFinalCommitment("invalid signers.size=%d\n", signers.size());
+        return false;
+    }
+    if (validMembers.size() != params.size) {
+        LogPrintfFinalCommitment("invalid signers.size=%d\n", signers.size());
+        return false;
+    }
+    return true;
+}
+
+void CFinalCommitment::ToJson(UniValue& obj) const
+{
+    obj.setObject();
+    obj.push_back(Pair("version", (int)nVersion));
+    obj.push_back(Pair("llmqType", (int)llmqType));
+    obj.push_back(Pair("quorumHash", quorumHash.ToString()));
+    obj.push_back(Pair("signersCount", CountSigners()));
+    obj.push_back(Pair("validMembersCount", CountValidMembers()));
+    obj.push_back(Pair("quorumPublicKey", quorumPublicKey.ToString()));
+}
+
+}

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -49,7 +49,7 @@ public:
     }
 
     bool Verify(const std::vector<CDeterministicMNCPtr>& members) const;
-    bool VerifyNull() const;
+    bool VerifyNull(int nHeight) const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;
 
     void ToJson(UniValue& obj) const;
@@ -79,7 +79,6 @@ public:
             return false;
         }
         if (quorumPublicKey.IsValid() ||
-            !quorumVvecHash.IsNull() ||
             membersSig.IsValid() ||
             quorumSig.IsValid()) {
             return false;

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DASH_QUORUMS_COMMITMENT_H
+#define DASH_QUORUMS_COMMITMENT_H
+
+#include "consensus/params.h"
+
+#include "evo/deterministicmns.h"
+
+#include "bls/bls.h"
+
+namespace llmq
+{
+
+// This message is an aggregation of all received premature commitments and only valid if
+// enough (>=threshold) premature commitments were aggregated
+// This is mined on-chain as part of TRANSACTION_QUORUM_COMMITMENT
+class CFinalCommitment
+{
+public:
+    static const uint16_t CURRENT_VERSION = 1;
+
+public:
+    uint16_t nVersion{CURRENT_VERSION};
+    uint8_t llmqType{Consensus::LLMQ_NONE};
+    uint256 quorumHash;
+    std::vector<bool> signers;
+    std::vector<bool> validMembers;
+
+    CBLSPublicKey quorumPublicKey;
+    uint256 quorumVvecHash;
+
+    CBLSSignature quorumSig; // recovered threshold sig of blockHash+validMembers+pubKeyHash+vvecHash
+    CBLSSignature membersSig; // aggregated member sig of blockHash+validMembers+pubKeyHash+vvecHash
+
+public:
+    CFinalCommitment() {}
+    CFinalCommitment(const Consensus::LLMQParams& params, const uint256& _quorumHash);
+
+    int CountSigners() const
+    {
+        return (int)std::count(signers.begin(), signers.end(), true);
+    }
+    int CountValidMembers() const
+    {
+        return (int)std::count(validMembers.begin(), validMembers.end(), true);
+    }
+
+    bool Verify(const std::vector<CDeterministicMNCPtr>& members) const;
+    bool VerifyNull() const;
+    bool VerifySizes(const Consensus::LLMQParams& params) const;
+
+    void ToJson(UniValue& obj) const;
+
+public:
+    ADD_SERIALIZE_METHODS
+
+    template<typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(nVersion);
+        READWRITE(llmqType);
+        READWRITE(quorumHash);
+        READWRITE(DYNBITSET(signers));
+        READWRITE(DYNBITSET(validMembers));
+        READWRITE(quorumPublicKey);
+        READWRITE(quorumVvecHash);
+        READWRITE(quorumSig);
+        READWRITE(membersSig);
+    }
+
+public:
+    bool IsNull() const
+    {
+        if (std::count(signers.begin(), signers.end(), true) ||
+            std::count(validMembers.begin(), validMembers.end(), true)) {
+            return false;
+        }
+        if (quorumPublicKey.IsValid() ||
+            !quorumVvecHash.IsNull() ||
+            membersSig.IsValid() ||
+            quorumSig.IsValid()) {
+            return false;
+        }
+        return true;
+    }
+};
+
+}
+
+#endif //DASH_QUORUMS_COMMITMENT_H

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "quorums_init.h"
+
+#include "quorums_blockprocessor.h"
+#include "quorums_commitment.h"
+
+namespace llmq
+{
+
+void InitLLMQSystem(CEvoDB& evoDb)
+{
+    quorumBlockProcessor = new CQuorumBlockProcessor(evoDb);
+}
+
+void DestroyLLMQSystem()
+{
+    delete quorumBlockProcessor;
+    quorumBlockProcessor = nullptr;
+}
+
+}

--- a/src/llmq/quorums_init.h
+++ b/src/llmq/quorums_init.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DASH_QUORUMS_INIT_H
+#define DASH_QUORUMS_INIT_H
+
+class CEvoDB;
+
+namespace llmq
+{
+
+void InitLLMQSystem(CEvoDB& evoDb);
+void DestroyLLMQSystem();
+
+}
+
+#endif //DASH_QUORUMS_INIT_H

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "quorums_utils.h"
+
+#include "chainparams.h"
+#include "random.h"
+
+namespace llmq
+{
+
+std::vector<CDeterministicMNCPtr> CLLMQUtils::GetAllQuorumMembers(Consensus::LLMQType llmqType, const uint256& blockHash)
+{
+    auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    auto allMns = deterministicMNManager->GetListForBlock(blockHash);
+    auto modifier = ::SerializeHash(std::make_pair((uint8_t)llmqType, blockHash));
+    return allMns.CalculateQuorum(params.size, modifier);
+}
+
+uint256 CLLMQUtils::BuildCommitmentHash(uint8_t llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash)
+{
+    CHashWriter hw(SER_NETWORK, 0);
+    hw << llmqType;
+    hw << blockHash;
+    hw << DYNBITSET(validMembers);
+    hw << pubKey;
+    hw << vvecHash;
+    return hw.GetHash();
+}
+
+
+}

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DASH_QUORUMS_UTILS_H
+#define DASH_QUORUMS_UTILS_H
+
+#include "consensus/params.h"
+
+#include "evo/deterministicmns.h"
+
+#include <vector>
+
+namespace llmq
+{
+
+class CLLMQUtils
+{
+public:
+    // includes members which failed DKG
+    static std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const uint256& blockHash);
+
+    static uint256 BuildCommitmentHash(uint8_t llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash);
+};
+
+}
+
+#endif//DASH_QUORUMS_UTILS_H

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -19,6 +19,7 @@ enum {
     TRANSACTION_PROVIDER_UPDATE_REGISTRAR = 3,
     TRANSACTION_PROVIDER_UPDATE_REVOKE = 4,
     TRANSACTION_COINBASE = 5,
+    TRANSACTION_QUORUM_COMMITMENT = 6,
 };
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -71,6 +71,7 @@ const char *MNGOVERNANCEOBJECTVOTE="govobjvote";
 const char *MNVERIFY="mnv";
 const char *GETMNLISTDIFF="getmnlistd";
 const char *MNLISTDIFF="mnlistdiff";
+const char *QFCOMMITMENT="qfcommit";
 };
 
 static const char* ppszTypeName[] =
@@ -98,6 +99,7 @@ static const char* ppszTypeName[] =
     NetMsgType::MNGOVERNANCEOBJECTVOTE,
     NetMsgType::MNVERIFY,
     "compact block", // Should never occur
+    NetMsgType::QFCOMMITMENT,
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -157,6 +159,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::MNVERIFY,
     NetMsgType::GETMNLISTDIFF,
     NetMsgType::MNLISTDIFF,
+    NetMsgType::QFCOMMITMENT,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -270,6 +270,7 @@ extern const char *MNGOVERNANCEOBJECTVOTE;
 extern const char *MNVERIFY;
 extern const char *GETMNLISTDIFF;
 extern const char *MNLISTDIFF;
+extern const char *QFCOMMITMENT;
 };
 
 /* Get a vector of all valid message types (see above) */
@@ -371,6 +372,7 @@ enum GetDataMsg {
     // Nodes may always request a MSG_CMPCT_BLOCK in a getdata, however,
     // MSG_CMPCT_BLOCK should not appear in any invs except as a part of getdata.
     MSG_CMPCT_BLOCK = 20, //!< Defined in BIP152
+    MSG_QUORUM_FINAL_COMMITMENT = 21,
 };
 
 /** inv message data */

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -15,6 +15,7 @@
 #include "util.h"
 
 #include "evo/deterministicmns.h"
+#include "llmq/quorums_init.h"
 
 #include <QDir>
 #include <QtGlobal>
@@ -53,6 +54,9 @@ void RPCNestedTests::rpcNestedTests()
     pblocktree = new CBlockTreeDB(1 << 20, true);
     pcoinsdbview = new CCoinsViewDB(1 << 23, true);
     deterministicMNManager = new CDeterministicMNManager(*evoDb);
+
+    llmq::InitLLMQSystem(*evoDb);
+
     pcoinsTip = new CCoinsViewCache(pcoinsdbview);
     InitBlockIndex(chainparams);
     {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -32,6 +32,7 @@
 #include "evo/specialtx.h"
 #include "evo/providertx.h"
 #include "evo/cbtx.h"
+#include "llmq/quorums_commitment.h"
 
 #include <stdint.h>
 
@@ -165,6 +166,13 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
             UniValue obj;
             cbTx.ToJson(obj);
             entry.push_back(Pair("cbTx", obj));
+        }
+    } else if (tx.nType == TRANSACTION_QUORUM_COMMITMENT) {
+        llmq::CFinalCommitment qcTx;
+        if (GetTxPayload(tx, qcTx)) {
+            UniValue obj;
+            qcTx.ToJson(obj);
+            entry.push_back(Pair("qcTx", obj));
         }
     }
 

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -27,6 +27,7 @@
 #include "evo/specialtx.h"
 #include "evo/deterministicmns.h"
 #include "evo/cbtx.h"
+#include "llmq/quorums_init.h"
 
 #include <memory>
 
@@ -73,6 +74,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         pblocktree = new CBlockTreeDB(1 << 20, true);
         pcoinsdbview = new CCoinsViewDB(1 << 23, true);
         deterministicMNManager = new CDeterministicMNManager(*evoDb);
+        llmq::InitLLMQSystem(*evoDb);
         pcoinsTip = new CCoinsViewCache(pcoinsdbview);
         InitBlockIndex(chainparams);
         {
@@ -95,6 +97,7 @@ TestingSetup::~TestingSetup()
         threadGroup.join_all();
         UnloadBlockIndex();
         delete pcoinsTip;
+        llmq::DestroyLLMQSystem();
         delete deterministicMNManager;
         delete pcoinsdbview;
         delete pblocktree;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -514,10 +514,15 @@ int GetUTXOConfirmations(const COutPoint& outpoint)
 
 bool CheckTransaction(const CTransaction& tx, CValidationState &state)
 {
+    bool allowEmptyTxInOut = false;
+    if (tx.nType == TRANSACTION_QUORUM_COMMITMENT) {
+        allowEmptyTxInOut = true;
+    }
+
     // Basic checks that don't depend on any context
-    if (tx.vin.empty())
+    if (!allowEmptyTxInOut && tx.vin.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vin-empty");
-    if (tx.vout.empty())
+    if (!allowEmptyTxInOut && tx.vout.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits
     if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_LEGACY_BLOCK_SIZE)


### PR DESCRIPTION
This is the first PR of a series of PRs resulting from an internal discussion we had. We need to have all on-chain consensus for LLMQs included into v13 already, as otherwise deployment of v14 will require miner support (BIP9 signaling) again.

The reason is that v13 will very likely ship without PoSe and we depend on v14 delivering rudimentary PoSe asap, so we should prepare ourselfs for a fast finalization and deployment of v14 with LLMQs.

The on-chain consensus changes include LLMQ commitments and the rudimentary PoSe system which is built on-top of the information gathered from successful LLMQ DKG sessions. The rudimentary PoSe system will be the next PR. Inclusion of these changes into v13 ensures a smooth upgrade to v14 later, as v13 (including miners) will be compatible.

As we'll have to test this properly on testnet, we will also have to include a "dummy DKG" implementation. This dummy DKG would be insecure by definition and ONLY FOR TESTNET. The reason for using the dummy DKG first is that it will be easier/faster to review.

If review of the real (non-dummy) DKG goes well and is fast enough, we might also include the real DKG and start testing it on testnet (not active on mainnet).

This PR also includes some simple fork-logic so that we can activate enforcement and validation of commitments and null commitments on testnet. The plan for mainnet is to activate this together with the BIP9 deployment, but as the BIP9 deployment has already activated at block 264000 on testnet, we'll have to handle this properly as otherwise the chain would have to be reverted (loosing all registered DIP3 MNs). If review of this PR takes longer, I'll bump the activation height for testnet by a few hundred/thousand blocks.

This PR introduces 3 different LLMQ types for mainnet/testnet/devnet:
1. 50 members and threshold of 30 (60%), once per hour
This one is targeted for InstantSend
2. 400 members and threshold of 240 (60%), once every 12 hours
This one is targeted for consensus critical decisions that require more security
3. 400 members and threshold of 340 (85%), once every 24 hours
This one is targeted for signalling of minimum protocol versions and deployment logic.

I've prepared my [llmq](https://github.com/dashpay/dash/pull/2311) branch to be based on this PR, in case you want to see what comes next. The commits planned for v13 are up until "Test simple PoSe in DIP3 tests". Everything that comes after that commit is for v14.