### PR TITLE
 Properly initialize confirmedHash in CSimplifiedMNListEntry

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -380,7 +380,7 @@ public:
 
         // This is temporary until we reset testnet for retesting of the full DIP3 deployment
         consensus.nTemporaryTestnetForkDIP3Height = 264000;
-        consensus.nTemporaryTestnetForkHeight = 271000;
+        consensus.nTemporaryTestnetForkHeight = 273000;
         consensus.nTemporaryTestnetForkDIP3BlockHash.SetHex("00000048e6e71d4bd90e7c456dcb94683ae832fcad13e1760d8283f7e89f332f");
 
         fMiningRequiresPeers = true;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -378,6 +378,11 @@ public:
         // Testnet Dash BIP44 coin type is '1' (All coin's testnet default)
         nExtCoinType = 1;
 
+        // This is temporary until we reset testnet for retesting of the full DIP3 deployment
+        consensus.nTemporaryTestnetForkDIP3Height = 264000;
+        consensus.nTemporaryTestnetForkHeight = 271000;
+        consensus.nTemporaryTestnetForkDIP3BlockHash.SetHex("00000048e6e71d4bd90e7c456dcb94683ae832fcad13e1760d8283f7e89f332f");
+
         fMiningRequiresPeers = true;
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -95,6 +95,11 @@ struct Params {
     int nMinimumDifficultyBlocks{0};
     int nHighSubsidyBlocks{0};
     int nHighSubsidyFactor{1};
+
+    // This is temporary until we reset testnet for retesting of the full DIP3 deployment
+    int nTemporaryTestnetForkDIP3Height{0};
+    uint256 nTemporaryTestnetForkDIP3BlockHash;
+    int nTemporaryTestnetForkHeight{0};
 };
 } // namespace Consensus
 

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -7,6 +7,7 @@
 #include "simplifiedmns.h"
 #include "specialtx.h"
 
+#include "chainparams.h"
 #include "univalue.h"
 #include "validation.h"
 
@@ -71,6 +72,19 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     }
 
     CSimplifiedMNList sml(tmpMNList);
+
+    // BEGIN TEMPORARY CODE
+    const auto& consensus = Params().GetConsensus();
+    if (consensus.nTemporaryTestnetForkHeight != 0 &&
+        pindexPrev->nHeight + 1 >= consensus.nTemporaryTestnetForkDIP3Height &&
+        pindexPrev->nHeight + 1 < consensus.nTemporaryTestnetForkHeight &&
+        chainActive[consensus.nTemporaryTestnetForkDIP3Height]->GetBlockHash() == consensus.nTemporaryTestnetForkDIP3BlockHash) {
+        for (auto& sme : sml.mnList) {
+            sme.confirmedHash.SetNull();
+        }
+    }
+    // END TEMPORARY CODE
+
     bool mutated = false;
     merkleRootRet = sml.CalcMerkleRoot(&mutated);
     return !mutated;

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -15,6 +15,7 @@
 
 CSimplifiedMNListEntry::CSimplifiedMNListEntry(const CDeterministicMN& dmn) :
     proRegTxHash(dmn.proTxHash),
+    confirmedHash(dmn.pdmnState->confirmedHash),
     service(dmn.pdmnState->addr),
     pubKeyOperator(dmn.pdmnState->pubKeyOperator),
     keyIDVoting(dmn.pdmnState->keyIDVoting),


### PR DESCRIPTION
It was reported that the confirmedHash field in the DIP4 p2p messages is always empty. The reason was simply that it was not initialized in the CSimplifiedMNListEntry.

Fixing this would however invalidate all DIP3 blocks, so we'll have to add some temporary fork logic. This fork logic can be removed when we later reset testnet. The fork-height is currently set to 271000, which we might need to increase if the next RC takes too long.