### PR TITLE
 Include masternodeProTxHash in CTxLockVote

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -94,6 +94,7 @@ void CActiveDeterministicMasternodeManager::Init()
         return;
     }
 
+    activeMasternodeInfo.proTxHash = mnListEntry->proTxHash;
     activeMasternodeInfo.outpoint = mnListEntry->collateralOutpoint;
     state = MASTERNODE_READY;
 }
@@ -113,6 +114,7 @@ void CActiveDeterministicMasternodeManager::UpdatedBlockTip(const CBlockIndex* p
         if (!mnList.IsMNValid(mnListEntry->proTxHash)) {
             // MN disappeared from MN list
             state = MASTERNODE_REMOVED;
+            activeMasternodeInfo.proTxHash = uint256();
             activeMasternodeInfo.outpoint.SetNull();
             // MN might have reappeared in same block with a new ProTx (with same masternode key)
             Init();

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -37,6 +37,7 @@ struct CActiveMasternodeInfo {
     std::unique_ptr<CBLSSecretKey> blsKeyOperator;
 
     // Initialized while registering Masternode
+    uint256 proTxHash;
     COutPoint outpoint;
     CService service;
 };


### PR DESCRIPTION
Currently SPV nodes have no chance to figure out which MN signed a lock vote. This is because only the collateralOutpoint of the MN is included in the vote, which is not part of the DIP4 coinbase commitment and also not in the p2p messages.

This PR adds the proTxHash of the DIP3 MN to the vote, which should allow SPV clients to verify lock votes against the deterministic MN list.

Currently, the added field depends on proto version `70212`, which will cause some propagation issues on testnet until enough nodes have upgraded, simply because all nodes are already at `70212`. To avoid this, we could add a proto bump for this change. @UdjinM6 what do you think?