### PR TITLE
[GUI] Realign tx filter widgets

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -51,10 +51,10 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     hlayout->setContentsMargins(0,0,0,0);
     if (platformStyle->getUseExtraSpacing()) {
         hlayout->setSpacing(0);
-        hlayout->addSpacing(6);
+        hlayout->addSpacing(STATUS_COLUMN_WIDTH - 1);
     } else {
         hlayout->setSpacing(1);
-        hlayout->addSpacing(5);
+        hlayout->addSpacing(STATUS_COLUMN_WIDTH - 2);
     }
     QString theme = GUIUtil::getThemeName();
     watchOnlyWidget = new QComboBox(this);
@@ -664,6 +664,6 @@ bool TransactionView::eventFilter(QObject *obj, QEvent *event)
 // show/hide column Watch-only
 void TransactionView::updateWatchOnlyColumn(bool fHaveWatchOnly)
 {
-    watchOnlyWidget->setVisible(true);
+    watchOnlyWidget->setVisible(fHaveWatchOnly);
     transactionView->setColumnHidden(TransactionTableModel::Watchonly, !fHaveWatchOnly);
 }


### PR DESCRIPTION
Also hide watch-only filter when no watch-only addresses are used (corresponding column already has this kind of behaviour).

No watch-only:
Before:
<img width="290" alt="screenshot 2018-11-23 at 12 29 45" src="https://user-images.githubusercontent.com/1935069/48936303-94899480-ef1b-11e8-9ea4-5954d1d4caab.png">

After:
<img width="315" alt="screenshot 2018-11-23 at 12 28 34" src="https://user-images.githubusercontent.com/1935069/48936311-9bb0a280-ef1b-11e8-9e6a-86c89ddb7f3d.png">

With watch-only:
Before:
<img width="319" alt="screenshot 2018-11-23 at 12 33 26" src="https://user-images.githubusercontent.com/1935069/48936462-14176380-ef1c-11e8-89f6-1622be4d5126.png">

After:
<img width="345" alt="screenshot 2018-11-23 at 12 33 42" src="https://user-images.githubusercontent.com/1935069/48936474-1b3e7180-ef1c-11e8-8b1e-88d3922f3c0a.png">
