### PR TITLE
Add 0 entry to vTxSigOps when adding quorum commitments

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -158,6 +158,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
             if (llmq::quorumBlockProcessor->GetMinableCommitmentTx(p.first, pindexPrev, qcTx)) {
                 pblock->vtx.emplace_back(qcTx);
                 pblocktemplate->vTxFees.emplace_back(0);
+                pblocktemplate->vTxSigOps.emplace_back(0);
             }
         }
     }


### PR DESCRIPTION
This fixes a crash observed on Travis. The same crash is likely to happen
outside of Travis as well later.