### PR TITLE
Should check dsq queue regardless of the mixing state

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -448,9 +448,10 @@ bool CPrivateSendClientSession::CheckTimeout()
 void CPrivateSendClientManager::CheckTimeout()
 {
     if (fMasternodeMode) return;
-    if (!fEnablePrivateSend) return;
 
     CheckQueue();
+
+    if (!fEnablePrivateSend) return;
 
     LOCK(cs_deqsessions);
     for (auto& session : deqSessions) {


### PR DESCRIPTION
Otherwise long running node gets its queue filled up eventually and starts rejecting new dsq and ignoring new dstxes as a result.