### PR TITLE
 Implement CDummyDKG and CDummyCommitment until we have the real DKG merged

### DIFF
--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -361,7 +361,7 @@ class DIP3Test(BitcoinTestFramework):
             banned = False
             t = time.time()
             while (not punished or not banned) and (time.time() - t) < 30:
-                self.nodes[0].generate(4)
+                self.nodes[0].generate(2)
                 self.sync_all()
 
                 info = self.nodes[0].protx('info', mn.protx_hash)

--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -360,14 +360,14 @@ class DIP3Test(BitcoinTestFramework):
             punished = False
             banned = False
             t = time.time()
-            while (not punished or not banned) and (time.time() - t) < 30:
-                time.sleep(0.5)
+            while (not punished or not banned) and (time.time() - t) < 60:
+                time.sleep(1)
 
                 # 2 dummy phases
                 for j in range(2):
                     self.nodes[0].generate(2)
                     self.sync_all()
-                    time.sleep(0.5)
+                    time.sleep(1)
 
                 info = self.nodes[0].protx('info', mn.protx_hash)
                 if not punished:
@@ -379,6 +379,7 @@ class DIP3Test(BitcoinTestFramework):
 
                 # Fast-forward to next DKG session
                 self.nodes[0].generate(24 - (self.nodes[0].getblockcount() % 24))
+                self.sync_all()
             assert(punished and banned)
 
     def create_mn(self, node, idx, alias):

--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -361,8 +361,13 @@ class DIP3Test(BitcoinTestFramework):
             banned = False
             t = time.time()
             while (not punished or not banned) and (time.time() - t) < 30:
-                self.nodes[0].generate(2)
-                self.sync_all()
+                time.sleep(0.5)
+
+                # 2 dummy phases
+                for j in range(2):
+                    self.nodes[0].generate(2)
+                    self.sync_all()
+                    time.sleep(0.5)
 
                 info = self.nodes[0].protx('info', mn.protx_hash)
                 if not punished:
@@ -372,7 +377,8 @@ class DIP3Test(BitcoinTestFramework):
                     if info['state']['PoSeBanHeight'] != -1:
                         banned = True
 
-                time.sleep(0.5)
+                # Fast-forward to next DKG session
+                self.nodes[0].generate(24 - (self.nodes[0].getblockcount() % 24))
             assert(punished and banned)
 
     def create_mn(self, node, idx, alias):

--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -341,6 +341,40 @@ class DIP3Test(BitcoinTestFramework):
         print("testing instant send with replaced MNs")
         self.test_instantsend(20, 5)
 
+        print("testing simple PoSe")
+        self.assert_mnlists(mns_protx)
+        self.nodes[0].spork('SPORK_17_QUORUM_DKG_ENABLED', 0)
+        self.wait_for_sporks()
+
+        height = self.nodes[0].getblockcount()
+        skip_count = 24 - (height % 24)
+        if skip_count != 0:
+            self.nodes[0].generate(skip_count)
+
+        for i in range(len(mns_protx), len(mns_protx) - 2, -1):
+            mn = mns_protx[len(mns_protx) - 1]
+            mns_protx.remove(mn)
+            self.stop_node(mn.idx)
+            self.nodes.remove(mn.node)
+
+            punished = False
+            banned = False
+            t = time.time()
+            while (not punished or not banned) and (time.time() - t) < 30:
+                self.nodes[0].generate(4)
+                self.sync_all()
+
+                info = self.nodes[0].protx('info', mn.protx_hash)
+                if not punished:
+                    if info['state']['PoSePenalty'] > 0:
+                        punished = True
+                if not banned:
+                    if info['state']['PoSeBanHeight'] != -1:
+                        banned = True
+
+                time.sleep(0.5)
+            assert(punished and banned)
+
     def create_mn(self, node, idx, alias):
         mn = Masternode()
         mn.idx = idx

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -141,6 +141,7 @@ BITCOIN_CORE_H = \
   limitedmap.h \
   llmq/quorums_commitment.h \
   llmq/quorums_blockprocessor.h \
+  llmq/quorums_dummydkg.h \
   llmq/quorums_utils.h \
   llmq/quorums_init.h \
   masternode.h \
@@ -249,6 +250,7 @@ libdash_server_a_SOURCES = \
   governance-votedb.cpp \
   llmq/quorums_commitment.cpp \
   llmq/quorums_blockprocessor.cpp \
+  llmq/quorums_dummydkg.cpp \
   llmq/quorums_utils.cpp \
   llmq/quorums_init.cpp \
   masternode.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -293,6 +293,7 @@ public:
         vSporkAddresses = {"Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh"};
         nMinSporkKeys = 1;
         fBIP9CheckMasternodesUpgraded = true;
+        consensus.fLLMQAllowDummyCommitments = false;
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -462,6 +463,7 @@ public:
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
         nMinSporkKeys = 1;
         fBIP9CheckMasternodesUpgraded = true;
+        consensus.fLLMQAllowDummyCommitments = true;
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -608,6 +610,7 @@ public:
         nMinSporkKeys = 1;
         // devnets are started with no blocks and no MN, so we can't check for upgraded MN (as there are none)
         fBIP9CheckMasternodesUpgraded = false;
+        consensus.fLLMQAllowDummyCommitments = true;
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -720,6 +723,7 @@ public:
         nMinSporkKeys = 1;
         // regtest usually has no masternodes in most tests, so don't check for upgraged MNs
         fBIP9CheckMasternodesUpgraded = false;
+        consensus.fLLMQAllowDummyCommitments = true;
 
         checkpointData = (CCheckpointData){
             boost::assign::map_list_of

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -157,7 +157,8 @@ struct Params {
     int nHighSubsidyFactor{1};
 
     std::map<LLMQType, LLMQParams> llmqs;
-	
+    bool fLLMQAllowDummyCommitments;
+
     // This is temporary until we reset testnet for retesting of the full DIP3 deployment
     int nTemporaryTestnetForkDIP3Height{0};
     uint256 nTemporaryTestnetForkDIP3BlockHash;

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -16,6 +16,8 @@
 
 #include "evo/deterministicmns.h"
 
+#include "llmq/quorums_dummydkg.h"
+
 void CDSNotificationInterface::InitializeCurrentBlockTip()
 {
     LOCK(cs_main);
@@ -38,6 +40,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
         return;
 
     deterministicMNManager->UpdatedBlockTip(pindexNew);
+    llmq::quorumDummyDKG->UpdatedBlockTip(pindexNew, fInitialDownload);
 
     masternodeSync.UpdatedBlockTip(pindexNew, fInitialDownload, connman);
 

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -98,15 +98,15 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CV
         }
     }
 
+    if (!llmq::quorumBlockProcessor->ProcessBlock(block, pindex->pprev, state)) {
+        return false;
+    }
+
     if (!deterministicMNManager->ProcessBlock(block, pindex->pprev, state)) {
         return false;
     }
 
     if (!CheckCbTxMerkleRootMNList(block, pindex, state)) {
-        return false;
-    }
-
-    if (!llmq::quorumBlockProcessor->ProcessBlock(block, pindex->pprev, state)) {
         return false;
     }
 
@@ -122,11 +122,11 @@ bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex)
         }
     }
 
-    if (!llmq::quorumBlockProcessor->UndoBlock(block, pindex)) {
+    if (!deterministicMNManager->UndoBlock(block, pindex)) {
         return false;
     }
 
-    if (!deterministicMNManager->UndoBlock(block, pindex)) {
+    if (!llmq::quorumBlockProcessor->UndoBlock(block, pindex)) {
         return false;
     }
 

--- a/src/llmq/quorums_dummydkg.cpp
+++ b/src/llmq/quorums_dummydkg.cpp
@@ -1,0 +1,454 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "quorums_dummydkg.h"
+
+#include "quorums_blockprocessor.h"
+#include "quorums_commitment.h"
+#include "quorums_utils.h"
+
+#include "evo/specialtx.h"
+
+#include "activemasternode.h"
+#include "chain.h"
+#include "chainparams.h"
+#include "consensus/validation.h"
+#include "net.h"
+#include "net_processing.h"
+#include "primitives/block.h"
+#include "spork.h"
+#include "validation.h"
+
+namespace llmq
+{
+
+CDummyDKG* quorumDummyDKG;
+
+void CDummyDKG::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
+{
+    if (strCommand == NetMsgType::QDCOMMITMENT) {
+        if (!Params().GetConsensus().fLLMQAllowDummyCommitments) {
+            Misbehaving(pfrom->id, 100);
+            return;
+        }
+        if (!sporkManager.IsSporkActive(SPORK_17_QUORUM_DKG_ENABLED)) {
+            return;
+        }
+
+        CDummyCommitment qc;
+        vRecv >> qc;
+
+        uint256 hash = ::SerializeHash(qc);
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(hash);
+        }
+
+        ProcessDummyCommitment(pfrom->id, qc);
+    }
+}
+
+void CDummyDKG::ProcessDummyCommitment(NodeId from, const llmq::CDummyCommitment& qc)
+{
+    if (!Params().GetConsensus().llmqs.count((Consensus::LLMQType)qc.llmqType)) {
+        LOCK(cs_main);
+        LogPrintf("CDummyDKG::%s -- invalid commitment type %d, peer=%d\n", __func__,
+                  qc.llmqType, from);
+        if (from != -1) {
+            Misbehaving(from, 100);
+        }
+        return;
+    }
+
+    auto type = (Consensus::LLMQType)qc.llmqType;
+    const auto& params = Params().GetConsensus().llmqs.at(type);
+
+    if (qc.validMembers.size() != params.size) {
+        LOCK(cs_main);
+        LogPrintf("CDummyDKG::%s -- invalid validMembers size %d, peer=%d\n", __func__,
+                  qc.validMembers.size(), from);
+        if (from != -1) {
+            Misbehaving(from, 100);
+        }
+        return;
+    }
+
+    int curQuorumHeight;
+    const CBlockIndex* quorumIndex;
+    {
+        LOCK(cs_main);
+        curQuorumHeight = chainActive.Height() - (chainActive.Height() % params.dkgInterval);
+        quorumIndex = chainActive[curQuorumHeight];
+    }
+    uint256 quorumHash = quorumIndex->GetBlockHash();
+    if (qc.quorumHash != quorumHash) {
+        LogPrintf("CDummyDKG::%s -- dummy commitment for wrong quorum, peer=%d\n", __func__,
+                  from);
+        return;
+    }
+
+    auto members = CLLMQUtils::GetAllQuorumMembers(type, qc.quorumHash);
+    if (members.size() != params.size) {
+        LOCK(cs_main);
+        LogPrintf("CDummyDKG::%s -- invalid members count %d, peer=%d\n", __func__,
+                  members.size(), from);
+        if (from != -1) {
+            Misbehaving(from, 100);
+        }
+        return;
+    }
+    if (qc.signer >= members.size()) {
+        LOCK(cs_main);
+        LogPrintf("CDummyDKG::%s -- invalid signer %d, peer=%d\n", __func__,
+                  qc.signer, from);
+        if (from != -1) {
+            Misbehaving(from, 100);
+        }
+        return;
+    }
+    if (qc.CountValidMembers() < params.minSize) {
+        LOCK(cs_main);
+        LogPrintf("CDummyDKG::%s -- invalid validMembers count %d, peer=%d\n", __func__,
+                  qc.CountValidMembers(), from);
+        if (from != -1) {
+            Misbehaving(from, 100);
+        }
+        return;
+    }
+
+    auto signer = members[qc.signer];
+
+    {
+        LOCK(sessionCs);
+        for (const auto& p : curSessions[type].dummyCommitmentsFromMembers) {
+            if (p.second.count(signer->proTxHash)) {
+                return;
+            }
+        }
+    }
+
+    auto svec = BuildDeterministicSvec(type, qc.quorumHash);
+    auto vvec = BuildVvec(svec);
+    auto vvecHash = ::SerializeHash(vvec);
+
+    auto commitmentHash = CLLMQUtils::BuildCommitmentHash((uint8_t)type, qc.quorumHash, qc.validMembers, vvec[0], vvecHash);
+
+    // verify member sig
+    if (!qc.membersSig.VerifyInsecure(signer->pdmnState->pubKeyOperator, commitmentHash)) {
+        LOCK(cs_main);
+        LogPrintf("CDummyDKG::%s -- invalid memberSig, peer=%d\n", __func__,
+                  from);
+        if (from != -1) {
+            Misbehaving(from, 100);
+        }
+        return;
+    }
+
+    // recover public key share
+    CBLSPublicKey sharePk;
+    if (!sharePk.PublicKeyShare(vvec, CBLSId::FromHash(signer->proTxHash))) {
+        LOCK(cs_main);
+        LogPrintf("CDummyDKG::%s -- failed to recover public key share, peer=%d\n", __func__,
+                  from);
+        if (from != -1) {
+            Misbehaving(from, 100);
+        }
+        return;
+    }
+
+    // verify sig share
+    if (!qc.quorumSig.VerifyInsecure(sharePk, commitmentHash)) {
+        LOCK(cs_main);
+        LogPrintf("CDummyDKG::%s -- invalid quorumSig, peer=%d\n", __func__,
+                  from);
+        if (from != -1) {
+            Misbehaving(from, 100);
+        }
+        return;
+    }
+
+    LogPrintf("CDummyDKG::%s -- processed dummy commitment for quorum %s:%d, validMembers=%d, signer=%d, peer=%d\n", __func__,
+              qc.quorumHash.ToString(), qc.llmqType, qc.CountValidMembers(), qc.signer, from);
+
+    uint256 hash = ::SerializeHash(qc);
+    {
+        LOCK(sessionCs);
+
+        // Mark all members as bad initially and clear that state when we receive a valid dummy commitment from them
+        // This information is then used in the next sessions to determine which ones are valid
+        if (curSessions[type].dummyCommitments.empty()) {
+            for (const auto& dmn : members) {
+                curSessions[type].badMembers.emplace(dmn->proTxHash);
+            }
+        }
+
+        curSessions[type].badMembers.erase(signer->proTxHash);
+        curSessions[type].dummyCommitments[hash] = qc;
+        curSessions[type].dummyCommitmentsFromMembers[commitmentHash][signer->proTxHash] = hash;
+    }
+
+    CInv inv(MSG_QUORUM_DUMMY_COMMITMENT, hash);
+    g_connman->RelayInv(inv, DMN_PROTO_VERSION);
+}
+
+void CDummyDKG::UpdatedBlockTip(const CBlockIndex* pindex, bool fInitialDownload)
+{
+    if (fInitialDownload) {
+        return;
+    }
+
+    if (!fMasternodeMode) {
+        return;
+    }
+
+    bool fDIP0003Active = VersionBitsState(chainActive.Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0003, versionbitscache) == THRESHOLD_ACTIVE;
+    if (!fDIP0003Active) {
+        return;
+    }
+
+    if (!sporkManager.IsSporkActive(SPORK_17_QUORUM_DKG_ENABLED)) {
+        return;
+    }
+
+    for (const auto& p : Params().GetConsensus().llmqs) {
+        const auto& params = p.second;
+        int phaseIndex = pindex->nHeight % params.dkgInterval;
+        if (phaseIndex == 0) {
+            CreateDummyCommitment(params.type, pindex);
+        } else if (phaseIndex == params.dkgPhaseBlocks * 2) {
+            CreateFinalCommitment(params.type, pindex);
+        }
+    }
+}
+
+void CDummyDKG::CreateDummyCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pindex)
+{
+    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    int quorumHeight = pindex->nHeight - (pindex->nHeight % params.dkgInterval);
+    const CBlockIndex* quorumIndex;
+    {
+        LOCK(cs_main);
+        quorumIndex = chainActive[quorumHeight];
+    }
+    uint256 quorumHash = quorumIndex->GetBlockHash();
+
+    auto members = CLLMQUtils::GetAllQuorumMembers(llmqType, quorumHash);
+    if (members.size() != params.size) {
+        return;
+    }
+
+    int myIdx = -1;
+    for (size_t i = 0; i < members.size(); i++) {
+        if (members[i]->collateralOutpoint == activeMasternodeInfo.outpoint) {
+            myIdx = (int)i;
+            break;
+        }
+    }
+    if (myIdx == -1) {
+        return;
+    }
+    auto signer = members[myIdx];
+
+    auto svec = BuildDeterministicSvec(llmqType, quorumHash);
+    auto vvec = BuildVvec(svec);
+    auto vvecHash = ::SerializeHash(vvec);
+    auto validMembers = GetValidMembers(llmqType, members);
+
+    auto commitmentHash = CLLMQUtils::BuildCommitmentHash((uint8_t)llmqType, quorumHash, validMembers, vvec[0], vvecHash);
+
+    CDummyCommitment qc;
+    qc.llmqType = (uint8_t)llmqType;
+    qc.quorumHash = quorumHash;
+    qc.signer = (uint16_t)myIdx;
+    qc.validMembers = validMembers;
+
+    qc.membersSig = activeMasternodeInfo.blsKeyOperator->Sign(commitmentHash);
+
+    CBLSSecretKey skShare;
+    if (!skShare.SecretKeyShare(svec, CBLSId::FromHash(signer->proTxHash))) {
+        return;
+    }
+    qc.quorumSig = skShare.Sign(commitmentHash);
+
+    ProcessDummyCommitment(-1, qc);
+}
+
+void CDummyDKG::CreateFinalCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pindex)
+{
+    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    int quorumHeight = pindex->nHeight - (pindex->nHeight % params.dkgInterval);
+    const CBlockIndex* quorumIndex;
+    {
+        LOCK(cs_main);
+        quorumIndex = chainActive[quorumHeight];
+    }
+    uint256 quorumHash = quorumIndex->GetBlockHash();
+
+    auto members = CLLMQUtils::GetAllQuorumMembers(llmqType, quorumHash);
+    if (members.size() != params.size) {
+        return;
+    }
+
+    auto svec = BuildDeterministicSvec(llmqType, quorumHash);
+    auto vvec = BuildVvec(svec);
+    auto vvecHash = ::SerializeHash(vvec);
+
+    LOCK(sessionCs);
+    auto& session = curSessions[llmqType];
+
+    for (const auto& p : session.dummyCommitmentsFromMembers) {
+        const auto& commitmentHash = p.first;
+        if (p.second.size() < params.minSize) {
+            continue;
+        }
+
+        const auto& firstQc = session.dummyCommitments[p.second.begin()->second];
+
+        CFinalCommitment fqc(params, quorumHash);
+        fqc.validMembers = firstQc.validMembers;
+        fqc.quorumPublicKey = vvec[0];
+        fqc.quorumVvecHash = vvecHash;
+
+        std::vector<CBLSSignature> quorumSigs;
+        std::vector<CBLSId> quorumSigIds;
+        std::vector<CBLSSignature> memberSigs;
+        std::vector<CBLSPublicKey> memberPubKeys;
+
+        for (const auto& p2 : p.second) {
+            const auto& proTxHash = p2.first;
+            const auto& qc = session.dummyCommitments[p2.second];
+
+            int signerIdx = -1;
+            for (size_t i = 0; i < members.size(); i++) {
+                if (members[i]->proTxHash == proTxHash) {
+                    signerIdx = (int)i;
+                    break;
+                }
+            }
+            if (signerIdx == -1) {
+                break;
+            }
+            fqc.signers[signerIdx] = true;
+            if (quorumSigs.size() < params.threshold) {
+                quorumSigs.emplace_back(qc.quorumSig);
+                quorumSigIds.emplace_back(CBLSId::FromHash(proTxHash));
+            }
+            memberSigs.emplace_back(qc.membersSig);
+            memberPubKeys.emplace_back(members[signerIdx]->pdmnState->pubKeyOperator);
+        }
+
+        if (!fqc.quorumSig.Recover(quorumSigs, quorumSigIds)) {
+            LogPrintf("CDummyDKG::%s -- recovery failed for quorum %s:%d, validMembers=%d, signers=%d\n", __func__,
+                      fqc.quorumHash.ToString(), fqc.llmqType, fqc.CountValidMembers(), fqc.CountSigners());
+            continue;
+        }
+        fqc.membersSig = CBLSSignature::AggregateSecure(memberSigs, memberPubKeys, commitmentHash);
+
+        if (!fqc.Verify(members)) {
+            LogPrintf("CDummyDKG::%s -- self created final commitment is invalid for quorum %s:%d, validMembers=%d, signers=%d\n", __func__,
+                      fqc.quorumHash.ToString(), fqc.llmqType, fqc.CountValidMembers(), fqc.CountSigners());
+            continue;
+        }
+
+        LogPrintf("CDummyDKG::%s -- self created final commitment for quorum %s:%d, validMembers=%d, signers=%d\n", __func__,
+                  fqc.quorumHash.ToString(), fqc.llmqType, fqc.CountValidMembers(), fqc.CountSigners());
+        quorumBlockProcessor->AddMinableCommitment(fqc);
+    }
+
+    prevSessions[llmqType].badMembers = curSessions[llmqType].badMembers;
+    prevSessions[llmqType].dummyCommitments = std::move(curSessions[llmqType].dummyCommitments);
+    prevSessions[llmqType].dummyCommitmentsFromMembers = std::move(curSessions[llmqType].dummyCommitmentsFromMembers);
+}
+
+std::vector<bool> CDummyDKG::GetValidMembers(Consensus::LLMQType llmqType, const std::vector<CDeterministicMNCPtr>& members)
+{
+    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    std::vector<bool> ret(params.size, false);
+
+    LOCK(sessionCs);
+
+    // Valid members are members that sent us a dummy commitment in the previous session
+
+    for (size_t i = 0; i < params.size; i++) {
+        if (!prevSessions[llmqType].badMembers.count(members[i]->proTxHash)) {
+            ret[i] = true;
+        }
+    }
+
+    // set all to valid if last sessions failed (this reboots everything)
+    if (std::count(ret.begin(), ret.end(), true) < params.minSize) {
+        for (size_t i = 0; i < params.size; i++) {
+            ret[i] = true;
+        }
+    }
+    return ret;
+}
+
+// The returned secret key vector is NOT SECURE AT ALL!!
+// It is known by everyone. This is only for testnet/devnet/regtest, so this is fine. Also, we won't do any meaningful
+// things with the commitments. This is only needed to make the final commitments validate
+BLSSecretKeyVector CDummyDKG::BuildDeterministicSvec(Consensus::LLMQType llmqType, const uint256& quorumHash)
+{
+    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
+
+    CHash256 seed_;
+    seed_.Write((unsigned char*)&llmqType, 1);
+    seed_.Write(quorumHash.begin(), quorumHash.size());
+
+    uint256 seed;
+    seed_.Finalize(seed.begin());
+
+    BLSSecretKeyVector svec;
+    svec.reserve(params.size);
+    for (size_t i = 0; i < params.threshold; i++) {
+        CBLSSecretKey sk;
+        while (true) {
+            seed = ::SerializeHash(seed);
+            sk.SetBuf(seed.begin(), seed.size());
+            if (sk.IsValid()) {
+                break;
+            }
+        }
+        svec.emplace_back(sk);
+    }
+
+    return svec;
+}
+
+BLSPublicKeyVector CDummyDKG::BuildVvec(const BLSSecretKeyVector& svec)
+{
+    BLSPublicKeyVector vvec;
+    vvec.reserve(svec.size());
+    for (size_t i = 0; i < svec.size(); i++) {
+        vvec.emplace_back(svec[i].GetPublicKey());
+    }
+    return vvec;
+}
+
+bool CDummyDKG::HasDummyCommitment(const uint256& hash)
+{
+    LOCK(sessionCs);
+    for (const auto& p : curSessions) {
+        auto it = p.second.dummyCommitments.find(hash);
+        if (it != p.second.dummyCommitments.end()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CDummyDKG::GetDummyCommitment(const uint256& hash, CDummyCommitment& ret)
+{
+    LOCK(sessionCs);
+    for (const auto& p : curSessions) {
+        auto it = p.second.dummyCommitments.find(hash);
+        if (it != p.second.dummyCommitments.end()) {
+            ret = it->second;
+            return true;
+        }
+    }
+    return false;
+}
+
+}

--- a/src/llmq/quorums_dummydkg.h
+++ b/src/llmq/quorums_dummydkg.h
@@ -25,7 +25,7 @@ class CConnman;
  * This is only used on testnet/devnet/regtest and will NEVER be used on
  * mainnet. It is NOT SECURE AT ALL! It will actually be removed later when the real DKG is introduced.
  *
- * It works by using a deterministic secure vector as the secure polynomial. Everying can calculate this
+ * It works by using a deterministic secure vector as the secure polynomial. Everyone can calculate this
  * polynomial by himself, which makes it insecure by definition.
  *
  * The purpose of this dummy implementation is to test final LLMQ commitments and simple PoSe on-chain.

--- a/src/llmq/quorums_dummydkg.h
+++ b/src/llmq/quorums_dummydkg.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2018 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DASH_QUORUMS_DUMMYDKG_H
+#define DASH_QUORUMS_DUMMYDKG_H
+
+#include "llmq/quorums_commitment.h"
+
+#include "consensus/params.h"
+#include "net.h"
+#include "primitives/transaction.h"
+#include "sync.h"
+
+#include "bls/bls.h"
+
+#include <map>
+
+class CNode;
+class CConnman;
+
+/**
+ * Implementation of an insecure dummy DKG
+ *
+ * This is only used on testnet/devnet/regtest and will NEVER be used on
+ * mainnet. It is NOT SECURE AT ALL! It will actually be removed later when the real DKG is introduced.
+ *
+ * It works by using a deterministic secure vector as the secure polynomial. Everying can calculate this
+ * polynomial by himself, which makes it insecure by definition.
+ *
+ * The purpose of this dummy implementation is to test final LLMQ commitments and simple PoSe on-chain.
+ * The dummy DKG first creates dummy commitments and propagates these to all nodes. They can then create
+ * a valid LLMQ commitment from these, which validates with the normal commitment validation code.
+ *
+ * After these have been mined on-chain, they are indistinguishable from commitments created from the real
+ * DKG, making them good enough for testing.
+ *
+ * The validMembers bitset is created from information of past dummy DKG sessions. If nodes failed to provide
+ * the dummy commitments, they will be marked as bad in the next session. This might create some chaos and
+ * finalizable commitments, but this is ok and will sort itself out after some sessions.
+ */
+
+namespace llmq
+{
+
+// This message is only allowed on testnet/devnet/regtest
+// If any peer tries to send this message on mainnet, it is banned immediately
+// It is used to test commitments on testnet without actually running a full-blown DKG.
+class CDummyCommitment
+{
+public:
+    uint8_t llmqType{Consensus::LLMQ_NONE};
+    uint256 quorumHash;
+    uint16_t signer{(uint16_t)-1};
+
+    std::vector<bool> validMembers;
+
+    CBLSSignature quorumSig;
+    CBLSSignature membersSig;
+
+public:
+    int CountValidMembers() const
+    {
+        return (int)std::count(validMembers.begin(), validMembers.end(), true);
+    }
+
+public:
+    ADD_SERIALIZE_METHODS
+
+    template<typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(llmqType);
+        READWRITE(quorumHash);
+        READWRITE(signer);
+        READWRITE(DYNBITSET(validMembers));
+        READWRITE(quorumSig);
+        READWRITE(membersSig);
+    }
+};
+
+class CDummyDKGSession
+{
+public:
+    std::set<uint256> badMembers;
+    std::map<uint256, CDummyCommitment> dummyCommitments;
+    std::map<uint256, std::map<uint256, uint256>> dummyCommitmentsFromMembers;
+};
+
+// It simulates the result of a DKG session by deterministically calculating a secret/public key vector
+// !!!THIS IS NOT SECURE AT ALL AND WILL NEVER BE USED ON MAINNET!!!
+// The whole dummy DKG will be removed when we add the real DKG
+class CDummyDKG
+{
+private:
+    CCriticalSection sessionCs;
+    std::map<Consensus::LLMQType, CDummyDKGSession> prevSessions;
+    std::map<Consensus::LLMQType, CDummyDKGSession> curSessions;
+
+public:
+    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
+    void ProcessDummyCommitment(NodeId from, const CDummyCommitment& qc);
+
+    void UpdatedBlockTip(const CBlockIndex* pindex, bool fInitialDownload);
+    void CreateDummyCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pindex);
+    void CreateFinalCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pindex);
+
+    bool HasDummyCommitment(const uint256& hash);
+    bool GetDummyCommitment(const uint256& hash, CDummyCommitment& ret);
+
+private:
+    std::vector<bool> GetValidMembers(Consensus::LLMQType llmqType, const std::vector<CDeterministicMNCPtr>& members);
+    BLSSecretKeyVector BuildDeterministicSvec(Consensus::LLMQType llmqType, const uint256& quorumHash);
+    BLSPublicKeyVector BuildVvec(const BLSSecretKeyVector& svec);
+};
+
+extern CDummyDKG* quorumDummyDKG;
+
+}
+
+#endif//DASH_QUORUMS_DUMMYDKG_H

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -6,6 +6,7 @@
 
 #include "quorums_blockprocessor.h"
 #include "quorums_commitment.h"
+#include "quorums_dummydkg.h"
 
 namespace llmq
 {
@@ -13,10 +14,13 @@ namespace llmq
 void InitLLMQSystem(CEvoDB& evoDb)
 {
     quorumBlockProcessor = new CQuorumBlockProcessor(evoDb);
+    quorumDummyDKG = new CDummyDKG();
 }
 
 void DestroyLLMQSystem()
 {
+    delete quorumDummyDKG;
+    quorumDummyDKG = nullptr;
     delete quorumBlockProcessor;
     quorumBlockProcessor = nullptr;
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -45,6 +45,7 @@
 #include "evo/deterministicmns.h"
 #include "evo/simplifiedmns.h"
 #include "llmq/quorums_commitment.h"
+#include "llmq/quorums_dummydkg.h"
 #include "llmq/quorums_blockprocessor.h"
 
 #include <boost/thread.hpp>
@@ -967,6 +968,8 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
     case MSG_QUORUM_FINAL_COMMITMENT:
         return llmq::quorumBlockProcessor->HasMinableCommitment(inv.hash);
+    case MSG_QUORUM_DUMMY_COMMITMENT:
+        return llmq::quorumDummyDKG->HasDummyCommitment(inv.hash);
     }
 
     // Don't know what it is, just say we already got one
@@ -1284,6 +1287,20 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     llmq::CFinalCommitment o;
                     if (llmq::quorumBlockProcessor->GetMinableCommitmentByHash(inv.hash, o)) {
                         connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::QFCOMMITMENT, o));
+                        push = true;
+                    }
+                }
+
+                if (!push && (inv.type == MSG_QUORUM_DUMMY_COMMITMENT)) {
+                    if (!consensusParams.fLLMQAllowDummyCommitments) {
+                        Misbehaving(pfrom->id, 100);
+                        pfrom->fDisconnect = true;
+                        return;
+                    }
+
+                    llmq::CDummyCommitment o;
+                    if (llmq::quorumDummyDKG->GetDummyCommitment(inv.hash, o)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::QDCOMMITMENT, o));
                         push = true;
                     }
                 }
@@ -2899,6 +2916,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             masternodeSync.ProcessMessage(pfrom, strCommand, vRecv);
             governance.ProcessMessage(pfrom, strCommand, vRecv, connman);
             llmq::quorumBlockProcessor->ProcessMessage(pfrom, strCommand, vRecv, connman);
+            llmq::quorumDummyDKG->ProcessMessage(pfrom, strCommand, vRecv, connman);
         }
         else
         {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -72,6 +72,7 @@ const char *MNVERIFY="mnv";
 const char *GETMNLISTDIFF="getmnlistd";
 const char *MNLISTDIFF="mnlistdiff";
 const char *QFCOMMITMENT="qfcommit";
+const char *QDCOMMITMENT="qdcommit";
 };
 
 static const char* ppszTypeName[] =
@@ -100,6 +101,7 @@ static const char* ppszTypeName[] =
     NetMsgType::MNVERIFY,
     "compact block", // Should never occur
     NetMsgType::QFCOMMITMENT,
+    NetMsgType::QDCOMMITMENT,
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -160,6 +162,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::GETMNLISTDIFF,
     NetMsgType::MNLISTDIFF,
     NetMsgType::QFCOMMITMENT,
+    NetMsgType::QDCOMMITMENT,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -271,6 +271,7 @@ extern const char *MNVERIFY;
 extern const char *GETMNLISTDIFF;
 extern const char *MNLISTDIFF;
 extern const char *QFCOMMITMENT;
+extern const char *QDCOMMITMENT;
 };
 
 /* Get a vector of all valid message types (see above) */
@@ -373,6 +374,7 @@ enum GetDataMsg {
     // MSG_CMPCT_BLOCK should not appear in any invs except as a part of getdata.
     MSG_CMPCT_BLOCK = 20, //!< Defined in BIP152
     MSG_QUORUM_FINAL_COMMITMENT = 21,
+    MSG_QUORUM_DUMMY_COMMITMENT = 22, // only valid on testnet/devnet/regtest
 };
 
 /** inv message data */

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -29,6 +29,7 @@ std::map<int, int64_t> mapSporkDefaults = {
     {SPORK_14_REQUIRE_SENTINEL_FLAG,         4070908800ULL}, // OFF
     {SPORK_15_DETERMINISTIC_MNS_ENABLED,     4070908800ULL}, // OFF
     {SPORK_16_INSTANTSEND_AUTOLOCKS,         4070908800ULL}, // OFF
+    {SPORK_17_QUORUM_DKG_ENABLED,            4070908800ULL}, // OFF
 };
 
 bool CSporkManager::SporkValueIsActive(int nSporkID, int64_t &nActiveValueRet) const
@@ -284,6 +285,7 @@ int CSporkManager::GetSporkIDByName(const std::string& strName)
     if (strName == "SPORK_14_REQUIRE_SENTINEL_FLAG")            return SPORK_14_REQUIRE_SENTINEL_FLAG;
     if (strName == "SPORK_15_DETERMINISTIC_MNS_ENABLED")        return SPORK_15_DETERMINISTIC_MNS_ENABLED;
     if (strName == "SPORK_16_INSTANTSEND_AUTOLOCKS")            return SPORK_16_INSTANTSEND_AUTOLOCKS;
+    if (strName == "SPORK_17_QUORUM_DKG_ENABLED")               return SPORK_17_QUORUM_DKG_ENABLED;
 
     LogPrint("spork", "CSporkManager::GetSporkIDByName -- Unknown Spork name '%s'\n", strName);
     return -1;
@@ -303,6 +305,7 @@ std::string CSporkManager::GetSporkNameByID(int nSporkID)
         case SPORK_14_REQUIRE_SENTINEL_FLAG:            return "SPORK_14_REQUIRE_SENTINEL_FLAG";
         case SPORK_15_DETERMINISTIC_MNS_ENABLED:        return "SPORK_15_DETERMINISTIC_MNS_ENABLED";
         case SPORK_16_INSTANTSEND_AUTOLOCKS:            return "SPORK_16_INSTANTSEND_AUTOLOCKS";
+        case SPORK_17_QUORUM_DKG_ENABLED:               return "SPORK_17_QUORUM_DKG_ENABLED";
         default:
             LogPrint("spork", "CSporkManager::GetSporkNameByID -- Unknown Spork ID %d\n", nSporkID);
             return "Unknown";

--- a/src/spork.h
+++ b/src/spork.h
@@ -28,9 +28,10 @@ static const int SPORK_12_RECONSIDER_BLOCKS                             = 10011;
 static const int SPORK_14_REQUIRE_SENTINEL_FLAG                         = 10013;
 static const int SPORK_15_DETERMINISTIC_MNS_ENABLED                     = 10014;
 static const int SPORK_16_INSTANTSEND_AUTOLOCKS                         = 10015;
+static const int SPORK_17_QUORUM_DKG_ENABLED                            = 10016;
 
 static const int SPORK_START                                            = SPORK_2_INSTANTSEND_ENABLED;
-static const int SPORK_END                                              = SPORK_16_INSTANTSEND_AUTOLOCKS;
+static const int SPORK_END                                              = SPORK_17_QUORUM_DKG_ENABLED;
 
 extern std::map<int, int64_t> mapSporkDefaults;
 extern CSporkManager sporkManager;


### PR DESCRIPTION
This implements the dummy DKG mentioned in https://github.com/dashpay/dash/pull/2477

This will only run on testnet/devnet/regtest and only if SPORK_17_QUORUM_DKG_ENABLED is enabled. The same spork will later be reused for the real DKG.

The dummy DKG uses deterministicaly generated secret polynomials, which is then used to derive the quorum public keys and secret key shares of individual "members". This is as insecure as something can be in regard to the quorum key and will NEVER be used on mainnet. Even on testnet, these keys won't be used for anything other then the validation of the commitment.

The dummy DKG is however good enough to test the simple PoSe functionality on testnet. Imagine it as some kind of voting on offline/slow MNs. Each MN will remember which other MNs didn't participate in previous rounds and then mark those as bad in the next round. If enough MNs (>=threshold) mark the same members as bad, they'll eventually get PoSe punished and if it happens multiple times they get PoSe banned. This type of voting is secure, even with the dummy DKG as no single member is able to create a valid commitment that punishes another member if not enough other MNs agree.