### PR TITLE
Do not sort resulting vector in SelectCoinsGroupedByAddresses

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -1347,6 +1347,11 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(CConnman& connman)
         return false;
     }
 
+    // Start from smallest balances first to consume tiny amounts and cleanup UTXO a bit
+    std::sort(vecTally.begin(), vecTally.end(), [](const CompactTallyItem& a, const CompactTallyItem& b) {
+        return a.nAmount < b.nAmount;
+    });
+
     // First try to use only non-denominated funds
     for (const auto& item : vecTally) {
         if (!MakeCollateralAmounts(item, false, connman)) continue;
@@ -1454,6 +1459,11 @@ bool CPrivateSendClientSession::CreateDenominated(CConnman& connman)
         LogPrint("privatesend", "CPrivateSendClientSession::CreateDenominated -- SelectCoinsGroupedByAddresses can't find any inputs!\n");
         return false;
     }
+
+    // Start from largest balances first to speed things up by creating txes with larger/largest denoms included
+    std::sort(vecTally.begin(), vecTally.end(), [](const CompactTallyItem& a, const CompactTallyItem& b) {
+        return a.nAmount > b.nAmount;
+    });
 
     bool fCreateMixingCollaterals = !pwalletMain->HasCollateralInputs();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3060,15 +3060,6 @@ bool CWallet::SelectPSInOutPairsByDenominations(int nDenom, CAmount nValueMin, C
     return nValueTotal >= nValueMin && nDenom == nDenomResult;
 }
 
-struct CompareByAmount
-{
-    bool operator()(const CompactTallyItem& t1,
-                    const CompactTallyItem& t2) const
-    {
-        return t1.nAmount > t2.nAmount;
-    }
-};
-
 bool CWallet::SelectCoinsGroupedByAddresses(std::vector<CompactTallyItem>& vecTallyRet, bool fSkipDenominated, bool fAnonymizable, bool fSkipUnconfirmed, int nMaxOupointsPerAddress) const
 {
     LOCK2(cs_main, cs_wallet);
@@ -3142,14 +3133,12 @@ bool CWallet::SelectCoinsGroupedByAddresses(std::vector<CompactTallyItem>& vecTa
     }
 
     // construct resulting vector
+    // NOTE: vecTallyRet is "sorted" by txdest (i.e. address), just like mapTally
     vecTallyRet.clear();
     for (const auto& item : mapTally) {
         if(fAnonymizable && item.second.nAmount < nSmallestDenom) continue;
         vecTallyRet.push_back(item.second);
     }
-
-    // order by amounts per address, from smallest to largest
-    std::sort(vecTallyRet.rbegin(), vecTallyRet.rend(), CompareByAmount());
 
     // cache already confirmed anonymizable entries for later use, no cache should be saved when the limit is specified
     if(nMaxOupointsPerAddress != -1 && fAnonymizable && fSkipUnconfirmed) {


### PR DESCRIPTION
Apply specific sort in each case separately instead (when needed). See comments in code for more info.