### PR TITLE
Revert "Apply similar logic to vecMasternodesUsed"

### DIFF
--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -952,10 +952,10 @@ bool CPrivateSendClientManager::DoAutomaticDenominating(CConnman& connman, bool 
         return false;
     }
 
-    int nMnCount = mnodeman.CountMasternodes();
+    int nMnCountEnabled = mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION);
 
     // If we've used 90% of the Masternode list then drop the oldest first ~30%
-    int nThreshold_high = nMnCount * 0.9;
+    int nThreshold_high = nMnCountEnabled * 0.9;
     int nThreshold_low = nThreshold_high * 0.7;
     LogPrint("privatesend", "Checking vecMasternodesUsed: size: %d, threshold: %d\n", (int)vecMasternodesUsed.size(), nThreshold_high);
 


### PR DESCRIPTION
This reverts commit ebb120005292bc077d6dd7c4ce8adbe25167bf16 from #2487 . After testing it for a while it urned out that it's in fact causing more harm than good by delaying the purge of used masternodes way too far and thus slowing down creation of new sessions. With this there are going to be more failed/rejected sessions (due to `nDsqCount` checks later) but at least some of them are going to succeed eventually, which is probably better comparing to not even trying.

To clarify: by "failed session" I mean it's going to fail to even be created, not stuck/non-mined txes. Going to test this to see if it causes stuck txes but I think it shouldn't.