### PR TITLE
Add quorumModifierHash to instant send lock vote

### DIFF
--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -244,10 +244,15 @@ void CInstantSend::Vote(CTxLockCandidate& txLockCandidate, CConnman& connman)
         int nLockInputHeight = nPrevoutHeight + Params().GetConsensus().nInstantSendConfirmationsRequired - 2;
 
         int nRank;
+        uint256 confirmedBlockHash;
         int nMinRequiredProtocol = std::max(MIN_INSTANTSEND_PROTO_VERSION, mnpayments.GetMinMasternodePaymentsProto());
-        if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, nLockInputHeight, nMinRequiredProtocol)) {
+        if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, confirmedBlockHash, nLockInputHeight, nMinRequiredProtocol)) {
             LogPrint("instantsend", "CInstantSend::Vote -- Can't calculate rank for masternode %s\n", activeMasternodeInfo.outpoint.ToStringShort());
             continue;
+        }
+        if (!deterministicMNManager->IsDeterministicMNsSporkActive()) {
+            // not used until spork15 activation
+            confirmedBlockHash = uint256();
         }
 
         int nSignaturesTotal = COutPointLock::SIGNATURES_TOTAL;
@@ -282,7 +287,7 @@ void CInstantSend::Vote(CTxLockCandidate& txLockCandidate, CConnman& connman)
 
         // we haven't voted for this outpoint yet, let's try to do this now
         // Please note that activeMasternodeInfo.proTxHash is only valid after spork15 activation
-        CTxLockVote vote(txHash, outpointLockPair.first, activeMasternodeInfo.outpoint, activeMasternodeInfo.proTxHash);
+        CTxLockVote vote(txHash, outpointLockPair.first, confirmedBlockHash, activeMasternodeInfo.outpoint, activeMasternodeInfo.proTxHash);
 
         if (!vote.Sign()) {
             LogPrintf("CInstantSend::Vote -- Failed to sign consensus vote\n");
@@ -1052,12 +1057,23 @@ bool CTxLockVote::IsValid(CNode* pnode, CConnman& connman) const
     int nLockInputHeight = coin.nHeight + Params().GetConsensus().nInstantSendConfirmationsRequired - 2;
 
     int nRank;
+    uint256 confirmedBlockHash;
     int nMinRequiredProtocol = std::max(MIN_INSTANTSEND_PROTO_VERSION, mnpayments.GetMinMasternodePaymentsProto());
-    if (!mnodeman.GetMasternodeRank(outpointMasternode, nRank, nLockInputHeight, nMinRequiredProtocol)) {
+    if (!mnodeman.GetMasternodeRank(outpointMasternode, nRank, confirmedBlockHash, nLockInputHeight, nMinRequiredProtocol)) {
         //can be caused by past versions trying to vote with an invalid protocol
         LogPrint("instantsend", "CTxLockVote::IsValid -- Can't calculate rank for masternode %s\n", outpointMasternode.ToStringShort());
         return false;
     }
+    if (!outpointConfirmedBlock.IsNull()) {
+        if (outpointConfirmedBlock != confirmedBlockHash) {
+            LogPrint("instantsend", "CTxLockVote::IsValid -- invalid outpointConfirmedBlock %s, expected %s\n", outpointConfirmedBlock.ToString(), confirmedBlockHash.ToString());
+            return false;
+        }
+    } else if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        LogPrint("instantsend", "CTxLockVote::IsValid -- missing outpointConfirmedBlock while DIP3 is active\n");
+        return false;
+    }
+
     LogPrint("instantsend", "CTxLockVote::IsValid -- Masternode %s, rank=%d\n", outpointMasternode.ToStringShort(), nRank);
 
     int nSignaturesTotal = COutPointLock::SIGNATURES_TOTAL;

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -287,7 +287,7 @@ void CInstantSend::Vote(CTxLockCandidate& txLockCandidate, CConnman& connman)
 
         // we haven't voted for this outpoint yet, let's try to do this now
         // Please note that activeMasternodeInfo.proTxHash is only valid after spork15 activation
-        CTxLockVote vote(txHash, outpointLockPair.first, confirmedBlockHash, activeMasternodeInfo.outpoint, activeMasternodeInfo.proTxHash);
+        CTxLockVote vote(txHash, outpointLockPair.first, activeMasternodeInfo.outpoint, confirmedBlockHash, activeMasternodeInfo.proTxHash);
 
         if (!vote.Sign()) {
             LogPrintf("CInstantSend::Vote -- Failed to sign consensus vote\n");

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -235,6 +235,7 @@ private:
     COutPoint outpoint;
     // TODO remove this member when the legacy masternode code is removed after DIP3 deployment
     COutPoint outpointMasternode;
+    uint256 outpointConfirmedBlock;
     uint256 masternodeProTxHash;
     std::vector<unsigned char> vchMasternodeSignature;
     // local memory only
@@ -246,16 +247,18 @@ public:
         txHash(),
         outpoint(),
         outpointMasternode(),
+        outpointConfirmedBlock(),
         masternodeProTxHash(),
         vchMasternodeSignature(),
         nConfirmedHeight(-1),
         nTimeCreated(GetTime())
         {}
 
-    CTxLockVote(const uint256& txHashIn, const COutPoint& outpointIn, const COutPoint& outpointMasternodeIn, const uint256& masternodeProTxHashIn) :
+    CTxLockVote(const uint256& txHashIn, const COutPoint& outpointIn, const uint256& outpointConfirmedBlockIn, const COutPoint& outpointMasternodeIn, const uint256& masternodeProTxHashIn) :
         txHash(txHashIn),
         outpoint(outpointIn),
         outpointMasternode(outpointMasternodeIn),
+        outpointConfirmedBlock(outpointConfirmedBlockIn),
         masternodeProTxHash(masternodeProTxHashIn),
         vchMasternodeSignature(),
         nConfirmedHeight(-1),
@@ -270,8 +273,9 @@ public:
         READWRITE(outpoint);
         READWRITE(outpointMasternode);
         if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-            // Starting with spork15 activation, the proTxHash is included. When we bump to >= 70213, we can remove
+            // Starting with spork15 activation, the proTxHash and outpointConfirmedBlock is included. When we bump to >= 70213, we can remove
             // the surrounding if. We might also remove outpointMasternode as well later
+            READWRITE(outpointConfirmedBlock);
             READWRITE(masternodeProTxHash);
         }
         if (!(s.GetType() & SER_GETHASH)) {

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -235,7 +235,7 @@ private:
     COutPoint outpoint;
     // TODO remove this member when the legacy masternode code is removed after DIP3 deployment
     COutPoint outpointMasternode;
-    uint256 outpointConfirmedBlock;
+    uint256 quorumModifierHash;
     uint256 masternodeProTxHash;
     std::vector<unsigned char> vchMasternodeSignature;
     // local memory only
@@ -247,18 +247,18 @@ public:
         txHash(),
         outpoint(),
         outpointMasternode(),
-        outpointConfirmedBlock(),
+        quorumModifierHash(),
         masternodeProTxHash(),
         vchMasternodeSignature(),
         nConfirmedHeight(-1),
         nTimeCreated(GetTime())
         {}
 
-    CTxLockVote(const uint256& txHashIn, const COutPoint& outpointIn, const COutPoint& outpointMasternodeIn, const uint256& outpointConfirmedBlockIn, const uint256& masternodeProTxHashIn) :
+    CTxLockVote(const uint256& txHashIn, const COutPoint& outpointIn, const COutPoint& outpointMasternodeIn, const uint256& quorumModifierHashIn, const uint256& masternodeProTxHashIn) :
         txHash(txHashIn),
         outpoint(outpointIn),
         outpointMasternode(outpointMasternodeIn),
-        outpointConfirmedBlock(outpointConfirmedBlockIn),
+        quorumModifierHash(quorumModifierHashIn),
         masternodeProTxHash(masternodeProTxHashIn),
         vchMasternodeSignature(),
         nConfirmedHeight(-1),
@@ -273,9 +273,9 @@ public:
         READWRITE(outpoint);
         READWRITE(outpointMasternode);
         if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-            // Starting with spork15 activation, the proTxHash and outpointConfirmedBlock is included. When we bump to >= 70213, we can remove
+            // Starting with spork15 activation, the proTxHash and quorumModifierHash is included. When we bump to >= 70213, we can remove
             // the surrounding if. We might also remove outpointMasternode as well later
-            READWRITE(outpointConfirmedBlock);
+            READWRITE(quorumModifierHash);
             READWRITE(masternodeProTxHash);
         }
         if (!(s.GetType() & SER_GETHASH)) {

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -254,7 +254,7 @@ public:
         nTimeCreated(GetTime())
         {}
 
-    CTxLockVote(const uint256& txHashIn, const COutPoint& outpointIn, const uint256& outpointConfirmedBlockIn, const COutPoint& outpointMasternodeIn, const uint256& masternodeProTxHashIn) :
+    CTxLockVote(const uint256& txHashIn, const COutPoint& outpointIn, const COutPoint& outpointMasternodeIn, const uint256& outpointConfirmedBlockIn, const uint256& masternodeProTxHashIn) :
         txHash(txHashIn),
         outpoint(outpointIn),
         outpointMasternode(outpointMasternodeIn),

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -906,8 +906,9 @@ bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, std::s
     if(!fMasternodeMode && nBlockHeight < nValidationHeight) return true;
 
     int nRank;
+    uint256 confirmedBlockHash;
 
-    if(!mnodeman.GetMasternodeRank(masternodeOutpoint, nRank, nBlockHeight - 101, nMinRequiredProtocol)) {
+    if(!mnodeman.GetMasternodeRank(masternodeOutpoint, nRank, confirmedBlockHash, nBlockHeight - 101, nMinRequiredProtocol)) {
         LogPrint("mnpayments", "CMasternodePaymentVote::%s -- Can't calculate rank for masternode %s\n", __func__,
                     masternodeOutpoint.ToStringShort());
         return false;
@@ -947,8 +948,9 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight, CConnman& connman)
     if(!masternodeSync.IsMasternodeListSynced()) return false;
 
     int nRank;
+    uint256 confirmedBlockHash;
 
-    if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, nBlockHeight - 101, GetMinMasternodePaymentsProto())) {
+    if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, confirmedBlockHash, nBlockHeight - 101, GetMinMasternodePaymentsProto())) {
         LogPrint("mnpayments", "CMasternodePayments::%s -- Unknown Masternode\n", __func__);
         return false;
     }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -906,9 +906,8 @@ bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, std::s
     if(!fMasternodeMode && nBlockHeight < nValidationHeight) return true;
 
     int nRank;
-    uint256 confirmedBlockHash;
 
-    if(!mnodeman.GetMasternodeRank(masternodeOutpoint, nRank, confirmedBlockHash, nBlockHeight - 101, nMinRequiredProtocol)) {
+    if(!mnodeman.GetMasternodeRank(masternodeOutpoint, nRank, nBlockHeight - 101, nMinRequiredProtocol)) {
         LogPrint("mnpayments", "CMasternodePaymentVote::%s -- Can't calculate rank for masternode %s\n", __func__,
                     masternodeOutpoint.ToStringShort());
         return false;
@@ -948,9 +947,8 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight, CConnman& connman)
     if(!masternodeSync.IsMasternodeListSynced()) return false;
 
     int nRank;
-    uint256 confirmedBlockHash;
 
-    if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, confirmedBlockHash, nBlockHeight - 101, GetMinMasternodePaymentsProto())) {
+    if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, nBlockHeight - 101, GetMinMasternodePaymentsProto())) {
         LogPrint("mnpayments", "CMasternodePayments::%s -- Unknown Masternode\n", __func__);
         return false;
     }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -820,6 +820,12 @@ bool CMasternodeMan::GetMasternodeScores(const uint256& nBlockHash, CMasternodeM
     return !vecMasternodeScoresRet.empty();
 }
 
+bool CMasternodeMan::GetMasternodeRank(const COutPoint& outpoint, int& nRankRet, int nBlockHeight, int nMinProtocol)
+{
+    uint256 tmp;
+    return GetMasternodeRank(outpoint, nRankRet, tmp, nBlockHeight, nMinProtocol);
+}
+
 bool CMasternodeMan::GetMasternodeRank(const COutPoint& outpoint, int& nRankRet, uint256& blockHashRet, int nBlockHeight, int nMinProtocol)
 {
     nRankRet = -1;
@@ -1609,9 +1615,8 @@ void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerif
     }
 
     int nRank;
-    uint256 confirmedBlockHash;
 
-    if (!GetMasternodeRank(mnv.masternodeOutpoint2, nRank, confirmedBlockHash, mnv.nBlockHeight, MIN_POSE_PROTO_VERSION)) {
+    if (!GetMasternodeRank(mnv.masternodeOutpoint2, nRank, mnv.nBlockHeight, MIN_POSE_PROTO_VERSION)) {
         LogPrint("masternode", "CMasternodeMan::ProcessVerifyBroadcast -- Can't calculate rank for masternode %s\n",
                     mnv.masternodeOutpoint2.ToStringShort());
         return;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -820,7 +820,7 @@ bool CMasternodeMan::GetMasternodeScores(const uint256& nBlockHash, CMasternodeM
     return !vecMasternodeScoresRet.empty();
 }
 
-bool CMasternodeMan::GetMasternodeRank(const COutPoint& outpoint, int& nRankRet, int nBlockHeight, int nMinProtocol)
+bool CMasternodeMan::GetMasternodeRank(const COutPoint& outpoint, int& nRankRet, uint256& blockHashRet, int nBlockHeight, int nMinProtocol)
 {
     nRankRet = -1;
 
@@ -828,8 +828,8 @@ bool CMasternodeMan::GetMasternodeRank(const COutPoint& outpoint, int& nRankRet,
         return false;
 
     // make sure we know about this block
-    uint256 nBlockHash = uint256();
-    if (!GetBlockHash(nBlockHash, nBlockHeight)) {
+    blockHashRet = uint256();
+    if (!GetBlockHash(blockHashRet, nBlockHeight)) {
         LogPrintf("CMasternodeMan::%s -- ERROR: GetBlockHash() failed at nBlockHeight %d\n", __func__, nBlockHeight);
         return false;
     }
@@ -837,7 +837,7 @@ bool CMasternodeMan::GetMasternodeRank(const COutPoint& outpoint, int& nRankRet,
     LOCK(cs);
 
     score_pair_vec_t vecMasternodeScores;
-    if (!GetMasternodeScores(nBlockHash, vecMasternodeScores, nMinProtocol))
+    if (!GetMasternodeScores(blockHashRet, vecMasternodeScores, nMinProtocol))
         return false;
 
     int nRank = 0;
@@ -1609,8 +1609,9 @@ void CMasternodeMan::ProcessVerifyBroadcast(CNode* pnode, const CMasternodeVerif
     }
 
     int nRank;
+    uint256 confirmedBlockHash;
 
-    if (!GetMasternodeRank(mnv.masternodeOutpoint2, nRank, mnv.nBlockHeight, MIN_POSE_PROTO_VERSION)) {
+    if (!GetMasternodeRank(mnv.masternodeOutpoint2, nRank, confirmedBlockHash, mnv.nBlockHeight, MIN_POSE_PROTO_VERSION)) {
         LogPrint("masternode", "CMasternodeMan::ProcessVerifyBroadcast -- Can't calculate rank for masternode %s\n",
                     mnv.masternodeOutpoint2.ToStringShort());
         return;

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -186,7 +186,7 @@ public:
     std::map<COutPoint, CMasternode> GetFullMasternodeMap();
 
     bool GetMasternodeRanks(rank_pair_vec_t& vecMasternodeRanksRet, int nBlockHeight = -1, int nMinProtocol = 0);
-    bool GetMasternodeRank(const COutPoint &outpoint, int& nRankRet, int nBlockHeight = -1, int nMinProtocol = 0);
+    bool GetMasternodeRank(const COutPoint &outpoint, int& nRankRet, uint256& blockHashRet, int nBlockHeight = -1, int nMinProtocol = 0);
 
     void ProcessMasternodeConnections(CConnman& connman);
     std::pair<CService, std::set<uint256> > PopScheduledMnbRequestConnection();

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -186,6 +186,7 @@ public:
     std::map<COutPoint, CMasternode> GetFullMasternodeMap();
 
     bool GetMasternodeRanks(rank_pair_vec_t& vecMasternodeRanksRet, int nBlockHeight = -1, int nMinProtocol = 0);
+    bool GetMasternodeRank(const COutPoint &outpoint, int& nRankRet, int nBlockHeight = -1, int nMinProtocol = 0);
     bool GetMasternodeRank(const COutPoint &outpoint, int& nRankRet, uint256& blockHashRet, int nBlockHeight = -1, int nMinProtocol = 0);
 
     void ProcessMasternodeConnections(CConnman& connman);


### PR DESCRIPTION
This is for SPV clients which need to verify instant send lock votes. To do so, they have to calculate the masternode quorum on its own, with only the data available through the deterministic masternode list, the votes and the transaction itself.