### PR TITLE
Fix check for nTemporaryTestnetForkDIP3Height

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -76,7 +76,7 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     // BEGIN TEMPORARY CODE
     const auto& consensus = Params().GetConsensus();
     if (consensus.nTemporaryTestnetForkHeight != 0 &&
-        pindexPrev->nHeight + 1 >= consensus.nTemporaryTestnetForkDIP3Height &&
+        pindexPrev->nHeight + 1 > consensus.nTemporaryTestnetForkDIP3Height &&
         pindexPrev->nHeight + 1 < consensus.nTemporaryTestnetForkHeight &&
         chainActive[consensus.nTemporaryTestnetForkDIP3Height]->GetBlockHash() == consensus.nTemporaryTestnetForkDIP3BlockHash) {
         for (auto& sme : sml.mnList) {

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -282,7 +282,7 @@ bool CQuorumBlockProcessor::IsCommitmentRequired(Consensus::LLMQType llmqType, c
         LOCK(cs_main);
         const auto& consensus = Params().GetConsensus();
         if (consensus.nTemporaryTestnetForkDIP3Height != 0 &&
-            pindexPrev->nHeight + 1 >= consensus.nTemporaryTestnetForkDIP3Height &&
+            pindexPrev->nHeight + 1 > consensus.nTemporaryTestnetForkDIP3Height &&
             pindexPrev->nHeight + 1 < consensus.nTemporaryTestnetForkHeight &&
             chainActive[consensus.nTemporaryTestnetForkDIP3Height]->GetBlockHash() == consensus.nTemporaryTestnetForkDIP3BlockHash) {
             allowMissingQc = true;


### PR DESCRIPTION
This caused a crash when performing a full-sync.