### PR TITLE
Deserialize CFinalCommitmentTxPayload instead of CFinalCommitment in TxToJSON

### DIFF
--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -144,6 +144,17 @@ void CFinalCommitment::ToJson(UniValue& obj) const
     obj.push_back(Pair("quorumPublicKey", quorumPublicKey.ToString()));
 }
 
+void CFinalCommitmentTxPayload::ToJson(UniValue& obj) const
+{
+    obj.setObject();
+    obj.push_back(Pair("version", (int)nVersion));
+    obj.push_back(Pair("height", (int)nHeight));
+
+    UniValue qcObj;
+    commitment.ToJson(qcObj);
+    obj.push_back(Pair("commitment", qcObj));
+}
+
 bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
 {
     CFinalCommitmentTxPayload qcTx;

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -108,6 +108,8 @@ public:
         READWRITE(nHeight);
         READWRITE(commitment);
     }
+
+    void ToJson(UniValue& obj) const;
 };
 
 bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -171,7 +171,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         llmq::CFinalCommitmentTxPayload qcTx;
         if (GetTxPayload(tx, qcTx)) {
             UniValue obj;
-            qcTx.commitment.ToJson(obj);
+            qcTx.ToJson(obj);
             entry.push_back(Pair("qcTx", obj));
         }
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -168,10 +168,10 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
             entry.push_back(Pair("cbTx", obj));
         }
     } else if (tx.nType == TRANSACTION_QUORUM_COMMITMENT) {
-        llmq::CFinalCommitment qcTx;
+        llmq::CFinalCommitmentTxPayload qcTx;
         if (GetTxPayload(tx, qcTx)) {
             UniValue obj;
-            qcTx.ToJson(obj);
+            qcTx.commitment.ToJson(obj);
             entry.push_back(Pair("qcTx", obj));
         }
     }


### PR DESCRIPTION
This fixes missing `qcTx` entries in `getrawtransaction <txhash> 1`.
Example: `getrawtransaction f96ca72497c5ad795e8a4d1c840ebc1e5804f75171f73e6df4b3dc010e21c50c 1`