### PR TITLE
Punish nodes which keep requesting and then rejecting blocks

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1403,7 +1403,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // on rules which are incompatible to ours. Better to ban him after some time as it might otherwise keep
             // asking for the same block (if -addnode/-connect was used on the other side).
             LOCK(cs_main);
-            Misbehaving(pfrom->id, 10);
+            Misbehaving(pfrom->id, 1);
         }
 
         if (fDebug) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1410,10 +1410,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             std::ostringstream ss;
             ss << strMsg << " code " << itostr(ccode) << ": " << strReason;
 
-            if (strMsg == NetMsgType::BLOCK || strMsg == NetMsgType::TX)
-            {
-                uint256 hash;
-                vRecv >> hash;
+            if (strMsg == NetMsgType::BLOCK || strMsg == NetMsgType::TX) {
                 ss << ": hash " << hash.ToString();
             }
             LogPrint("net", "Reject %s\n", SanitizeString(ss.str()));

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1398,6 +1398,14 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             LogPrint("net", "Unparseable reject message received\n");
         }
 
+        if (strMsg == NetMsgType::BLOCK) {
+            // The node requested a block from us and then rejected it, which indicates that it's most likely running
+            // on rules which are incompatible to ours. Better to ban him after some time as it might otherwise keep
+            // asking for the same block (if -addnode/-connect was used on the other side).
+            LOCK(cs_main);
+            Misbehaving(pfrom->id, 10);
+        }
+
         if (fDebug) {
             std::ostringstream ss;
             ss << strMsg << " code " << itostr(ccode) << ": " << strReason;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1386,25 +1386,29 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
     if (strCommand == NetMsgType::REJECT)
     {
-        if (fDebug) {
-            try {
-                std::string strMsg; unsigned char ccode; std::string strReason;
-                vRecv >> LIMITED_STRING(strMsg, CMessageHeader::COMMAND_SIZE) >> ccode >> LIMITED_STRING(strReason, MAX_REJECT_MESSAGE_LENGTH);
-
-                std::ostringstream ss;
-                ss << strMsg << " code " << itostr(ccode) << ": " << strReason;
-
-                if (strMsg == NetMsgType::BLOCK || strMsg == NetMsgType::TX)
-                {
-                    uint256 hash;
-                    vRecv >> hash;
-                    ss << ": hash " << hash.ToString();
-                }
-                LogPrint("net", "Reject %s\n", SanitizeString(ss.str()));
-            } catch (const std::ios_base::failure&) {
-                // Avoid feedback loops by preventing reject messages from triggering a new reject message.
-                LogPrint("net", "Unparseable reject message received\n");
+        std::string strMsg; unsigned char ccode; std::string strReason;
+        uint256 hash;
+        try {
+            vRecv >> LIMITED_STRING(strMsg, CMessageHeader::COMMAND_SIZE) >> ccode >> LIMITED_STRING(strReason, MAX_REJECT_MESSAGE_LENGTH);
+            if (strMsg == NetMsgType::BLOCK || strMsg == NetMsgType::TX) {
+                vRecv >> hash;
             }
+        } catch (const std::ios_base::failure&) {
+            // Avoid feedback loops by preventing reject messages from triggering a new reject message.
+            LogPrint("net", "Unparseable reject message received\n");
+        }
+
+        if (fDebug) {
+            std::ostringstream ss;
+            ss << strMsg << " code " << itostr(ccode) << ": " << strReason;
+
+            if (strMsg == NetMsgType::BLOCK || strMsg == NetMsgType::TX)
+            {
+                uint256 hash;
+                vRecv >> hash;
+                ss << ": hash " << hash.ToString();
+            }
+            LogPrint("net", "Reject %s\n", SanitizeString(ss.str()));
         }
     }
 


### PR DESCRIPTION
I observed very high load on my masternodes as other nodes kept re-requesting the same block (274000) in a very high rate. It looks like these nodes had my MN added with `-addnode` (confirmed by one of the owners), which circumvents banning of my node even though the blocks were not compliant with their local consensus rules (they were still on rc4, so they didn't have the testnet hardfork).

This PR adds a ban score of 10 for nodes that reject blocks. The idea is that whoever keeps requesting and then rejecting blocks is very likely on a non-upgraded/incompatible software, so we can't really help that node anyway and better ban him for some time.