### PR TITLE
Fix GUI warnings in debug.log

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -94,9 +94,9 @@ MasternodeList::MasternodeList(const PlatformStyle* platformStyle, QWidget* pare
     contextMenuDIP3->addAction(copyProTxHashAction);
     contextMenuDIP3->addAction(copyCollateralOutpointAction);
     connect(ui->tableWidgetMasternodesDIP3, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showContextMenuDIP3(const QPoint&)));
-    connect(ui->tableWidgetMasternodesDIP3, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(on_extraInfoDIP3_clicked()));
-    connect(copyProTxHashAction, SIGNAL(triggered()), this, SLOT(on_copyProTxHash_clicked()));
-    connect(copyCollateralOutpointAction, SIGNAL(triggered()), this, SLOT(on_copyCollateralOutpoint_clicked()));
+    connect(ui->tableWidgetMasternodesDIP3, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(extraInfoDIP3_clicked()));
+    connect(copyProTxHashAction, SIGNAL(triggered()), this, SLOT(copyProTxHash_clicked()));
+    connect(copyCollateralOutpointAction, SIGNAL(triggered()), this, SLOT(copyCollateralOutpoint_clicked()));
 
     timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(updateNodeList()));
@@ -691,7 +691,7 @@ CDeterministicMNCPtr MasternodeList::GetSelectedDIP3MN()
     return mnList.GetUniquePropertyMN(addr);
 }
 
-void MasternodeList::on_extraInfoDIP3_clicked()
+void MasternodeList::extraInfoDIP3_clicked()
 {
     auto dmn = GetSelectedDIP3MN();
     if (!dmn) {
@@ -708,7 +708,7 @@ void MasternodeList::on_extraInfoDIP3_clicked()
     QMessageBox::information(this, strWindowtitle, strText);
 }
 
-void MasternodeList::on_copyProTxHash_clicked()
+void MasternodeList::copyProTxHash_clicked()
 {
     auto dmn = GetSelectedDIP3MN();
     if (!dmn) {
@@ -718,7 +718,7 @@ void MasternodeList::on_copyProTxHash_clicked()
     QApplication::clipboard()->setText(QString::fromStdString(dmn->proTxHash.ToString()));
 }
 
-void MasternodeList::on_copyCollateralOutpoint_clicked()
+void MasternodeList::copyCollateralOutpoint_clicked()
 {
     auto dmn = GetSelectedDIP3MN();
     if (!dmn) {

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -91,8 +91,8 @@ private Q_SLOTS:
     void on_tableWidgetMyMasternodes_itemSelectionChanged();
     void on_UpdateButton_clicked();
 
-    void on_extraInfoDIP3_clicked();
-    void on_copyProTxHash_clicked();
-    void on_copyCollateralOutpoint_clicked();
+    void extraInfoDIP3_clicked();
+    void copyProTxHash_clicked();
+    void copyCollateralOutpoint_clicked();
 };
 #endif // MASTERNODELIST_H


### PR DESCRIPTION
Specifically:

```
GUI: QMetaObject::connectSlotsByName: No matching signal for on_extraInfoDIP3_doubleClicked()
GUI: QMetaObject::connectSlotsByName: No matching signal for on_copyProTxHash_clicked()
GUI: QMetaObject::connectSlotsByName: No matching signal for on_copyCollateralOutpoint_clicked()
```

Explanation: should not use `on_<widget>_<signal>` slot names when you only want to link signal<->slot manually cause qt also tries to connect them automagically and it fails to do so because there are no such widgets (e.g. buttons for the regular masternodes tab where we in fact reuse their slots for other stuff like context menu and double click event).