### PR TITLE
Call ProcessTick every second, handle tick cooldown inside

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2078,7 +2078,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (!fLiteMode) {
         scheduler.scheduleEvery(boost::bind(&CNetFulfilledRequestManager::DoMaintenance, boost::ref(netfulfilledman)), 60);
-        scheduler.scheduleEvery(boost::bind(&CMasternodeSync::DoMaintenance, boost::ref(masternodeSync), boost::ref(*g_connman)), MASTERNODE_SYNC_TICK_SECONDS);
+        scheduler.scheduleEvery(boost::bind(&CMasternodeSync::DoMaintenance, boost::ref(masternodeSync), boost::ref(*g_connman)), 1);
         scheduler.scheduleEvery(boost::bind(&CMasternodeMan::DoMaintenance, boost::ref(mnodeman), boost::ref(*g_connman)), 1);
         scheduler.scheduleEvery(boost::bind(&CActiveLegacyMasternodeManager::DoMaintenance, boost::ref(legacyActiveMasternodeManager), boost::ref(*g_connman)), MASTERNODE_MIN_MNP_SECONDS);
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -150,6 +150,12 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
         nTimeLastProcess = GetTime();
         return;
     }
+
+    if(GetTime() - nTimeLastProcess < MASTERNODE_SYNC_TICK_SECONDS) {
+        // too early, nothing to do here
+        return;
+    }
+
     nTimeLastProcess = GetTime();
 
     // reset sync status in case of any other sync failure


### PR DESCRIPTION
I noticed that when a node is overwhelmed by processing `mnw`s `ProcessTick` takes so long that it is executed every 20-ish seconds or so instead of being executed every 6-ish. The way scheduler works (i.e. `start this again when previous run is over`) is way too imprecise for small periods like this, running every second and checking actual time conditions inside the function itself should work better in this case.