### PR TITLE
Avoid printing DIP3/DIP4 related logs twice

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -67,7 +67,7 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     LOCK(deterministicMNManager->cs);
 
     CDeterministicMNList tmpMNList;
-    if (!deterministicMNManager->BuildNewListFromBlock(block, pindexPrev, state, tmpMNList)) {
+    if (!deterministicMNManager->BuildNewListFromBlock(block, pindexPrev, state, tmpMNList, false)) {
         return false;
     }
 

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -336,7 +336,7 @@ public:
      * @param proTxHash
      * @param penalty
      */
-    void PoSePunish(const uint256& proTxHash, int penalty);
+    void PoSePunish(const uint256& proTxHash, int penalty, bool debugLogs);
 
     /**
      * Decrease penalty score of MN by 1.
@@ -459,8 +459,8 @@ public:
     void UpdatedBlockTip(const CBlockIndex* pindex);
 
     // the returned list will not contain the correct block hash (we can't know it yet as the coinbase TX is not updated yet)
-    bool BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state, CDeterministicMNList& mnListRet);
-    void HandleQuorumCommitment(llmq::CFinalCommitment& qc, CDeterministicMNList& mnList);
+    bool BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state, CDeterministicMNList& mnListRet, bool debugLogs);
+    void HandleQuorumCommitment(llmq::CFinalCommitment& qc, CDeterministicMNList& mnList, bool debugLogs);
     void DecreasePoSePenalties(CDeterministicMNList& mnList);
 
     CDeterministicMNList GetListForBlock(const uint256& blockHash);


### PR DESCRIPTION
All logging that happens in BuildNewListFromBlock is currently printed twice.
This is because BuildNewListFromBlock is called while processing the block
and also while calculating the DIP4 MN list commitment.

This commit adds the debugLogs to this method to allow omitting logs while
called from the DIP4 code.