### PR TITLE
Also stop asking other peers for a TX when ProcessTxLockRequest fails

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2025,6 +2025,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         CInv inv(nInvType, tx.GetHash());
         pfrom->AddInventoryKnown(inv);
+        {
+            LOCK(cs_main);
+            connman.RemoveAskFor(inv.hash);
+        }
 
         // Process custom logic, no matter if tx will be accepted to mempool later or not
         if (strCommand == NetMsgType::TXLOCKREQUEST || fCanAutoLock) {
@@ -2070,8 +2074,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
 
         LOCK(cs_main);
-
-        connman.RemoveAskFor(inv.hash);
 
         bool fMissingInputs = false;
         CValidationState state;


### PR DESCRIPTION
This is moving up the RemoveAskFor call above the ProcessTxLockRequest
call. If ProcessTxLockRequest fails, we should not re-request the same
TX/IX from other nodes as it will continue to fail.