### PR TITLE
Serialize the block header in CBlockHeader::GetHash()

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -398,9 +398,6 @@ libdash_consensus_a_SOURCES = \
   script/script_error.h \
   serialize.h \
   streams.h \
-  support/allocators/zeroafterfree.h \
-  support/cleanse.cpp \
-  support/cleanse.h \
   tinyformat.h \
   uint256.cpp \
   uint256.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -397,6 +397,10 @@ libdash_consensus_a_SOURCES = \
   script/script_error.cpp \
   script/script_error.h \
   serialize.h \
+  streams.h \
+  support/allocators/zeroafterfree.h \
+  support/cleanse.cpp \
+  support/cleanse.h \
   tinyformat.h \
   uint256.cpp \
   uint256.h \

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -5,17 +5,18 @@
 
 #include "primitives/block.h"
 
-#include "streams.h"
 #include "hash.h"
+#include "streams.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 #include "crypto/common.h"
 
 uint256 CBlockHeader::GetHash() const
 {
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    std::vector<unsigned char> vch(80);
+    CVectorWriter ss(SER_NETWORK, PROTOCOL_VERSION, vch, 0);
     ss << *this;
-    return HashX11((const char *)&ss[0], (const char *)&ss[0] + ss.size());
+    return HashX11((const char *)vch.data(), (const char *)vch.data() + vch.size());
 }
 
 std::string CBlock::ToString() const

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -5,6 +5,7 @@
 
 #include "primitives/block.h"
 
+#include "streams.h"
 #include "hash.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
@@ -12,7 +13,9 @@
 
 uint256 CBlockHeader::GetHash() const
 {
-    return HashX11(BEGIN(nVersion), END(nNonce));
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << *this;
+    return HashX11((const char *)&ss[0], (const char *)&ss[0] + ss.size());
 }
 
 std::string CBlock::ToString() const


### PR DESCRIPTION
Dash's change of Bitcoin's CBlockHeader::GetHash() to HashX11 omitted the serialization step, which broke portability to big-endian system. Re-add the serialization to restore the portability. Closes #2520.