### PR TITLE
Allow skipping of MN payments with zero duffs

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -610,14 +610,21 @@ bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, 
             return false;
         }
 
-        if (dmnPayee->nOperatorReward == 0 || dmnPayee->pdmnState->scriptOperatorPayout == CScript()) {
-            voutMasternodePaymentsRet.emplace_back(masternodeReward, dmnPayee->pdmnState->scriptPayout);
-        } else {
-            CAmount operatorReward = (masternodeReward * dmnPayee->nOperatorReward) / 10000;
+        CAmount operatorReward = 0;;
+        if (dmnPayee->nOperatorReward != 0 && dmnPayee->pdmnState->scriptOperatorPayout != CScript()) {
+            // This calculation might eventually turn out to result in 0 even if an operator reward percentage is given
+            // This will however only happen in a few years when the block rewards drops very low
+            operatorReward = (masternodeReward * dmnPayee->nOperatorReward) / 10000;
             masternodeReward -= operatorReward;
+        }
+
+        if (masternodeReward > 0) {
             voutMasternodePaymentsRet.emplace_back(masternodeReward, dmnPayee->pdmnState->scriptPayout);
+        }
+        if (operatorReward > 0) {
             voutMasternodePaymentsRet.emplace_back(operatorReward, dmnPayee->pdmnState->scriptOperatorPayout);
         }
+
         return true;
     } else {
         LOCK(cs_mapMasternodeBlocks);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -610,10 +610,10 @@ bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, 
             return false;
         }
 
-        CAmount operatorReward = 0;;
+        CAmount operatorReward = 0;
         if (dmnPayee->nOperatorReward != 0 && dmnPayee->pdmnState->scriptOperatorPayout != CScript()) {
-            // This calculation might eventually turn out to result in 0 even if an operator reward percentage is given
-            // This will however only happen in a few years when the block rewards drops very low
+            // This calculation might eventually turn out to result in 0 even if an operator reward percentage is given.
+            // This will however only happen in a few years when the block rewards drops very low.
             operatorReward = (masternodeReward * dmnPayee->nOperatorReward) / 10000;
             masternodeReward -= operatorReward;
         }


### PR DESCRIPTION
In case a MNO uses an operator reward of 100%, the normal reward will be 0
duffs. It doesn't make sense to enforce these payments.

This will cause a fork when miners start to mine with the new version, but
only for nodes that didn't upgrade.