### PR TITLE
Use correct time field when removing pre-DIP3 votes

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -816,7 +816,7 @@ std::vector<uint256> CGovernanceObject::RemoveOldVotes(unsigned int nMinTime)
         auto& miRef = itMnPair->second.mapInstances;
         auto itVotePair = miRef.begin();
         while (itVotePair != miRef.end()) {
-            if (itVotePair->second.nTime < nMinTime) {
+            if (itVotePair->second.nCreationTime < nMinTime) {
                 miRef.erase(itVotePair++);
             } else {
                 ++itVotePair;


### PR DESCRIPTION
nTime is not the timestamp from the vote object. nCreationTime is the
correct field to use.

This fixes continues deletion of votes.