### PR TITLE
Refactor CQuorumBlockProcessor and CDeterministicMNManager

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -428,14 +428,14 @@ CDeterministicMNManager::CDeterministicMNManager(CEvoDB& _evoDb) :
 {
 }
 
-bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& _state)
+bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& _state)
 {
     LOCK(cs);
 
-    int nHeight = pindexPrev->nHeight + 1;
+    int nHeight = pindex->nHeight;
 
     CDeterministicMNList newList;
-    if (!BuildNewListFromBlock(block, pindexPrev, _state, newList, true)) {
+    if (!BuildNewListFromBlock(block, pindex->pprev, _state, newList, true)) {
         return false;
     }
 
@@ -445,7 +445,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
 
     newList.SetBlockHash(block.GetHash());
 
-    CDeterministicMNList oldList = GetListForBlock(pindexPrev->GetBlockHash());
+    CDeterministicMNList oldList = GetListForBlock(pindex->pprev->GetBlockHash());
     CDeterministicMNListDiff diff = oldList.BuildDiff(newList);
 
     evoDb.Write(std::make_pair(DB_LIST_DIFF, diff.blockHash), diff);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -453,7 +453,7 @@ private:
 public:
     CDeterministicMNManager(CEvoDB& _evoDb);
 
-    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state);
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
     void UpdatedBlockTip(const CBlockIndex* pindex);

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -98,7 +98,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CV
         }
     }
 
-    if (!llmq::quorumBlockProcessor->ProcessBlock(block, pindex->pprev, state)) {
+    if (!llmq::quorumBlockProcessor->ProcessBlock(block, pindex, state)) {
         return false;
     }
 

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -102,7 +102,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CV
         return false;
     }
 
-    if (!deterministicMNManager->ProcessBlock(block, pindex->pprev, state)) {
+    if (!deterministicMNManager->ProcessBlock(block, pindex, state)) {
         return false;
     }
 

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -114,8 +114,6 @@ bool CQuorumBlockProcessor::ProcessBlock(const CBlock& block, const CBlockIndex*
         return true;
     }
 
-    int nHeight = pindexPrev->nHeight + 1;
-
     std::map<Consensus::LLMQType, CFinalCommitment> qcs;
     if (!GetCommitmentsFromBlock(block, pindex->pprev, qcs, state)) {
         return false;
@@ -126,8 +124,6 @@ bool CQuorumBlockProcessor::ProcessBlock(const CBlock& block, const CBlockIndex*
     // allowed, including null commitments.
     for (const auto& p : Params().GetConsensus().llmqs) {
         auto type = p.first;
-
-        uint256 quorumHash = GetQuorumBlockHash(type, pindexPrev);
 
         // does the currently processed block contain a (possibly null) commitment for the current session?
         bool hasCommitmentInNewBlock = qcs.count(type) != 0;
@@ -383,8 +379,6 @@ bool CQuorumBlockProcessor::GetMinableCommitmentByHash(const uint256& commitment
 bool CQuorumBlockProcessor::GetMinableCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev, CFinalCommitment& ret)
 {
     AssertLockHeld(cs_main);
-
-    int nHeight = pindexPrev->nHeight + 1;
 
     if (!IsCommitmentRequired(llmqType, pindexPrev)) {
         // no commitment required

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -34,7 +34,7 @@ public:
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
-    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state);
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
     void AddMinableCommitment(const CFinalCommitment& fqc);


### PR DESCRIPTION
It's currently pretty confusing the way `pindexPrev` is used in these two imo. This PR basically switches it to `pindex` when processing current block and keeps `pindexPrev` only for places where we try to figure out commitments for the next block (i.e. `GetMinableCommitment/Tx`). Similar logic was applied to `CDeterministicMNManager` too. IMO it makes it much easier to read/understand.

Also dropped few unused statements while at it.