### PR TITLE
Ensure EvoDB consistency for quorum commitments by storing the best block hash

### DIFF
--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -159,6 +159,7 @@ class WalletBackupTest(BitcoinTestFramework):
         # Start node2 with no chain
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+        shutil.rmtree(self.options.tmpdir + "/node2/regtest/evodb")
 
         # Restore wallets from backup
         shutil.copyfile(tmpdir + "/node0/wallet.bak", tmpdir + "/node0/regtest/wallet.dat")
@@ -180,6 +181,7 @@ class WalletBackupTest(BitcoinTestFramework):
         #start node2 with no chain
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+        shutil.rmtree(self.options.tmpdir + "/node2/regtest/evodb")
 
         self.start_three()
 

--- a/src/evo/evodb.cpp
+++ b/src/evo/evodb.cpp
@@ -11,3 +11,20 @@ CEvoDB::CEvoDB(size_t nCacheSize, bool fMemory, bool fWipe) :
     dbTransaction(db)
 {
 }
+
+bool CEvoDB::VerifyBestBlock(const uint256& hash)
+{
+    // Make sure evodb is consistent.
+    // If we already have best block hash saved, the previous block should match it.
+    uint256 hashBestBlock;
+    bool fHasBestBlock = Read(EVODB_BEST_BLOCK, hashBestBlock);
+    uint256 hashBlockIndex = fHasBestBlock ? hash : uint256();
+    assert(hashBestBlock == hashBlockIndex);
+
+    return fHasBestBlock;
+}
+
+void CEvoDB::WriteBestBlock(const uint256& hash)
+{
+    Write(EVODB_BEST_BLOCK, hash);
+}

--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -7,6 +7,7 @@
 
 #include "dbwrapper.h"
 #include "sync.h"
+#include "uint256.h"
 
 static const std::string EVODB_BEST_BLOCK = "b_b";
 
@@ -59,6 +60,9 @@ public:
     {
         return db;
     }
+
+    bool VerifyBestBlock(const uint256& hash);
+    void WriteBestBlock(const uint256& hash);
 };
 
 extern CEvoDB* evoDb;

--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -8,6 +8,8 @@
 #include "dbwrapper.h"
 #include "sync.h"
 
+static const std::string EVODB_BEST_BLOCK = "b_b";
+
 class CEvoDB
 {
 private:


### PR DESCRIPTION
This approach is similar to the one used for chainstate currently.

Ensures that:
- nodes that upgraded after DIP3 has all the data processed correctly (they will crash and require reindex);
- `evodb/` is removed when `blocks/` is removed (otherwise sync will fail due to duplicate records).

~Based on #2536 because I needed `pindex` for this, will rebase later. See 15eb4c1 for actual changes.~
