### PR TITLE
Remove ProTxs from mempool that refer to a ProRegTx for which the collateral was spent

### DIFF
--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -50,11 +50,16 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
         fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(chainName);
+        evoDb = new CEvoDB(1 << 20, true, true);
+        deterministicMNManager = new CDeterministicMNManager(*evoDb);
         noui_connect();
 }
 
 BasicTestingSetup::~BasicTestingSetup()
 {
+        delete deterministicMNManager;
+        delete evoDb;
+
         ECC_Stop();
         g_connman.reset();
 }
@@ -70,10 +75,8 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         boost::filesystem::create_directories(pathTemp);
         ForceSetArg("-datadir", pathTemp.string());
         mempool.setSanityCheck(1.0);
-        evoDb = new CEvoDB(1 << 20, true, true);
         pblocktree = new CBlockTreeDB(1 << 20, true);
         pcoinsdbview = new CCoinsViewDB(1 << 23, true);
-        deterministicMNManager = new CDeterministicMNManager(*evoDb);
         llmq::InitLLMQSystem(*evoDb);
         pcoinsTip = new CCoinsViewCache(pcoinsdbview);
         InitBlockIndex(chainparams);
@@ -98,10 +101,8 @@ TestingSetup::~TestingSetup()
         UnloadBlockIndex();
         delete pcoinsTip;
         llmq::DestroyLLMQSystem();
-        delete deterministicMNManager;
         delete pcoinsdbview;
         delete pblocktree;
-        delete evoDb;
         boost::filesystem::remove_all(pathTemp);
 }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -585,6 +585,7 @@ public:
     void removeProTxPubKeyConflicts(const CTransaction &tx, const CKeyID &keyId);
     void removeProTxPubKeyConflicts(const CTransaction &tx, const CBLSPublicKey &pubKey);
     void removeProTxCollateralConflicts(const CTransaction &tx, const COutPoint &collateralOutpoint);
+    void removeProTxSpentCollateralConflicts(const CTransaction &tx);
     void removeProTxConflicts(const CTransaction &tx);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -534,6 +534,7 @@ private:
     typedef std::map<uint256, std::vector<CSpentIndexKey> > mapSpentIndexInserted;
     mapSpentIndexInserted mapSpentInserted;
 
+    std::multimap<uint256, uint256> mapProTxRefs; // proTxHash -> transaction (all TXs that refer to an existing proTx)
     std::map<CService, uint256> mapProTxAddresses;
     std::map<CKeyID, uint256> mapProTxPubKeyIDs;
     std::map<uint256, uint256> mapProTxBlsPubKeyHashes;


### PR DESCRIPTION
See commits.

I observed TXs never being removed even though the collaterals were spent already, causing `getblocktemplate` and `generate` to fail. This PR fixes this.