### PR TITLE
Reintroduce BLSInit to correctly set secure alloctor callbacks

### DIFF
--- a/src/bench/bench_dash.cpp
+++ b/src/bench/bench_dash.cpp
@@ -19,6 +19,7 @@ main(int argc, char** argv)
     ECC_Start();
     ECCVerifyHandle verifyHandle;
 
+    BLSInit();
     SetupEnvironment();
     fPrintToDebugLog = false; // don't want to write to debug.log file
 

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -462,3 +462,11 @@ static void secure_free(void* p)
     return get_secure_allocator().deallocate(ptr, n);
 }
 #endif
+
+bool BLSInit()
+{
+#ifndef BUILD_BITCOIN_INTERNAL
+    bls::BLS::SetSecureAllocator(secure_allocate, secure_free);
+#endif
+    return true;
+}

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -300,4 +300,6 @@ typedef std::shared_ptr<BLSPublicKeyVector> BLSPublicKeyVectorPtr;
 typedef std::shared_ptr<BLSSecretKeyVector> BLSSecretKeyVectorPtr;
 typedef std::shared_ptr<BLSSignatureVector> BLSSignatureVectorPtr;
 
+bool BLSInit();
+
 #endif // DASH_CRYPTO_BLS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -855,6 +855,10 @@ bool InitSanityCheck(void)
     if (!glibc_sanity_test() || !glibcxx_sanity_test())
         return false;
 
+    if (!BLSInit()) {
+        return false;
+    }
+
     return true;
 }
 

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -44,6 +44,7 @@ extern void noui_connect();
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 {
         ECC_Start();
+        BLSInit();
         SetupEnvironment();
         SetupNetworking();
         InitSignatureCache();


### PR DESCRIPTION
https://github.com/dashpay/dash/pull/2409 removed the need to call the
Init method of the Chia BLS library, but we also accidently removed the
initialization of the secure allocator.