### PR TITLE
Revert "Sort recipients in SendCoins dialog via BIP69 rule"

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -254,11 +254,6 @@ void SendCoinsDialog::on_sendButton_clicked()
         return;
     }
 
-    // apply BIP69
-    if (bBIP69Enabled) {
-        std::sort(recipients.begin(), recipients.end(), CompareSendCoinsRecipientBIP69());
-    }
-
     QString strFunds = tr("using") + " <b>" + tr("anonymous funds") + "</b>";
     QString strFee = "";
     recipients[0].inputType = ONLY_DENOMINATED;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -101,15 +101,6 @@ public:
     }
 };
 
-// same as CompareOutputBIP69 in primitives/transaction.h
-struct CompareSendCoinsRecipientBIP69
-{
-    inline bool operator()(const SendCoinsRecipient& a, const SendCoinsRecipient& b) const
-    {
-        return a.amount < b.amount || (a.amount == b.amount && a.address < b.address);
-    }
-};
-
 /** Interface to Bitcoin wallet from Qt view code. */
 class WalletModel : public QObject
 {


### PR DESCRIPTION
Looks like it's not enough to sort recipients _before_ tx is created because when there are two of them with the same amount but the "greater" one (by scriptPubKey) is set to be the one to subtract the fee from - they are going to switch and create the same bug/confusion again. Would like to revert this one and merge #2548 as a solution instead.