### PR TITLE
Make sure that we can get inputType and fUseInstantSend regardless of the way recipients are sorted

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -261,10 +261,11 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     QString strFunds = tr("using") + " <b>" + tr("anonymous funds") + "</b>";
     QString strFee = "";
-    recipients[0].inputType = ONLY_DENOMINATED;
 
     if(ui->checkUsePrivateSend->isChecked()) {
-        recipients[0].inputType = ONLY_DENOMINATED;
+        for (SendCoinsRecipient& rcp : recipients) {
+            rcp.inputType = ONLY_DENOMINATED;
+        }
         strFunds = tr("using") + " <b>" + tr("anonymous funds") + "</b>";
         QString strNearestAmount(
             BitcoinUnits::formatWithUnit(
@@ -273,16 +274,22 @@ void SendCoinsDialog::on_sendButton_clicked()
             "(privatesend requires this amount to be rounded up to the nearest %1)."
         ).arg(strNearestAmount));
     } else {
-        recipients[0].inputType = ALL_COINS;
+        for (SendCoinsRecipient& rcp : recipients) {
+            rcp.inputType = ALL_COINS;
+        }
         strFunds = tr("using") + " <b>" + tr("any available funds (not anonymous)") + "</b>";
     }
 
     if(ui->checkUseInstantSend->isChecked()) {
-        recipients[0].fUseInstantSend = true;
+        for (SendCoinsRecipient& rcp : recipients) {
+            rcp.fUseInstantSend = true;
+        }
         strFunds += " ";
         strFunds += tr("and InstantSend");
     } else {
-        recipients[0].fUseInstantSend = false;
+        for (SendCoinsRecipient& rcp : recipients) {
+            rcp.fUseInstantSend = false;
+        }
     }
 
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -263,9 +263,6 @@ void SendCoinsDialog::on_sendButton_clicked()
     QString strFee = "";
 
     if(ui->checkUsePrivateSend->isChecked()) {
-        for (SendCoinsRecipient& rcp : recipients) {
-            rcp.inputType = ONLY_DENOMINATED;
-        }
         strFunds = tr("using") + " <b>" + tr("anonymous funds") + "</b>";
         QString strNearestAmount(
             BitcoinUnits::formatWithUnit(
@@ -274,24 +271,18 @@ void SendCoinsDialog::on_sendButton_clicked()
             "(privatesend requires this amount to be rounded up to the nearest %1)."
         ).arg(strNearestAmount));
     } else {
-        for (SendCoinsRecipient& rcp : recipients) {
-            rcp.inputType = ALL_COINS;
-        }
         strFunds = tr("using") + " <b>" + tr("any available funds (not anonymous)") + "</b>";
     }
 
     if(ui->checkUseInstantSend->isChecked()) {
-        for (SendCoinsRecipient& rcp : recipients) {
-            rcp.fUseInstantSend = true;
-        }
         strFunds += " ";
         strFunds += tr("and InstantSend");
-    } else {
-        for (SendCoinsRecipient& rcp : recipients) {
-            rcp.fUseInstantSend = false;
-        }
     }
 
+    for (SendCoinsRecipient& rcp : recipients) {
+        rcp.inputType = ui->checkUsePrivateSend->isChecked() ? ONLY_DENOMINATED : ALL_COINS;
+        rcp.fUseInstantSend = ui->checkUseInstantSend->isChecked();
+    }
 
     fNewRecipientAllowed = false;
     // request unlock only if was locked or unlocked for mixing:


### PR DESCRIPTION
Noticed this issue after #2546. Shouldn't appear if we merge #2548 but I think it would be nice to merge this one anyway.