### PR TITLE
Bail out from update methods in MasternodeList when shutdown is requested

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -274,6 +274,10 @@ void MasternodeList::updateMyMasternodeInfo(QString strAlias, QString strAddr, c
 
 void MasternodeList::updateMyNodeList(bool fForce)
 {
+    if (ShutdownRequested()) {
+        return;
+    }
+
     TRY_LOCK(cs_mymnlist, fLockAcquired);
     if (!fLockAcquired) return;
 
@@ -310,6 +314,10 @@ void MasternodeList::updateMyNodeList(bool fForce)
 
 void MasternodeList::updateNodeList()
 {
+    if (ShutdownRequested()) {
+        return;
+    }
+
     TRY_LOCK(cs_mnlist, fLockAcquired);
     if (!fLockAcquired) return;
 
@@ -380,6 +388,10 @@ void MasternodeList::updateNodeList()
 
 void MasternodeList::updateDIP3List()
 {
+    if (ShutdownRequested()) {
+        return;
+    }
+
     TRY_LOCK(cs_dip3list, fLockAcquired);
     if (!fLockAcquired) return;
 


### PR DESCRIPTION
This fixes a crash reported by multiple users. It sometimes happens when the Qt wallet is closed. Discovered the cause by letting one of these users run a version with #2420 compiled in. Stacktrace looks like:

```
2018-12-11 18:35:26 #### signal Segmentation fault ####
   0#: (0x560482E80786) stacktraces.cpp:583        - HandlePosixSignal
   1#: (0x7F2CDFC2E6B0) <unknown-file>             - ???
   2#: (0x7F2CDFC266B0) <unknown-file>             - ???
   3#: (0x560482A258ED) recursive_mutex.hpp:113    - boost::recursive_mutex::lock()
   4#: (0x560482A258ED) sync.h:60                  - AnnotatedMixin<boost::recursive_mutex>::lock()
   5#: (0x560482A258ED) lock_types.hpp:346         - boost::unique_lock<CCriticalSection>::lock()
   6#: (0x560482A258ED) sync.h:125                 - CMutexLock<CCriticalSection>::Enter(char const, char const, int)
   7#: (0x560482A258ED) sync.h:146                 - CMutexLock<CCriticalSection>::CMutexLock(CCriticalSection&, char const, char const, int, bool)
   8#: (0x560482A2596E) deterministicmns.cpp:861   - CDeterministicMNManager::IsDeterministicMNsSporkActive(int)
   9#: (0x5604829AEB4E) masternodelist.cpp:338     - MasternodeList::updateNodeList()
  10#: (0x5604829FEB7D) moc_masternodelist.cpp:148 - MasternodeList::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)
  11#: (0x560483A12461) <unknown-file>             - ???
  12#: (0x560483A1E69D) <unknown-file>             - ???
  13#: (0x560483A12F6B) <unknown-file>             - ???
  14#: (0x56048310BC4C) <unknown-file>             - ???
  15#: (0x560483112B6F) <unknown-file>             - ???
  16#: (0x5604839E3D88) <unknown-file>             - ???
  17#: (0x560483A37A3E) <unknown-file>             - ???
```