### PR TITLE
Allow up to MASTERNODE_MAX_MIXING_TXES (5) DSTXes per MN in a row

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -24,14 +24,12 @@
 
 
 CMasternode::CMasternode() :
-    masternode_info_t{ MASTERNODE_ENABLED, PROTOCOL_VERSION, GetAdjustedTime()},
-    fAllowMixingTx(true)
+    masternode_info_t{ MASTERNODE_ENABLED, PROTOCOL_VERSION, GetAdjustedTime()}
 {}
 
 CMasternode::CMasternode(CService addr, COutPoint outpoint, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, int nProtocolVersionIn) :
     masternode_info_t{ MASTERNODE_ENABLED, nProtocolVersionIn, GetAdjustedTime(),
-                       outpoint, addr, pubKeyCollateralAddressNew, pubKeyMasternodeNew},
-    fAllowMixingTx(true)
+                       outpoint, addr, pubKeyCollateralAddressNew, pubKeyMasternodeNew}
 {}
 
 CMasternode::CMasternode(const CMasternode& other) :
@@ -42,7 +40,7 @@ CMasternode::CMasternode(const CMasternode& other) :
     nBlockLastPaid(other.nBlockLastPaid),
     nPoSeBanScore(other.nPoSeBanScore),
     nPoSeBanHeight(other.nPoSeBanHeight),
-    fAllowMixingTx(other.fAllowMixingTx),
+    nMixingTxCount(other.nMixingTxCount),
     fUnitTest(other.fUnitTest)
 {}
 
@@ -50,14 +48,12 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
     masternode_info_t{ mnb.nActiveState, mnb.nProtocolVersion, mnb.sigTime,
                        mnb.outpoint, mnb.addr, mnb.pubKeyCollateralAddress, mnb.pubKeyMasternode},
     lastPing(mnb.lastPing),
-    vchSig(mnb.vchSig),
-    fAllowMixingTx(true)
+    vchSig(mnb.vchSig)
 {}
 
 CMasternode::CMasternode(const uint256 &proTxHash, const CDeterministicMNCPtr& dmn) :
     masternode_info_t{ MASTERNODE_ENABLED, DMN_PROTO_VERSION, GetAdjustedTime(),
-                       dmn->collateralOutpoint, dmn->pdmnState->addr, CKeyID() /* not valid with DIP3 */, dmn->pdmnState->keyIDOwner, dmn->pdmnState->pubKeyOperator, dmn->pdmnState->keyIDVoting},
-    fAllowMixingTx(true)
+                       dmn->collateralOutpoint, dmn->pdmnState->addr, CKeyID() /* not valid with DIP3 */, dmn->pdmnState->keyIDOwner, dmn->pdmnState->pubKeyOperator, dmn->pdmnState->keyIDVoting}
 {
 }
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -24,6 +24,7 @@ static const int MASTERNODE_EXPIRATION_SECONDS          = 120 * 60;
 static const int MASTERNODE_NEW_START_REQUIRED_SECONDS  = 180 * 60;
 
 static const int MASTERNODE_POSE_BAN_MAX_SCORE          = 5;
+static const int MASTERNODE_MAX_MIXING_TXES             = 5;
 
 //
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network
@@ -179,7 +180,7 @@ public:
     int nBlockLastPaid{};
     int nPoSeBanScore{};
     int nPoSeBanHeight{};
-    bool fAllowMixingTx{};
+    int nMixingTxCount{};
     bool fUnitTest = false;
 
     // KEEP TRACK OF GOVERNANCE ITEMS EACH MASTERNODE HAS VOTE UPON FOR RECALCULATION
@@ -217,7 +218,7 @@ public:
         READWRITE(nProtocolVersion);
         READWRITE(nPoSeBanScore);
         READWRITE(nPoSeBanHeight);
-        READWRITE(fAllowMixingTx);
+        READWRITE(nMixingTxCount);
         READWRITE(fUnitTest);
         READWRITE(mapGovernanceObjectsVotedOn);
     }
@@ -275,6 +276,11 @@ public:
         return false;
     }
 
+    bool IsValidForMixingTxes() const
+    {
+        return nMixingTxCount <= MASTERNODE_MAX_MIXING_TXES;
+    }
+
     bool IsValidNetAddr();
     static bool IsValidNetAddr(CService addrIn);
 
@@ -308,7 +314,7 @@ public:
         nBlockLastPaid = from.nBlockLastPaid;
         nPoSeBanScore = from.nPoSeBanScore;
         nPoSeBanHeight = from.nPoSeBanHeight;
-        fAllowMixingTx = from.fAllowMixingTx;
+        nMixingTxCount = from.nMixingTxCount;
         fUnitTest = from.fUnitTest;
         mapGovernanceObjectsVotedOn = from.mapGovernanceObjectsVotedOn;
         return *this;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -28,7 +28,7 @@
 /** Masternode manager */
 CMasternodeMan mnodeman;
 
-const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-11";
+const std::string CMasternodeMan::SERIALIZATION_VERSION_STRING = "CMasternodeMan-Version-12";
 const int CMasternodeMan::LAST_PAID_SCAN_BLOCKS = 100;
 
 struct CompareLastPaidBlock
@@ -136,7 +136,7 @@ bool CMasternodeMan::AllowMixing(const COutPoint &outpoint)
     }
     nDsqCount++;
     pmn->nLastDsq = nDsqCount;
-    pmn->fAllowMixingTx = true;
+    pmn->nMixingTxCount = 0;
 
     return true;
 }
@@ -148,7 +148,7 @@ bool CMasternodeMan::DisallowMixing(const COutPoint &outpoint)
     if (!pmn) {
         return false;
     }
-    pmn->fAllowMixingTx = false;
+    pmn->nMixingTxCount++;
 
     return true;
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2086,7 +2086,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 return false;
             }
 
-            if(!mn.fAllowMixingTx) {
+            if(!mn.IsValidForMixingTxes()) {
                 LogPrint("privatesend", "DSTX -- Masternode %s is sending too many transactions %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
                 return true;
                 // TODO: Not an error? Could it be that someone is relaying old DSTXes


### PR DESCRIPTION
Currently we only allow one single dstx per mn in a row but that's from a perspective of a local node and when half of the network goes down and getting rebuilt from scratch this restriction got all messed up and nodes start producing dstxes which are refused to be processed by the long running nodes i.e. mining pools and thus never got mined. This is not really a big deal for mainnet since we do not expect half of the network to go down there but happens quite often on testnet. This patch lifts the restriction to some higher (and a bit unrealistic for normal use case but still safe in terms of DoS) value.