### PR TITLE
Correctly handle spent collaterals for MNs that were registered in the same block

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1280,8 +1280,16 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
         }
         if (mapProTxAddresses.count(proTx.addr) || mapProTxPubKeyIDs.count(proTx.keyIDOwner) || mapProTxBlsPubKeyHashes.count(proTx.pubKeyOperator.GetHash()))
             return true;
-        if (!proTx.collateralOutpoint.hash.IsNull() && mapProTxCollaterals.count(proTx.collateralOutpoint))
-            return true;
+        if (!proTx.collateralOutpoint.hash.IsNull()) {
+            if (mapProTxCollaterals.count(proTx.collateralOutpoint)) {
+                // there is another ProRegTx that refers to the same collateral
+                return true;
+            }
+            if (mapNextTx.count(proTx.collateralOutpoint)) {
+                // there is another tx that spends the collateral
+                return true;
+            }
+        }
         return false;
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
         CProUpServTx proTx;


### PR DESCRIPTION
Without this, MNOs are able to register a MN and spend the collateral in the same block. This in turn skips the spent collateral check, leading to the MN not being removed, which theoretically allows to re-register unlimited MNs.