### PR TITLE
Bump PROTOCOL_VERSION and DMN_PROTO_VERSION to 70213

### DIFF
--- a/src/instantx.h
+++ b/src/instantx.h
@@ -273,7 +273,7 @@ public:
         READWRITE(outpoint);
         READWRITE(outpointMasternode);
         if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-            // Starting with spork15 activation, the proTxHash and quorumModifierHash is included. When we bump to >= 70213, we can remove
+            // Starting with spork15 activation, the proTxHash and quorumModifierHash is included. When we bump to >= 70214, we can remove
             // the surrounding if. We might also remove outpointMasternode as well later
             READWRITE(quorumModifierHash);
             READWRITE(masternodeProTxHash);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1615,7 +1615,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
     // BEGIN TEMPORARY CODE
     if (pfrom->nVersion < nMinPeerProtoVersion) {
-        // disconnect from peers with version < 70212 after DIP3 has activated through the BIP9 deployment
+        // disconnect from peers with version < 70213 after DIP3 has activated through the BIP9 deployment
         LogPrintf("peer=%d using obsolete version %i after DIP3 activation; disconnecting\n", pfrom->id, pfrom->GetSendVersion());
         connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE,
                 strprintf("Version must be %d or greater", nMinPeerProtoVersion)));

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -24,7 +24,7 @@ static const int PRIVATESEND_QUEUE_TIMEOUT = 30;
 static const int PRIVATESEND_SIGNING_TIMEOUT = 15;
 
 //! minimum peer version accepted by mixing pool
-static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70212;
+static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70213;
 
 static const size_t PRIVATESEND_ENTRY_MAX_SIZE = 9;
 

--- a/src/version.h
+++ b/src/version.h
@@ -23,7 +23,7 @@ static const int GETHEADERS_VERSION = 70077;
 static const int MIN_PEER_PROTO_VERSION = 70210;
 
 //! disconnect from peers older than this proto version when DIP3 is activated via the BIP9 deployment
-static const int MIN_PEER_PROTO_VERSION_DIP3 = 70212;
+static const int MIN_PEER_PROTO_VERSION_DIP3 = 70213;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70212;
+static const int PROTOCOL_VERSION = 70213;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -48,6 +48,6 @@ static const int DIP0001_PROTOCOL_VERSION = 70208;
 static const int SHORT_IDS_BLOCKS_VERSION = 70209;
 
 //! introduction of DIP3/deterministic masternodes
-static const int DMN_PROTO_VERSION = 70212;
+static const int DMN_PROTO_VERSION = 70213;
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
This will disconnect all nodes from the old testnet chain when DIP3 gets
activated through BIP9.

Also update comments where 70212/70213 was referenced.