### PR TITLE
Remove legacy MN list tabs on spork15 activation

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -402,6 +402,10 @@ void MasternodeList::updateDIP3List()
         return;
     }
 
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        ui->dip3NoteLabel->setVisible(false);
+    }
+
     TRY_LOCK(cs_dip3list, fLockAcquired);
     if (!fLockAcquired) return;
 
@@ -426,10 +430,6 @@ void MasternodeList::updateDIP3List()
     ui->tableWidgetMasternodesDIP3->setSortingEnabled(false);
     ui->tableWidgetMasternodesDIP3->clearContents();
     ui->tableWidgetMasternodesDIP3->setRowCount(0);
-
-    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
-        ui->dip3NoteLabel->setVisible(false);
-    }
 
     auto mnList = deterministicMNManager->GetListAtChainTip();
     auto projectedPayees = mnList.GetProjectedMNPayees(mnList.GetValidMNsCount());

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -277,6 +277,9 @@ void MasternodeList::updateMyNodeList(bool fForce)
     if (ShutdownRequested()) {
         return;
     }
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        return;
+    }
 
     TRY_LOCK(cs_mymnlist, fLockAcquired);
     if (!fLockAcquired) return;

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -318,6 +318,16 @@ void MasternodeList::updateNodeList()
         return;
     }
 
+    if (deterministicMNManager->IsDeterministicMNsSporkActive()) {
+        // we misuse the fact that updateNodeList is called regularely here and remove both tabs
+        if (ui->tabWidget->indexOf(ui->tabDIP3Masternodes) != 0) {
+            // remove "My Masternode" and "All Masternodes" tabs
+            ui->tabWidget->removeTab(0);
+            ui->tabWidget->removeTab(0);
+        }
+        return;
+    }
+
     TRY_LOCK(cs_mnlist, fLockAcquired);
     if (!fLockAcquired) return;
 


### PR DESCRIPTION
A few testers were confused by strange values being shown in the "My Masternodes" tab after spork15 activation. The reason is that outdated/not-initialized data is shown. Instead of fixing this, it's maybe better to simply remove these tabs on spork15 activation.