### PR TITLE
Use DIP3 MNs in auto-IX tests

### DIFF
--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -118,7 +118,6 @@ class AutoIXMempoolTest(DashTestFramework):
     def run_test(self):
         # make sure masternodes are synced
         sync_masternodes(self.nodes)
-        self.enforce_masternode_payments()  # required for bip9 activation
         self.activate_autoix_bip9()
         self.set_autoix_spork_state(True)
 

--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -16,14 +16,14 @@ is full (more than 0.1 part from max value).
 
 '''
 
-MAX_MEMPOOL_SIZE = 5 # max node mempool in MBs
+MAX_MEMPOOL_SIZE = 1 # max node mempool in MBs
 MB_SIZE = 1000000 # C++ code use this coefficient to calc MB in mempool
 AUTO_IX_MEM_THRESHOLD = 0.1
 
 
 class AutoIXMempoolTest(DashTestFramework):
     def __init__(self):
-        super().__init__(13, 10, ["-maxmempool=%d" % MAX_MEMPOOL_SIZE])
+        super().__init__(13, 10, ["-maxmempool=%d" % MAX_MEMPOOL_SIZE, '-limitdescendantsize=10'])
         # set sender,  receiver
         self.receiver_idx = self.num_nodes - 2
         self.sender_idx = self.num_nodes - 3

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -125,7 +125,6 @@ class AutoInstantSendTest(DashTestFramework):
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
             
-        self.enforce_masternode_payments()  # required for bip9 activation
         assert(self.get_autoix_bip9_status() == 'defined')
         assert(not self.get_autoix_spork_state())
 

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -15,8 +15,7 @@ Test automatic InstantSend locks functionality.
 
 Checks that simple transactions automatically become InstantSend locked, 
 complex transactions don't become IS-locked and this functionality is
-activated only if it is BIP9-activated and SPORK_16_INSTANTSEND_AUTOLOCKS is 
-active.
+activated only if SPORK_16_INSTANTSEND_AUTOLOCKS is active.
 
 Also checks that this functionality doesn't influence regular InstantSend
 transactions with high fee. 
@@ -125,7 +124,6 @@ class AutoInstantSendTest(DashTestFramework):
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
             
-        assert(self.get_autoix_bip9_status() == 'defined')
         assert(not self.get_autoix_spork_state())
 
         assert(self.send_regular_IX())


### PR DESCRIPTION
~This currently builds on #2586. I'll rebase after it is merged.~

This PR needs to be merged before we start removing of legacy/compatibility MN code.

Tests are quite slow atm as they need to mine 500 blocks and sync these to 13 nodes. I'll later optimize this by tweaking the DIP3 activation height for regtest (can't do this now as it might break other tests).