### PR TITLE
Backport: #10365: [tests] increase timeouts in sendheaders test

### DIFF
--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -294,7 +294,7 @@ class SendHeadersTest(BitcoinTestFramework):
             if i == 0:
                 # first request the block
                 test_node.get_data([tip])
-                test_node.wait_for_block(tip, timeout=5)
+                test_node.wait_for_block(tip)
             elif i == 1:
                 # next try requesting header and block
                 test_node.get_headers(locator=[old_tip], hashstop=tip)
@@ -309,7 +309,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 new_block = create_block(tip, create_coinbase(height+1), block_time)
                 new_block.solve()
                 test_node.send_header_for_blocks([new_block])
-                test_node.wait_for_getdata([new_block.sha256], timeout=5)
+                test_node.wait_for_getdata([new_block.sha256])
                 test_node.send_message(msg_block(new_block))
                 test_node.sync_with_ping() # make sure this block is processed
                 inv_node.clear_last_announcement()
@@ -348,18 +348,18 @@ class SendHeadersTest(BitcoinTestFramework):
                 if j == 0:
                     # Announce via inv
                     test_node.send_block_inv(tip)
-                    test_node.wait_for_getheaders(timeout=5)
+                    test_node.wait_for_getheaders()
                     # Should have received a getheaders now
                     test_node.send_header_for_blocks(blocks)
                     # Test that duplicate inv's won't result in duplicate
                     # getdata requests, or duplicate headers announcements
                     [ inv_node.send_block_inv(x.sha256) for x in blocks ]
-                    test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=5)
+                    test_node.wait_for_getdata([x.sha256 for x in blocks])
                     inv_node.sync_with_ping()
                 else:
                     # Announce via headers
                     test_node.send_header_for_blocks(blocks)
-                    test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=5)
+                    test_node.wait_for_getdata([x.sha256 for x in blocks])
                     # Test that duplicate headers won't result in duplicate
                     # getdata requests (the check is further down)
                     inv_node.send_header_for_blocks(blocks)
@@ -546,7 +546,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_getheaders = None
             test_node.send_header_for_blocks([blocks[1]])
-            test_node.wait_for_getheaders(timeout=1)
+            test_node.wait_for_getheaders()
             test_node.send_header_for_blocks(blocks)
             test_node.wait_for_getdata([x.sha256 for x in blocks])
             [ test_node.send_message(msg_block(x)) for x in blocks ]
@@ -569,7 +569,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_getheaders = None
             test_node.send_header_for_blocks([blocks[i]])
-            test_node.wait_for_getheaders(timeout=1)
+            test_node.wait_for_getheaders()
 
         # Next header will connect, should re-set our count:
         test_node.send_header_for_blocks([blocks[0]])
@@ -584,7 +584,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_getheaders = None
             test_node.send_header_for_blocks([blocks[i%len(blocks)]])
-            test_node.wait_for_getheaders(timeout=1)
+            test_node.wait_for_getheaders()
 
         # Eventually this stops working.
         with mininode_lock:

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1227,6 +1227,8 @@ class msg_reject(object):
 
 # Helper function
 def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), sleep=0.05):
+    if attempts == float('inf') and timeout == float('inf'):
+        timeout = 60
     attempt = 0
     elapsed = 0
 


### PR DESCRIPTION
This backports https://github.com/bitcoin/bitcoin/pull/10365 to fix flaky sendheaders.py tests.

Original PR description:

56befa0 [tests] increase timeouts in sendheaders test (John Newbery)
b0bfa23 [tests] Make wait_until timeout 60 seconds by default (John Newbery)

Tree-SHA512: ca68ad91a7cabb0673f230631a9f2196a4a394cf7cea7a266b3dad3923f7887d2a192ceedd68f7a4a06d105a7d13870e75e971193b93476f8d72b34639d7c3d1