### PR TITLE
Directly use deterministicMNManager instead of compat code in CMasternodeMan

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -151,6 +151,15 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNByCollateral(const COutPoint& co
     return GetUniquePropertyMN(collateralOutpoint);
 }
 
+CDeterministicMNCPtr CDeterministicMNList::GetValidMNByCollateral(const COutPoint& collateralOutpoint) const
+{
+    auto dmn = GetMNByCollateral(collateralOutpoint);
+    if (dmn && !IsMNValid(dmn)) {
+        return nullptr;
+    }
+    return dmn;
+}
+
 static int CompareByLastPaid_GetHeight(const CDeterministicMN& dmn)
 {
     int height = dmn.pdmnState->nLastPaidHeight;
@@ -824,20 +833,6 @@ CDeterministicMNList CDeterministicMNManager::GetListAtChainTip()
 {
     LOCK(cs);
     return GetListForBlock(tipBlockHash);
-}
-
-bool CDeterministicMNManager::HasValidMNCollateralAtChainTip(const COutPoint& outpoint)
-{
-    auto mnList = GetListAtChainTip();
-    auto dmn = mnList.GetMNByCollateral(outpoint);
-    return dmn && mnList.IsMNValid(dmn);
-}
-
-bool CDeterministicMNManager::HasMNCollateralAtChainTip(const COutPoint& outpoint)
-{
-    auto mnList = GetListAtChainTip();
-    auto dmn = mnList.GetMNByCollateral(outpoint);
-    return dmn != nullptr;
 }
 
 bool CDeterministicMNManager::IsProTxWithCollateral(const CTransactionRef& tx, uint32_t n)

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -289,10 +289,23 @@ public:
     {
         return GetMN(proTxHash) != nullptr;
     }
+    bool HasValidMN(const uint256& proTxHash) const
+    {
+        return GetValidMN(proTxHash) != nullptr;
+    }
+    bool HasMNByCollateral(const COutPoint& collateralOutpoint) const
+    {
+        return GetMNByCollateral(collateralOutpoint) != nullptr;
+    }
+    bool HasValidMNByCollateral(const COutPoint& collateralOutpoint) const
+    {
+        return GetValidMNByCollateral(collateralOutpoint) != nullptr;
+    }
     CDeterministicMNCPtr GetMN(const uint256& proTxHash) const;
     CDeterministicMNCPtr GetValidMN(const uint256& proTxHash) const;
     CDeterministicMNCPtr GetMNByOperatorKey(const CBLSPublicKey& pubKey);
     CDeterministicMNCPtr GetMNByCollateral(const COutPoint& collateralOutpoint) const;
+    CDeterministicMNCPtr GetValidMNByCollateral(const COutPoint& collateralOutpoint) const;
     CDeterministicMNCPtr GetMNPayee() const;
 
     /**
@@ -478,10 +491,6 @@ public:
 
     CDeterministicMNList GetListForBlock(const uint256& blockHash);
     CDeterministicMNList GetListAtChainTip();
-
-    // TODO remove after removal of old non-deterministic lists
-    bool HasValidMNCollateralAtChainTip(const COutPoint& outpoint);
-    bool HasMNCollateralAtChainTip(const COutPoint& outpoint);
 
     // Test if given TX is a ProRegTx which also contains the collateral at index n
     bool IsProTxWithCollateral(const CTransactionRef& tx, uint32_t n);

--- a/src/governance-vote.cpp
+++ b/src/governance-vote.cpp
@@ -256,20 +256,16 @@ bool CGovernanceVote::IsValid(bool useVotingKey) const
         return false;
     }
 
-    masternode_info_t infoMn;
-    if (!mnodeman.GetMasternodeInfo(masternodeOutpoint, infoMn)) {
+    auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMNByCollateral(masternodeOutpoint);
+    if (!dmn) {
         LogPrint("gobject", "CGovernanceVote::IsValid -- Unknown Masternode - %s\n", masternodeOutpoint.ToStringShort());
         return false;
     }
 
     if (useVotingKey) {
-        return CheckSignature(infoMn.keyIDVoting);
+        return CheckSignature(dmn->pdmnState->keyIDVoting);
     } else {
-        if (deterministicMNManager->IsDIP3Active()) {
-            return CheckSignature(infoMn.blsPubKeyOperator);
-        } else {
-            return CheckSignature(infoMn.legacyKeyIDOperator);
-        }
+        return CheckSignature(dmn->pdmnState->pubKeyOperator);
     }
 }
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1079,7 +1079,7 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
     int nMaxObjRequestsPerNode = 1;
     size_t nProjectedVotes = 2000;
     if (Params().NetworkIDString() != CBaseChainParams::MAIN) {
-        nMaxObjRequestsPerNode = std::max(1, int(nProjectedVotes / std::max(1, mnodeman.size())));
+        nMaxObjRequestsPerNode = std::max(1, int(nProjectedVotes / std::max(1, (int)deterministicMNManager->GetListAtChainTip().GetValidMNsCount())));
     }
 
     {

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1108,10 +1108,9 @@ bool CTxLockVote::CheckSignature() const
 {
     std::string strError;
 
-    masternode_info_t infoMn;
-
-    if (!mnodeman.GetMasternodeInfo(outpointMasternode, infoMn)) {
-        LogPrintf("CTxLockVote::CheckSignature -- Unknown Masternode: masternode=%s\n", outpointMasternode.ToString());
+    auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMN(masternodeProTxHash);
+    if (!dmn) {
+        LogPrintf("CTxLockVote::CheckSignature -- Unknown Masternode: masternode=%s\n", masternodeProTxHash.ToString());
         return false;
     }
 
@@ -1119,7 +1118,7 @@ bool CTxLockVote::CheckSignature() const
 
     CBLSSignature sig;
     sig.SetBuf(vchMasternodeSignature);
-    if (!sig.IsValid() || !sig.VerifyInsecure(infoMn.blsPubKeyOperator, hash)) {
+    if (!sig.IsValid() || !sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator, hash)) {
         LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1029,7 +1029,9 @@ bool CTxLockRequest::IsSimple() const
 
 bool CTxLockVote::IsValid(CNode* pnode, CConnman& connman) const
 {
-    if (!mnodeman.Has(outpointMasternode)) {
+    auto mnList = deterministicMNManager->GetListAtChainTip();
+
+    if (!mnList.HasValidMNByCollateral(outpointMasternode)) {
         LogPrint("instantsend", "CTxLockVote::IsValid -- Unknown masternode %s\n", outpointMasternode.ToStringShort());
         mnodeman.AskForMN(pnode, outpointMasternode, connman);
         return false;

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -245,8 +245,7 @@ void CInstantSend::Vote(CTxLockCandidate& txLockCandidate, CConnman& connman)
 
         int nRank;
         uint256 quorumModifierHash;
-        int nMinRequiredProtocol = std::max(MIN_INSTANTSEND_PROTO_VERSION, mnpayments.GetMinMasternodePaymentsProto());
-        if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, quorumModifierHash, nLockInputHeight, nMinRequiredProtocol)) {
+        if (!mnodeman.GetMasternodeRank(activeMasternodeInfo.outpoint, nRank, quorumModifierHash, nLockInputHeight)) {
             LogPrint("instantsend", "CInstantSend::Vote -- Can't calculate rank for masternode %s\n", activeMasternodeInfo.outpoint.ToStringShort());
             continue;
         }
@@ -1061,8 +1060,7 @@ bool CTxLockVote::IsValid(CNode* pnode, CConnman& connman) const
 
     int nRank;
     uint256 expectedQuorumModifierHash;
-    int nMinRequiredProtocol = std::max(MIN_INSTANTSEND_PROTO_VERSION, mnpayments.GetMinMasternodePaymentsProto());
-    if (!mnodeman.GetMasternodeRank(outpointMasternode, nRank, expectedQuorumModifierHash, nLockInputHeight, nMinRequiredProtocol)) {
+    if (!mnodeman.GetMasternodeRank(outpointMasternode, nRank, expectedQuorumModifierHash, nLockInputHeight)) {
         //can be caused by past versions trying to vote with an invalid protocol
         LogPrint("instantsend", "CTxLockVote::IsValid -- Can't calculate rank for masternode %s\n", outpointMasternode.ToStringShort());
         return false;

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1126,7 +1126,6 @@ bool CTxLockVote::CheckSignature() const
 
 bool CTxLockVote::Sign()
 {
-    std::string strError;
 
     uint256 hash = GetSignatureHash();
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1115,35 +1115,14 @@ bool CTxLockVote::CheckSignature() const
         return false;
     }
 
-    if (deterministicMNManager->IsDIP3Active()) {
-        uint256 hash = GetSignatureHash();
+    uint256 hash = GetSignatureHash();
 
-        CBLSSignature sig;
-        sig.SetBuf(vchMasternodeSignature);
-        if (!sig.IsValid() || !sig.VerifyInsecure(infoMn.blsPubKeyOperator, hash)) {
-            LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
-            return false;
-        }
-    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetSignatureHash();
-
-        if (!CHashSigner::VerifyHash(hash, infoMn.legacyKeyIDOperator, vchMasternodeSignature, strError)) {
-            // could be a signature in old format
-            std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
-            if (!CMessageSigner::VerifyMessage(infoMn.legacyKeyIDOperator, vchMasternodeSignature, strMessage, strError)) {
-                // nope, not in old format either
-                LogPrintf("CTxLockVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
-                return false;
-            }
-        }
-    } else {
-        std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
-        if (!CMessageSigner::VerifyMessage(infoMn.legacyKeyIDOperator, vchMasternodeSignature, strMessage, strError)) {
-            LogPrintf("CTxLockVote::CheckSignature -- VerifyMessage() failed, error: %s\n", strError);
-            return false;
-        }
+    CBLSSignature sig;
+    sig.SetBuf(vchMasternodeSignature);
+    if (!sig.IsValid() || !sig.VerifyInsecure(infoMn.blsPubKeyOperator, hash)) {
+        LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
+        return false;
     }
-
     return true;
 }
 
@@ -1151,40 +1130,13 @@ bool CTxLockVote::Sign()
 {
     std::string strError;
 
-    if (deterministicMNManager->IsDIP3Active()) {
-        uint256 hash = GetSignatureHash();
+    uint256 hash = GetSignatureHash();
 
-        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
-        if (!sig.IsValid()) {
-            return false;
-        }
-        sig.GetBuf(vchMasternodeSignature);
-    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetSignatureHash();
-
-        if (!CHashSigner::SignHash(hash, activeMasternodeInfo.legacyKeyOperator, vchMasternodeSignature)) {
-            LogPrintf("CTxLockVote::Sign -- SignHash() failed\n");
-            return false;
-        }
-
-        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.legacyKeyIDOperator, vchMasternodeSignature, strError)) {
-            LogPrintf("CTxLockVote::Sign -- VerifyHash() failed, error: %s\n", strError);
-            return false;
-        }
-    } else {
-        std::string strMessage = txHash.ToString() + outpoint.ToStringShort();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchMasternodeSignature, activeMasternodeInfo.legacyKeyOperator)) {
-            LogPrintf("CTxLockVote::Sign -- SignMessage() failed\n");
-            return false;
-        }
-
-        if (!CMessageSigner::VerifyMessage(activeMasternodeInfo.legacyKeyIDOperator, vchMasternodeSignature, strMessage, strError)) {
-            LogPrintf("CTxLockVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
-            return false;
-        }
+    CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
+    if (!sig.IsValid()) {
+        return false;
     }
-
+    sig.GetBuf(vchMasternodeSignature);
     return true;
 }
 

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -468,7 +468,8 @@ void CInstantSend::UpdateVotedOutpoints(const CTxLockVote& vote, CTxLockCandidat
                     txLockCandidate.MarkOutpointAsAttacked(vote.GetOutpoint());
                     it2->second.MarkOutpointAsAttacked(vote.GetOutpoint());
                     // apply maximum PoSe ban score to this masternode i.e. PoSe-ban it instantly
-                    mnodeman.PoSeBan(vote.GetMasternodeOutpoint());
+                    // TODO Call new PoSe system when it's ready
+                    //mnodeman.PoSeBan(vote.GetMasternodeOutpoint());
                     // NOTE: This vote must be relayed further to let all other nodes know about such
                     // misbehaviour of this masternode. This way they should also be able to construct
                     // conflicting lock and PoSe-ban this masternode.

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -1038,15 +1038,16 @@ bool CTxLockVote::IsValid(CNode* pnode, CConnman& connman) const
     }
 
     // Verify that masternodeProTxHash belongs to the same MN referred by the collateral
-    // Only v13 nodes will send us locks with this field set, and only after spork15 activation
+    // This is a leftover from the legacy non-deterministic MN list where we used the collateral to identify MNs
+    // TODO eventually remove the collateral from CTxLockVote
     if (!masternodeProTxHash.IsNull()) {
-        masternode_info_t mnInfo;
-        if (!mnodeman.GetMasternodeInfo(masternodeProTxHash, mnInfo) || mnInfo.outpoint != outpointMasternode) {
+        auto dmn = mnList.GetValidMN(masternodeProTxHash);
+        if (!dmn || dmn->collateralOutpoint != outpointMasternode) {
             LogPrint("instantsend", "CTxLockVote::IsValid -- invalid masternodeProTxHash %s\n", masternodeProTxHash.ToString());
             return false;
         }
-    } else if (deterministicMNManager->IsDIP3Active()) {
-        LogPrint("instantsend", "CTxLockVote::IsValid -- missing masternodeProTxHash while DIP3 is active\n");
+    } else {
+        LogPrint("instantsend", "CTxLockVote::IsValid -- missing masternodeProTxHash\n");
         return false;
     }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -645,32 +645,12 @@ bool CMasternodePayments::IsScheduled(const CDeterministicMNCPtr& dmnIn, int nNo
 {
     LOCK(cs_mapMasternodeBlocks);
 
-    if (deterministicMNManager->IsDIP3Active()) {
-        auto projectedPayees = deterministicMNManager->GetListAtChainTip().GetProjectedMNPayees(8);
-        for (const auto &dmn : projectedPayees) {
-            if (dmn->proTxHash == dmnIn->proTxHash) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    if(!masternodeSync.IsMasternodeListSynced()) return false;
-
-    CScript mnpayee;
-    mnpayee = GetScriptForDestination(mnInfo.keyIDCollateralAddress);
-
-    for(int64_t h = nCachedBlockHeight; h <= nCachedBlockHeight + 8; h++){
-        if(h == nNotBlockHeight) continue;
-        std::vector<CTxOut> voutMasternodePayments;
-        if(GetBlockTxOuts(h, 0, voutMasternodePayments)) {
-            for (const auto& txout : voutMasternodePayments) {
-                if (txout.scriptPubKey == mnpayee)
-                    return true;
-            }
+    auto projectedPayees = deterministicMNManager->GetListAtChainTip().GetProjectedMNPayees(8);
+    for (const auto &dmn : projectedPayees) {
+        if (dmn->proTxHash == dmnIn->proTxHash) {
+            return true;
         }
     }
-
     return false;
 }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -641,14 +641,14 @@ bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, 
 
 // Is this masternode scheduled to get paid soon?
 // -- Only look ahead up to 8 blocks to allow for propagation of the latest 2 blocks of votes
-bool CMasternodePayments::IsScheduled(const masternode_info_t& mnInfo, int nNotBlockHeight) const
+bool CMasternodePayments::IsScheduled(const CDeterministicMNCPtr& dmnIn, int nNotBlockHeight) const
 {
     LOCK(cs_mapMasternodeBlocks);
 
     if (deterministicMNManager->IsDIP3Active()) {
         auto projectedPayees = deterministicMNManager->GetListAtChainTip().GetProjectedMNPayees(8);
         for (const auto &dmn : projectedPayees) {
-            if (dmn->collateralOutpoint == mnInfo.outpoint) {
+            if (dmn->proTxHash == dmnIn->proTxHash) {
                 return true;
             }
         }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -1046,7 +1046,7 @@ void CMasternodePayments::CheckBlockVotes(int nBlockHeight)
                                               voteHash.ToString());
                         continue;
                     }
-                    if (itVote->second.masternodeOutpoint == mn.second.outpoint) {
+                    if (itVote->second.masternodeOutpoint == mn.second->collateralOutpoint) {
                         payee = itVote->second.payee;
                         found = true;
                         break;
@@ -1061,12 +1061,12 @@ void CMasternodePayments::CheckBlockVotes(int nBlockHeight)
             CBitcoinAddress address2(address1);
 
             debugStr += strprintf("    - %s - voted for %s\n",
-                                  mn.second.outpoint.ToStringShort(), address2.ToString());
+                                  mn.second->collateralOutpoint.ToStringShort(), address2.ToString());
         } else {
-            mapMasternodesDidNotVote.emplace(mn.second.outpoint, 0).first->second++;
+            mapMasternodesDidNotVote.emplace(mn.second->collateralOutpoint, 0).first->second++;
 
             debugStr += strprintf("    - %s - no vote received\n",
-                                  mn.second.outpoint.ToStringShort());
+                                  mn.second->collateralOutpoint.ToStringShort());
         }
 
         if (++i >= MNPAYMENTS_SIGNATURES_TOTAL) break;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -200,7 +200,7 @@ public:
 
     bool GetBlockTxOuts(int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const;
-    bool IsScheduled(const masternode_info_t& mnInfo, int nNotBlockHeight) const;
+    bool IsScheduled(const CDeterministicMNCPtr& dmn, int nNotBlockHeight) const;
 
     bool UpdateLastVote(const CMasternodePaymentVote& vote);
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -699,7 +699,7 @@ bool CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool f
         if(mnpair.second.nProtocolVersion < mnpayments.GetMinMasternodePaymentsProto()) continue;
 
         //it's in the list (up to 8 entries ahead of current block to allow propagation) -- so let's skip it
-        if(mnpayments.IsScheduled(mnpair.second, nBlockHeight)) continue;
+        //if(mnpayments.IsScheduled(mnpair.second, nBlockHeight)) continue;
 
         //it's too new, wait for a cycle
         if(fFilterSigTime && mnpair.second.sigTime + (nMnCount*2.6*60) > GetAdjustedTime()) continue;
@@ -1191,17 +1191,17 @@ void CMasternodeMan::DoFullVerificationStep(CConnman& connman)
 
     auto it = vecMasternodeRanks.begin() + nOffset;
     while(it != vecMasternodeRanks.end()) {
-        if(it->second.IsPoSeVerified() || it->second.IsPoSeBanned()) {
-            LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Already %s%s%s masternode %s address %s, skipping...\n",
-                        it->second.IsPoSeVerified() ? "verified" : "",
-                        it->second.IsPoSeVerified() && it->second.IsPoSeBanned() ? " and " : "",
-                        it->second.IsPoSeBanned() ? "banned" : "",
-                        it->second.outpoint.ToStringShort(), it->second.addr.ToString());
-            nOffset += MAX_POSE_CONNECTIONS;
-            if(nOffset >= (int)vecMasternodeRanks.size()) break;
-            it += MAX_POSE_CONNECTIONS;
-            continue;
-        }
+//        if(it->second.IsPoSeVerified() || it->second.IsPoSeBanned()) {
+//            LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Already %s%s%s masternode %s address %s, skipping...\n",
+//                        it->second.IsPoSeVerified() ? "verified" : "",
+//                        it->second.IsPoSeVerified() && it->second.IsPoSeBanned() ? " and " : "",
+//                        it->second.IsPoSeBanned() ? "banned" : "",
+//                        it->second.outpoint.ToStringShort(), it->second.addr.ToString());
+//            nOffset += MAX_POSE_CONNECTIONS;
+//            if(nOffset >= (int)vecMasternodeRanks.size()) break;
+//            it += MAX_POSE_CONNECTIONS;
+//            continue;
+//        }
         LogPrint("masternode", "CMasternodeMan::DoFullVerificationStep -- Verifying masternode %s rank %d/%d address %s\n",
                     it->second->collateralOutpoint.ToStringShort(), it->first, nRanksTotal, it->second->pdmnState->addr.ToString());
         CAddress addr = CAddress(it->second->pdmnState->addr, NODE_NETWORK);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -643,7 +643,7 @@ bool CMasternodeMan::Has(const COutPoint& outpoint)
 {
     LOCK(cs);
     if (deterministicMNManager->IsDIP3Active()) {
-        return deterministicMNManager->HasValidMNCollateralAtChainTip(outpoint);
+        return deterministicMNManager->GetListAtChainTip().HasValidMNByCollateral(outpoint);
     } else {
         return mapMasternodes.find(outpoint) != mapMasternodes.end();
     }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -127,6 +127,16 @@ void CMasternodeMan::AskForMN(CNode* pnode, const COutPoint& outpoint, CConnman&
     connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSEG, outpoint));
 }
 
+bool CMasternodeMan::IsValidForMixingTxes(const COutPoint& outpoint)
+{
+    LOCK(cs);
+    CMasternode* pmn = Find(outpoint);
+    if (!pmn) {
+        return false;
+    }
+    return pmn->IsValidForMixingTxes();
+}
+
 bool CMasternodeMan::AllowMixing(const COutPoint &outpoint)
 {
     LOCK(cs);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -747,51 +747,6 @@ bool CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool f
     return mnInfoRet.fInfoValid;
 }
 
-masternode_info_t CMasternodeMan::FindRandomNotInVec(const std::vector<COutPoint> &vecToExclude, int nProtocolVersion)
-{
-    LOCK(cs);
-
-    nProtocolVersion = nProtocolVersion == -1 ? mnpayments.GetMinMasternodePaymentsProto() : nProtocolVersion;
-
-    int nCountEnabled = CountEnabled(nProtocolVersion);
-    int nCountNotExcluded = nCountEnabled - vecToExclude.size();
-
-    LogPrintf("CMasternodeMan::FindRandomNotInVec -- %d enabled masternodes, %d masternodes to choose from\n", nCountEnabled, nCountNotExcluded);
-    if(nCountNotExcluded < 1) return masternode_info_t();
-
-    // fill a vector of pointers
-    std::vector<const CMasternode*> vpMasternodesShuffled;
-    for (const auto& mnpair : mapMasternodes) {
-        vpMasternodesShuffled.push_back(&mnpair.second);
-    }
-
-    FastRandomContext insecure_rand;
-    // shuffle pointers
-    std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), insecure_rand);
-    bool fExclude;
-
-    // loop through
-    for (const auto& pmn : vpMasternodesShuffled) {
-        if(pmn->nProtocolVersion < nProtocolVersion || !pmn->IsEnabled()) continue;
-        fExclude = false;
-        for (const auto& outpointToExclude : vecToExclude) {
-            if(pmn->outpoint == outpointToExclude) {
-                fExclude = true;
-                break;
-            }
-        }
-        if(fExclude) continue;
-        if (deterministicMNManager->IsDIP3Active() && !deterministicMNManager->HasValidMNCollateralAtChainTip(pmn->outpoint))
-            continue;
-        // found the one not in vecToExclude
-        LogPrint("masternode", "CMasternodeMan::FindRandomNotInVec -- found, masternode=%s\n", pmn->outpoint.ToStringShort());
-        return pmn->GetInfo();
-    }
-
-    LogPrint("masternode", "CMasternodeMan::FindRandomNotInVec -- failed\n");
-    return masternode_info_t();
-}
-
 std::map<COutPoint, CMasternode> CMasternodeMan::GetFullMasternodeMap()
 {
     LOCK(cs);

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -137,6 +137,7 @@ public:
     void AskForMN(CNode *pnode, const COutPoint& outpoint, CConnman& connman);
 
     bool PoSeBan(const COutPoint &outpoint);
+    bool IsValidForMixingTxes(const COutPoint &outpoint);
     bool AllowMixing(const COutPoint &outpoint);
     bool DisallowMixing(const COutPoint &outpoint);
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -140,6 +140,7 @@ public:
     bool IsValidForMixingTxes(const COutPoint &outpoint);
     bool AllowMixing(const COutPoint &outpoint);
     bool DisallowMixing(const COutPoint &outpoint);
+    int64_t GetLastDsq(const COutPoint &outpoint);
 
     /// Check all Masternodes
     void Check();

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -182,9 +182,6 @@ public:
     /// Same as above but use current block height
     bool GetNextMasternodeInQueueForPayment(bool fFilterSigTime, int& nCountRet, masternode_info_t& mnInfoRet);
 
-    /// Find a random entry
-    masternode_info_t FindRandomNotInVec(const std::vector<COutPoint> &vecToExclude, int nProtocolVersion = -1);
-
     std::map<COutPoint, CMasternode> GetFullMasternodeMap();
 
     bool GetMasternodeRanks(rank_pair_vec_t& vecMasternodeRanksRet, int nBlockHeight = -1, int nMinProtocol = 0);

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -8,6 +8,8 @@
 #include "masternode.h"
 #include "sync.h"
 
+#include "evo/deterministicmns.h"
+
 class CMasternodeMan;
 class CConnman;
 
@@ -16,9 +18,9 @@ extern CMasternodeMan mnodeman;
 class CMasternodeMan
 {
 public:
-    typedef std::pair<arith_uint256, const CMasternode*> score_pair_t;
+    typedef std::pair<arith_uint256, CDeterministicMNCPtr> score_pair_t;
     typedef std::vector<score_pair_t> score_pair_vec_t;
-    typedef std::pair<int, const CMasternode> rank_pair_t;
+    typedef std::pair<int, CDeterministicMNCPtr> rank_pair_t;
     typedef std::vector<rank_pair_t> rank_pair_vec_t;
 
 private:
@@ -80,7 +82,7 @@ private:
     /// Find an entry
     CMasternode* Find(const COutPoint& outpoint);
 
-    bool GetMasternodeScores(const uint256& nBlockHash, score_pair_vec_t& vecMasternodeScoresRet, int nMinProtocol = 0);
+    bool GetMasternodeScores(const uint256& nBlockHash, score_pair_vec_t& vecMasternodeScoresRet);
 
     void SyncSingle(CNode* pnode, const COutPoint& outpoint, CConnman& connman);
     void SyncAll(CNode* pnode, CConnman& connman);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2079,21 +2079,20 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 return true; // not an error
             }
 
-            CMasternode mn;
-
-            if(!mnodeman.Get(dstx.masternodeOutpoint, mn)) {
+            auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMNByCollateral(dstx.masternodeOutpoint);
+            if(!dmn) {
                 LogPrint("privatesend", "DSTX -- Can't find masternode %s to verify %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
                 return false;
             }
 
-            if(!mn.IsValidForMixingTxes()) {
+            if(!mnodeman.IsValidForMixingTxes(dstx.masternodeOutpoint)) {
                 LogPrint("privatesend", "DSTX -- Masternode %s is sending too many transactions %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
                 return true;
                 // TODO: Not an error? Could it be that someone is relaying old DSTXes
                 // we have no idea about (e.g we were offline)? How to handle them?
             }
 
-            if (!dstx.CheckSignature(mn.legacyKeyIDOperator, mn.blsPubKeyOperator)) {
+            if (!dstx.CheckSignature(dmn->pdmnState->pubKeyOperator)) {
                 LogPrint("privatesend", "DSTX -- CheckSignature() failed for %s\n", hashTx.ToString());
                 return false;
             }

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -66,7 +66,8 @@ void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& 
         if (!dmn) return;
 
         if (!dsq.CheckSignature(dmn->pdmnState->pubKeyOperator)) {
-            // TODO ban?
+            LOCK(cs_main);
+            Misbehaving(pfrom->id, 10);
             return;
         }
 

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -10,8 +10,11 @@
 #include "privatesend.h"
 #include "wallet/wallet.h"
 
+#include "evo/deterministicmns.h"
+
 class CPrivateSendClientManager;
 class CConnman;
+class CNode;
 
 static const int DENOMS_COUNT_MAX = 100;
 
@@ -92,7 +95,7 @@ private:
     std::string strLastMessage;
     std::string strAutoDenomResult;
 
-    masternode_info_t infoMixingMasternode;
+    CDeterministicMNCPtr mixingMasternode;
     CMutableTransaction txMyCollateral; // client side collateral
     CPendingDsaRequest pendingDsaRequest;
 
@@ -139,7 +142,7 @@ public:
         fLastEntryAccepted(false),
         strLastMessage(),
         strAutoDenomResult(),
-        infoMixingMasternode(),
+        mixingMasternode(),
         txMyCollateral(),
         pendingDsaRequest(),
         keyHolderStorage()
@@ -154,7 +157,7 @@ public:
 
     std::string GetStatus(bool fWaitForBlock);
 
-    bool GetMixingMasternodeInfo(masternode_info_t& mnInfoRet) const;
+    bool GetMixingMasternodeInfo(CDeterministicMNCPtr& ret) const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun = false);
@@ -235,7 +238,7 @@ public:
     std::string GetStatuses();
     std::string GetSessionDenoms();
 
-    bool GetMixingMasternodesInfo(std::vector<masternode_info_t>& vecMnInfoRet) const;
+    bool GetMixingMasternodesInfo(std::vector<CDeterministicMNCPtr>& vecDmnsRet) const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun = false);

--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -248,7 +248,7 @@ public:
     void ProcessPendingDsaRequest(CConnman& connman);
 
     void AddUsedMasternode(const COutPoint& outpointMn);
-    masternode_info_t GetNotUsedMasternode();
+    CDeterministicMNCPtr GetRandomNotUsedMasternode();
 
     void UpdatedSuccessBlock();
 

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -10,6 +10,7 @@
 #include "init.h"
 #include "masternode-sync.h"
 #include "masternodeman.h"
+#include "net_processing.h"
 #include "netmessagemaker.h"
 #include "script/interpreter.h"
 #include "txmempool.h"
@@ -118,7 +119,8 @@ void CPrivateSendServer::ProcessMessage(CNode* pfrom, const std::string& strComm
         if (!dmn) return;
 
         if (!dsq.CheckSignature(dmn->pdmnState->pubKeyOperator)) {
-            // TODO ban?
+            LOCK(cs_main);
+            Misbehaving(pfrom->id, 10);
             return;
         }
 

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -50,7 +50,6 @@ bool CPrivateSendQueue::Sign()
 {
     if (!fMasternodeMode) return false;
 
-    std::string strError = "";
 
     uint256 hash = GetSignatureHash();
     CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
@@ -64,7 +63,6 @@ bool CPrivateSendQueue::Sign()
 
 bool CPrivateSendQueue::CheckSignature(const CBLSPublicKey& blsPubKey) const
 {
-    std::string strError = "";
     uint256 hash = GetSignatureHash();
 
     CBLSSignature sig;
@@ -96,7 +94,6 @@ bool CPrivateSendBroadcastTx::Sign()
 {
     if (!fMasternodeMode) return false;
 
-    std::string strError = "";
 
     uint256 hash = GetSignatureHash();
 
@@ -111,7 +108,6 @@ bool CPrivateSendBroadcastTx::Sign()
 
 bool CPrivateSendBroadcastTx::CheckSignature(const CBLSPublicKey& blsPubKey) const
 {
-    std::string strError = "";
 
     uint256 hash = GetSignatureHash();
 

--- a/src/privatesend.cpp
+++ b/src/privatesend.cpp
@@ -98,71 +98,28 @@ bool CPrivateSendBroadcastTx::Sign()
 
     std::string strError = "";
 
-    if (deterministicMNManager->IsDIP3Active()) {
-        uint256 hash = GetSignatureHash();
+    uint256 hash = GetSignatureHash();
 
-        CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
-        if (!sig.IsValid()) {
-            return false;
-        }
-        sig.GetBuf(vchSig);
-    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetSignatureHash();
-
-        if (!CHashSigner::SignHash(hash, activeMasternodeInfo.legacyKeyOperator, vchSig)) {
-            LogPrintf("CPrivateSendBroadcastTx::Sign -- SignHash() failed\n");
-            return false;
-        }
-
-        if (!CHashSigner::VerifyHash(hash, activeMasternodeInfo.legacyKeyIDOperator, vchSig, strError)) {
-            LogPrintf("CPrivateSendBroadcastTx::Sign -- VerifyHash() failed, error: %s\n", strError);
-            return false;
-        }
-    } else {
-        std::string strMessage = tx->GetHash().ToString() + std::to_string(sigTime);
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig, activeMasternodeInfo.legacyKeyOperator)) {
-            LogPrintf("CPrivateSendBroadcastTx::Sign -- SignMessage() failed\n");
-            return false;
-        }
-
-        if (!CMessageSigner::VerifyMessage(activeMasternodeInfo.legacyKeyIDOperator, vchSig, strMessage, strError)) {
-            LogPrintf("CPrivateSendBroadcastTx::Sign -- VerifyMessage() failed, error: %s\n", strError);
-            return false;
-        }
+    CBLSSignature sig = activeMasternodeInfo.blsKeyOperator->Sign(hash);
+    if (!sig.IsValid()) {
+        return false;
     }
+    sig.GetBuf(vchSig);
 
     return true;
 }
 
-bool CPrivateSendBroadcastTx::CheckSignature(const CKeyID& keyIDOperator, const CBLSPublicKey& blsPubKey) const
+bool CPrivateSendBroadcastTx::CheckSignature(const CBLSPublicKey& blsPubKey) const
 {
     std::string strError = "";
 
-    if (deterministicMNManager->IsDIP3Active()) {
-        uint256 hash = GetSignatureHash();
+    uint256 hash = GetSignatureHash();
 
-        CBLSSignature sig;
-        sig.SetBuf(vchSig);
-        if (!sig.IsValid() || !sig.VerifyInsecure(blsPubKey, hash)) {
-            LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
-            return false;
-        }
-    } else if (sporkManager.IsSporkActive(SPORK_6_NEW_SIGS)) {
-        uint256 hash = GetSignatureHash();
-
-        if (!CHashSigner::VerifyHash(hash, keyIDOperator, vchSig, strError)) {
-            // we don't care about dstxes with old signature format
-            LogPrintf("CPrivateSendBroadcastTx::CheckSignature -- VerifyHash() failed, error: %s\n", strError);
-            return false;
-        }
-    } else {
-        std::string strMessage = tx->GetHash().ToString() + std::to_string(sigTime);
-
-        if (!CMessageSigner::VerifyMessage(keyIDOperator, vchSig, strMessage, strError)) {
-            LogPrintf("CPrivateSendBroadcastTx::CheckSignature -- Got bad dstx signature, error: %s\n", strError);
-            return false;
-        }
+    CBLSSignature sig;
+    sig.SetBuf(vchSig);
+    if (!sig.IsValid() || !sig.VerifyInsecure(blsPubKey, hash)) {
+        LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
+        return false;
     }
 
     return true;

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -306,7 +306,7 @@ public:
     uint256 GetSignatureHash() const;
 
     bool Sign();
-    bool CheckSignature(const CKeyID& keyIDOperator, const CBLSPublicKey& blsPubKey) const;
+    bool CheckSignature(const CBLSPublicKey& blsPubKey) const;
 
     void SetConfirmedHeight(int nConfirmedHeightIn) { nConfirmedHeight = nConfirmedHeightIn; }
     bool IsExpired(int nHeight);

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -225,7 +225,7 @@ public:
      */
     bool Sign();
     /// Check if we have a valid Masternode address
-    bool CheckSignature(const CKeyID& keyIDOperator, const CBLSPublicKey& blsPubKey) const;
+    bool CheckSignature(const CBLSPublicKey& blsPubKey) const;
 
     bool Relay(CConnman& connman);
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -83,10 +83,10 @@ int ClientModel::getNumConnections(unsigned int flags) const
 QString ClientModel::getMasternodeCountString() const
 {
     // return tr("Total: %1 (PS compatible: %2 / Enabled: %3) (IPv4: %4, IPv6: %5, TOR: %6)").arg(QString::number((int)mnodeman.size()))
-    return tr("Total: %1 (PS compatible: %2 / Enabled: %3)")
-            .arg(QString::number((int)mnodeman.CountMasternodes(0)))
-            .arg(QString::number((int)mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION)))
-            .arg(QString::number((int)mnodeman.CountEnabled()));
+    auto mnList = deterministicMNManager->GetListAtChainTip();
+    return tr("Total: %1 (Enabled: %2)")
+            .arg(QString::number((int)mnList.GetAllMNsCount()))
+            .arg(QString::number((int)mnList.GetValidMNsCount()));
             // .arg(QString::number((int)mnodeman.CountByIP(NET_IPV4)))
             // .arg(QString::number((int)mnodeman.CountByIP(NET_IPV6)))
             // .arg(QString::number((int)mnodeman.CountByIP(NET_TOR)));

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -261,7 +261,8 @@ UniValue gobject_submit(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Must wait for client to sync with masternode network. Try again in a minute or so.");
     }
 
-    bool fMnFound = mnodeman.Has(activeMasternodeInfo.outpoint);
+    auto mnList = deterministicMNManager->GetListAtChainTip();
+    bool fMnFound = mnList.HasValidMNByCollateral(activeMasternodeInfo.outpoint);
 
     DBG( std::cout << "gobject: submit activeMasternodeInfo.keyIDOperator = " << activeMasternodeInfo.legacyKeyIDOperator.ToString()
          << ", outpoint = " << activeMasternodeInfo.outpoint.ToStringShort()

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -412,10 +412,9 @@ UniValue gobject_vote_conf(const JSONRPCRequest& request)
     UniValue statusObj(UniValue::VOBJ);
     UniValue returnObj(UniValue::VOBJ);
 
-    CMasternode mn;
-    bool fMnFound = mnodeman.Get(activeMasternodeInfo.outpoint, mn);
+    auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMNByCollateral(activeMasternodeInfo.outpoint);
 
-    if (!fMnFound) {
+    if (!dmn) {
         nFailed++;
         statusObj.push_back(Pair("result", "failed"));
         statusObj.push_back(Pair("errorMessage", "Can't find masternode by collateral output"));
@@ -425,19 +424,16 @@ UniValue gobject_vote_conf(const JSONRPCRequest& request)
         return returnObj;
     }
 
-    CGovernanceVote vote(mn.outpoint, hash, eVoteSignal, eVoteOutcome);
+    CGovernanceVote vote(dmn->collateralOutpoint, hash, eVoteSignal, eVoteOutcome);
 
     bool signSuccess = false;
-    if (deterministicMNManager->IsDIP3Active()) {
-        if (govObjType == GOVERNANCE_OBJECT_PROPOSAL && eVoteSignal == VOTE_SIGNAL_FUNDING) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Can't use vote-conf for proposals when deterministic masternodes are active");
-        }
-        if (activeMasternodeInfo.blsKeyOperator) {
-            signSuccess = vote.Sign(*activeMasternodeInfo.blsKeyOperator);
-        }
-    } else {
-        signSuccess = vote.Sign(activeMasternodeInfo.legacyKeyOperator, activeMasternodeInfo.legacyKeyIDOperator);
+    if (govObjType == GOVERNANCE_OBJECT_PROPOSAL && eVoteSignal == VOTE_SIGNAL_FUNDING) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Can't use vote-conf for proposals");
     }
+    if (activeMasternodeInfo.blsKeyOperator) {
+        signSuccess = vote.Sign(*activeMasternodeInfo.blsKeyOperator);
+    }
+
     if (!signSuccess) {
         nFailed++;
         statusObj.push_back(Pair("result", "failed"));
@@ -466,9 +462,9 @@ UniValue gobject_vote_conf(const JSONRPCRequest& request)
     return returnObj;
 }
 
-UniValue VoteWithMasternodeList(const std::vector<CMasternodeConfig::CMasternodeEntry>& entries,
-                                const uint256& hash, vote_signal_enum_t eVoteSignal,
-                                vote_outcome_enum_t eVoteOutcome)
+UniValue VoteWithMasternodes(const std::map<uint256, CKey>& keys,
+                             const uint256& hash, vote_signal_enum_t eVoteSignal,
+                             vote_outcome_enum_t eVoteOutcome)
 {
     int govObjType;
     {
@@ -483,59 +479,31 @@ UniValue VoteWithMasternodeList(const std::vector<CMasternodeConfig::CMasternode
     int nSuccessful = 0;
     int nFailed = 0;
 
+    auto mnList = deterministicMNManager->GetListAtChainTip();
+
     UniValue resultsObj(UniValue::VOBJ);
 
-    for (const auto& mne : entries) {
-        CPubKey pubKeyOperator;
-        CKey keyOperator;
+    for (const auto& p : keys) {
+        const auto& proTxHash = p.first;
+        const auto& key = p.second;
 
         UniValue statusObj(UniValue::VOBJ);
 
-        if (!CMessageSigner::GetKeysFromSecret(mne.getPrivKey(), keyOperator, pubKeyOperator)) {
+        auto dmn = mnList.GetValidMN(proTxHash);
+        if (!dmn) {
             nFailed++;
             statusObj.push_back(Pair("result", "failed"));
-            statusObj.push_back(Pair("errorMessage", "Masternode signing error, could not set key correctly"));
-            resultsObj.push_back(Pair(mne.getAlias(), statusObj));
+            statusObj.push_back(Pair("errorMessage", "Can't find masternode by proTxHash"));
+            resultsObj.push_back(Pair(proTxHash.ToString(), statusObj));
             continue;
         }
 
-        uint256 nTxHash;
-        nTxHash.SetHex(mne.getTxHash());
-
-        int nOutputIndex = 0;
-        if (!ParseInt32(mne.getOutputIndex(), &nOutputIndex)) {
-            continue;
-        }
-
-        COutPoint outpoint(nTxHash, nOutputIndex);
-
-        CMasternode mn;
-        bool fMnFound = mnodeman.Get(outpoint, mn);
-
-        if (!fMnFound) {
-            nFailed++;
-            statusObj.push_back(Pair("result", "failed"));
-            statusObj.push_back(Pair("errorMessage", "Can't find masternode by collateral output"));
-            resultsObj.push_back(Pair(mne.getAlias(), statusObj));
-            continue;
-        }
-
-        if (deterministicMNManager->IsDIP3Active()) {
-            if (govObjType == GOVERNANCE_OBJECT_PROPOSAL && mn.keyIDVoting != pubKeyOperator.GetID()) {
-                nFailed++;
-                statusObj.push_back(Pair("result", "failed"));
-                statusObj.push_back(Pair("errorMessage", "Can't vote on proposal when key does not match voting key"));
-                resultsObj.push_back(Pair(mne.getAlias(), statusObj));
-                continue;
-            }
-        }
-
-        CGovernanceVote vote(mn.outpoint, hash, eVoteSignal, eVoteOutcome);
-        if (!vote.Sign(keyOperator, pubKeyOperator.GetID())) {
+        CGovernanceVote vote(dmn->collateralOutpoint, hash, eVoteSignal, eVoteOutcome);
+        if (!vote.Sign(key, key.GetPubKey().GetID())) {
             nFailed++;
             statusObj.push_back(Pair("result", "failed"));
             statusObj.push_back(Pair("errorMessage", "Failure to sign."));
-            resultsObj.push_back(Pair(mne.getAlias(), statusObj));
+            resultsObj.push_back(Pair(proTxHash.ToString(), statusObj));
             continue;
         }
 
@@ -549,7 +517,7 @@ UniValue VoteWithMasternodeList(const std::vector<CMasternodeConfig::CMasternode
             statusObj.push_back(Pair("errorMessage", exception.GetMessage()));
         }
 
-        resultsObj.push_back(Pair(mne.getAlias(), statusObj));
+        resultsObj.push_back(Pair(proTxHash.ToString(), statusObj));
     }
 
     UniValue returnObj(UniValue::VOBJ);
@@ -559,11 +527,12 @@ UniValue VoteWithMasternodeList(const std::vector<CMasternodeConfig::CMasternode
     return returnObj;
 }
 
+#ifdef ENABLE_WALLET
 void gobject_vote_many_help()
 {
     throw std::runtime_error(
                 "gobject vote-many <governance-hash> <vote> <vote-outcome>\n"
-                "Vote on a governance object by all masternodes (using masternode.conf setup)\n"
+                "Vote on a governance object by all masternodes for which the voting key is present in the local wallet\n"
                 "\nArguments:\n"
                 "1. governance-hash   (string, required) hash of the governance object\n"
                 "2. vote              (string, required) vote, possible values: [funding|valid|delete|endorsed]\n"
@@ -592,66 +561,33 @@ UniValue gobject_vote_many(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid vote outcome. Please use one of the following: 'yes', 'no' or 'abstain'");
     }
 
-    std::vector<CMasternodeConfig::CMasternodeEntry> entries = masternodeConfig.getEntries();
-
-#ifdef ENABLE_WALLET
-    // This is a hack to maintain code-level backwards compatibility with masternode.conf and the deterministic masternodes.
-    // Deterministic masternode keys are managed inside the wallet instead of masternode.conf
-    // This allows voting on proposals when you have the MN voting key in your wallet
-    // We can remove this when we remove support for masternode.conf and only support wallet based masternode
-    // management
-    if (deterministicMNManager->IsDIP3Active()) {
-        if (!pwalletMain) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "vote-many not supported when wallet is disabled.");
-        }
-        entries.clear();
-
-        auto mnList = deterministicMNManager->GetListAtChainTip();
-        mnList.ForEachMN(true, [&](const CDeterministicMNCPtr& dmn) {
-            bool found = false;
-            for (const auto &mne : entries) {
-                uint256 nTxHash;
-                nTxHash.SetHex(mne.getTxHash());
-
-                int nOutputIndex = 0;
-                if(!ParseInt32(mne.getOutputIndex(), &nOutputIndex)) {
-                    continue;
-                }
-
-                if (nTxHash == dmn->collateralOutpoint.hash && (uint32_t)nOutputIndex == dmn->collateralOutpoint.n) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                CKey ownerKey;
-                if (pwalletMain->GetKey(dmn->pdmnState->keyIDVoting, ownerKey)) {
-                    CBitcoinSecret secret(ownerKey);
-                    CMasternodeConfig::CMasternodeEntry mne(dmn->proTxHash.ToString(), dmn->pdmnState->addr.ToStringIPPort(false), secret.ToString(), dmn->collateralOutpoint.hash.ToString(), itostr(dmn->collateralOutpoint.n));
-                    entries.push_back(mne);
-                }
-            }
-        });
-    }
-#else
-    if (deterministicMNManager->IsDIP3Active()) {
+    if (!pwalletMain) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "vote-many not supported when wallet is disabled.");
     }
-#endif
 
-    return VoteWithMasternodeList(entries, hash, eVoteSignal, eVoteOutcome);
+    std::map<uint256, CKey> votingKeys;
+
+    auto mnList = deterministicMNManager->GetListAtChainTip();
+    mnList.ForEachMN(true, [&](const CDeterministicMNCPtr& dmn) {
+        CKey votingKey;
+        if (pwalletMain->GetKey(dmn->pdmnState->keyIDVoting, votingKey)) {
+            votingKeys.emplace(dmn->proTxHash, votingKey);
+        }
+    });
+
+    return VoteWithMasternodes(votingKeys, hash, eVoteSignal, eVoteOutcome);
 }
 
 void gobject_vote_alias_help()
 {
     throw std::runtime_error(
                 "gobject vote-alias <governance-hash> <vote> <vote-outcome> <alias-name>\n"
-                "Vote on a governance object by masternode alias (using masternode.conf setup)\n"
+                "Vote on a governance object by masternode's voting key (if present in local wallet)\n"
                 "\nArguments:\n"
                 "1. governance-hash   (string, required) hash of the governance object\n"
                 "2. vote              (string, required) vote, possible values: [funding|valid|delete|endorsed]\n"
                 "3. vote-outcome      (string, required) vote outcome, possible values: [yes|no|abstain]\n"
-                "4. alias-name        (string, required) masternode alias or proTxHash after DIP3 activation"
+                "4. protx-hash        (string, required) masternode's proTxHash"
                 );
 }
 
@@ -676,41 +612,27 @@ UniValue gobject_vote_alias(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid vote outcome. Please use one of the following: 'yes', 'no' or 'abstain'");
     }
 
-    std::vector<CMasternodeConfig::CMasternodeEntry> entries;
-
-    if (deterministicMNManager->IsDIP3Active()) {
-#ifdef ENABLE_WALLET
-        if (!pwalletMain) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "vote-alias not supported when wallet is disabled");
-        }
-
-        uint256 proTxHash = ParseHashV(request.params[4], "alias-name");
-        auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMN(proTxHash);
-        if (!dmn) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid or unknown proTxHash");
-        }
-
-        CKey votingKey;
-        if (!pwalletMain->GetKey(dmn->pdmnState->keyIDVoting, votingKey)) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Voting ekey %s not known by wallet", CBitcoinAddress(dmn->pdmnState->keyIDVoting).ToString()));
-        }
-
-        CBitcoinSecret secret(votingKey);
-        CMasternodeConfig::CMasternodeEntry mne(dmn->proTxHash.ToString(), dmn->pdmnState->addr.ToStringIPPort(false), secret.ToString(), dmn->collateralOutpoint.hash.ToString(), itostr(dmn->collateralOutpoint.n));
-        entries.push_back(mne);
-#else
+    if (!pwalletMain) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "vote-alias not supported when wallet is disabled");
-#endif
-    } else {
-        std::string strAlias = request.params[4].get_str();
-        for (const auto& mne : masternodeConfig.getEntries()) {
-            if (strAlias == mne.getAlias())
-                entries.push_back(mne);
-        }
     }
 
-    return VoteWithMasternodeList(entries, hash, eVoteSignal, eVoteOutcome);
+    uint256 proTxHash = ParseHashV(request.params[4], "protx-hash");
+    auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMN(proTxHash);
+    if (!dmn) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid or unknown proTxHash");
+    }
+
+    CKey votingKey;
+    if (!pwalletMain->GetKey(dmn->pdmnState->keyIDVoting, votingKey)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Voting key %s not known by wallet", CBitcoinAddress(dmn->pdmnState->keyIDVoting).ToString()));
+    }
+
+    std::map<uint256, CKey> votingKeys;
+    votingKeys.emplace(proTxHash, votingKey);
+
+    return VoteWithMasternodes(votingKeys, hash, eVoteSignal, eVoteOutcome);
 }
+#endif
 
 UniValue ListObjects(const std::string& strCachedSignal, const std::string& strType, int nStartTime)
 {
@@ -1063,10 +985,12 @@ UniValue gobject(const JSONRPCRequest& request)
         return gobject_submit(request);
     } else if (strCommand == "vote-conf") {
         return gobject_vote_conf(request);
+#ifdef ENABLE_WALLET
     } else if (strCommand == "vote-many") {
         return gobject_vote_many(request);
     } else if (strCommand == "vote-alias") {
         return gobject_vote_alias(request);
+#endif
     } else if (strCommand == "list") {
         // USERS CAN QUERY THE SYSTEM FOR A LIST OF VARIOUS GOVERNANCE ITEMS
         return gobject_list(request);
@@ -1133,10 +1057,9 @@ UniValue voteraw(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Malformed base64 encoding");
     }
 
-    CMasternode mn;
-    bool fMnFound = mnodeman.Get(outpoint, mn);
+    auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMNByCollateral(outpoint);
 
-    if (!fMnFound) {
+    if (!dmn) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Failure to find masternode in list : " + outpoint.ToStringShort());
     }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -148,7 +148,7 @@ void masternode_list_help()
             "                   partial match)\n"
             "  keyid          - Print the masternode (not collateral) key id\n"
             "  rank           - Print rank of a masternode based on current block\n"
-            "  status         - Print masternode status: ENABED / POSE_BAN / OUTPOINT_SPENT\n"
+            "  status         - Print masternode status: ENABLED / POSE_BAN / OUTPOINT_SPENT\n"
             "                   (can be additionally filtered, partial match)\n"
         );
 }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -99,13 +99,13 @@ UniValue getpoolinfo(const JSONRPCRequest& request)
     // obj.push_back(Pair("entries",           pprivateSendBase->GetEntriesCount()));
     obj.push_back(Pair("status",            privateSendClient.GetStatuses()));
 
-    std::vector<masternode_info_t> vecMnInfo;
-    if (privateSendClient.GetMixingMasternodesInfo(vecMnInfo)) {
+    std::vector<CDeterministicMNCPtr> vecDmns;
+    if (privateSendClient.GetMixingMasternodesInfo(vecDmns)) {
         UniValue pools(UniValue::VARR);
-        for (const auto& mnInfo : vecMnInfo) {
+        for (const auto& dmn : vecDmns) {
             UniValue pool(UniValue::VOBJ);
-            pool.push_back(Pair("outpoint",      mnInfo.outpoint.ToStringShort()));
-            pool.push_back(Pair("addr",          mnInfo.addr.ToString()));
+            pool.push_back(Pair("outpoint",      dmn->collateralOutpoint.ToStringShort()));
+            pool.push_back(Pair("addr",          dmn->pdmnState->addr.ToString()));
             pools.push_back(pool);
         }
         obj.push_back(Pair("pools", pools));

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -142,12 +142,13 @@ void masternode_list_help()
             "  info           - Print info in format 'status payee IP'\n"
             "                   (can be additionally filtered, partial match)\n"
             "  json           - Print info in JSON format (can be additionally filtered, partial match)\n"
+            "  keyIDOwner     - Print the masternode owner key id\n"
+            "  keyIDVoting    - Print the masternode voting key id\n"
             "  lastpaidblock  - Print the last block height a node was paid on the network\n"
             "  lastpaidtime   - Print the last time a node was paid on the network\n"
             "  payee          - Print Dash address associated with a masternode (can be additionally filtered,\n"
             "                   partial match)\n"
-            "  keyid          - Print the masternode (not collateral) key id\n"
-            "  rank           - Print rank of a masternode based on current block\n"
+            "  pubKeyOperator - Print the masternode operator public key\n"
             "  status         - Print masternode status: ENABLED / POSE_BAN / OUTPOINT_SPENT\n"
             "                   (can be additionally filtered, partial match)\n"
         );
@@ -812,10 +813,13 @@ UniValue masternodelist(const JSONRPCRequest& request)
     if (request.params.size() >= 1) strMode = request.params[0].get_str();
     if (request.params.size() == 2) strFilter = request.params[1].get_str();
 
+    std::transform(strMode.begin(), strMode.end(), strMode.begin(), ::tolower);
+
     if (request.fHelp || (
                 strMode != "addr" && strMode != "full" && strMode != "info" && strMode != "json" &&
+                strMode != "keyidowner" && strMode != "keyidvoting" &&
                 strMode != "lastpaidtime" && strMode != "lastpaidblock" &&
-                strMode != "payee" && strMode != "pubkey" &&
+                strMode != "payee" && strMode != "pubkeyoperator" &&
                 strMode != "status"))
     {
         masternode_list_help();
@@ -863,7 +867,7 @@ UniValue masternodelist(const JSONRPCRequest& request)
         }
 
         if (strMode == "addr") {
-            std::string strAddress = dmn->pdmnState->ToString();
+            std::string strAddress = dmn->pdmnState->addr.ToString(false);
             if (strFilter !="" && strAddress.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.push_back(Pair(strOutpoint, strAddress));
@@ -871,7 +875,7 @@ UniValue masternodelist(const JSONRPCRequest& request)
             std::ostringstream streamFull;
             streamFull << std::setw(18) <<
                            dmnToStatus(dmn) << " " <<
-                           payeeStr << " " <<
+                           payeeStr << " " << std::setw(10) <<
                            dmnToLastPaidTime(dmn) << " "  << std::setw(6) <<
                            dmn->pdmnState->nLastPaidHeight << " " <<
                            dmn->pdmnState->addr.ToString();
@@ -916,13 +920,13 @@ UniValue masternodelist(const JSONRPCRequest& request)
             if (strFilter !="" && payeeStr.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.push_back(Pair(strOutpoint, payeeStr));
-        } else if (strMode == "keyIDOwner") {
+        } else if (strMode == "keyidowner") {
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
             obj.push_back(Pair(strOutpoint, HexStr(dmn->pdmnState->keyIDOwner)));
-        } else if (strMode == "pubKeyOperator") {
+        } else if (strMode == "pubkeyoperator") {
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
             obj.push_back(Pair(strOutpoint, dmn->pdmnState->pubKeyOperator.ToString()));
-        } else if (strMode == "keyIDVoting") {
+        } else if (strMode == "keyidvoting") {
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
             obj.push_back(Pair(strOutpoint, HexStr(dmn->pdmnState->keyIDVoting)));
         } else if (strMode == "status") {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -224,25 +224,15 @@ UniValue masternode_count(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() > 2)
         masternode_count_help();
 
-    int nCount;
-    int total = mnodeman.CountMasternodes(0);
-    if (deterministicMNManager->IsDIP3Active()) {
-        nCount = mnodeman.CountEnabled();
-    } else {
-        masternode_info_t mnInfo;
-        mnodeman.GetNextMasternodeInQueueForPayment(true, nCount, mnInfo);
-    }
-
-    int ps = mnodeman.CountEnabled(MIN_PRIVATESEND_PEER_PROTO_VERSION);
-    int enabled = mnodeman.CountEnabled();
+    auto mnList = deterministicMNManager->GetListAtChainTip();
+    int total = mnList.GetAllMNsCount();
+    int enabled = mnList.GetValidMNsCount();
 
     if (request.params.size() == 1) {
         UniValue obj(UniValue::VOBJ);
 
         obj.push_back(Pair("total", total));
-        obj.push_back(Pair("ps_compatible", ps));
         obj.push_back(Pair("enabled", enabled));
-        obj.push_back(Pair("qualify", nCount));
 
         return obj;
     }
@@ -252,18 +242,12 @@ UniValue masternode_count(const JSONRPCRequest& request)
     if (strMode == "total")
         return total;
 
-    if (strMode == "ps")
-        return ps;
-
     if (strMode == "enabled")
         return enabled;
 
-    if (strMode == "qualify")
-        return nCount;
-
     if (strMode == "all")
-        return strprintf("Total: %d (PS Compatible: %d / Enabled: %d / Qualify: %d)",
-            total, ps, enabled, nCount);
+        return strprintf("Total: %d (Enabled: %d)",
+            total, enabled);
 
     throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown mode value");
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1828,35 +1828,7 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
         ThresholdState state = VersionBitsState(pindexPrev, params, pos, versionbitscache);
         const struct BIP9DeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
         if (vbinfo.check_mn_protocol && state == THRESHOLD_STARTED && fCheckMasternodesUpgraded) {
-            if (deterministicMNManager->IsDIP3Active()) {
-                auto mnList = deterministicMNManager->GetListForBlock(pindexPrev->GetBlockHash());
-                auto payee = mnList.GetMNPayee();
-                if (!payee) {
-                    continue;
-                }
-            } else {
-                std::vector<CTxOut> voutMasternodePayments;
-                masternode_info_t mnInfo;
-                if (!mnpayments.GetBlockTxOuts(pindexPrev->nHeight + 1, 0, voutMasternodePayments)) {
-                    // no votes for this block
-                    continue;
-                }
-                bool mnKnown = false;
-                for (const auto& txout : voutMasternodePayments) {
-                    if (mnodeman.GetMasternodeInfo(txout.scriptPubKey, mnInfo)) {
-                        mnKnown = true;
-                        break;
-                    }
-                }
-                if (!mnKnown) {
-                    // unknown masternode
-                    continue;
-                }
-                if (mnInfo.nProtocolVersion < DMN_PROTO_VERSION) {
-                    // masternode is not upgraded yet
-                    continue;
-                }
-            }
+            // TODO implement new logic for MN upgrade checks (e.g. with LLMQ based feature/version voting)
         }
         if (state == THRESHOLD_LOCKED_IN || state == THRESHOLD_STARTED) {
             nVersion |= VersionBitsMask(params, (Consensus::DeploymentPos)i);


### PR DESCRIPTION
This is extracted from #2566. It removes most uses of `CMasternodeMan` and replaces it with direct use of `deterministicMNManager`. I tried to avoid mixing in code removal as much as possible, but this was still required in some places where `deterministicMNManager` can not provide the same (legacy) functionality. I also had to remove support for legacy operator keys in various `Sign/Verify` methods as the legacy operator pubkey is not available anymore when directly using `deterministicMNManager`.

This leaves `CMasternodeMan` and most of its code unused. It's now only used for governance and PS metadata. The next PR will remove all unused code and the PR after that will refactor `CMasternodeMan` into `CMasternodeMetaMan` (as seen in #2566).