### PR TITLE
Fix flaky autoix tests by disabling autoix while filling mempool

### DIFF
--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -133,7 +133,7 @@ class AutoIXMempoolTest(DashTestFramework):
         sender = self.nodes[self.sender_idx]
         receiver = self.nodes[self.receiver_idx]
         sender_address = sender.getnewaddress()
-        for i in range(0, 3):
+        for i in range(0, 4):
             self.nodes[0].sendtoaddress(sender_address, 2.0)
         for i in range(0, 6):
             set_mocktime(get_mocktime() + 1)
@@ -152,6 +152,13 @@ class AutoIXMempoolTest(DashTestFramework):
         # autoIX is not working now
         assert(not self.send_simple_tx(sender, receiver))
         # regular IX is still working
+        assert(self.send_regular_IX(sender, receiver))
+
+        # generate one block to clean up mempool and retry auto and regular IX
+        # generate 2 more blocks to have enough confirmations for IX
+        self.nodes[0].generate(3)
+        self.sync_all()
+        assert(self.send_simple_tx(sender, receiver))
         assert(self.send_regular_IX(sender, receiver))
 
 

--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -79,6 +79,10 @@ class AutoIXMempoolTest(DashTestFramework):
         return info['SPORK_16_INSTANTSEND_AUTOLOCKS']
 
     def set_autoix_spork_state(self, state):
+        # Increment mocktime as otherwise nodes will not update sporks
+        set_mocktime(get_mocktime() + 1)
+        set_node_times(self.nodes, get_mocktime())
+
         if state:
             value = 0
         else:

--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -145,7 +145,9 @@ class AutoIXMempoolTest(DashTestFramework):
         assert(self.send_simple_tx(sender, receiver))
 
         # fill mempool with transactions
+        self.set_autoix_spork_state(False)
         self.fill_mempool()
+        self.set_autoix_spork_state(True)
 
         # autoIX is not working now
         assert(not self.send_simple_tx(sender, receiver))


### PR DESCRIPTION
See individual commits.

Tests were failing very often as the CPU was overloaded while filling the mempool, resulting in timeouts while syncing mempools.