### PR TITLE
Try to fix flaky IX tests in DIP3 tests

### DIFF
--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -375,7 +375,7 @@ class DIP3Test(BitcoinTestFramework):
                     if to_node is not None and from_node is not to_node:
                         break
                 to_address = to_node.getnewaddress()
-                txid = from_node.instantsendtoaddress(to_address, 0.01)
+                txid = from_node.instantsendtoaddress(to_address, 0.1)
                 for node in self.nodes:
                     if node is not None:
                         self.wait_for_instant_lock(node, to_node_idx, txid, timeout=timeout)


### PR DESCRIPTION
This will hopefully fix flaky tests as seen in https://api.travis-ci.org/v3/job/474288097/log.txt

The reason for these tests to fail is that in some situations sending TXs results in more inputs being selected then actually needed, which then overloads the CPU. This happens because `SelectCoinsMinConf` forces a minimum change of `MIN_CHANGE`, which in turn forces adding of more inputs then needed, especially when the spent amount is less then `MIN_CHANGE`.

This is an issue we should eventually fix in the future, independent from this PR. This PR only tries to increase the sent amount so that in most cases large enough inputs are selected so that one or two of them are enough. The PR also gives more funding to individual nodes.