### PR TITLE
 Add real timestamp to log output when mock time is enabled

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -316,8 +316,12 @@ static std::string LogTimestampStr(const std::string &str, std::atomic_bool *fSt
         return str;
 
     if (*fStartedNewLine) {
+        if (IsMockTime()) {
+            int64_t nRealTimeMicros = GetTimeMicros();
+            strStamped = DateTimeStrFormat("(real %Y-%m-%d %H:%M:%S) ", nRealTimeMicros/1000000);
+        }
         int64_t nTimeMicros = GetLogTimeMicros();
-        strStamped = DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTimeMicros/1000000);
+        strStamped += DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTimeMicros/1000000);
         if (fLogTimeMicros)
             strStamped += strprintf(".%06d", nTimeMicros%1000000);
         strStamped += ' ' + str;

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -29,6 +29,11 @@ void SetMockTime(int64_t nMockTimeIn)
     nMockTime = nMockTimeIn;
 }
 
+bool IsMockTime()
+{
+    return nMockTime != 0;
+}
+
 int64_t GetTimeMillis()
 {
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -25,6 +25,7 @@ int64_t GetTimeMicros();
 int64_t GetSystemTimeInSeconds(); // Like GetTime(), but not mockable
 int64_t GetLogTimeMicros();
 void SetMockTime(int64_t nMockTimeIn);
+bool IsMockTime();
 void MilliSleep(int64_t n);
 
 std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);


### PR DESCRIPTION
This PR adds an additional timestamp to log entries when mocktime is enabled in tests. I always found it very annoying to not being able to debug timing issues on Travis after we switched nearly all tests to use mock time. This should fix this.