### PR TITLE
[PrivateSend] Allow more than 3 mixing participants

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -296,7 +296,8 @@ public:
         fAllowMultipleAddressesFromGroup = false;
         fAllowMultiplePorts = false;
 
-        nPoolMaxTransactions = 3;
+        nPoolMinParticipants = 3;
+        nPoolMaxParticipants = 5;
         nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
 
         vSporkAddresses = {"Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh"};
@@ -463,7 +464,8 @@ public:
         fAllowMultipleAddressesFromGroup = false;
         fAllowMultiplePorts = false;
 
-        nPoolMaxTransactions = 3;
+        nPoolMinParticipants = 3;
+        nPoolMaxParticipants = 5;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
@@ -608,7 +610,8 @@ public:
         fAllowMultipleAddressesFromGroup = true;
         fAllowMultiplePorts = true;
 
-        nPoolMaxTransactions = 3;
+        nPoolMinParticipants = 3;
+        nPoolMaxParticipants = 5;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -86,7 +86,8 @@ public:
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     const ChainTxData& TxData() const { return chainTxData; }
-    int PoolMaxTransactions() const { return nPoolMaxTransactions; }
+    int PoolMinParticipants() const { return nPoolMinParticipants; }
+    int PoolMaxParticipants() const { return nPoolMaxParticipants; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
     const std::vector<std::string>& SporkAddresses() const { return vSporkAddresses; }
     int MinSporkKeys() const { return nMinSporkKeys; }
@@ -116,7 +117,8 @@ protected:
     bool fAllowMultiplePorts;
     CCheckpointData checkpointData;
     ChainTxData chainTxData;
-    int nPoolMaxTransactions;
+    int nPoolMinParticipants;
+    int nPoolMaxParticipants;
     int nFulfilledRequestExpireTime;
     std::vector<std::string> vSporkAddresses;
     int nMinSporkKeys;

--- a/src/privatesend-client.cpp
+++ b/src/privatesend-client.cpp
@@ -320,14 +320,14 @@ std::string CPrivateSendClientSession::GetStatus(bool fWaitForBlock)
             return _("PrivateSend request complete:") + " " + _("Your transaction was accepted into the pool!");
         } else {
             if (nStatusMessageProgress % 70 <= 40)
-                return strprintf(_("Submitted following entries to masternode: %u / %d"), nEntriesCount, CPrivateSend::GetMaxPoolTransactions());
+                return strprintf(_("Submitted following entries to masternode: %u"), nEntriesCount);
             else if (nStatusMessageProgress % 70 <= 50)
                 strSuffix = ".";
             else if (nStatusMessageProgress % 70 <= 60)
                 strSuffix = "..";
             else if (nStatusMessageProgress % 70 <= 70)
                 strSuffix = "...";
-            return strprintf(_("Submitted to masternode, waiting for more entries ( %u / %d ) %s"), nEntriesCount, CPrivateSend::GetMaxPoolTransactions(), strSuffix);
+            return strprintf(_("Submitted to masternode, waiting for more entries ( %u ) %s"), nEntriesCount, strSuffix);
         }
     case POOL_STATE_SIGNING:
         if (nStatusMessageProgress % 70 <= 40)

--- a/src/privatesend-server.h
+++ b/src/privatesend-server.h
@@ -22,6 +22,9 @@ private:
     // to behave honestly. If they don't it takes their money.
     std::vector<CTransactionRef> vecSessionCollaterals;
 
+    // Maximum number of participants in a certain session, random between min and max.
+    int nSessionMaxParticipants;
+
     bool fUnitTest;
 
     /// Add a clients entry to the pool
@@ -45,7 +48,7 @@ private:
     bool CreateNewSession(const CPrivateSendAccept& dsa, PoolMessage& nMessageIDRet, CConnman& connman);
     bool AddUserToExistingSession(const CPrivateSendAccept& dsa, PoolMessage& nMessageIDRet);
     /// Do we have enough users to take entries?
-    bool IsSessionReady() { return (int)vecSessionCollaterals.size() >= CPrivateSend::GetMaxPoolTransactions(); }
+    bool IsSessionReady() { return (int)vecSessionCollaterals.size() >= nSessionMaxParticipants; }
 
     /// Check that all inputs are signed. (Are all inputs signed?)
     bool IsSignaturesComplete();

--- a/src/privatesend.h
+++ b/src/privatesend.h
@@ -403,8 +403,9 @@ public:
 
     static std::string GetMessageByID(PoolMessage nMessageID);
 
-    /// Get the maximum number of transactions for the pool
-    static int GetMaxPoolTransactions() { return Params().PoolMaxTransactions(); }
+    /// Get the minimum/maximum number of participants for the pool
+    static int GetMinPoolParticipants() { return Params().PoolMinParticipants(); }
+    static int GetMaxPoolParticipants() { return Params().PoolMaxParticipants(); }
 
     static CAmount GetMaxPoolAmount() { return vecStandardDenominations.empty() ? 0 : PRIVATESEND_ENTRY_MAX_SIZE * vecStandardDenominations.front(); }
 


### PR DESCRIPTION
The number of mixing participants will now randomly range from 3-5 resulting in a average of 4. This increases the raw anonymity set by over 3 times `(4 participants ^ 4 rounds) / (3 participants ^ 4 rounds)` as well as removing a major metadata leakage. 