### PR TITLE
[PrivateSend] Fallback to less participants if possible, fix too long timeouts on server side

### DIFF
--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -244,7 +244,6 @@ void CPrivateSendServer::ProcessMessage(CNode* pfrom, const std::string& strComm
             RelayStatus(STATUS_ACCEPTED, connman);
         } else {
             PushStatus(pfrom, STATUS_REJECTED, nMessageID, connman);
-            SetNull();
         }
 
     } else if (strCommand == NetMsgType::DSSIGNFINALTX) {
@@ -484,7 +483,7 @@ void CPrivateSendServer::ChargeRandomFees(CConnman& connman)
 
         CValidationState state;
         if (!AcceptToMemoryPool(mempool, state, txCollateral, false, NULL, false, maxTxFee)) {
-            // should never really happen
+            // Can happen if this collateral belongs to some misbehaving participant we punished earlier
             LogPrintf("CPrivateSendServer::ChargeRandomFees -- ERROR: AcceptToMemoryPool failed!\n");
         } else {
             connman.RelayTransaction(*txCollateral);
@@ -498,18 +497,40 @@ void CPrivateSendServer::ChargeRandomFees(CConnman& connman)
 void CPrivateSendServer::CheckTimeout(CConnman& connman)
 {
     if (!fMasternodeMode) return;
+    if (nState == POOL_STATE_IDLE) return;
 
     CheckQueue();
 
     int nTimeout = (nState == POOL_STATE_SIGNING) ? PRIVATESEND_SIGNING_TIMEOUT : PRIVATESEND_QUEUE_TIMEOUT;
     bool fTimeout = GetTime() - nTimeLastSuccessfulStep >= nTimeout;
 
-    if (nState != POOL_STATE_IDLE && fTimeout) {
-        LogPrint("privatesend", "CPrivateSendServer::CheckTimeout -- %s timed out (%ds) -- resetting\n",
-            (nState == POOL_STATE_SIGNING) ? "Signing" : "Session", nTimeout);
-        ChargeFees(connman);
-        SetNull();
+    // Too early to do anything
+    if (!fTimeout) return;
+
+    // See if we have at least min number of participants, if so - we can still do smth
+    if (nState == POOL_STATE_QUEUE && vecSessionCollaterals.size() >= CPrivateSend::GetMinPoolParticipants()) {
+        LogPrint("privatesend", "CPrivateSendServer::CheckTimeout -- Queue for %d participants timed out (%ds) -- falling back to %d participants\n",
+            nSessionMaxParticipants, nTimeout, vecSessionCollaterals.size());
+        nSessionMaxParticipants = vecSessionCollaterals.size();
+        return;
     }
+
+    if (nState == POOL_STATE_ACCEPTING_ENTRIES && GetEntriesCount() >= CPrivateSend::GetMinPoolParticipants()) {
+        LogPrint("privatesend", "CPrivateSendServer::CheckTimeout -- Accepting entries for %d participants timed out (%ds) -- falling back to %d participants\n",
+            nSessionMaxParticipants, nTimeout, GetEntriesCount());
+        // Punish misbehaving participants
+        ChargeFees(connman);
+        // Try to complete this session ignoring the misbehaving ones
+        nSessionMaxParticipants = GetEntriesCount();
+        CheckPool(connman);
+        return;
+    }
+
+    // All other cases
+    LogPrint("privatesend", "CPrivateSendServer::CheckTimeout -- %s timed out (%ds) -- resetting\n",
+        (nState == POOL_STATE_SIGNING) ? "Signing" : "Session", nTimeout);
+    ChargeFees(connman);
+    SetNull();
 }
 
 /*

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -638,7 +638,6 @@ bool CPrivateSendServer::AddEntry(const CPrivateSendEntry& entryNew, PoolMessage
 
     LogPrint("privatesend", "CPrivateSendServer::AddEntry -- adding entry %d of %d required\n", GetEntriesCount(), nSessionMaxParticipants);
     nMessageIDRet = MSG_ENTRIES_ADDED;
-    nTimeLastSuccessfulStep = GetTime();
 
     return true;
 }
@@ -747,7 +746,6 @@ bool CPrivateSendServer::CreateNewSession(const CPrivateSendAccept& dsa, PoolMes
     nSessionMaxParticipants = CPrivateSend::GetMinPoolParticipants() + GetRandInt(CPrivateSend::GetMaxPoolParticipants() - CPrivateSend::GetMinPoolParticipants() + 1);
 
     SetState(POOL_STATE_QUEUE);
-    nTimeLastSuccessfulStep = GetTime();
 
     if (!fUnitTest) {
         //broadcast that I'm accepting entries, only if it's the first entry through
@@ -790,7 +788,6 @@ bool CPrivateSendServer::AddUserToExistingSession(const CPrivateSendAccept& dsa,
     // count new user as accepted to an existing session
 
     nMessageIDRet = MSG_NOERR;
-    nTimeLastSuccessfulStep = GetTime();
     vecSessionCollaterals.push_back(MakeTransactionRef(dsa.txCollateral));
 
     LogPrintf("CPrivateSendServer::AddUserToExistingSession -- new user accepted, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  nSessionMaxParticipants: %d\n",
@@ -897,6 +894,7 @@ void CPrivateSendServer::SetState(PoolState nStateNew)
     }
 
     LogPrintf("CPrivateSendServer::SetState -- nState: %d, nStateNew: %d\n", nState, nStateNew);
+    nTimeLastSuccessfulStep = GetTime();
     nState = nStateNew;
 }
 

--- a/src/privatesend-server.cpp
+++ b/src/privatesend-server.cpp
@@ -331,8 +331,8 @@ void CPrivateSendServer::CreateFinalTransaction(CConnman& connman)
     LogPrint("privatesend", "CPrivateSendServer::CreateFinalTransaction -- finalMutableTransaction=%s", txNew.ToString());
 
     // request signatures from clients
-    RelayFinalTransaction(finalMutableTransaction, connman);
     SetState(POOL_STATE_SIGNING);
+    RelayFinalTransaction(finalMutableTransaction, connman);
 }
 
 void CPrivateSendServer::CommitFinalTransaction(CConnman& connman)


### PR DESCRIPTION
Mixing on testnet (3 local wallet, 1 remote one) I noticed that very few sessions with more than 3 participants succeeded while sessions with 3 participants were much more likely to succeed. I found two reasons why this happens so far:
- some clients are simply late because they were mixing somewhere else (aka not enough liquidity for this specific session)
- we are bumping timeouts on server side too much, so (if some new participant comes late) by the time timeout hits, the first participant is already timed out locally long time ago and won't participate.

f8e6b64 should try to fallback to whatever number of participant responded at each preparation step (`dsa` and `dsvin`), still making sure that it's above minimum though.

aec0fe9 should synchronise timeouts, that's basically a legacy bug which wasn't that noticeable with only 3 participants.

e155bac is a tiny cleanup, no functional changes and should not really affect the process in any way, it's just for the sake of consistency with the rest of the code.

UPDATE: Running this on my testnet masternode and had a couple of successful fallbacks (5->4, 4->3, 5->3) at different mixing states, everything looks good so far.