### PR TITLE
Add checkbox to show only masternodes the wallet has keys for

### DIFF
--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -74,6 +74,16 @@
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="checkBoxMyMasternodesOnly">
+             <property name="toolTip">
+              <string>Show only masternodes this wallet has keys for.</string>
+             </property>
+             <property name="text">
+              <string>My masternodes only</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="horizontalSpacer_4">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -65,6 +65,7 @@ private:
 private Q_SLOTS:
     void showContextMenuDIP3(const QPoint&);
     void on_filterLineEditDIP3_textChanged(const QString& strFilterIn);
+    void on_checkBoxMyMasternodesOnly_stateChanged(int state);
 
     void extraInfoDIP3_clicked();
     void copyProTxHash_clicked();


### PR DESCRIPTION
I simply tired filtering the list manually all the time, so thought this might be a good idea ;)

It looks like this (on mac):
<img width="985" alt="screenshot 2019-01-13 at 03 58 38" src="https://user-images.githubusercontent.com/1935069/51080164-997eef00-16e7-11e9-82ba-efe94b41e7f7.png">

Works the same way as `protx list wallet` rpc does, I basically extracted key/script filtering part from there.