### PR TITLE
Bring back ResetLocalSessionStatus call

### DIFF
--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -124,6 +124,9 @@ void CDKGSessionHandler::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBl
     int phaseInt = quorumStageInt / params.dkgPhaseBlocks;
     if (fNewPhase && phaseInt >= QuorumPhase_Initialized && phaseInt <= QuorumPhase_Idle) {
         phase = static_cast<QuorumPhase>(phaseInt);
+        if (phase == QuorumPhase_Initialized) {
+            quorumDKGDebugManager->ResetLocalSessionStatus(params.type, quorumHash, quorumHeight);
+        }
     }
 
     quorumDKGDebugManager->UpdateLocalStatus([&](CDKGDebugStatus& status) {


### PR DESCRIPTION
It was dropped accidentally on refactoring in #2637 https://github.com/dashpay/dash/pull/2637/commits/02c1e24b8c31c872289675111e7de8c3bf2e78d7#diff-3d087cee3392d8baafc373f3e0effea2L126 🙈 

This fixes `llmq-signing.py` failures like in https://travis-ci.org/dashpay/dash/jobs/482901330