### PR TITLE
Fix confusion between dip3 activation and enforcement

### DIFF
--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -23,7 +23,7 @@ AUTO_IX_MEM_THRESHOLD = 0.1
 
 class AutoIXMempoolTest(DashTestFramework):
     def __init__(self):
-        super().__init__(13, 10, ["-maxmempool=%d" % MAX_MEMPOOL_SIZE, '-limitdescendantsize=10'], fast_dip3_activation=True)
+        super().__init__(13, 10, ["-maxmempool=%d" % MAX_MEMPOOL_SIZE, '-limitdescendantsize=10'], fast_dip3_enforcement=True)
         # set sender,  receiver
         self.receiver_idx = self.num_nodes - 2
         self.sender_idx = self.num_nodes - 3

--- a/qa/rpc-tests/dip3-deterministicmns.py
+++ b/qa/rpc-tests/dip3-deterministicmns.py
@@ -24,7 +24,7 @@ class DIP3Test(BitcoinTestFramework):
 
         self.extra_args = ["-budgetparams=10:10:10"]
         self.extra_args += ["-sporkkey=cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"]
-        self.extra_args += ["-bip9params=dip0003:0:999999999999:45:45", "-dip3activationheight=150"]
+        self.extra_args += ["-bip9params=dip0003:0:999999999999:45:45", "-dip3enforcementheight=150"]
 
     def setup_network(self):
         disable_mocktime()

--- a/qa/rpc-tests/llmq-signing.py
+++ b/qa/rpc-tests/llmq-signing.py
@@ -17,7 +17,7 @@ Checks LLMQs signing sessions
 
 class LLMQSigningTest(DashTestFramework):
     def __init__(self):
-        super().__init__(11, 10, [], fast_dip3_activation=True)
+        super().__init__(11, 10, [], fast_dip3_enforcement=True)
 
     def run_test(self):
 

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -23,7 +23,7 @@ transactions with high fee.
 
 class AutoInstantSendTest(DashTestFramework):
     def __init__(self):
-        super().__init__(14, 10, [], fast_dip3_activation=True)
+        super().__init__(14, 10, [], fast_dip3_enforcement=True)
         # set sender,  receiver,  isolated nodes
         self.isolated_idx = self.num_nodes - 1
         self.receiver_idx = self.num_nodes - 2

--- a/qa/rpc-tests/p2p-instantsend.py
+++ b/qa/rpc-tests/p2p-instantsend.py
@@ -14,7 +14,7 @@ InstantSendTest -- test InstantSend functionality (prevent doublespend for uncon
 
 class InstantSendTest(DashTestFramework):
     def __init__(self):
-        super().__init__(14, 10, [], fast_dip3_activation=True)
+        super().__init__(14, 10, [], fast_dip3_enforcement=True)
         # set sender,  receiver,  isolated nodes
         self.isolated_idx = self.num_nodes - 1
         self.receiver_idx = self.num_nodes - 2

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -220,7 +220,7 @@ class MasternodeInfo:
 
 
 class DashTestFramework(BitcoinTestFramework):
-    def __init__(self, num_nodes, masterodes_count, extra_args, fast_dip3_activation=False):
+    def __init__(self, num_nodes, masterodes_count, extra_args, fast_dip3_enforcement=False):
         super().__init__()
         self.mn_count = masterodes_count
         self.num_nodes = num_nodes
@@ -232,9 +232,9 @@ class DashTestFramework(BitcoinTestFramework):
 
         self.extra_args += ["-sporkkey=cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"]
 
-        self.fast_dip3_activation = fast_dip3_activation
-        if fast_dip3_activation:
-            self.extra_args += ["-bip9params=dip0003:0:999999999999:10:5", "-dip3activationheight=50"]
+        self.fast_dip3_enforcement = fast_dip3_enforcement
+        if fast_dip3_enforcement:
+            self.extra_args += ["-bip9params=dip0003:0:999999999999:10:5", "-dip3enforcementheight=50"]
 
     def create_simple_node(self):
         idx = len(self.nodes)
@@ -345,7 +345,7 @@ class DashTestFramework(BitcoinTestFramework):
         sync_masternodes(self.nodes, True)
 
         # activate DIP3
-        if not self.fast_dip3_activation:
+        if not self.fast_dip3_enforcement:
             while self.nodes[0].getblockcount() < 500:
                 self.nodes[0].generate(10)
         self.sync_all()

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -61,7 +61,7 @@ void CActiveMasternodeManager::Init()
 
     if (!fMasternodeMode) return;
 
-    if (!deterministicMNManager->IsDIP3Active()) return;
+    if (!deterministicMNManager->IsDIP3Enforced()) return;
 
     // Check that our local network configuration is correct
     if (!fListen) {
@@ -131,7 +131,7 @@ void CActiveMasternodeManager::UpdatedBlockTip(const CBlockIndex* pindexNew, con
 
     if (!fMasternodeMode) return;
 
-    if (!deterministicMNManager->IsDIP3Active(pindexNew->nHeight)) return;
+    if (!deterministicMNManager->IsDIP3Enforced(pindexNew->nHeight)) return;
 
     if (state == MASTERNODE_READY) {
         auto mnList = deterministicMNManager->GetListForBlock(pindexNew->GetBlockHash());

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -225,8 +225,8 @@ public:
         consensus.BIP65Height = 619382; // 00000000000076d8fcea02ec0963de4abfd01e771fec0863f960c2c64fe6f357
         consensus.BIP66Height = 245817; // 00000000000b1fa2dfa312863570e13fae9ca7b5566cb27e55422620b469aefa
         consensus.DIP0001Height = 782208;
-        consensus.DIP0003Height = 1000000000; // TODO update after DIP3 is deployed
-        consensus.DIP0003Hash = uint256(); // TODO update after DIP3 is deployed
+        consensus.DIP0003EnforcementHeight = 1000000000; // TODO update after DIP3 is deployed
+        consensus.DIP0003EnforcementHash = uint256(); // TODO update after DIP3 is deployed
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -396,8 +396,8 @@ public:
         consensus.BIP65Height = 2431; // 0000039cf01242c7f921dcb4806a5994bc003b48c1973ae0c89b67809c2bb2ab
         consensus.BIP66Height = 2075; // 0000002acdd29a14583540cb72e1c5cc83783560e38fa7081495d474fe1671f7
         consensus.DIP0001Height = 5500;
-        consensus.DIP0003Height = 7300;
-        consensus.DIP0003Hash = uint256S("00000055ebc0e974ba3a3fb785c5ad4365a39637d4df168169ee80d313612f8f");
+        consensus.DIP0003EnforcementHeight = 7300;
+        consensus.DIP0003EnforcementHash = uint256S("00000055ebc0e974ba3a3fb785c5ad4365a39637d4df168169ee80d313612f8f");
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -543,8 +543,8 @@ public:
         consensus.BIP65Height = 1; // BIP65 activated immediately on devnet
         consensus.BIP66Height = 1; // BIP66 activated immediately on devnet
         consensus.DIP0001Height = 2; // DIP0001 activated immediately on devnet
-        consensus.DIP0003Height = 2; // DIP0003 activated immediately on devnet
-        consensus.DIP0003Hash = uint256();
+        consensus.DIP0003EnforcementHeight = 2; // DIP0003 activated immediately on devnet
+        consensus.DIP0003EnforcementHash = uint256();
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -695,8 +695,8 @@ public:
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
         consensus.DIP0001Height = 2000;
-        consensus.DIP0003Height = 500;
-        consensus.DIP0003Hash = uint256();
+        consensus.DIP0003EnforcementHeight = 500;
+        consensus.DIP0003EnforcementHash = uint256();
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -801,9 +801,9 @@ public:
         }
     }
 
-    void UpdateDIP3ActivationHeight(int nHeight)
+    void UpdateDIP3EnforcementHeight(int nHeight)
     {
-        consensus.DIP0003Height = nHeight;
+        consensus.DIP0003EnforcementHeight = nHeight;
     }
 
     void UpdateBudgetParameters(int nMasternodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock)
@@ -854,9 +854,9 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
     regTestParams.UpdateBIP9Parameters(d, nStartTime, nTimeout, nWindowSize, nThreshold);
 }
 
-void UpdateRegtestDIP3ActivationHeight(int nHeight)
+void UpdateRegtestDIP3EnforcementHeight(int nHeight)
 {
-    regTestParams.UpdateDIP3ActivationHeight(nHeight);
+    regTestParams.UpdateDIP3EnforcementHeight(nHeight);
 }
 
 void UpdateRegtestBudgetParameters(int nMasternodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -150,7 +150,7 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 /**
  * Allows modifying the DIP3 activation height
  */
-void UpdateRegtestDIP3ActivationHeight(int nHeight);
+void UpdateRegtestDIP3EnforcementHeight(int nHeight);
 
 /**
  * Allows modifying the budget regtest parameters.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -151,8 +151,10 @@ struct Params {
     /** Block height at which DIP0001 becomes active */
     int DIP0001Height;
     /** Block height at which DIP0003 becomes active */
-    int DIP0003Height;
-    uint256 DIP0003Hash;
+    int DIP0003ActivationHeight;
+    /** Block height at which DIP0003 becomes enforced */
+    int DIP0003EnforcementHeight;
+    uint256 DIP0003EnforcementHash;
     /**
      * Minimum blocks including miner confirmation of the total of nMinerConfirmationWindow blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -150,8 +150,6 @@ struct Params {
     int BIP66Height;
     /** Block height at which DIP0001 becomes active */
     int DIP0001Height;
-    /** Block height at which DIP0003 becomes active */
-    int DIP0003ActivationHeight;
     /** Block height at which DIP0003 becomes enforced */
     int DIP0003EnforcementHeight;
     uint256 DIP0003EnforcementHash;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -481,13 +481,13 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
     }
 
     const auto& consensusParams = Params().GetConsensus();
-    if (nHeight == consensusParams.DIP0003Height) {
-        if (!consensusParams.DIP0003Hash.IsNull() && consensusParams.DIP0003Hash != pindex->GetBlockHash()) {
-            LogPrintf("CDeterministicMNManager::%s -- DIP3 activation block has wrong hash: hash=%s, expected=%s, nHeight=%d\n", __func__,
-                    pindex->GetBlockHash().ToString(), consensusParams.DIP0003Hash.ToString(), nHeight);
-            return _state.DoS(100, false, REJECT_INVALID, "bad-dip3-block");
+    if (nHeight == consensusParams.DIP0003EnforcementHeight) {
+        if (!consensusParams.DIP0003EnforcementHash.IsNull() && consensusParams.DIP0003EnforcementHash != pindex->GetBlockHash()) {
+            LogPrintf("CDeterministicMNManager::%s -- DIP3 enforcement block has wrong hash: hash=%s, expected=%s, nHeight=%d\n", __func__,
+                    pindex->GetBlockHash().ToString(), consensusParams.DIP0003EnforcementHash.ToString(), nHeight);
+            return _state.DoS(100, false, REJECT_INVALID, "bad-dip3-enf-block");
         }
-        LogPrintf("CDeterministicMNManager::%s -- DIP3 is active now. nHeight=%d\n", __func__, nHeight);
+        LogPrintf("CDeterministicMNManager::%s -- DIP3 is enforced now. nHeight=%d\n", __func__, nHeight);
     }
 
     LOCK(cs);
@@ -518,8 +518,8 @@ bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* 
     }
 
     const auto& consensusParams = Params().GetConsensus();
-    if (nHeight == consensusParams.DIP0003Height) {
-        LogPrintf("CDeterministicMNManager::%s -- DIP3 is not active anymore. nHeight=%d\n", __func__, nHeight);
+    if (nHeight == consensusParams.DIP0003EnforcementHeight) {
+        LogPrintf("CDeterministicMNManager::%s -- DIP3 is not enforced anymore. nHeight=%d\n", __func__, nHeight);
     }
 
     return true;
@@ -875,7 +875,7 @@ bool CDeterministicMNManager::IsProTxWithCollateral(const CTransactionRef& tx, u
     return true;
 }
 
-bool CDeterministicMNManager::IsDIP3Active(int nHeight)
+bool CDeterministicMNManager::IsDIP3Enforced(int nHeight)
 {
     LOCK(cs);
 
@@ -883,7 +883,7 @@ bool CDeterministicMNManager::IsDIP3Active(int nHeight)
         nHeight = tipHeight;
     }
 
-    return nHeight >= Params().GetConsensus().DIP0003Height;
+    return nHeight >= Params().GetConsensus().DIP0003EnforcementHeight;
 }
 
 void CDeterministicMNManager::CleanupCache(int nHeight)

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -495,7 +495,7 @@ public:
     // Test if given TX is a ProRegTx which also contains the collateral at index n
     bool IsProTxWithCollateral(const CTransactionRef& tx, uint32_t n);
 
-    bool IsDIP3Active(int nHeight = -1);
+    bool IsDIP3Enforced(int nHeight = -1);
 
 private:
     void CleanupCache(int nHeight);

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -186,7 +186,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
             return state.DoS(10, false, REJECT_DUPLICATE, "bad-protx-dup-key");
         }
 
-        if (!deterministicMNManager->IsDIP3Active(pindexPrev->nHeight)) {
+        if (!deterministicMNManager->IsDIP3Enforced(pindexPrev->nHeight)) {
             if (ptx.keyIDOwner != ptx.keyIDVoting) {
                 return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-not-same");
             }
@@ -330,7 +330,7 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
             }
         }
 
-        if (!deterministicMNManager->IsDIP3Active(pindexPrev->nHeight)) {
+        if (!deterministicMNManager->IsDIP3Enforced(pindexPrev->nHeight)) {
             if (dmn->pdmnState->keyIDOwner != ptx.keyIDVoting) {
                 return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-not-same");
             }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -579,7 +579,7 @@ void CGovernanceManager::DoMaintenance(CConnman& connman)
 {
     if (fLiteMode || !masternodeSync.IsSynced() || ShutdownRequested()) return;
 
-    if (deterministicMNManager->IsDIP3Active()) {
+    if (deterministicMNManager->IsDIP3Enforced()) {
         RemoveInvalidProposalVotes();
     }
 
@@ -1301,7 +1301,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex* pindex, CConnman& co
     nCachedBlockHeight = pindex->nHeight;
     LogPrint("gobject", "CGovernanceManager::UpdatedBlockTip -- nCachedBlockHeight: %d\n", nCachedBlockHeight);
 
-    if (deterministicMNManager->IsDIP3Active(pindex->nHeight)) {
+    if (deterministicMNManager->IsDIP3Enforced(pindex->nHeight)) {
         RemoveInvalidProposalVotes();
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1324,8 +1324,8 @@ bool AppInitParameterInteraction()
         }
     }
 
-    if (IsArgSet("-dip3activationheight")) {
-        UpdateRegtestDIP3ActivationHeight(GetArg("-dip3activationheight", 0));
+    if (IsArgSet("-dip3enforcementheight")) {
+        UpdateRegtestDIP3EnforcementHeight(GetArg("-dip3enforcementheight", 0));
     }
 
     if (IsArgSet("-budgetparams")) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -318,7 +318,7 @@ std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(Consensus::LLMQType llmqTyp
 
     CBlockIndex* pindex = mapBlockIndex[startBlock];
 
-    while (pindex != NULL && result.size() < maxCount && deterministicMNManager->IsDIP3Active(pindex->nHeight)) {
+    while (pindex != NULL && result.size() < maxCount && deterministicMNManager->IsDIP3Enforced(pindex->nHeight)) {
         if (HasQuorum(llmqType, pindex->GetBlockHash())) {
             auto quorum = GetQuorum(llmqType, pindex->GetBlockHash());
             if (quorum) {

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -163,7 +163,7 @@ bool CDKGSessionHandler::InitNewQuorum(int newQuorumHeight, const uint256& newQu
 
     curSession = std::make_shared<CDKGSession>(params, evoDb, blsWorker, dkgManager);
 
-    if (!deterministicMNManager->IsDIP3Active(newQuorumHeight)) {
+    if (!deterministicMNManager->IsDIP3Enforced(newQuorumHeight)) {
         return false;
     }
 

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -48,7 +48,7 @@ void CDKGSessionManager::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBl
 
     if (fInitialDownload)
         return;
-    if (!deterministicMNManager->IsDIP3Active(pindexNew->nHeight))
+    if (!deterministicMNManager->IsDIP3Enforced(pindexNew->nHeight))
         return;
     if (!sporkManager.IsSporkActive(SPORK_17_QUORUM_DKG_ENABLED))
         return;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -363,7 +363,7 @@ bool CMasternodePayments::IsScheduled(const CDeterministicMNCPtr& dmnIn, int nNo
 
 bool CMasternodePayments::IsTransactionValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward) const
 {
-    if (!deterministicMNManager->IsDIP3Active(nBlockHeight)) {
+    if (!deterministicMNManager->IsDIP3Enforced(nBlockHeight)) {
         // can't verify historical blocks here
         return true;
     }

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -279,8 +279,8 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChainDIP3Setup)
         nHeight++;
     }
 
-    int DIP0003HeightBackup = Params().GetConsensus().DIP0003Height;
-    const_cast<Consensus::Params&>(Params().GetConsensus()).DIP0003Height = chainActive.Height() + 1;
+    int DIP0003EnforcementHeightBackup = Params().GetConsensus().DIP0003EnforcementHeight;
+    const_cast<Consensus::Params&>(Params().GetConsensus()).DIP0003EnforcementHeight = chainActive.Height() + 1;
     CreateAndProcessBlock({}, coinbaseKey);
     deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
     nHeight++;
@@ -399,6 +399,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChainDIP3Setup)
     }
     BOOST_ASSERT(foundRevived);
 
-    const_cast<Consensus::Params&>(Params().GetConsensus()).DIP0003Height = DIP0003HeightBackup;
+    const_cast<Consensus::Params&>(Params().GetConsensus()).DIP0003EnforcementHeight = DIP0003EnforcementHeightBackup;
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
These are two different events - activation (bip9 based) and enforcement (spork and later specific block based one) but we use the same term "activation" for both of them which is confusing. This should make it a bit clearer.