### PR TITLE
Drop cs_main from UpdatedBlockTip in CDKGSessionManager/CDKGSessionHandler

### DIFF
--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -111,11 +111,10 @@ CDKGSessionHandler::~CDKGSessionHandler()
 
 void CDKGSessionHandler::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
 {
-    AssertLockHeld(cs_main);
     LOCK(cs);
 
     int quorumStageInt = pindexNew->nHeight % params.dkgInterval;
-    CBlockIndex* pindexQuorum = chainActive[pindexNew->nHeight - quorumStageInt];
+    const CBlockIndex* pindexQuorum = pindexNew->GetAncestor(pindexNew->nHeight - quorumStageInt);
 
     quorumHeight = pindexQuorum->nHeight;
     quorumHash = pindexQuorum->GetBlockHash();

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -53,8 +53,6 @@ void CDKGSessionManager::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBl
     if (!sporkManager.IsSporkActive(SPORK_17_QUORUM_DKG_ENABLED))
         return;
 
-    LOCK(cs_main);
-
     for (auto& qt : dkgSessionHandlers) {
         qt.second.UpdatedBlockTip(pindexNew, pindexFork, fInitialDownload);
     }


### PR DESCRIPTION
`UpdatedBlockTip` is meant to be `cs_main`-free, let's try to keep it this way.