### PR TITLE
Don't leak skShare in logs

### DIFF
--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -915,7 +915,7 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
     }
     t2.stop();
 
-    logger.Batch("skShare=%s, pubKeyShare=%s", skShare.ToString(), skShare.GetPublicKey().ToString());
+    logger.Batch("pubKeyShare=%s", skShare.GetPublicKey().ToString());
 
     cxxtimer::Timer t3(true);
     qc.quorumPublicKey = (*vvec)[0];


### PR DESCRIPTION
Better not take any risks here, even though leaking single skShares is not that bad on its own.