### PR TITLE
Optimize DKG debug message processing for performance and lower bandwidth

### DIFF
--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -471,8 +471,12 @@ class DashTestFramework(BitcoinTestFramework):
         while time() - t < timeout:
             all_ok = True
             for node in self.nodes:
-                s = node.quorum("dkgstatus")["session"]["llmq_10"]
-                if "receivedFinalCommitment" not in s or not s["receivedFinalCommitment"]:
+                s = node.quorum("dkgstatus")
+                if "minableCommitments" not in s:
+                    all_ok = False
+                    break
+                s = s["minableCommitments"]
+                if "llmq_10" not in s:
                     all_ok = False
                     break
             if all_ok:

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -446,7 +446,11 @@ class DashTestFramework(BitcoinTestFramework):
         while time() - t < timeout:
             all_ok = True
             for mn in self.mninfo:
-                s = mn.node.quorum("dkgstatus")["session"]["llmq_10"]
+                s = mn.node.quorum("dkgstatus")["session"]
+                if "llmq_10" not in s:
+                    all_ok = False
+                    break
+                s = s["llmq_10"]
                 if "phase" not in s:
                     all_ok = False
                     break

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -337,14 +337,6 @@ void CQuorumBlockProcessor::AddMinableCommitment(const CFinalCommitment& fqc)
         }
     }
 
-    quorumDKGDebugManager->UpdateLocalSessionStatus((Consensus::LLMQType)fqc.llmqType, [&](CDKGDebugSessionStatus& status) {
-        if (status.quorumHash != fqc.quorumHash || status.receivedFinalCommitment) {
-            return false;
-        }
-        status.receivedFinalCommitment = true;
-        return true;
-    });
-
     // We only relay the new commitment if it's new or better then the old one
     if (relay) {
         CInv inv(MSG_QUORUM_FINAL_COMMITMENT, commitmentHash);

--- a/src/llmq/quorums_debug.cpp
+++ b/src/llmq/quorums_debug.cpp
@@ -305,7 +305,7 @@ bool CDKGDebugManager::AlreadyHave(const CInv& inv)
         return true;
     }
 
-    return statuses.count(inv.hash) != 0;
+    return statuses.count(inv.hash) != 0 || seenStatuses.count(inv.hash) != 0;
 }
 
 bool CDKGDebugManager::GetDebugStatus(const uint256& hash, llmq::CDKGDebugStatus& ret)

--- a/src/llmq/quorums_debug.cpp
+++ b/src/llmq/quorums_debug.cpp
@@ -289,7 +289,6 @@ UniValue CDKGDebugStatus::ToJson(int detailLevel) const
     UniValue ret(UniValue::VOBJ);
 
     ret.push_back(Pair("proTxHash", proTxHash.ToString()));
-    ret.push_back(Pair("height", (int)nHeight));
     ret.push_back(Pair("time", nTime));
     ret.push_back(Pair("timeStr", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime)));
 

--- a/src/llmq/quorums_debug.cpp
+++ b/src/llmq/quorums_debug.cpp
@@ -96,7 +96,6 @@ UniValue CDKGDebugSessionStatus::ToJson(int detailLevel) const
     push(receivedComplaints, "receivedComplaints");
     push(receivedJustifications, "receivedJustifications");
     push(receivedPrematureCommitments, "receivedPrematureCommitments");
-    ret.push_back(Pair("receivedFinalCommitment", receivedFinalCommitment));
 
     if (detailLevel == 2) {
         UniValue arr(UniValue::VARR);
@@ -365,7 +364,6 @@ void CDKGDebugManager::InitLocalSessionStatus(Consensus::LLMQType llmqType, cons
     session.statusBitset = 0;
     session.members.clear();
     session.members.resize((size_t)params.size);
-    session.receivedFinalCommitment = false;
 }
 
 void CDKGDebugManager::UpdateLocalStatus(std::function<bool(CDKGDebugStatus& status)>&& func)

--- a/src/llmq/quorums_debug.cpp
+++ b/src/llmq/quorums_debug.cpp
@@ -217,6 +217,10 @@ void CDKGDebugManager::ProcessPending()
         pend = std::move(pendingIncomingStatuses);
     }
 
+    if (!sporkManager.IsSporkActive(SPORK_18_QUORUM_DEBUG_ENABLED)) {
+        return;
+    }
+
     CBLSInsecureBatchVerifier<NodeId, uint256> batchVerifier(true, 8);
     for (const auto& p : pend) {
         const auto& hash = p.first;

--- a/src/llmq/quorums_debug.h
+++ b/src/llmq/quorums_debug.h
@@ -145,7 +145,13 @@ public:
 class CDKGDebugManager
 {
 private:
+    CScheduler* scheduler;
+
     CCriticalSection cs;
+
+    std::map<uint256, int64_t> seenStatuses;
+    std::multimap<uint256, std::pair<CDKGDebugStatus, NodeId>> pendingIncomingStatuses;
+    bool hasScheduledProcessPending{false};
 
     std::map<uint256, CDKGDebugStatus> statuses;
     std::map<uint256, uint256> statusesForMasternodes;
@@ -154,10 +160,13 @@ private:
     uint256 lastStatusHash;
 
 public:
-    CDKGDebugManager(CScheduler* scheduler);
+    CDKGDebugManager(CScheduler* _scheduler);
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
-    void ProcessDebugStatusMessage(NodeId nodeId, CDKGDebugStatus& status);
+    bool PreVerifyDebugStatusMessage(const uint256& hash, CDKGDebugStatus& status, bool& retBan);
+    void ScheduleProcessPending();
+    void ProcessPending();
+    void ProcessDebugStatusMessage(const uint256& hash, const CDKGDebugStatus& status);
 
     bool AlreadyHave(const CInv& inv);
     bool GetDebugStatus(const uint256& hash, CDKGDebugStatus& ret);

--- a/src/llmq/quorums_debug.h
+++ b/src/llmq/quorums_debug.h
@@ -36,7 +36,7 @@ public:
             bool receivedJustification : 1;
             bool receivedPrematureCommitment : 1;
         };
-        uint16_t statusBitset;
+        uint8_t statusBitset;
     };
 
     std::set<uint16_t> complaintsFromMembers;
@@ -74,7 +74,7 @@ public:
 
             bool aborted : 1;
         };
-        uint16_t statusBitset;
+        uint8_t statusBitset;
     };
 
     std::vector<CDKGDebugMemberStatus> members;

--- a/src/llmq/quorums_debug.h
+++ b/src/llmq/quorums_debug.h
@@ -78,7 +78,6 @@ public:
     };
 
     std::vector<CDKGDebugMemberStatus> members;
-    bool receivedFinalCommitment{false};
 
 public:
     CDKGDebugSessionStatus() : statusBitset(0) {}
@@ -95,7 +94,6 @@ public:
         READWRITE(phase);
         READWRITE(statusBitset);
         READWRITE(members);
-        READWRITE(receivedFinalCommitment);
     }
 
     UniValue ToJson(int detailLevel) const;

--- a/src/llmq/quorums_debug.h
+++ b/src/llmq/quorums_debug.h
@@ -106,7 +106,6 @@ class CDKGDebugStatus
 public:
     uint256 proTxHash;
     int64_t nTime{0};
-    uint32_t nHeight{0};
 
     std::map<uint8_t, CDKGDebugSessionStatus> sessions;
 
@@ -120,7 +119,6 @@ public:
     {
         READWRITE(proTxHash);
         READWRITE(nTime);
-        READWRITE(nHeight);
         READWRITE(sessions);
     }
 

--- a/src/llmq/quorums_debug.h
+++ b/src/llmq/quorums_debug.h
@@ -171,7 +171,8 @@ public:
     bool GetDebugStatusForMasternode(const uint256& proTxHash, CDKGDebugStatus& ret);
     void GetLocalDebugStatus(CDKGDebugStatus& ret);
 
-    void ResetLocalSessionStatus(Consensus::LLMQType llmqType, const uint256& quorumHash, int quorumHeight);
+    void ResetLocalSessionStatus(Consensus::LLMQType llmqType);
+    void InitLocalSessionStatus(Consensus::LLMQType llmqType, const uint256& quorumHash, int quorumHeight);
 
     void UpdateLocalStatus(std::function<bool(CDKGDebugStatus& status)>&& func);
     void UpdateLocalSessionStatus(Consensus::LLMQType llmqType, std::function<bool(CDKGDebugSessionStatus& status)>&& func);

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -94,6 +94,10 @@ bool CDKGSession::Init(int _height, const uint256& _quorumHash, const std::vecto
         }
     }
 
+    if (!myProTxHash.IsNull()) {
+        quorumDKGDebugManager->InitLocalSessionStatus(params.type, quorumHash, height);
+    }
+
     CDKGLogger logger(*this, __func__);
 
     if (myProTxHash.IsNull()) {

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -124,12 +124,6 @@ void CDKGSessionHandler::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBl
     if (fNewPhase && phaseInt >= QuorumPhase_Initialized && phaseInt <= QuorumPhase_Idle) {
         phase = static_cast<QuorumPhase>(phaseInt);
     }
-
-    quorumDKGDebugManager->UpdateLocalStatus([&](CDKGDebugStatus& status) {
-        bool changed = status.nHeight != pindexNew->nHeight;
-        status.nHeight = (uint32_t)pindexNew->nHeight;
-        return changed;
-    });
 }
 
 void CDKGSessionHandler::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -361,7 +361,7 @@ void CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
         return;
     }
 
-    CBLSInsecureBatchVerifier<NodeId, uint256> batchVerifier;
+    CBLSInsecureBatchVerifier<NodeId, uint256> batchVerifier(false);
 
     size_t verifyCount = 0;
     for (auto& p : recSigsByNode) {
@@ -376,7 +376,7 @@ void CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
     }
 
     cxxtimer::Timer verifyTimer;
-    batchVerifier.Verify(false);
+    batchVerifier.Verify();
     verifyTimer.stop();
 
     LogPrint("llmq", "CSigningManager::%s -- verified recovered sig(s). count=%d, vt=%d, nodes=%d\n", __func__, verifyCount, verifyTimer.count(), recSigsByNode.size());

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -474,7 +474,7 @@ void CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
         return;
     }
 
-    CBLSInsecureBatchVerifier<NodeId, SigShareKey> batchVerifier;
+    CBLSInsecureBatchVerifier<NodeId, SigShareKey> batchVerifier(true);
 
     size_t verifyCount = 0;
     for (auto& p : sigSharesByNodes) {
@@ -502,7 +502,7 @@ void CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
     }
 
     cxxtimer::Timer verifyTimer;
-    batchVerifier.Verify(true);
+    batchVerifier.Verify();
     verifyTimer.stop();
 
     LogPrint("llmq", "CSigSharesManager::%s -- verified sig shares. count=%d, vt=%d, nodes=%d\n", __func__, verifyCount, verifyTimer.count(), sigSharesByNodes.size());

--- a/src/netmessagemaker.h
+++ b/src/netmessagemaker.h
@@ -19,6 +19,7 @@ public:
     {
         CSerializedNetMsg msg;
         msg.command = std::move(sCommand);
+        msg.data.reserve(4 * 1024);
         CVectorWriter{ SER_NETWORK, nFlags | nVersion, msg.data, 0, std::forward<Args>(args)... };
         return msg;
     }

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -156,11 +156,8 @@ UniValue quorum_dkgstatus(const JSONRPCRequest& request)
 
     auto ret = status.ToJson(detailLevel);
 
-    int tipHeight;
-    {
-        LOCK(cs_main);
-        tipHeight = chainActive.Height();
-    }
+    LOCK(cs_main);
+    int tipHeight = chainActive.Height();
 
     UniValue minableCommitments(UniValue::VOBJ);
     for (const auto& p : Params().GetConsensus().llmqs) {

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -7,6 +7,7 @@
 #include "validation.h"
 
 #include "llmq/quorums.h"
+#include "llmq/quorums_blockprocessor.h"
 #include "llmq/quorums_debug.h"
 #include "llmq/quorums_dkgsession.h"
 #include "llmq/quorums_signing.h"
@@ -153,7 +154,28 @@ UniValue quorum_dkgstatus(const JSONRPCRequest& request)
         }
     }
 
-    return status.ToJson(detailLevel);
+    auto ret = status.ToJson(detailLevel);
+
+    int tipHeight;
+    {
+        LOCK(cs_main);
+        tipHeight = chainActive.Height();
+    }
+
+    UniValue minableCommitments(UniValue::VOBJ);
+    for (const auto& p : Params().GetConsensus().llmqs) {
+        auto& params = p.second;
+        llmq::CFinalCommitment fqc;
+        if (llmq::quorumBlockProcessor->GetMinableCommitment(params.type, tipHeight, fqc)) {
+            UniValue obj(UniValue::VOBJ);
+            fqc.ToJson(obj);
+            minableCommitments.push_back(Pair(params.name, obj));
+        }
+    }
+
+    ret.push_back(Pair("minableCommitments", minableCommitments));
+
+    return ret;
 }
 
 void quorum_sign_help()


### PR DESCRIPTION
Profiling has shown that a lot of time is spent processing DKG debug messages. There are multiple reasons for this:

1. Serialization of the messages was unnecessarily expensive due to the message buffer being constantly resized
2. Verification of the signatures was not batched
3. ALL MNs were constantly sending status messages, even if they were not participating in any DKGs

See individual commits for the fixes