### PR TITLE
Missing = characters

### DIFF
--- a/doc/build-cross.md
+++ b/doc/build-cross.md
@@ -32,7 +32,7 @@ $ make HOST=x86_64-apple-darwin11 -j4
 When building Dash Core, use
 
 ```bash
-$ ./configure --prefix `pwd`/depends/x86_64-apple-darwin11
+$ ./configure --prefix=`pwd`/depends/x86_64-apple-darwin11
 ```
 
 Windows 64bit/32bit Cross-compilation
@@ -68,7 +68,7 @@ $ make HOST=x86_64-w64-mingw32 -j4
 When building Dash Core, use
 
 ```bash
-$ ./configure --prefix `pwd`/depends/x86_64-w64-mingw32
+$ ./configure --prefix=`pwd`/depends/x86_64-w64-mingw32
 ```
 
 These commands will build for Windows 64bit. If you want to compile for 32bit,
@@ -91,5 +91,5 @@ $ make HOST=arm-linux-gnueabihf -j4
 When building Dash Core, use
 
 ```bash
-$ ./configure --prefix `pwd`/depends/arm-linux-gnueabihf
+$ ./configure --prefix=`pwd`/depends/arm-linux-gnueabihf
 ```

--- a/doc/build-generic.md
+++ b/doc/build-generic.md
@@ -39,7 +39,7 @@ Building Dash Core
 
 ```bash
 $ ./autogen.sh
-$ ./configure --prefix `pwd`/depends/<host>
+$ ./configure --prefix=`pwd`/depends/<host>
 $ make
 $ make install # optional
 ```


### PR DESCRIPTION
Missing = characters in ./configure commands in build instructions