### PR TITLE
Add missing help text for `operatorPayoutAddress`

### DIFF
--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -62,6 +62,11 @@ std::string GetHelpString(int nParamNum, std::string strParamName)
             "%d. \"operatorKey\"              (string, required) The operator private key belonging to the\n"
             "                              registered operator public key.\n"
         },
+        {"operatorPayoutAddress",
+            "%d. \"operatorPayoutAddress\"    (string, optional) The address used for operator reward payments.\n"
+            "                              Only allowed when the ProRegTx had a non-zero operatorReward value.\n"
+            "                              If set to an empty string, the currently active payout address is reused.\n"
+        },
         {"operatorPubKey",
             "%d. \"operatorPubKey\"           (string, required) The operator BLS public key. The private key does not have to be known.\n"
             "                              It has to match the private key which is later used when operating the masternode.\n"


### PR DESCRIPTION
Help text extracted from https://github.com/dashpay/dash/pull/2649/files#diff-674372671ecffb349f70c7e27ed93f2aL498

Kudos to @thephez for finding the issue 👍 