### PR TITLE
Allow to override llmqChainLocks with "-llmqchainlocks" on devnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -667,6 +667,10 @@ public:
         consensus.nHighSubsidyBlocks = nHighSubsidyBlocks;
         consensus.nHighSubsidyFactor = nHighSubsidyFactor;
     }
+
+    void UpdateLLMQChainLocks(Consensus::LLMQType llmqType) {
+        consensus.llmqChainLocks = llmqType;
+    }
 };
 static CDevNetParams *devNetParams;
 
@@ -872,4 +876,10 @@ void UpdateDevnetSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSub
 {
     assert(devNetParams);
     devNetParams->UpdateSubsidyAndDiffParams(nMinimumDifficultyBlocks, nHighSubsidyBlocks, nHighSubsidyFactor);
+}
+
+void UpdateDevnetLLMQChainLocks(Consensus::LLMQType llmqType)
+{
+    assert(devNetParams);
+    devNetParams->UpdateLLMQChainLocks(llmqType);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -162,4 +162,9 @@ void UpdateRegtestBudgetParameters(int nMasternodePaymentsStartBlock, int nBudge
  */
 void UpdateDevnetSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor);
 
+/**
+ * Allows modifying the LLMQ type for ChainLocks.
+ */
+void UpdateDevnetLLMQChainLocks(Consensus::LLMQType llmqType);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1368,6 +1368,23 @@ bool AppInitParameterInteraction()
         return InitError("Difficulty and subsidy parameters may only be overridden on devnet.");
     }
 
+    if (chainparams.NetworkIDString() == CBaseChainParams::DEVNET) {
+        std::string llmqChainLocks = GetArg("-llmqchainlocks", Params().GetConsensus().llmqs.at(Params().GetConsensus().llmqChainLocks).name);
+        Consensus::LLMQType llmqType = Consensus::LLMQ_NONE;
+        for (const auto& p : Params().GetConsensus().llmqs) {
+            if (p.second.name == llmqChainLocks) {
+                llmqType = p.first;
+                break;
+            }
+        }
+        if (llmqType == Consensus::LLMQ_NONE) {
+            return InitError("Invalid LLMQ type specified for -llmqchainlocks.");
+        }
+        UpdateDevnetLLMQChainLocks(llmqType);
+    } else if (IsArgSet("-llmqchainlocks")) {
+        return InitError("LLMQ type for ChainLocks can only be overridden on devnet.");
+    }
+
     return true;
 }
 


### PR DESCRIPTION
I'd like to deploy ChainLocks to a devnet that uses a 400 members LLMQ instead of the default 50 members LLMQ, which requires this change.