### PR TITLE
Stop checking MN protocol version before signalling DIP3

### DIFF
--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -30,7 +30,7 @@ const struct BIP9DeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION
     {
         /*.name =*/ "dip0003",
         /*.gbt_force =*/ true,
-        /*.check_mn_protocol =*/ true,
+        /*.check_mn_protocol =*/ false,
     }
 };
 


### PR DESCRIPTION
We had some internal discussions about the way we let miners signal for DIP3 and it turned out that the threshold of 80% miner support in combination with the requirement to have MNs upgraded at 80% was too conservative.

The purpose of the check for upgraded MNs was introduced to make sure that miners don't signal deployments before enough MNs have upgraded. However, choosing a high value like 80% as a threshold for a deployment in combination with the upgrade check actually requires about 90% of support from miners AND masternodes at the same time, which is not what was intended.

At the moment, we have about 70% of masternodes upgraded to v13, making it safe for miners to signal for every block already. When signalling has reached 80%, we can also assume that upgraded masternodes % will also be higher already.

This PR removes the check for upgraded MNs, allowing miners to signal on every block. The PR will be backport to the v13 branch and released through that branch.