### PR TITLE
Call existsProviderTxConflict after CheckSpecialTx

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -667,10 +667,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     if (fRequireStandard && !IsStandardTx(tx, reason))
         return state.DoS(0, false, REJECT_NONSTANDARD, reason);
 
-    if (pool.existsProviderTxConflict(tx)) {
-        return state.DoS(0, false, REJECT_DUPLICATE, "protx-dup");
-    }
-
     // Only accept nLockTime-using transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
     // be mined yet.
@@ -870,6 +866,10 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         // mined
         if (!CheckSpecialTx(tx, chainActive.Tip(), state))
             return false;
+
+        if (pool.existsProviderTxConflict(tx)) {
+            return state.DoS(0, false, REJECT_DUPLICATE, "protx-dup");
+        }
 
         // If we aren't going to actually accept it but just were verifying it, we are fine already
         if(fDryRun) return true;


### PR DESCRIPTION
Otherwise we might end up passing and invalid proTx into it, causing
assertions to fail and thus crash the process.

This should also be backported to v13.