### PR TITLE
Minimal fix for litemode vs bad-protx-key-not-same issue

### DIFF
--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -186,7 +186,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
             return state.DoS(10, false, REJECT_DUPLICATE, "bad-protx-dup-key");
         }
 
-        if (!deterministicMNManager->IsDeterministicMNsSporkActive(pindexPrev->nHeight)) {
+        if (!fLiteMode && !deterministicMNManager->IsDeterministicMNsSporkActive(pindexPrev->nHeight)) {
             if (ptx.keyIDOwner != ptx.keyIDVoting) {
                 return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-not-same");
             }
@@ -330,7 +330,7 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
             }
         }
 
-        if (!deterministicMNManager->IsDeterministicMNsSporkActive(pindexPrev->nHeight)) {
+        if (!fLiteMode && !deterministicMNManager->IsDeterministicMNsSporkActive(pindexPrev->nHeight)) {
             if (dmn->pdmnState->keyIDOwner != ptx.keyIDVoting) {
                 return state.DoS(10, false, REJECT_INVALID, "bad-protx-key-not-same");
             }


### PR DESCRIPTION
Fixes #2693 

"Minimal" because we should probably disable all of the evo/llmq stuff in `-litemode` completely but that would be much more invasive and would require some testing to make sure we did that in a safe way (`develop` is not affected by #2693 btw because it uses fixed height instead of a spork).

EDIT: This actually might be not an issue at all if we release 0.14 shortly after spork15 activation which seems feasible.