### PR TITLE
Less cs_main locks in quorums

### DIFF
--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -91,20 +91,24 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
 
-public:
     bool HasQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash);
 
-    // all these methods will lock cs_main
-    CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType,const uint256& quorumHash);
+    // all these methods will lock cs_main for a short period of time
+    CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash);
     CQuorumCPtr GetNewestQuorum(Consensus::LLMQType llmqType);
     std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, size_t maxCount);
-    std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, const uint256& startBlock, size_t maxCount);
+
+    // this one is cs_main-free
+    std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, const CBlockIndex* pindexStart, size_t maxCount);
 
 private:
+    // all private methods here are cs_main-free
     void EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex *pindexNew);
 
-    bool BuildQuorumFromCommitment(const CFinalCommitment& qc, std::shared_ptr<CQuorum>& quorum) const;
+    bool BuildQuorumFromCommitment(const CFinalCommitment& qc, const CBlockIndex* pindexQuorum, std::shared_ptr<CQuorum>& quorum) const;
     bool BuildQuorumContributions(const CFinalCommitment& fqc, std::shared_ptr<CQuorum>& quorum) const;
+
+    CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const CBlockIndex* pindex);
 };
 
 extern CQuorumManager* quorumManager;

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -561,17 +561,17 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
     auto& llmqParams = Params().GetConsensus().llmqs.at(llmqType);
     size_t poolSize = (size_t)llmqParams.signingActiveQuorumCount;
 
-    uint256 startBlock;
+    CBlockIndex* pindexStart;
     {
         LOCK(cs_main);
         int startBlockHeight = signHeight - SIGN_HEIGHT_OFFSET;
         if (startBlockHeight > chainActive.Height()) {
             return nullptr;
         }
-        startBlock = chainActive[startBlockHeight]->GetBlockHash();
+        pindexStart = chainActive[startBlockHeight];
     }
 
-    auto quorums = quorumManager->ScanQuorums(llmqType, startBlock, poolSize);
+    auto quorums = quorumManager->ScanQuorums(llmqType, pindexStart, poolSize);
     if (quorums.empty()) {
         return nullptr;
     }

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -259,19 +259,15 @@ bool CSigningManager::PreVerifyRecoveredSig(NodeId nodeId, const CRecoveredSig& 
         return false;
     }
 
-    CQuorumCPtr quorum;
-    {
-        LOCK(cs_main);
+    CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, recoveredSig.quorumHash);
 
-        quorum = quorumManager->GetQuorum(llmqType, recoveredSig.quorumHash);
-        if (!quorum) {
-            LogPrintf("CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
-                      recoveredSig.quorumHash.ToString(), nodeId);
-            return false;
-        }
-        if (!CLLMQUtils::IsQuorumActive(llmqType, quorum->quorumHash)) {
-            return false;
-        }
+    if (!quorum) {
+        LogPrintf("CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
+                  recoveredSig.quorumHash.ToString(), nodeId);
+        return false;
+    }
+    if (!CLLMQUtils::IsQuorumActive(llmqType, quorum->quorumHash)) {
+        return false;
     }
 
     if (!recoveredSig.sig.IsValid()) {
@@ -316,37 +312,34 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
         }
     }
 
-    {
-        LOCK(cs_main);
-        for (auto& p : retSigShares) {
-            NodeId nodeId = p.first;
-            auto& v = p.second;
+    for (auto& p : retSigShares) {
+        NodeId nodeId = p.first;
+        auto& v = p.second;
 
-            for (auto it = v.begin(); it != v.end();) {
-                auto& recSig = *it;
+        for (auto it = v.begin(); it != v.end();) {
+            auto& recSig = *it;
 
-                Consensus::LLMQType llmqType = (Consensus::LLMQType) recSig.llmqType;
-                auto quorumKey = std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.quorumHash);
-                if (!retQuorums.count(quorumKey)) {
-                    CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, recSig.quorumHash);
-                    if (!quorum) {
-                        LogPrintf("CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
-                                  recSig.quorumHash.ToString(), nodeId);
-                        it = v.erase(it);
-                        continue;
-                    }
-                    if (!CLLMQUtils::IsQuorumActive(llmqType, quorum->quorumHash)) {
-                        LogPrintf("CSigningManager::%s -- quorum %s not active anymore, node=%d\n", __func__,
-                                  recSig.quorumHash.ToString(), nodeId);
-                        it = v.erase(it);
-                        continue;
-                    }
-
-                    retQuorums.emplace(quorumKey, quorum);
+            Consensus::LLMQType llmqType = (Consensus::LLMQType) recSig.llmqType;
+            auto quorumKey = std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.quorumHash);
+            if (!retQuorums.count(quorumKey)) {
+                CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, recSig.quorumHash);
+                if (!quorum) {
+                    LogPrintf("CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
+                              recSig.quorumHash.ToString(), nodeId);
+                    it = v.erase(it);
+                    continue;
+                }
+                if (!CLLMQUtils::IsQuorumActive(llmqType, quorum->quorumHash)) {
+                    LogPrintf("CSigningManager::%s -- quorum %s not active anymore, node=%d\n", __func__,
+                              recSig.quorumHash.ToString(), nodeId);
+                    it = v.erase(it);
+                    continue;
                 }
 
-                ++it;
+                retQuorums.emplace(quorumKey, quorum);
             }
+
+            ++it;
         }
     }
 }

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -347,31 +347,26 @@ bool CSigSharesManager::PreVerifyBatchedSigShares(NodeId nodeId, const CBatchedS
         return false;
     }
 
-    CQuorumCPtr quorum;
-    {
-        LOCK(cs_main);
-
-        quorum = quorumManager->GetQuorum(llmqType, batchedSigShares.quorumHash);
-        if (!quorum) {
-            // TODO should we ban here?
-            LogPrintf("CSigSharesManager::%s -- quorum %s not found, node=%d\n", __func__,
-                      batchedSigShares.quorumHash.ToString(), nodeId);
-            return false;
-        }
-        if (!CLLMQUtils::IsQuorumActive(llmqType, quorum->quorumHash)) {
-            // quorum is too old
-            return false;
-        }
-        if (!quorum->IsMember(activeMasternodeInfo.proTxHash)) {
-            // we're not a member so we can't verify it (we actually shouldn't have received it)
-            return false;
-        }
-        if (quorum->quorumVvec == nullptr) {
-            // TODO we should allow to ask other nodes for the quorum vvec if we missed it in the DKG
-            LogPrintf("CSigSharesManager::%s -- we don't have the quorum vvec for %s, no verification possible. node=%d\n", __func__,
-                      batchedSigShares.quorumHash.ToString(), nodeId);
-            return false;
-        }
+    CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, batchedSigShares.quorumHash);
+    if (!quorum) {
+        // TODO should we ban here?
+        LogPrintf("CSigSharesManager::%s -- quorum %s not found, node=%d\n", __func__,
+                  batchedSigShares.quorumHash.ToString(), nodeId);
+        return false;
+    }
+    if (!CLLMQUtils::IsQuorumActive(llmqType, quorum->quorumHash)) {
+        // quorum is too old
+        return false;
+    }
+    if (!quorum->IsMember(activeMasternodeInfo.proTxHash)) {
+        // we're not a member so we can't verify it (we actually shouldn't have received it)
+        return false;
+    }
+    if (quorum->quorumVvec == nullptr) {
+        // TODO we should allow to ask other nodes for the quorum vvec if we missed it in the DKG
+        LogPrintf("CSigSharesManager::%s -- we don't have the quorum vvec for %s, no verification possible. node=%d\n", __func__,
+                  batchedSigShares.quorumHash.ToString(), nodeId);
+        return false;
     }
 
     std::set<uint16_t> dupMembers;
@@ -994,17 +989,14 @@ void CSigSharesManager::Cleanup()
         }
     }
 
-    {
-        // Find quorums which became inactive
-        LOCK(cs_main);
-        for (auto it = quorumsToCheck.begin(); it != quorumsToCheck.end(); ) {
-            if (CLLMQUtils::IsQuorumActive(it->first, it->second)) {
-                it = quorumsToCheck.erase(it);
-            } else {
-                ++it;
-            }
+    for (auto it = quorumsToCheck.begin(); it != quorumsToCheck.end(); ) {
+        if (CLLMQUtils::IsQuorumActive(it->first, it->second)) {
+            it = quorumsToCheck.erase(it);
+        } else {
+            ++it;
         }
     }
+
     {
         // Now delete sessions which are for inactive quorums
         LOCK(cs);

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -989,6 +989,7 @@ void CSigSharesManager::Cleanup()
         }
     }
 
+    // Find quorums which became inactive
     for (auto it = quorumsToCheck.begin(); it != quorumsToCheck.end(); ) {
         if (CLLMQUtils::IsQuorumActive(it->first, it->second)) {
             it = quorumsToCheck.erase(it);

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -99,8 +99,6 @@ std::set<size_t> CLLMQUtils::CalcDeterministicWatchConnections(Consensus::LLMQTy
 
 bool CLLMQUtils::IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quorumHash)
 {
-    AssertLockHeld(cs_main);
-
     auto& params = Params().GetConsensus().llmqs.at(llmqType);
 
     // sig shares and recovered sigs are only accepted from recent/active quorums

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -38,7 +38,7 @@ UniValue quorum_list(const JSONRPCRequest& request)
     for (auto& p : Params().GetConsensus().llmqs) {
         UniValue v(UniValue::VARR);
 
-        auto quorums = llmq::quorumManager->ScanQuorums(p.first, chainActive.Tip()->GetBlockHash(), count);
+        auto quorums = llmq::quorumManager->ScanQuorums(p.first, chainActive.Tip(), count);
         for (auto& q : quorums) {
             v.push_back(q->quorumHash.ToString());
         }


### PR DESCRIPTION
Avoid locking `cs_main` in `CQuorumManager::UpdatedBlockTip()` by splitting most of the functions it is using and moving `cs_main` lock outside. `CLLMQUtils::IsQuorumActive()` doesn't really need `cs_main` too.