### PR TITLE
Optimize LLMQs sending of sig shares

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2429,8 +2429,18 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
     }
 
 #ifndef WIN32
-    if (pipe2(wakeupPipe, O_NONBLOCK) != 0) {
+    if (pipe(wakeupPipe) != 0) {
         wakeupPipe[0] = wakeupPipe[1] = -1;
+        LogPrint("net", "pipe() for wakeupPipe failed\n");
+    } else {
+        int fFlags = fcntl(wakeupPipe[0], F_GETFL, 0);
+        if (fcntl(wakeupPipe[0], F_SETFL, fFlags | O_NONBLOCK) == -1) {
+            LogPrint("net", "fcntl for O_NONBLOCK on wakeupPipe failed\n");
+        }
+        fFlags = fcntl(wakeupPipe[1], F_GETFL, 0);
+        if (fcntl(wakeupPipe[1], F_SETFL, fFlags | O_NONBLOCK) == -1) {
+            LogPrint("net", "fcntl for O_NONBLOCK on wakeupPipe failed\n");
+        }
     }
 #endif
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3054,7 +3054,7 @@ bool CConnman::NodeFullyConnected(const CNode* pnode)
     return pnode && pnode->fSuccessfullyConnected && !pnode->fDisconnect;
 }
 
-void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
+void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg, bool allowOptimisticSend)
 {
     size_t nMessageSize = msg.data.size();
     size_t nTotalSize = nMessageSize + CMessageHeader::HEADER_SIZE;
@@ -3071,7 +3071,7 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
     size_t nBytesSent = 0;
     {
         LOCK(pnode->cs_vSend);
-        bool optimisticSend(pnode->vSendMsg.empty());
+        bool optimisticSend(allowOptimisticSend && pnode->vSendMsg.empty());
 
         //log total amount of bytes per command
         pnode->mapSendBytesPerMsgCmd[msg.command] += nTotalSize;

--- a/src/net.h
+++ b/src/net.h
@@ -201,7 +201,7 @@ public:
 
     bool IsMasternodeOrDisconnectRequested(const CService& addr);
 
-    void PushMessage(CNode* pnode, CSerializedNetMsg&& msg);
+    void PushMessage(CNode* pnode, CSerializedNetMsg&& msg, bool allowOptimisticSend = true);
 
     template<typename Condition, typename Callable>
     bool ForEachNodeContinueIf(const Condition& cond, Callable&& func)

--- a/src/net.h
+++ b/src/net.h
@@ -408,6 +408,8 @@ public:
     unsigned int GetReceiveFloodSize() const;
 
     void WakeMessageHandler();
+    void WakeSelect();
+
 private:
     struct ListenSocket {
         SOCKET socket;
@@ -524,6 +526,11 @@ private:
     std::atomic<bool> flagInterruptMsgProc;
 
     CThreadInterrupt interruptNet;
+
+#ifndef WIN32
+    /** a pipe which is added to select() calls to wakeup before the timeout */
+    int wakeupPipe[2]{-1,-1};
+#endif
 
     std::thread threadDNSAddressSeed;
     std::thread threadSocketHandler;


### PR DESCRIPTION
Profiling has shown that in the `CSigSharesManager::WorkThreadMain` thread a lot of time (10%-20%) is spent in the socket `send()` method. I assume this is not CPU intensive and simply blocking/waiting time, even though the sockets are in non-blocking mode.

It happens because `CConnman::PushMessage` does "optimistic sending" when the `vSendMsg` buffer is empty. One would assume that calling `send()` is cheap on a non-blocking socket, but this seems to not be the case.

With this PR, `WorkThreadMain` will always push sig shares related messages into `vSendMsg` and then let the network thread handle the actual sending.