### PR TITLE
Optimize LLMQs initialization and (de)serialization of BLS signatures

### DIFF
--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -423,6 +423,34 @@ bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::v
     return true;
 }
 
+CBLSLazySignature::CBLSLazySignature(CBLSSignature& _sig) :
+    bufValid(false),
+    sigInitialized(true),
+    sig(_sig)
+{
+
+}
+
+void CBLSLazySignature::SetSig(const CBLSSignature& _sig)
+{
+    bufValid = false;
+    sigInitialized = true;
+    sig = _sig;
+}
+
+const CBLSSignature& CBLSLazySignature::GetSig() const
+{
+    if (!bufValid && !sigInitialized) {
+        static CBLSSignature invalidSig;
+        return invalidSig;
+    }
+    if (!sigInitialized) {
+        sig.SetBuf(buf, sizeof(buf));
+        sigInitialized = true;
+    }
+    return sig;
+}
+
 #ifndef BUILD_BITCOIN_INTERNAL
 
 static std::once_flag init_flag;

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -51,7 +51,18 @@ public:
 
     CBLSWrapper()
     {
-        UpdateHash();
+        struct NullHash {
+            uint256 hash;
+            NullHash() {
+                char buf[_SerSize];
+                memset(buf, 0, _SerSize);
+                CHashWriter ss(SER_GETHASH, 0);
+                ss.write(buf, _SerSize);
+                hash = ss.GetHash();
+            }
+        };
+        static NullHash nullHash;
+        cachedHash = nullHash.hash;
     }
 
     CBLSWrapper(const CBLSWrapper& ref) = default;


### PR DESCRIPTION
See individual commits.

Profiling has shown that the message handler thread is blocked quite a lot by deserialization of BLS signatures when sig share batches arrive. This PR moves the heavy part of the deserialization into `CSigSharesManager::WorkThreadMain`, so that the message handler thread can continue working on other messages.