### PR TITLE
Avoid using ordered maps in LLMQ signing code

### DIFF
--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <unordered_set>
 
 namespace llmq
 {
@@ -357,8 +358,8 @@ bool CSigningManager::PreVerifyRecoveredSig(NodeId nodeId, const CRecoveredSig& 
 
 void CSigningManager::CollectPendingRecoveredSigsToVerify(
         size_t maxUniqueSessions,
-        std::map<NodeId, std::list<CRecoveredSig>>& retSigShares,
-        std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums)
+        std::unordered_map<NodeId, std::list<CRecoveredSig>>& retSigShares,
+        std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums)
 {
     {
         LOCK(cs);
@@ -366,7 +367,7 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
             return;
         }
 
-        std::set<std::pair<NodeId, uint256>> uniqueSignHashes;
+        std::unordered_set<std::pair<NodeId, uint256>> uniqueSignHashes;
         CLLMQUtils::IterateNodesRandom(pendingRecoveredSigs, [&]() {
             return uniqueSignHashes.size() < maxUniqueSessions;
         }, [&](NodeId nodeId, std::list<CRecoveredSig>& ns) {
@@ -423,8 +424,8 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
 
 bool CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
 {
-    std::map<NodeId, std::list<CRecoveredSig>> recSigsByNode;
-    std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr> quorums;
+    std::unordered_map<NodeId, std::list<CRecoveredSig>> recSigsByNode;
+    std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr> quorums;
 
     CollectPendingRecoveredSigsToVerify(32, recSigsByNode, quorums);
     if (recSigsByNode.empty()) {
@@ -453,7 +454,7 @@ bool CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
 
     LogPrint("llmq", "CSigningManager::%s -- verified recovered sig(s). count=%d, vt=%d, nodes=%d\n", __func__, verifyCount, verifyTimer.count(), recSigsByNode.size());
 
-    std::set<uint256> processed;
+    std::unordered_set<uint256> processed;
     for (auto& p : recSigsByNode) {
         NodeId nodeId = p.first;
         auto& v = p.second;

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -135,7 +135,7 @@ private:
     CRecoveredSigsDb db;
 
     // Incoming and not verified yet
-    std::map<NodeId, std::list<CRecoveredSig>> pendingRecoveredSigs;
+    std::unordered_map<NodeId, std::list<CRecoveredSig>> pendingRecoveredSigs;
 
     // must be protected by cs
     FastRandomContext rnd;
@@ -156,7 +156,7 @@ private:
     void ProcessMessageRecoveredSig(CNode* pfrom, const CRecoveredSig& recoveredSig, CConnman& connman);
     bool PreVerifyRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, bool& retBan);
 
-    void CollectPendingRecoveredSigsToVerify(size_t maxUniqueSessions, std::map<NodeId, std::list<CRecoveredSig>>& retSigShares, std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums);
+    void CollectPendingRecoveredSigsToVerify(size_t maxUniqueSessions, std::unordered_map<NodeId, std::list<CRecoveredSig>>& retSigShares, std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums);
     bool ProcessPendingRecoveredSigs(CConnman& connman); // called from the worker thread of CSigSharesManager
     void ProcessRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, const CQuorumCPtr& quorum, CConnman& connman);
     void Cleanup(); // called from the worker thread of CSigSharesManager

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -20,33 +20,6 @@ namespace llmq
 
 CSigSharesManager* quorumSigSharesManager = nullptr;
 
-template<typename M>
-static std::pair<typename M::const_iterator, typename M::const_iterator> FindBySignHash(const M& m, const uint256& signHash)
-{
-    return std::make_pair(
-            m.lower_bound(std::make_pair(signHash, (uint16_t)0)),
-            m.upper_bound(std::make_pair(signHash, std::numeric_limits<uint16_t>::max()))
-    );
-}
-template<typename M>
-static size_t CountBySignHash(const M& m, const uint256& signHash)
-{
-    auto itPair = FindBySignHash(m, signHash);
-    size_t count = 0;
-    while (itPair.first != itPair.second) {
-        count++;
-        ++itPair.first;
-    }
-    return count;
-}
-
-template<typename M>
-static void RemoveBySignHash(M& m, const uint256& signHash)
-{
-    auto itPair = FindBySignHash(m, signHash);
-    m.erase(itPair.first, itPair.second);
-}
-
 void CSigShare::UpdateKey()
 {
     key.first = CLLMQUtils::BuildSignHash(*this);
@@ -157,9 +130,8 @@ void CSigSharesNodeState::MarkKnows(Consensus::LLMQType llmqType, const uint256&
 void CSigSharesNodeState::RemoveSession(const uint256& signHash)
 {
     sessions.erase(signHash);
-    //pendingIncomingRecSigs.erase(signHash);
-    RemoveBySignHash(requestedSigShares, signHash);
-    RemoveBySignHash(pendingIncomingSigShares, signHash);
+    requestedSigShares.EraseAllForSignHash(signHash);
+    pendingIncomingSigShares.EraseAllForSignHash(signHash);
 }
 
 CSigSharesInv CBatchedSigShares::ToInv() const
@@ -304,13 +276,13 @@ void CSigSharesManager::ProcessMessageBatchedSigShares(CNode* pfrom, const CBatc
 
         for (size_t i = 0; i < batchedSigShares.sigShares.size(); i++) {
             CSigShare sigShare = batchedSigShares.RebuildSigShare(i);
-            nodeState.requestedSigShares.erase(sigShare.GetKey());
+            nodeState.requestedSigShares.Erase(sigShare.GetKey());
 
             // TODO track invalid sig shares received for PoSe?
             // It's important to only skip seen *valid* sig shares here. If a node sends us a
             // batch of mostly valid sig shares with a single invalid one and thus batched
             // verification fails, we'd skip the valid ones in the future if received from other nodes
-            if (this->sigShares.count(sigShare.GetKey())) {
+            if (this->sigShares.Has(sigShare.GetKey())) {
                 continue;
             }
 
@@ -333,7 +305,7 @@ void CSigSharesManager::ProcessMessageBatchedSigShares(CNode* pfrom, const CBatc
     LOCK(cs);
     auto& nodeState = nodeStates[pfrom->id];
     for (auto& s : sigShares) {
-        nodeState.pendingIncomingSigShares.emplace(s.GetKey(), s);
+        nodeState.pendingIncomingSigShares.Add(s.GetKey(), s);
     }
 }
 
@@ -413,18 +385,18 @@ void CSigSharesManager::CollectPendingSigSharesToVerify(
         CLLMQUtils::IterateNodesRandom(nodeStates, [&]() {
             return uniqueSignHashes.size() < maxUniqueSessions;
         }, [&](NodeId nodeId, CSigSharesNodeState& ns) {
-            if (ns.pendingIncomingSigShares.empty()) {
+            if (ns.pendingIncomingSigShares.Empty()) {
                 return false;
             }
-            auto& sigShare = ns.pendingIncomingSigShares.begin()->second;
+            auto& sigShare = *ns.pendingIncomingSigShares.GetFirst();
 
-            bool alreadyHave = this->sigShares.count(sigShare.GetKey()) != 0;
+            bool alreadyHave = this->sigShares.Has(sigShare.GetKey());
             if (!alreadyHave) {
                 uniqueSignHashes.emplace(nodeId, sigShare.GetSignHash());
                 retSigShares[nodeId].emplace_back(sigShare);
             }
-            ns.pendingIncomingSigShares.erase(ns.pendingIncomingSigShares.begin());
-            return !ns.pendingIncomingSigShares.empty();
+            ns.pendingIncomingSigShares.Erase(sigShare.GetKey());
+            return !ns.pendingIncomingSigShares.Empty();
         }, rnd);
 
         if (retSigShares.empty()) {
@@ -570,12 +542,12 @@ void CSigSharesManager::ProcessSigShare(NodeId nodeId, const CSigShare& sigShare
 
     {
         LOCK(cs);
-        
-        if (!sigShares.emplace(sigShare.GetKey(), sigShare).second) {
+
+        if (!sigShares.Add(sigShare.GetKey(), sigShare)) {
             return;
         }
         
-        sigSharesToAnnounce.emplace(sigShare.GetKey());
+        sigSharesToAnnounce.Add(sigShare.GetKey(), true);
         firstSeenForSessions.emplace(sigShare.GetSignHash(), GetTimeMillis());
 
         if (!quorumNodes.empty()) {
@@ -591,7 +563,7 @@ void CSigSharesManager::ProcessSigShare(NodeId nodeId, const CSigShare& sigShare
             }
         }
 
-        size_t sigShareCount = CountBySignHash(sigShares, sigShare.GetSignHash());
+        size_t sigShareCount = sigShares.CountForSignHash(sigShare.GetSignHash());
         if (sigShareCount >= quorum->params.threshold) {
             canTryRecovery = true;
         }
@@ -616,11 +588,14 @@ void CSigSharesManager::TryRecoverSig(const CQuorumCPtr& quorum, const uint256& 
         auto k = std::make_pair(quorum->params.type, id);
 
         auto signHash = CLLMQUtils::BuildSignHash(quorum->params.type, quorum->quorumHash, id, msgHash);
-        auto itPair = FindBySignHash(sigShares, signHash);
+        auto sigShares = this->sigShares.GetAllForSignHash(signHash);
+        if (!sigShares) {
+            return;
+        }
 
         sigSharesForRecovery.reserve((size_t) quorum->params.threshold);
         idsForRecovery.reserve((size_t) quorum->params.threshold);
-        for (auto it = itPair.first; it != itPair.second && sigSharesForRecovery.size() < quorum->params.threshold; ++it) {
+        for (auto it = sigShares->begin(); it != sigShares->end() && sigSharesForRecovery.size() < quorum->params.threshold; ++it) {
             auto& sigShare = it->second;
             sigSharesForRecovery.emplace_back(sigShare.sigShare.GetSig());
             idsForRecovery.emplace_back(CBLSId::FromHash(quorum->members[sigShare.quorumMember]->proTxHash));
@@ -690,16 +665,15 @@ void CSigSharesManager::CollectSigSharesToRequest(std::map<NodeId, std::map<uint
             continue;
         }
 
-        for (auto it = nodeState.requestedSigShares.begin(); it != nodeState.requestedSigShares.end();) {
-            if (now - it->second >= SIG_SHARE_REQUEST_TIMEOUT) {
+        nodeState.requestedSigShares.EraseIf([&](const SigShareKey& k, int64_t t) {
+            if (now - t >= SIG_SHARE_REQUEST_TIMEOUT) {
                 // timeout while waiting for this one, so retry it with another node
-                LogPrint("llmq", "CSigSharesManager::%s -- timeout while waiting for %s-%d, node=%d\n", __func__,
-                         it->first.first.ToString(), it->first.second, nodeId);
-                it = nodeState.requestedSigShares.erase(it);
-            } else {
-                ++it;
+                LogPrint("llmq", "CSigSharesManager::CollectSigSharesToRequest -- timeout while waiting for %s-%d, node=%d\n",
+                         k.first.ToString(), k.second, nodeId);
+                return true;
             }
-        }
+            return false;
+        });
 
         std::map<uint256, CSigSharesInv>* invMap = nullptr;
 
@@ -716,21 +690,21 @@ void CSigSharesManager::CollectSigSharesToRequest(std::map<NodeId, std::map<uint
                     continue;
                 }
                 auto k = std::make_pair(signHash, (uint16_t) i);
-                if (sigShares.count(k)) {
+                if (sigShares.Has(k)) {
                     // we already have it
                     session.announced.inv[i] = false;
                     continue;
                 }
-                if (nodeState.requestedSigShares.size() >= maxRequestsForNode) {
+                if (nodeState.requestedSigShares.Size() >= maxRequestsForNode) {
                     // too many pending requests for this node
                     break;
                 }
-                auto it = sigSharesRequested.find(k);
-                if (it != sigSharesRequested.end()) {
-                    if (now - it->second.second >= SIG_SHARE_REQUEST_TIMEOUT && nodeId != it->second.first) {
+                auto p = sigSharesRequested.Get(k);
+                if (p) {
+                    if (now - p->second >= SIG_SHARE_REQUEST_TIMEOUT && nodeId != p->first) {
                         // other node timed out, re-request from this node
                         LogPrint("llmq", "CSigSharesManager::%s -- other node timeout while waiting for %s-%d, re-request from=%d, node=%d\n", __func__,
-                                 it->first.first.ToString(), it->first.second, nodeId, it->second.first);
+                                 k.first.ToString(), k.second, nodeId, p->first);
                     } else {
                         continue;
                     }
@@ -738,10 +712,10 @@ void CSigSharesManager::CollectSigSharesToRequest(std::map<NodeId, std::map<uint
                 // if we got this far we should do a request
 
                 // track when we initiated the request so that we can detect timeouts
-                nodeState.requestedSigShares.emplace(k, now);
+                nodeState.requestedSigShares.Add(k, now);
 
                 // don't request it from other nodes until a timeout happens
-                auto& r = sigSharesRequested[k];
+                auto& r = sigSharesRequested.GetOrAdd(k);
                 r.first = nodeId;
                 r.second = now;
 
@@ -791,21 +765,20 @@ void CSigSharesManager::CollectSigSharesToSend(std::map<NodeId, std::map<uint256
                 session.requested.inv[i] = false;
 
                 auto k = std::make_pair(signHash, (uint16_t)i);
-                auto it = sigShares.find(k);
-                if (it == sigShares.end()) {
+                const CSigShare* sigShare = sigShares.Get(k);
+                if (!sigShare) {
                     // he requested something we don'have
                     session.requested.inv[i] = false;
                     continue;
                 }
 
-                auto& sigShare = it->second;
                 if (batchedSigShares.sigShares.empty()) {
-                    batchedSigShares.llmqType = sigShare.llmqType;
-                    batchedSigShares.quorumHash = sigShare.quorumHash;
-                    batchedSigShares.id = sigShare.id;
-                    batchedSigShares.msgHash = sigShare.msgHash;
+                    batchedSigShares.llmqType = sigShare->llmqType;
+                    batchedSigShares.quorumHash = sigShare->quorumHash;
+                    batchedSigShares.id = sigShare->id;
+                    batchedSigShares.msgHash = sigShare->msgHash;
                 }
-                batchedSigShares.sigShares.emplace_back((uint16_t)i, sigShare.sigShare);
+                batchedSigShares.sigShares.emplace_back((uint16_t)i, sigShare->sigShare);
             }
 
             if (!batchedSigShares.sigShares.empty()) {
@@ -824,16 +797,15 @@ void CSigSharesManager::CollectSigSharesToAnnounce(std::map<NodeId, std::map<uin
 {
     std::set<std::pair<Consensus::LLMQType, uint256>> quorumNodesPrepared;
 
-    for (auto& sigShareKey : this->sigSharesToAnnounce) {
+    this->sigSharesToAnnounce.ForEach([&](const SigShareKey& sigShareKey, bool) {
         auto& signHash = sigShareKey.first;
         auto quorumMember = sigShareKey.second;
-        auto sigShareIt = sigShares.find(sigShareKey);
-        if (sigShareIt == sigShares.end()) {
-            continue;
+        const CSigShare* sigShare = sigShares.Get(sigShareKey);
+        if (!sigShare) {
+            return;
         }
-        auto& sigShare = sigShareIt->second;
 
-        auto quorumKey = std::make_pair((Consensus::LLMQType)sigShare.llmqType, sigShare.quorumHash);
+        auto quorumKey = std::make_pair((Consensus::LLMQType)sigShare->llmqType, sigShare->quorumHash);
         if (quorumNodesPrepared.emplace(quorumKey).second) {
             // make sure we announce to at least the nodes which we know through the inter-quorum-communication system
             auto nodeIds = g_connman->GetMasternodeQuorumNodes(quorumKey.first, quorumKey.second);
@@ -860,7 +832,7 @@ void CSigSharesManager::CollectSigSharesToAnnounce(std::map<NodeId, std::map<uin
                 continue;
             }
 
-            auto& session = nodeState.GetOrCreateSession((Consensus::LLMQType)sigShare.llmqType, signHash);
+            auto& session = nodeState.GetOrCreateSession((Consensus::LLMQType)sigShare->llmqType, signHash);
 
             if (session.knows.inv[quorumMember]) {
                 // he already knows that one
@@ -869,18 +841,18 @@ void CSigSharesManager::CollectSigSharesToAnnounce(std::map<NodeId, std::map<uin
 
             auto& inv = sigSharesToAnnounce[nodeId][signHash];
             if (inv.inv.empty()) {
-                inv.Init((Consensus::LLMQType)sigShare.llmqType, signHash);
+                inv.Init((Consensus::LLMQType)sigShare->llmqType, signHash);
             }
             inv.inv[quorumMember] = true;
             session.knows.inv[quorumMember] = true;
         }
-    }
+    });
 
     // don't announce these anymore
     // nodes which did not send us a valid sig share before were left out now, but this is ok as it only results in slower
     // propagation for the first signing session of a fresh quorum. The sig shares should still arrive on all nodes due to
     // the deterministic inter-quorum-communication system
-    this->sigSharesToAnnounce.clear();
+    this->sigSharesToAnnounce.Clear();
 }
 
 bool CSigSharesManager::SendMessages()
@@ -972,13 +944,15 @@ void CSigSharesManager::Cleanup()
             }
         }
         for (auto& signHash : timeoutSessions) {
-            size_t count = CountBySignHash(sigShares, signHash);
+            size_t count = sigShares.CountForSignHash(signHash);
 
             if (count > 0) {
-                auto itPair = FindBySignHash(sigShares, signHash);
-                auto& firstSigShare = itPair.first->second;
+                auto m = sigShares.GetAllForSignHash(signHash);
+                assert(m);
+
+                auto& oneSigShare = m->begin()->second;
                 LogPrintf("CSigSharesManager::%s -- signing session timed out. signHash=%s, id=%s, msgHash=%s, sigShareCount=%d\n", __func__,
-                          signHash.ToString(), firstSigShare.id.ToString(), firstSigShare.msgHash.ToString(), count);
+                          signHash.ToString(), oneSigShare.id.ToString(), oneSigShare.msgHash.ToString(), count);
             } else {
                 LogPrintf("CSigSharesManager::%s -- signing session timed out. signHash=%s, sigShareCount=%d\n", __func__,
                           signHash.ToString(), count);
@@ -988,21 +962,21 @@ void CSigSharesManager::Cleanup()
 
         // Remove sessions which were succesfully recovered
         std::set<uint256> doneSessions;
-        for (auto& p : sigShares) {
-            if (doneSessions.count(p.second.GetSignHash())) {
-                continue;
+        sigShares.ForEach([&](const SigShareKey& k, const CSigShare& sigShare) {
+            if (doneSessions.count(sigShare.GetSignHash())) {
+                return;
             }
-            if (quorumSigningManager->HasRecoveredSigForSession(p.second.GetSignHash())) {
-                doneSessions.emplace(p.second.GetSignHash());
+            if (quorumSigningManager->HasRecoveredSigForSession(sigShare.GetSignHash())) {
+                doneSessions.emplace(sigShare.GetSignHash());
             }
-        }
+        });
         for (auto& signHash : doneSessions) {
             RemoveSigSharesForSession(signHash);
         }
 
-        for (auto& p : sigShares) {
-            quorumsToCheck.emplace((Consensus::LLMQType)p.second.llmqType, p.second.quorumHash);
-        }
+        sigShares.ForEach([&](const SigShareKey& k, const CSigShare& sigShare) {
+            quorumsToCheck.emplace((Consensus::LLMQType) sigShare.llmqType, sigShare.quorumHash);
+        });
     }
 
     // Find quorums which became inactive
@@ -1018,11 +992,11 @@ void CSigSharesManager::Cleanup()
         // Now delete sessions which are for inactive quorums
         LOCK(cs);
         std::set<uint256> inactiveQuorumSessions;
-        for (auto& p : sigShares) {
-            if (quorumsToCheck.count(std::make_pair((Consensus::LLMQType)p.second.llmqType, p.second.quorumHash))) {
-                inactiveQuorumSessions.emplace(p.second.GetSignHash());
+        sigShares.ForEach([&](const SigShareKey& k, const CSigShare& sigShare) {
+            if (quorumsToCheck.count(std::make_pair((Consensus::LLMQType)sigShare.llmqType, sigShare.quorumHash))) {
+                inactiveQuorumSessions.emplace(sigShare.GetSignHash());
             }
-        }
+        });
         for (auto& signHash : inactiveQuorumSessions) {
             RemoveSigSharesForSession(signHash);
         }
@@ -1042,9 +1016,9 @@ void CSigSharesManager::Cleanup()
     for (auto nodeId : nodeStatesToDelete) {
         auto& nodeState = nodeStates[nodeId];
         // remove global requested state to force a re-request from another node
-        for (auto& p : nodeState.requestedSigShares) {
-            sigSharesRequested.erase(p.first);
-        }
+        nodeState.requestedSigShares.ForEach([&](const SigShareKey& k, bool) {
+            sigSharesRequested.Erase(k);
+        });
         nodeStates.erase(nodeId);
     }
 
@@ -1058,9 +1032,9 @@ void CSigSharesManager::RemoveSigSharesForSession(const uint256& signHash)
         ns.RemoveSession(signHash);
     }
 
-    RemoveBySignHash(sigSharesRequested, signHash);
-    RemoveBySignHash(sigSharesToAnnounce, signHash);
-    RemoveBySignHash(sigShares, signHash);
+    sigSharesRequested.EraseAllForSignHash(signHash);
+    sigSharesToAnnounce.EraseAllForSignHash(signHash);
+    sigShares.EraseAllForSignHash(signHash);
     firstSeenForSessions.erase(signHash);
 }
 
@@ -1073,9 +1047,9 @@ void CSigSharesManager::RemoveBannedNodeStates()
     for (auto it = nodeStates.begin(); it != nodeStates.end();) {
         if (IsBanned(it->first)) {
             // re-request sigshares from other nodes
-            for (auto& p : it->second.requestedSigShares) {
-                sigSharesRequested.erase(p.first);
-            }
+            it->second.requestedSigShares.ForEach([&](const SigShareKey& k, int64_t) {
+                sigSharesRequested.Erase(k);
+            });
             it = nodeStates.erase(it);
         } else {
             ++it;
@@ -1102,10 +1076,10 @@ void CSigSharesManager::BanNode(NodeId nodeId)
     auto& nodeState = it->second;
 
     // Whatever we requested from him, let's request it from someone else now
-    for (auto& p : nodeState.requestedSigShares) {
-        sigSharesRequested.erase(p.first);
-    }
-    nodeState.requestedSigShares.clear();
+    nodeState.requestedSigShares.ForEach([&](const SigShareKey& k, int64_t) {
+        sigSharesRequested.Erase(k);
+    });
+    nodeState.requestedSigShares.Clear();
 
     nodeState.banned = true;
 }

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -18,15 +18,30 @@
 
 #include <thread>
 #include <mutex>
+#include <unordered_map>
 
 class CEvoDB;
 class CScheduler;
 
 namespace llmq
 {
-
 // <signHash, quorumMember>
 typedef std::pair<uint256, uint16_t> SigShareKey;
+}
+
+namespace std {
+    template <>
+    struct hash<llmq::SigShareKey>
+    {
+        std::size_t operator()(const llmq::SigShareKey& k) const
+        {
+            return (std::size_t)((k.second + 1) * k.first.GetCheapHash());
+        }
+    };
+}
+
+namespace llmq
+{
 
 // this one does not get transmitted over the wire as it is batched inside CBatchedSigShares
 class CSigShare
@@ -130,6 +145,151 @@ public:
     CSigSharesInv ToInv() const;
 };
 
+template<typename T>
+class SigShareMap
+{
+private:
+    std::unordered_map<uint256, std::unordered_map<uint16_t, T>> internalMap;
+
+public:
+    bool Add(const SigShareKey& k, const T& v)
+    {
+        auto& m = internalMap[k.first];
+        return m.emplace(k.second, v).second;
+    }
+
+    void Erase(const SigShareKey& k)
+    {
+        auto it = internalMap.find(k.first);
+        if (it == internalMap.end()) {
+            return;
+        }
+        it->second.erase(k.second);
+        if (it->second.empty()) {
+            internalMap.erase(it);
+        }
+    }
+
+    void Clear()
+    {
+        internalMap.clear();
+    }
+
+    bool Has(const SigShareKey& k) const
+    {
+        auto it = internalMap.find(k.first);
+        if (it == internalMap.end()) {
+            return false;
+        }
+        return it->second.count(k.second) != 0;
+    }
+
+    T* Get(const SigShareKey& k)
+    {
+        auto it = internalMap.find(k.first);
+        if (it == internalMap.end()) {
+            return nullptr;
+        }
+
+        auto jt = it->second.find(k.second);
+        if (jt == it->second.end()) {
+            return nullptr;
+        }
+
+        return &jt->second;
+    }
+
+    T& GetOrAdd(const SigShareKey& k)
+    {
+        T* v = Get(k);
+        if (!v) {
+            Add(k, T());
+            v = Get(k);
+        }
+        return *v;
+    }
+
+    const T* GetFirst() const
+    {
+        if (internalMap.empty()) {
+            return nullptr;
+        }
+        return &internalMap.begin()->second.begin()->second;
+    }
+
+    size_t Size() const
+    {
+        size_t s = 0;
+        for (auto& p : internalMap) {
+            s += p.second.size();
+        }
+        return s;
+    }
+
+    size_t CountForSignHash(const uint256& signHash) const
+    {
+        auto it = internalMap.find(signHash);
+        if (it == internalMap.end()) {
+            return 0;
+        }
+        return it->second.size();
+    }
+
+    bool Empty() const
+    {
+        return internalMap.empty();
+    }
+
+    const std::unordered_map<uint16_t, T>* GetAllForSignHash(const uint256& signHash)
+    {
+        auto it = internalMap.find(signHash);
+        if (it == internalMap.end()) {
+            return nullptr;
+        }
+        return &it->second;
+    }
+
+    void EraseAllForSignHash(const uint256& signHash)
+    {
+        internalMap.erase(signHash);
+    }
+
+    template<typename F>
+    void EraseIf(F&& f)
+    {
+        for (auto it = internalMap.begin(); it != internalMap.end(); ) {
+            SigShareKey k;
+            k.first = it->first;
+            for (auto jt = it->second.begin(); jt != it->second.end(); ) {
+                k.second = jt->first;
+                if (f(k, jt->second)) {
+                    jt = it->second.erase(jt);
+                } else {
+                    ++jt;
+                }
+            }
+            if (it->second.empty()) {
+                it = internalMap.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    template<typename F>
+    void ForEach(F&& f)
+    {
+        for (auto& p : internalMap) {
+            SigShareKey k;
+            k.first = p.first;
+            for (auto& p2 : p.second) {
+                k.second = p2.first;
+                f(k, p2.second);
+            }
+        }
+    }
+};
+
 class CSigSharesNodeState
 {
 public:
@@ -141,8 +301,8 @@ public:
     // TODO limit number of sessions per node
     std::map<uint256, Session> sessions;
 
-    std::map<SigShareKey, CSigShare> pendingIncomingSigShares;
-    std::map<SigShareKey, int64_t> requestedSigShares;
+    SigShareMap<CSigShare> pendingIncomingSigShares;
+    SigShareMap<int64_t> requestedSigShares;
 
     // elements are added whenever we receive a valid sig share from this node
     // this triggers us to send inventory items to him as he seems to be interested in these
@@ -174,12 +334,12 @@ private:
     std::thread workThread;
     CThreadInterrupt workInterrupt;
 
-    std::map<SigShareKey, CSigShare> sigShares;
+    SigShareMap<CSigShare> sigShares;
     std::map<uint256, int64_t> firstSeenForSessions;
 
     std::map<NodeId, CSigSharesNodeState> nodeStates;
-    std::map<SigShareKey, std::pair<NodeId, int64_t>> sigSharesRequested;
-    std::set<SigShareKey> sigSharesToAnnounce;
+    SigShareMap<std::pair<NodeId, int64_t>> sigSharesRequested;
+    SigShareMap<bool> sigSharesToAnnounce;
 
     std::vector<std::tuple<const CQuorumCPtr, uint256, uint256>> pendingSigns;
 

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -19,6 +19,7 @@
 #include <thread>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 
 class CEvoDB;
 class CScheduler;
@@ -36,6 +37,14 @@ namespace std {
         std::size_t operator()(const llmq::SigShareKey& k) const
         {
             return (std::size_t)((k.second + 1) * k.first.GetCheapHash());
+        }
+    };
+    template <>
+    struct hash<std::pair<NodeId, uint256>>
+    {
+        std::size_t operator()(const std::pair<NodeId, uint256>& k) const
+        {
+            return (std::size_t)((k.first + 1) * k.second.GetCheapHash());
         }
     };
 }
@@ -299,14 +308,14 @@ public:
         CSigSharesInv knows;
     };
     // TODO limit number of sessions per node
-    std::map<uint256, Session> sessions;
+    std::unordered_map<uint256, Session> sessions;
 
     SigShareMap<CSigShare> pendingIncomingSigShares;
     SigShareMap<int64_t> requestedSigShares;
 
     // elements are added whenever we receive a valid sig share from this node
     // this triggers us to send inventory items to him as he seems to be interested in these
-    std::set<std::pair<Consensus::LLMQType, uint256>> interestedIn;
+    std::unordered_set<std::pair<Consensus::LLMQType, uint256>> interestedIn;
 
     bool banned{false};
 
@@ -335,9 +344,9 @@ private:
     CThreadInterrupt workInterrupt;
 
     SigShareMap<CSigShare> sigShares;
-    std::map<uint256, int64_t> firstSeenForSessions;
+    std::unordered_map<uint256, int64_t> firstSeenForSessions;
 
-    std::map<NodeId, CSigSharesNodeState> nodeStates;
+    std::unordered_map<NodeId, CSigSharesNodeState> nodeStates;
     SigShareMap<std::pair<NodeId, int64_t>> sigSharesRequested;
     SigShareMap<bool> sigSharesToAnnounce;
 
@@ -371,10 +380,10 @@ private:
     bool VerifySigSharesInv(NodeId from, const CSigSharesInv& inv);
     bool PreVerifyBatchedSigShares(NodeId nodeId, const CBatchedSigShares& batchedSigShares, bool& retBan);
 
-    void CollectPendingSigSharesToVerify(size_t maxUniqueSessions, std::map<NodeId, std::vector<CSigShare>>& retSigShares, std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums);
+    void CollectPendingSigSharesToVerify(size_t maxUniqueSessions, std::unordered_map<NodeId, std::vector<CSigShare>>& retSigShares, std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums);
     bool ProcessPendingSigShares(CConnman& connman);
 
-    void ProcessPendingSigSharesFromNode(NodeId nodeId, const std::vector<CSigShare>& sigShares, const std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& quorums, CConnman& connman);
+    void ProcessPendingSigSharesFromNode(NodeId nodeId, const std::vector<CSigShare>& sigShares, const std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& quorums, CConnman& connman);
 
     void ProcessSigShare(NodeId nodeId, const CSigShare& sigShare, CConnman& connman, const CQuorumCPtr& quorum);
     void TryRecoverSig(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash, CConnman& connman);
@@ -387,9 +396,9 @@ private:
     void BanNode(NodeId nodeId);
 
     bool SendMessages();
-    void CollectSigSharesToRequest(std::map<NodeId, std::map<uint256, CSigSharesInv>>& sigSharesToRequest);
-    void CollectSigSharesToSend(std::map<NodeId, std::map<uint256, CBatchedSigShares>>& sigSharesToSend);
-    void CollectSigSharesToAnnounce(std::map<NodeId, std::map<uint256, CSigSharesInv>>& sigSharesToAnnounce);
+    void CollectSigSharesToRequest(std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv>>& sigSharesToRequest);
+    void CollectSigSharesToSend(std::unordered_map<NodeId, std::unordered_map<uint256, CBatchedSigShares>>& sigSharesToSend);
+    void CollectSigSharesToAnnounce(std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv>>& sigSharesToAnnounce);
     bool SignPendingSigShares();
     void WorkThreadMain();
 };


### PR DESCRIPTION
As profiling has shown, these get too expensive when they get larger. Better to use unordered maps whenever possible.

~This PR currently also includes #2706 as it depends on the hashing for `std::pair<Consensus::LLMQType, uint256>`. I'll remove it when it got merged.~