### PR TITLE
Separate init/destroy and start/stop steps in LLMQ flow

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -236,6 +236,7 @@ void PrepareShutdown()
     StopREST();
     StopRPC();
     StopHTTPServer();
+    llmq::StopLLMQSystem();
 
     // fRPCInWarmup should be `false` if we completed the loading sequence
     // before a shutdown request was received
@@ -2065,6 +2066,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             scheduler.scheduleEvery(boost::bind(&CPrivateSendClientManager::DoMaintenance, boost::ref(privateSendClient), boost::ref(*g_connman)), 1);
 #endif // ENABLE_WALLET
     }
+
+    llmq::StartLLMQSystem();
 
     // ********************************************************* Step 12: start node
 

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -28,10 +28,18 @@ std::string CChainLockSig::ToString() const
 CChainLocksHandler::CChainLocksHandler(CScheduler* _scheduler) :
     scheduler(_scheduler)
 {
-    quorumSigningManager->RegisterRecoveredSigsListener(this);
 }
 
 CChainLocksHandler::~CChainLocksHandler()
+{
+}
+
+void CChainLocksHandler::RegisterAsRecoveredSigsListener()
+{
+    quorumSigningManager->RegisterRecoveredSigsListener(this);
+}
+
+void CChainLocksHandler::UnregisterAsRecoveredSigsListener()
 {
     quorumSigningManager->UnregisterRecoveredSigsListener(this);
 }

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -68,7 +68,9 @@ public:
     CChainLocksHandler(CScheduler* _scheduler);
     ~CChainLocksHandler();
 
-public:
+    void RegisterAsRecoveredSigsListener();
+    void UnregisterAsRecoveredSigsListener();
+
     bool AlreadyHave(const CInv& inv);
     bool GetChainLockByHash(const uint256& hash, CChainLockSig& ret);
 

--- a/src/llmq/quorums_debug.cpp
+++ b/src/llmq/quorums_debug.cpp
@@ -111,6 +111,10 @@ UniValue CDKGDebugSessionStatus::ToJson(int detailLevel) const
 CDKGDebugManager::CDKGDebugManager(CScheduler* _scheduler) :
     scheduler(_scheduler)
 {
+}
+
+void CDKGDebugManager::StartScheduler()
+{
     if (scheduler) {
         scheduler->scheduleEvery([&]() {
             SendLocalStatus();

--- a/src/llmq/quorums_debug.h
+++ b/src/llmq/quorums_debug.h
@@ -158,6 +158,8 @@ private:
 public:
     CDKGDebugManager(CScheduler* _scheduler);
 
+    void StartScheduler();
+
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
     bool PreVerifyDebugStatusMessage(const uint256& hash, CDKGDebugStatus& status, bool& retBan);
     void ScheduleProcessPending();

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -25,17 +25,25 @@ CDKGSessionManager::CDKGSessionManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker) :
     evoDb(_evoDb),
     blsWorker(_blsWorker)
 {
+}
+
+CDKGSessionManager::~CDKGSessionManager()
+{
+}
+
+void CDKGSessionManager::StartMessageHandlerPool()
+{
     for (const auto& qt : Params().GetConsensus().llmqs) {
         dkgSessionHandlers.emplace(std::piecewise_construct,
                 std::forward_as_tuple(qt.first),
-                std::forward_as_tuple(qt.second, _evoDb, messageHandlerPool, blsWorker, *this));
+                std::forward_as_tuple(qt.second, evoDb, messageHandlerPool, blsWorker, *this));
     }
 
     messageHandlerPool.resize(2);
     RenameThreadPool(messageHandlerPool, "quorum-msg");
 }
 
-CDKGSessionManager::~CDKGSessionManager()
+void CDKGSessionManager::StopMessageHandlerPool()
 {
     messageHandlerPool.stop(true);
 }

--- a/src/llmq/quorums_dkgsessionmgr.h
+++ b/src/llmq/quorums_dkgsessionmgr.h
@@ -50,6 +50,9 @@ public:
     CDKGSessionManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker);
     ~CDKGSessionManager();
 
+    void StartMessageHandlerPool();
+    void StopMessageHandlerPool();
+
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -31,13 +31,6 @@ void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests)
     chainLocksHandler = new CChainLocksHandler(scheduler);
 }
 
-void InterruptLLMQSystem()
-{
-    if (quorumSigSharesManager) {
-        quorumSigSharesManager->InterruptWorkerThread();
-    }
-}
-
 void DestroyLLMQSystem()
 {
     delete chainLocksHandler;
@@ -54,6 +47,42 @@ void DestroyLLMQSystem()
     quorumBlockProcessor = nullptr;
     delete quorumDKGDebugManager;
     quorumDKGDebugManager = nullptr;
+}
+
+void StartLLMQSystem()
+{
+    if (quorumDKGDebugManager) {
+        quorumDKGDebugManager->StartScheduler();
+    }
+    if (quorumDKGSessionManager) {
+        quorumDKGSessionManager->StartMessageHandlerPool();
+    }
+    if (quorumSigSharesManager) {
+        quorumSigSharesManager->StartWorkerThread();
+    }
+    if (chainLocksHandler) {
+        chainLocksHandler->RegisterAsRecoveredSigsListener();
+    }
+}
+
+void StopLLMQSystem()
+{
+    if (chainLocksHandler) {
+        chainLocksHandler->UnregisterAsRecoveredSigsListener();
+    }
+    if (quorumSigSharesManager) {
+        quorumSigSharesManager->StopWorkerThread();
+    }
+    if (quorumDKGSessionManager) {
+        quorumDKGSessionManager->StopMessageHandlerPool();
+    }
+}
+
+void InterruptLLMQSystem()
+{
+    if (quorumSigSharesManager) {
+        quorumSigSharesManager->InterruptWorkerThread();
+    }
 }
 
 }

--- a/src/llmq/quorums_init.h
+++ b/src/llmq/quorums_init.h
@@ -14,10 +14,14 @@ namespace llmq
 // If true, we will connect to all new quorums and watch their communication
 static const bool DEFAULT_WATCH_QUORUMS = false;
 
+// Init/destroy LLMQ globals
 void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests);
-void InterruptLLMQSystem();
 void DestroyLLMQSystem();
 
+// Manage scheduled tasks, threads, listeners etc.
+void StartLLMQSystem();
+void StopLLMQSystem();
+void InterruptLLMQSystem();
 }
 
 #endif //DASH_QUORUMS_INIT_H

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -192,6 +192,8 @@ public:
     CSigSharesManager();
     ~CSigSharesManager();
 
+    void StartWorkerThread();
+    void StopWorkerThread();
     void InterruptWorkerThread();
 
 public:
@@ -201,9 +203,6 @@ public:
     void Sign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
 
 private:
-    void StartWorkerThread();
-    void StopWorkerThread();
-
     void ProcessMessageSigSharesInv(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
     void ProcessMessageGetSigShares(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
     void ProcessMessageBatchedSigShares(CNode* pfrom, const CBatchedSigShares& batchedSigShares, CConnman& connman);


### PR DESCRIPTION
Turned out that some changes in #2703 can cause crashes and stale threads because worker thread deals with too many stuff that are outside of `CSigSharesManager` (and which might be deleted by the time it tries to access them). Also, `workInterrupt` wasn't handled properly too...

But while debugging this issue I realized that we actually mix init/start and destroy/stop steps a lot in LLMQ, so this PR not only fixes issues mentioned above, but also splits the flow for other (existing) LLMQ modules to avoid similar issues in the future.