### PR TITLE
Implement new algo for quorum connections

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -122,8 +122,6 @@ static Consensus::LLMQParams llmq10_60 = {
 
         .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
 
-        .neighborConnections = 2,
-        .diagonalConnections = 2,
         .keepOldConnections = 24,
 };
 
@@ -142,8 +140,6 @@ static Consensus::LLMQParams llmq50_60 = {
 
         .signingActiveQuorumCount = 24, // a full day worth of LLMQs
 
-        .neighborConnections = 2,
-        .diagonalConnections = 2,
         .keepOldConnections = 24,
 };
 
@@ -162,8 +158,6 @@ static Consensus::LLMQParams llmq400_60 = {
 
         .signingActiveQuorumCount = 4, // two days worth of LLMQs
 
-        .neighborConnections = 4,
-        .diagonalConnections = 4,
         .keepOldConnections = 4,
 };
 
@@ -183,8 +177,6 @@ static Consensus::LLMQParams llmq400_85 = {
 
         .signingActiveQuorumCount = 4, // two days worth of LLMQs
 
-        .neighborConnections = 4,
-        .diagonalConnections = 4,
         .keepOldConnections = 4,
 };
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -107,14 +107,6 @@ struct LLMQParams {
     // Number of quorums to consider "active" for signing sessions
     int signingActiveQuorumCount;
 
-    // Used for inter-quorum communication. This is the number of deterministic connections built to the clockwise
-    // neighbors on the circle shaped nodes topography
-    int neighborConnections;
-
-    // Used for inter-quorum communication. This is the number of deterministic connections built diagonally to the
-    // member on the circle shaped nodes topography.
-    int diagonalConnections;
-
     // Used for inter-quorum communication. This is the number of quorums for which we should keep old connections. This
     // should be at least as much as the active quorums set.
     int keepOldConnections;


### PR DESCRIPTION
Turned out that diagonal connections are wasteful for quorums with even sizes because we actually connect same nodes twice (in/out). Also, we have to manually figure out params for different quorum/ring sizes every time which is more of a guess and hard to predict if/how many slots are we going to waste.

Here's how current algo looks graphically:
<img width="461" alt="screenshot 2019-02-16 at 19 02 54" src="https://user-images.githubusercontent.com/1935069/52902126-8d71da00-321d-11e9-8c53-8ac057809509.png">

(https://github.com/dashpay/dips/blob/master/dip-0006.md#intra-quorum-communication)


I propose to use new algo and connect to nodes at indexes `(i+2^k)%n` where `k`: `0..floor(log2(n-1))-1`, `n`: size of the quorum/ring. This solves both issues at once.

Here's how it looks graphically.:
<img width="533" alt="screenshot 2019-02-17 at 21 49 25" src="https://user-images.githubusercontent.com/1935069/52917566-182a0600-32fe-11e9-8547-515bbc114ba0.png">
(Here gaps 1 and 2 are black; gap 4 - red; gap 8 - green. And yes, I'm pretty bad at aligning things but you get the idea :) (_EDIT: should be a bit better now_))

Quorum size vs connections in new algo: 10->3, 20->4 (we don't have quorums of this size atm, this is only an example to compare to DIP6), 50->5, 400->8. You can see that it has comparable numbers without having to guess optimal values but what is especially nice about it is that all connections are spread in such a way that no connection slots are wasted.