### PR TITLE
Introduce "session announcements" and session IDs used in LLMQ P2P messages

### DIFF
--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -160,36 +160,6 @@ bool CSigSharesNodeState::GetSessionInfoByRecvId(uint32_t sessionId, SessionInfo
     return true;
 }
 
-void CSigSharesNodeState::MarkAnnounced(const uint256& signHash, const CSigSharesInv& inv)
-{
-    GetOrCreateSession((Consensus::LLMQType)inv.llmqType, signHash).announced.Merge(inv);
-}
-
-void CSigSharesNodeState::MarkRequested(const uint256& signHash, const CSigSharesInv& inv)
-{
-    GetOrCreateSession((Consensus::LLMQType)inv.llmqType, signHash).requested.Merge(inv);
-}
-
-void CSigSharesNodeState::MarkKnows(const uint256& signHash, const CSigSharesInv& inv)
-{
-    GetOrCreateSession((Consensus::LLMQType)inv.llmqType, signHash).knows.Merge(inv);
-}
-
-void CSigSharesNodeState::MarkAnnounced(Consensus::LLMQType llmqType, const uint256& signHash, uint16_t quorumMember)
-{
-    GetOrCreateSession(llmqType, signHash).announced.Set(quorumMember, true);
-}
-
-void CSigSharesNodeState::MarkRequested(Consensus::LLMQType llmqType, const uint256& signHash, uint16_t quorumMember)
-{
-    GetOrCreateSession(llmqType, signHash).requested.Set(quorumMember, true);
-}
-
-void CSigSharesNodeState::MarkKnows(Consensus::LLMQType llmqType, const uint256& signHash, uint16_t quorumMember)
-{
-    GetOrCreateSession(llmqType, signHash).knows.Set(quorumMember, true);
-}
-
 void CSigSharesNodeState::RemoveSession(const uint256& signHash)
 {
     auto it = sessions.find(signHash);

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -324,7 +324,7 @@ void CSigSharesManager::ProcessMessageBatchedSigShares(CNode* pfrom, const CBatc
         auto& nodeState = nodeStates[pfrom->id];
 
         for (size_t i = 0; i < batchedSigShares.sigShares.size(); i++) {
-            CSigShare sigShare = batchedSigShares.RebuildSigShare(i);
+            CSigShare sigShare = RebuildSigShare(sessionInfo, batchedSigShares, i);
             nodeState.requestedSigShares.Erase(sigShare.GetKey());
 
             // TODO track invalid sig shares received for PoSe?
@@ -978,6 +978,21 @@ bool CSigSharesManager::SendMessages()
     }
 
     return didSend;
+}
+
+CSigShare CSigSharesManager::RebuildSigShare(const CSigSharesNodeState::SessionInfo& session, const CBatchedSigShares& batchedSigShares, size_t idx)
+{
+    assert(idx < batchedSigShares.sigShares.size());
+    auto& s = batchedSigShares.sigShares[idx];
+    CSigShare sigShare;
+    sigShare.llmqType = session.llmqType;
+    sigShare.quorumHash = session.quorumHash;
+    sigShare.quorumMember = s.first;
+    sigShare.id = session.id;
+    sigShare.msgHash = session.msgHash;
+    sigShare.sigShare = s.second;
+    sigShare.UpdateKey();
+    return sigShare;
 }
 
 void CSigSharesManager::Cleanup()

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -127,21 +127,6 @@ public:
         READWRITE(sigShares);
     }
 
-    CSigShare RebuildSigShare(size_t idx) const
-    {
-        assert(idx < sigShares.size());
-        auto& s = sigShares[idx];
-        CSigShare sigShare;
-        sigShare.llmqType = llmqType;
-        sigShare.quorumHash = quorumHash;
-        sigShare.quorumMember = s.first;
-        sigShare.id = id;
-        sigShare.msgHash = msgHash;
-        sigShare.sigShare = s.second;
-        sigShare.UpdateKey();
-        return sigShare;
-    }
-
     CSigSharesInv ToInv(Consensus::LLMQType llmqType) const;
 };
 
@@ -392,6 +377,8 @@ private:
     void TryRecoverSig(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash, CConnman& connman);
 
 private:
+    CSigShare RebuildSigShare(const CSigSharesNodeState::SessionInfo& session, const CBatchedSigShares& batchedSigShares, size_t idx);
+
     void Cleanup();
     void RemoveSigSharesForSession(const uint256& signHash);
     void RemoveBannedNodeStates();

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -391,8 +391,8 @@ private:
     void ProcessMessageGetSigShares(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
     void ProcessMessageBatchedSigShares(CNode* pfrom, const CBatchedSigShares& batchedSigShares, CConnman& connman);
 
-    bool VerifySigSharesInv(NodeId from, const CSigSharesInv& inv);
-    bool PreVerifyBatchedSigShares(NodeId nodeId, const CBatchedSigShares& batchedSigShares, bool& retBan);
+    bool VerifySigSharesInv(NodeId from, Consensus::LLMQType llmqType, const CSigSharesInv& inv);
+    bool PreVerifyBatchedSigShares(NodeId nodeId, const CSigSharesNodeState::SessionInfo& session, const CBatchedSigShares& batchedSigShares, bool& retBan);
 
     void CollectPendingSigSharesToVerify(size_t maxUniqueSessions,
             std::unordered_map<NodeId, std::vector<CSigShare>>& retSigShares,

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -56,6 +56,32 @@ public:
     }
 };
 
+// Nodes will first announce a signing session with a sessionId to be used in all future P2P messages related to that
+// session. We locally keep track of the mapping for each node. We also assign new sessionIds for outgoing sessions
+// and send QSIGSESANN messages appropriately. All values except the max value for uint32_t are valid as sessionId
+class CSigSesAnn
+{
+public:
+    uint32_t sessionId{(uint32_t)-1};
+    uint8_t llmqType;
+    uint256 quorumHash;
+    uint256 id;
+    uint256 msgHash;
+
+    ADD_SERIALIZE_METHODS
+
+    template<typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(VARINT(sessionId));
+        READWRITE(llmqType);
+        READWRITE(quorumHash);
+        READWRITE(id);
+        READWRITE(msgHash);
+    }
+
+    std::string ToString() const;
+};
+
 class CSigSharesInv
 {
 public:
@@ -344,6 +370,7 @@ public:
     void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);
 
 private:
+    void ProcessMessageSigSesAnn(CNode* pfrom, const CSigSesAnn& ann, CConnman& connman);
     void ProcessMessageSigSharesInv(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
     void ProcessMessageGetSigShares(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
     void ProcessMessageBatchedSigShares(CNode* pfrom, const CBatchedSigShares& batchedSigShares, CConnman& connman);

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -328,14 +328,6 @@ public:
     Session* GetSessionByRecvId(uint32_t sessionId);
     bool GetSessionInfoByRecvId(uint32_t sessionId, SessionInfo& retInfo);
 
-    void MarkAnnounced(const uint256& signHash, const CSigSharesInv& inv);
-    void MarkRequested(const uint256& signHash, const CSigSharesInv& inv);
-    void MarkKnows(const uint256& signHash, const CSigSharesInv& inv);
-
-    void MarkAnnounced(Consensus::LLMQType llmqType, const uint256& signHash, uint16_t quorumMember);
-    void MarkRequested(Consensus::LLMQType llmqType, const uint256& signHash, uint16_t quorumMember);
-    void MarkKnows(Consensus::LLMQType llmqType, const uint256& signHash, uint16_t quorumMember);
-
     void RemoveSession(const uint256& signHash);
 };
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -65,6 +65,7 @@ const char *QJUSTIFICATION="qjustify";
 const char *QPCOMMITMENT="qpcommit";
 const char *QWATCH="qwatch";
 const char *QDEBUGSTATUS="qdebugstatus";
+const char *QSIGSESANN="qsigsesann";
 const char *QSIGSHARESINV="qsigsinv";
 const char *QGETSIGSHARES="qgetsigs";
 const char *QBSIGSHARES="qbsigs";
@@ -165,6 +166,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::QPCOMMITMENT,
     NetMsgType::QWATCH,
     NetMsgType::QDEBUGSTATUS,
+    NetMsgType::QSIGSESANN,
     NetMsgType::QSIGSHARESINV,
     NetMsgType::QGETSIGSHARES,
     NetMsgType::QBSIGSHARES,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -271,6 +271,7 @@ extern const char *QJUSTIFICATION;
 extern const char *QPCOMMITMENT;
 extern const char *QWATCH;
 extern const char *QDEBUGSTATUS;
+extern const char *QSIGSESANN;
 extern const char *QSIGSHARESINV;
 extern const char *QGETSIGSHARES;
 extern const char *QBSIGSHARES;


### PR DESCRIPTION
Instead of transmitting all the necessary information belonging to a signing session in every `CBatchedSigShares` and `CSigSharesInv` messages, we will now assign session IDs to individual signing sessions and send an announcement with the necessary information before sending the inventory and batched sigs messages. After the announcemetn, we use the session ID to refer to the session information.

This reduces the overhead in `CBatchedSigShares` from 97 bytes to 1-10 bytes (it's a VARINT). The overhead for `CSigSharesInv` is reduced from 33 bytes to 1-10 bytes.

I decided to implement this optimization after observing a lot of traffic being caused by `CSigSharesInv` messages while doing load testing with LLMQ based InstantSend. 

I assume that in the old system the overhead would get more and more when bandwidth is low while load is high. The reason is that the system reverts to sending smaller but more frequent batches when bandwidth is low, resulting in queues to fill up and slowing down the system even more.

That problem is probably still there even with this optimization, but it should be less severe. I'll handle the actual problem in another PR (avoid sending small batches when nodes send buffers are non-empty)