### PR TITLE
Only return from wait_for_chainlock when the block is actually processed

### DIFF
--- a/qa/rpc-tests/llmq-chainlocks.py
+++ b/qa/rpc-tests/llmq-chainlocks.py
@@ -102,7 +102,7 @@ class LLMQChainLocksTest(DashTestFramework):
         while time() - t < 15:
             try:
                 block = node.getblock(block_hash)
-                if block["chainlock"]:
+                if block["confirmations"] > 0 and block["chainlock"]:
                     return
             except:
                 # block might not be on the node yet


### PR DESCRIPTION
getblock also returns blocks which are not processed yet or in the middle
of processing.

This should fix a test failure seen in https://travis-ci.org/dashpay/dash/builds/498748006?utm_source=github_status&utm_medium=notification