### PR TITLE
Send/Receive multiple messages as part of one P2P message in CSigSharesManager

### DIFF
--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1056,7 +1056,7 @@ bool CSigSharesManager::SendMessages()
                 LogPrint("llmq", "CSigSharesManager::SendMessages -- QSIGSESANN signHash=%s, sessionId=%d, node=%d\n",
                          CLLMQUtils::BuildSignHash(sigSesAnn).ToString(), sigSesAnn.sessionId, pnode->id);
                 msgs.emplace_back(sigSesAnn);
-                if (msgs.size() >= MAX_MSGS_CNT_QSIGSESANN) {
+                if (msgs.size() == MAX_MSGS_CNT_QSIGSESANN) {
                     g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSESANN, msgs), false);
                     msgs.clear();
                 }
@@ -1075,7 +1075,7 @@ bool CSigSharesManager::SendMessages()
                 LogPrint("llmq", "CSigSharesManager::SendMessages -- QGETSIGSHARES signHash=%s, inv={%s}, node=%d\n",
                          p.first.ToString(), p.second.ToString(), pnode->id);
                 msgs.emplace_back(std::move(p.second));
-                if (msgs.size() >= MAX_MSGS_CNT_QGETSIGSHARES) {
+                if (msgs.size() == MAX_MSGS_CNT_QGETSIGSHARES) {
                     g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QGETSIGSHARES, msgs), false);
                     msgs.clear();
                 }
@@ -1123,7 +1123,7 @@ bool CSigSharesManager::SendMessages()
                 LogPrint("llmq", "CSigSharesManager::SendMessages -- QSIGSHARESINV signHash=%s, inv={%s}, node=%d\n",
                          p.first.ToString(), p.second.ToString(), pnode->id);
                 msgs.emplace_back(std::move(p.second));
-                if (msgs.size() >= MAX_MSGS_CNT_QSIGSHARESINV) {
+                if (msgs.size() == MAX_MSGS_CNT_QSIGSHARESINV) {
                     g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSHARESINV, msgs), false);
                     msgs.clear();
                 }

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1059,11 +1059,12 @@ bool CSigSharesManager::SendMessages()
                 if (msgs.size() == MAX_MSGS_CNT_QSIGSESANN) {
                     g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSESANN, msgs), false);
                     msgs.clear();
+                    didSend = true;
                 }
-                didSend = true;
             }
             if (!msgs.empty()) {
                 g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSESANN, msgs), false);
+                didSend = true;
             }
         }
 
@@ -1078,11 +1079,12 @@ bool CSigSharesManager::SendMessages()
                 if (msgs.size() == MAX_MSGS_CNT_QGETSIGSHARES) {
                     g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QGETSIGSHARES, msgs), false);
                     msgs.clear();
+                    didSend = true;
                 }
-                didSend = true;
             }
             if (!msgs.empty()) {
                 g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QGETSIGSHARES, msgs), false);
+                didSend = true;
             }
         }
 
@@ -1104,14 +1106,15 @@ bool CSigSharesManager::SendMessages()
                     g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QBSIGSHARES, msgs), false);
                     msgs.clear();
                     totalSigsCount = 0;
+                    didSend = true;
                 }
                 totalSigsCount += p.second.sigShares.size();
                 msgs.emplace_back(std::move(p.second));
 
-                didSend = true;
             }
             if (!msgs.empty()) {
                 g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QBSIGSHARES, std::move(msgs)), false);
+                didSend = true;
             }
         }
 
@@ -1126,11 +1129,12 @@ bool CSigSharesManager::SendMessages()
                 if (msgs.size() == MAX_MSGS_CNT_QSIGSHARESINV) {
                     g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSHARESINV, msgs), false);
                     msgs.clear();
+                    didSend = true;
                 }
-                didSend = true;
             }
             if (!msgs.empty()) {
                 g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSHARESINV, msgs), false);
+                didSend = true;
             }
         }
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -241,7 +241,6 @@ void CSigSharesManager::ProcessMessage(CNode* pfrom, const std::string& strComma
                 return;
             }
         }
-        // not accounting as pending msg (as it's not batched in any way)
     } else if (strCommand == NetMsgType::QSIGSHARESINV) {
         std::vector<CSigSharesInv> msgs;
         vRecv >> msgs;
@@ -255,8 +254,6 @@ void CSigSharesManager::ProcessMessage(CNode* pfrom, const std::string& strComma
                 return;
             }
         }
-        LOCK(cs);
-        nodeStates[pfrom->id].pendingReceivedMsgCount += msgs.size();
     } else if (strCommand == NetMsgType::QGETSIGSHARES) {
         std::vector<CSigSharesInv> msgs;
         vRecv >> msgs;
@@ -287,8 +284,6 @@ void CSigSharesManager::ProcessMessage(CNode* pfrom, const std::string& strComma
                 return;
             }
         }
-        LOCK(cs);
-        nodeStates[pfrom->id].pendingReceivedMsgCount += msgs.size();
     }
 }
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -327,10 +327,6 @@ bool CSigSharesManager::ProcessMessageSigSesAnn(CNode* pfrom, const CSigSesAnn& 
 
 bool CSigSharesManager::VerifySigSharesInv(NodeId from, Consensus::LLMQType llmqType, const CSigSharesInv& inv)
 {
-    if (!fMasternodeMode || activeMasternodeInfo.proTxHash.IsNull()) {
-        return false;
-    }
-
     size_t quorumSize = (size_t)Params().GetConsensus().llmqs.at(llmqType).size;
 
     if (inv.inv.size() != quorumSize) {

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -337,6 +337,13 @@ class CSigSharesManager : public CRecoveredSigsListener
     static const int64_t SESSION_TOTAL_TIMEOUT = 5 * 60 * 1000;
     static const int64_t SIG_SHARE_REQUEST_TIMEOUT = 5 * 1000;
 
+    // we try to keep total message size below 10k
+    const size_t MAX_MSGS_CNT_QSIGSESANN = 100;
+    const size_t MAX_MSGS_CNT_QGETSIGSHARES = 200;
+    const size_t MAX_MSGS_CNT_QSIGSHARESINV = 200;
+    // 400 is the maximum quorum size, so this is also the maximum number of sigs we need to support
+    const size_t MAX_MSGS_TOTAL_BATCHED_SIGS = 400;
+
 private:
     CCriticalSection cs;
 

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -378,10 +378,11 @@ public:
     void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);
 
 private:
-    void ProcessMessageSigSesAnn(CNode* pfrom, const CSigSesAnn& ann, CConnman& connman);
-    void ProcessMessageSigSharesInv(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
-    void ProcessMessageGetSigShares(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
-    void ProcessMessageBatchedSigShares(CNode* pfrom, const CBatchedSigShares& batchedSigShares, CConnman& connman);
+    // all of these return false when the currently processed message should be aborted (as each message actually contains multiple messages)
+    bool ProcessMessageSigSesAnn(CNode* pfrom, const CSigSesAnn& ann, CConnman& connman);
+    bool ProcessMessageSigSharesInv(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
+    bool ProcessMessageGetSigShares(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);
+    bool ProcessMessageBatchedSigShares(CNode* pfrom, const CBatchedSigShares& batchedSigShares, CConnman& connman);
 
     bool VerifySigSharesInv(NodeId from, Consensus::LLMQType llmqType, const CSigSharesInv& inv);
     bool PreVerifyBatchedSigShares(NodeId nodeId, const CSigSharesNodeState::SessionInfo& session, const CBatchedSigShares& batchedSigShares, bool& retBan);


### PR DESCRIPTION
Many messages, especially QSIGSHARESINV and QGETSIGSHARES, are very small
by nature (5-14 bytes for a 50 members LLMQ). The message headers are
24 bytes, meaning that we produce a lot of overhead for these small messages.
This sums up quite a bit when thousands of signing sessions are happening
in parallel.
    
This commit changes all related P2P messages to send a vector of messages
instead of a single message.