### PR TITLE
Actually start the timers for sig share and recSig verification

### DIFF
--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -466,7 +466,7 @@ bool CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
         }
     }
 
-    cxxtimer::Timer verifyTimer;
+    cxxtimer::Timer verifyTimer(true);
     batchVerifier.Verify();
     verifyTimer.stop();
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -563,7 +563,7 @@ bool CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
         }
     }
 
-    cxxtimer::Timer verifyTimer;
+    cxxtimer::Timer verifyTimer(true);
     batchVerifier.Verify();
     verifyTimer.stop();
 


### PR DESCRIPTION
Was wondering why verification was always 0ms...this explains it :)