### PR TITLE
Backport bitcoin#14385: qt: avoid system harfbuzz and bz2

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-zlib --without-png --disable-static
+  $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -76,6 +76,7 @@ $(package)_config_opts += -prefix $(host_prefix)
 $(package)_config_opts += -qt-libpng
 $(package)_config_opts += -qt-libjpeg
 $(package)_config_opts += -qt-pcre
+$(package)_config_opts += -qt-harfbuzz
 $(package)_config_opts += -system-zlib
 $(package)_config_opts += -reduce-exports
 $(package)_config_opts += -static


### PR DESCRIPTION
freetype 2.7.1 incompatible with newer harfbuzz, so it interrupt checking Qt plugins as follows. This patch that port from Bitcoin avoids the issue.

```
configure:25956: checking for static Qt plugins: -lqxcb -lxcb-static
configure:25974: g++ -m64 -std=c++14 -o conftest -fPIC -pipe -static-libstdc++ -O2 -O2 -g0 -s -I/tmp/dash/depends/x86_64-pc-linux-gnu/include/QtCore -I/tmp/dash/depends/x86_64-pc-linux-gnu/include/QtGui -I/tmp/dash/depends/x86_64-pc-linux-gnu/include/QtNetwork -I/tmp/dash/depends/x86_64-pc-linux-gnu/include/QtWidgets  -I/tmp/dash/depends/x86_64-pc-linux-gnu/share/../include/  -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS -L/tmp/dash/depends/x86_64-pc-linux-gnu/share/../lib  conftest.cpp -lqxcb -lxcb-static -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lQt5XcbQpa -lX11 -lX11-xcb -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lxcb -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lxcb-static -lQt5DBus -lfontconfig -lfreetype -lqtpng -lharfbuzz -lz -lqtpcre -lm -ldl -lrt -lpthread -lfontconfig -lfreetype -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lz -lqtpcre -lm -ldl -lrt -lpthread -lqtpng -lharfbuzz -lz -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5Gui -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lz -lqtpcre -lm -ldl -lrt -lpthread -lqtpng -lharfbuzz -lz -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5PlatformSupport -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpng -lharfbuzz -lQt5DBus -lz -lqtpcre -lm -ldl -lrt -lpthread -lfontconfig -lfreetype -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5Gui -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lz -lqtpcre -lm -ldl -lrt -lpthread -lqtpng -lharfbuzz -lz -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt  -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lX11-xcb -lX11 -lpthread -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lXau -lxcb -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lXau  -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lQt5PlatformSupport -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpng -lharfbuzz -lQt5DBus -lz -lqtpcre -lm -ldl -lrt -lpthread -lfontconfig -lfreetype -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5Gui -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lz -lqtpcre -lm -ldl -lrt -lpthread -lqtpng -lharfbuzz -lz -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt  -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5Gui -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lz -lqtpcre -lm -ldl -lrt -lpthread -lqtpng -lharfbuzz -lz -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5Network -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lz -lqtpcre -lm -ldl -lrt -lpthread -lz -lssl -lcrypto -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5Widgets -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpng -lharfbuzz -lz -lqtpcre -lm -ldl -lrt -lpthread -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt -lQt5Gui -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lz -lqtpcre -lm -ldl -lrt -lpthread -lqtpng -lharfbuzz -lz -lQt5Core -lpthread -lz -L/tmp/dash/depends/x86_64-pc-linux-gnu/lib -lqtpcre -lm -ldl -lrt  -L/tmp/dash/depends/x86_64-pc-linux-gnu/share/../plugins/platforms  >&5
conftest.cpp:67: warning: "QT_STATICPLUGIN" redefined
     #define QT_STATICPLUGIN
 
conftest.cpp:64: note: this is the location of the previous definition
 #define QT_STATICPLUGIN 1
 
/usr/bin/ld: /usr/lib/gcc/x86_64-redhat-linux/8/../../../../lib64/libharfbuzz.so: undefined reference to `FT_Done_MM_Var'
collect2: error: ld returned 1 exit status
configure:25974: $? = 1
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "Dash Core"
| #define PACKAGE_TARNAME "dashcore"
| #define PACKAGE_VERSION "0.14.0"
| #define PACKAGE_STRING "Dash Core 0.14.0"
| #define PACKAGE_BUGREPORT "https://github.com/dashpay/dash/issues"
| #define PACKAGE_URL "https://dash.org/"
| #define HAVE_CXX14 1
| #define STDC_HEADERS 1
| #define HAVE_SYS_TYPES_H 1
| #define HAVE_SYS_STAT_H 1
| #define HAVE_STDLIB_H 1
| #define HAVE_STRING_H 1
| #define HAVE_MEMORY_H 1
| #define HAVE_STRINGS_H 1
| #define HAVE_INTTYPES_H 1
| #define HAVE_STDINT_H 1
| #define HAVE_UNISTD_H 1
| #define HAVE_DLFCN_H 1
| #define LT_OBJDIR ".libs/"
| #define STACKTRACE_WRAPPED_CXX_ABI 1
| #define HAVE_PTHREAD_PRIO_INHERIT 1
| #define HAVE_PTHREAD 1
| #define HAVE_DECL_STRERROR_R 1
| #define HAVE_STRERROR_R 1
| #define STRERROR_R_CHAR_P 1
| #define HAVE_FUNC_ATTRIBUTE_VISIBILITY 1
| #define HAVE_ENDIAN_H 1
| #define HAVE_BYTESWAP_H 1
| #define HAVE_STDIO_H 1
| #define HAVE_STDLIB_H 1
| #define HAVE_UNISTD_H 1
| #define HAVE_STRINGS_H 1
| #define HAVE_SYS_TYPES_H 1
| #define HAVE_SYS_STAT_H 1
| #define HAVE_SYS_SELECT_H 1
| #define HAVE_SYS_PRCTL_H 1
| #define HAVE_DECL_STRNLEN 1
| #define HAVE_DECL_DAEMON 1
| #define HAVE_DECL_LE16TOH 1
| #define HAVE_DECL_LE32TOH 1
| #define HAVE_DECL_LE64TOH 1
| #define HAVE_DECL_HTOLE16 1
| #define HAVE_DECL_HTOLE32 1
| #define HAVE_DECL_HTOLE64 1
| #define HAVE_DECL_BE16TOH 1
| #define HAVE_DECL_BE32TOH 1
| #define HAVE_DECL_BE64TOH 1
| #define HAVE_DECL_HTOBE16 1
| #define HAVE_DECL_HTOBE32 1
| #define HAVE_DECL_HTOBE64 1
| #define HAVE_DECL_BSWAP_16 1
| #define HAVE_DECL_BSWAP_32 1
| #define HAVE_DECL_BSWAP_64 1
| #define HAVE_MSG_NOSIGNAL 1
| #define HAVE_MALLOPT_ARENA_MAX 1
| #define HAVE_VISIBILITY_ATTRIBUTE 1
| #define HAVE_SYS_GETRANDOM 1
| #define HAVE_GETENTROPY 1
| #define HAVE_MINIUPNPC_MINIWGET_H 1
| #define HAVE_MINIUPNPC_MINIUPNPC_H 1
| #define HAVE_MINIUPNPC_UPNPCOMMANDS_H 1
| #define HAVE_MINIUPNPC_UPNPERRORS_H 1
| #define QT_STATICPLUGIN 1
| /* end confdefs.h.  */
| 
|     #define QT_STATICPLUGIN
|     #include <QtPlugin>
|     Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
| int
| main ()
| {
| return 0;
|   ;
|   return 0;
| }
configure:25978: result: no
configure:25982: WARNING: Could not resolve: -lqxcb -lxcb-static; dash-qt frontend will not be built
configure:26965: checking whether to build Dash Core GUI
configure:26995: result: no (Qt5)
```
---
- https://github.com/bitcoin/bitcoin/pull/14385