### PR TITLE
Stop g_connman first before deleting it

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -255,6 +255,10 @@ void PrepareShutdown()
     MapPort(false);
     UnregisterValidationInterface(peerLogic.get());
     peerLogic.reset();
+    if (g_connman) {
+        // make sure to stop all threads before g_connman is reset to nullptr as these threads might still be accessing it
+        g_connman->Stop();
+    }
     g_connman.reset();
 
     if (!fLiteMode && !fRPCInWarmup) {


### PR DESCRIPTION
This fixes crashes that happen on exit when the message handler thread is accessing `g_connman`, as calling `g_connman.reset()` caused `g_connman` to become `nullptr` too early.