### PR TITLE
Implement LLMQ based InstantSend

### DIFF
--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -161,8 +161,12 @@ class AutoIXMempoolTest(DashTestFramework):
 
         # fill mempool with transactions
         self.set_autoix_spork_state(False)
+        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 4070908800)
+        self.wait_for_sporks_same()
         self.fill_mempool()
         self.set_autoix_spork_state(True)
+        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
+        self.wait_for_sporks_same()
 
         # autoIX is not working now
         assert(not self.send_simple_tx(sender, receiver))

--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -130,7 +130,7 @@ class AutoIXMempoolTest(DashTestFramework):
         print("Test old InstantSend")
         self.test_auto();
 
-        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 1)
+        self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 0)
         self.wait_for_sporks_same()
 
         print("Test new InstantSend")

--- a/qa/rpc-tests/autoix-mempool.py
+++ b/qa/rpc-tests/autoix-mempool.py
@@ -122,6 +122,21 @@ class AutoIXMempoolTest(DashTestFramework):
     def run_test(self):
         # make sure masternodes are synced
         sync_masternodes(self.nodes)
+
+        self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        self.wait_for_sporks_same()
+        self.mine_quorum()
+
+        print("Test old InstantSend")
+        self.test_auto();
+
+        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 1)
+        self.wait_for_sporks_same()
+
+        print("Test new InstantSend")
+        self.test_auto(True);
+
+    def test_auto(self, new_is = False):
         self.activate_autoix_bip9()
         self.set_autoix_spork_state(True)
 
@@ -151,8 +166,8 @@ class AutoIXMempoolTest(DashTestFramework):
 
         # autoIX is not working now
         assert(not self.send_simple_tx(sender, receiver))
-        # regular IX is still working
-        assert(self.send_regular_IX(sender, receiver))
+        # regular IX is still working for old IS but not for new one
+        assert(not self.send_regular_IX(sender, receiver) if new_is else self.send_regular_IX(sender, receiver))
 
         # generate one block to clean up mempool and retry auto and regular IX
         # generate 2 more blocks to have enough confirmations for IX

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -124,7 +124,7 @@ class AutoInstantSendTest(DashTestFramework):
         print("Test old InstantSend")
         self.test_auto();
 
-        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 1)
+        self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 0)
         self.wait_for_sporks_same()
 
         print("Test new InstantSend")

--- a/qa/rpc-tests/p2p-instantsend.py
+++ b/qa/rpc-tests/p2p-instantsend.py
@@ -21,6 +21,20 @@ class InstantSendTest(DashTestFramework):
         self.sender_idx = self.num_nodes - 3
 
     def run_test(self):
+        self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        self.wait_for_sporks_same()
+        self.mine_quorum()
+
+        print("Test old InstantSend")
+        self.test_doublespend()
+
+        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 1)
+        self.wait_for_sporks_same()
+
+        print("Test new InstantSend")
+        self.test_doublespend()
+
+    def test_doublespend(self):
         # feed the sender with some balance
         sender_addr = self.nodes[self.sender_idx].getnewaddress()
         self.nodes[0].sendtoaddress(sender_addr, 1)
@@ -73,7 +87,12 @@ class InstantSendTest(DashTestFramework):
             assert (res['hash'] != wrong_block)
             # wait for long time only for first node
             timeout = 1
-
+        # mine more blocks
+        # TODO: mine these blocks on an isolated node
+        set_mocktime(get_mocktime() + 1)
+        set_node_times(self.nodes, get_mocktime())
+        self.nodes[0].generate(2)
+        self.sync_all()
 
 if __name__ == '__main__':
     InstantSendTest().main()

--- a/qa/rpc-tests/p2p-instantsend.py
+++ b/qa/rpc-tests/p2p-instantsend.py
@@ -28,7 +28,7 @@ class InstantSendTest(DashTestFramework):
         print("Test old InstantSend")
         self.test_doublespend()
 
-        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 1)
+        self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 0)
         self.wait_for_sporks_same()
 
         print("Test new InstantSend")

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -498,36 +498,44 @@ class DashTestFramework(BitcoinTestFramework):
             set_mocktime(get_mocktime() + 1)
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(skip_count)
+        sync_blocks(self.nodes)
 
         # Make sure all reached phase 1 (init)
         self.wait_for_quorum_phase(1, None, 0)
+        # Give nodes some time to connect to neighbors
+        sleep(2)
         set_mocktime(get_mocktime() + 1)
         set_node_times(self.nodes, get_mocktime())
         self.nodes[0].generate(2)
+        sync_blocks(self.nodes)
 
         # Make sure all reached phase 2 (contribute) and received all contributions
         self.wait_for_quorum_phase(2, "receivedContributions", expected_valid_count)
         set_mocktime(get_mocktime() + 1)
         set_node_times(self.nodes, get_mocktime())
         self.nodes[0].generate(2)
+        sync_blocks(self.nodes)
 
         # Make sure all reached phase 3 (complain) and received all complaints
         self.wait_for_quorum_phase(3, "receivedComplaints" if expected_valid_count != 10 else None, expected_valid_count)
         set_mocktime(get_mocktime() + 1)
         set_node_times(self.nodes, get_mocktime())
         self.nodes[0].generate(2)
+        sync_blocks(self.nodes)
 
         # Make sure all reached phase 4 (justify)
         self.wait_for_quorum_phase(4, None, 0)
         set_mocktime(get_mocktime() + 1)
         set_node_times(self.nodes, get_mocktime())
         self.nodes[0].generate(2)
+        sync_blocks(self.nodes)
 
         # Make sure all reached phase 5 (commit)
         self.wait_for_quorum_phase(5, "receivedPrematureCommitments", expected_valid_count)
         set_mocktime(get_mocktime() + 1)
         set_node_times(self.nodes, get_mocktime())
         self.nodes[0].generate(2)
+        sync_blocks(self.nodes)
 
         # Make sure all reached phase 6 (mining)
         self.wait_for_quorum_phase(6, None, 0)
@@ -544,6 +552,7 @@ class DashTestFramework(BitcoinTestFramework):
             set_mocktime(get_mocktime() + 1)
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
+            sync_blocks(self.nodes)
 
         sync_blocks(self.nodes)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -173,6 +173,7 @@ BITCOIN_CORE_H = \
   llmq/quorums_dkgsessionmgr.h \
   llmq/quorums_dkgsession.h \
   llmq/quorums_init.h \
+  llmq/quorums_instantsend.h \
   llmq/quorums_signing.h \
   llmq/quorums_signing_shares.h \
   llmq/quorums_utils.h \
@@ -291,6 +292,7 @@ libdash_server_a_SOURCES = \
   llmq/quorums_dkgsessionmgr.cpp \
   llmq/quorums_dkgsession.cpp \
   llmq/quorums_init.cpp \
+  llmq/quorums_instantsend.cpp \
   llmq/quorums_signing.cpp \
   llmq/quorums_signing_shares.cpp \
   llmq/quorums_utils.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -623,6 +623,7 @@ public:
         consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
         consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
         consensus.llmqChainLocks = Consensus::LLMQ_50_60;
+        consensus.llmqForInstantSend = Consensus::LLMQ_50_60;
 
         fMiningRequiresPeers = true;
         fDefaultConsistencyChecks = false;
@@ -787,6 +788,7 @@ public:
         consensus.llmqs[Consensus::LLMQ_10_60] = llmq10_60;
         consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
         consensus.llmqChainLocks = Consensus::LLMQ_10_60;
+        consensus.llmqForInstantSend = Consensus::LLMQ_10_60;
     }
 
     void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout, int64_t nWindowSize, int64_t nThreshold)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -308,6 +308,7 @@ public:
         consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
         consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
         consensus.llmqChainLocks = Consensus::LLMQ_400_60;
+        consensus.llmqForInstantSend = Consensus::LLMQ_50_60;
 
         fMiningRequiresPeers = true;
         fDefaultConsistencyChecks = false;
@@ -476,6 +477,7 @@ public:
         consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
         consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
         consensus.llmqChainLocks = Consensus::LLMQ_50_60;
+        consensus.llmqForInstantSend = Consensus::LLMQ_50_60;
 
         fMiningRequiresPeers = true;
         fDefaultConsistencyChecks = false;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -174,6 +174,7 @@ struct Params {
 
     std::map<LLMQType, LLMQParams> llmqs;
     LLMQType llmqChainLocks;
+    LLMQType llmqForInstantSend{LLMQ_NONE};
 };
 } // namespace Consensus
 

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -18,6 +18,7 @@
 
 #include "llmq/quorums.h"
 #include "llmq/quorums_chainlocks.h"
+#include "llmq/quorums_instantsend.h"
 #include "llmq/quorums_dkgsessionmgr.h"
 
 void CDSNotificationInterface::InitializeCurrentBlockTip()
@@ -72,6 +73,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
 void CDSNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock)
 {
+    llmq::quorumInstantSendManager->SyncTransaction(tx, pindex, posInBlock);
     instantsend.SyncTransaction(tx, pindex, posInBlock);
     CPrivateSend::SyncTransaction(tx, pindex, posInBlock);
 }
@@ -81,4 +83,9 @@ void CDSNotificationInterface::NotifyMasternodeListChanged(const CDeterministicM
     governance.CheckMasternodeOrphanObjects(connman);
     governance.CheckMasternodeOrphanVotes(connman);
     governance.UpdateCachesAndClean();
+}
+
+void CDSNotificationInterface::NotifyChainLock(const CBlockIndex* pindex)
+{
+    llmq::quorumInstantSendManager->NotifyChainLock(pindex);
 }

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -71,9 +71,15 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     llmq::quorumDKGSessionManager->UpdatedBlockTip(pindexNew, pindexFork, fInitialDownload);
 }
 
+void CDSNotificationInterface::NewPoWValidBlock(const CBlockIndex* pindex, const std::shared_ptr<const CBlock>& block)
+{
+    llmq::chainLocksHandler->NewPoWValidBlock(pindex, block);
+}
+
 void CDSNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock)
 {
     llmq::quorumInstantSendManager->SyncTransaction(tx, pindex, posInBlock);
+    llmq::chainLocksHandler->SyncTransaction(tx, pindex, posInBlock);
     instantsend.SyncTransaction(tx, pindex, posInBlock);
     CPrivateSend::SyncTransaction(tx, pindex, posInBlock);
 }

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -21,6 +21,7 @@ protected:
     void AcceptedBlockHeader(const CBlockIndex *pindexNew) override;
     void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
+    void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) override;
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) override;
     void NotifyMasternodeListChanged(const CDeterministicMNList& newList) override;
     void NotifyChainLock(const CBlockIndex* pindex);

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -23,6 +23,7 @@ protected:
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) override;
     void NotifyMasternodeListChanged(const CDeterministicMNList& newList) override;
+    void NotifyChainLock(const CBlockIndex* pindex);
 
 private:
     CConnman& connman;

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -24,7 +24,7 @@ protected:
     void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) override;
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) override;
     void NotifyMasternodeListChanged(const CDeterministicMNList& newList) override;
-    void NotifyChainLock(const CBlockIndex* pindex);
+    void NotifyChainLock(const CBlockIndex* pindex) override;
 
 private:
     CConnman& connman;

--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -16,6 +16,8 @@
 #include "util.h"
 #include "validation.h"
 
+#include "llmq/quorums_instantsend.h"
+
 #include <string>
 #include <univalue.h>
 
@@ -618,7 +620,7 @@ bool CGovernanceObject::IsCollateralValid(std::string& strError, bool& fMissingC
     }
 
     if ((nConfirmationsIn < GOVERNANCE_FEE_CONFIRMATIONS) &&
-        (!instantsend.IsLockedInstantSendTransaction(nCollateralHash))) {
+        (!instantsend.IsLockedInstantSendTransaction(nCollateralHash) || llmq::quorumInstantSendManager->IsLocked(nCollateralHash))) {
         strError = strprintf("Collateral requires at least %d confirmations to be relayed throughout the network (it has only %d)", GOVERNANCE_FEE_CONFIRMATIONS, nConfirmationsIn);
         if (nConfirmationsIn >= GOVERNANCE_MIN_RELAY_FEE_CONFIRMATIONS) {
             fMissingConfirmations = true;

--- a/src/instantx.h
+++ b/src/instantx.h
@@ -45,11 +45,12 @@ extern int nCompleteTXLocks;
  */
 class CInstantSend
 {
-private:
-    static const std::string SERIALIZATION_VERSION_STRING;
+public:
     /// Automatic locks of "simple" transactions are only allowed
     /// when mempool usage is lower than this threshold
     static const double AUTO_IX_MEMPOOL_THRESHOLD;
+private:
+    static const std::string SERIALIZATION_VERSION_STRING;
 
     // Keep track of current block height
     int nCachedBlockHeight;

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -344,6 +344,8 @@ void CChainLocksHandler::NewPoWValidBlock(const CBlockIndex* pindex, const std::
         return;
     }
 
+    int64_t curTime = GetAdjustedTime();
+
     // We listen for NewPoWValidBlock so that we can collect all TX ids of all included TXs of newly received blocks
     // We need this information later when we try to sign a new tip, so that we can determine if all included TXs are
     // safe.
@@ -357,13 +359,9 @@ void CChainLocksHandler::NewPoWValidBlock(const CBlockIndex* pindex, const std::
             }
         }
         txs->emplace(tx->GetHash());
-    }
-    blockTxs[pindex->GetBlockHash()] = txs;
-
-    int64_t curTime = GetAdjustedTime();
-    for (auto& tx : block->vtx) {
         txFirstSeenTime.emplace(tx->GetHash(), curTime);
     }
+    blockTxs[pindex->GetBlockHash()] = txs;
 }
 
 void CChainLocksHandler::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int posInBlock)

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -149,6 +149,11 @@ void CChainLocksHandler::ProcessNewChainLock(NodeId from, const llmq::CChainLock
 
     LogPrintf("CChainLocksHandler::%s -- processed new CLSIG (%s), peer=%d\n",
               __func__, clsig.ToString(), from);
+
+    if (lastNotifyChainLockBlockIndex != bestChainLockBlockIndex) {
+        lastNotifyChainLockBlockIndex = bestChainLockBlockIndex;
+        GetMainSignals().NotifyChainLock(bestChainLockBlockIndex);
+    }
 }
 
 void CChainLocksHandler::AcceptedBlockHeader(const CBlockIndex* pindexNew)
@@ -204,6 +209,11 @@ void CChainLocksHandler::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBl
         if (bestChainLockBlockIndex == pindexNew) {
             // we first got the CLSIG, then the header, and then the block was connected.
             // In this case there is no need to continue here.
+            // However, NotifyChainLock might not have been called yet, so call it now if needed
+            if (lastNotifyChainLockBlockIndex != bestChainLockBlockIndex) {
+                lastNotifyChainLockBlockIndex = bestChainLockBlockIndex;
+                GetMainSignals().NotifyChainLock(bestChainLockBlockIndex);
+            }
             return;
         }
 

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -35,12 +35,16 @@ CChainLocksHandler::~CChainLocksHandler()
 {
 }
 
-void CChainLocksHandler::RegisterAsRecoveredSigsListener()
+void CChainLocksHandler::Start()
 {
     quorumSigningManager->RegisterRecoveredSigsListener(this);
+    scheduler->scheduleEvery([&]() {
+        // regularely retry signing the current chaintip as it might have failed before due to missing ixlocks
+        TrySignChainTip();
+    }, 5000);
 }
 
-void CChainLocksHandler::UnregisterAsRecoveredSigsListener()
+void CChainLocksHandler::Stop()
 {
     quorumSigningManager->UnregisterRecoveredSigsListener(this);
 }
@@ -184,30 +188,52 @@ void CChainLocksHandler::AcceptedBlockHeader(const CBlockIndex* pindexNew)
 
 void CChainLocksHandler::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork)
 {
+    // don't call TrySignChainTip directly but instead let the scheduler call it. This way we ensure that cs_main is
+    // never locked and TrySignChainTip is not called twice in parallel
+    LOCK(cs);
+    if (tryLockChainTipScheduled) {
+        return;
+    }
+    tryLockChainTipScheduled = true;
+    scheduler->scheduleFromNow([&]() {
+        TrySignChainTip();
+        LOCK(cs);
+        tryLockChainTipScheduled = false;
+    }, 0);
+}
+
+void CChainLocksHandler::TrySignChainTip()
+{
+    Cleanup();
+
+    const CBlockIndex* pindex;
+    {
+        LOCK(cs_main);
+        pindex = chainActive.Tip();
+    }
+
     if (!fMasternodeMode) {
         return;
     }
-    if (!pindexNew->pprev) {
+    if (!pindex->pprev) {
         return;
     }
     if (!sporkManager.IsSporkActive(SPORK_19_CHAINLOCKS_ENABLED)) {
         return;
     }
 
-    Cleanup();
-
     // DIP8 defines a process called "Signing attempts" which should run before the CLSIG is finalized
     // To simplify the initial implementation, we skip this process and directly try to create a CLSIG
     // This will fail when multiple blocks compete, but we accept this for the initial implementation.
     // Later, we'll add the multiple attempts process.
 
-    uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, pindexNew->nHeight));
-    uint256 msgHash = pindexNew->GetBlockHash();
+    uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, pindex->nHeight));
+    uint256 msgHash = pindex->GetBlockHash();
 
     {
         LOCK(cs);
 
-        if (bestChainLockBlockIndex == pindexNew) {
+        if (bestChainLockBlockIndex == pindex) {
             // we first got the CLSIG, then the header, and then the block was connected.
             // In this case there is no need to continue here.
             // However, NotifyChainLock might not have been called yet, so call it now if needed
@@ -218,26 +244,26 @@ void CChainLocksHandler::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBl
             return;
         }
 
-        if (InternalHasConflictingChainLock(pindexNew->nHeight, pindexNew->GetBlockHash())) {
+        if (InternalHasConflictingChainLock(pindex->nHeight, pindex->GetBlockHash())) {
             if (!inEnforceBestChainLock) {
                 // we accepted this block when there was no lock yet, but now a conflicting lock appeared. Invalidate it.
                 LogPrintf("CChainLocksHandler::%s -- conflicting lock after block was accepted, invalidating now\n",
                           __func__);
-                ScheduleInvalidateBlock(pindexNew);
+                ScheduleInvalidateBlock(pindex);
             }
             return;
         }
 
-        if (bestChainLock.nHeight >= pindexNew->nHeight) {
+        if (bestChainLock.nHeight >= pindex->nHeight) {
             // already got the same CLSIG or a better one
             return;
         }
 
-        if (pindexNew->nHeight == lastSignedHeight) {
+        if (pindex->nHeight == lastSignedHeight) {
             // already signed this one
             return;
         }
-        lastSignedHeight = pindexNew->nHeight;
+        lastSignedHeight = pindex->nHeight;
         lastSignedRequestId = requestId;
         lastSignedMsgHash = msgHash;
     }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -307,7 +307,7 @@ void CChainLocksHandler::TrySignChainTip()
                     }
                 }
 
-                if (txAge < WAIT_FOR_IXLOCK_TIMEOUT && !quorumInstantSendManager->IsLocked(txid)) {
+                if (txAge < WAIT_FOR_ISLOCK_TIMEOUT && !quorumInstantSendManager->IsLocked(txid)) {
                     LogPrintf("CChainLocksHandler::%s -- not signing block %s due to TX %s not being ixlocked and not old enough. age=%d\n", __func__,
                               pindexWalk->GetBlockHash().ToString(), txid.ToString(), txAge);
                     return;
@@ -396,7 +396,7 @@ bool CChainLocksHandler::IsTxSafeForMining(const uint256& txid)
         }
     }
 
-    if (txAge < WAIT_FOR_IXLOCK_TIMEOUT && !quorumInstantSendManager->IsLocked(txid)) {
+    if (txAge < WAIT_FOR_ISLOCK_TIMEOUT && !quorumInstantSendManager->IsLocked(txid)) {
         return false;
     }
     return true;

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -47,7 +47,7 @@ class CChainLocksHandler : public CRecoveredSigsListener
     static const int64_t CLEANUP_SEEN_TIMEOUT = 24 * 60 * 60 * 1000;
 
     // how long to wait for ixlocks until we consider a block with non-ixlocked TXs to be safe to sign
-    static const int64_t WAIT_FOR_IXLOCK_TIMEOUT = 10 * 60;
+    static const int64_t WAIT_FOR_ISLOCK_TIMEOUT = 10 * 60;
 
 private:
     CScheduler* scheduler;

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -49,6 +49,7 @@ class CChainLocksHandler : public CRecoveredSigsListener
 private:
     CScheduler* scheduler;
     CCriticalSection cs;
+    bool tryLockChainTipScheduled{false};
     std::atomic<bool> inEnforceBestChainLock{false};
 
     uint256 bestChainLockHash;
@@ -74,8 +75,8 @@ public:
     CChainLocksHandler(CScheduler* _scheduler);
     ~CChainLocksHandler();
 
-    void RegisterAsRecoveredSigsListener();
-    void UnregisterAsRecoveredSigsListener();
+    void Start();
+    void Stop();
 
     bool AlreadyHave(const CInv& inv);
     bool GetChainLockByHash(const uint256& hash, CChainLockSig& ret);
@@ -86,6 +87,7 @@ public:
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork);
     void NewPoWValidBlock(const CBlockIndex* pindex, const std::shared_ptr<const CBlock>& block);
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock);
+    void TrySignChainTip();
     void EnforceBestChainLock();
     virtual void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -55,6 +55,7 @@ private:
 
     CChainLockSig bestChainLockWithKnownBlock;
     const CBlockIndex* bestChainLockBlockIndex{nullptr};
+    const CBlockIndex* lastNotifyChainLockBlockIndex{nullptr};
 
     int32_t lastSignedHeight{-1};
     uint256 lastSignedRequestId;

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -12,6 +12,7 @@
 #include "chainparams.h"
 
 #include <atomic>
+#include <unordered_set>
 
 class CBlockIndex;
 class CScheduler;
@@ -61,6 +62,10 @@ private:
     uint256 lastSignedRequestId;
     uint256 lastSignedMsgHash;
 
+    // We keep track of txids from recently received blocks so that we can check if all TXs got ixlocked
+    std::unordered_map<uint256, std::shared_ptr<std::unordered_set<uint256, StaticSaltedHasher>>> blockTxs;
+    std::unordered_map<uint256, int64_t> txFirstSeenTime;
+
     std::map<uint256, int64_t> seenChainLocks;
 
     int64_t lastCleanupTime{0};
@@ -79,6 +84,8 @@ public:
     void ProcessNewChainLock(NodeId from, const CChainLockSig& clsig, const uint256& hash);
     void AcceptedBlockHeader(const CBlockIndex* pindexNew);
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork);
+    void NewPoWValidBlock(const CBlockIndex* pindex, const std::shared_ptr<const CBlock>& block);
+    void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock);
     void EnforceBestChainLock();
     virtual void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -46,6 +46,9 @@ class CChainLocksHandler : public CRecoveredSigsListener
     static const int64_t CLEANUP_INTERVAL = 1000 * 30;
     static const int64_t CLEANUP_SEEN_TIMEOUT = 24 * 60 * 60 * 1000;
 
+    // how long to wait for ixlocks until we consider a block with non-ixlocked TXs to be safe to sign
+    static const int64_t WAIT_FOR_IXLOCK_TIMEOUT = 10 * 60;
+
 private:
     CScheduler* scheduler;
     CCriticalSection cs;
@@ -93,6 +96,8 @@ public:
 
     bool HasChainLock(int nHeight, const uint256& blockHash);
     bool HasConflictingChainLock(int nHeight, const uint256& blockHash);
+
+    bool IsTxSafeForMining(const uint256& txid);
 
 private:
     // these require locks to be held already

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -10,6 +10,7 @@
 #include "quorums_chainlocks.h"
 #include "quorums_debug.h"
 #include "quorums_dkgsessionmgr.h"
+#include "quorums_instantsend.h"
 #include "quorums_signing.h"
 #include "quorums_signing_shares.h"
 
@@ -29,10 +30,13 @@ void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests)
     quorumSigSharesManager = new CSigSharesManager();
     quorumSigningManager = new CSigningManager(unitTests);
     chainLocksHandler = new CChainLocksHandler(scheduler);
+    quorumInstantSendManager = new CInstantSendManager(scheduler);
 }
 
 void DestroyLLMQSystem()
 {
+    delete quorumInstantSendManager;
+    quorumInstantSendManager = nullptr;
     delete chainLocksHandler;
     chainLocksHandler = nullptr;
     delete quorumSigningManager;
@@ -64,10 +68,16 @@ void StartLLMQSystem()
     if (chainLocksHandler) {
         chainLocksHandler->RegisterAsRecoveredSigsListener();
     }
+    if (quorumInstantSendManager) {
+        quorumInstantSendManager->RegisterAsRecoveredSigsListener();
+    }
 }
 
 void StopLLMQSystem()
 {
+    if (quorumInstantSendManager) {
+        quorumInstantSendManager->UnregisterAsRecoveredSigsListener();
+    }
     if (chainLocksHandler) {
         chainLocksHandler->UnregisterAsRecoveredSigsListener();
     }

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -66,7 +66,7 @@ void StartLLMQSystem()
         quorumSigSharesManager->StartWorkerThread();
     }
     if (chainLocksHandler) {
-        chainLocksHandler->RegisterAsRecoveredSigsListener();
+        chainLocksHandler->Start();
     }
     if (quorumInstantSendManager) {
         quorumInstantSendManager->RegisterAsRecoveredSigsListener();
@@ -79,7 +79,7 @@ void StopLLMQSystem()
         quorumInstantSendManager->UnregisterAsRecoveredSigsListener();
     }
     if (chainLocksHandler) {
-        chainLocksHandler->UnregisterAsRecoveredSigsListener();
+        chainLocksHandler->Stop();
     }
     if (quorumSigSharesManager) {
         quorumSigSharesManager->StopWorkerThread();

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1,0 +1,883 @@
+// Copyright (c) 2019 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "quorums_chainlocks.h"
+#include "quorums_instantsend.h"
+#include "quorums_utils.h"
+
+#include "bls/bls_batchverifier.h"
+#include "chainparams.h"
+#include "coins.h"
+#include "txmempool.h"
+#include "masternode-sync.h"
+#include "net_processing.h"
+#include "scheduler.h"
+#include "spork.h"
+#include "validation.h"
+#include "wallet/wallet.h"
+
+// needed for nCompleteTXLocks
+#include "instantx.h"
+
+#include <boost/algorithm/string/replace.hpp>
+
+namespace llmq
+{
+
+static const std::string INPUTLOCK_REQUESTID_PREFIX = "inlock";
+static const std::string IXLOCK_REQUESTID_PREFIX = "ixlock";
+
+CInstantSendManager* quorumInstantSendManager;
+
+uint256 CInstantXLock::GetRequestId() const
+{
+    CHashWriter hw(SER_GETHASH, 0);
+    hw << IXLOCK_REQUESTID_PREFIX;
+    hw << inputs;
+    return hw.GetHash();
+}
+
+CInstantSendManager::CInstantSendManager(CScheduler* _scheduler) :
+    scheduler(_scheduler)
+{
+}
+
+CInstantSendManager::~CInstantSendManager()
+{
+}
+
+void CInstantSendManager::RegisterAsRecoveredSigsListener()
+{
+    quorumSigningManager->RegisterRecoveredSigsListener(this);
+}
+
+void CInstantSendManager::UnregisterAsRecoveredSigsListener()
+{
+    quorumSigningManager->UnregisterRecoveredSigsListener(this);
+}
+
+bool CInstantSendManager::ProcessTx(CNode* pfrom, const CTransaction& tx, CConnman& connman, const Consensus::Params& params)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return true;
+    }
+
+    auto llmqType = params.llmqForInstantSend;
+    if (llmqType == Consensus::LLMQ_NONE) {
+        return true;
+    }
+    if (!fMasternodeMode) {
+        return true;
+    }
+
+    // Ignore any InstantSend messages until blockchain is synced
+    if (!masternodeSync.IsBlockchainSynced()) {
+        return true;
+    }
+
+    if (IsConflicted(tx)) {
+        return false;
+    }
+
+    if (!CheckCanLock(tx, true, params)) {
+        return false;
+    }
+
+    std::vector<uint256> ids;
+    ids.reserve(tx.vin.size());
+
+    for (const auto& in : tx.vin) {
+        auto id = ::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, in.prevout));
+        ids.emplace_back(id);
+    }
+
+    {
+        LOCK(cs);
+        size_t alreadyVotedCount = 0;
+        for (size_t i = 0; i < ids.size(); i++) {
+            auto it = inputVotes.find(ids[i]);
+            if (it != inputVotes.end()) {
+                if (it->second != tx.GetHash()) {
+                    LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: input %s is conflicting with ixlock %s\n", __func__,
+                            tx.GetHash().ToString(), tx.vin[i].prevout.ToStringShort(), it->second.ToString());
+                    return false;
+                }
+                alreadyVotedCount++;
+            }
+        }
+        if (alreadyVotedCount == ids.size()) {
+            return true;
+        }
+
+        for (auto& id : ids) {
+            inputVotes.emplace(id, tx.GetHash());
+        }
+    }
+
+    // don't even try the actual signing if any input is conflicting
+    for (auto& id : ids) {
+        if (quorumSigningManager->IsConflicting(llmqType, id, tx.GetHash())) {
+            return false;
+        }
+    }
+    for (auto& id : ids) {
+        quorumSigningManager->AsyncSignIfMember(llmqType, id, tx.GetHash());
+    }
+
+    // We might have received all input locks before we got the corresponding TX. In this case, we have to sign the
+    // ixlock now instead of waiting for the input locks.
+    TrySignInstantXLock(tx);
+
+    return true;
+}
+
+bool CInstantSendManager::CheckCanLock(const CTransaction& tx, bool printDebug, const Consensus::Params& params)
+{
+    int nInstantSendConfirmationsRequired = params.nInstantSendConfirmationsRequired;
+
+    uint256 txHash = tx.GetHash();
+    CAmount nValueIn = 0;
+    for (const auto& in : tx.vin) {
+        CAmount v = 0;
+        if (!CheckCanLock(in.prevout, printDebug, &txHash, &v, params)) {
+            return false;
+        }
+
+        nValueIn += v;
+    }
+
+    // TODO decide if we should limit max input values. This was ok to do in the old system, but in the new system
+    // where we want to have all TXs locked at some point, this is counterproductive (especially when ChainLocks later
+    // depend on all TXs being locked first)
+//    CAmount maxValueIn = sporkManager.GetSporkValue(SPORK_5_INSTANTSEND_MAX_VALUE);
+//    if (nValueIn > maxValueIn * COIN) {
+//        if (printDebug) {
+//            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: TX input value too high. nValueIn=%f, maxValueIn=%d", __func__,
+//                     tx.GetHash().ToString(), nValueIn / (double)COIN, maxValueIn);
+//        }
+//        return false;
+//    }
+
+    return true;
+}
+
+bool CInstantSendManager::CheckCanLock(const COutPoint& outpoint, bool printDebug, const uint256* _txHash, CAmount* retValue, const Consensus::Params& params)
+{
+    int nInstantSendConfirmationsRequired = params.nInstantSendConfirmationsRequired;
+
+    if (IsLocked(outpoint.hash)) {
+        // if prevout was ix locked, allow locking of descendants (no matter if prevout is in mempool or already mined)
+        return true;
+    }
+
+    static uint256 txHashNull;
+    const uint256* txHash = &txHashNull;
+    if (_txHash) {
+        txHash = _txHash;
+    }
+
+    auto mempoolTx = mempool.get(outpoint.hash);
+    if (mempoolTx) {
+        if (printDebug) {
+            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: parent mempool TX %s is not locked\n", __func__,
+                     txHash->ToString(), outpoint.hash.ToString());
+        }
+        return false;
+    }
+
+    Coin coin;
+    const CBlockIndex* pindexMined = nullptr;
+    {
+        LOCK(cs_main);
+        if (!pcoinsTip->GetCoin(outpoint, coin) || coin.IsSpent()) {
+            if (printDebug) {
+                LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: failed to find UTXO %s\n", __func__,
+                         txHash->ToString(), outpoint.ToStringShort());
+            }
+            return false;
+        }
+        pindexMined = chainActive[coin.nHeight];
+    }
+
+    int nTxAge = chainActive.Height() - coin.nHeight + 1;
+    // 1 less than the "send IX" gui requires, in case of a block propagating the network at the time
+    int nConfirmationsRequired = nInstantSendConfirmationsRequired - 1;
+
+    if (nTxAge < nConfirmationsRequired) {
+        if (!llmq::chainLocksHandler->HasChainLock(pindexMined->nHeight, pindexMined->GetBlockHash())) {
+            if (printDebug) {
+                LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: outpoint %s too new and not ChainLocked. nTxAge=%d, nConfirmationsRequired=%d\n", __func__,
+                         txHash->ToString(), outpoint.ToStringShort(), nTxAge, nConfirmationsRequired);
+            }
+            return false;
+        }
+    }
+
+    if (retValue) {
+        *retValue = coin.out.nValue;
+    }
+
+    return true;
+}
+
+void CInstantSendManager::HandleNewRecoveredSig(const CRecoveredSig& recoveredSig)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return;
+    }
+
+    auto llmqType = Params().GetConsensus().llmqForInstantSend;
+    if (llmqType == Consensus::LLMQ_NONE) {
+        return;
+    }
+    auto& params = Params().GetConsensus().llmqs.at(llmqType);
+
+    uint256 txid;
+    bool isInstantXLock = false;
+    {
+        LOCK(cs);
+        auto it = inputVotes.find(recoveredSig.id);
+        if (it != inputVotes.end()) {
+            txid = it->second;
+        }
+        if (creatingInstantXLocks.count(recoveredSig.id)) {
+            isInstantXLock = true;
+        }
+    }
+    if (!txid.IsNull()) {
+        HandleNewInputLockRecoveredSig(recoveredSig, txid);
+    } else if (isInstantXLock) {
+        HandleNewInstantXLockRecoveredSig(recoveredSig);
+    }
+}
+
+void CInstantSendManager::HandleNewInputLockRecoveredSig(const CRecoveredSig& recoveredSig, const uint256& txid)
+{
+    auto llmqType = Params().GetConsensus().llmqForInstantSend;
+
+    CTransactionRef tx;
+    uint256 hashBlock;
+    if (!GetTransaction(txid, tx, Params().GetConsensus(), hashBlock, true)) {
+        return;
+    }
+
+    if (LogAcceptCategory("instantsend")) {
+        for (auto& in : tx->vin) {
+            auto id = ::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, in.prevout));
+            if (id == recoveredSig.id) {
+                LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: got recovered sig for input %s\n", __func__,
+                         txid.ToString(), in.prevout.ToStringShort());
+                break;
+            }
+        }
+    }
+
+    TrySignInstantXLock(*tx);
+}
+
+void CInstantSendManager::TrySignInstantXLock(const CTransaction& tx)
+{
+    auto llmqType = Params().GetConsensus().llmqForInstantSend;
+
+    for (auto& in : tx.vin) {
+        auto id = ::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, in.prevout));
+        if (!quorumSigningManager->HasRecoveredSig(llmqType, id, tx.GetHash())) {
+            return;
+        }
+    }
+
+    LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: got all recovered sigs, creating CInstantXLock\n", __func__,
+            tx.GetHash().ToString());
+
+    CInstantXLockInfo ixlockInfo;
+    ixlockInfo.time = GetTimeMillis();
+    ixlockInfo.ixlock.txid = tx.GetHash();
+    for (auto& in : tx.vin) {
+        ixlockInfo.ixlock.inputs.emplace_back(in.prevout);
+    }
+
+    auto id = ixlockInfo.ixlock.GetRequestId();
+
+    if (quorumSigningManager->HasRecoveredSigForId(llmqType, id)) {
+        return;
+    }
+
+    {
+        LOCK(cs);
+        auto e = creatingInstantXLocks.emplace(id, ixlockInfo);
+        if (!e.second) {
+            return;
+        }
+        txToCreatingInstantXLocks.emplace(tx.GetHash(), &e.first->second);
+    }
+
+    quorumSigningManager->AsyncSignIfMember(llmqType, id, tx.GetHash());
+}
+
+void CInstantSendManager::HandleNewInstantXLockRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
+{
+    CInstantXLockInfo ixlockInfo;
+
+    {
+        LOCK(cs);
+        auto it = creatingInstantXLocks.find(recoveredSig.id);
+        if (it == creatingInstantXLocks.end()) {
+            return;
+        }
+
+        ixlockInfo = std::move(it->second);
+        creatingInstantXLocks.erase(it);
+        txToCreatingInstantXLocks.erase(ixlockInfo.ixlock.txid);
+    }
+
+    if (ixlockInfo.ixlock.txid != recoveredSig.msgHash) {
+        LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: ixlock conflicts with %s, dropping own version", __func__,
+                ixlockInfo.ixlock.txid.ToString(), recoveredSig.msgHash.ToString());
+        return;
+    }
+
+    ixlockInfo.ixlock.sig = recoveredSig.sig;
+    ProcessInstantXLock(-1, ::SerializeHash(ixlockInfo.ixlock), ixlockInfo.ixlock);
+}
+
+void CInstantSendManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return;
+    }
+
+    if (strCommand == NetMsgType::IXLOCK) {
+        CInstantXLock ixlock;
+        vRecv >> ixlock;
+        ProcessMessageInstantXLock(pfrom, ixlock, connman);
+    }
+}
+
+void CInstantSendManager::ProcessMessageInstantXLock(CNode* pfrom, const llmq::CInstantXLock& ixlock, CConnman& connman)
+{
+    bool ban = false;
+    if (!PreVerifyInstantXLock(pfrom->id, ixlock, ban)) {
+        if (ban) {
+            LOCK(cs_main);
+            Misbehaving(pfrom->id, 100);
+        }
+        return;
+    }
+
+    auto hash = ::SerializeHash(ixlock);
+
+    LOCK(cs);
+    if (pendingInstantXLocks.count(hash) || finalInstantXLocks.count(hash)) {
+        return;
+    }
+
+    LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, ixlock=%s: received ixlock, peer=%d\n", __func__,
+            ixlock.txid.ToString(), hash.ToString(), pfrom->id);
+
+    pendingInstantXLocks.emplace(hash, std::make_pair(pfrom->id, std::move(ixlock)));
+
+    if (!hasScheduledProcessPending) {
+        hasScheduledProcessPending = true;
+        scheduler->schedule([&] {
+            ProcessPendingInstantXLocks();
+        }, boost::chrono::system_clock::now() + boost::chrono::milliseconds(100));
+    }
+}
+
+bool CInstantSendManager::PreVerifyInstantXLock(NodeId nodeId, const llmq::CInstantXLock& ixlock, bool& retBan)
+{
+    retBan = false;
+
+    if (ixlock.txid.IsNull() || !ixlock.sig.IsValid() || ixlock.inputs.empty()) {
+        retBan = true;
+        return false;
+    }
+
+    std::set<COutPoint> dups;
+    for (auto& o : ixlock.inputs) {
+        if (!dups.emplace(o).second) {
+            retBan = true;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void CInstantSendManager::ProcessPendingInstantXLocks()
+{
+    auto llmqType = Params().GetConsensus().llmqForInstantSend;
+
+    decltype(pendingInstantXLocks) pend;
+
+    {
+        LOCK(cs);
+        hasScheduledProcessPending = false;
+        pend = std::move(pendingInstantXLocks);
+    }
+
+    if (!IsNewInstantSendEnabled()) {
+        return;
+    }
+
+    int tipHeight;
+    {
+        LOCK(cs_main);
+        tipHeight = chainActive.Height();
+    }
+
+    CBLSBatchVerifier<NodeId, uint256> batchVerifier(false, true, 8);
+    std::unordered_map<uint256, std::pair<CQuorumCPtr, CRecoveredSig>> recSigs;
+
+    for (const auto& p : pend) {
+        auto& hash = p.first;
+        auto nodeId = p.second.first;
+        auto& ixlock = p.second.second;
+
+        auto id = ixlock.GetRequestId();
+
+        // no need to verify an IXLOCK if we already have verified the recovered sig that belongs to it
+        if (quorumSigningManager->HasRecoveredSig(llmqType, id, ixlock.txid)) {
+            continue;
+        }
+
+        auto quorum = quorumSigningManager->SelectQuorumForSigning(llmqType, tipHeight, id);
+        if (!quorum) {
+            // should not happen, but if one fails to select, all others will also fail to select
+            return;
+        }
+        uint256 signHash = CLLMQUtils::BuildSignHash(llmqType, quorum->quorumHash, id, ixlock.txid);
+        batchVerifier.PushMessage(nodeId, hash, signHash, ixlock.sig, quorum->quorumPublicKey);
+
+        // We can reconstruct the CRecoveredSig objects from the ixlock and pass it to the signing manager, which
+        // avoids unnecessary double-verification of the signature. We however only do this when verification here
+        // turns out to be good (which is checked further down)
+        if (!quorumSigningManager->HasRecoveredSigForId(llmqType, id)) {
+            CRecoveredSig recSig;
+            recSig.llmqType = llmqType;
+            recSig.quorumHash = quorum->quorumHash;
+            recSig.id = id;
+            recSig.msgHash = ixlock.txid;
+            recSig.sig = ixlock.sig;
+            recSigs.emplace(std::piecewise_construct,
+                    std::forward_as_tuple(hash),
+                    std::forward_as_tuple(std::move(quorum), std::move(recSig)));
+        }
+    }
+
+    batchVerifier.Verify();
+
+    if (!batchVerifier.badSources.empty()) {
+        LOCK(cs_main);
+        for (auto& nodeId : batchVerifier.badSources) {
+            // Let's not be too harsh, as the peer might simply be unlucky and might have sent us an old lock which
+            // does not validate anymore due to changed quorums
+            Misbehaving(nodeId, 20);
+        }
+    }
+    for (const auto& p : pend) {
+        auto& hash = p.first;
+        auto nodeId = p.second.first;
+        auto& ixlock = p.second.second;
+
+        if (batchVerifier.badMessages.count(hash)) {
+            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, ixlock=%s: invalid sig in ixlock, peer=%d\n", __func__,
+                     ixlock.txid.ToString(), hash.ToString(), nodeId);
+            continue;
+        }
+
+        ProcessInstantXLock(nodeId, hash, ixlock);
+
+        // See comment further on top. We pass a reconstructed recovered sig to the signing manager to avoid
+        // double-verification of the sig.
+        auto it = recSigs.find(hash);
+        if (it != recSigs.end()) {
+            auto& quorum = it->second.first;
+            auto& recSig = it->second.second;
+            if (!quorumSigningManager->HasRecoveredSigForId(llmqType, recSig.id)) {
+                recSig.UpdateHash();
+                LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, ixlock=%s: passing reconstructed recSig to signing mgr, peer=%d\n", __func__,
+                         ixlock.txid.ToString(), hash.ToString(), nodeId);
+                quorumSigningManager->PushReconstructedRecoveredSig(recSig, quorum);
+            }
+        }
+    }
+}
+
+void CInstantSendManager::ProcessInstantXLock(NodeId from, const uint256& hash, const CInstantXLock& ixlock)
+{
+    {
+        LOCK(cs_main);
+        g_connman->RemoveAskFor(hash);
+    }
+
+    CInstantXLockInfo ixlockInfo;
+    ixlockInfo.time = GetTimeMillis();
+    ixlockInfo.ixlock = ixlock;
+    ixlockInfo.ixlockHash = hash;
+
+    uint256 hashBlock;
+    // we ignore failure here as we must be able to propagate the lock even if we don't have the TX locally
+    if (GetTransaction(ixlock.txid, ixlockInfo.tx, Params().GetConsensus(), hashBlock)) {
+        if (!hashBlock.IsNull()) {
+            {
+                LOCK(cs_main);
+                ixlockInfo.pindexMined = mapBlockIndex.at(hashBlock);
+            }
+
+            // Let's see if the TX that was locked by this ixlock is already mined in a ChainLocked block. If yes,
+            // we can simply ignore the ixlock, as the ChainLock implies locking of all TXs in that chain
+            if (llmq::chainLocksHandler->HasChainLock(ixlockInfo.pindexMined->nHeight, ixlockInfo.pindexMined->GetBlockHash())) {
+                LogPrint("instantsend", "CInstantSendManager::%s -- txlock=%s, ixlock=%s: dropping ixlock as it already got a ChainLock in block %s, peer=%d\n", __func__,
+                         ixlock.txid.ToString(), hash.ToString(), hashBlock.ToString(), from);
+                return;
+            }
+        }
+    }
+
+    {
+        LOCK(cs);
+        auto e = finalInstantXLocks.emplace(hash, ixlockInfo);
+        if (!e.second) {
+            return;
+        }
+        auto ixlockInfoPtr = &e.first->second;
+
+        creatingInstantXLocks.erase(ixlockInfoPtr->ixlock.GetRequestId());
+        txToCreatingInstantXLocks.erase(ixlockInfoPtr->ixlock.txid);
+
+        LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, ixlock=%s: processsing ixlock, peer=%d\n", __func__,
+                 ixlock.txid.ToString(), hash.ToString(), from);
+
+        if (!txToInstantXLock.emplace(ixlock.txid, ixlockInfoPtr).second) {
+            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, ixlock=%s: duplicate ixlock, other ixlock=%s, peer=%d\n", __func__,
+                    ixlock.txid.ToString(), hash.ToString(), txToInstantXLock[ixlock.txid]->ixlockHash.ToString(), from);
+            txToInstantXLock.erase(hash);
+            return;
+        }
+        for (size_t i = 0; i < ixlock.inputs.size(); i++) {
+            auto& in = ixlock.inputs[i];
+            if (!inputToInstantXLock.emplace(in, ixlockInfoPtr).second) {
+                LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, ixlock=%s: conflicting input in ixlock. input=%s, other ixlock=%s, peer=%d\n", __func__,
+                         ixlock.txid.ToString(), hash.ToString(), in.ToStringShort(), inputToInstantXLock[in]->ixlockHash.ToString(), from);
+                txToInstantXLock.erase(hash);
+                for (size_t j = 0; j < i; j++) {
+                    inputToInstantXLock.erase(ixlock.inputs[j]);
+                }
+                return;
+            }
+        }
+    }
+
+    CInv inv(MSG_IXLOCK, hash);
+    g_connman->RelayInv(inv);
+
+    RemoveMempoolConflictsForLock(hash, ixlock);
+    RetryLockMempoolTxs(ixlock.txid);
+
+    UpdateWalletTransaction(ixlock.txid);
+}
+
+void CInstantSendManager::UpdateWalletTransaction(const uint256& txid)
+{
+#ifdef ENABLE_WALLET
+    if (!pwalletMain) {
+        return;
+    }
+
+    if (pwalletMain->UpdatedTransaction(txid)) {
+        // bumping this to update UI
+        nCompleteTXLocks++;
+        // notify an external script once threshold is reached
+        std::string strCmd = GetArg("-instantsendnotify", "");
+        if (!strCmd.empty()) {
+            boost::replace_all(strCmd, "%s", txid.GetHex());
+            boost::thread t(runCommand, strCmd); // thread runs free
+        }
+    }
+#endif
+
+    LOCK(cs);
+    auto it = txToInstantXLock.find(txid);
+    if (it == txToInstantXLock.end()) {
+        return;
+    }
+    if (it->second->tx == nullptr) {
+        return;
+    }
+
+    GetMainSignals().NotifyTransactionLock(*it->second->tx);
+}
+
+void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int posInBlock)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return;
+    }
+
+    {
+        LOCK(cs);
+        auto it = txToInstantXLock.find(tx.GetHash());
+        if (it == txToInstantXLock.end()) {
+            return;
+        }
+        auto ixlockInfo = it->second;
+        if (ixlockInfo->tx == nullptr) {
+            ixlockInfo->tx = MakeTransactionRef(tx);
+        }
+
+        if (posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK) {
+            UpdateIxLockMinedBlock(ixlockInfo, nullptr);
+            return;
+        }
+        UpdateIxLockMinedBlock(ixlockInfo, pindex);
+    }
+
+    if (IsLocked(tx.GetHash())) {
+        RetryLockMempoolTxs(tx.GetHash());
+    }
+}
+
+void CInstantSendManager::NotifyChainLock(const CBlockIndex* pindex)
+{
+    {
+        LOCK(cs);
+
+        // Let's find all ixlocks that correspond to TXs which are part of the freshly ChainLocked chain and then delete
+        // the ixlocks. We do this because the ChainLocks imply locking and thus it's not needed to further track
+        // or propagate the ixlocks
+        std::unordered_set<uint256> toDelete;
+        while (pindex && pindex != pindexLastChainLock) {
+            auto its = blockToInstantXLocks.equal_range(pindex->GetBlockHash());
+            while (its.first != its.second) {
+                auto ixlockInfo = its.first->second;
+                LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, ixlock=%s: removing ixlock as it got ChainLocked in block %s\n", __func__,
+                         ixlockInfo->ixlock.txid.ToString(), ixlockInfo->ixlockHash.ToString(), pindex->GetBlockHash().ToString());
+                toDelete.emplace(its.first->second->ixlockHash);
+                ++its.first;
+            }
+
+            pindex = pindex->pprev;
+        }
+
+        pindexLastChainLock = pindex;
+
+        for (auto& ixlockHash : toDelete) {
+            RemoveFinalIxLock(ixlockHash);
+        }
+    }
+
+    RetryLockMempoolTxs(uint256());
+}
+
+void CInstantSendManager::UpdateIxLockMinedBlock(llmq::CInstantXLockInfo* ixlockInfo, const CBlockIndex* pindex)
+{
+    AssertLockHeld(cs);
+    
+    if (ixlockInfo->pindexMined == pindex) {
+        return;
+    }
+    
+    if (ixlockInfo->pindexMined) {
+        auto its = blockToInstantXLocks.equal_range(ixlockInfo->pindexMined->GetBlockHash());
+        while (its.first != its.second) {
+            if (its.first->second == ixlockInfo) {
+                its.first = blockToInstantXLocks.erase(its.first);
+            } else {
+                ++its.first;
+            }
+        }
+    }
+    
+    if (pindex) {
+        blockToInstantXLocks.emplace(pindex->GetBlockHash(), ixlockInfo);
+    }
+    
+    ixlockInfo->pindexMined = pindex;
+}
+
+void CInstantSendManager::RemoveFinalIxLock(const uint256& hash)
+{
+    AssertLockHeld(cs);
+    
+    auto it = finalInstantXLocks.find(hash);
+    if (it == finalInstantXLocks.end()) {
+        return;
+    }
+    auto& ixlockInfo = it->second;
+
+    txToInstantXLock.erase(ixlockInfo.ixlock.txid);
+    for (auto& in : ixlockInfo.ixlock.inputs) {
+        auto inputRequestId = ::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, in));
+        inputVotes.erase(inputRequestId);
+        inputToInstantXLock.erase(in);
+    }
+    UpdateIxLockMinedBlock(&ixlockInfo, nullptr);
+}
+
+void CInstantSendManager::RemoveMempoolConflictsForLock(const uint256& hash, const CInstantXLock& ixlock)
+{
+    LOCK(mempool.cs);
+
+    std::unordered_map<uint256, CTransactionRef> toDelete;
+
+    for (auto& in : ixlock.inputs) {
+        auto it = mempool.mapNextTx.find(in);
+        if (it == mempool.mapNextTx.end()) {
+            continue;
+        }
+        if (it->second->GetHash() != ixlock.txid) {
+            toDelete.emplace(it->second->GetHash(), mempool.get(it->second->GetHash()));
+
+            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, ixlock=%s: mempool TX %s with input %s conflicts with ixlock\n", __func__,
+                     ixlock.txid.ToString(), hash.ToString(), it->second->GetHash().ToString(), in.ToStringShort());
+        }
+    }
+
+    for (auto& p : toDelete) {
+        mempool.removeRecursive(*p.second, MemPoolRemovalReason::CONFLICT);
+    }
+}
+
+void CInstantSendManager::RetryLockMempoolTxs(const uint256& lockedParentTx)
+{
+    // Let's retry all mempool TXs which don't have an ixlock yet and where the parents got ChainLocked now
+
+    std::unordered_map<uint256, CTransactionRef> txs;
+
+    {
+        LOCK(mempool.cs);
+
+        if (lockedParentTx.IsNull()) {
+            txs.reserve(mempool.mapTx.size());
+            for (auto it = mempool.mapTx.begin(); it != mempool.mapTx.end(); ++it) {
+                txs.emplace(it->GetTx().GetHash(), it->GetSharedTx());
+            }
+        } else {
+            auto it = mempool.mapNextTx.lower_bound(COutPoint(lockedParentTx, 0));
+            while (it != mempool.mapNextTx.end() && it->first->hash == lockedParentTx) {
+                txs.emplace(it->second->GetHash(), mempool.get(it->second->GetHash()));
+                ++it;
+            }
+        }
+    }
+    for (auto& p : txs) {
+        auto& tx = p.second;
+        {
+            LOCK(cs);
+            if (txToCreatingInstantXLocks.count(tx->GetHash())) {
+                // we're already in the middle of locking this one
+                continue;
+            }
+            if (IsLocked(tx->GetHash())) {
+                continue;
+            }
+            if (IsConflicted(*tx)) {
+                // should not really happen as we have already filtered these out
+                continue;
+            }
+        }
+
+        // CheckCanLock is already called by ProcessTx, so we should avoid calling it twice. But we also shouldn't spam
+        // the logs when retrying TXs that are not ready yet.
+        if (LogAcceptCategory("instantsend")) {
+            if (!CheckCanLock(*tx, false, Params().GetConsensus())) {
+                continue;
+            }
+            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: retrying to lock\n", __func__,
+                     tx->GetHash().ToString());
+        }
+
+        ProcessTx(nullptr, *tx, *g_connman, Params().GetConsensus());
+    }
+}
+
+bool CInstantSendManager::AlreadyHave(const CInv& inv)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return true;
+    }
+
+    LOCK(cs);
+    return finalInstantXLocks.count(inv.hash) != 0 || pendingInstantXLocks.count(inv.hash) != 0;
+}
+
+bool CInstantSendManager::GetInstantXLockByHash(const uint256& hash, llmq::CInstantXLock& ret)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return false;
+    }
+
+    LOCK(cs);
+    auto it = finalInstantXLocks.find(hash);
+    if (it == finalInstantXLocks.end()) {
+        return false;
+    }
+    ret = it->second.ixlock;
+    return true;
+}
+
+bool CInstantSendManager::IsLocked(const uint256& txHash)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return false;
+    }
+
+    LOCK(cs);
+    return txToInstantXLock.count(txHash) != 0;
+}
+
+bool CInstantSendManager::IsConflicted(const CTransaction& tx)
+{
+    LOCK(cs);
+    uint256 dummy;
+    return GetConflictingTx(tx, dummy);
+}
+
+bool CInstantSendManager::GetConflictingTx(const CTransaction& tx, uint256& retConflictTxHash)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return false;
+    }
+
+    LOCK(cs);
+    for (const auto& in : tx.vin) {
+        auto it = inputToInstantXLock.find(in.prevout);
+        if (it == inputToInstantXLock.end()) {
+            continue;
+        }
+
+        if (it->second->ixlock.txid != tx.GetHash()) {
+            retConflictTxHash = it->second->ixlock.txid;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool IsOldInstantSendEnabled()
+{
+    int spork2Value = sporkManager.GetSporkValue(SPORK_2_INSTANTSEND_ENABLED);
+    if (spork2Value == 0) {
+        return true;
+    }
+    return false;
+}
+
+bool IsNewInstantSendEnabled()
+{
+    int spork2Value = sporkManager.GetSporkValue(SPORK_2_INSTANTSEND_ENABLED);
+    if (spork2Value == 1) {
+        return true;
+    }
+    return false;
+}
+
+bool IsInstantSendEnabled()
+{
+    int spork2Value = sporkManager.GetSporkValue(SPORK_2_INSTANTSEND_ENABLED);
+    return spork2Value == 0 || spork2Value == 1;
+}
+
+}

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -15,7 +15,10 @@
 #include "scheduler.h"
 #include "spork.h"
 #include "validation.h"
+
+#ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
+#endif
 
 // needed for nCompleteTXLocks
 #include "instantx.h"

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -137,6 +137,10 @@ bool CInstantSendManager::ProcessTx(CNode* pfrom, const CTransaction& tx, CConnm
 
 bool CInstantSendManager::CheckCanLock(const CTransaction& tx, bool printDebug, const Consensus::Params& params)
 {
+    if (sporkManager.IsSporkActive(SPORK_16_INSTANTSEND_AUTOLOCKS) && (mempool.UsedMemoryShare() > CInstantSend::AUTO_IX_MEMPOOL_THRESHOLD)) {
+        return false;
+    }
+
     int nInstantSendConfirmationsRequired = params.nInstantSendConfirmationsRequired;
 
     uint256 txHash = tx.GetHash();

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -382,9 +382,9 @@ void CInstantSendManager::ProcessMessageInstantXLock(CNode* pfrom, const llmq::C
 
     if (!hasScheduledProcessPending) {
         hasScheduledProcessPending = true;
-        scheduler->schedule([&] {
+        scheduler->scheduleFromNow([&] {
             ProcessPendingInstantXLocks();
-        }, boost::chrono::system_clock::now() + boost::chrono::milliseconds(100));
+        }, 100);
     }
 }
 

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -861,26 +861,17 @@ bool CInstantSendManager::GetConflictingTx(const CTransaction& tx, uint256& retC
 
 bool IsOldInstantSendEnabled()
 {
-    int spork2Value = sporkManager.GetSporkValue(SPORK_2_INSTANTSEND_ENABLED);
-    if (spork2Value == 0) {
-        return true;
-    }
-    return false;
+    return sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED) && !sporkManager.IsSporkActive(SPORK_20_INSTANTSEND_LLMQ_BASED);
 }
 
 bool IsNewInstantSendEnabled()
 {
-    int spork2Value = sporkManager.GetSporkValue(SPORK_2_INSTANTSEND_ENABLED);
-    if (spork2Value == 1) {
-        return true;
-    }
-    return false;
+    return sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED) && sporkManager.IsSporkActive(SPORK_20_INSTANTSEND_LLMQ_BASED);
 }
 
 bool IsInstantSendEnabled()
 {
-    int spork2Value = sporkManager.GetSporkValue(SPORK_2_INSTANTSEND_ENABLED);
-    return spork2Value == 0 || spork2Value == 1;
+    return sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED);
 }
 
 }

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -721,6 +721,7 @@ void CInstantSendManager::RemoveFinalISLock(const uint256& hash)
         inputToInstantSendLock.erase(in);
     }
     UpdateISLockMinedBlock(&islockInfo, nullptr);
+    finalInstantSendLocks.erase(it);
 }
 
 void CInstantSendManager::RemoveMempoolConflictsForLock(const uint256& hash, const CInstantSendLock& islock)

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -1,0 +1,149 @@
+// Copyright (c) 2019 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DASH_QUORUMS_INSTANTX_H
+#define DASH_QUORUMS_INSTANTX_H
+
+#include "quorums_signing.h"
+
+#include "coins.h"
+#include "primitives/transaction.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+class CScheduler;
+
+namespace llmq
+{
+
+class CInstantXLock
+{
+public:
+    std::vector<COutPoint> inputs;
+    uint256 txid;
+    CBLSSignature sig;
+
+public:
+    ADD_SERIALIZE_METHODS
+
+    template<typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(inputs);
+        READWRITE(txid);
+        READWRITE(sig);
+    }
+
+    uint256 GetRequestId() const;
+};
+
+class CInstantXLockInfo
+{
+public:
+    // might be nullptr when ixlock is received before the TX itself
+    CTransactionRef tx;
+    CInstantXLock ixlock;
+    // only valid when recovered sig was received
+    uint256 ixlockHash;
+    // time when it was created/received
+    int64_t time;
+
+    // might be null initially (when TX was not mined yet) and will later be filled by SyncTransaction
+    const CBlockIndex* pindexMined{nullptr};
+};
+
+class CInstantSendManager : public CRecoveredSigsListener
+{
+private:
+    CCriticalSection cs;
+    CScheduler* scheduler;
+
+    /**
+     * These are the votes/signatures we performed locally. It's indexed by the LLMQ requestId, which is
+     * hash(TXLOCK_REQUESTID_PREFIX, prevout). The map values are the txids we voted for. This map is used to
+     * avoid voting for the same input twice.
+     */
+    std::unordered_map<uint256, uint256, StaticSaltedHasher> inputVotes;
+
+    /**
+     * These are the ixlocks that are currently in the middle of being created. Entries are created when we observed
+     * recovered signatures for all inputs of a TX. At the same time, we initiate signing of our sigshare for the ixlock.
+     * When the recovered sig for the ixlock later arrives, we can finish the ixlock and propagate it.
+     */
+    std::unordered_map<uint256, CInstantXLockInfo, StaticSaltedHasher> creatingInstantXLocks;
+    // maps from txid to the in-progress ixlock
+    std::unordered_map<uint256, CInstantXLockInfo*, StaticSaltedHasher> txToCreatingInstantXLocks;
+
+    /**
+     * These are the final ixlocks, indexed by their own hash. The other maps are used to get from TXs, inputs and blocks
+     * to ixlocks.
+     */
+    std::unordered_map<uint256, CInstantXLockInfo, StaticSaltedHasher> finalInstantXLocks;
+    std::unordered_map<uint256, CInstantXLockInfo*, StaticSaltedHasher> txToInstantXLock;
+    std::unordered_map<COutPoint, CInstantXLockInfo*, SaltedOutpointHasher> inputToInstantXLock;
+    std::unordered_multimap<uint256, CInstantXLockInfo*, StaticSaltedHasher> blockToInstantXLocks;
+
+    const CBlockIndex* pindexLastChainLock{nullptr};
+
+    // Incoming and not verified yet
+    std::unordered_map<uint256, std::pair<NodeId, CInstantXLock>> pendingInstantXLocks;
+    bool hasScheduledProcessPending{false};
+
+public:
+    CInstantSendManager(CScheduler* _scheduler);
+    ~CInstantSendManager();
+
+    void RegisterAsRecoveredSigsListener();
+    void UnregisterAsRecoveredSigsListener();
+
+public:
+    bool ProcessTx(CNode* pfrom, const CTransaction& tx, CConnman& connman, const Consensus::Params& params);
+    bool CheckCanLock(const CTransaction& tx, bool printDebug, const Consensus::Params& params);
+    bool CheckCanLock(const COutPoint& outpoint, bool printDebug, const uint256* _txHash, CAmount* retValue, const Consensus::Params& params);
+    bool IsLocked(const uint256& txHash);
+    bool IsConflicted(const CTransaction& tx);
+    bool GetConflictingTx(const CTransaction& tx, uint256& retConflictTxHash);
+
+    virtual void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);
+    void HandleNewInputLockRecoveredSig(const CRecoveredSig& recoveredSig, const uint256& txid);
+    void HandleNewInstantXLockRecoveredSig(const CRecoveredSig& recoveredSig);
+
+    void TrySignInstantXLock(const CTransaction& tx);
+
+    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
+    void ProcessMessageInstantXLock(CNode* pfrom, const CInstantXLock& ixlock, CConnman& connman);
+    bool PreVerifyInstantXLock(NodeId nodeId, const CInstantXLock& ixlock, bool& retBan);
+    void ProcessPendingInstantXLocks();
+    void ProcessInstantXLock(NodeId from, const uint256& hash, const CInstantXLock& ixlock);
+    void UpdateWalletTransaction(const uint256& txid);
+
+    void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock);
+    void NotifyChainLock(const CBlockIndex* pindex);
+    void UpdateIxLockMinedBlock(CInstantXLockInfo* ixlockInfo, const CBlockIndex* pindex);
+    void RemoveFinalIxLock(const uint256& hash);
+
+    void RemoveMempoolConflictsForLock(const uint256& hash, const CInstantXLock& ixlock);
+    void RetryLockMempoolTxs(const uint256& lockedParentTx);
+
+    bool AlreadyHave(const CInv& inv);
+    bool GetInstantXLockByHash(const uint256& hash, CInstantXLock& ret);
+};
+
+extern CInstantSendManager* quorumInstantSendManager;
+
+// The meaning of spork 2 has changed in v0.14. Before that, spork 2 was simply time based and either enabled or not
+// After 0.14, spork 2 can have 3 states.
+// 0 = old system is active (0 is compatible with the value set on mainnet at time of deployment)
+// 1 = new system is active (old nodes will interpret this as the old system being enabled, but then won't get enough IX lock votes)
+// everything else = disabled
+// TODO When the new system is fully deployed and enabled, we can remove this special handling of the spork in a future version
+// and revert to the old behaviour.
+bool IsOldInstantSendEnabled();
+bool IsNewInstantSendEnabled();
+bool IsInstantSendEnabled();
+
+}
+
+#endif//DASH_QUORUMS_INSTANTX_H

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -133,13 +133,11 @@ public:
 
 extern CInstantSendManager* quorumInstantSendManager;
 
-// The meaning of spork 2 has changed in v0.14. Before that, spork 2 was simply time based and either enabled or not
-// After 0.14, spork 2 can have 3 states.
-// 0 = old system is active (0 is compatible with the value set on mainnet at time of deployment)
-// 1 = new system is active (old nodes will interpret this as the old system being enabled, but then won't get enough IX lock votes)
-// everything else = disabled
-// TODO When the new system is fully deployed and enabled, we can remove this special handling of the spork in a future version
-// and revert to the old behaviour.
+// This involves 2 sporks: SPORK_2_INSTANTSEND_ENABLED and SPORK_20_INSTANTSEND_LLMQ_BASED
+// SPORK_2_INSTANTSEND_ENABLED generally enables/disables InstantSend and SPORK_20_INSTANTSEND_LLMQ_BASED switches
+// between the old and the new (LLMQ based) system
+// TODO When the new system is fully deployed and enabled, we can remove this special handling in a future version
+// and revert to only using SPORK_2_INSTANTSEND_ENABLED.
 bool IsOldInstantSendEnabled();
 bool IsNewInstantSendEnabled();
 bool IsInstantSendEnabled();

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -440,7 +440,7 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
     }
 }
 
-bool CSigningManager::ProcessPendingReconstructedRecoveredSigs()
+void CSigningManager::ProcessPendingReconstructedRecoveredSigs()
 {
     decltype(pendingReconstructedRecoveredSigs) l;
     {

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -543,7 +543,7 @@ void CSigningManager::ProcessRecoveredSig(NodeId nodeId, const CRecoveredSig& re
                 } else {
                     // Looks like we're trying to process a recSig that is already known. This might happen if the same
                     // recSig comes in through regular QRECSIG messages and at the same time through some other message
-                    // which allowed to reconstruct a recSig (e.g. IXLOCK). In this case, just bail out.
+                    // which allowed to reconstruct a recSig (e.g. ISLOCK). In this case, just bail out.
                 }
                 return;
             } else {

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -126,6 +126,7 @@ private:
 
     // Incoming and not verified yet
     std::unordered_map<NodeId, std::list<CRecoveredSig>> pendingRecoveredSigs;
+    std::list<std::pair<CRecoveredSig, CQuorumCPtr>> pendingReconstructedRecoveredSigs;
 
     // must be protected by cs
     FastRandomContext rnd;
@@ -142,6 +143,10 @@ public:
 
     void ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
+    // This is called when a recovered signature was was reconstructed from another P2P message and is known to be valid
+    // This is the case for example when a signature appears as part of InstantSend or ChainLocks
+    void PushReconstructedRecoveredSig(const CRecoveredSig& recoveredSig, const CQuorumCPtr& quorum);
+
 private:
     void ProcessMessageRecoveredSig(CNode* pfrom, const CRecoveredSig& recoveredSig, CConnman& connman);
     bool PreVerifyRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, bool& retBan);
@@ -149,6 +154,7 @@ private:
     void CollectPendingRecoveredSigsToVerify(size_t maxUniqueSessions,
             std::unordered_map<NodeId, std::list<CRecoveredSig>>& retSigShares,
             std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr, StaticSaltedHasher>& retQuorums);
+    bool ProcessPendingReconstructedRecoveredSigs();
     bool ProcessPendingRecoveredSigs(CConnman& connman); // called from the worker thread of CSigSharesManager
     void ProcessRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, const CQuorumCPtr& quorum, CConnman& connman);
     void Cleanup(); // called from the worker thread of CSigSharesManager

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -154,7 +154,7 @@ private:
     void CollectPendingRecoveredSigsToVerify(size_t maxUniqueSessions,
             std::unordered_map<NodeId, std::list<CRecoveredSig>>& retSigShares,
             std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr, StaticSaltedHasher>& retQuorums);
-    bool ProcessPendingReconstructedRecoveredSigs();
+    void ProcessPendingReconstructedRecoveredSigs();
     bool ProcessPendingRecoveredSigs(CConnman& connman); // called from the worker thread of CSigSharesManager
     void ProcessRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, const CQuorumCPtr& quorum, CConnman& connman);
     void Cleanup(); // called from the worker thread of CSigSharesManager

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -454,7 +454,8 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             continue;
         }
 
-        if (!llmq::chainLocksHandler->IsTxSafeForMining(mi->GetTx().GetHash())) {
+        if (mi != mempool.mapTx.get<ancestor_score>().end() &&
+                !llmq::chainLocksHandler->IsTxSafeForMining(mi->GetTx().GetHash())) {
             ++mi;
             continue;
         }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -287,11 +287,15 @@ bool BlockAssembler::TestPackage(uint64_t packageSize, unsigned int packageSigOp
 
 // Perform transaction-level checks before adding to block:
 // - transaction finality (locktime)
+// - safe TXs in regard to ChainLocks
 bool BlockAssembler::TestPackageTransactions(const CTxMemPool::setEntries& package)
 {
     BOOST_FOREACH (const CTxMemPool::txiter it, package) {
         if (!IsFinalTx(it->GetTx(), nHeight, nLockTimeCutoff))
             return false;
+        if (!llmq::chainLocksHandler->IsTxSafeForMining(it->GetTx().GetHash())) {
+            return false;
+        }
     }
     return true;
 }
@@ -332,6 +336,10 @@ bool BlockAssembler::TestForBlock(CTxMemPool::txiter iter)
     // as long as reorgs keep the mempool consistent.
     if (!IsFinalTx(iter->GetTx(), nHeight, nLockTimeCutoff))
         return false;
+
+    if (!llmq::chainLocksHandler->IsTxSafeForMining(iter->GetTx().GetHash())) {
+        return false;
+    }
 
     return true;
 }
@@ -454,12 +462,6 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             continue;
         }
 
-        if (mi != mempool.mapTx.get<ancestor_score>().end() &&
-                !llmq::chainLocksHandler->IsTxSafeForMining(mi->GetTx().GetHash())) {
-            ++mi;
-            continue;
-        }
-
         // Now that mi is not stale, determine which transaction to evaluate:
         // the next entry from mapTx, or the best from mapModifiedTx?
         bool fUsingModified = false;
@@ -530,7 +532,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         onlyUnconfirmed(ancestors);
         ancestors.insert(iter);
 
-        // Test if all tx's are Final
+        // Test if all tx's are Final and safe
         if (!TestPackageTransactions(ancestors)) {
             if (fUsingModified) {
                 mapModifiedTx.get<ancestor_score>().erase(modit);
@@ -605,10 +607,6 @@ void BlockAssembler::addPriorityTxs()
         // then put it in the waitSet
         if (isStillDependent(iter)) {
             waitPriMap.insert(std::make_pair(iter, actualPriority));
-            continue;
-        }
-
-        if (!llmq::chainLocksHandler->IsTxSafeForMining(iter->GetTx().GetHash())) {
             continue;
         }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -34,6 +34,7 @@
 #include "evo/deterministicmns.h"
 
 #include "llmq/quorums_blockprocessor.h"
+#include "llmq/quorums_chainlocks.h"
 
 #include <algorithm>
 #include <boost/thread.hpp>
@@ -453,6 +454,11 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             continue;
         }
 
+        if (!llmq::chainLocksHandler->IsTxSafeForMining(mi->GetTx().GetHash())) {
+            ++mi;
+            continue;
+        }
+
         // Now that mi is not stale, determine which transaction to evaluate:
         // the next entry from mapTx, or the best from mapModifiedTx?
         bool fUsingModified = false;
@@ -598,6 +604,10 @@ void BlockAssembler::addPriorityTxs()
         // then put it in the waitSet
         if (isStillDependent(iter)) {
             waitPriMap.insert(std::make_pair(iter, actualPriority));
+            continue;
+        }
+
+        if (!llmq::chainLocksHandler->IsTxSafeForMining(iter->GetTx().GetHash())) {
             continue;
         }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2094,6 +2094,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 instantsend.Vote(tx.GetHash(), connman);
             }
 
+            if (nInvType != MSG_TXLOCK_REQUEST) {
+                llmq::quorumInstantSendManager->ProcessTx(pfrom, tx, connman, chainparams.GetConsensus());
+            }
+
             mempool.check(pcoinsTip);
             connman.RelayTransaction(tx);
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
@@ -2138,6 +2142,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                             vWorkQueue.emplace_back(orphanHash, i);
                         }
                         vEraseQueue.push_back(orphanHash);
+
+                        llmq::quorumInstantSendManager->ProcessTx(pfrom, orphanTx, connman, chainparams.GetConsensus());
                     }
                     else if (!fMissingInputs2)
                     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -977,7 +977,7 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         return llmq::quorumSigningManager->AlreadyHave(inv);
     case MSG_CLSIG:
         return llmq::chainLocksHandler->AlreadyHave(inv);
-    case MSG_IXLOCK:
+    case MSG_ISLOCK:
         return llmq::quorumInstantSendManager->AlreadyHave(inv);
     }
 
@@ -1299,10 +1299,10 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     }
                 }
 
-                if (!push && (inv.type == MSG_IXLOCK)) {
-                    llmq::CInstantXLock o;
-                    if (llmq::quorumInstantSendManager->GetInstantXLockByHash(inv.hash, o)) {
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::IXLOCK, o));
+                if (!push && (inv.type == MSG_ISLOCK)) {
+                    llmq::CInstantSendLock o;
+                    if (llmq::quorumInstantSendManager->GetInstantSendLockByHash(inv.hash, o)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::ISLOCK, o));
                         push = true;
                     }
                 }
@@ -1788,7 +1788,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                             case MSG_CLSIG:
                                 doubleRequestDelay = 5 * 1000000;
                                 break;
-                            case MSG_IXLOCK:
+                            case MSG_ISLOCK:
                                 doubleRequestDelay = 5 * 1000000;
                                 break;
                         }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -71,6 +71,7 @@ const char *QGETSIGSHARES="qgetsigs";
 const char *QBSIGSHARES="qbsigs";
 const char *QSIGREC="qsigrec";
 const char *CLSIG="clsig";
+const char *IXLOCK="ixlock";
 };
 
 static const char* ppszTypeName[] =
@@ -107,6 +108,7 @@ static const char* ppszTypeName[] =
     NetMsgType::QDEBUGSTATUS,
     NetMsgType::QSIGREC,
     NetMsgType::CLSIG,
+    NetMsgType::IXLOCK,
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -172,6 +174,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::QBSIGSHARES,
     NetMsgType::QSIGREC,
     NetMsgType::CLSIG,
+    NetMsgType::IXLOCK,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -71,7 +71,7 @@ const char *QGETSIGSHARES="qgetsigs";
 const char *QBSIGSHARES="qbsigs";
 const char *QSIGREC="qsigrec";
 const char *CLSIG="clsig";
-const char *IXLOCK="ixlock";
+const char *ISLOCK="islock";
 };
 
 static const char* ppszTypeName[] =
@@ -108,7 +108,7 @@ static const char* ppszTypeName[] =
     NetMsgType::QDEBUGSTATUS,
     NetMsgType::QSIGREC,
     NetMsgType::CLSIG,
-    NetMsgType::IXLOCK,
+    NetMsgType::ISLOCK,
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -174,7 +174,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::QBSIGSHARES,
     NetMsgType::QSIGREC,
     NetMsgType::CLSIG,
-    NetMsgType::IXLOCK,
+    NetMsgType::ISLOCK,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -277,7 +277,7 @@ extern const char *QGETSIGSHARES;
 extern const char *QBSIGSHARES;
 extern const char *QSIGREC;
 extern const char *CLSIG;
-extern const char *IXLOCK;
+extern const char *ISLOCK;
 };
 
 /* Get a vector of all valid message types (see above) */
@@ -380,7 +380,7 @@ enum GetDataMsg {
     MSG_QUORUM_DEBUG_STATUS = 27,
     MSG_QUORUM_RECOVERED_SIG = 28,
     MSG_CLSIG = 29,
-    MSG_IXLOCK = 30,
+    MSG_ISLOCK = 30,
 };
 
 /** inv message data */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -277,6 +277,7 @@ extern const char *QGETSIGSHARES;
 extern const char *QBSIGSHARES;
 extern const char *QSIGREC;
 extern const char *CLSIG;
+extern const char *IXLOCK;
 };
 
 /* Get a vector of all valid message types (see above) */
@@ -379,6 +380,7 @@ enum GetDataMsg {
     MSG_QUORUM_DEBUG_STATUS = 27,
     MSG_QUORUM_RECOVERED_SIG = 28,
     MSG_CLSIG = 29,
+    MSG_IXLOCK = 30,
 };
 
 /** inv message data */

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -21,6 +21,8 @@
 
 #include "instantx.h"
 
+#include "llmq/quorums_instantsend.h"
+
 #include <stdint.h>
 #include <string>
 
@@ -50,6 +52,11 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
             strTxStatus = tr("%1/unconfirmed").arg(nDepth);
         } else {
             strTxStatus = tr("%1 confirmations").arg(nDepth);
+        }
+
+        if (llmq::quorumInstantSendManager->IsLocked(wtx.GetHash())) {
+            strTxStatus += tr(" (verified via LLMQ based InstantSend)");
+            return strTxStatus;
         }
 
         if(!instantsend.HasTxLockRequest(wtx.GetHash())) return strTxStatus; // regular tx

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -28,6 +28,7 @@
 #include "evo/cbtx.h"
 
 #include "llmq/quorums_chainlocks.h"
+#include "llmq/quorums_instantsend.h"
 
 #include <stdint.h>
 
@@ -409,7 +410,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
 
     info.push_back(Pair("depends", depends));
     info.push_back(Pair("instantsend", instantsend.HasTxLockRequest(tx.GetHash())));
-    info.push_back(Pair("instantlock", instantsend.IsLockedInstantSendTransaction(tx.GetHash())));
+    info.push_back(Pair("instantlock", instantsend.IsLockedInstantSendTransaction(tx.GetHash()) || llmq::quorumInstantSendManager->IsLocked(tx.GetHash())));
 }
 
 UniValue mempoolToJSON(bool fVerbose = false)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1020,6 +1020,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_TRANSACTION_ERROR, state.GetRejectReason());
             }
         }
+        llmq::quorumInstantSendManager->ProcessTx(nullptr, *tx, *g_connman, Params().GetConsensus());
     } else if (fHaveChain) {
         throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -36,6 +36,7 @@
 
 #include "llmq/quorums_chainlocks.h"
 #include "llmq/quorums_commitment.h"
+#include "llmq/quorums_instantsend.h"
 
 #include <stdint.h>
 
@@ -199,7 +200,8 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         }
     }
     bool fLocked = instantsend.IsLockedInstantSendTransaction(txid);
-    entry.push_back(Pair("instantlock", fLocked));
+    bool fLLMQLocked = llmq::quorumInstantSendManager->IsLocked(txid);
+    entry.push_back(Pair("instantlock", fLocked || fLLMQLocked));
     entry.push_back(Pair("chainlock", chainLock));
 }
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -29,6 +29,7 @@ std::map<int, int64_t> mapSporkDefaults = {
     {SPORK_17_QUORUM_DKG_ENABLED,            4070908800ULL}, // OFF
     {SPORK_18_QUORUM_DEBUG_ENABLED,          4070908800ULL}, // OFF
     {SPORK_19_CHAINLOCKS_ENABLED,            4070908800ULL}, // OFF
+    {SPORK_20_INSTANTSEND_LLMQ_BASED,        4070908800ULL}, // OFF
 };
 
 bool CSporkManager::SporkValueIsActive(int nSporkID, int64_t &nActiveValueRet) const
@@ -291,6 +292,7 @@ int CSporkManager::GetSporkIDByName(const std::string& strName)
     if (strName == "SPORK_17_QUORUM_DKG_ENABLED")               return SPORK_17_QUORUM_DKG_ENABLED;
     if (strName == "SPORK_18_QUORUM_DEBUG_ENABLED")             return SPORK_18_QUORUM_DEBUG_ENABLED;
     if (strName == "SPORK_19_CHAINLOCKS_ENABLED")               return SPORK_19_CHAINLOCKS_ENABLED;
+    if (strName == "SPORK_20_INSTANTSEND_LLMQ_BASED")           return SPORK_20_INSTANTSEND_LLMQ_BASED;
 
     LogPrint("spork", "CSporkManager::GetSporkIDByName -- Unknown Spork name '%s'\n", strName);
     return -1;
@@ -310,6 +312,7 @@ std::string CSporkManager::GetSporkNameByID(int nSporkID)
         case SPORK_17_QUORUM_DKG_ENABLED:               return "SPORK_17_QUORUM_DKG_ENABLED";
         case SPORK_18_QUORUM_DEBUG_ENABLED:             return "SPORK_18_QUORUM_DEBUG_ENABLED";
         case SPORK_19_CHAINLOCKS_ENABLED:               return "SPORK_19_CHAINLOCKS_ENABLED";
+        case SPORK_20_INSTANTSEND_LLMQ_BASED:           return "SPORK_20_INSTANTSEND_LLMQ_BASED";
         default:
             LogPrint("spork", "CSporkManager::GetSporkNameByID -- Unknown Spork ID %d\n", nSporkID);
             return "Unknown";

--- a/src/spork.h
+++ b/src/spork.h
@@ -28,9 +28,10 @@ static const int SPORK_16_INSTANTSEND_AUTOLOCKS                         = 10015;
 static const int SPORK_17_QUORUM_DKG_ENABLED                            = 10016;
 static const int SPORK_18_QUORUM_DEBUG_ENABLED                          = 10017;
 static const int SPORK_19_CHAINLOCKS_ENABLED                            = 10018;
+static const int SPORK_20_INSTANTSEND_LLMQ_BASED                        = 10019;
 
 static const int SPORK_START                                            = SPORK_2_INSTANTSEND_ENABLED;
-static const int SPORK_END                                              = SPORK_19_CHAINLOCKS_ENABLED;
+static const int SPORK_END                                              = SPORK_20_INSTANTSEND_LLMQ_BASED;
 
 extern std::map<int, int64_t> mapSporkDefaults;
 extern CSporkManager sporkManager;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -24,6 +24,8 @@
 #include "evo/specialtx.h"
 #include "evo/providertx.h"
 
+#include "llmq/quorums_instantsend.h"
+
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
                                  int64_t _nTime, double _entryPriority, unsigned int _entryHeight,
                                  CAmount _inChainInputValue,
@@ -1497,7 +1499,7 @@ int CTxMemPool::Expire(int64_t time) {
     setEntries toremove;
     while (it != mapTx.get<entry_time>().end() && it->GetTime() < time) {
         // locked txes do not expire until mined and have sufficient confirmations
-        if (instantsend.IsLockedInstantSendTransaction(it->GetTx().GetHash())) {
+        if (instantsend.IsLockedInstantSendTransaction(it->GetTx().GetHash()) || llmq::quorumInstantSendManager->IsLocked(it->GetTx().GetHash())) {
             it++;
             continue;
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2209,13 +2209,49 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
     LogPrint("bench", "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs]\n", nInputs - 1, 0.001 * (nTime4 - nTime2), nInputs <= 1 ? 0 : 0.001 * (nTime4 - nTime2) / (nInputs-1), nTimeVerify * 0.000001);
 
 
-    // DASH : MODIFIED TO CHECK MASTERNODE PAYMENTS AND SUPERBLOCKS
+    // DASH
 
     // It's possible that we simply don't have enough data and this could fail
     // (i.e. block itself could be a correct one and we need to store it),
     // that's why this is in ConnectBlock. Could be the other way around however -
     // the peer who sent us this block is missing some data and wasn't able
     // to recognize that block is actually invalid.
+
+    // DASH : CHECK TRANSACTIONS FOR INSTANTSEND
+
+    if (sporkManager.IsSporkActive(SPORK_3_INSTANTSEND_BLOCK_FILTERING)) {
+        // Require other nodes to comply, send them some data in case they are missing it.
+        for (const auto& tx : block.vtx) {
+            // skip txes that have no inputs
+            if (tx->vin.empty()) continue;
+            // LOOK FOR TRANSACTION LOCK IN OUR MAP OF OUTPOINTS
+            for (const auto& txin : tx->vin) {
+                uint256 hashLocked;
+                if (instantsend.GetLockedOutPointTxHash(txin.prevout, hashLocked) && hashLocked != tx->GetHash()) {
+                    // The node which relayed this should switch to correct chain.
+                    // TODO: relay instantsend data/proof.
+                    LOCK(cs_main);
+                    mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
+                    return state.DoS(10, error("ConnectBlock(DASH): transaction %s conflicts with transaction lock %s", tx->GetHash().ToString(), hashLocked.ToString()),
+                                     REJECT_INVALID, "conflict-tx-lock");
+                }
+            }
+            uint256 txConflict;
+            if (llmq::quorumInstantSendManager->GetConflictingTx(*tx, txConflict)) {
+                // The node which relayed this should switch to correct chain.
+                // TODO: relay instantsend data/proof.
+                LOCK(cs_main);
+                mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
+                return state.DoS(10, error("ConnectBlock(DASH): transaction %s conflicts with transaction lock %s", tx->GetHash().ToString(), txConflict.ToString()),
+                                 REJECT_INVALID, "conflict-tx-lock");
+            }
+        }
+    } else {
+        LogPrintf("ConnectBlock(DASH): spork is off, skipping transaction locking checks\n");
+    }
+
+    // DASH : MODIFIED TO CHECK MASTERNODE PAYMENTS AND SUPERBLOCKS
+
     // TODO: resync data (both ways?) and try to reprocess this block later.
     CAmount blockReward = nFees + GetBlockSubsidy(pindex->pprev->nBits, pindex->pprev->nHeight, chainparams.GetConsensus());
     std::string strError = "";
@@ -3268,44 +3304,6 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     for (unsigned int i = 1; i < block.vtx.size(); i++)
         if (block.vtx[i]->IsCoinBase())
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-multiple", false, "more than one coinbase");
-
-
-    // DASH : CHECK TRANSACTIONS FOR INSTANTSEND
-
-    if(sporkManager.IsSporkActive(SPORK_3_INSTANTSEND_BLOCK_FILTERING)) {
-        // We should never accept block which conflicts with completed transaction lock,
-        // that's why this is in CheckBlock unlike coinbase payee/amount.
-        // Require other nodes to comply, send them some data in case they are missing it.
-        for(const auto& tx : block.vtx) {
-            // skip coinbase, it has no inputs
-            if (tx->IsCoinBase()) continue;
-            // LOOK FOR TRANSACTION LOCK IN OUR MAP OF OUTPOINTS
-            for (const auto& txin : tx->vin) {
-                uint256 hashLocked;
-                if(instantsend.GetLockedOutPointTxHash(txin.prevout, hashLocked) && hashLocked != tx->GetHash()) {
-                    // The node which relayed this will have to switch later,
-                    // relaying instantsend data won't help it.
-                    LOCK(cs_main);
-                    mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
-                    return state.DoS(100, false, REJECT_INVALID, "conflict-tx-lock", false, 
-                                     strprintf("transaction %s conflicts with transaction lock %s", tx->GetHash().ToString(), hashLocked.ToString()));
-                }
-            }
-            uint256 txConflict;
-            if (llmq::quorumInstantSendManager->GetConflictingTx(*tx, txConflict)) {
-                // The node which relayed this will have to switch later,
-                // relaying instantsend data won't help it.
-                LOCK(cs_main);
-                mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
-                return state.DoS(100, false, REJECT_INVALID, "conflict-tx-lock", false,
-                                 strprintf("transaction %s conflicts with transaction lock %s", tx->GetHash().ToString(), txConflict.ToString()));
-            }
-        }
-    } else {
-        LogPrintf("CheckBlock(DASH): spork is off, skipping transaction locking checks\n");
-    }
-
-    // END DASH
 
     // Check transactions
     for (const auto& tx : block.vtx)

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -18,6 +18,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
     g_signals.NotifyTransactionLock.connect(boost::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, _1));
+    g_signals.NotifyChainLock.connect(boost::bind(&CValidationInterface::NotifyChainLock, pwalletIn, _1));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
@@ -40,6 +41,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
+    g_signals.NotifyChainLock.disconnect(boost::bind(&CValidationInterface::NotifyChainLock, pwalletIn, _1));
     g_signals.NotifyTransactionLock.disconnect(boost::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, _1));
     g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
@@ -61,6 +63,7 @@ void UnregisterAllValidationInterfaces() {
     g_signals.SetBestChain.disconnect_all_slots();
     g_signals.UpdatedTransaction.disconnect_all_slots();
     g_signals.NotifyTransactionLock.disconnect_all_slots();
+    g_signals.NotifyChainLock.disconnect_all_slots();
     g_signals.SyncTransaction.disconnect_all_slots();
     g_signals.UpdatedBlockTip.disconnect_all_slots();
     g_signals.NewPoWValidBlock.disconnect_all_slots();

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -39,6 +39,7 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) {}
     virtual void NotifyTransactionLock(const CTransaction &tx) {}
+    virtual void NotifyChainLock(const CBlockIndex* pindex) {}
     virtual void NotifyGovernanceVote(const CGovernanceVote &vote) {}
     virtual void NotifyGovernanceObject(const CGovernanceObject &object) {}
     virtual void NotifyInstantSendDoubleSpendAttempt(const CTransaction &currentTx, const CTransaction &previousTx) {}
@@ -76,6 +77,8 @@ struct CMainSignals {
     boost::signals2::signal<void (const CTransaction &, const CBlockIndex *pindex, int posInBlock)> SyncTransaction;
     /** Notifies listeners of an updated transaction lock without new data. */
     boost::signals2::signal<void (const CTransaction &)> NotifyTransactionLock;
+    /** Notifies listeners of a ChainLock. */
+    boost::signals2::signal<void (const CBlockIndex* pindex)> NotifyChainLock;
     /** Notifies listeners of a new governance vote. */
     boost::signals2::signal<void (const CGovernanceVote &)> NotifyGovernanceVote;
     /** Notifies listeners of a new governance object. */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -23,6 +23,7 @@
 #include "privatesend-client.h"
 
 #include "llmq/quorums_chainlocks.h"
+#include "llmq/quorums_instantsend.h"
 
 #include <stdint.h>
 
@@ -65,12 +66,13 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     AssertLockHeld(cs_main); // for mapBlockIndex
     int confirms = wtx.GetDepthInMainChain();
     bool fLocked = instantsend.IsLockedInstantSendTransaction(wtx.GetHash());
+    bool fLLMQLocked = llmq::quorumInstantSendManager->IsLocked(wtx.GetHash());
     bool chainlock = false;
     if (confirms > 0) {
         chainlock = llmq::chainLocksHandler->HasChainLock(mapBlockIndex[wtx.hashBlock]->nHeight, wtx.hashBlock);
     }
     entry.push_back(Pair("confirmations", confirms));
-    entry.push_back(Pair("instantlock", fLocked));
+    entry.push_back(Pair("instantlock", fLocked || fLLMQLocked));
     entry.push_back(Pair("chainlock", chainlock));
     if (wtx.IsCoinBase())
         entry.push_back(Pair("generated", true));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -386,7 +386,12 @@ static void SendMoney(CWallet * const pwallet, const CTxDestination &address, CA
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
     CValidationState state;
-    if (!pwallet->CommitTransaction(wtxNew, reservekey, g_connman.get(), state, fUseInstantSend ? NetMsgType::TXLOCKREQUEST : NetMsgType::TX)) {
+    // the new IX system does not require explicit IX messages
+    std::string strCommand = NetMsgType::TX;
+    if (fUseInstantSend && llmq::IsOldInstantSendEnabled()) {
+        strCommand = NetMsgType::TXLOCKREQUEST;
+    }
+    if (!pwallet->CommitTransaction(wtxNew, reservekey, g_connman.get(), state, strCommand)) {
         strError = strprintf("Error: The transaction was rejected! Reason given: %s", state.GetRejectReason());
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
@@ -1136,7 +1141,12 @@ UniValue sendmany(const JSONRPCRequest& request)
     if (!fCreated)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, strFailReason);
     CValidationState state;
-    if (!pwallet->CommitTransaction(wtx, keyChange, g_connman.get(), state, fUseInstantSend ? NetMsgType::TXLOCKREQUEST : NetMsgType::TX)) {
+    // the new IX system does not require explicit IX messages
+    std::string strCommand = NetMsgType::TX;
+    if (fUseInstantSend && llmq::IsOldInstantSendEnabled()) {
+        strCommand = NetMsgType::TXLOCKREQUEST;
+    }
+    if (!pwallet->CommitTransaction(wtx, keyChange, g_connman.get(), state, strCommand)) {
         strFailReason = strprintf("Transaction commit failed:: %s", state.GetRejectReason());
         throw JSONRPCError(RPC_WALLET_ERROR, strFailReason);
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1921,6 +1921,9 @@ bool CWalletTx::RelayWalletTransaction(CConnman* connman, const std::string& str
                     instantsend.RejectLockRequest((CTxLockRequest)*this);
                 }
             }
+
+            llmq::quorumInstantSendManager->ProcessTx(nullptr, *this->tx, *connman, Params().GetConsensus());
+
             if (connman) {
                 connman->RelayTransaction((CTransaction)*this);
                 return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -36,6 +36,8 @@
 
 #include "evo/providertx.h"
 
+#include "llmq/quorums_instantsend.h"
+
 #include <assert.h>
 
 #include <boost/algorithm/string/replace.hpp>
@@ -5426,7 +5428,7 @@ int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet) const
 
 bool CMerkleTx::IsLockedByInstantSend() const
 {
-    return instantsend.IsLockedInstantSendTransaction(GetHash());
+    return instantsend.IsLockedInstantSendTransaction(GetHash()) || llmq::quorumInstantSendManager->IsLocked(GetHash());
 }
 
 int CMerkleTx::GetBlocksToMaturity() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3346,7 +3346,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                                 int& nChangePosInOut, std::string& strFailReason, const CCoinControl* coinControl, bool sign, AvailableCoinsType nCoinType, bool fUseInstantSend, int nExtraPayloadSize)
 {
     if (!llmq::IsOldInstantSendEnabled()) {
-        // The new system does not require special handling for InstantSend as this is all done in CInstantXManager.
+        // The new system does not require special handling for InstantSend as this is all done in CInstantSendManager.
         // There is also no need for an extra fee anymore.
         fUseInstantSend = false;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3345,6 +3345,12 @@ bool CWallet::ConvertList(std::vector<CTxIn> vecTxIn, std::vector<CAmount>& vecA
 bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet,
                                 int& nChangePosInOut, std::string& strFailReason, const CCoinControl* coinControl, bool sign, AvailableCoinsType nCoinType, bool fUseInstantSend, int nExtraPayloadSize)
 {
+    if (!llmq::IsOldInstantSendEnabled()) {
+        // The new system does not require special handling for InstantSend as this is all done in CInstantXManager.
+        // There is also no need for an extra fee anymore.
+        fUseInstantSend = false;
+    }
+
     CAmount nFeePay = fUseInstantSend ? CTxLockRequest().GetMinFee(true) : 0;
 
     CAmount nValue = 0;


### PR DESCRIPTION
This PR includes an initial implementation of LLMQ based InstantSend. It is meant to be present in parallel to the old InstantSend system.

Switching between the old and the new system happens via `SPORK_2_INSTANTSEND_ENABLED`, which became a new meaning. When set to 0 (as on testnet/mainet right now), it will use the old system. When set to 1, it will use the new system. When set to anything else, it's considered disabled. This is only meant to be temporary until the old system is removed, at which time we can revert back to the old meaning of spork 2.

The new system is very likely not going to be ready for v14, so we won't activate it. Reason is that more testing is required, especially in regard to performance and load.

The new system has a few differences to the old system:
1. There is no explicit lock request required. All TXs are meant to be ixlocked, no matter how many inputs or how much funds they move. We might need to add limits to the amount of inputs, or add some kind of prioritization logic that prefers to sign small TXs first, so that DDoS is not that easily pulled off.
2. The minimum number of confirmations required for TX inputs is lifted when the input is part of a ChainLocked chain (it's enough to have a CLSIG for the current tip). In case inputs were too young and there were no ChainLocks, the system will retry later when with confirmations or when a ChainLock comes in.
3. The system will also lock TXs for which inputs are not confirmed on-chain, but only when the parent TXs are in the local mempool and also locked by InstantSend. This means that InstantSend can be chained now! In case the conditions are not met, the system will retry locking later when it determines that parents got locked.
4. ixlocks do not timeout anymore. They are only removed from the system when TXs get confirmed through ChainLocked blocks. This gives some risk in regard to RAM filling up, but only when ChainLocks are disabled. I will also add (cached) persistence for ixlocks in a later PR, so that the risk of filled RAM is removed.

I did quite a bit of load testing on private devnets and also plan to make a public devnet in the next days so that people can play around. Results of the load testing so far:
1. When there is no load on the network, ixlocks get created in 2-3 seconds, even with simulated network latency and low avg bandwidth
2. When there is high load, for example 1000 TXs sent in a few seconds, it takes around 35 seconds to lock all TXs. When latency (e.g. 50ms) and low bandwidth (e.g. 2mbit) is simulated, it takes about 90 seconds for 1000 TXs to get IX confirmed. I'm not very happy with these numbers, and it looks like we'll need a rewrite of the signing session code (hint: UDP + direkt push instead of custom inv system). This is the main reason I believe that LLMQ based InstantSend might not be ready when v14 is deployed.
3. Bandwidth usage is pretty high. I reduced it to the absolute minimum with the optimizations that got merged in the last days, but IMHO its still too high. Only solution I see right now is what I mentioned in 2. already (UDP).

As an alternative to the signing session code rewrite for UDP and targeting v15 (or whatever the next version would be), another option is to add another minimum TX fee for large TXs. This would allow to add LLMQ based InstantSend to v14 and then later optimize it so that all TXs can use it, independent from their size.