### PR TITLE
Only include selected TX types into CMerkleBlock

### DIFF
--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -19,10 +19,24 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter& filter)
     vMatch.reserve(block.vtx.size());
     vHashes.reserve(block.vtx.size());
 
+    const static std::set<int> allowedTxTypes = {
+            TRANSACTION_NORMAL,
+            TRANSACTION_PROVIDER_REGISTER,
+            TRANSACTION_PROVIDER_UPDATE_SERVICE,
+            TRANSACTION_PROVIDER_UPDATE_REGISTRAR,
+            TRANSACTION_PROVIDER_UPDATE_REVOKE,
+            TRANSACTION_COINBASE,
+    };
+
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
-        const uint256& hash = block.vtx[i]->GetHash();
-        if (filter.IsRelevantAndUpdate(*block.vtx[i]))
+        const auto& tx = *block.vtx[i];
+        if (tx.nVersion == 3 && !allowedTxTypes.count(tx.nType)) {
+            continue;
+        }
+
+        const uint256& hash = tx.GetHash();
+        if (filter.IsRelevantAndUpdate(tx))
         {
             vMatch.push_back(true);
             vMatchedTxn.push_back(std::make_pair(i, hash));


### PR DESCRIPTION
It was reported on iOS that CMerkleBlock sometimes included the dummy
quorum commitments introduced with v13, which led to banning of nodes as
these were not supported/expected there.

We should in general only include TXs here that are of interest for SPV
nodes, so we should maintain the list of allowed TX types.