### PR TITLE
Implement 2-stage commit for CEvoDB to avoid inconsistencies after crashes

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -506,7 +506,7 @@ public:
         deletes.clear();
     }
 
-    bool Commit() {
+    void Commit() {
         CDBBatch batch(db);
         for (auto &p : deletes) {
             for (auto &p2 : p.second) {
@@ -520,7 +520,6 @@ public:
         }
         bool ret = db.WriteBatch(batch, true);
         Clear();
-        return ret;
     }
 
     bool IsClean() {
@@ -541,13 +540,12 @@ public:
         if (!didCommitOrRollback)
             Rollback();
     }
-    bool Commit() {
+    void Commit() {
         assert(!didCommitOrRollback);
         didCommitOrRollback = true;
-        bool result = dbTransaction.Commit();
+        dbTransaction.Commit();
         if (commitHandler)
             commitHandler();
-        return result;
     }
     void Rollback() {
         assert(!didCommitOrRollback);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2506,7 +2506,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     }
     LogPrint("bench", "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, IsInitialBlockDownload() ? FLUSH_STATE_IF_NEEDED : FLUSH_STATE_ALWAYS))
+    if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
         return false;
     // Resurrect mempool transactions from the disconnected block.
     std::vector<uint256> vHashUpdate;
@@ -2596,7 +2596,7 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
     int64_t nTime4 = GetTimeMicros(); nTimeFlush += nTime4 - nTime3;
     LogPrint("bench", "  - Flush: %.2fms [%.2fs]\n", (nTime4 - nTime3) * 0.001, nTimeFlush * 0.000001);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, IsInitialBlockDownload() ? FLUSH_STATE_IF_NEEDED : FLUSH_STATE_ALWAYS))
+    if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
         return false;
     int64_t nTime5 = GetTimeMicros(); nTimeChainState += nTime5 - nTime4;
     LogPrint("bench", "  - Writing chainstate: %.2fms [%.2fs]\n", (nTime5 - nTime4) * 0.001, nTimeChainState * 0.000001);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2394,6 +2394,9 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode, int n
         // Flush the chainstate (which may refer to block index entries).
         if (!pcoinsTip->Flush())
             return AbortNode(state, "Failed to write to coin database");
+        if (!evoDb->CommitRootTransaction()) {
+            return AbortNode(state, "Failed to commit EvoDB");
+        }
         nLastFlush = nNow;
     }
     if (fDoFullFlush || ((mode == FLUSH_STATE_ALWAYS || mode == FLUSH_STATE_PERIODIC) && nNow > nLastSetChain + (int64_t)DATABASE_WRITE_INTERVAL * 1000000)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2499,8 +2499,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
         bool flushed = view.Flush();
         assert(flushed);
-        bool committed = dbTx->Commit();
-        assert(committed);
+        dbTx->Commit();
     }
     LogPrint("bench", "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
     // Write the chain state to disk, if necessary.
@@ -2589,8 +2588,7 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
         LogPrint("bench", "  - Connect total: %.2fms [%.2fs]\n", (nTime3 - nTime2) * 0.001, nTimeConnectTotal * 0.000001);
         bool flushed = view.Flush();
         assert(flushed);
-        bool committed = dbTx->Commit();
-        assert(committed);
+        dbTx->Commit();
     }
     int64_t nTime4 = GetTimeMicros(); nTimeFlush += nTime4 - nTime3;
     LogPrint("bench", "  - Flush: %.2fms [%.2fs]\n", (nTime4 - nTime3) * 0.001, nTimeFlush * 0.000001);


### PR DESCRIPTION
Currently, when Dash crashes, the chainstate DB and CEvoDB are left in an inconsistent way. Recent PRs/commits have added `VerifyBestBlock` and `WriteBestBlock` to CEvoDB so that we can at least detect inconsistencies at startup. This however leads to Dash not starting anymore and forcing a reindex upon the user.

This PR introduces 2-stage commits for CEvoDB. First stage commits happen after block connect/disconnect (the same way as before), but instead of directly writing into LevelDB, it will move the transaction contents into a second stage transaction. The second stage transaction is committed at the same time when the chainstate is flushed. This should fix many of the situations where reindex was required before.