### PR TITLE
Make -masternodeblsprivkey mandatory when -masternode is given

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1968,7 +1968,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 return InitError(_("Invalid masternodeblsprivkey. Please see documenation."));
             }
         } else {
-            InitWarning(_("You should specify a masternodeblsprivkey in the configuration. Please see documentation for help."));
+            return InitError(_("You must specify a masternodeblsprivkey in the configuration. Please see documentation for help."));
         }
 
         // init and register activeMasternodeManager


### PR DESCRIPTION
This should also be backported to v13, where DIP3 has already activated and BLS operator keys will become mandatory with spork15 activation.