### PR TITLE
Implement persistence for LLMQ based InstantSend

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -227,6 +227,7 @@ BITCOIN_CORE_H = \
   txmempool.h \
   ui_interface.h \
   undo.h \
+  unordered_lru_cache.h \
   util.h \
   utilmoneystr.h \
   utiltime.h \

--- a/src/llmq/quorums_dkgsession.h
+++ b/src/llmq/quorums_dkgsession.h
@@ -13,7 +13,6 @@
 #include "bls/bls_worker.h"
 
 #include "evo/deterministicmns.h"
-#include "evo/evodb.h"
 
 #include "llmq/quorums_utils.h"
 
@@ -246,7 +245,6 @@ class CDKGSession
 private:
     const Consensus::LLMQParams& params;
 
-    CEvoDB& evoDb;
     CBLSWorker& blsWorker;
     CBLSWorkerCache cache;
     CDKGSessionManager& dkgManager;
@@ -287,8 +285,8 @@ private:
     std::set<uint256> validCommitments;
 
 public:
-    CDKGSession(const Consensus::LLMQParams& _params, CEvoDB& _evoDb, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager) :
-        params(_params), evoDb(_evoDb), blsWorker(_blsWorker), cache(_blsWorker), dkgManager(_dkgManager) {}
+    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager) :
+        params(_params), blsWorker(_blsWorker), cache(_blsWorker), dkgManager(_dkgManager) {}
 
     bool Init(int _height, const uint256& _quorumHash, const std::vector<CDeterministicMNCPtr>& mns, const uint256& _myProTxHash);
 

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -83,13 +83,12 @@ void CDKGPendingMessages::Clear()
 
 //////
 
-CDKGSessionHandler::CDKGSessionHandler(const Consensus::LLMQParams& _params, CEvoDB& _evoDb, ctpl::thread_pool& _messageHandlerPool, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager) :
+CDKGSessionHandler::CDKGSessionHandler(const Consensus::LLMQParams& _params, ctpl::thread_pool& _messageHandlerPool, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager) :
     params(_params),
-    evoDb(_evoDb),
     messageHandlerPool(_messageHandlerPool),
     blsWorker(_blsWorker),
     dkgManager(_dkgManager),
-    curSession(std::make_shared<CDKGSession>(_params, _evoDb, _blsWorker, _dkgManager)),
+    curSession(std::make_shared<CDKGSession>(_params, _blsWorker, _dkgManager)),
     pendingContributions((size_t)_params.size * 2), // we allow size*2 messages as we need to make sure we see bad behavior (double messages)
     pendingComplaints((size_t)_params.size * 2),
     pendingJustifications((size_t)_params.size * 2),
@@ -146,7 +145,7 @@ bool CDKGSessionHandler::InitNewQuorum(int newQuorumHeight, const uint256& newQu
 
     const auto& consensus = Params().GetConsensus();
 
-    curSession = std::make_shared<CDKGSession>(params, evoDb, blsWorker, dkgManager);
+    curSession = std::make_shared<CDKGSession>(params, blsWorker, dkgManager);
 
     if (!deterministicMNManager->IsDIP3Enforced(newQuorumHeight)) {
         return false;

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -102,7 +102,6 @@ private:
     std::atomic<bool> stopRequested{false};
 
     const Consensus::LLMQParams& params;
-    CEvoDB& evoDb;
     ctpl::thread_pool& messageHandlerPool;
     CBLSWorker& blsWorker;
     CDKGSessionManager& dkgManager;
@@ -119,7 +118,7 @@ private:
     CDKGPendingMessages pendingPrematureCommitments;
 
 public:
-    CDKGSessionHandler(const Consensus::LLMQParams& _params, CEvoDB& _evoDb, ctpl::thread_pool& _messageHandlerPool, CBLSWorker& blsWorker, CDKGSessionManager& _dkgManager);
+    CDKGSessionHandler(const Consensus::LLMQParams& _params, ctpl::thread_pool& _messageHandlerPool, CBLSWorker& blsWorker, CDKGSessionManager& _dkgManager);
     ~CDKGSessionHandler();
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -36,7 +36,7 @@ void CDKGSessionManager::StartMessageHandlerPool()
     for (const auto& qt : Params().GetConsensus().llmqs) {
         dkgSessionHandlers.emplace(std::piecewise_construct,
                 std::forward_as_tuple(qt.first),
-                std::forward_as_tuple(qt.second, evoDb, messageHandlerPool, blsWorker, *this));
+                std::forward_as_tuple(qt.second, messageHandlerPool, blsWorker, *this));
     }
 
     messageHandlerPool.resize(2);

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -21,8 +21,8 @@ CDKGSessionManager* quorumDKGSessionManager;
 static const std::string DB_VVEC = "qdkg_V";
 static const std::string DB_SKCONTRIB = "qdkg_S";
 
-CDKGSessionManager::CDKGSessionManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker) :
-    evoDb(_evoDb),
+CDKGSessionManager::CDKGSessionManager(CDBWrapper& _llmqDb, CBLSWorker& _blsWorker) :
+    llmqDb(_llmqDb),
     blsWorker(_blsWorker)
 {
 }
@@ -204,12 +204,12 @@ bool CDKGSessionManager::GetPrematureCommitment(const uint256& hash, CDKGPrematu
 
 void CDKGSessionManager::WriteVerifiedVvecContribution(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& proTxHash, const BLSVerificationVectorPtr& vvec)
 {
-    evoDb.GetRawDB().Write(std::make_tuple(DB_VVEC, (uint8_t)llmqType, quorumHash, proTxHash), *vvec);
+    llmqDb.Write(std::make_tuple(DB_VVEC, (uint8_t)llmqType, quorumHash, proTxHash), *vvec);
 }
 
 void CDKGSessionManager::WriteVerifiedSkContribution(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& proTxHash, const CBLSSecretKey& skContribution)
 {
-    evoDb.GetRawDB().Write(std::make_tuple(DB_SKCONTRIB, (uint8_t)llmqType, quorumHash, proTxHash), skContribution);
+    llmqDb.Write(std::make_tuple(DB_SKCONTRIB, (uint8_t)llmqType, quorumHash, proTxHash), skContribution);
 }
 
 bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::vector<bool>& validMembers, std::vector<uint16_t>& memberIndexesRet, std::vector<BLSVerificationVectorPtr>& vvecsRet, BLSSecretKeyVector& skContributionsRet)
@@ -257,10 +257,10 @@ bool CDKGSessionManager::GetVerifiedContribution(Consensus::LLMQType llmqType, c
     BLSVerificationVector vvec;
     BLSVerificationVectorPtr vvecPtr;
     CBLSSecretKey skContribution;
-    if (evoDb.GetRawDB().Read(std::make_tuple(DB_VVEC, (uint8_t)llmqType, quorumHash, proTxHash), vvec)) {
+    if (llmqDb.Read(std::make_tuple(DB_VVEC, (uint8_t)llmqType, quorumHash, proTxHash), vvec)) {
         vvecPtr = std::make_shared<BLSVerificationVector>(std::move(vvec));
     }
-    evoDb.GetRawDB().Read(std::make_tuple(DB_SKCONTRIB, (uint8_t)llmqType, quorumHash, proTxHash), skContribution);
+    llmqDb.Read(std::make_tuple(DB_SKCONTRIB, (uint8_t)llmqType, quorumHash, proTxHash), skContribution);
 
     it = contributionsCache.emplace(cacheKey, ContributionsCacheEntry{GetTimeMillis(), vvecPtr, skContribution}).first;
 

--- a/src/llmq/quorums_dkgsessionmgr.h
+++ b/src/llmq/quorums_dkgsessionmgr.h
@@ -21,7 +21,7 @@ class CDKGSessionManager
     static const int64_t MAX_CONTRIBUTION_CACHE_TIME = 60 * 1000;
 
 private:
-    CEvoDB& evoDb;
+    CDBWrapper& llmqDb;
     CBLSWorker& blsWorker;
     ctpl::thread_pool messageHandlerPool;
 
@@ -47,7 +47,7 @@ private:
     std::map<ContributionsCacheKey, ContributionsCacheEntry> contributionsCache;
 
 public:
-    CDKGSessionManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker);
+    CDKGSessionManager(CDBWrapper& _llmqDb, CBLSWorker& _blsWorker);
     ~CDKGSessionManager();
 
     void StartMessageHandlerPool();

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -30,7 +30,7 @@ void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests)
 
     quorumDKGDebugManager = new CDKGDebugManager(scheduler);
     quorumBlockProcessor = new CQuorumBlockProcessor(evoDb);
-    quorumDKGSessionManager = new CDKGSessionManager(evoDb, blsWorker);
+    quorumDKGSessionManager = new CDKGSessionManager(*llmqDb, blsWorker);
     quorumManager = new CQuorumManager(evoDb, blsWorker, *quorumDKGSessionManager);
     quorumSigSharesManager = new CSigSharesManager();
     quorumSigningManager = new CSigningManager(unitTests);

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -14,6 +14,7 @@
 #include "quorums_signing.h"
 #include "quorums_signing_shares.h"
 
+#include "dbwrapper.h"
 #include "scheduler.h"
 
 namespace llmq
@@ -21,8 +22,12 @@ namespace llmq
 
 static CBLSWorker blsWorker;
 
+CDBWrapper* llmqDb;
+
 void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests)
 {
+    llmqDb = new CDBWrapper(unitTests ? "" : (GetDataDir() / "llmq"), 1 << 20, unitTests);
+
     quorumDKGDebugManager = new CDKGDebugManager(scheduler);
     quorumBlockProcessor = new CQuorumBlockProcessor(evoDb);
     quorumDKGSessionManager = new CDKGSessionManager(evoDb, blsWorker);
@@ -51,6 +56,8 @@ void DestroyLLMQSystem()
     quorumBlockProcessor = nullptr;
     delete quorumDKGDebugManager;
     quorumDKGDebugManager = nullptr;
+    delete llmqDb;
+    llmqDb = nullptr;
 }
 
 void StartLLMQSystem()

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -35,7 +35,7 @@ void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests)
     quorumSigSharesManager = new CSigSharesManager();
     quorumSigningManager = new CSigningManager(*llmqDb, unitTests);
     chainLocksHandler = new CChainLocksHandler(scheduler);
-    quorumInstantSendManager = new CInstantSendManager(scheduler);
+    quorumInstantSendManager = new CInstantSendManager(scheduler, *llmqDb);
 }
 
 void DestroyLLMQSystem()

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -33,7 +33,7 @@ void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests)
     quorumDKGSessionManager = new CDKGSessionManager(*llmqDb, blsWorker);
     quorumManager = new CQuorumManager(evoDb, blsWorker, *quorumDKGSessionManager);
     quorumSigSharesManager = new CSigSharesManager();
-    quorumSigningManager = new CSigningManager(unitTests);
+    quorumSigningManager = new CSigningManager(*llmqDb, unitTests);
     chainLocksHandler = new CChainLocksHandler(scheduler);
     quorumInstantSendManager = new CInstantSendManager(scheduler);
 }

--- a/src/llmq/quorums_init.h
+++ b/src/llmq/quorums_init.h
@@ -5,6 +5,7 @@
 #ifndef DASH_QUORUMS_INIT_H
 #define DASH_QUORUMS_INIT_H
 
+class CDBWrapper;
 class CEvoDB;
 class CScheduler;
 
@@ -13,6 +14,8 @@ namespace llmq
 
 // If true, we will connect to all new quorums and watch their communication
 static const bool DEFAULT_WATCH_QUORUMS = false;
+
+extern CDBWrapper* llmqDb;
 
 // Init/destroy LLMQ globals
 void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests);

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -732,6 +732,7 @@ void CInstantSendManager::NotifyChainLock(const CBlockIndex* pindex)
     while (pindex && pindex->GetBlockHash() != lastChainLockBlock) {
         CBlock block;
         {
+            LOCK(cs_main);
             if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
                 pindex = pindex->pprev;
                 continue;

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -41,8 +41,122 @@ uint256 CInstantSendLock::GetRequestId() const
     return hw.GetHash();
 }
 
-CInstantSendManager::CInstantSendManager(CScheduler* _scheduler) :
-    scheduler(_scheduler)
+////////////////
+
+void CInstantSendDb::WriteNewInstantSendLock(const uint256& hash, const CInstantSendLock& islock)
+{
+    CDBBatch batch(db);
+    batch.Write(std::make_tuple(std::string("is_i"), hash), islock);
+    batch.Write(std::make_tuple(std::string("is_tx"), islock.txid), hash);
+    for (auto& in : islock.inputs) {
+        batch.Write(std::make_tuple(std::string("is_in"), in), hash);
+    }
+    db.WriteBatch(batch);
+
+    auto p = std::make_shared<CInstantSendLock>(islock);
+    islockCache.insert(hash, p);
+    txidCache.insert(islock.txid, hash);
+    for (auto& in : islock.inputs) {
+        outpointCache.insert(in, hash);
+    }
+}
+
+void CInstantSendDb::RemoveInstantSendLock(const uint256& hash, CInstantSendLockPtr islock)
+{
+    if (!islock) {
+        islock = GetInstantSendLockByHash(hash);
+        if (!islock) {
+            return;
+        }
+    }
+
+    CDBBatch batch(db);
+    batch.Erase(std::make_tuple(std::string("is_i"), hash));
+    batch.Erase(std::make_tuple(std::string("is_tx"), islock->txid));
+    for (auto& in : islock->inputs) {
+        batch.Erase(std::make_tuple(std::string("is_in"), in));
+    }
+    db.WriteBatch(batch);
+
+    islockCache.erase(hash);
+    txidCache.erase(islock->txid);
+    for (auto& in : islock->inputs) {
+        outpointCache.erase(in);
+    }
+}
+
+CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByHash(const uint256& hash)
+{
+    CInstantSendLockPtr ret;
+    if (islockCache.get(hash, ret)) {
+        return ret;
+    }
+
+    ret = std::make_shared<CInstantSendLock>();
+    bool exists = db.Read(std::make_tuple(std::string("is_i"), hash), *ret);
+    if (!exists) {
+        ret = nullptr;
+    }
+    islockCache.insert(hash, ret);
+    return ret;
+}
+
+CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByTxid(const uint256& txid)
+{
+    uint256 islockHash;
+
+    bool found = txidCache.get(txid, islockHash);
+    if (found && islockHash.IsNull()) {
+        return nullptr;
+    }
+
+    if (!found) {
+        found = db.Read(std::make_tuple(std::string("is_tx"), txid), islockHash);
+        txidCache.insert(txid, islockHash);
+    }
+
+    if (!found) {
+        return nullptr;
+    }
+    return GetInstantSendLockByHash(islockHash);
+}
+
+CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByInput(const COutPoint& outpoint)
+{
+    uint256 islockHash;
+    bool found = outpointCache.get(outpoint, islockHash);
+    if (found && islockHash.IsNull()) {
+        return nullptr;
+    }
+
+    if (!found) {
+        found = db.Read(std::make_tuple(std::string("is_in"), outpoint), islockHash);
+        outpointCache.insert(outpoint, islockHash);
+    }
+
+    if (!found) {
+        return nullptr;
+    }
+    return GetInstantSendLockByHash(islockHash);
+}
+
+void CInstantSendDb::WriteLastChainLockBlock(const uint256& hash)
+{
+    db.Write(std::make_tuple(std::string("is_lcb")), hash);
+}
+
+uint256 CInstantSendDb::GetLastChainLockBlock()
+{
+    uint256 hashBlock;
+    db.Read(std::make_tuple(std::string("is_lcb")), hashBlock);
+    return hashBlock;
+}
+
+////////////////
+
+CInstantSendManager::CInstantSendManager(CScheduler* _scheduler, CDBWrapper& _llmqDb) :
+    scheduler(_scheduler),
+    db(_llmqDb)
 {
 }
 
@@ -287,14 +401,13 @@ void CInstantSendManager::TrySignInstantSendLock(const CTransaction& tx)
     LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: got all recovered sigs, creating CInstantSendLock\n", __func__,
             tx.GetHash().ToString());
 
-    CInstantSendLockInfo islockInfo;
-    islockInfo.time = GetTimeMillis();
-    islockInfo.islock.txid = tx.GetHash();
+    CInstantSendLock islock;
+    islock.txid = tx.GetHash();
     for (auto& in : tx.vin) {
-        islockInfo.islock.inputs.emplace_back(in.prevout);
+        islock.inputs.emplace_back(in.prevout);
     }
 
-    auto id = islockInfo.islock.GetRequestId();
+    auto id = islock.GetRequestId();
 
     if (quorumSigningManager->HasRecoveredSigForId(llmqType, id)) {
         return;
@@ -302,7 +415,7 @@ void CInstantSendManager::TrySignInstantSendLock(const CTransaction& tx)
 
     {
         LOCK(cs);
-        auto e = creatingInstantSendLocks.emplace(id, islockInfo);
+        auto e = creatingInstantSendLocks.emplace(id, std::move(islock));
         if (!e.second) {
             return;
         }
@@ -314,7 +427,7 @@ void CInstantSendManager::TrySignInstantSendLock(const CTransaction& tx)
 
 void CInstantSendManager::HandleNewInstantSendLockRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
 {
-    CInstantSendLockInfo islockInfo;
+    CInstantSendLock islock;
 
     {
         LOCK(cs);
@@ -323,19 +436,19 @@ void CInstantSendManager::HandleNewInstantSendLockRecoveredSig(const llmq::CReco
             return;
         }
 
-        islockInfo = std::move(it->second);
+        islock = std::move(it->second);
         creatingInstantSendLocks.erase(it);
-        txToCreatingInstantSendLocks.erase(islockInfo.islock.txid);
+        txToCreatingInstantSendLocks.erase(islock.txid);
     }
 
-    if (islockInfo.islock.txid != recoveredSig.msgHash) {
+    if (islock.txid != recoveredSig.msgHash) {
         LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s: islock conflicts with %s, dropping own version", __func__,
-                islockInfo.islock.txid.ToString(), recoveredSig.msgHash.ToString());
+                islock.txid.ToString(), recoveredSig.msgHash.ToString());
         return;
     }
 
-    islockInfo.islock.sig = recoveredSig.sig;
-    ProcessInstantSendLock(-1, ::SerializeHash(islockInfo.islock), islockInfo.islock);
+    islock.sig = recoveredSig.sig;
+    ProcessInstantSendLock(-1, ::SerializeHash(islock), islock);
 }
 
 void CInstantSendManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
@@ -365,7 +478,10 @@ void CInstantSendManager::ProcessMessageInstantSendLock(CNode* pfrom, const llmq
     auto hash = ::SerializeHash(islock);
 
     LOCK(cs);
-    if (pendingInstantSendLocks.count(hash) || finalInstantSendLocks.count(hash)) {
+    if (db.GetInstantSendLockByHash(hash) != nullptr) {
+        return;
+    }
+    if (pendingInstantSendLocks.count(hash)) {
         return;
     }
 
@@ -509,23 +625,20 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
         g_connman->RemoveAskFor(hash);
     }
 
-    CInstantSendLockInfo islockInfo;
-    islockInfo.time = GetTimeMillis();
-    islockInfo.islock = islock;
-    islockInfo.islockHash = hash;
-
+    CTransactionRef tx;
     uint256 hashBlock;
     // we ignore failure here as we must be able to propagate the lock even if we don't have the TX locally
-    if (GetTransaction(islock.txid, islockInfo.tx, Params().GetConsensus(), hashBlock)) {
+    if (GetTransaction(islock.txid, tx, Params().GetConsensus(), hashBlock)) {
         if (!hashBlock.IsNull()) {
+            const CBlockIndex* pindexMined;
             {
                 LOCK(cs_main);
-                islockInfo.pindexMined = mapBlockIndex.at(hashBlock);
+                pindexMined = mapBlockIndex.at(hashBlock);
             }
 
             // Let's see if the TX that was locked by this islock is already mined in a ChainLocked block. If yes,
             // we can simply ignore the islock, as the ChainLock implies locking of all TXs in that chain
-            if (llmq::chainLocksHandler->HasChainLock(islockInfo.pindexMined->nHeight, islockInfo.pindexMined->GetBlockHash())) {
+            if (llmq::chainLocksHandler->HasChainLock(pindexMined->nHeight, pindexMined->GetBlockHash())) {
                 LogPrint("instantsend", "CInstantSendManager::%s -- txlock=%s, islock=%s: dropping islock as it already got a ChainLock in block %s, peer=%d\n", __func__,
                          islock.txid.ToString(), hash.ToString(), hashBlock.ToString(), from);
                 return;
@@ -535,36 +648,29 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
 
     {
         LOCK(cs);
-        auto e = finalInstantSendLocks.emplace(hash, islockInfo);
-        if (!e.second) {
-            return;
-        }
-        auto islockInfoPtr = &e.first->second;
-
-        creatingInstantSendLocks.erase(islockInfoPtr->islock.GetRequestId());
-        txToCreatingInstantSendLocks.erase(islockInfoPtr->islock.txid);
 
         LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, islock=%s: processsing islock, peer=%d\n", __func__,
                  islock.txid.ToString(), hash.ToString(), from);
 
-        if (!txToInstantSendLock.emplace(islock.txid, islockInfoPtr).second) {
-            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, islock=%s: duplicate islock, other islock=%s, peer=%d\n", __func__,
-                    islock.txid.ToString(), hash.ToString(), txToInstantSendLock[islock.txid]->islockHash.ToString(), from);
-            txToInstantSendLock.erase(hash);
+        creatingInstantSendLocks.erase(islock.GetRequestId());
+        txToCreatingInstantSendLocks.erase(islock.txid);
+
+        CInstantSendLockPtr otherIsLock;
+        if (db.GetInstantSendLockByHash(hash)) {
             return;
         }
-        for (size_t i = 0; i < islock.inputs.size(); i++) {
-            auto& in = islock.inputs[i];
-            if (!inputToInstantSendLock.emplace(in, islockInfoPtr).second) {
+        if (otherIsLock = db.GetInstantSendLockByTxid(islock.txid)) {
+            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, islock=%s: duplicate islock, other islock=%s, peer=%d\n", __func__,
+                     islock.txid.ToString(), hash.ToString(), ::SerializeHash(*otherIsLock).ToString(), from);
+        }
+        for (auto& in : islock.inputs) {
+            if (otherIsLock = db.GetInstantSendLockByInput(in)) {
                 LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, islock=%s: conflicting input in islock. input=%s, other islock=%s, peer=%d\n", __func__,
-                         islock.txid.ToString(), hash.ToString(), in.ToStringShort(), inputToInstantSendLock[in]->islockHash.ToString(), from);
-                txToInstantSendLock.erase(hash);
-                for (size_t j = 0; j < i; j++) {
-                    inputToInstantSendLock.erase(islock.inputs[j]);
-                }
-                return;
+                         islock.txid.ToString(), hash.ToString(), in.ToStringShort(), ::SerializeHash(*otherIsLock).ToString(), from);
             }
         }
+
+        db.WriteNewInstantSendLock(hash, islock);
     }
 
     CInv inv(MSG_ISLOCK, hash);
@@ -573,10 +679,10 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
     RemoveMempoolConflictsForLock(hash, islock);
     RetryLockMempoolTxs(islock.txid);
 
-    UpdateWalletTransaction(islock.txid);
+    UpdateWalletTransaction(islock.txid, tx);
 }
 
-void CInstantSendManager::UpdateWalletTransaction(const uint256& txid)
+void CInstantSendManager::UpdateWalletTransaction(const uint256& txid, const CTransactionRef& tx)
 {
 #ifdef ENABLE_WALLET
     if (!pwalletMain) {
@@ -595,40 +701,15 @@ void CInstantSendManager::UpdateWalletTransaction(const uint256& txid)
     }
 #endif
 
-    LOCK(cs);
-    auto it = txToInstantSendLock.find(txid);
-    if (it == txToInstantSendLock.end()) {
-        return;
+    if (tx) {
+        GetMainSignals().NotifyTransactionLock(*tx);
     }
-    if (it->second->tx == nullptr) {
-        return;
-    }
-
-    GetMainSignals().NotifyTransactionLock(*it->second->tx);
 }
 
 void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int posInBlock)
 {
     if (!IsNewInstantSendEnabled()) {
         return;
-    }
-
-    {
-        LOCK(cs);
-        auto it = txToInstantSendLock.find(tx.GetHash());
-        if (it == txToInstantSendLock.end()) {
-            return;
-        }
-        auto islockInfo = it->second;
-        if (islockInfo->tx == nullptr) {
-            islockInfo->tx = MakeTransactionRef(tx);
-        }
-
-        if (posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK) {
-            UpdateISLockMinedBlock(islockInfo, nullptr);
-            return;
-        }
-        UpdateISLockMinedBlock(islockInfo, pindex);
     }
 
     if (IsLocked(tx.GetHash())) {
@@ -638,80 +719,58 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
 
 void CInstantSendManager::NotifyChainLock(const CBlockIndex* pindex)
 {
+    uint256 lastChainLockBlock;
     {
         LOCK(cs);
+        db.GetLastChainLockBlock();
+    }
 
-        // Let's find all islocks that correspond to TXs which are part of the freshly ChainLocked chain and then delete
-        // the islocks. We do this because the ChainLocks imply locking and thus it's not needed to further track
-        // or propagate the islocks
-        std::unordered_set<uint256> toDelete;
-        while (pindex && pindex != pindexLastChainLock) {
-            auto its = blockToInstantSendLocks.equal_range(pindex->GetBlockHash());
-            while (its.first != its.second) {
-                auto islockInfo = its.first->second;
-                LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, islock=%s: removing islock as it got ChainLocked in block %s\n", __func__,
-                         islockInfo->islock.txid.ToString(), islockInfo->islockHash.ToString(), pindex->GetBlockHash().ToString());
-                toDelete.emplace(its.first->second->islockHash);
-                ++its.first;
+    // Let's find all islocks that correspond to TXs which are part of the freshly ChainLocked chain and then delete
+    // the islocks. We do this because the ChainLocks imply locking and thus it's not needed to further track
+    // or propagate the islocks
+    std::unordered_set<uint256> toDelete;
+    while (pindex && pindex->GetBlockHash() != lastChainLockBlock) {
+        CBlock block;
+        {
+            if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
+                pindex = pindex->pprev;
+                continue;
             }
-
-            pindex = pindex->pprev;
         }
 
-        pindexLastChainLock = pindex;
-
-        for (auto& islockHash : toDelete) {
-            RemoveFinalISLock(islockHash);
+        LOCK(cs);
+        for (const auto& tx : block.vtx) {
+            auto islock = db.GetInstantSendLockByTxid(tx->GetHash());
+            if (!islock) {
+                continue;
+            }
+            auto hash = ::SerializeHash(*islock);
+            LogPrint("instantsend", "CInstantSendManager::%s -- txid=%s, islock=%s: removing islock as it got ChainLocked in block %s\n", __func__,
+                     islock->txid.ToString(), hash.ToString(), pindex->GetBlockHash().ToString());
+            RemoveFinalISLock(hash, islock);
         }
+
+        pindex = pindex->pprev;
+    }
+
+    {
+        LOCK(cs);
+        db.WriteLastChainLockBlock(pindex ? pindex->GetBlockHash() : uint256());
     }
 
     RetryLockMempoolTxs(uint256());
 }
 
-void CInstantSendManager::UpdateISLockMinedBlock(llmq::CInstantSendLockInfo* islockInfo, const CBlockIndex* pindex)
+void CInstantSendManager::RemoveFinalISLock(const uint256& hash, const CInstantSendLockPtr& islock)
 {
     AssertLockHeld(cs);
-    
-    if (islockInfo->pindexMined == pindex) {
-        return;
-    }
-    
-    if (islockInfo->pindexMined) {
-        auto its = blockToInstantSendLocks.equal_range(islockInfo->pindexMined->GetBlockHash());
-        while (its.first != its.second) {
-            if (its.first->second == islockInfo) {
-                its.first = blockToInstantSendLocks.erase(its.first);
-            } else {
-                ++its.first;
-            }
-        }
-    }
-    
-    if (pindex) {
-        blockToInstantSendLocks.emplace(pindex->GetBlockHash(), islockInfo);
-    }
-    
-    islockInfo->pindexMined = pindex;
-}
 
-void CInstantSendManager::RemoveFinalISLock(const uint256& hash)
-{
-    AssertLockHeld(cs);
+    db.RemoveInstantSendLock(hash, islock);
     
-    auto it = finalInstantSendLocks.find(hash);
-    if (it == finalInstantSendLocks.end()) {
-        return;
-    }
-    auto& islockInfo = it->second;
-
-    txToInstantSendLock.erase(islockInfo.islock.txid);
-    for (auto& in : islockInfo.islock.inputs) {
+    for (auto& in : islock->inputs) {
         auto inputRequestId = ::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, in));
         inputRequestIds.erase(inputRequestId);
-        inputToInstantSendLock.erase(in);
     }
-    UpdateISLockMinedBlock(&islockInfo, nullptr);
-    finalInstantSendLocks.erase(it);
 }
 
 void CInstantSendManager::RemoveMempoolConflictsForLock(const uint256& hash, const CInstantSendLock& islock)
@@ -798,7 +857,7 @@ bool CInstantSendManager::AlreadyHave(const CInv& inv)
     }
 
     LOCK(cs);
-    return finalInstantSendLocks.count(inv.hash) != 0 || pendingInstantSendLocks.count(inv.hash) != 0;
+    return db.GetInstantSendLockByHash(inv.hash) != nullptr || pendingInstantSendLocks.count(inv.hash) != 0;
 }
 
 bool CInstantSendManager::GetInstantSendLockByHash(const uint256& hash, llmq::CInstantSendLock& ret)
@@ -808,11 +867,11 @@ bool CInstantSendManager::GetInstantSendLockByHash(const uint256& hash, llmq::CI
     }
 
     LOCK(cs);
-    auto it = finalInstantSendLocks.find(hash);
-    if (it == finalInstantSendLocks.end()) {
+    auto islock = db.GetInstantSendLockByHash(hash);
+    if (!islock) {
         return false;
     }
-    ret = it->second.islock;
+    ret = *islock;
     return true;
 }
 
@@ -823,7 +882,7 @@ bool CInstantSendManager::IsLocked(const uint256& txHash)
     }
 
     LOCK(cs);
-    return txToInstantSendLock.count(txHash) != 0;
+    return db.GetInstantSendLockByTxid(txHash) != nullptr;
 }
 
 bool CInstantSendManager::IsConflicted(const CTransaction& tx)
@@ -841,13 +900,13 @@ bool CInstantSendManager::GetConflictingTx(const CTransaction& tx, uint256& retC
 
     LOCK(cs);
     for (const auto& in : tx.vin) {
-        auto it = inputToInstantSendLock.find(in.prevout);
-        if (it == inputToInstantSendLock.end()) {
+        auto otherIsLock = db.GetInstantSendLockByInput(in.prevout);
+        if (!otherIsLock) {
             continue;
         }
 
-        if (it->second->islock.txid != tx.GetHash()) {
-            retConflictTxHash = it->second->islock.txid;
+        if (otherIsLock->txid != tx.GetHash()) {
+            retConflictTxHash = otherIsLock->txid;
             return true;
         }
     }

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -61,11 +61,10 @@ private:
     CScheduler* scheduler;
 
     /**
-     * These are the votes/signatures we performed locally. It's indexed by the LLMQ requestId, which is
-     * hash(TXLOCK_REQUESTID_PREFIX, prevout). The map values are the txids we voted for. This map is used to
-     * avoid voting for the same input twice.
+     * Request ids of inputs that we signed. Used to determine if a recovered signature belongs to an
+     * in-progress input lock.
      */
-    std::unordered_map<uint256, uint256, StaticSaltedHasher> inputVotes;
+    std::unordered_set<uint256, StaticSaltedHasher> inputRequestIds;
 
     /**
      * These are the islocks that are currently in the middle of being created. Entries are created when we observed

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -24,8 +24,8 @@ namespace llmq
 
 CSigningManager* quorumSigningManager;
 
-CRecoveredSigsDb::CRecoveredSigsDb(bool fMemory) :
-    db(fMemory ? "" : (GetDataDir() / "llmq"), 1 << 20, fMemory)
+CRecoveredSigsDb::CRecoveredSigsDb(CDBWrapper& _db) :
+    db(_db)
 {
 }
 
@@ -290,8 +290,8 @@ void CRecoveredSigsDb::WriteVoteForId(Consensus::LLMQType llmqType, const uint25
 
 //////////////////
 
-CSigningManager::CSigningManager(bool fMemory) :
-    db(fMemory)
+CSigningManager::CSigningManager(CDBWrapper& llmqDb, bool fMemory) :
+    db(llmqDb)
 {
 }
 

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -686,6 +686,16 @@ bool CSigningManager::IsConflicting(Consensus::LLMQType llmqType, const uint256&
     return false;
 }
 
+bool CSigningManager::HasVotedOnId(Consensus::LLMQType llmqType, const uint256& id)
+{
+    return db.HasVotedOnId(llmqType, id);
+}
+
+bool CSigningManager::GetVoteForId(Consensus::LLMQType llmqType, const uint256& id, uint256& msgHashRet)
+{
+    return db.GetVoteForId(llmqType, id, msgHashRet);
+}
+
 CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType, int signHeight, const uint256& selectionHash)
 {
     auto& llmqParams = Params().GetConsensus().llmqs.at(llmqType);

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -170,6 +170,9 @@ public:
     bool HasRecoveredSigForSession(const uint256& signHash);
     bool IsConflicting(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash);
 
+    bool HasVotedOnId(Consensus::LLMQType llmqType, const uint256& id);
+    bool GetVoteForId(Consensus::LLMQType llmqType, const uint256& id, uint256& msgHashRet);
+
     CQuorumCPtr SelectQuorumForSigning(Consensus::LLMQType llmqType, int signHeight, const uint256& selectionHash);
 
     // Verifies a recovered sig that was signed while the chain tip was at signedAtTip

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -72,7 +72,7 @@ class CRecoveredSigsDb
     static const size_t MAX_CACHE_TRUNCATE_THRESHOLD = 50000;
 
 private:
-    CDBWrapper db;
+    CDBWrapper& db;
 
     CCriticalSection cs;
     std::unordered_map<std::pair<Consensus::LLMQType, uint256>, std::pair<bool, int64_t>, StaticSaltedHasher> hasSigForIdCache;
@@ -80,7 +80,7 @@ private:
     std::unordered_map<uint256, std::pair<bool, int64_t>, StaticSaltedHasher> hasSigForHashCache;
 
 public:
-    CRecoveredSigsDb(bool fMemory);
+    CRecoveredSigsDb(CDBWrapper& _db);
 
     bool HasRecoveredSig(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash);
     bool HasRecoveredSigForId(Consensus::LLMQType llmqType, const uint256& id);
@@ -136,7 +136,7 @@ private:
     std::vector<CRecoveredSigsListener*> recoveredSigsListeners;
 
 public:
-    CSigningManager(bool fMemory);
+    CSigningManager(CDBWrapper& llmqDb, bool fMemory);
 
     bool AlreadyHave(const CInv& inv);
     bool GetRecoveredSigForGetData(const uint256& hash, CRecoveredSig& ret);

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -10,6 +10,7 @@
 #include "net.h"
 #include "chainparams.h"
 #include "saltedhasher.h"
+#include "unordered_lru_cache.h"
 
 #include <unordered_map>
 
@@ -68,16 +69,13 @@ public:
 
 class CRecoveredSigsDb
 {
-    static const size_t MAX_CACHE_SIZE = 30000;
-    static const size_t MAX_CACHE_TRUNCATE_THRESHOLD = 50000;
-
 private:
     CDBWrapper& db;
 
     CCriticalSection cs;
-    std::unordered_map<std::pair<Consensus::LLMQType, uint256>, std::pair<bool, int64_t>, StaticSaltedHasher> hasSigForIdCache;
-    std::unordered_map<uint256, std::pair<bool, int64_t>, StaticSaltedHasher> hasSigForSessionCache;
-    std::unordered_map<uint256, std::pair<bool, int64_t>, StaticSaltedHasher> hasSigForHashCache;
+    unordered_lru_cache<std::pair<Consensus::LLMQType, uint256>, bool, StaticSaltedHasher, 30000> hasSigForIdCache;
+    unordered_lru_cache<uint256, bool, StaticSaltedHasher, 30000> hasSigForSessionCache;
+    unordered_lru_cache<uint256, bool, StaticSaltedHasher, 30000> hasSigForHashCache;
 
 public:
     CRecoveredSigsDb(CDBWrapper& _db);

--- a/src/unordered_lru_cache.h
+++ b/src/unordered_lru_cache.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2019 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UNORDERED_LRU_CACHE_H
+#define BITCOIN_UNORDERED_LRU_CACHE_H
+
+#include <unordered_map>
+
+template<typename Key, typename Value, typename Hasher, size_t MaxSize = 0, size_t TruncateThreshold = 0>
+class unordered_lru_cache
+{
+private:
+    typedef std::unordered_map<Key, std::pair<Value, int64_t>, Hasher> MapType;
+
+    MapType cacheMap;
+    size_t maxSize;
+    size_t truncateThreshold;
+    int64_t accessCounter{0};
+
+public:
+    unordered_lru_cache(size_t _maxSize = MaxSize, size_t _truncateThreshold = TruncateThreshold) :
+        maxSize(_maxSize),
+        truncateThreshold(_truncateThreshold == 0 ? _maxSize * 2 : _truncateThreshold)
+    {
+        // either specify maxSize through template arguments or the contructor and fail otherwise
+        assert(_maxSize != 0);
+    }
+
+
+    template<typename Value2>
+    void _emplace(const Key& key, Value2&& v)
+    {
+        truncate_if_needed();
+        auto it = cacheMap.find(key);
+        if (it == cacheMap.end()) {
+            cacheMap.emplace(key, std::make_pair(std::forward<Value2>(v), accessCounter++));
+        } else {
+            it->second.first = std::forward<Value2>(v);
+            it->second.second = accessCounter++;
+        }
+    }
+
+    void emplace(const Key& key, Value&& v)
+    {
+        _emplace(key, v);
+    }
+
+    void insert(const Key& key, const Value& v)
+    {
+        _emplace(key, v);
+    }
+
+    bool get(const Key& key, Value& value)
+    {
+        auto it = cacheMap.find(key);
+        if (it != cacheMap.end()) {
+            it->second.second = accessCounter++;
+            value = it->second.first;
+            return true;
+        }
+        return false;
+    }
+
+    bool exists(const Key& key)
+    {
+        auto it = cacheMap.find(key);
+        if (it != cacheMap.end()) {
+            it->second.second = accessCounter++;
+            return true;
+        }
+        return false;
+    }
+
+    void erase(const Key& key)
+    {
+        cacheMap.erase(key);
+    }
+
+    void clear()
+    {
+        cacheMap.clear();
+    }
+
+private:
+    void truncate_if_needed()
+    {
+        typedef typename MapType::iterator Iterator;
+
+        if (cacheMap.size() <= truncateThreshold) {
+            return;
+        }
+
+        std::vector<Iterator> vec;
+        vec.reserve(cacheMap.size());
+        for (auto it = cacheMap.begin(); it != cacheMap.end(); ++it) {
+            vec.emplace_back(it);
+        }
+        // sort by last access time (descending order)
+        std::sort(vec.begin(), vec.end(), [](const Iterator& it1, const Iterator& it2) {
+            return it1->second.second > it2->second.second;
+        });
+
+        for (size_t i = maxSize; i < vec.size(); i++) {
+            cacheMap.erase(vec[i]);
+        }
+    }
+};
+
+#endif // BITCOIN_UNORDERED_LRU_CACHE_H

--- a/src/unordered_lru_cache.h
+++ b/src/unordered_lru_cache.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UNORDERED_LRU_CACHE_H
-#define BITCOIN_UNORDERED_LRU_CACHE_H
+#ifndef DASH_UNORDERED_LRU_CACHE_H
+#define DASH_UNORDERED_LRU_CACHE_H
 
 #include <unordered_map>
 
@@ -107,4 +107,4 @@ private:
     }
 };
 
-#endif // BITCOIN_UNORDERED_LRU_CACHE_H
+#endif // DASH_UNORDERED_LRU_CACHE_H


### PR DESCRIPTION
This PR makes finished/final InstantSend locks persistent, which means they are still present after restart of the node.

It also introduces `unordered_lru_cache` for `CInstantSendDb` and also switches `CRecoveredSigsDb` to use it as well.