### PR TITLE
Fix deadlock in CSigSharesManager::SendMessages

### DIFF
--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -101,7 +101,7 @@ public:
         READWRITE(AUTOBITSET(inv, (size_t)invSize));
     }
 
-    void Init(Consensus::LLMQType _llmqType);
+    void Init(size_t size);
     bool IsSet(uint16_t quorumMember) const;
     void Set(uint16_t quorumMember, bool v);
     void Merge(const CSigSharesInv& inv2);

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -127,7 +127,7 @@ public:
         READWRITE(sigShares);
     }
 
-    CSigSharesInv ToInv(Consensus::LLMQType llmqType) const;
+    std::string ToInvString() const;
 };
 
 template<typename T>


### PR DESCRIPTION
Locking "cs" at this location caused a (potential) deadlock due to changed
order of cs and cs_vNodes locking. This changes the method to not require
the session object anymore which removes the need for locking.