### PR TITLE
Do not hold cs_vNodes in CSigSharesManager::SendMessages() for too long

### DIFF
--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1052,7 +1052,9 @@ bool CSigSharesManager::SendMessages()
 
     bool didSend = false;
 
-    g_connman->ForEachNode([&](CNode* pnode) {
+    std::vector<CNode*> vNodesCopy = g_connman->CopyNodeVector(CConnman::FullyConnectedOnly);
+
+    for (auto& pnode : vNodesCopy) {
         CNetMsgMaker msgMaker(pnode->GetSendVersion());
 
         auto it1 = sigSessionAnnouncements.find(pnode->id);
@@ -1144,9 +1146,10 @@ bool CSigSharesManager::SendMessages()
                 didSend = true;
             }
         }
+    }
 
-        return true;
-    });
+    // looped through all nodes, release them
+    g_connman->ReleaseNodeVector(vNodesCopy);
 
     if (didSend) {
         g_connman->WakeSelect();


### PR DESCRIPTION
Should speed up networking a bit (by letting other threads to access vNodes too) and also fixes the same issue as #2757 