### PR TITLE
Use confirmations instead of time to decide if tx is "safe" for mining

### DIFF
--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -622,8 +622,8 @@ void CChainLocksHandler::Cleanup()
             it = txFirstSeenBlockHeight.erase(it);
         } else if (!hashBlock.IsNull()) {
             auto pindex = mapBlockIndex.at(hashBlock);
-            if (chainActive.Tip()->GetAncestor(pindex->nHeight) == pindex && chainActive.Height() - pindex->nHeight >= WAIT_FOR_ISLOCK_BLOCKS) {
-                // tx got confirmed >= WAIT_FOR_ISLOCK_BLOCKS times, so we can stop keeping track of it
+            if (chainActive.Tip()->GetAncestor(pindex->nHeight) == pindex && chainActive.Height() - pindex->nHeight >= CLEANUP_ISLOCK_BLOCKS) {
+                // tx got confirmed >= CLEANUP_ISLOCK_BLOCKS times, so we can stop keeping track of it
                 it = txFirstSeenBlockHeight.erase(it);
             } else {
                 ++it;

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -47,7 +47,8 @@ class CChainLocksHandler : public CRecoveredSigsListener
     static const int64_t CLEANUP_SEEN_TIMEOUT = 24 * 60 * 60 * 1000;
 
     // how many blocks to wait for ixlocks until we consider a block with non-ixlocked TXs to be safe to sign
-    static const int WAIT_FOR_ISLOCK_BLOCKS = 6;
+    static const int WAIT_FOR_ISLOCK_BLOCKS = 4;
+    static const int CLEANUP_ISLOCK_BLOCKS = 6;
 
 private:
     CScheduler* scheduler;

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -46,8 +46,8 @@ class CChainLocksHandler : public CRecoveredSigsListener
     static const int64_t CLEANUP_INTERVAL = 1000 * 30;
     static const int64_t CLEANUP_SEEN_TIMEOUT = 24 * 60 * 60 * 1000;
 
-    // how long to wait for ixlocks until we consider a block with non-ixlocked TXs to be safe to sign
-    static const int64_t WAIT_FOR_ISLOCK_TIMEOUT = 10 * 60;
+    // how many blocks to wait for ixlocks until we consider a block with non-ixlocked TXs to be safe to sign
+    static const int WAIT_FOR_ISLOCK_CONFIRMATIONS = 6;
 
 private:
     CScheduler* scheduler;
@@ -68,7 +68,7 @@ private:
 
     // We keep track of txids from recently received blocks so that we can check if all TXs got ixlocked
     std::unordered_map<uint256, std::shared_ptr<std::unordered_set<uint256, StaticSaltedHasher>>> blockTxs;
-    std::unordered_map<uint256, int64_t> txFirstSeenTime;
+    std::unordered_map<uint256, int> txFirstSeenBlockHeight;
 
     std::map<uint256, int64_t> seenChainLocks;
 
@@ -97,7 +97,7 @@ public:
     bool HasChainLock(int nHeight, const uint256& blockHash);
     bool HasConflictingChainLock(int nHeight, const uint256& blockHash);
 
-    bool IsTxSafeForMining(const uint256& txid);
+    bool IsTxSafeForMining(const uint256& txid, int nHeight);
 
 private:
     // these require locks to be held already

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -47,7 +47,7 @@ class CChainLocksHandler : public CRecoveredSigsListener
     static const int64_t CLEANUP_SEEN_TIMEOUT = 24 * 60 * 60 * 1000;
 
     // how many blocks to wait for ixlocks until we consider a block with non-ixlocked TXs to be safe to sign
-    static const int WAIT_FOR_ISLOCK_CONFIRMATIONS = 6;
+    static const int WAIT_FOR_ISLOCK_BLOCKS = 6;
 
 private:
     CScheduler* scheduler;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -293,7 +293,7 @@ bool BlockAssembler::TestPackageTransactions(const CTxMemPool::setEntries& packa
     BOOST_FOREACH (const CTxMemPool::txiter it, package) {
         if (!IsFinalTx(it->GetTx(), nHeight, nLockTimeCutoff))
             return false;
-        if (!llmq::chainLocksHandler->IsTxSafeForMining(it->GetTx().GetHash())) {
+        if (!llmq::chainLocksHandler->IsTxSafeForMining(it->GetTx().GetHash(), nHeight)) {
             return false;
         }
     }
@@ -337,7 +337,7 @@ bool BlockAssembler::TestForBlock(CTxMemPool::txiter iter)
     if (!IsFinalTx(iter->GetTx(), nHeight, nLockTimeCutoff))
         return false;
 
-    if (!llmq::chainLocksHandler->IsTxSafeForMining(iter->GetTx().GetHash())) {
+    if (!llmq::chainLocksHandler->IsTxSafeForMining(iter->GetTx().GetHash(), nHeight)) {
         return false;
     }
 


### PR DESCRIPTION
This should ensure that all nodes arrive at the same decision most of the time.