### PR TITLE
Move simple PoSe tests into llmq-simplepose.py

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -46,6 +46,7 @@ BASE_SCRIPTS= [
     'multikeysporks.py',
     'llmq-signing.py', # NOTE: needs dash_hash to pass
     'llmq-chainlocks.py', # NOTE: needs dash_hash to pass
+    'llmq-simplepose.py', # NOTE: needs dash_hash to pass
     # vv Tests less than 60s vv
     'sendheaders.py', # NOTE: needs dash_hash to pass
     'zapwallettxes.py',

--- a/qa/rpc-tests/llmq-simplepose.py
+++ b/qa/rpc-tests/llmq-simplepose.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import DashTestFramework
+from test_framework.util import *
+from time import *
+
+'''
+llmq-simplepose.py
+
+Checks simple PoSe system based on LLMQ commitments
+
+'''
+
+class LLMQSimplePoSeTest(DashTestFramework):
+    def __init__(self):
+        super().__init__(11, 10, [], fast_dip3_enforcement=True)
+
+    def run_test(self):
+
+        self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        self.wait_for_sporks_same()
+
+        # check if mining quorums with all nodes being online succeeds without punishment/banning
+        for i in range(3):
+            self.mine_quorum(expected_valid_count=10)
+        for mn in self.mninfo:
+            assert(not self.check_punished(mn) and not self.check_punished(mn))
+
+        # Now lets kill MNs one by one and verify that punishment/banning happens
+        for i in range(len(self.mninfo), len(self.mninfo) - 2, -1):
+            mn = self.mninfo[len(self.mninfo) - 1]
+            self.mninfo.remove(mn)
+            self.stop_node(mn.nodeIdx)
+            self.nodes.remove(mn.node)
+
+            t = time()
+            while (not self.check_punished(mn) or not self.check_banned(mn)) and (time() - t) < 120:
+                self.mine_quorum(expected_valid_count=i-1)
+
+            assert(self.check_punished(mn) and self.check_banned(mn))
+
+    def check_punished(self, mn):
+        info = self.nodes[0].protx('info', mn.proTxHash)
+        if info['state']['PoSePenalty'] > 0:
+            return True
+        return False
+
+    def check_banned(self, mn):
+        info = self.nodes[0].protx('info', mn.proTxHash)
+        if info['state']['PoSeBanHeight'] != -1:
+            return True
+        return False
+
+if __name__ == '__main__':
+    LLMQSimplePoSeTest().main()

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -473,7 +473,7 @@ class DashTestFramework(BitcoinTestFramework):
                 return False
         return True
 
-    def wait_for_quorum_phase(self, phase, check_received_messages, check_received_messages_count, timeout=15):
+    def wait_for_quorum_phase(self, phase, check_received_messages, check_received_messages_count, timeout=30):
         t = time()
         while time() - t < timeout:
             all_ok = True

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -329,6 +329,7 @@ class DashTestFramework(BitcoinTestFramework):
             args = ['-masternode=1',
                     '-masternodeblsprivkey=%s' % self.mninfo[idx].keyOperator] + self.extra_args
             node = start_node(idx + start_idx, self.options.tmpdir, args)
+            self.mninfo[idx].nodeIdx = idx + start_idx
             self.mninfo[idx].node = node
             self.nodes[idx + start_idx] = node
             wait_to_sync(node, True)

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -216,11 +216,6 @@ bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, 
 {
     auto members = CLLMQUtils::GetAllQuorumMembers(llmqType, quorumHash);
 
-    if (validMembers.size() != members.size()) {
-        // should never happen as we should always call this method with correct params
-        return false;
-    }
-
     memberIndexesRet.clear();
     vvecsRet.clear();
     skContributionsRet.clear();


### PR DESCRIPTION
These tend to fail quite often on Travis due to multiple reasons. One
reason is that establishing intra quorum connections take some time and
the tests in dip3-deterministicmns.py did not sleep long enough. Another
reason is that the individual stages were not really checked for completion
but instead just a hardcoded sleep was used. And another reason was that
with a total of 13 MNs, it's not guaranteed that every DKG results in one
MN to be punished.