### PR TITLE
Backport PRs from Bitcoin required to make ActivateBestChain cs_main free on entry

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -94,6 +94,7 @@ BASE_SCRIPTS= [
     'p2p-leaktests.py',
     'p2p-compactblocks.py',
     'sporks.py',
+    'p2p-fingerprint.py',
 ]
 
 ZMQ_SCRIPTS = [

--- a/qa/rpc-tests/p2p-fingerprint.py
+++ b/qa/rpc-tests/p2p-fingerprint.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test various fingerprinting protections.
+
+If an stale block more than a month old or its header are requested by a peer,
+the node should pretend that it does not have it to avoid fingerprinting.
+"""
+
+import time
+
+from test_framework.blocktools import (create_block, create_coinbase)
+from test_framework.mininode import (
+    CInv,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    msg_headers,
+    msg_block,
+    msg_getdata,
+    msg_getheaders,
+    wait_until,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    p2p_port,
+)
+
+class P2PFingerprintTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    # Build a chain of blocks on top of given one
+    def build_chain(self, nblocks, prev_hash, prev_height, prev_median_time):
+        blocks = []
+        for _ in range(nblocks):
+            coinbase = create_coinbase(prev_height + 1)
+            block_time = prev_median_time + 1
+            block = create_block(int(prev_hash, 16), coinbase, block_time)
+            block.solve()
+
+            blocks.append(block)
+            prev_hash = block.hash
+            prev_height += 1
+            prev_median_time = block_time
+        return blocks
+
+    # Send a getdata request for a given block hash
+    def send_block_request(self, block_hash, node):
+        msg = msg_getdata()
+        msg.inv.append(CInv(2, block_hash))  # 2 == "Block"
+        node.send_message(msg)
+
+    # Send a getheaders request for a given single block hash
+    def send_header_request(self, block_hash, node):
+        msg = msg_getheaders()
+        msg.hashstop = block_hash
+        node.send_message(msg)
+
+    # Check whether last block received from node has a given hash
+    def last_block_equals(self, expected_hash, node):
+        block_msg = node.last_message.get("block")
+        return block_msg and block_msg.block.rehash() == expected_hash
+
+    # Check whether last block header received from node has a given hash
+    def last_header_equals(self, expected_hash, node):
+        headers_msg = node.last_message.get("headers")
+        return (headers_msg and
+                headers_msg.headers and
+                headers_msg.headers[0].rehash() == expected_hash)
+
+    # Checks that stale blocks timestamped more than a month ago are not served
+    # by the node while recent stale blocks and old active chain blocks are.
+    # This does not currently test that stale blocks timestamped within the
+    # last month but that have over a month's worth of work are also withheld.
+    def run_test(self):
+        node0 = NodeConnCB()
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], node0))
+        node0.add_connection(connections[0])
+
+        NetworkThread().start()
+        node0.wait_for_verack()
+
+        # Set node time to 60 days ago
+        self.nodes[0].setmocktime(int(time.time()) - 60 * 24 * 60 * 60)
+
+        # Generating a chain of 10 blocks
+        block_hashes = self.nodes[0].generate(nblocks=10)
+
+        # Create longer chain starting 2 blocks before current tip
+        height = len(block_hashes) - 2
+        block_hash = block_hashes[height - 1]
+        block_time = self.nodes[0].getblockheader(block_hash)["mediantime"] + 1
+        new_blocks = self.build_chain(5, block_hash, height, block_time)
+
+        # Force reorg to a longer chain
+        node0.send_message(msg_headers(new_blocks))
+        node0.wait_for_getdata()
+        for block in new_blocks:
+            node0.send_and_ping(msg_block(block))
+
+        # Check that reorg succeeded
+        assert_equal(self.nodes[0].getblockcount(), 13)
+
+        stale_hash = int(block_hashes[-1], 16)
+
+        # Check that getdata request for stale block succeeds
+        self.send_block_request(stale_hash, node0)
+        test_function = lambda: self.last_block_equals(stale_hash, node0)
+        wait_until(test_function, timeout=3)
+
+        # Check that getheader request for stale block header succeeds
+        self.send_header_request(stale_hash, node0)
+        test_function = lambda: self.last_header_equals(stale_hash, node0)
+        wait_until(test_function, timeout=3)
+
+        # Longest chain is extended so stale is much older than chain tip
+        self.nodes[0].setmocktime(0)
+        tip = self.nodes[0].generate(nblocks=1)[0]
+        assert_equal(self.nodes[0].getblockcount(), 14)
+
+        # Send getdata & getheaders to refresh last received getheader message
+        block_hash = int(tip, 16)
+        self.send_block_request(block_hash, node0)
+        self.send_header_request(block_hash, node0)
+        node0.sync_with_ping()
+
+        # Request for very old stale block should now fail
+        self.send_block_request(stale_hash, node0)
+        time.sleep(3)
+        assert not self.last_block_equals(stale_hash, node0)
+
+        # Request for very old stale block header should now fail
+        self.send_header_request(stale_hash, node0)
+        time.sleep(3)
+        assert not self.last_header_equals(stale_hash, node0)
+
+        # Verify we can fetch very old blocks and headers on the active chain
+        block_hash = int(block_hashes[2], 16)
+        self.send_block_request(block_hash, node0)
+        self.send_header_request(block_hash, node0)
+        node0.sync_with_ping()
+
+        self.send_block_request(block_hash, node0)
+        test_function = lambda: self.last_block_equals(block_hash, node0)
+        wait_until(test_function, timeout=3)
+
+        self.send_header_request(block_hash, node0)
+        test_function = lambda: self.last_header_equals(block_hash, node0)
+        wait_until(test_function, timeout=3)
+
+if __name__ == '__main__':
+    P2PFingerprintTest().main()

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -10,6 +10,17 @@ Setup:
   receive inv's (omitted from testing description below, this is our control).
   Second node is used for creating reorgs.
 
+test_null_locators
+==================
+
+Sends two getheaders requests with null locator values. First request's hashstop
+value refers to validated block, while second request's hashstop value refers to
+a block which hasn't been validated. Verifies only the first request returns
+headers.
+
+test_nonnull_locators
+=====================
+
 Part 1: No headers announcements before "sendheaders"
 a. node mines a block [expect: inv]
    send getdata for the block [expect: block]
@@ -279,6 +290,29 @@ class SendHeadersTest(BitcoinTestFramework):
         inv_node.wait_for_verack()
         test_node.wait_for_verack()
 
+        self.test_null_locators(test_node)
+        self.test_nonnull_locators(test_node, inv_node)
+
+    def test_null_locators(self, test_node):
+        tip = self.nodes[0].getblockheader(self.nodes[0].generate(1)[0])
+        tip_hash = int(tip["hash"], 16)
+
+        self.log.info("Verify getheaders with null locator and valid hashstop returns headers.")
+        test_node.clear_last_announcement()
+        test_node.get_headers(locator=[], hashstop=tip_hash)
+        assert_equal(test_node.check_last_announcement(headers=[tip_hash]), True)
+
+        self.log.info("Verify getheaders with null locator and invalid hashstop does not return headers.")
+        block = create_block(int(tip["hash"], 16), create_coinbase(tip["height"] + 1), tip["mediantime"] + 1)
+        block.solve()
+        test_node.send_header_for_blocks([block])
+        test_node.clear_last_announcement()
+        test_node.get_headers(locator=[], hashstop=int(block.hash, 16))
+        test_node.sync_with_ping()
+        assert_equal(test_node.block_announced, False)
+        test_node.send_message(msg_block(block))
+
+    def test_nonnull_locators(self, test_node, inv_node):
         tip = int(self.nodes[0].getbestblockhash(), 16)
 
         # PART 1

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1177,8 +1177,8 @@ class msg_getheaders(object):
 class msg_headers(object):
     command = b"headers"
 
-    def __init__(self):
-        self.headers = []
+    def __init__(self, headers=None):
+        self.headers = headers if headers is not None else []
 
     def deserialize(self, f):
         # comment in dashd indicates these should be deserialized as blocks

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -771,11 +771,13 @@ bool IsBanned(NodeId pnode)
 
 // To prevent fingerprinting attacks, only send blocks/headers outside of the
 // active chain if they are no more than a month older (both in time, and in
-// best equivalent proof of work) than the best header chain we know about.
-static bool StaleBlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+// best equivalent proof of work) than the best header chain we know about and
+// we fully-validated them at some point.
+static bool BlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
     AssertLockHeld(cs_main);
-    return (pindexBestHeader != nullptr) &&
+    if (chainActive.Contains(pindex)) return true;
+    return pindex->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != nullptr) &&
         (pindexBestHeader->GetBlockTime() - pindex->GetBlockTime() < STALE_RELAY_AGE_LIMIT) &&
         (GetBlockProofEquivalentTime(*pindexBestHeader, *pindex, *pindexBestHeader, consensusParams) < STALE_RELAY_AGE_LIMIT);
 }
@@ -1084,14 +1086,9 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                         CValidationState dummy;
                         ActivateBestChain(dummy, Params(), a_recent_block);
                     }
-                    if (chainActive.Contains(mi->second)) {
-                        send = true;
-                    } else {
-                        send = mi->second->IsValid(BLOCK_VALID_SCRIPTS) &&
-                            StaleBlockRequestAllowed(mi->second, consensusParams);
-                        if (!send) {
-                            LogPrintf("%s: ignoring request from peer=%i for old block that isn't in the main chain\n", __func__, pfrom->GetId());
-                        }
+                    send = BlockRequestAllowed(mi->second, consensusParams);
+                    if (!send) {
+                        LogPrintf("%s: ignoring request from peer=%i for old block that isn't in the main chain\n", __func__, pfrom->GetId());
                     }
                 }
                 // disconnect node in case we have reached the outbound limit for serving historical blocks
@@ -1986,8 +1983,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 return true;
             pindex = (*mi).second;
 
-            if (!chainActive.Contains(pindex) &&
-                !StaleBlockRequestAllowed(pindex, chainparams.GetConsensus())) {
+            if (!BlockRequestAllowed(pindex, chainparams.GetConsensus())) {
                 LogPrintf("%s: ignoring request from peer=%i for old block header that isn't in the main chain\n", __func__, pfrom->GetId());
                 return true;
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -86,6 +86,14 @@ static std::vector<std::pair<uint256, CTransactionRef>> vExtraTxnForCompact GUAR
 
 static const uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL; // SHA256("main address relay")[0:8]
 
+/// Age after which a stale block will no longer be served if requested as
+/// protection against fingerprinting. Set to one month, denominated in seconds.
+static const int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
+
+/// Age after which a block is considered historical for purposes of rate
+/// limiting block relay. Set to one week, denominated in seconds.
+static const int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
+
 // Internal stuff
 namespace {
     /** Number of nodes with fSyncStarted. */
@@ -761,6 +769,17 @@ bool IsBanned(NodeId pnode)
 // blockchain -> download logic notification
 //
 
+// To prevent fingerprinting attacks, only send blocks/headers outside of the
+// active chain if they are no more than a month older (both in time, and in
+// best equivalent proof of work) than the best header chain we know about.
+static bool StaleBlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+{
+    AssertLockHeld(cs_main);
+    return (pindexBestHeader != nullptr) &&
+        (pindexBestHeader->GetBlockTime() - pindex->GetBlockTime() < STALE_RELAY_AGE_LIMIT) &&
+        (GetBlockProofEquivalentTime(*pindexBestHeader, *pindex, *pindexBestHeader, consensusParams) < STALE_RELAY_AGE_LIMIT);
+}
+
 PeerLogicValidation::PeerLogicValidation(CConnman* connmanIn) : connman(connmanIn) {
     // Initialize global variables that cannot be constructed at startup.
     recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));
@@ -1068,13 +1087,8 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     if (chainActive.Contains(mi->second)) {
                         send = true;
                     } else {
-                        static const int nOneMonth = 30 * 24 * 60 * 60;
-                        // To prevent fingerprinting attacks, only send blocks outside of the active
-                        // chain if they are valid, and no more than a month older (both in time, and in
-                        // best equivalent proof of work) than the best header chain we know about.
-                        send = mi->second->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != NULL) &&
-                            (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() < nOneMonth) &&
-                            (GetBlockProofEquivalentTime(*pindexBestHeader, *mi->second, *pindexBestHeader, consensusParams) < nOneMonth);
+                        send = mi->second->IsValid(BLOCK_VALID_SCRIPTS) &&
+                            StaleBlockRequestAllowed(mi->second, consensusParams);
                         if (!send) {
                             LogPrintf("%s: ignoring request from peer=%i for old block that isn't in the main chain\n", __func__, pfrom->GetId());
                         }
@@ -1082,8 +1096,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                 }
                 // disconnect node in case we have reached the outbound limit for serving historical blocks
                 // never disconnect whitelisted nodes
-                static const int nOneWeek = 7 * 24 * 60 * 60; // assume > 1 week = historical
-                if (send && connman.OutboundTargetReached(true) && ( ((pindexBestHeader != NULL) && (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() > nOneWeek)) || inv.type == MSG_FILTERED_BLOCK) && !pfrom->fWhitelisted)
+                if (send && connman.OutboundTargetReached(true) && ( ((pindexBestHeader != NULL) && (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() > HISTORICAL_BLOCK_AGE)) || inv.type == MSG_FILTERED_BLOCK) && !pfrom->fWhitelisted)
                 {
                     LogPrint("net", "historical block serving limit reached, disconnect peer=%d\n", pfrom->GetId());
 
@@ -1972,6 +1985,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             if (mi == mapBlockIndex.end())
                 return true;
             pindex = (*mi).second;
+
+            if (!chainActive.Contains(pindex) &&
+                !StaleBlockRequestAllowed(pindex, chainparams.GetConsensus())) {
+                LogPrintf("%s: ignoring request from peer=%i for old block header that isn't in the main chain\n", __func__, pfrom->GetId());
+                return true;
+            }
         }
         else
         {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3348,8 +3348,7 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
                     {
                         LOCK(cs_most_recent_block);
                         if (most_recent_block_hash == pBestIndex->GetBlockHash()) {
-                            CBlockHeaderAndShortTxIDs cmpctblock(*most_recent_block);
-                            connman.PushMessage(pto, msgMaker.Make(NetMsgType::CMPCTBLOCK, cmpctblock));
+                            connman.PushMessage(pto, msgMaker.Make(NetMsgType::CMPCTBLOCK, *most_recent_compact_block));
                             fGotBlockFromCache = true;
                         }
                     }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -162,6 +162,16 @@ void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine,
     abort();
 }
 
+void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs)
+{
+    for (const std::pair<void*, CLockLocation>& i : *lockstack) {
+        if (i.first == cs) {
+            fprintf(stderr, "Assertion failed: lock %s held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld().c_str());
+            abort();
+        }
+    }
+}
+
 void DeleteLock(void* cs)
 {
     if (!lockdata.available) {

--- a/src/sync.h
+++ b/src/sync.h
@@ -76,14 +76,17 @@ void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs
 void LeaveCritical();
 std::string LocksHeld();
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs);
+void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs);
 void DeleteLock(void* cs);
 #else
 void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 void static inline LeaveCritical() {}
 void static inline AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) {}
+void static inline AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) {}
 void static inline DeleteLock(void* cs) {}
 #endif
 #define AssertLockHeld(cs) AssertLockHeldInternal(#cs, __FILE__, __LINE__, &cs)
+#define AssertLockNotHeld(cs) AssertLockNotHeldInternal(#cs, __FILE__, __LINE__, &cs)
 
 /**
  * Wrapped boost mutex: supports recursive locking, but no waiting

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -257,6 +257,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         createAndProcessEmptyBlock();
     }
 
+    {
     LOCK(cs_main);
 
     // Just to make sure we can still make simple blocks
@@ -507,8 +508,12 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     for (int i = 0; i < CBlockIndex::nMedianTimeSpan; i++)
         chainActive.Tip()->GetAncestor(chainActive.Tip()->nHeight - i)->nTime += 512; //Trick the MedianTimePast
 
+    } // unlock cs_main while calling createAndProcessEmptyBlock
+
     // Mine an empty block
     createAndProcessEmptyBlock();
+
+    LOCK(cs_main);
 
     SetMockTime(chainActive.Tip()->GetMedianTimePast() + 1);
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -210,7 +210,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     entry.dPriority = 111.0;
     entry.nHeight = 11;
 
-    LOCK(cs_main);
     fCheckpointsEnabled = false;
 
     // Simple block creation, nothing special yet:
@@ -224,28 +223,30 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     auto createAndProcessEmptyBlock = [&]() {
         int i = chainActive.Height();
         CBlock *pblock = &pemptyblocktemplate->block; // pointer for convenience
-        pblock->nVersion = 2;
-        pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
-        CMutableTransaction txCoinbase(*pblock->vtx[0]);
-        txCoinbase.nVersion = 1;
-        txCoinbase.vin[0].scriptSig = CScript() << (chainActive.Height() + 1);
-        txCoinbase.vin[0].scriptSig.push_back(blockinfo[i].extranonce);
-        txCoinbase.vin[0].scriptSig.push_back(chainActive.Height());
-        txCoinbase.vout[0].scriptPubKey = CScript();
-        pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
-        if (txFirst.size() == 0)
-            baseheight = chainActive.Height();
-        if (txFirst.size() < 4)
-            txFirst.push_back(pblock->vtx[0]);
-        pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
-        pblock->nNonce = blockinfo[i].nonce;
+        {
+            LOCK(cs_main);
+            pblock->nVersion = 2;
+            pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
+            CMutableTransaction txCoinbase(*pblock->vtx[0]);
+            txCoinbase.nVersion = 1;
+            txCoinbase.vin[0].scriptSig = CScript() << (chainActive.Height() + 1);
+            txCoinbase.vin[0].scriptSig.push_back(blockinfo[i].extranonce);
+            txCoinbase.vin[0].scriptSig.push_back(chainActive.Height());
+            txCoinbase.vout[0].scriptPubKey = CScript();
+            pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
+            if (txFirst.size() == 0)
+                baseheight = chainActive.Height();
+            if (txFirst.size() < 4)
+                txFirst.push_back(pblock->vtx[0]);
+            pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+            pblock->nNonce = blockinfo[i].nonce;
 
-        // This will usually succeed in the first round as we take the nonce from blockinfo
-        // It's however usefull when adding new blocks with unknown nonces (you should add the found block to blockinfo)
-        while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, chainparams.GetConsensus())) {
-            pblock->nNonce++;
+            // This will usually succeed in the first round as we take the nonce from blockinfo
+            // It's however usefull when adding new blocks with unknown nonces (you should add the found block to blockinfo)
+            while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, chainparams.GetConsensus())) {
+                pblock->nNonce++;
+            }
         }
-
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, NULL));
         pblock->hashPrevBlock = pblock->GetHash();
@@ -255,6 +256,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     {
         createAndProcessEmptyBlock();
     }
+
+    LOCK(cs_main);
 
     // Just to make sure we can still make simple blocks
     BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2886,6 +2886,7 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
     // far from a guarantee. Things in the P2P/RPC will often end up calling
     // us in the middle of ProcessNewBlock - do not assume pblock is set
     // sanely for performance or correctness!
+    AssertLockNotHeld(cs_main);
 
     CBlockIndex *pindexMostWork = NULL;
     CBlockIndex *pindexNewTip = NULL;
@@ -3599,6 +3600,8 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
 
 bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
 {
+    AssertLockNotHeld(cs_main);
+
     {
         CBlockIndex *pindex = NULL;
         if (fNewBlock) *fNewBlock = false;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -363,13 +363,13 @@ BOOST_AUTO_TEST_CASE(ApproximateBestSubset)
 
 BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
 {
-    LOCK(cs_main);
-
     // Cap last block file size, and mine new block in a new block file.
     CBlockIndex* oldTip = chainActive.Tip();
     GetBlockFileInfo(oldTip->GetBlockPos().nFile)->nSize = MAX_BLOCKFILE_SIZE;
     CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
     CBlockIndex* newTip = chainActive.Tip();
+
+    LOCK(cs_main);
 
     // Verify ScanForWalletTransactions picks up transactions in both the old
     // and new block files.
@@ -435,8 +435,6 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
 BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 {
     CWallet *pwalletMainBackup = ::pwalletMain;
-    LOCK(cs_main);
-
     // Create two blocks with same timestamp to verify that importwallet rescan
     // will pick up both blocks, not just the first.
     const int64_t BLOCK_TIME = chainActive.Tip()->GetBlockTimeMax() + 5;
@@ -449,6 +447,8 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     const int64_t KEY_TIME = BLOCK_TIME + 7200;
     SetMockTime(KEY_TIME);
     coinbaseTxns.emplace_back(*CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey())).vtx[0]);
+
+    LOCK(cs_main);
 
     // Import key into wallet and call dumpwallet to create backup file.
     {


### PR DESCRIPTION
While working on enforcement of ChainLocks I discovered a race condition in ActivateBestChain due to it being called from multiple threads at the same time. This resulted in signals being invoked in undefined order, so it happened that signals for block 5 were called before block 4. This ends up in all kinds of issues that might occur, of which one is test failures due to `waitforblockheight` waiting forever. I'm also pretty sure that there are other possible issues with this which are much more severe.

This type of parallel invocation of `ActivateBestChain` is very unlikely in plain Bitcoin code, as it is only called from the message handler thread and when manually calling `invalidateblock` or `reconsiderblock`. But it becomes a lot more likely to happen in Dash with ChainLocks involved which call `ActivateBestChain` from different threads.

This PR does not really solve the issue, but it prepares the code for the actual fix. This PR makes `ActivateBestChain` require that `cs_main` is NOT held on entry, which will later allow us to introduce a new mutex that prevents execution of `ActivateBestChain` in parallel. With `cs_main` held on entry, it would lead to regular deadlocks.

This mainly PR consists of a few cherry-picks from bitcoin#11824. Please ignore the tile of bitcoin#11824 as the actually added functionality is not what we're interested in here. We're only interested in a few of the supporting commits.

Cherry picking these commits led to merge conflicts in many places due to out-of-order backporting. I decided to backport other PRs as well so that cherry-picking the commits from bitcoin#11824 was more or less conflict free. These other PRs are bitcoin#9665, bitcoin#11113 and bitcoin#11580. While backporting bitcoin#9665, I then realized that a previous backport was erroneous, so I also added a fix in b8ac517d7dd4239f7bfb0d660e80045f19fb6f87.