### PR TITLE
Multiple fixes/refactorings for ChainLocks

### DIFF
--- a/qa/rpc-tests/llmq-chainlocks.py
+++ b/qa/rpc-tests/llmq-chainlocks.py
@@ -68,17 +68,17 @@ class LLMQChainLocksTest(DashTestFramework):
 
         # Keep node connected and let it try to reorg the chain
         good_tip = self.nodes[0].getbestblockhash()
-        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         # Restart it so that it forgets all the chainlocks from the past
         stop_node(self.nodes[0], 0)
         self.nodes[0] = start_node(0, self.options.tmpdir, self.extra_args)
         connect_nodes(self.nodes[0], 1)
+        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         # Now try to reorg the chain
         self.nodes[0].generate(2)
-        sleep(2)
+        sleep(6)
         assert(self.nodes[1].getbestblockhash() == good_tip)
         self.nodes[0].generate(2)
-        sleep(2)
+        sleep(6)
         assert(self.nodes[1].getbestblockhash() == good_tip)
 
         # Now let the node which is on the wrong chain reorg back to the locked chain

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -430,7 +430,7 @@ void CChainLocksHandler::EnforceBestChainLock()
             ResetBlockFailureFlags(mapBlockIndex.at(currentBestChainLockBlockIndex->GetBlockHash()));
         }
 
-        activateNeeded = chainActive.Tip() != currentBestChainLockBlockIndex;
+        activateNeeded = chainActive.Tip()->GetAncestor(currentBestChainLockBlockIndex->nHeight) != currentBestChainLockBlockIndex;
     }
 
     CValidationState state;

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -405,10 +405,16 @@ void CChainLocksHandler::EnforceBestChainLock()
 {
     CChainLockSig clsig;
     const CBlockIndex* pindex;
+    const CBlockIndex* bestChainLockBlockIndex;
     {
         LOCK(cs);
         clsig = bestChainLockWithKnownBlock;
-        pindex = bestChainLockBlockIndex;
+        pindex = bestChainLockBlockIndex = this->bestChainLockBlockIndex;
+
+        if (!bestChainLockBlockIndex) {
+            // we don't have the header/block, so we can't do anything right now
+            return;
+        }
     }
 
     bool activateNeeded;

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -411,6 +411,7 @@ void CChainLocksHandler::EnforceBestChainLock()
         pindex = bestChainLockBlockIndex;
     }
 
+    bool activateNeeded;
     {
         LOCK(cs_main);
 
@@ -438,10 +439,12 @@ void CChainLocksHandler::EnforceBestChainLock()
         if (!bestChainLockBlockIndex->IsValid()) {
             ResetBlockFailureFlags(mapBlockIndex.at(bestChainLockBlockIndex->GetBlockHash()));
         }
+
+        activateNeeded = chainActive.Tip() != bestChainLockBlockIndex;
     }
 
     CValidationState state;
-    if (!ActivateBestChain(state, Params())) {
+    if (activateNeeded && !ActivateBestChain(state, Params())) {
         LogPrintf("CChainLocksHandler::%s -- ActivateBestChain failed: %s\n", __func__, FormatStateMessage(state));
     }
 }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -389,13 +389,13 @@ void CChainLocksHandler::EnforceBestChainLock()
 {
     CChainLockSig clsig;
     const CBlockIndex* pindex;
-    const CBlockIndex* bestChainLockBlockIndex;
+    const CBlockIndex* currentBestChainLockBlockIndex;
     {
         LOCK(cs);
         clsig = bestChainLockWithKnownBlock;
-        pindex = bestChainLockBlockIndex = this->bestChainLockBlockIndex;
+        pindex = currentBestChainLockBlockIndex = this->bestChainLockBlockIndex;
 
-        if (!bestChainLockBlockIndex) {
+        if (!currentBestChainLockBlockIndex) {
             // we don't have the header/block, so we can't do anything right now
             return;
         }
@@ -426,11 +426,11 @@ void CChainLocksHandler::EnforceBestChainLock()
         // can happen right now is when missing superblock triggers caused the main chain to be dismissed first. When
         // the trigger later appears, this should bring us to the correct chain eventually. Please note that this does
         // NOT enforce invalid blocks in any way, it just causes re-validation.
-        if (!bestChainLockBlockIndex->IsValid()) {
-            ResetBlockFailureFlags(mapBlockIndex.at(bestChainLockBlockIndex->GetBlockHash()));
+        if (!currentBestChainLockBlockIndex->IsValid()) {
+            ResetBlockFailureFlags(mapBlockIndex.at(currentBestChainLockBlockIndex->GetBlockHash()));
         }
 
-        activateNeeded = chainActive.Tip() != bestChainLockBlockIndex;
+        activateNeeded = chainActive.Tip() != currentBestChainLockBlockIndex;
     }
 
     CValidationState state;
@@ -441,10 +441,10 @@ void CChainLocksHandler::EnforceBestChainLock()
     const CBlockIndex* pindexNotify = nullptr;
     {
         LOCK(cs_main);
-        if (lastNotifyChainLockBlockIndex != bestChainLockBlockIndex &&
-            chainActive.Tip()->GetAncestor(bestChainLockBlockIndex->nHeight) == bestChainLockBlockIndex) {
-            lastNotifyChainLockBlockIndex = bestChainLockBlockIndex;
-            pindexNotify = bestChainLockBlockIndex;
+        if (lastNotifyChainLockBlockIndex != currentBestChainLockBlockIndex &&
+            chainActive.Tip()->GetAncestor(currentBestChainLockBlockIndex->nHeight) == currentBestChainLockBlockIndex) {
+            lastNotifyChainLockBlockIndex = currentBestChainLockBlockIndex;
+            pindexNotify = currentBestChainLockBlockIndex;
         }
     }
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -53,7 +53,6 @@ private:
     CScheduler* scheduler;
     CCriticalSection cs;
     bool tryLockChainTipScheduled{false};
-    std::atomic<bool> inEnforceBestChainLock{false};
 
     uint256 bestChainLockHash;
     CChainLockSig bestChainLock;

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -103,7 +103,6 @@ private:
     bool InternalHasChainLock(int nHeight, const uint256& blockHash);
     bool InternalHasConflictingChainLock(int nHeight, const uint256& blockHash);
 
-    void ScheduleInvalidateBlock(const CBlockIndex* pindex);
     void DoInvalidateBlock(const CBlockIndex* pindex, bool activateBestChain);
 
     void Cleanup();

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -553,7 +553,7 @@ void CDKGSessionHandler::PhaseHandlerThread()
                 status.aborted = true;
                 return true;
             });
-            LogPrintf("CDKGSessionHandler::%s -- aborted current DKG session\n", __func__);
+            LogPrintf("CDKGSessionHandler::%s -- aborted current DKG session for llmq=%s\n", __func__, params.name);
         }
     }
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2888,6 +2888,11 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
     // sanely for performance or correctness!
     AssertLockNotHeld(cs_main);
 
+    // make sure that no matter what, only one thread is executing ActivateBestChain. This avoids a race condition when
+    // validation signals are invoked, which might result in out-of-order execution.
+    static CCriticalSection cs_activateBestChain;
+    LOCK(cs_activateBestChain);
+
     CBlockIndex *pindexMostWork = NULL;
     CBlockIndex *pindexNewTip = NULL;
     do {


### PR DESCRIPTION
See individual commits. ~The PR currently includes #2764 as well as it otherwise runs into deadlocks due to the fix in 5aae9907043da8811d5a0308b0d5fdc723413ff6. I'll remove these commits with a rebase after merge.~

The target of this PR is to remove all enforcement logic from signal handlers and move them into the scheduler instead. Otherwise we end up with recursive calls of signals and I don't even want to know what kind of issues might arise from this.

The PR also adds an additional step to enforcement, which is the resetting of failure flags on the CL signed chain. This lets the node retry connecting the correct chain until it eventually succeeds. This is especially important when nodes fork off due to missing superblock triggers.