### PR TITLE
Implement retroactive IS locking of transactions first seen in blocks instead of mempool

### DIFF
--- a/qa/rpc-tests/autois-mempool.py
+++ b/qa/rpc-tests/autois-mempool.py
@@ -104,9 +104,17 @@ class AutoISMempoolTest(DashTestFramework):
         assert(not self.send_regular_instantsend(sender, receiver, False) if new_is else self.send_regular_instantsend(sender, receiver))
 
         # generate one block to clean up mempool and retry auto and regular IS
-        # generate 2 more blocks to have enough confirmations for IS
-        self.nodes[0].generate(3)
+        # generate 5 more blocks to avoid retroactive signing (which would overload Travis)
+        set_mocktime(get_mocktime() + 1)
+        set_node_times(self.nodes, get_mocktime())
+        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 4070908800)
+        self.wait_for_sporks_same()
+        self.nodes[0].generate(6)
         self.sync_all()
+        set_mocktime(get_mocktime() + 1)
+        set_node_times(self.nodes, get_mocktime())
+        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
+        self.wait_for_sporks_same()
         assert(self.send_simple_tx(sender, receiver))
         assert(self.send_regular_instantsend(sender, receiver, not new_is))
 

--- a/qa/rpc-tests/autois-mempool.py
+++ b/qa/rpc-tests/autois-mempool.py
@@ -56,6 +56,10 @@ class AutoISMempoolTest(DashTestFramework):
         self.log.info("Test old InstantSend")
         self.test_auto();
 
+        # Generate 6 block to avoid retroactive signing overloading Travis
+        self.nodes[0].generate(6)
+        sync_blocks(self.nodes)
+
         self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 0)
         self.wait_for_sporks_same()
 

--- a/qa/rpc-tests/llmq-chainlocks.py
+++ b/qa/rpc-tests/llmq-chainlocks.py
@@ -88,6 +88,37 @@ class LLMQChainLocksTest(DashTestFramework):
         self.wait_for_chainlock(self.nodes[0], self.nodes[1].getbestblockhash())
         assert(self.nodes[0].getbestblockhash() == self.nodes[1].getbestblockhash())
 
+        # Enable LLMQ bases InstantSend, which also enables checks for "safe" transactions
+        self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 0)
+        self.wait_for_sporks_same()
+
+        # Isolate a node and let it create some transactions which won't get IS locked
+        self.nodes[0].setnetworkactive(False)
+        txs = []
+        for i in range(3):
+            txs.append(self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1))
+        # Assert that after block generation these TXs are NOT included (as they are "unsafe")
+        self.nodes[0].generate(1)
+        for txid in txs:
+            tx = self.nodes[0].getrawtransaction(txid, 1)
+            assert("confirmations" not in tx)
+        sleep(1)
+        assert(not self.nodes[0].getblock(self.nodes[0].getbestblockhash())["chainlock"])
+        # Disable LLMQ based InstantSend for a very short time (this never gets propagated to other nodes)
+        self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 4070908800)
+        # Now the TXs should be included
+        self.nodes[0].generate(1)
+        self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 0)
+        # Assert that TXs got included now
+        for txid in txs:
+            tx = self.nodes[0].getrawtransaction(txid, 1)
+            assert("confirmations" in tx and tx["confirmations"] > 0)
+        # Enable network on first node again, which will cause the blocks to propagate and IS locks to happen retroactively
+        # for the mined TXs, which will then allow the network to create a CLSIG
+        self.nodes[0].setnetworkactive(True)
+        connect_nodes(self.nodes[0], 1)
+        self.wait_for_chainlock(self.nodes[0], self.nodes[1].getbestblockhash())
+
     def wait_for_chainlock_tip_all_nodes(self):
         for node in self.nodes:
             tip = node.getbestblockhash()

--- a/qa/rpc-tests/p2p-autoinstantsend.py
+++ b/qa/rpc-tests/p2p-autoinstantsend.py
@@ -39,6 +39,10 @@ class AutoInstantSendTest(DashTestFramework):
         self.log.info("Test old InstantSend")
         self.test_auto();
 
+        # Generate 6 block to avoid retroactive signing overloading Travis
+        self.nodes[0].generate(6)
+        sync_blocks(self.nodes)
+
         self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 0)
         self.wait_for_sporks_same()
 

--- a/qa/rpc-tests/p2p-instantsend.py
+++ b/qa/rpc-tests/p2p-instantsend.py
@@ -28,6 +28,10 @@ class InstantSendTest(DashTestFramework):
         self.log.info("Test old InstantSend")
         self.test_doublespend()
 
+        # Generate 6 block to avoid retroactive signing overloading Travis
+        self.nodes[0].generate(6)
+        sync_blocks(self.nodes)
+
         self.nodes[0].spork("SPORK_20_INSTANTSEND_LLMQ_BASED", 0)
         self.wait_for_sporks_same()
 

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -71,11 +71,6 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     llmq::quorumDKGSessionManager->UpdatedBlockTip(pindexNew, pindexFork, fInitialDownload);
 }
 
-void CDSNotificationInterface::NewPoWValidBlock(const CBlockIndex* pindex, const std::shared_ptr<const CBlock>& block)
-{
-    llmq::chainLocksHandler->NewPoWValidBlock(pindex, block);
-}
-
 void CDSNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock)
 {
     llmq::quorumInstantSendManager->SyncTransaction(tx, pindex, posInBlock);

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -21,7 +21,6 @@ protected:
     void AcceptedBlockHeader(const CBlockIndex *pindexNew) override;
     void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
-    void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) override;
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) override;
     void NotifyMasternodeListChanged(const CDeterministicMNList& newList) override;
     void NotifyChainLock(const CBlockIndex* pindex) override;

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -87,7 +87,6 @@ public:
     void ProcessNewChainLock(NodeId from, const CChainLockSig& clsig, const uint256& hash);
     void AcceptedBlockHeader(const CBlockIndex* pindexNew);
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork);
-    void NewPoWValidBlock(const CBlockIndex* pindex, const std::shared_ptr<const CBlock>& block);
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock);
     void TrySignChainTip();
     void EnforceBestChainLock();

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -711,8 +711,17 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
         return;
     }
 
-    if (IsLocked(tx.GetHash())) {
+    if (posInBlock == 0) {
+        // coinbase can't be locked
+        return;
+    }
+
+    bool locked = IsLocked(tx.GetHash());
+    bool chainlocked = pindex && chainLocksHandler->HasChainLock(pindex->nHeight, pindex->GetBlockHash());
+    if (locked || chainlocked) {
         RetryLockTxs(tx.GetHash());
+    } else {
+        ProcessTx(tx, Params().GetConsensus());
     }
 }
 

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -711,8 +711,8 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
         return;
     }
 
-    if (posInBlock == 0) {
-        // coinbase can't be locked
+    if (tx.IsCoinBase() || tx.vin.empty()) {
+        // coinbase can't and TXs with no inputs be locked
         return;
     }
 

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -856,7 +856,20 @@ void CInstantSendManager::RetryLockTxs(const uint256& lockedParentTx)
         }
 
         for (const auto& tx : block.vtx) {
-            txs.emplace(tx->GetHash(), tx);
+            if (lockedParentTx.IsNull()) {
+                txs.emplace(tx->GetHash(), tx);
+            } else {
+                bool isChild  = false;
+                for (auto& in : tx->vin) {
+                    if (in.prevout.hash == lockedParentTx) {
+                        isChild = true;
+                        break;
+                    }
+                }
+                if (isChild) {
+                    txs.emplace(tx->GetHash(), tx);
+                }
+            }
         }
 
         pindexWalk = pindexWalk->pprev;

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -124,7 +124,7 @@ public:
     void RemoveFinalISLock(const uint256& hash, const CInstantSendLockPtr& islock);
 
     void RemoveMempoolConflictsForLock(const uint256& hash, const CInstantSendLock& islock);
-    void RetryLockMempoolTxs(const uint256& lockedParentTx);
+    void RetryLockTxs(const uint256& lockedParentTx);
 
     bool AlreadyHave(const CInv& inv);
     bool GetInstantSendLockByHash(const uint256& hash, CInstantSendLock& ret);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2164,10 +2164,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 instantsend.Vote(tx.GetHash(), connman);
             }
 
-            if (nInvType != MSG_TXLOCK_REQUEST) {
-                llmq::quorumInstantSendManager->ProcessTx(tx, chainparams.GetConsensus());
-            }
-
             mempool.check(pcoinsTip);
             connman.RelayTransaction(tx);
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
@@ -2212,8 +2208,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                             vWorkQueue.emplace_back(orphanHash, i);
                         }
                         vEraseQueue.push_back(orphanHash);
-
-                        llmq::quorumInstantSendManager->ProcessTx(orphanTx, chainparams.GetConsensus());
                     }
                     else if (!fMissingInputs2)
                     {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1020,7 +1020,6 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_TRANSACTION_ERROR, state.GetRejectReason());
             }
         }
-        llmq::quorumInstantSendManager->ProcessTx(*tx, Params().GetConsensus());
     } else if (fHaveChain) {
         throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1921,8 +1921,6 @@ bool CWalletTx::RelayWalletTransaction(CConnman* connman, const std::string& str
                 }
             }
 
-            llmq::quorumInstantSendManager->ProcessTx(*this->tx, Params().GetConsensus());
-
             if (connman) {
                 connman->RelayTransaction((CTransaction)*this);
                 return true;


### PR DESCRIPTION
This implements "retroactive signing" of TXs which were not known before a block appears that contains the TX. This implicitly enables retroactive signing of CLSIGs when included transactions were previously considered "unsafe".

The PR also includes a few fixes for issues I encountered while implementing/testing this.