### PR TITLE
Relay spork after updating internal spork maps

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -235,10 +235,12 @@ bool CSporkManager::UpdateSpork(int nSporkID, int64_t nValue, CConnman& connman)
             LogPrintf("CSporkManager::UpdateSpork: failed to find keyid for private key\n");
             return false;
         }
+        {
+            LOCK(cs);
+            mapSporksByHash[spork.GetHash()] = spork;
+            mapSporksActive[nSporkID][keyIDSigner] = spork;
+        }
         spork.Relay(connman);
-        LOCK(cs);
-        mapSporksByHash[spork.GetHash()] = spork;
-        mapSporksActive[nSporkID][keyIDSigner] = spork;
         return true;
     }
 


### PR DESCRIPTION
Otherwise regtest nodes might end up sending "getdata" too fast, which
results in the spork not being propagated.

Fixes test failures on Travis as seen in https://travis-ci.org/dashpay/dash/jobs/507716717