### PR TITLE
Disable in-wallet miner for win/macos Travis/Gitian builds

### DIFF
--- a/ci/matrix.sh
+++ b/ci/matrix.sh
@@ -41,7 +41,7 @@ elif [ "$BUILD_TARGET" = "win32" ]; then
   export DPKG_ADD_ARCH="i386"
   export DEP_OPTS="NO_QT=1"
   export PACKAGES="python3 nsis g++-mingw-w64-i686 wine-stable wine32 bc"
-  export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports"
+  export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --disable-miner"
   export DIRECT_WINE_EXEC_TESTS=true
   export RUN_TESTS=true
 elif [ "$BUILD_TARGET" = "win64" ]; then
@@ -49,7 +49,7 @@ elif [ "$BUILD_TARGET" = "win64" ]; then
   export DPKG_ADD_ARCH="i386"
   export DEP_OPTS="NO_QT=1"
   export PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-stable wine64 bc"
-  export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports"
+  export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --disable-miner"
   export DIRECT_WINE_EXEC_TESTS=true
   export RUN_TESTS=true
 elif [ "$BUILD_TARGET" = "linux32" ]; then
@@ -82,7 +82,7 @@ elif [ "$BUILD_TARGET" = "linux64_release" ]; then
 elif [ "$BUILD_TARGET" = "mac" ]; then
   export HOST=x86_64-apple-darwin11
   export PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools"
-  export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports"
+  export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --disable-miner"
   export OSX_SDK=10.11
   export GOAL="deploy"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -199,6 +199,17 @@ AC_ARG_ENABLE([stacktraces],
     [enable_stacktraces=$enableval],
     [enable_stacktraces=no])
 
+# Enable in-wallet miner
+AC_ARG_ENABLE([miner],
+    [AS_HELP_STRING([--enable-miner],
+                    [enable in-wallet miner (default is yes)])],
+    [enable_miner=$enableval],
+    [enable_miner=yes])
+AM_CONDITIONAL([ENABLE_MINER], [test x$enable_miner = xyes])
+if test "x$enable_miner" = xyes; then
+    AC_DEFINE(ENABLE_MINER, 1, [Define this symbol if in-wallet miner should be enabled])
+fi
+
 # Turn warnings into errors
 AC_ARG_ENABLE([werror],
     [AS_HELP_STRING([--enable-werror],
@@ -1243,6 +1254,7 @@ echo "  with bench    = $use_bench"
 echo "  with upnp     = $use_upnp"
 echo "  debug enabled = $enable_debug"
 echo "  stacktraces enabled = $enable_stacktraces"
+echo "  miner enabled = $enable_miner"
 echo "  werror        = $enable_werror"
 echo 
 echo "  target os     = $TARGET_OS"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -37,7 +37,7 @@ files:
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin11"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
+  CONFIGFLAGS="--enable-reduce-exports --disable-miner --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg genisoimage"
 

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -31,7 +31,7 @@ files: []
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
+  CONFIGFLAGS="--enable-reduce-exports --disable-miner --disable-bench --disable-gui-tests"
   FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"
   HOST_CFLAGS="-O2 -g"

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -30,10 +30,12 @@ public:
 static const CRPCConvertParam vRPCConvertParams[] =
 {
     { "setmocktime", 0, "timestamp" },
+#if ENABLE_MINER
     { "generate", 0, "nblocks" },
     { "generate", 1, "maxtries" },
     { "generatetoaddress", 0, "nblocks" },
     { "generatetoaddress", 2, "maxtries" },
+#endif // ENABLE_MINER
     { "getnetworkhashps", 0, "nblocks" },
     { "getnetworkhashps", 1, "height" },
     { "sendtoaddress", 1, "amount" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -104,6 +104,7 @@ UniValue getnetworkhashps(const JSONRPCRequest& request)
     return GetNetworkHashPS(request.params.size() > 0 ? request.params[0].get_int() : 120, request.params.size() > 1 ? request.params[1].get_int() : -1);
 }
 
+#if ENABLE_MINER
 UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, uint64_t nMaxTries, bool keepScript)
 {
     static const int nInnerLoopCount = 0x10000;
@@ -222,6 +223,7 @@ UniValue generatetoaddress(const JSONRPCRequest& request)
 
     return generateBlocks(coinbaseScript, nGenerate, nMaxTries, false);
 }
+#endif // ENABLE_MINER
 
 UniValue getmininginfo(const JSONRPCRequest& request)
 {
@@ -903,9 +905,10 @@ static const CRPCCommand commands[] =
     { "mining",             "getblocktemplate",       &getblocktemplate,       true,  {"template_request"} },
     { "mining",             "submitblock",            &submitblock,            true,  {"hexdata","parameters"} },
 
+#if ENABLE_MINER
     { "generating",         "generate",               &generate,               true,  {"nblocks","maxtries"} },
     { "generating",         "generatetoaddress",      &generatetoaddress,      true,  {"nblocks","address","maxtries"} },
-
+#endif // ENABLE_MINER
     { "util",               "estimatefee",            &estimatefee,            true,  {"nblocks"} },
     { "util",               "estimatesmartfee",       &estimatesmartfee,       true,  {"nblocks"} },
 };

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -320,6 +320,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     BOOST_CHECK_EQUAL(adr.get_str(), "2001:4d48:ac57:400:cacf:e9ff:fe1d:9c63/128");
 }
 
+#if ENABLE_MINER
 BOOST_AUTO_TEST_CASE(rpc_convert_values_generatetoaddress)
 {
     UniValue result;
@@ -342,5 +343,6 @@ BOOST_AUTO_TEST_CASE(rpc_convert_values_generatetoaddress)
     BOOST_CHECK_EQUAL(result[1].get_str(), "yTG8jLL3MvteKXgbEcHyaN7JvTPCejQpSh");
     BOOST_CHECK_EQUAL(result[2].get_int(), 9);
 }
+#endif // ENABLE_MINER
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This should lower AV false-positive score for our win/macos release binaries quite a bit.

Before:
https://www.virustotal.com/#/file/f0b6f5833a177d0254ce874a8cdf5b317e648fc05e53db1b6444d0f19f807d9b/detection (17)
After:
https://www.virustotal.com/#/file/30046d2a7bd29b3441df2591ba38f53c559ba8613064e3ed597881da91bcab41/detection (4)

Bitcoin `master` (for comparison):
https://www.virustotal.com/#/file/1feaf335225525bb492a74929c5bdeb48772fcd4cca02a20d1bc846d906eadf2/detection (6)

Not sure what else could be removed to make every AV happy (suggestions are welcome!) but this PR resolves issues with most major AVs already, so imo it's good enough even if there is nothing else we can do to improve it further.

Downsides:
- 3 more Travis builds;
- have to drop some rpcs in such builds (but "normal" users shouldn't care and advanced ones should be able to build binaries themselves);
- have to disable some unit test in such builds (but similar builds with mining enabled should catch issues if any).