### PR TITLE
Skip mempool.dat when wallet is starting in "zap" mode

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4513,6 +4513,11 @@ static const uint64_t MEMPOOL_DUMP_VERSION = 1;
 
 bool LoadMempool(void)
 {
+    if (GetBoolArg("-zapwallettxes", false)) {
+        LogPrintf("Skipping mempool.dat because of zapwallettxes\n");
+        return true;
+    }
+
     int64_t nExpiryTimeout = GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60;
     FILE* filestr = fopen((GetDataDir() / "mempool.dat").string().c_str(), "rb");
     CAutoFile file(filestr, SER_DISK, CLIENT_VERSION);


### PR DESCRIPTION
This should fix an issue with txes stuck in local mempool and injected back into wallet after `zapwalletxes` has done its work (which was defeating the purpose of `zapwalletxes`).