### PR TITLE
Introduce "qsendrecsigs" to indicate that plain recovered sigs should be sent

### DIFF
--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -519,7 +519,11 @@ void CSigningManager::ProcessRecoveredSig(NodeId nodeId, const CRecoveredSig& re
     }
 
     CInv inv(MSG_QUORUM_RECOVERED_SIG, recoveredSig.GetHash());
-    g_connman->RelayInv(inv, LLMQS_PROTO_VERSION);
+    g_connman->ForEachNode([&](CNode* pnode) {
+        if (pnode->nVersion >= LLMQS_PROTO_VERSION && pnode->fSendRecSigs) {
+            pnode->PushInventory(inv);
+        }
+    });
 
     for (auto& l : listeners) {
         l->HandleNewRecoveredSig(recoveredSig);

--- a/src/net.h
+++ b/src/net.h
@@ -820,7 +820,7 @@ public:
     // If true, we will announce/send him plain recovered sigs (usually true for full nodes)
     std::atomic<bool> fSendRecSigs{false};
     // If true, we will send him all quorum related messages, even if he is not a member of our quorums
-    std::atomic_bool qwatch{false};
+    std::atomic<bool> qwatch{false};
 
     CNode(NodeId id, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress &addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const std::string &addrNameIn = "", bool fInboundIn = false);
     ~CNode();

--- a/src/net.h
+++ b/src/net.h
@@ -817,6 +817,8 @@ public:
     // Whether a ping is requested.
     std::atomic<bool> fPingQueued;
 
+    // If true, we will announce/send him plain recovered sigs (usually true for full nodes)
+    std::atomic<bool> fSendRecSigs{false};
     // If true, we will send him all quorum related messages, even if he is not a member of our quorums
     std::atomic_bool qwatch{false};
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1681,6 +1681,14 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::SENDCMPCT, fAnnounceUsingCMPCTBLOCK, nCMPCTBLOCKVersion));
         }
 
+        if (pfrom->nVersion >= LLMQS_PROTO_VERSION) {
+            // Tell our peer that we're interested in plain LLMQ recovered signatures.
+            // Otherwise the peer would only announce/send messages resulting from QRECSIG,
+            // e.g. InstantSend locks or ChainLocks. SPV nodes should not send this message
+            // as they are usually only interested in the higher level messages
+            connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::QSENDRECSIGS, true));
+        }
+
         if (GetBoolArg("-watchquorums", llmq::DEFAULT_WATCH_QUORUMS)) {
             connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::QWATCH));
         }
@@ -1760,6 +1768,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             State(pfrom->GetId())->fPreferHeaderAndIDs = fAnnounceUsingCMPCTBLOCK;
             State(pfrom->GetId())->fSupportsDesiredCmpctVersion = true;
         }
+    }
+
+
+    else if (strCommand == NetMsgType::QSENDRECSIGS) {
+        bool b;
+        vRecv >> b;
+        pfrom->fSendRecSigs = b;
     }
 
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -58,6 +58,7 @@ const char *MNGOVERNANCEOBJECT="govobj";
 const char *MNGOVERNANCEOBJECTVOTE="govobjvote";
 const char *GETMNLISTDIFF="getmnlistd";
 const char *MNLISTDIFF="mnlistdiff";
+const char *QSENDRECSIGS="qsendrecsigs";
 const char *QFCOMMITMENT="qfcommit";
 const char *QCONTRIB="qcontrib";
 const char *QCOMPLAINT="qcomplaint";
@@ -161,6 +162,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::MNGOVERNANCEOBJECTVOTE,
     NetMsgType::GETMNLISTDIFF,
     NetMsgType::MNLISTDIFF,
+    NetMsgType::QSENDRECSIGS,
     NetMsgType::QFCOMMITMENT,
     NetMsgType::QCONTRIB,
     NetMsgType::QCOMPLAINT,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -264,6 +264,7 @@ extern const char *MNGOVERNANCEOBJECT;
 extern const char *MNGOVERNANCEOBJECTVOTE;
 extern const char *GETMNLISTDIFF;
 extern const char *MNLISTDIFF;
+extern const char *QSENDRECSIGS;
 extern const char *QFCOMMITMENT;
 extern const char *QCONTRIB;
 extern const char *QCOMPLAINT;


### PR DESCRIPTION
This avoids sending unnecessary data to SPV clients and other node implementations that don't know how to deal with `qrecsig`.