### PR TITLE
Implement MNAUTH and allow unlimited inbound MN connections

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,12 +134,12 @@ BITCOIN_CORE_H = \
   cuckoocache.h \
   ctpl.h \
   cxxtimer.hpp \
-  evo/evodb.h \
-  evo/specialtx.h \
-  evo/providertx.h \
-  evo/deterministicmns.h \
   evo/cbtx.h \
+  evo/deterministicmns.h \
+  evo/evodb.h \
+  evo/providertx.h \
   evo/simplifiedmns.h \
+  evo/specialtx.h \
   privatesend.h \
   privatesend-client.h \
   privatesend-server.h \
@@ -267,12 +267,12 @@ libdash_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   dsnotificationinterface.cpp \
-  evo/evodb.cpp \
-  evo/specialtx.cpp \
-  evo/providertx.cpp \
-  evo/deterministicmns.cpp \
   evo/cbtx.cpp \
+  evo/deterministicmns.cpp \
+  evo/evodb.cpp \
+  evo/providertx.cpp \
   evo/simplifiedmns.cpp \
+  evo/specialtx.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ BITCOIN_CORE_H = \
   evo/cbtx.h \
   evo/deterministicmns.h \
   evo/evodb.h \
+  evo/mnauth.h \
   evo/providertx.h \
   evo/simplifiedmns.h \
   evo/specialtx.h \
@@ -270,6 +271,7 @@ libdash_server_a_SOURCES = \
   evo/cbtx.cpp \
   evo/deterministicmns.cpp \
   evo/evodb.cpp \
+  evo/mnauth.cpp \
   evo/providertx.cpp \
   evo/simplifiedmns.cpp \
   evo/specialtx.cpp \

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -15,6 +15,7 @@
 #include "validation.h"
 
 #include "evo/deterministicmns.h"
+#include "evo/mnauth.h"
 
 #include "llmq/quorums.h"
 #include "llmq/quorums_chainlocks.h"
@@ -81,6 +82,7 @@ void CDSNotificationInterface::SyncTransaction(const CTransaction &tx, const CBl
 
 void CDSNotificationInterface::NotifyMasternodeListChanged(const CDeterministicMNList& newList)
 {
+    CMNAuth::NotifyMasternodeListChanged(newList);
     governance.CheckMasternodeOrphanObjects(connman);
     governance.CheckMasternodeOrphanVotes(connman);
     governance.UpdateCachesAndClean();

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2019 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "mnauth.h"
+
+#include "activemasternode.h"
+#include "evo/deterministicmns.h"
+#include "masternode-sync.h"
+#include "net.h"
+#include "net_processing.h"
+#include "netmessagemaker.h"
+#include "validation.h"
+
+#include <unordered_set>
+
+void CMNAuth::PushMNAUTH(CNode* pnode, CConnman& connman)
+{
+    if (!fMasternodeMode || activeMasternodeInfo.proTxHash.IsNull()) {
+        return;
+    }
+
+    uint256 signHash;
+    {
+        LOCK(pnode->cs_mnauth);
+        if (pnode->receivedMNAuthChallenge.IsNull()) {
+            return;
+        }
+        // We include fInbound in signHash to forbid interchanging of challenges by a man in the middle. This way
+        // we protect ourself against MITM in this form:
+        //   node1 <- Eve -> node2
+        // It does not protect against:
+        //   node1 -> Eve -> node2
+        // This is ok as we only use MNAUTH as a DoS protection and not for sensitive stuff
+        signHash = ::SerializeHash(std::make_tuple(*activeMasternodeInfo.blsPubKeyOperator, pnode->receivedMNAuthChallenge, pnode->fInbound));
+    }
+
+    CMNAuth mnauth;
+    mnauth.proRegTxHash = activeMasternodeInfo.proTxHash;
+    mnauth.sig = activeMasternodeInfo.blsKeyOperator->Sign(signHash);
+
+    LogPrint("net", "CMNAuth::%s -- Sending MNAUTH, peer=%d\n", __func__, pnode->id);
+
+    connman.PushMessage(pnode, CNetMsgMaker(pnode->GetSendVersion()).Make(NetMsgType::MNAUTH, mnauth));
+}
+
+void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
+{
+    if (!fMasternodeMode) {
+        return;
+    }
+
+    if (!masternodeSync.IsBlockchainSynced()) {
+        // we can't really verify MNAUTH messages when we don't have the latest MN list
+        return;
+    }
+
+    if (strCommand == NetMsgType::MNAUTH) {
+        CMNAuth mnauth;
+        vRecv >> mnauth;
+
+        {
+            LOCK(pnode->cs_mnauth);
+            // only one MNAUTH allowed
+            if (!pnode->verifiedProRegTx.IsNull()) {
+                LOCK(cs_main);
+                Misbehaving(pnode->id, 100);
+                return;
+            }
+        }
+
+        if (mnauth.proRegTxHash.IsNull() || !mnauth.sig.IsValid()) {
+            LOCK(cs_main);
+            Misbehaving(pnode->id, 100);
+            return;
+        }
+
+        auto mnList = deterministicMNManager->GetListAtChainTip();
+        auto dmn = mnList.GetValidMN(mnauth.proRegTxHash);
+        if (!dmn) {
+            LOCK(cs_main);
+            Misbehaving(pnode->id, 10);
+            // in case he was unlucky and not up to date, let him retry the whole verification process
+            pnode->fDisconnect = true;
+            return;
+        }
+
+        uint256 signHash;
+        {
+            LOCK(pnode->cs_mnauth);
+            // See comment in PushMNAUTH (fInbound is negated here as we're on the other side of the connection)
+            signHash = ::SerializeHash(std::make_tuple(dmn->pdmnState->pubKeyOperator, pnode->sentMNAuthChallenge, !pnode->fInbound));
+        }
+
+        if (!mnauth.sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator, signHash)) {
+            LOCK(cs_main);
+            Misbehaving(pnode->id, 10);
+            // in case he was unlucky and not up to date, let him retry the whole verification process
+            pnode->fDisconnect = true;
+            return;
+        }
+
+        connman.ForEachNode([&](CNode* pnode2) {
+            if (pnode2->verifiedProRegTx == mnauth.proRegTxHash) {
+                LogPrint("net", "CMNAuth::ProcessMessage -- Masternode %s has already verified as peer %d, dropping old connection. peer=%d\n",
+                        mnauth.proRegTxHash.ToString(), pnode2->id, pnode->id);
+                pnode2->fDisconnect = true;
+            }
+        });
+
+        {
+            LOCK(pnode->cs_mnauth);
+            pnode->verifiedProRegTx = mnauth.proRegTxHash;
+            pnode->verifiedPubKey = dmn->pdmnState->pubKeyOperator.GetHash();
+        }
+
+        LogPrint("net", "CMNAuth::%s -- Valid MNAUTH for %s, peer=%d\n", __func__, mnauth.proRegTxHash.ToString(), pnode->id);
+    }
+}
+
+void CMNAuth::NotifyMasternodeListChanged(const CDeterministicMNList& newList)
+{
+    std::unordered_set<uint256> pubKeys;
+    g_connman->ForEachNode([&](const CNode* pnode) {
+        LOCK(pnode->cs_mnauth);
+        if (!pnode->verifiedProRegTx.IsNull()) {
+            pubKeys.emplace(pnode->verifiedProRegTx);
+        }
+    });
+    newList.ForEachMN(true, [&](const CDeterministicMNCPtr& dmn) {
+        pubKeys.erase(dmn->pdmnState->pubKeyOperator.GetHash());
+    });
+    g_connman->ForEachNode([&](CNode* pnode) {
+        LOCK(pnode->cs_mnauth);
+        if (!pnode->verifiedProRegTx.IsNull() && pubKeys.count(pnode->verifiedPubKey)) {
+            LogPrint("net", "CMNAuth::NotifyMasternodeListChanged -- Disconnecting MN %s due to key changed/removed, peer=%d\n",
+                    pnode->verifiedProRegTx.ToString(), pnode->id);
+            pnode->fDisconnect = true;
+        }
+    });
+}

--- a/src/evo/mnauth.h
+++ b/src/evo/mnauth.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DASH_MNAUTH_H
+#define DASH_MNAUTH_H
+
+#include "bls/bls.h"
+#include "serialize.h"
+
+class CConnman;
+class CDataStream;
+class CDeterministicMN;
+class CDeterministicMNList;
+class CNode;
+class UniValue;
+
+/**
+ * This class handles the p2p message MNAUTH. MNAUTH is sent directly after VERACK and authenticates the sender as a
+ * masternode. It is only sent when the sender is actually a masternode.
+ *
+ * MNAUTH signs a challenge that was previously sent via VERSION. The challenge is signed differently depending on
+ * the connection being an inbound or outbound connection, which avoids MITM of this form:
+ *   node1 <- Eve -> node2
+ * while still allowing:
+ *   node1 -> Eve -> node2
+ *
+ * This is fine as we only use this mechanism for DoS protection. It allows us to keep masternode connections open for
+ * a very long time without evicting the connections when inbound connection limits are hit (non-MNs will then be evicted).
+ *
+ * If we ever want to add transfer of sensible data, THIS AUTHENTICATION MECHANISM IS NOT ENOUGH!! We'd need to implement
+ * proper encryption for these connections first.
+ */
+
+class CMNAuth
+{
+public:
+    uint256 proRegTxHash;
+    CBLSSignature sig;
+
+public:
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(proRegTxHash);
+        READWRITE(sig);
+    }
+
+    static void PushMNAUTH(CNode* pnode, CConnman& connman);
+    static void ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
+    static void NotifyMasternodeListChanged(const CDeterministicMNList& newList);
+};
+
+
+#endif //DASH_MNAUTH_H

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -191,19 +191,19 @@ void CQuorumManager::EnsureQuorumConnections(Consensus::LLMQType llmqType, const
         }
 
         if (!g_connman->HasMasternodeQuorumNodes(llmqType, quorum->quorumHash)) {
-            std::set<CService> connections;
+            std::map<CService, uint256> connections;
             if (quorum->IsMember(myProTxHash)) {
                 connections = CLLMQUtils::GetQuorumConnections(llmqType, quorum->quorumHash, myProTxHash);
             } else {
                 auto cindexes = CLLMQUtils::CalcDeterministicWatchConnections(llmqType, quorum->quorumHash, quorum->members.size(), 1);
                 for (auto idx : cindexes) {
-                    connections.emplace(quorum->members[idx]->pdmnState->addr);
+                    connections.emplace(quorum->members[idx]->pdmnState->addr, quorum->members[idx]->proTxHash);
                 }
             }
             if (!connections.empty()) {
                 std::string debugMsg = strprintf("CQuorumManager::%s -- adding masternodes quorum connections for quorum %s:\n", __func__, quorum->quorumHash.ToString());
                 for (auto& c : connections) {
-                    debugMsg += strprintf("  %s\n", c.ToString(false));
+                    debugMsg += strprintf("  %s\n", c.first.ToString(false));
                 }
                 LogPrint("llmq", debugMsg);
                 g_connman->AddMasternodeQuorumNodes(llmqType, quorum->quorumHash, connections);

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -41,12 +41,12 @@ uint256 CLLMQUtils::BuildSignHash(Consensus::LLMQType llmqType, const uint256& q
     return h.GetHash();
 }
 
-std::set<CService> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember)
+std::map<CService, uint256> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember)
 {
     auto& params = Params().GetConsensus().llmqs.at(llmqType);
 
     auto mns = GetAllQuorumMembers(llmqType, blockHash);
-    std::set<CService> result;
+    std::map<CService, uint256> result;
     for (size_t i = 0; i < mns.size(); i++) {
         auto& dmn = mns[i];
         if (dmn->proTxHash == forMember) {
@@ -59,7 +59,7 @@ std::set<CService> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType
                 if (otherDmn == dmn) {
                     continue;
                 }
-                result.emplace(otherDmn->pdmnState->addr);
+                result.emplace(otherDmn->pdmnState->addr, otherDmn->proTxHash);
                 gap <<= 1;
             }
             // there can be no two members with the same proTxHash, so return early

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -31,7 +31,7 @@ public:
         return BuildSignHash((Consensus::LLMQType)s.llmqType, s.quorumHash, s.id, s.msgHash);
     }
 
-    static std::set<CService> GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember);
+    static std::map<CService, uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember);
     static std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType, const uint256& blockHash, size_t memberCount, size_t connectionCount);
 
     static bool IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quorumHash);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -986,7 +986,7 @@ bool CConnman::AttemptToEvictConnection()
                 }
                 // if MNAUTH was valid, the node is always protected (and at the same time not accounted when
                 // checking incoming connection limits)
-                if (!node->verifiedProRegTx.IsNull()) {
+                if (!node->verifiedProRegTxHash.IsNull()) {
                     isProtected = true;
                 }
                 if (isProtected) {
@@ -1093,7 +1093,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
         BOOST_FOREACH(CNode* pnode, vNodes) {
             if (pnode->fInbound) {
                 nInbound++;
-                if (!pnode->verifiedProRegTx.IsNull()) {
+                if (!pnode->verifiedProRegTxHash.IsNull()) {
                     nVerifiedInboundMasternodes++;
                 }
             }
@@ -2048,11 +2048,11 @@ void CConnman::ThreadOpenMasternodeConnections()
             return;
 
         std::set<CService> connectedNodes;
-        std::set<uint256> connectedProRegTxs;
+        std::set<uint256> connectedProRegTxHashes;
         ForEachNode([&](const CNode* pnode) {
             connectedNodes.emplace(pnode->addr);
-            if (!pnode->verifiedProRegTx.IsNull()) {
-                connectedProRegTxs.emplace(pnode->verifiedProRegTx);
+            if (!pnode->verifiedProRegTxHash.IsNull()) {
+                connectedProRegTxHashes.emplace(pnode->verifiedProRegTxHash);
             }
         });
 
@@ -2070,8 +2070,8 @@ void CConnman::ThreadOpenMasternodeConnections()
             for (const auto& group : masternodeQuorumNodes) {
                 for (const auto& p : group.second) {
                     auto& addr = p.first;
-                    auto& proRegTx = p.second;
-                    if (!connectedNodes.count(addr) && !IsMasternodeOrDisconnectRequested(addr) && !connectedProRegTxs.count(proRegTx)) {
+                    auto& proRegTxHash = p.second;
+                    if (!connectedNodes.count(addr) && !IsMasternodeOrDisconnectRequested(addr) && !connectedProRegTxHashes.count(proRegTxHash)) {
                         pending.emplace_back(addr);
                     }
                 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -712,10 +712,29 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
 
         // absorb network data
         int handled;
-        if (!msg.in_data)
+        if (!msg.in_data) {
             handled = msg.readHeader(pch, nBytes);
-        else
+            if (msg.in_data && nTimeFirstMessageReceived == 0) {
+                if (fSuccessfullyConnected) {
+                    // First message after VERSION/VERACK.
+                    // We record the time when the header is fully received and not when the full message is received.
+                    // otherwise a peer might send us a very large message as first message after VERSION/VERACK and fill
+                    // up our memory with multiple parallel connections doing this.
+                    nTimeFirstMessageReceived = nTimeMicros;
+                    fFirstMessageIsMNAUTH = msg.hdr.GetCommand() == NetMsgType::MNAUTH;
+                } else {
+                    // We're still in the VERSION/VERACK handshake process, so any message received in this state is
+                    // expected to be very small. This protects against attackers filling up memory by sending oversized
+                    // VERSION messages while the incoming connection is still protected against eviction
+                    if (msg.hdr.nMessageSize > 1024) {
+                        LogPrint("net", "Oversized VERSION/VERACK message from peer=%i, disconnecting\n", GetId());
+                        return false;
+                    }
+                }
+            }
+        } else {
             handled = msg.readData(pch, nBytes);
+        }
 
         if (handled < 0)
                 return false;
@@ -955,6 +974,26 @@ bool CConnman::AttemptToEvictConnection()
                 continue;
             if (node->fDisconnect)
                 continue;
+
+            if (fMasternodeMode) {
+                // This handles eviction protected nodes. Nodes are always protected for a short time after the connection
+                // was accepted. This short time is meant for the VERSION/VERACK exchange and the possible MNAUTH that might
+                // follow when the incoming connection is from another masternode. When another message then MNAUTH
+                // is received after VERSION/VERACK, the protection is lifted immediately.
+                bool isProtected = GetSystemTimeInSeconds() - node->nTimeConnected < INBOUND_EVICTION_PROTECTION_TIME;
+                if (node->nTimeFirstMessageReceived != 0 && !node->fFirstMessageIsMNAUTH) {
+                    isProtected = false;
+                }
+                // if MNAUTH was valid, the node is always protected (and at the same time not accounted when
+                // checking incoming connection limits)
+                if (!node->verifiedProRegTx.IsNull()) {
+                    isProtected = true;
+                }
+                if (isProtected) {
+                    continue;
+                }
+            }
+
             NodeEvictionCandidate candidate = {node->id, node->nTimeConnected, node->nMinPingUsecTime,
                                                node->nLastBlockTime, node->nLastTXTime,
                                                (node->nServices & nRelevantServices) == nRelevantServices,
@@ -1041,6 +1080,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     SOCKET hSocket = accept(hListenSocket.socket, (struct sockaddr*)&sockaddr, &len);
     CAddress addr;
     int nInbound = 0;
+    int nVerifiedInboundMasternodes = 0;
     int nMaxInbound = nMaxConnections - (nMaxOutbound + nMaxFeeler);
 
     if (hSocket != INVALID_SOCKET)
@@ -1050,9 +1090,15 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     bool whitelisted = hListenSocket.whitelisted || IsWhitelistedRange(addr);
     {
         LOCK(cs_vNodes);
-        BOOST_FOREACH(CNode* pnode, vNodes)
-            if (pnode->fInbound)
+        BOOST_FOREACH(CNode* pnode, vNodes) {
+            if (pnode->fInbound) {
                 nInbound++;
+                if (!pnode->verifiedProRegTx.IsNull()) {
+                    nVerifiedInboundMasternodes++;
+                }
+            }
+        }
+
     }
 
     if (hSocket == INVALID_SOCKET)
@@ -1092,7 +1138,12 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
         return;
     }
 
-    if (nInbound >= nMaxInbound)
+    // Evict connections until we are below nMaxInbound. In case eviction protection resulted in nodes to not be evicted
+    // before, they might get evicted in batches now (after the protection timeout).
+    // We don't evict verified MN connections and also don't take them into account when checking limits. We can do this
+    // because we know that such connections are naturally limited by the total number of MNs, so this is not usable
+    // for attacks.
+    while (nInbound - nVerifiedInboundMasternodes >= nMaxInbound)
     {
         if (!AttemptToEvictConnection()) {
             // No connection to evict, disconnect the new connection
@@ -1100,6 +1151,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
             CloseSocket(hSocket);
             return;
         }
+        nInbound--;
     }
 
     // don't accept incoming connections until fully synced
@@ -2983,6 +3035,8 @@ unsigned int CConnman::GetSendBufferSize() const{ return nSendBufferMaxSize; }
 
 CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const std::string& addrNameIn, bool fInboundIn) :
     nTimeConnected(GetSystemTimeInSeconds()),
+    nTimeFirstMessageReceived(0),
+    fFirstMessageIsMNAUTH(false),
     addr(addrIn),
     fInbound(fInboundIn),
     id(idIn),

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2661,7 +2661,7 @@ bool CConnman::AddPendingMasternode(const CService& service)
     return true;
 }
 
-bool CConnman::AddMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::set<CService>& addresses)
+bool CConnman::AddMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::map<CService, uint256>& addresses)
 {
     LOCK(cs_vPendingMasternodes);
     auto it = masternodeQuorumNodes.find(std::make_pair(llmqType, quorumHash));
@@ -2691,7 +2691,7 @@ std::set<uint256> CConnman::GetMasternodeQuorums(Consensus::LLMQType llmqType)
     return result;
 }
 
-std::set<CService> CConnman::GetMasternodeQuorumAddresses(Consensus::LLMQType llmqType, const uint256& quorumHash) const
+std::map<CService, uint256> CConnman::GetMasternodeQuorumAddresses(Consensus::LLMQType llmqType, const uint256& quorumHash) const
 {
     LOCK(cs_vPendingMasternodes);
     auto it = masternodeQuorumNodes.find(std::make_pair(llmqType, quorumHash));

--- a/src/net.h
+++ b/src/net.h
@@ -829,8 +829,8 @@ public:
     mutable CCriticalSection cs_mnauth;
     uint256 sentMNAuthChallenge;
     uint256 receivedMNAuthChallenge;
-    uint256 verifiedProRegTx;
-    uint256 verifiedPubKey;
+    uint256 verifiedProRegTxHash;
+    uint256 verifiedPubKeyHash;
 
     // If true, we will announce/send him plain recovered sigs (usually true for full nodes)
     std::atomic<bool> fSendRecSigs{false};

--- a/src/net.h
+++ b/src/net.h
@@ -356,10 +356,10 @@ public:
     std::vector<AddedNodeInfo> GetAddedNodeInfo();
 
     bool AddPendingMasternode(const CService& addr);
-    bool AddMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::set<CService>& addresses);
+    bool AddMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::map<CService, uint256>& addresses);
     bool HasMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash);
     std::set<uint256> GetMasternodeQuorums(Consensus::LLMQType llmqType);
-    std::set<CService> GetMasternodeQuorumAddresses(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
+    std::map<CService, uint256> GetMasternodeQuorumAddresses(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
     // also returns QWATCH nodes
     std::set<NodeId> GetMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
     void RemoveMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash);
@@ -493,7 +493,7 @@ private:
     std::vector<std::string> vAddedNodes;
     CCriticalSection cs_vAddedNodes;
     std::vector<CService> vPendingMasternodes;
-    std::map<std::pair<Consensus::LLMQType, uint256>, std::set<CService>> masternodeQuorumNodes; // protected by cs_vPendingMasternodes
+    std::map<std::pair<Consensus::LLMQType, uint256>, std::map<CService, uint256>> masternodeQuorumNodes; // protected by cs_vPendingMasternodes
     mutable CCriticalSection cs_vPendingMasternodes;
     std::vector<CNode*> vNodes;
     std::list<CNode*> vNodesDisconnected;

--- a/src/net.h
+++ b/src/net.h
@@ -68,6 +68,8 @@ static const int MAX_ADDNODE_CONNECTIONS = 8;
 /** Maximum number if outgoing masternodes */
 static const int MAX_OUTBOUND_MASTERNODE_CONNECTIONS = 30;
 static const int MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN = 250;
+/** Eviction protection time for incoming connections  */
+static const int INBOUND_EVICTION_PROTECTION_TIME = 1;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */
@@ -726,6 +728,8 @@ public:
     const int64_t nTimeConnected;
     std::atomic<int64_t> nTimeOffset;
     std::atomic<int64_t> nLastWarningTime;
+    std::atomic<int64_t> nTimeFirstMessageReceived;
+    std::atomic<bool> fFirstMessageIsMNAUTH;
     const CAddress addr;
     std::atomic<int> nNumWarningsSkipped;
     std::atomic<int> nVersion;

--- a/src/net.h
+++ b/src/net.h
@@ -821,6 +821,13 @@ public:
     // If true, we will send him PrivateSend queue messages
     std::atomic<bool> fSendDSQueue{false};
 
+    // Challenge sent in VERSION to be answered with MNAUTH (only happens between MNs)
+    mutable CCriticalSection cs_mnauth;
+    uint256 sentMNAuthChallenge;
+    uint256 receivedMNAuthChallenge;
+    uint256 verifiedProRegTx;
+    uint256 verifiedPubKey;
+
     // If true, we will announce/send him plain recovered sigs (usually true for full nodes)
     std::atomic<bool> fSendRecSigs{false};
     // If true, we will send him all quorum related messages, even if he is not a member of our quorums

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -74,6 +74,7 @@ const char *QBSIGSHARES="qbsigs";
 const char *QSIGREC="qsigrec";
 const char *CLSIG="clsig";
 const char *ISLOCK="islock";
+const char *MNAUTH="mnauth";
 };
 
 static const char* ppszTypeName[] =
@@ -179,6 +180,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::QSIGREC,
     NetMsgType::CLSIG,
     NetMsgType::ISLOCK,
+    NetMsgType::MNAUTH,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -280,6 +280,7 @@ extern const char *QBSIGSHARES;
 extern const char *QSIGREC;
 extern const char *CLSIG;
 extern const char *ISLOCK;
+extern const char *MNAUTH;
 };
 
 /* Get a vector of all valid message types (see above) */


### PR DESCRIPTION
This implements MNAUTH, which allows us to verify that an incoming connection is indeed from another MN. This in turn allows us to exclude inbound MN connections from limit checks and at the same time protect these connections from eviction.

This is required to ensure that intra-quorum connections stay active as long as they are needed and never get evicted due to MNs being spammed with inbound connections.

The reason we can exclude authenticated MN connections from eviction is because these are naturally limited. MNAUTH will drop any previous connections that were authenticated with the same MN, which means that each MN can cause only one incoming authenticated (non-evictable) connection.

MNAUTH is also sent/verified for outgoing connections, this is however not of interest when it comes to the inbound connection eviction and DoS (or network partition) protection. It is however useful to avoid unnecessarily connecting to a MN that already connected to us when ensuring intra-quorum connections.