### PR TITLE
Bump MAX_OUTBOUND_MASTERNODE_CONNECTIONS to 250 on masternodes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2519,7 +2519,7 @@ void CConnman::Interrupt()
     }
 
     if (semMasternodeOutbound) {
-        for (int i=0; i<fMasternodeMode ? MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN : MAX_OUTBOUND_MASTERNODE_CONNECTIONS; i++) {
+        for (int i=0; i<(fMasternodeMode ? MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN : MAX_OUTBOUND_MASTERNODE_CONNECTIONS); i++) {
             semMasternodeOutbound->post();
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2519,7 +2519,8 @@ void CConnman::Interrupt()
     }
 
     if (semMasternodeOutbound) {
-        for (int i=0; i<(fMasternodeMode ? MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN : MAX_OUTBOUND_MASTERNODE_CONNECTIONS); i++) {
+        int nMaxMasternodeOutbound = fMasternodeMode ? MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN : MAX_OUTBOUND_MASTERNODE_CONNECTIONS;
+        for (int i = 0; i < nMaxMasternodeOutbound; i++) {
             semMasternodeOutbound->post();
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2414,7 +2414,7 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
 
     if (semMasternodeOutbound == NULL) {
         // initialize semaphore
-        semMasternodeOutbound = new CSemaphore(MAX_OUTBOUND_MASTERNODE_CONNECTIONS);
+        semMasternodeOutbound = new CSemaphore(fMasternodeMode ? MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN : MAX_OUTBOUND_MASTERNODE_CONNECTIONS);
     }
 
     //
@@ -2519,7 +2519,7 @@ void CConnman::Interrupt()
     }
 
     if (semMasternodeOutbound) {
-        for (int i=0; i<MAX_OUTBOUND_MASTERNODE_CONNECTIONS; i++) {
+        for (int i=0; i<fMasternodeMode ? MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN : MAX_OUTBOUND_MASTERNODE_CONNECTIONS; i++) {
             semMasternodeOutbound->post();
         }
     }

--- a/src/net.h
+++ b/src/net.h
@@ -67,6 +67,7 @@ static const int MAX_OUTBOUND_CONNECTIONS = 8;
 static const int MAX_ADDNODE_CONNECTIONS = 8;
 /** Maximum number if outgoing masternodes */
 static const int MAX_OUTBOUND_MASTERNODE_CONNECTIONS = 30;
+static const int MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN = 250;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */


### PR DESCRIPTION
Masternodes now need to connect to much more other MNs due to the intra-quorum communication.

250 is a very conservative value loosely based on the absolute worst-case number of outgoing connections required, assuming that a MN manages to become part of all 24 active LLMQs.

250 might sound a lot, but in reality the chance of a MN being part of any single LLMQ is pretty low. For a quorum size of 50 and total number of 4500 masternodes, the chance is 1.11% to be part of a new LLMQ. Assuming we have 24 active LLMQs and the current DKG, we have a total chance of 27.77% to be part of any LLMQ at any time. Being a member of one LLMQ requires 5 outgoing connections. Being part of 2 LLMQs has a chance of 7.7%. For 4 LLMQs it's down to 0.5%, and so on. Even if you're extremely un-/lucky to be part of 10 LLMQs (chance of 0.0002%), you'd only have 50 extra connections so far (which any decent VPS should be able to handle).