### PR TITLE
Disable logging of libevent debug messages

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -371,8 +371,9 @@ static void libevent_log_cb(int severity, const char *msg)
 #endif
     if (severity >= EVENT_LOG_WARN) // Log warn messages and higher without debug category
         LogPrintf("libevent: %s\n", msg);
-    else
-        LogPrint("libevent", "libevent: %s\n", msg);
+    // The below code causes log spam on Travis and the output of these logs has never been of any use so far
+    //else
+    //    LogPrint("libevent", "libevent: %s\n", msg);
 }
 
 bool InitHTTPServer()


### PR DESCRIPTION
This still keeps the "libevent" logging category in place, but it now only logs >= EVENT_LOG_WARN severity.

https://api.travis-ci.org/v3/job/509488096/log.txt is an example of why we should do this. Logs on Travis are completely filled with libevent logging and the actual/important logs are cut off.