### PR TITLE
Fix loop in CLLMQUtils::GetQuorumConnections to add at least 2 connections

### DIFF
--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -50,10 +50,13 @@ std::set<CService> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType
     for (size_t i = 0; i < mns.size(); i++) {
         auto& dmn = mns[i];
         if (dmn->proTxHash == forMember) {
-            // Connect to nodes at indexes (i+2^k)%n, k: 0..floor(log2(n-1))-1, n: size of the quorum/ring
+            // Connect to nodes at indexes (i+2^k)%n, where
+            //   k: 0..min(1, floor(log2(n-1))-1)
+            //   n: size of the quorum/ring
             int gap = 1;
             int gap_max = (int)mns.size() - 1;
-            while (gap_max >>= 1) {
+            int k = 0;
+            while ((gap_max >>= 1) || k <= 1) {
                 size_t idx = (i + gap) % mns.size();
                 auto& otherDmn = mns[idx];
                 if (otherDmn == dmn) {
@@ -61,6 +64,7 @@ std::set<CService> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType
                 }
                 result.emplace(otherDmn->pdmnState->addr);
                 gap <<= 1;
+                k++;
             }
             // there can be no two members with the same proTxHash, so return early
             break;

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -51,7 +51,7 @@ std::set<CService> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType
         auto& dmn = mns[i];
         if (dmn->proTxHash == forMember) {
             // Connect to nodes at indexes (i+2^k)%n, where
-            //   k: 0..min(1, floor(log2(n-1))-1)
+            //   k: 0..max(1, floor(log2(n-1))-1)
             //   n: size of the quorum/ring
             int gap = 1;
             int gap_max = (int)mns.size() - 1;

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -52,7 +52,7 @@ std::set<CService> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType
         if (dmn->proTxHash == forMember) {
             // Connect to nodes at indexes (i+2^k)%n, k: 0..floor(log2(n-1))-1, n: size of the quorum/ring
             int gap = 1;
-            int gap_max = mns.size() - 1;
+            int gap_max = (int)mns.size() - 1;
             while (gap_max >>= 1) {
                 size_t idx = (i + gap) % mns.size();
                 auto& otherDmn = mns[idx];


### PR DESCRIPTION
When reaching very small quorum sizes, the current algorithm results in
only a single connection to be added. This would be fine usually, but is an
issue when this connection fails. We should always have at least one backup
connection.

This fixes simple PoSe test failures where the quorum size gets down to 4
with one of the 4 members being down. If other nodes are unlucky to connect
to this node, they fail as well even though 3 members in a quorum should
work fine.

This should fix test failures as seen in https://travis-ci.org/dashpay/dash/jobs/509806921