### PR TITLE
Stop tracking interested/participating nodes and send/announce to MNAUTH peers

### DIFF
--- a/src/llmq/quorums_dkgsession.h
+++ b/src/llmq/quorums_dkgsession.h
@@ -277,7 +277,6 @@ private:
     std::map<uint256, CDKGJustification> justifications;
     std::map<uint256, CDKGPrematureCommitment> prematureCommitments;
     std::set<CInv> invSet;
-    std::set<CService> participatingNodes;
 
     std::vector<size_t> pendingContributionVerifications;
 
@@ -336,7 +335,6 @@ public:
     bool AreWeMember() const { return !myProTxHash.IsNull(); }
     void MarkBadMember(size_t idx);
 
-    void AddParticipatingNode(NodeId nodeId);
     void RelayInvToParticipants(const CInv& inv) const;
 
 public:

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -435,14 +435,6 @@ bool ProcessPendingMessageBatch(CDKGSession& session, CDKGPendingMessages& pendi
         }
     }
 
-    for (const auto& p : preverifiedMessages) {
-        NodeId nodeId = p.first;
-        if (badNodes.count(nodeId)) {
-            continue;
-        }
-        session.AddParticipatingNode(nodeId);
-    }
-
     return true;
 }
 
@@ -492,12 +484,6 @@ void CDKGSessionHandler::HandleDKGRound()
             }
             LogPrint("llmq", debugMsg);
             g_connman->AddMasternodeQuorumNodes(params.type, curQuorumHash, connections);
-
-            auto participatingNodesTmp = g_connman->GetMasternodeQuorumAddresses(params.type, curQuorumHash);
-            LOCK(curSession->invCs);
-            for (auto& p : participatingNodesTmp) {
-                curSession->participatingNodes.emplace(p.first);
-            }
         }
     }
 

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -81,10 +81,6 @@ void CDKGSessionManager::ProcessMessage(CNode* pfrom, const std::string& strComm
 
     if (strCommand == NetMsgType::QWATCH) {
         pfrom->qwatch = true;
-        for (auto& p : dkgSessionHandlers) {
-            LOCK2(p.second.cs, p.second.curSession->invCs);
-            p.second.curSession->participatingNodes.emplace(pfrom->addr);
-        }
         return;
     }
 

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -316,10 +316,6 @@ public:
     SigShareMap<CSigShare> pendingIncomingSigShares;
     SigShareMap<int64_t> requestedSigShares;
 
-    // elements are added whenever we receive a valid sig share from this node
-    // this triggers us to send inventory items to him as he seems to be interested in these
-    std::unordered_set<std::pair<Consensus::LLMQType, uint256>, StaticSaltedHasher> interestedIn;
-
     bool banned{false};
 
     Session& GetOrCreateSessionFromShare(const CSigShare& sigShare);

--- a/src/masternode-utils.cpp
+++ b/src/masternode-utils.cpp
@@ -73,7 +73,7 @@ void CMasternodeUtils::ProcessMasternodeConnections(CConnman& connman)
 #endif // ENABLE_WALLET
 
     connman.ForEachNode(CConnman::AllNodes, [&](CNode* pnode) {
-        if (pnode->fMasternode && !connman.IsMasternodeQuorumNode(pnode->addr)) {
+        if (pnode->fMasternode && !connman.IsMasternodeQuorumNode(pnode)) {
 #ifdef ENABLE_WALLET
             bool fFound = false;
             for (const auto& dmn : vecDmns) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2785,12 +2785,17 @@ void CConnman::RemoveMasternodeQuorumNodes(Consensus::LLMQType llmqType, const u
     masternodeQuorumNodes.erase(std::make_pair(llmqType, quorumHash));
 }
 
-bool CConnman::IsMasternodeQuorumNode(const CService& addr)
+bool CConnman::IsMasternodeQuorumNode(const CNode* pnode)
 {
     LOCK(cs_vPendingMasternodes);
     for (const auto& p : masternodeQuorumNodes) {
-        if (p.second.count(addr)) {
-            return true;
+        for (const auto& p2 : p.second) {
+            if (p2.first == (CService)pnode->addr) {
+                return true;
+            }
+            if (!pnode->verifiedProRegTxHash.IsNull() && p2.second == pnode->verifiedProRegTxHash) {
+                return true;
+            }
         }
     }
     return false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2766,12 +2766,18 @@ std::set<NodeId> CConnman::GetMasternodeQuorumNodes(Consensus::LLMQType llmqType
     if (it == masternodeQuorumNodes.end()) {
         return {};
     }
+    std::set<uint256> proRegTxHashes;
+    for (auto& p : it->second) {
+        proRegTxHashes.emplace(p.second);
+    }
+
     std::set<NodeId> nodes;
     for (const auto pnode : vNodes) {
         if (pnode->fDisconnect) {
             continue;
         }
-        if (!pnode->qwatch && !it->second.count(pnode->addr)) {
+        if (!pnode->qwatch && !it->second.count(pnode->addr) &&
+            (pnode->verifiedProRegTxHash.IsNull() || !proRegTxHashes.count(pnode->verifiedProRegTxHash))) {
             continue;
         }
         nodes.emplace(pnode->id);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2749,16 +2749,6 @@ std::set<uint256> CConnman::GetMasternodeQuorums(Consensus::LLMQType llmqType)
     return result;
 }
 
-std::map<CService, uint256> CConnman::GetMasternodeQuorumAddresses(Consensus::LLMQType llmqType, const uint256& quorumHash) const
-{
-    LOCK(cs_vPendingMasternodes);
-    auto it = masternodeQuorumNodes.find(std::make_pair(llmqType, quorumHash));
-    if (it == masternodeQuorumNodes.end()) {
-        return {};
-    }
-    return it->second;
-}
-
 std::set<NodeId> CConnman::GetMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash) const
 {
     LOCK2(cs_vNodes, cs_vPendingMasternodes);

--- a/src/net.h
+++ b/src/net.h
@@ -365,7 +365,7 @@ public:
     // also returns QWATCH nodes
     std::set<NodeId> GetMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
     void RemoveMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash);
-    bool IsMasternodeQuorumNode(const CService& addr);
+    bool IsMasternodeQuorumNode(const CNode* pnode);
 
     size_t GetNodeCount(NumConnections num);
     void GetNodeStats(std::vector<CNodeStats>& vstats);

--- a/src/net.h
+++ b/src/net.h
@@ -361,7 +361,6 @@ public:
     bool AddMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::map<CService, uint256>& addresses);
     bool HasMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash);
     std::set<uint256> GetMasternodeQuorums(Consensus::LLMQType llmqType);
-    std::map<CService, uint256> GetMasternodeQuorumAddresses(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
     // also returns QWATCH nodes
     std::set<NodeId> GetMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
     void RemoveMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash);


### PR DESCRIPTION
With the introduction of MNAUTH we also introduced an optimization to not connect to quorum members when there is already an incoming connection from the same member. This however results in DKGs messages and sig shares not being sent to these nodes. This is also the reason for recent test failures.

This PR makes the DKG and sig shares manager take all MNAUTHed connections into account. This also included incoming connections from other members. At the same time, this removes the need for the tracking of participating/interested nodes, which this PR now also removes.