### PR TITLE
Prepare Dash-related stuff before starting ThreadImport

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -817,16 +817,19 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
     // GetMainSignals().UpdatedBlockTip(chainActive.Tip());
     pdsNotificationInterface->InitializeCurrentBlockTip();
 
-    bool fDIP003Active;
-    {
-        LOCK(cs_main);
-        if (chainActive.Tip()->pprev) {
-            fDIP003Active = VersionBitsState(chainActive.Tip()->pprev, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0003, versionbitscache) == THRESHOLD_ACTIVE;
+    if (fMasternodeMode) {
+        bool fDIP003Active{false};
+        {
+            LOCK(cs_main);
+            if (chainActive.Tip()->pprev) {
+                fDIP003Active = VersionBitsState(chainActive.Tip()->pprev, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0003, versionbitscache) == THRESHOLD_ACTIVE;
+            }
+        }
+        if (fDIP003Active) {
+            assert(activeMasternodeManager);
+            activeMasternodeManager->Init();
         }
     }
-
-    if (activeMasternodeManager && fDIP003Active)
-        activeMasternodeManager->Init();
 
 #ifdef ENABLE_WALLET
     // we can't do this before DIP3 is fully initialized


### PR DESCRIPTION
We need `activeMasternodeManager` to be non-`nullptr` in `ThreadImport` (which can happen atm if main thread is too slow) when running in masternode mode. Otherwise `activeMasternodeManager->Init()` in `loadblk` thread will not run which means we won't send `mnauth` to other nodes (because `activeMasternodeInfo.proTxHash.IsNull() == true`) i.e. they won't recognise us as a MN and won't send contributions etc. which in its turn causes tests to fail.

Other Dash-related stuff seems to be not affected by the order of these things but it's probably better to keep them all together.