### PR TITLE
Fix qt tests and actually run them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ env:
     - BUILD_TARGET=linux32
     - BUILD_TARGET=linux64
     - BUILD_TARGET=linux64_nowallet
+    - BUILD_TARGET=linux64_qt
     - BUILD_TARGET=linux64_release DOCKER_BUILD=true
     - BUILD_TARGET=mac
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ env:
     - BUILD_TARGET=linux32
     - BUILD_TARGET=linux64
     - BUILD_TARGET=linux64_nowallet
-    - BUILD_TARGET=linux64_qt
     - BUILD_TARGET=linux64_release DOCKER_BUILD=true
     - BUILD_TARGET=mac
 

--- a/ci/matrix.sh
+++ b/ci/matrix.sh
@@ -33,13 +33,11 @@ export MAKEJOBS="-j4"
 if [ "$BUILD_TARGET" = "arm-linux" ]; then
   export HOST=arm-linux-gnueabihf
   export PACKAGES="g++-arm-linux-gnueabihf"
-  export DEP_OPTS="NO_QT=1"
   export CHECK_DOC=1
   export BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 elif [ "$BUILD_TARGET" = "win32" ]; then
   export HOST=i686-w64-mingw32
   export DPKG_ADD_ARCH="i386"
-  export DEP_OPTS="NO_QT=1"
   export PACKAGES="python3 nsis g++-mingw-w64-i686 wine-stable wine32 bc"
   export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --disable-miner"
   export DIRECT_WINE_EXEC_TESTS=true
@@ -47,7 +45,6 @@ elif [ "$BUILD_TARGET" = "win32" ]; then
 elif [ "$BUILD_TARGET" = "win64" ]; then
   export HOST=x86_64-w64-mingw32
   export DPKG_ADD_ARCH="i386"
-  export DEP_OPTS="NO_QT=1"
   export PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-stable wine64 bc"
   export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --disable-miner"
   export DIRECT_WINE_EXEC_TESTS=true
@@ -55,7 +52,6 @@ elif [ "$BUILD_TARGET" = "win64" ]; then
 elif [ "$BUILD_TARGET" = "linux32" ]; then
   export HOST=i686-pc-linux-gnu
   export PACKAGES="g++-multilib bc python3-zmq"
-  export DEP_OPTS="NO_QT=1"
   export BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports --enable-stacktraces LDFLAGS=-static-libstdc++"
   export USE_SHELL="/bin/dash"
   export PYZMQ=true
@@ -63,7 +59,7 @@ elif [ "$BUILD_TARGET" = "linux32" ]; then
 elif [ "$BUILD_TARGET" = "linux64" ]; then
   export HOST=x86_64-unknown-linux-gnu
   export PACKAGES="bc python3-zmq"
-  export DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1"
+  export DEP_OPTS="NO_UPNP=1 DEBUG=1"
   export BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports --enable-stacktraces"
   export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG"
   export PYZMQ=true
@@ -73,17 +69,10 @@ elif [ "$BUILD_TARGET" = "linux64_nowallet" ]; then
   export PACKAGES="python3"
   export DEP_OPTS="NO_WALLET=1"
   export BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
-elif [ "$BUILD_TARGET" = "linux64_qt" ]; then
-  export HOST=x86_64-unknown-linux-gnu
-  export PACKAGES="bc python3-zmq"
-  export BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports"
-  export CPPFLAGS="-DDEBUG_LOCKORDER"
-  export PYZMQ=true
-  export RUN_TESTS=true
 elif [ "$BUILD_TARGET" = "linux64_release" ]; then
   export HOST=x86_64-unknown-linux-gnu
   export PACKAGES="bc python3-zmq"
-  export DEP_OPTS="NO_QT=1 NO_UPNP=1"
+  export DEP_OPTS="NO_UPNP=1"
   export BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports"
   export PYZMQ=true
 elif [ "$BUILD_TARGET" = "mac" ]; then

--- a/ci/matrix.sh
+++ b/ci/matrix.sh
@@ -73,6 +73,13 @@ elif [ "$BUILD_TARGET" = "linux64_nowallet" ]; then
   export PACKAGES="python3"
   export DEP_OPTS="NO_WALLET=1"
   export BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+elif [ "$BUILD_TARGET" = "linux64_qt" ]; then
+  export HOST=x86_64-unknown-linux-gnu
+  export PACKAGES="bc python3-zmq"
+  export BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports"
+  export CPPFLAGS="-DDEBUG_LOCKORDER"
+  export PYZMQ=true
+  export RUN_TESTS=true
 elif [ "$BUILD_TARGET" = "linux64_release" ]; then
   export HOST=x86_64-unknown-linux-gnu
   export PACKAGES="bc python3-zmq"

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -54,6 +54,7 @@ void RPCNestedTests::rpcNestedTests()
     pblocktree = new CBlockTreeDB(1 << 20, true);
     pcoinsdbview = new CCoinsViewDB(1 << 23, true);
     deterministicMNManager = new CDeterministicMNManager(*evoDb);
+    llmq::InitLLMQSystem(*evoDb, nullptr, true);
 
     pcoinsTip = new CCoinsViewCache(pcoinsdbview);
     InitBlockIndex(chainparams);
@@ -155,6 +156,7 @@ void RPCNestedTests::rpcNestedTests()
 #endif
 
     delete pcoinsTip;
+    llmq::DestroyLLMQSystem();
     delete deterministicMNManager;
     delete pcoinsdbview;
     delete pblocktree;


### PR DESCRIPTION
Qt tests fail when binaries are compiled with DEBUG_LOCKORDER flag. In fact we don't even run them because of `NO_QT=1` in all builds with `RUN_TESTS=true`. This should fix both issues.