### PR TITLE
Drop DBG macros uses from governance modules

### DIFF
--- a/src/governance-classes.cpp
+++ b/src/governance-classes.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-//#define ENABLE_DASH_DEBUG
-
 #include "governance-classes.h"
 #include "core_io.h"
 #include "init.h"
@@ -36,8 +34,6 @@ std::vector<std::string> SplitBy(const std::string& strCommand, const std::strin
 
 CAmount ParsePaymentAmount(const std::string& strAmount)
 {
-    DBG(std::cout << "ParsePaymentAmount Start: strAmount = " << strAmount << std::endl;);
-
     CAmount nAmount = 0;
     if (strAmount.empty()) {
         std::ostringstream ostr;
@@ -91,8 +87,6 @@ CAmount ParsePaymentAmount(const std::string& strAmount)
         throw std::runtime_error(ostr.str());
     }
 
-    DBG(std::cout << "ParsePaymentAmount Returning true nAmount = " << nAmount << std::endl;);
-
     return nAmount;
 }
 
@@ -102,17 +96,12 @@ CAmount ParsePaymentAmount(const std::string& strAmount)
 
 bool CGovernanceTriggerManager::AddNewTrigger(uint256 nHash)
 {
-    DBG(std::cout << "CGovernanceTriggerManager::AddNewTrigger: Start" << std::endl;);
     AssertLockHeld(governance.cs);
 
     // IF WE ALREADY HAVE THIS HASH, RETURN
     if (mapTrigger.count(nHash)) {
-        DBG(
-            std::cout << "CGovernanceTriggerManager::AddNewTrigger: Already have hash"
-                      << ", nHash = " << nHash.GetHex()
-                      << ", count = " << mapTrigger.count(nHash)
-                      << ", mapTrigger.size() = " << mapTrigger.size()
-                      << std::endl;);
+        LogPrint("gobject", "CGovernanceTriggerManager::AddNewTrigger -- Already have hash, nHash = %s, count = %d, size = %s\n",
+                    nHash.GetHex(), mapTrigger.count(nHash), mapTrigger.size());
         return false;
     }
 
@@ -121,23 +110,16 @@ bool CGovernanceTriggerManager::AddNewTrigger(uint256 nHash)
         CSuperblock_sptr pSuperblockTmp(new CSuperblock(nHash));
         pSuperblock = pSuperblockTmp;
     } catch (std::exception& e) {
-        DBG(std::cout << "CGovernanceTriggerManager::AddNewTrigger Error creating superblock"
-                      << ", e.what() = " << e.what()
-                      << std::endl;);
         LogPrintf("CGovernanceTriggerManager::AddNewTrigger -- Error creating superblock: %s\n", e.what());
         return false;
     } catch (...) {
         LogPrintf("CGovernanceTriggerManager::AddNewTrigger: Unknown Error creating superblock\n");
-        DBG(std::cout << "CGovernanceTriggerManager::AddNewTrigger Error creating superblock catchall" << std::endl;);
         return false;
     }
 
     pSuperblock->SetStatus(SEEN_OBJECT_IS_VALID);
 
-    DBG(std::cout << "CGovernanceTriggerManager::AddNewTrigger: Inserting trigger" << std::endl;);
     mapTrigger.insert(std::make_pair(nHash, pSuperblock));
-
-    DBG(std::cout << "CGovernanceTriggerManager::AddNewTrigger: End" << std::endl;);
 
     return true;
 }
@@ -150,12 +132,9 @@ bool CGovernanceTriggerManager::AddNewTrigger(uint256 nHash)
 
 void CGovernanceTriggerManager::CleanAndRemove()
 {
-    LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Start\n");
-    DBG(std::cout << "CGovernanceTriggerManager::CleanAndRemove: Start" << std::endl;);
     AssertLockHeld(governance.cs);
 
     // Remove triggers that are invalid or expired
-    DBG(std::cout << "CGovernanceTriggerManager::CleanAndRemove: mapTrigger.size() = " << mapTrigger.size() << std::endl;);
     LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- mapTrigger.size() = %d\n", mapTrigger.size());
 
     trigger_m_it it = mapTrigger.begin();
@@ -164,18 +143,15 @@ void CGovernanceTriggerManager::CleanAndRemove()
         CGovernanceObject* pObj = nullptr;
         CSuperblock_sptr& pSuperblock = it->second;
         if (!pSuperblock) {
-            DBG(std::cout << "CGovernanceTriggerManager::CleanAndRemove: NULL superblock marked for removal" << std::endl;);
             LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- NULL superblock marked for removal\n");
             remove = true;
         } else {
             pObj = governance.FindGovernanceObject(it->first);
             if (!pObj || pObj->GetObjectType() != GOVERNANCE_OBJECT_TRIGGER) {
-                DBG(std::cout << "CGovernanceTriggerManager::CleanAndRemove: Unknown or non-trigger superblock" << std::endl;);
                 LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Unknown or non-trigger superblock\n");
                 pSuperblock->SetStatus(SEEN_OBJECT_ERROR_INVALID);
             }
 
-            DBG(std::cout << "CGovernanceTriggerManager::CleanAndRemove: superblock status = " << pSuperblock->GetStatus() << std::endl;);
             LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- superblock status = %d\n", pSuperblock->GetStatus());
             switch (pSuperblock->GetStatus()) {
             case SEEN_OBJECT_ERROR_INVALID:
@@ -194,15 +170,11 @@ void CGovernanceTriggerManager::CleanAndRemove()
         LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- %smarked for removal\n", remove ? "" : "NOT ");
 
         if (remove) {
-            DBG(
-                std::string strDataAsPlainString = "NULL";
-                if (pObj) {
-                    strDataAsPlainString = pObj->GetDataAsPlainString();
-                } 
-                std::cout << "CGovernanceTriggerManager::CleanAndRemove: Removing object: "
-                          << strDataAsPlainString
-                          << std::endl;);
-            LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Removing trigger object\n");
+            std::string strDataAsPlainString = "NULL";
+            if (pObj) {
+                strDataAsPlainString = pObj->GetDataAsPlainString();
+            }
+            LogPrint("gobject", "CGovernanceTriggerManager::CleanAndRemove -- Removing trigger object %s\n", strDataAsPlainString);
             // mark corresponding object for deletion
             if (pObj) {
                 pObj->fCachedDelete = true;
@@ -216,8 +188,6 @@ void CGovernanceTriggerManager::CleanAndRemove()
             ++it;
         }
     }
-
-    DBG(std::cout << "CGovernanceTriggerManager::CleanAndRemove: End" << std::endl;);
 }
 
 /**
@@ -232,18 +202,13 @@ std::vector<CSuperblock_sptr> CGovernanceTriggerManager::GetActiveTriggers()
     AssertLockHeld(governance.cs);
     std::vector<CSuperblock_sptr> vecResults;
 
-    DBG(std::cout << "GetActiveTriggers: mapTrigger.size() = " << mapTrigger.size() << std::endl;);
-
     // LOOK AT THESE OBJECTS AND COMPILE A VALID LIST OF TRIGGERS
     for (const auto& pair : mapTrigger) {
         CGovernanceObject* pObj = governance.FindGovernanceObject(pair.first);
         if (pObj) {
-            DBG(std::cout << "GetActiveTriggers: pObj->GetDataAsPlainString() = " << pObj->GetDataAsPlainString() << std::endl;);
             vecResults.push_back(pair.second);
         }
     }
-
-    DBG(std::cout << "GetActiveTriggers: vecResults.size() = " << vecResults.size() << std::endl;);
 
     return vecResults;
 }
@@ -267,12 +232,9 @@ bool CSuperblockManager::IsSuperblockTriggered(int nBlockHeight)
 
     LogPrint("gobject", "CSuperblockManager::IsSuperblockTriggered -- vecTriggers.size() = %d\n", vecTriggers.size());
 
-    DBG(std::cout << "IsSuperblockTriggered Number triggers = " << vecTriggers.size() << std::endl;);
-
     for (const auto& pSuperblock : vecTriggers) {
         if (!pSuperblock) {
             LogPrintf("CSuperblockManager::IsSuperblockTriggered -- Non-superblock found, continuing\n");
-            DBG(std::cout << "IsSuperblockTriggered Not a superblock, continuing " << std::endl;);
             continue;
         }
 
@@ -280,7 +242,6 @@ bool CSuperblockManager::IsSuperblockTriggered(int nBlockHeight)
 
         if (!pObj) {
             LogPrintf("CSuperblockManager::IsSuperblockTriggered -- pObj == nullptr, continuing\n");
-            DBG(std::cout << "IsSuperblockTriggered pObj is NULL, continuing" << std::endl;);
             continue;
         }
 
@@ -292,10 +253,6 @@ bool CSuperblockManager::IsSuperblockTriggered(int nBlockHeight)
             LogPrint("gobject", "CSuperblockManager::IsSuperblockTriggered -- block height doesn't match nBlockHeight = %d, blockStart = %d, continuing\n",
                 nBlockHeight,
                 pSuperblock->GetBlockHeight());
-            DBG(std::cout << "IsSuperblockTriggered Not the target block, continuing"
-                          << ", nBlockHeight = " << nBlockHeight
-                          << ", superblock->GetBlockHeight() = " << pSuperblock->GetBlockHeight()
-                          << std::endl;);
             continue;
         }
 
@@ -305,11 +262,9 @@ bool CSuperblockManager::IsSuperblockTriggered(int nBlockHeight)
 
         if (pObj->IsSetCachedFunding()) {
             LogPrint("gobject", "CSuperblockManager::IsSuperblockTriggered -- fCacheFunding = true, returning true\n");
-            DBG(std::cout << "IsSuperblockTriggered returning true" << std::endl;);
             return true;
         } else {
             LogPrint("gobject", "CSuperblockManager::IsSuperblockTriggered -- fCacheFunding = false, continuing\n");
-            DBG(std::cout << "IsSuperblockTriggered No fCachedFunding, continuing" << std::endl;);
         }
     }
 
@@ -328,31 +283,22 @@ bool CSuperblockManager::GetBestSuperblock(CSuperblock_sptr& pSuperblockRet, int
     int nYesCount = 0;
 
     for (const auto& pSuperblock : vecTriggers) {
-        if (!pSuperblock) {
-            DBG(std::cout << "GetBestSuperblock Not a superblock, continuing" << std::endl;);
+        if (!pSuperblock || nBlockHeight != pSuperblock->GetBlockHeight()) {
             continue;
         }
 
         CGovernanceObject* pObj = pSuperblock->GetGovernanceObject();
 
         if (!pObj) {
-            DBG(std::cout << "GetBestSuperblock pObj is NULL, continuing" << std::endl;);
-            continue;
-        }
-
-        if (nBlockHeight != pSuperblock->GetBlockHeight()) {
-            DBG(std::cout << "GetBestSuperblock Not the target block, continuing" << std::endl;);
             continue;
         }
 
         // DO WE HAVE A NEW WINNER?
 
         int nTempYesCount = pObj->GetAbsoluteYesCount(VOTE_SIGNAL_FUNDING);
-        DBG(std::cout << "GetBestSuperblock nTempYesCount = " << nTempYesCount << std::endl;);
         if (nTempYesCount > nYesCount) {
             nYesCount = nTempYesCount;
             pSuperblockRet = pSuperblock;
-            DBG(std::cout << "GetBestSuperblock Valid superblock found, pSuperblock set" << std::endl;);
         }
     }
 
@@ -367,8 +313,6 @@ bool CSuperblockManager::GetBestSuperblock(CSuperblock_sptr& pSuperblockRet, int
 
 bool CSuperblockManager::GetSuperblockPayments(int nBlockHeight, std::vector<CTxOut>& voutSuperblockRet)
 {
-    DBG(std::cout << "CSuperblockManager::GetSuperblockPayments Start" << std::endl;);
-
     LOCK(governance.cs);
 
     // GET THE BEST SUPERBLOCK FOR THIS BLOCK HEIGHT
@@ -376,7 +320,6 @@ bool CSuperblockManager::GetSuperblockPayments(int nBlockHeight, std::vector<CTx
     CSuperblock_sptr pSuperblock;
     if (!CSuperblockManager::GetBestSuperblock(pSuperblock, nBlockHeight)) {
         LogPrint("gobject", "CSuperblockManager::GetSuperblockPayments -- Can't find superblock for height %d\n", nBlockHeight);
-        DBG(std::cout << "CSuperblockManager::GetSuperblockPayments Failed to get superblock for height, returning" << std::endl;);
         return false;
     }
 
@@ -386,7 +329,6 @@ bool CSuperblockManager::GetSuperblockPayments(int nBlockHeight, std::vector<CTx
     // GET SUPERBLOCK OUTPUTS
 
     // Superblock payments will be appended to the end of the coinbase vout vector
-    DBG(std::cout << "CSuperblockManager::GetSuperblockPayments Number payments: " << pSuperblock->CountPayments() << std::endl;);
 
     // TODO: How many payments can we add before things blow up?
     //       Consider at least following limits:
@@ -394,9 +336,7 @@ bool CSuperblockManager::GetSuperblockPayments(int nBlockHeight, std::vector<CTx
     //          - max "budget" available
     for (int i = 0; i < pSuperblock->CountPayments(); i++) {
         CGovernancePayment payment;
-        DBG(std::cout << "CSuperblockManager::GetSuperblockPayments i = " << i << std::endl;);
         if (pSuperblock->GetPayment(i, payment)) {
-            DBG(std::cout << "CSuperblockManager::GetSuperblockPayments Payment found " << std::endl;);
             // SET COINBASE OUTPUT TO SUPERBLOCK SETTING
 
             CTxOut txout = CTxOut(payment.nAmount, payment.script);
@@ -410,15 +350,12 @@ bool CSuperblockManager::GetSuperblockPayments(int nBlockHeight, std::vector<CTx
 
             // TODO: PRINT NICE N.N DASH OUTPUT
 
-            DBG(std::cout << "CSuperblockManager::GetSuperblockPayments Before LogPrintf call, nAmount = " << payment.nAmount << std::endl;);
-            LogPrintf("NEW Superblock : output %d (addr %s, amount %d)\n", i, address2.ToString(), payment.nAmount);
-            DBG(std::cout << "CSuperblockManager::GetSuperblockPayments After LogPrintf call " << std::endl;);
+            LogPrint("gobject", "CSuperblockManager::GetSuperblockPayments -- NEW Superblock: output %d (addr %s, amount %lld)\n",
+                        i, address2.ToString(), payment.nAmount);
         } else {
-            DBG(std::cout << "CSuperblockManager::GetSuperblockPayments Payment not found " << std::endl;);
+            LogPrint("gobject", "CSuperblockManager::GetSuperblockPayments -- Payment not found\n");
         }
     }
-
-    DBG(std::cout << "CSuperblockManager::GetSuperblockPayments End" << std::endl;);
 
     return true;
 }
@@ -464,22 +401,16 @@ CSuperblock::
     nStatus(SEEN_OBJECT_UNKNOWN),
     vecPayments()
 {
-    DBG(std::cout << "CSuperblock Constructor Start" << std::endl;);
-
     CGovernanceObject* pGovObj = GetGovernanceObject();
 
     if (!pGovObj) {
-        DBG(std::cout << "CSuperblock Constructor pGovObjIn is NULL, returning" << std::endl;);
         throw std::runtime_error("CSuperblock: Failed to find Governance Object");
     }
 
-    DBG(std::cout << "CSuperblock Constructor pGovObj : "
-                  << pGovObj->GetDataAsPlainString()
-                  << ", nObjectType = " << pGovObj->GetObjectType()
-                  << std::endl;);
+    LogPrint("gobject", "CSuperblock -- Constructor pGovObj: %s, nObjectType = %d\n",
+                pGovObj->GetDataAsPlainString(), pGovObj->GetObjectType());
 
     if (pGovObj->GetObjectType() != GOVERNANCE_OBJECT_TRIGGER) {
-        DBG(std::cout << "CSuperblock Constructor pGovObj not a trigger, returning" << std::endl;);
         throw std::runtime_error("CSuperblock: Governance Object not a trigger");
     }
 
@@ -495,8 +426,6 @@ CSuperblock::
 
     LogPrint("gobject", "CSuperblock -- nBlockHeight = %d, strAddresses = %s, strAmounts = %s, vecPayments.size() = %d\n",
         nBlockHeight, strAddresses, strAmounts, vecPayments.size());
-
-    DBG(std::cout << "CSuperblock Constructor End" << std::endl;);
 }
 
 /**
@@ -580,8 +509,6 @@ void CSuperblock::ParsePaymentSchedule(const std::string& strPaymentAddresses, c
       AMOUNTS = [AMOUNT1|2|3|4|5|6]
     */
 
-    DBG(std::cout << "CSuperblock::ParsePaymentSchedule vecParsed1.size() = " << vecParsed1.size() << std::endl;);
-
     for (int i = 0; i < (int)vecParsed1.size(); i++) {
         CBitcoinAddress address(vecParsed1[i]);
         if (!address.IsValid()) {
@@ -603,16 +530,9 @@ void CSuperblock::ParsePaymentSchedule(const std::string& strPaymentAddresses, c
             throw std::runtime_error(ostr.str());
         }
 
-        DBG(std::cout << "CSuperblock::ParsePaymentSchedule i = " << i
-                      << ", vecParsed2[i] = " << vecParsed2[i]
-                      << std::endl;);
-
         CAmount nAmount = ParsePaymentAmount(vecParsed2[i]);
 
-        DBG(std::cout << "CSuperblock::ParsePaymentSchedule: "
-                      << "amount string = " << vecParsed2[i]
-                      << ", nAmount = " << nAmount
-                      << std::endl;);
+        LogPrint("gobject", "CSuperblock::ParsePaymentSchedule -- i = %d, amount string = %s, nAmount = %lld\n", i, vecParsed2[i], nAmount);
 
         CGovernancePayment payment(address, nAmount);
         if (payment.IsValid()) {
@@ -676,7 +596,7 @@ bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, CAmount b
     int nPayments = CountPayments();
     int nMinerAndMasternodePayments = nOutputs - nPayments;
 
-    LogPrint("gobject", "CSuperblock::IsValid nOutputs = %d, nPayments = %d, GetDataAsHexString = %s\n",
+    LogPrint("gobject", "CSuperblock::IsValid -- nOutputs = %d, nPayments = %d, GetDataAsHexString = %s\n",
         nOutputs, nPayments, GetGovernanceObject()->GetDataAsHexString());
 
     // We require an exact match (including order) between the expected

--- a/src/governance-classes.h
+++ b/src/governance-classes.h
@@ -4,8 +4,6 @@
 #ifndef GOVERNANCE_CLASSES_H
 #define GOVERNANCE_CLASSES_H
 
-//#define ENABLE_DASH_DEBUG
-
 #include "base58.h"
 #include "governance.h"
 #include "key.h"

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -5,8 +5,6 @@
 #ifndef GOVERNANCE_OBJECT_H
 #define GOVERNANCE_OBJECT_H
 
-//#define ENABLE_DASH_DEBUG
-
 #include "cachemultimap.h"
 #include "governance-exceptions.h"
 #include "governance-vote.h"

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -296,8 +296,6 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, CGovernance
 
 void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman& connman, CNode* pfrom)
 {
-    DBG(std::cout << "CGovernanceManager::AddGovernanceObject START" << std::endl;);
-
     uint256 nHash = govobj.GetHash();
     std::string strHash = nHash.ToString();
 
@@ -328,13 +326,10 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
 
     // SHOULD WE ADD THIS OBJECT TO ANY OTHER MANANGERS?
 
-    DBG(std::cout << "CGovernanceManager::AddGovernanceObject Before trigger block, GetDataAsPlainString = "
-                  << govobj.GetDataAsPlainString()
-                  << ", nObjectType = " << govobj.nObjectType
-                  << std::endl;);
+    LogPrint("gobject", "CGovernanceManager::AddGovernanceObject -- Before trigger block, GetDataAsPlainString = %s, nObjectType = %d\n",
+                govobj.GetDataAsPlainString(), govobj.nObjectType);
 
     if (govobj.nObjectType == GOVERNANCE_OBJECT_TRIGGER) {
-        DBG(std::cout << "CGovernanceManager::AddGovernanceObject Before AddNewTrigger" << std::endl;);
         if (!triggerman.AddNewTrigger(nHash)) {
             LogPrint("gobject", "CGovernanceManager::AddGovernanceObject -- undo adding invalid trigger object: hash = %s\n", nHash.ToString());
             CGovernanceObject& objref = objpair.first->second;
@@ -344,7 +339,6 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
             }
             return;
         }
-        DBG(std::cout << "CGovernanceManager::AddGovernanceObject After AddNewTrigger" << std::endl;);
     }
 
     LogPrintf("CGovernanceManager::AddGovernanceObject -- %s new, received from %s\n", strHash, pfrom ? pfrom->GetAddrName() : "nullptr");
@@ -362,9 +356,6 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
 
     // SEND NOTIFICATION TO SCRIPT/ZMQ
     GetMainSignals().NotifyGovernanceObject(govobj);
-
-
-    DBG(std::cout << "CGovernanceManager::AddGovernanceObject END" << std::endl;);
 }
 
 void CGovernanceManager::UpdateCachesAndClean()

--- a/src/governance.h
+++ b/src/governance.h
@@ -5,8 +5,6 @@
 #ifndef GOVERNANCE_H
 #define GOVERNANCE_H
 
-//#define ENABLE_DASH_DEBUG
-
 #include "bloom.h"
 #include "cachemap.h"
 #include "cachemultimap.h"

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-//#define ENABLE_DASH_DEBUG
-
 #include "activemasternode.h"
 #include "consensus/validation.h"
 #include "governance.h"
@@ -225,11 +223,8 @@ UniValue gobject_prepare(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "CommitTransaction failed! Reason given: " + state.GetRejectReason());
     }
 
-    DBG( std::cout << "gobject: prepare "
-         << " GetDataAsPlainString = " << govobj.GetDataAsPlainString()
-         << ", hash = " << govobj.GetHash().GetHex()
-         << ", txidFee = " << wtx.GetHash().GetHex()
-         << std::endl; );
+    LogPrint("gobject", "gobject_prepare -- GetDataAsPlainString = %s, hash = %s, txid = %s\n",
+                govobj.GetDataAsPlainString(), govobj.GetHash().ToString(), wtx.GetHash().ToString());
 
     return wtx.GetHash().ToString();
 }
@@ -261,10 +256,9 @@ UniValue gobject_submit(const JSONRPCRequest& request)
     auto mnList = deterministicMNManager->GetListAtChainTip();
     bool fMnFound = mnList.HasValidMNByCollateral(activeMasternodeInfo.outpoint);
 
-    DBG( std::cout << "gobject: submit activeMasternodeInfo.pubKeyOperator = " << (activeMasternodeInfo.blsPubKeyOperator ? activeMasternodeInfo.blsPubKeyOperator->ToString() : "N/A")
-         << ", outpoint = " << activeMasternodeInfo.outpoint.ToStringShort()
-         << ", params.size() = " << request.params.size()
-         << ", fMnFound = " << fMnFound << std::endl; );
+    LogPrint("gobject", "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
+            (activeMasternodeInfo.blsPubKeyOperator ? activeMasternodeInfo.blsPubKeyOperator->ToString() : "N/A"),
+            activeMasternodeInfo.outpoint.ToStringShort(), request.params.size(), fMnFound);
 
     // ASSEMBLE NEW GOVERNANCE OBJECT FROM USER PARAMETERS
 
@@ -290,11 +284,8 @@ UniValue gobject_submit(const JSONRPCRequest& request)
 
     CGovernanceObject govobj(hashParent, nRevision, nTime, txidFee, strDataHex);
 
-    DBG( std::cout << "gobject: submit "
-         << " GetDataAsPlainString = " << govobj.GetDataAsPlainString()
-         << ", hash = " << govobj.GetHash().GetHex()
-         << ", txidFee = " << txidFee.GetHex()
-         << std::endl; );
+    LogPrint("gobject", "gobject_submit -- GetDataAsPlainString = %s, hash = %s, txid = %s\n",
+                govobj.GetDataAsPlainString(), govobj.GetHash().ToString(), request.params[5].get_str());
 
     if (govobj.GetObjectType() == GOVERNANCE_OBJECT_PROPOSAL) {
         CProposalValidator validator(strDataHex, false);


### PR DESCRIPTION
Governance modules are stable, we don't need `DBG` here anymore imo. This PR either drops `DBG`s completely or replaces them with `governance` category limited `LogPrint`-s.

Note: `DBG` is still used in `CHDChain::Debug()` and HD wallet is still in "experimental" state, so we can't drop `DBG` definition itself yet.