### PR TITLE
Reset local/static cache in LogAcceptCategory when categories change

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -141,6 +141,8 @@ UniValue debug(const JSONRPCRequest& request)
 
     fDebug = GetArg("-debug", "") != "0";
 
+    ResetLogAcceptCategoryCache();
+
     return "Debug mode: " + (fDebug ? strMode : "off");
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -216,6 +216,7 @@ static boost::once_flag debugPrintInitFlag = BOOST_ONCE_INIT;
 static FILE* fileout = NULL;
 static boost::mutex* mutexDebugLog = NULL;
 static std::list<std::string>* vMsgsBeforeOpenLog;
+static std::atomic<int> logAcceptCategoryCacheCounter(0);
 
 static int FileWriteStr(const std::string &str, FILE *fp)
 {
@@ -260,6 +261,7 @@ bool LogAcceptCategory(const char* category)
         // where mapMultiArgs might be deleted before another
         // global destructor calls LogPrint()
         static boost::thread_specific_ptr<std::set<std::string> > ptrCategory;
+        static boost::thread_specific_ptr<int> cacheCounter;
 
         if (!fDebug) {
             if (ptrCategory.get() != NULL) {
@@ -269,8 +271,10 @@ bool LogAcceptCategory(const char* category)
             return false;
         }
 
-        if (ptrCategory.get() == NULL)
+        if (ptrCategory.get() == NULL || *cacheCounter != logAcceptCategoryCacheCounter.load())
         {
+            cacheCounter.reset(new int(logAcceptCategoryCacheCounter.load()));
+
             if (mapMultiArgs.count("-debug")) {
                 std::string strThreadName = GetThreadName();
                 LogPrintf("debug turned on:\n");
@@ -307,6 +311,11 @@ bool LogAcceptCategory(const char* category)
             return false;
     }
     return true;
+}
+
+void ResetLogAcceptCategoryCache()
+{
+    logAcceptCategoryCacheCounter++;
 }
 
 /**

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -275,6 +275,7 @@ bool LogAcceptCategory(const char* category)
         {
             cacheCounter.reset(new int(logAcceptCategoryCacheCounter.load()));
 
+            LOCK(cs_args);
             if (mapMultiArgs.count("-debug")) {
                 std::string strThreadName = GetThreadName();
                 LogPrintf("debug turned on:\n");

--- a/src/util.h
+++ b/src/util.h
@@ -91,6 +91,8 @@ bool SetupNetworking();
 
 /** Return true if log accepts specified category */
 bool LogAcceptCategory(const char* category);
+/** Reset internal log category caching (call this when debug categories have changed) */
+void ResetLogAcceptCategoryCache();
 /** Send a string to the log output */
 int LogPrintStr(const std::string &str);
 


### PR DESCRIPTION
Without this, it is always required to first set debug to 0, wait a few
seconds (until LogAcceptCategory is called by all affected threads) and
then call "debug somecategory". Otherwise "ptrCategory" never gets updated.
    
This PR also stores a cache counter locally and globally and updates
"ptrCategory" when the counters do not match.
