### PR TITLE
Fix potential deadlock in LoadWallet()

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1249,7 +1249,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
 
 void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
 {
-    LOCK2(cs_main, cs_wallet);
+    LOCK2(cs_main, cs_wallet); // check "LOCK2(cs_main, pwallet->cs_wallet);" in CWalletDB::LoadWallet()
 
     int conflictconfirms = 0;
     if (mapBlockIndex.count(hashBlock)) {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -586,7 +586,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
 
-    LOCK(pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet);
     try {
         int nMinVersion = 0;
         if (Read((std::string)"minversion", nMinVersion))


### PR DESCRIPTION
```
POTENTIAL DEADLOCK DETECTED
Previous lock order was:
 (1) cs_main  wallet/wallet.cpp:3881
 (2) cs_wallet  wallet/wallet.cpp:3881
Current lock order is:
 (2) pwallet->cs_wallet  wallet/walletdb.cpp:589
 (1) cs_main  wallet/wallet.cpp:1252
```