### PR TITLE
Refactor: fix layer violation for LLMQ based IS in UI

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -21,8 +21,6 @@
 
 #include "instantx.h"
 
-#include "llmq/quorums_instantsend.h"
-
 #include <stdint.h>
 #include <string>
 
@@ -59,8 +57,8 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
             }
         }
 
-        if (llmq::quorumInstantSendManager->IsLocked(wtx.GetHash())) {
-            strTxStatus += tr(" (verified via LLMQ based InstantSend)");
+        if (wtx.IsLockedByLLMQInstantSend()) {
+            strTxStatus += " (" + tr("verified via LLMQ based InstantSend") + ")";
             return strTxStatus;
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5405,6 +5405,11 @@ bool CMerkleTx::IsLockedByInstantSend() const
     return instantsend.IsLockedInstantSendTransaction(GetHash()) || llmq::quorumInstantSendManager->IsLocked(GetHash());
 }
 
+bool CMerkleTx::IsLockedByLLMQInstantSend() const
+{
+    return llmq::quorumInstantSendManager->IsLocked(GetHash());
+}
+
 bool CMerkleTx::IsChainLocked() const
 {
     AssertLockHeld(cs_main);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -271,6 +271,7 @@ public:
     int GetDepthInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
     bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet) > 0; }
     bool IsLockedByInstantSend() const;
+    bool IsLockedByLLMQInstantSend() const;
     bool IsChainLocked() const;
     int GetBlocksToMaturity() const;
     /** Pass this transaction to the mempool. Fails if absolute fee exceeds absurd fee. */


### PR DESCRIPTION
Ignoring the same issue for legacy IS because it's going to be removed later.

Also includes changes from ff15358 / #2638 