### PR TITLE
Drop all kind of invalid votes from all types of gobjects

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -229,13 +229,9 @@ void CGovernanceObject::ClearMasternodeVotes()
     }
 }
 
-std::set<uint256> CGovernanceObject::RemoveInvalidProposalVotes(const COutPoint& mnOutpoint)
+std::set<uint256> CGovernanceObject::RemoveInvalidVotes(const COutPoint& mnOutpoint)
 {
     LOCK(cs);
-
-    if (nObjectType != GOVERNANCE_OBJECT_PROPOSAL) {
-        return {};
-    }
 
     auto it = mapCurrentMNVotes.find(mnOutpoint);
     if (it == mapCurrentMNVotes.end()) {
@@ -243,7 +239,7 @@ std::set<uint256> CGovernanceObject::RemoveInvalidProposalVotes(const COutPoint&
         return {};
     }
 
-    auto removedVotes = fileVotes.RemoveInvalidProposalVotes(mnOutpoint);
+    auto removedVotes = fileVotes.RemoveInvalidVotes(mnOutpoint, nObjectType == GOVERNANCE_OBJECT_PROPOSAL);
     if (removedVotes.empty()) {
         return {};
     }
@@ -267,7 +263,7 @@ std::set<uint256> CGovernanceObject::RemoveInvalidProposalVotes(const COutPoint&
         for (auto& h : removedVotes) {
             removedStr += strprintf("  %s\n", h.ToString());
         }
-        LogPrintf("CGovernanceObject::%s -- Removed %d invalid votes for %s from MN %s:\n%s\n", __func__, removedVotes.size(), nParentHash.ToString(), mnOutpoint.ToString(), removedStr);
+        LogPrintf("CGovernanceObject::%s -- Removed %d invalid votes for %s from MN %s:\n%s", __func__, removedVotes.size(), nParentHash.ToString(), mnOutpoint.ToString(), removedStr);
         fDirtyCache = true;
     }
 

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -347,7 +347,7 @@ private:
 
     // Revalidate all votes from this MN and delete them if validation fails
     // This is the case for DIP3 MNs that change voting keys. Returns deleted vote hashes
-    std::set<uint256> RemoveInvalidProposalVotes(const COutPoint& mnOutpoint);
+    std::set<uint256> RemoveInvalidVotes(const COutPoint& mnOutpoint);
 
     void CheckOrphanVotes(CConnman& connman);
 };

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -345,8 +345,10 @@ private:
     /// Called when MN's which have voted on this object have been removed
     void ClearMasternodeVotes();
 
-    // Revalidate all votes from this MN and delete them if validation fails
-    // This is the case for DIP3 MNs that change voting keys. Returns deleted vote hashes
+    // Revalidate all votes from this MN and delete them if validation fails.
+    // This is the case for DIP3 MNs that changed voting or operator keys and
+    // also for MNs that were removed from the list completely.
+    // Returns deleted vote hashes.
     std::set<uint256> RemoveInvalidVotes(const COutPoint& mnOutpoint);
 
     void CheckOrphanVotes(CConnman& connman);

--- a/src/governance-votedb.cpp
+++ b/src/governance-votedb.cpp
@@ -68,14 +68,15 @@ void CGovernanceObjectVoteFile::RemoveVotesFromMasternode(const COutPoint& outpo
     }
 }
 
-std::set<uint256> CGovernanceObjectVoteFile::RemoveInvalidProposalVotes(const COutPoint& outpointMasternode)
+std::set<uint256> CGovernanceObjectVoteFile::RemoveInvalidVotes(const COutPoint& outpointMasternode, bool fProposal)
 {
     std::set<uint256> removedVotes;
 
     vote_l_it it = listVotes.begin();
     while (it != listVotes.end()) {
-        if (it->GetSignal() == VOTE_SIGNAL_FUNDING && it->GetMasternodeOutpoint() == outpointMasternode) {
-            if (!it->IsValid(true)) {
+        if (it->GetMasternodeOutpoint() == outpointMasternode) {
+            bool useVotingKey = fProposal && (it->GetSignal() == VOTE_SIGNAL_FUNDING);
+            if (!it->IsValid(useVotingKey)) {
                 removedVotes.emplace(it->GetHash());
                 --nMemoryVotes;
                 mapVoteIndex.erase(it->GetHash());

--- a/src/governance-votedb.h
+++ b/src/governance-votedb.h
@@ -73,7 +73,7 @@ public:
     std::vector<CGovernanceVote> GetVotes() const;
 
     void RemoveVotesFromMasternode(const COutPoint& outpointMasternode);
-    std::set<uint256> RemoveInvalidProposalVotes(const COutPoint& outpointMasternode);
+    std::set<uint256> RemoveInvalidVotes(const COutPoint& outpointMasternode, bool fProposal);
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -1353,8 +1353,7 @@ void CGovernanceManager::RemoveInvalidVotes()
         auto oldDmn = lastMNListForVotingKeys.GetMN(p.first);
         if (p.second->keyIDVoting != oldDmn->pdmnState->keyIDVoting) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
-        }
-        if (p.second->pubKeyOperator != oldDmn->pdmnState->pubKeyOperator) {
+        } else if (p.second->pubKeyOperator != oldDmn->pdmnState->pubKeyOperator) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         }
     }

--- a/src/governance.cpp
+++ b/src/governance.cpp
@@ -571,7 +571,7 @@ void CGovernanceManager::DoMaintenance(CConnman& connman)
     if (fLiteMode || !masternodeSync.IsSynced() || ShutdownRequested()) return;
 
     if (deterministicMNManager->IsDIP3Enforced()) {
-        RemoveInvalidProposalVotes();
+        RemoveInvalidVotes();
     }
 
     // CHECK OBJECTS WE'VE ASKED FOR, REMOVE OLD ENTRIES
@@ -1286,7 +1286,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex* pindex, CConnman& co
     LogPrint("gobject", "CGovernanceManager::UpdatedBlockTip -- nCachedBlockHeight: %d\n", nCachedBlockHeight);
 
     if (deterministicMNManager->IsDIP3Enforced(pindex->nHeight)) {
-        RemoveInvalidProposalVotes();
+        RemoveInvalidVotes();
     }
 
     CheckPostponedObjects(connman);
@@ -1341,7 +1341,7 @@ void CGovernanceManager::CleanOrphanObjects()
     }
 }
 
-void CGovernanceManager::RemoveInvalidProposalVotes()
+void CGovernanceManager::RemoveInvalidVotes()
 {
     auto curMNList = deterministicMNManager->GetListAtChainTip();
     auto diff = lastMNListForVotingKeys.BuildDiff(curMNList);
@@ -1354,6 +1354,9 @@ void CGovernanceManager::RemoveInvalidProposalVotes()
         if (p.second->keyIDVoting != oldDmn->pdmnState->keyIDVoting) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         }
+        if (p.second->pubKeyOperator != oldDmn->pdmnState->pubKeyOperator) {
+            changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
+        }
     }
     for (const auto& proTxHash : diff.removedMns) {
         auto oldDmn = lastMNListForVotingKeys.GetMN(proTxHash);
@@ -1362,7 +1365,7 @@ void CGovernanceManager::RemoveInvalidProposalVotes()
 
     for (const auto& outpoint : changedKeyMNs) {
         for (auto& p : mapObjects) {
-            auto removed = p.second.RemoveInvalidProposalVotes(outpoint);
+            auto removed = p.second.RemoveInvalidVotes(outpoint);
             if (removed.empty()) {
                 continue;
             }

--- a/src/governance.h
+++ b/src/governance.h
@@ -453,7 +453,7 @@ private:
 
     void CleanOrphanObjects();
 
-    void RemoveInvalidProposalVotes();
+    void RemoveInvalidVotes();
 
 };
 


### PR DESCRIPTION
Currently we only do so for proposal "funding" votes which looks incomplete.