### PR TITLE
Remove watchdogs from existence completely

### DIFF
--- a/src/governance-object.cpp
+++ b/src/governance-object.cpp
@@ -458,10 +458,6 @@ bool CGovernanceObject::IsValidLocally(std::string& strError, bool& fMissingMast
     }
 
     switch (nObjectType) {
-    case GOVERNANCE_OBJECT_WATCHDOG: {
-        // watchdogs are deprecated
-        return false;
-    }
     case GOVERNANCE_OBJECT_PROPOSAL: {
         CProposalValidator validator(GetDataAsHexString(), true);
         // Note: It's ok to have expired proposals
@@ -522,8 +518,6 @@ CAmount CGovernanceObject::GetMinCollateralFee() const
     case GOVERNANCE_OBJECT_PROPOSAL:
         return GOVERNANCE_PROPOSAL_FEE_TX;
     case GOVERNANCE_OBJECT_TRIGGER:
-        return 0;
-    case GOVERNANCE_OBJECT_WATCHDOG:
         return 0;
     default:
         return MAX_MONEY;

--- a/src/governance-object.h
+++ b/src/governance-object.h
@@ -31,7 +31,6 @@ static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 static const int GOVERNANCE_OBJECT_UNKNOWN = 0;
 static const int GOVERNANCE_OBJECT_PROPOSAL = 1;
 static const int GOVERNANCE_OBJECT_TRIGGER = 2;
-static const int GOVERNANCE_OBJECT_WATCHDOG = 3;
 
 static const CAmount GOVERNANCE_PROPOSAL_FEE_TX = (5.0 * COIN);
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -184,10 +184,6 @@ UniValue gobject_prepare(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Trigger objects need not be prepared (however only masternodes can create them)");
     }
 
-    if (govobj.GetObjectType() == GOVERNANCE_OBJECT_WATCHDOG) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Watchdogs are deprecated");
-    }
-
     LOCK2(cs_main, pwallet->cs_wallet);
 
     std::string strError = "";
@@ -292,10 +288,6 @@ UniValue gobject_submit(const JSONRPCRequest& request)
         if (!validator.Validate()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid proposal data, error messages:" + validator.GetErrorMessages());
         }
-    }
-
-    if (govobj.GetObjectType() == GOVERNANCE_OBJECT_WATCHDOG) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Watchdogs are deprecated");
     }
 
     // Attempt to sign triggers if we are a MN


### PR DESCRIPTION
Not urgent (doesn't need to go into 14.0), but I don't see the need to keep this logic around since watchdog objects are pretty ancient by now.