### PR TITLE
Set fAllowMultiplePorts to true for testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -496,7 +496,7 @@ public:
         fRequireRoutableExternalIP = true;
         fMineBlocksOnDemand = false;
         fAllowMultipleAddressesFromGroup = false;
-        fAllowMultiplePorts = false;
+        fAllowMultiplePorts = true;
 
         nPoolMinParticipants = 3;
         nPoolMaxParticipants = 5;


### PR DESCRIPTION
On testnet it's quite usual to have multiple MNs on the same IP. Now that
we have LLMQs and DKGs which require deterministic intra quorum connections,
we must allow them to connect to each other even if the IPs are shared very
often.