### PR TITLE
Fix blsWorker

### DIFF
--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -51,16 +51,19 @@ std::pair<std::function<void(T)>, std::future<T> > BuildFutureDoneCallback2()
 
 CBLSWorker::CBLSWorker()
 {
-    int workerCount = std::thread::hardware_concurrency() / 2;
-    workerCount = std::max(std::min(1, workerCount), 4);
-    workerPool.resize(workerCount);
-
-    RenameThreadPool(workerPool, "bls-worker");
 }
 
 CBLSWorker::~CBLSWorker()
 {
     Stop();
+}
+
+void CBLSWorker::Start()
+{
+    int workerCount = std::thread::hardware_concurrency() / 2;
+    workerCount = std::max(std::min(1, workerCount), 4);
+    workerPool.resize(workerCount);
+    RenameThreadPool(workerPool, "bls-worker");
 }
 
 void CBLSWorker::Stop()

--- a/src/bls/bls_worker.h
+++ b/src/bls/bls_worker.h
@@ -53,6 +53,7 @@ public:
     CBLSWorker();
     ~CBLSWorker();
 
+    void Start();
     void Stop();
 
     bool GenerateContributions(int threshold, const BLSIdVector& ids, BLSVerificationVectorPtr& vvecRet, BLSSecretKeyVector& skShares);


### PR DESCRIPTION
Use a pointer instead of a static variable, start/stop together with other llmq modules.