### PR TITLE
Re-introduce nInstantSendKeepLock check for LLMQ-based IS when spork19 is OFF

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -60,6 +60,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     if (fLiteMode)
         return;
 
+    llmq::quorumInstantSendManager->UpdatedBlockTip(pindexNew);
     llmq::chainLocksHandler->UpdatedBlockTip(pindexNew, pindexFork);
 
     CPrivateSend::UpdatedBlockTip(pindexNew);

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -122,6 +122,7 @@ public:
 
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock);
     void NotifyChainLock(const CBlockIndex* pindexChainLock);
+    void UpdatedBlockTip(const CBlockIndex* pindexNew);
     void RemoveFinalISLock(const uint256& hash, const CInstantSendLockPtr& islock);
 
     void RemoveMempoolConflictsForLock(const uint256& hash, const CInstantSendLock& islock);


### PR DESCRIPTION
This reuses `NotifyChainLock` cause effectively the same logic applies here as well.