### PR TITLE
[0.13.x] Change default value of spork15 to 1047200

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -27,7 +27,7 @@ std::map<int, int64_t> mapSporkDefaults = {
     {SPORK_10_MASTERNODE_PAY_UPDATED_NODES,  4070908800ULL}, // OFF
     {SPORK_12_RECONSIDER_BLOCKS,             0},             // 0 BLOCKS
     {SPORK_14_REQUIRE_SENTINEL_FLAG,         4070908800ULL}, // OFF
-    {SPORK_15_DETERMINISTIC_MNS_ENABLED,     4070908800ULL}, // OFF
+    {SPORK_15_DETERMINISTIC_MNS_ENABLED,     1047200},       // Hardened to mainnet activation height (we only did this for 0.13.x)
     {SPORK_16_INSTANTSEND_AUTOLOCKS,         4070908800ULL}, // OFF
     {SPORK_17_QUORUM_DKG_ENABLED,            4070908800ULL}, // OFF
 };


### PR DESCRIPTION
This is a hackish version of https://github.com/dashpay/dash/pull/2824,
meant for 0.13.x only. The reason for this hackish version is that the
code has diverged quite a bit and its not worth the effort to backport
the hardening code.

Even though 0.13.x included a lot of fixes for sporks handling and syncing,
I still feel more safe with hardening the spork15 block height. If
something goes wrong with spork syncing (e.g. its slower then the first
DIP2/3 block arrives), the whole sync process will fail otherwise.