### PR TITLE
Implement quorum merkle roots for DIP4 coinbases and add quorums to MNLISTDIFF

### DIFF
--- a/qa/rpc-tests/dip4-coinbasemerkleroots.py
+++ b/qa/rpc-tests/dip4-coinbasemerkleroots.py
@@ -84,11 +84,13 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         #############################
         # Now start testing quorum commitment merkle roots
 
-        height = self.nodes[0].getblockcount()
+        self.nodes[0].generate(1)
+        oldhash = self.nodes[0].getbestblockhash()
         # Test DIP8 activation once with a pre-existing quorum and once without (we don't know in which order it will activate on mainnet)
         self.test_dip8_quorum_merkle_root_activation(True)
         for n in self.nodes:
-            n.invalidateblock(n.getblockhash(height + 1))
+            n.invalidateblock(oldhash)
+        self.sync_all()
         first_quorum = self.test_dip8_quorum_merkle_root_activation(False)
 
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
@@ -252,6 +254,7 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
 
         while self.nodes[0].getblockchaininfo()["bip9_softforks"]["dip0008"]["status"] != "active":
             self.nodes[0].generate(4)
+            self.sync_all()
         self.nodes[0].generate(1)
         sync_blocks(self.nodes)
 

--- a/qa/rpc-tests/dip4-coinbasemerkleroots.py
+++ b/qa/rpc-tests/dip4-coinbasemerkleroots.py
@@ -81,6 +81,79 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         # When comparing genesis and best block, we shouldn't see the previously added and then deleted MN
         mnList = self.test_getmnlistdiff(null_hash, self.nodes[0].getbestblockhash(), {}, [], expectedUpdated2)
 
+        #############################
+        # Now start testing quorum commitment merkle roots
+
+        height = self.nodes[0].getblockcount()
+        # Test DIP8 activation once with a pre-existing quorum and once without (we don't know in which order it will activate on mainnet)
+        self.test_dip8_quorum_merkle_root_activation(True)
+        for n in self.nodes:
+            n.invalidateblock(n.getblockhash(height + 1))
+        first_quorum = self.test_dip8_quorum_merkle_root_activation(False)
+
+        self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        self.wait_for_sporks_same()
+
+        # Verify that the first quorum appears in MNLISTDIFF
+        expectedDeleted = []
+        expectedNew = [QuorumId(100, int(first_quorum, 16))]
+        quorumList = self.test_getmnlistdiff_quorums(null_hash, self.nodes[0].getbestblockhash(), {}, expectedDeleted, expectedNew)
+        baseBlockHash = self.nodes[0].getbestblockhash()
+
+        second_quorum = self.mine_quorum()
+
+        # Verify that the second quorum appears in MNLISTDIFF
+        expectedDeleted = []
+        expectedNew = [QuorumId(100, int(second_quorum, 16))]
+        quorums_before_third = self.test_getmnlistdiff_quorums(baseBlockHash, self.nodes[0].getbestblockhash(), quorumList, expectedDeleted, expectedNew)
+        block_before_third = self.nodes[0].getbestblockhash()
+
+        third_quorum = self.mine_quorum()
+
+        # Verify that the first quorum is deleted and the third quorum is added in MNLISTDIFF (the first got inactive)
+        expectedDeleted = [QuorumId(100, int(first_quorum, 16))]
+        expectedNew = [QuorumId(100, int(third_quorum, 16))]
+        self.test_getmnlistdiff_quorums(block_before_third, self.nodes[0].getbestblockhash(), quorums_before_third, expectedDeleted, expectedNew)
+
+        # Verify that the diff between genesis and best block is the current active set (second and third quorum)
+        expectedDeleted = []
+        expectedNew = [QuorumId(100, int(second_quorum, 16)), QuorumId(100, int(third_quorum, 16))]
+        self.test_getmnlistdiff_quorums(null_hash, self.nodes[0].getbestblockhash(), {}, expectedDeleted, expectedNew)
+
+        # Now verify that diffs are correct around the block that mined the third quorum.
+        # This tests the logic in CalcCbTxMerkleRootQuorums, which has to manually add the commitment from the current
+        # block
+        mined_in_block = self.nodes[0].quorum("info", 100, third_quorum)["minedBlock"]
+        prev_block = self.nodes[0].getblock(mined_in_block)["previousblockhash"]
+        prev_block2 = self.nodes[0].getblock(prev_block)["previousblockhash"]
+        next_block = self.nodes[0].getblock(mined_in_block)["nextblockhash"]
+        next_block2 = self.nodes[0].getblock(mined_in_block)["nextblockhash"]
+        # The 2 block before the quorum was mined should both give an empty diff
+        expectedDeleted = []
+        expectedNew = []
+        self.test_getmnlistdiff_quorums(block_before_third, prev_block2, quorums_before_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(block_before_third, prev_block, quorums_before_third, expectedDeleted, expectedNew)
+        # The block in which the quorum was mined and the 2 after that should all give the same diff
+        expectedDeleted = [QuorumId(100, int(first_quorum, 16))]
+        expectedNew = [QuorumId(100, int(third_quorum, 16))]
+        quorums_with_third = self.test_getmnlistdiff_quorums(block_before_third, mined_in_block, quorums_before_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(block_before_third, next_block, quorums_before_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(block_before_third, next_block2, quorums_before_third, expectedDeleted, expectedNew)
+        # A diff between the two block that happened after the quorum was mined should give an empty diff
+        expectedDeleted = []
+        expectedNew = []
+        self.test_getmnlistdiff_quorums(mined_in_block, next_block, quorums_with_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(mined_in_block, next_block2, quorums_with_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(next_block, next_block2, quorums_with_third, expectedDeleted, expectedNew)
+
+        # Using the same block for baseBlockHash and blockHash should give empty diffs
+        self.test_getmnlistdiff_quorums(prev_block, prev_block, quorums_before_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(prev_block2, prev_block2, quorums_before_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(mined_in_block, mined_in_block, quorums_with_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(next_block, next_block, quorums_with_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(next_block2, next_block2, quorums_with_third, expectedDeleted, expectedNew)
+
+
     def test_getmnlistdiff(self, baseBlockHash, blockHash, baseMNList, expectedDeleted, expectedUpdated):
         d = self.test_getmnlistdiff_base(baseBlockHash, blockHash)
 
@@ -107,6 +180,34 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
 
         return newMNList
 
+    def test_getmnlistdiff_quorums(self, baseBlockHash, blockHash, baseQuorumList, expectedDeleted, expectedNew):
+        d = self.test_getmnlistdiff_base(baseBlockHash, blockHash)
+
+        assert_equal(set(d.deletedQuorums), set(expectedDeleted))
+        assert_equal(set([QuorumId(e.llmqType, e.quorumHash) for e in d.newQuorums]), set(expectedNew))
+
+        newQuorumList = baseQuorumList.copy()
+
+        for e in d.deletedQuorums:
+            newQuorumList.pop(e)
+
+        for e in d.newQuorums:
+            newQuorumList[QuorumId(e.llmqType, e.quorumHash)] = e
+
+        cbtx = CCbTx()
+        cbtx.deserialize(BytesIO(d.cbTx.vExtraPayload))
+
+        if cbtx.version >= 2:
+            hashes = []
+            for qc in newQuorumList.values():
+                hashes.append(hash256(qc.serialize()))
+            hashes.sort()
+            merkleRoot = CBlock.get_merkle_root(hashes)
+            assert_equal(merkleRoot, cbtx.merkleRootQuorums)
+
+        return newQuorumList
+
+
     def test_getmnlistdiff_base(self, baseBlockHash, blockHash):
         hexstr = self.nodes[0].getblockheader(blockHash, False)
         header = FromHex(CBlockHeader(), hexstr)
@@ -128,8 +229,54 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         assert_equal(d2["cbTx"], d.cbTx.serialize().hex())
         assert_equal(set([int(e, 16) for e in d2["deletedMNs"]]), set(d.deletedMNs))
         assert_equal(set([int(e["proRegTxHash"], 16) for e in d2["mnList"]]), set([e.proRegTxHash for e in d.mnList]))
+        assert_equal(set([QuorumId(e["llmqType"], int(e["quorumHash"], 16)) for e in d2["deletedQuorums"]]), set(d.deletedQuorums))
+        assert_equal(set([QuorumId(e["llmqType"], int(e["quorumHash"], 16)) for e in d2["newQuorums"]]), set([QuorumId(e.llmqType, e.quorumHash) for e in d.newQuorums]))
 
         return d
+
+    def test_dip8_quorum_merkle_root_activation(self, with_initial_quorum):
+        if with_initial_quorum:
+            self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+            self.wait_for_sporks_same()
+
+            # Mine one quorum before dip8 is activated
+            self.mine_quorum()
+
+        self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 4070908800)
+        self.wait_for_sporks_same()
+
+        cbtx = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)["tx"][0]
+        assert(cbtx["cbTx"]["version"] == 1)
+
+        assert(self.nodes[0].getblockchaininfo()["bip9_softforks"]["dip0008"]["status"] != "active")
+
+        while self.nodes[0].getblockchaininfo()["bip9_softforks"]["dip0008"]["status"] != "active":
+            self.nodes[0].generate(4)
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # Assert that merkleRootQuorums is present and 0 (we have no quorums yet)
+        cbtx = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)["tx"][0]
+        assert_equal(cbtx["cbTx"]["version"], 2)
+        assert("merkleRootQuorums" in cbtx["cbTx"])
+        merkleRootQuorums = int(cbtx["cbTx"]["merkleRootQuorums"], 16)
+
+        if with_initial_quorum:
+            assert(merkleRootQuorums != 0)
+        else:
+            assert_equal(merkleRootQuorums, 0)
+
+        set_mocktime(get_mocktime() + 1)
+        set_node_times(self.nodes, get_mocktime())
+        self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        self.wait_for_sporks_same()
+
+        # Mine quorum and verify that merkleRootQuorums has changed
+        quorum = self.mine_quorum()
+        cbtx = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)["tx"][0]
+        assert(int(cbtx["cbTx"]["merkleRootQuorums"], 16) != merkleRootQuorums)
+
+        return quorum
 
     def confirm_mns(self):
         while True:

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -56,7 +56,7 @@ def create_coinbase(height, pubkey = None, dip4_activated=False):
     if dip4_activated:
         coinbase.nVersion = 3
         coinbase.nType = 5
-        cbtx_payload = CCbTx(1, height, 0)
+        cbtx_payload = CCbTx(2, height, 0, 0)
         coinbase.vExtraPayload = cbtx_payload.serialize()
     coinbase.calc_sha256()
     return coinbase

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -309,7 +309,7 @@ class CInv(object):
 
     def __repr__(self):
         return "CInv(type=%s hash=%064x)" \
-            % (self.typemap[self.type], self.hash)
+            % (self.typemap.get(self.type, "%d" % self.type), self.hash)
 
 
 class CBlockLocator(object):

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -683,11 +683,14 @@ class DashTestFramework(BitcoinTestFramework):
             set_node_times(self.nodes, get_mocktime())
             self.nodes[0].generate(1)
             sync_blocks(self.nodes)
+        new_quorum = self.nodes[0].quorum("list", 1)["llmq_5_60"][0]
 
         # Mine 8 (SIGN_HEIGHT_OFFSET) more blocks to make sure that the new quorum gets eligable for signing sessions
         self.nodes[0].generate(8)
 
         sync_blocks(self.nodes)
+
+        return new_quorum
 
 # Test framework for doing p2p comparison testing, which sets up some bitcoind
 # binaries:

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -684,6 +684,9 @@ class DashTestFramework(BitcoinTestFramework):
             self.nodes[0].generate(1)
             sync_blocks(self.nodes)
 
+        # Mine 8 (SIGN_HEIGHT_OFFSET) more blocks to make sure that the new quorum gets eligable for signing sessions
+        self.nodes[0].generate(8)
+
         sync_blocks(self.nodes)
 
 # Test framework for doing p2p comparison testing, which sets up some bitcoind

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -159,14 +159,18 @@ public:
     void Next();
 
     template<typename K> bool GetKey(K& key) {
-        leveldb::Slice slKey = piter->key();
         try {
-            CDataStream ssKey(slKey.data(), slKey.data() + slKey.size(), SER_DISK, CLIENT_VERSION);
+            CDataStream ssKey = GetKey();
             ssKey >> key;
         } catch (const std::exception&) {
             return false;
         }
         return true;
+    }
+
+    CDataStream GetKey() {
+        leveldb::Slice slKey = piter->key();
+        return CDataStream(slKey.data(), slKey.data() + slKey.size(), SER_DISK, CLIENT_VERSION);
     }
 
     unsigned int GetKeySize() {
@@ -389,8 +393,153 @@ public:
 
 };
 
+template<typename CDBTransaction>
+class CDBTransactionIterator
+{
+private:
+    CDBTransaction& transaction;
+
+    typedef typename std::remove_pointer<decltype(transaction.parent.NewIterator())>::type ParentIterator;
+
+    // We maintain 2 iterators, one for the transaction and one for the parent
+    // At all times, only one of both provides the current value. The decision is made by comparing the current keys
+    // of both iterators, so that always the smaller key is the current one. On Next(), the previously chosen iterator
+    // is advanced.
+    typename CDBTransaction::WritesMap::iterator transactionIt;
+    std::unique_ptr<ParentIterator> parentIt;
+    CDataStream parentKey;
+    bool curIsParent{false};
+
+public:
+    CDBTransactionIterator(CDBTransaction& _transaction) :
+            transaction(_transaction),
+            parentKey(SER_DISK, CLIENT_VERSION)
+    {
+        transactionIt = transaction.writes.end();
+        parentIt = std::unique_ptr<ParentIterator>(transaction.parent.NewIterator());
+    }
+
+    void SeekToFirst() {
+        transactionIt = transaction.writes.begin();
+        parentIt->SeekToFirst();
+        SkipDeletedAndOverwritten();
+        DecideCur();
+    }
+
+    template<typename K>
+    void Seek(const K& key) {
+        Seek(CDBTransaction::KeyToDataStream(key));
+    }
+
+    void Seek(const CDataStream& ssKey) {
+        transactionIt = transaction.writes.lower_bound(ssKey);
+        parentIt->Seek(ssKey);
+        SkipDeletedAndOverwritten();
+        DecideCur();
+    }
+
+    bool Valid() {
+        return transactionIt != transaction.writes.end() || parentIt->Valid();
+    }
+
+    void Next() {
+        if (transactionIt == transaction.writes.end() && !parentIt->Valid()) {
+            return;
+        }
+        if (curIsParent) {
+            assert(parentIt->Valid());
+            parentIt->Next();
+            SkipDeletedAndOverwritten();
+        } else {
+            assert(transactionIt != transaction.writes.end());
+            ++transactionIt;
+        }
+        DecideCur();
+    }
+
+    template<typename K>
+    bool GetKey(K& key) {
+        if (!Valid()) {
+            return false;
+        }
+
+        if (curIsParent) {
+            return parentIt->GetKey(key);
+        } else {
+            try {
+                // TODO try to avoid this copy (we need a stream that allows reading from external buffers)
+                CDataStream ssKey = transactionIt->first;
+                ssKey >> key;
+            } catch (const std::exception&) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    CDataStream GetKey() {
+        if (!Valid()) {
+            return CDataStream(SER_DISK, CLIENT_VERSION);
+        }
+        if (curIsParent) {
+            return parentIt->GetKey();
+        } else {
+            return transactionIt->first;
+        }
+    }
+
+    unsigned int GetKeySize() {
+        if (!Valid()) {
+            return 0;
+        }
+        if (curIsParent) {
+            return parentIt->GetKeySize();
+        } else {
+            return transactionIt->first.vKey.size();
+        }
+    }
+
+    template<typename V>
+    bool GetValue(V& value) {
+        if (!Valid()) {
+            return false;
+        }
+        if (curIsParent) {
+            return transaction.Read(parentKey, value);
+        } else {
+            return transaction.Read(transactionIt->first, value);
+        }
+    };
+
+private:
+    void SkipDeletedAndOverwritten() {
+        while (parentIt->Valid()) {
+            parentKey = parentIt->GetKey();
+            if (!transaction.deletes.count(parentKey) && !transaction.writes.count(parentKey)) {
+                break;
+            }
+        }
+    }
+
+    void DecideCur() {
+        if (transactionIt != transaction.writes.end() && !parentIt->Valid()) {
+            curIsParent = false;
+        } else if (transactionIt == transaction.writes.end() && parentIt->Valid()) {
+            curIsParent = true;
+        } else if (transactionIt != transaction.writes.end() && parentIt->Valid()) {
+            if (CDBTransaction::DataStreamCmp::less(transactionIt->first, parentKey)) {
+                curIsParent = false;
+            } else {
+                curIsParent = true;
+            }
+        }
+    }
+};
+
 template<typename Parent, typename CommitTarget>
 class CDBTransaction {
+    friend class CDBTransactionIterator<CDBTransaction>;
+
 protected:
     Parent &parent;
     CommitTarget &commitTarget;
@@ -519,6 +668,13 @@ public:
 
     bool IsClean() {
         return writes.empty() && deletes.empty();
+    }
+
+    CDBTransactionIterator<CDBTransaction>* NewIterator() {
+        return new CDBTransactionIterator<CDBTransaction>(*this);
+    }
+    std::unique_ptr<CDBTransactionIterator<CDBTransaction>> NewIteratorUniquePtr() {
+        return std::make_unique<CDBTransactionIterator<CDBTransaction>>(*this);
     }
 };
 

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -107,7 +107,8 @@ bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPre
         v.reserve(p.second.size());
         for (const auto& p2 : p.second) {
             llmq::CFinalCommitment qc;
-            bool found = llmq::quorumBlockProcessor->GetMinedCommitment(p.first, p2->GetBlockHash(), qc);
+            uint256 minedBlockHash;
+            bool found = llmq::quorumBlockProcessor->GetMinedCommitment(p.first, p2->GetBlockHash(), qc, minedBlockHash);
             assert(found);
             v.emplace_back(::SerializeHash(qc));
             hashCount++;

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -4,10 +4,14 @@
 
 #include "cbtx.h"
 #include "deterministicmns.h"
+#include "llmq/quorums.h"
+#include "llmq/quorums_blockprocessor.h"
+#include "llmq/quorums_commitment.h"
 #include "simplifiedmns.h"
 #include "specialtx.h"
 
 #include "chainparams.h"
+#include "consensus/merkle.h"
 #include "univalue.h"
 #include "validation.h"
 
@@ -34,11 +38,18 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidatio
         return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-height");
     }
 
+    if (pindexPrev) {
+        bool fDIP0008Active = VersionBitsState(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0008, versionbitscache) == THRESHOLD_ACTIVE;
+        if (fDIP0008Active && cbTx.nVersion < 2) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-version");
+        }
+    }
+
     return true;
 }
 
 // This can only be done after the block has been fully processed, as otherwise we won't have the finished MN list
-bool CheckCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindex, CValidationState& state)
+bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state)
 {
     if (block.vtx[0]->nType != TRANSACTION_COINBASE) {
         return true;
@@ -56,6 +67,14 @@ bool CheckCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindex, C
         }
         if (calculatedMerkleRoot != cbTx.merkleRootMNList) {
             return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-mnmerkleroot");
+        }
+        if (cbTx.nVersion >= 2) {
+            if (!CalcCbTxMerkleRootQuorums(block, pindex->pprev, calculatedMerkleRoot, state)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-quorummerkleroot");
+            }
+            if (calculatedMerkleRoot != cbTx.merkleRootQuorums) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-cbtx-quorummerkleroot");
+            }
         }
     }
 
@@ -78,10 +97,67 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
     return !mutated;
 }
 
+bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, CValidationState& state)
+{
+    auto quorums = llmq::quorumBlockProcessor->GetMinedAndActiveCommitmentsUntilBlock(pindexPrev);
+    std::map<Consensus::LLMQType, std::vector<uint256>> qcHashes;
+    size_t hashCount = 0;
+    for (const auto& p : quorums) {
+        auto& v = qcHashes[p.first];
+        v.reserve(p.second.size());
+        for (const auto& p2 : p.second) {
+            llmq::CFinalCommitment qc;
+            bool found = llmq::quorumBlockProcessor->GetMinedCommitment(p.first, p2->GetBlockHash(), qc);
+            assert(found);
+            v.emplace_back(::SerializeHash(qc));
+            hashCount++;
+        }
+    }
+
+    // now add the commitments from the current block, which are not returned by GetMinedAndActiveCommitmentsUntilBlock
+    // due to the use of pindexPrev (we don't have the tip index here)
+    for (size_t i = 1; i < block.vtx.size(); i++) {
+        auto& tx = block.vtx[i];
+
+        if (tx->nVersion == 3 && tx->nType == TRANSACTION_QUORUM_COMMITMENT) {
+            llmq::CFinalCommitmentTxPayload qc;
+            if (!GetTxPayload(*tx, qc)) {
+                assert(false);
+            }
+            if (qc.commitment.IsNull()) {
+                continue;
+            }
+            auto qcHash = ::SerializeHash(qc.commitment);
+            const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)qc.commitment.llmqType);
+            auto& v = qcHashes[params.type];
+            if (v.size() == params.signingActiveQuorumCount) {
+                v.pop_back();
+            }
+            v.emplace_back(qcHash);
+            hashCount++;
+            assert(v.size() <= params.signingActiveQuorumCount);
+        }
+    }
+
+    std::vector<uint256> qcHashesVec;
+    qcHashesVec.reserve(hashCount);
+
+    for (const auto& p : qcHashes) {
+        for (const auto& h : p.second) {
+            qcHashesVec.emplace_back(h);
+        }
+    }
+    std::sort(qcHashesVec.begin(), qcHashesVec.end());
+
+    bool mutated = false;
+    merkleRootRet = ComputeMerkleRoot(qcHashesVec, &mutated);
+    return !mutated;
+}
+
 std::string CCbTx::ToString() const
 {
-    return strprintf("CCbTx(nHeight=%d, nVersion=%d, merkleRootMNList=%s)",
-        nVersion, nHeight, merkleRootMNList.ToString());
+    return strprintf("CCbTx(nHeight=%d, nVersion=%d, merkleRootMNList=%s, merkleRootQuorums=%s)",
+        nVersion, nHeight, merkleRootMNList.ToString(), merkleRootQuorums.ToString());
 }
 
 void CCbTx::ToJson(UniValue& obj) const
@@ -91,4 +167,7 @@ void CCbTx::ToJson(UniValue& obj) const
     obj.push_back(Pair("version", (int)nVersion));
     obj.push_back(Pair("height", (int)nHeight));
     obj.push_back(Pair("merkleRootMNList", merkleRootMNList.ToString()));
+    if (nVersion >= 2) {
+        obj.push_back(Pair("merkleRootQuorums", merkleRootQuorums.ToString()));
+    }
 }

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -16,12 +16,13 @@ class UniValue;
 class CCbTx
 {
 public:
-    static const uint16_t CURRENT_VERSION = 1;
+    static const uint16_t CURRENT_VERSION = 2;
 
 public:
     uint16_t nVersion{CURRENT_VERSION};
     int32_t nHeight{0};
     uint256 merkleRootMNList;
+    uint256 merkleRootQuorums;
 
 public:
     ADD_SERIALIZE_METHODS;
@@ -32,6 +33,10 @@ public:
         READWRITE(nVersion);
         READWRITE(nHeight);
         READWRITE(merkleRootMNList);
+
+        if (nVersion >= 2) {
+            READWRITE(merkleRootQuorums);
+        }
     }
 
     std::string ToString() const;
@@ -40,7 +45,8 @@ public:
 
 bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 
-bool CheckCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindex, CValidationState& state);
+bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, CValidationState& state);
 bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, CValidationState& state);
+bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, CValidationState& state);
 
 #endif //DASH_CBTX_H

--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -35,6 +35,11 @@ public:
         return t;
     }
 
+    CurTransaction& GetCurTransaction()
+    {
+        return curDBTransaction;
+    }
+
     template <typename K, typename V>
     bool Read(const K& key, V& value)
     {

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -118,7 +118,8 @@ bool CSimplifiedMNListDiff::BuildQuorumsDiff(const CBlockIndex* baseBlockIndex, 
     for (auto& p : quorumHashes) {
         if (!baseQuorumHashes.count(p)) {
             llmq::CFinalCommitment qc;
-            if (!llmq::quorumBlockProcessor->GetMinedCommitment(p.first, p.second, qc)) {
+            uint256 minedBlockHash;
+            if (!llmq::quorumBlockProcessor->GetMinedCommitment(p.first, p.second, qc, minedBlockHash)) {
                 return false;
             }
             newQuorums.emplace_back(qc);

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -10,10 +10,16 @@
 #include "netaddress.h"
 #include "pubkey.h"
 #include "serialize.h"
+#include "version.h"
 
 class UniValue;
 class CDeterministicMNList;
 class CDeterministicMN;
+
+namespace llmq
+{
+    class CFinalCommitment;
+}
 
 class CSimplifiedMNListEntry
 {
@@ -107,6 +113,10 @@ public:
     std::vector<uint256> deletedMNs;
     std::vector<CSimplifiedMNListEntry> mnList;
 
+    // starting with proto version LLMQS_PROTO_VERSION, we also transfer changes in active quorums
+    std::vector<std::pair<uint8_t, uint256>> deletedQuorums; // p<LLMQType, quorumHash>
+    std::vector<llmq::CFinalCommitment> newQuorums;
+
 public:
     ADD_SERIALIZE_METHODS;
 
@@ -119,9 +129,19 @@ public:
         READWRITE(cbTx);
         READWRITE(deletedMNs);
         READWRITE(mnList);
+
+        if (s.GetVersion() >= LLMQS_PROTO_VERSION) {
+            READWRITE(deletedQuorums);
+            READWRITE(newQuorums);
+        }
     }
 
 public:
+    CSimplifiedMNListDiff();
+    ~CSimplifiedMNListDiff();
+
+    bool BuildQuorumsDiff(const CBlockIndex* baseBlockIndex, const CBlockIndex* blockIndex);
+
     void ToJson(UniValue& obj) const;
 };
 

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -106,7 +106,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CV
         return false;
     }
 
-    if (!CheckCbTxMerkleRootMNList(block, pindex, state)) {
+    if (!CheckCbTxMerkleRoots(block, pindex, state)) {
         return false;
     }
 

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -36,6 +36,7 @@ public:
     const Consensus::LLMQParams& params;
     CFinalCommitment qc;
     int height;
+    uint256 minedBlockHash;
     std::vector<CDeterministicMNCPtr> members;
 
     // These are only valid when we either participated in the DKG or fully watched it
@@ -52,7 +53,7 @@ private:
 public:
     CQuorum(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker) : params(_params), blsCache(_blsWorker), stopCachePopulatorThread(false) {}
     ~CQuorum();
-    void Init(const CFinalCommitment& _qc, int _height, const std::vector<CDeterministicMNCPtr>& _members);
+    void Init(const CFinalCommitment& _qc, int _height, const uint256& _minedBlockHash, const std::vector<CDeterministicMNCPtr>& _members);
 
     bool IsMember(const uint256& proTxHash) const;
     bool IsValidMember(const uint256& proTxHash) const;
@@ -104,7 +105,7 @@ private:
     // all private methods here are cs_main-free
     void EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex *pindexNew);
 
-    bool BuildQuorumFromCommitment(const CFinalCommitment& qc, const CBlockIndex* pindexQuorum, std::shared_ptr<CQuorum>& quorum) const;
+    bool BuildQuorumFromCommitment(const CFinalCommitment& qc, const CBlockIndex* pindexQuorum, const uint256& minedBlockHash, std::shared_ptr<CQuorum>& quorum) const;
     bool BuildQuorumContributions(const CFinalCommitment& fqc, std::shared_ptr<CQuorum>& quorum) const;
 
     CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const CBlockIndex* pindex);

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -7,6 +7,7 @@
 
 #include "evo/evodb.h"
 #include "evo/deterministicmns.h"
+#include "llmq/quorums_commitment.h"
 
 #include "validationinterface.h"
 #include "consensus/params.h"
@@ -33,11 +34,9 @@ class CQuorum
     friend class CQuorumManager;
 public:
     const Consensus::LLMQParams& params;
-    uint256 quorumHash;
+    CFinalCommitment qc;
     int height;
     std::vector<CDeterministicMNCPtr> members;
-    std::vector<bool> validMembers;
-    CBLSPublicKey quorumPublicKey;
 
     // These are only valid when we either participated in the DKG or fully watched it
     BLSVerificationVectorPtr quorumVvec;
@@ -53,7 +52,7 @@ private:
 public:
     CQuorum(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker) : params(_params), blsCache(_blsWorker), stopCachePopulatorThread(false) {}
     ~CQuorum();
-    void Init(const uint256& quorumHash, int height, const std::vector<CDeterministicMNCPtr>& members, const std::vector<bool>& validMembers, const CBLSPublicKey& quorumPublicKey);
+    void Init(const CFinalCommitment& _qc, int _height, const std::vector<CDeterministicMNCPtr>& _members);
 
     bool IsMember(const uint256& proTxHash) const;
     bool IsValidMember(const uint256& proTxHash) const;

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -37,6 +37,8 @@ private:
 public:
     CQuorumBlockProcessor(CEvoDB& _evoDb) : evoDb(_evoDb) {}
 
+    void UpgradeDB();
+
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state);

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -58,7 +58,7 @@ public:
 
 private:
     bool GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state);
-    bool ProcessCommitment(const CBlockIndex* pindex, const CFinalCommitment& qc, CValidationState& state);
+    bool ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, CValidationState& state);
     bool IsMiningPhase(Consensus::LLMQType llmqType, int nHeight);
     bool IsCommitmentRequired(Consensus::LLMQType llmqType, int nHeight);
     uint256 GetQuorumBlockHash(Consensus::LLMQType llmqType, int nHeight);

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -51,7 +51,7 @@ public:
     bool GetMinableCommitmentTx(Consensus::LLMQType llmqType, int nHeight, CTransactionRef& ret);
 
     bool HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash);
-    bool GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, CFinalCommitment& ret);
+    bool GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, CFinalCommitment& ret, uint256& retMinedBlockHash);
 
     std::vector<const CBlockIndex*> GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t maxCount);
     std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> GetMinedAndActiveCommitmentsUntilBlock(const CBlockIndex* pindex);

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -53,7 +53,8 @@ public:
     bool HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash);
     bool GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, CFinalCommitment& ret);
 
-    uint256 GetFirstMinedQuorumHash(Consensus::LLMQType llmqType);
+    std::vector<const CBlockIndex*> GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t maxCount);
+    std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> GetMinedAndActiveCommitmentsUntilBlock(const CBlockIndex* pindex);
 
 private:
     bool GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state);

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -65,6 +65,8 @@ void DestroyLLMQSystem()
 
 void StartLLMQSystem()
 {
+    quorumBlockProcessor->UpgradeDB();
+
     if (blsWorker) {
         blsWorker->Start();
     }

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -578,8 +578,8 @@ void CInstantSendManager::ProcessPendingInstantSendLocks()
             // should not happen, but if one fails to select, all others will also fail to select
             return;
         }
-        uint256 signHash = CLLMQUtils::BuildSignHash(llmqType, quorum->quorumHash, id, islock.txid);
-        batchVerifier.PushMessage(nodeId, hash, signHash, islock.sig, quorum->quorumPublicKey);
+        uint256 signHash = CLLMQUtils::BuildSignHash(llmqType, quorum->qc.quorumHash, id, islock.txid);
+        batchVerifier.PushMessage(nodeId, hash, signHash, islock.sig, quorum->qc.quorumPublicKey);
 
         // We can reconstruct the CRecoveredSig objects from the islock and pass it to the signing manager, which
         // avoids unnecessary double-verification of the signature. We however only do this when verification here
@@ -587,7 +587,7 @@ void CInstantSendManager::ProcessPendingInstantSendLocks()
         if (!quorumSigningManager->HasRecoveredSigForId(llmqType, id)) {
             CRecoveredSig recSig;
             recSig.llmqType = llmqType;
-            recSig.quorumHash = quorum->quorumHash;
+            recSig.quorumHash = quorum->qc.quorumHash;
             recSig.id = id;
             recSig.msgHash = islock.txid;
             recSig.sig = islock.sig;

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -104,7 +104,7 @@ bool CLLMQUtils::IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quo
     // fail while we are on the brink of a new quorum
     auto quorums = quorumManager->ScanQuorums(llmqType, (int)params.signingActiveQuorumCount + 1);
     for (auto& q : quorums) {
-        if (q->quorumHash == quorumHash) {
+        if (q->qc.quorumHash == quorumHash) {
             return true;
         }
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -221,11 +221,11 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
         CValidationState state;
         if (!CalcCbTxMerkleRootMNList(*pblock, pindexPrev, cbTx.merkleRootMNList, state)) {
-            throw std::runtime_error(strprintf("%s: CalcSMLMerkleRootForNewBlock failed: %s", __func__, FormatStateMessage(state)));
+            throw std::runtime_error(strprintf("%s: CalcCbTxMerkleRootMNList failed: %s", __func__, FormatStateMessage(state)));
         }
         if (fDIP0008Active_context) {
             if (!CalcCbTxMerkleRootQuorums(*pblock, pindexPrev, cbTx.merkleRootQuorums, state)) {
-                throw std::runtime_error(strprintf("%s: CalcSMLMerkleRootForNewBlock failed: %s", __func__, FormatStateMessage(state)));
+                throw std::runtime_error(strprintf("%s: CalcCbTxMerkleRootQuorums failed: %s", __func__, FormatStateMessage(state)));
             }
         }
 

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -40,7 +40,7 @@ UniValue quorum_list(const JSONRPCRequest& request)
 
         auto quorums = llmq::quorumManager->ScanQuorums(p.first, chainActive.Tip(), count);
         for (auto& q : quorums) {
-            v.push_back(q->quorumHash.ToString());
+            v.push_back(q->qc.quorumHash.ToString());
         }
 
         ret.push_back(Pair(p.second.name, v));
@@ -87,15 +87,15 @@ UniValue quorum_info(const JSONRPCRequest& request)
     UniValue ret(UniValue::VOBJ);
 
     ret.push_back(Pair("height", quorum->height));
-    ret.push_back(Pair("quorumHash", quorum->quorumHash.ToString()));
+    ret.push_back(Pair("quorumHash", quorum->qc.quorumHash.ToString()));
 
     UniValue membersArr(UniValue::VARR);
     for (size_t i = 0; i < quorum->members.size(); i++) {
         auto& dmn = quorum->members[i];
         UniValue mo(UniValue::VOBJ);
         mo.push_back(Pair("proTxHash", dmn->proTxHash.ToString()));
-        mo.push_back(Pair("valid", quorum->validMembers[i]));
-        if (quorum->validMembers[i]) {
+        mo.push_back(Pair("valid", quorum->qc.validMembers[i]));
+        if (quorum->qc.validMembers[i]) {
             CBLSPublicKey pubKey = quorum->GetPubKeyShare(i);
             if (pubKey.IsValid()) {
                 mo.push_back(Pair("pubKeyShare", pubKey.ToString()));
@@ -105,7 +105,7 @@ UniValue quorum_info(const JSONRPCRequest& request)
     }
 
     ret.push_back(Pair("members", membersArr));
-    ret.push_back(Pair("quorumPublicKey", quorum->quorumPublicKey.ToString()));
+    ret.push_back(Pair("quorumPublicKey", quorum->qc.quorumPublicKey.ToString()));
     CBLSSecretKey skShare = quorum->GetSkShare();
     if (includeSkShare && skShare.IsValid()) {
         ret.push_back(Pair("secretKeyShare", skShare.ToString()));

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -73,13 +73,15 @@ UniValue quorum_info(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid LLMQ type");
     }
 
-    uint256 blockHash = ParseHashV(request.params[2], "quorumHash");
+    const auto& llmqParams = Params().GetConsensus().llmqs.at(llmqType);
+
+    uint256 quorumHash = ParseHashV(request.params[2], "quorumHash");
     bool includeSkShare = false;
     if (request.params.size() > 3) {
         includeSkShare = ParseBoolV(request.params[3], "includeSkShare");
     }
 
-    auto quorum = llmq::quorumManager->GetQuorum(llmqType, blockHash);
+    auto quorum = llmq::quorumManager->GetQuorum(llmqType, quorumHash);
     if (!quorum) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "quorum not found");
     }
@@ -88,6 +90,7 @@ UniValue quorum_info(const JSONRPCRequest& request)
 
     ret.push_back(Pair("height", quorum->height));
     ret.push_back(Pair("quorumHash", quorum->qc.quorumHash.ToString()));
+    ret.push_back(Pair("minedBlock", quorum->minedBlockHash.ToString()));
 
     UniValue membersArr(UniValue::VARR);
     for (size_t i = 0; i < quorum->members.size(); i++) {

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -177,6 +177,9 @@ CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns,
         if (!CalcCbTxMerkleRootMNList(block, chainActive.Tip(), cbTx.merkleRootMNList, state)) {
             BOOST_ASSERT(false);
         }
+        if (!CalcCbTxMerkleRootQuorums(block, chainActive.Tip(), cbTx.merkleRootQuorums, state)) {
+            BOOST_ASSERT(false);
+        }
         CMutableTransaction tmpTx = *block.vtx[0];
         SetTxPayload(tmpTx, cbTx);
         block.vtx[0] = MakeTransactionRef(tmpTx);


### PR DESCRIPTION
This adds merkle roots for the currently active LLMQ sets to the DIP4 coinbase. This also results in a version bump for CCbTx.

The `MNLISTDIFF` P2P message and `protx diff` RPC are also enhanced to include the new quorum information. It is structured the same way as with the masternode list diffs and includes deleted and new quorums.

With these changes, SPV nodes should be able to maintain the active quorum sets and verify incoming InstantSend locks and ChainLocks based on this information.

This PR also adds tests for the added functionality.