### PR TITLE
Remove netfulfilledman.h duplicate

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -25,7 +25,6 @@
 #include "miner.h"
 #include "netbase.h"
 #include "net.h"
-#include "netfulfilledman.h"
 #include "net_processing.h"
 #include "policy/policy.h"
 #include "rpc/server.h"


### PR DESCRIPTION
netfulfilledman.h included in init.cpp twice as shown below. This commit removes the first entry and leaves the entry that is nested with the other Dash specific includes.

https://github.com/dashpay/dash/blob/4570079e53ad859c571aeac3f132cf2969888e14/src/init.cpp#L28

https://github.com/dashpay/dash/blob/4570079e53ad859c571aeac3f132cf2969888e14/src/init.cpp#L61