### PR TITLE
Better handle removing of fully confirmed IS locks

### DIFF
--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -66,9 +66,6 @@ public:
     uint256 GetInstantSendLockHashByTxid(const uint256& txid);
     CInstantSendLockPtr GetInstantSendLockByTxid(const uint256& txid);
     CInstantSendLockPtr GetInstantSendLockByInput(const COutPoint& outpoint);
-
-    void WriteLastChainLockBlock(const uint256& hashBlock);
-    uint256 GetLastChainLockBlock();
 };
 
 class CInstantSendManager : public CRecoveredSigsListener

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -128,7 +128,8 @@ public:
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock);
     void NotifyChainLock(const CBlockIndex* pindexChainLock);
     void UpdatedBlockTip(const CBlockIndex* pindexNew);
-    void RemoveFinalISLock(const uint256& hash, const CInstantSendLockPtr& islock);
+
+    void HandleFullyConfirmedBlock(const CBlockIndex* pindex);
 
     void RemoveMempoolConflictsForLock(const uint256& hash, const CInstantSendLock& islock);
     void RetryLockTxs(const uint256& lockedParentTx);

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -56,9 +56,11 @@ public:
 
     void WriteNewInstantSendLock(const uint256& hash, const CInstantSendLock& islock);
     void RemoveInstantSendLock(const uint256& hash, CInstantSendLockPtr islock);
+    void RemoveInstantSendLock(CDBBatch& batch, const uint256& hash, CInstantSendLockPtr islock);
 
     void WriteInstantSendLockMined(const uint256& hash, int nHeight);
     void RemoveInstantSendLockMined(const uint256& hash, int nHeight);
+    std::unordered_map<uint256, CInstantSendLockPtr> RemoveConfirmedInstantSendLocks(int nUntilHeight);
 
     CInstantSendLockPtr GetInstantSendLockByHash(const uint256& hash);
     uint256 GetInstantSendLockHashByTxid(const uint256& txid);

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -57,6 +57,9 @@ public:
     void WriteNewInstantSendLock(const uint256& hash, const CInstantSendLock& islock);
     void RemoveInstantSendLock(const uint256& hash, CInstantSendLockPtr islock);
 
+    void WriteInstantSendLockMined(const uint256& hash, int nHeight);
+    void RemoveInstantSendLockMined(const uint256& hash, int nHeight);
+
     CInstantSendLockPtr GetInstantSendLockByHash(const uint256& hash);
     uint256 GetInstantSendLockHashByTxid(const uint256& txid);
     CInstantSendLockPtr GetInstantSendLockByTxid(const uint256& txid);


### PR DESCRIPTION
This makes CInstantSendManager track in which block an IS locked transaction was mined and then uses this information to find IS locks to remove when blocks get sufficiently confirmed (via ChainLocks or 6 confs if CL is disabled).

This solves 2 issues:
1. While iterating the confirmed blocks, we used ReadBlockFromDisk to gather the included TXs and find the IS locks. This is quite slow.
2. We used the last ChainLock to figure out when to stop iteration. This however means that the first iteration will run down to genesis, causing a hang. It was even worse with 1. combined.

This PR also fixes an issue with wallet transactions not being properly updated when IS locks were removed.

Testing this PR is a bit harder atm as the current `develop` branch disconnects most 0.14 nodes due to invalid IS locks. This is due to the changes/fixes found in #2833. To test this PR, you'll have to locally revert #2833: `git revert -m1 20ec1de4c68392a51b7f4b51e0617e89df87a539`