### PR TITLE
Remove unused forward declaration

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -31,7 +31,6 @@ class WalletFrame;
 class WalletModel;
 class HelpMessageDialog;
 class ModalOverlay;
-class MasternodeList;
 
 class CWallet;
 


### PR DESCRIPTION
Another super trivial change. Spotted when grepping MasternodeList.