### PR TITLE
Add RPC for BLS secret to public key

### DIFF
--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1168,10 +1168,10 @@ UniValue bls_generate(const JSONRPCRequest& request)
     return ret;
 }
 
-void bls_sk2pk_help()
+void bls_fromsecret_help()
 {
     throw std::runtime_error(
-            "bls sk2pk \"secret\"\n"
+            "bls fromsecret \"secret\"\n"
             "\nParses a BLS secret key and returns the secret/public key pair.\n"
             "\nArguments:\n"
             "1. \"secret\"                (string, required) The BLS secret key\n"
@@ -1181,14 +1181,14 @@ void bls_sk2pk_help()
             "  \"public\": \"xxxx\",        (string) BLS public key\n"
             "}\n"
             "\nExamples:\n"
-            + HelpExampleCli("bls sk2pk", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+            + HelpExampleCli("bls fromsecret", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
     );
 }
 
-UniValue bls_sk2pk(const JSONRPCRequest& request)
+UniValue bls_fromsecret(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 2) {
-        bls_sk2pk_help();
+        bls_fromsecret_help();
     }
 
     CBLSSecretKey sk;
@@ -1212,7 +1212,7 @@ UniValue bls_sk2pk(const JSONRPCRequest& request)
             "1. \"command\"        (string, required) The command to execute\n"
             "\nAvailable commands:\n"
             "  generate          - Create a BLS secret/public key pair\n"
-            "  sk2pk             - Parse a BLS secret key and return the secret/public key pair\n"
+            "  fromsecret        - Parse a BLS secret key and return the secret/public key pair\n"
             );
 }
 
@@ -1229,8 +1229,8 @@ UniValue _bls(const JSONRPCRequest& request)
 
     if (command == "generate") {
         return bls_generate(request);
-    } else if (command == "sk2pk") {
-        return bls_sk2pk(request);
+    } else if (command == "fromsecret") {
+        return bls_fromsecret(request);
     } else {
         bls_help();
     }

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1171,8 +1171,10 @@ UniValue bls_generate(const JSONRPCRequest& request)
 void bls_sk2pk_help()
 {
     throw std::runtime_error(
-            "bls sk2pk <secret-key>\n"
+            "bls sk2pk \"secret\"\n"
             "\nParses a BLS secret key and returns the secret/public key pair.\n"
+            "\nArguments:\n"
+            "1. \"secret\"                (string, required) The BLS secret key\n"
             "\nResult:\n"
             "{\n"
             "  \"secret\": \"xxxx\",        (string) BLS secret key\n"
@@ -1188,19 +1190,11 @@ UniValue bls_sk2pk(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 2) {
         bls_sk2pk_help();
     }
-    std::string strBLSPrivKey;
-    strBLSPrivKey = request.params[1].get_str();
-
-    if (!IsHex(strBLSPrivKey)) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Secret key must be a valid hex string of length 64");
-    }
-    auto b = ParseHex(strBLSPrivKey);
-    if (b.size() != 32) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Secret key must be 32 bytes long, not %d", (int)b.size()));
-    }
 
     CBLSSecretKey sk;
-    sk.SetBuf((const uint8_t*)b.data(), b.size());
+    if (!sk.SetHexStr(request.params[1].get_str())) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Secret key must be a valid hex string of length %d", sk.SerSize*2));
+    }
 
     UniValue ret(UniValue::VOBJ);
     ret.push_back(Pair("secret", sk.ToString()));

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1141,8 +1141,10 @@ UniValue protx(const JSONRPCRequest& request)
 void bls_generate_help()
 {
     throw std::runtime_error(
-            "bls generate\n"
-            "\nReturns a BLS secret/public key pair.\n"
+            "bls generate ( \"secret\" )\n"
+            "\nCreate a new BLS secret/public key pair or restore one from a provided BLS secret key.\n"
+            "\nArguments:\n"
+            "1. \"secret\"                (string, optional) The BLS secret key.\n"
             "\nResult:\n"
             "{\n"
             "  \"secret\": \"xxxx\",        (string) BLS secret key\n"
@@ -1150,49 +1152,20 @@ void bls_generate_help()
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("bls generate", "")
+            + HelpExampleCli("bls generate", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
     );
 }
 
 UniValue bls_generate(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() != 1) {
+    if (request.fHelp || (request.params.size() != 1 && request.params.size() != 2)) {
         bls_generate_help();
     }
 
     CBLSSecretKey sk;
-    sk.MakeNewKey();
-
-    UniValue ret(UniValue::VOBJ);
-    ret.push_back(Pair("secret", sk.ToString()));
-    ret.push_back(Pair("public", sk.GetPublicKey().ToString()));
-    return ret;
-}
-
-void bls_sk2pk_help()
-{
-    throw std::runtime_error(
-            "bls sk2pk \"secret\"\n"
-            "\nParses a BLS secret key and returns the secret/public key pair.\n"
-            "\nArguments:\n"
-            "1. \"secret\"                (string, required) The BLS secret key\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"secret\": \"xxxx\",        (string) BLS secret key\n"
-            "  \"public\": \"xxxx\",        (string) BLS public key\n"
-            "}\n"
-            "\nExamples:\n"
-            + HelpExampleCli("bls sk2pk", "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
-    );
-}
-
-UniValue bls_sk2pk(const JSONRPCRequest& request)
-{
-    if (request.fHelp || request.params.size() != 2) {
-        bls_sk2pk_help();
-    }
-
-    CBLSSecretKey sk;
-    if (!sk.SetHexStr(request.params[1].get_str())) {
+    if (request.params.size() == 1) {
+        sk.MakeNewKey();
+    } else if (!sk.SetHexStr(request.params[1].get_str())) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Secret key must be a valid hex string of length %d", sk.SerSize*2));
     }
 
@@ -1211,8 +1184,7 @@ UniValue bls_sk2pk(const JSONRPCRequest& request)
             "\nArguments:\n"
             "1. \"command\"        (string, required) The command to execute\n"
             "\nAvailable commands:\n"
-            "  generate          - Create a BLS secret/public key pair\n"
-            "  sk2pk             - Parse a BLS secret key and return the secret/public key pair\n"
+            "  generate          - Create a new BLS secret/public key pair or restore one from a provided BLS secret key\n"
             );
 }
 
@@ -1229,8 +1201,6 @@ UniValue _bls(const JSONRPCRequest& request)
 
     if (command == "generate") {
         return bls_generate(request);
-    } else if (command == "sk2pk") {
-        return bls_sk2pk(request);
     } else {
         bls_help();
     }


### PR DESCRIPTION
This is a tool for BLS keys to verify the public key which comes from the secret key using the Core BLS library, and is helpful when debugging keys that may have been generated elsewhere (like in Dash Masternode Tool, as an example).

It just accepts a BLS secret key in hex format and outputs a secret / public keypair, similar to the output of `bls generate`.

I'm open to re-naming as I'm not sure `sk2pk` is the best name, but can't think of any better names which aren't really long to type.