### PR TITLE
Call HandleFullyConfirmedBlock when ChainLocks are enabled but not enforced

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -818,7 +818,10 @@ void CInstantSendManager::NotifyChainLock(const CBlockIndex* pindexChainLock)
 
 void CInstantSendManager::UpdatedBlockTip(const CBlockIndex* pindexNew)
 {
-    if (sporkManager.IsSporkActive(SPORK_19_CHAINLOCKS_ENABLED)) {
+    // TODO remove this after DIP8 has activated
+    bool fDIP0008Active = VersionBitsState(pindexNew->pprev, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0008, versionbitscache) == THRESHOLD_ACTIVE;
+
+    if (sporkManager.IsSporkActive(SPORK_19_CHAINLOCKS_ENABLED) && fDIP0008Active) {
         // Nothing to do here. We should keep all islocks and let chainlocks handle them.
         return;
     }


### PR DESCRIPTION
Otherwise IS locks never get removed before DIP8 activates via BIP9.