### PR TITLE
Connect to most recently updated address in ThreadOpenMasternodeConnections

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -168,6 +168,11 @@ CDeterministicMNCPtr CDeterministicMNList::GetValidMNByCollateral(const COutPoin
     return dmn;
 }
 
+CDeterministicMNCPtr CDeterministicMNList::GetValidMNByService(const CService& service) const
+{
+    return GetUniquePropertyMN(service);
+}
+
 static int CompareByLastPaid_GetHeight(const CDeterministicMN& dmn)
 {
     int height = dmn.pdmnState->nLastPaidHeight;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -306,6 +306,7 @@ public:
     CDeterministicMNCPtr GetMNByOperatorKey(const CBLSPublicKey& pubKey);
     CDeterministicMNCPtr GetMNByCollateral(const COutPoint& collateralOutpoint) const;
     CDeterministicMNCPtr GetValidMNByCollateral(const COutPoint& collateralOutpoint) const;
+    CDeterministicMNCPtr GetValidMNByService(const CService& service) const;
     CDeterministicMNCPtr GetMNPayee() const;
 
     /**

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -41,12 +41,12 @@ uint256 CLLMQUtils::BuildSignHash(Consensus::LLMQType llmqType, const uint256& q
     return h.GetHash();
 }
 
-std::map<CService, uint256> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember)
+std::set<uint256> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember)
 {
     auto& params = Params().GetConsensus().llmqs.at(llmqType);
 
     auto mns = GetAllQuorumMembers(llmqType, blockHash);
-    std::map<CService, uint256> result;
+    std::set<uint256> result;
     for (size_t i = 0; i < mns.size(); i++) {
         auto& dmn = mns[i];
         if (dmn->proTxHash == forMember) {
@@ -62,7 +62,7 @@ std::map<CService, uint256> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType
                 if (otherDmn == dmn) {
                     continue;
                 }
-                result.emplace(otherDmn->pdmnState->addr, otherDmn->proTxHash);
+                result.emplace(otherDmn->proTxHash);
                 gap <<= 1;
                 k++;
             }

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -31,7 +31,7 @@ public:
         return BuildSignHash((Consensus::LLMQType)s.llmqType, s.quorumHash, s.id, s.msgHash);
     }
 
-    static std::map<CService, uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember);
+    static std::set<uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember);
     static std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType, const uint256& blockHash, size_t memberCount, size_t connectionCount);
 
     static bool IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quorumHash);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2069,19 +2069,19 @@ void CConnman::ThreadOpenMasternodeConnections()
             std::vector<CService> pending;
             for (const auto& group : masternodeQuorumNodes) {
                 for (const auto& p : group.second) {
-                    auto& addr = p.first;
+                    auto& addr2 = p.first;
                     auto& proRegTxHash = p.second;
-                    if (!connectedNodes.count(addr) && !IsMasternodeOrDisconnectRequested(addr) && !connectedProRegTxHashes.count(proRegTxHash)) {
-                        pending.emplace_back(addr);
+                    if (!connectedNodes.count(addr2) && !IsMasternodeOrDisconnectRequested(addr2) && !connectedProRegTxHashes.count(proRegTxHash)) {
+                        pending.emplace_back(addr2);
                     }
                 }
             }
 
             if (!vPendingMasternodes.empty()) {
-                auto addr = vPendingMasternodes.front();
+                auto addr2 = vPendingMasternodes.front();
                 vPendingMasternodes.erase(vPendingMasternodes.begin());
-                if (!connectedNodes.count(addr) && !IsMasternodeOrDisconnectRequested(addr)) {
-                    pending.emplace_back(addr);
+                if (!connectedNodes.count(addr2) && !IsMasternodeOrDisconnectRequested(addr2)) {
+                    pending.emplace_back(addr2);
                 }
             }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3247,20 +3247,6 @@ bool CConnman::ForNode(NodeId id, std::function<bool(const CNode* pnode)> cond, 
     return found != nullptr && cond(found) && func(found);
 }
 
-void CConnman::ForEachQuorumMember(Consensus::LLMQType llmqType, const uint256& quorumHash, std::function<bool(CNode* pnode)> func) const
-{
-    LOCK2(cs_vNodes, cs_vPendingMasternodes);
-    auto it = masternodeQuorumNodes.find(std::make_pair(llmqType, quorumHash));
-    if (it == masternodeQuorumNodes.end()) {
-        return;
-    }
-    for (auto&& pnode : vNodes) {
-        if(it->second.count(pnode->addr)) {
-            func(pnode);
-        }
-    }
-}
-
 bool CConnman::IsMasternodeOrDisconnectRequested(const CService& addr) {
     return ForNode(addr, AllNodes, [](CNode* pnode){
         return pnode->fMasternode || pnode->fDisconnect;

--- a/src/net.h
+++ b/src/net.h
@@ -356,7 +356,7 @@ public:
     std::vector<AddedNodeInfo> GetAddedNodeInfo();
 
     bool AddPendingMasternode(const CService& addr);
-    bool AddMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::map<CService, uint256>& addresses);
+    bool AddMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::set<uint256>& proTxHashes);
     bool HasMasternodeQuorumNodes(Consensus::LLMQType llmqType, const uint256& quorumHash);
     std::set<uint256> GetMasternodeQuorums(Consensus::LLMQType llmqType);
     // also returns QWATCH nodes
@@ -492,7 +492,7 @@ private:
     std::vector<std::string> vAddedNodes;
     CCriticalSection cs_vAddedNodes;
     std::vector<CService> vPendingMasternodes;
-    std::map<std::pair<Consensus::LLMQType, uint256>, std::map<CService, uint256>> masternodeQuorumNodes; // protected by cs_vPendingMasternodes
+    std::map<std::pair<Consensus::LLMQType, uint256>, std::set<uint256>> masternodeQuorumNodes; // protected by cs_vPendingMasternodes
     mutable CCriticalSection cs_vPendingMasternodes;
     std::vector<CNode*> vNodes;
     std::list<CNode*> vNodesDisconnected;

--- a/src/net.h
+++ b/src/net.h
@@ -306,8 +306,6 @@ public:
         ForEachNodeThen(FullyConnectedOnly, pre, post);
     }
 
-    void ForEachQuorumMember(Consensus::LLMQType llmqType, const uint256& quorumHash, std::function<bool(CNode* pnode)> func) const;
-
     std::vector<CNode*> CopyNodeVector(std::function<bool(const CNode* pnode)> cond);
     std::vector<CNode*> CopyNodeVector();
     void ReleaseNodeVector(const std::vector<CNode*>& vecNodes);


### PR DESCRIPTION
This fixes an issue where intra quorum connections from older LLMQs are tried on stale addresses. When a MNO issues `update_service` and changes the IP:port, we should connect to the updated IP:port even if the LLMQ internally uses older versions of the DMN object/state.

This also avoids connecting to masternodes which are not in the valid set anymore (banned or spent collateral).