### PR TITLE
Refactor and fix missing calls to NotifyMasternodeListChanged

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -81,9 +81,9 @@ void CDSNotificationInterface::SyncTransaction(const CTransaction &tx, const CBl
     CPrivateSend::SyncTransaction(tx, pindex, posInBlock);
 }
 
-void CDSNotificationInterface::NotifyMasternodeListChanged(const CDeterministicMNList& newList)
+void CDSNotificationInterface::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff)
 {
-    CMNAuth::NotifyMasternodeListChanged(newList);
+    CMNAuth::NotifyMasternodeListChanged(undo, oldMNList, diff);
     governance.CheckMasternodeOrphanObjects(connman);
     governance.CheckMasternodeOrphanVotes(connman);
     governance.UpdateCachesAndClean();

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -22,7 +22,7 @@ protected:
     void NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) override;
-    void NotifyMasternodeListChanged(const CDeterministicMNList& newList) override;
+    void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) override;
     void NotifyChainLock(const CBlockIndex* pindex) override;
 
 private:

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -497,7 +497,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
     }
 
     // Don't hold cs while calling signals
-    if (!diff.addedMNs.empty() || !diff.removedMns.empty()) {
+    if (diff.HasChanges()) {
         GetMainSignals().NotifyMasternodeListChanged(false, oldList, diff);
     }
 
@@ -541,7 +541,7 @@ bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* 
         mnListsCache.erase(blockHash);
     }
 
-    if (!diff.addedMNs.empty() || !diff.removedMns.empty()) {
+    if (diff.HasChanges()) {
         auto inversedDiff = curList.BuildDiff(prevList);
         GetMainSignals().NotifyMasternodeListChanged(true, curList, inversedDiff);
     }

--- a/src/evo/mnauth.h
+++ b/src/evo/mnauth.h
@@ -12,6 +12,7 @@ class CConnman;
 class CDataStream;
 class CDeterministicMN;
 class CDeterministicMNList;
+class CDeterministicMNListDiff;
 class CNode;
 class UniValue;
 
@@ -50,7 +51,7 @@ public:
 
     static void PushMNAUTH(CNode* pnode, CConnman& connman);
     static void ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
-    static void NotifyMasternodeListChanged(const CDeterministicMNList& newList);
+    static void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff);
 };
 
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -30,7 +30,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.NotifyGovernanceObject.connect(boost::bind(&CValidationInterface::NotifyGovernanceObject, pwalletIn, _1));
     g_signals.NotifyGovernanceVote.connect(boost::bind(&CValidationInterface::NotifyGovernanceVote, pwalletIn, _1));
     g_signals.NotifyInstantSendDoubleSpendAttempt.connect(boost::bind(&CValidationInterface::NotifyInstantSendDoubleSpendAttempt, pwalletIn, _1, _2));
-    g_signals.NotifyMasternodeListChanged.connect(boost::bind(&CValidationInterface::NotifyMasternodeListChanged, pwalletIn, _1));
+    g_signals.NotifyMasternodeListChanged.connect(boost::bind(&CValidationInterface::NotifyMasternodeListChanged, pwalletIn, _1, _2, _3));
 }
 
 void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
@@ -51,7 +51,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.NotifyGovernanceObject.disconnect(boost::bind(&CValidationInterface::NotifyGovernanceObject, pwalletIn, _1));
     g_signals.NotifyGovernanceVote.disconnect(boost::bind(&CValidationInterface::NotifyGovernanceVote, pwalletIn, _1));
     g_signals.NotifyInstantSendDoubleSpendAttempt.disconnect(boost::bind(&CValidationInterface::NotifyInstantSendDoubleSpendAttempt, pwalletIn, _1, _2));
-    g_signals.NotifyMasternodeListChanged.disconnect(boost::bind(&CValidationInterface::NotifyMasternodeListChanged, pwalletIn, _1));
+    g_signals.NotifyMasternodeListChanged.disconnect(boost::bind(&CValidationInterface::NotifyMasternodeListChanged, pwalletIn, _1, _2, _3));
 }
 
 void UnregisterAllValidationInterfaces() {

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -21,6 +21,7 @@ class CValidationState;
 class CGovernanceVote;
 class CGovernanceObject;
 class CDeterministicMNList;
+class CDeterministicMNListDiff;
 class uint256;
 
 // These functions dispatch to one or all registered wallets
@@ -43,7 +44,7 @@ protected:
     virtual void NotifyGovernanceVote(const CGovernanceVote &vote) {}
     virtual void NotifyGovernanceObject(const CGovernanceObject &object) {}
     virtual void NotifyInstantSendDoubleSpendAttempt(const CTransaction &currentTx, const CTransaction &previousTx) {}
-    virtual void NotifyMasternodeListChanged(const CDeterministicMNList& newList) {}
+    virtual void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual bool UpdatedTransaction(const uint256 &hash) { return false;}
     virtual void Inventory(const uint256 &hash) {}
@@ -86,7 +87,7 @@ struct CMainSignals {
     /** Notifies listeners of a attempted InstantSend double spend*/
     boost::signals2::signal<void(const CTransaction &currentTx, const CTransaction &previousTx)> NotifyInstantSendDoubleSpendAttempt;
     /** Notifies listeners that the MN list changed */
-    boost::signals2::signal<void(const CDeterministicMNList& newList)> NotifyMasternodeListChanged;
+    boost::signals2::signal<void(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff)> NotifyMasternodeListChanged;
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
     boost::signals2::signal<bool (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a new active block chain. */


### PR DESCRIPTION
This PR is made of 2 parts:
1. Fix the issue mentioned in the PR title. We never called NotifyMasternodeListChanged when only `diff.updatedMns` was non-empty.
2. Refactor the NotifyMasternodeListChanged interface to work with `oldList` and `diff` instead of passing the new `newList`.