### PR TITLE
Collection of minor performance optimizations

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -331,6 +331,14 @@ static inline uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, 
     return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash);
 }
 
+
+// A replacement for x % n. This assumes that x and n are 32bit integers, and x is a uniformly random distributed 32bit value
+// which should be the case for a good hash.
+// See https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+static inline uint32_t FastMod(uint32_t x, size_t n) {
+    return ((uint64_t)x * (uint64_t)n) >> 32;
+}
+
 void CRollingBloomFilter::insert(const std::vector<unsigned char>& vKey)
 {
     if (nEntriesThisGeneration == nEntriesPerGeneration) {
@@ -354,7 +362,8 @@ void CRollingBloomFilter::insert(const std::vector<unsigned char>& vKey)
     for (int n = 0; n < nHashFuncs; n++) {
         uint32_t h = RollingBloomHash(n, nTweak, vKey);
         int bit = h & 0x3F;
-        uint32_t pos = (h >> 6) % data.size();
+        /* FastMod works with the upper bits of h, so it is safe to ignore that the lower bits of h are already used for bit. */
+        uint32_t pos = FastMod(h, data.size());
         /* The lowest bit of pos is ignored, and set to zero for the first bit, and to one for the second. */
         data[pos & ~1] = (data[pos & ~1] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration & 1)) << bit;
         data[pos | 1] = (data[pos | 1] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration >> 1)) << bit;
@@ -372,7 +381,7 @@ bool CRollingBloomFilter::contains(const std::vector<unsigned char>& vKey) const
     for (int n = 0; n < nHashFuncs; n++) {
         uint32_t h = RollingBloomHash(n, nTweak, vKey);
         int bit = h & 0x3F;
-        uint32_t pos = (h >> 6) % data.size();
+        uint32_t pos = FastMod(h, data.size());
         /* If the relevant bit is not set in either data[pos & ~1] or data[pos | 1], the filter does not contain vKey */
         if (!(((data[pos & ~1] | data[pos | 1]) >> bit) & 1)) {
             return false;

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -6,7 +6,9 @@
 #define BITCOIN_LIMITEDMAP_H
 
 #include <assert.h>
+#include <algorithm>
 #include <unordered_map>
+#include <vector>
 
 /** STL-like map container that only keeps the N elements with the highest value. */
 template <typename K, typename V, typename Hash = std::hash<K>>

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -11,8 +11,11 @@
 #include <vector>
 
 /** STL-like map container that only keeps the N elements with the highest value. */
+// WARNING, this was initially the "limitedmap" class from Bitcoin, but now does not maintain ordering. If any backports
+// ever start using this map in a way that requires ordering, do NOT use this as it is but instead reintroduce the original
+// limitedmap
 template <typename K, typename V, typename Hash = std::hash<K>>
-class limitedmap
+class unordered_limitedmap
 {
 public:
     typedef K key_type;
@@ -30,7 +33,7 @@ protected:
     size_type nPruneAfterSize;
 
 public:
-    limitedmap(size_type nMaxSizeIn, size_type nPruneAfterSizeIn = 0)
+    unordered_limitedmap(size_type nMaxSizeIn, size_type nPruneAfterSizeIn = 0)
     {
         assert(nMaxSizeIn > 0);
         nMaxSize = nMaxSizeIn;

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -7,21 +7,22 @@
 
 #include <assert.h>
 #include <map>
+#include <unordered_map>
 
 /** STL-like map container that only keeps the N elements with the highest value. */
-template <typename K, typename V>
+template <typename K, typename V, typename Hash = std::hash<K>>
 class limitedmap
 {
 public:
     typedef K key_type;
     typedef V mapped_type;
     typedef std::pair<const key_type, mapped_type> value_type;
-    typedef typename std::map<K, V>::const_iterator const_iterator;
-    typedef typename std::map<K, V>::size_type size_type;
+    typedef typename std::unordered_map<K, V, Hash>::const_iterator const_iterator;
+    typedef typename std::unordered_map<K, V, Hash>::size_type size_type;
 
 protected:
-    std::map<K, V> map;
-    typedef typename std::map<K, V>::iterator iterator;
+    std::unordered_map<K, V, Hash> map;
+    typedef typename std::unordered_map<K, V, Hash>::iterator iterator;
     std::multimap<V, iterator> rmap;
     typedef typename std::multimap<V, iterator>::iterator rmap_iterator;
     size_type nMaxSize;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3162,7 +3162,7 @@ void CNode::AskFor(const CInv& inv, int64_t doubleRequestDelay)
     // We're using vecAskFor as a priority queue,
     // the key is the earliest time the request can be sent
     int64_t nRequestTime;
-    unordered_limitedmap<uint256, int64_t>::const_iterator it = mapAlreadyAskedFor.find(inv.hash);
+    auto it = mapAlreadyAskedFor.find(inv.hash);
     if (it != mapAlreadyAskedFor.end())
         nRequestTime = it->second;
     else

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3142,11 +3142,11 @@ CNode::~CNode()
 
 void CNode::AskFor(const CInv& inv, int64_t doubleRequestDelay)
 {
-    if (mapAskFor.size() > MAPASKFOR_MAX_SZ || setAskFor.size() > SETASKFOR_MAX_SZ) {
+    if (vecAskFor.size() > MAPASKFOR_MAX_SZ || setAskFor.size() > SETASKFOR_MAX_SZ) {
         int64_t nNow = GetTime();
         if(nNow - nLastWarningTime > WARNING_INTERVAL) {
-            LogPrintf("CNode::AskFor -- WARNING: inventory message dropped: mapAskFor.size = %d, setAskFor.size = %d, MAPASKFOR_MAX_SZ = %d, SETASKFOR_MAX_SZ = %d, nSkipped = %d, peer=%d\n",
-                      mapAskFor.size(), setAskFor.size(), MAPASKFOR_MAX_SZ, SETASKFOR_MAX_SZ, nNumWarningsSkipped, id);
+            LogPrintf("CNode::AskFor -- WARNING: inventory message dropped: vecAskFor.size = %d, setAskFor.size = %d, MAPASKFOR_MAX_SZ = %d, SETASKFOR_MAX_SZ = %d, nSkipped = %d, peer=%d\n",
+                      vecAskFor.size(), setAskFor.size(), MAPASKFOR_MAX_SZ, SETASKFOR_MAX_SZ, nNumWarningsSkipped, id);
             nLastWarningTime = nNow;
             nNumWarningsSkipped = 0;
         }
@@ -3159,7 +3159,7 @@ void CNode::AskFor(const CInv& inv, int64_t doubleRequestDelay)
     if (!setAskFor.insert(inv.hash).second)
         return;
 
-    // We're using mapAskFor as a priority queue,
+    // We're using vecAskFor as a priority queue,
     // the key is the earliest time the request can be sent
     int64_t nRequestTime;
     limitedmap<uint256, int64_t>::const_iterator it = mapAlreadyAskedFor.find(inv.hash);
@@ -3183,18 +3183,15 @@ void CNode::AskFor(const CInv& inv, int64_t doubleRequestDelay)
         mapAlreadyAskedFor.update(it, nRequestTime);
     else
         mapAlreadyAskedFor.insert(std::make_pair(inv.hash, nRequestTime));
-    mapAskFor.insert(std::make_pair(nRequestTime, inv));
+    vecAskFor.emplace_back(nRequestTime, inv);
 }
 
 void CNode::RemoveAskFor(const uint256& hash)
 {
-    setAskFor.erase(hash);
-    for (auto it = mapAskFor.begin(); it != mapAskFor.end();) {
-        if (it->second.hash == hash) {
-            it = mapAskFor.erase(it);
-        } else {
-            ++it;
-        }
+    if (setAskFor.erase(hash)) {
+        vecAskFor.erase(std::remove_if(vecAskFor.begin(), vecAskFor.end(), [&](const std::pair<int64_t, CInv>& item) {
+            return item.second.hash == hash;
+        }), vecAskFor.end());
     }
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -85,7 +85,7 @@ std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};
 std::string strSubVersion;
 
-limitedmap<uint256, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);
+limitedmap<uint256, int64_t, StaticSaltedHasher> mapAlreadyAskedFor(MAX_INV_SZ);
 
 // Signals for message handling
 static CNodeSignals g_signals;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -85,7 +85,7 @@ std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};
 std::string strSubVersion;
 
-limitedmap<uint256, int64_t, StaticSaltedHasher> mapAlreadyAskedFor(MAX_INV_SZ);
+unordered_limitedmap<uint256, int64_t, StaticSaltedHasher> mapAlreadyAskedFor(MAX_INV_SZ);
 
 // Signals for message handling
 static CNodeSignals g_signals;
@@ -3162,7 +3162,7 @@ void CNode::AskFor(const CInv& inv, int64_t doubleRequestDelay)
     // We're using vecAskFor as a priority queue,
     // the key is the earliest time the request can be sent
     int64_t nRequestTime;
-    limitedmap<uint256, int64_t>::const_iterator it = mapAlreadyAskedFor.find(inv.hash);
+    unordered_limitedmap<uint256, int64_t>::const_iterator it = mapAlreadyAskedFor.find(inv.hash);
     if (it != mapAlreadyAskedFor.end())
         nRequestTime = it->second;
     else

--- a/src/net.h
+++ b/src/net.h
@@ -15,6 +15,7 @@
 #include "netaddress.h"
 #include "protocol.h"
 #include "random.h"
+#include "saltedhasher.h"
 #include "streams.h"
 #include "sync.h"
 #include "uint256.h"
@@ -604,7 +605,7 @@ extern bool fDiscover;
 extern bool fListen;
 extern bool fRelayTxes;
 
-extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
+extern limitedmap<uint256, int64_t, StaticSaltedHasher> mapAlreadyAskedFor;
 
 /** Subversion as sent to the P2P network in `version` messages */
 extern std::string strSubVersion;

--- a/src/net.h
+++ b/src/net.h
@@ -795,7 +795,7 @@ public:
     std::vector<CInv> vInventoryOtherToSend;
     CCriticalSection cs_inventory;
     std::unordered_set<uint256, StaticSaltedHasher> setAskFor;
-    std::multimap<int64_t, CInv> mapAskFor;
+    std::vector<std::pair<int64_t, CInv>> vecAskFor;
     int64_t nNextInvSend;
     // Used for headers announcements - unfiltered blocks to relay
     // Also protected by cs_inventory

--- a/src/net.h
+++ b/src/net.h
@@ -606,7 +606,7 @@ extern bool fDiscover;
 extern bool fListen;
 extern bool fRelayTxes;
 
-extern limitedmap<uint256, int64_t, StaticSaltedHasher> mapAlreadyAskedFor;
+extern unordered_limitedmap<uint256, int64_t, StaticSaltedHasher> mapAlreadyAskedFor;
 
 /** Subversion as sent to the P2P network in `version` messages */
 extern std::string strSubVersion;

--- a/src/net.h
+++ b/src/net.h
@@ -29,6 +29,7 @@
 #include <thread>
 #include <memory>
 #include <condition_variable>
+#include <unordered_set>
 
 #ifndef WIN32
 #include <arpa/inet.h>
@@ -793,7 +794,7 @@ public:
     // List of non-tx/non-block inventory items
     std::vector<CInv> vInventoryOtherToSend;
     CCriticalSection cs_inventory;
-    std::set<uint256> setAskFor;
+    std::unordered_set<uint256, StaticSaltedHasher> setAskFor;
     std::multimap<int64_t, CInv> mapAskFor;
     int64_t nNextInvSend;
     // Used for headers announcements - unfiltered blocks to relay

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <string>
 #include <string.h>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -685,12 +687,16 @@ template<typename Stream, typename... Elements> void Unserialize(Stream& is, std
  */
 template<typename Stream, typename K, typename T, typename Pred, typename A> void Serialize(Stream& os, const std::map<K, T, Pred, A>& m);
 template<typename Stream, typename K, typename T, typename Pred, typename A> void Unserialize(Stream& is, std::map<K, T, Pred, A>& m);
+template<typename Stream, typename K, typename T, typename Hash, typename Pred, typename A> void Serialize(Stream& os, const std::unordered_map<K, T, Hash, Pred, A>& m);
+template<typename Stream, typename K, typename T, typename Hash, typename Pred, typename A> void Unserialize(Stream& is, std::unordered_map<K, T, Hash, Pred, A>& m);
 
 /**
  * set
  */
 template<typename Stream, typename K, typename Pred, typename A> void Serialize(Stream& os, const std::set<K, Pred, A>& m);
 template<typename Stream, typename K, typename Pred, typename A> void Unserialize(Stream& is, std::set<K, Pred, A>& m);
+template<typename Stream, typename K, typename Hash, typename Pred, typename A> void Serialize(Stream& os, const std::unordered_set<K, Hash, Pred, A>& m);
+template<typename Stream, typename K, typename Hash, typename Pred, typename A> void Unserialize(Stream& is, std::unordered_set<K, Hash, Pred, A>& m);
 
 /**
  * shared_ptr
@@ -952,53 +958,100 @@ void Unserialize(Stream& is, std::tuple<Elements...>& item)
 /**
  * map
  */
-template<typename Stream, typename K, typename T, typename Pred, typename A>
-void Serialize(Stream& os, const std::map<K, T, Pred, A>& m)
+template<typename Stream, typename Map>
+void SerializeMap(Stream& os, const Map& m)
 {
     WriteCompactSize(os, m.size());
-    for (typename std::map<K, T, Pred, A>::const_iterator mi = m.begin(); mi != m.end(); ++mi)
+    for (auto mi = m.begin(); mi != m.end(); ++mi)
         Serialize(os, (*mi));
 }
 
-template<typename Stream, typename K, typename T, typename Pred, typename A>
-void Unserialize(Stream& is, std::map<K, T, Pred, A>& m)
+template<typename Stream, typename Map>
+void UnserializeMap(Stream& is, Map& m)
 {
     m.clear();
     unsigned int nSize = ReadCompactSize(is);
-    typename std::map<K, T, Pred, A>::iterator mi = m.begin();
+    auto mi = m.begin();
     for (unsigned int i = 0; i < nSize; i++)
     {
-        std::pair<K, T> item;
+        std::pair<typename std::remove_const<typename Map::key_type>::type, typename std::remove_const<typename Map::mapped_type>::type> item;
         Unserialize(is, item);
         mi = m.insert(mi, item);
     }
 }
 
+template<typename Stream, typename K, typename T, typename Pred, typename A>
+void Serialize(Stream& os, const std::map<K, T, Pred, A>& m)
+{
+    SerializeMap(os, m);
+}
 
+template<typename Stream, typename K, typename T, typename Pred, typename A>
+void Unserialize(Stream& is, std::map<K, T, Pred, A>& m)
+{
+    UnserializeMap(is, m);
+}
+
+template<typename Stream, typename K, typename T, typename Hash, typename Pred, typename A>
+void Serialize(Stream& os, const std::unordered_map<K, T, Hash, Pred, A>& m)
+{
+    SerializeMap(os, m);
+}
+
+template<typename Stream, typename K, typename T, typename Hash, typename Pred, typename A>
+void Unserialize(Stream& is, std::unordered_map<K, T, Hash, Pred, A>& m)
+{
+    UnserializeMap(is, m);
+}
 
 /**
  * set
  */
+
+template<typename Stream, typename Set>
+void SerializeSet(Stream& os, const Set& m)
+{
+    WriteCompactSize(os, m.size());
+    for (auto it = m.begin(); it != m.end(); ++it)
+        Serialize(os, (*it));
+}
+
+template<typename Stream, typename Set>
+void UnserializeSet(Stream& is, Set& m)
+{
+    m.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    auto it = m.begin();
+    for (unsigned int i = 0; i < nSize; i++)
+    {
+        typename std::remove_const<typename Set::key_type>::type key;
+        Unserialize(is, key);
+        it = m.insert(it, key);
+    }
+}
+
 template<typename Stream, typename K, typename Pred, typename A>
 void Serialize(Stream& os, const std::set<K, Pred, A>& m)
 {
-    WriteCompactSize(os, m.size());
-    for (typename std::set<K, Pred, A>::const_iterator it = m.begin(); it != m.end(); ++it)
-        Serialize(os, (*it));
+    SerializeSet(os, m);
 }
 
 template<typename Stream, typename K, typename Pred, typename A>
 void Unserialize(Stream& is, std::set<K, Pred, A>& m)
 {
-    m.clear();
-    unsigned int nSize = ReadCompactSize(is);
-    typename std::set<K, Pred, A>::iterator it = m.begin();
-    for (unsigned int i = 0; i < nSize; i++)
-    {
-        K key;
-        Unserialize(is, key);
-        it = m.insert(it, key);
-    }
+    UnserializeSet(is, m);
+}
+
+template<typename Stream, typename K, typename Hash, typename Pred, typename A>
+void Serialize(Stream& os, const std::unordered_set<K, Hash, Pred, A>& m)
+{
+    SerializeSet(os, m);
+}
+
+template<typename Stream, typename K, typename Hash, typename Pred, typename A>
+void Unserialize(Stream& is, std::unordered_set<K, Hash, Pred, A>& m)
+{
+    UnserializeSet(is, m);
 }
 
 /**

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -39,7 +39,7 @@ bool CSporkManager::SporkValueIsActive(int nSporkID, int64_t &nActiveValueRet) c
     if (!mapSporksActive.count(nSporkID)) return false;
 
     // calc how many values we have and how many signers vote for every value
-    std::map<int64_t, int> mapValueCounts;
+    std::unordered_map<int64_t, int> mapValueCounts;
     for (const auto& pair: mapSporksActive.at(nSporkID)) {
         mapValueCounts[pair.second.nValue]++;
         if (mapValueCounts.at(pair.second.nValue) >= nMinSporkKeys) {

--- a/src/spork.h
+++ b/src/spork.h
@@ -10,6 +10,9 @@
 #include "utilstrencodings.h"
 #include "key.h"
 
+#include <unordered_map>
+#include <unordered_set>
+
 class CSporkMessage;
 class CSporkManager;
 
@@ -136,8 +139,8 @@ private:
     static const std::string SERIALIZATION_VERSION_STRING;
 
     mutable CCriticalSection cs;
-    std::map<uint256, CSporkMessage> mapSporksByHash;
-    std::map<int, std::map<CKeyID, CSporkMessage> > mapSporksActive;
+    std::unordered_map<uint256, CSporkMessage> mapSporksByHash;
+    std::unordered_map<int, std::map<CKeyID, CSporkMessage> > mapSporksActive;
 
     std::set<CKeyID> setSporkPubKeyIDs;
     int nMinSporkKeys;

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -13,7 +13,7 @@ BOOST_FIXTURE_TEST_SUITE(limitedmap_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(limitedmap_test)
 {
     // create a limitedmap capped at 10 items
-    limitedmap<int, int> map(10);
+    unordered_limitedmap<int, int> map(10);
 
     // check that the max size is 10
     BOOST_CHECK(map.max_size() == 10);
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
     BOOST_CHECK(map.count(-1) == 0);
 
     // iterate over the map, both with an index and an iterator
-    limitedmap<int, int>::const_iterator it = map.begin();
+    unordered_limitedmap<int, int>::const_iterator it = map.begin();
     for (int i = 0; i < 10; i++) {
         // make sure the item is present
         BOOST_CHECK(map.count(i) == 1);

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -48,14 +48,15 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
         BOOST_CHECK(map.count(i) == 1);
 
         // use the iterator to check for the expected key and value
-        BOOST_CHECK(it->first == i);
-        BOOST_CHECK(it->second == i + 1);
+        //BOOST_CHECK(it->first == i);
+        //BOOST_CHECK(it->second == i + 1);
         
         // use find to check for the value
         BOOST_CHECK(map.find(i)->second == i + 1);
         
         // update and recheck
-        map.update(it, i + 2);
+        auto jt = map.find(i);
+        map.update(jt, i + 2);
         BOOST_CHECK(map.find(i)->second == i + 2);
 
         it++;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-extern std::map<std::string, std::string> mapArgs;
+extern std::unordered_map<std::string, std::string> mapArgs;
 
 BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -126,9 +126,9 @@ const char * const BITCOIN_CONF_FILENAME = "dash.conf";
 const char * const BITCOIN_PID_FILENAME = "dashd.pid";
 
 CCriticalSection cs_args;
-std::map<std::string, std::string> mapArgs;
-static std::map<std::string, std::vector<std::string> > _mapMultiArgs;
-const std::map<std::string, std::vector<std::string> >& mapMultiArgs = _mapMultiArgs;
+std::unordered_map<std::string, std::string> mapArgs;
+static std::unordered_map<std::string, std::vector<std::string> > _mapMultiArgs;
+const std::unordered_map<std::string, std::vector<std::string> >& mapMultiArgs = _mapMultiArgs;
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugLog = true;

--- a/src/util.h
+++ b/src/util.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <stdint.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <boost/filesystem/path.hpp>
@@ -61,7 +62,7 @@ public:
     boost::signals2::signal<std::string (const char* psz)> Translate;
 };
 
-extern const std::map<std::string, std::vector<std::string> >& mapMultiArgs;
+extern const std::unordered_map<std::string, std::vector<std::string> >& mapMultiArgs;
 extern bool fDebug;
 extern bool fPrintToConsole;
 extern bool fPrintToDebugLog;


### PR DESCRIPTION
See individual commits. Most of these are related to using unordered maps/sets instead of ordered ones and are the result of multiple profiling sessions. All these small optimizations add up to about 10% of CPU usage on the message handler thread.

This PR also contains a backport of bitcoin#13176 as I've also noticed unexpected high CPU use for `CNode::AddInventoryKnown`.