### PR TITLE
Add cache to CQuorumManager::ScanQuorums

### DIFF
--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -11,6 +11,8 @@
 
 #include "validationinterface.h"
 #include "consensus/params.h"
+#include "saltedhasher.h"
+#include "unordered_lru_cache.h"
 
 #include "bls/bls.h"
 #include "bls/bls_worker.h"
@@ -85,6 +87,7 @@ private:
 
     CCriticalSection quorumsCacheCs;
     std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumPtr> quorumsCache;
+    unordered_lru_cache<std::pair<Consensus::LLMQType, uint256>, std::vector<CQuorumCPtr>, StaticSaltedHasher, 32> scanQuorumsCache;
 
 public:
     CQuorumManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager);


### PR DESCRIPTION
Profiling has shown that about 10% of time is spent in `ScanQuorums`. Calls mainly originate from `CLLMQUtils::IsQuorumActive` and thus `maxCount` is usually `signingActiveQuorumCount + 1`, so the cache implementation is optimized for this case but also very well supports smaller (e.g. exactly `signingActiveQuorumCount`, which is also commonly used) values. Larger values (e.g. RPC `quorum list`) result in the cache not being used/filled.

The cache results in `ScanQuorums` to not show in profiling anymore.