### PR TITLE
Move processing of InstantSend locks into its own worker thread

### DIFF
--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -36,7 +36,7 @@ void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests, bool f
     quorumSigSharesManager = new CSigSharesManager();
     quorumSigningManager = new CSigningManager(*llmqDb, unitTests);
     chainLocksHandler = new CChainLocksHandler(scheduler);
-    quorumInstantSendManager = new CInstantSendManager(scheduler, *llmqDb);
+    quorumInstantSendManager = new CInstantSendManager(*llmqDb);
 }
 
 void DestroyLLMQSystem()

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -84,14 +84,14 @@ void StartLLMQSystem()
         chainLocksHandler->Start();
     }
     if (quorumInstantSendManager) {
-        quorumInstantSendManager->RegisterAsRecoveredSigsListener();
+        quorumInstantSendManager->Start();
     }
 }
 
 void StopLLMQSystem()
 {
     if (quorumInstantSendManager) {
-        quorumInstantSendManager->UnregisterAsRecoveredSigsListener();
+        quorumInstantSendManager->Stop();
     }
     if (chainLocksHandler) {
         chainLocksHandler->Stop();
@@ -112,6 +112,9 @@ void InterruptLLMQSystem()
 {
     if (quorumSigSharesManager) {
         quorumSigSharesManager->InterruptWorkerThread();
+    }
+    if (quorumInstantSendManager) {
+        quorumInstantSendManager->InterruptWorkerThread();
     }
 }
 

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -12,7 +12,6 @@
 #include "txmempool.h"
 #include "masternode-sync.h"
 #include "net_processing.h"
-#include "scheduler.h"
 #include "spork.h"
 #include "validation.h"
 
@@ -24,6 +23,7 @@
 #include "instantx.h"
 
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/thread.hpp>
 
 namespace llmq
 {
@@ -208,8 +208,7 @@ CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByInput(const COutPoint& o
 
 ////////////////
 
-CInstantSendManager::CInstantSendManager(CScheduler* _scheduler, CDBWrapper& _llmqDb) :
-    scheduler(_scheduler),
+CInstantSendManager::CInstantSendManager(CDBWrapper& _llmqDb) :
     db(_llmqDb)
 {
 }

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -211,6 +211,7 @@ CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByInput(const COutPoint& o
 CInstantSendManager::CInstantSendManager(CDBWrapper& _llmqDb) :
     db(_llmqDb)
 {
+    workInterrupt.reset();
 }
 
 CInstantSendManager::~CInstantSendManager()

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -14,8 +14,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-class CScheduler;
-
 namespace llmq
 {
 
@@ -72,7 +70,6 @@ class CInstantSendManager : public CRecoveredSigsListener
 {
 private:
     CCriticalSection cs;
-    CScheduler* scheduler;
     CInstantSendDb db;
 
     std::thread workThread;
@@ -97,7 +94,7 @@ private:
     std::unordered_map<uint256, std::pair<NodeId, CInstantSendLock>> pendingInstantSendLocks;
 
 public:
-    CInstantSendManager(CScheduler* _scheduler, CDBWrapper& _llmqDb);
+    CInstantSendManager(CDBWrapper& _llmqDb);
     ~CInstantSendManager();
 
     void Start();

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -75,6 +75,9 @@ private:
     CScheduler* scheduler;
     CInstantSendDb db;
 
+    std::thread workThread;
+    CThreadInterrupt workInterrupt;
+
     /**
      * Request ids of inputs that we signed. Used to determine if a recovered signature belongs to an
      * in-progress input lock.
@@ -92,14 +95,14 @@ private:
 
     // Incoming and not verified yet
     std::unordered_map<uint256, std::pair<NodeId, CInstantSendLock>> pendingInstantSendLocks;
-    bool hasScheduledProcessPending{false};
 
 public:
     CInstantSendManager(CScheduler* _scheduler, CDBWrapper& _llmqDb);
     ~CInstantSendManager();
 
-    void RegisterAsRecoveredSigsListener();
-    void UnregisterAsRecoveredSigsListener();
+    void Start();
+    void Stop();
+    void InterruptWorkerThread();
 
 public:
     bool ProcessTx(const CTransaction& tx, const Consensus::Params& params);
@@ -133,6 +136,8 @@ public:
 
     bool AlreadyHave(const CInv& inv);
     bool GetInstantSendLockByHash(const uint256& hash, CInstantSendLock& ret);
+
+    void WorkThreadMain();
 };
 
 extern CInstantSendManager* quorumInstantSendManager;

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -118,7 +118,7 @@ public:
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
     void ProcessMessageInstantSendLock(CNode* pfrom, const CInstantSendLock& islock, CConnman& connman);
     bool PreVerifyInstantSendLock(NodeId nodeId, const CInstantSendLock& islock, bool& retBan);
-    void ProcessPendingInstantSendLocks();
+    bool ProcessPendingInstantSendLocks();
     void ProcessInstantSendLock(NodeId from, const uint256& hash, const CInstantSendLock& islock);
     void UpdateWalletTransaction(const uint256& txid, const CTransactionRef& tx);
 


### PR DESCRIPTION
Using the scheduler was not a good idea for this, as it results in the scheduler thread being blocked most of the time when some load comes in.