### PR TITLE
Use lazy BLS signatures more often and don't always verify self-recovered sigs

### DIFF
--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -434,13 +434,19 @@ void CBLSLazySignature::SetSig(const CBLSSignature& _sig)
 const CBLSSignature& CBLSLazySignature::GetSig() const
 {
     std::unique_lock<std::mutex> l(mutex);
+    static CBLSSignature invalidSig;
     if (!bufValid && !sigInitialized) {
-        static CBLSSignature invalidSig;
         return invalidSig;
     }
     if (!sigInitialized) {
         sig.SetBuf(buf, sizeof(buf));
-        sigInitialized = true;
+        if (!sig.CheckMalleable(buf, sizeof(buf))) {
+            bufValid = false;
+            sigInitialized = false;
+            sig = invalidSig;
+        } else {
+            sigInitialized = true;
+        }
     }
     return sig;
 }

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -423,6 +423,7 @@ bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::v
     return true;
 }
 
+#ifndef BUILD_BITCOIN_INTERNAL
 void CBLSLazySignature::SetSig(const CBLSSignature& _sig)
 {
     std::unique_lock<std::mutex> l(mutex);
@@ -450,8 +451,6 @@ const CBLSSignature& CBLSLazySignature::GetSig() const
     }
     return sig;
 }
-
-#ifndef BUILD_BITCOIN_INTERNAL
 
 static std::once_flag init_flag;
 static mt_pooled_secure_allocator<uint8_t>* secure_allocator_instance;

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -423,16 +423,9 @@ bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::v
     return true;
 }
 
-CBLSLazySignature::CBLSLazySignature(CBLSSignature& _sig) :
-    bufValid(false),
-    sigInitialized(true),
-    sig(_sig)
-{
-
-}
-
 void CBLSLazySignature::SetSig(const CBLSSignature& _sig)
 {
+    std::unique_lock<std::mutex> l(mutex);
     bufValid = false;
     sigInitialized = true;
     sig = _sig;
@@ -440,6 +433,7 @@ void CBLSLazySignature::SetSig(const CBLSSignature& _sig)
 
 const CBLSSignature& CBLSLazySignature::GetSig() const
 {
+    std::unique_lock<std::mutex> l(mutex);
     if (!bufValid && !sigInitialized) {
         static CBLSSignature invalidSig;
         return invalidSig;

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -176,10 +176,6 @@ public:
         char buf[SerSize] = {0};
         GetBuf(buf, SerSize);
         s.write((const char*)buf, SerSize);
-
-        // if (s.GetType() != SER_GETHASH) {
-        //    CheckMalleable(buf, SerSize);
-        // }
     }
     template <typename Stream>
     inline void Unserialize(Stream& s, bool checkMalleable = true)
@@ -188,23 +184,22 @@ public:
         s.read((char*)buf, SerSize);
         SetBuf(buf, SerSize);
 
-        if (checkMalleable) {
-            CheckMalleable(buf, SerSize);
+        if (checkMalleable && !CheckMalleable(buf, SerSize)) {
+            throw std::ios_base::failure("malleable BLS object");
         }
     }
 
-    inline void CheckMalleable(void* buf, size_t size) const
+    inline bool CheckMalleable(void* buf, size_t size) const
     {
         char buf2[SerSize];
-        C tmp;
-        tmp.SetBuf(buf, SerSize);
-        tmp.GetBuf(buf2, SerSize);
+        GetBuf(buf2, SerSize);
         if (memcmp(buf, buf2, SerSize)) {
             // TODO not sure if this is actually possible with the BLS libs. I'm assuming here that somewhere deep inside
             // these libs masking might happen, so that 2 different binary representations could result in the same object
             // representation
-            throw std::ios_base::failure("malleable BLS object");
+            return false;
         }
+        return true;
     }
 
     inline std::string ToString() const

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -309,6 +309,7 @@ protected:
     bool InternalGetBuf(void* buf) const;
 };
 
+#ifndef BUILD_BITCOIN_INTERNAL
 class CBLSLazySignature
 {
 private:
@@ -375,6 +376,7 @@ public:
     void SetSig(const CBLSSignature& _sig);
     const CBLSSignature& GetSig() const;
 };
+#endif
 
 typedef std::vector<CBLSId> BLSIdVector;
 typedef std::vector<CBLSPublicKey> BLSVerificationVector;

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -499,7 +499,7 @@ void CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recove
 
         clsig.nHeight = lastSignedHeight;
         clsig.blockHash = lastSignedMsgHash;
-        clsig.sig = recoveredSig.sig;
+        clsig.sig = recoveredSig.sig.GetSig();
     }
     ProcessNewChainLock(-1, clsig, ::SerializeHash(clsig));
 }

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -22,7 +22,7 @@ class CInstantSendLock
 public:
     std::vector<COutPoint> inputs;
     uint256 txid;
-    CBLSSignature sig;
+    CBLSLazySignature sig;
 
 public:
     ADD_SERIALIZE_METHODS

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -24,34 +24,25 @@ public:
     uint256 quorumHash;
     uint256 id;
     uint256 msgHash;
-    CBLSSignature sig;
+    CBLSLazySignature sig;
 
     // only in-memory
     uint256 hash;
 
 public:
 
-    template<typename Stream>
-    inline void Serialize(Stream& s) const
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        s << llmqType;
-        s << quorumHash;
-        s << id;
-        s << msgHash;
-        s << sig;
-    }
-    template<typename Stream>
-    inline void Unserialize(Stream& s, bool checkMalleable = true, bool updateHash = true, bool skipSig = false)
-    {
-        s >> llmqType;
-        s >> quorumHash;
-        s >> id;
-        s >> msgHash;
-        if (!skipSig) {
-            sig.Unserialize(s, checkMalleable);
-            if (updateHash) {
-                UpdateHash();
-            }
+        READWRITE(llmqType);
+        READWRITE(quorumHash);
+        READWRITE(id);
+        READWRITE(msgHash);
+        READWRITE(sig);
+        if (ser_action.ForRead()) {
+            UpdateHash();
         }
     }
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -762,11 +762,11 @@ void CSigSharesManager::TryRecoverSig(const CQuorumCPtr& quorum, const uint256& 
     rs.quorumHash = quorum->qc.quorumHash;
     rs.id = id;
     rs.msgHash = msgHash;
-    rs.sig = recoveredSig;
+    rs.sig.SetSig(recoveredSig);
     rs.UpdateHash();
 
     auto signHash = CLLMQUtils::BuildSignHash(rs);
-    bool valid = rs.sig.VerifyInsecure(quorum->qc.quorumPublicKey, signHash);
+    bool valid = recoveredSig.VerifyInsecure(quorum->qc.quorumPublicKey, signHash);
     if (!valid) {
         // this should really not happen as we have verified all signature shares before
         LogPrintf("CSigSharesManager::%s -- own recovered signature is invalid. id=%s, msgHash=%s\n", __func__,

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -765,13 +765,18 @@ void CSigSharesManager::TryRecoverSig(const CQuorumCPtr& quorum, const uint256& 
     rs.sig.SetSig(recoveredSig);
     rs.UpdateHash();
 
-    auto signHash = CLLMQUtils::BuildSignHash(rs);
-    bool valid = recoveredSig.VerifyInsecure(quorum->qc.quorumPublicKey, signHash);
-    if (!valid) {
-        // this should really not happen as we have verified all signature shares before
-        LogPrintf("CSigSharesManager::%s -- own recovered signature is invalid. id=%s, msgHash=%s\n", __func__,
-                  id.ToString(), msgHash.ToString());
-        return;
+    // There should actually be no need to verify the self-recovered signatures as it should always succeed. Let's
+    // however still verify it from time to time, so that we have a chance to catch bugs. We do only this sporadic
+    // verification because this is unbatched and thus slow verification that happens here.
+    if (((recoveredSigsCounter++) % 100) == 0) {
+        auto signHash = CLLMQUtils::BuildSignHash(rs);
+        bool valid = recoveredSig.VerifyInsecure(quorum->qc.quorumPublicKey, signHash);
+        if (!valid) {
+            // this should really not happen as we have verified all signature shares before
+            LogPrintf("CSigSharesManager::%s -- own recovered signature is invalid. id=%s, msgHash=%s\n", __func__,
+                      id.ToString(), msgHash.ToString());
+            return;
+        }
     }
 
     quorumSigningManager->ProcessRecoveredSig(-1, rs, quorum, connman);

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -361,6 +361,7 @@ private:
     FastRandomContext rnd;
 
     int64_t lastCleanupTime{0};
+    std::atomic<uint32_t> recoveredSigsCounter{0};
 
 public:
     CSigSharesManager();


### PR DESCRIPTION
This avoid expensive BLS signature deserialization in the message handler thread. The expensive part is implicitly moved into the worker threads now.

This PR also changes how often we verify self-recovered signatures to only 1 out of 100 recoveries. There is actually no need to verify these at all, but sporadically doing so ensures that we catch unexpected bugs.