### PR TITLE
Don't wake up select if it was already woken up

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -546,7 +546,7 @@ private:
     /** a pipe which is added to select() calls to wakeup before the timeout */
     int wakeupPipe[2]{-1,-1};
 #endif
-    std::atomic<bool> isInSelect{false};
+    std::atomic<bool> wakeupSelectNeeded{false};
 
     std::thread threadDNSAddressSeed;
     std::thread threadSocketHandler;


### PR DESCRIPTION
This avoids calling WakeupSelect() for each node instead of just once.