### PR TITLE
Bump mempool counter on each successful IS lock

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -805,6 +805,8 @@ void CInstantSendManager::UpdateWalletTransaction(const uint256& txid, const CTr
 
     if (tx) {
         GetMainSignals().NotifyTransactionLock(*tx);
+        // bump mempool counter to make sure newly mined txes are picked up by getblocktemplate
+        mempool.AddTransactionsUpdated(1);
     }
 }
 


### PR DESCRIPTION
Noticed that recent txes aren't picked up by getblocktemplate (until next block or new txes) after their IS-locks finally arrive.