### PR TITLE
Don't disconnect peers on MNAUTH verification failure

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -74,10 +74,10 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
         auto mnList = deterministicMNManager->GetListAtChainTip();
         auto dmn = mnList.GetValidMN(mnauth.proRegTxHash);
         if (!dmn) {
-            LOCK(cs_main);
+            // in case he was unlucky and not up to date, just let him be connected as a regular node, which gives him
+            // a chance to get up-to-date and thus realize by himself that he's not a MN anymore. We still give him a
+            // low DoS score.
             Misbehaving(pnode->id, 10);
-            // in case he was unlucky and not up to date, let him retry the whole verification process
-            pnode->fDisconnect = true;
             return;
         }
 
@@ -90,9 +90,9 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
 
         if (!mnauth.sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator, signHash)) {
             LOCK(cs_main);
+            // Same as above, MN seems to not know about his fate yet, so give him a chance to update. If this is a
+            // malicious actor (DoSing us), we'll ban him soon.
             Misbehaving(pnode->id, 10);
-            // in case he was unlucky and not up to date, let him retry the whole verification process
-            pnode->fDisconnect = true;
             return;
         }
 

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -74,6 +74,7 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
         auto mnList = deterministicMNManager->GetListAtChainTip();
         auto dmn = mnList.GetValidMN(mnauth.proRegTxHash);
         if (!dmn) {
+            LOCK(cs_main);
             // in case he was unlucky and not up to date, just let him be connected as a regular node, which gives him
             // a chance to get up-to-date and thus realize by himself that he's not a MN anymore. We still give him a
             // low DoS score.


### PR DESCRIPTION
Only give them a DoS score.

When MNs get removed from the valid set or their key changes, they might get into a situation where all nodes disconnect them and give them no chance to get up-to-date and thus they never learn about the change in the MN list. This PR fixes this.