### PR TITLE
Wait longer until re-requesting recovered sigs and ISLOCKs from other peers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1891,13 +1891,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                         // some messages need to be re-requested faster when the first announcing peer did not answer to GETDATA
                         switch (inv.type) {
                             case MSG_QUORUM_RECOVERED_SIG:
-                                doubleRequestDelay = 5 * 1000000;
+                                doubleRequestDelay = 15 * 1000000;
                                 break;
                             case MSG_CLSIG:
                                 doubleRequestDelay = 5 * 1000000;
                                 break;
                             case MSG_ISLOCK:
-                                doubleRequestDelay = 5 * 1000000;
+                                doubleRequestDelay = 10 * 1000000;
                                 break;
                         }
                         pfrom->AskFor(inv, doubleRequestDelay);


### PR DESCRIPTION
Observed on testnet that MNs tend to re-request the same objects multiple
times when load becomes high, which results in the same objects being
received multiple times.