### PR TITLE
Use larger nPruneAfterSizeIn parameter for mapAlreadyAskedFor

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -85,7 +85,7 @@ std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfLimited[NET_MAX] = {};
 std::string strSubVersion;
 
-unordered_limitedmap<uint256, int64_t, StaticSaltedHasher> mapAlreadyAskedFor(MAX_INV_SZ);
+unordered_limitedmap<uint256, int64_t, StaticSaltedHasher> mapAlreadyAskedFor(MAX_INV_SZ, MAX_INV_SZ * 2);
 
 // Signals for message handling
 static CNodeSignals g_signals;


### PR DESCRIPTION
unordered_limitedmap was meant to be used with much larger
nPruneAfterSizeIn values to maintain good performance. The way it is used right now
will result in pruning too often on high load.