### PR TITLE
Mark block as invalid when ProcessSpecialTxsInBlock fails

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2243,8 +2243,8 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
     }
 
     if (!ProcessSpecialTxsInBlock(block, pindex, state, fJustCheck)) {
-        return error("ConnectBlock(DASH): ProcessSpecialTxsInBlock for block %s failed with %s",
-                     pindex->GetBlockHash().ToString(), FormatStateMessage(state));
+        return state.DoS(100, error("ConnectBlock(DASH): ProcessSpecialTxsInBlock for block %s failed with %s",
+                     pindex->GetBlockHash().ToString(), FormatStateMessage(state)), REJECT_INVALID, "bad-special-tx");
     }
 
     int64_t nTime5 = GetTimeMicros(); nTimePayeeAndSpecial += nTime5 - nTime4;


### PR DESCRIPTION
And ban the misbehaving node. Unlike the payee/amount part this one is based on the on-chain data only and we can be pretty sure that this node actually misbehaves.