### PR TITLE
Implement `isolate_node`/`reconnect_isolated_node` in tests

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -455,6 +455,19 @@ def connect_nodes_bi(nodes, a, b):
     connect_nodes(nodes[a], b)
     connect_nodes(nodes[b], a)
 
+def isolate_node(node, timeout=5):
+    node.setnetworkactive(False)
+    st = time.time()
+    while time.time() < st + timeout:
+        if node.getconnectioncount() == 0:
+            return
+        time.sleep(0.5)
+    raise AssertionError("disconnect_node timed out")
+
+def reconnect_isolated_node(node, node_num):
+    node.setnetworkactive(True)
+    connect_nodes(node, node_num)
+
 def find_output(node, txid, amount):
     """
     Return index to output of txid with value amount


### PR DESCRIPTION
Looks like Travis is too slow and peers are disconnected _after_ `setnetworkactive(True)` and the following connect attempt which drops the freshly established connection (and tests fail). To fix this we should confirm that peers were actually disconnected on an isolated node (`getconnectioncount ` rpc should return 0) before proceeding further.

Note: this PR includes #2898 , will rebase once it is merged (I decided not to request changes in the original PR  because this patch also fixes similar potential issues with `llmq-chainlocks.py`)