### PR TITLE
Print inputs on which we voted and quorums used for signing

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -425,9 +425,14 @@ bool CInstantSendManager::ProcessTx(const CTransaction& tx, const Consensus::Par
         return true;
     }
 
-    for (auto& id : ids) {
+    for (size_t i = 0; i < tx.vin.size(); i++) {
+        auto& in = tx.vin[i];
+        auto& id = ids[i];
         inputRequestIds.emplace(id);
-        quorumSigningManager->AsyncSignIfMember(llmqType, id, tx.GetHash());
+        if (quorumSigningManager->AsyncSignIfMember(llmqType, id, tx.GetHash())) {
+            LogPrintf("CInstantSendManager::%s -- txid=%s: voted on input %s with id %s\n", __func__,
+                      tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString());
+        }
     }
 
     // We might have received all input locks before we got the corresponding TX. In this case, we have to sign the

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -984,11 +984,6 @@ void CSigSharesManager::CollectSigSharesToAnnounce(std::unordered_map<NodeId, st
 
 bool CSigSharesManager::SendMessages()
 {
-    std::multimap<CService, NodeId> nodesByAddress;
-    g_connman->ForEachNode([&nodesByAddress](CNode* pnode) {
-        nodesByAddress.emplace(pnode->addr, pnode->id);
-    });
-
     std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>> sigSharesToRequest;
     std::unordered_map<NodeId, std::unordered_map<uint256, CBatchedSigShares, StaticSaltedHasher>> sigSharesToSend;
     std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>> sigSharesToAnnounce;

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1436,8 +1436,8 @@ void CSigSharesManager::Sign(const CQuorumCPtr& quorum, const uint256& id, const
 
     sigShare.UpdateKey();
 
-    LogPrint("llmq-sigs", "CSigSharesManager::%s -- signed sigShare. signHash=%s, id=%s, msgHash=%s, time=%s\n", __func__,
-              signHash.ToString(), sigShare.id.ToString(), sigShare.msgHash.ToString(), t.count());
+    LogPrint("llmq-sigs", "CSigSharesManager::%s -- signed sigShare. signHash=%s, id=%s, msgHash=%s, llmqType=%d, quorum=%s, time=%s\n", __func__,
+              signHash.ToString(), sigShare.id.ToString(), sigShare.msgHash.ToString(), quorum->params.type, quorum->qc.quorumHash.ToString(), t.count());
     ProcessSigShare(-1, sigShare, *g_connman, quorum);
 }
 


### PR DESCRIPTION
Also print the corresponding requestId. This makes debugging InstantSend
issues easier.