### PR TITLE
Fall back to ReadBlockFromDisk when blockTxs is not filled yet

### DIFF
--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -391,6 +391,7 @@ CChainLocksHandler::BlockTxs::mapped_type CChainLocksHandler::GetBlockTxs(const 
         LogPrint("chainlocks", "CChainLocksHandler::%s -- blockTxs for %s not found. Trying ReadBlockFromDisk\n", __func__,
                  blockHash.ToString());
 
+        uint32_t blockTime;
         {
             LOCK(cs_main);
             auto pindex = mapBlockIndex.at(blockHash);
@@ -406,10 +407,15 @@ CChainLocksHandler::BlockTxs::mapped_type CChainLocksHandler::GetBlockTxs(const 
                 }
                 ret->emplace(tx->GetHash());
             }
+
+            blockTime = block.nTime;
         }
 
         LOCK(cs);
         blockTxs.emplace(blockHash, ret);
+        for (auto& txid : *ret) {
+            txFirstSeenTime.emplace(txid, blockTime);
+        }
     }
     return ret;
 }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -302,6 +302,10 @@ void CChainLocksHandler::TrySignChainTip()
             }
 
             auto txids = GetBlockTxs(pindexWalk->GetBlockHash());
+            if (!txids) {
+                pindexWalk = pindexWalk->pprev;
+                continue;
+            }
 
             for (auto& txid : *txids) {
                 int64_t txAge = 0;

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -301,18 +301,7 @@ void CChainLocksHandler::TrySignChainTip()
                 break;
             }
 
-            decltype(blockTxs.begin()->second) txids;
-            {
-                LOCK(cs);
-                auto it = blockTxs.find(pindexWalk->GetBlockHash());
-                if (it == blockTxs.end()) {
-                    // this should actually not happen as NewPoWValidBlock should have been called before
-                    LogPrint("chainlocks", "CChainLocksHandler::%s -- blockTxs for %s not found\n", __func__,
-                              pindexWalk->GetBlockHash().ToString());
-                    return;
-                }
-                txids = it->second;
-            }
+            auto txids = GetBlockTxs(pindexWalk->GetBlockHash());
 
             for (auto& txid : *txids) {
                 int64_t txAge = 0;
@@ -380,6 +369,49 @@ void CChainLocksHandler::SyncTransaction(const CTransaction& tx, const CBlockInd
             txs.emplace(tx.GetHash());
         }
     }
+}
+
+CChainLocksHandler::BlockTxs::mapped_type CChainLocksHandler::GetBlockTxs(const uint256& blockHash)
+{
+    AssertLockNotHeld(cs);
+    AssertLockNotHeld(cs_main);
+
+    CChainLocksHandler::BlockTxs::mapped_type ret;
+
+    {
+        LOCK(cs);
+        auto it = blockTxs.find(blockHash);
+        if (it != blockTxs.end()) {
+            ret = it->second;
+        }
+    }
+    if (!ret) {
+        // This should only happen when freshly started.
+        // If running for some time, SyncTransaction should have been called before which fills blockTxs.
+        LogPrint("chainlocks", "CChainLocksHandler::%s -- blockTxs for %s not found. Trying ReadBlockFromDisk\n", __func__,
+                 blockHash.ToString());
+
+        {
+            LOCK(cs_main);
+            auto pindex = mapBlockIndex.at(blockHash);
+            CBlock block;
+            if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
+                return nullptr;
+            }
+
+            ret = std::make_shared<std::unordered_set<uint256, StaticSaltedHasher>>();
+            for (auto& tx : block.vtx) {
+                if (tx->IsCoinBase() || tx->vin.empty()) {
+                    continue;
+                }
+                ret->emplace(tx->GetHash());
+            }
+        }
+
+        LOCK(cs);
+        blockTxs.emplace(blockHash, ret);
+    }
+    return ret;
 }
 
 bool CChainLocksHandler::IsTxSafeForMining(const uint256& txid)

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -68,7 +68,8 @@ private:
     uint256 lastSignedMsgHash;
 
     // We keep track of txids from recently received blocks so that we can check if all TXs got ixlocked
-    std::unordered_map<uint256, std::shared_ptr<std::unordered_set<uint256, StaticSaltedHasher>>> blockTxs;
+    typedef std::unordered_map<uint256, std::shared_ptr<std::unordered_set<uint256, StaticSaltedHasher>>> BlockTxs;
+    BlockTxs blockTxs;
     std::unordered_map<uint256, int64_t> txFirstSeenTime;
 
     std::map<uint256, int64_t> seenChainLocks;
@@ -106,6 +107,8 @@ private:
     bool InternalHasConflictingChainLock(int nHeight, const uint256& blockHash);
 
     void DoInvalidateBlock(const CBlockIndex* pindex, bool activateBestChain);
+
+    BlockTxs::mapped_type GetBlockTxs(const uint256& blockHash);
 
     void Cleanup();
 };


### PR DESCRIPTION
This handles the case where a MN is freshly started and SyncTransaction
was not been called for older transactions/blocks.