### PR TITLE
Bump "keepOldConnections" by one for all LLMQ types

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -122,7 +122,7 @@ static Consensus::LLMQParams llmq5_60 = {
 
         .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
 
-        .keepOldConnections = 24,
+        .keepOldConnections = 3,
 };
 
 static Consensus::LLMQParams llmq50_60 = {
@@ -140,7 +140,7 @@ static Consensus::LLMQParams llmq50_60 = {
 
         .signingActiveQuorumCount = 24, // a full day worth of LLMQs
 
-        .keepOldConnections = 24,
+        .keepOldConnections = 25,
 };
 
 static Consensus::LLMQParams llmq400_60 = {
@@ -158,7 +158,7 @@ static Consensus::LLMQParams llmq400_60 = {
 
         .signingActiveQuorumCount = 4, // two days worth of LLMQs
 
-        .keepOldConnections = 4,
+        .keepOldConnections = 5,
 };
 
 // Used for deployment and min-proto-version signalling, so it needs a higher threshold
@@ -177,7 +177,7 @@ static Consensus::LLMQParams llmq400_85 = {
 
         .signingActiveQuorumCount = 4, // two days worth of LLMQs
 
-        .keepOldConnections = 4,
+        .keepOldConnections = 5,
 };
 
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -109,7 +109,7 @@ struct LLMQParams {
     int signingActiveQuorumCount;
 
     // Used for inter-quorum communication. This is the number of quorums for which we should keep old connections. This
-    // should be at least as much as the active quorums set.
+    // should be at least one more then the active quorums set.
     int keepOldConnections;
 };
 


### PR DESCRIPTION
And for llmq5_60, set it to 3 instead of 24 (which was incorrect from the
beginning).

Increasing all LLMQs "keepOldConnections" by one is required because we
don't use the tip when scanning active quorums, but a block that is 8 blocks
in the past. This however means that we need to keep connections for one
additional quorum alive.

This fixes an issue with signing sessions randomly failing with timeouts.