### PR TITLE
Merge bitcoin#9963: util: Properly handle errors during log message formatting

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -212,7 +212,7 @@ void CQuorumManager::EnsureQuorumConnections(Consensus::LLMQType llmqType, const
                             debugMsg += strprintf("  %s (%s)\n", c.ToString(), dmn->pdmnState->addr.ToString(false));
                         }
                     }
-                    LogPrint("llmq", debugMsg);
+                    LogPrint("llmq", debugMsg.c_str());
                 }
                 g_connman->AddMasternodeQuorumNodes(llmqType, quorum->qc.quorumHash, connections);
             }

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -489,7 +489,7 @@ void CDKGSessionHandler::HandleDKGRound()
                         debugMsg += strprintf("  %s (%s)\n", c.ToString(), dmn->pdmnState->addr.ToString(false));
                     }
                 }
-                LogPrint("llmq-dkg", debugMsg);
+                LogPrint("llmq-dkg", debugMsg.c_str());
             }
             g_connman->AddMasternodeQuorumNodes(params.type, curQuorumHash, connections);
         }

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -123,7 +123,7 @@ namespace tinyformat {}
 namespace tfm = tinyformat;
 
 // Error handling; calls assert() by default.
-#define TINYFORMAT_ERROR(reasonString) throw std::runtime_error(reasonString)
+#define TINYFORMAT_ERROR(reasonString) throw tinyformat::format_error(reasonString)
 
 // Define for C++11 variadic templates which make the code shorter & more
 // general.  If you don't define this, C++11 support is autodetected below.
@@ -163,6 +163,13 @@ namespace tfm = tinyformat;
 #endif
 
 namespace tinyformat {
+
+class format_error: public std::runtime_error
+{
+public:
+    format_error(const std::string &what): std::runtime_error(what) {
+    }
+};
 
 //------------------------------------------------------------------------------
 namespace detail {

--- a/src/util.h
+++ b/src/util.h
@@ -40,7 +40,7 @@
 #ifdef ENABLE_DASH_DEBUG
 #define DBG( x ) x
 #else
-#define DBG( x ) 
+#define DBG( x )
 #endif
 
 //Dash only features
@@ -110,14 +110,24 @@ std::string SafeStringFormat(const std::string& fmt, const Args&... args)
     }
 }
 
-#define LogPrint(category, ...) do { \
-    if (LogAcceptCategory((category))) { \
-        LogPrintStr(SafeStringFormat(__VA_ARGS__)); \
-    } \
-} while(0)
+/** Get format string from VA_ARGS for error reporting */
+template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }
 
 #define LogPrintf(...) do { \
-    LogPrintStr(SafeStringFormat(__VA_ARGS__)); \
+    std::string _log_msg_; /* Unlikely name to avoid shadowing variables */ \
+    try { \
+        _log_msg_ = tfm::format(__VA_ARGS__); \
+    } catch (tinyformat::format_error &e) { \
+        /* Original format string will have newline so don't add one here */ \
+        _log_msg_ = "Error \"" + std::string(e.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
+    } \
+    LogPrintStr(_log_msg_); \
+} while(0)
+
+#define LogPrint(category, ...) do { \
+    if (LogAcceptCategory((category))) { \
+        LogPrintf(__VA_ARGS__); \
+    } \
 } while(0)
 
 template<typename... Args>


### PR DESCRIPTION
Decided to break this off the main set since it should have been in like pr2 and I missed it. I could cherry-pick this into pr10 if wanted

b651270 util: Throw tinyformat::format_error on formatting error (Wladimir J. van der Laan)
3b092bd util: Properly handle errors during log message formatting (Wladimir J. van der Laan)

Tree-SHA512: 85e3b7afec2255fc88034187f1abd6060e9421de17ed4e3d918416f393429a99cc2c974b362099aaaff6970549df47664bea4c857c4e46acc0789663201dc541