### PR TITLE
Skip processing in SyncTransaction when chain is not synced yet

### DIFF
--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -347,6 +347,10 @@ void CChainLocksHandler::TrySignChainTip()
 
 void CChainLocksHandler::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int posInBlock)
 {
+    if (!masternodeSync.IsBlockchainSynced()) {
+        return;
+    }
+
     bool handleTx = true;
     if (tx.IsCoinBase() || tx.vin.empty()) {
         handleTx = false;

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -964,6 +964,10 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
         }
     }
 
+    if (!masternodeSync.IsBlockchainSynced()) {
+        return;
+    }
+
     bool chainlocked = pindex && chainLocksHandler->HasChainLock(pindex->nHeight, pindex->GetBlockHash());
     if (islockHash.IsNull() && !chainlocked) {
         ProcessTx(tx, Params().GetConsensus());


### PR DESCRIPTION
Applies to CInstantSendManager and CChainLocksHandler. This fixes extremely
high RAM usage on reindex and resync, which happens due to many/all transactions
being kept track of non-locked TXs (nonLockedTxs) and TXs per
block (blockTxs).

Targeted for 0.14.