### PR TITLE
Fix duplicate `-instantsendnotify` invocation

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1117,10 +1117,6 @@ void CInstantSendManager::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
             RemoveNonLockedTx(txid, true);
         }
     }
-
-    for (auto& p : removeISLocks) {
-        UpdateWalletTransaction(p.second->txid, nullptr);
-    }
 }
 
 void CInstantSendManager::RemoveMempoolConflictsForLock(const uint256& hash, const CInstantSendLock& islock)


### PR DESCRIPTION
We shouldn't be calling `UpdateWalletTransaction` while removing IS-locks. Not sure how it got there...

~Actual changes https://github.com/dashpay/dash/commit/4feea5a144835d5fbf6e34149bc89b871fe06224?w=1#diff-9f8ffdc36e4e8ae82358e8fa2a6fd5e7L1121~