### PR TITLE
Also gracefully timeout Travis builds when building source takes >30min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,13 +71,14 @@ script:
     - export TRAVIS_COMMIT_LOG=`git log --format=fuller -1`
     # Our scripts try to be Travis agnostic
     - $DOCKER_RUN_IN_BUILDER ./ci/build_depends.sh;
-    # Gracefully stop build without running into timeouts (which won't update caches) when building depends took too long
-    # Next build should fix this situation as it will start with a populated depends cache
-    - if [ $SECONDS -gt 1200 ]; then export DEPENDS_TIMEOUT="true"; false; fi # The "false" here ensures that the build is marked as failed even though the whole script returns 0
-    - test "$DEPENDS_TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/build_src.sh
-    - test "$DEPENDS_TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_unittests.sh
-    - test "$DEPENDS_TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_integrationtests.sh --jobs=3
-    - test "$DEPENDS_TIMEOUT" != "true" && if [ "$DOCKER_BUILD" = "true" ]; then BUILD_DIR=build-ci/dashcore-$BUILD_TARGET ./docker/build-docker.sh; fi
+    # Gracefully stop build without running into timeouts (which won't update caches) when building depends or source took too long
+    # Next build should fix this situation as it will start with a populated cache
+    - if [ $SECONDS -gt 1200 ]; then export TIMEOUT="true"; false; fi # The "false" here ensures that the build is marked as failed even though the whole script returns 0
+    - test "$TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/build_src.sh
+    - if [ $SECONDS -gt 1800 ]; then export TIMEOUT="true"; false; fi # The "false" here ensures that the build is marked as failed even though the whole script returns 0
+    - test "$TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_unittests.sh
+    - test "$TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_integrationtests.sh --jobs=3
+    - test "$TIMEOUT" != "true" && if [ "$DOCKER_BUILD" = "true" ]; then BUILD_DIR=build-ci/dashcore-$BUILD_TARGET ./docker/build-docker.sh; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG


### PR DESCRIPTION
We assume 15-20 minutes for running integration tests, so we can spend a
maximum of 30 minutes for building depends and source.