### PR TITLE
[PrivateSend] Start MaxParticipants at 10 and decay with time

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -328,7 +328,7 @@ public:
         fAllowMultiplePorts = false;
 
         nPoolMinParticipants = 3;
-        nPoolMaxParticipants = 5;
+        nPoolMaxParticipants = 10;
         nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
 
         vSporkAddresses = {"Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh"};
@@ -507,7 +507,7 @@ public:
         fAllowMultiplePorts = true;
 
         nPoolMinParticipants = 3;
-        nPoolMaxParticipants = 5;
+        nPoolMaxParticipants = 10;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
@@ -664,7 +664,7 @@ public:
         fAllowMultiplePorts = true;
 
         nPoolMinParticipants = 3;
-        nPoolMaxParticipants = 5;
+        nPoolMaxParticipants = 10;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};

--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -758,7 +758,8 @@ bool CPrivateSendServer::CreateNewSession(const CPrivateSendAccept& dsa, PoolMes
     nMessageIDRet = MSG_NOERR;
     nSessionID = GetRandInt(999999) + 1;
     nSessionDenom = dsa.nDenom;
-    nSessionStartTime = GetTime();
+    // Add randomness to stop a client from predicting number of participants based on timing
+    nSessionStartTime = GetTime() + GetRandInt(PRIVATESEND_QUEUE_GOAL_TIME / 2);
 
     SetState(POOL_STATE_QUEUE);
 
@@ -918,6 +919,8 @@ int CPrivateSendServer::GetSessionMaxParticipants()
     // The percent time remaining until the 'Goal' time is reached.
     double percentTimeRemaining = 1.0 -
             ((double)(GetTime() - nSessionStartTime) / (double)PRIVATESEND_QUEUE_GOAL_TIME);
+    // due to randomizing nSessionStartTime, check that it is not negative
+    percentTimeRemaining = std::max(0.0, percentTimeRemaining);
     int maxParticipants = percentTimeRemaining * CPrivateSend::GetMaxPoolParticipants();
 
     return std::max(CPrivateSend::GetMinPoolParticipants(), maxParticipants);

--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -813,7 +813,7 @@ bool CPrivateSendServer::AddUserToExistingSession(const CPrivateSendAccept& dsa,
 
 bool CPrivateSendServer::IsSessionReady()
 {
-    return nSessionStartTime && (int)vecSessionCollaterals.size() >= CPrivateSendServer::GetSessionMaxParticipants();
+    return nSessionStartTime > 0 && (int)vecSessionCollaterals.size() >= CPrivateSendServer::GetSessionMaxParticipants();
 }
 
 void CPrivateSendServer::RelayFinalTransaction(const CTransaction& txFinal, CConnman& connman)

--- a/src/privatesend/privatesend-server.h
+++ b/src/privatesend/privatesend-server.h
@@ -22,9 +22,6 @@ private:
     // to behave honestly. If they don't it takes their money.
     std::vector<CTransactionRef> vecSessionCollaterals;
 
-    // Maximum number of participants in a certain session, random between min and max.
-    int nSessionMaxParticipants;
-
     //The sessions start time, used for variable participant count
     int nSessionStartTime;
 
@@ -77,7 +74,7 @@ private:
 public:
     CPrivateSendServer() :
         vecSessionCollaterals(),
-        nSessionMaxParticipants(0),
+        nSessionStartTime(0),
         fUnitTest(false) {}
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);

--- a/src/privatesend/privatesend-server.h
+++ b/src/privatesend/privatesend-server.h
@@ -25,6 +25,9 @@ private:
     // Maximum number of participants in a certain session, random between min and max.
     int nSessionMaxParticipants;
 
+    //The sessions start time, used for variable participant count
+    int nSessionStartTime;
+
     bool fUnitTest;
 
     /// Add a clients entry to the pool
@@ -58,7 +61,8 @@ private:
     bool IsInputScriptSigValid(const CTxIn& txin);
     /// Are these outputs compatible with other client in the pool?
     bool IsOutputsCompatibleWithSessionDenom(const std::vector<CTxOut>& vecTxOut);
-
+    // Maximum number of participants in a certain session, starts at max and decreases with time based on PRIVATESEND_QUEUE_GOAL_TIME
+    int GetSessionMaxParticipants();
     // Set the 'state' value, with some logging and capturing when the state changed
     void SetState(PoolState nStateNew);
 

--- a/src/privatesend/privatesend.h
+++ b/src/privatesend/privatesend.h
@@ -23,6 +23,9 @@ static const int PRIVATESEND_AUTO_TIMEOUT_MAX = 15;
 static const int PRIVATESEND_QUEUE_TIMEOUT = 30;
 static const int PRIVATESEND_SIGNING_TIMEOUT = 15;
 
+// Used to automatically adjust the number of participants in a round.
+static const int PRIVATESEND_QUEUE_GOAL_TIME = 40;
+
 //! minimum peer version accepted by mixing pool
 static const int MIN_PRIVATESEND_PEER_PROTO_VERSION = 70213;
 


### PR DESCRIPTION
This will start the MaxParticipants at 10 (theoretical max of 90 inputs and outputs which should be an okay size), at 20 seconds MaxParticipants will be at 5, and continue to decrease with time until it reaches the minimum, 3. This will allow for stronger mixing rounds (more participants) when there is liquidity in the network while also minimally affecting the speed when there is low liquidity.