### PR TITLE
Fix off-by-one error in InstantSend mining info removal when disconnecting blocks

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -961,11 +961,12 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
     }
 
     bool inMempool = mempool.get(tx.GetHash()) != nullptr;
+    bool isDisconnect = pindex && posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK;
 
     // Are we called from validation.cpp/MemPoolConflictRemovalTracker?
     // TODO refactor this when we backport the BlockConnected signal from Bitcoin, as it gives better info about
     // conflicted TXs
-    bool isConflictRemoved = !pindex && posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK && !inMempool;
+    bool isConflictRemoved = isDisconnect && !inMempool;
 
     if (isConflictRemoved) {
         LOCK(cs);
@@ -980,7 +981,7 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
 
         // update DB about when an IS lock was mined
         if (!islockHash.IsNull() && pindex) {
-            if (posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK) {
+            if (isDisconnect) {
                 db.RemoveInstantSendLockMined(islockHash, pindex->nHeight);
             } else {
                 db.WriteInstantSendLockMined(islockHash, pindex->nHeight);
@@ -1001,7 +1002,7 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
     if (!chainlocked && islockHash.IsNull()) {
         // TX is not locked, so make sure it is tracked
         AddNonLockedTx(MakeTransactionRef(tx));
-        nonLockedTxs.at(tx.GetHash()).pindexMined = posInBlock != CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK ? pindex : nullptr;
+        nonLockedTxs.at(tx.GetHash()).pindexMined = !isDisconnect ? pindex : nullptr;
     } else {
         // TX is locked, so make sure we don't track it anymore
         RemoveNonLockedTx(tx.GetHash(), true);

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -982,7 +982,8 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
         // update DB about when an IS lock was mined
         if (!islockHash.IsNull() && pindex) {
             if (isDisconnect) {
-                db.RemoveInstantSendLockMined(islockHash, pindex->nHeight);
+                // SyncTransaction is called with pprev
+                db.RemoveInstantSendLockMined(islockHash, pindex->nHeight + 1);
             } else {
                 db.WriteInstantSendLockMined(islockHash, pindex->nHeight);
             }


### PR DESCRIPTION
SyncTransaction is called with `pindex->pprev` and not with `pindex` when blocks are disconnected, so we need to call RemoveInstantSendLockMined with `nHeight + 1`