### PR TITLE
Refactor validation signals for ChainLocks, InstantSend and PrivateSend to get rid of SyncTransaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,28 +37,40 @@ add_definitions(
 )
 
 file(GLOB SOURCE_FILES
+        src/*.cpp
+        src/*.h
         src/bench/*.cpp
         src/bench/*.h
         src/bls/*.cpp
         src/bls/*.h
         src/compat/*.cpp
         src/compat/*.h
-        src/consensus/*.h
         src/consensus/*.cpp
+        src/consensus/*.h
         src/crypto/*.c
-        src/crypto/*.h
         src/crypto/*.cpp
+        src/crypto/*.h
+        src/evo/*.cpp
+        src/evo/*.h
         src/leveldb/db/*.cc
         src/leveldb/db/*.h
         src/leveldb/include/*.h
+        src/llmq/*.cpp
+        src/llmq/*.h
+        src/masternode/*.cpp
+        src/masternode/*.h
         src/policy/*.cpp
         src/policy/*.h
         src/primitives/*.cpp
         src/primitives/*.h
-        src/qt/test/*.cpp
-        src/qt/test/*.h
+        src/privatesend/*.cpp
+        src/privatesend/*.h
         src/qt/*.cpp
         src/qt/*.h
+        src/qt/test/*.cpp
+        src/qt/test/*.h
+        src/rpc/*.cpp
+        src/rpc/*.h
         src/script/*.cpp
         src/script/*.h
         src/secp256k1/include/*.h
@@ -67,19 +79,11 @@ file(GLOB SOURCE_FILES
         src/univalue/include/*.h
         src/univalue/lib/*.cpp
         src/univalue/lib/*.h
-        src/wallet/test/*.cpp
         src/wallet/*.cpp
         src/wallet/*.h
+        src/wallet/test/*.cpp
         src/zmq/*.cpp
         src/zmq/*.h
-        src/*.cpp
-        src/*.h
-        src/evo/*.h
-        src/evo/*.cpp
-        src/llmq/*.h
-        src/llmq/*.cpp
-        src/rpc/*.cpp
-        src/rpc/*.h
         )
 
 add_executable(dash ${SOURCE_FILES})

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -72,18 +72,12 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     llmq::quorumDKGSessionManager->UpdatedBlockTip(pindexNew, fInitialDownload);
 }
 
-void CDSNotificationInterface::SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, int posInBlock)
-{
-    // TODO when the old InstantSend system is removed, also remove this whole method and all the surrounding compatiblity code
-    instantsend.SyncTransaction(tx, pindex, posInBlock);
-}
-
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx)
 {
     llmq::quorumInstantSendManager->TransactionAddedToMempool(ptx);
     llmq::chainLocksHandler->TransactionAddedToMempool(ptx);
     CPrivateSend::TransactionAddedToMempool(ptx);
-    SyncTransaction(ptx);
+    instantsend.SyncTransaction(ptx);
 }
 
 void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted)
@@ -101,10 +95,10 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
     CPrivateSend::BlockConnected(pblock, pindex, vtxConflicted);
 
     for (const CTransactionRef& ptx : vtxConflicted) {
-        SyncTransaction(ptx);
+        instantsend.SyncTransaction(ptx);
     }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
-        SyncTransaction(pblock->vtx[i], pindex, i);
+        instantsend.SyncTransaction(pblock->vtx[i], pindex, i);
     }
 }
 
@@ -115,7 +109,7 @@ void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBl
     CPrivateSend::BlockDisconnected(pblock, pindexDisconnected);
 
     for (const CTransactionRef& ptx : pblock->vtx) {
-        SyncTransaction(ptx, pindexDisconnected->pprev, -1);
+        instantsend.SyncTransaction(ptx, pindexDisconnected->pprev, -1);
     }
 }
 

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -75,13 +75,13 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 void CDSNotificationInterface::SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, int posInBlock)
 {
     instantsend.SyncTransaction(tx, pindex, posInBlock);
-    CPrivateSend::SyncTransaction(tx, pindex, posInBlock);
 }
 
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx)
 {
     llmq::quorumInstantSendManager->TransactionAddedToMempool(ptx);
     llmq::chainLocksHandler->TransactionAddedToMempool(ptx);
+    CPrivateSend::TransactionAddedToMempool(ptx);
     SyncTransaction(ptx);
 }
 
@@ -97,6 +97,7 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
 
     llmq::quorumInstantSendManager->BlockConnected(pblock, pindex, vtxConflicted);
     llmq::chainLocksHandler->BlockConnected(pblock, pindex, vtxConflicted);
+    CPrivateSend::BlockConnected(pblock, pindex, vtxConflicted);
 
     for (const CTransactionRef& ptx : vtxConflicted) {
         SyncTransaction(ptx);
@@ -110,6 +111,7 @@ void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBl
 {
     llmq::quorumInstantSendManager->BlockDisconnected(pblock, pindexDisconnected);
     llmq::chainLocksHandler->BlockDisconnected(pblock, pindexDisconnected);
+    CPrivateSend::BlockDisconnected(pblock, pindexDisconnected);
 
     for (const CTransactionRef& ptx : pblock->vtx) {
         SyncTransaction(ptx, pindexDisconnected->pprev, -1);

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -74,6 +74,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
 void CDSNotificationInterface::SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, int posInBlock)
 {
+    // TODO when the old InstantSend system is removed, also remove this whole method and all the surrounding compatiblity code
     instantsend.SyncTransaction(tx, pindex, posInBlock);
 }
 

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -74,7 +74,6 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
 void CDSNotificationInterface::SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, int posInBlock)
 {
-    llmq::quorumInstantSendManager->SyncTransaction(tx, pindex, posInBlock);
     llmq::chainLocksHandler->SyncTransaction(tx, pindex, posInBlock);
     instantsend.SyncTransaction(tx, pindex, posInBlock);
     CPrivateSend::SyncTransaction(tx, pindex, posInBlock);
@@ -82,6 +81,7 @@ void CDSNotificationInterface::SyncTransaction(const CTransactionRef& tx, const 
 
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx)
 {
+    llmq::quorumInstantSendManager->TransactionAddedToMempool(ptx);
     SyncTransaction(ptx);
 }
 
@@ -95,6 +95,8 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
     // to abandon a transaction and then have it inadvertantly cleared by
     // the notification that the conflicted transaction was evicted.
 
+    llmq::quorumInstantSendManager->BlockConnected(pblock, pindex, vtxConflicted);
+
     for (const CTransactionRef& ptx : vtxConflicted) {
         SyncTransaction(ptx);
     }
@@ -105,6 +107,8 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
 
 void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
 {
+    llmq::quorumInstantSendManager->BlockDisconnected(pblock, pindexDisconnected);
+
     for (const CTransactionRef& ptx : pblock->vtx) {
         SyncTransaction(ptx, pindexDisconnected->pprev, -1);
     }

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -74,7 +74,6 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
 void CDSNotificationInterface::SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, int posInBlock)
 {
-    llmq::chainLocksHandler->SyncTransaction(tx, pindex, posInBlock);
     instantsend.SyncTransaction(tx, pindex, posInBlock);
     CPrivateSend::SyncTransaction(tx, pindex, posInBlock);
 }
@@ -82,6 +81,7 @@ void CDSNotificationInterface::SyncTransaction(const CTransactionRef& tx, const 
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx)
 {
     llmq::quorumInstantSendManager->TransactionAddedToMempool(ptx);
+    llmq::chainLocksHandler->TransactionAddedToMempool(ptx);
     SyncTransaction(ptx);
 }
 
@@ -96,6 +96,7 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
     // the notification that the conflicted transaction was evicted.
 
     llmq::quorumInstantSendManager->BlockConnected(pblock, pindex, vtxConflicted);
+    llmq::chainLocksHandler->BlockConnected(pblock, pindex, vtxConflicted);
 
     for (const CTransactionRef& ptx : vtxConflicted) {
         SyncTransaction(ptx);
@@ -108,6 +109,7 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
 void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
 {
     llmq::quorumInstantSendManager->BlockDisconnected(pblock, pindexDisconnected);
+    llmq::chainLocksHandler->BlockDisconnected(pblock, pindexDisconnected);
 
     for (const CTransactionRef& ptx : pblock->vtx) {
         SyncTransaction(ptx, pindexDisconnected->pprev, -1);

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -103,10 +103,10 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
     }
 }
 
-void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
+void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
-        SyncTransaction(ptx, pindex, -1);
+        SyncTransaction(ptx, pindexDisconnected->pprev, -1);
     }
 }
 

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -23,7 +23,7 @@ protected:
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
     void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) override;
     void NotifyChainLock(const CBlockIndex* pindex, const llmq::CChainLockSig& clsig) override;
 

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -29,8 +29,6 @@ protected:
 
 private:
     CConnman& connman;
-    /* Used by TransactionAddedToMemorypool/BlockConnected/Disconnected */
-    void SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex = nullptr, int posInBlock = 0);
 };
 
 #endif // BITCOIN_DSNOTIFICATIONINTERFACE_H

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -345,6 +345,21 @@ void CChainLocksHandler::TrySignChainTip()
     quorumSigningManager->AsyncSignIfMember(Params().GetConsensus().llmqChainLocks, requestId, msgHash);
 }
 
+void CChainLocksHandler::TransactionAddedToMempool(const CTransactionRef& tx)
+{
+
+}
+
+void CChainLocksHandler::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted)
+{
+
+}
+
+void CChainLocksHandler::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
+{
+
+}
+
 void CChainLocksHandler::SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, int posInBlock)
 {
     if (!masternodeSync.IsBlockchainSynced()) {

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -90,6 +90,9 @@ public:
     void ProcessNewChainLock(NodeId from, const CChainLockSig& clsig, const uint256& hash);
     void AcceptedBlockHeader(const CBlockIndex* pindexNew);
     void UpdatedBlockTip(const CBlockIndex* pindexNew);
+    void TransactionAddedToMempool(const CTransactionRef& tx);
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted);
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected);
     void SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex = nullptr, int posInBlock = 0);
     void CheckActiveState();
     void TrySignChainTip();

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -93,7 +93,6 @@ public:
     void TransactionAddedToMempool(const CTransactionRef& tx);
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted);
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected);
-    void SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex = nullptr, int posInBlock = 0);
     void CheckActiveState();
     void TrySignChainTip();
     void EnforceBestChainLock();

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -949,7 +949,7 @@ void CInstantSendManager::UpdateWalletTransaction(const CTransactionRef& tx, con
     mempool.AddTransactionsUpdated(1);
 }
 
-void CInstantSendManager::SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, int posInBlock)
+void CInstantSendManager::ProcessNewTransaction(const CTransactionRef& tx, const CBlockIndex* pindex)
 {
     if (!IsNewInstantSendEnabled()) {
         return;
@@ -1006,6 +1006,26 @@ void CInstantSendManager::SyncTransaction(const CTransactionRef& tx, const CBloc
         // TX is locked, so make sure we don't track it anymore
         RemoveNonLockedTx(tx->GetHash(), true);
     }
+}
+
+void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
+{
+    ProcessNewTransaction(tx, nullptr);
+}
+
+void CInstantSendManager::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted)
+{
+    if (!IsNewInstantSendEnabled()) {
+        return;
+    }
+
+    for (const auto& tx : pblock->vtx) {
+        ProcessNewTransaction(tx, pindex);
+    }
+}
+
+void CInstantSendManager::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
+{
 }
 
 void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx)

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -986,7 +986,7 @@ void CInstantSendManager::ProcessNewTransaction(const CTransactionRef& tx, const
     if (!chainlocked && islockHash.IsNull()) {
         // TX is not locked, so make sure it is tracked
         AddNonLockedTx(tx);
-        nonLockedTxs.at(tx->GetHash()).pindexMined = posInBlock != -1 ? pindex : nullptr;
+        nonLockedTxs.at(tx->GetHash()).pindexMined = pindex;
     } else {
         // TX is locked, so make sure we don't track it anymore
         RemoveNonLockedTx(tx->GetHash(), true);

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -956,7 +956,7 @@ void CInstantSendManager::ProcessNewTransaction(const CTransactionRef& tx, const
     }
 
     if (tx->IsCoinBase() || tx->vin.empty()) {
-        // coinbase can't and TXs with no inputs be locked
+        // coinbase and TXs with no inputs can't be locked
         return;
     }
 

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -141,7 +141,10 @@ public:
     void ProcessInstantSendLock(NodeId from, const uint256& hash, const CInstantSendLock& islock);
     void UpdateWalletTransaction(const CTransactionRef& tx, const CInstantSendLock& islock);
 
-    void SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex = nullptr, int posInBlock = 0);
+    void ProcessNewTransaction(const CTransactionRef& tx, const CBlockIndex* pindex);
+    void TransactionAddedToMempool(const CTransactionRef& tx);
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted);
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected);
     void AddNonLockedTx(const CTransactionRef& tx);
     void RemoveNonLockedTx(const uint256& txid, bool retryChildren);
     void RemoveConflictedTx(const CTransaction& tx);

--- a/src/privatesend/privatesend.cpp
+++ b/src/privatesend/privatesend.cpp
@@ -513,11 +513,13 @@ void CPrivateSend::UpdateDSTXConfirmedHeight(const CTransactionRef& tx, int nHei
 {
     AssertLockHeld(cs_mapdstx);
 
-    uint256 txHash = tx->GetHash();
-    if (!mapDSTX.count(txHash)) return;
+    auto it = mapDSTX.find(tx->GetHash());
+    if (it == mapDSTX.end()) {
+        return;
+    }
 
-    mapDSTX[txHash].SetConfirmedHeight(nHeight);
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSend::%s -- txid=%s, nHeight=%d\n", __func__, txHash.ToString(), nHeight);
+    it->second.SetConfirmedHeight(nHeight);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSend::%s -- txid=%s, nHeight=%d\n", __func__, tx->GetHash().ToString(), nHeight);
 }
 
 void CPrivateSend::TransactionAddedToMempool(const CTransactionRef& tx)

--- a/src/privatesend/privatesend.h
+++ b/src/privatesend/privatesend.h
@@ -422,7 +422,12 @@ public:
     static CPrivateSendBroadcastTx GetDSTX(const uint256& hash);
 
     static void UpdatedBlockTip(const CBlockIndex* pindex);
-    static void SyncTransaction(const CTransactionRef& tx, const CBlockIndex* pindex = nullptr, int posInBlock = 0);
+
+    static void UpdateDSTXConfirmedHeight(const CTransactionRef& tx, int nHeight);
+    static void TransactionAddedToMempool(const CTransactionRef& tx);
+    static void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted);
+    static void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected);
+
 };
 
 #endif

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2542,7 +2542,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     UpdateTip(pindexDelete->pprev, chainparams);
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
-    GetMainSignals().BlockDisconnected(pblock, pindexDelete->pprev);
+    GetMainSignals().BlockDisconnected(pblock, pindexDelete);
     return true;
 }
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -45,7 +45,7 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     virtual void TransactionAddedToMempool(const CTransactionRef &ptxn) {}
     virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted) {}
-    virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex) {}
+    virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindexDisconnected) {}
     virtual void NotifyTransactionLock(const CTransaction &tx, const llmq::CInstantSendLock& islock) {}
     virtual void NotifyChainLock(const CBlockIndex* pindex, const llmq::CChainLockSig& clsig) {}
     virtual void NotifyGovernanceVote(const CGovernanceVote &vote) {}
@@ -79,7 +79,7 @@ struct CMainSignals {
      */
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::vector<CTransactionRef> &)> BlockConnected;
     /** Notifies listeners of a block being disconnected */
-    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex* pindex)> BlockDisconnected;
+    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex* pindexDisconnected)> BlockDisconnected;
     /** Notifies listeners of an updated transaction lock without new data. */
     boost::signals2::signal<void (const CTransaction &, const llmq::CInstantSendLock& islock)> NotifyTransactionLock;
     /** Notifies listeners of a ChainLock. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1353,7 +1353,7 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
     }
 }
 
-void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) {
+void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) {
     LOCK2(cs_main, cs_wallet);
 
     for (const CTransactionRef& ptx : pblock->vtx) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -953,7 +953,7 @@ public:
     bool LoadToWallet(const CWalletTx& wtxIn);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -202,7 +202,7 @@ void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBloc
     }
 }
 
-void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
+void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         // Do a normal notify for each transaction removed in block disconnection

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -27,7 +27,7 @@ protected:
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void NotifyChainLock(const CBlockIndex *pindex, const llmq::CChainLockSig& clsig) override;
     void NotifyTransactionLock(const CTransaction &tx, const llmq::CInstantSendLock& islock) override;


### PR DESCRIPTION
https://github.com/dashpay/dash/pull/2931 has removed the SyncTransaction signal but used some compatiblity code for CDSNotificationInterface so that things still worked. This PR removes the compatibility code and refactors/reimplements signal handling in a way that it doesn't need SyncTransaction anymore.