### PR TITLE
Use Travis stages instead of custom timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,89 @@ env:
     - secure: "RLzlMhfLqwSBrZqJOVOd61suXBn+HtUR3vOZfuFYF/Qmjjj5TE41+rObZmzc54hP/ZL+OH6blnibpvfDXlX+eN38ivFQfuxkJIGL68SJsEwNBRwW39Yw6Hl5RdI41MLCH7ByN15wifLp1JKBilHJ7XGMOUjI7P0yl7JjX8GBXUCtJbVLRugo80/yn+XQ1NdnlpbpYHNjMEQFWSODPa3pSK5McWvyQjDZDgS+IkdrZmIYJPMa7bmKH5I/edUPSmXQT905FgEwq9u8XR0SyBopli21EK9l6GkXIIvmDTYz5vT26Apvi2B4Aoazlklg+KNRUJuLGerpt6kbnU0gMSUChVkFfFhOk6GRSN3a/AUfD2FOudvMhet2QvlPHx+GYdEUr5XVo5HW42pHsqfD6eDtHd8VLTsHP0q4C8V85fNMv21lkkehy2ry8fx/RRy6x4O2wg2mua+79UkGKXp75gMKzWEcth34PCFCOu37l2F8R/ANnrQ52K/8vIQ88TtU2OpYX89fHjLojBxu+WKEBGZH2LRPsZBOUHeeO5C/xKDrhZU24ORnMW8wg66Qg5GIX1KI4a8yp73Mpues5hzpJ6wkMuRrQt40ymKndLCjv8KSd+5BfP6Or/KIrzDNYdZaasjk7JNi6rcZmm9d3fTAo+Ja/mjpUCIOo3SX14luzVCJIig="
     - DOCKER_BUILD=false
 
-  matrix:
-    - BUILD_TARGET=arm-linux
-    - BUILD_TARGET=win32
-    - BUILD_TARGET=win64
-    - BUILD_TARGET=linux32
-    - BUILD_TARGET=linux64
-    - BUILD_TARGET=linux64_nowallet
-    - BUILD_TARGET=linux64_release DOCKER_BUILD=true
-    - BUILD_TARGET=mac
+stages:
+  - build depends
+  - build src
+  - run tests
+  - build docker
+
+builddepends: &builddepends
+  stage: build depends
+  script:
+    - $DOCKER_RUN_IN_BUILDER ./ci/build_depends.sh
+
+buildsrc: &buildsrc
+  stage: build src
+  script:
+    - $DOCKER_RUN_IN_BUILDER ./ci/build_depends.sh
+    - $DOCKER_RUN_IN_BUILDER ./ci/build_src.sh
+
+runtests: &runtests
+  stage: run tests
+  script:
+    - $DOCKER_RUN_IN_BUILDER ./ci/build_depends.sh
+    - $DOCKER_RUN_IN_BUILDER ./ci/build_src.sh
+    - $DOCKER_RUN_IN_BUILDER ./ci/test_unittests.sh
+    - $DOCKER_RUN_IN_BUILDER ./ci/test_integrationtests.sh --jobs=3
+
+builddocker: &builddocker
+  stage: build docker
+  script:
+    # no need to run tests again here
+    - if [ "$DOCKER_BUILD" = "true" ]; then $DOCKER_RUN_IN_BUILDER ./ci/build_depends.sh && $DOCKER_RUN_IN_BUILDER ./ci/build_src.sh && BUILD_DIR=build-ci/dashcore-$BUILD_TARGET ./docker/build-docker.sh; fi
+
+jobs:
+  include:
+    # build depends
+    - <<: *builddepends
+      env: BUILD_TARGET=arm-linux
+    - <<: *builddepends
+      env: BUILD_TARGET=win32
+    - <<: *builddepends
+      env: BUILD_TARGET=win64
+    - <<: *builddepends
+      env: BUILD_TARGET=linux32
+    - <<: *builddepends
+      env: BUILD_TARGET=linux64
+    - <<: *builddepends
+      env: BUILD_TARGET=linux64_nowallet
+    - <<: *builddepends
+      env: BUILD_TARGET=linux64_release DOCKER_BUILD=true
+    - <<: *builddepends
+      env: BUILD_TARGET=mac
+    # build source
+    - <<: *buildsrc
+      env: BUILD_TARGET=arm-linux
+    - <<: *buildsrc
+      env: BUILD_TARGET=win32
+    - <<: *buildsrc
+      env: BUILD_TARGET=win64
+    - <<: *buildsrc
+      env: BUILD_TARGET=linux32
+    - <<: *buildsrc
+      env: BUILD_TARGET=linux64
+    - <<: *buildsrc
+      env: BUILD_TARGET=linux64_nowallet
+    - <<: *buildsrc
+      env: BUILD_TARGET=linux64_release DOCKER_BUILD=true
+    - <<: *buildsrc
+      env: BUILD_TARGET=mac
+    # run tests (no tests for arm-linux and mac)
+    - <<: *runtests
+      env: BUILD_TARGET=win32
+    - <<: *runtests
+      env: BUILD_TARGET=win64
+    - <<: *runtests
+      env: BUILD_TARGET=linux32
+    - <<: *runtests
+      env: BUILD_TARGET=linux64
+    - <<: *runtests
+      env: BUILD_TARGET=linux64_nowallet
+    - <<: *runtests
+      env: BUILD_TARGET=linux64_release DOCKER_BUILD=true
+    # build docker
+    - <<: *builddocker
+      env: BUILD_TARGET=linux64_release DOCKER_BUILD=true
 
 before_cache:
   # Save builder image
@@ -53,6 +127,7 @@ install:
     - export JOB_NUMBER="$TRAVIS_JOB_NUMBER"
     - export HOST_SRC_DIR=$TRAVIS_BUILD_DIR
     - export HOST_CACHE_DIR=$HOME/cache
+    - export TRAVIS_COMMIT_LOG=`git log --format=fuller -1`
     - source ./ci/matrix.sh
     - mkdir -p $HOST_CACHE_DIR/docker && mkdir -p $HOST_CACHE_DIR/ccache && mkdir -p $HOST_CACHE_DIR/depends && mkdir -p $HOST_CACHE_DIR/sdk-sources
     # Keep this as it makes caching related debugging easier
@@ -67,18 +142,6 @@ before_script:
     - python3 -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
     # Build docker image only for develop branch of the main repo
     - if [ "$TRAVIS_REPO_SLUG" != "dashpay/dash" -o "$TRAVIS_BRANCH" != "develop" -o "$TRAVIS_PULL_REQUEST" != "false" ]; then export DOCKER_BUILD="false"; echo DOCKER_BUILD=$DOCKER_BUILD; fi
-script:
-    - export TRAVIS_COMMIT_LOG=`git log --format=fuller -1`
-    # Our scripts try to be Travis agnostic
-    - $DOCKER_RUN_IN_BUILDER ./ci/build_depends.sh;
-    # Gracefully stop build without running into timeouts (which won't update caches) when building depends or source took too long
-    # Next build should fix this situation as it will start with a populated cache
-    - if [ $SECONDS -gt 1200 ]; then export TIMEOUT="true"; false; fi # The "false" here ensures that the build is marked as failed even though the whole script returns 0
-    - test "$TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/build_src.sh
-    - test "$TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_unittests.sh
-    - if [ $SECONDS -gt 1800 -a "$RUN_INTEGRATIONTESTS" = "true" ]; then export TIMEOUT="true"; false; fi # The "false" here ensures that the build is marked as failed even though the whole script returns 0
-    - test "$TIMEOUT" != "true" && $DOCKER_RUN_IN_BUILDER ./ci/test_integrationtests.sh --jobs=3
-    - test "$TIMEOUT" != "true" && if [ "$DOCKER_BUILD" = "true" ]; then BUILD_DIR=build-ci/dashcore-$BUILD_TARGET ./docker/build-docker.sh; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG


### PR DESCRIPTION
I guess this can be further optimised to avoid running scripts from older stages in each next stage, but it works fine as is and having this small overhead (1-2 minutes) is ok-ish imo (we already use some caching which helps a lot here, can be improve later if needed). Another thing to keep in mind is that jobs from the next stage won't start until _all_ jobs from the current stage are "green" (for example https://travis-ci.org/UdjinM6/dash/builds/538393902) which is probably not such a bad thing.