### PR TITLE
RPC docs helper updates

### DIFF
--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -873,7 +873,7 @@ UniValue gobject_getcurrentvotes(const JSONRPCRequest& request)
 {
     throw std::runtime_error(
             "gobject \"command\"...\n"
-            "Manage governance objects\n"
+            "Set of commands to manage governance objects.\n"
             "\nAvailable commands:\n"
             "  check              - Validate governance object data (proposal only)\n"
 #ifdef ENABLE_WALLET

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -872,7 +872,7 @@ UniValue gobject_getcurrentvotes(const JSONRPCRequest& request)
 [[ noreturn ]] void gobject_help()
 {
     throw std::runtime_error(
-            "gobject \"command\"...\n"
+            "gobject \"command\" ...\n"
             "Set of commands to manage governance objects.\n"
             "\nAvailable commands:\n"
             "  check              - Validate governance object data (proposal only)\n"

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -125,8 +125,8 @@ UniValue getpoolinfo(const JSONRPCRequest& request)
 void masternode_list_help()
 {
     throw std::runtime_error(
-            "masternode list ( \"mode\" \"filter\" )\n"
-            "Get a list of masternodes in different modes. This call is identical to masternodelist call.\n"
+            "masternodelist ( \"mode\" \"filter\" )\n"
+            "Get a list of masternodes in different modes. This call is identical to 'masternode list' call.\n"
             "\nArguments:\n"
             "1. \"mode\"      (string, optional/required to use filter, defaults = json) The mode to run list in\n"
             "2. \"filter\"    (string, optional) Filter results. Partial match by outpoint by default in all modes,\n"

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -420,7 +420,7 @@ UniValue masternode_winners(const JSONRPCRequest& request)
 [[ noreturn ]] void masternode_help()
 {
     throw std::runtime_error(
-        "masternode \"command\"...\n"
+        "masternode \"command\" ...\n"
         "Set of commands to execute masternode related actions\n"
         "\nArguments:\n"
         "1. \"command\"        (string or set of strings, required) The command to execute\n"


### PR DESCRIPTION
I found [this tool](https://github.com/thephez/rpc-docs-helper) and am currently looking into using it to streamline the RPC docs creation. These commits are related to things I found when trying it:
536e3cf makes the `gobject` consistent with all our other RPCs that have sub-commands so they can be recognized and handled
ee2e9d9 Currently `dash-cli help` returns 2 `masternode` entries instead of `masternode` and `masternode list`. This commit change that (although I am not sure that is a good idea).