### PR TITLE
[v0.14.0.x] Fix off-by-one error in InstantSend mining info removal when disconnecting blocks

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -958,7 +958,8 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
         // update DB about when an IS lock was mined
         if (!islockHash.IsNull() && pindex) {
             if (isDisconnect) {
-                db.RemoveInstantSendLockMined(islockHash, pindex->nHeight);
+                // SyncTransaction is called with pprev
+                db.RemoveInstantSendLockMined(islockHash, pindex->nHeight + 1);
             } else {
                 db.WriteInstantSendLockMined(islockHash, pindex->nHeight);
             }

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -937,11 +937,12 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
     }
 
     bool inMempool = mempool.get(tx.GetHash()) != nullptr;
+    bool isDisconnect = pindex && posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK;
 
     // Are we called from validation.cpp/MemPoolConflictRemovalTracker?
     // TODO refactor this when we backport the BlockConnected signal from Bitcoin, as it gives better info about
     // conflicted TXs
-    bool isConflictRemoved = !pindex && posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK && !inMempool;
+    bool isConflictRemoved = isDisconnect && !inMempool;
 
     if (isConflictRemoved) {
         LOCK(cs);
@@ -956,7 +957,7 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
 
         // update DB about when an IS lock was mined
         if (!islockHash.IsNull() && pindex) {
-            if (posInBlock == CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK) {
+            if (isDisconnect) {
                 db.RemoveInstantSendLockMined(islockHash, pindex->nHeight);
             } else {
                 db.WriteInstantSendLockMined(islockHash, pindex->nHeight);
@@ -977,7 +978,7 @@ void CInstantSendManager::SyncTransaction(const CTransaction& tx, const CBlockIn
     if (!chainlocked && islockHash.IsNull()) {
         // TX is not locked, so make sure it is tracked
         AddNonLockedTx(MakeTransactionRef(tx));
-        nonLockedTxs.at(tx.GetHash()).pindexMined = posInBlock != CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK ? pindex : nullptr;
+        nonLockedTxs.at(tx.GetHash()).pindexMined = !isDisconnect ? pindex : nullptr;
     } else {
         // TX is locked, so make sure we don't track it anymore
         RemoveNonLockedTx(tx.GetHash(), true);


### PR DESCRIPTION
This is the same fix as in #2940. The original PR was closes as it didn't make sense to merge it into develop anymore. It's however still useful to backport this into 0.14.0.1