### PR TITLE
Fix bls and bls_dkg bench

### DIFF
--- a/src/bench/bench_dash.cpp
+++ b/src/bench/bench_dash.cpp
@@ -11,6 +11,7 @@
 
 #include "bls/bls.h"
 
+void InitBLSTests();
 void CleanupBLSTests();
 void CleanupBLSDkgTests();
 
@@ -24,6 +25,7 @@ main(int argc, char** argv)
     ECCVerifyHandle verifyHandle;
 
     BLSInit();
+    InitBLSTests();
     SetupEnvironment();
     fPrintToDebugLog = false; // don't want to write to debug.log file
 

--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -11,6 +11,11 @@
 
 CBLSWorker blsWorker;
 
+void InitBLSTests()
+{
+    blsWorker.Start();
+}
+
 void CleanupBLSTests()
 {
     blsWorker.Stop();


### PR DESCRIPTION
Properly start the blsWorker before running any BLS related benchmark tests. Failure to do so results in certain bench tests getting stuck. Possibly related to #2820 .