### PR TITLE
Inject custom specialization of std::hash for SporkId enum into std

### DIFF
--- a/src/spork.h
+++ b/src/spork.h
@@ -37,6 +37,17 @@ enum SporkId : int32_t {
 };
 template<> struct is_serializable_enum<SporkId> : std::true_type {};
 
+namespace std
+{
+    template<> struct hash<SporkId>
+    {
+        std::size_t operator()(SporkId const& id) const noexcept
+        {
+            return std::hash<int>{}(id);
+        }
+    };
+}
+
 struct CSporkDef
 {
     SporkId sporkId{SPORK_INVALID};


### PR DESCRIPTION
This should fix compilation on gcc5.