### PR TITLE
[RPC] add hex field for detail transaction for blockToJSON

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -138,7 +138,9 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     {
         if(txDetails)
         {
+            std::string strHex = EncodeHexTx(*tx);
             UniValue objTx(UniValue::VOBJ);
+            objTx.push_back(Pair("hex", strHex));
             TxToJSON(*tx, uint256(), objTx);
             txs.push_back(objTx);
         }


### PR DESCRIPTION
Added missing 'hex' field for detail transaction for blockToJSON
https://bitcoin.org/en/developer-reference#getblock