### PR TITLE
Fix UI masternode list lag

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -505,7 +505,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
     // Don't hold cs while calling signals
     if (diff.HasChanges()) {
         GetMainSignals().NotifyMasternodeListChanged(false, oldList, diff);
-        uiInterface.NotifyMasternodeListChanged();
+        uiInterface.NotifyMasternodeListChanged(newList);
     }
 
     if (nHeight == consensusParams.DIP0003EnforcementHeight) {
@@ -550,7 +550,7 @@ bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* 
     if (diff.HasChanges()) {
         auto inversedDiff = curList.BuildDiff(prevList);
         GetMainSignals().NotifyMasternodeListChanged(true, curList, inversedDiff);
-        uiInterface.NotifyMasternodeListChanged();
+        uiInterface.NotifyMasternodeListChanged(prevList);
     }
 
     const auto& consensusParams = Params().GetConsensus();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -364,14 +364,14 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
     }
 }
 
-static void NotifyMasternodeListChanged(ClientModel *clientmodel)
+static void NotifyMasternodeListChanged(ClientModel *clientmodel, const CDeterministicMNList& newList)
 {
     static int64_t nLastMasternodeUpdateNotification = 0;
     int64_t now = GetTimeMillis();
     // if we are in-sync, update the UI regardless of last update time
     // no need to refresh masternode list/stats as often as blocks etc.
     if (masternodeSync.IsBlockchainSynced() || now - nLastMasternodeUpdateNotification > MODEL_UPDATE_DELAY*4*5) {
-        clientmodel->refreshMasternodeList();
+        clientmodel->setMasternodeList(newList);
         nLastMasternodeUpdateNotification = now;
     }
 }
@@ -392,7 +392,7 @@ void ClientModel::subscribeToCoreSignals()
     uiInterface.BannedListChanged.connect(boost::bind(BannedListChanged, this));
     uiInterface.NotifyBlockTip.connect(boost::bind(BlockTipChanged, this, _1, _2, false));
     uiInterface.NotifyHeaderTip.connect(boost::bind(BlockTipChanged, this, _1, _2, true));
-    uiInterface.NotifyMasternodeListChanged.connect(boost::bind(NotifyMasternodeListChanged, this));
+    uiInterface.NotifyMasternodeListChanged.connect(boost::bind(NotifyMasternodeListChanged, this, _1));
     uiInterface.NotifyAdditionalDataSyncProgressChanged.connect(boost::bind(NotifyAdditionalDataSyncProgressChanged, this, _1));
 }
 
@@ -406,6 +406,6 @@ void ClientModel::unsubscribeFromCoreSignals()
     uiInterface.BannedListChanged.disconnect(boost::bind(BannedListChanged, this));
     uiInterface.NotifyBlockTip.disconnect(boost::bind(BlockTipChanged, this, _1, _2, false));
     uiInterface.NotifyHeaderTip.disconnect(boost::bind(BlockTipChanged, this, _1, _2, true));
-    uiInterface.NotifyMasternodeListChanged.disconnect(boost::bind(NotifyMasternodeListChanged, this));
+    uiInterface.NotifyMasternodeListChanged.disconnect(boost::bind(NotifyMasternodeListChanged, this, _1));
     uiInterface.NotifyAdditionalDataSyncProgressChanged.disconnect(boost::bind(NotifyAdditionalDataSyncProgressChanged, this, _1));
 }

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -111,7 +111,7 @@ public:
     boost::signals2::signal<void (bool, const CBlockIndex *)> NotifyHeaderTip;
 
     /** Masternode list has changed */
-    boost::signals2::signal<void (void)> NotifyMasternodeListChanged;
+    boost::signals2::signal<void (const CDeterministicMNList&)> NotifyMasternodeListChanged;
 
     /** Additional data sync progress changed */
     boost::signals2::signal<void (double nSyncProgress)> NotifyAdditionalDataSyncProgressChanged;


### PR DESCRIPTION
`NotifyMasternodeListChanged` is called before the tip is updated which means we can't rely on `GetListAtChainTip()` and have to pass the list into `CClientUIInterface`.