### PR TITLE
Multiple speed optimizations for deterministic MN list handling

### DIFF
--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -424,33 +424,6 @@ bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::v
 }
 
 #ifndef BUILD_BITCOIN_INTERNAL
-void CBLSLazySignature::SetSig(const CBLSSignature& _sig)
-{
-    std::unique_lock<std::mutex> l(mutex);
-    bufValid = false;
-    sigInitialized = true;
-    sig = _sig;
-}
-
-const CBLSSignature& CBLSLazySignature::GetSig() const
-{
-    std::unique_lock<std::mutex> l(mutex);
-    static CBLSSignature invalidSig;
-    if (!bufValid && !sigInitialized) {
-        return invalidSig;
-    }
-    if (!sigInitialized) {
-        sig.SetBuf(buf, sizeof(buf));
-        if (!sig.CheckMalleable(buf, sizeof(buf))) {
-            bufValid = false;
-            sigInitialized = false;
-            sig = invalidSig;
-        } else {
-            sigInitialized = true;
-        }
-    }
-    return sig;
-}
 
 static std::once_flag init_flag;
 static mt_pooled_secure_allocator<uint8_t>* secure_allocator_instance;

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -403,6 +403,21 @@ public:
         return obj;
     }
 
+    bool operator==(const CBLSLazyWrapper& r) const
+    {
+        if (bufValid && r.bufValid) {
+            return memcmp(buf, r.buf, sizeof(buf)) == 0;
+        }
+        if (objInitialized && r.objInitialized) {
+            return obj == r.obj;
+        }
+        return Get() == r.Get();
+    }
+
+    bool operator!=(const CBLSLazyWrapper& r) const
+    {
+        return !(*this == r);
+    }
 };
 typedef CBLSLazyWrapper<CBLSSignature> CBLSLazySignature;
 typedef CBLSLazyWrapper<CBLSPublicKey> CBLSLazyPublicKey;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -857,12 +857,14 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const uint256& blo
         }
 
         if (evoDb.Read(std::make_pair(DB_LIST_SNAPSHOT, blockHashTmp), snapshot)) {
+            mnListsCache.emplace(blockHashTmp, snapshot);
             break;
         }
 
         CDeterministicMNListDiff diff;
         if (!evoDb.Read(std::make_pair(DB_LIST_DIFF, blockHashTmp), diff)) {
             snapshot = CDeterministicMNList(blockHashTmp, -1);
+            mnListsCache.emplace(blockHashTmp, snapshot);
             break;
         }
 
@@ -877,9 +879,10 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const uint256& blo
             snapshot.SetBlockHash(diff.blockHash);
             snapshot.SetHeight(diff.nHeight);
         }
+
+        mnListsCache.emplace(diff.blockHash, snapshot);
     }
 
-    mnListsCache.emplace(blockHash, snapshot);
     return snapshot;
 }
 

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -44,7 +44,7 @@ public:
     uint256 confirmedHashWithProRegTxHash;
 
     CKeyID keyIDOwner;
-    CBLSPublicKey pubKeyOperator;
+    CBLSLazyPublicKey pubKeyOperator;
     CKeyID keyIDVoting;
     CService addr;
     CScript scriptPayout;
@@ -55,7 +55,7 @@ public:
     CDeterministicMNState(const CProRegTx& proTx)
     {
         keyIDOwner = proTx.keyIDOwner;
-        pubKeyOperator = proTx.pubKeyOperator;
+        pubKeyOperator.Set(proTx.pubKeyOperator);
         keyIDVoting = proTx.keyIDVoting;
         addr = proTx.addr;
         scriptPayout = proTx.scriptPayout;
@@ -89,7 +89,7 @@ public:
 
     void ResetOperatorFields()
     {
-        pubKeyOperator = CBLSPublicKey();
+        pubKeyOperator.Set(CBLSPublicKey());
         addr = CService();
         scriptOperatorPayout = CScript();
         nRevocationReason = CProUpRevTx::REASON_NOT_SPECIFIED;

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -89,7 +89,7 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
             signHash = ::SerializeHash(std::make_tuple(dmn->pdmnState->pubKeyOperator, pnode->sentMNAuthChallenge, !pnode->fInbound));
         }
 
-        if (!mnauth.sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator, signHash)) {
+        if (!mnauth.sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator.Get(), signHash)) {
             LOCK(cs_main);
             // Same as above, MN seems to not know about his fate yet, so give him a chance to update. If this is a
             // malicious actor (DoSing us), we'll ban him soon.

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -257,7 +257,7 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
         if (!CheckInputsHash(tx, ptx, state)) {
             return false;
         }
-        if (!CheckHashSig(ptx, mn->pdmnState->pubKeyOperator, state)) {
+        if (!CheckHashSig(ptx, mn->pdmnState->pubKeyOperator.Get(), state)) {
             return false;
         }
     }
@@ -376,7 +376,7 @@ bool CheckProUpRevTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
 
         if (!CheckInputsHash(tx, ptx, state))
             return false;
-        if (!CheckHashSig(ptx, dmn->pdmnState->pubKeyOperator, state))
+        if (!CheckHashSig(ptx, dmn->pdmnState->pubKeyOperator.Get(), state))
             return false;
     }
 

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -37,7 +37,7 @@ uint256 CSimplifiedMNListEntry::CalcHash() const
 std::string CSimplifiedMNListEntry::ToString() const
 {
     return strprintf("CSimplifiedMNListEntry(proRegTxHash=%s, confirmedHash=%s, service=%s, pubKeyOperator=%s, votingAddress=%s, isValid=%d)",
-        proRegTxHash.ToString(), confirmedHash.ToString(), service.ToString(false), pubKeyOperator.ToString(), CBitcoinAddress(keyIDVoting).ToString(), isValid);
+        proRegTxHash.ToString(), confirmedHash.ToString(), service.ToString(false), pubKeyOperator.Get().ToString(), CBitcoinAddress(keyIDVoting).ToString(), isValid);
 }
 
 void CSimplifiedMNListEntry::ToJson(UniValue& obj) const
@@ -47,7 +47,7 @@ void CSimplifiedMNListEntry::ToJson(UniValue& obj) const
     obj.push_back(Pair("proRegTxHash", proRegTxHash.ToString()));
     obj.push_back(Pair("confirmedHash", confirmedHash.ToString()));
     obj.push_back(Pair("service", service.ToString(false)));
-    obj.push_back(Pair("pubKeyOperator", pubKeyOperator.ToString()));
+    obj.push_back(Pair("pubKeyOperator", pubKeyOperator.Get().ToString()));
     obj.push_back(Pair("votingAddress", CBitcoinAddress(keyIDVoting).ToString()));
     obj.push_back(Pair("isValid", isValid));
 }

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -27,7 +27,7 @@ public:
     uint256 proRegTxHash;
     uint256 confirmedHash;
     CService service;
-    CBLSPublicKey pubKeyOperator;
+    CBLSLazyPublicKey pubKeyOperator;
     CKeyID keyIDVoting;
     bool isValid;
 

--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -490,8 +490,8 @@ bool CGovernanceObject::IsValidLocally(std::string& strError, bool& fMissingConf
         }
 
         // Check that we have a valid MN signature
-        if (!CheckSignature(dmn->pdmnState->pubKeyOperator)) {
-            strError = "Invalid masternode signature for: " + strOutpoint + ", pubkey = " + dmn->pdmnState->pubKeyOperator.ToString();
+        if (!CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
+            strError = "Invalid masternode signature for: " + strOutpoint + ", pubkey = " + dmn->pdmnState->pubKeyOperator.Get().ToString();
             return false;
         }
 

--- a/src/governance/governance-vote.cpp
+++ b/src/governance/governance-vote.cpp
@@ -280,7 +280,7 @@ bool CGovernanceVote::IsValid(bool useVotingKey) const
     if (useVotingKey) {
         return CheckSignature(dmn->pdmnState->keyIDVoting);
     } else {
-        return CheckSignature(dmn->pdmnState->pubKeyOperator);
+        return CheckSignature(dmn->pdmnState->pubKeyOperator.Get());
     }
 }
 

--- a/src/instantsend.cpp
+++ b/src/instantsend.cpp
@@ -1124,7 +1124,7 @@ bool CTxLockVote::CheckSignature() const
 
     CBLSSignature sig;
     sig.SetBuf(vchMasternodeSignature);
-    if (!sig.IsValid() || !sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator, hash)) {
+    if (!sig.IsValid() || !sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator.Get(), hash)) {
         LogPrintf("CTxLockVote::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -571,7 +571,7 @@ void CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recove
 
         clsig.nHeight = lastSignedHeight;
         clsig.blockHash = lastSignedMsgHash;
-        clsig.sig = recoveredSig.sig.GetSig();
+        clsig.sig = recoveredSig.sig.Get();
     }
     ProcessNewChainLock(-1, clsig, ::SerializeHash(clsig));
 }

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -86,7 +86,7 @@ bool CFinalCommitment::Verify(const std::vector<CDeterministicMNCPtr>& members, 
             if (!signers[i]) {
                 continue;
             }
-            memberPubKeys.emplace_back(members[i]->pdmnState->pubKeyOperator);
+            memberPubKeys.emplace_back(members[i]->pdmnState->pubKeyOperator.Get());
         }
 
         if (!membersSig.VerifySecureAggregated(memberPubKeys, commitmentHash)) {

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -187,7 +187,7 @@ void CDKGSession::SendContributions(CDKGPendingMessages& pendingMessages)
             skContrib.MakeNewKey();
         }
 
-        if (!qc.contributions->Encrypt(i, m->dmn->pdmnState->pubKeyOperator, skContrib, PROTOCOL_VERSION)) {
+        if (!qc.contributions->Encrypt(i, m->dmn->pdmnState->pubKeyOperator.Get(), skContrib, PROTOCOL_VERSION)) {
             logger.Batch("failed to encrypt contribution for %s", m->dmn->proTxHash.ToString());
             return;
         }
@@ -1219,7 +1219,7 @@ std::vector<CFinalCommitment> CDKGSession::FinalizeCommitments()
 
             fqc.signers[signerIndex] = true;
             aggSigs.emplace_back(qc.sig);
-            aggPks.emplace_back(m->dmn->pdmnState->pubKeyOperator);
+            aggPks.emplace_back(m->dmn->pdmnState->pubKeyOperator.Get());
 
             signerIds.emplace_back(m->id);
             thresholdSigs.emplace_back(qc.quorumSig);

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -313,7 +313,7 @@ std::set<NodeId> BatchVerifyMessageSigs(CDKGSession& session, const std::vector<
             break;
         }
 
-        pubKeys.emplace_back(member->dmn->pdmnState->pubKeyOperator);
+        pubKeys.emplace_back(member->dmn->pdmnState->pubKeyOperator.Get());
         messageHashes.emplace_back(msgHash);
     }
     if (!revertToSingleVerification) {
@@ -353,7 +353,7 @@ std::set<NodeId> BatchVerifyMessageSigs(CDKGSession& session, const std::vector<
 
         const auto& msg = *p.second;
         auto member = session.GetMember(msg.proTxHash);
-        bool valid = msg.sig.VerifyInsecure(member->dmn->pdmnState->pubKeyOperator, msg.GetSignHash());
+        bool valid = msg.sig.VerifyInsecure(member->dmn->pdmnState->pubKeyOperator.Get(), msg.GetSignHash());
         if (!valid) {
             ret.emplace(p.first);
         }

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -769,7 +769,7 @@ bool CInstantSendManager::ProcessPendingInstantSendLocks()
             continue;
         }
 
-        if (!islock.sig.GetSig().IsValid()) {
+        if (!islock.sig.Get().IsValid()) {
             batchVerifier.badSources.emplace(nodeId);
             continue;
         }
@@ -787,7 +787,7 @@ bool CInstantSendManager::ProcessPendingInstantSendLocks()
             return false;
         }
         uint256 signHash = CLLMQUtils::BuildSignHash(llmqType, quorum->qc.quorumHash, id, islock.txid);
-        batchVerifier.PushMessage(nodeId, hash, signHash, islock.sig.GetSig(), quorum->qc.quorumPublicKey);
+        batchVerifier.PushMessage(nodeId, hash, signHash, islock.sig.Get(), quorum->qc.quorumPublicKey);
 
         // We can reconstruct the CRecoveredSig objects from the islock and pass it to the signing manager, which
         // avoids unnecessary double-verification of the signature. We however only do this when verification here

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -31,8 +31,8 @@ UniValue CRecoveredSig::ToJson() const
     ret.push_back(Pair("quorumHash", quorumHash.ToString()));
     ret.push_back(Pair("id", id.ToString()));
     ret.push_back(Pair("msgHash", msgHash.ToString()));
-    ret.push_back(Pair("sig", sig.GetSig().ToString()));
-    ret.push_back(Pair("hash", sig.GetSig().GetHash().ToString()));
+    ret.push_back(Pair("sig", sig.Get().ToString()));
+    ret.push_back(Pair("hash", sig.Get().GetHash().ToString()));
     return ret;
 }
 
@@ -575,13 +575,13 @@ bool CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
 
         for (auto& recSig : v) {
             // we didn't verify the lazy signature until now
-            if (!recSig.sig.GetSig().IsValid()) {
+            if (!recSig.sig.Get().IsValid()) {
                 batchVerifier.badSources.emplace(nodeId);
                 break;
             }
 
             const auto& quorum = quorums.at(std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.quorumHash));
-            batchVerifier.PushMessage(nodeId, recSig.GetHash(), CLLMQUtils::BuildSignHash(recSig), recSig.sig.GetSig(), quorum->qc.quorumPublicKey);
+            batchVerifier.PushMessage(nodeId, recSig.GetHash(), CLLMQUtils::BuildSignHash(recSig), recSig.sig.Get(), quorum->qc.quorumPublicKey);
             verifyCount++;
         }
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2180,7 +2180,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 // we have no idea about (e.g we were offline)? How to handle them?
             }
 
-            if (!dstx.CheckSignature(dmn->pdmnState->pubKeyOperator)) {
+            if (!dstx.CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
                 LogPrint(BCLog::PRIVATESEND, "DSTX -- CheckSignature() failed for %s\n", hashTx.ToString());
                 return false;
             }

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -66,7 +66,7 @@ void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& 
         auto dmn = mnList.GetValidMNByCollateral(dsq.masternodeOutpoint);
         if (!dmn) return;
 
-        if (!dsq.CheckSignature(dmn->pdmnState->pubKeyOperator)) {
+        if (!dsq.CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
             LOCK(cs_main);
             Misbehaving(pfrom->id, 10);
             return;

--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -121,7 +121,7 @@ void CPrivateSendServer::ProcessMessage(CNode* pfrom, const std::string& strComm
         auto dmn = mnList.GetValidMNByCollateral(dsq.masternodeOutpoint);
         if (!dmn) return;
 
-        if (!dsq.CheckSignature(dmn->pdmnState->pubKeyOperator)) {
+        if (!dsq.CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
             LOCK(cs_main);
             Misbehaving(pfrom->id, 10);
             return;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -367,14 +367,7 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
 
 static void NotifyMasternodeListChanged(ClientModel *clientmodel, const CDeterministicMNList& newList)
 {
-    static int64_t nLastMasternodeUpdateNotification = 0;
-    int64_t now = GetTimeMillis();
-    // if we are in-sync, update the UI regardless of last update time
-    // no need to refresh masternode list/stats as often as blocks etc.
-    if (masternodeSync.IsBlockchainSynced() || now - nLastMasternodeUpdateNotification > MODEL_UPDATE_DELAY*4*5) {
-        clientmodel->setMasternodeList(newList);
-        nLastMasternodeUpdateNotification = now;
-    }
+    clientmodel->setMasternodeList(newList);
 }
 
 static void NotifyAdditionalDataSyncProgressChanged(ClientModel *clientmodel, double nSyncProgress)

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -12,7 +12,7 @@
 #include <QTimer>
 #include <QWidget>
 
-#define MASTERNODELIST_UPDATE_SECONDS 15
+#define MASTERNODELIST_UPDATE_SECONDS 3
 #define MASTERNODELIST_FILTER_COOLDOWN_SECONDS 3
 
 namespace Ui
@@ -42,6 +42,7 @@ public:
 private:
     QMenu* contextMenuDIP3;
     int64_t nTimeFilterUpdatedDIP3;
+    int64_t nTimeUpdatedDIP3;
     bool fFilterUpdatedDIP3;
 
     QTimer* timer;
@@ -54,9 +55,11 @@ private:
 
     QString strCurrentFilterDIP3;
 
+    bool mnListChanged;
+
     CDeterministicMNCPtr GetSelectedDIP3MN();
 
-    void updateDIP3List(bool fForce);
+    void updateDIP3List();
 
 Q_SIGNALS:
     void doubleClicked(const QModelIndex&);
@@ -70,7 +73,7 @@ private Q_SLOTS:
     void copyProTxHash_clicked();
     void copyCollateralOutpoint_clicked();
 
+    void handleMasternodeListChanged();
     void updateDIP3ListScheduled();
-    void updateDIP3ListForced();
 };
 #endif // MASTERNODELIST_H

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -569,7 +569,7 @@ UniValue masternodelist(const JSONRPCRequest& request)
                            CBitcoinAddress(dmn->pdmnState->keyIDOwner).ToString() << " " <<
                            CBitcoinAddress(dmn->pdmnState->keyIDVoting).ToString() << " " <<
                            collateralAddressStr << " " <<
-                           dmn->pdmnState->pubKeyOperator.ToString();
+                           dmn->pdmnState->pubKeyOperator.Get().ToString();
             std::string strInfo = streamInfo.str();
             if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
@@ -583,7 +583,7 @@ UniValue masternodelist(const JSONRPCRequest& request)
             objMN.push_back(Pair("owneraddress", CBitcoinAddress(dmn->pdmnState->keyIDOwner).ToString()));
             objMN.push_back(Pair("votingaddress", CBitcoinAddress(dmn->pdmnState->keyIDVoting).ToString()));
             objMN.push_back(Pair("collateraladdress", collateralAddressStr));
-            objMN.push_back(Pair("pubkeyoperator", dmn->pdmnState->pubKeyOperator.ToString()));
+            objMN.push_back(Pair("pubkeyoperator", dmn->pdmnState->pubKeyOperator.Get().ToString()));
             obj.push_back(Pair(strOutpoint, objMN));
         } else if (strMode == "lastpaidblock") {
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
@@ -600,7 +600,7 @@ UniValue masternodelist(const JSONRPCRequest& request)
             obj.push_back(Pair(strOutpoint, CBitcoinAddress(dmn->pdmnState->keyIDOwner).ToString()));
         } else if (strMode == "pubkeyoperator") {
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
-            obj.push_back(Pair(strOutpoint, dmn->pdmnState->pubKeyOperator.ToString()));
+            obj.push_back(Pair(strOutpoint, dmn->pdmnState->pubKeyOperator.Get().ToString()));
         } else if (strMode == "status") {
             std::string strStatus = dmnToStatus(dmn);
             if (strFilter !="" && strStatus.find(strFilter) == std::string::npos &&

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -623,7 +623,7 @@ UniValue protx_update_service(const JSONRPCRequest& request)
         throw std::runtime_error(strprintf("masternode with proTxHash %s not found", ptx.proTxHash.ToString()));
     }
 
-    if (keyOperator.GetPublicKey() != dmn->pdmnState->pubKeyOperator) {
+    if (keyOperator.GetPublicKey() != dmn->pdmnState->pubKeyOperator.Get()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("the operator key does not belong to the registered public key"));
     }
 
@@ -713,7 +713,7 @@ UniValue protx_update_registrar(const JSONRPCRequest& request)
     if (!dmn) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("masternode %s not found", ptx.proTxHash.ToString()));
     }
-    ptx.pubKeyOperator = dmn->pdmnState->pubKeyOperator;
+    ptx.pubKeyOperator = dmn->pdmnState->pubKeyOperator.Get();
     ptx.keyIDVoting = dmn->pdmnState->keyIDVoting;
     ptx.scriptPayout = dmn->pdmnState->scriptPayout;
 
@@ -808,7 +808,7 @@ UniValue protx_revoke(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("masternode %s not found", ptx.proTxHash.ToString()));
     }
 
-    if (keyOperator.GetPublicKey() != dmn->pdmnState->pubKeyOperator) {
+    if (keyOperator.GetPublicKey() != dmn->pdmnState->pubKeyOperator.Get()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("the operator key does not belong to the registered public key"));
     }
 

--- a/src/test/evo_simplifiedmns_tests.cpp
+++ b/src/test/evo_simplifiedmns_tests.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
         CBLSSecretKey sk;
         sk.SetBuf(skBuf, sizeof(skBuf));
 
-        smle.pubKeyOperator = sk.GetPublicKey();
+        smle.pubKeyOperator.Set(sk.GetPublicKey());
         smle.keyIDVoting.SetHex(strprintf("%040x", i));
         smle.isValid = true;
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -450,7 +450,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
         auto dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTx.proTxHash);
         assert(dmn);
         newit->validForProTxKey = ::SerializeHash(dmn->pdmnState->pubKeyOperator);
-        if (dmn->pdmnState->pubKeyOperator != proTx.pubKeyOperator) {
+        if (dmn->pdmnState->pubKeyOperator.Get() != proTx.pubKeyOperator) {
             newit->isKeyChangeProTx = true;
         }
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_REVOKE) {
@@ -461,7 +461,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
         auto dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTx.proTxHash);
         assert(dmn);
         newit->validForProTxKey = ::SerializeHash(dmn->pdmnState->pubKeyOperator);
-        if (dmn->pdmnState->pubKeyOperator != CBLSPublicKey()) {
+        if (dmn->pdmnState->pubKeyOperator.Get() != CBLSPublicKey()) {
             newit->isKeyChangeProTx = true;
         }
     }
@@ -1285,7 +1285,7 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
             return true; // i.e. failed to find validated ProTx == conflict
         }
         // only allow one operator key change in the mempool
-        if (dmn->pdmnState->pubKeyOperator != proTx.pubKeyOperator) {
+        if (dmn->pdmnState->pubKeyOperator.Get() != proTx.pubKeyOperator) {
             if (hasKeyChangeInMempool(proTx.proTxHash)) {
                 return true;
             }
@@ -1307,7 +1307,7 @@ bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
             return true; // i.e. failed to find validated ProTx == conflict
         }
         // only allow one operator key change in the mempool
-        if (dmn->pdmnState->pubKeyOperator != CBLSPublicKey()) {
+        if (dmn->pdmnState->pubKeyOperator.Get() != CBLSPublicKey()) {
             if (hasKeyChangeInMempool(proTx.proTxHash)) {
                 return true;
             }


### PR DESCRIPTION
See individual commits. Profiling has shown that a lot of time is spent while loading quorums, which internally load historical MN lists. The main speedup in this PR comes from using CBLSLazyPublicKey and by caching intermediate lists in GetListForBlock.

I also noticed that dash-qt spends a lot of time updating the masternode list UI. Most time was spent in GetProjectedMNPayees, which is also optimized in this PR. And to further optimize MN list updating, I changed it to update at a max rate of once per 3 seconds.

I'd suggest to backport this to 14.0.2, as the delay in startup time is quite annoying atm.