### PR TITLE
Back off for 1m when connecting to quorum masternodes

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -533,6 +533,23 @@ void CAddrMan::SetServices_(const CService& addr, ServiceFlags nServices)
     info.nServices = nServices;
 }
 
+CAddrInfo CAddrMan::GetAddressInfo_(const CService& addr)
+{
+    CAddrInfo* pinfo = Find(addr);
+
+    // if not found, bail out
+    if (!pinfo)
+        return CAddrInfo();
+
+    CAddrInfo& info = *pinfo;
+
+    // check whether we are talking about the exact same CService (including same port)
+    if (info != addr)
+        return CAddrInfo();
+
+    return *pinfo;
+}
+
 int CAddrMan::RandomInt(int nMax){
     return GetRandInt(nMax);
 }

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -265,6 +265,9 @@ protected:
     //! Update an entry's service bits.
     void SetServices_(const CService &addr, ServiceFlags nServices);
 
+    //! Get address info for address
+    CAddrInfo GetAddressInfo_(const CService& addr);
+
 public:
     /**
      * serialized format:
@@ -593,6 +596,18 @@ public:
         Check();
         SetServices_(addr, nServices);
         Check();
+    }
+
+    CAddrInfo GetAddressInfo(const CService& addr)
+    {
+        CAddrInfo addrRet;
+        {
+            LOCK(cs);
+            Check();
+            addrRet = GetAddressInfo_(addr);
+            Check();
+        }
+        return addrRet;
     }
 
 };


### PR DESCRIPTION
This avoids log spamming when intra quorum connections cause a connection attempt to an offline MN. We only allow one connection attempt per minute now.

This should also be backported to 0.14.0.2 when #2967 is backported.