### PR TITLE
Run extended tests when Travis is started through cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ runtests: &runtests
     - $DOCKER_RUN_IN_BUILDER ./ci/build_depends.sh
     - $DOCKER_RUN_IN_BUILDER ./ci/build_src.sh
     - $DOCKER_RUN_IN_BUILDER ./ci/test_unittests.sh
-    - $DOCKER_RUN_IN_BUILDER ./ci/test_integrationtests.sh --jobs=3
+    - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning,dbcrash"; fi
+    - $DOCKER_RUN_IN_BUILDER ./ci/test_integrationtests.sh --jobs=3 ${extended}
 
 builddocker: &builddocker
   stage: build docker


### PR DESCRIPTION
This allows daily testing of extended tests. The --exclude also contains
"dbcrash", which we haven't backported yet, but I decided to leave it in
when I copied the code from Bitcoin, so that we later don't forget to add
it.