### PR TITLE
Remove skipped denom from the list on tx commit

### DIFF
--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -685,7 +685,7 @@ void CPrivateSendClientManager::AddSkippedDenom(const CAmount& nDenomValue)
 
 void CPrivateSendClientManager::RemoveSkippedDenom(const CAmount& nDenomValue)
 {
-    std::remove(vecDenominationsSkipped.begin(), vecDenominationsSkipped.end(), nDenomValue);
+    vecDenominationsSkipped.erase(std::remove(vecDenominationsSkipped.begin(), vecDenominationsSkipped.end(), nDenomValue), vecDenominationsSkipped.end());
 }
 
 bool CPrivateSendClientManager::WaitForAnotherBlock()

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -683,6 +683,11 @@ void CPrivateSendClientManager::AddSkippedDenom(const CAmount& nDenomValue)
     vecDenominationsSkipped.push_back(nDenomValue);
 }
 
+void CPrivateSendClientManager::RemoveSkippedDenom(const CAmount& nDenomValue)
+{
+    std::remove(vecDenominationsSkipped.begin(), vecDenominationsSkipped.end(), nDenomValue);
+}
+
 bool CPrivateSendClientManager::WaitForAnotherBlock()
 {
     if (!masternodeSync.IsBlockchainSynced()) return true;

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -227,7 +227,7 @@ public:
 
     bool IsDenomSkipped(const CAmount& nDenomValue);
     void AddSkippedDenom(const CAmount& nDenomValue);
-    void ClearSkippedDenominations() { vecDenominationsSkipped.clear(); }
+    void RemoveSkippedDenom(const CAmount& nDenomValue);
 
     void SetMinBlocksToWait(int nMinBlocksToWaitIn) { nMinBlocksToWait = nMinBlocksToWaitIn; }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3524,8 +3524,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     if (nCoinType == ONLY_DENOMINATED) {
                         nFeeRet += nChange;
                         wtxNew.mapValue["DS"] = "1";
-                        // recheck skipped denominations during next mixing
-                        privateSendClient.ClearSkippedDenominations();
                     } else {
 
                         // Fill a vout to ourself
@@ -3806,6 +3804,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, CCon
                 coin.BindWallet(this);
                 NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
                 updated_hahes.insert(txin.prevout.hash);
+                privateSendClient.RemoveSkippedDenom(coin.tx->vout[txin.prevout.n].nValue);
             }
         }
 


### PR DESCRIPTION
Regardless of the tx type (PS or not).

This fixes a bug with mixing not starting when already mixed funds were sent back to yourself via normal tx (for whatever reason).