### PR TITLE
Only load signingActiveQuorumCount + 1 quorums into cache

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -313,7 +313,7 @@ std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(Consensus::LLMQType llmqTyp
     auto& params = Params().GetConsensus().llmqs.at(llmqType);
 
     auto cacheKey = std::make_pair(llmqType, pindexStart->GetBlockHash());
-    const size_t cacheMaxSize = 25; // largest active set + 1
+    const size_t cacheMaxSize = params.signingActiveQuorumCount + 1;
 
     std::vector<CQuorumCPtr> result;
 


### PR DESCRIPTION
No need to load 25 quorums when we're scanning for the larger quorums which
only have 4 active quorums. This avoids loading thousands of masternode
lists unnecessarily.