### PR TITLE
Enable stacktrace support in gitian builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ if(DEFINED DEPENDS_PREFIX)
 endif()
 
 add_definitions(
+        -DENABLE_STACKTRACES=1
         -DENABLE_WALLET=1
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(DEFINED DEPENDS_PREFIX)
 endif()
 
 add_definitions(
-        -DENABLE_STACKTRACES=1
+        -DENABLE_CRASH_HOOKS=1
         -DENABLE_WALLET=1
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -249,7 +249,7 @@ AX_CHECK_LINK_FLAG([-Wl,-wrap=__cxa_allocate_exception], [LINK_WRAP_SUPPORTED=ye
 AM_CONDITIONAL([STACKTRACE_WRAPPED_CXX_ABI],[test x$LINK_WRAP_SUPPORTED = xyes])
 
 if test x$LINK_WRAP_SUPPORTED = "xyes"; then
-  AC_DEFINE(STACKTRACE_WRAPPED_CXX_ABI, 1, [Define this symbol to use wrapped CXX ABIs for exception stacktraces])],
+  AC_DEFINE(STACKTRACE_WRAPPED_CXX_ABI, 1, [Define this symbol to use wrapped CXX ABIs for exception stacktraces])
 fi
 
 # Needed for MinGW targets when debug symbols are enabled as compiled objects get very large

--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,7 @@ AC_PATH_PROG(HEXDUMP,hexdump)
 AC_PATH_TOOL(READELF, readelf)
 AC_PATH_TOOL(CPPFILT, c++filt)
 AC_PATH_TOOL(OBJCOPY, objcopy)
+AC_PATH_TOOL(DSYMUTIL, dsymutil)
 
 AC_ARG_VAR(PYTHONPATH, Augments the default search path for python module files)
 
@@ -1140,6 +1141,18 @@ else
   AC_MSG_RESULT([no])
 fi
 
+# When compiled natively on MacOS, we need to specify --flat to avoid producing a dSYM bundle
+# When cross-compiled on linux, we're using a different version of the tool that only supports flat symbol files
+AC_MSG_CHECKING([whether dsymutil needs --flat])
+if test x$DSYMUTIL != x && ($DSYMUTIL --help | grep -q \\--flat); then
+AC_MSG_RESULT([yes])
+	DSYMUTIL_FLAT="$DSYMUTIL --flat"
+else
+	AC_MSG_RESULT([no])
+	DSYMUTIL_FLAT="$DSYMUTIL"
+fi
+AC_MSG_RESULT($dsymutil_needs_flat)
+
 if test x$build_bitcoin_utils$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests = xnononononono; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
@@ -1203,6 +1216,7 @@ AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(ZMQ_LIBS)
 AC_SUBST(PROTOBUF_LIBS)
 AC_SUBST(QR_LIBS)
+AC_SUBST(DSYMUTIL_FLAT)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile share/setup.nsi share/qt/Info.plist test/functional/config.ini])
 AC_CONFIG_FILES([test/util/buildenv.py],[chmod +x test/util/buildenv.py])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])

--- a/configure.ac
+++ b/configure.ac
@@ -230,9 +230,10 @@ if test "x$enable_debug" = xyes; then
     if test "x$GXX" = xyes; then
         CXXFLAGS="$CXXFLAGS -g3 -O0"
     fi
-elif test "x$enable_crashhooks" = xyes; then
-    # Enable debug information but don't turn off optimization
-    # (stacktraces will be suboptimal, but better than nothing)
+else
+    # We always enable at at least -g1 debug info to support proper stacktraces in crash infos
+    # Stacktraces will be suboptimal due to optimization, but better than nothing. Also, -fno-omit-frame-pointer
+    # mitigates this a little bit
     if test "x$GCC" = xyes; then
         CFLAGS="$CFLAGS -g1 -fno-omit-frame-pointer"
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -246,9 +246,7 @@ if test "x$enable_stacktraces" = xyes; then
     AC_DEFINE(ENABLE_STACKTRACES, 1, [Define this symbol if stacktraces should be enabled])
 fi
 AX_CHECK_LINK_FLAG([-Wl,-wrap=__cxa_allocate_exception], [LINK_WRAP_SUPPORTED=yes],,,)
-AX_CHECK_COMPILE_FLAG([-rdynamic], [RDYNAMIC_SUPPORTED=yes],,,)
 AM_CONDITIONAL([STACKTRACE_WRAPPED_CXX_ABI],[test x$LINK_WRAP_SUPPORTED = xyes])
-AM_CONDITIONAL([RDYNAMIC_SUPPORTED],[test x$RDYNAMIC_SUPPORTED = xyes])
 
 if test x$LINK_WRAP_SUPPORTED = "xyes"; then
   AC_DEFINE(STACKTRACE_WRAPPED_CXX_ABI, 1, [Define this symbol to use wrapped CXX ABIs for exception stacktraces])],

--- a/configure.ac
+++ b/configure.ac
@@ -1141,12 +1141,12 @@ else
   AC_MSG_RESULT([no])
 fi
 
-# When compiled natively on MacOS, we need to specify --flat to avoid producing a dSYM bundle
+# When compiled natively on MacOS, we need to specify -flat to avoid producing a dSYM bundle
 # When cross-compiled on linux, we're using a different version of the tool that only supports flat symbol files
-AC_MSG_CHECKING([whether dsymutil needs --flat])
-if test x$DSYMUTIL != x && ($DSYMUTIL --help | grep -q \\--flat); then
+AC_MSG_CHECKING([whether dsymutil needs -flat])
+if test x$DSYMUTIL != x && ($DSYMUTIL --help | grep -q \\-flat); then
 AC_MSG_RESULT([yes])
-	DSYMUTIL_FLAT="$DSYMUTIL --flat"
+	DSYMUTIL_FLAT="$DSYMUTIL -flat"
 else
 	AC_MSG_RESULT([no])
 	DSYMUTIL_FLAT="$DSYMUTIL"

--- a/configure.ac
+++ b/configure.ac
@@ -192,12 +192,12 @@ AC_ARG_ENABLE([debug],
     [enable_debug=$enableval],
     [enable_debug=no])
 
-# Enable exception stacktraces
-AC_ARG_ENABLE([stacktraces],
-    [AS_HELP_STRING([--enable-stacktraces],
-                    [gather and print exception stack traces (default is no)])],
-    [enable_stacktraces=$enableval],
-    [enable_stacktraces=no])
+# Enable crash hooks
+AC_ARG_ENABLE([crash-hooks],
+    [AS_HELP_STRING([--enable-crash-hooks],
+                    [hook into exception/signal/assert handling to gather stack traces (default is no)])],
+    [enable_crashhooks=$enableval],
+    [enable_crashhooks=no])
 
 # Enable in-wallet miner
 AC_ARG_ENABLE([miner],
@@ -229,7 +229,7 @@ if test "x$enable_debug" = xyes; then
     if test "x$GXX" = xyes; then
         CXXFLAGS="$CXXFLAGS -g3 -O0"
     fi
-elif test "x$enable_stacktraces" = xyes; then
+elif test "x$enable_crashhooks" = xyes; then
     # Enable debug information but don't turn off optimization
     # (stacktraces will be suboptimal, but better than nothing)
     if test "x$GCC" = xyes; then
@@ -241,15 +241,15 @@ elif test "x$enable_stacktraces" = xyes; then
     fi
 fi
 
-AM_CONDITIONAL([ENABLE_STACKTRACES], [test x$enable_stacktraces = xyes])
-if test "x$enable_stacktraces" = xyes; then
-    AC_DEFINE(ENABLE_STACKTRACES, 1, [Define this symbol if stacktraces should be enabled])
+AM_CONDITIONAL([ENABLE_CRASH_HOOKS], [test x$enable_crashhooks = xyes])
+if test "x$enable_crashhooks" = xyes; then
+    AC_DEFINE(ENABLE_CRASH_HOOKS, 1, [Define this symbol if crash hooks should be enabled])
 fi
 AX_CHECK_LINK_FLAG([-Wl,-wrap=__cxa_allocate_exception], [LINK_WRAP_SUPPORTED=yes],,,)
-AM_CONDITIONAL([STACKTRACE_WRAPPED_CXX_ABI],[test x$LINK_WRAP_SUPPORTED = xyes])
+AM_CONDITIONAL([CRASH_HOOKS_WRAPPED_CXX_ABI],[test x$LINK_WRAP_SUPPORTED = xyes])
 
 if test x$LINK_WRAP_SUPPORTED = "xyes"; then
-  AC_DEFINE(STACKTRACE_WRAPPED_CXX_ABI, 1, [Define this symbol to use wrapped CXX ABIs for exception stacktraces])
+  AC_DEFINE(CRASH_HOOKS_WRAPPED_CXX_ABI, 1, [Define this symbol to use wrapped CXX ABIs for exception stacktraces])
 fi
 
 # Needed for MinGW targets when debug symbols are enabled as compiled objects get very large
@@ -1275,7 +1275,7 @@ echo "  with test           = $use_tests"
 echo "  with bench          = $use_bench"
 echo "  with upnp           = $use_upnp"
 echo "  debug enabled       = $enable_debug"
-echo "  stacktraces enabled = $enable_stacktraces"
+echo "  crash hooks enabled = $enable_crashhooks"
 echo "  miner enabled       = $enable_miner"
 echo "  werror              = $enable_werror"
 echo 

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -38,7 +38,7 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-pc-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu"
-  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
+  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests --enable-crash-hooks"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -146,6 +146,7 @@ script: |
 
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
     make ${MAKEOPTS}
+    make -C src osx_debug
     make install-strip DESTDIR=${INSTALLPATH}
 
     make osx_volname
@@ -170,12 +171,15 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find ${DISTNAME} | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find .. -name *.debug -exec cp {} ${DISTNAME}/bin \;
+    find ${DISTNAME} -not -name "*.debug" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find ${DISTNAME} -name "*.debug" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}-debug.tar.gz
     cd ../../
   done
   mkdir -p $OUTDIR/src
   mv $SOURCEDIST $OUTDIR/src
-  mv ${OUTDIR}/${DISTNAME}-x86_64-*.tar.gz ${OUTDIR}/${DISTNAME}-osx64.tar.gz
+  mv ${OUTDIR}/${DISTNAME}-x86_64-apple-darwin11.tar.gz ${OUTDIR}/${DISTNAME}-osx64.tar.gz
+  mv ${OUTDIR}/${DISTNAME}-x86_64-apple-darwin11-debug.tar.gz ${OUTDIR}/${DISTNAME}-osx64-debug.tar.gz
 
   # Compress ccache (otherwise the assert file will get too huge)
   if [ "$CCACHE_DIR" != "" ]; then

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -171,9 +171,9 @@ script: |
     find . -name "lib*.la" -delete
     find . -name "lib*.a" -delete
     rm -rf ${DISTNAME}/lib/pkgconfig
-    find .. -name *.debug -exec cp {} ${DISTNAME}/bin \;
-    find ${DISTNAME} -not -name "*.debug" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
-    find ${DISTNAME} -name "*.debug" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}-debug.tar.gz
+    find .. -name *.dSYM -exec cp -ra {} ${DISTNAME}/bin \;
+    find ${DISTNAME} -not -path '*.dSYM*' | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
+    find ${DISTNAME} -path '*.dSYM*' | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}-debug.tar.gz
     cd ../../
   done
   mkdir -p $OUTDIR/src

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -37,7 +37,7 @@ files:
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin11"
-  CONFIGFLAGS="--enable-reduce-exports --disable-miner --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
+  CONFIGFLAGS="--enable-reduce-exports --disable-miner --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage --enable-crash-hooks"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg genisoimage"
 

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -31,7 +31,7 @@ files: []
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
-  CONFIGFLAGS="--enable-reduce-exports --disable-miner --disable-bench --disable-gui-tests"
+  CONFIGFLAGS="--enable-reduce-exports --disable-miner --disable-bench --disable-gui-tests --enable-crash-hooks"
   FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"
   HOST_CFLAGS="-O2 -g"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -618,7 +618,7 @@ CLEANFILES += univalue/*.gcda univalue/*.gcno
 CLEANFILES += wallet/*.gcda wallet/*.gcno
 CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
 CLEANFILES += zmq/*.gcda zmq/*.gcno
-CLEANFILES += *.debug qt/*.debug
+CLEANFILES += *.debug test/*.debug bench/*.debug qt/*.debug qt/test/*.debug
 
 IMMER_DIST = immer
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -618,7 +618,6 @@ CLEANFILES += univalue/*.gcda univalue/*.gcno
 CLEANFILES += wallet/*.gcda wallet/*.gcno
 CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
 CLEANFILES += zmq/*.gcda zmq/*.gcno
-CLEANFILES += *.debug test/*.debug bench/*.debug qt/*.debug qt/test/*.debug
 
 IMMER_DIST = immer
 
@@ -642,6 +641,7 @@ clean-local:
 	-rm -f leveldb/*/*.gcda leveldb/*/*.gcno leveldb/helpers/memenv/*.gcda leveldb/helpers/memenv/*.gcno
 	-rm -f config.h
 	-rm -rf test/__pycache__
+	-rm -rf *.dSYM test/*.dSYM bench/*.dSYM qt/*.dSYM qt/test/*.dSYM
 
 .rc.o:
 	@test -f $(WINDRES)
@@ -666,7 +666,7 @@ endif
 
 
 osx_debug: $(bin_PROGRAMS)
-	for i in $(bin_PROGRAMS); do $(DSYMUTIL_FLAT) -o $$i.debug $$i &> /dev/null ; done
+	for i in $(bin_PROGRAMS); do mkdir -p $$i.dSYM/Contents/Resources/DWARF && $(DSYMUTIL_FLAT) -o $$i.dSYM/Contents/Resources/DWARF/$$(basename $$i) $$i &> /dev/null ; done
 
 %.pb.cc %.pb.h: %.proto
 	@test -f $(PROTOC)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,11 +21,6 @@ LDFLAGS_WRAP_EXCEPTIONS += -Wl,-wrap,__assert_fail
 endif
 endif
 
-if RDYNAMIC_SUPPORTED
-# This gives better stacktraces
-AM_CXXFLAGS += -rdynamic
-endif
-
 if TARGET_WINDOWS
 BACKTRACE_LIB = -ldbghelp -lbacktrace
 else

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -618,6 +618,7 @@ CLEANFILES += univalue/*.gcda univalue/*.gcno
 CLEANFILES += wallet/*.gcda wallet/*.gcno
 CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
 CLEANFILES += zmq/*.gcda zmq/*.gcno
+CLEANFILES += *.debug qt/*.debug
 
 IMMER_DIST = immer
 
@@ -662,6 +663,10 @@ if HARDEN
 	@echo "Checking binary security..."
 	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) $(top_srcdir)/contrib/devtools/security-check.py < $(bin_PROGRAMS)
 endif
+
+
+osx_debug: $(bin_PROGRAMS)
+	for i in $(bin_PROGRAMS); do $(DSYMUTIL_FLAT) -o $$i.debug $$i &> /dev/null ; done
 
 %.pb.cc %.pb.h: %.proto
 	@test -f $(PROTOC)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,8 +10,8 @@ AM_CXXFLAGS = $(HARDENED_CXXFLAGS) $(ERROR_CXXFLAGS)
 AM_CPPFLAGS = $(HARDENED_CPPFLAGS)
 EXTRA_LIBRARIES =
 
-if ENABLE_STACKTRACES
-if STACKTRACE_WRAPPED_CXX_ABI
+if ENABLE_CRASH_HOOKS
+if CRASH_HOOKS_WRAPPED_CXX_ABI
 # Wrap internal C++ ABI's so that we can attach stacktraces to exceptions
 LDFLAGS_WRAP_EXCEPTIONS = -Wl,-wrap,__cxa_allocate_exception -Wl,-wrap,__cxa_free_exception
 if TARGET_WINDOWS
@@ -20,12 +20,12 @@ else
 LDFLAGS_WRAP_EXCEPTIONS += -Wl,-wrap,__assert_fail
 endif
 endif
+endif
 
 if TARGET_WINDOWS
 BACKTRACE_LIB = -ldbghelp -lbacktrace
 else
 BACKTRACE_LIB = -lbacktrace
-endif
 endif
 
 if EMBEDDED_UNIVALUE

--- a/src/dash-cli.cpp
+++ b/src/dash-cli.cpp
@@ -80,8 +80,8 @@ static int AppInitRPC(int argc, char* argv[])
     //
     gArgs.ParseParameters(argc, argv);
 
-    if (gArgs.IsArgSet("-printstacktrace")) {
-        std::cout << GetCrashInfoStrFromSerializedStr(gArgs.GetArg("-printstacktrace", "")) << std::endl;
+    if (gArgs.IsArgSet("-printcrashinfo")) {
+        std::cout << GetCrashInfoStrFromSerializedStr(gArgs.GetArg("-printcrashinfo", "")) << std::endl;
         return true;
     }
 

--- a/src/dash-cli.cpp
+++ b/src/dash-cli.cpp
@@ -79,6 +79,12 @@ static int AppInitRPC(int argc, char* argv[])
     // Parameters
     //
     gArgs.ParseParameters(argc, argv);
+
+    if (gArgs.IsArgSet("-printstacktrace")) {
+        std::cout << GetCrashInfoStrFromSerializedStr(gArgs.GetArg("-printstacktrace", "")) << std::endl;
+        return true;
+    }
+
     if (argc<2 || gArgs.IsArgSet("-?") || gArgs.IsArgSet("-h") || gArgs.IsArgSet("-help") || gArgs.IsArgSet("-version")) {
         std::string strUsage = strprintf(_("%s RPC client version"), _(PACKAGE_NAME)) + " " + FormatFullVersion() + "\n";
         if (!gArgs.IsArgSet("-version")) {

--- a/src/dash-tx.cpp
+++ b/src/dash-tx.cpp
@@ -43,6 +43,11 @@ static int AppInitRawTx(int argc, char* argv[])
     //
     gArgs.ParseParameters(argc, argv);
 
+    if (gArgs.IsArgSet("-printcrashinfo")) {
+        std::cout << GetCrashInfoStrFromSerializedStr(gArgs.GetArg("-printcrashinfo", "")) << std::endl;
+        return true;
+    }
+
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
     try {
         SelectParams(ChainNameFromCommandLine());

--- a/src/dashd.cpp
+++ b/src/dashd.cpp
@@ -76,6 +76,11 @@ bool AppInit(int argc, char* argv[])
     // If Qt is used, parameters/dash.conf are parsed in qt/dash.cpp's main()
     gArgs.ParseParameters(argc, argv);
 
+    if (gArgs.IsArgSet("-printcrashinfo")) {
+        std::cout << GetCrashInfoStrFromSerializedStr(gArgs.GetArg("-printcrashinfo", "")) << std::endl;
+        return true;
+    }
+
     // Process help and version before taking care about datadir
     if (gArgs.IsArgSet("-?") || gArgs.IsArgSet("-h") ||  gArgs.IsArgSet("-help") || gArgs.IsArgSet("-version"))
     {

--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -622,6 +622,13 @@ int main(int argc, char *argv[])
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
     translationInterface.Translate.connect(Translate);
 
+    if (gArgs.IsArgSet("-printcrashinfo")) {
+        auto crashInfo = GetCrashInfoStrFromSerializedStr(gArgs.GetArg("-printcrashinfo", ""));
+        std::cout << crashInfo << std::endl;
+        QMessageBox::critical(0, QObject::tr(PACKAGE_NAME), QString::fromStdString(crashInfo));
+        return EXIT_SUCCESS;
+    }
+
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
     if (gArgs.IsArgSet("-?") || gArgs.IsArgSet("-h") || gArgs.IsArgSet("-help") || gArgs.IsArgSet("-version"))

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -393,7 +393,7 @@ static std::string GetCrashInfoStrNoDebugInfo(crash_info ci)
     ds << ci;
 
     auto ciStr = EncodeBase32((const unsigned char*)ds.data(), ds.size());
-    return strprintf("No debug information available for stacktrace. You should download debug information from Github and then run:\n"
+    return strprintf("No debug information available for stacktrace. You should add debug information and then run:\n"
                      "%s -printcrashinfo=%s\n", g_exeFileBaseName, ciStr);
 }
 

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -126,6 +126,10 @@ static backtrace_state* GetLibBacktraceState()
     // but luckily we can just specify the .dbg file here as it's a valid PE/XCOFF file
     static std::string debugFileName = g_exeFileName + ".dbg";
     static const char* exeFileNamePtr = fs::exists(debugFileName) ? debugFileName.c_str() : g_exeFileName.c_str();
+#elif __APPLE__
+    // libbacktrace is not able to locate the debug information as it's not in the standard dSYM bundle format
+    static std::string debugFileName = g_exeFileName + ".debug";
+    static const char* exeFileNamePtr = fs::exists(debugFileName) ? debugFileName.c_str() : g_exeFileName.c_str();
 #else
     static const char* exeFileNamePtr = g_exeFileName.empty() ? nullptr : g_exeFileName.c_str();
 #endif

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -126,10 +126,6 @@ static backtrace_state* GetLibBacktraceState()
     // but luckily we can just specify the .dbg file here as it's a valid PE/XCOFF file
     static std::string debugFileName = g_exeFileName + ".dbg";
     static const char* exeFileNamePtr = fs::exists(debugFileName) ? debugFileName.c_str() : g_exeFileName.c_str();
-#elif __APPLE__
-    // libbacktrace is not able to locate the debug information as it's not in the standard dSYM bundle format
-    static std::string debugFileName = g_exeFileName + ".debug";
-    static const char* exeFileNamePtr = fs::exists(debugFileName) ? debugFileName.c_str() : g_exeFileName.c_str();
 #else
     static const char* exeFileNamePtr = g_exeFileName.empty() ? nullptr : g_exeFileName.c_str();
 #endif

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -220,17 +220,6 @@ static __attribute__((noinline)) std::vector<uintptr_t> GetStackFrames(size_t sk
     return ret;
 }
 #else
-static int my_backtrace_simple_callback(void *data, uintptr_t pc)
-{
-    auto v = (std::vector<uintptr_t>*)data;
-    v->emplace_back(pc);
-    if (v->size() >= 128) {
-        // abort
-        return 1;
-    }
-    return 0;
-}
-
 static __attribute__((noinline)) std::vector<uintptr_t> GetStackFrames(size_t skip, size_t max_frames)
 {
     // FYI, this is not using libbacktrace, but "backtrace()" from <execinfo.h>

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "stacktraces.h"
+#include "fs.h"
 #include "tinyformat.h"
 #include "random.h"
 #include "util.h"
@@ -39,7 +40,6 @@
 #ifdef ENABLE_STACKTRACES
 #include <backtrace.h>
 #endif
-#include <libgen.h> // for basename()
 #include <string.h>
 
 static void PrintCrashInfo(const std::string& s)
@@ -306,9 +306,7 @@ static std::string GetStackFrameInfosStr(const std::vector<stackframe_info>& sis
 
         std::string lstr;
         if (!si.filename.empty()) {
-            std::vector<char> vecFilename(si.filename.size() + 1, '\0');
-            strcpy(vecFilename.data(), si.filename.c_str());
-            lstr += basename(vecFilename.data());
+            lstr += fs::path(si.filename).filename().string();
         } else {
             lstr += "<unknown-file>";
         }

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -393,8 +393,10 @@ static std::string GetCrashInfoStrNoDebugInfo(crash_info ci)
     ds << ci;
 
     auto ciStr = EncodeBase32((const unsigned char*)ds.data(), ds.size());
-    return strprintf("No debug information available for stacktrace. You should add debug information and then run:\n"
-                     "%s -printcrashinfo=%s\n", g_exeFileBaseName, ciStr);
+    std::string s = ci.crashDescription + "\n";
+    s += strprintf("No debug information available for stacktrace. You should add debug information and then run:\n"
+                   "%s -printcrashinfo=%s\n", g_exeFileBaseName, ciStr);
+    return s;
 }
 
 static std::string GetCrashInfoStr(const crash_info& ci, size_t spaces = 2);

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -72,7 +72,7 @@ std::string DemangleSymbol(const std::string& name)
 static std::atomic<bool> skipAbortSignal(false);
 
 #ifdef ENABLE_STACKTRACES
-ssize_t GetExeFileNameImpl(char* buf, size_t bufSize)
+static ssize_t GetExeFileNameImpl(char* buf, size_t bufSize)
 {
 #if WIN32
     std::vector<TCHAR> tmp(bufSize);
@@ -101,7 +101,7 @@ ssize_t GetExeFileNameImpl(char* buf, size_t bufSize)
 #endif
 }
 
-std::string GetExeFileName()
+static std::string GetExeFileName()
 {
     std::vector<char> buf(1024);
     while (true) {
@@ -116,6 +116,9 @@ std::string GetExeFileName()
     }
 }
 
+static std::string g_exeFileName = GetExeFileName();
+static std::string g_exeFileBaseName = fs::path(g_exeFileName).filename().string();
+
 static void my_backtrace_error_callback (void *data, const char *msg,
                                   int errnum)
 {
@@ -124,8 +127,7 @@ static void my_backtrace_error_callback (void *data, const char *msg,
 
 static backtrace_state* GetLibBacktraceState()
 {
-    static std::string exeFileName = GetExeFileName();
-    static const char* exeFileNamePtr = exeFileName.empty() ? nullptr : exeFileName.c_str();
+    static const char* exeFileNamePtr = g_exeFileName.empty() ? nullptr : g_exeFileName.c_str();
     static backtrace_state* st = backtrace_create_state(exeFileNamePtr, 1, my_backtrace_error_callback, NULL);
     return st;
 }

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -127,7 +127,14 @@ static void my_backtrace_error_callback (void *data, const char *msg,
 
 static backtrace_state* GetLibBacktraceState()
 {
+#if WIN32
+    // libbacktrace is not able to handle the DWARF debuglink in the .exe
+    // but luckily we can just specify the .dbg file here as it's a valid PE/XCOFF file
+    static std::string debugFileName = g_exeFileName + ".dbg";
+    static const char* exeFileNamePtr = fs::exists(debugFileName) ? debugFileName.c_str() : g_exeFileName.c_str();
+#else
     static const char* exeFileNamePtr = g_exeFileName.empty() ? nullptr : g_exeFileName.c_str();
+#endif
     static backtrace_state* st = backtrace_create_state(exeFileNamePtr, 1, my_backtrace_error_callback, NULL);
     return st;
 }

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -6,7 +6,9 @@
 #include "fs.h"
 #include "tinyformat.h"
 #include "random.h"
+#include "streams.h"
 #include "util.h"
+#include "utilstrencodings.h"
 
 #include "dash-config.h"
 
@@ -276,6 +278,17 @@ struct stackframe_info {
     std::string filename;
     int lineno{-1};
     std::string function;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(pc);
+        READWRITE(filename);
+        READWRITE(lineno);
+        READWRITE(function);
+    }
 };
 
 static int my_backtrace_full_callback (void *data, uintptr_t pc, const char *filename, int lineno, const char *function)
@@ -324,6 +337,16 @@ struct crash_info_header
     std::string magic;
     uint16_t version;
     std::string exeFileName;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(magic);
+        READWRITE(version);
+        READWRITE(exeFileName);
+    }
 };
 
 struct crash_info
@@ -331,6 +354,16 @@ struct crash_info
     std::string crashDescription;
     std::vector<uint64_t> stackframes;
     std::vector<stackframe_info> stackframeInfos;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(crashDescription);
+        READWRITE(stackframes);
+        READWRITE(stackframeInfos);
+    }
 
     void ConvertAddresses(int64_t offset)
     {
@@ -342,10 +375,31 @@ struct crash_info
         }
     }
 };
+
+static std::string GetCrashInfoStrNoDebugInfo(crash_info ci)
+{
+    static uint64_t basePtr = GetBaseAddress();
+
+    CDataStream ds(SER_DISK, 0);
+
+    crash_info_header hdr;
+    hdr.magic = "DashCrashInfo";
+    hdr.version = 1;
+    hdr.exeFileName = g_exeFileBaseName;
+    ds << hdr;
+
+    ci.ConvertAddresses(-(int64_t)basePtr);
+    ds << ci;
+
+    auto ciStr = EncodeBase32((const unsigned char*)ds.data(), ds.size());
+    return strprintf("No debug information available for stacktrace. You should download debug information from Github and then run:\n"
+                     "%s -printcrashinfo=%s\n", g_exeFileBaseName, ciStr);
+}
+
 static std::string GetCrashInfoStr(const crash_info& ci, size_t spaces)
 {
     if (ci.stackframeInfos.empty()) {
-        return "";
+        return GetCrashInfoStrNoDebugInfo(ci);
     }
 
     std::string sp;

--- a/src/stacktraces.h
+++ b/src/stacktraces.h
@@ -16,6 +16,7 @@
 std::string DemangleSymbol(const std::string& name);
 
 std::string GetPrettyExceptionStr(const std::exception_ptr& e);
+std::string GetCrashInfoStrFromSerializedStr(const std::string& ciStr);
 
 template<typename T>
 std::string GetExceptionWhat(const T& e);

--- a/src/stacktraces.h
+++ b/src/stacktraces.h
@@ -15,9 +15,6 @@
 
 std::string DemangleSymbol(const std::string& name);
 
-std::string GetCurrentStacktraceStr(size_t skip = 0, size_t max_depth = 16);
-
-std::string GetExceptionStacktraceStr(const std::exception_ptr& e);
 std::string GetPrettyExceptionStr(const std::exception_ptr& e);
 
 template<typename T>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -602,7 +602,7 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
 
 static std::string FormatException(const std::exception_ptr pex, const char* pszThread)
 {
-    return strprintf("EXCEPTION: %s", GetPrettyExceptionStr(pex));
+    return GetPrettyExceptionStr(pex);
 }
 
 void PrintExceptionContinue(const std::exception_ptr pex, const char* pszThread)


### PR DESCRIPTION
This PR enables stacktrace support in the release builds done by Gitian.

It expects debug information to be present in `dashd.debug` (linux) and `dashd.exe.dbg` (windows). These debug files are split/stripped as part of the Gitian build already. If debug information is not present, a serialized crash info is printed which can then be used later to extract the stacktrace. This allows easier debugging and support when users report unexpected crashes. They can now provide us with the serialized crash info and we are able to extract the stacktraces even when the user did not run with debug info. We might consider releasing debug files as well in the future.

With the debug file present, it looks like:
```
2019-06-26 20:18:37 Windows Exception: EXCEPTION_INT_DIVIDE_BY_ZERO
   0#: (0x007BD0B4) wallet.cpp:5147 - CWallet::InitAutoBackup()
   1#: (0x0041F929) init.cpp:1558   - AppInitMain(boost::thread_group&, CScheduler&)
```

Without the debug file present, it looks like:
```
2019-06-26 20:19:41 No debug information available for stacktrace. You should download debug information from Github and then run:
dashd.exe -printcrashinfo=bvcgc43iinzgc43ijfxgm3ybaaewiyltnbsc4zlymuxvo2lomrxxo4zaiv4ggzlqoruw63r2ebcvqq2fkbkest2ol5eu4vc7irevmskeivpuewk7ljcvetycwtihwaaaaaaaakpzieaaaaaaaaaa====
```

This can then be used to extract the stacktrace with the same executable but with the debug file present:
```
$ wine ./dashcore-0.14.1/bin/dashd.exe -printcrashinfo=bvcgc43iinzgc43ijfxgm3ybaaewiyltnbsc4zlymuxvo2lomrxxo4zaiv4ggzlqoruw63r2ebcvqq2fkbkest2ol5eu4vc7irevmskeivpuewk7ljcvetycwtihwaaaaaaaakpzieaaaaaaaaaa====
Windows Exception: EXCEPTION_INT_DIVIDE_BY_ZERO
   0#: (0x007BD0B4) wallet.cpp:5147 - CWallet::InitAutoBackup()
   1#: (0x0041F929) init.cpp:1558   - AppInitMain(boost::thread_group&, CScheduler&)
```

As you can see, this was invoked with `wine`. Serialized stacktraces can be taken from native Windows and then be extracted with wine, and vice versa.