### PR TITLE
Fix excessive memory use when flushing chainstate and EvoDB

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -170,6 +170,11 @@ public:
     }
 
 public:
+    inline void Serialize(CSizeComputer& s) const
+    {
+        s.seek(SerSize);
+    }
+
     template <typename Stream>
     inline void Serialize(Stream& s) const
     {
@@ -354,6 +359,11 @@ public:
         }
         hash = r.hash;
         return *this;
+    }
+
+    inline void Serialize(CSizeComputer& s) const
+    {
+        s.seek(BLSObject::SerSize);
     }
 
     template<typename Stream>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -550,6 +550,7 @@ class CDBTransaction {
 protected:
     Parent &parent;
     CommitTarget &commitTarget;
+    ssize_t memoryUsage{0}; // signed, just in case we made an error in the calculations so that we don't get an overflow
 
     struct DataStreamCmp {
         static bool less(const CDataStream& a, const CDataStream& b) {
@@ -563,6 +564,8 @@ protected:
     };
 
     struct ValueHolder {
+        size_t memoryUsage;
+        ValueHolder(size_t _memoryUsage) : memoryUsage(_memoryUsage) {}
         virtual ~ValueHolder() = default;
         virtual void Write(const CDataStream& ssKey, CommitTarget &parent) = 0;
     };
@@ -570,7 +573,7 @@ protected:
 
     template <typename V>
     struct ValueHolderImpl : ValueHolder {
-        ValueHolderImpl(const V &_value) : value(_value) { }
+        ValueHolderImpl(const V &_value, size_t _memoryUsage) : ValueHolder(_memoryUsage), value(_value) {}
 
         virtual void Write(const CDataStream& ssKey, CommitTarget &commitTarget) {
             // we're moving the value instead of copying it. This means that Write() can only be called once per
@@ -604,9 +607,18 @@ public:
 
     template <typename V>
     void Write(const CDataStream& ssKey, const V& v) {
-        deletes.erase(ssKey);
+        auto valueMemoryUsage = ::GetSerializeSize(v, SER_DISK, CLIENT_VERSION);
+
+        if (deletes.erase(ssKey)) {
+            memoryUsage -= ssKey.size();
+        }
         auto it = writes.emplace(ssKey, nullptr).first;
-        it->second = std::make_unique<ValueHolderImpl<V>>(v);
+        if (it->second) {
+            memoryUsage -= ssKey.size() + it->second->memoryUsage;
+        }
+        it->second = std::make_unique<ValueHolderImpl<V>>(v, valueMemoryUsage);
+
+        memoryUsage += ssKey.size() + valueMemoryUsage;
     }
 
     template <typename K, typename V>
@@ -656,13 +668,20 @@ public:
     }
 
     void Erase(const CDataStream& ssKey) {
-        writes.erase(ssKey);
-        deletes.emplace(ssKey);
+        auto it = writes.find(ssKey);
+        if (it != writes.end()) {
+            memoryUsage -= ssKey.size() + it->second->memoryUsage;
+            writes.erase(it);
+        }
+        if (deletes.emplace(ssKey).second) {
+            memoryUsage += ssKey.size();
+        }
     }
 
     void Clear() {
         writes.clear();
         deletes.clear();
+        memoryUsage = 0;
     }
 
     void Commit() {
@@ -677,6 +696,19 @@ public:
 
     bool IsClean() {
         return writes.empty() && deletes.empty();
+    }
+
+    size_t GetMemoryUsage() const {
+        if (memoryUsage < 0) {
+            // something went wrong when we accounted/calculated used memory...
+            static volatile bool didPrint = false;
+            if (!didPrint) {
+                LogPrintf("CDBTransaction::%s -- negative memoryUsage (%d)", __func__, memoryUsage);
+                didPrint = true;
+            }
+            return 0;
+        }
+        return (size_t)memoryUsage;
     }
 
     CDBTransactionIterator<CDBTransaction>* NewIterator() {

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -195,6 +195,21 @@ void UnserializeImmerMap(Stream& is, immer::map<K, T, Hash, Equal>& m)
     }
 }
 
+// For some reason the compiler is not able to choose the correct Serialize/Deserialize methods without a specialized
+// version of SerReadWrite. It otherwise always chooses the version that calls a.Serialize()
+template<typename Stream, typename K, typename T, typename Hash, typename Equal>
+inline void SerReadWrite(Stream& s, const immer::map<K, T, Hash, Equal>& m, CSerActionSerialize ser_action)
+{
+    ::SerializeImmerMap(s, m);
+}
+
+template<typename Stream, typename K, typename T, typename Hash, typename Equal>
+inline void SerReadWrite(Stream& s, immer::map<K, T, Hash, Equal>& obj, CSerActionUnserialize ser_action)
+{
+    ::UnserializeImmerMap(s, obj);
+}
+
+
 class CDeterministicMNList
 {
 public:
@@ -226,13 +241,8 @@ public:
     {
         READWRITE(blockHash);
         READWRITE(nHeight);
-        if (ser_action.ForRead()) {
-            UnserializeImmerMap(s, mnMap);
-            UnserializeImmerMap(s, mnUniquePropertyMap);
-        } else {
-            SerializeImmerMap(s, mnMap);
-            SerializeImmerMap(s, mnUniquePropertyMap);
-        }
+        READWRITE(mnMap);
+        READWRITE(mnUniquePropertyMap);
     }
 
 public:

--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -73,6 +73,11 @@ public:
         return db;
     }
 
+    size_t GetMemoryUsage()
+    {
+        return rootDBTransaction.GetMemoryUsage();
+    }
+
     bool CommitRootTransaction();
 
     bool VerifyBestBlock(const uint256& hash);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2563,7 +2563,8 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
       chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), chainActive.Tip()->nVersion,
       log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
       DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
-      GuessVerificationProgress(chainParams.TxData(), chainActive.Tip()), (pcoinsTip->DynamicMemoryUsage() + evoDb->GetMemoryUsage()) * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
+      GuessVerificationProgress(chainParams.TxData(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
+    strMessage += strprintf(" evodb_cache=%.1fMiB", evoDb->GetMemoryUsage() * (1.0 / (1<<20)));
     if (!warningMessages.empty())
         strMessage += strprintf(" warning='%s'", boost::algorithm::join(warningMessages, ", "));
     LogPrintf("%s\n", strMessage);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2423,6 +2423,7 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
     }
     int64_t nMempoolSizeMax = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     int64_t cacheSize = pcoinsTip->DynamicMemoryUsage() * DB_PEAK_USAGE_FACTOR;
+    cacheSize += evoDb->GetMemoryUsage() * DB_PEAK_USAGE_FACTOR;
     int64_t nTotalSpace = nCoinCacheUsage + std::max<int64_t>(nMempoolSizeMax - nMempoolUsage, 0);
     // The cache is large and we're within 10% and 10 MiB of the limit, but we have time now (not in the middle of a block processing).
     bool fCacheLarge = mode == FLUSH_STATE_PERIODIC && cacheSize > std::max((9 * nTotalSpace) / 10, nTotalSpace - MAX_BLOCK_COINSDB_USAGE * 1024 * 1024);
@@ -2562,7 +2563,7 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
       chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), chainActive.Tip()->nVersion,
       log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
       DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
-      GuessVerificationProgress(chainParams.TxData(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
+      GuessVerificationProgress(chainParams.TxData(), chainActive.Tip()), (pcoinsTip->DynamicMemoryUsage() + evoDb->GetMemoryUsage()) * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
     if (!warningMessages.empty())
         strMessage += strprintf(" warning='%s'", boost::algorithm::join(warningMessages, ", "));
     LogPrintf("%s\n", strMessage);


### PR DESCRIPTION
When deciding whether to flush or not, `FlushStateToDisk` was ignoring the memory used by EvoDB, which in some situations results in the EvoDB caches to grow to several GB. This is especially the case when masternode lists change in many consecutive blocks, which for example is the case in the days after LLMQ DKG activation, which caused a lot of PoSe (and the corresponding decreasing of PoSe scores for each blocks) to happen.

This PR adds accounting for used memory in `CDBTransaction` and `CEvoDB` and takes this into account when doing the decision if flushing is needed or not.

This should also be backported to v14.0.2 as it fixes many crashes on reindex as reported by multiple users.