### PR TITLE
Fix compilation on Ubuntu 16.04

### DIFF
--- a/depends/packages/backtrace.mk
+++ b/depends/packages/backtrace.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=8da6daa0a582c9bbd1f2933501168b4c43664700f604f43e922e85b99e5049bc
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --prefix=$(host_prefix)
+$(package)_config_opts=--disable-shared --enable-host-shared --prefix=$(host_prefix)
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
Compiling latest develop on Ubuntu 16.04:
```
/usr/bin/ld: /path/to/dash/depends/x86_64-pc-linux-gnu/lib/libbacktrace.a(fileline.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a shared object; recompile with -fPIC
/path/to/dash/depends/x86_64-pc-linux-gnu/lib/libbacktrace.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:4465: recipe for target 'dashd' failed
```

This should fix it.