### PR TITLE
Use std::unique_ptr for mnList in CSimplifiedMNList

### DIFF
--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -74,7 +74,7 @@ public:
 class CSimplifiedMNList
 {
 public:
-    std::vector<CSimplifiedMNListEntry> mnList;
+    std::vector<std::unique_ptr<CSimplifiedMNListEntry>> mnList;
 
 public:
     CSimplifiedMNList() {}


### PR DESCRIPTION
This allows much faster sorting as it avoids copying/swapping
expensive objects.

Profiling has shown that around 15% of CPU time is spent with sorting the simplified MN list when doing a reindex.