### PR TITLE
remove DS mixes once they have been included in a chainlocked block

### DIFF
--- a/src/privatesend/privatesend.cpp
+++ b/src/privatesend/privatesend.cpp
@@ -119,8 +119,9 @@ bool CPrivateSendBroadcastTx::CheckSignature(const CBLSPublicKey& blsPubKey) con
 bool CPrivateSendBroadcastTx::IsExpired(const CBlockIndex* pindex)
 {
     // expire confirmed DSTXes after ~1h since confirmation or chainlocked confirmation
-    return (nConfirmedHeight != -1) && ((pindex->nHeight - nConfirmedHeight > 24) ||
-            (pindex->nHeight - nConfirmedHeight >= 0 && llmq::chainLocksHandler->HasChainLock(pindex->nHeight, *pindex->phashBlock)));
+    if (nConfirmedHeight == -1 || pindex->nHeight < nConfirmedHeight) return false; // not mined yet
+    if (pindex->nHeight - nConfirmedHeight > 24) return true; // mined more then an hour ago
+    return llmq::chainLocksHandler->HasChainLock(pindex->nHeight, *pindex->phashBlock);
 }
 
 bool CPrivateSendBroadcastTx::IsValidStructure()

--- a/src/privatesend/privatesend.h
+++ b/src/privatesend/privatesend.h
@@ -351,7 +351,7 @@ public:
     bool CheckSignature(const CBLSPublicKey& blsPubKey) const;
 
     void SetConfirmedHeight(int nConfirmedHeightIn) { nConfirmedHeight = nConfirmedHeightIn; }
-    bool IsExpired(int nHeight);
+    bool IsExpired(const CBlockIndex* pindex);
     bool IsValidStructure();
 };
 
@@ -427,7 +427,7 @@ private:
 
     static CCriticalSection cs_mapdstx;
 
-    static void CheckDSTXes(int nHeight);
+    static void CheckDSTXes(const CBlockIndex* pindex);
 
 public:
     static void InitStandardDenominations();


### PR DESCRIPTION
Probably actually not that big of a deal, since there never are THAT many mixes in the span of 24 blocks, however there is no need to keep them once they have been confirmed in a locked block