### PR TITLE
Optimize on-disk deterministic masternode storage to reduce size of evodb

### DIFF
--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -390,6 +390,11 @@ public:
         pdb->CompactRange(&slKey1, &slKey2);
     }
 
+    void CompactFull() const
+    {
+        pdb->CompactRange(nullptr, nullptr);
+    }
+
 };
 
 template<typename CDBTransaction>

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -615,8 +615,7 @@ void CDeterministicMNManager::UpdatedBlockTip(const CBlockIndex* pindex)
 {
     LOCK(cs);
 
-    tipHeight = pindex->nHeight;
-    tipBlockHash = pindex->GetBlockHash();
+    tipIndex = pindex;
 }
 
 bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& _state, CDeterministicMNList& mnListRet, bool debugLogs)
@@ -941,7 +940,10 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const uint256& blo
 CDeterministicMNList CDeterministicMNManager::GetListAtChainTip()
 {
     LOCK(cs);
-    return GetListForBlock(tipBlockHash);
+    if (!tipIndex) {
+        return {};
+    }
+    return GetListForBlock(tipIndex->GetBlockHash());
 }
 
 bool CDeterministicMNManager::IsProTxWithCollateral(const CTransactionRef& tx, uint32_t n)
@@ -971,7 +973,7 @@ bool CDeterministicMNManager::IsDIP3Enforced(int nHeight)
     LOCK(cs);
 
     if (nHeight == -1) {
-        nHeight = tipHeight;
+        nHeight = tipIndex->nHeight;
     }
 
     return nHeight >= Params().GetConsensus().DIP0003EnforcementHeight;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -366,7 +366,7 @@ CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNL
         auto fromPtr = GetMN(toPtr->proTxHash);
         if (fromPtr == nullptr) {
             diffRet.addedMNs.emplace_back(toPtr);
-        } else {
+        } else if (fromPtr != toPtr || fromPtr->pdmnState != toPtr->pdmnState) {
             CDeterministicMNStateDiff stateDiff(*fromPtr->pdmnState, *toPtr->pdmnState);
             if (stateDiff.fields) {
                 diffRet.updatedMNs.emplace(toPtr->internalId, std::move(stateDiff));
@@ -919,7 +919,7 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const uint256& blo
             break;
         }
 
-        listDiff.emplace_front(diff);
+        listDiff.emplace_front(std::move(diff));
         blockHashTmp = diff.prevBlockHash;
     }
 

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -656,10 +656,10 @@ public:
 
     // the returned list will not contain the correct block hash (we can't know it yet as the coinbase TX is not updated yet)
     bool BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state, CDeterministicMNList& mnListRet, bool debugLogs);
-    void HandleQuorumCommitment(llmq::CFinalCommitment& qc, CDeterministicMNList& mnList, bool debugLogs);
+    void HandleQuorumCommitment(llmq::CFinalCommitment& qc, const CBlockIndex* pindexQuorum, CDeterministicMNList& mnList, bool debugLogs);
     void DecreasePoSePenalties(CDeterministicMNList& mnList);
 
-    CDeterministicMNList GetListForBlock(const uint256& blockHash);
+    CDeterministicMNList GetListForBlock(const CBlockIndex* pindex);
     CDeterministicMNList GetListAtChainTip();
 
     // Test if given TX is a ProRegTx which also contains the collateral at index n

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -83,8 +83,8 @@ public:
         READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);
         READWRITE(addr);
-        READWRITE(*(CScriptBase*)(&scriptPayout));
-        READWRITE(*(CScriptBase*)(&scriptOperatorPayout));
+        READWRITE(scriptPayout);
+        READWRITE(scriptOperatorPayout);
     }
 
     void ResetOperatorFields()

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -644,8 +644,7 @@ private:
     CEvoDB& evoDb;
 
     std::map<uint256, CDeterministicMNList> mnListsCache;
-    int tipHeight{-1};
-    uint256 tipBlockHash;
+    const CBlockIndex* tipIndex{nullptr};
 
 public:
     CDeterministicMNManager(CEvoDB& _evoDb);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -601,6 +601,37 @@ public:
     }
 };
 
+// TODO can be removed in a future version
+class CDeterministicMNListDiff_OldFormat
+{
+public:
+    uint256 prevBlockHash;
+    uint256 blockHash;
+    int nHeight{-1};
+    std::map<uint256, CDeterministicMNCPtr> addedMNs;
+    std::map<uint256, CDeterministicMNStateCPtr> updatedMNs;
+    std::set<uint256> removedMns;
+
+public:
+    template<typename Stream>
+    void Unserialize(Stream& s) {
+        addedMNs.clear();
+        s >> prevBlockHash;
+        s >> blockHash;
+        s >> nHeight;
+        size_t cnt = ReadCompactSize(s);
+        for (size_t i = 0; i < cnt; i++) {
+            uint256 proTxHash;
+            auto dmn = std::make_shared<CDeterministicMN>();
+            s >> proTxHash;
+            dmn->Unserialize(s, true);
+            addedMNs.emplace(proTxHash, dmn);
+        }
+        s >> updatedMNs;
+        s >> removedMns;
+    }
+};
+
 class CDeterministicMNManager
 {
     static const int SNAPSHOT_LIST_PERIOD = 576; // once per day
@@ -636,6 +667,11 @@ public:
     bool IsProTxWithCollateral(const CTransactionRef& tx, uint32_t n);
 
     bool IsDIP3Enforced(int nHeight = -1);
+
+public:
+    // TODO these can all be removed in a future version
+    bool UpgradeDiff(CDBBatch& batch, const CBlockIndex* pindexNext, const CDeterministicMNList& curMNList, CDeterministicMNList& newMNList);
+    void UpgradeDBIfNeeded();
 
 private:
     void CleanupCache(int nHeight);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -466,7 +466,7 @@ public:
 
     CDeterministicMNListDiff BuildDiff(const CDeterministicMNList& to) const;
     CSimplifiedMNListDiff BuildSimplifiedDiff(const CDeterministicMNList& to) const;
-    CDeterministicMNList ApplyDiff(const CDeterministicMNListDiff& diff) const;
+    CDeterministicMNList ApplyDiff(const CBlockIndex* pindex, const CDeterministicMNListDiff& diff) const;
 
     void AddMN(const CDeterministicMNCPtr& dmn);
     void UpdateMN(const CDeterministicMNCPtr& oldDmn, const CDeterministicMNStateCPtr& pdmnState);
@@ -541,9 +541,6 @@ private:
 class CDeterministicMNListDiff
 {
 public:
-    uint256 prevBlockHash;
-    uint256 blockHash;
-    int nHeight{-1};
     std::vector<CDeterministicMNCPtr> addedMNs;
     // keys are all relating to the internalId of MNs
     std::map<uint64_t, CDeterministicMNStateDiff> updatedMNs;
@@ -553,9 +550,6 @@ public:
     template<typename Stream>
     void Serialize(Stream& s) const
     {
-        s << prevBlockHash;
-        s << blockHash;
-        s << nHeight;
         s << addedMNs;
         WriteCompactSize(s, updatedMNs.size());
         for (const auto& p : updatedMNs) {
@@ -576,9 +570,6 @@ public:
 
         size_t tmp;
         uint64_t tmp2;
-        s >> prevBlockHash;
-        s >> blockHash;
-        s >> nHeight;
         s >> addedMNs;
         tmp = ReadCompactSize(s);
         for (size_t i = 0; i < tmp; i++) {

--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -9,7 +9,9 @@
 #include "sync.h"
 #include "uint256.h"
 
-static const std::string EVODB_BEST_BLOCK = "b_b";
+// "b_b" was used in the initial version of deterministic MN storage
+// "b_b2" was used after compact diffs were introduced
+static const std::string EVODB_BEST_BLOCK = "b_b2";
 
 class CEvoDB
 {

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -127,11 +127,15 @@ void CMNAuth::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList&
         if (pnode->verifiedProRegTxHash.IsNull()) {
             return;
         }
+        auto verifiedDmn = oldMNList.GetMN(pnode->verifiedProRegTxHash);
+        if (!verifiedDmn) {
+            return;
+        }
         bool doRemove = false;
-        if (diff.removedMns.count(pnode->verifiedProRegTxHash)) {
+        if (diff.removedMns.count(verifiedDmn->internalId)) {
             doRemove = true;
         } else {
-            auto it = diff.updatedMNs.find(pnode->verifiedProRegTxHash);
+            auto it = diff.updatedMNs.find(verifiedDmn->internalId);
             if (it != diff.updatedMNs.end()) {
                 if ((it->second.fields & CDeterministicMNStateDiff::Field_pubKeyOperator) && it->second.state.pubKeyOperator.GetHash() != pnode->verifiedPubKeyHash) {
                     doRemove = true;

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -133,7 +133,7 @@ void CMNAuth::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList&
         } else {
             auto it = diff.updatedMNs.find(pnode->verifiedProRegTxHash);
             if (it != diff.updatedMNs.end()) {
-                if (it->second->pubKeyOperator.GetHash() != pnode->verifiedPubKeyHash) {
+                if ((it->second.fields & CDeterministicMNStateDiff::Field_pubKeyOperator) && it->second.state.pubKeyOperator.GetHash() != pnode->verifiedPubKeyHash) {
                     doRemove = true;
                 }
             }

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -174,7 +174,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
     }
 
     if (pindexPrev) {
-        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev->GetBlockHash());
+        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev);
 
         // only allow reusing of addresses when it's for the same collateral (which replaces the old MN)
         if (mnList.HasUniqueProperty(ptx.addr) && mnList.GetUniquePropertyMN(ptx.addr)->collateralOutpoint != collateralOutpoint) {
@@ -232,7 +232,7 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
     }
 
     if (pindexPrev) {
-        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev->GetBlockHash());
+        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev);
         auto mn = mnList.GetMN(ptx.proTxHash);
         if (!mn) {
             return state.DoS(100, false, REJECT_INVALID, "bad-protx-hash");
@@ -297,7 +297,7 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
     }
 
     if (pindexPrev) {
-        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev->GetBlockHash());
+        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev);
         auto dmn = mnList.GetMN(ptx.proTxHash);
         if (!dmn) {
             return state.DoS(100, false, REJECT_INVALID, "bad-protx-hash");
@@ -369,7 +369,7 @@ bool CheckProUpRevTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
     }
 
     if (pindexPrev) {
-        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev->GetBlockHash());
+        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev);
         auto dmn = mnList.GetMN(ptx.proTxHash);
         if (!dmn)
             return state.DoS(100, false, REJECT_INVALID, "bad-protx-hash");

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -50,7 +50,7 @@ public:
         READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);
         READWRITE(nOperatorReward);
-        READWRITE(*(CScriptBase*)(&scriptPayout));
+        READWRITE(scriptPayout);
         READWRITE(inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(vchSig);
@@ -108,7 +108,7 @@ public:
         READWRITE(nVersion);
         READWRITE(proTxHash);
         READWRITE(addr);
-        READWRITE(*(CScriptBase*)(&scriptOperatorPayout));
+        READWRITE(scriptOperatorPayout);
         READWRITE(inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(sig);
@@ -160,7 +160,7 @@ public:
         READWRITE(nMode);
         READWRITE(pubKeyOperator);
         READWRITE(keyIDVoting);
-        READWRITE(*(CScriptBase*)(&scriptPayout));
+        READWRITE(scriptPayout);
         READWRITE(inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(vchSig);

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -221,6 +221,11 @@ bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& bloc
     auto dmnList = deterministicMNManager->GetListForBlock(blockIndex);
     mnListDiffRet = baseDmnList.BuildSimplifiedDiff(dmnList);
 
+    // We need to return the value that was provided by the other peer as it otherwise won't be able to recognize the
+    // response. This will usually be identical to the block found in baseBlockIndex. The only difference is when a
+    // null block hash was provided to get the diff from the genesis block.
+    mnListDiffRet.baseBlockHash = baseBlockHash;
+
     if (!mnListDiffRet.BuildQuorumsDiff(baseBlockIndex, blockIndex)) {
         errorRet = strprintf("failed to build quorums diff");
         return false;

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -217,8 +217,8 @@ bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& bloc
 
     LOCK(deterministicMNManager->cs);
 
-    auto baseDmnList = deterministicMNManager->GetListForBlock(baseBlockHash);
-    auto dmnList = deterministicMNManager->GetListForBlock(blockHash);
+    auto baseDmnList = deterministicMNManager->GetListForBlock(baseBlockIndex);
+    auto dmnList = deterministicMNManager->GetListForBlock(blockIndex);
     mnListDiffRet = baseDmnList.BuildSimplifiedDiff(dmnList);
 
     if (!mnListDiffRet.BuildQuorumsDiff(baseBlockIndex, blockIndex)) {

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1275,9 +1275,9 @@ void CGovernanceManager::RemoveInvalidVotes()
     std::vector<COutPoint> changedKeyMNs;
     for (const auto& p : diff.updatedMNs) {
         auto oldDmn = lastMNListForVotingKeys.GetMN(p.first);
-        if (p.second->keyIDVoting != oldDmn->pdmnState->keyIDVoting) {
+        if ((p.second.fields & CDeterministicMNStateDiff::Field_keyIDVoting) && p.second.state.keyIDVoting != oldDmn->pdmnState->keyIDVoting) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
-        } else if (p.second->pubKeyOperator != oldDmn->pdmnState->pubKeyOperator) {
+        } else if ((p.second.fields & CDeterministicMNStateDiff::Field_pubKeyOperator) && p.second.state.pubKeyOperator != oldDmn->pdmnState->pubKeyOperator) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         }
     }

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -24,7 +24,7 @@ CGovernanceManager governance;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-14";
+const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-15";
 const int CGovernanceManager::MAX_TIME_FUTURE_DEVIATION = 60 * 60;
 const int CGovernanceManager::RELIABLE_PROPAGATION_TIME = 60;
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1274,15 +1274,15 @@ void CGovernanceManager::RemoveInvalidVotes()
 
     std::vector<COutPoint> changedKeyMNs;
     for (const auto& p : diff.updatedMNs) {
-        auto oldDmn = lastMNListForVotingKeys.GetMN(p.first);
+        auto oldDmn = lastMNListForVotingKeys.GetMNByInternalId(p.first);
         if ((p.second.fields & CDeterministicMNStateDiff::Field_keyIDVoting) && p.second.state.keyIDVoting != oldDmn->pdmnState->keyIDVoting) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         } else if ((p.second.fields & CDeterministicMNStateDiff::Field_pubKeyOperator) && p.second.state.pubKeyOperator != oldDmn->pdmnState->pubKeyOperator) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         }
     }
-    for (const auto& proTxHash : diff.removedMns) {
-        auto oldDmn = lastMNListForVotingKeys.GetMN(proTxHash);
+    for (const auto& id : diff.removedMns) {
+        auto oldDmn = lastMNListForVotingKeys.GetMNByInternalId(id);
         changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
     }
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -339,6 +339,7 @@ public:
         LOCK(cs);
         std::string strVersion;
         if (ser_action.ForRead()) {
+            Clear();
             READWRITE(strVersion);
             if (strVersion != SERIALIZATION_VERSION_STRING) {
                 return;

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -340,6 +340,9 @@ public:
         std::string strVersion;
         if (ser_action.ForRead()) {
             READWRITE(strVersion);
+            if (strVersion != SERIALIZATION_VERSION_STRING) {
+                return;
+            }
         } else {
             strVersion = SERIALIZATION_VERSION_STRING;
             READWRITE(strVersion);
@@ -351,10 +354,6 @@ public:
         READWRITE(mapObjects);
         READWRITE(mapLastMasternodeObject);
         READWRITE(lastMNListForVotingKeys);
-        if (ser_action.ForRead() && (strVersion != SERIALIZATION_VERSION_STRING)) {
-            Clear();
-            return;
-        }
     }
 
     void UpdatedBlockTip(const CBlockIndex* pindex, CConnman& connman);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1859,6 +1859,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     break;
                 }
 
+                deterministicMNManager->UpgradeDBIfNeeded();
+
                 uiInterface.InitMessage(_("Verifying blocks..."));
                 if (fHavePruned && gArgs.GetArg("-checkblocks", DEFAULT_CHECKBLOCKS) > MIN_BLOCKS_TO_KEEP) {
                     LogPrintf("Prune: pruned datadir may not have more than %d blocks; only checking available blocks",

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -37,7 +37,7 @@ class CQuorum
 public:
     const Consensus::LLMQParams& params;
     CFinalCommitment qc;
-    int height;
+    const CBlockIndex* pindexQuorum;
     uint256 minedBlockHash;
     std::vector<CDeterministicMNCPtr> members;
 
@@ -55,7 +55,7 @@ private:
 public:
     CQuorum(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker) : params(_params), blsCache(_blsWorker), stopCachePopulatorThread(false) {}
     ~CQuorum();
-    void Init(const CFinalCommitment& _qc, int _height, const uint256& _minedBlockHash, const std::vector<CDeterministicMNCPtr>& _members);
+    void Init(const CFinalCommitment& _qc, const CBlockIndex* _pindexQuorum, const uint256& _minedBlockHash, const std::vector<CDeterministicMNCPtr>& _members);
 
     bool IsMember(const uint256& proTxHash) const;
     bool IsValidMember(const uint256& proTxHash) const;

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -57,6 +57,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& strC
         const auto& params = Params().GetConsensus().llmqs.at(type);
 
         // Verify that quorumHash is part of the active chain and that it's the first block in the DKG interval
+        const CBlockIndex* pquorumIndex;
         {
             LOCK(cs_main);
             if (!mapBlockIndex.count(qc.quorumHash)) {
@@ -66,7 +67,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& strC
                 // fully synced
                 return;
             }
-            auto pquorumIndex = mapBlockIndex[qc.quorumHash];
+            pquorumIndex = mapBlockIndex[qc.quorumHash];
             if (chainActive.Tip()->GetAncestor(pquorumIndex->nHeight) != pquorumIndex) {
                 LogPrintf("CQuorumBlockProcessor::%s -- block %s not in active chain, peer=%d\n", __func__,
                           qc.quorumHash.ToString(), pfrom->GetId());
@@ -98,7 +99,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& strC
             }
         }
 
-        auto members = CLLMQUtils::GetAllQuorumMembers(type, qc.quorumHash);
+        auto members = CLLMQUtils::GetAllQuorumMembers(type, pquorumIndex);
 
         if (!qc.Verify(members, true)) {
             LOCK(cs_main);
@@ -203,14 +204,14 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-height");
     }
 
-    auto members = CLLMQUtils::GetAllQuorumMembers(params.type, quorumHash);
+    auto quorumIndex = mapBlockIndex.at(qc.quorumHash);
+    auto members = CLLMQUtils::GetAllQuorumMembers(params.type, quorumIndex);
 
     if (!qc.Verify(members, true)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
     }
 
     // Store commitment in DB
-    auto quorumIndex = mapBlockIndex.at(qc.quorumHash);
     evoDb.Write(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(params.type, quorumHash)), std::make_pair(qc, blockHash));
     evoDb.Write(BuildInversedHeightKey(params.type, nHeight), quorumIndex->nHeight);
 

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -169,7 +169,7 @@ bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, 
         return true;
     }
 
-    auto members = CLLMQUtils::GetAllQuorumMembers(params.type, qcTx.commitment.quorumHash);
+    auto members = CLLMQUtils::GetAllQuorumMembers(params.type, pindexQuorum);
     if (!qcTx.commitment.Verify(members, false)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
     }

--- a/src/llmq/quorums_debug.cpp
+++ b/src/llmq/quorums_debug.cpp
@@ -5,6 +5,7 @@
 #include "quorums_debug.h"
 
 #include "chainparams.h"
+#include "validation.h"
 
 #include "evo/deterministicmns.h"
 #include "quorums_utils.h"
@@ -23,7 +24,17 @@ UniValue CDKGDebugSessionStatus::ToJson(int detailLevel) const
 
     std::vector<CDeterministicMNCPtr> dmnMembers;
     if (detailLevel == 2) {
-        dmnMembers = CLLMQUtils::GetAllQuorumMembers((Consensus::LLMQType) llmqType, quorumHash);
+        const CBlockIndex* pindex = nullptr;
+        {
+            LOCK(cs_main);
+            auto it = mapBlockIndex.find(quorumHash);
+            if (it != mapBlockIndex.end()) {
+                pindex = it->second;
+            }
+        }
+        if (pindex != nullptr) {
+            dmnMembers = CLLMQUtils::GetAllQuorumMembers((Consensus::LLMQType) llmqType, pindex);
+        }
     }
 
     ret.push_back(Pair("llmqType", llmqType));

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -60,7 +60,7 @@ static bool ShouldSimulateError(const std::string& type)
 }
 
 CDKGLogger::CDKGLogger(const CDKGSession& _quorumDkg, const std::string& _func) :
-    CDKGLogger(_quorumDkg.params.type, _quorumDkg.quorumHash, _quorumDkg.height, _quorumDkg.AreWeMember(), _func)
+    CDKGLogger(_quorumDkg.params.type, _quorumDkg.pindexQuorum->GetBlockHash(), _quorumDkg.pindexQuorum->nHeight, _quorumDkg.AreWeMember(), _func)
 {
 }
 
@@ -88,14 +88,13 @@ CDKGMember::CDKGMember(CDeterministicMNCPtr _dmn, size_t _idx) :
 
 }
 
-bool CDKGSession::Init(int _height, const uint256& _quorumHash, const std::vector<CDeterministicMNCPtr>& mns, const uint256& _myProTxHash)
+bool CDKGSession::Init(const CBlockIndex* _pindexQuorum, const std::vector<CDeterministicMNCPtr>& mns, const uint256& _myProTxHash)
 {
     if (mns.size() < params.minSize) {
         return false;
     }
 
-    height = _height;
-    quorumHash = _quorumHash;
+    pindexQuorum = _pindexQuorum;
 
     members.resize(mns.size());
     memberIds.resize(members.size());
@@ -121,7 +120,7 @@ bool CDKGSession::Init(int _height, const uint256& _quorumHash, const std::vecto
     }
 
     if (!myProTxHash.IsNull()) {
-        quorumDKGDebugManager->InitLocalSessionStatus(params.type, quorumHash, height);
+        quorumDKGDebugManager->InitLocalSessionStatus(params.type, pindexQuorum->GetBlockHash(), pindexQuorum->nHeight);
     }
 
     CDKGLogger logger(*this, __func__);
@@ -170,7 +169,7 @@ void CDKGSession::SendContributions(CDKGPendingMessages& pendingMessages)
 
     CDKGContribution qc;
     qc.llmqType = params.type;
-    qc.quorumHash = quorumHash;
+    qc.quorumHash = pindexQuorum->GetBlockHash();
     qc.proTxHash = myProTxHash;
     qc.vvec = vvecContribution;
 
@@ -216,7 +215,7 @@ bool CDKGSession::PreVerifyMessage(const uint256& hash, const CDKGContribution& 
 
     retBan = false;
 
-    if (qc.quorumHash != quorumHash) {
+    if (qc.quorumHash != pindexQuorum->GetBlockHash()) {
         logger.Batch("contribution for wrong quorum, rejecting");
         return false;
     }
@@ -316,7 +315,7 @@ void CDKGSession::ReceiveMessage(const uint256& hash, const CDKGContribution& qc
         return;
     }
 
-    dkgManager.WriteVerifiedVvecContribution(params.type, qc.quorumHash, qc.proTxHash, qc.vvec);
+    dkgManager.WriteVerifiedVvecContribution(params.type, pindexQuorum, qc.proTxHash, qc.vvec);
 
     bool complain = false;
     CBLSSecretKey skContribution;
@@ -398,7 +397,7 @@ void CDKGSession::VerifyPendingContributions()
             });
         } else {
             size_t memberIdx = memberIndexes[i];
-            dkgManager.WriteVerifiedSkContribution(params.type, quorumHash, members[memberIdx]->dmn->proTxHash, skContributions[i]);
+            dkgManager.WriteVerifiedSkContribution(params.type, pindexQuorum, members[memberIdx]->dmn->proTxHash, skContributions[i]);
         }
     }
 
@@ -449,7 +448,7 @@ void CDKGSession::SendComplaint(CDKGPendingMessages& pendingMessages)
 
     CDKGComplaint qc(params);
     qc.llmqType = params.type;
-    qc.quorumHash = quorumHash;
+    qc.quorumHash = pindexQuorum->GetBlockHash();
     qc.proTxHash = myProTxHash;
 
     int badCount = 0;
@@ -490,7 +489,7 @@ bool CDKGSession::PreVerifyMessage(const uint256& hash, const CDKGComplaint& qc,
 
     retBan = false;
 
-    if (qc.quorumHash != quorumHash) {
+    if (qc.quorumHash != pindexQuorum->GetBlockHash()) {
         logger.Batch("complaint for wrong quorum, rejecting");
         return false;
     }
@@ -643,7 +642,7 @@ void CDKGSession::SendJustification(CDKGPendingMessages& pendingMessages, const 
 
     CDKGJustification qj;
     qj.llmqType = params.type;
-    qj.quorumHash = quorumHash;
+    qj.quorumHash = pindexQuorum->GetBlockHash();
     qj.proTxHash = myProTxHash;
     qj.contributions.reserve(forMembers.size());
 
@@ -688,7 +687,7 @@ bool CDKGSession::PreVerifyMessage(const uint256& hash, const CDKGJustification&
 
     retBan = false;
 
-    if (qj.quorumHash != quorumHash) {
+    if (qj.quorumHash != pindexQuorum->GetBlockHash()) {
         logger.Batch("justification for wrong quorum, rejecting");
         return false;
     }
@@ -824,7 +823,7 @@ void CDKGSession::ReceiveMessage(const uint256& hash, const CDKGJustification& q
                 receivedSkContributions[member->idx] = skContribution;
                 member->weComplain = false;
 
-                dkgManager.WriteVerifiedSkContribution(params.type, quorumHash, member->dmn->proTxHash, skContribution);
+                dkgManager.WriteVerifiedSkContribution(params.type, pindexQuorum, member->dmn->proTxHash, skContribution);
             }
             member->complaintsFromOthers.erase(member2->dmn->proTxHash);
         }
@@ -899,7 +898,7 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
 
     CDKGPrematureCommitment qc(params);
     qc.llmqType = params.type;
-    qc.quorumHash = quorumHash;
+    qc.quorumHash = pindexQuorum->GetBlockHash();
     qc.proTxHash = myProTxHash;
 
     for (size_t i = 0; i < members.size(); i++) {
@@ -925,7 +924,7 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
     std::vector<uint16_t> memberIndexes;
     std::vector<BLSVerificationVectorPtr> vvecs;
     BLSSecretKeyVector skContributions;
-    if (!dkgManager.GetVerifiedContributions(params.type, quorumHash, qc.validMembers, memberIndexes, vvecs, skContributions)) {
+    if (!dkgManager.GetVerifiedContributions(params.type, pindexQuorum, qc.validMembers, memberIndexes, vvecs, skContributions)) {
         logger.Batch("failed to get valid contributions");
         return;
     }
@@ -1012,7 +1011,7 @@ bool CDKGSession::PreVerifyMessage(const uint256& hash, const CDKGPrematureCommi
 
     retBan = false;
 
-    if (qc.quorumHash != quorumHash) {
+    if (qc.quorumHash != pindexQuorum->GetBlockHash()) {
         logger.Batch("commitment for wrong quorum, rejecting");
         return false;
     }
@@ -1091,7 +1090,7 @@ void CDKGSession::ReceiveMessage(const uint256& hash, const CDKGPrematureCommitm
     std::vector<BLSVerificationVectorPtr> vvecs;
     BLSSecretKeyVector skContributions;
     BLSVerificationVectorPtr quorumVvec;
-    if (dkgManager.GetVerifiedContributions(params.type, qc.quorumHash, qc.validMembers, memberIndexes, vvecs, skContributions)) {
+    if (dkgManager.GetVerifiedContributions(params.type, pindexQuorum, qc.validMembers, memberIndexes, vvecs, skContributions)) {
         quorumVvec = cache.BuildQuorumVerificationVector(::SerializeHash(memberIndexes), vvecs);
     }
 

--- a/src/llmq/quorums_dkgsession.h
+++ b/src/llmq/quorums_dkgsession.h
@@ -249,8 +249,7 @@ private:
     CBLSWorkerCache cache;
     CDKGSessionManager& dkgManager;
 
-    uint256 quorumHash;
-    int height{-1};
+    const CBlockIndex* pindexQuorum;
 
 private:
     std::vector<std::unique_ptr<CDKGMember>> members;
@@ -287,7 +286,7 @@ public:
     CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager) :
         params(_params), blsWorker(_blsWorker), cache(_blsWorker), dkgManager(_dkgManager) {}
 
-    bool Init(int _height, const uint256& _quorumHash, const std::vector<CDeterministicMNCPtr>& mns, const uint256& _myProTxHash);
+    bool Init(const CBlockIndex* pindexQuorum, const std::vector<CDeterministicMNCPtr>& mns, const uint256& _myProTxHash);
 
     size_t GetMyMemberIndex() const { return myIdx; }
 

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -139,7 +139,7 @@ void CDKGSessionHandler::ProcessMessage(CNode* pfrom, const std::string& strComm
     }
 }
 
-bool CDKGSessionHandler::InitNewQuorum(int newQuorumHeight, const uint256& newQuorumHash)
+bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pindexQuorum)
 {
     //AssertLockHeld(cs_main);
 
@@ -147,13 +147,13 @@ bool CDKGSessionHandler::InitNewQuorum(int newQuorumHeight, const uint256& newQu
 
     curSession = std::make_shared<CDKGSession>(params, blsWorker, dkgManager);
 
-    if (!deterministicMNManager->IsDIP3Enforced(newQuorumHeight)) {
+    if (!deterministicMNManager->IsDIP3Enforced(pindexQuorum->nHeight)) {
         return false;
     }
 
-    auto mns = CLLMQUtils::GetAllQuorumMembers(params.type, newQuorumHash);
+    auto mns = CLLMQUtils::GetAllQuorumMembers(params.type, pindexQuorum);
 
-    if (!curSession->Init(newQuorumHeight, newQuorumHash, mns, activeMasternodeInfo.proTxHash)) {
+    if (!curSession->Init(pindexQuorum, mns, activeMasternodeInfo.proTxHash)) {
         LogPrintf("CDKGSessionManager::%s -- quorum initialiation failed\n", __func__);
         return false;
     }
@@ -455,7 +455,13 @@ void CDKGSessionHandler::HandleDKGRound()
         curQuorumHeight = quorumHeight;
     }
 
-    if (!InitNewQuorum(curQuorumHeight, curQuorumHash)) {
+    const CBlockIndex* pindexQuorum;
+    {
+        LOCK(cs_main);
+        pindexQuorum = mapBlockIndex.at(curQuorumHash);
+    }
+
+    if (!InitNewQuorum(pindexQuorum)) {
         // should actually never happen
         WaitForNewQuorum(curQuorumHash);
         throw AbortPhaseException();
@@ -470,16 +476,16 @@ void CDKGSessionHandler::HandleDKGRound()
     if (curSession->AreWeMember() || gArgs.GetBoolArg("-watchquorums", DEFAULT_WATCH_QUORUMS)) {
         std::set<uint256> connections;
         if (curSession->AreWeMember()) {
-            connections = CLLMQUtils::GetQuorumConnections(params.type, curQuorumHash, curSession->myProTxHash);
+            connections = CLLMQUtils::GetQuorumConnections(params.type, pindexQuorum, curSession->myProTxHash);
         } else {
-            auto cindexes = CLLMQUtils::CalcDeterministicWatchConnections(params.type, curQuorumHash, curSession->members.size(), 1);
+            auto cindexes = CLLMQUtils::CalcDeterministicWatchConnections(params.type, pindexQuorum, curSession->members.size(), 1);
             for (auto idx : cindexes) {
                 connections.emplace(curSession->members[idx]->dmn->proTxHash);
             }
         }
         if (!connections.empty()) {
             if (LogAcceptCategory(BCLog::LLMQ_DKG)) {
-                std::string debugMsg = strprintf("CDKGSessionManager::%s -- adding masternodes quorum connections for quorum %s:\n", __func__, curSession->quorumHash.ToString());
+                std::string debugMsg = strprintf("CDKGSessionManager::%s -- adding masternodes quorum connections for quorum %s:\n", __func__, curSession->pindexQuorum->GetBlockHash().ToString());
                 auto mnList = deterministicMNManager->GetListAtChainTip();
                 for (const auto& c : connections) {
                     auto dmn = mnList.GetValidMN(c);

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -125,7 +125,7 @@ public:
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
 private:
-    bool InitNewQuorum(int newQuorumHeight, const uint256& newQuorumHash);
+    bool InitNewQuorum(const CBlockIndex* pindexQuorum);
 
     std::pair<QuorumPhase, uint256> GetPhaseAndQuorumHash() const;
 

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -198,19 +198,19 @@ bool CDKGSessionManager::GetPrematureCommitment(const uint256& hash, CDKGPrematu
     return false;
 }
 
-void CDKGSessionManager::WriteVerifiedVvecContribution(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& proTxHash, const BLSVerificationVectorPtr& vvec)
+void CDKGSessionManager::WriteVerifiedVvecContribution(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, const BLSVerificationVectorPtr& vvec)
 {
-    llmqDb.Write(std::make_tuple(DB_VVEC, llmqType, quorumHash, proTxHash), *vvec);
+    llmqDb.Write(std::make_tuple(DB_VVEC, llmqType, pindexQuorum->GetBlockHash(), proTxHash), *vvec);
 }
 
-void CDKGSessionManager::WriteVerifiedSkContribution(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& proTxHash, const CBLSSecretKey& skContribution)
+void CDKGSessionManager::WriteVerifiedSkContribution(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, const CBLSSecretKey& skContribution)
 {
-    llmqDb.Write(std::make_tuple(DB_SKCONTRIB, llmqType, quorumHash, proTxHash), skContribution);
+    llmqDb.Write(std::make_tuple(DB_SKCONTRIB, llmqType, pindexQuorum->GetBlockHash(), proTxHash), skContribution);
 }
 
-bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::vector<bool>& validMembers, std::vector<uint16_t>& memberIndexesRet, std::vector<BLSVerificationVectorPtr>& vvecsRet, BLSSecretKeyVector& skContributionsRet)
+bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const std::vector<bool>& validMembers, std::vector<uint16_t>& memberIndexesRet, std::vector<BLSVerificationVectorPtr>& vvecsRet, BLSSecretKeyVector& skContributionsRet)
 {
-    auto members = CLLMQUtils::GetAllQuorumMembers(llmqType, quorumHash);
+    auto members = CLLMQUtils::GetAllQuorumMembers(llmqType, pindexQuorum);
 
     memberIndexesRet.clear();
     vvecsRet.clear();
@@ -222,7 +222,7 @@ bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, 
         if (validMembers[i]) {
             BLSVerificationVectorPtr vvec;
             CBLSSecretKey skContribution;
-            if (!GetVerifiedContribution(llmqType, quorumHash, members[i]->proTxHash, vvec, skContribution)) {
+            if (!GetVerifiedContribution(llmqType, pindexQuorum, members[i]->proTxHash, vvec, skContribution)) {
                 return false;
             }
 
@@ -234,10 +234,10 @@ bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, 
     return true;
 }
 
-bool CDKGSessionManager::GetVerifiedContribution(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& proTxHash, BLSVerificationVectorPtr& vvecRet, CBLSSecretKey& skContributionRet)
+bool CDKGSessionManager::GetVerifiedContribution(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, BLSVerificationVectorPtr& vvecRet, CBLSSecretKey& skContributionRet)
 {
     LOCK(contributionsCacheCs);
-    ContributionsCacheKey cacheKey = {llmqType, quorumHash, proTxHash};
+    ContributionsCacheKey cacheKey = {llmqType, pindexQuorum->GetBlockHash(), proTxHash};
     auto it = contributionsCache.find(cacheKey);
     if (it != contributionsCache.end()) {
         vvecRet = it->second.vvec;
@@ -248,10 +248,10 @@ bool CDKGSessionManager::GetVerifiedContribution(Consensus::LLMQType llmqType, c
     BLSVerificationVector vvec;
     BLSVerificationVectorPtr vvecPtr;
     CBLSSecretKey skContribution;
-    if (llmqDb.Read(std::make_tuple(DB_VVEC, llmqType, quorumHash, proTxHash), vvec)) {
+    if (llmqDb.Read(std::make_tuple(DB_VVEC, llmqType, pindexQuorum->GetBlockHash(), proTxHash), vvec)) {
         vvecPtr = std::make_shared<BLSVerificationVector>(std::move(vvec));
     }
-    llmqDb.Read(std::make_tuple(DB_SKCONTRIB, llmqType, quorumHash, proTxHash), skContribution);
+    llmqDb.Read(std::make_tuple(DB_SKCONTRIB, llmqType, pindexQuorum->GetBlockHash(), proTxHash), skContribution);
 
     it = contributionsCache.emplace(cacheKey, ContributionsCacheEntry{GetTimeMillis(), vvecPtr, skContribution}).first;
 

--- a/src/llmq/quorums_dkgsessionmgr.h
+++ b/src/llmq/quorums_dkgsessionmgr.h
@@ -63,10 +63,10 @@ public:
     bool GetPrematureCommitment(const uint256& hash, CDKGPrematureCommitment& ret) const;
 
     // Verified contributions are written while in the DKG
-    void WriteVerifiedVvecContribution(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& proTxHash, const BLSVerificationVectorPtr& vvec);
-    void WriteVerifiedSkContribution(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& proTxHash, const CBLSSecretKey& skContribution);
-    bool GetVerifiedContributions(Consensus::LLMQType llmqType, const uint256& quorumHash, const std::vector<bool>& validMembers, std::vector<uint16_t>& memberIndexesRet, std::vector<BLSVerificationVectorPtr>& vvecsRet, BLSSecretKeyVector& skContributionsRet);
-    bool GetVerifiedContribution(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& proTxHash, BLSVerificationVectorPtr& vvecRet, CBLSSecretKey& skContributionRet);
+    void WriteVerifiedVvecContribution(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, const BLSVerificationVectorPtr& vvec);
+    void WriteVerifiedSkContribution(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, const CBLSSecretKey& skContribution);
+    bool GetVerifiedContributions(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const std::vector<bool>& validMembers, std::vector<uint16_t>& memberIndexesRet, std::vector<BLSVerificationVectorPtr>& vvecsRet, BLSSecretKeyVector& skContributionsRet);
+    bool GetVerifiedContribution(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, BLSVerificationVectorPtr& vvecRet, CBLSSecretKey& skContributionRet);
 
 private:
     void CleanupCache();

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -14,14 +14,9 @@ namespace llmq
 
 std::vector<CDeterministicMNCPtr> CLLMQUtils::GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum)
 {
-    return GetAllQuorumMembers(llmqType, pindexQuorum->GetBlockHash());
-}
-
-std::vector<CDeterministicMNCPtr> CLLMQUtils::GetAllQuorumMembers(Consensus::LLMQType llmqType, const uint256& blockHash)
-{
     auto& params = Params().GetConsensus().llmqs.at(llmqType);
-    auto allMns = deterministicMNManager->GetListForBlock(blockHash);
-    auto modifier = ::SerializeHash(std::make_pair(llmqType, blockHash));
+    auto allMns = deterministicMNManager->GetListForBlock(pindexQuorum);
+    auto modifier = ::SerializeHash(std::make_pair(llmqType, pindexQuorum->GetBlockHash()));
     return allMns.CalculateQuorum(params.size, modifier);
 }
 
@@ -50,7 +45,7 @@ std::set<uint256> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType,
 {
     auto& params = Params().GetConsensus().llmqs.at(llmqType);
 
-    auto mns = GetAllQuorumMembers(llmqType, pindexQuorum->GetBlockHash());
+    auto mns = GetAllQuorumMembers(llmqType, pindexQuorum);
     std::set<uint256> result;
     for (size_t i = 0; i < mns.size(); i++) {
         auto& dmn = mns[i];

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -19,6 +19,7 @@ class CLLMQUtils
 {
 public:
     // includes members which failed DKG
+    static std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
     static std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const uint256& blockHash);
 
     static uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash);
@@ -31,8 +32,8 @@ public:
         return BuildSignHash((Consensus::LLMQType)s.llmqType, s.quorumHash, s.id, s.msgHash);
     }
 
-    static std::set<uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const uint256& blockHash, const uint256& forMember);
-    static std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType, const uint256& blockHash, size_t memberCount, size_t connectionCount);
+    static std::set<uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& forMember);
+    static std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, size_t memberCount, size_t connectionCount);
 
     static bool IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quorumHash);
 

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -20,7 +20,6 @@ class CLLMQUtils
 public:
     // includes members which failed DKG
     static std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
-    static std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const uint256& blockHash);
 
     static uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash);
     static uint256 BuildSignHash(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& id, const uint256& msgHash);

--- a/src/masternode/activemasternode.cpp
+++ b/src/masternode/activemasternode.cpp
@@ -134,7 +134,7 @@ void CActiveMasternodeManager::UpdatedBlockTip(const CBlockIndex* pindexNew, con
     if (!deterministicMNManager->IsDIP3Enforced(pindexNew->nHeight)) return;
 
     if (state == MASTERNODE_READY) {
-        auto mnList = deterministicMNManager->GetListForBlock(pindexNew->GetBlockHash());
+        auto mnList = deterministicMNManager->GetListForBlock(pindexNew);
         if (!mnList.IsMNValid(mnListEntry->proTxHash)) {
             // MN disappeared from MN list
             state = MASTERNODE_REMOVED;

--- a/src/masternode/masternode-meta.cpp
+++ b/src/masternode/masternode-meta.cpp
@@ -118,7 +118,6 @@ std::string CMasternodeMetaMan::ToString() const
     std::ostringstream info;
 
     info << "Masternodes: meta infos object count: " << (int)metaInfos.size() <<
-         ", deterministic masternode count: " << deterministicMNManager->GetListAtChainTip().GetAllMNsCount() <<
          ", nDsqCount: " << (int)nDsqCount;
     return info.str();
 }

--- a/src/masternode/masternode-meta.h
+++ b/src/masternode/masternode-meta.h
@@ -100,6 +100,7 @@ public:
 
         std::string strVersion;
         if(ser_action.ForRead()) {
+            Clear();
             READWRITE(strVersion);
             if (strVersion != SERIALIZATION_VERSION_STRING) {
                 return;

--- a/src/masternode/masternode-meta.h
+++ b/src/masternode/masternode-meta.h
@@ -101,6 +101,9 @@ public:
         std::string strVersion;
         if(ser_action.ForRead()) {
             READWRITE(strVersion);
+            if (strVersion != SERIALIZATION_VERSION_STRING) {
+                return;
+            }
         }
         else {
             strVersion = SERIALIZATION_VERSION_STRING;
@@ -122,10 +125,6 @@ public:
         }
 
         READWRITE(nDsqCount);
-
-        if(ser_action.ForRead() && (strVersion != SERIALIZATION_VERSION_STRING)) {
-            Clear();
-        }
     }
 
 public:

--- a/src/masternode/masternode-payments.cpp
+++ b/src/masternode/masternode-payments.cpp
@@ -271,7 +271,7 @@ std::map<int, std::string> GetRequiredPaymentsStrings(int nStartHeight, int nEnd
     bool doProjection = false;
     for(int h = nStartHeight; h < nEndHeight; h++) {
         if (h <= nChainTipHeight) {
-            auto payee = deterministicMNManager->GetListForBlock(chainActive[h - 1]->GetBlockHash()).GetMNPayee();
+            auto payee = deterministicMNManager->GetListForBlock(chainActive[h - 1]).GetMNPayee();
             mapPayments.emplace(h, GetRequiredPaymentsString(h, payee));
         } else {
             doProjection = true;
@@ -323,13 +323,13 @@ bool CMasternodePayments::GetBlockTxOuts(int nBlockHeight, CAmount blockReward, 
 
     CAmount masternodeReward = GetMasternodePayment(nBlockHeight, blockReward);
 
-    uint256 blockHash;
+    const CBlockIndex* pindex;
     {
         LOCK(cs_main);
-        blockHash = chainActive[nBlockHeight - 1]->GetBlockHash();
+        pindex = chainActive[nBlockHeight - 1];
     }
     uint256 proTxHash;
-    auto dmnPayee = deterministicMNManager->GetListForBlock(blockHash).GetMNPayee();
+    auto dmnPayee = deterministicMNManager->GetListForBlock(pindex).GetMNPayee();
     if (!dmnPayee) {
         return false;
     }

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -972,7 +972,7 @@ UniValue protx_list(const JSONRPCRequest& request)
             setOutpts.emplace(outpt);
         }
 
-        CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(chainActive[height]->GetBlockHash());
+        CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(chainActive[height]);
         mnList.ForEachMN(false, [&](const CDeterministicMNCPtr& dmn) {
             if (setOutpts.count(dmn->collateralOutpoint) ||
                 CheckWalletOwnsKey(pwallet, dmn->pdmnState->keyIDOwner) ||
@@ -997,7 +997,7 @@ UniValue protx_list(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid height specified");
         }
 
-        CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(chainActive[height]->GetBlockHash());
+        CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(chainActive[height]);
         bool onlyValid = type == "valid";
         mnList.ForEachMN(onlyValid, [&](const CDeterministicMNCPtr& dmn) {
             ret.push_back(BuildDMNListEntry(pwallet, dmn, detailed));

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -222,7 +222,7 @@ UniValue quorum_memberof(const JSONRPCRequest& request)
         pindexTip = chainActive.Tip();
     }
 
-    auto mnList = deterministicMNManager->GetListForBlock(pindexTip->GetBlockHash());
+    auto mnList = deterministicMNManager->GetListForBlock(pindexTip);
     auto dmn = mnList.GetMN(protxHash);
     if (!dmn) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "masternode not found");

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -80,7 +80,7 @@ UniValue BuildQuorumInfo(const llmq::CQuorumCPtr& quorum, bool includeMembers, b
 {
     UniValue ret(UniValue::VOBJ);
 
-    ret.push_back(Pair("height", quorum->height));
+    ret.push_back(Pair("height", quorum->pindexQuorum->nHeight));
     ret.push_back(Pair("type", quorum->params.name));
     ret.push_back(Pair("quorumHash", quorum->qc.quorumHash.ToString()));
     ret.push_back(Pair("minedBlock", quorum->minedBlockHash.ToString()));

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -648,6 +648,15 @@ public:
         // The default std::vector::clear() does not release memory.
         CScriptBase().swap(*this);
     }
+
+    template<typename Stream>
+    void Serialize(Stream& s) const {
+        s << *(CScriptBase*)this;
+    }
+    template<typename Stream>
+    void Unserialize(Stream& s) {
+        s >> *(CScriptBase*)this;
+    }
 };
 
 class CReserveScript

--- a/src/spentindex.h
+++ b/src/spentindex.h
@@ -216,7 +216,7 @@ struct CAddressUnspentValue {
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(satoshis);
-        READWRITE(*(CScriptBase*)(&script));
+        READWRITE(script);
         READWRITE(blockHeight);
     }
 


### PR DESCRIPTION
This PR reduces the size of the evodb LevelDB instance from >700m to around ~180m and should also reduce future growth a lot. The optimizations are basically the following, but for details look into the commits.

1. We store a diff of the MN list for every block. The diff is between the previous block and the current block. In the old version of `CDeterministicMNListDiff`, we stored a full-blown copy of the whole MN state (`CDeterministicMNState`) for each changed MN. So, even if just a single field (e.g. `nPoSePenalty`, which might change for every block) has changed, the whole state needs to be stored, which needs about 230 bytes per changed MN. In the new version, we only store the individual changed fields per MN. This is implemented in `CDeterministicMNStateDiff`. This reduces the size per MN to just a few bytes.
2. Every 576 blocks we store a full snapshot of the current MN list. This resulted in a few MB per snapshot. This is reduced in this PR by omitting serialization of the `mnUniquePropertyMap` map, which can actually be simply reconstructed from the MN list. This still requires around 1.7MB per snapshot, but it's still a lot better then before. Future optimizations (another PR) might reduce this even further by deleting old and not needed snapshots (we can always reconstruct MN lists based on much older snapshots).
3. Track `internalId`'s for each MN and use this as a key in `CDeterministicMNListDiff`. This reduces the required bytes per changed MN in a diff by another ~30 bytes.
4. Remove `blockHash`, `prevBlockHash` and `nHeight` from `CDeterministicMNListDiff`. These should actually be known already at the time it is loaded from evodb and then processed. This change required some refactoring in deterministic MN and quorum handling to use `CBlockIndex*` in many places where the block hash and/or height were used before.

This PR also includes upgrade code which is executed the first time Dash Core is started with an old evodb present. It simply goes through all the old diffs and converts them to the new format, while at the same time rewriting snapshots.