### PR TITLE
Fix relaying of governance objects when collaterals are not fully confirmed

### DIFF
--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -675,7 +675,7 @@ bool CGovernanceObject::GetCurrentMNVotes(const COutPoint& mnCollateralOutpoint,
     return true;
 }
 
-void CGovernanceObject::Relay(CConnman& connman)
+void CGovernanceObject::Relay(CConnman& connman, bool fOnlyISLocked)
 {
     // Do not relay until fully synced
     if (!masternodeSync.IsSynced()) {
@@ -683,8 +683,13 @@ void CGovernanceObject::Relay(CConnman& connman)
         return;
     }
 
+    int relayProtoVersion = MIN_GOVERNANCE_PEER_PROTO_VERSION;
+    if (fOnlyISLocked) {
+        relayProtoVersion = GOVERNANCE_RELAY_FIX_PROTO_VERSION;
+    }
+
     CInv inv(MSG_GOVERNANCE_OBJECT, GetHash());
-    connman.RelayInv(inv, MIN_GOVERNANCE_PEER_PROTO_VERSION);
+    connman.RelayInv(inv, relayProtoVersion);
 }
 
 void CGovernanceObject::UpdateSentinelVariables()

--- a/src/governance/governance-object.h
+++ b/src/governance/governance-object.h
@@ -264,10 +264,10 @@ public:
 
     bool IsValidLocally(std::string& strError, bool fCheckCollateral) const;
 
-    bool IsValidLocally(std::string& strError, bool& fMissingConfirmations, bool fCheckCollateral) const;
+    bool IsValidLocally(std::string& strError, bool& fMissingConfirmations, bool& fOnlyISLocked, bool fCheckCollateral) const;
 
     /// Check the collateral transaction for the budget proposal/finalized budget
-    bool IsCollateralValid(std::string& strError, bool& fMissingConfirmations) const;
+    bool IsCollateralValid(std::string& strError, bool& fMissingConfirmations, bool& fOnlyISLocked) const;
 
     void UpdateLocalValidity();
 

--- a/src/governance/governance-object.h
+++ b/src/governance/governance-object.h
@@ -26,6 +26,7 @@ class CGovernanceVote;
 static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70213;
 static const int GOVERNANCE_FILTER_PROTO_VERSION = 70206;
 static const int GOVERNANCE_POSE_BANNED_VOTES_VERSION = 70215;
+static const int GOVERNANCE_RELAY_FIX_PROTO_VERSION = 70216;
 
 static const double GOVERNANCE_FILTER_FP_RATE = 0.001;
 
@@ -277,7 +278,7 @@ public:
 
     UniValue GetJSONObject();
 
-    void Relay(CConnman& connman);
+    void Relay(CConnman& connman, bool fOnlyISLocked);
 
     uint256 GetHash() const;
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -176,7 +176,8 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
         // CHECK OBJECT AGAINST LOCAL BLOCKCHAIN
 
         bool fMissingConfirmations = false;
-        bool fIsValid = govobj.IsValidLocally(strError, fMissingConfirmations, true);
+        bool fOnlyISLocked = false;
+        bool fIsValid = govobj.IsValidLocally(strError, fMissingConfirmations, fOnlyISLocked, true);
 
         if (fRateCheckBypassed && fIsValid) {
             if (!MasternodeRateCheck(govobj, true)) {
@@ -291,7 +292,9 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
 
     // MAKE SURE THIS OBJECT IS OK
 
-    if (!govobj.IsValidLocally(strError, true)) {
+    bool fMissingConfirmations = false;
+    bool fOnlyISLocked = false;
+    if (!govobj.IsValidLocally(strError, fMissingConfirmations, fOnlyISLocked, true)) {
         LogPrintf("CGovernanceManager::AddGovernanceObject -- invalid governance object - %s - (nCachedBlockHeight %d) \n", strError, nCachedBlockHeight);
         return;
     }
@@ -861,7 +864,8 @@ void CGovernanceManager::CheckPostponedObjects(CConnman& connman)
 
         std::string strError;
         bool fMissingConfirmations;
-        if (govobj.IsCollateralValid(strError, fMissingConfirmations)) {
+        bool fOnlyISLocked;
+        if (govobj.IsCollateralValid(strError, fMissingConfirmations, fOnlyISLocked)) {
             if (govobj.IsValidLocally(strError, false)) {
                 AddGovernanceObject(govobj, connman);
             } else {

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -242,6 +242,7 @@ private:
     hash_time_m_t mapErasedGovernanceObjects;
 
     object_m_t mapPostponedObjects;
+    hash_s_t setOnlyISLockedObjects;
     hash_s_t setAdditionalRelayObjects;
 
     object_ref_cm_t cmapVoteToObject;

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -329,7 +329,7 @@ UniValue gobject_submit(const JSONRPCRequest& request)
 
     if (fMissingConfirmations) {
         governance.AddPostponedObject(govobj);
-        govobj.Relay(*g_connman);
+        govobj.Relay(*g_connman, false);
     } else {
         governance.AddGovernanceObject(govobj, *g_connman);
     }

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -309,9 +309,10 @@ UniValue gobject_submit(const JSONRPCRequest& request)
 
     std::string strError = "";
     bool fMissingConfirmations;
+    bool fOnlyISLocked;
     {
         LOCK(cs_main);
-        if (!govobj.IsValidLocally(strError, fMissingConfirmations, true) && !fMissingConfirmations) {
+        if (!govobj.IsValidLocally(strError, fOnlyISLocked, fMissingConfirmations, true) && !fMissingConfirmations) {
             LogPrintf("gobject(submit) -- Object submission rejected because object is not valid - hash = %s, strError = %s\n", strHash, strError);
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Governance object is not valid - " + strHash + " - " + strError);
         }

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70215;
+static const int PROTOCOL_VERSION = 70216;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
See commit messages. We might need to backport this to 0.14.0.x, but I'm not 100% sure about it. The current behavior on mainnet should be that governance objects are simply not relayed until the collateral is fully confirmed. There is however a small chance of nodes getting banned by other nodes when they try to relay an object before the first on-chain confirmation, but IMHO the chance is pretty small and it's also not usable for an attack (as it would be quite expensive due to burning of 5 Dash).