### PR TITLE
Remove support for InstantSend locked gobject collaterals

### DIFF
--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -8,15 +8,12 @@
 #include "governance-validators.h"
 #include "governance-vote.h"
 #include "governance.h"
-#include "instantsend.h"
 #include "masternode/masternode-meta.h"
 #include "masternode/masternode-sync.h"
 #include "messagesigner.h"
 #include "spork.h"
 #include "util.h"
 #include "validation.h"
-
-#include "llmq/quorums_instantsend.h"
 
 #include <string>
 #include <univalue.h>
@@ -589,8 +586,7 @@ bool CGovernanceObject::IsCollateralValid(std::string& strError, bool& fMissingC
         }
     }
 
-    if ((nConfirmationsIn < GOVERNANCE_FEE_CONFIRMATIONS) &&
-        (!instantsend.IsLockedInstantSendTransaction(nCollateralHash) || llmq::quorumInstantSendManager->IsLocked(nCollateralHash))) {
+    if ((nConfirmationsIn < GOVERNANCE_FEE_CONFIRMATIONS)) {
         strError = strprintf("Collateral requires at least %d confirmations to be relayed throughout the network (it has only %d)", GOVERNANCE_FEE_CONFIRMATIONS, nConfirmationsIn);
         if (nConfirmationsIn >= GOVERNANCE_MIN_RELAY_FEE_CONFIRMATIONS) {
             fMissingConfirmations = true;


### PR DESCRIPTION
As of #3018, this feature is broken right now and it's not worth the effort and complexity to fix this. Instead, we just remove it.