### PR TITLE
Backport #12783: macOS: disable AppNap during sync (and mixing)

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -97,9 +97,6 @@
   <key>NSHighResolutionCapable</key>
     <string>True</string>
 
-  <key>LSAppNapIsDisabled</key>
-    <string>True</string>
-
   <key>NSRequiresAquaSystemAppearance</key>
     <string>True</string>
 

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -103,7 +103,8 @@ QT_MOC_CPP = \
 
 BITCOIN_MM = \
   qt/macdockiconhandler.mm \
-  qt/macnotificationhandler.mm
+  qt/macnotificationhandler.mm \
+  qt/macos_appnap.mm
 
 QT_MOC = \
   qt/dash.moc \
@@ -142,6 +143,7 @@ BITCOIN_QT_H = \
   qt/intro.h \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
+  qt/macos_appnap.h \
   qt/modaloverlay.h \
   qt/masternodelist.h \
   qt/networkstyle.h \

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -24,6 +24,7 @@
 #include "utilitydialog.h"
 
 #ifdef ENABLE_WALLET
+#include "privatesend/privatesend-client.h"
 #include "walletframe.h"
 #include "walletmodel.h"
 #endif // ENABLE_WALLET
@@ -266,6 +267,10 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
         connect(progressBar, SIGNAL(clicked(QPoint)), this, SLOT(showModalOverlay()));
     }
 #endif
+
+#ifdef Q_OS_MAC
+    m_app_nap_inhibitor = new CAppNapInhibitor;
+#endif
 }
 
 BitcoinGUI::~BitcoinGUI()
@@ -277,6 +282,7 @@ BitcoinGUI::~BitcoinGUI()
     if(trayIcon) // Hide tray icon, as deleting will let it linger until quit (on Ubuntu)
         trayIcon->hide();
 #ifdef Q_OS_MAC
+    delete m_app_nap_inhibitor;
     delete appMenuBar;
     MacDockIconHandler::cleanup();
 #endif
@@ -950,6 +956,15 @@ void BitcoinGUI::updateHeadersSyncProgressLabel()
 
 void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool header)
 {
+#ifdef Q_OS_MAC
+    // Disabling macOS App Nap on initial sync, disk, reindex operations and mixing.
+    (!masternodeSync.IsSynced()
+#ifdef ENABLE_WALLET
+        || privateSendClient.fPrivateSendRunning
+#endif // ENABLE_WALLET
+    ) ? m_app_nap_inhibitor->disableAppNap() : m_app_nap_inhibitor->enableAppNap();
+#endif // Q_OS_MAC
+
     if (modalOverlay)
     {
         if (header)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -958,11 +958,15 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
 {
 #ifdef Q_OS_MAC
     // Disabling macOS App Nap on initial sync, disk, reindex operations and mixing.
-    (!masternodeSync.IsSynced()
+    bool disableAppNap = !masternodeSync.IsSynced();
 #ifdef ENABLE_WALLET
-        || privateSendClient.fPrivateSendRunning
+    disableAppNap |= privateSendClient.fPrivateSendRunning;
 #endif // ENABLE_WALLET
-    ) ? m_app_nap_inhibitor->disableAppNap() : m_app_nap_inhibitor->enableAppNap();
+    if (disableAppNap) {
+        m_app_nap_inhibitor->disableAppNap();
+    } else {
+        m_app_nap_inhibitor->enableAppNap();
+    }
 #endif // Q_OS_MAC
 
     if (modalOverlay)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -23,8 +23,6 @@
 #include <qt/macos_appnap.h>
 #endif
 
-#include <memory>
-
 class ClientModel;
 class NetworkStyle;
 class Notificator;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -19,6 +19,12 @@
 #include <QPushButton>
 #include <QSystemTrayIcon>
 
+#ifdef Q_OS_MAC
+#include <qt/macos_appnap.h>
+#endif
+
+#include <memory>
+
 class ClientModel;
 class NetworkStyle;
 class Notificator;
@@ -132,6 +138,10 @@ private:
     RPCConsole *rpcConsole;
     HelpMessageDialog *helpMessageDialog;
     ModalOverlay *modalOverlay;
+
+#ifdef Q_OS_MAC
+    CAppNapInhibitor* m_app_nap_inhibitor = nullptr;
+#endif
 
     /** Keep track of previous number of blocks, to detect progress */
     int prevBlocks;

--- a/src/qt/macos_appnap.h
+++ b/src/qt/macos_appnap.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MACOS_APPNAP_H
+#define BITCOIN_QT_MACOS_APPNAP_H
+
+#include <memory>
+
+class CAppNapInhibitor final
+{
+public:
+    explicit CAppNapInhibitor();
+    ~CAppNapInhibitor();
+
+    void disableAppNap();
+    void enableAppNap();
+
+private:
+    class CAppNapImpl;
+    std::unique_ptr<CAppNapImpl> impl;
+};
+
+#endif // BITCOIN_QT_MACOS_APPNAP_H

--- a/src/qt/macos_appnap.mm
+++ b/src/qt/macos_appnap.mm
@@ -1,0 +1,71 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "macos_appnap.h"
+
+#include <AvailabilityMacros.h>
+#include <Foundation/NSProcessInfo.h>
+#include <Foundation/Foundation.h>
+
+class CAppNapInhibitor::CAppNapImpl
+{
+public:
+    ~CAppNapImpl()
+    {
+        if(activityId)
+            enableAppNap();
+    }
+
+    void disableAppNap()
+    {
+        if (!activityId)
+        {
+            @autoreleasepool {
+                const NSActivityOptions activityOptions =
+                NSActivityUserInitiatedAllowingIdleSystemSleep &
+                ~(NSActivitySuddenTerminationDisabled |
+                NSActivityAutomaticTerminationDisabled);
+
+                id processInfo = [NSProcessInfo processInfo];
+                if ([processInfo respondsToSelector:@selector(beginActivityWithOptions:reason:)])
+                {
+                    activityId = [processInfo beginActivityWithOptions: activityOptions reason:@"Temporarily disable App Nap for dash-qt."];
+                    [activityId retain];
+                }
+            }
+        }
+    }
+
+    void enableAppNap()
+    {
+        if(activityId)
+        {
+            @autoreleasepool {
+                id processInfo = [NSProcessInfo processInfo];
+                if ([processInfo respondsToSelector:@selector(endActivity:)])
+                    [processInfo endActivity:activityId];
+
+                [activityId release];
+                activityId = nil;
+            }
+        }
+    }
+
+private:
+    NSObject* activityId;
+};
+
+CAppNapInhibitor::CAppNapInhibitor() : impl(new CAppNapImpl()) {}
+
+CAppNapInhibitor::~CAppNapInhibitor() = default;
+
+void CAppNapInhibitor::disableAppNap()
+{
+    impl->disableAppNap();
+}
+
+void CAppNapInhibitor::enableAppNap()
+{
+    impl->enableAppNap();
+}


### PR DESCRIPTION
bitcoin#12783 1e0f3c44992fb82e6bf36c2ef9277b0759c17c4c macOS: disable AppNap during sync (Alexey Ivanov)

Original pull request description:
```
  Code based on pull/5804. Tested only on macOS 10.13.3 and should support 10.9+.

  What macOS versions bitcoin core currently supports?

Tree-SHA512: 85809b8d8d8a05169437b4268988da0b7372c29c6da3223ebdc106dc16dcb6d3caa5c52ace3591467005b50a63fd8b2ab1cb071cb4f450032932df25d5063315
```

The same issue is affecting mixing (which is quite annoying), so I modified it accordingly. Tested on 10.14.5 and it seems to be working as expected. Images below are for `this patch` (2192), `official 0.14.0.2 app` (2201) and `current develop` (2203), all started in regtest mode at ~ the same time.

After a minute or so, not synced:

<img width="879" alt="Screenshot 2019-07-11 at 08 27 23" src="https://user-images.githubusercontent.com/1935069/61024421-421bbc00-a3b6-11e9-80d4-39123387d5f1.png">

Forced sync (`mnsync next`), generated 1 block, waited ~1 minute:

<img width="881" alt="Screenshot 2019-07-11 at 08 46 27" src="https://user-images.githubusercontent.com/1935069/61025460-79d83300-a3b9-11e9-942a-bf0f4adb1aee.png">

Started mixing, generated 1 more block, waited ~1 minute:

<img width="881" alt="Screenshot 2019-07-11 at 08 52 42" src="https://user-images.githubusercontent.com/1935069/61025479-8e1c3000-a3b9-11e9-9599-618db05d2e7a.png">
