### PR TITLE
Fix osslsigncode compile issue in gitian-build

### DIFF
--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -5,7 +5,8 @@ suites:
 architectures:
 - "amd64"
 packages:
-- "libssl-dev"
+# Once osslsigncode supports openssl 1.1, we can change this back to libssl-dev
+- "libssl1.0-dev"
 - "autoconf"
 remotes:
 - "url": "https://github.com/dashpay/dash-detached-sigs.git"


### PR DESCRIPTION
This is a backport of https://github.com/bitcoin/bitcoin/pull/13782 which allows us to build `osslcodesign` for verifying detached pkcs7 signatures of Windows binaries.