### PR TITLE
Do not count 0-fee txes for fee estimation

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -686,8 +686,8 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
         // This transaction should only count for fee estimation if the
         // node is not behind, and the transaction is not dependent on any other
-        // transactions in the mempool.
-        bool validForFeeEstimation = IsCurrentForFeeEstimation() && pool.HasNoInputsOf(tx);
+        // transactions in the mempool. Also ignore 0-fee txes.
+        bool validForFeeEstimation = (nFees != 0) && IsCurrentForFeeEstimation() && pool.HasNoInputsOf(tx);
 
         // Store transaction in memory
         pool.addUnchecked(hash, entry, setAncestors, validForFeeEstimation);


### PR DESCRIPTION
These are usually PS mixing ones which are prioritised internally. They should not be counted for the fee estimation because this damages the estimation results otherwise.