### PR TITLE
Use less alarming fee warning note

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -771,7 +771,7 @@
             </font>
             </property>
             <property name="text">
-             <string>Warning: Fee estimation is currently not possible.</string>
+             <string>Note: Not enough data for fee estimation, using the fallback fee instead.</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -750,9 +750,6 @@ void SendCoinsDialog::updateSmartFeeLabel()
         ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
         ui->labelFeeEstimation->setText("");
         ui->fallbackFeeWarningLabel->setVisible(true);
-        int lightness = ui->fallbackFeeWarningLabel->palette().color(QPalette::WindowText).lightness();
-        QColor warning_colour(255 - (lightness / 5), 176 - (lightness / 3), 48 - (lightness / 14));
-        ui->fallbackFeeWarningLabel->setStyleSheet("QLabel { color: " + warning_colour.name() + "; }");
         ui->fallbackFeeWarningLabel->setIndent(QFontMetrics(ui->fallbackFeeWarningLabel->font()).width("x"));
     }
     else


### PR DESCRIPTION
Some users were complaining that this note looks like smth is broken and it's too alarming when in fact everything should work just fine given the fact that using even minimal default fee is ok in Dash atm.

Before:
<img width="848" alt="Screenshot 2019-07-25 at 16 25 12" src="https://user-images.githubusercontent.com/1935069/61878011-db8bb780-aef8-11e9-9cb9-f27823df73a5.png">


After:
<img width="850" alt="Screenshot 2019-07-25 at 12 54 16" src="https://user-images.githubusercontent.com/1935069/61877852-82238880-aef8-11e9-8786-4cc8d5344545.png">
