### PR TITLE
Bail out properly on Evo DB consistency check failures in ConnectBlock/DisconnectBlock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1393,6 +1393,7 @@ static DisconnectResult DisconnectBlock(const CBlock& block, CValidationState& s
     if (fDIP0003Active && !fHasBestBlock) {
         // Nodes that upgraded after DIP3 activation will have to reindex to ensure evodb consistency
         AbortNode("Found EvoDB inconsistency, you must reindex to continue");
+        return DISCONNECT_FAILED;
     }
 
     bool fClean = true;
@@ -1688,7 +1689,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
 
         if (fDIP0003Active && !fHasBestBlock) {
             // Nodes that upgraded after DIP3 activation will have to reindex to ensure evodb consistency
-            AbortNode("Found EvoDB inconsistency, you must reindex to continue");
+            return AbortNode(state, "Found EvoDB inconsistency, you must reindex to continue");
         }
     }
 


### PR DESCRIPTION
Noticed this while reviewing #3043