### PR TITLE
Merge #11308: [qa] zapwallettxes: Wait up to 3s for mempool reload

### DIFF
--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -15,9 +15,11 @@
   been zapped.
 """
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (assert_equal,
-                                 assert_raises_jsonrpc,
-                                 )
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    wait_until,
+)
 
 class ZapWalletTXesTest (BitcoinTestFramework):
 
@@ -57,6 +59,8 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         # transaction is zapped from the wallet, but is re-added when the mempool is reloaded.
         self.stop_node(0)
         self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-persistmempool=1", "-zapwallettxes=2"])
+
+        wait_until(lambda: self.nodes[0].getmempoolinfo()['size'] == 1, timeout=3)
 
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
         assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)

--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -18,8 +18,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_jsonrpc,
-    wait_until,
 )
+from test_framework.mininode import wait_until
 
 class ZapWalletTXesTest (BitcoinTestFramework):
 


### PR DESCRIPTION
fadd0c16b [qa] zapwallettxes: Wait up to 3s for mempool reload (MarcoFalke)

Pull request description:

  There had been intermittent test failures on zapwallettxes, as no time was allotted to reload the mempool.

Tree-SHA512: 993254d2aaca6ea42fceefffed0cf90bdda91c64150179ef2a11337c3fe2cc6bf42b83ea9d9a1a575204fbde2676d7203443b00d053e8c2ed43e017c09d3ab11