### PR TITLE
Change regtest and devnet p2p/rpc ports

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -635,7 +635,7 @@ public:
         pchMessageStart[1] = 0xca;
         pchMessageStart[2] = 0xff;
         pchMessageStart[3] = 0xce;
-        nDefaultPort = 19999;
+        nDefaultPort = 19799;
         nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlock(1417713337, 1096447, 0x207fffff, 1, 50 * COIN);
@@ -782,7 +782,7 @@ public:
         pchMessageStart[1] = 0xc1;
         pchMessageStart[2] = 0xb7;
         pchMessageStart[3] = 0xdc;
-        nDefaultPort = 19994;
+        nDefaultPort = 19899;
         nPruneAfterHeight = 1000;
 
         genesis = CreateGenesisBlock(1417713337, 1096447, 0x207fffff, 1, 50 * COIN);

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -59,7 +59,7 @@ class CBaseDevNetParams : public CBaseChainParams
 public:
     CBaseDevNetParams(const std::string &dataDir)
     {
-        nRPCPort = 19998;
+        nRPCPort = 19798;
         strDataDir = dataDir;
     }
 };
@@ -72,7 +72,7 @@ class CBaseRegTestParams : public CBaseChainParams
 public:
     CBaseRegTestParams()
     {
-        nRPCPort = 18332;
+        nRPCPort = 19898;
         strDataDir = "regtest";
     }
 };


### PR DESCRIPTION
Differentiate testnet/devent/regtest ports. Also, 18332 is bitcoin's testnet rpc port which we forgot to tweak long time ago it seems (introduced in v0.12.1) 🙈 