### PR TITLE
Rework govobject/trigger cleanup a bit

### DIFF
--- a/src/governance/governance-classes.cpp
+++ b/src/governance/governance-classes.cpp
@@ -177,10 +177,7 @@ void CGovernanceTriggerManager::CleanAndRemove()
             LogPrint(BCLog::GOBJECT, "CGovernanceTriggerManager::CleanAndRemove -- Removing trigger object %s\n", strDataAsPlainString);
             // mark corresponding object for deletion
             if (pObj) {
-                pObj->fCachedDelete = true;
-                if (pObj->nDeletionTime == 0) {
-                    pObj->nDeletionTime = GetAdjustedTime();
-                }
+                pObj->PrepareDeletion(GetAdjustedTime());
             }
             // delete the trigger
             mapTrigger.erase(it++);
@@ -690,8 +687,8 @@ bool CSuperblock::IsExpired()
         CGovernanceObject* pgovobj = GetGovernanceObject();
         if (pgovobj) {
             LogPrint(BCLog::GOBJECT, "CSuperblock::IsExpired -- Expiring outdated object: %s\n", pgovobj->GetHash().ToString());
-            pgovobj->fExpired = true;
-            pgovobj->nDeletionTime = GetAdjustedTime();
+            pgovobj->SetExpired();
+            pgovobj->PrepareDeletion(GetAdjustedTime());
         }
     }
 

--- a/src/governance/governance-classes.h
+++ b/src/governance/governance-classes.h
@@ -172,7 +172,7 @@ public:
     CAmount GetPaymentsTotalAmount();
 
     bool IsValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
-    bool IsExpired();
+    bool IsExpired() const;
 };
 
 #endif

--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -227,6 +227,7 @@ void CGovernanceObject::ClearMasternodeVotes()
         if (!mnList.HasMNByCollateral(it->first)) {
             fileVotes.RemoveVotesFromMasternode(it->first);
             mapCurrentMNVotes.erase(it++);
+            fDirtyCache = true;
         } else {
             ++it;
         }

--- a/src/governance/governance-object.h
+++ b/src/governance/governance-object.h
@@ -107,10 +107,6 @@ struct vote_rec_t {
 
 class CGovernanceObject
 {
-    friend class CGovernanceManager;
-    friend class CGovernanceTriggerManager;
-    friend class CSuperblock;
-
 public: // Types
     typedef std::map<COutPoint, vote_rec_t> vote_m_t;
 
@@ -246,6 +242,11 @@ public:
         return fExpired;
     }
 
+    void SetExpired()
+    {
+        fExpired = true;
+    }
+
     const CGovernanceObjectVoteFile& GetVoteFile() const
     {
         return fileVotes;
@@ -272,6 +273,14 @@ public:
     void UpdateLocalValidity();
 
     void UpdateSentinelVariables();
+
+    void PrepareDeletion(int64_t nDeletionTime_)
+    {
+        fCachedDelete = true;
+        if (nDeletionTime == 0) {
+            nDeletionTime = nDeletionTime_;
+        }
+    }
 
     CAmount GetMinCollateralFee() const;
 
@@ -329,7 +338,6 @@ public:
         // AFTER DESERIALIZATION OCCURS, CACHED VARIABLES MUST BE CALCULATED MANUALLY
     }
 
-private:
     // FUNCTIONS FOR DEALING WITH DATA STRING
     void LoadData();
     void GetData(UniValue& objResult);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -310,16 +310,12 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
     // SHOULD WE ADD THIS OBJECT TO ANY OTHER MANANGERS?
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::AddGovernanceObject -- Before trigger block, GetDataAsPlainString = %s, nObjectType = %d\n",
-                govobj.GetDataAsPlainString(), govobj.nObjectType);
+                govobj.GetDataAsPlainString(), govobj.GetObjectType());
 
-    if (govobj.nObjectType == GOVERNANCE_OBJECT_TRIGGER) {
+    if (govobj.GetObjectType() == GOVERNANCE_OBJECT_TRIGGER) {
         if (!triggerman.AddNewTrigger(nHash)) {
             LogPrint(BCLog::GOBJECT, "CGovernanceManager::AddGovernanceObject -- undo adding invalid trigger object: hash = %s\n", nHash.ToString());
-            CGovernanceObject& objref = objpair.first->second;
-            objref.fCachedDelete = true;
-            if (objref.nDeletionTime == 0) {
-                objref.nDeletionTime = GetAdjustedTime();
-            }
+            objpair.first->second.PrepareDeletion(GetAdjustedTime());
             return;
         }
     }
@@ -355,7 +351,6 @@ void CGovernanceManager::UpdateCachesAndClean()
             continue;
         }
         it->second.ClearMasternodeVotes();
-        it->second.fDirtyCache = true;
     }
 
     ScopedLockBool guard(cs, fRateChecksEnabled, false);
@@ -429,10 +424,7 @@ void CGovernanceManager::UpdateCachesAndClean()
                 CProposalValidator validator(pObj->GetDataAsHexString(), true);
                 if (!validator.Validate()) {
                     LogPrintf("CGovernanceManager::UpdateCachesAndClean -- set for deletion expired obj %s\n", strHash);
-                    pObj->fCachedDelete = true;
-                    if (pObj->nDeletionTime == 0) {
-                        pObj->nDeletionTime = nNow;
-                    }
+                    pObj->PrepareDeletion(nNow);
                 }
             }
             ++it;
@@ -999,7 +991,7 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
                 if (mapAskedRecently[nHash].size() >= nPeersPerHashMax) continue;
             }
 
-            if (objPair.second.nObjectType == GOVERNANCE_OBJECT_TRIGGER) {
+            if (objPair.second.GetObjectType() == GOVERNANCE_OBJECT_TRIGGER) {
                 vTriggerObjHashes.push_back(nHash);
             } else {
                 vOtherObjHashes.push_back(nHash);
@@ -1107,15 +1099,12 @@ void CGovernanceManager::AddCachedTriggers()
     for (auto& objpair : mapObjects) {
         CGovernanceObject& govobj = objpair.second;
 
-        if (govobj.nObjectType != GOVERNANCE_OBJECT_TRIGGER) {
+        if (govobj.GetObjectType() != GOVERNANCE_OBJECT_TRIGGER) {
             continue;
         }
 
         if (!triggerman.AddNewTrigger(govobj.GetHash())) {
-            govobj.fCachedDelete = true;
-            if (govobj.nDeletionTime == 0) {
-                govobj.nDeletionTime = GetAdjustedTime();
-            }
+            govobj.PrepareDeletion(GetAdjustedTime());
         }
     }
 }


### PR DESCRIPTION
This PR includes `CGovernanceObject` refactoring (which encapsulates govobject updates and which was dropped from #3066 due to a potential change in the behaviour) and further changes in `CGovernanceTriggerManager::CleanAndRemove()` and `CSuperblock::IsExpired()` to fix a potential bug revealed by the initial refactoring https://github.com/dashpay/dash/pull/3066#discussion_r315940036. To be fair, `CSuperblock::IsExpired()` is not used anywhere else but in `CGovernanceTriggerManager::CleanAndRemove()` it seems, so there should be no _actual_ difference (i.e. we are safe but current code looks dirty :)).