### PR TITLE
Add LDFLAGS_WRAP_EXCEPTIONS to dash_fuzzy linking

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -131,7 +131,7 @@ endif
 test_test_dash_fuzzy_SOURCES = test/test_dash_fuzzy.cpp
 test_test_dash_fuzzy_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_test_dash_fuzzy_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
-test_test_dash_fuzzy_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_test_dash_fuzzy_LDFLAGS = $(LDFLAGS_WRAP_EXCEPTIONS) $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
 test_test_dash_fuzzy_LDADD = \
   $(LIBUNIVALUE) \


### PR DESCRIPTION
This fixed compilation of dash_fuzzy with stacktraces.