### PR TITLE
Remove liquidity provider privatesend

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -594,8 +594,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-privatesendrounds=<n>", strprintf(_("Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)"), MIN_PRIVATESEND_ROUNDS, MAX_PRIVATESEND_ROUNDS, DEFAULT_PRIVATESEND_ROUNDS));
     strUsage += HelpMessageOpt("-privatesendamount=<n>", strprintf(_("Keep N DASH anonymized (%u-%u, default: %u)"), MIN_PRIVATESEND_AMOUNT, MAX_PRIVATESEND_AMOUNT, DEFAULT_PRIVATESEND_AMOUNT));
     strUsage += HelpMessageOpt("-privatesenddenoms=<n>", strprintf(_("Create up to N inputs of each denominated amount (%u-%u, default: %u)"), MIN_PRIVATESEND_DENOMS, MAX_PRIVATESEND_DENOMS, DEFAULT_PRIVATESEND_DENOMS));
-    strUsage += HelpMessageOpt("-liquidityprovider=<n>", strprintf(_("Provide liquidity to PrivateSend by infrequently mixing coins on a continual basis (%u-%u, default: %u, 1=very frequent, high fees, %u=very infrequent, low fees)"),
-        MIN_PRIVATESEND_LIQUIDITY, MAX_PRIVATESEND_LIQUIDITY, DEFAULT_PRIVATESEND_LIQUIDITY, MAX_PRIVATESEND_LIQUIDITY));
 #endif // ENABLE_WALLET
 
     strUsage += HelpMessageGroup(_("InstantSend options:"));
@@ -953,24 +951,6 @@ void InitParameterInteraction()
     }
 
 #ifdef ENABLE_WALLET
-    int nLiqProvTmp = gArgs.GetArg("-liquidityprovider", DEFAULT_PRIVATESEND_LIQUIDITY);
-    if (nLiqProvTmp > 0) {
-        gArgs.ForceSetArg("-enableprivatesend", "1");
-        LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -enableprivatesend=1\n", __func__, nLiqProvTmp);
-        gArgs.ForceSetArg("-privatesendautostart", "1");
-        LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -privatesendautostart=1\n", __func__, nLiqProvTmp);
-        gArgs.ForceSetArg("-privatesendsessions", itostr(MIN_PRIVATESEND_SESSIONS));
-        LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -privatesendsessions=%d\n", __func__, nLiqProvTmp, itostr(std::numeric_limits<int>::max()));
-        gArgs.ForceSetArg("-privatesendrounds", itostr(std::numeric_limits<int>::max()));
-        LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -privatesendrounds=%d\n", __func__, nLiqProvTmp, itostr(std::numeric_limits<int>::max()));
-        gArgs.ForceSetArg("-privatesendamount", itostr(MAX_PRIVATESEND_AMOUNT));
-        LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -privatesendamount=%d\n", __func__, nLiqProvTmp, MAX_PRIVATESEND_AMOUNT);
-        gArgs.ForceSetArg("-privatesenddenoms", itostr(MAX_PRIVATESEND_DENOMS));
-        LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -privatesenddenoms=%d\n", __func__, nLiqProvTmp, itostr(MAX_PRIVATESEND_DENOMS));
-        gArgs.ForceSetArg("-privatesendmultisession", "0");
-        LogPrintf("%s: parameter interaction: -liquidityprovider=%d -> setting -privatesendmultisession=0\n", __func__, nLiqProvTmp);
-    }
-
     if (gArgs.IsArgSet("-hdseed") && IsHex(gArgs.GetArg("-hdseed", "not hex")) && (gArgs.IsArgSet("-mnemonic") || gArgs.IsArgSet("-mnemonicpassphrase"))) {
         gArgs.ForceRemoveArg("-mnemonic");
         gArgs.ForceRemoveArg("-mnemonicpassphrase");
@@ -1942,13 +1922,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     // ********************************************************* Step 10b: setup PrivateSend
 
 #ifdef ENABLE_WALLET
-    privateSendClient.nLiquidityProvider = std::min(std::max((int)gArgs.GetArg("-liquidityprovider", DEFAULT_PRIVATESEND_LIQUIDITY), MIN_PRIVATESEND_LIQUIDITY), MAX_PRIVATESEND_LIQUIDITY);
     int nMaxRounds = MAX_PRIVATESEND_ROUNDS;
-    if(privateSendClient.nLiquidityProvider) {
-        // special case for liquidity providers only, normal clients should use default value
-        privateSendClient.SetMinBlocksToWait(privateSendClient.nLiquidityProvider * 15);
-        nMaxRounds = std::numeric_limits<int>::max();
-    }
 
     if (vpwallets.empty()) {
         privateSendClient.fEnablePrivateSend = privateSendClient.fPrivateSendRunning = false;
@@ -1963,12 +1937,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     privateSendClient.nPrivateSendDenoms = std::min(std::max((int)gArgs.GetArg("-privatesenddenoms", DEFAULT_PRIVATESEND_DENOMS), MIN_PRIVATESEND_DENOMS), MAX_PRIVATESEND_DENOMS);
 
     if (privateSendClient.fEnablePrivateSend) {
-        LogPrintf("PrivateSend: liquidityprovider=%d, autostart=%d, multisession=%d, "
+        LogPrintf("PrivateSend: autostart=%d, multisession=%d, "
             "sessions=%d, rounds=%d, amount=%d, denoms=%d\n",
-            privateSendClient.nLiquidityProvider, privateSendClient.fPrivateSendRunning,
-            privateSendClient.fPrivateSendMultiSession, privateSendClient.nPrivateSendSessions,
-            privateSendClient.nPrivateSendRounds, privateSendClient.nPrivateSendAmount,
-            privateSendClient.nPrivateSendDenoms);
+            privateSendClient.fPrivateSendRunning, privateSendClient.fPrivateSendMultiSession,
+            privateSendClient.nPrivateSendSessions, privateSendClient.nPrivateSendRounds,
+            privateSendClient.nPrivateSendAmount, privateSendClient.nPrivateSendDenoms);
     }
 #endif // ENABLE_WALLET
 

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -20,17 +20,14 @@ static const int MIN_PRIVATESEND_SESSIONS = 1;
 static const int MIN_PRIVATESEND_ROUNDS = 2;
 static const int MIN_PRIVATESEND_AMOUNT = 2;
 static const int MIN_PRIVATESEND_DENOMS = 10;
-static const int MIN_PRIVATESEND_LIQUIDITY = 0;
 static const int MAX_PRIVATESEND_SESSIONS = 10;
 static const int MAX_PRIVATESEND_ROUNDS = 16;
 static const int MAX_PRIVATESEND_DENOMS = 100000;
 static const int MAX_PRIVATESEND_AMOUNT = MAX_MONEY / COIN;
-static const int MAX_PRIVATESEND_LIQUIDITY = 100;
 static const int DEFAULT_PRIVATESEND_SESSIONS = 4;
 static const int DEFAULT_PRIVATESEND_ROUNDS = 4;
 static const int DEFAULT_PRIVATESEND_AMOUNT = 1000;
 static const int DEFAULT_PRIVATESEND_DENOMS = 300;
-static const int DEFAULT_PRIVATESEND_LIQUIDITY = 0;
 
 static const bool DEFAULT_PRIVATESEND_AUTOSTART = false;
 static const bool DEFAULT_PRIVATESEND_MULTISESSION = false;
@@ -198,7 +195,6 @@ public:
     int nPrivateSendRounds;
     int nPrivateSendAmount;
     int nPrivateSendDenoms;
-    int nLiquidityProvider;
     bool fEnablePrivateSend;
     bool fPrivateSendRunning;
     bool fPrivateSendMultiSession;
@@ -217,7 +213,6 @@ public:
         nPrivateSendRounds(DEFAULT_PRIVATESEND_ROUNDS),
         nPrivateSendAmount(DEFAULT_PRIVATESEND_AMOUNT),
         nPrivateSendDenoms(DEFAULT_PRIVATESEND_DENOMS),
-        nLiquidityProvider(DEFAULT_PRIVATESEND_LIQUIDITY),
         fEnablePrivateSend(false),
         fPrivateSendRunning(false),
         fPrivateSendMultiSession(DEFAULT_PRIVATESEND_MULTISESSION),

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -227,8 +227,6 @@ public:
     void AddSkippedDenom(const CAmount& nDenomValue);
     void RemoveSkippedDenom(const CAmount& nDenomValue);
 
-    void SetMinBlocksToWait(int nMinBlocksToWaitIn) { nMinBlocksToWait = nMinBlocksToWaitIn; }
-
     void ResetPool();
 
     std::string GetStatuses();

--- a/src/qt/dashstrings.cpp
+++ b/src/qt/dashstrings.cpp
@@ -194,10 +194,6 @@ QT_TRANSLATE_NOOP("dash-core", ""
 "PrivateSend uses exact denominated amounts to send funds, you might simply "
 "need to anonymize some more coins."),
 QT_TRANSLATE_NOOP("dash-core", ""
-"Provide liquidity to PrivateSend by infrequently mixing coins on a continual "
-"basis (%u-%u, default: %u, 1=very frequent, high fees, %u=very infrequent, "
-"low fees)"),
-QT_TRANSLATE_NOOP("dash-core", ""
 "Prune configured below the minimum of %d MiB.  Please use a higher number."),
 QT_TRANSLATE_NOOP("dash-core", ""
 "Prune: last wallet synchronisation goes beyond pruned data. You need to -"


### PR DESCRIPTION
The reason behind this is two fold:
1. it is very likely nobody is currently running this on the mainnet (due to already strong liquidity), it provides no use for testnet as there you can just enable mixing and get the same affect. Because of this reason I find it okay to just remove it outright.
2. even if people did use it (or if some do as a novelty) it likely hurts the privacy of the system. This is because as a liquidity provider your outputs will always take many (sometimes hundreds) blocks before being used in a new mixing round, whereas real user's funds will normally be mixed again very rapidly.

Signed-off-by: Pasta <pasta@dashboost.org>