### PR TITLE
Tools window: Information - make "InstantSend locks" and "Number of Masternodes" fields copyable

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -232,8 +232,17 @@
        </item>
        <item row="9" column="1">
         <widget class="QLabel" name="masternodeCount">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
          <property name="text">
           <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -417,8 +426,17 @@
        </item>
        <item row="16" column="1">
         <widget class="QLabel" name="instantSendLockCount">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
          <property name="text">
           <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Brings the properties of the dash specific fields in the debug menu in line with the bitcoin fields' properties. 
Initially discovered when I tried clicking on them because I like clicking on things. It made me sad when I couldn't click on it.

Signed-off-by: Pasta <pasta@dashboost.org>