### PR TITLE
Don't care about governance cache while the blockchain isn't synced yet

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -339,6 +339,11 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
 
 void CGovernanceManager::UpdateCachesAndClean()
 {
+    // Return on initial sync, spammed the debug.log and provided no use
+    if (!masternodeSync.IsBlockchainSynced()) {
+        return;
+    }
+
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::UpdateCachesAndClean\n");
 
     std::vector<uint256> vecDirtyHashes = mmetaman.GetAndClearDirtyGovernanceObjectHashes();


### PR DESCRIPTION
```
2019-09-14 05:31:13 CGovernanceManager::UpdateCachesAndClean -- Governance Objects: 0 (Proposals: 0, Triggers: 0, Other: 0; Erased: 0), Votes: 0 59m 60m
```

I also noticed a significant slow down in sync around DIP3 activation. I'm not sure if this slow-down is due to calculating the MN-List and diffs (not fixed by this commit) or if it is caused by the pushing to notification (hopefully fixed by this commit).

Be warned, I have not actually tested this commit yet. I'll try to get on that tomorrow.

Signed-off-by: Pasta <pasta@dashboost.org>