### PR TITLE
Fix chia_bls include prefix

### DIFF
--- a/depends/packages/chia_bls.mk
+++ b/depends/packages/chia_bls.mk
@@ -13,7 +13,7 @@ $(package)_dependencies=gmp
 
 define $(package)_set_vars
   $(package)_config_opts=-DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix)
-  $(package)_config_opts+= -DCMAKE_PREFIX_PATH=$(host_prefix)
+  $(package)_config_opts+= -DCMAKE_PREFIX_PATH=$($(package)_staging_dir)/$(host_prefix)
   $(package)_config_opts+= -DSTLIB=ON -DSHLIB=OFF -DSTBIN=ON
   $(package)_config_opts_linux=-DOPSYS=LINUX -DCMAKE_SYSTEM_NAME=Linux
   $(package)_config_opts_darwin=-DOPSYS=MACOSX -DCMAKE_SYSTEM_NAME=Darwin


### PR DESCRIPTION
When I try and build chia_bls dependency in Alpine linux, the compiler can't find the path to the `gmp.h` header:

```
/home/alpine/dash/depends/work/build/x86_64-pc-linux-gnu/chia_bls/v20181101-7d7df22e185/contrib/relic/include/relic_types.h:39:10: fatal error: gmp.h: No such file or directory
 #include <gmp.h>
          ^~~~~~~
compilation terminated.
```

I am assuming this can be found in `<staging-dir>/<host-triplet>` but not sure why this is working in Ubuntu but not on Alpine. For some reason it's not finding the gmp header directly in `dash/depends/<host-triplet>`.

This patch allows the compiler to find the header files and build the chia_bls dependency.