### PR TITLE
Refresh zeromq 4.1.5 patches

### DIFF
--- a/depends/patches/zeromq/9114d3957725acd34aa8b8d011585812f3369411.patch
+++ b/depends/patches/zeromq/9114d3957725acd34aa8b8d011585812f3369411.patch
@@ -8,15 +8,15 @@ Subject: [PATCH] enable static libraries on mingw
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure.ac b/configure.ac
-index 393505b..e92131a 100644
+index d702461..da24aa5 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -265,7 +265,7 @@ case "${host_os}" in
+@@ -261,7 +261,7 @@ case "${host_os}" in
          libzmq_dso_visibility="no"
-
+ 
          if test "x$enable_static" = "xyes"; then
 -            AC_MSG_ERROR([Building static libraries is not supported under MinGW32])
 +            CPPFLAGS="-DZMQ_STATIC"
          fi
-
- 	# Set FD_SETSIZE to 1024
+         ;;
+     *cygwin*)

--- a/depends/patches/zeromq/9e6745c12e0b100cd38acecc16ce7db02905e27c.patch
+++ b/depends/patches/zeromq/9e6745c12e0b100cd38acecc16ce7db02905e27c.patch
@@ -8,15 +8,15 @@ Subject: [PATCH] Fix autotools for static MinGW builds
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure.ac b/configure.ac
-index 5a0fa14..def6ea7 100644
+index da24aa5..abfd88b 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -259,7 +259,7 @@ case "${host_os}" in
+@@ -261,7 +261,7 @@ case "${host_os}" in
          libzmq_dso_visibility="no"
-
+ 
          if test "x$enable_static" = "xyes"; then
 -            CPPFLAGS="-DZMQ_STATIC"
 +            CPPFLAGS="-DZMQ_STATIC $CPPFLAGS"
          fi
-
- 	# Set FD_SETSIZE to 1024
+         ;;
+     *cygwin*)


### PR DESCRIPTION
Some implementations of the `patch` tool cannot handle fuzz / divergence (such as the Alpine Linux version). This just updates the surrounding context code so that patch can be applied more cleanly.

This partially fixes #3090. An alternative to this is to backport the zeromq upgrades that Bitcoin implemented and drop 4.1.5 for 4.2.2+.