### PR TITLE
Ensure execinfo.h and linker flags set in autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -631,7 +631,7 @@ if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
 fi
 
-AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h])
+AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h execinfo.h])
 
 AC_CHECK_DECLS([strnlen])
 
@@ -734,6 +734,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYSCTL_ARND, 1,[Define this symbol if the BSD sysctl(KERN_ARND) is available]) ],
  [ AC_MSG_RESULT(no)]
 )
+
+# ensure backtrace() is found, check -lexecinfo if necessary
+AC_SEARCH_LIBS([backtrace], [execinfo], [], [
+  AC_MSG_ERROR([Unable to find backtrace()])
+])
 
 # Check for reduced exports
 if test x$use_reduce_exports = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -736,9 +736,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
 )
 
 # ensure backtrace() is found, check -lexecinfo if necessary
-AC_SEARCH_LIBS([backtrace], [execinfo], [], [
-  AC_MSG_ERROR([Unable to find backtrace()])
-])
+if test x$TARGET_OS != xwindows; then
+  AC_SEARCH_LIBS([backtrace], [execinfo], [], [
+    AC_MSG_ERROR([Unable to find backtrace()])
+  ])
+fi
 
 # Check for reduced exports
 if test x$use_reduce_exports = xyes; then


### PR DESCRIPTION
The purpose of this PR is to allow compilation on non-GNU libc (glibc) systems, such as Alpine linux, and this will also require a couple more fixes to the depends system (detailed in issue #3090).

This specific PR modifies the configure.ac (autoconf) file to do 2 things:

1. Ensures `execinfo.h` exists in the include path (this a required import in `stacktraces.cpp` anyway).
2. Adds the `-lexecinfo` flag only if required.

As for 2, on a glibc based system (such as Ubuntu), the output from this configure change looks like this: `checking for library containing backtrace... none required`

On Alpine, which uses musl libc instead of the GNU libc, the configure script will error if the libexecinfo package is not installed:

```
checking for library containing backtrace... no
configure: error: Unable to find backtrace()
```

... but works correctly (and adds the appropriate linker flag) if it's installed: `checking for library containing backtrace... -lexecinfo`