### PR TITLE
Add OpenSSL termios fix for musl libc

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -3,6 +3,7 @@ $(package)_version=1.0.1k
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
+$(package)_patches=0001-Add-OpenSSL-termios-fix-for-musl-libc.patch
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
@@ -58,6 +59,7 @@ $(package)_config_opts_i686_mingw32=mingw
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/0001-Add-OpenSSL-termios-fix-for-musl-libc.patch && \
   sed -i.old "/define DATE/d" util/mkbuildinf.pl && \
   sed -i.old "s|engines apps test|engines|" Makefile.org
 endef

--- a/depends/patches/openssl/0001-Add-OpenSSL-termios-fix-for-musl-libc.patch
+++ b/depends/patches/openssl/0001-Add-OpenSSL-termios-fix-for-musl-libc.patch
@@ -1,0 +1,17 @@
+diff --git a/crypto/ui/ui_openssl.c b/crypto/ui/ui_openssl.c
+index a38c758..d99edc2 100644
+--- a/crypto/ui/ui_openssl.c
++++ b/crypto/ui/ui_openssl.c
+@@ -190,9 +190,9 @@
+ # undef  SGTTY
+ #endif
+ 
+-#if defined(linux) && !defined(TERMIO)
+-# undef  TERMIOS
+-# define TERMIO
++#if defined(linux)
++# define TERMIOS
++# undef  TERMIO
+ # undef  SGTTY
+ #endif
+ 


### PR DESCRIPTION
This should be the last bit left for fixing #3090. This is a known issue as `TERMIOS` (not `TERMIO`) should be the default, and is fixed in later versions of OpenSSL. As such, this should not affect other Linuxes or POSIX systems.

There is discussion on the OpenSSL repo here: https://github.com/openssl/openssl/issues/163
