### PR TITLE
Backport bitcoin#10854: Avoid using sizes on non-fixed-width types to derive protocol constants

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3825,7 +3825,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 vecTxDSInTmp.clear();
                 for (const auto& coin : setCoins) {
                     CTxIn txin = CTxIn(coin.outpoint,CScript(),
-                                              std::numeric_limits<unsigned int>::max()-1);
+                                              CTxIn::SEQUENCE_FINAL - 1);
                     vecTxDSInTmp.push_back(CTxDSIn(txin, coin.txout.scriptPubKey));
                     txNew.vin.push_back(txin);
                 }


### PR DESCRIPTION
The original PR did a few more changes in RBF code which is missing in Dash.