### PR TITLE
Whitelist nodes in llmq_dkgerrors.py

### DIFF
--- a/test/functional/llmq-dkgerrors.py
+++ b/test/functional/llmq-dkgerrors.py
@@ -15,7 +15,7 @@ Simulate and check DKG errors
 
 class LLMQDKGErrors(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 5, [], fast_dip3_enforcement=True)
+        self.set_dash_test_params(6, 5, ["-whitelist=127.0.0.1"], fast_dip3_enforcement=True)
 
     def run_test(self):
 


### PR DESCRIPTION
This fixes a few rare test failures