### PR TITLE
[0.14.0.x] Remove check for mempool size in CInstantSendManager::CheckCanLock

### DIFF
--- a/qa/rpc-tests/autois-mempool.py
+++ b/qa/rpc-tests/autois-mempool.py
@@ -99,9 +99,10 @@ class AutoISMempoolTest(DashTestFramework):
         self.wait_for_sporks_same()
 
         # autoIS is not working now
-        assert(not self.send_simple_tx(sender, receiver))
-        # regular IS is still working for old IS but not for new one
-        assert(not self.send_regular_instantsend(sender, receiver, False) if new_is else self.send_regular_instantsend(sender, receiver))
+        if not new_is:
+            assert(not self.send_simple_tx(sender, receiver))
+            # regular IS is still working for old IS but not for new one
+            assert(not self.send_regular_instantsend(sender, receiver, False) if new_is else self.send_regular_instantsend(sender, receiver))
 
         # generate one block to clean up mempool and retry auto and regular IS
         # generate 5 more blocks to avoid retroactive signing (which would overload Travis)

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -459,10 +459,6 @@ bool CInstantSendManager::ProcessTx(const CTransaction& tx, const Consensus::Par
 
 bool CInstantSendManager::CheckCanLock(const CTransaction& tx, bool printDebug, const Consensus::Params& params)
 {
-    if (sporkManager.IsSporkActive(SPORK_16_INSTANTSEND_AUTOLOCKS) && (mempool.UsedMemoryShare() > CInstantSend::AUTO_IX_MEMPOOL_THRESHOLD)) {
-        return false;
-    }
-
     if (tx.vin.empty()) {
         // can't lock TXs without inputs (e.g. quorum commitments)
         return false;


### PR DESCRIPTION
This should not have been here at all and is already removed in develop.
Recent InstantSend failures on mainnet were partly related to this check.