### PR TITLE
Few fixes for `wait_for_instantlock`

### DIFF
--- a/test/functional/llmq-is-cl-conflicts.py
+++ b/test/functional/llmq-is-cl-conflicts.py
@@ -9,7 +9,7 @@ from test_framework import mininode
 from test_framework.blocktools import get_masternode_payment, create_coinbase, create_block
 from test_framework.mininode import *
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import sync_blocks, p2p_port, assert_raises_rpc_error, set_node_times
+from test_framework.util import sync_blocks, sync_mempools, p2p_port, assert_raises_rpc_error, set_node_times
 
 '''
 llmq-is-cl-conflicts.py
@@ -102,6 +102,8 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
         rawtx4 = self.nodes[0].signrawtransaction(rawtx4)['hex']
         rawtx4_txid = self.nodes[0].sendrawtransaction(rawtx4)
 
+        # wait for transactions to propagate
+        sync_mempools(self.nodes)
         for node in self.nodes:
             self.wait_for_instantlock(rawtx1_txid, node)
             self.wait_for_instantlock(rawtx4_txid, node)
@@ -143,6 +145,8 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
         rawtx5 = self.nodes[0].createrawtransaction(inputs, {self.nodes[0].getnewaddress(): 0.999})
         rawtx5 = self.nodes[0].signrawtransaction(rawtx5)['hex']
         rawtx5_txid = self.nodes[0].sendrawtransaction(rawtx5)
+        # wait for the transaction to propagate
+        sync_mempools(self.nodes)
         for node in self.nodes:
             self.wait_for_instantlock(rawtx5_txid, node)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -38,7 +38,9 @@ from .util import (
     sync_blocks,
     sync_mempools,
     sync_masternodes,
-    wait_to_sync)
+    wait_to_sync,
+    wait_until,
+)
 
 class TestStatus(Enum):
     PASSED = 1
@@ -687,22 +689,12 @@ class DashTestFramework(BitcoinTestFramework):
         return ret
 
     def wait_for_instantlock(self, txid, node):
-        # wait for instantsend locks
-        start = time.time()
-        locked = False
-        while True:
+        def check_instantlock():
             try:
-                is_tx = node.getrawtransaction(txid, True)
-                if is_tx['instantlock']:
-                    locked = True
-                    break
+                return node.getrawtransaction(txid, True)["instantlock"]
             except:
-                # TX not received yet?
-                pass
-            if time.time() > start + 10:
-                break
-            time.sleep(0.5)
-        return locked
+                return False
+        wait_until(check_instantlock, timeout=10, sleep=0.5)
 
     def wait_for_sporks_same(self, timeout=30):
         st = time.time()


### PR DESCRIPTION
Pls see individual commits for details.

Note: `p2p-instantsend.py` is expected to fail randomly now because of propagation issues which were not caught previously (should be fixed via #3124).

~Note2: Also needs #3122 to be merged first to import `wait_until`, will rebase~ included similar changes here