### PR TITLE
Ignore recent rejects filter for locked txes

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -955,7 +955,7 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                 if (mapOrphanTransactions.count(inv.hash)) return true;
             }
 
-            return recentRejects->contains(inv.hash) ||
+            return (recentRejects->contains(inv.hash) && !llmq::quorumInstantSendManager->IsLocked(inv.hash)) ||
                    mempool.exists(inv.hash) ||
                    pcoinsTip->HaveCoinInCache(COutPoint(inv.hash, 0)) || // Best effort: only try output 0 and 1
                    pcoinsTip->HaveCoinInCache(COutPoint(inv.hash, 1));

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -955,6 +955,11 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                 if (mapOrphanTransactions.count(inv.hash)) return true;
             }
 
+            // When we receive an islock for a previously rejected transaction, we have to
+            // drop the first-seen tx (which such a locked transaction was conflicting with)
+            // and re-request the locked transaction (which did not make it into the mempool
+            // previously due to txn-mempool-conflict rule). This means that we must ignore
+            // recentRejects filter for such locked txes here.
             return (recentRejects->contains(inv.hash) && !llmq::quorumInstantSendManager->IsLocked(inv.hash)) ||
                    mempool.exists(inv.hash) ||
                    pcoinsTip->HaveCoinInCache(COutPoint(inv.hash, 0)) || // Best effort: only try output 0 and 1


### PR DESCRIPTION
If we had a conflicting tx in the mempool before the locked tx arrived and the locked one arrived before the corresponding islock (i.e. we don't really know it's the one that should be included yet), the locked one is going to be rejected due to a mempool conflict. The old tx is going to be removed from the mempool by an incoming islock a bit later, however, we won't be able to re-request the locked tx until the tip changes because of the recentRejects filter. This patch fixes it.