### PR TITLE
Backport orphan TX tests and dependent PRs

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -208,46 +208,46 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
     return true;
 }
 
-bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight)
+bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee)
 {
-    // This doesn't trigger the DoS code on purpose; if it did, it would make it easier
-    // for an attacker to attempt to split the network.
-    if (!inputs.HaveInputs(tx))
-        return state.Invalid(false, 0, "", "Inputs unavailable");
+    // are the actual inputs available?
+    if (!inputs.HaveInputs(tx)) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-missingorspent", false,
+                         strprintf("%s: inputs missing/spent", __func__));
+    }
 
     CAmount nValueIn = 0;
-    CAmount nFees = 0;
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
-    {
+    for (unsigned int i = 0; i < tx.vin.size(); ++i) {
         const COutPoint &prevout = tx.vin[i].prevout;
         const Coin& coin = inputs.AccessCoin(prevout);
         assert(!coin.IsSpent());
 
         // If prev is coinbase, check that it's matured
-        if (coin.IsCoinBase()) {
-            if (nSpendHeight - coin.nHeight < COINBASE_MATURITY)
-                return state.Invalid(false,
-                                     REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
-                                     strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
+        if (coin.IsCoinBase() && nSpendHeight - coin.nHeight < COINBASE_MATURITY) {
+            return state.Invalid(false,
+                REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
+                strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
         }
 
         // Check for negative or overflow input values
         nValueIn += coin.out.nValue;
-        if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn))
+        if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");
-
+        }
     }
 
-    if (nValueIn < tx.GetValueOut())
+    const CAmount value_out = tx.GetValueOut();
+    if (nValueIn < value_out) {
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-in-belowout", false,
-                         strprintf("value in (%s) < value out (%s)", FormatMoney(nValueIn), FormatMoney(tx.GetValueOut())));
+            strprintf("value in (%s) < value out (%s)", FormatMoney(nValueIn), FormatMoney(value_out)));
+    }
 
     // Tally transaction fees
-    CAmount nTxFee = nValueIn - tx.GetValueOut();
-    if (nTxFee < 0)
-        return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-negative");
-    nFees += nTxFee;
-    if (!MoneyRange(nFees))
+    const CAmount txfee_aux = nValueIn - value_out;
+    if (!MoneyRange(txfee_aux)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
+    }
+
+    txfee = txfee_aux;
     return true;
 }

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CONSENSUS_TX_VERIFY_H
 #define BITCOIN_CONSENSUS_TX_VERIFY_H
 
+#include "amount.h"
+
 #include <stdint.h>
 #include <vector>
 
@@ -22,9 +24,10 @@ namespace Consensus {
 /**
  * Check whether all inputs of this transaction are valid (no double spends and amounts)
  * This does not modify the UTXO set. This does not check scripts and sigs.
+ * @param[out] txfee Set to the transaction fee if successful.
  * Preconditions: tx.IsCoinBase() is false.
  */
-bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight);
+bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1006,6 +1006,15 @@ void CTxMemPool::clear()
     _clear();
 }
 
+static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& mempoolDuplicate, const int64_t spendheight)
+{
+    CValidationState state;
+    CAmount txfee = 0;
+    bool fCheckResult = tx.IsCoinBase() || Consensus::CheckTxInputs(tx, state, mempoolDuplicate, spendheight, txfee);
+    assert(fCheckResult);
+    UpdateCoins(tx, mempoolDuplicate, 1000000);
+}
+
 void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 {
     if (nCheckFrequency == 0)
@@ -1020,7 +1029,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     uint64_t innerUsage = 0;
 
     CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(pcoins));
-    const int64_t nSpendHeight = GetSpendHeight(mempoolDuplicate);
+    const int64_t spendheight = GetSpendHeight(mempoolDuplicate);
 
     LOCK(cs);
     std::list<const CTxMemPoolEntry*> waitingOnDependants;
@@ -1099,11 +1108,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         if (fDependsWait)
             waitingOnDependants.push_back(&(*it));
         else {
-            CValidationState state;
-            bool fCheckResult = tx.IsCoinBase() ||
-                Consensus::CheckTxInputs(tx, state, mempoolDuplicate, nSpendHeight);
-            assert(fCheckResult);
-            UpdateCoins(tx, mempoolDuplicate, 1000000);
+            CheckInputsAndUpdateCoins(tx, mempoolDuplicate, spendheight);
         }
     }
     unsigned int stepsSinceLastRemove = 0;
@@ -1116,10 +1121,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             stepsSinceLastRemove++;
             assert(stepsSinceLastRemove < waitingOnDependants.size());
         } else {
-            bool fCheckResult = entry->GetTx().IsCoinBase() ||
-                Consensus::CheckTxInputs(entry->GetTx(), state, mempoolDuplicate, nSpendHeight);
-            assert(fCheckResult);
-            UpdateCoins(entry->GetTx(), mempoolDuplicate, 1000000);
+            CheckInputsAndUpdateCoins(entry->GetTx(), mempoolDuplicate, spendheight);
             stepsSinceLastRemove = 0;
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -604,7 +604,6 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         CCoinsView dummy;
         CCoinsViewCache view(&dummy);
 
-        CAmount nValueIn = 0;
         LockPoints lp;
         {
         LOCK(pool.cs);
@@ -635,8 +634,6 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         // Bring the best block into scope
         view.GetBestBlock();
 
-        nValueIn = view.GetValueIn(tx);
-
         // we have all inputs cached now, so switch back to dummy, so we don't need to keep lock on mempool
         view.SetBackend(dummy);
 
@@ -647,6 +644,12 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         // CoinsViewCache instead of create its own
         if (!CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp))
             return state.DoS(0, false, REJECT_NONSTANDARD, "non-BIP68-final");
+
+        } // end LOCK(pool.cs)
+
+        CAmount nFees = 0;
+        if (!Consensus::CheckTxInputs(tx, state, view, GetSpendHeight(view), nFees)) {
+            return error("%s: Consensus::CheckTxInputs: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
         }
 
         // Check for non-standard pay-to-script-hash in inputs
@@ -655,8 +658,6 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
         unsigned int nSigOps = GetTransactionSigOpCount(tx, view, STANDARD_SCRIPT_VERIFY_FLAGS);
 
-        CAmount nValueOut = tx.GetValueOut();
-        CAmount nFees = nValueIn-nValueOut;
         // nModifiedFees includes any fee deltas from PrioritiseTransaction
         CAmount nModifiedFees = nFees;
         pool.ApplyDelta(hash, nModifiedFees);
@@ -1296,9 +1297,6 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
 {
     if (!tx.IsCoinBase())
     {
-        if (!Consensus::CheckTxInputs(tx, state, inputs, GetSpendHeight(inputs)))
-            return false;
-
         if (pvChecks)
             pvChecks->reserve(tx.vin.size());
 
@@ -1967,9 +1965,15 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
 
         if (!tx.IsCoinBase())
         {
-            if (!view.HaveInputs(tx))
-                return state.DoS(100, error("ConnectBlock(): inputs missing/spent"),
-                                 REJECT_INVALID, "bad-txns-inputs-missingorspent");
+            CAmount txfee = 0;
+            if (!Consensus::CheckTxInputs(tx, state, view, pindex->nHeight, txfee)) {
+                return error("%s: Consensus::CheckTxInputs: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
+            }
+            nFees += txfee;
+            if (!MoneyRange(nFees)) {
+                return state.DoS(100, error("%s: accumulated fee in the block out of range.", __func__),
+                                 REJECT_INVALID, "bad-txns-accumulated-fee-outofrange");
+            }
 
             // Check that transaction is BIP68 final
             // BIP68 lock checks (as opposed to nLockTime checks) must
@@ -2037,8 +2041,6 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         txdata.emplace_back(tx);
         if (!tx.IsCoinBase())
         {
-
-            nFees += view.GetValueIn(tx)-tx.GetValueOut();
 
             std::vector<CScriptCheck> vChecks;
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -68,7 +68,7 @@ a callback class that derives from `NodeConnCB` and pass that to the
 `NodeConn` object, your code will receive the appropriate callbacks when
 events of interest arrive.
 
-- Call `NetworkThread.start()` after all `NodeConn` objects are created to
+- Call `network_thread_start()` after all `NodeConn` objects are created to
 start the networking thread.  (Continue with the test logic in your existing
 thread.)
 

--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -38,7 +38,8 @@ from test_framework.mininode import (CBlockHeader,
                                      CTransaction,
                                      CTxIn,
                                      CTxOut,
-                                     NetworkThread,
+                                     network_thread_join,
+                                     network_thread_start,
                                      NodeConnCB,
                                      msg_block,
                                      msg_headers)
@@ -103,7 +104,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # Connect to node0
         p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
 
-        NetworkThread().start()  # Start up network handling in another thread
+        network_thread_start()
         self.nodes[0].p2p.wait_for_verack()
 
         # Build the blockchain
@@ -164,13 +165,22 @@ class AssumeValidTest(BitcoinTestFramework):
             self.block_time += 1
             height += 1
 
+        # We're adding new connections so terminate the network thread
+        self.nodes[0].disconnect_p2ps()
+        network_thread_join()
+
         # Start node1 and node2 with assumevalid so they accept a block with a bad signature.
         self.start_node(1, extra_args=self.extra_args + ["-assumevalid=" + hex(block102.sha256)])
-        p2p1 = self.nodes[1].add_p2p_connection(BaseNode())
-        p2p1.wait_for_verack()
-
         self.start_node(2, extra_args=self.extra_args + ["-assumevalid=" + hex(block102.sha256)])
+
+        p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
+        p2p1 = self.nodes[1].add_p2p_connection(BaseNode())
         p2p2 = self.nodes[2].add_p2p_connection(BaseNode())
+
+        network_thread_start()
+
+        p2p0.wait_for_verack()
+        p2p1.wait_for_verack()
         p2p2.wait_for_verack()
 
         # Make sure nodes actually accept the many headers

--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -39,13 +39,12 @@ from test_framework.mininode import (CBlockHeader,
                                      CTxIn,
                                      CTxOut,
                                      NetworkThread,
-                                     NodeConn,
                                      NodeConnCB,
                                      msg_block,
                                      msg_headers)
 from test_framework.script import (CScript, OP_TRUE)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (p2p_port, assert_equal, set_node_times)
+from test_framework.util import (assert_equal, set_node_times)
 
 class BaseNode(NodeConnCB):
     def send_header_for_blocks(self, new_blocks):
@@ -66,13 +65,13 @@ class AssumeValidTest(BitcoinTestFramework):
         # signature so we can pass in the block hash as assumevalid.
         self.start_node(0, extra_args=self.extra_args)
 
-    def send_blocks_until_disconnected(self, node):
+    def send_blocks_until_disconnected(self, p2p_conn):
         """Keep sending blocks to the node until we're disconnected."""
         for i in range(len(self.blocks)):
-            if not node.connection:
+            if not p2p_conn.connection:
                 break
             try:
-                node.send_message(msg_block(self.blocks[i]))
+                p2p_conn.send_message(msg_block(self.blocks[i]))
             # TODO There is a race condition between send_message and on_close which causes an AttributError on Travis
             # We can reenable the correct exception handling and the assert when Bitcoin 0.16 mininode.py changes have been
             # backported
@@ -102,13 +101,10 @@ class AssumeValidTest(BitcoinTestFramework):
     def run_test(self):
 
         # Connect to node0
-        node0 = BaseNode()
-        connections = []
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], node0))
-        node0.add_connection(connections[0])
+        p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
 
         NetworkThread().start()  # Start up network handling in another thread
-        node0.wait_for_verack()
+        self.nodes[0].p2p.wait_for_verack()
 
         # Build the blockchain
         self.tip = int(self.nodes[0].getbestblockhash(), 16)
@@ -170,16 +166,12 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Start node1 and node2 with assumevalid so they accept a block with a bad signature.
         self.start_node(1, extra_args=self.extra_args + ["-assumevalid=" + hex(block102.sha256)])
-        node1 = BaseNode()  # connects to node1
-        connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1], node1))
-        node1.add_connection(connections[1])
-        node1.wait_for_verack()
+        p2p1 = self.nodes[1].add_p2p_connection(BaseNode())
+        p2p1.wait_for_verack()
 
         self.start_node(2, extra_args=self.extra_args + ["-assumevalid=" + hex(block102.sha256)])
-        node2 = BaseNode()  # connects to node2
-        connections.append(NodeConn('127.0.0.1', p2p_port(2), self.nodes[2], node2))
-        node2.add_connection(connections[2])
-        node2.wait_for_verack()
+        p2p2 = self.nodes[2].add_p2p_connection(BaseNode())
+        p2p2.wait_for_verack()
 
         # Make sure nodes actually accept the many headers
         self.mocktime = self.block_time
@@ -189,27 +181,27 @@ class AssumeValidTest(BitcoinTestFramework):
         # node0 does not need to receive all headers
         # node1 must receive all headers as otherwise assumevalid is ignored in ConnectBlock
         # node2 should NOT receive all headers to force skipping of the assumevalid check in ConnectBlock
-        node0.send_header_for_blocks(self.blocks[0:2000])
-        node1.send_header_for_blocks(self.blocks[0:2000])
-        node1.send_header_for_blocks(self.blocks[2000:4000])
-        node1.send_header_for_blocks(self.blocks[4000:6000])
-        node1.send_header_for_blocks(self.blocks[6000:8000])
-        node1.send_header_for_blocks(self.blocks[8000:])
-        node2.send_header_for_blocks(self.blocks[0:200])
+        p2p0.send_header_for_blocks(self.blocks[0:2000])
+        p2p1.send_header_for_blocks(self.blocks[0:2000])
+        p2p1.send_header_for_blocks(self.blocks[2000:4000])
+        p2p1.send_header_for_blocks(self.blocks[4000:6000])
+        p2p1.send_header_for_blocks(self.blocks[6000:8000])
+        p2p1.send_header_for_blocks(self.blocks[8000:])
+        p2p2.send_header_for_blocks(self.blocks[0:200])
 
         # Send blocks to node0. Block 102 will be rejected.
-        self.send_blocks_until_disconnected(node0)
+        self.send_blocks_until_disconnected(p2p0)
         self.assert_blockchain_height(self.nodes[0], 101)
 
         # Send 200 blocks to node1. All blocks, including block 102, will be accepted.
         for i in range(200):
-            node1.send_message(msg_block(self.blocks[i]))
+            p2p1.send_message(msg_block(self.blocks[i]))
         # Syncing so many blocks can take a while on slow systems. Give it plenty of time to sync.
-        node1.sync_with_ping(300)
+        p2p1.sync_with_ping(300)
         assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 200)
 
         # Send blocks to node2. Block 102 will be rejected.
-        self.send_blocks_until_disconnected(node2)
+        self.send_blocks_until_disconnected(p2p2)
         self.assert_blockchain_height(self.nodes[2], 101)
 
 if __name__ == '__main__':

--- a/test/functional/bip65-cltv-p2p.py
+++ b/test/functional/bip65-cltv-p2p.py
@@ -68,7 +68,7 @@ class BIP65Test(BitcoinTestFramework):
     def run_test(self):
         self.nodes[0].add_p2p_connection(NodeConnCB())
 
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
 
         # wait_for_verack ensures that the P2P connection is fully up.
         self.nodes[0].p2p.wait_for_verack()

--- a/test/functional/bip68-112-113-p2p.py
+++ b/test/functional/bip68-112-113-p2p.py
@@ -45,7 +45,7 @@ bip112tx_special - test negative argument to OP_CSV
 
 from test_framework.test_framework import (ComparisonTestFramework, GENESISTIME)
 from test_framework.util import *
-from test_framework.mininode import ToHex, CTransaction, NetworkThread
+from test_framework.mininode import ToHex, CTransaction, network_thread_start
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import *
@@ -105,7 +105,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)
         test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
         test.run()
 
     def send_generic_input_tx(self, node, coinbases):

--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -22,7 +22,7 @@ import itertools
 
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
-from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.mininode import CTransaction, network_thread_start
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript, OP_1NEGATE, OP_CHECKSEQUENCEVERIFY, OP_DROP
@@ -36,7 +36,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
     def run_test(self):
         self.test = TestManager(self, self.options.tmpdir)
         self.test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
         self.test.run()
 
     def create_transaction(self, node, coinbase, to_address, amount):
@@ -244,7 +244,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         self.setup_chain()
         self.setup_network()
         self.test.add_all_connections(self.nodes)
-        NetworkThread().start()
+        network_thread_start()
         self.test.test_nodes[0].wait_for_verack()
 
     def get_tests(self):

--- a/test/functional/bipdersig-p2p.py
+++ b/test/functional/bipdersig-p2p.py
@@ -57,7 +57,7 @@ class BIP66Test(BitcoinTestFramework):
     def run_test(self):
         self.nodes[0].add_p2p_connection(NodeConnCB())
 
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
 
         # wait_for_verack ensures that the P2P connection is fully up.
         self.nodes[0].p2p.wait_for_verack()

--- a/test/functional/invalidblockrequest.py
+++ b/test/functional/invalidblockrequest.py
@@ -10,75 +10,64 @@ In this test we connect to one node over p2p, and test block requests:
 3) Invalid block with bad coinbase value should be rejected and not
 re-requested.
 """
-
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
-from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.blocktools import *
-from test_framework.mininode import network_thread_start
 import copy
 
-# Use the ComparisonTestFramework with 1 node: only use --testbinary.
-class InvalidBlockRequestTest(ComparisonTestFramework):
+from test_framework.blocktools import create_block, create_coinbase, create_transaction, network_thread_start
+from test_framework.mininode import P2PDataStore, COIN
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, sync_masternodes
 
-    ''' Can either run this test as 1 node with expected answers, or two and compare them. 
-        Change the "outcome" variable from each TestInstance object to only do the comparison. '''
+
+class InvalidBlockRequestTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
+        self.extra_args = [["-whitelist=127.0.0.1"]]
 
     def run_test(self):
-        test = TestManager(self, self.options.tmpdir)
-        test.add_all_connections(self.nodes)
-        self.tip = None
-        self.block_time = None
+        # Add p2p connection to node0
+        node = self.nodes[0]  # convenience reference to the node
+        node.add_p2p_connection(P2PDataStore())
+
         network_thread_start()
         sync_masternodes(self.nodes, True)
-        test.run()
+        node.p2p.wait_for_verack()
 
-    def get_tests(self):
-        if self.tip is None:
-            self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
-        self.block_time = self.mocktime + 1
+        best_block = node.getblock(node.getbestblockhash())
+        tip = int(node.getbestblockhash(), 16)
+        height = best_block["height"] + 1
+        block_time = best_block["time"] + 1
 
-        '''
-        Create a new block with an anyone-can-spend coinbase
-        '''
+        self.log.info("Create a new block with an anyone-can-spend coinbase")
+
         height = 1
-        block = create_block(self.tip, create_coinbase(height), self.block_time)
-        self.block_time += 1
+        block = create_block(tip, create_coinbase(height), block_time)
         block.solve()
         # Save the coinbase for later
-        self.block1 = block
-        self.tip = block.sha256
-        height += 1
-        yield TestInstance([[block, True]])
+        block1 = block
+        tip = block.sha256
+        node.p2p.send_blocks_and_test([block1], node, True)
 
-        '''
-        Now we need that block to mature so we can spend the coinbase.
-        '''
-        test = TestInstance(sync_every_block=False)
-        for i in range(100):
-            block = create_block(self.tip, create_coinbase(height), self.block_time)
-            block.solve()
-            self.tip = block.sha256
-            self.block_time += 1
-            test.blocks_and_transactions.append([block, True])
-            height += 1
-        yield test
+        self.log.info("Mature the block.")
+        node.generate(100)
 
-        '''
-        Now we use merkle-root malleability to generate an invalid block with
-        same blockheader.
-        Manufacture a block with 3 transactions (coinbase, spend of prior
-        coinbase, spend of that spend).  Duplicate the 3rd transaction to 
-        leave merkle root and blockheader unchanged but invalidate the block.
-        '''
-        block2 = create_block(self.tip, create_coinbase(height), self.block_time)
-        self.block_time += 1
+        best_block = node.getblock(node.getbestblockhash())
+        tip = int(node.getbestblockhash(), 16)
+        height = best_block["height"] + 1
+        block_time = best_block["time"] + 1
+
+        # Use merkle-root malleability to generate an invalid block with
+        # same blockheader.
+        # Manufacture a block with 3 transactions (coinbase, spend of prior
+        # coinbase, spend of that spend).  Duplicate the 3rd transaction to
+        # leave merkle root and blockheader unchanged but invalidate the block.
+        self.log.info("Test merkle root malleability.")
+
+        block2 = create_block(tip, create_coinbase(height), block_time)
+        block_time += 1
 
         # b'0x51' is OP_TRUE
-        tx1 = create_transaction(self.block1.vtx[0], 0, b'\x51', 50 * COIN)
+        tx1 = create_transaction(block1.vtx[0], 0, b'\x51', 50 * COIN)
         tx2 = create_transaction(tx1, 0, b'\x51', 50 * COIN)
 
         block2.vtx.extend([tx1, tx2])
@@ -94,24 +83,20 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         assert_equal(orig_hash, block2.rehash())
         assert(block2_orig.vtx != block2.vtx)
 
-        self.tip = block2.sha256
-        yield TestInstance([[block2, RejectResult(16, b'bad-txns-duplicate')], [block2_orig, True]])
-        height += 1
+        node.p2p.send_blocks_and_test([block2], node, False, False, 16, b'bad-txns-duplicate')
 
-        '''
-        Make sure that a totally screwed up block is not valid.
-        '''
-        block3 = create_block(self.tip, create_coinbase(height), self.block_time)
-        self.block_time += 1
-        block3.vtx[0].vout[0].nValue = 1000 * COIN # Too high!
-        block3.vtx[0].sha256=None
+        self.log.info("Test very broken block.")
+
+        block3 = create_block(tip, create_coinbase(height), block_time)
+        block_time += 1
+        block3.vtx[0].vout[0].nValue = 1000 * COIN  # Too high!
+        block3.vtx[0].sha256 = None
         block3.vtx[0].calc_sha256()
         block3.hashMerkleRoot = block3.calc_merkle_root()
         block3.rehash()
         block3.solve()
 
-        yield TestInstance([[block3, RejectResult(16, b'bad-cb-amount')]])
-
+        node.p2p.send_blocks_and_test([block3], node, False, False, 16, b'bad-cb-amount')
 
 if __name__ == '__main__':
     InvalidBlockRequestTest().main()

--- a/test/functional/invalidblockrequest.py
+++ b/test/functional/invalidblockrequest.py
@@ -15,6 +15,7 @@ from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import *
 from test_framework.comptool import TestManager, TestInstance, RejectResult
 from test_framework.blocktools import *
+from test_framework.mininode import network_thread_start
 import copy
 
 # Use the ComparisonTestFramework with 1 node: only use --testbinary.
@@ -31,7 +32,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         test.add_all_connections(self.nodes)
         self.tip = None
         self.block_time = None
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
         sync_masternodes(self.nodes, True)
         test.run()
 

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -35,12 +35,10 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.log.info("Create a new block with an anyone-can-spend coinbase.")
         height = 1
         block = create_block(tip, create_coinbase(height), block_time)
-        block_time += 1
         block.solve()
         # Save the coinbase for later
         block1 = block
         tip = block.sha256
-        height += 1
         node.p2p.send_blocks_and_test([block], node, success=True)
 
         self.log.info("Mature the block.")
@@ -51,7 +49,10 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         tx1 = create_transaction(block1.vtx[0], 0, b'\x64', 50 * COIN)
         node.p2p.send_txs_and_test([tx1], node, success=False, reject_code=16, reject_reason=b'mandatory-script-verify-flag-failed (Invalid OP_IF construction)')
 
-        # TODO: test further transactions...
+        # Verify valid transaction
+        tx1 = create_transaction(block1.vtx[0], 0, b'', 50 * COIN - 12000)
+        node.p2p.send_txs_and_test([tx1], node, success=True)
+
 
 if __name__ == '__main__':
     InvalidTxRequestTest().main()

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -5,7 +5,6 @@
 """Test node responses to invalid transactions.
 
 In this test we connect to one node over p2p, and test tx requests."""
-import time
 
 from test_framework.blocktools import create_block, create_coinbase, create_transaction
 from test_framework.mininode import (

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -26,7 +26,7 @@ class InvalidTxRequestTest(ComparisonTestFramework):
         test.add_all_connections(self.nodes)
         self.tip = None
         self.block_time = None
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
         test.run()
 
     def get_tests(self):

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -8,24 +8,48 @@ In this test we connect to one node over p2p, and test tx requests."""
 import time
 
 from test_framework.blocktools import create_block, create_coinbase, create_transaction
-from test_framework.mininode import COIN
-from test_framework.mininode import network_thread_start, P2PDataStore
+from test_framework.mininode import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+)
+from test_framework.mininode import network_thread_start, P2PDataStore, network_thread_join
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    wait_until,
+)
 
 class InvalidTxRequestTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [["-whitelist=127.0.0.1"]]
+
+    def bootstrap_p2p(self, *, num_connections=1):
+        """Add a P2P connection to the node.
+
+        Helper to connect and wait for version handshake."""
+        for _ in range(num_connections):
+            self.nodes[0].add_p2p_connection(P2PDataStore())
+        network_thread_start()
+        self.nodes[0].p2p.wait_for_verack()
+
+    def reconnect_p2p(self, **kwargs):
+        """Tear down and bootstrap the P2P connection to the node.
+
+        The node gets disconnected several times in this test. This helper
+        method reconnects the p2p and restarts the network thread."""
+        self.nodes[0].disconnect_p2ps()
+        network_thread_join()
+        self.bootstrap_p2p(**kwargs)
 
     def run_test(self):
-        # Add p2p connection to node0
         node = self.nodes[0]  # convenience reference to the node
-        node.add_p2p_connection(P2PDataStore())
 
-        network_thread_start()
-        node.p2p.wait_for_verack()
+        self.bootstrap_p2p()  # Add one p2p connection to the node
 
         best_block = self.nodes[0].getbestblockhash()
         tip = int(best_block, 16)
@@ -46,12 +70,73 @@ class InvalidTxRequestTest(BitcoinTestFramework):
 
         # b'\x64' is OP_NOTIF
         # Transaction will be rejected with code 16 (REJECT_INVALID)
+        # and we get disconnected immediately
+        self.log.info('Test a transaction that is rejected')
         tx1 = create_transaction(block1.vtx[0], 0, b'\x64', 50 * COIN)
-        node.p2p.send_txs_and_test([tx1], node, success=False, reject_code=16, reject_reason=b'mandatory-script-verify-flag-failed (Invalid OP_IF construction)')
+        node.p2p.send_txs_and_test([tx1], node, success=False, expect_disconnect=True)
 
-        # Verify valid transaction
-        tx1 = create_transaction(block1.vtx[0], 0, b'', 50 * COIN - 12000)
-        node.p2p.send_txs_and_test([tx1], node, success=True)
+        # Make two p2p connections to provide the node with orphans
+        # * p2ps[0] will send valid orphan txs (one with low fee)
+        # * p2ps[1] will send an invalid orphan tx (and is later disconnected for that)
+        self.reconnect_p2p(num_connections=2)
+
+        self.log.info('Test orphan transaction handling ... ')
+        # Create a root transaction that we withold until all dependend transactions
+        # are sent out and in the orphan cache
+        tx_withhold = CTransaction()
+        tx_withhold.vin.append(CTxIn(outpoint=COutPoint(block1.vtx[0].sha256, 0)))
+        tx_withhold.vout.append(CTxOut(nValue=50 * COIN - 12000, scriptPubKey=b'\x51'))
+        tx_withhold.calc_sha256()
+
+        # Our first orphan tx with some outputs to create further orphan txs
+        tx_orphan_1 = CTransaction()
+        tx_orphan_1.vin.append(CTxIn(outpoint=COutPoint(tx_withhold.sha256, 0)))
+        tx_orphan_1.vout = [CTxOut(nValue=10 * COIN, scriptPubKey=b'\x51')] * 3
+        tx_orphan_1.calc_sha256()
+
+        # A valid transaction with low fee
+        tx_orphan_2_no_fee = CTransaction()
+        tx_orphan_2_no_fee.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 0)))
+        tx_orphan_2_no_fee.vout.append(CTxOut(nValue=10 * COIN, scriptPubKey=b'\x51'))
+
+        # A valid transaction with sufficient fee
+        tx_orphan_2_valid = CTransaction()
+        tx_orphan_2_valid.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 1)))
+        tx_orphan_2_valid.vout.append(CTxOut(nValue=10 * COIN - 12000, scriptPubKey=b'\x51'))
+        tx_orphan_2_valid.calc_sha256()
+
+        # An invalid transaction with negative fee
+        tx_orphan_2_invalid = CTransaction()
+        tx_orphan_2_invalid.vin.append(CTxIn(outpoint=COutPoint(tx_orphan_1.sha256, 2)))
+        tx_orphan_2_invalid.vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=b'\x51'))
+
+        self.log.info('Send the orphans ... ')
+        # Send valid orphan txs from p2ps[0]
+        node.p2p.send_txs_and_test([tx_orphan_1, tx_orphan_2_no_fee, tx_orphan_2_valid], node, success=False)
+        # Send invalid tx from p2ps[1]
+        node.p2ps[1].send_txs_and_test([tx_orphan_2_invalid], node, success=False)
+
+        assert_equal(0, node.getmempoolinfo()['size'])  # Mempool should be empty
+        assert_equal(2, len(node.getpeerinfo()))  # p2ps[1] is still connected
+
+        self.log.info('Send the withhold tx ... ')
+        node.p2p.send_txs_and_test([tx_withhold], node, success=True)
+
+        # Transactions that should end up in the mempool
+        expected_mempool = {
+            t.hash
+            for t in [
+                tx_withhold,  # The transaction that is the root for all orphans
+                tx_orphan_1,  # The orphan transaction that splits the coins
+                tx_orphan_2_valid,  # The valid transaction (with sufficient fee)
+            ]
+        }
+        # Transactions that do not end up in the mempool
+        # tx_orphan_no_fee, because it has too low fee (p2ps[0] is not disconnected for relaying that tx)
+        # tx_orphan_invaid, because it has negative fee (p2ps[1] is disconnected for relaying that tx)
+
+        wait_until(lambda: 1 == len(node.getpeerinfo()), timeout=12)  # p2ps[1] is no longer connected
+        assert_equal(expected_mempool, set(node.getrawmempool()))
 
 
 if __name__ == '__main__':

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -4,66 +4,52 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test node responses to invalid transactions.
 
-In this test we connect to one node over p2p, and test tx requests.
-"""
+In this test we connect to one node over p2p, and test tx requests."""
+import time
 
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.blocktools import *
+from test_framework.blocktools import create_block, create_coinbase, create_transaction
+from test_framework.mininode import COIN
+from test_framework.mininode import network_thread_start, P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
 
+class InvalidTxRequestTest(BitcoinTestFramework):
 
-# Use the ComparisonTestFramework with 1 node: only use --testbinary.
-class InvalidTxRequestTest(ComparisonTestFramework):
-
-    ''' Can either run this test as 1 node with expected answers, or two and compare them. 
-        Change the "outcome" variable from each TestInstance object to only do the comparison. '''
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
+        self.extra_args = [["-whitelist=127.0.0.1"]]
 
     def run_test(self):
-        test = TestManager(self, self.options.tmpdir)
-        test.add_all_connections(self.nodes)
-        self.tip = None
-        self.block_time = None
+        # Add p2p connection to node0
+        node = self.nodes[0]  # convenience reference to the node
+        node.add_p2p_connection(P2PDataStore())
+
         network_thread_start()
-        test.run()
+        node.p2p.wait_for_verack()
 
-    def get_tests(self):
-        if self.tip is None:
-            self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
-        self.block_time = self.mocktime + 1
+        best_block = self.nodes[0].getbestblockhash()
+        tip = int(best_block, 16)
+        best_block_time = self.nodes[0].getblock(best_block)['time']
+        block_time = best_block_time + 1
 
-        '''
-        Create a new block with an anyone-can-spend coinbase
-        '''
+        self.log.info("Create a new block with an anyone-can-spend coinbase.")
         height = 1
-        block = create_block(self.tip, create_coinbase(height), self.block_time)
-        self.block_time += 1
+        block = create_block(tip, create_coinbase(height), block_time)
+        block_time += 1
         block.solve()
         # Save the coinbase for later
-        self.block1 = block
-        self.tip = block.sha256
+        block1 = block
+        tip = block.sha256
         height += 1
-        yield TestInstance([[block, True]])
+        node.p2p.send_blocks_and_test([block], node, success=True)
 
-        '''
-        Now we need that block to mature so we can spend the coinbase.
-        '''
-        test = TestInstance(sync_every_block=False)
-        for i in range(100):
-            block = create_block(self.tip, create_coinbase(height), self.block_time)
-            block.solve()
-            self.tip = block.sha256
-            self.block_time += 1
-            test.blocks_and_transactions.append([block, True])
-            height += 1
-        yield test
+        self.log.info("Mature the block.")
+        self.nodes[0].generate(100)
 
         # b'\x64' is OP_NOTIF
         # Transaction will be rejected with code 16 (REJECT_INVALID)
-        tx1 = create_transaction(self.block1.vtx[0], 0, b'\x64', 50 * COIN)
-        yield TestInstance([[tx1, RejectResult(16, b'mandatory-script-verify-flag-failed')]])
+        tx1 = create_transaction(block1.vtx[0], 0, b'\x64', 50 * COIN)
+        node.p2p.send_txs_and_test([tx1], node, success=False, reject_code=16, reject_reason=b'mandatory-script-verify-flag-failed (Invalid OP_IF construction)')
 
         # TODO: test further transactions...
 

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -62,7 +62,7 @@ class MaxUploadTest(BitcoinTestFramework):
         for _ in range(3):
             p2p_conns.append(self.nodes[0].add_p2p_connection(TestNode()))
 
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
         for p2pc in p2p_conns:
             p2pc.wait_for_verack()
 
@@ -154,7 +154,7 @@ class MaxUploadTest(BitcoinTestFramework):
         # Reconnect to self.nodes[0]
         self.nodes[0].add_p2p_connection(TestNode())
 
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
         self.nodes[0].p2p.wait_for_verack()
 
         #retrieve 20 blocks which should be enough to break the 1MB limit

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -59,7 +59,7 @@ class MaxUploadTest(BitcoinTestFramework):
         # p2p_conns[2] will test resetting the counters
         p2p_conns = []
 
-        for i in range(3):
+        for _ in range(3):
             p2p_conns.append(self.nodes[0].add_p2p_connection(TestNode()))
 
         NetworkThread().start() # Start up network handling in another thread
@@ -144,8 +144,7 @@ class MaxUploadTest(BitcoinTestFramework):
 
         self.log.info("Peer 2 able to download old block")
 
-        for i in range(3):
-            self.nodes[0].disconnect_p2p()
+        self.nodes[0].disconnect_p2ps()
 
         #stop and start node 0 with 1MB maxuploadtarget, whitelist 127.0.0.1
         self.log.info("Restarting nodes with -whitelist=127.0.0.1")

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -54,19 +54,17 @@ class MaxUploadTest(BitcoinTestFramework):
         # Generate some old blocks
         self.nodes[0].generate(130)
 
-        # test_nodes[0] will only request old blocks
-        # test_nodes[1] will only request new blocks
-        # test_nodes[2] will test resetting the counters
-        test_nodes = []
-        connections = []
+        # p2p_conns[0] will only request old blocks
+        # p2p_conns[1] will only request new blocks
+        # p2p_conns[2] will test resetting the counters
+        p2p_conns = []
 
         for i in range(3):
-            test_nodes.append(TestNode())
-            connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_nodes[i]))
-            test_nodes[i].add_connection(connections[i])
+            p2p_conns.append(self.nodes[0].add_p2p_connection(TestNode()))
 
         NetworkThread().start() # Start up network handling in another thread
-        [x.wait_for_verack() for x in test_nodes]
+        for p2pc in p2p_conns:
+            p2pc.wait_for_verack()
 
         # Test logic begins here
 
@@ -88,7 +86,7 @@ class MaxUploadTest(BitcoinTestFramework):
         big_new_block = self.nodes[0].getbestblockhash()
         big_new_block = int(big_new_block, 16)
 
-        # test_nodes[0] will test what happens if we just keep requesting the
+        # p2p_conns[0] will test what happens if we just keep requesting the
         # the same big old block too many times (expect: disconnect)
 
         getdata_request = msg_getdata()
@@ -102,34 +100,34 @@ class MaxUploadTest(BitcoinTestFramework):
         # 144MB will be reserved for relaying new blocks, so expect this to
         # succeed for ~70 tries.
         for i in range(success_count):
-            test_nodes[0].send_message(getdata_request)
-            test_nodes[0].sync_with_ping()
-            assert_equal(test_nodes[0].block_receive_map[big_old_block], i+1)
+            p2p_conns[0].send_message(getdata_request)
+            p2p_conns[0].sync_with_ping()
+            assert_equal(p2p_conns[0].block_receive_map[big_old_block], i+1)
 
         assert_equal(len(self.nodes[0].getpeerinfo()), 3)
         # At most a couple more tries should succeed (depending on how long 
         # the test has been running so far).
         for i in range(3):
-            test_nodes[0].send_message(getdata_request)
-        test_nodes[0].wait_for_disconnect()
+            p2p_conns[0].send_message(getdata_request)
+        p2p_conns[0].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)
         self.log.info("Peer 0 disconnected after downloading old block too many times")
 
-        # Requesting the current block on test_nodes[1] should succeed indefinitely,
+        # Requesting the current block on p2p_conns[1] should succeed indefinitely,
         # even when over the max upload target.
         # We'll try 200 times
         getdata_request.inv = [CInv(2, big_new_block)]
         for i in range(200):
-            test_nodes[1].send_message(getdata_request)
-            test_nodes[1].sync_with_ping()
-            assert_equal(test_nodes[1].block_receive_map[big_new_block], i+1)
+            p2p_conns[1].send_message(getdata_request)
+            p2p_conns[1].sync_with_ping()
+            assert_equal(p2p_conns[1].block_receive_map[big_new_block], i+1)
 
         self.log.info("Peer 1 able to repeatedly download new block")
 
-        # But if test_nodes[1] tries for an old block, it gets disconnected too.
+        # But if p2p_conns[1] tries for an old block, it gets disconnected too.
         getdata_request.inv = [CInv(2, big_old_block)]
-        test_nodes[1].send_message(getdata_request)
-        test_nodes[1].wait_for_disconnect()
+        p2p_conns[1].send_message(getdata_request)
+        p2p_conns[1].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 1)
 
         self.log.info("Peer 1 disconnected after trying to download old block")
@@ -137,39 +135,38 @@ class MaxUploadTest(BitcoinTestFramework):
         self.log.info("Advancing system time on node to clear counters...")
 
         # If we advance the time by 24 hours, then the counters should reset,
-        # and test_nodes[2] should be able to retrieve the old block.
+        # and p2p_conns[2] should be able to retrieve the old block.
         self.nodes[0].setmocktime(current_mocktime)
-        test_nodes[2].sync_with_ping()
-        test_nodes[2].send_message(getdata_request)
-        test_nodes[2].sync_with_ping()
-        assert_equal(test_nodes[2].block_receive_map[big_old_block], 1)
+        p2p_conns[2].sync_with_ping()
+        p2p_conns[2].send_message(getdata_request)
+        p2p_conns[2].sync_with_ping()
+        assert_equal(p2p_conns[2].block_receive_map[big_old_block], 1)
 
         self.log.info("Peer 2 able to download old block")
 
-        [c.disconnect_node() for c in connections]
+        for i in range(3):
+            self.nodes[0].disconnect_p2p()
 
         #stop and start node 0 with 1MB maxuploadtarget, whitelist 127.0.0.1
         self.log.info("Restarting nodes with -whitelist=127.0.0.1")
         self.stop_node(0)
         self.start_node(0, ["-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000", "-maxtipage="+str(2*60*60*24*7), "-mocktime="+str(current_mocktime)])
 
-        #recreate/reconnect a test node
-        test_nodes = [TestNode()]
-        connections = [NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_nodes[0])]
-        test_nodes[0].add_connection(connections[0])
+        # Reconnect to self.nodes[0]
+        self.nodes[0].add_p2p_connection(TestNode())
 
         NetworkThread().start() # Start up network handling in another thread
-        test_nodes[0].wait_for_verack()
+        self.nodes[0].p2p.wait_for_verack()
 
         #retrieve 20 blocks which should be enough to break the 1MB limit
         getdata_request.inv = [CInv(2, big_new_block)]
         for i in range(20):
-            test_nodes[0].send_message(getdata_request)
-            test_nodes[0].sync_with_ping()
-            assert_equal(test_nodes[0].block_receive_map[big_new_block], i+1)
+            self.nodes[0].p2p.send_message(getdata_request)
+            self.nodes[0].p2p.sync_with_ping()
+            assert_equal(self.nodes[0].p2p.block_receive_map[big_new_block], i+1)
 
         getdata_request.inv = [CInv(2, big_old_block)]
-        test_nodes[0].send_and_ping(getdata_request)
+        self.nodes[0].p2p.send_and_ping(getdata_request)
         assert_equal(len(self.nodes[0].getpeerinfo()), 1) #node is still connected because of the whitelist
 
         self.log.info("Peer still connected after trying to download old block (whitelisted)")

--- a/test/functional/nulldummy.py
+++ b/test/functional/nulldummy.py
@@ -15,7 +15,7 @@ Generate 427 more blocks.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.mininode import CTransaction, network_thread_start
 from test_framework.blocktools import create_coinbase, create_block
 from test_framework.script import CScript
 from io import BytesIO
@@ -45,7 +45,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
         self.address = self.nodes[0].getnewaddress()
         self.ms_address = self.nodes[0].addmultisigaddress(1,[self.address])
 
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
         self.coinbase_blocks = self.nodes[0].generate(2) # Block 2
         coinbase_txid = []
         for i in self.coinbase_blocks:

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -206,7 +206,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # The node should have requested the blocks at some point, so
         # disconnect/reconnect first
 
-        self.nodes[0].disconnect_p2p()
+        self.nodes[0].disconnect_p2ps()
         test_node = self.nodes[0].add_p2p_connection(NodeConnCB())
 
         test_node.wait_for_verack()
@@ -291,7 +291,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         except AssertionError:
             test_node.wait_for_disconnect()
 
-            self.nodes[0].disconnect_p2p()
+            self.nodes[0].disconnect_p2ps()
             test_node = self.nodes[0].add_p2p_connection(NodeConnCB())
 
             NetworkThread().start() # Start up network handling in another thread

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -83,7 +83,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # min_work_node connects to node1
         min_work_node = self.nodes[1].add_p2p_connection(NodeConnCB())
 
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
 
         # Test logic begins here
         test_node.wait_for_verack()
@@ -207,9 +207,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         # disconnect/reconnect first
 
         self.nodes[0].disconnect_p2ps()
-        test_node = self.nodes[0].add_p2p_connection(NodeConnCB())
+        self.nodes[1].disconnect_p2ps()
+        network_thread_join()
 
+        test_node = self.nodes[0].add_p2p_connection(NodeConnCB())
+        network_thread_start()
         test_node.wait_for_verack()
+
         test_node.send_message(msg_block(block_h1f))
 
         test_node.sync_with_ping()
@@ -294,7 +298,7 @@ class AcceptBlockTest(BitcoinTestFramework):
             self.nodes[0].disconnect_p2ps()
             test_node = self.nodes[0].add_p2p_connection(NodeConnCB())
 
-            NetworkThread().start() # Start up network handling in another thread
+            network_thread_start()
             test_node.wait_for_verack()
 
         # We should have failed reorg and switched back to 290 (but have block 291)

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -712,23 +712,12 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
-        self.test_node = TestNode()
-        self.second_node = TestNode()
-        self.old_node = TestNode()
-
-        connections = []
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.test_node))
-        connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1],
-                    self.second_node, services=NODE_NETWORK))
-        connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1],
-                    self.old_node, services=NODE_NETWORK))
-        self.test_node.add_connection(connections[0])
-        self.second_node.add_connection(connections[1])
-        self.old_node.add_connection(connections[2])
+        self.test_node = self.nodes[0].add_p2p_connection(TestNode())
+        self.second_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK)
+        self.old_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK)
 
         NetworkThread().start()  # Start up network handling in another thread
 
-        # Test logic begins here
         self.test_node.wait_for_verack()
 
         # We will need UTXOs to construct transactions in later tests.

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -716,7 +716,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.second_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK)
         self.old_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK)
 
-        NetworkThread().start()  # Start up network handling in another thread
+        network_thread_start()
 
         self.test_node.wait_for_verack()
 

--- a/test/functional/p2p-fingerprint.py
+++ b/test/functional/p2p-fingerprint.py
@@ -15,7 +15,6 @@ from test_framework.blocktools import (create_block, create_coinbase)
 from test_framework.mininode import (
     CInv,
     NetworkThread,
-    NodeConn,
     NodeConnCB,
     msg_headers,
     msg_block,
@@ -78,11 +77,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
     # This does not currently test that stale blocks timestamped within the
     # last month but that have over a month's worth of work are also withheld.
     def run_test(self):
-        node0 = NodeConnCB()
-
-        connections = []
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], node0))
-        node0.add_connection(connections[0])
+        node0 = self.nodes[0].add_p2p_connection(NodeConnCB())
 
         NetworkThread().start()
         node0.wait_for_verack()

--- a/test/functional/p2p-fingerprint.py
+++ b/test/functional/p2p-fingerprint.py
@@ -14,12 +14,12 @@ import time
 from test_framework.blocktools import (create_block, create_coinbase)
 from test_framework.mininode import (
     CInv,
-    NetworkThread,
     NodeConnCB,
     msg_headers,
     msg_block,
     msg_getdata,
     msg_getheaders,
+    network_thread_start,
     wait_until,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -79,7 +79,7 @@ class P2PFingerprintTest(BitcoinTestFramework):
     def run_test(self):
         node0 = self.nodes[0].add_p2p_connection(NodeConnCB())
 
-        NetworkThread().start()
+        network_thread_start()
         node0.wait_for_verack()
 
         # Set node time to 60 days ago

--- a/test/functional/p2p-fullblocktest.py
+++ b/test/functional/p2p-fullblocktest.py
@@ -17,6 +17,7 @@ from test_framework.comptool import TestManager, TestInstance, RejectResult
 from test_framework.blocktools import *
 from test_framework.key import CECKey
 from test_framework.script import *
+from test_framework.mininode import network_thread_start
 import struct
 
 class PreviousSpendableOutput(object):
@@ -69,7 +70,7 @@ class FullBlockTest(ComparisonTestFramework):
     def run_test(self):
         self.test = TestManager(self, self.options.tmpdir)
         self.test.add_all_connections(self.nodes)
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
         sync_masternodes(self.nodes, True)
         self.test.run()
 

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -113,8 +113,7 @@ class P2PLeakTest(BitcoinTestFramework):
         #This node should have been banned
         assert not no_version_bannode.connected
 
-        for _ in range(5):
-            self.nodes[0].disconnect_p2p()
+        self.nodes[0].disconnect_p2ps()
 
         # Make sure no unexpected messages came in
         assert(no_version_bannode.unexpected_msg == False)

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -98,7 +98,7 @@ class P2PLeakTest(BitcoinTestFramework):
         no_version_idlenode = self.nodes[0].add_p2p_connection(CNodeNoVersionIdle(), send_version=False)
         no_verack_idlenode = self.nodes[0].add_p2p_connection(CNodeNoVerackIdle())
 
-        NetworkThread().start()  # Start up network handling in another thread
+        network_thread_start()
 
         wait_until(lambda: no_version_bannode.ever_connected, timeout=10, lock=mininode_lock)
         wait_until(lambda: no_version_idlenode.ever_connected, timeout=10, lock=mininode_lock)

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -19,16 +19,14 @@ class P2PMempoolTests(BitcoinTestFramework):
         self.extra_args = [["-peerbloomfilters=0"]]
 
     def run_test(self):
-        #connect a mininode
-        aTestNode = NodeConnCB()
-        node = NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], aTestNode)
-        aTestNode.add_connection(node)
+        # Add a p2p connection
+        self.nodes[0].add_p2p_connection(NodeConnCB())
         NetworkThread().start()
-        aTestNode.wait_for_verack()
+        self.nodes[0].p2p.wait_for_verack()
 
         #request mempool
-        aTestNode.send_message(msg_mempool())
-        aTestNode.wait_for_disconnect()
+        self.nodes[0].p2p.send_message(msg_mempool())
+        self.nodes[0].p2p.wait_for_disconnect()
 
         #mininode must be disconnected at this point
         assert_equal(len(self.nodes[0].getpeerinfo()), 0)

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -21,7 +21,7 @@ class P2PMempoolTests(BitcoinTestFramework):
     def run_test(self):
         # Add a p2p connection
         self.nodes[0].add_p2p_connection(NodeConnCB())
-        NetworkThread().start()
+        network_thread_start()
         self.nodes[0].p2p.wait_for_verack()
 
         #request mempool

--- a/test/functional/p2p-timeouts.py
+++ b/test/functional/p2p-timeouts.py
@@ -43,7 +43,7 @@ class TimeoutsTest(BitcoinTestFramework):
         no_version_node = self.nodes[0].add_p2p_connection(TestNode(), send_version=False)
         no_send_node = self.nodes[0].add_p2p_connection(TestNode(), send_version=False)
 
-        NetworkThread().start()  # Start up network handling in another thread
+        network_thread_start()
 
         sleep(1)
 

--- a/test/functional/p2p-timeouts.py
+++ b/test/functional/p2p-timeouts.py
@@ -39,46 +39,37 @@ class TimeoutsTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
-        self.no_verack_node = TestNode() # never send verack
-        self.no_version_node = TestNode() # never send version (just ping)
-        self.no_send_node = TestNode() # never send anything
-
-        connections = []
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_verack_node))
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_version_node, send_version=False))
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_send_node, send_version=False))
-        self.no_verack_node.add_connection(connections[0])
-        self.no_version_node.add_connection(connections[1])
-        self.no_send_node.add_connection(connections[2])
+        no_verack_node = self.nodes[0].add_p2p_connection(TestNode())
+        no_version_node = self.nodes[0].add_p2p_connection(TestNode(), send_version=False)
+        no_send_node = self.nodes[0].add_p2p_connection(TestNode(), send_version=False)
 
         NetworkThread().start()  # Start up network handling in another thread
 
         sleep(1)
 
-        assert(self.no_verack_node.connected)
-        assert(self.no_version_node.connected)
-        assert(self.no_send_node.connected)
+        assert no_verack_node.connected
+        assert no_version_node.connected
+        assert no_send_node.connected
 
-        ping_msg = msg_ping()
-        connections[0].send_message(ping_msg)
-        connections[1].send_message(ping_msg)
+        no_verack_node.send_message(msg_ping())
+        no_version_node.send_message(msg_ping())
 
         sleep(30)
 
-        assert "version" in self.no_verack_node.last_message
+        assert "version" in no_verack_node.last_message
 
-        assert(self.no_verack_node.connected)
-        assert(self.no_version_node.connected)
-        assert(self.no_send_node.connected)
+        assert no_verack_node.connected
+        assert no_version_node.connected
+        assert no_send_node.connected
 
-        connections[0].send_message(ping_msg)
-        connections[1].send_message(ping_msg)
+        no_verack_node.send_message(msg_ping())
+        no_version_node.send_message(msg_ping())
 
         sleep(31)
 
-        assert(not self.no_verack_node.connected)
-        assert(not self.no_version_node.connected)
-        assert(not self.no_send_node.connected)
+        assert not no_verack_node.connected
+        assert not no_version_node.connected
+        assert not no_send_node.connected
 
 if __name__ == '__main__':
     TimeoutsTest().main()

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -66,7 +66,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         # Setup the p2p connection and start up the network thread.
         self.nodes[0].add_p2p_connection(TestNode())
 
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
 
         # Test logic begins here
         self.nodes[0].p2p.wait_for_verack()

--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -222,7 +222,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # direct fetching
         test_node = self.nodes[0].add_p2p_connection(TestNode(), services=0)
 
-        NetworkThread().start() # Start up network handling in another thread
+        network_thread_start()
 
         # Test logic begins here
         inv_node.wait_for_verack()

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -2031,13 +2031,13 @@ class P2PDataStore(NodeConnCB):
         if reject_reason is not None:
             wait_until(lambda: self.reject_reason_received == reject_reason, lock=mininode_lock)
 
-    def send_txs_and_test(self, txs, rpc, success=True, reject_code=None, reject_reason=None):
+    def send_txs_and_test(self, txs, rpc, success=True, expect_disconnect=False, reject_code=None, reject_reason=None):
         """Send txs to test node and test whether they're accepted to the mempool.
 
          - add all txs to our tx_store
          - send tx messages for all txs
-         - if success is True: assert that the tx is accepted to the mempool
-         - if success is False: assert that the tx is not accepted to the mempool
+         - if success is True/False: assert that the txs are/are not accepted to the mempool
+         - if expect_disconnect is True: Skip the sync with ping
          - if reject_code and reject_reason are set: assert that the correct reject message is received."""
 
         with mininode_lock:
@@ -2050,7 +2050,10 @@ class P2PDataStore(NodeConnCB):
         for tx in txs:
             self.send_message(msg_tx(tx))
 
-        self.sync_with_ping()
+        if expect_disconnect:
+            self.wait_for_disconnect()
+        else:
+            self.sync_with_ping()
 
         raw_mempool = rpc.getrawmempool()
         if success:

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -1932,7 +1932,7 @@ class EarlyDisconnectError(Exception):
     def __str__(self):
         return repr(self.value)
 
-class P2PDataStore(P2PInterface):
+class P2PDataStore(NodeConnCB):
     """A P2P data store class.
 
     Keeps a block and transaction store and responds correctly to getdata and getheaders requests."""
@@ -1948,7 +1948,7 @@ class P2PDataStore(P2PInterface):
         self.tx_store = {}
         self.getdata_requests = []
 
-    def on_getdata(self, message):
+    def on_getdata(self, conn, message):
         """Check for the tx/block in our stores and if found, reply with an inv message."""
         for inv in message.inv:
             self.getdata_requests.append(inv.hash)
@@ -1959,7 +1959,7 @@ class P2PDataStore(P2PInterface):
             else:
                 logger.debug('getdata message type {} received.'.format(hex(inv.type)))
 
-    def on_getheaders(self, message):
+    def on_getheaders(self, conn, message):
         """Search back through our block store for the locator, and reply with a headers message if found."""
 
         locator, hash_stop = message.locator, message.hashstop
@@ -1991,7 +1991,7 @@ class P2PDataStore(P2PInterface):
         if response is not None:
             self.send_message(response)
 
-    def on_reject(self, message):
+    def on_reject(self, conn, message):
         """Store reject reason and code for testing."""
         self.reject_code_received = message.code
         self.reject_reason_received = message.reason

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -13,13 +13,15 @@ import os
 import subprocess
 import time
 
+from .authproxy import JSONRPCException
+from .mininode import NodeConn
 from .util import (
     assert_equal,
     get_rpc_proxy,
     rpc_url,
     wait_until,
+    p2p_port,
 )
-from .authproxy import JSONRPCException
 
 BITCOIND_PROC_WAIT_TIMEOUT = 60
 
@@ -31,9 +33,11 @@ class TestNode():
     - state about the node (whether it's running, etc)
     - a Python subprocess.Popen object representing the running process
     - an RPC connection to the node
+    - one or more P2P connections to the node
 
-    To make things easier for the test writer, a bit of magic is happening under the covers.
-    Any unrecognised messages will be dispatched to the RPC connection."""
+
+    To make things easier for the test writer, any unrecognised messages will
+    be dispatched to the RPC connection."""
 
     def __init__(self, i, dirname, extra_args, rpchost, timewait, binary, stderr, mocktime, coverage_dir):
         self.index = i
@@ -66,10 +70,12 @@ class TestNode():
         self.url = None
         self.log = logging.getLogger('TestFramework.node%d' % i)
 
-    def __getattr__(self, *args, **kwargs):
+        self.p2ps = []
+
+    def __getattr__(self, name):
         """Dispatches any unrecognised messages to the RPC connection."""
         assert self.rpc_connected and self.rpc is not None, "Error: no RPC connection"
-        return self.rpc.__getattr__(*args, **kwargs)
+        return getattr(self.rpc, name)
 
     def start(self, extra_args=None, stderr=None):
         """Start the node."""
@@ -122,6 +128,7 @@ class TestNode():
             self.stop()
         except http.client.CannotSendRequest:
             self.log.exception("Unable to stop node.")
+        del self.p2ps[:]
 
     def is_node_stopped(self):
         """Checks whether the node has stopped.
@@ -153,6 +160,38 @@ class TestNode():
         care of cleaning up resources."""
         self.encryptwallet(passphrase)
         self.wait_until_stopped()
+
+    def add_p2p_connection(self, p2p_conn, **kwargs):
+        """Add a p2p connection to the node.
+
+        This method adds the p2p connection to the self.p2ps list and also
+        returns the connection to the caller."""
+        if 'dstport' not in kwargs:
+            kwargs['dstport'] = p2p_port(self.index)
+        if 'dstaddr' not in kwargs:
+            kwargs['dstaddr'] = '127.0.0.1'
+        self.p2ps.append(p2p_conn)
+        kwargs.update({'rpc': self.rpc, 'callback': p2p_conn})
+        p2p_conn.add_connection(NodeConn(**kwargs))
+
+        return p2p_conn
+
+    @property
+    def p2p(self):
+        """Return the first p2p connection
+
+        Convenience property - most tests only use a single p2p connection to each
+        node, so this saves having to write node.p2ps[0] many times."""
+        assert self.p2ps, "No p2p connection"
+        return self.p2ps[0]
+
+    def disconnect_p2p(self, index=0):
+        """Close the p2p connection to the node."""
+        # Connection could have already been closed by other end. Calling disconnect_p2p()
+        # on an already disconnected p2p connection is not an error.
+        if self.p2ps[index].connection is not None:
+            self.p2ps[index].connection.disconnect_node()
+        del self.p2ps[index]
 
 class TestNodeCLI():
     """Interface to bitcoin-cli for an individual node"""

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -185,13 +185,14 @@ class TestNode():
         assert self.p2ps, "No p2p connection"
         return self.p2ps[0]
 
-    def disconnect_p2p(self, index=0):
-        """Close the p2p connection to the node."""
-        # Connection could have already been closed by other end. Calling disconnect_p2p()
-        # on an already disconnected p2p connection is not an error.
-        if self.p2ps[index].connection is not None:
-            self.p2ps[index].connection.disconnect_node()
-        del self.p2ps[index]
+    def disconnect_p2ps(self):
+        """Close all p2p connections to the node."""
+        for p in self.p2ps:
+            # Connection could have already been closed by other end.
+            if p.connection is not None:
+                p.connection.disconnect_node()
+        self.p2ps = []
+
 
 class TestNodeCLI():
     """Interface to bitcoin-cli for an individual node"""


### PR DESCRIPTION
See individual commits.

The purpose of this PR is to bring in orphan TX tests into develop. This required to backport a few PRs before actually being able to backport bitcoin#13003.

I later realized that backporting bitcoin#11773 and probably bitcoin#11772 was not needed, but now the work is done and I'd like to include this here as well.

Backporting the orphan tests revealed a bug that is fixed by backporting bitcoin#8498. Without this fix, fee validation would happen before `nValueIn < value_out` validation, causing rejection due to too low fees (actually, negative fees) instead of rejection and banning due to an invalid TX.