### PR TITLE
Remove legacy proposal format

### DIFF
--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -445,7 +445,7 @@ bool CGovernanceObject::IsValidLocally(std::string& strError, bool& fMissingConf
 
     switch (nObjectType) {
     case GOVERNANCE_OBJECT_PROPOSAL: {
-        CProposalValidator validator(GetDataAsHexString(), true);
+        CProposalValidator validator(GetDataAsHexString());
         // Note: It's ok to have expired proposals
         // they are going to be cleared by CGovernanceManager::UpdateCachesAndClean()
         // TODO: should they be tagged as "expired" to skip vote downloading?

--- a/src/governance/governance-validators.cpp
+++ b/src/governance/governance-validators.cpp
@@ -14,10 +14,9 @@
 const size_t MAX_DATA_SIZE = 512;
 const size_t MAX_NAME_SIZE = 40;
 
-CProposalValidator::CProposalValidator(const std::string& strHexData, bool fAllowLegacyFormat) :
+CProposalValidator::CProposalValidator(const std::string& strHexData) :
     objJSON(UniValue::VOBJ),
     fJSONValid(false),
-    fAllowLegacyFormat(fAllowLegacyFormat),
     strErrorMessages()
 {
     if (!strHexData.empty()) {

--- a/src/governance/governance-validators.cpp
+++ b/src/governance/governance-validators.cpp
@@ -205,17 +205,10 @@ void CProposalValidator::ParseJSONData(const std::string& strJSONData)
 
         obj.read(strJSONData);
 
-        if (obj.isObject()) {
-            objJSON = obj;
-        } else {
-            if (fAllowLegacyFormat) {
-                std::vector<UniValue> arr1 = obj.getValues();
-                std::vector<UniValue> arr2 = arr1.at(0).getValues();
-                objJSON = arr2.at(1);
-            } else {
-                throw std::runtime_error("Legacy proposal serialization format not allowed");
-            }
+        if (!obj.isObject()) {
+            throw std::runtime_error("Invalid proposal serialization");
         }
+        objJSON = obj;
 
         fJSONValid = true;
     } catch (std::exception& e) {

--- a/src/governance/governance-validators.h
+++ b/src/governance/governance-validators.h
@@ -14,11 +14,10 @@ class CProposalValidator
 private:
     UniValue objJSON;
     bool fJSONValid;
-    bool fAllowLegacyFormat;
     std::string strErrorMessages;
 
 public:
-    CProposalValidator(const std::string& strDataHexIn = std::string(), bool fAllowLegacyFormat = true);
+    CProposalValidator(const std::string& strDataHexIn = std::string());
 
     bool Validate(bool fCheckExpiration = true);
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -426,7 +426,7 @@ void CGovernanceManager::UpdateCachesAndClean()
         } else {
             // NOTE: triggers are handled via triggerman
             if (pObj->GetObjectType() == GOVERNANCE_OBJECT_PROPOSAL) {
-                CProposalValidator validator(pObj->GetDataAsHexString(), true);
+                CProposalValidator validator(pObj->GetDataAsHexString());
                 if (!validator.Validate()) {
                     LogPrintf("CGovernanceManager::UpdateCachesAndClean -- set for deletion expired obj %s\n", strHash);
                     pObj->PrepareDeletion(nNow);

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -101,7 +101,7 @@ UniValue gobject_check(const JSONRPCRequest& request)
     CGovernanceObject govobj(hashParent, nRevision, nTime, uint256(), strDataHex);
 
     if (govobj.GetObjectType() == GOVERNANCE_OBJECT_PROPOSAL) {
-        CProposalValidator validator(strDataHex, false);
+        CProposalValidator validator(strDataHex);
         if (!validator.Validate())  {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid proposal data, error messages:" + validator.GetErrorMessages());
         }
@@ -176,7 +176,7 @@ UniValue gobject_prepare(const JSONRPCRequest& request)
                 govobj.GetDataAsPlainString(), govobj.GetHash().ToString());
 
     if (govobj.GetObjectType() == GOVERNANCE_OBJECT_PROPOSAL) {
-        CProposalValidator validator(strDataHex, false);
+        CProposalValidator validator(strDataHex);
         if (!validator.Validate()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid proposal data, error messages:" + validator.GetErrorMessages());
         }
@@ -284,7 +284,7 @@ UniValue gobject_submit(const JSONRPCRequest& request)
                 govobj.GetDataAsPlainString(), govobj.GetHash().ToString(), request.params[5].get_str());
 
     if (govobj.GetObjectType() == GOVERNANCE_OBJECT_PROPOSAL) {
-        CProposalValidator validator(strDataHex, false);
+        CProposalValidator validator(strDataHex);
         if (!validator.Validate()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid proposal data, error messages:" + validator.GetErrorMessages());
         }

--- a/src/test/governance_validators_tests.cpp
+++ b/src/test/governance_validators_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(valid_proposals_test)
         // legacy format w/validation flag off
         CProposalValidator validator0(strHexData1, false);
         BOOST_CHECK(!validator0.Validate());
-        BOOST_CHECK_EQUAL(validator0.GetErrorMessages(), "Legacy proposal serialization format not allowed;JSON parsing error;");
+        BOOST_CHECK_EQUAL(validator0.GetErrorMessages(), "Invalid proposal serialization;JSON parsing error;");
 
         // new format
         std::string strHexData2 = HexStr(objProposal.write());

--- a/src/test/governance_validators_tests.cpp
+++ b/src/test/governance_validators_tests.cpp
@@ -43,20 +43,15 @@ BOOST_AUTO_TEST_CASE(valid_proposals_test)
     for(size_t i = 0; i < tests.size(); ++i) {
         const UniValue& objProposal = tests[i];
 
-        // legacy format
+        // legacy format (invalid now)
         std::string strHexData1 = CreateEncodedProposalObject(objProposal);
-        CProposalValidator validator1(strHexData1, true);
-        BOOST_CHECK_MESSAGE(validator1.Validate(false), validator1.GetErrorMessages());
-        BOOST_CHECK_MESSAGE(!validator1.Validate(), validator1.GetErrorMessages());
+        CProposalValidator validator1(strHexData1);
+        BOOST_CHECK(!validator1.Validate());
+        BOOST_CHECK_EQUAL(validator1.GetErrorMessages(), "Invalid proposal serialization;JSON parsing error;");
 
-        // legacy format w/validation flag off
-        CProposalValidator validator0(strHexData1, false);
-        BOOST_CHECK(!validator0.Validate());
-        BOOST_CHECK_EQUAL(validator0.GetErrorMessages(), "Invalid proposal serialization;JSON parsing error;");
-
-        // new format
+        // only correct format
         std::string strHexData2 = HexStr(objProposal.write());
-        CProposalValidator validator2(strHexData2, false);
+        CProposalValidator validator2(strHexData2);
         BOOST_CHECK_MESSAGE(validator2.Validate(false), validator2.GetErrorMessages());
         BOOST_CHECK_MESSAGE(!validator2.Validate(), validator2.GetErrorMessages());
     }
@@ -72,14 +67,8 @@ BOOST_AUTO_TEST_CASE(invalid_proposals_test)
     for(size_t i = 0; i < tests.size(); ++i) {
         const UniValue& objProposal = tests[i];
 
-        // legacy format
-        std::string strHexData1 = CreateEncodedProposalObject(objProposal);
-        CProposalValidator validator1(strHexData1, true);
-        BOOST_CHECK_MESSAGE(!validator1.Validate(false), validator1.GetErrorMessages());
-
-        // new format
         std::string strHexData2 = HexStr(objProposal.write());
-        CProposalValidator validator2(strHexData2, false);
+        CProposalValidator validator2(strHexData2);
         BOOST_CHECK_MESSAGE(!validator2.Validate(false), validator2.GetErrorMessages());
     }
 }

--- a/src/test/governance_validators_tests.cpp
+++ b/src/test/governance_validators_tests.cpp
@@ -20,7 +20,7 @@ extern UniValue read_json(const std::string& jsondata);
 
 BOOST_FIXTURE_TEST_SUITE(governance_validators_tests, BasicTestingSetup)
 
-std::string CreateEncodedProposalObject(const UniValue& objJSON)
+std::string CreateLegacyProposalObject(const UniValue& objJSON)
 {
     UniValue innerArray(UniValue::VARR);
     innerArray.push_back(UniValue("proposal"));
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(valid_proposals_test)
         const UniValue& objProposal = tests[i];
 
         // legacy format (invalid now)
-        std::string strHexData1 = CreateEncodedProposalObject(objProposal);
+        std::string strHexData1 = CreateLegacyProposalObject(objProposal);
         CProposalValidator validator1(strHexData1);
         BOOST_CHECK(!validator1.Validate());
         BOOST_CHECK_EQUAL(validator1.GetErrorMessages(), "Invalid proposal serialization;JSON parsing error;");


### PR DESCRIPTION
Please see individual commits.

There are no legacy format proposals on the network any longer. This slightly cleans up the Proposal validator code and ensures no proposals will be validated.

There is also a slight but unlikely chance that someone could custom-compile Dash and relay a legacy format proposal. Currently we are only checking in the JSONRPC entry point.