### PR TITLE
Fixes and refactorings related to using mnsync in tests

### DIFF
--- a/test/functional/invalidblockrequest.py
+++ b/test/functional/invalidblockrequest.py
@@ -15,7 +15,7 @@ import copy
 from test_framework.blocktools import create_block, create_coinbase, create_transaction, network_thread_start
 from test_framework.mininode import P2PDataStore, COIN
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, sync_masternodes
+from test_framework.util import assert_equal
 
 
 class InvalidBlockRequestTest(BitcoinTestFramework):
@@ -30,7 +30,6 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         node.add_p2p_connection(P2PDataStore())
 
         network_thread_start()
-        sync_masternodes(self.nodes, True)
         node.p2p.wait_for_verack()
 
         best_block = node.getblock(node.getbestblockhash())

--- a/test/functional/p2p-fullblocktest.py
+++ b/test/functional/p2p-fullblocktest.py
@@ -71,7 +71,6 @@ class FullBlockTest(ComparisonTestFramework):
         self.test = TestManager(self, self.options.tmpdir)
         self.test.add_all_connections(self.nodes)
         network_thread_start()
-        sync_masternodes(self.nodes, True)
         self.test.run()
 
     def add_transactions_to_block(self, block, tx_list):

--- a/test/functional/sporks.py
+++ b/test/functional/sporks.py
@@ -63,9 +63,6 @@ class SporkTest(BitcoinTestFramework):
         assert(self.get_test_spork_state(self.nodes[0]))
         assert(self.get_test_spork_state(self.nodes[1]))
 
-        # Force finish mnsync node as otherwise it will never send out headers to other peers
-        wait_to_sync(self.nodes[1], fast_mnsync=True)
-
         # Generate one block to kick off masternode sync, which also starts sporks syncing for node2
         self.nodes[1].generate(1)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -30,6 +30,7 @@ from .util import (
     connect_nodes,
     copy_datadir,
     disconnect_nodes,
+    force_finish_mnsync,
     initialize_datadir,
     log_filename,
     p2p_port,
@@ -37,8 +38,6 @@ from .util import (
     satoshi_round,
     sync_blocks,
     sync_mempools,
-    sync_masternodes,
-    wait_to_sync,
     wait_until,
 )
 
@@ -580,7 +579,7 @@ class DashTestFramework(BitcoinTestFramework):
             self.start_node(idx + start_idx, extra_args=args)
             self.mninfo[idx].nodeIdx = idx + start_idx
             self.mninfo[idx].node = self.nodes[idx + start_idx]
-            wait_to_sync(self.mninfo[idx].node, True)
+            force_finish_mnsync(self.mninfo[idx].node)
 
         def do_connect(idx):
             for i in range(0, idx + 1):
@@ -606,8 +605,6 @@ class DashTestFramework(BitcoinTestFramework):
             job.result()
         jobs.clear()
 
-        sync_masternodes(self.nodes, True)
-
         executor.shutdown()
 
     def setup_network(self):
@@ -624,7 +621,6 @@ class DashTestFramework(BitcoinTestFramework):
         self.log.info("Creating and starting %s simple nodes", num_simple_nodes)
         for i in range(0, num_simple_nodes):
             self.create_simple_node()
-        sync_masternodes(self.nodes, True)
 
         self.log.info("Activating DIP3")
         if not self.fast_dip3_enforcement:


### PR DESCRIPTION
While reviewing #3127 I suggested that we should keep `sync_masternodes` assuming it was helping tests to pass... but after digging a bit I realized that I was wrong and we don't need `sync_masternodes` and `wait_to_sync` in tests that do not use MNs at all actually. These functions were introduced in https://github.com/dashpay/dash/pull/950 back when we had non-deterministic MN list. They are still useful for MN test nodes (MNs won't accept incoming connections while syncing, there is actually a bug related to this in `dip3-deterministicmns.py` which is fixed in the second commit) but we can drop them everywhere else. Also, there is no need for the "slow" sync mode, it's always the "fast" one now and we can simplify the function.