### PR TITLE
Some refactoring for spork related functionality in tests

### DIFF
--- a/test/functional/dip3-deterministicmns.py
+++ b/test/functional/dip3-deterministicmns.py
@@ -289,22 +289,6 @@ class DIP3Test(BitcoinTestFramework):
             self.log.error('expected: ' + str(expected))
             raise AssertionError("mnlists does not match provided mns")
 
-    def wait_for_sporks(self, timeout=30):
-        st = time.time()
-        while time.time() < st + timeout:
-            if self.compare_sporks():
-                return
-            time.sleep(0.5)
-        raise AssertionError("wait_for_sporks timed out")
-
-    def compare_sporks(self):
-        sporks = self.nodes[0].spork('show')
-        for node in self.nodes[1:]:
-            sporks2 = node.spork('show')
-            if sporks != sporks2:
-                return False
-        return True
-
     def compare_mnlist(self, node, mns):
         mnlist = node.masternode('list', 'status')
         for mn in mns:

--- a/test/functional/multikeysporks.py
+++ b/test/functional/multikeysporks.py
@@ -88,45 +88,45 @@ class MultiKeySporkTest(BitcoinTestFramework):
             for j in range(i, 5):
                 connect_nodes(self.nodes[i], j)
 
-    def get_test_spork_state(self, node):
+    def get_test_spork_value(self, node):
         info = node.spork('show')
         # use InstantSend spork for tests
         return info['SPORK_2_INSTANTSEND_ENABLED']
 
-    def set_test_spork_state(self, node, value):
+    def set_test_spork_value(self, node, value):
         # use InstantSend spork for tests
         node.spork('SPORK_2_INSTANTSEND_ENABLED', value)
 
     def run_test(self):
         # check test spork default state
         for node in self.nodes:
-            assert(self.get_test_spork_state(node) == 4070908800)
+            assert(self.get_test_spork_value(node) == 4070908800)
 
         self.bump_mocktime(1)
         set_node_times(self.nodes, self.mocktime)
         # first and second signers set spork value
-        self.set_test_spork_state(self.nodes[0], 1)
-        self.set_test_spork_state(self.nodes[1], 1)
+        self.set_test_spork_value(self.nodes[0], 1)
+        self.set_test_spork_value(self.nodes[1], 1)
         # spork change requires at least 3 signers
         time.sleep(10)
         for node in self.nodes:
-            assert(self.get_test_spork_state(node) != 1)
+            assert(self.get_test_spork_value(node) != 1)
 
         # third signer set spork value
-        self.set_test_spork_state(self.nodes[2], 1)
+        self.set_test_spork_value(self.nodes[2], 1)
         # now spork state is changed
         for node in self.nodes:
-            wait_until(lambda: self.get_test_spork_state(node) == 1, sleep=0.1, timeout=10)
+            wait_until(lambda: self.get_test_spork_value(node) == 1, sleep=0.1, timeout=10)
 
         self.bump_mocktime(1)
         set_node_times(self.nodes, self.mocktime)
         # now set the spork again with other signers to test
         # old and new spork messages interaction
-        self.set_test_spork_state(self.nodes[2], 2)
-        self.set_test_spork_state(self.nodes[3], 2)
-        self.set_test_spork_state(self.nodes[4], 2)
+        self.set_test_spork_value(self.nodes[2], 2)
+        self.set_test_spork_value(self.nodes[3], 2)
+        self.set_test_spork_value(self.nodes[4], 2)
         for node in self.nodes:
-            wait_until(lambda: self.get_test_spork_state(node) == 2, sleep=0.1, timeout=10)
+            wait_until(lambda: self.get_test_spork_value(node) == 2, sleep=0.1, timeout=10)
 
 
 if __name__ == '__main__':

--- a/test/functional/sporks.py
+++ b/test/functional/sporks.py
@@ -2,11 +2,10 @@
 # Copyright (c) 2018 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-import time
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import connect_nodes, wait_until
 
 '''
 '''
@@ -44,16 +43,7 @@ class SporkTest(BitcoinTestFramework):
 
         # check spork propagation for connected nodes
         self.set_test_spork_state(self.nodes[0], True)
-        start = time.time()
-        sent = False
-        while True:
-            if self.get_test_spork_state(self.nodes[1]):
-                sent = True
-                break
-            if time.time() > start + 10:
-                break
-            time.sleep(0.1)
-        assert(sent)
+        wait_until(lambda: self.get_test_spork_state(self.nodes[1]), sleep=0.1, timeout=10)
 
         # restart nodes to check spork persistence
         self.stop_node(0)
@@ -68,17 +58,7 @@ class SporkTest(BitcoinTestFramework):
 
         # connect new node and check spork propagation after restoring from cache
         connect_nodes(self.nodes[1], 2)
-        start = time.time()
-        sent = False
-        while True:
-            if self.get_test_spork_state(self.nodes[2]):
-                sent = True
-                break
-            if time.time() > start + 10:
-                break
-            time.sleep(0.1)
-        assert(sent)
-
+        wait_until(lambda: self.get_test_spork_state(self.nodes[2]), sleep=0.1, timeout=10)
 
 if __name__ == '__main__':
     SporkTest().main()


### PR DESCRIPTION
Currently based on #3136 (because of `wait_to_sync` in `sporks.py`), will rebase.