### PR TITLE
Don't use travis_apt_get_update and invoke apt-get update manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,8 @@ before_cache:
   - docker save dash-builder-$BUILD_TARGET-$TRAVIS_JOB_NUMBER $(docker history -q dash-builder-$BUILD_TARGET-$TRAVIS_JOB_NUMBER | grep -v \<missing\>) | gzip -2 > $HOME/cache/docker/dash-builder-$BUILD_TARGET.tar.gz
 
 before_install:
-  - travis_retry travis_apt_get_update
+  - sudo rm -rf "${TRAVIS_ROOT}/var/lib/apt/lists/"*
+  - travis_retry sudo sudo apt-get update 2>&1
   - travis_retry sudo apt-get -yq --no-install-suggests --no-install-recommends install docker-ce realpath
 
 install:


### PR DESCRIPTION
Something goes wrong in very rare cases when using travis_apt_get_update,
but no debug output is printed. We could use "travis_apt_get_update debug"
but I prefer to do the call manually as it makes more clear what's
happening. Also, travis_retry with travis_apt_get_update causes the "rm -rf"
to be re-executed for each try, making us start from the beginning again
and again which also increases the chance of multiple failures in a row.