### PR TITLE
Avoid propagating InstantSend related old recovered sigs

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1160,11 +1160,11 @@ void CInstantSendManager::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
 
             // no need to keep recovered sigs for fully confirmed IS locks, as there is no chance for conflicts
             // from now on. All inputs are spent now and can't be spend in any other TX.
-            quorumSigningManager->RemoveRecoveredSig(consensusParams.llmqTypeInstantSend, inputRequestId);
+            quorumSigningManager->TruncateRecoveredSig(consensusParams.llmqTypeInstantSend, inputRequestId);
         }
 
         // same as in the loop
-        quorumSigningManager->RemoveRecoveredSig(consensusParams.llmqTypeInstantSend, islock->GetRequestId());
+        quorumSigningManager->TruncateRecoveredSig(consensusParams.llmqTypeInstantSend, islock->GetRequestId());
     }
 
     // Find all previously unlocked TXs that got locked by this fully confirmed (ChainLock) block and remove them

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -149,6 +149,7 @@ public:
     void AddNonLockedTx(const CTransactionRef& tx, const CBlockIndex* pindexMined);
     void RemoveNonLockedTx(const uint256& txid, bool retryChildren);
     void RemoveConflictedTx(const CTransaction& tx);
+    void TruncateRecoveredSigsForInputs(const CInstantSendLock& islock);
 
     void NotifyChainLock(const CBlockIndex* pindexChainLock);
     void UpdatedBlockTip(const CBlockIndex* pindexNew);

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -259,7 +259,7 @@ void CRecoveredSigsDb::WriteRecoveredSig(const llmq::CRecoveredSig& recSig)
     }
 }
 
-void CRecoveredSigsDb::RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType llmqType, const uint256& id, bool deleteTimeKey)
+void CRecoveredSigsDb::RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType llmqType, const uint256& id, bool deleteHashKey, bool deleteTimeKey)
 {
     AssertLockHeld(cs);
 
@@ -276,7 +276,9 @@ void CRecoveredSigsDb::RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType l
     auto k4 = std::make_tuple(std::string("rs_s"), signHash);
     batch.Erase(k1);
     batch.Erase(k2);
-    batch.Erase(k3);
+    if (deleteHashKey) {
+        batch.Erase(k3);
+    }
     batch.Erase(k4);
 
     if (deleteTimeKey) {
@@ -292,14 +294,27 @@ void CRecoveredSigsDb::RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType l
 
     hasSigForIdCache.erase(std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.id));
     hasSigForSessionCache.erase(signHash);
-    hasSigForHashCache.erase(recSig.GetHash());
+    if (deleteHashKey) {
+        hasSigForHashCache.erase(recSig.GetHash());
+    }
 }
 
+// Completely remove any traces of the recovered sig
 void CRecoveredSigsDb::RemoveRecoveredSig(Consensus::LLMQType llmqType, const uint256& id)
 {
     LOCK(cs);
     CDBBatch batch(db);
-    RemoveRecoveredSig(batch, llmqType, id, true);
+    RemoveRecoveredSig(batch, llmqType, id, true, true);
+    db.WriteBatch(batch);
+}
+
+// Remove the recovered sig itself and all keys required to get from id -> recSig
+// This will leave the byHash key in-place so that HasRecoveredSigForHash still returns true
+void CRecoveredSigsDb::TruncateRecoveredSig(Consensus::LLMQType llmqType, const uint256& id)
+{
+    LOCK(cs);
+    CDBBatch batch(db);
+    RemoveRecoveredSig(batch, llmqType, id, false, false);
     db.WriteBatch(batch);
 }
 
@@ -339,7 +354,7 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
     {
         LOCK(cs);
         for (auto& e : toDelete) {
-            RemoveRecoveredSig(batch, e.first, e.second, false);
+            RemoveRecoveredSig(batch, e.first, e.second, true, false);
 
             if (batch.SizeEstimate() >= (1 << 24)) {
                 db.WriteBatch(batch);

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -473,7 +473,8 @@ void CSigningManager::ProcessMessageRecoveredSig(CNode* pfrom, const CRecoveredS
         return;
     }
 
-    LogPrint(BCLog::LLMQ, "CSigningManager::%s -- signHash=%s, node=%d\n", __func__, CLLMQUtils::BuildSignHash(recoveredSig).ToString(), pfrom->GetId());
+    LogPrint(BCLog::LLMQ, "CSigningManager::%s -- signHash=%s, id=%s, msgHash=%s, node=%d\n", __func__,
+            CLLMQUtils::BuildSignHash(recoveredSig).ToString(), recoveredSig.id.ToString(), recoveredSig.msgHash.ToString(), pfrom->GetId());
 
     LOCK(cs);
     pendingRecoveredSigs[pfrom->GetId()].emplace_back(recoveredSig);

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -672,6 +672,10 @@ void CSigningManager::ProcessRecoveredSig(NodeId nodeId, const CRecoveredSig& re
         connman.RemoveAskFor(recoveredSig.GetHash());
     }
 
+    if (db.HasRecoveredSigForHash(recoveredSig.GetHash())) {
+        return;
+    }
+
     std::vector<CRecoveredSigsListener*> listeners;
     {
         LOCK(cs);
@@ -725,9 +729,9 @@ void CSigningManager::PushReconstructedRecoveredSig(const llmq::CRecoveredSig& r
     pendingReconstructedRecoveredSigs.emplace_back(recoveredSig, quorum);
 }
 
-void CSigningManager::RemoveRecoveredSig(Consensus::LLMQType llmqType, const uint256& id)
+void CSigningManager::TruncateRecoveredSig(Consensus::LLMQType llmqType, const uint256& id)
 {
-    db.RemoveRecoveredSig(llmqType, id);
+    db.TruncateRecoveredSig(llmqType, id);
 }
 
 void CSigningManager::Cleanup()

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -147,8 +147,10 @@ public:
     // This is the case for example when a signature appears as part of InstantSend or ChainLocks
     void PushReconstructedRecoveredSig(const CRecoveredSig& recoveredSig, const CQuorumCPtr& quorum);
 
-    // Same as RemoveRecoveredSig, but leaves the key for recSig hash in the DB, so that AlreadyHave keeps returning true
-    // Cleanup will later remove the remains
+    // This is called when a recovered signature can be safely removed from the DB. This is only safe when some other
+    // mechanism prevents possible conflicts. As an example, ChainLocks prevent conflicts in confirmed TXs InstantSend votes
+    // This won't completely remove all traces of the recovered sig but instead leave the hash entry in the DB. This
+    // allows AlreadyHave to keep returning true. Cleanup will later remove the remains
     void TruncateRecoveredSig(Consensus::LLMQType llmqType, const uint256& id);
 
 private:

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -147,9 +147,9 @@ public:
     // This is the case for example when a signature appears as part of InstantSend or ChainLocks
     void PushReconstructedRecoveredSig(const CRecoveredSig& recoveredSig, const CQuorumCPtr& quorum);
 
-    // This is called when a recovered signature can be safely removed from the DB. This is only safe when some other
-    // mechanism prevents possible conflicts. As an example, ChainLocks prevent conflicts in confirmed TXs InstantSend votes
-    void RemoveRecoveredSig(Consensus::LLMQType llmqType, const uint256& id);
+    // Same as RemoveRecoveredSig, but leaves the key for recSig hash in the DB, so that AlreadyHave keeps returning true
+    // Cleanup will later remove the remains
+    void TruncateRecoveredSig(Consensus::LLMQType llmqType, const uint256& id);
 
 private:
     void ProcessMessageRecoveredSig(CNode* pfrom, const CRecoveredSig& recoveredSig, CConnman& connman);

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -85,6 +85,7 @@ public:
     bool GetRecoveredSigById(Consensus::LLMQType llmqType, const uint256& id, CRecoveredSig& ret);
     void WriteRecoveredSig(const CRecoveredSig& recSig);
     void RemoveRecoveredSig(Consensus::LLMQType llmqType, const uint256& id);
+    void TruncateRecoveredSig(Consensus::LLMQType llmqType, const uint256& id);
 
     void CleanupOldRecoveredSigs(int64_t maxAge);
 
@@ -97,7 +98,7 @@ public:
 
 private:
     bool ReadRecoveredSig(Consensus::LLMQType llmqType, const uint256& id, CRecoveredSig& ret);
-    void RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType llmqType, const uint256& id, bool deleteTimeKey);
+    void RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType llmqType, const uint256& id, bool deleteHashKey, bool deleteTimeKey);
 };
 
 class CRecoveredSigsListener


### PR DESCRIPTION
This PR implements "truncating" of recovered sigs in the LLMQ DB. Truncating means that the sig itself is deleted from the DB, but the hash of it is left in the DB so that we won't re-request it later. It also avoids reprocessing of the sig when another node sends it to us after we've already got it from another node.

This fixes issues when other nodes are unable to keep up with the network. In this case requesting sigs from them will timeout and cause us to re-request from another node. When we then get the sig from the second node, we'll process and relay it. If an InstantSend lock comes in which uses that sig, the code in `CInstantSendManager` causes the recovered sig to be deleted by calling `RemoveRecoveredSig`. After some time, the first node might end up sending us the same sig again, causing us to re-process and re-propagate the recovered signature. Neighbor nodes will now get the same sig from us, even thought they also have seen it already, which makes them re-process and re-propagate it as well. This then continues until the whole network has seen and processed the sig twice.

Changing the removal to "truncating" fixes this issue as it stops re-processing and re-propagation.