### PR TITLE
Fix updateConfirmations slowness for huge wallets

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -275,10 +275,12 @@ void TransactionTableModel::updateConfirmations()
 {
     // Blocks came in since last poll.
     // Invalidate status (number of confirmations) and (possibly) description
-    //  for all rows. Qt is smart enough to only actually request the data for the
-    //  visible rows.
-    Q_EMIT dataChanged(index(0, Status), index(priv->size()-1, Status));
-    Q_EMIT dataChanged(index(0, ToAddress), index(priv->size()-1, ToAddress));
+    // for the first 1000 rows. Qt is smart enough to only actually request the data for the
+    // visible rows, but invalidating data for like 100k+ rows slows things down a lot anyway.
+    // Invalildating the first 1000 rows should be enough in most cases.
+    size_t rows = std::min(priv->size(), 1000);
+    Q_EMIT dataChanged(index(0, Status), index(rows - 1, Status));
+    Q_EMIT dataChanged(index(0, ToAddress), index(rows - 1, ToAddress));
 }
 
 void TransactionTableModel::updateNumISLocks(int numISLocks)


### PR DESCRIPTION
This fixes only the GUI part. Another part of the slowness for huge wallets is the wallet itself (which reveals itself whenever you try to create a tx) but this patch removes the major freeze and GUI is much more responsive now.