### PR TITLE
Use wallet UTXOs whenever possible to avoid looping through all wallet txes

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2443,8 +2443,13 @@ CAmount CWallet::GetBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
-        {
+        std::set<uint256> setWalletTxesCounted;
+        for (const auto& outpoint : setWalletUTXO) {
+            if (!setWalletTxesCounted.emplace(outpoint.hash).second) continue;
+
+            const auto it = mapWallet.find(outpoint.hash);
+            if (it == mapWallet.end()) continue;
+
             const CWalletTx* pcoin = &(*it).second;
             if (pcoin->IsTrusted())
                 nTotal += pcoin->GetAvailableCredit();
@@ -2570,8 +2575,13 @@ CAmount CWallet::GetUnconfirmedBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
-        {
+        std::set<uint256> setWalletTxesCounted;
+        for (const auto& outpoint : setWalletUTXO) {
+            if (!setWalletTxesCounted.emplace(outpoint.hash).second) continue;
+
+            const auto it = mapWallet.find(outpoint.hash);
+            if (it == mapWallet.end()) continue;
+
             const CWalletTx* pcoin = &(*it).second;
             if (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0 && !pcoin->IsLockedByInstantSend() && pcoin->InMempool())
                 nTotal += pcoin->GetAvailableCredit();
@@ -2585,8 +2595,13 @@ CAmount CWallet::GetImmatureBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
-        {
+        std::set<uint256> setWalletTxesCounted;
+        for (const auto& outpoint : setWalletUTXO) {
+            if (!setWalletTxesCounted.emplace(outpoint.hash).second) continue;
+
+            const auto it = mapWallet.find(outpoint.hash);
+            if (it == mapWallet.end()) continue;
+
             const CWalletTx* pcoin = &(*it).second;
             nTotal += pcoin->GetImmatureCredit();
         }
@@ -2599,8 +2614,13 @@ CAmount CWallet::GetWatchOnlyBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
-        {
+        std::set<uint256> setWalletTxesCounted;
+        for (const auto& outpoint : setWalletUTXO) {
+            if (!setWalletTxesCounted.emplace(outpoint.hash).second) continue;
+
+            const auto it = mapWallet.find(outpoint.hash);
+            if (it == mapWallet.end()) continue;
+
             const CWalletTx* pcoin = &(*it).second;
             if (pcoin->IsTrusted())
                 nTotal += pcoin->GetAvailableWatchOnlyCredit();
@@ -2615,8 +2635,13 @@ CAmount CWallet::GetUnconfirmedWatchOnlyBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
-        {
+        std::set<uint256> setWalletTxesCounted;
+        for (const auto& outpoint : setWalletUTXO) {
+            if (!setWalletTxesCounted.emplace(outpoint.hash).second) continue;
+
+            const auto it = mapWallet.find(outpoint.hash);
+            if (it == mapWallet.end()) continue;
+
             const CWalletTx* pcoin = &(*it).second;
             if (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0 && !pcoin->IsLockedByInstantSend() && pcoin->InMempool())
                 nTotal += pcoin->GetAvailableWatchOnlyCredit();
@@ -2630,8 +2655,13 @@ CAmount CWallet::GetImmatureWatchOnlyBalance() const
     CAmount nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);
-        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
-        {
+        std::set<uint256> setWalletTxesCounted;
+        for (const auto& outpoint : setWalletUTXO) {
+            if (!setWalletTxesCounted.emplace(outpoint.hash).second) continue;
+
+            const auto it = mapWallet.find(outpoint.hash);
+            if (it == mapWallet.end()) continue;
+
             const CWalletTx* pcoin = &(*it).second;
             nTotal += pcoin->GetImmatureWatchOnlyCredit();
         }
@@ -2706,8 +2736,13 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
 
         CAmount nTotal = 0;
 
-        for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
-        {
+        std::set<uint256> setWalletTxesCounted;
+        for (const auto& outpoint : setWalletUTXO) {
+            if (!setWalletTxesCounted.emplace(outpoint.hash).second) continue;
+
+            const auto it = mapWallet.find(outpoint.hash);
+            if (it == mapWallet.end()) continue;
+
             const uint256& wtxid = it->first;
             const CWalletTx* pcoin = &(*it).second;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -10,6 +10,7 @@
 #include "amount.h"
 #include "base58.h"
 #include "policy/feerate.h"
+#include "saltedhasher.h"
 #include "streams.h"
 #include "tinyformat.h"
 #include "ui_interface.h"
@@ -518,6 +519,14 @@ public:
     std::set<uint256> GetConflicts() const;
 };
 
+struct WalletTxHasher
+{
+    StaticSaltedHasher h;
+    size_t operator()(const CWalletTx* a) const
+    {
+        return h(a->GetHash());
+    }
+};
 
 class CInputCoin {
 public:
@@ -774,6 +783,9 @@ private:
     // Used to NotifyTransactionChanged of the previous block's coinbase when
     // the next block comes in
     uint256 hashPrevBestCoinbase;
+
+    // A helper function which loops through wallet UTXOs
+    std::unordered_set<const CWalletTx*, WalletTxHasher> GetSpendableTXs() const;
 
 public:
     /*


### PR DESCRIPTION
This applies the same idea as #1655 to regular/non-PS wallet functions.