### PR TITLE
Disable move ctor/operator for CKeyHolder

### DIFF
--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -28,11 +28,11 @@ CScript CKeyHolder::GetScriptForDestination() const
 
 CScript CKeyHolderStorage::AddKey(CWallet* pwallet)
 {
-    auto keyHolder = std::unique_ptr<CKeyHolder>(new CKeyHolder(pwallet));
-    auto script = keyHolder->GetScriptForDestination();
+    auto keyHolderPtr = std::unique_ptr<CKeyHolder>(new CKeyHolder(pwallet));
+    auto script = keyHolderPtr->GetScriptForDestination();
 
     LOCK(cs_storage);
-    storage.emplace_back(std::move(keyHolder));
+    storage.emplace_back(std::move(keyHolderPtr));
     LogPrintf("CKeyHolderStorage::%s -- storage size %lld\n", __func__, storage.size());
     return script;
 }

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -15,8 +15,8 @@ private:
 
 public:
     CKeyHolder(CWallet* pwalletIn);
-    CKeyHolder(CKeyHolder&&) = default;
-    CKeyHolder& operator=(CKeyHolder&&) = default;
+    CKeyHolder(CKeyHolder&&) = delete;
+    CKeyHolder& operator=(CKeyHolder&&) = delete;
     void KeepKey();
     void ReturnKey();
 


### PR DESCRIPTION
The first commit fixes these warnings:
```
In file included from dsnotificationinterface.cpp:12:
In file included from ./privatesend/privatesend-client.h:8:
./privatesend/privatesend-util.h:18:5: warning: explicitly defaulted move constructor is implicitly deleted [-Wdefaulted-function-deleted]
    CKeyHolder(CKeyHolder&&) = default;
    ^
./privatesend/privatesend-util.h:13:17: note: move constructor of 'CKeyHolder' is implicitly deleted because field 'reserveKey' has a deleted move constructor
    CReserveKey reserveKey;
                ^
./wallet/wallet.h:1282:5: note: 'CReserveKey' has been explicitly marked deleted here
    CReserveKey(const CReserveKey&) = delete;
    ^
In file included from dsnotificationinterface.cpp:12:
In file included from ./privatesend/privatesend-client.h:8:
./privatesend/privatesend-util.h:19:17: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
    CKeyHolder& operator=(CKeyHolder&&) = default;
                ^
./privatesend/privatesend-util.h:13:17: note: move assignment operator of 'CKeyHolder' is implicitly deleted because field 'reserveKey' has a deleted move assignment operator
    CReserveKey reserveKey;
                ^
./wallet/wallet.h:1283:18: note: 'operator=' has been explicitly marked deleted here
    CReserveKey& operator=(const CReserveKey&) = delete;
                 ^
2 warnings generated.
```

The second one is just a simple refactoring to use better names.