### PR TITLE
Only track last seen time instead of first and last seen time

### DIFF
--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -675,18 +675,10 @@ void CSigSharesManager::ProcessSigShare(NodeId nodeId, const CSigShare& sigShare
         if (!sigShares.Add(sigShare.GetKey(), sigShare)) {
             return;
         }
-        
         sigSharesToAnnounce.Add(sigShare.GetKey(), true);
 
-        auto it = timeSeenForSessions.find(sigShare.GetSignHash());
-        if (it == timeSeenForSessions.end()) {
-            auto t = GetTimeMillis();
-            // insert first-seen and last-seen time
-            timeSeenForSessions.emplace(sigShare.GetSignHash(), std::make_pair(t, t));
-        } else {
-            // update last-seen time
-            it->second.second = GetTimeMillis();
-        }
+        // Update the time we've seen the last sigShare
+        timeSeenForSessions[sigShare.GetSignHash()] = GetTimeMillis();
 
         if (!quorumNodes.empty()) {
             // don't announce and wait for other nodes to request this share and directly send it to them
@@ -1214,10 +1206,9 @@ void CSigSharesManager::Cleanup()
         std::unordered_set<uint256, StaticSaltedHasher> timeoutSessions;
         for (auto& p : timeSeenForSessions) {
             auto& signHash = p.first;
-            int64_t firstSeenTime = p.second.first;
-            int64_t lastSeenTime = p.second.second;
+            int64_t lastSeenTime = p.second;
 
-            if (now - firstSeenTime >= SESSION_TOTAL_TIMEOUT || now - lastSeenTime >= SESSION_NEW_SHARES_TIMEOUT) {
+            if (now - lastSeenTime >= SESSION_NEW_SHARES_TIMEOUT) {
                 timeoutSessions.emplace(signHash);
             }
         }

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -329,7 +329,6 @@ public:
 class CSigSharesManager : public CRecoveredSigsListener
 {
     static const int64_t SESSION_NEW_SHARES_TIMEOUT = 60 * 1000;
-    static const int64_t SESSION_TOTAL_TIMEOUT = 5 * 60 * 1000;
     static const int64_t SIG_SHARE_REQUEST_TIMEOUT = 5 * 1000;
 
     // we try to keep total message size below 10k
@@ -347,8 +346,8 @@ private:
 
     SigShareMap<CSigShare> sigShares;
 
-    // stores time of first and last receivedSigShare. Used to detect timeouts
-    std::unordered_map<uint256, std::pair<int64_t, int64_t>, StaticSaltedHasher> timeSeenForSessions;
+    // stores time of last receivedSigShare. Used to detect timeouts
+    std::unordered_map<uint256, int64_t, StaticSaltedHasher> timeSeenForSessions;
 
     std::unordered_map<NodeId, CSigSharesNodeState> nodeStates;
     SigShareMap<std::pair<NodeId, int64_t>> sigSharesRequested;


### PR DESCRIPTION
This avoids a few rare timeouts when part of the network only sees a new TX via a block while the other part has seen it via the mempool.