### PR TITLE
Wait for sporks to propagate in llmq-chainlocks.py before mining new blocks

### DIFF
--- a/test/functional/llmq-chainlocks.py
+++ b/test/functional/llmq-chainlocks.py
@@ -36,6 +36,7 @@ class LLMQChainLocksTest(DashTestFramework):
             self.mine_quorum()
 
         self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
+        self.wait_for_sporks_same()
 
         self.log.info("Mine single block, wait for chainlock")
         self.nodes[0].generate(1)


### PR DESCRIPTION
The bug was introduced in https://github.com/dashpay/dash/pull/3149/commits/e5ebabeddd9563899d2f64bcdaf15d639c799bb8