### PR TITLE
Backport bitcoin#11252: [P2P] When clearing addrman clear mapInfo and mapAddr.

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -478,6 +478,8 @@ public:
         nTried = 0;
         nNew = 0;
         nLastGood = 1; //Initially at 1 so that "never" is strictly worse.
+        mapInfo.clear();
+        mapAddr.clear();
     }
 
     CAddrMan(bool _discriminatePorts = false) :


### PR DESCRIPTION
b86a42077 when clearing addrman clear mapInfo and mapAddr (Gregory Sanders)

Pull request description:

  Power failure on my machine resulted in a corrupted addrman that would hit bad assertions when trying to serialize the "cleared" addrman to disk: https://github.com/bitcoin/bitcoin/blob/6866b4912b8013ed748d12250209f7079a3c92e6/src/addrman.h#L320

Tree-SHA512: 07ca8b6cbd88407e5f3f0dccb346ae31bd1392f4210b2d5c5647c853986bfec95cf70240b92bafdc61b90e452a5d8315962738d10c10c2b53fdabff10503d05a