### PR TITLE
Always run extended tests in .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ stages:
     - ./ci/build_depends.sh
     - ./ci/build_src.sh
     - ./ci/test_unittests.sh
-    - ./ci/test_integrationtests.sh
+    - ./ci/test_integrationtests.sh --extended --exclude pruning,dbcrash
 
   after_script:
     # Copy all cache files into cache-artifact so that they get uploaded. We only do this for develop so that artifacts


### PR DESCRIPTION
These require only ~4m more, which is fine in Gitlab as we don't have so
strict limits. This makes the cron job obsolete.
