### PR TITLE
Disable styling for scrollbars on macos

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -321,6 +321,7 @@ RES_IMAGES = \
 RES_CSS = \
   qt/res/css/light.css \
   qt/res/css/light-hires.css \
+  qt/res/css/scrollbars.css \
   qt/res/css/trad.css
 
 RES_MOVIES = $(wildcard $(srcdir)/qt/res/movies/spinner-*.png)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -247,6 +247,19 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
         progressBar->setStyleSheet("QProgressBar { background-color: #F8F8F8; border: 1px solid grey; border-radius: 7px; padding: 1px; text-align: center; } QProgressBar::chunk { background: QLinearGradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #00CCFF, stop: 1 #33CCFF); border-radius: 7px; margin: 0px; }");
     }
 
+#ifndef Q_OS_MAC
+    // Apply some styling to scrollbars
+    QString theme = settings.value("theme", "").toString();
+    if (theme != "trad") { // No scrollbar styling for the traditional theme
+        QFile qFile(QString(":/css/scrollbars"));
+        QString styleSheet;
+        if (qFile.open(QFile::ReadOnly)) {
+            styleSheet = QLatin1String(qFile.readAll());
+        }
+        this->setStyleSheet(styleSheet);
+    }
+#endif
+
     statusBar()->addWidget(progressBarLabel);
     statusBar()->addWidget(progressBar);
     statusBar()->addPermanentWidget(frameBlocks);

--- a/src/qt/dash.qrc
+++ b/src/qt/dash.qrc
@@ -59,6 +59,7 @@
     <qresource prefix="/css">
         <file alias="light">res/css/light.css</file>
         <file alias="light-hires">res/css/light-hires.css</file>
+        <file alias="scrollbars">res/css/scrollbars.css</file>
         <file alias="trad">res/css/trad.css</file>
     </qresource>
     <qresource prefix="/images">

--- a/src/qt/res/css/light-hires.css
+++ b/src/qt/res/css/light-hires.css
@@ -302,7 +302,6 @@ border:0px;
 }
 
 .QTableView { /* Table - has to be selected as a class otherwise it throws off QCalendarWidget */
-background:transparent;
 border:0px solid #fff;
 }
 
@@ -316,91 +315,9 @@ background-color:#f0f0f0;
 color:#333;
 }
 
-QScrollBar { /* Scroll Bar */
-
-}
-
-QScrollBar:vertical { /* Vertical Scroll Bar Attributes */
-border:0;
-background:#ffffff;
-width:18px;
-margin: 18px 0px 18px 0px;
-}
-
-QScrollBar:horizontal { /* Horizontal Scroll Bar Attributes */
-border:0;
-background:#ffffff;
-height:18px;
-margin: 0px 18px 0px 18px;
-}
-
-
-QScrollBar::handle:vertical { /* Scroll Bar Slider - vertical */
-background:#e0e0e0;
-min-height:10px;
-}
-
-QScrollBar::handle:horizontal { /* Scroll Bar Slider - horizontal */
-background:#e0e0e0;
-min-width:10px;
-}
-
-QScrollBar::add-page, QScrollBar::sub-page { /* Scroll Bar Background */
-background:#F8F6F6;
-}
-
-QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical, QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal { /* Define Arrow Button Dimensions */
-background-color:#F8F6F6;
-border: 1px solid #f2f0f0;
-width:16px;
-height:16px;
-}
-
-QScrollBar::add-line:vertical:pressed, QScrollBar::sub-line:vertical:pressed, QScrollBar::add-line:horizontal:pressed, QScrollBar::sub-line:horizontal:pressed {
-background-color:#e0e0e0;
-}
-
-QScrollBar::sub-line:vertical { /* Vertical - top button position */
-subcontrol-position:top;
-subcontrol-origin: margin;
-}
-
-QScrollBar::add-line:vertical { /* Vertical - bottom button position */
-subcontrol-position:bottom;
-subcontrol-origin: margin;
-}
-
-QScrollBar::sub-line:horizontal { /* Vertical - left button position */
-subcontrol-position:left;
-subcontrol-origin: margin;
-}
-
-QScrollBar::add-line:horizontal { /* Vertical - right button position */
-subcontrol-position:right;
-subcontrol-origin: margin;
-}
-
-QScrollBar:up-arrow, QScrollBar:down-arrow, QScrollBar:left-arrow, QScrollBar:right-arrow { /* Arrows Icon */
-width:10px;
-height:10px;
-}
-
-QScrollBar:up-arrow {
-background-image: url(':/images/arrow_up_small');
-}
-
-QScrollBar:down-arrow {
-background-image: url(':/images/arrow_down_small');
-}
-
-QScrollBar:left-arrow {
-background-image: url(':/images/arrow_left_small');
-}
-
-QScrollBar:right-arrow {
-background-image: url(':/images/arrow_right_small');
-}
-
+/* Do NOT apply any styles to QScrollBar here,
+ * it's OS dependent and should be handled via platform specific code.
+*/
 
 /*******************************************************/
 
@@ -752,10 +669,6 @@ background-color:#F8F6F6;
 
 QDialog#HelpMessageDialog QScrollArea * {
 background-color:#ffffff;
-}
-
-QDialog#HelpMessageDialog QScrollBar:vertical, QDialog#HelpMessageDialog QScrollBar:horizontal {
-border:0;
 }
 
 /* About Dash Dialog */

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -302,7 +302,6 @@ border:0px;
 }
 
 .QTableView { /* Table - has to be selected as a class otherwise it throws off QCalendarWidget */
-background:transparent;
 border:0px solid #fff;
 }
 
@@ -316,91 +315,9 @@ background-color:#f0f0f0;
 color:#333;
 }
 
-QScrollBar { /* Scroll Bar */
-
-}
-
-QScrollBar:vertical { /* Vertical Scroll Bar Attributes */
-border:0;
-background:#ffffff;
-width:18px;
-margin: 18px 0px 18px 0px;
-}
-
-QScrollBar:horizontal { /* Horizontal Scroll Bar Attributes */
-border:0;
-background:#ffffff;
-height:18px;
-margin: 0px 18px 0px 18px;
-}
-
-
-QScrollBar::handle:vertical { /* Scroll Bar Slider - vertical */
-background:#e0e0e0;
-min-height:10px;
-}
-
-QScrollBar::handle:horizontal { /* Scroll Bar Slider - horizontal */
-background:#e0e0e0;
-min-width:10px;
-}
-
-QScrollBar::add-page, QScrollBar::sub-page { /* Scroll Bar Background */
-background:#F8F6F6;
-}
-
-QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical, QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal { /* Define Arrow Button Dimensions */
-background-color:#F8F6F6;
-border: 1px solid #f2f0f0;
-width:16px;
-height:16px;
-}
-
-QScrollBar::add-line:vertical:pressed, QScrollBar::sub-line:vertical:pressed, QScrollBar::add-line:horizontal:pressed, QScrollBar::sub-line:horizontal:pressed {
-background-color:#e0e0e0;
-}
-
-QScrollBar::sub-line:vertical { /* Vertical - top button position */
-subcontrol-position:top;
-subcontrol-origin: margin;
-}
-
-QScrollBar::add-line:vertical { /* Vertical - bottom button position */
-subcontrol-position:bottom;
-subcontrol-origin: margin;
-}
-
-QScrollBar::sub-line:horizontal { /* Vertical - left button position */
-subcontrol-position:left;
-subcontrol-origin: margin;
-}
-
-QScrollBar::add-line:horizontal { /* Vertical - right button position */
-subcontrol-position:right;
-subcontrol-origin: margin;
-}
-
-QScrollBar:up-arrow, QScrollBar:down-arrow, QScrollBar:left-arrow, QScrollBar:right-arrow { /* Arrows Icon */
-width:10px;
-height:10px;
-}
-
-QScrollBar:up-arrow {
-background-image: url(':/images/arrow_up_small');
-}
-
-QScrollBar:down-arrow {
-background-image: url(':/images/arrow_down_small');
-}
-
-QScrollBar:left-arrow {
-background-image: url(':/images/arrow_left_small');
-}
-
-QScrollBar:right-arrow {
-background-image: url(':/images/arrow_right_small');
-}
-
+/* Do NOT apply any styles to QScrollBar here,
+ * it's OS dependent and should be handled via platform specific code.
+*/
 
 /*******************************************************/
 
@@ -752,10 +669,6 @@ background-color:#F8F6F6;
 
 QDialog#HelpMessageDialog QScrollArea * {
 background-color:#ffffff;
-}
-
-QDialog#HelpMessageDialog QScrollBar:vertical, QDialog#HelpMessageDialog QScrollBar:horizontal {
-border:0;
 }
 
 /* About Dash Dialog */

--- a/src/qt/res/css/scrollbars.css
+++ b/src/qt/res/css/scrollbars.css
@@ -1,0 +1,87 @@
+QScrollBar:vertical { /* Vertical Scroll Bar Attributes */
+    border:0;
+    background:#ffffff;
+    width:18px;
+    margin: 18px 0px 18px 0px;
+}
+
+QScrollBar:horizontal { /* Horizontal Scroll Bar Attributes */
+    border:0;
+    background:#ffffff;
+    height:18px;
+    margin: 0px 18px 0px 18px;
+}
+
+QScrollBar::handle:vertical { /* Scroll Bar Slider - vertical */
+    background:#e0e0e0;
+    min-height:10px;
+}
+
+QScrollBar::handle:horizontal { /* Scroll Bar Slider - horizontal */
+    background:#e0e0e0;
+    min-width:10px;
+}
+
+QScrollBar::add-page, QScrollBar::sub-page { /* Scroll Bar Background */
+    background:#F8F6F6;
+}
+
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical, QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal { /* Define Arrow Button Dimensions */
+    background-color:#F8F6F6;
+    border: 1px solid #f2f0f0;
+    width:16px;
+    height:16px;
+}
+
+QScrollBar::add-line:vertical:pressed, QScrollBar::sub-line:vertical:pressed, QScrollBar::add-line:horizontal:pressed, QScrollBar::sub-line:horizontal:pressed {
+    background-color:#e0e0e0;
+}
+
+QScrollBar::sub-line:vertical { /* Vertical - top button position */
+    subcontrol-position:top;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:vertical { /* Vertical - bottom button position */
+    subcontrol-position:bottom;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::sub-line:horizontal { /* Vertical - left button position */
+    subcontrol-position:left;
+    subcontrol-origin: margin;
+}
+
+QScrollBar::add-line:horizontal { /* Vertical - right button position */
+    subcontrol-position:right;
+    subcontrol-origin: margin;
+}
+
+QScrollBar:up-arrow, QScrollBar:down-arrow, QScrollBar:left-arrow, QScrollBar:right-arrow { /* Arrows Icon */
+    width:10px;
+    height:10px;
+}
+
+QScrollBar:up-arrow {
+    background-image: url(':/images/arrow_up_small');
+}
+
+QScrollBar:down-arrow {
+    background-image: url(':/images/arrow_down_small');
+}
+
+QScrollBar:left-arrow {
+    background-image: url(':/images/arrow_left_small');
+}
+
+QScrollBar:right-arrow {
+    background-image: url(':/images/arrow_right_small');
+}
+
+QDialog#HelpMessageDialog QScrollBar:vertical, QDialog#HelpMessageDialog QScrollBar:horizontal {
+   border:0;
+}
+
+.QTableView { /* Table - has to be selected as a class otherwise it throws off QCalendarWidget */
+   background:transparent;
+}

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -153,6 +153,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     vlayout->addWidget(createDateRangeWidget());
     vlayout->addWidget(view);
     vlayout->setSpacing(0);
+#ifndef Q_OS_MAC
     int width = view->verticalScrollBar()->sizeHint().width();
     // Cover scroll bar width with spacing
     if (platformStyle->getUseExtraSpacing()) {
@@ -162,6 +163,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     }
     // Always show scroll bar
     view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+#endif
     view->setTabKeyNavigation(false);
     view->setContextMenuPolicy(Qt::CustomContextMenu);
 


### PR DESCRIPTION
Scrollbars on macos are built-in and disappear when scrolling is done. Styling them and forcing them to be always shown makes things look broken. There also should be no additional spacing in the transaction list header on macos (which purpose was to align right borders of the header and the table itself when there is a scrollbar outside of the table).

Before:
<img width="175" alt="Screenshot 2019-10-30 at 15 56 32" src="https://user-images.githubusercontent.com/1935069/67860010-f8560d80-fb2d-11e9-8f97-555897158ee6.png">

After:
<img width="163" alt="Screenshot 2019-10-30 at 15 59 18" src="https://user-images.githubusercontent.com/1935069/67860184-4539e400-fb2e-11e9-8b85-a8c993cc84e9.png">
