### PR TITLE
Slightly optimize ApproximateBestSubset and its usage for PS txes

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2863,6 +2863,7 @@ static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const C
 
     vfBest.assign(vValue.size(), true);
     nBest = nTotalLower;
+    int nBestCount = 0;
 
     FastRandomContext insecure_rand;
 
@@ -2870,6 +2871,7 @@ static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const C
     {
         vfIncluded.assign(vValue.size(), false);
         CAmount nTotal = 0;
+        int nTotalCount = 0;
         bool fReachedTarget = false;
         for (int nPass = 0; nPass < 2 && !fReachedTarget; nPass++)
         {
@@ -2884,16 +2886,19 @@ static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const C
                 if (nPass == 0 ? insecure_rand.randbool() : !vfIncluded[i])
                 {
                     nTotal += vValue[i].txout.nValue;
+                    ++nTotalCount;
                     vfIncluded[i] = true;
                     if (nTotal >= nTargetValue)
                     {
                         fReachedTarget = true;
-                        if (nTotal < nBest)
+                        if (nTotal < nBest || (nTotal == nBest && nTotalCount < nBestCount))
                         {
                             nBest = nTotal;
+                            nBestCount = nTotalCount;
                             vfBest = vfIncluded;
                         }
                         nTotal -= vValue[i].txout.nValue;
+                        --nTotalCount;
                         vfIncluded[i] = false;
                     }
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3052,7 +3052,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     CAmount nBest;
 
     ApproximateBestSubset(vValue, nTotalLower, nTargetValue, vfBest, nBest);
-    if (nBest != nTargetValue && nTotalLower >= nTargetValue + nMinChange)
+    if (nBest != nTargetValue && nMinChange != 0 && nTotalLower >= nTargetValue + nMinChange)
         ApproximateBestSubset(vValue, nTotalLower, nTargetValue + nMinChange, vfBest, nBest);
 
     // If we have a bigger coin and (either the stochastic approximation didn't find a good solution,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2863,7 +2863,7 @@ static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const C
 
     vfBest.assign(vValue.size(), true);
     nBest = nTotalLower;
-    int nBestCount = 0;
+    int nBestInputCount = 0;
 
     FastRandomContext insecure_rand;
 
@@ -2871,7 +2871,7 @@ static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const C
     {
         vfIncluded.assign(vValue.size(), false);
         CAmount nTotal = 0;
-        int nTotalCount = 0;
+        int nTotalInputCount = 0;
         bool fReachedTarget = false;
         for (int nPass = 0; nPass < 2 && !fReachedTarget; nPass++)
         {
@@ -2886,19 +2886,19 @@ static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const C
                 if (nPass == 0 ? insecure_rand.randbool() : !vfIncluded[i])
                 {
                     nTotal += vValue[i].txout.nValue;
-                    ++nTotalCount;
+                    ++nTotalInputCount;
                     vfIncluded[i] = true;
                     if (nTotal >= nTargetValue)
                     {
                         fReachedTarget = true;
-                        if (nTotal < nBest || (nTotal == nBest && nTotalCount < nBestCount))
+                        if (nTotal < nBest || (nTotal == nBest && nTotalInputCount < nBestInputCount))
                         {
                             nBest = nTotal;
-                            nBestCount = nTotalCount;
+                            nBestInputCount = nTotalInputCount;
                             vfBest = vfIncluded;
                         }
                         nTotal -= vValue[i].txout.nValue;
-                        --nTotalCount;
+                        --nTotalInputCount;
                         vfIncluded[i] = false;
                     }
                 }


### PR DESCRIPTION
I noticed that `ApproximateBestSubset` picks quite suboptimal sets of coins sometimes. This isn't a big deal for regular txes with some random amounts but for PS txes this means that instead of picking say 2x0.1 it's quite common to have 1x0.1 and 10x0.01 i.e. 11 inputs instead of just two. Doing so not only spams blockchain with needlessly oversized txes but can also degrade user privacy. ae2f68d fixes this by picking subsets with less inputs for the same amounts.

Also, we do not allow any change outputs for PS txes, so running `ApproximateBestSubset` twice makes no sense and we can save some cpu here (5d89b84).