### PR TITLE
Net: Make tor connections off by default

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -126,9 +126,8 @@ This means that if Tor is running (and proper authentication has been configured
 Dash Core automatically creates a hidden service to listen on. This will positively 
 affect the number of available .onion nodes.
 
-This new feature is enabled by default if Dash Core is listening (`-listen`), and
-requires a Tor connection to work. It can be explicitly disabled with `-listenonion=0`
-and, if not disabled, configured using the `-torcontrol` and `-torpassword` settings.
+This feature is disabled by default. It can be explicitly enabled with `-listenonion=1`
+and configured using the `-torcontrol` and `-torpassword` settings.
 To show verbose debugging information, pass `-debug=tor`.
 
 Connecting to Tor's control socket API requires one of two authentication methods to be 

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -11,7 +11,7 @@
 #include "scheduler.h"
 
 extern const std::string DEFAULT_TOR_CONTROL;
-static const bool DEFAULT_LISTEN_ONION = true;
+static const bool DEFAULT_LISTEN_ONION = false;
 
 void StartTorControl(boost::thread_group& threadGroup, CScheduler& scheduler);
 void InterruptTorControl();


### PR DESCRIPTION
Right now `dash-qt` wallet tries to connect to a tor service even if it wasn't configured to `-listen`.  I guess not many users of the QT wallet do connect through tor.
This pollutes `debug.log` file with useless messages and intervenes actual debugging.

In case one is running `dashd` with the intent of relaying on tor, he could turn it back with a CLI option `-listenonion=1`