### PR TITLE
Few Qt tweaks

### DIFF
--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -15,13 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="topLayout">
    <property name="leftMargin">
-    <number>0</number>
+    <number>20</number>
    </property>
    <property name="topMargin">
     <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>20</number>
    </property>
    <property name="bottomMargin">
     <number>0</number>
@@ -45,138 +45,128 @@
       </spacer>
      </item>
      <item>
-      <widget class="QTabWidget" name="tabWidget">
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <widget class="QWidget" name="tabDIP3Masternodes">
-        <attribute name="title">
-         <string>DIP3 Masternodes</string>
-        </attribute>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <item row="0" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <property name="bottomMargin">
-            <number>0</number>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label_filter_2">
+           <property name="text">
+            <string>Filter List:</string>
            </property>
-           <item>
-            <widget class="QLabel" name="label_filter_2">
-             <property name="text">
-              <string>Filter List:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="filterLineEditDIP3">
-             <property name="toolTip">
-              <string>Filter masternode list</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="checkBoxMyMasternodesOnly">
-             <property name="toolTip">
-              <string>Show only masternodes this wallet has keys for.</string>
-             </property>
-             <property name="text">
-              <string>My masternodes only</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_4">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>10</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_count_2">
-             <property name="text">
-              <string>Node Count:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="countLabelDIP3">
-             <property name="text">
-              <string>0</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          </widget>
          </item>
-         <item row="1" column="0">
-          <widget class="QTableWidget" name="tableWidgetMasternodesDIP3">
-           <property name="editTriggers">
-            <set>QAbstractItemView::NoEditTriggers</set>
+         <item>
+          <widget class="QLineEdit" name="filterLineEditDIP3">
+           <property name="toolTip">
+            <string>Filter masternode list</string>
            </property>
-           <property name="alternatingRowColors">
-            <bool>true</bool>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="checkBoxMyMasternodesOnly">
+           <property name="toolTip">
+            <string>Show only masternodes this wallet has keys for.</string>
            </property>
-           <property name="selectionMode">
-            <enum>QAbstractItemView::SingleSelection</enum>
+           <property name="text">
+            <string>My masternodes only</string>
            </property>
-           <property name="selectionBehavior">
-            <enum>QAbstractItemView::SelectRows</enum>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
-           <property name="sortingEnabled">
-            <bool>true</bool>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>10</width>
+             <height>20</height>
+            </size>
            </property>
-           <attribute name="horizontalHeaderStretchLastSection">
-            <bool>true</bool>
-           </attribute>
-           <column>
-            <property name="text">
-             <string>Address</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Status</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>PoSe Score</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Registered</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Last Paid</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Next Payment</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Payee</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>Operator Reward</string>
-            </property>
-           </column>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_count_2">
+           <property name="text">
+            <string>Node Count:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="countLabelDIP3">
+           <property name="text">
+            <string>0</string>
+           </property>
           </widget>
          </item>
         </layout>
-       </widget>
-      </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QTableWidget" name="tableWidgetMasternodesDIP3">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Address</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Status</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>PoSe Score</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Registered</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Last Paid</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Next Payment</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Payee</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Operator Reward</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -745,6 +745,38 @@
              </layout>
             </item>
             <item>
+             <spacer name="verticalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>1</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="fallbackFeeWarningLabel">
+              <property name="toolTip">
+               <string>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</string>
+              </property>
+              <property name="font">
+              <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+              </font>
+              </property>
+              <property name="text">
+               <string>Note: Not enough data for fee estimation, using the fallback fee instead.</string>
+              </property>
+              <property name="wordWrap">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer_5">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -760,36 +792,14 @@
            </layout>
           </item>
           <item>
-           <widget class="QLabel" name="fallbackFeeWarningLabel">
-            <property name="toolTip">
-             <string>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</string>
-            </property>
-            <property name="font">
-            <font>
-                <weight>75</weight>
-                <bold>true</bold>
-            </font>
-            </property>
-            <property name="text">
-             <string>Note: Not enough data for fee estimation, using the fallback fee instead.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
            <spacer name="horizontalSpacer_4">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::MinimumExpanding</enum>
-            </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
-              <height>20</height>
+              <width>1</width>
+              <height>1</height>
              </size>
             </property>
            </spacer>

--- a/src/qt/res/css/light-hires.css
+++ b/src/qt/res/css/light-hires.css
@@ -1007,7 +1007,7 @@ min-height:30px;
 QWidget .QFrame#frame_2 .QLabel#labelTransactionsStatus { /* Recent Transactions Sync Status */
 qproperty-alignment: 'AlignBottom | AlignRight';
 min-width:93px;
-margin-top:83px;
+margin-top:0;
 margin-left:16px;
 margin-right:5px;
 min-height:16px;

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -1007,7 +1007,7 @@ min-height:30px;
 QWidget .QFrame#frame_2 .QLabel#labelTransactionsStatus { /* Recent Transactions Sync Status */
 qproperty-alignment: 'AlignBottom | AlignRight';
 min-width:93px;
-margin-top:83px;
+margin-top:0;
 margin-left:16px;
 margin-right:5px;
 min-height:16px;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -752,7 +752,6 @@ void SendCoinsDialog::updateSmartFeeLabel()
         ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
         ui->labelFeeEstimation->setText("");
         ui->fallbackFeeWarningLabel->setVisible(true);
-        ui->fallbackFeeWarningLabel->setIndent(QFontMetrics(ui->fallbackFeeWarningLabel->font()).width("x"));
     }
     else
     {


### PR DESCRIPTION
4d368f0 - fix "out of sync" label which made tx list to "jump" when it disappears (no more "jumps" after the patch)

Before:
<img width="383" alt="Screenshot 2019-11-14 at 16 17 03" src="https://user-images.githubusercontent.com/1935069/68860799-4ad12580-06fb-11ea-96b2-645b122edb77.png">
After:
<img width="401" alt="Screenshot 2019-11-14 at 16 18 22" src="https://user-images.githubusercontent.com/1935069/68860855-61777c80-06fb-11ea-85c8-bfd92a8823bd.png">


118c522 - fix warning label which becomes too long in some languages and caused wallet width to grow a lot beyond min width (hard to see from screenshots, just try switching languages and you'll see what I mean here)

Before:
<img width="987" alt="Screenshot 2019-11-14 at 16 17 27" src="https://user-images.githubusercontent.com/1935069/68860800-4ad12580-06fb-11ea-9937-ec16dd915718.png">
<img width="1135" alt="Screenshot 2019-11-14 at 16 23 07" src="https://user-images.githubusercontent.com/1935069/68860801-4ad12580-06fb-11ea-855f-bdc6839b1060.png">
After:
<img width="982" alt="Screenshot 2019-11-14 at 16 18 36" src="https://user-images.githubusercontent.com/1935069/68860857-62101300-06fb-11ea-827c-645496e39591.png">
<img width="974" alt="Screenshot 2019-11-14 at 16 23 33" src="https://user-images.githubusercontent.com/1935069/68860856-61777c80-06fb-11ea-8dff-282644318a0a.png">


88ca137 - DIP3 masternodes is the only valid type now, no need for sub-tabs (also, background color match the one on other tabs now)

Before:
<img width="976" alt="Screenshot 2019-11-14 at 16 17 54" src="https://user-images.githubusercontent.com/1935069/68860806-4b69bc00-06fb-11ea-83ec-a5c73071f446.png">
After:
<img width="976" alt="Screenshot 2019-11-14 at 16 18 48" src="https://user-images.githubusercontent.com/1935069/68860853-61777c80-06fb-11ea-9bc3-c55f1fdf22bb.png">
