### PR TITLE
Fix off-by-one error for coinbase txes confirmation icons

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -544,7 +544,7 @@ QVariant TransactionTableModel::txStatusDecoration(const TransactionRecord *wtx)
         return QIcon(":/icons/transaction_conflicted");
     case TransactionStatus::Immature: {
         int total = wtx->status.depth + wtx->status.matures_in;
-        int part = (wtx->status.depth * 4 / total) + 1;
+        int part = (wtx->status.depth * 5 / total) + 1;
         return QIcon(QString(":/icons/transaction_%1").arg(part));
         }
     case TransactionStatus::MaturesWarning:


### PR DESCRIPTION
We have 5 icons to show pending confirmation state `/icons/transaction_1`..`/icons/transaction_5`

Here is an example of calculations for the transaction which is about to be fully confirmed.
Current code: `(100*4/101)+1` = 4.96... but it's `int` -> `4`
New code: `(100*5/101)+1` = 5.95... but it's `int` -> `5`

Thanks to Craig Durham for discovering the issue.