### PR TITLE
Add collateral, owner and voting addresses to masternode list table

### DIFF
--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -164,6 +164,21 @@
            <string>Operator Reward</string>
           </property>
          </column>
+         <column>
+          <property name="text">
+           <string>Collateral Address</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Owner Address</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Voting Address</string>
+          </property>
+         </column>
         </widget>
        </item>
       </layout>

--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -126,7 +126,7 @@
          </attribute>
          <column>
           <property name="text">
-           <string>Address</string>
+           <string>Service</string>
           </property>
          </column>
          <column>
@@ -156,7 +156,7 @@
          </column>
          <column>
           <property name="text">
-           <string>Payee</string>
+           <string>Payout Address</string>
           </property>
          </column>
          <column>

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -155,7 +155,7 @@ void MasternodeList::updateDIP3List()
         return;
     }
 
-    LOCK(cs_dip3list);
+    LOCK2(cs_main, cs_dip3list); // locking cs_main beforehand for GetUTXOCoin to avoid GUI freezes
 
     QString strToFilter;
     ui->countLabelDIP3->setText("Updating...");

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -140,7 +140,8 @@ void MasternodeList::updateDIP3ListScheduled()
             fFilterUpdatedDIP3 = false;
         }
     } else if (mnListChanged) {
-        int64_t nSecondsToWait = nTimeUpdatedDIP3 - GetTime() + MASTERNODELIST_UPDATE_SECONDS;
+        int64_t nMnListUpdateSecods = masternodeSync.IsBlockchainSynced() ? MASTERNODELIST_UPDATE_SECONDS : MASTERNODELIST_UPDATE_SECONDS*10;
+        int64_t nSecondsToWait = nTimeUpdatedDIP3 - GetTime() + nMnListUpdateSecods;
 
         if (nSecondsToWait <= 0) {
             updateDIP3List();

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -201,17 +201,15 @@ void MasternodeList::updateDIP3List()
         QTableWidgetItem* nextPaymentItem = new QTableWidgetItem(nextPayments.count(dmn->proTxHash) ? QString::number(nextPayments[dmn->proTxHash]) : tr("UNKNOWN"));
 
         CTxDestination payeeDest;
-        QString payeeStr;
+        QString payeeStr = tr("UNKNOWN");
         if (ExtractDestination(dmn->pdmnState->scriptPayout, payeeDest)) {
             payeeStr = QString::fromStdString(CBitcoinAddress(payeeDest).ToString());
-        } else {
-            payeeStr = tr("UNKNOWN");
         }
         QTableWidgetItem* payeeItem = new QTableWidgetItem(payeeStr);
 
-        QString operatorRewardStr;
+        QString operatorRewardStr = tr("NONE");
         if (dmn->nOperatorReward) {
-            operatorRewardStr += QString::number(dmn->nOperatorReward / 100.0, 'f', 2) + "% ";
+            operatorRewardStr = QString::number(dmn->nOperatorReward / 100.0, 'f', 2) + "% ";
 
             if (dmn->pdmnState->scriptOperatorPayout != CScript()) {
                 CTxDestination operatorDest;
@@ -223,8 +221,6 @@ void MasternodeList::updateDIP3List()
             } else {
                 operatorRewardStr += tr("but not claimed");
             }
-        } else {
-            operatorRewardStr = tr("NONE");
         }
         QTableWidgetItem* operatorRewardItem = new QTableWidgetItem(operatorRewardStr);
 


### PR DESCRIPTION
I did not notice any slowdown or GUI lags despite using `GetUTXOCoin` here (which locks `cs_main`), please test to see if that's the case for you too. This PR also tweaks table headers to match RPC output a bit better and unifies somewhat related code a bit.

Thanks to Craig Durham for the suggestion.