### PR TITLE
Fix styles for progress dialogs, shutdown window and text selection

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1499,6 +1499,7 @@ void BitcoinGUI::showProgress(const QString &title, int nProgress)
     if (nProgress == 0)
     {
         progressDialog = new QProgressDialog(title, "", 0, 100);
+        progressDialog->setStyleSheet(GUIUtil::loadStyleSheet());
         progressDialog->setWindowModality(Qt::ApplicationModal);
         progressDialog->setMinimumDuration(0);
         progressDialog->setCancelButton(0);

--- a/src/qt/res/css/light-hires.css
+++ b/src/qt/res/css/light-hires.css
@@ -107,6 +107,10 @@ font-size:12px;
 background-color:#f2f2f2;
 }
 
+QWidget { /* override text selection background color for all text widgets */
+selection-background-color: #999;
+}
+
 /*******************************************************/
 
 QPushButton { /* Global Button Style */

--- a/src/qt/res/css/light-hires.css
+++ b/src/qt/res/css/light-hires.css
@@ -388,6 +388,12 @@ QDialog QWidget { /* Remove Annoying Focus Rectangle */
 outline: 0;
 }
 
+/* SHUTDOWN WINDOW */
+
+QWidget#ShutdownWindow {
+background-color: #F8F6F6;
+}
+
 /*******************************************************/
 /* FILE MENU */
 

--- a/src/qt/res/css/light-hires.css
+++ b/src/qt/res/css/light-hires.css
@@ -380,6 +380,10 @@ color:#333;
 
 /* DIALOG BOXES */
 
+.QProgressDialog {
+background-color: #F8F6F6;
+}
+
 QDialog QWidget { /* Remove Annoying Focus Rectangle */
 outline: 0;
 }

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -107,6 +107,10 @@ font-size:12px;
 background-color:#f2f2f2;
 }
 
+QWidget { /* override text selection background color for all text widgets */
+selection-background-color: #999;
+}
+
 /*******************************************************/
 
 QPushButton { /* Global Button Style */

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -388,6 +388,12 @@ QDialog QWidget { /* Remove Annoying Focus Rectangle */
 outline: 0;
 }
 
+/* SHUTDOWN WINDOW */
+
+QWidget#ShutdownWindow {
+background-color: #F8F6F6;
+}
+
 /*******************************************************/
 /* FILE MENU */
 

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -380,6 +380,10 @@ color:#333;
 
 /* DIALOG BOXES */
 
+.QProgressDialog {
+background-color: #F8F6F6;
+}
+
 QDialog QWidget { /* Remove Annoying Focus Rectangle */
 outline: 0;
 }

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -14,6 +14,7 @@
 #include "bitcoingui.h"
 #include "clientmodel.h"
 #include "guiconstants.h"
+#include "guiutil.h"
 #include "intro.h"
 #include "paymentrequestplus.h"
 #include "guiutil.h"
@@ -199,6 +200,11 @@ void HelpMessageDialog::on_okButton_accepted()
 ShutdownWindow::ShutdownWindow(QWidget *parent, Qt::WindowFlags f):
     QWidget(parent, f)
 {
+    setObjectName("ShutdownWindow");
+
+    /* Open CSS when configured */
+    this->setStyleSheet(GUIUtil::loadStyleSheet());
+
     QVBoxLayout *layout = new QVBoxLayout();
     layout->addWidget(new QLabel(
         tr("%1 is shutting down...").arg(tr(PACKAGE_NAME)) + "<br /><br />" +

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -366,6 +366,7 @@ void WalletView::showProgress(const QString &title, int nProgress)
     if (nProgress == 0)
     {
         progressDialog = new QProgressDialog(title, "", 0, 100);
+        progressDialog->setStyleSheet(GUIUtil::loadStyleSheet());
         progressDialog->setWindowModality(Qt::ApplicationModal);
         progressDialog->setMinimumDuration(0);
         progressDialog->setCancelButton(0);


### PR DESCRIPTION
These issues became visible to me after switching to Dark Mode on macOS but I think any OS with custom themes might have similar ones.

Before:
<img width="205" alt="Screenshot 2019-11-21 at 03 02 34" src="https://user-images.githubusercontent.com/1935069/69289163-b429ca80-0c0c-11ea-98c7-d2a8a1b74a4e.png">
<img width="199" alt="Screenshot 2019-11-21 at 03 07 43" src="https://user-images.githubusercontent.com/1935069/69289165-b429ca80-0c0c-11ea-9955-a1ff91d3d5e1.png">
<img width="412" alt="Screenshot 2019-11-21 at 03 04 50" src="https://user-images.githubusercontent.com/1935069/69289169-b429ca80-0c0c-11ea-9280-d32f5f8e33e2.png">
<img width="464" alt="Screenshot 2019-11-21 at 02 58 46" src="https://user-images.githubusercontent.com/1935069/69289171-b4c26100-0c0c-11ea-8256-4ea52d887ee1.png">
(and yes, some text in rpc response above is actually selected, I can confirm it by copying and pasting somewhere else)

After:
<img width="202" alt="Screenshot 2019-11-21 at 03 03 25" src="https://user-images.githubusercontent.com/1935069/69289207-d4598980-0c0c-11ea-98b8-733798c0e0ca.png">
<img width="201" alt="Screenshot 2019-11-21 at 03 08 25" src="https://user-images.githubusercontent.com/1935069/69289208-d4f22000-0c0c-11ea-9b11-bc2d633e595b.png">
<img width="388" alt="Screenshot 2019-11-21 at 03 05 57" src="https://user-images.githubusercontent.com/1935069/69289209-d4f22000-0c0c-11ea-9f2b-72f4340309fa.png">
<img width="464" alt="Screenshot 2019-11-21 at 02 59 29" src="https://user-images.githubusercontent.com/1935069/69289210-d4f22000-0c0c-11ea-88a2-fe1bc7ebf86a.png">
