### PR TITLE
Tweak "Send" popup and refactor related code a bit

### DIFF
--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -61,7 +61,7 @@ private:
     ClientModel *clientModel;
     WalletModel *model;
     bool fNewRecipientAllowed;
-    void send(QList<SendCoinsRecipient> recipients, QString strFee, QString strFunds);
+    void send(QList<SendCoinsRecipient> recipients);
     bool fFeeMinimized;
     const PlatformStyle *platformStyle;
 


### PR DESCRIPTION
Few key points:
- highlight when not all recipients are displayed, move this info closer to the actual list (I tweaked `MAX_SEND_POPUP_ENTRIES = 1` temporary to take screenshots and make it easier to show the issue, not included in this PR ofc)
- clarify fee rounding text for PrivateSend, wasn't accurate
- show transactions size and actual fee rate explicitly
- show number of inputs PrivateSend tx is going to consume and warn if this number is 10 or higher

Also refactored some related code by moving few pieces closer to the places they are actually used and/or simplifying them.

Before:
<img width="848" alt="Screenshot 2019-11-25 at 15 09 55" src="https://user-images.githubusercontent.com/1935069/69539990-aec6da00-0f96-11ea-9b1b-f07c6dd5197a.png">
<img width="874" alt="Screenshot 2019-11-25 at 15 10 30" src="https://user-images.githubusercontent.com/1935069/69539991-af5f7080-0f96-11ea-8b7a-6f5cba4603b0.png">
<img width="864" alt="Screenshot 2019-11-25 at 15 11 08" src="https://user-images.githubusercontent.com/1935069/69539992-af5f7080-0f96-11ea-8f4c-6b2eae5b1406.png">

After:
<img width="869" alt="Screenshot 2019-11-25 at 15 12 04" src="https://user-images.githubusercontent.com/1935069/69540014-bd14f600-0f96-11ea-9831-702e3ebee1e7.png">
<img width="906" alt="Screenshot 2019-11-25 at 15 12 34" src="https://user-images.githubusercontent.com/1935069/69540015-bdad8c80-0f96-11ea-84c3-b876f70b6705.png">
<img width="884" alt="Screenshot 2019-11-25 at 15 13 18" src="https://user-images.githubusercontent.com/1935069/69540017-be462300-0f96-11ea-9d66-42e5b4d6702e.png">
