### PR TITLE
Tests: Fix the way nodes are connected to each other in setup_network/start_masternodes

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -632,6 +632,11 @@ class DashTestFramework(BitcoinTestFramework):
         self.prepare_datadirs()
         self.start_masternodes()
 
+        # non-masternodes where disconnected from the control node during prepare_datadirs,
+        # let's reconnect them back to make sure they receive updates
+        for i in range(0, num_simple_nodes):
+            connect_nodes(self.nodes[i+1], 0)
+
         self.bump_mocktime(1)
         set_node_times(self.nodes, self.mocktime)
         self.nodes[0].generate(1)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -581,8 +581,8 @@ class DashTestFramework(BitcoinTestFramework):
             force_finish_mnsync(self.mninfo[idx].node)
 
         def do_connect(idx):
-            for i in range(0, idx + 1):
-                connect_nodes(self.nodes[idx + start_idx], i)
+            # Connect to the control node only, masternodes should take care of intra-quorum connections themselves
+            connect_nodes(self.mninfo[idx].node, 0)
 
         jobs = []
 


### PR DESCRIPTION
Masternodes should take care of intra-quorum connections themselves. Have to take care of non-masternode/"simple" nodes manually though.

(backport candidate because of #3219 being a backport candidate too)