### PR TITLE
Merge master 0.14.0.4/5 back into develop

### DIFF
--- a/doc/release-notes/dash/release-notes-0.14.0.3.md
+++ b/doc/release-notes/dash/release-notes-0.14.0.3.md
@@ -1,0 +1,169 @@
+Dash Core version 0.14.0.3
+==========================
+
+Release is now available from:
+
+  <https://www.dash.org/downloads/#wallets>
+
+This is a new minor version release, bringing various bugfixes and improvements.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/dashpay/dash/issues>
+
+
+Upgrading and downgrading
+=========================
+
+How to Upgrade
+--------------
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), then run the
+installer (on Windows) or just copy over /Applications/Dash-Qt (on Mac) or
+dashd/dash-qt (on Linux). If you upgrade after DIP0003 activation and you were
+using version < 0.13 you will have to reindex (start with -reindex-chainstate
+or -reindex) to make sure your wallet has all the new data synced. Upgrading from
+version 0.13 should not require any additional actions.
+
+Due to the changes in the "evodb" database format introduced in this release, the
+first startup of Dash Core will run a migration process which can take a few minutes
+to finish. After the migration, a downgrade to an older version is only possible with
+a reindex (or reindex-chainstate).
+
+Downgrade warning
+-----------------
+
+### Downgrade to a version < 0.14.0.3
+
+Downgrading to a version smaller than 0.14.0.3 is not supported anymore due to changes
+in the "evodb" database format. If you need to use an older version, you have to perform
+a reindex or re-sync the whole chain.
+
+Notable changes
+===============
+
+Database space usage improvements
+--------------------------------
+Version 0.13.0.0 introduced a new database (evodb) which is found in the datadir of Dash Core. It turned
+out that this database grows quite fast when a lot of changes inside the deterministic masternode list happen,
+which is for example the case when a lot PoSe punishing/banning is happening. Such a situation happened
+immediately after the activation LLMQ DKGs, causing the database to grow a lot. This release introduces
+a new format in which information in "evodb" is stored, which causes it grow substantially slower.  
+
+Version 0.14.0.0 also introduced a new database (llmq) which is also found in the datadir of Dash Core.
+This database stores all LLMQ signatures for 7 days. After 7 days, a cleanup task removes old signatures.
+The idea was that the "llmq" database would grow in the beginning and then stay at an approximately constant
+size. The recent stress test on mainnet has however shown that the database grows too much and causes a risk
+of out-of-space situations. This release will from now also remove signatures when the corresponding InstantSend
+lock is fully confirmed on-chain (superseded by a ChainLock). This should remove >95% of all signatures from
+the database. After the upgrade, no space saving will be observed however as this logic is only applied to new
+signatures, which means that it will take 7 days until the whole "llmq" database gets to its minimum size.
+
+DKG and LLMQ signing failures fixed
+-----------------------------------
+Recent stress tests have shown that masternodes start to ban each other under high load and specific situations.
+This release fixes this and thus makes it a highly recommended upgrade for masternodes.
+
+MacOS: macOS: disable AppNap during sync and mixing
+---------------------------------------------------
+AppNap is disabled now when Dash Core is syncing/reindexing or mixing.
+
+Signed binaries for Windows
+---------------------------
+This release is the first one to include signed binaries for Windows.
+
+New RPC command: quorum memberof <proTxHash>
+--------------------------------------------
+This RPC allows you to verify which quorums a masternode is supposed to be a member of. It will also show
+if the masternode succesfully participated in the DKG process.
+
+More information about number of InstantSend locks
+--------------------------------------------------
+The debug console will now show how many InstantSend locks Dash Core knows about. Please note that this number
+does not necessarily equal the number of mempool transactions.
+
+The "getmempoolinfo" RPC also has a new field now which shows the same information.
+
+0.14.0.3 Change log
+===================
+
+See detailed [set of changes](https://github.com/dashpay/dash/compare/v0.14.0.2...dashpay:v0.14.0.3).
+
+- [`f2443709b`](https://github.com/dashpay/dash/commit/f2443709b) Update release-notes.md for 0.14.0.3 (#3054)
+- [`17ba23871`](https://github.com/dashpay/dash/commit/17ba23871) Re-verify invalid IS sigs when the active quorum set rotated (#3052)
+- [`8c49d9b54`](https://github.com/dashpay/dash/commit/8c49d9b54) Remove recovered sigs from the LLMQ db when corresponding IS locks get confirmed (#3048)
+- [`2e0cf8a30`](https://github.com/dashpay/dash/commit/2e0cf8a30) Add "instantsendlocks" to getmempoolinfo RPC (#3047)
+- [`a8fb8252e`](https://github.com/dashpay/dash/commit/a8fb8252e) Use fEnablePrivateSend instead of fPrivateSendRunning
+- [`a198a04e0`](https://github.com/dashpay/dash/commit/a198a04e0) Show number of InstantSend locks in Debug Console (#2919)
+- [`013169d63`](https://github.com/dashpay/dash/commit/013169d63) Optimize on-disk deterministic masternode storage to reduce size of evodb (#3017)
+- [`9ac7a998b`](https://github.com/dashpay/dash/commit/9ac7a998b) Add "isValidMember" and "memberIndex" to "quorum memberof" and allow to specify quorum scan count (#3009)
+- [`99824a879`](https://github.com/dashpay/dash/commit/99824a879) Implement "quorum memberof" (#3004)
+- [`7ea319fd2`](https://github.com/dashpay/dash/commit/7ea319fd2) Bail out properly on Evo DB consistency check failures in ConnectBlock/DisconnectBlock (#3044)
+- [`b1ffedb2d`](https://github.com/dashpay/dash/commit/b1ffedb2d) Do not count 0-fee txes for fee estimation (#3037)
+- [`974055a9b`](https://github.com/dashpay/dash/commit/974055a9b) Fix broken link in PrivateSend info dialog (#3031)
+- [`781b16579`](https://github.com/dashpay/dash/commit/781b16579) Merge pull request #3028 from PastaPastaPasta/backport-12588
+- [`5af6ce91d`](https://github.com/dashpay/dash/commit/5af6ce91d) Add Dash Core Group codesign certificate (#3027)
+- [`873ab896c`](https://github.com/dashpay/dash/commit/873ab896c) Fix osslsigncode compile issue in gitian-build (#3026)
+- [`ea8569e97`](https://github.com/dashpay/dash/commit/ea8569e97) Backport #12783: macOS: disable AppNap during sync (and mixing) (#3024)
+- [`4286dde49`](https://github.com/dashpay/dash/commit/4286dde49) Remove support for InstantSend locked gobject collaterals (#3019)
+- [`788d42dbc`](https://github.com/dashpay/dash/commit/788d42dbc) Bump version to 0.14.0.3 and copy release notes (#3053)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Alexander Block (codablock)
+- Nathan Marley (nmarley)
+- PastaPastaPasta
+- strophy
+- UdjinM6
+
+As well as everyone that submitted issues and reviewed pull requests.
+
+Older releases
+==============
+
+Dash was previously known as Darkcoin.
+
+Darkcoin tree 0.8.x was a fork of Litecoin tree 0.8, original name was XCoin
+which was first released on Jan/18/2014.
+
+Darkcoin tree 0.9.x was the open source implementation of masternodes based on
+the 0.8.x tree and was first released on Mar/13/2014.
+
+Darkcoin tree 0.10.x used to be the closed source implementation of Darksend
+which was released open source on Sep/25/2014.
+
+Dash Core tree 0.11.x was a fork of Bitcoin Core tree 0.9,
+Darkcoin was rebranded to Dash.
+
+Dash Core tree 0.12.0.x was a fork of Bitcoin Core tree 0.10.
+
+Dash Core tree 0.12.1.x was a fork of Bitcoin Core tree 0.12.
+
+These release are considered obsolete. Old release notes can be found here:
+
+- [v0.14.0.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.14.0.2.md) released July/4/2019
+- [v0.14.0.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.14.0.1.md) released May/31/2019
+- [v0.14.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.14.0.md) released May/22/2019
+- [v0.13.3](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.13.3.md) released Apr/04/2019
+- [v0.13.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.13.2.md) released Mar/15/2019
+- [v0.13.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.13.1.md) released Feb/9/2019
+- [v0.13.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.13.0.md) released Jan/14/2019
+- [v0.12.3.4](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.3.4.md) released Dec/14/2018
+- [v0.12.3.3](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.3.3.md) released Sep/19/2018
+- [v0.12.3.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.3.2.md) released Jul/09/2018
+- [v0.12.3.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.3.1.md) released Jul/03/2018
+- [v0.12.2.3](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.2.3.md) released Jan/12/2018
+- [v0.12.2.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.2.2.md) released Dec/17/2017
+- [v0.12.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.2.md) released Nov/08/2017
+- [v0.12.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.1.md) released Feb/06/2017
+- [v0.12.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.12.0.md) released Aug/15/2015
+- [v0.11.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.11.2.md) released Mar/04/2015
+- [v0.11.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.11.1.md) released Feb/10/2015
+- [v0.11.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.11.0.md) released Jan/15/2015
+- [v0.10.x](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.10.0.md) released Sep/25/2014
+- [v0.9.x](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.9.0.md) released Mar/13/2014
+

--- a/doc/release-notes/dash/release-notes-0.14.0.4.md
+++ b/doc/release-notes/dash/release-notes-0.14.0.4.md
@@ -1,4 +1,4 @@
-Dash Core version 0.14.0.5
+Dash Core version 0.14.0.4
 ==========================
 
 Release is now available from:
@@ -6,8 +6,6 @@ Release is now available from:
   <https://www.dash.org/downloads/#wallets>
 
 This is a new minor version release, bringing various bugfixes and improvements.
-It is highly recommended to upgrade to this release as it contains a critical
-fix for a possible DoS vector.
 
 Please report bugs using the issue tracker at github:
 
@@ -45,42 +43,79 @@ a reindex or re-sync the whole chain.
 Notable changes
 ===============
 
-Fix for a DoS vector
---------------------
+Fix respends of freshly received InstantSend transactions
+---------------------------------------------------------
 
-This release fixes a serious DoS vector which allows to cause memory exhaustion until the point of
-out-of-memory related crashes. We highly recommend upgrading all nodes. Thanks to Bitcoin ABC
-developers for finding and reporting this issue to us.
+A bug in Dash Core caused respends to not work before a received InstantSend transaction was confirmed in at least
+one block. This is fixed in this release, so that InstantSend locked mempool transactions can be
+respent immediately in Dash Core (other wallets were not affected).
 
-Better handling of non-locked transactions in mined blocks
-----------------------------------------------------------
+Deprecation of SPORK_16_INSTANTSEND_AUTOLOCKS
+---------------------------------------------
 
-We observed multiple cases of ChainLocks failing on mainnet. We tracked this down to a situation where
-PrivateSend mixing transactions were first rejected by parts of the network (0.14.0.4 nodes) while other parts
-(<=0.14.0.3) accepted the transaction into the mempool. This caused InstantSend locking to fail for these
-transactions, while non-upgraded miners still included the transactions into blocks after 10 minutes.
-This caused blocks to not get ChainLocked for at least 10 minutes. This release improves an already existent
-fallback mechanism (retroactive InstantSend locking) to also work for transaction which are already partially
-known in the network. This should cause ChainLocks to succeed in such situations.
+With the activation of SPORK_20_INSTANTSEND_LLMQ_BASED a few month ago, all transactions started to be locked via
+InstantSend, which already partly deprecated SPORK_16_INSTANTSEND_AUTOLOCKS. This release removes the last use
+of SPORK_16_INSTANTSEND_AUTOLOCKS, which caused InstantSend to stop working when the mempool got too large.
 
-0.14.0.5 Change log
+Improve orphan transaction limit handling
+-----------------------------------------
+
+Instead of limiting orphan transaction by number of transaction, we limit orphans by total size in bytes
+now. This allows to have thousands of orphan transactions before hitting the limit.
+
+Discrepancies in orphan sets between nodes and handling of those was one of the major limiting factors in
+the stress tests performed by an unknown entity on mainnet.
+
+Improve re-requesting for already known transactions
+----------------------------------------------------
+
+Previously, Dash would re-request old transactions even though they were already known locally. This
+happened when the outputs were respent very shortly after confirmation of the transaction. This lead to
+wrongly handling these transactions as orphans, filling up the orphan set and hitting limits very fast.
+This release fixes this for nodes which have txindex enabled, which is the case for all masternodes. Normal
+nodes (without txindex) can ignore the issue as they are not involved in active InstantSend locking.
+
+Another issue fixed in this release is the re-requesting of transactions after an InstantSend lock invalidated
+a conflicting transaction.
+
+Multiple improvements to PrivateSend
+------------------------------------
+
+Multiple improvements to PrivateSend are introduced in this release, leading to faster mixing and more
+reasonable selection of UTXOs when sending PrivateSend funds.
+
+Fix for CVE-2017-18350
+----------------------
+
+Bitcoin silently implemented a hidden fix for [CVE-2017-18350](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-November/017453.html).
+in Bitcoin v0.15.1. This release of Dash Core includes a backport of this fix.
+
+
+0.14.0.4 Change log
 ===================
 
-See detailed [set of changes](https://github.com/dashpay/dash/compare/v0.14.0.4...dashpay:v0.14.0.5).
+See detailed [set of changes](https://github.com/dashpay/dash/compare/v0.14.0.3...dashpay:v0.14.0.4).
 
-- [`20d4a27778`](https://github.com/dashpay/dash/commit/dc07a0c5e1) Make sure mempool txes are properly processed by CChainLocksHandler despite node restarts (#3230)
-- [`dc07a0c5e1`](https://github.com/dashpay/dash/commit/dc07a0c5e1) [v0.14.0.x] Bump version and prepare release notes (#3228)
-- [`401da32090`](https://github.com/dashpay/dash/commit/401da32090) More fixes in llmq-is-retroactive tests
-- [`33721eaa11`](https://github.com/dashpay/dash/commit/33721eaa11) Make llmq-is-retroactive test compatible with 0.14.0.x
-- [`85bd162a3e`](https://github.com/dashpay/dash/commit/85bd162a3e) Make wait_for_xxx methods compatible with 0.14.0.x
-- [`22cfddaf12`](https://github.com/dashpay/dash/commit/22cfddaf12) Allow re-signing of IS locks when performing retroactive signing (#3219)
-- [`a8b8891a1d`](https://github.com/dashpay/dash/commit/a8b8891a1d) Add wait_for_xxx methods as found in develop
-- [`8dae12cc60`](https://github.com/dashpay/dash/commit/8dae12cc60) More/better logging for InstantSend
-- [`fdd19cf667`](https://github.com/dashpay/dash/commit/fdd19cf667) Tests: Fix the way nodes are connected to each other in setup_network/start_masternodes (#3221)
-- [`41f0e9d028`](https://github.com/dashpay/dash/commit/41f0e9d028) More fixes related to extra_args
-- [`5213118601`](https://github.com/dashpay/dash/commit/5213118601) Tests: Allow specifying different cmd-line params for each masternode (#3222)
-- [`2fef21fd80`](https://github.com/dashpay/dash/commit/2fef21fd80) Don't join thread in CQuorum::~CQuorum when called from within the thread (#3223)
-- [`e69c6c3207`](https://github.com/dashpay/dash/commit/e69c6c3207) Merge #12392: Fix ignoring tx data requests when fPauseSend is set on a peer (#3225)
+- [`5f98ed7a5`](https://github.com/dashpay/dash/commit/5f98ed7a5) [v0.14.0.x] Bump version to 0.14.0.4 and draft release notes (#3203)
+- [`c0dda38fe`](https://github.com/dashpay/dash/commit/c0dda38fe) Circumvent BIP69 sorting in fundrawtransaction.py test (#3100)
+- [`64ae6365f`](https://github.com/dashpay/dash/commit/64ae6365f) Fix compile issues
+- [`36473015b`](https://github.com/dashpay/dash/commit/36473015b) Merge #11397: net: Improve and document SOCKS code
+- [`66e298728`](https://github.com/dashpay/dash/commit/66e298728) Slightly optimize ApproximateBestSubset and its usage for PS txes (#3184)
+- [`16b6b6f7c`](https://github.com/dashpay/dash/commit/16b6b6f7c) Update activemn if protx info changed (#3176)
+- [`ce6687130`](https://github.com/dashpay/dash/commit/ce6687130) Actually update spent index on DisconnectBlock (#3167)
+- [`9b49bfda8`](https://github.com/dashpay/dash/commit/9b49bfda8) Only track last seen time instead of first and last seen time (#3165)
+- [`ad720eef1`](https://github.com/dashpay/dash/commit/ad720eef1) Merge #17118: build: depends macOS: point --sysroot to SDK (#3161)
+- [`909d6a4ba`](https://github.com/dashpay/dash/commit/909d6a4ba) Simulate BlockConnected/BlockDisconnected for PS caches
+- [`db7f471c7`](https://github.com/dashpay/dash/commit/db7f471c7) Few fixes related to SelectCoinsGroupedByAddresses (#3144)
+- [`1acd4742c`](https://github.com/dashpay/dash/commit/1acd4742c) Various fixes for mixing queues (#3138)
+- [`0031d6b04`](https://github.com/dashpay/dash/commit/0031d6b04) Also consider txindex for transactions in AlreadyHave() (#3126)
+- [`c4be5ac4d`](https://github.com/dashpay/dash/commit/c4be5ac4d) Ignore recent rejects filter for locked txes (#3124)
+- [`f2d401aa8`](https://github.com/dashpay/dash/commit/f2d401aa8) Make orphan TX map limiting dependent on total TX size instead of TX count (#3121)
+- [`87ff566a0`](https://github.com/dashpay/dash/commit/87ff566a0) Update/modernize macOS plist (#3074)
+- [`2141d5f9d`](https://github.com/dashpay/dash/commit/2141d5f9d) Fix bip69 vs change position issue (#3063)
+- [`75fddde67`](https://github.com/dashpay/dash/commit/75fddde67) Partially revert 3061 (#3150)
+- [`c74f2cd8b`](https://github.com/dashpay/dash/commit/c74f2cd8b) Fix SelectCoinsMinConf to allow instant respends (#3061)
+- [`2e7ec2369`](https://github.com/dashpay/dash/commit/2e7ec2369) [0.14.0.x] Remove check for mempool size in CInstantSendManager::CheckCanLock (#3119)
 
 Credits
 =======
@@ -88,6 +123,8 @@ Credits
 Thanks to everyone who directly contributed to this release:
 
 - Alexander Block (codablock)
+- Nathan Marley (nmarley)
+- PastaPastaPasta
 - UdjinM6
 
 As well as everyone that submitted issues and reviewed pull requests.
@@ -115,7 +152,6 @@ Dash Core tree 0.12.1.x was a fork of Bitcoin Core tree 0.12.
 
 These release are considered obsolete. Old release notes can be found here:
 
-- [v0.14.0.4](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.14.0.4.md) released November/22/2019
 - [v0.14.0.3](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.14.0.3.md) released August/15/2019
 - [v0.14.0.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.14.0.2.md) released July/4/2019
 - [v0.14.0.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.14.0.1.md) released May/31/2019


### PR DESCRIPTION
We skipped 0.14.0.4 merge earlier actually, so that's a part of this PR as well. I omitted all the 0.14.0.x backports/version bumps specific changes, so this boils down to merging back release notes basically (as it should).