### PR TITLE
Try to avoid being marked as a bad quorum member when we sleep for too long in SleepBeforePhase

### DIFF
--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -237,7 +237,7 @@ void CDKGSessionHandler::SleepBeforePhase(QuorumPhase curPhase,
     }
 
     // expected time for a full phase
-    double phaseTime = params.dkgPhaseBlocks * Params().GetConsensus().nPowTargetSpacing * 1000;
+    double phaseTime = (params.dkgPhaseBlocks - 1) * Params().GetConsensus().nPowTargetSpacing * 1000;
     // expected time per member
     phaseTime = phaseTime / params.size;
     // Don't expect perfect block times and thus reduce the phase time to be on the secure side (caller chooses factor)

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -107,6 +107,7 @@ private:
     CDKGSessionManager& dkgManager;
 
     QuorumPhase phase{QuorumPhase_Idle};
+    int currentHeight{-1};
     int quorumHeight{-1};
     uint256 quorumHash;
     std::shared_ptr<CDKGSession> curSession;


### PR DESCRIPTION
The issue should not happen a lot naturally and withholding blocks to cause potential issues intentionally is risky and costly due to ChainLocks. Plus `randomSleepFactor` should mostly mitigate the issue already too. However these few additional tweaks could help to bring the probability of such an event even lower I think.

Pls see individual commits. 

Thanks to @mrdefacto for pointing out a potential issue.