### PR TITLE
Push islock invs when syncing mempool

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1438,6 +1438,17 @@ bool CInstantSendManager::GetInstantSendLockByHash(const uint256& hash, llmq::CI
     return true;
 }
 
+bool CInstantSendManager::GetInstantSendLockHashByTxid(const uint256& txid, uint256& ret)
+{
+    if (!IsInstantSendEnabled()) {
+        return false;
+    }
+
+    LOCK(cs);
+    ret = db.GetInstantSendLockHashByTxid(txid);
+    return !ret.IsNull();
+}
+
 bool CInstantSendManager::IsLocked(const uint256& txHash)
 {
     if (!IsInstantSendEnabled()) {

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -164,6 +164,7 @@ public:
 
     bool AlreadyHave(const CInv& inv);
     bool GetInstantSendLockByHash(const uint256& hash, CInstantSendLock& ret);
+    bool GetInstantSendLockHashByTxid(const uint256& txid, uint256& ret);
 
     size_t GetInstantSendLockCount();
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3799,6 +3799,13 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                         connman->PushMessage(pto, msgMaker.Make(NetMsgType::INV, vInv));
                         vInv.clear();
                     }
+                    // Prepare an inv with a corresponding InstantSend lock to be sent later too
+                    uint256 islockHash;
+                    if (llmq::quorumInstantSendManager->GetInstantSendLockHashByTxid(hash, islockHash)) {
+                        LogPrint(BCLog::NET, "SendMessages -- preparing islock %s %s\n", hash.ToString(), islockHash.ToString());
+                        CInv islockInv(MSG_ISLOCK, islockHash);
+                        pto->PushInventory(islockInv);
+                    }
                 }
                 pto->timeLastMempoolReq = GetTime();
             }


### PR DESCRIPTION
This extends `mempool` p2p command from BIP35 by serving invs for corresponding InstandSend locks too. This should help nodes which utilise this command and InstantSend locks (SPV wallets) to display correct info right from the start.