### PR TITLE
move privatesend rpc methods from rpc/masternode.cpp to new rpc/privatesend.cpp

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -339,6 +339,7 @@ libdash_server_a_SOURCES = \
   rpc/rpcevo.cpp \
   rpc/rpcquorums.cpp \
   rpc/server.cpp \
+  rpc/privatesend.cpp \
   script/sigcache.cpp \
   script/ismine.cpp \
   spork.cpp \

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -8,165 +8,27 @@
 #include "init.h"
 #include "netbase.h"
 #include "validation.h"
-#include "masternode/masternode-payments.h"
-#include "masternode/masternode-sync.h"
-#ifdef ENABLE_WALLET
-#include "privatesend/privatesend-client.h"
-#endif // ENABLE_WALLET
-#include "privatesend/privatesend-server.h"
-#include "rpc/server.h"
 #include "util.h"
 #include "utilmoneystr.h"
 #include "txmempool.h"
 
-#include "wallet/coincontrol.h"
-#include "wallet/rpcwallet.h"
-
 #include "evo/specialtx.h"
 #include "evo/deterministicmns.h"
+
+#include "masternode/masternode-payments.h"
+#include "masternode/masternode-sync.h"
+
+#include "rpc/server.h"
+
+#include "wallet/coincontrol.h"
+#include "wallet/rpcwallet.h"
+#include "wallet/wallet.h"
 
 #include <fstream>
 #include <iomanip>
 #include <univalue.h>
 
 UniValue masternodelist(const JSONRPCRequest& request);
-
-#ifdef ENABLE_WALLET
-UniValue privatesend(const JSONRPCRequest& request)
-{
-    CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
-        return NullUniValue;
-
-    if (request.fHelp || request.params.size() != 1)
-        throw std::runtime_error(
-            "privatesend \"command\"\n"
-            "\nArguments:\n"
-            "1. \"command\"        (string or set of strings, required) The command to execute\n"
-            "\nAvailable commands:\n"
-            "  start       - Start mixing\n"
-            "  stop        - Stop mixing\n"
-            "  reset       - Reset mixing\n"
-            );
-
-    if (fMasternodeMode)
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "Client-side mixing is not supported on masternodes");
-
-    if (!privateSendClient.fEnablePrivateSend) {
-        if (fLiteMode) {
-            // mixing is disabled by default in lite mode
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing is disabled in lite mode, use -enableprivatesend command line option to enable mixing again");
-        } else if (!gArgs.GetBoolArg("-enableprivatesend", true)) {
-            // otherwise it's on by default, unless cmd line option says otherwise
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing is disabled via -enableprivatesend=0 command line option, remove it to enable mixing again");
-        } else {
-            // neither litemode nor enableprivatesend=false casee,
-            // most likely smth bad happened and we disabled it while running the wallet
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing is disabled due to some internal error");
-        }
-    }
-
-    if (request.params[0].get_str() == "start") {
-        {
-            LOCK(pwallet->cs_wallet);
-            if (pwallet->IsLocked(true))
-                throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please unlock wallet for mixing with walletpassphrase first.");
-        }
-
-        privateSendClient.fPrivateSendRunning = true;
-        bool result = privateSendClient.DoAutomaticDenominating(*g_connman);
-        return "Mixing " + (result ? "started successfully" : ("start failed: " + privateSendClient.GetStatuses() + ", will retry"));
-    }
-
-    if (request.params[0].get_str() == "stop") {
-        privateSendClient.fPrivateSendRunning = false;
-        return "Mixing was stopped";
-    }
-
-    if (request.params[0].get_str() == "reset") {
-        privateSendClient.ResetPool();
-        return "Mixing was reset";
-    }
-
-    return "Unknown command, please see \"help privatesend\"";
-}
-#endif // ENABLE_WALLET
-
-UniValue getpoolinfo(const JSONRPCRequest& request)
-{
-    throw std::runtime_error(
-        "getpoolinfo\n"
-        "DEPRECATED. Please use getprivatesendinfo instead.\n"
-    );
-}
-
-UniValue getprivatesendinfo(const JSONRPCRequest& request)
-{
-    if (request.fHelp || request.params.size() != 0) {
-        throw std::runtime_error(
-            "getprivatesendinfo\n"
-            "Returns an object containing an information about PrivateSend settings and state.\n"
-            "\nResult (for regular nodes):\n"
-            "{\n"
-            "  \"enabled\": true|false,             (bool) Whether mixing functionality is enabled\n"
-            "  \"running\": true|false,             (bool) Whether mixing is currently running\n"
-            "  \"multisession\": true|false,        (bool) Whether PrivateSend Multisession option is enabled\n"
-            "  \"max_sessions\": xxx,               (numeric) How many parallel mixing sessions can there be at once\n"
-            "  \"max_rounds\": xxx,                 (numeric) How many rounds to mix\n"
-            "  \"max_amount\": xxx,                 (numeric) How many " + CURRENCY_UNIT + " to keep mixed\n"
-            "  \"max_denoms\": xxx,                 (numeric) How many inputs of each denominated amount to create\n"
-            "  \"queue_size\": xxx,                 (numeric) How many queues there are currently on the network\n"
-            "  \"sessions\":                        (array of json objects)\n"
-            "    [\n"
-            "      {\n"
-            "      \"protxhash\": \"...\",            (string) The ProTxHash of the masternode\n"
-            "      \"outpoint\": \"txid-index\",      (string) The outpoint of the masternode\n"
-            "      \"service\": \"host:port\",        (string) The IP address and port of the masternode\n"
-            "      \"denomination\": xxx,           (numeric) The denomination of the mixing session in " + CURRENCY_UNIT + "\n"
-            "      \"state\": \"...\",                (string) Current state of the mixing session\n"
-            "      \"entries_count\": xxx,          (numeric) The number of entries in the mixing session\n"
-            "      }\n"
-            "      ,...\n"
-            "    ],\n"
-            "  \"keys_left\": xxx,                  (numeric) How many new keys are left since last automatic backup\n"
-            "  \"warnings\": \"...\"                  (string) Warnings if any\n"
-            "}\n"
-            "\nResult (for masternodes):\n"
-            "{\n"
-            "  \"queue_size\": xxx,                 (numeric) How many queues there are currently on the network\n"
-            "  \"denomination\": xxx,               (numeric) The denomination of the mixing session in " + CURRENCY_UNIT + "\n"
-            "  \"state\": \"...\",                    (string) Current state of the mixing session\n"
-            "  \"entries_count\": xxx,              (numeric) The number of entries in the mixing session\n"
-            "}\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getprivatesendinfo", "")
-            + HelpExampleRpc("getprivatesendinfo", "")
-        );
-    }
-
-    UniValue obj(UniValue::VOBJ);
-
-    if (fMasternodeMode) {
-        privateSendServer.GetJsonInfo(obj);
-        return obj;
-    }
-
-
-#ifdef ENABLE_WALLET
-    privateSendClient.GetJsonInfo(obj);
-
-    CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) {
-        return obj;
-    }
-
-    obj.push_back(Pair("keys_left",     pwallet->nKeysLeftSinceAutoBackup));
-    obj.push_back(Pair("warnings",      pwallet->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING
-                                                ? "WARNING: keypool is almost depleted!" : ""));
-#endif // ENABLE_WALLET
-
-    return obj;
-}
 
 void masternode_list_help()
 {
@@ -668,11 +530,6 @@ static const CRPCCommand commands[] =
   //  --------------------- ------------------------  -----------------------  ------ ----------
     { "dash",               "masternode",             &masternode,             true,  {} },
     { "dash",               "masternodelist",         &masternodelist,         true,  {} },
-    { "dash",               "getpoolinfo",            &getpoolinfo,            true,  {} },
-    { "dash",               "getprivatesendinfo",     &getprivatesendinfo,     true,  {} },
-#ifdef ENABLE_WALLET
-    { "dash",               "privatesend",            &privatesend,            false, {} },
-#endif // ENABLE_WALLET
 };
 
 void RegisterMasternodeRPCCommands(CRPCTable &t)

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -22,7 +22,9 @@
 
 #include "wallet/coincontrol.h"
 #include "wallet/rpcwallet.h"
+#ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
+#endif // ENABLE_WALLET
 
 #include <fstream>
 #include <iomanip>

--- a/src/rpc/privatesend.cpp
+++ b/src/rpc/privatesend.cpp
@@ -142,7 +142,7 @@ static const CRPCCommand commands[] =
 #endif // ENABLE_WALLET
         };
 
-void RegisterMasternodeRPCCommands(CRPCTable &t)
+void RegisterPrivateSendRPCCommands(CRPCTable &t)
 {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         t.appendCommand(commands[vcidx].name, &commands[vcidx]);

--- a/src/rpc/privatesend.cpp
+++ b/src/rpc/privatesend.cpp
@@ -1,0 +1,149 @@
+// Copyright (c) 2019 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "validation.h"
+#ifdef ENABLE_WALLET
+#include "privatesend/privatesend-client.h"
+#endif // ENABLE_WALLET
+#include "privatesend/privatesend-server.h"
+#include "rpc/server.h"
+
+#include <univalue.h>
+
+#ifdef ENABLE_WALLET
+UniValue privatesend(const JSONRPCRequest& request)
+{
+    CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
+        return NullUniValue;
+
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+            "privatesend \"command\"\n"
+            "\nArguments:\n"
+            "1. \"command\"        (string or set of strings, required) The command to execute\n"
+            "\nAvailable commands:\n"
+            "  start       - Start mixing\n"
+            "  stop        - Stop mixing\n"
+            "  reset       - Reset mixing\n"
+        );
+
+    if (fMasternodeMode)
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Client-side mixing is not supported on masternodes");
+
+    if (!privateSendClient.fEnablePrivateSend) {
+        if (fLiteMode) {
+            // mixing is disabled by default in lite mode
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing is disabled in lite mode, use -enableprivatesend command line option to enable mixing again");
+        } else if (!gArgs.GetBoolArg("-enableprivatesend", true)) {
+            // otherwise it's on by default, unless cmd line option says otherwise
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing is disabled via -enableprivatesend=0 command line option, remove it to enable mixing again");
+        } else {
+            // neither litemode nor enableprivatesend=false casee,
+            // most likely smth bad happened and we disabled it while running the wallet
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing is disabled due to some internal error");
+        }
+    }
+
+    if (request.params[0].get_str() == "start") {
+        {
+            LOCK(pwallet->cs_wallet);
+            if (pwallet->IsLocked(true))
+                throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please unlock wallet for mixing with walletpassphrase first.");
+        }
+
+        privateSendClient.fPrivateSendRunning = true;
+        bool result = privateSendClient.DoAutomaticDenominating(*g_connman);
+        return "Mixing " + (result ? "started successfully" : ("start failed: " + privateSendClient.GetStatuses() + ", will retry"));
+    }
+
+    if (request.params[0].get_str() == "stop") {
+        privateSendClient.fPrivateSendRunning = false;
+        return "Mixing was stopped";
+    }
+
+    if (request.params[0].get_str() == "reset") {
+        privateSendClient.ResetPool();
+        return "Mixing was reset";
+    }
+
+    return "Unknown command, please see \"help privatesend\"";
+}
+#endif // ENABLE_WALLET
+
+UniValue getpoolinfo(const JSONRPCRequest& request)
+{
+    throw std::runtime_error(
+            "getpoolinfo\n"
+            "DEPRECATED. Please use getprivatesendinfo instead.\n"
+    );
+}
+
+UniValue getprivatesendinfo(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0) {
+        throw std::runtime_error(
+                "getprivatesendinfo\n"
+                "Returns an object containing an information about PrivateSend settings and state.\n"
+                "\nResult (for regular nodes):\n"
+                "{\n"
+                "  \"enabled\": true|false,             (bool) Whether mixing functionality is enabled\n"
+                "  \"running\": true|false,             (bool) Whether mixing is currently running\n"
+                "  \"multisession\": true|false,        (bool) Whether PrivateSend Multisession option is enabled\n"
+                "  \"max_sessions\": xxx,               (numeric) How many parallel mixing sessions can there be at once\n"
+                "  \"max_rounds\": xxx,                 (numeric) How many rounds to mix\n"
+                "  \"max_amount\": xxx,                 (numeric) How many " + CURRENCY_UNIT + " to keep mixed\n"
+                "  \"max_denoms\": xxx,                 (numeric) How many inputs of each denominated amount to create\n"
+                "  \"queue_size\": xxx,                 (numeric) How many queues there are currently on the network\n"
+                "  \"sessions\":                        (array of json objects)\n"
+                "    [\n"
+                "      {\n"
+                "      \"protxhash\": \"...\",            (string) The ProTxHash of the masternode\n"
+                "      \"outpoint\": \"txid-index\",      (string) The outpoint of the masternode\n"
+                "      \"service\": \"host:port\",        (string) The IP address and port of the masternode\n"
+                "      \"denomination\": xxx,           (numeric) The denomination of the mixing session in " + CURRENCY_UNIT + "\n"
+                + HelpExampleCli("getprivatesendinfo", "")
+                + HelpExampleRpc("getprivatesendinfo", "")
+        );
+    }
+
+    UniValue obj(UniValue::VOBJ);
+
+    if (fMasternodeMode) {
+        privateSendServer.GetJsonInfo(obj);
+        return obj;
+    }
+
+
+#ifdef ENABLE_WALLET
+    privateSendClient.GetJsonInfo(obj);
+
+    CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!pwallet) {
+        return obj;
+    }
+
+    obj.push_back(Pair("keys_left",     pwallet->nKeysLeftSinceAutoBackup));
+    obj.push_back(Pair("warnings",      pwallet->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING
+                                        ? "WARNING: keypool is almost depleted!" : ""));
+#endif // ENABLE_WALLET
+
+    return obj;
+}
+
+static const CRPCCommand commands[] =
+        { //  category              name                      actor (function)         okSafe argNames
+                //  --------------------- ------------------------  -----------------------  ------ ----------
+                { "dash",               "getpoolinfo",            &getpoolinfo,            true,  {} },
+                { "dash",               "getprivatesendinfo",     &getprivatesendinfo,     true,  {} },
+#ifdef ENABLE_WALLET
+                { "dash",               "privatesend",            &privatesend,            false, {} },
+#endif // ENABLE_WALLET
+        };
+
+void RegisterMasternodeRPCCommands(CRPCTable &t)
+{
+    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
+        t.appendCommand(commands[vcidx].name, &commands[vcidx]);
+}

--- a/src/rpc/privatesend.cpp
+++ b/src/rpc/privatesend.cpp
@@ -103,6 +103,22 @@ UniValue getprivatesendinfo(const JSONRPCRequest& request)
                 "      \"outpoint\": \"txid-index\",      (string) The outpoint of the masternode\n"
                 "      \"service\": \"host:port\",        (string) The IP address and port of the masternode\n"
                 "      \"denomination\": xxx,           (numeric) The denomination of the mixing session in " + CURRENCY_UNIT + "\n"
+                "      \"state\": \"...\",                (string) Current state of the mixing session\n"
+                "      \"entries_count\": xxx,          (numeric) The number of entries in the mixing session\n"
+                "      }\n"
+                "      ,...\n"
+                "    ],\n"
+                "  \"keys_left\": xxx,                  (numeric) How many new keys are left since last automatic backup\n"
+                "  \"warnings\": \"...\"                  (string) Warnings if any\n"
+                "}\n"
+                "\nResult (for masternodes):\n"
+                "{\n"
+                "  \"queue_size\": xxx,                 (numeric) How many queues there are currently on the network\n"
+                "  \"denomination\": xxx,               (numeric) The denomination of the mixing session in " + CURRENCY_UNIT + "\n"
+                "  \"state\": \"...\",                    (string) Current state of the mixing session\n"
+                "  \"entries_count\": xxx,              (numeric) The number of entries in the mixing session\n"
+                "}\n"
+                "\nExamples:\n"
                 + HelpExampleCli("getprivatesendinfo", "")
                 + HelpExampleRpc("getprivatesendinfo", "")
         );
@@ -133,14 +149,14 @@ UniValue getprivatesendinfo(const JSONRPCRequest& request)
 }
 
 static const CRPCCommand commands[] =
-        { //  category              name                      actor (function)         okSafe argNames
-                //  --------------------- ------------------------  -----------------------  ------ ----------
-                { "dash",               "getpoolinfo",            &getpoolinfo,            true,  {} },
-                { "dash",               "getprivatesendinfo",     &getprivatesendinfo,     true,  {} },
+    { //  category              name                      actor (function)         okSafe argNames
+        //  --------------------- ------------------------  -----------------------  ------ ----------
+        { "dash",               "getpoolinfo",            &getpoolinfo,            true,  {} },
+        { "dash",               "getprivatesendinfo",     &getprivatesendinfo,     true,  {} },
 #ifdef ENABLE_WALLET
-                { "dash",               "privatesend",            &privatesend,            false, {} },
+        { "dash",               "privatesend",            &privatesend,            false, {} },
 #endif // ENABLE_WALLET
-        };
+};
 
 void RegisterPrivateSendRPCCommands(CRPCTable &t)
 {

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -21,6 +21,8 @@ void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
 /** Register masternode RPC commands */
 void RegisterMasternodeRPCCommands(CRPCTable &tableRPC);
+/** Register PrivateSend RPC commands */
+void RegisterPrivateSendRPCCommands(CRPCTable &tableRPC);
 /** Register governance RPC commands */
 void RegisterGovernanceRPCCommands(CRPCTable &tableRPC);
 /** Register Evo RPC commands */
@@ -36,6 +38,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
     RegisterMiningRPCCommands(t);
     RegisterRawTransactionRPCCommands(t);
     RegisterMasternodeRPCCommands(t);
+    RegisterPrivateSendRPCCommands(t);
     RegisterGovernanceRPCCommands(t);
     RegisterEvoRPCCommands(t);
     RegisterQuorumsRPCCommands(t);


### PR DESCRIPTION
Doesn't really make sense imo for those rpc commands to be in masternode.cpp.

Should be just a move only and then adjusting imports