### PR TITLE
Don't disconnect masternode connections when we have less then the desired amount of outbound nodes

### DIFF
--- a/src/masternode/masternode-utils.cpp
+++ b/src/masternode/masternode-utils.cpp
@@ -27,6 +27,17 @@ void CMasternodeUtils::ProcessMasternodeConnections(CConnman& connman)
     privateSendClient.GetMixingMasternodesInfo(vecDmns);
 #endif // ENABLE_WALLET
 
+    // Don't disconnect masternode connections when we have less then the desired amount of outbound nodes
+    int nonMasternodeCount = 0;
+    connman.ForEachNode(CConnman::AllNodes, [&](CNode* pnode) {
+        if (!pnode->fInbound && !pnode->fFeeler && !pnode->m_manual_connection && !pnode->fMasternode) {
+            nonMasternodeCount++;
+        }
+    });
+    if (nonMasternodeCount < connman.GetMaxOutboundNodeCount()) {
+        return;
+    }
+
     connman.ForEachNode(CConnman::AllNodes, [&](CNode* pnode) {
         if (pnode->fMasternode && !connman.IsMasternodeQuorumNode(pnode)) {
 #ifdef ENABLE_WALLET

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2924,6 +2924,11 @@ size_t CConnman::GetNodeCount(NumConnections flags)
     return nNum;
 }
 
+size_t CConnman::GetMaxOutboundNodeCount()
+{
+    return nMaxOutbound;
+}
+
 void CConnman::GetNodeStats(std::vector<CNodeStats>& vstats)
 {
     vstats.clear();

--- a/src/net.h
+++ b/src/net.h
@@ -407,6 +407,7 @@ public:
     bool IsMasternodeQuorumNode(const CNode* pnode);
 
     size_t GetNodeCount(NumConnections num);
+    size_t GetMaxOutboundNodeCount();
     void GetNodeStats(std::vector<CNodeStats>& vstats);
     bool DisconnectNode(const std::string& node);
     bool DisconnectNode(NodeId id);


### PR DESCRIPTION
This avoids situations where we end up disconnecting (nearly) all outgoing peers when masternode connection cleanup is happening.

This also indirectly fixes test failures like [this](https://gitlab.com/dashpay/dash/-/jobs/389981389#L3411), where cleanup happened directly after a block was requested via `getdata`.

The real reason for this test failure is actually a different one, but I was not able to pin it down. What happens is that node4 gets a header announced from peer=1. Node4 then reacts with a `getdata` to retrieve the block. Shortly after that, peer=1 is disconnected due to the masternode connection cleanup. Approximately at the same time node4 receives a `cmpctblock` from peer=0, which is however ignored due to [this](https://github.com/dashpay/dash/blob/697d289ebc724086581473c761075f0c7e6b2e73/src/net_processing.cpp#L2719) code (`FillBlock` fails). It gets into this code because `FinalizeNode` was not called at this point, so that the block is considered as in-flight.

I would expect that even after peer=1 is disconnect, `FindNextBlocksToDownload` would realize that the block in not in-flight anymore and needs to be re-requested from another node. But for some reason this is not happening. I was not able to reproduce this locally. As I'm unable to fix the actual bug, I decided to implement a fix that avoids the disconnect in this situation. This fix is also useful on its own as I believe.