### PR TITLE
A few fixes for integration tests

### DIFF
--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -109,6 +109,11 @@ class VersionBitsWarningTest(BitcoinTestFramework):
             pass
         self.start_nodes()
 
+        # TODO this is a workaround. We have to wait for IBD to finish before we generate a block, as otherwise there
+        # won't be any warning generated. This workaround must be removed when we backport https://github.com/bitcoin/bitcoin/pull/12264
+        self.nodes[0].generate(1)
+        time.sleep(5)
+
         # Connecting one block should be enough to generate an error.
         self.nodes[0].generate(1)
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getinfo()["errors"])

--- a/test/functional/wallet-encryption.py
+++ b/test/functional/wallet-encryption.py
@@ -39,7 +39,7 @@ class WalletEncryptionTest(BitcoinTestFramework):
         assert_equal(privkey, self.nodes[0].dumpprivkey(address))
 
         # Check that the timeout is right
-        time.sleep(2)
+        time.sleep(4)  # Wait a little bit longer to make sure wallet gets locked
         assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)
 
         # Test wrong passphrase


### PR DESCRIPTION
This fixes 2 failures, one on [Gitlab](https://gitlab.com/dashpay/dash/pipelines/106537779) and one on [Travis](https://travis-ci.org/dashpay/dash/builds/631746678?utm_medium=notification&utm_source=github_status). Both happen due to overload.