### PR TITLE
Use -Wno-psabi for arm builds on Travis/Gitlab

### DIFF
--- a/ci/matrix.sh
+++ b/ci/matrix.sh
@@ -36,7 +36,9 @@ if [ "$BUILD_TARGET" = "arm-linux" ]; then
   export HOST=arm-linux-gnueabihf
   export PACKAGES="g++-arm-linux-gnueabihf"
   export CHECK_DOC=1
-  export BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+  # -Wno-psabi is to disable ABI warnings: "note: parameter passing for argument of type ... changed in GCC 7.1"
+  # This could be removed once the ABI change warning does not show up by default
+  export BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports CXXFLAGS=-Wno-psabi"
 elif [ "$BUILD_TARGET" = "win32" ]; then
   export HOST=i686-w64-mingw32
   export DPKG_ADD_ARCH="i386"


### PR DESCRIPTION
This avoids spamming logs with "note: parameter passing for argument of type " warnings.