### PR TITLE
A few optimizations/speedups for Dash related tests

### DIFF
--- a/test/functional/dip3-deterministicmns.py
+++ b/test/functional/dip3-deterministicmns.py
@@ -37,7 +37,7 @@ class DIP3Test(BitcoinTestFramework):
         self.start_node(0, extra_args=self.extra_args)
         for i in range(1, self.num_nodes):
             if i < len(self.nodes) and self.nodes[i] is not None and self.nodes[i].process is not None:
-                connect_nodes_bi(self.nodes, 0, i)
+                connect_nodes(self.nodes[i], 0)
 
     def stop_controller_node(self):
         self.log.info("stopping controller node")
@@ -263,10 +263,8 @@ class DIP3Test(BitcoinTestFramework):
         extra_args = ['-masternodeblsprivkey=%s' % mn.blsMnkey]
         self.start_node(mn.idx, extra_args = self.extra_args + extra_args)
         force_finish_mnsync(self.nodes[mn.idx])
-        for i in range(0, len(self.nodes)):
-            if i < len(self.nodes) and self.nodes[i] is not None and self.nodes[i].process is not None and i != mn.idx:
-                connect_nodes_bi(self.nodes, mn.idx, i)
         mn.node = self.nodes[mn.idx]
+        connect_nodes(mn.node, 0)
         self.sync_all()
 
     def spend_mn_collateral(self, mn, with_dummy_input_output=False):

--- a/test/functional/dip3-deterministicmns.py
+++ b/test/functional/dip3-deterministicmns.py
@@ -50,7 +50,7 @@ class DIP3Test(BitcoinTestFramework):
     def run_test(self):
         self.log.info("funding controller node")
         while self.nodes[0].getbalance() < (self.num_initial_mn + 3) * 1000:
-            self.nodes[0].generate(1) # generate enough for collaterals
+            self.nodes[0].generate(10) # generate enough for collaterals
         self.log.info("controller node has {} dash".format(self.nodes[0].getbalance()))
 
         # Make sure we're below block 135 (which activates dip3)
@@ -66,8 +66,8 @@ class DIP3Test(BitcoinTestFramework):
         mns.append(before_dip3_mn)
 
         # block 150 starts enforcing DIP3 MN payments
-        while self.nodes[0].getblockcount() < 150:
-            self.nodes[0].generate(1)
+        self.nodes[0].generate(150 - self.nodes[0].getblockcount())
+        assert(self.nodes[0].getblockcount() == 150)
 
         self.log.info("mining final block for DIP3 activation")
         self.nodes[0].generate(1)

--- a/test/functional/dip4-coinbasemerkleroots.py
+++ b/test/functional/dip4-coinbasemerkleroots.py
@@ -39,6 +39,7 @@ class TestNode(NodeConnCB):
 class LLMQCoinbaseCommitmentsTest(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(6, 5, fast_dip3_enforcement=True)
+        self.set_dash_dip8_activation(200)
 
     def run_test(self):
         self.test_node = TestNode()

--- a/test/functional/llmq-chainlocks.py
+++ b/test/functional/llmq-chainlocks.py
@@ -19,6 +19,7 @@ Checks LLMQs based ChainLocks
 class LLMQChainLocksTest(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(6, 5, fast_dip3_enforcement=True)
+        self.set_dash_dip8_activation(10)
 
     def run_test(self):
 

--- a/test/functional/llmq-dkgerrors.py
+++ b/test/functional/llmq-dkgerrors.py
@@ -16,6 +16,7 @@ Simulate and check DKG errors
 class LLMQDKGErrors(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(6, 5, [["-whitelist=127.0.0.1"]] * 6, fast_dip3_enforcement=True)
+        self.set_dash_dip8_activation(10)
 
     def run_test(self):
 

--- a/test/functional/llmq-is-cl-conflicts.py
+++ b/test/functional/llmq-is-cl-conflicts.py
@@ -49,6 +49,7 @@ class TestNode(NodeConnCB):
 class LLMQ_IS_CL_Conflicts(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(6, 5, fast_dip3_enforcement=True)
+        self.set_dash_dip8_activation(10)
         #disable_mocktime()
 
     def run_test(self):

--- a/test/functional/llmq-is-retroactive.py
+++ b/test/functional/llmq-is-retroactive.py
@@ -22,6 +22,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
     def set_test_params(self):
         # -whitelist is needed to avoid the trickling logic on node0
         self.set_dash_test_params(6, 5, [["-whitelist=127.0.0.1"], [], [], [], ["-minrelaytxfee=0.001"], ["-minrelaytxfee=0.001"]], fast_dip3_enforcement=True)
+        self.set_dash_dip8_activation(10)
 
     def run_test(self):
         while self.nodes[0].getblockchaininfo()["bip9_softforks"]["dip0008"]["status"] != "active":

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -499,6 +499,12 @@ class DashTestFramework(BitcoinTestFramework):
             for i in range(0, num_nodes):
                 self.extra_args[i] += ["-dip3params=30:50"]
 
+    def set_dash_dip8_activation(self, activate_after_block):
+        window = int((activate_after_block + 2) / 3)
+        threshold = int((window + 1) / 2)
+        for i in range(0, self.num_nodes):
+            self.extra_args[i].append("-vbparams=dip0008:0:999999999999:%d:%d" % (window, threshold))
+
     def create_simple_node(self):
         idx = len(self.nodes)
         self.add_nodes(1, extra_args=[self.extra_args[idx]])

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -617,7 +617,7 @@ class DashTestFramework(BitcoinTestFramework):
         while self.nodes[0].getbalance() < required_balance:
             self.bump_mocktime(1)
             set_node_times(self.nodes, self.mocktime)
-            self.nodes[0].generate(1)
+            self.nodes[0].generate(10)
         num_simple_nodes = self.num_nodes - self.mn_count - 1
         self.log.info("Creating and starting %s simple nodes", num_simple_nodes)
         for i in range(0, num_simple_nodes):


### PR DESCRIPTION
This is a collection of some optimizations, see individual commits for details.

Local run without optimizations:
```
$ python3 test/functional/test_runner.py -j 4 --keepcache dip4-coinbasemerkleroots.py llmq-chainlocks.py llmq-dkgerrors.py llmq-is-cl-conflicts.py llmq-is-retroactive.py llmq-signing.py llmq-simplepose.py p2p-instantsend.py dip3-deterministicmns.py
TEST                        | STATUS    | DURATION

dip3-deterministicmns.py    | ✓ Passed  | 37 s
dip4-coinbasemerkleroots.py | ✓ Passed  | 43 s
llmq-chainlocks.py          | ✓ Passed  | 49 s
llmq-dkgerrors.py           | ✓ Passed  | 44 s
llmq-is-cl-conflicts.py     | ✓ Passed  | 31 s
llmq-is-retroactive.py      | ✓ Passed  | 125 s
llmq-signing.py             | ✓ Passed  | 32 s
llmq-simplepose.py          | ✓ Passed  | 32 s
p2p-instantsend.py          | ✓ Passed  | 43 s

ALL                         | ✓ Passed  | 436 s (accumulated) 
Runtime: 157 s
```

With optimizations:
```
$ python3 test/functional/test_runner.py -j 4 --keepcache dip4-coinbasemerkleroots.py llmq-chainlocks.py llmq-dkgerrors.py llmq-is-cl-conflicts.py llmq-is-retroactive.py llmq-signing.py llmq-simplepose.py p2p-instantsend.py dip3-deterministicmns.py
TEST                        | STATUS    | DURATION

dip3-deterministicmns.py    | ✓ Passed  | 20 s
dip4-coinbasemerkleroots.py | ✓ Passed  | 33 s
llmq-chainlocks.py          | ✓ Passed  | 40 s
llmq-dkgerrors.py           | ✓ Passed  | 39 s
llmq-is-cl-conflicts.py     | ✓ Passed  | 25 s
llmq-is-retroactive.py      | ✓ Passed  | 118 s
llmq-signing.py             | ✓ Passed  | 29 s
llmq-simplepose.py          | ✓ Passed  | 29 s
p2p-instantsend.py          | ✓ Passed  | 47 s

ALL                         | ✓ Passed  | 380 s (accumulated) 
Runtime: 144 s
```