### PR TITLE
Make a deep copy of extra_args before modifying it in set_dash_test_params

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Base class for RPC testing."""
-
+import copy
 from collections import deque
 from enum import Enum
 import logging
@@ -492,12 +492,12 @@ class DashTestFramework(BitcoinTestFramework):
         if extra_args is None:
             extra_args = [[]] * num_nodes
         assert_equal(len(extra_args), num_nodes)
-        self.extra_args = extra_args
+        self.extra_args = [copy.deepcopy(a) for a in extra_args]
         self.extra_args[0] += ["-sporkkey=cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"]
         self.fast_dip3_enforcement = fast_dip3_enforcement
         if fast_dip3_enforcement:
             for i in range(0, num_nodes):
-                self.extra_args[i] += ["-dip3params=30:50"]
+                self.extra_args[i].append("-dip3params=30:50")
 
     def create_simple_node(self):
         idx = len(self.nodes)


### PR DESCRIPTION
Otherwise we end up having the same list instance for every entry in
extra_args, which means modifying index 0 also affects all other indexes.

Noticed this while looking at "ps aux | grep dashd" output. It turned out
that parameters like "-dip3params" were passed multiple times to each node.