### PR TITLE
Add -whitelist to all nodes in smartfees.py

### DIFF
--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -151,8 +151,8 @@ class EstimateFeeTest(BitcoinTestFramework):
         which we will use to generate our transactions.
         """
         self.add_nodes(3, extra_args=[["-maxorphantxsize=1000", "-whitelist=127.0.0.1"],
-                                      ["-blockmaxsize=17000", "-maxorphantxsize=1000"],
-                                      ["-blockmaxsize=8000", "-maxorphantxsize=1000"]])
+                                      ["-blockmaxsize=17000", "-maxorphantxsize=1000", "-whitelist=127.0.0.1"],
+                                      ["-blockmaxsize=8000", "-maxorphantxsize=1000", "-whitelist=127.0.0.1"]])
         # Use node0 to mine blocks for input splitting
         # Node1 mines small blocks but that are bigger than the expected transaction rate.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,


### PR DESCRIPTION
This speeds up mempool synchronization a lot due to trickling being forced.
This will later conflict with bitcoin#16493 and bitcoin#16535, but this can
easily be resolved (it does the same).