### PR TITLE
Speed up prevector initialization and vector assignment from prevectors

### DIFF
--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -80,7 +80,7 @@ PREVECTOR_TEST(Resize, 28900, 90300)
 
 typedef prevector<28, unsigned char> prevec;
 
-static void A_PrevectorAssign1(benchmark::State& state)
+static void PrevectorAssign(benchmark::State& state)
 {
     prevec t;
     t.resize(28);
@@ -94,7 +94,7 @@ static void A_PrevectorAssign1(benchmark::State& state)
     }
 }
 
-static void A_PrevectorAssign2(benchmark::State& state)
+static void PrevectorAssignTo(benchmark::State& state)
 {
     prevec t;
     t.resize(28);
@@ -108,5 +108,5 @@ static void A_PrevectorAssign2(benchmark::State& state)
     }
 }
 
-BENCHMARK(A_PrevectorAssign1)
-BENCHMARK(A_PrevectorAssign2)
+BENCHMARK(PrevectorAssign)
+BENCHMARK(PrevectorAssignTo)

--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -103,7 +103,7 @@ static void A_PrevectorAssign2(benchmark::State& state)
         for (int i = 0; i < 1000; ++i) {
             prevec::const_iterator b = t.begin() + 5;
             prevec::const_iterator e = b + 4;
-            v.assign(&*b, &*e);
+            t.assign_to(b, e, v);
         }
     }
 }

--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -88,7 +88,7 @@ static void PrevectorAssign(benchmark::State& state)
     while (state.KeepRunning()) {
         for (int i = 0; i < 1000; ++i) {
             prevec::const_iterator b = t.begin() + 5;
-            prevec::const_iterator e = b + 4;
+            prevec::const_iterator e = b + 20;
             v.assign(b, e);
         }
     }
@@ -102,7 +102,7 @@ static void PrevectorAssignTo(benchmark::State& state)
     while (state.KeepRunning()) {
         for (int i = 0; i < 1000; ++i) {
             prevec::const_iterator b = t.begin() + 5;
-            prevec::const_iterator e = b + 4;
+            prevec::const_iterator e = b + 20;
             t.assign_to(b, e, v);
         }
     }

--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -75,3 +75,38 @@ void PrevectorResize(benchmark::State& state)
 PREVECTOR_TEST(Clear, 28300, 88600)
 PREVECTOR_TEST(Destructor, 28800, 88900)
 PREVECTOR_TEST(Resize, 28900, 90300)
+
+#include <vector>
+
+typedef prevector<28, unsigned char> prevec;
+
+static void A_PrevectorAssign1(benchmark::State& state)
+{
+    prevec t;
+    t.resize(28);
+    std::vector<unsigned char> v;
+    while (state.KeepRunning()) {
+        for (int i = 0; i < 1000; ++i) {
+            prevec::const_iterator b = t.begin() + 5;
+            prevec::const_iterator e = b + 4;
+            v.assign(b, e);
+        }
+    }
+}
+
+static void A_PrevectorAssign2(benchmark::State& state)
+{
+    prevec t;
+    t.resize(28);
+    std::vector<unsigned char> v;
+    while (state.KeepRunning()) {
+        for (int i = 0; i < 1000; ++i) {
+            prevec::const_iterator b = t.begin() + 5;
+            prevec::const_iterator e = b + 4;
+            v.assign(&*b, &*e);
+        }
+    }
+}
+
+BENCHMARK(A_PrevectorAssign1)
+BENCHMARK(A_PrevectorAssign2)

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -538,7 +538,15 @@ public:
     const value_type* data() const {
         return item_ptr(0);
     }
+
+    template<typename V>
+    static void assign_to(const_iterator b, const_iterator e, V& v) {
+        // We know that internally the iterators are pointing to continues memory, so we can directly use the pointers here
+        // This avoids internal use of std::copy and operator++ on the iterators and instead allows efficient memcpy/memmove
+        v.assign(&*b, &*e);
+    }
 };
+
 #pragma pack(pop)
 
 #endif // BITCOIN_PREVECTOR_H

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -560,7 +560,15 @@ public:
     static void assign_to(const_iterator b, const_iterator e, V& v) {
         // We know that internally the iterators are pointing to continues memory, so we can directly use the pointers here
         // This avoids internal use of std::copy and operator++ on the iterators and instead allows efficient memcpy/memmove
-        v.assign(&*b, &*e);
+        if (IS_TRIVIALLY_CONSTRUCTIBLE<T>::value) {
+            auto s = e - b;
+            if (v.size() != s) {
+                v.resize(s);
+            }
+            ::memmove(v.data(), &*b, s);
+        } else {
+            v.assign(&*b, &*e);
+        }
     }
 };
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -225,6 +225,23 @@ private:
         }
     }
 
+    void fill(T* dst, const_iterator first, const_iterator last) {
+        ptrdiff_t count = last - first;
+        fill(dst, &*first, count);
+    }
+
+    void fill(T* dst, const T* src, ptrdiff_t count) {
+        if (IS_TRIVIALLY_CONSTRUCTIBLE<T>::value) {
+            ::memmove(dst, src, count * sizeof(T));
+        } else {
+            for (ptrdiff_t i = 0; i < count; i++) {
+                new(static_cast<void*>(dst)) T(*src);
+                ++dst;
+                ++src;
+            }
+        }
+    }
+
 public:
     void assign(size_type n, const T& val) {
         clear();

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -563,7 +563,7 @@ public:
             if (end() - pc < 0 || (unsigned int)(end() - pc) < nSize)
                 return false;
             if (pvchRet)
-                pvchRet->assign(pc, pc + nSize);
+                assign_to(pc, pc + nSize, *pvchRet);
             pc += nSize;
         }
 


### PR DESCRIPTION
This should speed up tests and production nodes.

I've seen prevector showing up in nearly all profiling session that I've done the last year. These two optimizations should finally remove the last bits of it that is visible in profiling.