### PR TITLE
Don't load caches when blocks/chainstate was deleted and also delete old caches

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2065,6 +2065,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     // LOAD SERIALIZED DAT FILES INTO DATA CACHES FOR INTERNAL USE
 
     bool fIgnoreCacheFiles = fLiteMode || fReindex || fReindexChainState;
+    {
+        LOCK(cs_main);
+        // was blocks/chainstate deleted?
+        if (chainActive.Tip() == nullptr) {
+            fIgnoreCacheFiles = true;
+        }
+    }
     if (!fIgnoreCacheFiles) {
         fs::path pathDB = GetDataDir();
         std::string strDBName;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2072,35 +2072,50 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             fIgnoreCacheFiles = true;
         }
     }
-    if (!fIgnoreCacheFiles) {
-        fs::path pathDB = GetDataDir();
-        std::string strDBName;
+    fs::path pathDB = GetDataDir();
+    std::string strDBName;
 
-        strDBName = "mncache.dat";
-        uiInterface.InitMessage(_("Loading masternode cache..."));
-        CFlatDB<CMasternodeMetaMan> flatdb1(strDBName, "magicMasternodeCache");
+    strDBName = "mncache.dat";
+    uiInterface.InitMessage(_("Loading masternode cache..."));
+    CFlatDB<CMasternodeMetaMan> flatdb1(strDBName, "magicMasternodeCache");
+    if (!fIgnoreCacheFiles) {
         if(!flatdb1.Load(mmetaman)) {
             return InitError(_("Failed to load masternode cache from") + "\n" + (pathDB / strDBName).string());
         }
+    } else {
+        CMasternodeMetaMan mmetamanTmp;
+        if(!flatdb1.Dump(mmetamanTmp)) {
+            return InitError(_("Failed to clear masternode cache at") + "\n" + (pathDB / strDBName).string());
+        }
+    }
 
-        strDBName = "governance.dat";
-        uiInterface.InitMessage(_("Loading governance cache..."));
-        CFlatDB<CGovernanceManager> flatdb3(strDBName, "magicGovernanceCache");
+    strDBName = "governance.dat";
+    uiInterface.InitMessage(_("Loading governance cache..."));
+    CFlatDB<CGovernanceManager> flatdb3(strDBName, "magicGovernanceCache");
+    if (!fIgnoreCacheFiles) {
         if(!flatdb3.Load(governance)) {
             return InitError(_("Failed to load governance cache from") + "\n" + (pathDB / strDBName).string());
         }
         governance.InitOnLoad();
+    } else {
+        CGovernanceManager governanceTmp;
+        if(!flatdb3.Dump(governanceTmp)) {
+            return InitError(_("Failed to clear governance cache at") + "\n" + (pathDB / strDBName).string());
+        }
+    }
 
-        strDBName = "netfulfilled.dat";
-        uiInterface.InitMessage(_("Loading fulfilled requests cache..."));
-        CFlatDB<CNetFulfilledRequestManager> flatdb4(strDBName, "magicFulfilledCache");
+    strDBName = "netfulfilled.dat";
+    uiInterface.InitMessage(_("Loading fulfilled requests cache..."));
+    CFlatDB<CNetFulfilledRequestManager> flatdb4(strDBName, "magicFulfilledCache");
+    if (!fIgnoreCacheFiles) {
         if(!flatdb4.Load(netfulfilledman)) {
             return InitError(_("Failed to load fulfilled requests cache from") + "\n" + (pathDB / strDBName).string());
         }
     } else {
-        fs::remove(GetDataDir() / "mncache.dat");
-        fs::remove(GetDataDir() / "governance.dat");
-        fs::remove(GetDataDir() / "netfulfilled.dat");
+        CNetFulfilledRequestManager netfulfilledmanTmp;
+        if(!flatdb4.Dump(netfulfilledmanTmp)) {
+            return InitError(_("Failed to clear fulfilled requests cache at") + "\n" + (pathDB / strDBName).string());
+        }
     }
 
     // ********************************************************* Step 10c: schedule Dash-specific tasks

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2097,6 +2097,10 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         if(!flatdb4.Load(netfulfilledman)) {
             return InitError(_("Failed to load fulfilled requests cache from") + "\n" + (pathDB / strDBName).string());
         }
+    } else {
+        fs::remove(GetDataDir() / "mncache.dat");
+        fs::remove(GetDataDir() / "governance.dat");
+        fs::remove(GetDataDir() / "netfulfilled.dat");
     }
 
     // ********************************************************* Step 10c: schedule Dash-specific tasks

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2064,12 +2064,12 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // LOAD SERIALIZED DAT FILES INTO DATA CACHES FOR INTERNAL USE
 
-    bool fIgnoreCacheFiles = fLiteMode || fReindex || fReindexChainState;
+    bool fLoadCacheFiles = !(fLiteMode || fReindex || fReindexChainState);
     {
         LOCK(cs_main);
         // was blocks/chainstate deleted?
         if (chainActive.Tip() == nullptr) {
-            fIgnoreCacheFiles = true;
+            fLoadCacheFiles = false;
         }
     }
     fs::path pathDB = GetDataDir();
@@ -2078,7 +2078,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     strDBName = "mncache.dat";
     uiInterface.InitMessage(_("Loading masternode cache..."));
     CFlatDB<CMasternodeMetaMan> flatdb1(strDBName, "magicMasternodeCache");
-    if (!fIgnoreCacheFiles) {
+    if (fLoadCacheFiles) {
         if(!flatdb1.Load(mmetaman)) {
             return InitError(_("Failed to load masternode cache from") + "\n" + (pathDB / strDBName).string());
         }
@@ -2092,7 +2092,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     strDBName = "governance.dat";
     uiInterface.InitMessage(_("Loading governance cache..."));
     CFlatDB<CGovernanceManager> flatdb3(strDBName, "magicGovernanceCache");
-    if (!fIgnoreCacheFiles) {
+    if (fLoadCacheFiles) {
         if(!flatdb3.Load(governance)) {
             return InitError(_("Failed to load governance cache from") + "\n" + (pathDB / strDBName).string());
         }
@@ -2107,7 +2107,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     strDBName = "netfulfilled.dat";
     uiInterface.InitMessage(_("Loading fulfilled requests cache..."));
     CFlatDB<CNetFulfilledRequestManager> flatdb4(strDBName, "magicFulfilledCache");
-    if (!fIgnoreCacheFiles) {
+    if (fLoadCacheFiles) {
         if(!flatdb4.Load(netfulfilledman)) {
             return InitError(_("Failed to load fulfilled requests cache from") + "\n" + (pathDB / strDBName).string());
         }


### PR DESCRIPTION
This fixes issues with inconsistent governance.dat (and possibly others) after node operators manually delete blocks/chainstate.