### PR TITLE
Backport "--failfast" and "--ci" for test_runner.py

### DIFF
--- a/ci/test_integrationtests.sh
+++ b/ci/test_integrationtests.sh
@@ -18,7 +18,7 @@ export LD_LIBRARY_PATH=$BUILD_DIR/depends/$HOST/lib
 cd build-ci/dashcore-$BUILD_TARGET
 
 set +e
-./test/functional/test_runner.py --coverage --quiet --failfast --nocleanup --tmpdir=$(pwd)/testdatadirs $PASS_ARGS
+./test/functional/test_runner.py --ci --coverage --quiet --failfast --nocleanup --tmpdir=$(pwd)/testdatadirs $PASS_ARGS
 RESULT=$?
 set -e
 

--- a/ci/test_integrationtests.sh
+++ b/ci/test_integrationtests.sh
@@ -18,7 +18,7 @@ export LD_LIBRARY_PATH=$BUILD_DIR/depends/$HOST/lib
 cd build-ci/dashcore-$BUILD_TARGET
 
 set +e
-./test/functional/test_runner.py --coverage --quiet --nocleanup --tmpdir=$(pwd)/testdatadirs $PASS_ARGS
+./test/functional/test_runner.py --coverage --quiet --failfast --nocleanup --tmpdir=$(pwd)/testdatadirs $PASS_ARGS
 RESULT=$?
 set -e
 


### PR DESCRIPTION
This backports bitcoin#13105 and bitcoin#14630. One test is current timing out in #3277, causing Travis and Gitlab to timeout without any meaningful info. This PR will allow us to debug such cases.