### PR TITLE
Only load valid themes, fallback to "Light" theme otherwise

### DIFF
--- a/src/qt/dash.qrc
+++ b/src/qt/dash.qrc
@@ -54,10 +54,12 @@
         <file alias="network_disabled">res/icons/network_disabled.png</file>
     </qresource>
     <qresource prefix="/css">
-        <file alias="dark">res/css/dark.css</file>
-        <file alias="light">res/css/light.css</file>
         <file alias="scrollbars">res/css/scrollbars.css</file>
-        <file alias="trad">res/css/trad.css</file>
+    </qresource>
+    <qresource prefix="/themes">
+        <file alias="Dark">res/css/dark.css</file>
+        <file alias="Light">res/css/light.css</file>
+        <file alias="Traditional">res/css/trad.css</file>
     </qresource>
     <qresource prefix="/images">
         <file alias="arrow_down">res/images/arrow_down.png</file>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -942,23 +942,12 @@ void migrateQtSettings()
 QString loadStyleSheet()
 {
     QSettings settings;
-    bool fValidTheme{false};
-
     QString theme = settings.value("theme", "").toString();
 
-    if (!theme.isEmpty()) {
-        // Make sure settings are pointing to an existent theme
-        QDir themes(":themes");
-        for (const QString &entry : themes.entryList()) {
-            if (entry == theme) {
-                fValidTheme = true;
-                break;
-            }
-        }
-    }
-
+    QDir themes(":themes");
+    // Make sure settings are pointing to an existent theme
     // Set "Light" theme by default if settings are missing or incorrect
-    if(!fValidTheme) {
+    if theme.isEmpty() || !themes.exists(theme) {
         theme = "Light";
         settings.setValue("theme", theme);
     }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -947,7 +947,7 @@ QString loadStyleSheet()
     QDir themes(":themes");
     // Make sure settings are pointing to an existent theme
     // Set "Light" theme by default if settings are missing or incorrect
-    if theme.isEmpty() || !themes.exists(theme) {
+    if (theme.isEmpty() || !themes.exists(theme)) {
         theme = "Light";
         settings.setValue("theme", theme);
     }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -941,25 +941,34 @@ void migrateQtSettings()
 // Open CSS when configured
 QString loadStyleSheet()
 {
-    QString styleSheet;
     QSettings settings;
-    QString cssName;
+    bool fValidTheme{false};
+
     QString theme = settings.value("theme", "").toString();
 
-    if(!theme.isEmpty()){
-        cssName = QString(":/css/") + theme;
-    }
-    else {
-        cssName = QString(":/css/light");
-        settings.setValue("theme", "light");
+    if (!theme.isEmpty()) {
+        // Make sure settings are pointing to an existent theme
+        QDir themes(":themes");
+        for (const QString &entry : themes.entryList()) {
+            if (entry == theme) {
+                fValidTheme = true;
+                break;
+            }
+        }
     }
 
-    QFile qFile(cssName);
+    // Set "Light" theme by default if settings are missing or incorrect
+    if(!fValidTheme) {
+        theme = "Light";
+        settings.setValue("theme", theme);
+    }
+
+    QFile qFile(":themes/" + theme);
     if (qFile.open(QFile::ReadOnly)) {
-        styleSheet = QLatin1String(qFile.readAll());
+        return QLatin1String(qFile.readAll());
     }
 
-    return styleSheet;
+    return QString();
 }
 
 void setClipboard(const QString& str)

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -89,9 +89,10 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     }
 
     /* Theme selector */
-    ui->theme->addItem(QString("Dark"), QVariant("dark"));
-    ui->theme->addItem(QString("Light"), QVariant("light"));
-    ui->theme->addItem(QString("Traditional"), QVariant("trad"));
+    QDir themes(":themes");
+    for (const QString &entry : themes.entryList()) {
+        ui->theme->addItem(entry, QVariant(entry));
+    }
 
     /* Language selector */
     QDir translations(":translations");


### PR DESCRIPTION
This should help to avoid issues for users still using old themes we removed in #3141 - without this patch they would see some ugly non-styled version the first time they run v0.15 and would have to pick the theme manually.