### PR TITLE
Bump PROTOCOL_VERSION

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70215;
+static const int PROTOCOL_VERSION = 70216;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
Rationale:
- We removed "alert" p2p message and changed "mempool" message behaviour a bit. It probably makes sense to bump PROTOCOL_VERSION now. This should also help to distinguish v0.15 nodes from late v0.14.0.x ones.
- ~We no longer need to support pre-v0.14 nodes.~ We do have quite a few mobile SPV wallets running on low end Android phones though. Postponing MIN_PEER_PROTO_VERSION bump till later.