### PR TITLE
Fix dip4-coinbasemerkleroots.py race condition

### DIFF
--- a/test/functional/dip4-coinbasemerkleroots.py
+++ b/test/functional/dip4-coinbasemerkleroots.py
@@ -24,13 +24,13 @@ class TestNode(NodeConnCB):
         self.last_mnlistdiff = message
 
     def wait_for_mnlistdiff(self, timeout=30):
-        self.last_mnlistdiff = None
         def received_mnlistdiff():
             return self.last_mnlistdiff is not None
         return wait_until(received_mnlistdiff, timeout=timeout)
 
     def getmnlistdiff(self, baseBlockHash, blockHash):
         msg = msg_getmnlistd(baseBlockHash, blockHash)
+        self.last_mnlistdiff = None
         self.send_message(msg)
         self.wait_for_mnlistdiff()
         return self.last_mnlistdiff


### PR DESCRIPTION
Sometimes the node we ask for mnlistdiff is so fast to reply that we receive the message back before we reset `last_mnlistdiff` and `wait_until` fails. To fix this we should reset it before sending the message, not after.

Should fix test failures like https://gitlab.com/dashpay/dash/-/jobs/410132154#L3438