### PR TITLE
Fix empty TRAVIS_COMMIT_RANGE for one-commit-branch builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,8 @@ before_install:
   - travis_retry sudo apt-get -yq --no-install-suggests --no-install-recommends install docker-ce realpath
 
 install:
+    # Fix annoying Travis bug: a branch with a single commit has an empty TRAVIS_COMMIT_RANGE sometimes
+    - if [ -z "$TRAVIS_COMMIT_RANGE" ]; then export TRAVIS_COMMIT_RANGE="HEAD~..HEAD"; fi
     # Our scripts try to be Travis agnostic
     - export PULL_REQUEST="$TRAVIS_PULL_REQUEST"
     - export COMMIT_RANGE="$TRAVIS_COMMIT_RANGE"


### PR DESCRIPTION
Example failure: https://travis-ci.org/UdjinM6/dash/jobs/639967097#L561 (note empty `echo $TRAVIS_COMMIT_RANGE` output few lines below)
