### PR TITLE
Add `automake` package to dash-win-signer's packages list

### DIFF
--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -7,6 +7,7 @@ architectures:
 packages:
 - "libssl-dev"
 - "autoconf"
+- "automake"
 - "libtool"
 - "pkg-config"
 remotes:


### PR DESCRIPTION
Fixes
```
+ ./autogen.sh
Preparing the osslsigncode build system...please wait
Found GNU Autoconf version 2.69
ERROR: Unable to locate GNU Automake.
ERROR:  To prepare the osslsigncode build system from scratch,
        at least version 1.6.0 of GNU Automake must be installed.
```