### PR TITLE
Refactor PS a bit and make it so that the expected flow for mixing is to time out and fallback

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -365,7 +365,7 @@ public:
         fAllowMultiplePorts = false;
 
         nPoolMinParticipants = 3;
-        nPoolMaxParticipants = 20;
+        nPoolMaxParticipants = 5; // TODO: bump on next HF / mandatory upgrade
         nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
 
         vSporkAddresses = {"Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh"};
@@ -541,7 +541,7 @@ public:
         fAllowMultiplePorts = true;
 
         nPoolMinParticipants = 2;
-        nPoolMaxParticipants = 20;
+        nPoolMaxParticipants = 5;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
@@ -696,7 +696,7 @@ public:
         fAllowMultiplePorts = true;
 
         nPoolMinParticipants = 2;
-        nPoolMaxParticipants = 20;
+        nPoolMaxParticipants = 5;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
@@ -807,7 +807,7 @@ public:
 
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
         nPoolMinParticipants = 2;
-        nPoolMaxParticipants = 20;
+        nPoolMaxParticipants = 5;
 
         // privKey: cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK
         vSporkAddresses = {"yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW"};

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -365,7 +365,7 @@ public:
         fAllowMultiplePorts = false;
 
         nPoolMinParticipants = 3;
-        nPoolMaxParticipants = 5;
+        nPoolMaxParticipants = 20;
         nFulfilledRequestExpireTime = 60*60; // fulfilled requests expire in 1 hour
 
         vSporkAddresses = {"Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh"};
@@ -540,8 +540,8 @@ public:
         fAllowMultipleAddressesFromGroup = false;
         fAllowMultiplePorts = true;
 
-        nPoolMinParticipants = 3;
-        nPoolMaxParticipants = 5;
+        nPoolMinParticipants = 2;
+        nPoolMaxParticipants = 20;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
@@ -695,8 +695,8 @@ public:
         fAllowMultipleAddressesFromGroup = true;
         fAllowMultiplePorts = true;
 
-        nPoolMinParticipants = 3;
-        nPoolMaxParticipants = 5;
+        nPoolMinParticipants = 2;
+        nPoolMaxParticipants = 20;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
@@ -806,8 +806,8 @@ public:
         fAllowMultiplePorts = true;
 
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
-        nPoolMinParticipants = 3;
-        nPoolMaxParticipants = 5;
+        nPoolMinParticipants = 2;
+        nPoolMaxParticipants = 20;
 
         // privKey: cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK
         vSporkAddresses = {"yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW"};

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -540,7 +540,7 @@ public:
         fAllowMultipleAddressesFromGroup = false;
         fAllowMultiplePorts = true;
 
-        nPoolMinParticipants = 2;
+        nPoolMinParticipants = 3; // TODO drop to 2 with next mandatory upgrade
         nPoolMaxParticipants = 5;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 
@@ -695,7 +695,7 @@ public:
         fAllowMultipleAddressesFromGroup = true;
         fAllowMultiplePorts = true;
 
-        nPoolMinParticipants = 2;
+        nPoolMinParticipants = 3; // same, drop to 2 w/ breaking change
         nPoolMaxParticipants = 5;
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
 

--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -454,7 +454,7 @@ bool CPrivateSendServer::HasTimedOut()
 }
 
 //
-// Check for extranious timeout
+// Check for extraneous timeout
 //
 void CPrivateSendServer::CheckTimeout(CConnman& connman)
 {

--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -222,7 +222,6 @@ void CPrivateSendServer::SetNull()
 {
     // MN side
     vecSessionCollaterals.clear();
-    nSessionMaxParticipants = 0;
 
     CPrivateSendBaseSession::SetNull();
     CPrivateSendBaseManager::SetNull();
@@ -237,9 +236,20 @@ void CPrivateSendServer::CheckPool(CConnman& connman)
 
     LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CheckPool -- entries count %lu\n", GetEntriesCount());
 
-    // If entries are full, create finalized transaction
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES && GetEntriesCount() >= nSessionMaxParticipants) {
+    // If we have an entry for each collateral, then create final tx
+    if (nState == POOL_STATE_ACCEPTING_ENTRIES && GetEntriesCount() == vecSessionCollaterals.size()) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CheckPool -- FINALIZE TRANSACTIONS\n");
+        CreateFinalTransaction(connman);
+        return;
+    }
+
+    // Check for Time Out
+    // If we timed out while accepting entries, then if we have more than minimum, create final tx
+    if (nState == POOL_STATE_ACCEPTING_ENTRIES && CPrivateSendServer::HasTimedOut()
+            && GetEntriesCount() >= CPrivateSend::GetMinPoolParticipants()) {
+        // Punish misbehaving participants
+        ChargeFees(connman);
+        // Try to complete this session ignoring the misbehaving ones
         CreateFinalTransaction(connman);
         return;
     }
@@ -382,10 +392,10 @@ void CPrivateSendServer::ChargeFees(CConnman& connman)
     if (vecOffendersCollaterals.empty()) return;
 
     //mostly offending? Charge sometimes
-    if ((int)vecOffendersCollaterals.size() >= nSessionMaxParticipants - 1 && GetRandInt(100) > 33) return;
+    if ((int)vecOffendersCollaterals.size() >= vecSessionCollaterals.size() - 1 && GetRandInt(100) > 33) return;
 
     //everyone is an offender? That's not right
-    if ((int)vecOffendersCollaterals.size() >= nSessionMaxParticipants) return;
+    if ((int)vecOffendersCollaterals.size() >= vecSessionCollaterals.size()) return;
 
     //charge one of the offenders randomly
     std::random_shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end());
@@ -432,8 +442,19 @@ void CPrivateSendServer::ConsumeCollateral(CConnman& connman, const CTransaction
     }
 }
 
+bool CPrivateSendServer::HasTimedOut()
+{
+    if (!fMasternodeMode) return false;
+
+    if (nState == POOL_STATE_IDLE) return false;
+
+    int nTimeout = (nState == POOL_STATE_SIGNING) ? PRIVATESEND_SIGNING_TIMEOUT : PRIVATESEND_QUEUE_TIMEOUT;
+
+    return GetTime() - nTimeLastSuccessfulStep >= nTimeout;
+}
+
 //
-// Check for various timeouts (queue objects, mixing, etc)
+// Check for extranious timeout
 //
 void CPrivateSendServer::CheckTimeout(CConnman& connman)
 {
@@ -441,36 +462,11 @@ void CPrivateSendServer::CheckTimeout(CConnman& connman)
 
     CheckQueue();
 
-    if (nState == POOL_STATE_IDLE) return;
-
-    int nTimeout = (nState == POOL_STATE_SIGNING) ? PRIVATESEND_SIGNING_TIMEOUT : PRIVATESEND_QUEUE_TIMEOUT;
-    bool fTimeout = GetTime() - nTimeLastSuccessfulStep >= nTimeout;
-
     // Too early to do anything
-    if (!fTimeout) return;
+    if (!CPrivateSendServer::HasTimedOut()) return;
 
-    // See if we have at least min number of participants, if so - we can still do something
-    if (nState == POOL_STATE_QUEUE && vecSessionCollaterals.size() >= CPrivateSend::GetMinPoolParticipants()) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CheckTimeout -- Queue for %d participants timed out (%ds) -- falling back to %d participants\n",
-            nSessionMaxParticipants, nTimeout, vecSessionCollaterals.size());
-        nSessionMaxParticipants = vecSessionCollaterals.size();
-        return;
-    }
-
-    if (nState == POOL_STATE_ACCEPTING_ENTRIES && GetEntriesCount() >= CPrivateSend::GetMinPoolParticipants()) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CheckTimeout -- Accepting entries for %d participants timed out (%ds) -- falling back to %d participants\n",
-            nSessionMaxParticipants, nTimeout, GetEntriesCount());
-        // Punish misbehaving participants
-        ChargeFees(connman);
-        // Try to complete this session ignoring the misbehaving ones
-        nSessionMaxParticipants = GetEntriesCount();
-        CheckPool(connman);
-        return;
-    }
-
-    // All other cases
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CheckTimeout -- %s timed out (%ds) -- resetting\n",
-        (nState == POOL_STATE_SIGNING) ? "Signing" : "Session", nTimeout);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CheckTimeout -- %s timed out -- resetting\n",
+        (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
     ChargeFees(connman);
     SetNull();
 }
@@ -488,7 +484,8 @@ void CPrivateSendServer::CheckForCompleteQueue(CConnman& connman)
         SetState(POOL_STATE_ACCEPTING_ENTRIES);
 
         CPrivateSendQueue dsq(nSessionDenom, activeMasternodeInfo.outpoint, GetAdjustedTime(), true);
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s)\n", dsq.ToString());
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s) "
+                                     "with %d participants\n", dsq.ToString(), vecSessionCollaterals.size());
         dsq.Sign();
         dsq.Relay(connman);
     }
@@ -544,7 +541,7 @@ bool CPrivateSendServer::AddEntry(CConnman& connman, const CPrivateSendEntry& en
 {
     if (!fMasternodeMode) return false;
 
-    if (GetEntriesCount() >= nSessionMaxParticipants) {
+    if (GetEntriesCount() >= vecSessionCollaterals.size()) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::%s -- ERROR: entries is full!\n", __func__);
         nMessageIDRet = ERR_ENTRIES_FULL;
         return false;
@@ -593,7 +590,7 @@ bool CPrivateSendServer::AddEntry(CConnman& connman, const CPrivateSendEntry& en
 
     vecEntries.push_back(entry);
 
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::%s -- adding entry %d of %d required\n", __func__, GetEntriesCount(), nSessionMaxParticipants);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::%s -- adding entry %d of %d required\n", __func__, GetEntriesCount(), CPrivateSend::GetMaxPoolParticipants());
     nMessageIDRet = MSG_ENTRIES_ADDED;
 
     return true;
@@ -689,7 +686,6 @@ bool CPrivateSendServer::CreateNewSession(const CPrivateSendAccept& dsa, PoolMes
     nMessageIDRet = MSG_NOERR;
     nSessionID = GetRandInt(999999) + 1;
     nSessionDenom = dsa.nDenom;
-    nSessionMaxParticipants = CPrivateSend::GetMinPoolParticipants() + GetRandInt(CPrivateSend::GetMaxPoolParticipants() - CPrivateSend::GetMinPoolParticipants() + 1);
 
     SetState(POOL_STATE_QUEUE);
 
@@ -703,8 +699,8 @@ bool CPrivateSendServer::CreateNewSession(const CPrivateSendAccept& dsa, PoolMes
     }
 
     vecSessionCollaterals.push_back(MakeTransactionRef(dsa.txCollateral));
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CreateNewSession -- new session created, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  nSessionMaxParticipants: %d\n",
-        nSessionID, nSessionDenom, CPrivateSend::GetDenominationsToString(nSessionDenom), vecSessionCollaterals.size(), nSessionMaxParticipants);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::CreateNewSession -- new session created, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  CPrivateSend::GetMaxPoolParticipants(): %d\n",
+        nSessionID, nSessionDenom, CPrivateSend::GetDenominationsToString(nSessionDenom), vecSessionCollaterals.size(), CPrivateSend::GetMaxPoolParticipants());
 
     return true;
 }
@@ -736,15 +732,18 @@ bool CPrivateSendServer::AddUserToExistingSession(const CPrivateSendAccept& dsa,
     nMessageIDRet = MSG_NOERR;
     vecSessionCollaterals.push_back(MakeTransactionRef(dsa.txCollateral));
 
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::AddUserToExistingSession -- new user accepted, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  nSessionMaxParticipants: %d\n",
-        nSessionID, nSessionDenom, CPrivateSend::GetDenominationsToString(nSessionDenom), vecSessionCollaterals.size(), nSessionMaxParticipants);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::AddUserToExistingSession -- new user accepted, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  CPrivateSend::GetMaxPoolParticipants(): %d\n",
+        nSessionID, nSessionDenom, CPrivateSend::GetDenominationsToString(nSessionDenom), vecSessionCollaterals.size(), CPrivateSend::GetMaxPoolParticipants());
 
     return true;
 }
 
+// Returns true if either max size has been reached or if the mix timed out and min size was reached
 bool CPrivateSendServer::IsSessionReady()
 {
-    return nSessionMaxParticipants != 0 && (int)vecSessionCollaterals.size() >= nSessionMaxParticipants;
+    if ((int)vecSessionCollaterals.size() >= CPrivateSend::GetMaxPoolParticipants()) return true;
+    if (CPrivateSendServer::HasTimedOut() && (int)vecSessionCollaterals.size() >= CPrivateSend::GetMinPoolParticipants()) return true;
+    return false;
 }
 
 void CPrivateSendServer::RelayFinalTransaction(const CTransaction& txFinal, CConnman& connman)
@@ -851,8 +850,9 @@ void CPrivateSendServer::DoMaintenance(CConnman& connman)
 
     if (!masternodeSync.IsBlockchainSynced() || ShutdownRequested()) return;
 
-    privateSendServer.CheckTimeout(connman);
     privateSendServer.CheckForCompleteQueue(connman);
+    privateSendServer.CheckPool(connman);
+    privateSendServer.CheckTimeout(connman);
 }
 
 void CPrivateSendServer::GetJsonInfo(UniValue& obj) const

--- a/src/privatesend/privatesend-server.h
+++ b/src/privatesend/privatesend-server.h
@@ -23,9 +23,6 @@ private:
     // to behave honestly. If they don't it takes their money.
     std::vector<CTransactionRef> vecSessionCollaterals;
 
-    // Maximum number of participants in a certain session, random between min and max.
-    int nSessionMaxParticipants;
-
     bool fUnitTest;
 
     /// Add a clients entry to the pool
@@ -72,11 +69,11 @@ private:
 public:
     CPrivateSendServer() :
         vecSessionCollaterals(),
-        nSessionMaxParticipants(0),
         fUnitTest(false) {}
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
+    bool HasTimedOut();
     void CheckTimeout(CConnman& connman);
     void CheckForCompleteQueue(CConnman& connman);
 


### PR DESCRIPTION
1. ~Changes min number of participants on RegTest/DevNet/TestNet to 2~
2. ~Changes the max number of participants on all nets to 20 (more on this later)~
3. removes variability on max number of participants (and in turn removes the nMaxSessionParticipants variable)
4. Created a HasTimedOut method which returns true if it has timed out and false otherwise.
5. Changed flow in the case of normal time outs (more than min participants but less than max participants). These checks are now done in the main method associated with that stage of mixing, so in CheckPool the flow is to check if there are max 
 6. Made `CheckPool` and `CheckForCompleteQueue` get called before `CheckTimeout` to ensure that we don't time out and reset when we don't need to

The expected flow for a mix now is that it will try to add as many participants as possible in the timeout time allocated (capped at ~20~ 5). Once it times out, if it has more than the min needed, it will advance to the next stage. 

The primary intent behind this PR is that 1 mix with 10 participants is better than 3 mixes with 10 participants total. Having more people per mix allows for higher privacy per round. This also probably makes analyzing even harder since you have no idea how many participants could be present (between 3 and ~20~ 5).
