### PR TITLE
Add unit tests for CPrivateSend::IsCollateralAmount

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -97,7 +97,8 @@ BITCOIN_TESTS =\
   test/versionbits_tests.cpp \
   test/uint256_tests.cpp \
   test/univalue_tests.cpp \
-  test/util_tests.cpp
+  test/util_tests.cpp \
+  test/privatesend_tests.cpp
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -68,6 +68,7 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
+  test/privatesend_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \
   test/ratecheck_tests.cpp \
@@ -97,8 +98,7 @@ BITCOIN_TESTS =\
   test/versionbits_tests.cpp \
   test/uint256_tests.cpp \
   test/univalue_tests.cpp \
-  test/util_tests.cpp \
-  test/privatesend_tests.cpp
+  test/util_tests.cpp
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \

--- a/src/test/privatesend_tests.cpp
+++ b/src/test/privatesend_tests.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_dash.h"
+
+#include "amount.h"
+#include "privatesend/privatesend.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(privatesend_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(ps_collatoral_tests)
+{
+    // Good collateral values
+    BOOST_CHECK(CPrivateSend::IsCollateralAmount(0.00010000 * COIN));
+    BOOST_CHECK(CPrivateSend::IsCollateralAmount(0.00012345 * COIN));
+    BOOST_CHECK(CPrivateSend::IsCollateralAmount(0.00032123 * COIN));
+    BOOST_CHECK(CPrivateSend::IsCollateralAmount(0.00019000 * COIN));
+
+    // Bad collateral values
+    BOOST_CHECK(!CPrivateSend::IsCollateralAmount(0.00009999 * COIN));
+    BOOST_CHECK(!CPrivateSend::IsCollateralAmount(0.00040001 * COIN));
+    BOOST_CHECK(!CPrivateSend::IsCollateralAmount(0.00100000 * COIN));
+    BOOST_CHECK(!CPrivateSend::IsCollateralAmount(0.00100001 * COIN));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -26,6 +26,7 @@
 #include "evo/deterministicmns.h"
 #include "evo/cbtx.h"
 #include "llmq/quorums_init.h"
+#include "privatesend/privatesend.h"
 
 #include <memory>
 
@@ -57,6 +58,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
         SetupNetworking();
         InitSignatureCache();
         InitScriptExecutionCache();
+        CPrivateSend::InitStandardDenominations();
         fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(chainName);


### PR DESCRIPTION
This adds a test for CPrivateSend::IsCollateralAmount

Most of the other PrivateSend features are difficult to do since they are wallet based, but I am looking into that.

Also,  the indentation of test_dash.cpp has been adjusted since I had to adjust the file to get the test to work. (This is in line with how bitcoin does formatting fixes, but I guess I could revert that if need be) 