### PR TITLE
Merge #11272: CKeystore/CCrypter: move relevant implementation out of…

### DIFF
--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -36,6 +36,33 @@ bool CBasicKeyStore::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
     return true;
 }
 
+bool CBasicKeyStore::HaveKey(const CKeyID &address) const
+{
+    LOCK(cs_KeyStore);
+    return mapKeys.count(address) > 0;
+}
+
+std::set<CKeyID> CBasicKeyStore::GetKeys() const
+{
+    LOCK(cs_KeyStore);
+    std::set<CKeyID> set_address;
+    for (const auto& mi : mapKeys) {
+        set_address.insert(mi.first);
+    }
+    return set_address;
+}
+
+bool CBasicKeyStore::GetKey(const CKeyID &address, CKey &keyOut) const
+{
+    LOCK(cs_KeyStore);
+    KeyMap::const_iterator mi = mapKeys.find(address);
+    if (mi != mapKeys.end()) {
+        keyOut = mi->second;
+        return true;
+    }
+    return false;
+}
+
 bool CBasicKeyStore::AddCScript(const CScript& redeemScript)
 {
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -65,37 +65,9 @@ protected:
 public:
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
-    bool HaveKey(const CKeyID &address) const override
-    {
-        bool result;
-        {
-            LOCK(cs_KeyStore);
-            result = (mapKeys.count(address) > 0);
-        }
-        return result;
-    }
-    std::set<CKeyID> GetKeys() const override
-    {
-        LOCK(cs_KeyStore);
-        std::set<CKeyID> set_address;
-        for (const auto& mi : mapKeys) {
-            set_address.insert(mi.first);
-        }
-        return set_address;
-    }
-    bool GetKey(const CKeyID &address, CKey &keyOut) const override
-    {
-        {
-            LOCK(cs_KeyStore);
-            KeyMap::const_iterator mi = mapKeys.find(address);
-            if (mi != mapKeys.end())
-            {
-                keyOut = mi->second;
-                return true;
-            }
-        }
-        return false;
-    }
+    bool HaveKey(const CKeyID &address) const override;
+    std::set<CKeyID> GetKeys() const override;
+    bool GetKey(const CKeyID &address, CKey &keyOut) const override;
     bool AddCScript(const CScript& redeemScript) override;
     bool HaveCScript(const CScriptID &hash) const override;
     bool GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const override;

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -206,7 +206,7 @@ bool CCryptoKeyStore::SetCrypted()
 //      !IsLocked(true) && IsLocked()
 // or if they are available for everything:
 //      !IsLocked()
-bool IsLocked(bool fForMixing = false) const
+bool CCryptoKeyStore::IsLocked(bool fForMixing) const
 {
     if (!IsCrypted())
         return false;

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -198,6 +198,35 @@ bool CCryptoKeyStore::SetCrypted()
     return true;
 }
 
+// This function should be used in a different combinations to determine
+// if CCryptoKeyStore is fully locked so that no operations requiring access
+// to private keys are possible:
+//      IsLocked(true)
+// or if CCryptoKeyStore's private keys are available for mixing only:
+//      !IsLocked(true) && IsLocked()
+// or if they are available for everything:
+//      !IsLocked()
+bool IsLocked(bool fForMixing = false) const
+{
+    if (!IsCrypted())
+        return false;
+    bool result;
+    {
+        LOCK(cs_KeyStore);
+        result = vMasterKey.empty();
+    }
+    // fForMixing   fOnlyMixingAllowed  return
+    // ---------------------------------------
+    // true         true                result
+    // true         false               result
+    // false        true                true
+    // false        false               result
+
+    if(!fForMixing && fOnlyMixingAllowed) return true;
+
+    return result;
+}
+
 bool CCryptoKeyStore::Lock(bool fAllowMixing)
 {
     if (!SetCrypted())
@@ -269,21 +298,23 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn, bool fForMixin
 
 bool CCryptoKeyStore::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
 {
-    {
-        LOCK(cs_KeyStore);
-        if (!IsCrypted())
-            return CBasicKeyStore::AddKeyPubKey(key, pubkey);
+    LOCK(cs_KeyStore);
+    if (!IsCrypted()) {
+        return CBasicKeyStore::AddKeyPubKey(key, pubkey);
+    }
 
-        if (IsLocked(true))
-            return false;
+    if (IsLocked(true)) {
+        return false;
+    }
 
-        std::vector<unsigned char> vchCryptedSecret;
-        CKeyingMaterial vchSecret(key.begin(), key.end());
-        if (!EncryptSecret(vMasterKey, vchSecret, pubkey.GetHash(), vchCryptedSecret))
-            return false;
+    std::vector<unsigned char> vchCryptedSecret;
+    CKeyingMaterial vchSecret(key.begin(), key.end());
+    if (!EncryptSecret(vMasterKey, vchSecret, pubkey.GetHash(), vchCryptedSecret)) {
+        return false;
+    }
 
-        if (!AddCryptedKey(pubkey, vchCryptedSecret))
-            return false;
+    if (!AddCryptedKey(pubkey, vchCryptedSecret)) {
+        return false;
     }
     return true;
 }
@@ -291,73 +322,89 @@ bool CCryptoKeyStore::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
 
 bool CCryptoKeyStore::AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret)
 {
-    {
-        LOCK(cs_KeyStore);
-        if (!SetCrypted())
-            return false;
-
-        mapCryptedKeys[vchPubKey.GetID()] = make_pair(vchPubKey, vchCryptedSecret);
+    LOCK(cs_KeyStore);
+    if (!SetCrypted()) {
+        return false;
     }
+
+    mapCryptedKeys[vchPubKey.GetID()] = make_pair(vchPubKey, vchCryptedSecret);
     return true;
+}
+
+bool CCryptoKeyStore::HaveKey(const CKeyID &address) const
+{
+    LOCK(cs_KeyStore);
+    if (!IsCrypted()) {
+        return CBasicKeyStore::HaveKey(address);
+    }
+    return mapCryptedKeys.count(address) > 0;
 }
 
 bool CCryptoKeyStore::GetKey(const CKeyID &address, CKey& keyOut) const
 {
-    {
-        LOCK(cs_KeyStore);
-        if (!IsCrypted())
-            return CBasicKeyStore::GetKey(address, keyOut);
+    LOCK(cs_KeyStore);
+    if (!IsCrypted()) {
+        return CBasicKeyStore::GetKey(address, keyOut);
+    }
 
-        CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
-        if (mi != mapCryptedKeys.end())
-        {
-            const CPubKey &vchPubKey = (*mi).second.first;
-            const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
-            return DecryptKey(vMasterKey, vchCryptedSecret, vchPubKey, keyOut);
-        }
+    CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
+    if (mi != mapCryptedKeys.end())
+    {
+        const CPubKey &vchPubKey = (*mi).second.first;
+        const std::vector<unsigned char> &vchCryptedSecret = (*mi).second.second;
+        return DecryptKey(vMasterKey, vchCryptedSecret, vchPubKey, keyOut);
     }
     return false;
 }
 
 bool CCryptoKeyStore::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
 {
-    {
-        LOCK(cs_KeyStore);
-        if (!IsCrypted())
-            return CBasicKeyStore::GetPubKey(address, vchPubKeyOut);
-
-        CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
-        if (mi != mapCryptedKeys.end())
-        {
-            vchPubKeyOut = (*mi).second.first;
-            return true;
-        }
-        // Check for watch-only pubkeys
+    LOCK(cs_KeyStore);
+    if (!IsCrypted())
         return CBasicKeyStore::GetPubKey(address, vchPubKeyOut);
+
+    CryptedKeyMap::const_iterator mi = mapCryptedKeys.find(address);
+    if (mi != mapCryptedKeys.end())
+    {
+        vchPubKeyOut = (*mi).second.first;
+        return true;
     }
+    // Check for watch-only pubkeys
+    return CBasicKeyStore::GetPubKey(address, vchPubKeyOut);
+}
+
+std::set<CKeyID> CCryptoKeyStore::GetKeys() const
+{
+    LOCK(cs_KeyStore);
+    if (!IsCrypted()) {
+        return CBasicKeyStore::GetKeys();
+    }
+    std::set<CKeyID> set_address;
+    for (const auto& mi : mapCryptedKeys) {
+        set_address.insert(mi.first);
+    }
+    return set_address;
 }
 
 bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
 {
-    {
-        LOCK(cs_KeyStore);
-        if (!mapCryptedKeys.empty() || IsCrypted())
-            return false;
+    LOCK(cs_KeyStore);
+    if (!mapCryptedKeys.empty() || IsCrypted())
+        return false;
 
-        fUseCrypto = true;
-        for (KeyMap::value_type& mKey : mapKeys)
-        {
-            const CKey &key = mKey.second;
-            CPubKey vchPubKey = key.GetPubKey();
-            CKeyingMaterial vchSecret(key.begin(), key.end());
-            std::vector<unsigned char> vchCryptedSecret;
-            if (!EncryptSecret(vMasterKeyIn, vchSecret, vchPubKey.GetHash(), vchCryptedSecret))
-                return false;
-            if (!AddCryptedKey(vchPubKey, vchCryptedSecret))
-                return false;
-        }
-        mapKeys.clear();
+    fUseCrypto = true;
+    for (KeyMap::value_type& mKey : mapKeys)
+    {
+        const CKey &key = mKey.second;
+        CPubKey vchPubKey = key.GetPubKey();
+        CKeyingMaterial vchSecret(key.begin(), key.end());
+        std::vector<unsigned char> vchCryptedSecret;
+        if (!EncryptSecret(vMasterKeyIn, vchSecret, vchPubKey.GetHash(), vchCryptedSecret))
+            return false;
+        if (!AddCryptedKey(vchPubKey, vchCryptedSecret))
+            return false;
     }
+    mapKeys.clear();
     return true;
 }
 

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -154,7 +154,7 @@ public:
 
     bool IsCrypted() const { return fUseCrypto; }
     bool IsLocked(bool fForMixing = false) const;
-    bool Lock(bool fForMixing);
+    bool Lock(bool fForMixing = false);
 
     virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -152,69 +152,16 @@ public:
     {
     }
 
-    bool IsCrypted() const
-    {
-        return fUseCrypto;
-    }
-
-    // This function should be used in a different combinations to determine
-    // if CCryptoKeyStore is fully locked so that no operations requiring access
-    // to private keys are possible:
-    //      IsLocked(true)
-    // or if CCryptoKeyStore's private keys are available for mixing only:
-    //      !IsLocked(true) && IsLocked()
-    // or if they are available for everything:
-    //      !IsLocked()
-    bool IsLocked(bool fForMixing = false) const
-    {
-        if (!IsCrypted())
-            return false;
-        bool result;
-        {
-            LOCK(cs_KeyStore);
-            result = vMasterKey.empty();
-        }
-        // fForMixing   fOnlyMixingAllowed  return
-        // ---------------------------------------
-        // true         true                result
-        // true         false               result
-        // false        true                true
-        // false        false               result
-
-        if(!fForMixing && fOnlyMixingAllowed) return true;
-
-        return result;
-    }
-
-    bool Lock(bool fAllowMixing = false);
+    bool IsCrypted() const { return fUseCrypto; }
+    bool IsLocked(bool fForMixing = false) const;
+    bool Lock(bool fForMixing);
 
     virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
-    bool HaveKey(const CKeyID &address) const override
-    {
-        {
-            LOCK(cs_KeyStore);
-            if (!IsCrypted()) {
-                return CBasicKeyStore::HaveKey(address);
-            }
-            return mapCryptedKeys.count(address) > 0;
-        }
-        return false;
-    }
+    bool HaveKey(const CKeyID &address) const override;
     bool GetKey(const CKeyID &address, CKey& keyOut) const override;
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
-    std::set<CKeyID> GetKeys() const override
-    {
-        LOCK(cs_KeyStore);
-        if (!IsCrypted()) {
-            return CBasicKeyStore::GetKeys();
-        }
-        std::set<CKeyID> set_address;
-        for (const auto& mi : mapCryptedKeys) {
-            set_address.insert(mi.first);
-        }
-        return set_address;
-    }
+    std::set<CKeyID> GetKeys() const override;
 
     virtual bool GetHDChain(CHDChain& hdChainRet) const override;
 


### PR DESCRIPTION
… the header

This currently does not build, but I don't really understand why

dd9bb25 Fix code style in keystore.cpp/crypter.cpp (Jonas Schnelli)
208fda6 CCrypter: move relevant implementation out of the header (Jonas Schnelli)
3155fd2 CKeystore: move relevant implementation out of the header (Jonas Schnelli)

Pull request description:

Tree-SHA512: 4ce73cca5609199b74b8ff2614ee2b6af949545a1332a3a0135c6453c98665d2b0da171c1e390c9a2aec6b12b7fad931ec90084bb7c2defe243786bfc70daf60