### PR TITLE
A couple of fixes for CActiveMasternodeManager::Init()

### DIFF
--- a/src/masternode/activemasternode.cpp
+++ b/src/masternode/activemasternode.cpp
@@ -110,7 +110,13 @@ void CActiveMasternodeManager::Init()
     if (Params().NetworkIDString() != CBaseChainParams::REGTEST) {
         // Check socket connectivity
         LogPrintf("CActiveDeterministicMasternodeManager::Init -- Checking inbound connection to '%s'\n", activeMasternodeInfo.service.ToString());
-        SOCKET hSocket;
+        SOCKET hSocket = CreateSocket(activeMasternodeInfo.service);
+        if (hSocket == INVALID_SOCKET) {
+            state = MASTERNODE_ERROR;
+            strError = "Could not create socket to connect to " + activeMasternodeInfo.service.ToString();
+            LogPrintf("CActiveMasternodeManager::Init -- ERROR: %s\n", strError);
+            return;
+        }
         bool fConnected = ConnectSocketDirectly(activeMasternodeInfo.service, hSocket, nConnectTimeout) && IsSelectableSocket(hSocket);
         CloseSocket(hSocket);
 

--- a/src/masternode/activemasternode.cpp
+++ b/src/masternode/activemasternode.cpp
@@ -107,25 +107,23 @@ void CActiveMasternodeManager::Init()
         return;
     }
 
-    if (Params().NetworkIDString() != CBaseChainParams::REGTEST) {
-        // Check socket connectivity
-        LogPrintf("CActiveDeterministicMasternodeManager::Init -- Checking inbound connection to '%s'\n", activeMasternodeInfo.service.ToString());
-        SOCKET hSocket = CreateSocket(activeMasternodeInfo.service);
-        if (hSocket == INVALID_SOCKET) {
-            state = MASTERNODE_ERROR;
-            strError = "Could not create socket to connect to " + activeMasternodeInfo.service.ToString();
-            LogPrintf("CActiveMasternodeManager::Init -- ERROR: %s\n", strError);
-            return;
-        }
-        bool fConnected = ConnectSocketDirectly(activeMasternodeInfo.service, hSocket, nConnectTimeout) && IsSelectableSocket(hSocket);
-        CloseSocket(hSocket);
+    // Check socket connectivity
+    LogPrintf("CActiveDeterministicMasternodeManager::Init -- Checking inbound connection to '%s'\n", activeMasternodeInfo.service.ToString());
+    SOCKET hSocket = CreateSocket(activeMasternodeInfo.service);
+    if (hSocket == INVALID_SOCKET) {
+        state = MASTERNODE_ERROR;
+        strError = "Could not create socket to connect to " + activeMasternodeInfo.service.ToString();
+        LogPrintf("CActiveMasternodeManager::Init -- ERROR: %s\n", strError);
+        return;
+    }
+    bool fConnected = ConnectSocketDirectly(activeMasternodeInfo.service, hSocket, nConnectTimeout) && IsSelectableSocket(hSocket);
+    CloseSocket(hSocket);
 
-        if (!fConnected) {
-            state = MASTERNODE_ERROR;
-            strError = "Could not connect to " + activeMasternodeInfo.service.ToString();
-            LogPrintf("CActiveDeterministicMasternodeManager::Init -- ERROR: %s\n", strError);
-            return;
-        }
+    if (!fConnected) {
+        state = MASTERNODE_ERROR;
+        strError = "Could not connect to " + activeMasternodeInfo.service.ToString();
+        LogPrintf("CActiveDeterministicMasternodeManager::Init -- ERROR: %s\n", strError);
+        return;
     }
 
     activeMasternodeInfo.proTxHash = dmn->proTxHash;

--- a/src/masternode/activemasternode.cpp
+++ b/src/masternode/activemasternode.cpp
@@ -72,7 +72,7 @@ void CActiveMasternodeManager::Init()
         // listen option is probably overwritten by something else, no good
         state = MASTERNODE_ERROR;
         strError = "Masternode must accept connections from outside. Make sure listen configuration option is not overwritten by some another parameter.";
-        LogPrintf("CActiveDeterministicMasternodeManager::Init -- ERROR: %s\n", strError);
+        LogPrintf("CActiveMasternodeManager::Init -- ERROR: %s\n", strError);
         return;
     }
 
@@ -108,7 +108,7 @@ void CActiveMasternodeManager::Init()
     }
 
     // Check socket connectivity
-    LogPrintf("CActiveDeterministicMasternodeManager::Init -- Checking inbound connection to '%s'\n", activeMasternodeInfo.service.ToString());
+    LogPrintf("CActiveMasternodeManager::Init -- Checking inbound connection to '%s'\n", activeMasternodeInfo.service.ToString());
     SOCKET hSocket = CreateSocket(activeMasternodeInfo.service);
     if (hSocket == INVALID_SOCKET) {
         state = MASTERNODE_ERROR;
@@ -122,7 +122,7 @@ void CActiveMasternodeManager::Init()
     if (!fConnected) {
         state = MASTERNODE_ERROR;
         strError = "Could not connect to " + activeMasternodeInfo.service.ToString();
-        LogPrintf("CActiveDeterministicMasternodeManager::Init -- ERROR: %s\n", strError);
+        LogPrintf("CActiveMasternodeManager::Init -- ERROR: %s\n", strError);
         return;
     }
 


### PR DESCRIPTION
Socket connectivity check is broken in `develop` due to changes brought by backporting 11363 via #3305 - have to create new socket manually now.

Not sure why we skip this part on regtest, I didn't notice any issues with tests after re-enabling it (diff ignoring changes in whitespaces: https://github.com/dashpay/dash/commit/669b21b704b2ab94a8cf915e0beab95f1512ea4f?w=1, Travis: https://travis-ci.org/UdjinM6/dash/builds/647121898).

Also, fixing incorrect log output while at it.