### PR TITLE
RPC: add pubKeyOperator to `quorum info`

### DIFF
--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -95,6 +95,7 @@ UniValue BuildQuorumInfo(const llmq::CQuorumCPtr& quorum, bool includeMembers, b
             auto& dmn = quorum->members[i];
             UniValue mo(UniValue::VOBJ);
             mo.push_back(Pair("proTxHash", dmn->proTxHash.ToString()));
+            mo.push_back(Pair("pubKeyOperator", dmn->pdmnState->pubKeyOperator.Get().ToString()));
             mo.push_back(Pair("valid", quorum->qc.validMembers[i]));
             if (quorum->qc.validMembers[i]) {
                 CBLSPublicKey pubKey = quorum->GetPubKeyShare(i);


### PR DESCRIPTION
On the Dash platform chain we use LLMQs to decide which nodes are validators. The abci interface requires a structure called `ValidatorUpdate` to set and update the validators. This structure uses the node's pubkey as an identifier. To provide a common link between the LLMQ member information and the Tendermint validators we need to include the `pubKeyOperator` field in the output of the `quorum info` rpc command.