### PR TITLE
Detect mixing session readiness based on the current pool state

### DIFF
--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -741,8 +741,17 @@ bool CPrivateSendServer::AddUserToExistingSession(const CPrivateSendAccept& dsa,
 // Returns true if either max size has been reached or if the mix timed out and min size was reached
 bool CPrivateSendServer::IsSessionReady()
 {
-    if ((int)vecSessionCollaterals.size() >= CPrivateSend::GetMaxPoolParticipants()) return true;
-    if (CPrivateSendServer::HasTimedOut() && (int)vecSessionCollaterals.size() >= CPrivateSend::GetMinPoolParticipants()) return true;
+    if (nState == POOL_STATE_QUEUE) {
+        if ((int)vecSessionCollaterals.size() >= CPrivateSend::GetMaxPoolParticipants()) {
+            return true;
+        }
+        if (CPrivateSendServer::HasTimedOut() && (int)vecSessionCollaterals.size() >= CPrivateSend::GetMinPoolParticipants()) {
+            return true;
+        }
+    }
+    if (nState == POOL_STATE_ACCEPTING_ENTRIES) {
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
#3309 changed the flow and added pool state dependant `HasTimedOut` into `IsSessionReady`. So once we switch from `POOL_STATE_QUEUE` to `POOL_STATE_ACCEPTING_ENTRIES` `IsSessionReady` returns `false` for the next `PRIVATESEND_SIGNING_TIMEOUT` (15) seconds which means that most incoming `DSVIN`s are rejected now. This PR fixes the issue by defining stricter rules for `IsSessionReady`.