### PR TITLE
Bring back "about" menu icon

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -229,6 +229,7 @@ RES_ICONS = \
   qt/res/icons/tx_input.png \
   qt/res/icons/tx_output.png \
   qt/res/icons/tx_mined.png \
+  qt/res/icons/about.png \
   qt/res/icons/about_qt.png \
   qt/res/icons/verify.png \
   qt/res/icons/fontbigger.png \

--- a/src/qt/dash.qrc
+++ b/src/qt/dash.qrc
@@ -44,6 +44,7 @@
         <file alias="filesave">res/icons/filesave.png</file>
         <file alias="debugwindow">res/icons/debugwindow.png</file>
         <file alias="browse">res/icons/browse.png</file>
+        <file alias="about">res/icons/about.png</file>
         <file alias="about_qt">res/icons/about_qt.png</file>
         <file alias="verify">res/icons/verify.png</file>
         <file alias="hd_enabled">res/icons/hd_enabled.png</file>


### PR DESCRIPTION
Changes suggested in https://github.com/dashpay/dash/pull/3000#issuecomment-505168279 turned into https://github.com/dashpay/dash/pull/3000/commits/922a514a958d9d1b12a3c50cdd0aee03fa9217ed after few rebases which not only removed lines for the image in About dialog but also dropped lines for the similarly named menu icon. This reverts incorrect changes.

Thanks to @thephez for finding the issue.