### PR TITLE
Few tweaks for MakeCollateralAmounts

### DIFF
--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1415,6 +1415,16 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
 
     if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
 
+    // Skip way too tiny amounts
+    if (tallyItem.nAmount < CPrivateSend::GetCollateralAmount()) {
+        return false;
+    }
+
+    // Skip single inputs that can be used as collaterals already
+    if (tallyItem.vecOutPoints.size() == 1 && CPrivateSend::IsCollateralAmount(tallyItem.nAmount)) {
+        return false;
+    }
+
     // denominated input is always a single one, so we can check its amount directly and return early
     if (!fTryDenominated && tallyItem.vecOutPoints.size() == 1 && CPrivateSend::IsDenominatedAmount(tallyItem.nAmount)) {
         return false;
@@ -1436,7 +1446,16 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
     assert(reservekeyCollateral.GetReservedKey(vchPubKey, false)); // should never fail, as we just unlocked
     scriptCollateral = GetScriptForDestination(vchPubKey.GetID());
 
-    vecSend.push_back((CRecipient){scriptCollateral, CPrivateSend::GetMaxCollateralAmount(), false});
+    CAmount nCollateralAmount{0};
+    if (tallyItem.nAmount > CPrivateSend::GetMaxCollateralAmount() + CPrivateSend::GetCollateralAmount()*2) {
+        // Change output will be large enough to be valid as a collateral or a source input for another run
+        nCollateralAmount = CPrivateSend::GetMaxCollateralAmount();
+    } else {
+        // Change output might be too small for another collateral if we try to create the largest collateral
+        // here, create a slightly smaller one instead
+        nCollateralAmount = CPrivateSend::GetMaxCollateralAmount() - CPrivateSend::GetCollateralAmount();
+    }
+    vecSend.push_back((CRecipient){scriptCollateral, nCollateralAmount, false});
 
     // try to use non-denominated and not mn-like funds first, select them explicitly
     CCoinControl coinControl;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -149,12 +149,20 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     && CPrivateSend::IsCollateralAmount(-nNet))
                 {
                     sub.type = TransactionRecord::PrivateSendCollateralPayment;
+                } else if (wtx.tx->vout.size() == 2) {
+                    CAmount nMaxCollateralAmount = CPrivateSend::GetMaxCollateralAmount();
+                    CAmount nPreMaxCollateralAmount = nMaxCollateralAmount  - CPrivateSend::GetCollateralAmount();
+                    bool fMakeCollateral =
+                        wtx.tx->vout[0].nValue == nMaxCollateralAmount ||
+                        wtx.tx->vout[1].nValue == nMaxCollateralAmount ||
+                        (wtx.tx->vout[0].nValue == nPreMaxCollateralAmount && CPrivateSend::IsCollateralAmount(wtx.tx->vout[1].nValue)) ||
+                        (wtx.tx->vout[1].nValue == nPreMaxCollateralAmount && CPrivateSend::IsCollateralAmount(wtx.tx->vout[0].nValue));
+                    if (fMakeCollateral) {
+                        sub.type = TransactionRecord::PrivateSendMakeCollaterals;
+                    }
                 } else {
                     for (const auto& txout : wtx.tx->vout) {
-                        if (txout.nValue == CPrivateSend::GetMaxCollateralAmount()) {
-                            sub.type = TransactionRecord::PrivateSendMakeCollaterals;
-                            continue; // Keep looking, could be a part of PrivateSendCreateDenominations
-                        } else if (CPrivateSend::IsDenominatedAmount(txout.nValue)) {
+                        if (CPrivateSend::IsDenominatedAmount(txout.nValue)) {
                             sub.type = TransactionRecord::PrivateSendCreateDenominations;
                             break; // Done, it's definitely a tx creating mixing denoms, no need to look any further
                         }


### PR DESCRIPTION
Fail early, avoid creating non-usable change outputs