### PR TITLE
Add configurable devnet quorums

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -124,6 +124,13 @@ void CChainParams::UpdateLLMQTestParams(int size, int threshold) {
     params.threshold = threshold;
 }
 
+void CChainParams::UpdateLLMQDevnetParams(int size, int threshold) {
+    auto& params = consensus.llmqs.at(Consensus::LLMQ_EVONET);
+    params.size = size;
+    params.minSize = threshold;
+    params.threshold = threshold;
+}
+
 static CBlock FindDevNetGenesisBlock(const Consensus::Params& params, const CBlock &prevBlock, const CAmount& reward)
 {
     std::string devNetName = GetDevNetName();
@@ -928,4 +935,9 @@ void UpdateDevnetLLMQChainLocks(Consensus::LLMQType llmqType)
 void UpdateLLMQTestParams(int size, int threshold)
 {
     globalChainParams->UpdateLLMQTestParams(size, threshold);
+}
+
+void UpdateLLMQDevnetParams(int size, int threshold)
+{
+    globalChainParams->UpdateLLMQDevnetParams(size, threshold);
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -707,6 +707,7 @@ public:
         nExtCoinType = 1;
 
         // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_EVONET] = llmq_evonet;
         consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
         consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
         consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,7 +125,7 @@ void CChainParams::UpdateLLMQTestParams(int size, int threshold) {
 }
 
 void CChainParams::UpdateLLMQDevnetParams(int size, int threshold) {
-    auto& params = consensus.llmqs.at(Consensus::LLMQ_EVONET);
+    auto& params = consensus.llmqs.at(Consensus::LLMQ_DEVNET);
     params.size = size;
     params.minSize = threshold;
     params.threshold = threshold;
@@ -175,9 +175,9 @@ static Consensus::LLMQParams llmq_test = {
 };
 
 // this one is for devnets only
-static Consensus::LLMQParams llmq_evonet = {
-        .type = Consensus::LLMQ_EVONET,
-        .name = "llmq_evonet",
+static Consensus::LLMQParams llmq_devnet = {
+        .type = Consensus::LLMQ_DEVNET,
+        .name = "llmq_devnet",
         .size = 10,
         .minSize = 7,
         .threshold = 6,
@@ -714,7 +714,7 @@ public:
         nExtCoinType = 1;
 
         // long living quorum params
-        consensus.llmqs[Consensus::LLMQ_EVONET] = llmq_evonet;
+        consensus.llmqs[Consensus::LLMQ_DEVNET] = llmq_devnet;
         consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
         consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
         consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -124,7 +124,7 @@ void CChainParams::UpdateLLMQTestParams(int size, int threshold) {
     params.threshold = threshold;
 }
 
-void CChainParams::UpdateLLMQDevnetParams(int size, int threshold) 
+void CChainParams::UpdateLLMQDevnetParams(int size, int threshold)
 {
     auto& params = consensus.llmqs.at(Consensus::LLMQ_DEVNET);
     params.size = size;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -167,6 +167,25 @@ static Consensus::LLMQParams llmq_test = {
         .keepOldConnections = 3,
 };
 
+// this one is for devnets only
+static Consensus::LLMQParams llmq_evonet = {
+        .type = Consensus::LLMQ_EVONET,
+        .name = "llmq_evonet",
+        .size = 10,
+        .minSize = 7,
+        .threshold = 6,
+
+        .dkgInterval = 24, // one DKG per hour
+        .dkgPhaseBlocks = 2,
+        .dkgMiningWindowStart = 10, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 18,
+        .dkgBadVotesThreshold = 7,
+
+        .signingActiveQuorumCount = 3, // just a few ones to allow easier testing
+
+        .keepOldConnections = 4,
+};
+
 static Consensus::LLMQParams llmq50_60 = {
         .type = Consensus::LLMQ_50_60,
         .name = "llmq_50_60",

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -124,7 +124,8 @@ void CChainParams::UpdateLLMQTestParams(int size, int threshold) {
     params.threshold = threshold;
 }
 
-void CChainParams::UpdateLLMQDevnetParams(int size, int threshold) {
+void CChainParams::UpdateLLMQDevnetParams(int size, int threshold) 
+{
     auto& params = consensus.llmqs.at(Consensus::LLMQ_DEVNET);
     params.size = size;
     params.minSize = threshold;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -85,6 +85,7 @@ public:
     void UpdateSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor);
     void UpdateLLMQChainLocks(Consensus::LLMQType llmqType);
     void UpdateLLMQTestParams(int size, int threshold);
+    void UpdateLLMQDevnetParams(int size, int threshold);
     int PoolMinParticipants() const { return nPoolMinParticipants; }
     int PoolMaxParticipants() const { return nPoolMaxParticipants; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
@@ -169,5 +170,10 @@ void UpdateDevnetLLMQChainLocks(Consensus::LLMQType llmqType);
  * Allows modifying parameters of the test LLMQ
  */
 void UpdateLLMQTestParams(int size, int threshold);
+
+/**
+ * Allows modifying parameters of the devnet LLMQ
+ */
+void UpdateLLMQDevnetParams(int size, int threshold);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -52,7 +52,7 @@ enum LLMQType : uint8_t
     LLMQ_TEST = 100, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
 
     // for devnets only
-    LLMQ_EVONET = 101, // 10 members, 6 (60%) threshold, one per hour. Params might differ when -llmqtestparams is used
+    LLMQ_DEVNET = 101, // 10 members, 6 (60%) threshold, one per hour. Params might differ when -llmqdevnetparams is used
 };
 
 // Configures a LLMQ and its DKG

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -50,6 +50,9 @@ enum LLMQType : uint8_t
 
     // for testing only
     LLMQ_TEST = 100, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
+
+    // for devnets only
+    LLMQ_EVONET = 101, // 10 members, 6 (60%) threshold, one per hour. Params might differ when -llmqtestparams is used
 };
 
 // Configures a LLMQ and its DKG

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1425,6 +1425,21 @@ bool AppInitParameterInteraction()
         return InitError("LLMQ type for ChainLocks can only be overridden on devnet.");
     }
 
+    if (chainparams.NetworkIDString() == CBaseChainParams::DEVNET) {
+        if (gArgs.IsArgSet("-llmqdevnetparams")) {
+            std::string s = gArgs.GetArg("-llmqdevnetparams", "");
+            std::vector<std::string> v;
+            boost::split(v, s, boost::is_any_of(":"));
+            int size, threshold;
+            if (v.size() != 2 || !ParseInt32(v[0], &size) || !ParseInt32(v[1], &threshold)) {
+                return InitError("Invalid -llmqdevnetparams specified");
+            }
+            UpdateLLMQDevnetParams(size, threshold);
+        }
+    } else if (gArgs.IsArgSet("-llmqdevnetparams")) {
+        return InitError("LLMQ devnet params can only be overridden on devnet.");
+    }
+
     if (chainparams.NetworkIDString() == CBaseChainParams::REGTEST) {
         if (gArgs.IsArgSet("-llmqtestparams")) {
             std::string s = gArgs.GetArg("-llmqtestparams", "");


### PR DESCRIPTION
In order to be able to start with validator set rotation testing on Evonet, we need a new "test" quorum type specifically for devnets. Until now the default configuration of this devnet LLMQ has only been discussed in the platform team internally. To make successive Evonet relaunches with a different set of LLMQ params easier and more flexible, e.g. larger quorum with higher threshold, a new startup param for devnets was added (`-llmqdevnetparams`) that copies the logic for updating the regtest LLMQ params.