### PR TITLE
Fix undefined behaviour in stacktrace printing

### DIFF
--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -262,6 +262,7 @@ static int dl_iterate_callback(struct dl_phdr_info* info, size_t s, void* data)
     if (info->dlpi_name == nullptr || info->dlpi_name[0] == '\0') {
         *p = info->dlpi_addr;
     }
+    return 0;
 }
 
 static uint64_t GetBaseAddress()


### PR DESCRIPTION
Not returning a value from a function with non-void return type is undefined behaviour in C++ (except for `main()` function).

Fortunately, this was causing a crash for `multiwallet` functional test when building with GCC 9.2 with default optimisation flags for building Fedora packages, so I was able to investigate, find this bug and fix it.

But even if it was not causing a crash and just returning some random garbage in `eax` register, it would lead to incorrect behaviour: non-zero return from a handler causes `dl_iterate_phdr()` to stop iteration.