### PR TITLE
Remove logging for waking of select()

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1402,7 +1402,6 @@ void CConnman::ThreadSocketHandler()
 #ifndef WIN32
         // drain the wakeup pipe
         if (FD_ISSET(wakeupPipe[0], &fdsetRecv)) {
-            LogPrint(BCLog::NET, "woke up select()\n");
             char buf[128];
             while (true) {
                 int r = read(wakeupPipe[0], buf, sizeof(buf));
@@ -1566,8 +1565,6 @@ void CConnman::WakeSelect()
     if (wakeupPipe[1] == -1) {
         return;
     }
-
-    LogPrint(BCLog::NET, "waking up select()\n");
 
     char buf[1];
     if (write(wakeupPipe[1], buf, 1) != 1) {


### PR DESCRIPTION
This was always quite spammy and so far never useful in debugging.