### PR TITLE
Faster opening of masternode connections

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2102,10 +2102,17 @@ void CConnman::ThreadOpenMasternodeConnections()
 
     auto& chainParams = Params();
 
+    bool didConnect = false;
     while (!interruptNet)
     {
-        if (!interruptNet.sleep_for(std::chrono::milliseconds(1000)))
+        int sleepTime = 1000;
+        if (didConnect) {
+            sleepTime = 100;
+        }
+        if (!interruptNet.sleep_for(std::chrono::milliseconds(sleepTime)))
             return;
+
+        didConnect = false;
 
         std::set<CService> connectedNodes;
         std::set<uint256> connectedProRegTxHashes;
@@ -2169,6 +2176,8 @@ void CConnman::ThreadOpenMasternodeConnections()
         if (!connectToDmn) {
             continue;
         }
+
+        didConnect = true;
 
         mmetaman.GetMetaInfo(connectToDmn->proTxHash)->SetLastOutboundAttempt(nANow);
 


### PR DESCRIPTION
Only sleep 100ms when we previously tried to connect a MN. The back-off
logic in ThreadOpenMasternodeConnections will prevent too many unsuccessful
connects to offline/bad nodes.