### PR TITLE
Call FlushBackgroundCallbacks before resetting CConnman

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -254,6 +254,10 @@ void PrepareShutdown()
     threadGroup.interrupt_all();
     threadGroup.join_all();
 
+    // After there are no more peers/RPC left to give us new data which may generate
+    // CValidationInterface callbacks, flush them...
+    GetMainSignals().FlushBackgroundCallbacks();
+
     if (!fLiteMode && !fRPCInWarmup) {
         // STORE DATA CACHES INTO SERIALIZED DAT FILES
         CFlatDB<CMasternodeMetaMan> flatdb1("mncache.dat", "magicMasternodeCache");
@@ -292,10 +296,6 @@ void PrepareShutdown()
     if (pcoinsTip != nullptr) {
         FlushStateToDisk();
     }
-
-    // After there are no more peers/RPC left to give us new data which may generate
-    // CValidationInterface callbacks, flush them...
-    GetMainSignals().FlushBackgroundCallbacks();
 
     // Any future callbacks will be dropped. This should absolutely be safe - if
     // missing a callback results in an unrecoverable situation, unclean shutdown


### PR DESCRIPTION
This fixes crashes on shutdown due to flushed callbacks still accessing g_connman and friends. This should fix failing tests like in https://gitlab.com/dashpay/dash/-/jobs/485301095