### PR TITLE
Hold CEvoDB lock while iterating mined commitments

### DIFF
--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -31,8 +31,9 @@ public:
 
 class CEvoDB
 {
-private:
+public:
     CCriticalSection cs;
+private:
     CDBWrapper db;
 
     typedef CDBTransaction<CDBWrapper, CDBBatch> RootTransaction;
@@ -53,6 +54,7 @@ public:
 
     CurTransaction& GetCurTransaction()
     {
+        AssertLockHeld(cs); // lock must be held from outside as long as the DB transaction is used
         return curDBTransaction;
     }
 

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -409,6 +409,8 @@ bool CQuorumBlockProcessor::GetMinedCommitment(Consensus::LLMQType llmqType, con
 // The returned quorums are in reversed order, so the most recent one is at index 0
 std::vector<const CBlockIndex*> CQuorumBlockProcessor::GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t maxCount)
 {
+    LOCK(evoDb.cs);
+
     auto dbIt = evoDb.GetCurTransaction().NewIteratorUniquePtr();
 
     auto firstKey = BuildInversedHeightKey(llmqType, pindex->nHeight);


### PR DESCRIPTION
Locally observed crashes in tests due to the iterator becoming invalid.