### PR TITLE
Implement more randomized behavior in GetQuorumConnections

### DIFF
--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -52,12 +52,14 @@ std::set<uint256> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType,
     std::set<uint256> result;
 
     if (sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+        uint256 forMemberHashed = ::SerializeHash(std::make_pair(forMember, pindexQuorum->GetBlockHash()));
         for (auto& dmn : mns) {
             // this will cause deterministic behaviour between incoming and outgoing connections.
             // Each member needs a connection to all other members, so we have each member paired. The below check
             // will be true on one side and false on the other side of the pairing, so we avoid having both members
             // initiating the connection.
-            if (!onlyOutbound || dmn->proTxHash < forMember) {
+            uint256 otherMemberHashed = ::SerializeHash(std::make_pair(dmn->proTxHash, pindexQuorum->GetBlockHash()));
+            if (!onlyOutbound || otherMemberHashed < forMemberHashed) {
                 result.emplace(dmn->proTxHash);
             }
         }


### PR DESCRIPTION
When taking the proTxHash naively, we might end up with a few unlucky MNs
which always have to perform most of the outbound connections while other
unlucky MNs would always have to wait for inbound connections. Hashing
the proTxHash with the quorum hash makes this more random.