### PR TITLE
Gradually bump mocktime in wait_for_quorum_connections

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -840,7 +840,7 @@ public:
         fMineBlocksOnDemand = true;
         fAllowMultipleAddressesFromGroup = true;
         fAllowMultiplePorts = true;
-        nLLMQConnectionRetryTimeout = 30; // must be lower then the LLMQ signing session timeout so that tests have control over failing behavior
+        nLLMQConnectionRetryTimeout = 1; // must be lower then the LLMQ signing session timeout so that tests have control over failing behavior
 
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
         nPoolMinParticipants = 2;

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -771,7 +771,7 @@ class DashTestFramework(BitcoinTestFramework):
             return all(node.spork('show') == sporks for node in self.nodes[1:])
         wait_until(check_sporks_same, timeout=timeout, sleep=0.5)
 
-    def wait_for_quorum_connections(self, expected_connections=2, timeout = 30, wait_proc=None):
+    def wait_for_quorum_connections(self, expected_connections=2, timeout = 60, wait_proc=None):
         def check_quorum_connections():
             all_ok = True
             for node in self.nodes:
@@ -795,7 +795,7 @@ class DashTestFramework(BitcoinTestFramework):
             if not all_ok and wait_proc is not None:
                 wait_proc()
             return all_ok
-        wait_until(check_quorum_connections, timeout=timeout, sleep=0.5)
+        wait_until(check_quorum_connections, timeout=timeout, sleep=1)
 
     def wait_for_quorum_phase(self, quorum_hash, phase, expected_member_count, check_received_messages, check_received_messages_count, timeout=30, sleep=0.1):
         def check_dkg_session():
@@ -870,7 +870,7 @@ class DashTestFramework(BitcoinTestFramework):
 
         self.log.info("Waiting for phase 1 (init)")
         def bump_time():
-            self.bump_mocktime(30)
+            self.bump_mocktime(1)
             set_node_times(self.nodes, self.mocktime)
         self.wait_for_quorum_phase(q, 1, expected_members, None, 0)
         self.wait_for_quorum_connections(expected_connections=expected_connections, wait_proc=bump_time)


### PR DESCRIPTION
`mine_quorum` might bump mocktime by 30 seconds a couple of times while waiting for connections which causes test failures sometimes.