### PR TITLE
Implement "concentrated recovery" of LLMQ signatures

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -173,6 +173,7 @@ static Consensus::LLMQParams llmq_test = {
         .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
 
         .keepOldConnections = 3,
+        .recoveryMembers = 3,
 };
 
 // this one is for devnets only
@@ -192,6 +193,7 @@ static Consensus::LLMQParams llmq_devnet = {
         .signingActiveQuorumCount = 3, // just a few ones to allow easier testing
 
         .keepOldConnections = 4,
+        .recoveryMembers = 6,
 };
 
 static Consensus::LLMQParams llmq50_60 = {
@@ -210,6 +212,7 @@ static Consensus::LLMQParams llmq50_60 = {
         .signingActiveQuorumCount = 24, // a full day worth of LLMQs
 
         .keepOldConnections = 25,
+        .recoveryMembers = 25,
 };
 
 static Consensus::LLMQParams llmq400_60 = {
@@ -228,6 +231,7 @@ static Consensus::LLMQParams llmq400_60 = {
         .signingActiveQuorumCount = 4, // two days worth of LLMQs
 
         .keepOldConnections = 5,
+        .recoveryMembers = 100,
 };
 
 // Used for deployment and min-proto-version signalling, so it needs a higher threshold
@@ -247,6 +251,7 @@ static Consensus::LLMQParams llmq400_85 = {
         .signingActiveQuorumCount = 4, // four days worth of LLMQs
 
         .keepOldConnections = 5,
+        .recoveryMembers = 100,
 };
 
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -114,6 +114,9 @@ struct LLMQParams {
     // Used for inter-quorum communication. This is the number of quorums for which we should keep old connections. This
     // should be at least one more then the active quorums set.
     int keepOldConnections;
+
+    // How many members should we try to send all sigShares to before we give up.
+    int recoveryMembers;
 };
 
 /**

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -983,7 +983,7 @@ void CSigSharesManager::CollectSigSharesToAnnounce(std::unordered_map<NodeId, st
 bool CSigSharesManager::SendMessages()
 {
     std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>> sigSharesToRequest;
-    std::unordered_map<NodeId, std::unordered_map<uint256, CBatchedSigShares, StaticSaltedHasher>> sigSharesToSend;
+    std::unordered_map<NodeId, std::unordered_map<uint256, CBatchedSigShares, StaticSaltedHasher>> sigShareBatchesToSend;
     std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>> sigSharesToAnnounce;
     std::unordered_map<NodeId, std::vector<CSigSesAnn>> sigSessionAnnouncements;
 
@@ -1009,7 +1009,7 @@ bool CSigSharesManager::SendMessages()
     {
         LOCK(cs);
         CollectSigSharesToRequest(sigSharesToRequest);
-        CollectSigSharesToSend(sigSharesToSend);
+        CollectSigSharesToSend(sigShareBatchesToSend);
         CollectSigSharesToAnnounce(sigSharesToAnnounce);
 
         for (auto& p : sigSharesToRequest) {
@@ -1017,7 +1017,7 @@ bool CSigSharesManager::SendMessages()
                 p2.second.sessionId = addSigSesAnnIfNeeded(p.first, p2.first);
             }
         }
-        for (auto& p : sigSharesToSend) {
+        for (auto& p : sigShareBatchesToSend) {
             for (auto& p2 : p.second) {
                 p2.second.sessionId = addSigSesAnnIfNeeded(p.first, p2.first);
             }
@@ -1076,8 +1076,8 @@ bool CSigSharesManager::SendMessages()
             }
         }
 
-        auto jt = sigSharesToSend.find(pnode->GetId());
-        if (jt != sigSharesToSend.end()) {
+        auto jt = sigShareBatchesToSend.find(pnode->GetId());
+        if (jt != sigShareBatchesToSend.end()) {
             size_t totalSigsCount = 0;
             std::vector<CBatchedSigShares> msgs;
             for (auto& p : jt->second) {

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1026,7 +1026,7 @@ void CSigSharesManager::CollectSigSharesToSend(std::unordered_map<NodeId, std::v
         proTxToNode.emplace(pnode->verifiedProRegTxHash, pnode);
     }
 
-    auto curTime = GetAdjustedTime();
+    auto curTime = GetTime();
 
     for (auto& p : signedSessions) {
         if (p.second.attempt > p.second.quorum->params.recoveryMembers) {

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -11,6 +11,7 @@
 #include <init.h>
 #include <net_processing.h>
 #include <netmessagemaker.h>
+#include <spork.h>
 #include <validation.h>
 
 #include <cxxtimer.hpp>
@@ -234,6 +235,23 @@ void CSigSharesManager::ProcessMessage(CNode* pfrom, const std::string& strComma
     // non-masternodes are not interested in sigshares
     if (!fMasternodeMode || activeMasternodeInfo.proTxHash.IsNull()) {
         return;
+    }
+
+    if (sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+        if (strCommand == NetMsgType::QSIGSHARE) {
+            std::vector<CSigShare> sigShares;
+            vRecv >> sigShares;
+
+            if (sigShares.size() > MAX_MSGS_SIG_SHARES) {
+                LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many sigs in QSIGSHARE message. cnt=%d, max=%d, node=%d\n", __func__, sigShares.size(), MAX_MSGS_SIG_SHARES, pfrom->GetId());
+                BanNode(pfrom->GetId());
+                return;
+            }
+
+            for (auto& sigShare : sigShares) {
+                ProcessMessageSigShare(pfrom->GetId(), sigShare, connman);
+            }
+        }
     }
 
     if (strCommand == NetMsgType::QSIGSESANN) {
@@ -465,6 +483,57 @@ bool CSigSharesManager::ProcessMessageBatchedSigShares(CNode* pfrom, const CBatc
     return true;
 }
 
+void CSigSharesManager::ProcessMessageSigShare(NodeId fromId, const CSigShare& sigShare, CConnman& connman)
+{
+    auto quorum = quorumManager->GetQuorum(sigShare.llmqType, sigShare.quorumHash);
+    if (!quorum) {
+        return;
+    }
+    if (!CLLMQUtils::IsQuorumActive(sigShare.llmqType, quorum->qc.quorumHash)) {
+        // quorum is too old
+        return;
+    }
+    if (!quorum->IsMember(activeMasternodeInfo.proTxHash)) {
+        // we're not a member so we can't verify it (we actually shouldn't have received it)
+        return;
+    }
+    if (quorum->quorumVvec == nullptr) {
+        // TODO we should allow to ask other nodes for the quorum vvec if we missed it in the DKG
+        LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- we don't have the quorum vvec for %s, no verification possible. node=%d\n", __func__,
+                 quorum->qc.quorumHash.ToString(), fromId);
+        return;
+    }
+
+    if (sigShare.quorumMember >= quorum->members.size()) {
+        LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- quorumMember out of bounds\n", __func__);
+        BanNode(fromId);
+        return;
+    }
+    if (!quorum->qc.validMembers[sigShare.quorumMember]) {
+        LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- quorumMember not valid\n", __func__);
+        BanNode(fromId);
+        return;
+    }
+
+    {
+        LOCK(cs);
+
+        if (sigShares.Has(sigShare.GetKey())) {
+            return;
+        }
+
+        if (quorumSigningManager->HasRecoveredSigForId((Consensus::LLMQType)sigShare.llmqType, sigShare.id)) {
+            return;
+        }
+
+        auto& nodeState = nodeStates[fromId];
+        nodeState.pendingIncomingSigShares.Add(sigShare.GetKey(), sigShare);
+    }
+
+    LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- signHash=%s, id=%s, msgHash=%s, member=%d, node=%d\n", __func__,
+             sigShare.GetSignHash().ToString(), sigShare.id.ToString(), sigShare.msgHash.ToString(), sigShare.quorumMember, fromId);
+}
+
 bool CSigSharesManager::PreVerifyBatchedSigShares(NodeId nodeId, const CSigSharesNodeState::SessionInfo& session, const CBatchedSigShares& batchedSigShares, bool& retBan)
 {
     retBan = false;
@@ -668,8 +737,10 @@ void CSigSharesManager::ProcessSigShare(NodeId nodeId, const CSigShare& sigShare
 
     // prepare node set for direct-push in case this is our sig share
     std::set<NodeId> quorumNodes;
-    if (sigShare.quorumMember == quorum->GetMemberIndex(activeMasternodeInfo.proTxHash)) {
-        quorumNodes = connman.GetMasternodeQuorumNodes((Consensus::LLMQType) sigShare.llmqType, sigShare.quorumHash);
+    if (!sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+        if (sigShare.quorumMember == quorum->GetMemberIndex(activeMasternodeInfo.proTxHash)) {
+            quorumNodes = connman.GetMasternodeQuorumNodes((Consensus::LLMQType) sigShare.llmqType, sigShare.quorumHash);
+        }
     }
 
     if (quorumSigningManager->HasRecoveredSigForId(llmqType, sigShare.id)) {
@@ -778,6 +849,21 @@ void CSigSharesManager::TryRecoverSig(const CQuorumCPtr& quorum, const uint256& 
     }
 
     quorumSigningManager->ProcessRecoveredSig(-1, rs, quorum, connman);
+}
+
+CDeterministicMNCPtr CSigSharesManager::SelectMemberForRecovery(const CQuorumCPtr& quorum, const uint256 &id, int attempt)
+{
+    assert(attempt < quorum->members.size());
+
+    std::vector<std::pair<uint256, CDeterministicMNCPtr>> v;
+    v.reserve(quorum->members.size());
+    for (size_t i = 0; i < quorum->members.size(); i++) {
+        auto h = ::SerializeHash(std::make_pair(quorum->members[i]->proTxHash, id));
+        v.emplace_back(h, quorum->members[i]);
+    }
+    std::sort(v.begin(), v.end());
+
+    return v[attempt].second;
 }
 
 void CSigSharesManager::CollectSigSharesToRequest(std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>>& sigSharesToRequest)
@@ -928,6 +1014,43 @@ void CSigSharesManager::CollectSigSharesToSend(std::unordered_map<NodeId, std::u
     }
 }
 
+void CSigSharesManager::CollectSigSharesToSend(std::unordered_map<NodeId, std::vector<CSigShare>>& sigSharesToSend, const std::vector<CNode*>& vNodes)
+{
+    AssertLockHeld(cs);
+
+    std::unordered_map<uint256, CNode*> proTxToNode;
+    for (CNode* pnode : vNodes) {
+        if (pnode->verifiedProRegTxHash.IsNull()) {
+            continue;
+        }
+        proTxToNode.emplace(pnode->verifiedProRegTxHash, pnode);
+    }
+
+    auto curTime = GetAdjustedTime();
+
+    for (auto& p : signedSessions) {
+        if (p.second.attempt > p.second.quorum->params.recoveryMembers) {
+            continue;
+        }
+
+        if (curTime >= p.second.nextAttemptTime) {
+            p.second.nextAttemptTime = curTime + SEND_FOR_RECOVERY_TIMEOUT;
+            auto dmn = SelectMemberForRecovery(p.second.quorum, p.second.sigShare.id, p.second.attempt);
+            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- sending to %s, signHash=%s\n", __func__,
+                     dmn->proTxHash.ToString(), p.second.sigShare.GetSignHash().ToString());
+            p.second.attempt++;
+
+            auto it = proTxToNode.find(dmn->proTxHash);
+            if (it == proTxToNode.end()) {
+                continue;
+            }
+
+            auto& m = sigSharesToSend[it->second->GetId()];
+            m.emplace_back(p.second.sigShare);
+        }
+    }
+}
+
 void CSigSharesManager::CollectSigSharesToAnnounce(std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>>& sigSharesToAnnounce)
 {
     AssertLockHeld(cs);
@@ -984,6 +1107,7 @@ bool CSigSharesManager::SendMessages()
 {
     std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>> sigSharesToRequest;
     std::unordered_map<NodeId, std::unordered_map<uint256, CBatchedSigShares, StaticSaltedHasher>> sigShareBatchesToSend;
+    std::unordered_map<NodeId, std::vector<CSigShare>> sigSharesToSend;
     std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>> sigSharesToAnnounce;
     std::unordered_map<NodeId, std::vector<CSigSesAnn>> sigSessionAnnouncements;
 
@@ -1006,11 +1130,17 @@ bool CSigSharesManager::SendMessages()
         return session->sendSessionId;
     };
 
+    std::vector<CNode*> vNodesCopy = g_connman->CopyNodeVector(CConnman::FullyConnectedOnly);
+
     {
         LOCK(cs);
-        CollectSigSharesToRequest(sigSharesToRequest);
-        CollectSigSharesToSend(sigShareBatchesToSend);
-        CollectSigSharesToAnnounce(sigSharesToAnnounce);
+        if (!sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+            CollectSigSharesToRequest(sigSharesToRequest);
+            CollectSigSharesToSend(sigShareBatchesToSend);
+            CollectSigSharesToAnnounce(sigSharesToAnnounce);
+        } else {
+            CollectSigSharesToSend(sigSharesToSend, vNodesCopy);
+        }
 
         for (auto& p : sigSharesToRequest) {
             for (auto& p2 : p.second) {
@@ -1030,8 +1160,6 @@ bool CSigSharesManager::SendMessages()
     }
 
     bool didSend = false;
-
-    std::vector<CNode*> vNodesCopy = g_connman->CopyNodeVector(CConnman::FullyConnectedOnly);
 
     for (auto& pnode : vNodesCopy) {
         CNetMsgMaker msgMaker(pnode->GetSendVersion());
@@ -1116,6 +1244,25 @@ bool CSigSharesManager::SendMessages()
             }
             if (!msgs.empty()) {
                 g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSHARESINV, msgs), false);
+                didSend = true;
+            }
+        }
+
+        auto lt = sigSharesToSend.find(pnode->GetId());
+        if (lt != sigSharesToSend.end()) {
+            std::vector<CSigShare> msgs;
+            for (auto& sigShare : lt->second) {
+                LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::SendMessages -- QSIGSHARE signHash=%s, node=%d\n",
+                         sigShare.GetSignHash().ToString(), pnode->GetId());
+                msgs.emplace_back(std::move(sigShare));
+                if (msgs.size() == MAX_MSGS_SIG_SHARES) {
+                    g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSHARE, msgs), false);
+                    msgs.clear();
+                    didSend = true;
+                }
+            }
+            if (!msgs.empty()) {
+                g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSHARE, msgs), false);
                 didSend = true;
             }
         }
@@ -1285,6 +1432,7 @@ void CSigSharesManager::RemoveSigSharesForSession(const uint256& signHash)
     sigSharesRequested.EraseAllForSignHash(signHash);
     sigSharesToAnnounce.EraseAllForSignHash(signHash);
     sigShares.EraseAllForSignHash(signHash);
+    signedSessions.erase(signHash);
     timeSeenForSessions.erase(signHash);
 }
 
@@ -1431,6 +1579,15 @@ void CSigSharesManager::Sign(const CQuorumCPtr& quorum, const uint256& id, const
     LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- signed sigShare. signHash=%s, id=%s, msgHash=%s, llmqType=%d, quorum=%s, time=%s\n", __func__,
               signHash.ToString(), sigShare.id.ToString(), sigShare.msgHash.ToString(), quorum->params.type, quorum->qc.quorumHash.ToString(), t.count());
     ProcessSigShare(-1, sigShare, *g_connman, quorum);
+
+    if (sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+        LOCK(cs);
+        auto& session = signedSessions[sigShare.GetSignHash()];
+        session.sigShare = sigShare;
+        session.quorum = quorum;
+        session.nextAttemptTime = 0;
+        session.attempt = 0;
+    }
 }
 
 // causes all known sigShares to be re-announced

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -857,9 +857,9 @@ CDeterministicMNCPtr CSigSharesManager::SelectMemberForRecovery(const CQuorumCPt
 
     std::vector<std::pair<uint256, CDeterministicMNCPtr>> v;
     v.reserve(quorum->members.size());
-    for (size_t i = 0; i < quorum->members.size(); i++) {
-        auto h = ::SerializeHash(std::make_pair(quorum->members[i]->proTxHash, id));
-        v.emplace_back(h, quorum->members[i]);
+    for (const auto& dmn : quorum->members) {
+        auto h = ::SerializeHash(std::make_pair(dmn->proTxHash, id));
+        v.emplace_back(h, dmn);
     }
     std::sort(v.begin(), v.end());
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1019,7 +1019,7 @@ void CSigSharesManager::CollectSigSharesToSend(std::unordered_map<NodeId, std::v
     AssertLockHeld(cs);
 
     std::unordered_map<uint256, CNode*> proTxToNode;
-    for (CNode* pnode : vNodes) {
+    for (const auto& pnode : vNodes) {
         if (pnode->verifiedProRegTxHash.IsNull()) {
             continue;
         }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -69,6 +69,7 @@ const char *QSIGSHARESINV="qsigsinv";
 const char *QGETSIGSHARES="qgetsigs";
 const char *QBSIGSHARES="qbsigs";
 const char *QSIGREC="qsigrec";
+const char *QSIGSHARE="qsigshare";
 const char *CLSIG="clsig";
 const char *ISLOCK="islock";
 const char *MNAUTH="mnauth";
@@ -135,6 +136,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::QGETSIGSHARES,
     NetMsgType::QBSIGSHARES,
     NetMsgType::QSIGREC,
+    NetMsgType::QSIGSHARE,
     NetMsgType::CLSIG,
     NetMsgType::ISLOCK,
     NetMsgType::MNAUTH,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -266,6 +266,7 @@ extern const char *QSIGSHARESINV;
 extern const char *QGETSIGSHARES;
 extern const char *QBSIGSHARES;
 extern const char *QSIGREC;
+extern const char *QSIGSHARE;
 extern const char *CLSIG;
 extern const char *ISLOCK;
 extern const char *MNAUTH;

--- a/test/functional/llmq-signing.py
+++ b/test/functional/llmq-signing.py
@@ -100,9 +100,9 @@ class LLMQSigningTest(DashTestFramework):
             self.mninfo[i].node.quorum("sign", 100, id, msgHash)
         wait_for_sigs(True, False, True, 15)
 
-        id = "0000000000000000000000000000000000000000000000000000000000000002"
-
         if self.options.spork21:
+            id = "0000000000000000000000000000000000000000000000000000000000000002"
+
             # Isolate the node that is responsible for the recovery of a signature and assert that recovery fails
             q = self.nodes[0].quorum('selectquorum', 100, id)
             mn = self.get_mninfo(q['recoveryMembers'][0])

--- a/test/functional/llmq-signing.py
+++ b/test/functional/llmq-signing.py
@@ -21,9 +21,15 @@ class LLMQSigningTest(DashTestFramework):
         self.set_dash_test_params(6, 5, fast_dip3_enforcement=True)
         self.set_dash_llmq_test_params(5, 3)
 
+    def add_options(self, parser):
+        parser.add_option("--spork21", dest="spork21", default=False, action="store_true",
+                          help="Test with spork21 enabled")
+
     def run_test(self):
 
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        if self.options.spork21:
+            self.nodes[0].spork("SPORK_21_QUORUM_ALL_CONNECTED", 0)
         self.wait_for_sporks_same()
 
         self.mine_quorum()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -939,11 +939,14 @@ class DashTestFramework(BitcoinTestFramework):
         qi = self.nodes[0].quorum('info', 100, q)
         result = []
         for m in qi['members']:
-            for mn in self.mninfo:
-                if mn.proTxHash == m['proTxHash']:
-                    result.append(mn)
-                    break
+            result.append(self.get_mninfo(m['proTxHash']))
         return result
+
+    def get_mninfo(self, proTxHash):
+        for mn in self.mninfo:
+            if mn.proTxHash == proTxHash:
+                return mn
+        return None
 
     def wait_for_mnauth(self, node, count, timeout=10):
         def test():

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -69,6 +69,7 @@ BASE_SCRIPTS= [
     'listtransactions.py',
     'multikeysporks.py',
     'llmq-signing.py', # NOTE: needs dash_hash to pass
+    'llmq-signing.py --spork21', # NOTE: needs dash_hash to pass
     'llmq-chainlocks.py', # NOTE: needs dash_hash to pass
     'llmq-connections.py', # NOTE: needs dash_hash to pass
     'llmq-simplepose.py', # NOTE: needs dash_hash to pass


### PR DESCRIPTION
This implements "concentrated recovery" (I'm happy for suggestions of better names...).

In the current system, signature shares are propagated to all LLMQ members, until one of them has enough shares collected to recover the signature. Until this recovered signature is propagated in the LLMQ, all members will keep propagating shares and verifying each one. This causes quite some load on the LLMQ, which will be avoided with the new system.

The new system sends all shares to only a single deterministically selected node, so that this node can recover the signature and propagate the recovered signature. This way only the recovered signature needs to be propagated and verified by all members. After sending the share to this single node, each member waits for one second and repeats sending it to another deterministically selected member. This process is repeated until a recovered signature is finally created and propagated.

The new system is activated with the previously added spork21.

My assumption with this change is that it can reduce the load on a LLMQ by a factor of up to 40x-50x.