### PR TITLE
Avoid some unnecessary work in network and message handler threads

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2436,11 +2436,20 @@ void CConnman::OpenMasternodeConnection(const CAddress &addrConnect, bool probe)
 
 void CConnman::ThreadMessageHandler()
 {
+    int64_t nLastForceSendMessages = 0;
+
     while (!flagInterruptMsgProc)
     {
         std::vector<CNode*> vNodesCopy = CopyNodeVector();
 
+        int64_t nNow = GetTimeMillis();
+
         bool fMoreWork = false;
+        bool fForceSendMessages = false;
+        if (nNow - nLastForceSendMessages >= 100) {
+            fForceSendMessages = true;
+            nLastForceSendMessages = nNow;
+        }
 
         for (CNode* pnode : vNodesCopy)
         {
@@ -2448,12 +2457,13 @@ void CConnman::ThreadMessageHandler()
                 continue;
 
             // Receive messages
-            bool fMoreNodeWork = m_msgproc->ProcessMessages(pnode, flagInterruptMsgProc);
+            bool fDidWork = false;
+            bool fMoreNodeWork = m_msgproc->ProcessMessages(pnode, flagInterruptMsgProc, fDidWork);
             fMoreWork |= (fMoreNodeWork && !pnode->fPauseSend);
             if (flagInterruptMsgProc)
                 return;
             // Send messages
-            {
+            if (fDidWork || fForceSendMessages) {
                 LOCK(pnode->cs_sendProcessing);
                 m_msgproc->SendMessages(pnode, flagInterruptMsgProc);
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1660,18 +1660,25 @@ void CConnman::SocketHandler()
             }
         }
 
-        InactivityCheck(pnode);
     }
     ReleaseNodeVector(vNodesCopy);
 }
 
 void CConnman::ThreadSocketHandler()
 {
+    int64_t nLastInactivityCheck = 0;
     while (!interruptNet)
     {
         DisconnectNodes();
         NotifyNumConnectionsChanged();
         SocketHandler();
+
+        if (GetTime() - nLastInactivityCheck > 10) {
+            ForEachNode([&](CNode* pnode) {
+                InactivityCheck(pnode);
+            });
+            nLastInactivityCheck = GetTime();
+        }
     }
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1666,10 +1666,15 @@ void CConnman::SocketHandler()
 
 void CConnman::ThreadSocketHandler()
 {
+    int64_t nLastDisconnectNodes = 0;
     int64_t nLastInactivityCheck = 0;
+
     while (!interruptNet)
     {
-        DisconnectNodes();
+        if (GetTime() - nLastDisconnectNodes > 1) {
+            DisconnectNodes();
+            nLastDisconnectNodes = GetTime();
+        }
         NotifyNumConnectionsChanged();
         SocketHandler();
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1671,18 +1671,18 @@ void CConnman::ThreadSocketHandler()
 
     while (!interruptNet)
     {
-        if (GetTime() - nLastDisconnectNodes > 1) {
+        if (GetTimeMillis() - nLastDisconnectNodes > 1000) {
             DisconnectNodes();
-            nLastDisconnectNodes = GetTime();
+            nLastDisconnectNodes = GetTimeMillis();
         }
         NotifyNumConnectionsChanged();
         SocketHandler();
 
-        if (GetTime() - nLastInactivityCheck > 10) {
+        if (GetTimeMillis() - nLastInactivityCheck > 10 * 1000) {
             ForEachNode([&](CNode* pnode) {
                 InactivityCheck(pnode);
             });
-            nLastInactivityCheck = GetTime();
+            nLastInactivityCheck = GetTimeMillis();
         }
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1666,24 +1666,19 @@ void CConnman::SocketHandler()
 
 void CConnman::ThreadSocketHandler()
 {
-    int64_t nLastDisconnectNodes = 0;
-    int64_t nLastInactivityCheck = 0;
+    int64_t nLastCleanupNodes = 0;
 
     while (!interruptNet)
     {
-        if (GetTimeMillis() - nLastDisconnectNodes > 1000) {
+        if (GetTimeMillis() - nLastCleanupNodes > 1000) {
+            ForEachNode(AllNodes, [&](CNode* pnode) {
+                InactivityCheck(pnode);
+            });
             DisconnectNodes();
-            nLastDisconnectNodes = GetTimeMillis();
+            nLastCleanupNodes = GetTimeMillis();
         }
         NotifyNumConnectionsChanged();
         SocketHandler();
-
-        if (GetTimeMillis() - nLastInactivityCheck > 10 * 1000) {
-            ForEachNode([&](CNode* pnode) {
-                InactivityCheck(pnode);
-            });
-            nLastInactivityCheck = GetTimeMillis();
-        }
     }
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -452,6 +452,7 @@ public:
 
     void WakeMessageHandler();
     void WakeSelect();
+    void DisconnectNodes();
 
     /** Attempts to obfuscate tx time through exponentially distributed emitting.
         Works assuming that a single interval is used.
@@ -476,7 +477,6 @@ private:
     void ThreadOpenConnections(std::vector<std::string> connect);
     void ThreadMessageHandler();
     void AcceptConnection(const ListenSocket& hListenSocket);
-    void DisconnectNodes();
     void NotifyNumConnectionsChanged();
     void InactivityCheck(CNode *pnode);
     bool GenerateSelectSet(std::set<SOCKET> &recv_set, std::set<SOCKET> &send_set, std::set<SOCKET> &error_set);

--- a/src/net.h
+++ b/src/net.h
@@ -556,6 +556,7 @@ private:
     std::vector<CNode*> vNodes;
     std::list<CNode*> vNodesDisconnected;
     mutable CCriticalSection cs_vNodes;
+    mutable CCriticalSection cs_vNodesDisconnected;
     std::atomic<NodeId> nLastNodeId;
     unsigned int nPrevNodeCount;
 

--- a/src/net.h
+++ b/src/net.h
@@ -633,7 +633,7 @@ struct CombinerAll
 class NetEventsInterface
 {
 public:
-    virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
+    virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt, bool &fRetDidWork) = 0;
     virtual bool SendMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;
     virtual void FinalizeNode(NodeId id, bool& update_connection_time) = 0;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3575,6 +3575,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
         pfrom->nProcessQueueSize -= msgs.front().vRecv.size() + CMessageHeader::HEADER_SIZE;
         pfrom->fPauseRecv = pfrom->nProcessQueueSize > connman->GetReceiveFloodSize();
         fMoreWork = !pfrom->vProcessMsg.empty();
+        fRetDidWork = true;
     }
     CNetMessage& msg(msgs.front());
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3934,7 +3934,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         //
         // Try sending block announcements via headers
         //
-        {
+        if (!pto->fMasternode) {
             // If we have less than MAX_BLOCKS_TO_ANNOUNCE in our
             // list of block hashes we're relaying, and our peer wants
             // headers announcements, then find the first header
@@ -4308,7 +4308,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         // Message: getdata (blocks)
         //
         std::vector<CInv> vGetData;
-        if (!pto->fClient && (fFetch || !IsInitialBlockDownload()) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+        if (!pto->fClient && !pto->fMasternode && (fFetch || !IsInitialBlockDownload()) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             std::vector<const CBlockIndex*> vToDownload;
             NodeId staller = -1;
             FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload, staller, consensusParams);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3529,7 +3529,7 @@ static bool SendRejectsAndCheckIfBanned(CNode* pnode, CConnman* connman)
     return false;
 }
 
-bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
+bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc, bool &fRetDidWork)
 {
     const CChainParams& chainparams = Params();
     //
@@ -3541,13 +3541,17 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     //  (x) data
     //
     bool fMoreWork = false;
+    fRetDidWork = false;
 
-    if (!pfrom->vRecvGetData.empty())
+    if (!pfrom->vRecvGetData.empty()) {
         ProcessGetData(pfrom, chainparams.GetConsensus(), connman, interruptMsgProc);
+        fRetDidWork = true;
+    }
 
     if (!pfrom->orphan_work_set.empty()) {
         LOCK2(cs_main, g_cs_orphans);
         ProcessOrphanTx(connman, pfrom->orphan_work_set);
+        fRetDidWork = true;
     }
 
     if (pfrom->fDisconnect)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3921,7 +3921,14 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         // transactions become unconfirmed and spams other nodes.
         if (!fReindex && !fImporting && !IsInitialBlockDownload())
         {
-            GetMainSignals().Broadcast(nTimeBestReceived, connman);
+            static int64_t nLastBroadcastTime = 0;
+            // HACK: Call this only once every few seconds. SendMessages is called once per peer, which makes this signal very expensive
+            // The proper solution would be to move this out of here, but this is not worth the effort right now as bitcoin#15632 will later do this.
+            // Luckily, the Broadcast signal is not used for anything else then CWallet::ResendWalletTransactionsBefore.
+            if (nNow - nLastBroadcastTime >= 5000000) {
+                GetMainSignals().Broadcast(nTimeBestReceived, connman);
+                nLastBroadcastTime = nNow;
+            }
         }
 
         //

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -53,7 +53,7 @@ public:
     void InitializeNode(CNode* pnode) override;
     void FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) override;
     /** Process protocol messages received from a given node */
-    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt) override;
+    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt, bool &fRetDidWork) override;
     /**
     * Send queued protocol messages to be sent to a give node.
     *

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -40,6 +40,7 @@ UniValue getconnectioncount(const JSONRPCRequest& request)
     if(!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
+    g_connman->DisconnectNodes();
     return (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL);
 }
 
@@ -125,6 +126,8 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
 
     if(!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+
+    g_connman->DisconnectNodes();
 
     std::vector<CNodeStats> vstats;
     g_connman->GetNodeStats(vstats);
@@ -465,6 +468,10 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
             + HelpExampleCli("getnetworkinfo", "")
             + HelpExampleRpc("getnetworkinfo", "")
         );
+
+    if (g_connman) {
+        g_connman->DisconnectNodes();
+    }
 
     LOCK(cs_main);
     UniValue obj(UniValue::VOBJ);

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -90,12 +90,12 @@ class BlockchainTest(BitcoinTestFramework):
         assert res['pruned']
         assert not res['automatic_pruning']
 
-        self.restart_node(0, ['-stopatheight=207', '-txindex=0', '-mocktime=%d' % self.mocktime])
+        self.restart_node(0, ['-stopatheight=207', '-txindex=0'])
         res = self.nodes[0].getblockchaininfo()
         # should have exact keys
         assert_equal(sorted(res.keys()), keys)
 
-        self.restart_node(0, ['-stopatheight=207', '-prune=550', '-txindex=0', '-mocktime=%d' % self.mocktime])
+        self.restart_node(0, ['-stopatheight=207', '-prune=550', '-txindex=0'])
         res = self.nodes[0].getblockchaininfo()
         # result should have these additional pruning keys if prune=550
         assert_equal(sorted(res.keys()), sorted(['pruneheight', 'automatic_pruning', 'prune_target_size'] + keys))
@@ -227,7 +227,7 @@ class BlockchainTest(BitcoinTestFramework):
             pass  # The node already shut down before response
         self.log.debug('Node should stop at this height...')
         self.nodes[0].wait_until_stopped()
-        self.start_node(0, ['-txindex=0', '-mocktime=%d' % self.mocktime])
+        self.start_node(0, ['-txindex=0'])
         assert_equal(self.nodes[0].getblockcount(), 207)
 
 

--- a/test/functional/llmq-signing.py
+++ b/test/functional/llmq-signing.py
@@ -74,6 +74,8 @@ class LLMQSigningTest(DashTestFramework):
         self.mninfo[2].node.quorum("sign", 100, id, msgHash)
         wait_for_sigs(True, False, True, 15)
 
+        recsig_time = self.mocktime
+
         # Mine one more quorum, so that we have 2 active ones, nothing should change
         self.mine_quorum()
         assert_sigs_nochange(True, False, True, 3)
@@ -83,8 +85,8 @@ class LLMQSigningTest(DashTestFramework):
         self.mine_quorum()
         assert_sigs_nochange(True, False, True, 3)
 
-        # fast forward 6.5 days, recovered sig should still be valid
-        self.bump_mocktime(int(60 * 60 * 24 * 6.5))
+        # fast forward until 0.5 days before cleanup is expected, recovered sig should still be valid
+        self.bump_mocktime(recsig_time + int(60 * 60 * 24 * 6.5) - self.mocktime)
         # Cleanup starts every 5 seconds
         wait_for_sigs(True, False, True, 15)
         # fast forward 1 day, recovered sig should not be valid anymore

--- a/test/functional/llmq-simplepose.py
+++ b/test/functional/llmq-simplepose.py
@@ -47,7 +47,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         # Lets restart masternodes with closed ports and verify that they get banned even though they are connected to other MNs (via outbound connections)
         def close_mn_port(mn):
             self.stop_node(mn.node.index)
-            self.start_masternode(mn, ["-listen=0", "-mocktime=%d" % self.mocktime])
+            self.start_masternode(mn, ["-listen=0"])
             connect_nodes(mn.node, 0)
             # Make sure the to-be-banned node is still connected well via outbound connections
             for mn2 in self.mninfo:
@@ -61,7 +61,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
 
         def force_old_mn_proto(mn):
             self.stop_node(mn.node.index)
-            self.start_masternode(mn, ["-pushversion=70216", "-mocktime=%d" % self.mocktime])
+            self.start_masternode(mn, ["-pushversion=70216"])
             connect_nodes(mn.node, 0)
             self.reset_probe_timeouts()
         self.test_banning(force_old_mn_proto, False)
@@ -102,7 +102,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
 
                 if restart:
                     self.stop_node(mn.node.index)
-                    self.start_masternode(mn, ["-mocktime=%d" % self.mocktime])
+                    self.start_masternode(mn)
                 else:
                     mn.node.setnetworkactive(True)
             connect_nodes(mn.node, 0)

--- a/test/functional/minchainwork.py
+++ b/test/functional/minchainwork.py
@@ -33,7 +33,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Force CanDirectFetch to return false (otherwise nMinimumChainWork is ignored)
-        self.mocktime += 21 * 2.6 * 60
+        self.bump_mocktime(21 * 2.6 * 60)
         # This test relies on the chain setup being:
         # node0 <- node1 <- node2
         # Before leaving IBD, nodes prefer to download blocks from outbound

--- a/test/functional/net.py
+++ b/test/functional/net.py
@@ -76,6 +76,7 @@ class NetTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], False)
         # Wait a bit for all sockets to close
         wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == 0, timeout=3)
+        wait_until(lambda: self.nodes[1].getnetworkinfo()['connections'] == 0, timeout=3)
 
         self.nodes[0].setnetworkactive(True)
         connect_nodes_bi(self.nodes, 0, 1)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -365,6 +365,8 @@ class BitcoinTestFramework():
 
     def disable_mocktime(self):
         self.mocktime = 0
+        for node in self.nodes:
+            node.mocktime = 0
 
     def bump_mocktime(self, t, update_nodes=True, nodes=None):
         self.mocktime += t
@@ -376,9 +378,13 @@ class BitcoinTestFramework():
         # with previous versions of the cache, set MOCKTIME
         # to regtest genesis time + (201 * 156)
         self.mocktime = GENESISTIME + (201 * 156)
+        for node in self.nodes:
+            node.mocktime = self.mocktime
 
     def set_genesis_mocktime(self):
         self.mocktime = GENESISTIME
+        for node in self.nodes:
+            node.mocktime = self.mocktime
 
     # Private helper methods. These should not be accessed by the subclass test scripts.
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -15,6 +15,7 @@ import subprocess
 import time
 
 from .authproxy import JSONRPCException
+from .messages import MY_SUBVERSION
 from .util import (
     assert_equal,
     delete_cookie_file,
@@ -218,6 +219,14 @@ class TestNode():
         for p in self.p2ps:
             p.peer_disconnect()
         del self.p2ps[:]
+
+        # wait for p2p connections to disappear from getpeerinfo()
+        def check_peers():
+            for p in self.getpeerinfo():
+                if p['subver'] == MY_SUBVERSION.decode():
+                    return False
+            return True
+        wait_until(check_peers, timeout=5)
 
 class TestNodeCLIAttr:
     def __init__(self, cli, command):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -59,6 +59,7 @@ class TestNode():
             self.binary = binary
         self.stderr = stderr
         self.coverage_dir = coverage_dir
+        self.mocktime = mocktime
         # Most callers will just need to add extra args to the standard list below. For those callers that need more flexibity, they can just set the args property directly.
         self.extra_args = extra_args
         self.args = [self.binary, "-datadir=" + self.datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(mocktime), "-uacomment=testnode%d" % i]
@@ -103,11 +104,14 @@ class TestNode():
             extra_args = self.extra_args
         if stderr is None:
             stderr = self.stderr
+        all_args = self.args + extra_args
+        if self.mocktime != 0:
+            all_args = all_args + ["-mocktime=%d" % self.mocktime]
         # Delete any existing cookie file -- if such a file exists (eg due to
         # unclean shutdown), it will get overwritten anyway by bitcoind, and
         # potentially interfere with our attempt to authenticate
         delete_cookie_file(self.datadir)
-        self.process = subprocess.Popen(self.args + extra_args, stderr=stderr, *args, **kwargs)
+        self.process = subprocess.Popen(all_args, stderr=stderr, *args, **kwargs)
         self.running = True
         self.log.debug("dashd started, waiting for RPC to come up")
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -358,6 +358,7 @@ def get_bip9_status(node, key):
 
 def set_node_times(nodes, t):
     for node in nodes:
+        node.mocktime = t
         node.setmocktime(t)
 
 def disconnect_nodes(from_connection, node_num):


### PR DESCRIPTION
~This is based on #3396. I'll rebase after it got merged. Please only review commits after "Introduce USE_WAKEUP_PIPE".~

These optimizations remove a lot of load from the network and message handler threads, as invoking it in every iteration for every node gets very expensive with hundreds of nodes.
