### PR TITLE
Add cache for CBlockTreeDB::HasTxIndex

### DIFF
--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -54,6 +54,14 @@ public:
         if (ret.second)
             prune();
     }
+    void insert_or_update(const value_type& x)
+    {
+        std::pair<iterator, bool> ret = map.insert(x);
+        if (ret.second)
+            prune();
+        else
+            ret.first->second = x.second;
+    }
     void erase(const key_type& k)
     {
         map.erase(k);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -265,7 +265,12 @@ bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos>
     CDBBatch batch(*this);
     for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
         batch.Write(std::make_pair(DB_TXINDEX, it->first), it->second);
-    return WriteBatch(batch);
+    bool ret = WriteBatch(batch);
+    LOCK(cs);
+    for (auto& p : vect) {
+        mapHasTxIndexCache.insert_or_update(std::make_pair(p.first, true));
+    }
+    return ret;
 }
 
 bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -9,7 +9,9 @@
 #include <coins.h>
 #include <dbwrapper.h>
 #include <chain.h>
+#include <limitedmap.h>
 #include <spentindex.h>
+#include <sync.h>
 
 #include <map>
 #include <string>
@@ -110,6 +112,10 @@ private:
 /** Access to the block database (blocks/index/) */
 class CBlockTreeDB : public CDBWrapper
 {
+private:
+    CCriticalSection cs;
+    unordered_limitedmap<uint256, bool> mapHasTxIndexCache;
+
 public:
     explicit CBlockTreeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 


### PR DESCRIPTION
This speeds up `AlreadyHave` for TXs that are actively propagated in the network at the moment.