### PR TITLE
Remove semaphore for masternode connections

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1257,7 +1257,6 @@ void CConnman::ThreadSocketHandler()
 
                     // release outbound grant (if any)
                     pnode->grantOutbound.Release();
-                    pnode->grantMasternodeOutbound.Release();
 
                     // close socket and cleanup
                     pnode->CloseSocketDisconnect();
@@ -2127,7 +2126,6 @@ void CConnman::ThreadOpenMasternodeConnections()
 
         auto mnList = deterministicMNManager->GetListAtChainTip();
 
-        CSemaphoreGrant grant(*semMasternodeOutbound);
         if (interruptNet)
             return;
 
@@ -2225,7 +2223,6 @@ void CConnman::ThreadOpenMasternodeConnections()
             if (pnode->fDisconnect) {
                 return false;
             }
-            grant.MoveTo(pnode->grantMasternodeOutbound);
             return true;
         });
         if (!connected) {
@@ -2608,11 +2605,6 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
         semAddnode = MakeUnique<CSemaphore>(nMaxAddnode);
     }
 
-    if (semMasternodeOutbound == nullptr) {
-        // initialize semaphore
-        semMasternodeOutbound = MakeUnique<CSemaphore>(fMasternodeMode ? MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN : MAX_OUTBOUND_MASTERNODE_CONNECTIONS);
-    }
-
     //
     // Start threads
     //
@@ -2721,13 +2713,6 @@ void CConnman::Interrupt()
             semAddnode->post();
         }
     }
-
-    if (semMasternodeOutbound) {
-        int nMaxMasternodeOutbound = fMasternodeMode ? MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN : MAX_OUTBOUND_MASTERNODE_CONNECTIONS;
-        for (int i = 0; i < nMaxMasternodeOutbound; i++) {
-            semMasternodeOutbound->post();
-        }
-    }
 }
 
 void CConnman::Stop()
@@ -2771,7 +2756,6 @@ void CConnman::Stop()
     vhListenSocket.clear();
     semOutbound.reset();
     semAddnode.reset();
-    semMasternodeOutbound.reset();
 
 #ifndef WIN32
     if (wakeupPipe[0] != -1) close(wakeupPipe[0]);

--- a/src/net.h
+++ b/src/net.h
@@ -79,9 +79,6 @@ static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 static const int MAX_OUTBOUND_CONNECTIONS = 8;
 /** Maximum number of addnode outgoing nodes */
 static const int MAX_ADDNODE_CONNECTIONS = 8;
-/** Maximum number if outgoing masternodes */
-static const int MAX_OUTBOUND_MASTERNODE_CONNECTIONS = 30;
-static const int MAX_OUTBOUND_MASTERNODE_CONNECTIONS_ON_MN = 250;
 /** Eviction protection time for incoming connections  */
 static const int INBOUND_EVICTION_PROTECTION_TIME = 1;
 /** -listen default */
@@ -558,7 +555,6 @@ private:
 
     std::unique_ptr<CSemaphore> semOutbound;
     std::unique_ptr<CSemaphore> semAddnode;
-    std::unique_ptr<CSemaphore> semMasternodeOutbound;
     int nMaxConnections;
     int nMaxOutbound;
     int nMaxAddnode;
@@ -823,7 +819,6 @@ public:
     // If 'true' this node will be disconnected after MNAUTH
     bool fMasternodeProbe;
     CSemaphoreGrant grantOutbound;
-    CSemaphoreGrant grantMasternodeOutbound;
     CCriticalSection cs_filter;
     std::unique_ptr<CBloomFilter> pfilter;
     std::atomic<int> nRefCount;


### PR DESCRIPTION
We now have hundreds of MN connections due to the new intra quorum connections,
which means having a limiting semaphore here doesn't make sense anymore. It
actually causes DKG and signing failures as not all necessary connections
can be established.


Masternode connections are still implicitely limited as there is always
only a limited set of LLMQs active.