### PR TITLE
Multiple fixes for failing tests

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3345,7 +3345,6 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fGetAddr = false;
     nNextLocalAddrSend = 0;
     nNextAddrSend = 0;
-    nNextInvSend = 0;
     fRelayTxes = false;
     fSentAddr = false;
     pfilter = MakeUnique<CBloomFilter>();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3457,8 +3457,20 @@ bool CConnman::IsMasternodeOrDisconnectRequested(const CService& addr) {
     });
 }
 
-int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds) {
-    return nNow + (int64_t)(log1p(GetRand(1ULL << 48) * -0.0000000000000035527136788 /* -1/2^48 */) * average_interval_seconds * -1000000.0 + 0.5);
+int64_t CConnman::PoissonNextSendInbound(int64_t now, int average_interval_seconds)
+{
+    if (m_next_send_inv_to_incoming < now) {
+        // If this function were called from multiple threads simultaneously
+        // it would possible that both update the next send variable, and return a different result to their caller.
+        // This is not possible in practice as only the net processing thread invokes this function.
+        m_next_send_inv_to_incoming = PoissonNextSend(now, average_interval_seconds);
+    }
+    return m_next_send_inv_to_incoming;
+}
+
+int64_t PoissonNextSend(int64_t now, int average_interval_seconds)
+{
+    return now + (int64_t)(log1p(GetRand(1ULL << 48) * -0.0000000000000035527136788 /* -1/2^48 */) * average_interval_seconds * -1000000.0 + 0.5);
 }
 
 std::vector<CNode*> CConnman::CopyNodeVector(std::function<bool(const CNode* pnode)> cond)

--- a/src/net.h
+++ b/src/net.h
@@ -865,7 +865,7 @@ public:
     // List of non-tx/non-block inventory items
     std::vector<CInv> vInventoryOtherToSend;
     CCriticalSection cs_inventory;
-    int64_t nNextInvSend;
+    std::chrono::microseconds nNextInvSend{0};
     // Used for headers announcements - unfiltered blocks to relay
     // Also protected by cs_inventory
     std::vector<uint256> vBlockHashesToAnnounce;
@@ -1061,9 +1061,13 @@ public:
     static void callCleanup();
 };
 
-
-
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
 int64_t PoissonNextSend(int64_t now, int average_interval_seconds);
+
+/** Wrapper to return mockable type */
+inline std::chrono::microseconds PoissonNextSend(std::chrono::microseconds now, std::chrono::seconds average_interval)
+{
+    return std::chrono::microseconds{PoissonNextSend(now.count(), average_interval.count())};
+}
 
 #endif // BITCOIN_NET_H

--- a/src/net.h
+++ b/src/net.h
@@ -453,6 +453,12 @@ public:
     void WakeMessageHandler();
     void WakeSelect();
 
+    /** Attempts to obfuscate tx time through exponentially distributed emitting.
+        Works assuming that a single interval is used.
+        Variable intervals will result in privacy decrease.
+    */
+    int64_t PoissonNextSendInbound(int64_t now, int average_interval_seconds);
+
 private:
     struct ListenSocket {
         SOCKET socket;
@@ -595,6 +601,8 @@ private:
      *  in excess of nMaxOutbound
      *  This takes the place of a feeler connection */
     std::atomic_bool m_try_another_outbound_peer;
+
+    std::atomic<int64_t> m_next_send_inv_to_incoming;
 
     friend struct CConnmanTest;
 };
@@ -1056,6 +1064,6 @@ public:
 
 
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
-int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds);
+int64_t PoissonNextSend(int64_t now, int average_interval_seconds);
 
 #endif // BITCOIN_NET_H

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -113,6 +113,19 @@ static const int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
 /// limiting block relay. Set to one week, denominated in seconds.
 static const int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
 
+/** Average delay between local address broadcasts in seconds. */
+static constexpr unsigned int AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL = 24 * 60 * 60;
+/** Average delay between peer address broadcasts in seconds. */
+static const unsigned int AVG_ADDRESS_BROADCAST_INTERVAL = 30;
+/** Average delay between trickled inventory transmissions in seconds.
+ *  Blocks and whitelisted receivers bypass this, regular outbound peers get half this delay,
+ *  Masternode outbound peers get quarter this delay. */
+static const unsigned int INVENTORY_BROADCAST_INTERVAL = 5;
+/** Maximum number of inventory items to send per transmission.
+ *  Limits the impact of low-fee transaction floods.
+ *  We have 4 times smaller block times in Dash, so we need to push 4 times more invs per 1MB. */
+static constexpr unsigned int INVENTORY_BROADCAST_MAX_PER_1MB_BLOCK = 4 * 7 * INVENTORY_BROADCAST_INTERVAL;
+
 // Internal stuff
 namespace {
     /** Number of nodes with fSyncStarted. */
@@ -4076,9 +4089,13 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
             bool fSendTrickle = pto->fWhitelisted || fMasternodeMode;
             if (pto->nNextInvSend < nNow) {
                 fSendTrickle = true;
-                // Use half the delay for regular outbound peers, as there is less privacy concern for them,
-                // and quarter the delay for Masternode outbound peers, as there is even less privacy concern in this case.
-                pto->nNextInvSend = PoissonNextSend(nNow, INVENTORY_BROADCAST_INTERVAL >> !pto->fInbound >> !pto->verifiedProRegTxHash.IsNull());
+                if (pto->fInbound) {
+                    pto->nNextInvSend = connman->PoissonNextSendInbound(nNow, INVENTORY_BROADCAST_INTERVAL);
+                } else {
+                    // Use half the delay for regular outbound peers, as there is less privacy concern for them.
+                    // and quarter the delay for Masternode outbound peers, as there is even less privacy concern in this case.
+                    pto->nNextInvSend = PoissonNextSend(nNow, INVENTORY_BROADCAST_INTERVAL >> 1 >> !pto->verifiedProRegTxHash.IsNull());
+                }
             }
 
             // Time to send but the peer has requested we not relay transactions.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4078,7 +4078,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                 fSendTrickle = true;
                 // Use half the delay for regular outbound peers, as there is less privacy concern for them,
                 // and quarter the delay for Masternode outbound peers, as there is even less privacy concern in this case.
-                pto->nNextInvSend = PoissonNextSend(nNow, INVENTORY_BROADCAST_INTERVAL >> !pto->fInbound >> pto->fMasternode);
+                pto->nNextInvSend = PoissonNextSend(nNow, INVENTORY_BROADCAST_INTERVAL >> !pto->fInbound >> !pto->verifiedProRegTxHash.IsNull());
             }
 
             // Time to send but the peer has requested we not relay transactions.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4092,7 +4092,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
             if (pto->nNextInvSend < current_time) {
                 fSendTrickle = true;
                 if (pto->fInbound) {
-                    pto->nNextInvSend = std::chrono::microseconds{connman->PoissonNextSendInbound(nNow, INVENTORY_BROADCAST_INTERVAL)};
+                    pto->nNextInvSend = std::chrono::microseconds{connman->PoissonNextSendInbound(current_time.count(), INVENTORY_BROADCAST_INTERVAL)};
                 } else {
                     // Use half the delay for regular outbound peers, as there is less privacy concern for them.
                     // and quarter the delay for Masternode outbound peers, as there is even less privacy concern in this case.

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -349,10 +349,17 @@ void GetStrongRandBytes(unsigned char* out, int num)
     memory_cleanse(buf, 64);
 }
 
+bool g_mock_deterministic_tests{false};
+
 uint64_t GetRand(uint64_t nMax)
 {
     if (nMax == 0)
         return 0;
+
+    // This will later conflict with bitcoin#14955. Simply take the bitcoin version as resolution
+    if (g_mock_deterministic_tests) {
+        return FastRandomContext(true).randrange(nMax);
+    }
 
     // The range of the random source must be a multiple of the modulus
     // to give every possible output value an equal possibility

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -356,7 +356,7 @@ uint64_t GetRand(uint64_t nMax)
     if (nMax == 0)
         return 0;
 
-    // This will later conflict with bitcoin#14955. Simply take the bitcoin version as resolution
+    // This will later conflict with bitcoin#14955. Simply take the bitcoin version as resolution and pass g_mock_deterministic_tests into FastRandomContext
     if (g_mock_deterministic_tests) {
         return FastRandomContext(true).randrange(nMax);
     }

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -564,6 +564,9 @@ static std::vector<unsigned char> RandomData()
 
 BOOST_AUTO_TEST_CASE(rolling_bloom)
 {
+    SeedInsecureRand(/* deterministic */ true);
+    g_mock_deterministic_tests = true;
+
     // last-100-entry, 1% false positive:
     CRollingBloomFilter rb1(100, 0.01);
 
@@ -588,12 +591,8 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
         if (rb1.contains(RandomData()))
             ++nHits;
     }
-    // Run test_dash with --log_level=message to see BOOST_TEST_MESSAGEs:
-    BOOST_TEST_MESSAGE("RollingBloomFilter got " << nHits << " false positives (~100 expected)");
-
-    // Insanely unlikely to get a fp count outside this range:
-    BOOST_CHECK(nHits > 25);
-    BOOST_CHECK(nHits < 175);
+    // Expect about 100 hits
+    BOOST_CHECK_EQUAL(nHits, 75);
 
     BOOST_CHECK(rb1.contains(data[DATASIZE-1]));
     rb1.reset();
@@ -620,10 +619,8 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
         if (rb1.contains(data[i]))
             ++nHits;
     }
-    // Expect about 5 false positives, more than 100 means
-    // something is definitely broken.
-    BOOST_TEST_MESSAGE("RollingBloomFilter got " << nHits << " false positives (~5 expected)");
-    BOOST_CHECK(nHits < 100);
+    // Expect about 5 false positives
+    BOOST_CHECK_EQUAL(nHits, 6);
 
     // last-1000-entry, 0.01% false positive:
     CRollingBloomFilter rb2(1000, 0.001);
@@ -634,6 +631,7 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
     for (int i = 0; i < DATASIZE; i++) {
         BOOST_CHECK(rb2.contains(data[i]));
     }
+    g_mock_deterministic_tests = false;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -187,4 +187,18 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     BOOST_CHECK(pnode2->fFeeler == false);
 }
 
+BOOST_AUTO_TEST_CASE(PoissonNextSend)
+{
+    g_mock_deterministic_tests = true;
+    int64_t now = 5000;
+    int average_interval_seconds = 600;
+
+    auto poisson = ::PoissonNextSend(now, average_interval_seconds);
+    std::chrono::microseconds poisson_chrono = ::PoissonNextSend(std::chrono::microseconds{now}, std::chrono::seconds{average_interval_seconds});
+
+    BOOST_CHECK_EQUAL(poisson, poisson_chrono.count());
+
+    g_mock_deterministic_tests = false;
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -18,9 +18,14 @@ BOOST_AUTO_TEST_CASE(osrandom_tests)
 BOOST_AUTO_TEST_CASE(fastrandom_tests)
 {
     // Check that deterministic FastRandomContexts are deterministic
+    g_mock_deterministic_tests = true;
     FastRandomContext ctx1(true);
     FastRandomContext ctx2(true);
 
+    for (int i = 10; i > 0; --i) {
+        BOOST_CHECK_EQUAL(GetRand(std::numeric_limits<uint64_t>::max()), uint64_t{10393729187455219830U});
+        BOOST_CHECK_EQUAL(GetRandInt(std::numeric_limits<int>::max()), int{769702006});
+    }
     BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
     BOOST_CHECK_EQUAL(ctx1.rand32(), ctx2.rand32());
     BOOST_CHECK_EQUAL(ctx1.rand64(), ctx2.rand64());
@@ -35,6 +40,11 @@ BOOST_AUTO_TEST_CASE(fastrandom_tests)
     BOOST_CHECK(ctx1.randbytes(50) == ctx2.randbytes(50));
 
     // Check that a nondeterministic ones are not
+    g_mock_deterministic_tests = false;
+    for (int i = 10; i > 0; --i) {
+        BOOST_CHECK(GetRand(std::numeric_limits<uint64_t>::max()) != uint64_t{10393729187455219830U});
+        BOOST_CHECK(GetRandInt(std::numeric_limits<int>::max()) != int{769702006});
+    }
     FastRandomContext ctx3;
     FastRandomContext ctx4;
     BOOST_CHECK(ctx3.rand64() != ctx4.rand64()); // extremely unlikely to be equal

--- a/src/test/test_dash.h
+++ b/src/test/test_dash.h
@@ -22,6 +22,11 @@
 extern uint256 insecure_rand_seed;
 extern FastRandomContext insecure_rand_ctx;
 
+/**
+ * Flag to make GetRand in random.h return the same number
+ */
+extern bool g_mock_deterministic_tests;
+
 static inline void SeedInsecureRand(bool fDeterministic = false)
 {
     if (fDeterministic) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -106,18 +106,6 @@ static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
-/** Average delay between local address broadcasts in seconds. */
-static const unsigned int AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL = 24 * 60 * 60;
-/** Average delay between peer address broadcasts in seconds. */
-static const unsigned int AVG_ADDRESS_BROADCAST_INTERVAL = 30;
-/** Average delay between trickled inventory transmissions in seconds.
- *  Blocks and whitelisted receivers bypass this, regular outbound peers get half this delay,
- *  Masternode outbound peers get quarter this delay. */
-static const unsigned int INVENTORY_BROADCAST_INTERVAL = 5;
-/** Maximum number of inventory items to send per transmission.
- *  Limits the impact of low-fee transaction floods.
- *  We have 4 times smaller block times in Dash, so we need to push 4 times more invs per 1MB. */
-static const unsigned int INVENTORY_BROADCAST_MAX_PER_1MB_BLOCK = 4 * 7 * INVENTORY_BROADCAST_INTERVAL;
 /** Block download timeout base, expressed in millionths of the block interval (i.e. 2.5 min) */
 static const int64_t BLOCK_DOWNLOAD_TIMEOUT_BASE = 1000000;
 /** Additional block download timeout per parallel downloading peer (i.e. 1.25 min) */

--- a/test/functional/addressindex.py
+++ b/test/functional/addressindex.py
@@ -215,7 +215,6 @@ class AddressIndexTest(BitcoinTestFramework):
         self.nodes[3].invalidateblock(best_hash)
         # Allow some time for the reorg to start
         self.bump_mocktime(2)
-        set_node_times(self.nodes, self.mocktime)
         self.sync_all()
 
         balance4 = self.nodes[1].getaddressbalance(address2)
@@ -259,7 +258,6 @@ class AddressIndexTest(BitcoinTestFramework):
         signed_tx = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
         memtxid1 = self.nodes[2].sendrawtransaction(signed_tx["hex"], True)
         self.bump_mocktime(2)
-        set_node_times(self.nodes, self.mocktime)
 
         tx2 = CTransaction()
         tx2.vin = [CTxIn(COutPoint(int(unspent[1]["txid"], 16), unspent[1]["vout"]))]
@@ -274,7 +272,6 @@ class AddressIndexTest(BitcoinTestFramework):
         signed_tx2 = self.nodes[2].signrawtransaction(binascii.hexlify(tx2.serialize()).decode("utf-8"))
         memtxid2 = self.nodes[2].sendrawtransaction(signed_tx2["hex"], True)
         self.bump_mocktime(2)
-        set_node_times(self.nodes, self.mocktime)
 
         mempool = self.nodes[2].getaddressmempool({"addresses": [address3]})
         assert_equal(len(mempool), 3)
@@ -302,7 +299,6 @@ class AddressIndexTest(BitcoinTestFramework):
         signed_tx3 = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
         memtxid3 = self.nodes[2].sendrawtransaction(signed_tx3["hex"], True)
         self.bump_mocktime(2)
-        set_node_times(self.nodes, self.mocktime)
 
         mempool3 = self.nodes[2].getaddressmempool({"addresses": [address3]})
         assert_equal(len(mempool3), 2)

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -45,7 +45,6 @@ class BlockchainTest(BitcoinTestFramework):
         self.set_genesis_mocktime()
         for i in range(200):
             self.bump_mocktime(156)
-            self.nodes[0].setmocktime(self.mocktime)
             self.nodes[0].generate(1)
         # Actual tests
         self._test_getblockchaininfo()

--- a/test/functional/dip4-coinbasemerkleroots.py
+++ b/test/functional/dip4-coinbasemerkleroots.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 from test_framework.mininode import *
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import p2p_port, assert_equal, sync_blocks, set_node_times
+from test_framework.util import p2p_port, assert_equal, sync_blocks
 
 '''
 dip4-coinbasemerkleroots.py
@@ -269,7 +269,6 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
             assert_equal(merkleRootQuorums, 0)
 
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.wait_for_sporks_same()
 

--- a/test/functional/disconnect_ban.py
+++ b/test/functional/disconnect_ban.py
@@ -10,7 +10,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     connect_nodes_bi,
     wait_until,
-	set_node_times,
 )
 
 class DisconnectBanTest(BitcoinTestFramework):
@@ -58,7 +57,6 @@ class DisconnectBanTest(BitcoinTestFramework):
         listBeforeShutdown = self.nodes[1].listbanned()
         assert_equal("192.168.0.1/32", listBeforeShutdown[2]['address'])
         self.bump_mocktime(2)
-        set_node_times(self.nodes, self.mocktime)
         wait_until(lambda: len(self.nodes[1].listbanned()) == 3, timeout=10)
 
         self.stop_node(1)

--- a/test/functional/getblocktemplate_longpoll.py
+++ b/test/functional/getblocktemplate_longpoll.py
@@ -63,8 +63,10 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         # min_relay_fee is fee per 1000 bytes, which should be more than enough.
         (txid, txhex, fee) = random_transaction(self.nodes, Decimal("1.1"), min_relay_fee, Decimal("0.001"), 20)
         # after one minute, every 10 seconds the mempool is probed, so in 80 seconds it should have returned
-        thr.join(60 + 20)
-        assert(not thr.is_alive())
+        def check():
+            self.bump_mocktime(1)
+            return not thr.is_alive()
+        wait_until(check, timeout=60 + 20, sleep=1)
 
 if __name__ == '__main__':
     GetBlockTemplateLPTest().main()

--- a/test/functional/llmq-connections.py
+++ b/test/functional/llmq-connections.py
@@ -52,7 +52,6 @@ class LLMQConnections(DashTestFramework):
 
         self.log.info("checking that probes age")
         self.bump_mocktime(60)
-        set_node_times(self.nodes, self.mocktime)
         for mn in self.get_quorum_masternodes(q):
             wait_until(lambda: self.get_mn_probe_count(mn.node, q, False) == 0)
 
@@ -70,7 +69,6 @@ class LLMQConnections(DashTestFramework):
         for mn in self.mninfo:
             wait_until(lambda: len(mn.node.getpeerinfo()) == 0)
         self.bump_mocktime(60)
-        set_node_times(self.nodes, self.mocktime)
         for mn in self.mninfo:
             mn.node.setnetworkactive(True)
 

--- a/test/functional/llmq-connections.py
+++ b/test/functional/llmq-connections.py
@@ -68,9 +68,9 @@ class LLMQConnections(DashTestFramework):
             mn.node.setnetworkactive(False)
         for mn in self.mninfo:
             wait_until(lambda: len(mn.node.getpeerinfo()) == 0)
-        self.bump_mocktime(60)
         for mn in self.mninfo:
             mn.node.setnetworkactive(True)
+        self.bump_mocktime(60)
 
         self.log.info("verify that all masternodes re-connected")
         for q in self.nodes[0].quorum('list')['llmq_test']:

--- a/test/functional/llmq-dkgerrors.py
+++ b/test/functional/llmq-dkgerrors.py
@@ -92,7 +92,6 @@ class LLMQDKGErrors(DashTestFramework):
         self.wait_for_sporks_same()
         for i in range(blockCount):
             self.bump_mocktime(1)
-            set_node_times(self.nodes, self.mocktime)
             self.nodes[0].generate(1)
         self.sync_all()
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)

--- a/test/functional/llmq-is-cl-conflicts.py
+++ b/test/functional/llmq-is-cl-conflicts.py
@@ -9,7 +9,7 @@ from test_framework import mininode
 from test_framework.blocktools import get_masternode_payment, create_coinbase, create_block
 from test_framework.mininode import *
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import sync_blocks, sync_mempools, p2p_port, assert_raises_rpc_error, set_node_times
+from test_framework.util import sync_blocks, sync_mempools, p2p_port, assert_raises_rpc_error
 
 '''
 llmq-is-cl-conflicts.py
@@ -181,7 +181,6 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
 
         # fast forward 11 minutes, so that the TX is considered safe and included in the next block
         self.bump_mocktime(int(60 * 11))
-        set_node_times(self.nodes, self.mocktime)
 
         # Mine the conflicting TX into a block
         good_tip = self.nodes[0].getbestblockhash()

--- a/test/functional/llmq-is-retroactive.py
+++ b/test/functional/llmq-is-retroactive.py
@@ -48,7 +48,6 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # are the only "neighbours" in intra-quorum connections for one of them.
         self.wait_for_instantlock(txid, self.nodes[0])
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         block = self.nodes[0].generate(1)[0]
         self.wait_for_chainlocked_block_all_nodes(block)
 
@@ -62,7 +61,6 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         reconnect_isolated_node(self.nodes[3], 0)
         # Make sure nodes actually try re-connecting quorum connections
         self.bump_mocktime(30)
-        set_node_times(self.nodes, self.mocktime)
         self.wait_for_mnauth(self.nodes[3], 2)
         # node 3 fully reconnected but the TX wasn't relayed to it, so there should be no IS lock
         self.wait_for_instantlock(txid, self.nodes[0], False, 5)
@@ -80,7 +78,6 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         txid = self.nodes[3].sendrawtransaction(rawtx)
         # Make node 3 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
-        set_node_times(self.nodes, self.mocktime)
         block = self.nodes[3].generatetoaddress(1, self.nodes[0].getnewaddress())[0]
         reconnect_isolated_node(self.nodes[3], 0)
         self.wait_for_chainlocked_block_all_nodes(block)
@@ -96,13 +93,11 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         reconnect_isolated_node(self.nodes[3], 0)
         # Make sure nodes actually try re-connecting quorum connections
         self.bump_mocktime(30)
-        set_node_times(self.nodes, self.mocktime)
         self.wait_for_mnauth(self.nodes[3], 2)
         # node 3 fully reconnected but the TX wasn't relayed to it, so there should be no IS lock
         self.wait_for_instantlock(txid, self.nodes[0], False, 5)
         # Make node0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
-        set_node_times(self.nodes, self.mocktime)
         block = self.nodes[0].generate(1)[0]
         self.wait_for_chainlocked_block_all_nodes(block)
 
@@ -136,12 +131,10 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         time.sleep(5)
         # Make the signing session for the IS lock timeout on nodes 1-3
         self.bump_mocktime(61)
-        set_node_times(self.nodes, self.mocktime)
         time.sleep(2) # make sure Cleanup() is called
         reconnect_isolated_node(self.nodes[3], 0)
         # Make sure nodes actually try re-connecting quorum connections
         self.bump_mocktime(30)
-        set_node_times(self.nodes, self.mocktime)
         self.wait_for_mnauth(self.nodes[3], 2)
         # node 3 fully reconnected but the signing session is already timed out on all nodes, so no IS lock
         self.wait_for_instantlock(txid, self.nodes[0], False, 5)
@@ -150,7 +143,6 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
             self.wait_for_instantlock(txid, self.nodes[0], False, 5)
         # Make node 0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
-        self.nodes[0].setmocktime(self.mocktime)
         block = self.nodes[0].generate(1)[0]
         self.wait_for_chainlocked_block_all_nodes(block)
 
@@ -164,12 +156,10 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         time.sleep(2) # make sure signing is done on node 2 (it's async)
         # Make the signing session for the IS lock timeout on node 3
         self.bump_mocktime(61)
-        set_node_times(self.nodes, self.mocktime)
         time.sleep(2) # make sure Cleanup() is called
         reconnect_isolated_node(self.nodes[3], 0)
         # Make sure nodes actually try re-connecting quorum connections
         self.bump_mocktime(30)
-        set_node_times(self.nodes, self.mocktime)
         self.wait_for_mnauth(self.nodes[3], 2)
         self.nodes[0].sendrawtransaction(rawtx)
         # Make sure nodes 1 and 2 received the TX
@@ -184,7 +174,6 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
             self.wait_for_instantlock(txid, self.nodes[0], False, 5)
         # Make node 0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
-        self.nodes[0].setmocktime(self.mocktime)
         block = self.nodes[0].generate(1)[0]
         self.wait_for_chainlocked_block_all_nodes(block)
 

--- a/test/functional/llmq-signing.py
+++ b/test/functional/llmq-signing.py
@@ -85,12 +85,10 @@ class LLMQSigningTest(DashTestFramework):
 
         # fast forward 6.5 days, recovered sig should still be valid
         self.bump_mocktime(int(60 * 60 * 24 * 6.5))
-        set_node_times(self.nodes, self.mocktime)
         # Cleanup starts every 5 seconds
         wait_for_sigs(True, False, True, 15)
         # fast forward 1 day, recovered sig should not be valid anymore
         self.bump_mocktime(int(60 * 60 * 24 * 1))
-        set_node_times(self.nodes, self.mocktime)
         # Cleanup starts every 5 seconds
         wait_for_sigs(False, False, False, 15)
 
@@ -116,7 +114,6 @@ class LLMQSigningTest(DashTestFramework):
             connect_nodes(mn.node, 0)
             # Let 1 second pass so that the next node is used for recovery, which should succeed
             self.bump_mocktime(1)
-            set_node_times(self.nodes, self.mocktime)
             wait_for_sigs(True, False, True, 5)
 
 if __name__ == '__main__':

--- a/test/functional/llmq-simplepose.py
+++ b/test/functional/llmq-simplepose.py
@@ -121,7 +121,6 @@ class LLMQSimplePoSeTest(DashTestFramework):
     def reset_probe_timeouts(self):
         # Make sure all masternodes will reconnect/re-probe
         self.bump_mocktime(60 * 60 + 1)
-        set_node_times(self.nodes, self.mocktime)
         self.sync_all()
 
     def check_punished(self, mn):

--- a/test/functional/multikeysporks.py
+++ b/test/functional/multikeysporks.py
@@ -5,7 +5,7 @@
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import connect_nodes, set_node_times, wait_until
+from test_framework.util import connect_nodes, wait_until
 
 '''
 multikeysporks.py
@@ -103,7 +103,6 @@ class MultiKeySporkTest(BitcoinTestFramework):
             assert(self.get_test_spork_value(node) == 4070908800)
 
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         # first and second signers set spork value
         self.set_test_spork_value(self.nodes[0], 1)
         self.set_test_spork_value(self.nodes[1], 1)
@@ -119,7 +118,6 @@ class MultiKeySporkTest(BitcoinTestFramework):
             wait_until(lambda: self.get_test_spork_value(node) == 1, sleep=0.1, timeout=10)
 
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         # now set the spork again with other signers to test
         # old and new spork messages interaction
         self.set_test_spork_value(self.nodes[2], 2)

--- a/test/functional/p2p-instantsend.py
+++ b/test/functional/p2p-instantsend.py
@@ -85,6 +85,8 @@ class InstantSendTest(DashTestFramework):
         # TODO: mine these blocks on an isolated node
         self.bump_mocktime(1)
         set_node_times(self.nodes, self.mocktime)
+        # make sure the above TX is on node0
+        self.sync_mempools([n for n in self.nodes if n is not isolated])
         self.nodes[0].generate(2)
         self.sync_all()
 

--- a/test/functional/p2p-instantsend.py
+++ b/test/functional/p2p-instantsend.py
@@ -5,7 +5,7 @@
 
 from test_framework.mininode import *
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import isolate_node, sync_mempools, set_node_times, reconnect_isolated_node, assert_equal, \
+from test_framework.util import isolate_node, sync_mempools, reconnect_isolated_node, assert_equal, \
     assert_raises_rpc_error
 
 '''
@@ -43,7 +43,6 @@ class InstantSendTest(DashTestFramework):
         sender_addr = sender.getnewaddress()
         self.nodes[0].sendtoaddress(sender_addr, 1)
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         self.nodes[0].generate(2)
         self.sync_all()
 
@@ -64,7 +63,6 @@ class InstantSendTest(DashTestFramework):
         isolated.sendrawtransaction(dblspnd_tx['hex'])
         # generate block on isolated node with doublespend transaction
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         isolated.generate(1)
         wrong_block = isolated.getbestblockhash()
         # connect isolated block to network
@@ -84,7 +82,6 @@ class InstantSendTest(DashTestFramework):
         # mine more blocks
         # TODO: mine these blocks on an isolated node
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         # make sure the above TX is on node0
         self.sync_mempools([n for n in self.nodes if n is not isolated])
         self.nodes[0].generate(2)
@@ -99,7 +96,6 @@ class InstantSendTest(DashTestFramework):
         sender_addr = sender.getnewaddress()
         self.nodes[0].sendtoaddress(sender_addr, 1)
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         self.nodes[0].generate(2)
         self.sync_all()
 
@@ -130,7 +126,6 @@ class InstantSendTest(DashTestFramework):
         assert_equal(receiver.getwalletinfo()["balance"], 0)
         # mine more blocks
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         self.nodes[0].generate(2)
         self.sync_all()
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -355,7 +355,7 @@ class BitcoinTestFramework():
             if 'wait' not in kwargs:
                 kwargs['wait'] = 0.1
             if 'wait_func' not in kwargs:
-                kwargs['wait_func'] = lambda: self.bump_mocktime(3, True, nodes=nodes)
+                kwargs['wait_func'] = lambda: self.bump_mocktime(3, nodes=nodes)
 
         sync_mempools(nodes or self.nodes, **kwargs)
 
@@ -366,7 +366,7 @@ class BitcoinTestFramework():
     def disable_mocktime(self):
         self.mocktime = 0
 
-    def bump_mocktime(self, t, update_nodes=False, nodes=None):
+    def bump_mocktime(self, t, update_nodes=True, nodes=None):
         self.mocktime += t
         if update_nodes:
             set_node_times(nodes or self.nodes, self.mocktime)
@@ -660,7 +660,6 @@ class DashTestFramework(BitcoinTestFramework):
         self.log.info("Generating %d coins" % required_balance)
         while self.nodes[0].getbalance() < required_balance:
             self.bump_mocktime(1)
-            set_node_times(self.nodes, self.mocktime)
             self.nodes[0].generate(10)
         num_simple_nodes = self.num_nodes - self.mn_count - 1
         self.log.info("Creating and starting %s simple nodes", num_simple_nodes)
@@ -684,12 +683,10 @@ class DashTestFramework(BitcoinTestFramework):
             connect_nodes(self.nodes[i+1], 0)
 
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
         self.nodes[0].generate(1)
         # sync nodes
         self.sync_all()
         self.bump_mocktime(1)
-        set_node_times(self.nodes, self.mocktime)
 
         mn_info = self.nodes[0].masternodelist("status")
         assert (len(mn_info) == self.mn_count)
@@ -894,50 +891,41 @@ class DashTestFramework(BitcoinTestFramework):
         # move forward to next DKG
         skip_count = 24 - (self.nodes[0].getblockcount() % 24)
         if skip_count != 0:
-            self.bump_mocktime(1)
-            set_node_times(nodes, self.mocktime)
+            self.bump_mocktime(1, nodes=nodes)
             self.nodes[0].generate(skip_count)
         sync_blocks(nodes)
 
         q = self.nodes[0].getbestblockhash()
 
         self.log.info("Waiting for phase 1 (init)")
-        def bump_time():
-            self.bump_mocktime(1)
-            set_node_times(nodes, self.mocktime)
         self.wait_for_quorum_phase(q, 1, expected_members, None, 0, mninfos)
-        self.wait_for_quorum_connections(expected_connections, nodes, wait_proc=bump_time)
-        self.wait_for_masternode_probes(expected_probes, mninfos, wait_proc=bump_time)
-        self.bump_mocktime(1)
-        set_node_times(nodes, self.mocktime)
+        self.wait_for_quorum_connections(expected_connections, nodes, wait_proc=lambda: self.bump_mocktime(1, nodes=nodes))
+        self.wait_for_masternode_probes(expected_probes, mninfos, wait_proc=lambda: self.bump_mocktime(1, nodes=nodes))
+        self.bump_mocktime(1, nodes=nodes)
         self.nodes[0].generate(2)
         sync_blocks(nodes)
 
         self.log.info("Waiting for phase 2 (contribute)")
         self.wait_for_quorum_phase(q, 2, expected_members, "receivedContributions", expected_contributions, mninfos)
-        self.bump_mocktime(1)
-        set_node_times(nodes, self.mocktime)
+        self.bump_mocktime(1, nodes=nodes)
         self.nodes[0].generate(2)
         sync_blocks(nodes)
 
         self.log.info("Waiting for phase 3 (complain)")
         self.wait_for_quorum_phase(q, 3, expected_members, "receivedComplaints", expected_complaints, mninfos)
-        self.bump_mocktime(1)
-        set_node_times(nodes, self.mocktime)
+        self.bump_mocktime(1, nodes=nodes)
         self.nodes[0].generate(2)
         sync_blocks(nodes)
 
         self.log.info("Waiting for phase 4 (justify)")
         self.wait_for_quorum_phase(q, 4, expected_members, "receivedJustifications", expected_justifications, mninfos)
-        self.bump_mocktime(1)
-        set_node_times(nodes, self.mocktime)
+        self.bump_mocktime(1, nodes=nodes)
         self.nodes[0].generate(2)
         sync_blocks(nodes)
 
         self.log.info("Waiting for phase 5 (commit)")
         self.wait_for_quorum_phase(q, 5, expected_members, "receivedPrematureCommitments", expected_commitments, mninfos)
-        self.bump_mocktime(1)
-        set_node_times(nodes, self.mocktime)
+        self.bump_mocktime(1, nodes=nodes)
         self.nodes[0].generate(2)
         sync_blocks(nodes)
 
@@ -948,13 +936,11 @@ class DashTestFramework(BitcoinTestFramework):
         self.wait_for_quorum_commitment(q, nodes)
 
         self.log.info("Mining final commitment")
-        self.bump_mocktime(1)
-        set_node_times(nodes, self.mocktime)
+        self.bump_mocktime(1, nodes=nodes)
         self.nodes[0].generate(1)
         while quorums == self.nodes[0].quorum("list"):
             time.sleep(2)
-            self.bump_mocktime(1)
-            set_node_times(nodes, self.mocktime)
+            self.bump_mocktime(1, nodes=nodes)
             self.nodes[0].generate(1)
             sync_blocks(nodes)
         new_quorum = self.nodes[0].quorum("list", 1)["llmq_test"][0]


### PR DESCRIPTION
This includes multiple fixes to make tests pass. This also required to backport bitcoin#13298 and bitcoin#17243 so that `bump_mocktim` also has an effect of the trickle logic. bitcoin#15324 had to be backported to fix unit tests compilation.

~This PR is currently based on #3409 and I'll rebase after it got merged.~