### PR TITLE
Deterministically choose which peers to drop on duplicate MNAUTH

### DIFF
--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -31,6 +31,7 @@ public:
         return BuildSignHash((Consensus::LLMQType)s.llmqType, s.quorumHash, s.id, s.msgHash);
     }
 
+    static uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2);
     static std::set<uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& forMember, bool onlyOutbound);
     static std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, size_t memberCount, size_t connectionCount);
 


### PR DESCRIPTION
This fixes situations where 2 MNs initiate a connection to each other and both verify MNAUTH at the same time resulting in both dropping connections to each other. When this happened, it was very likely that it would repeat multiple times until some randomness in processing time would "fix" it.

With this PR the decision which connection to drop is deterministic and both MNs will decide for the connection that does not match what was determined by `DeterministicOutboundConnection`.

This should fix a few flaky tests and also speed up intra quorum connections build up (especially with spork21)