### PR TITLE
Always pass current mocktime to started nodes

### DIFF
--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -90,12 +90,12 @@ class BlockchainTest(BitcoinTestFramework):
         assert res['pruned']
         assert not res['automatic_pruning']
 
-        self.restart_node(0, ['-stopatheight=207', '-txindex=0', '-mocktime=%d' % self.mocktime])
+        self.restart_node(0, ['-stopatheight=207', '-txindex=0'])
         res = self.nodes[0].getblockchaininfo()
         # should have exact keys
         assert_equal(sorted(res.keys()), keys)
 
-        self.restart_node(0, ['-stopatheight=207', '-prune=550', '-txindex=0', '-mocktime=%d' % self.mocktime])
+        self.restart_node(0, ['-stopatheight=207', '-prune=550', '-txindex=0'])
         res = self.nodes[0].getblockchaininfo()
         # result should have these additional pruning keys if prune=550
         assert_equal(sorted(res.keys()), sorted(['pruneheight', 'automatic_pruning', 'prune_target_size'] + keys))
@@ -227,7 +227,7 @@ class BlockchainTest(BitcoinTestFramework):
             pass  # The node already shut down before response
         self.log.debug('Node should stop at this height...')
         self.nodes[0].wait_until_stopped()
-        self.start_node(0, ['-txindex=0', '-mocktime=%d' % self.mocktime])
+        self.start_node(0, ['-txindex=0'])
         assert_equal(self.nodes[0].getblockcount(), 207)
 
 

--- a/test/functional/llmq-simplepose.py
+++ b/test/functional/llmq-simplepose.py
@@ -47,7 +47,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         # Lets restart masternodes with closed ports and verify that they get banned even though they are connected to other MNs (via outbound connections)
         def close_mn_port(mn):
             self.stop_node(mn.node.index)
-            self.start_masternode(mn, ["-listen=0", "-mocktime=%d" % self.mocktime])
+            self.start_masternode(mn, ["-listen=0"])
             connect_nodes(mn.node, 0)
             # Make sure the to-be-banned node is still connected well via outbound connections
             for mn2 in self.mninfo:
@@ -61,7 +61,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
 
         def force_old_mn_proto(mn):
             self.stop_node(mn.node.index)
-            self.start_masternode(mn, ["-pushversion=70216", "-mocktime=%d" % self.mocktime])
+            self.start_masternode(mn, ["-pushversion=70216"])
             connect_nodes(mn.node, 0)
             self.reset_probe_timeouts()
         self.test_banning(force_old_mn_proto, True, False, False)
@@ -105,7 +105,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
 
                 if restart:
                     self.stop_node(mn.node.index)
-                    self.start_masternode(mn, ["-mocktime=%d" % self.mocktime])
+                    self.start_masternode(mn)
                 else:
                     mn.node.setnetworkactive(True)
             connect_nodes(mn.node, 0)

--- a/test/functional/minchainwork.py
+++ b/test/functional/minchainwork.py
@@ -33,7 +33,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Force CanDirectFetch to return false (otherwise nMinimumChainWork is ignored)
-        self.mocktime += 21 * 2.6 * 60
+        self.bump_mocktime(21 * 2.6 * 60)
         # This test relies on the chain setup being:
         # node0 <- node1 <- node2
         # Before leaving IBD, nodes prefer to download blocks from outbound

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -365,6 +365,8 @@ class BitcoinTestFramework():
 
     def disable_mocktime(self):
         self.mocktime = 0
+        for node in self.nodes:
+            node.mocktime = 0
 
     def bump_mocktime(self, t, update_nodes=True, nodes=None):
         self.mocktime += t
@@ -376,9 +378,13 @@ class BitcoinTestFramework():
         # with previous versions of the cache, set MOCKTIME
         # to regtest genesis time + (201 * 156)
         self.mocktime = GENESISTIME + (201 * 156)
+        for node in self.nodes:
+            node.mocktime = self.mocktime
 
     def set_genesis_mocktime(self):
         self.mocktime = GENESISTIME
+        for node in self.nodes:
+            node.mocktime = self.mocktime
 
     # Private helper methods. These should not be accessed by the subclass test scripts.
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -58,6 +58,7 @@ class TestNode():
             self.binary = binary
         self.stderr = stderr
         self.coverage_dir = coverage_dir
+        self.mocktime = mocktime
         # Most callers will just need to add extra args to the standard list below. For those callers that need more flexibity, they can just set the args property directly.
         self.extra_args = extra_args
         self.args = [self.binary, "-datadir=" + self.datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(mocktime), "-uacomment=testnode%d" % i]
@@ -102,11 +103,14 @@ class TestNode():
             extra_args = self.extra_args
         if stderr is None:
             stderr = self.stderr
+        all_args = self.args + extra_args
+        if self.mocktime != 0:
+            all_args = all_args + ["-mocktime=%d" % self.mocktime]
         # Delete any existing cookie file -- if such a file exists (eg due to
         # unclean shutdown), it will get overwritten anyway by bitcoind, and
         # potentially interfere with our attempt to authenticate
         delete_cookie_file(self.datadir)
-        self.process = subprocess.Popen(self.args + extra_args, stderr=stderr, *args, **kwargs)
+        self.process = subprocess.Popen(all_args, stderr=stderr, *args, **kwargs)
         self.running = True
         self.log.debug("dashd started, waiting for RPC to come up")
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -358,6 +358,7 @@ def get_bip9_status(node, key):
 
 def set_node_times(nodes, t):
     for node in nodes:
+        node.mocktime = t
         node.setmocktime(t)
 
 def disconnect_nodes(from_connection, node_num):


### PR DESCRIPTION
Instead of using the initial value. This removes the need for manually
passing of -mocktime when restarting nodes.

It also fixes a few flaky test cases where nodes are getting restarted.