### PR TITLE
Improve network connections related logging

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -41,7 +41,7 @@ void CMNAuth::PushMNAUTH(CNode* pnode, CConnman& connman)
     mnauth.proRegTxHash = activeMasternodeInfo.proTxHash;
     mnauth.sig = activeMasternodeInfo.blsKeyOperator->Sign(signHash);
 
-    LogPrint(BCLog::NET, "CMNAuth::%s -- Sending MNAUTH, peer=%d\n", __func__, pnode->GetId());
+    LogPrint(BCLog::NET_NETCONN, "CMNAuth::%s -- Sending MNAUTH, peer=%d\n", __func__, pnode->GetId());
 
     connman.PushMessage(pnode, CNetMsgMaker(pnode->GetSendVersion()).Make(NetMsgType::MNAUTH, mnauth));
 }
@@ -117,7 +117,7 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
         if (!pnode->fInbound) {
             mmetaman.GetMetaInfo(mnauth.proRegTxHash)->SetLastOutboundSuccess(GetAdjustedTime());
             if (pnode->fMasternodeProbe) {
-                LogPrint(BCLog::NET, "CMNAuth::ProcessMessage -- masternode probe successful for %s, disconnecting. peer=%d\n",
+                LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- masternode probe successful for %s, disconnecting. peer=%d\n",
                          mnauth.proRegTxHash.ToString(), pnode->GetId());
                 pnode->fDisconnect = true;
                 return;
@@ -133,27 +133,27 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
             if (pnode2->verifiedProRegTxHash == mnauth.proRegTxHash) {
                 if (fMasternodeMode) {
                     auto deterministicOutbound = llmq::CLLMQUtils::DeterministicOutboundConnection(activeMasternodeInfo.proTxHash, mnauth.proRegTxHash);
-                    LogPrint(BCLog::NET, "CMNAuth::ProcessMessage -- Masternode %s has already verified as peer %d, deterministicOutbound=%s. peer=%d\n",
+                    LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- Masternode %s has already verified as peer %d, deterministicOutbound=%s. peer=%d\n",
                              mnauth.proRegTxHash.ToString(), pnode2->GetId(), deterministicOutbound.ToString(), pnode->GetId());
                     if (deterministicOutbound == activeMasternodeInfo.proTxHash) {
                         if (pnode2->fInbound) {
-                            LogPrint(BCLog::NET, "CMNAuth::ProcessMessage -- dropping old inbound, peer=%d\n", pnode2->GetId());
+                            LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- dropping old inbound, peer=%d\n", pnode2->GetId());
                             pnode2->fDisconnect = true;
                         } else if (pnode->fInbound) {
-                            LogPrint(BCLog::NET, "CMNAuth::ProcessMessage -- dropping new inbound, peer=%d\n", pnode->GetId());
+                            LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- dropping new inbound, peer=%d\n", pnode->GetId());
                             pnode->fDisconnect = true;
                         }
                     } else {
                         if (!pnode2->fInbound) {
-                            LogPrint(BCLog::NET, "CMNAuth::ProcessMessage -- dropping old outbound, peer=%d\n", pnode2->GetId());
+                            LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- dropping old outbound, peer=%d\n", pnode2->GetId());
                             pnode2->fDisconnect = true;
                         } else if (!pnode->fInbound) {
-                            LogPrint(BCLog::NET, "CMNAuth::ProcessMessage -- dropping new outbound, peer=%d\n", pnode->GetId());
+                            LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- dropping new outbound, peer=%d\n", pnode->GetId());
                             pnode->fDisconnect = true;
                         }
                     }
                 } else {
-                    LogPrint(BCLog::NET, "CMNAuth::ProcessMessage -- Masternode %s has already verified as peer %d, dropping new connection. peer=%d\n",
+                    LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- Masternode %s has already verified as peer %d, dropping new connection. peer=%d\n",
                             mnauth.proRegTxHash.ToString(), pnode2->GetId(), pnode->GetId());
                     pnode->fDisconnect = true;
                 }
@@ -170,7 +170,7 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
             pnode->verifiedPubKeyHash = dmn->pdmnState->pubKeyOperator.GetHash();
         }
 
-        LogPrint(BCLog::NET, "CMNAuth::%s -- Valid MNAUTH for %s, peer=%d\n", __func__, mnauth.proRegTxHash.ToString(), pnode->GetId());
+        LogPrint(BCLog::NET_NETCONN, "CMNAuth::%s -- Valid MNAUTH for %s, peer=%d\n", __func__, mnauth.proRegTxHash.ToString(), pnode->GetId());
     }
 }
 
@@ -203,7 +203,7 @@ void CMNAuth::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList&
         }
 
         if (doRemove) {
-            LogPrint(BCLog::NET, "CMNAuth::NotifyMasternodeListChanged -- Disconnecting MN %s due to key changed/removed, peer=%d\n",
+            LogPrint(BCLog::NET_NETCONN, "CMNAuth::NotifyMasternodeListChanged -- Disconnecting MN %s due to key changed/removed, peer=%d\n",
                      pnode->verifiedProRegTxHash.ToString(), pnode->GetId());
             pnode->fDisconnect = true;
         }

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -177,7 +177,7 @@ void CLLMQUtils::EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBl
                     debugMsg += strprintf("  %s (%s)\n", c.ToString(), dmn->pdmnState->addr.ToString(false));
                 }
             }
-            LogPrint(BCLog::LLMQ, debugMsg.c_str());
+            LogPrint(BCLog::NET_NETCONN, debugMsg.c_str());
         }
         g_connman->SetMasternodeQuorumNodes(llmqType, pindexQuorum->GetBlockHash(), connections);
     }
@@ -213,7 +213,7 @@ void CLLMQUtils::AddQuorumProbeConnections(Consensus::LLMQType llmqType, const C
                     debugMsg += strprintf("  %s (%s)\n", c.ToString(), dmn->pdmnState->addr.ToString(false));
                 }
             }
-            LogPrint(BCLog::LLMQ, debugMsg.c_str());
+            LogPrint(BCLog::NET_NETCONN, debugMsg.c_str());
         }
         g_connman->AddPendingProbeConnections(probeConnections);
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2408,14 +2408,22 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     } else if (FindNode(std::string(pszDest)))
         return;
 
-    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- connecting to %s\n", __func__, addrConnect.ToString(false));
+    auto getIpStr = [&]() {
+        if (fLogIPs) {
+            return addrConnect.ToString(false);
+        } else {
+            return std::string("new peer");
+        }
+    };
+
+    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- connecting to %s\n", __func__, getIpStr());
     CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure);
 
     if (!pnode) {
-        LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- ConnectNode failed for %s\n", __func__, addrConnect.ToString(false));
+        LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- ConnectNode failed for %s\n", __func__, getIpStr());
         return;
     }
-    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- succesfully connected to %s, sock=%d, peer=%d\n", __func__, addrConnect.ToString(false), pnode->hSocket, pnode->GetId());
+    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- succesfully connected to %s, sock=%d, peer=%d\n", __func__, getIpStr(), pnode->hSocket, pnode->GetId());
     if (grantOutbound)
         grantOutbound->MoveTo(pnode->grantOutbound);
     if (fOneShot)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1225,9 +1225,9 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     m_msgproc->InitializeNode(pnode);
 
     if (fLogIPs) {
-        LogPrint(BCLog::NET, "connection from %s accepted, peer=%d\n", addr.ToString(), pnode->GetId());
+        LogPrint(BCLog::NET_NETCONN, "connection from %s accepted, sock=%d, peer=%d\n", addr.ToString(), pnode->hSocket, pnode->GetId());
     } else {
-        LogPrint(BCLog::NET, "connection accepted, peer=%d\n", pnode->GetId());
+        LogPrint(BCLog::NET_NETCONN, "connection accepted, sock=%d, peer=%d\n", pnode->hSocket, pnode->GetId());
     }
 
     {
@@ -2291,7 +2291,7 @@ void CConnman::ThreadOpenMasternodeConnections()
                 vPendingMasternodes.erase(vPendingMasternodes.begin());
                 if (dmn && !connectedNodes.count(dmn->pdmnState->addr) && !IsMasternodeOrDisconnectRequested(dmn->pdmnState->addr)) {
                     connectToDmn = dmn;
-                    LogPrint(BCLog::NET, "CConnman::%s -- opening pending masternode connection to %s, service=%s\n", __func__, dmn->proTxHash.ToString(), dmn->pdmnState->addr.ToString(false));
+                    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- opening pending masternode connection to %s, service=%s\n", __func__, dmn->proTxHash.ToString(), dmn->pdmnState->addr.ToString(false));
                 }
             }
 
@@ -2317,7 +2317,7 @@ void CConnman::ThreadOpenMasternodeConnections()
 
                 if (!pending.empty()) {
                     connectToDmn = pending[GetRandInt(pending.size())];
-                    LogPrint(BCLog::NET, "CConnman::%s -- opening quorum connection to %s, service=%s\n", __func__, connectToDmn->proTxHash.ToString(), connectToDmn->pdmnState->addr.ToString(false));
+                    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- opening quorum connection to %s, service=%s\n", __func__, connectToDmn->proTxHash.ToString(), connectToDmn->pdmnState->addr.ToString(false));
                 }
             }
 
@@ -2352,7 +2352,7 @@ void CConnman::ThreadOpenMasternodeConnections()
                     masternodePendingProbes.erase(connectToDmn->proTxHash);
                     isProbe = true;
 
-                    LogPrint(BCLog::NET, "CConnman::%s -- probing masternode %s, service=%s\n", __func__, connectToDmn->proTxHash.ToString(), connectToDmn->pdmnState->addr.ToString(false));
+                    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- probing masternode %s, service=%s\n", __func__, connectToDmn->proTxHash.ToString(), connectToDmn->pdmnState->addr.ToString(false));
                 }
             }
         }
@@ -2374,7 +2374,7 @@ void CConnman::ThreadOpenMasternodeConnections()
             return true;
         });
         if (!connected) {
-            LogPrint(BCLog::NET, "CConnman::%s -- connection failed for masternode  %s, service=%s\n", __func__, connectToDmn->proTxHash.ToString(), connectToDmn->pdmnState->addr.ToString(false));
+            LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- connection failed for masternode  %s, service=%s\n", __func__, connectToDmn->proTxHash.ToString(), connectToDmn->pdmnState->addr.ToString(false));
             // reset last outbound success
             mmetaman.GetMetaInfo(connectToDmn->proTxHash)->SetLastOutboundSuccess(0);
         }
@@ -2408,14 +2408,14 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     } else if (FindNode(std::string(pszDest)))
         return;
 
-    LogPrint(BCLog::NET, "CConnman::%s -- connecting to %s\n", __func__, addrConnect.ToString(false));
+    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- connecting to %s\n", __func__, addrConnect.ToString(false));
     CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure);
 
     if (!pnode) {
-        LogPrint(BCLog::NET, "CConnman::%s -- ConnectNode failed for %s\n", __func__, addrConnect.ToString(false));
+        LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- ConnectNode failed for %s\n", __func__, addrConnect.ToString(false));
         return;
     }
-    LogPrint(BCLog::NET, "CConnman::%s -- succesfully connected to %s, peer=%d\n", __func__, addrConnect.ToString(false), pnode->GetId());
+    LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- succesfully connected to %s, sock=%d, peer=%d\n", __func__, addrConnect.ToString(false), pnode->hSocket, pnode->GetId());
     if (grantOutbound)
         grantOutbound->MoveTo(pnode->grantOutbound);
     if (fOneShot)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1225,9 +1225,9 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     m_msgproc->InitializeNode(pnode);
 
     if (fLogIPs) {
-        LogPrint(BCLog::NET, "connection from %s accepted\n", addr.ToString());
+        LogPrint(BCLog::NET, "connection from %s accepted, peer=%d\n", addr.ToString(), pnode->GetId());
     } else {
-        LogPrint(BCLog::NET, "connection accepted\n");
+        LogPrint(BCLog::NET, "connection accepted, peer=%d\n", pnode->GetId());
     }
 
     {
@@ -2374,6 +2374,7 @@ void CConnman::ThreadOpenMasternodeConnections()
             return true;
         });
         if (!connected) {
+            LogPrint(BCLog::NET, "CConnman::%s -- connection failed for masternode  %s, service=%s\n", __func__, connectToDmn->proTxHash.ToString(), connectToDmn->pdmnState->addr.ToString(false));
             // reset last outbound success
             mmetaman.GetMetaInfo(connectToDmn->proTxHash)->SetLastOutboundSuccess(0);
         }
@@ -2407,10 +2408,14 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     } else if (FindNode(std::string(pszDest)))
         return;
 
+    LogPrint(BCLog::NET, "CConnman::%s -- connecting to %s\n", __func__, addrConnect.ToString(false));
     CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure);
 
-    if (!pnode)
+    if (!pnode) {
+        LogPrint(BCLog::NET, "CConnman::%s -- ConnectNode failed for %s\n", __func__, addrConnect.ToString(false));
         return;
+    }
+    LogPrint(BCLog::NET, "CConnman::%s -- succesfully connected to %s, peer=%d\n", __func__, addrConnect.ToString(false), pnode->GetId());
     if (grantOutbound)
         grantOutbound->MoveTo(pnode->grantOutbound);
     if (fOneShot)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2128,9 +2128,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             if (pfrom->fInbound) {
                 pfrom->fMasternode = fOtherMasternode;
                 if (fOtherMasternode) {
-                    LogPrint(BCLog::NET, "peer=%d is an inbound masternode connection, not relaying anything to it\n", pfrom->GetId());
+                    LogPrint(BCLog::NET_NETCONN, "peer=%d is an inbound masternode connection, not relaying anything to it\n", pfrom->GetId());
                     if (!fMasternodeMode) {
-                        LogPrint(BCLog::NET, "but we're not a masternode, disconnecting\n");
+                        LogPrint(BCLog::NET_NETCONN, "but we're not a masternode, disconnecting\n");
                         pfrom->fDisconnect = true;
                         return true;
                     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -288,6 +288,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::MNSYNC, "mnsync"},
     {BCLog::PRIVATESEND, "privatesend"},
     {BCLog::SPORK, "spork"},
+    {BCLog::NETCONN, "netconn"},
     //End Dash
 
 };

--- a/src/util.h
+++ b/src/util.h
@@ -139,7 +139,10 @@ namespace BCLog {
         MNSYNC      = ((uint64_t)1 << 40),
         PRIVATESEND = ((uint64_t)1 << 41),
         SPORK       = ((uint64_t)1 << 42),
+        NETCONN     = ((uint64_t)1 << 43),
         //End Dash
+
+        NET_NETCONN = NET | NETCONN, // use this to have something logged in NET and NETCONN as well
 
         ALL         = ~(uint64_t)0,
     };


### PR DESCRIPTION
This does 2 things.
1. Add peer IDs log entries for fresh connections (inbound and outbound) to make it possible to associate new connections with peers.
2. Introduce NETCONN logging category which only logs connection related stuff. This is an alternative to enabling the NET category, which produces a lot of log entries and makes debugging hard. NET_NETCONN is a helper that allows to have logs in both NET and NETCONN categories.