### PR TITLE
Remove fix for fNetworkActive vs OpenNetworkConnection race

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2438,12 +2438,6 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     {
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
-
-        if (!fNetworkActive) {
-            // there is a small chance of fNetworkActive becoming false between the start of this method
-            // and the successful lock of cs_vNodes
-            pnode->CloseSocketDisconnect();
-        }
     }
 }
 


### PR DESCRIPTION
This is not needed anymore due to bitcoin#13212 being backported