### PR TITLE
Make socketevents mode (poll vs select) configurable via parameter

### DIFF
--- a/ci/test_integrationtests.sh
+++ b/ci/test_integrationtests.sh
@@ -17,8 +17,20 @@ export LD_LIBRARY_PATH=$BUILD_DIR/depends/$HOST/lib
 
 cd build-ci/dashcore-$BUILD_TARGET
 
+if [ "$SOCKETEVENTS" = "" ]; then
+  # Let's switch socketevents mode to some random mode
+  R=$(($RANDOM%2))
+  if [ "$R" == "0" ]; then
+    SOCKETEVENTS="select"
+  else
+    SOCKETEVENTS="poll"
+  fi
+fi
+echo "Using socketevents mode: $SOCKETEVENTS"
+EXTRA_ARGS="--dashd-arg=-socketevents=$SOCKETEVENTS"
+
 set +e
-./test/functional/test_runner.py --ci --coverage --failfast --nocleanup --tmpdir=$(pwd)/testdatadirs $PASS_ARGS
+./test/functional/test_runner.py --ci --coverage --failfast --nocleanup --tmpdir=$(pwd)/testdatadirs $PASS_ARGS $EXTRA_ARGS
 RESULT=$?
 set -e
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -426,6 +426,15 @@ void OnRPCStopped()
     LogPrint(BCLog::RPC, "RPC stopped.\n");
 }
 
+std::string GetSupportedSocketEventsStr()
+{
+    std::string strSupportedModes = "'select'";
+#ifdef USE_POLL
+    strSupportedModes += ", 'poll'";
+#endif
+    return strSupportedModes;
+}
+
 std::string HelpMessage(HelpMessageMode mode)
 {
     const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
@@ -512,6 +521,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), DEFAULT_PROXYRANDOMIZE));
     strUsage += HelpMessageOpt("-seednode=<ip>", _("Connect to a node to retrieve peer addresses, and disconnect"));
+    strUsage += HelpMessageOpt("-socketevents=<mode>", strprintf(_("Socket events mode, which must be one of: %s (default: %s)"), GetSupportedSocketEventsStr(), DEFAULT_SOCKETEVENTS));
     strUsage += HelpMessageOpt("-timeout=<n>", strprintf(_("Specify connection timeout in milliseconds (minimum: 1, default: %d)"), DEFAULT_CONNECT_TIMEOUT));
     strUsage += HelpMessageOpt("-torcontrol=<ip>:<port>", strprintf(_("Tor control port to use if onion listening enabled (default: %s)"), DEFAULT_TOR_CONTROL));
     strUsage += HelpMessageOpt("-torpassword=<pass>", _("Tor control port password (default: empty)"));
@@ -2307,6 +2317,18 @@ bool AppInitMain()
             connOptions.m_specified_outgoing = connect;
         }
     }
+
+    std::string strSocketEventsMode = gArgs.GetArg("-socketevents", DEFAULT_SOCKETEVENTS);
+    if (strSocketEventsMode == "select") {
+        connOptions.socketEventsMode = CConnman::SOCKETEVENTS_SELECT;
+#ifdef USE_POLL
+    } else if (strSocketEventsMode == "poll") {
+        connOptions.socketEventsMode = CConnman::SOCKETEVENTS_POLL;
+#endif
+    } else {
+        return InitError(strprintf(_("Invalid -socketevents ('%s') specified. Only these modes are supported: %s"), strSocketEventsMode, GetSupportedSocketEventsStr()));
+    }
+
     if (!connman.Start(scheduler, connOptions)) {
         return false;
     }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -442,6 +442,7 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
             "  \"timeoffset\": xxxxx,                   (numeric) the time offset\n"
             "  \"connections\": xxxxx,                  (numeric) the number of connections\n"
             "  \"networkactive\": true|false,           (bool) whether p2p networking is enabled\n"
+            "  \"socketevents\": \"xxx/\",              (string) the socket events mode, either epoll, poll or select\n"
             "  \"networks\": [                          (array) information per network\n"
             "  {\n"
             "    \"name\": \"xxx\",                     (string) network (ipv4, ipv6 or onion)\n"
@@ -485,6 +486,18 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
     if (g_connman) {
         obj.push_back(Pair("networkactive", g_connman->GetNetworkActive()));
         obj.push_back(Pair("connections",   (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL)));
+        std::string strSocketEvents;
+        switch (g_connman->GetSocketEventsMode()) {
+            case CConnman::SOCKETEVENTS_SELECT:
+                strSocketEvents = "select";
+                break;
+            case CConnman::SOCKETEVENTS_POLL:
+                strSocketEvents = "poll";
+                break;
+            default:
+                assert(false);
+        }
+        obj.push_back(Pair("socketevents", strSocketEvents));
     }
     obj.push_back(Pair("networks",      GetNetworksInfo()));
     obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -74,6 +74,7 @@ class BitcoinTestFramework():
         self.nodes = []
         self.mocktime = 0
         self.supports_cli = False
+        self.extra_args_from_options = []
         self.set_test_params()
 
         assert hasattr(self, "num_nodes"), "Test must set self.num_nodes in set_test_params()"
@@ -105,6 +106,8 @@ class BitcoinTestFramework():
                           help="Attach a python debugger if test fails")
         parser.add_option("--usecli", dest="usecli", default=False, action="store_true",
                           help="use bitcoin-cli instead of RPC for all commands")
+        parser.add_option("--dashd-arg", dest="dashd_extra_args", default=[], type='string', action='append',
+                          help="Pass extra args to all dashd instances")
         self.add_options(parser)
         (self.options, self.args) = parser.parse_args()
 
@@ -115,6 +118,8 @@ class BitcoinTestFramework():
         check_json_precision()
 
         self.options.cachedir = os.path.abspath(self.options.cachedir)
+
+        self.extra_args_from_options = self.options.dashd_extra_args
 
         # Set up temp directory and start logging
         if self.options.tmpdir:
@@ -254,7 +259,7 @@ class BitcoinTestFramework():
         assert_equal(len(binary), num_nodes)
         old_num_nodes = len(self.nodes)
         for i in range(num_nodes):
-            self.nodes.append(TestNode(old_num_nodes + i, self.options.tmpdir, extra_args[i], rpchost, timewait=timewait, binary=binary[i], stderr=stderr, mocktime=self.mocktime, coverage_dir=self.options.coveragedir, use_cli=self.options.usecli))
+            self.nodes.append(TestNode(old_num_nodes + i, self.options.tmpdir, extra_args[i], self.extra_args_from_options, rpchost, timewait=timewait, binary=binary[i], stderr=stderr, mocktime=self.mocktime, coverage_dir=self.options.coveragedir, use_cli=self.options.usecli))
 
     def start_node(self, i, *args, **kwargs):
         """Start a dashd"""
@@ -446,7 +451,7 @@ class BitcoinTestFramework():
                     args.append("-connect=127.0.0.1:" + str(p2p_port(0)))
                 if extra_args is not None:
                     args.extend(extra_args)
-                self.nodes.append(TestNode(i, self.options.cachedir, extra_args=[], rpchost=None, timewait=None, binary=None, stderr=stderr, mocktime=self.mocktime, coverage_dir=None))
+                self.nodes.append(TestNode(i, self.options.cachedir, extra_args=[], extra_args_from_options=self.extra_args_from_options, rpchost=None, timewait=None, binary=None, stderr=stderr, mocktime=self.mocktime, coverage_dir=None))
                 self.nodes[i].args = args
                 self.start_node(i)
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -44,7 +44,7 @@ class TestNode():
     To make things easier for the test writer, any unrecognised messages will
     be dispatched to the RPC connection."""
 
-    def __init__(self, i, dirname, extra_args, rpchost, timewait, binary, stderr, mocktime, coverage_dir, use_cli=False):
+    def __init__(self, i, dirname, extra_args, extra_args_from_options, rpchost, timewait, binary, stderr, mocktime, coverage_dir, use_cli=False):
         self.index = i
         self.datadir = os.path.join(dirname, "node" + str(i))
         self.rpchost = rpchost
@@ -62,6 +62,7 @@ class TestNode():
         self.mocktime = mocktime
         # Most callers will just need to add extra args to the standard list below. For those callers that need more flexibity, they can just set the args property directly.
         self.extra_args = extra_args
+        self.extra_args_from_options = extra_args_from_options
         self.args = [self.binary, "-datadir=" + self.datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(mocktime), "-uacomment=testnode%d" % i]
 
         self.cli = TestNodeCLI(os.getenv("BITCOINCLI", "dash-cli"), self.datadir)
@@ -104,7 +105,7 @@ class TestNode():
             extra_args = self.extra_args
         if stderr is None:
             stderr = self.stderr
-        all_args = self.args + extra_args
+        all_args = self.args + self.extra_args_from_options + extra_args
         if self.mocktime != 0:
             all_args = all_args + ["-mocktime=%d" % self.mocktime]
         # Delete any existing cookie file -- if such a file exists (eg due to


### PR DESCRIPTION
This allows us to test the socket-events mode at startup time instead of at compile time. This PR also adds some randomness in the selected mode for integration testing.

This will later become more useful when epoll support is implemented.