### PR TITLE
Refactor/Prepare CConnman for upcoming epoll support

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -963,6 +963,7 @@ size_t CConnman::SocketSendData(CNode *pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs
         assert(pnode->nSendSize == 0);
     }
     pnode->vSendMsg.erase(pnode->vSendMsg.begin(), it);
+    pnode->nSendMsgSize = pnode->vSendMsg.size();
     return nSentSize;
 }
 
@@ -3435,6 +3436,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fPauseRecv = false;
     fPauseSend = false;
     nProcessQueueSize = 0;
+    nSendMsgSize = 0;
 
     for (const std::string &msg : getAllNetMessageTypes())
         mapRecvBytesPerMsgCmd[msg] = 0;
@@ -3485,6 +3487,7 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
         pnode->vSendMsg.push_back(std::move(serializedHeader));
         if (nMessageSize)
             pnode->vSendMsg.push_back(std::move(msg.data));
+        pnode->nSendMsgSize = pnode->vSendMsg.size();
 
         // wake up select() call in case there was no pending data before (so it was not selecting this socket for sending)
         if (!hasPendingData && wakeupSelectNeeded)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -914,7 +914,7 @@ const uint256& CNetMessage::GetMessageHash() const
     return data_hash;
 }
 
-size_t CConnman::SocketSendData(CNode *pnode) const EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_vSend)
+size_t CConnman::SocketSendData(CNode *pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_vSend)
 {
     auto it = pnode->vSendMsg.begin();
     size_t nSentSize = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1690,7 +1690,7 @@ void CConnman::SocketHandler()
     for (CNode* pnode : vErrorNodes)
     {
         if (interruptNet) {
-            return;
+            break;
         }
         // let recv() return errors and then handle it
         SocketRecvData(pnode);
@@ -1699,7 +1699,7 @@ void CConnman::SocketHandler()
     for (CNode* pnode : vReceivableNodes)
     {
         if (interruptNet) {
-            return;
+            break;
         }
         if (pnode->fPauseRecv) {
             continue;
@@ -1710,7 +1710,7 @@ void CConnman::SocketHandler()
 
     for (CNode* pnode : vSendableNodes) {
         if (interruptNet) {
-            return;
+            break;
         }
 
         LOCK(pnode->cs_vSend);
@@ -1723,6 +1723,10 @@ void CConnman::SocketHandler()
     ReleaseNodeVector(vErrorNodes);
     ReleaseNodeVector(vReceivableNodes);
     ReleaseNodeVector(vSendableNodes);
+
+    if (interruptNet) {
+        return;
+    }
 
     {
         LOCK(cs_vNodes);

--- a/src/net.h
+++ b/src/net.h
@@ -510,6 +510,7 @@ private:
     NodeId GetNewNodeId();
 
     size_t SocketSendData(CNode *pnode);
+    size_t SocketRecvData(CNode* pnode);
     //!check is the banlist has unwritten changes
     bool BannedSetIsDirty();
     //!set the "dirty" flag for the banlist

--- a/src/net.h
+++ b/src/net.h
@@ -788,6 +788,7 @@ public:
     size_t nSendOffset; // offset inside the first vSendMsg already sent
     uint64_t nSendBytes GUARDED_BY(cs_vSend);
     std::list<std::vector<unsigned char>> vSendMsg GUARDED_BY(cs_vSend);
+    std::atomic<size_t> nSendMsgSize;
     CCriticalSection cs_vSend;
     CCriticalSection cs_hSocket;
     CCriticalSection cs_vRecv;

--- a/src/net.h
+++ b/src/net.h
@@ -486,10 +486,10 @@ private:
     void InactivityCheck(CNode *pnode);
     bool GenerateSelectSet(std::set<SOCKET> &recv_set, std::set<SOCKET> &send_set, std::set<SOCKET> &error_set);
 #ifdef USE_POLL
-    void SocketEventsPoll(std::set<SOCKET> &recv_set, std::set<SOCKET> &send_set, std::set<SOCKET> &error_set);
+    void SocketEventsPoll(std::set<SOCKET> &recv_set, std::set<SOCKET> &send_set, std::set<SOCKET> &error_set, bool fOnlyPoll);
 #endif
-    void SocketEventsSelect(std::set<SOCKET> &recv_set, std::set<SOCKET> &send_set, std::set<SOCKET> &error_set);
-    void SocketEvents(std::set<SOCKET> &recv_set, std::set<SOCKET> &send_set, std::set<SOCKET> &error_set);
+    void SocketEventsSelect(std::set<SOCKET> &recv_set, std::set<SOCKET> &send_set, std::set<SOCKET> &error_set, bool fOnlyPoll);
+    void SocketEvents(std::set<SOCKET> &recv_set, std::set<SOCKET> &send_set, std::set<SOCKET> &error_set, bool fOnlyPoll);
     void SocketHandler();
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();

--- a/src/net.h
+++ b/src/net.h
@@ -509,7 +509,7 @@ private:
 
     NodeId GetNewNodeId();
 
-    size_t SocketSendData(CNode *pnode) const;
+    size_t SocketSendData(CNode *pnode);
     //!check is the banlist has unwritten changes
     bool BannedSetIsDirty();
     //!set the "dirty" flag for the banlist

--- a/src/net.h
+++ b/src/net.h
@@ -604,6 +604,13 @@ private:
 
     SocketEventsMode socketEventsMode;
 
+    /** Protected by cs_vNodes */
+    std::unordered_map<NodeId, CNode*> mapReceivableNodes GUARDED_BY(cs_vNodes);
+    std::unordered_map<NodeId, CNode*> mapSendableNodes GUARDED_BY(cs_vNodes);
+    /** Protected by cs_mapNodesWithDataToSend */
+    std::unordered_map<NodeId, CNode*> mapNodesWithDataToSend GUARDED_BY(cs_mapNodesWithDataToSend);
+    mutable CCriticalSection cs_mapNodesWithDataToSend;
+
     std::thread threadDNSAddressSeed;
     std::thread threadSocketHandler;
     std::thread threadOpenAddedConnections;
@@ -852,6 +859,10 @@ public:
 
     std::atomic_bool fPauseRecv;
     std::atomic_bool fPauseSend;
+
+    std::atomic_bool fHasRecvData;
+    std::atomic_bool fCanSendData;
+
 protected:
 
     mapMsgCmdSize mapSendBytesPerMsgCmd;

--- a/src/net.h
+++ b/src/net.h
@@ -133,6 +133,7 @@ struct CSerializedNetMsg
 class NetEventsInterface;
 class CConnman
 {
+friend class CNode;
 public:
 
     enum NumConnections {
@@ -564,6 +565,7 @@ private:
     mutable CCriticalSection cs_vPendingMasternodes;
     std::vector<CNode*> vNodes;
     std::list<CNode*> vNodesDisconnected;
+    std::unordered_map<SOCKET, CNode*> mapSocketToNode;
     mutable CCriticalSection cs_vNodes;
     mutable CCriticalSection cs_vNodesDisconnected;
     std::atomic<NodeId> nLastNodeId;
@@ -1053,7 +1055,7 @@ public:
         vBlockHashesToAnnounce.push_back(hash);
     }
 
-    void CloseSocketDisconnect();
+    void CloseSocketDisconnect(CConnman* connman);
 
     void copyStats(CNodeStats &stats);
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -76,6 +76,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     LOCK(dummyNode1.cs_vSend);
     BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
     dummyNode1.vSendMsg.clear();
+    dummyNode1.nSendMsgSize = 0;
 
     int64_t nStartTime = GetTime();
     // Wait 21 minutes

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -29,12 +29,14 @@ void CConnmanTest::AddNode(CNode& node)
 {
     LOCK(g_connman->cs_vNodes);
     g_connman->vNodes.push_back(&node);
+    g_connman->mapSocketToNode.emplace(node.hSocket, &node);
 }
 
 void CConnmanTest::ClearNodes()
 {
     LOCK(g_connman->cs_vNodes);
     g_connman->vNodes.clear();
+    g_connman->mapSocketToNode.clear();
 }
 
 uint256 insecure_rand_seed = GetRandHash();

--- a/src/test/test_dash.cpp
+++ b/src/test/test_dash.cpp
@@ -37,6 +37,11 @@ void CConnmanTest::ClearNodes()
     LOCK(g_connman->cs_vNodes);
     g_connman->vNodes.clear();
     g_connman->mapSocketToNode.clear();
+
+    g_connman->mapReceivableNodes.clear();
+    g_connman->mapSendableNodes.clear();
+    LOCK(g_connman->cs_mapNodesWithDataToSend);
+    g_connman->mapNodesWithDataToSend.clear();
 }
 
 uint256 insecure_rand_seed = GetRandHash();


### PR DESCRIPTION
This is a set of refactoring which prepare us for the upcoming epoll support. I plan to use epoll in "edge triggered" (vs. level triggered) mode to reduce the number of events as much as possible.

Even though select/poll don't know about the concept of edge/level triggered modes, one can view/compare the behavior of select/poll with level triggered mode. This means, if a socket is given that has pending read data, select/poll will always immediately return even if the data is not fully read from the socket. Same when waiting for sockets to become sendable, select/poll will always return immediately until the socket is not sendable anymore. The old CConnman code relied on this behavior and thus always passed all sockets into select/poll, even if it did not drain the receive buffers.

Edge triggered mode (only epoll supports it) works differently. When it signals that a socket is readable, it won't ever re-signal for that same socket until the receive buffer is drained. Same with sendable sockets. This behavior would immediately lead to epoll blocking forever when one iteration of `SocketHandler()` doesn't drain the read buffer.

The refactorings in this PR change `SocketHandler()` and friends to not assume that select/poll would return immediately if the last recv did not drain buffers. This is done by keeping track of which peers are receivable/sendable and then only selecting/polling for peers which were are not receivable/sendable. The receivable/sendable state is then reset accordingly when read buffers get drained or send buffers get full (read()/send() return less then accepted).

With these refactorings, implementing epoll support with edge triggered mode gets a no-brainer.