### PR TITLE
Wakeup wakeup-pipe when new peers are added

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -84,9 +84,16 @@ enum BindFlags {
     BF_WHITELIST    = (1U << 2),
 };
 
+#ifndef USE_WAKEUP_PIPE
 // The set of sockets cannot be modified while waiting
 // The sleep time needs to be small to avoid new sockets stalling
 static const uint64_t SELECT_TIMEOUT_MILLISECONDS = 50;
+#else
+// select() is woken up through the wakeup pipe whenever a new node is added, so we can wait much longer.
+// We are however still somewhat limited in how long we can sleep as there is periodic work (cleanup) to be done in
+// the socket handler thread
+static const uint64_t SELECT_TIMEOUT_MILLISECONDS = 1000;
+#endif
 
 const static std::string NET_MESSAGE_COMMAND_OTHER = "*other*";
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1224,6 +1224,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     {
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
+        WakeSelect();
     }
 }
 
@@ -2473,6 +2474,7 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     {
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
+        WakeSelect();
     }
 }
 


### PR DESCRIPTION
This also allows us to increase the timeout for select/poll, which avoids unnecessary work in the socket handler thread.