### PR TITLE
Lower DEFAULT_PRIVATESEND_DENOMS

### DIFF
--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -27,7 +27,7 @@ static const int MAX_PRIVATESEND_AMOUNT = MAX_MONEY / COIN;
 static const int DEFAULT_PRIVATESEND_SESSIONS = 4;
 static const int DEFAULT_PRIVATESEND_ROUNDS = 4;
 static const int DEFAULT_PRIVATESEND_AMOUNT = 1000;
-static const int DEFAULT_PRIVATESEND_DENOMS = 300;
+static const int DEFAULT_PRIVATESEND_DENOMS = 50;
 
 static const bool DEFAULT_PRIVATESEND_AUTOSTART = false;
 static const bool DEFAULT_PRIVATESEND_MULTISESSION = false;


### PR DESCRIPTION
Default is way to high, this results in 300 0.001 Dash denominations being created(total .3 Dash). This also results in people's wallets being swamped with tiny denominations, but not having enough larger denominations. Current behavior results in users sending 1 Dash to mix, getting hundreds of inputs, and not being able to send 1 Dash without using hundreds of inputs(which hurts privacy).

I'm not sure this value is best, or if our CreateDenom algorithm could be improved, but 300 is WAY too high