### PR TITLE
Don't delete MN list snapshots and diffs from DB when reorgs take place

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -574,9 +574,6 @@ bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* 
             prevList = GetListForBlock(pindex->pprev);
         }
 
-        evoDb.Erase(std::make_pair(DB_LIST_DIFF, blockHash));
-        evoDb.Erase(std::make_pair(DB_LIST_SNAPSHOT, blockHash));
-
         mnListsCache.erase(blockHash);
     }
 


### PR DESCRIPTION
Deleting these from the DB means that future calls to GetListForBlock  for
the reorged/orphaned block will return an empty MN list. At the same time,
GetListForBlock will add the empty list to the internal MN list cache.

This behavior is not acceptable for multiple reasons:
1. A caller of GetListForBlock should always expect a valid list if that
   block was once in the best chain. We might otherwise run into strange
   behavior (e.g. GetAllQuorumMembers returning zero members)
2. If the chain is ever reorged back to the initial chain (that was
   orphaned), GetListForBlock should not return the invalid/empty cache
   entry for the previously orphaned block.

This should also fix test failures seen on Gitlab CI