### PR TITLE
Backport #13522: [tests] Fix p2p_sendheaders race

### DIFF
--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -304,6 +304,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 test_node.clear_block_announcements()  # since we requested headers...
             elif i == 2:
                 # this time announce own block via headers
+                inv_node.clear_block_announcements()
                 height = self.nodes[0].getblockcount()
                 last_time = self.nodes[0].getblock(self.nodes[0].getbestblockhash())['time']
                 block_time = last_time + 1
@@ -313,6 +314,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 test_node.wait_for_getdata([new_block.sha256])
                 test_node.send_message(msg_block(new_block))
                 test_node.sync_with_ping()  # make sure this block is processed
+                wait_until(lambda: inv_node.block_announced, timeout=60, lock=mininode_lock)
                 inv_node.clear_block_announcements()
                 test_node.clear_block_announcements()
 


### PR DESCRIPTION
Merge #13522: [tests] Fix p2p_sendheaders race

75848bcf40 [tests] Fix p2p_sendheaders race (John Newbery)

Pull request description:

  p2p_sendheaders has a race in part 1.3.

  part 1.2 sends a block to the node over the 'test_node' connection, but
  doesn't wait for an inv to be received on the 'inv_node' connection. If
  we get to part 1.3 before that inv has been received, then the
  subsequent call to check_last_inv_announcement could fail.

Tree-SHA512: ba9baffb3a9c0d379259190c737a7a4ad2e1133005a5b026af4f6b67a2978e24db39289551ad29134151879593ef5472be7e569a3557c0740fb51f5c56263d9a
