### PR TITLE
Implement epoll support

### DIFF
--- a/ci/test_integrationtests.sh
+++ b/ci/test_integrationtests.sh
@@ -19,11 +19,13 @@ cd build-ci/dashcore-$BUILD_TARGET
 
 if [ "$SOCKETEVENTS" = "" ]; then
   # Let's switch socketevents mode to some random mode
-  R=$(($RANDOM%2))
+  R=$(($RANDOM%3))
   if [ "$R" == "0" ]; then
     SOCKETEVENTS="select"
-  else
+  elif [ "$R" == "1" ]; then
     SOCKETEVENTS="poll"
+  else
+    SOCKETEVENTS="epoll"
   fi
 fi
 echo "Using socketevents mode: $SOCKETEVENTS"

--- a/src/compat.h
+++ b/src/compat.h
@@ -109,6 +109,10 @@ typedef char* sockopt_arg_type;
 #define USE_POLL
 #endif
 
+#if defined(__linux__)
+#define USE_EPOLL
+#endif
+
 bool static inline IsSelectableSocket(const SOCKET& s) {
 #if defined(USE_POLL) || defined(WIN32)
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -415,6 +415,9 @@ std::string GetSupportedSocketEventsStr()
 #ifdef USE_POLL
     strSupportedModes += ", 'poll'";
 #endif
+#ifdef USE_EPOLL
+    strSupportedModes += ", 'epoll'";
+#endif
     return strSupportedModes;
 }
 
@@ -2244,6 +2247,10 @@ bool AppInitMain()
 #ifdef USE_POLL
     } else if (strSocketEventsMode == "poll") {
         connOptions.socketEventsMode = CConnman::SOCKETEVENTS_POLL;
+#endif
+#ifdef USE_EPOLL
+    } else if (strSocketEventsMode == "epoll") {
+        connOptions.socketEventsMode = CConnman::SOCKETEVENTS_EPOLL;
 #endif
     } else {
         return InitError(strprintf(_("Invalid -socketevents ('%s') specified. Only these modes are supported: %s"), strSocketEventsMode, GetSupportedSocketEventsStr()));

--- a/src/net.h
+++ b/src/net.h
@@ -98,7 +98,9 @@ static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
 static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
 
-#if defined USE_POLL
+#if defined USE_EPOLL
+#define DEFAULT_SOCKETEVENTS "epoll"
+#elif defined USE_POLL
 #define DEFAULT_SOCKETEVENTS "poll"
 #else
 #define DEFAULT_SOCKETEVENTS "select"

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -494,6 +494,9 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
             case CConnman::SOCKETEVENTS_POLL:
                 strSocketEvents = "poll";
                 break;
+            case CConnman::SOCKETEVENTS_EPOLL:
+                strSocketEvents = "epoll";
+                break;
             default:
                 assert(false);
         }


### PR DESCRIPTION
As promised, here is the straight forward implementation of epoll on Linux, which should bring down overhead of the socket handler thread to nearly 0 (compared to 60-80% cpu load with select/poll when hundreds of connections are involved).