### PR TITLE
Update Windows build instructions

### DIFF
--- a/doc/build-cross.md
+++ b/doc/build-cross.md
@@ -45,7 +45,7 @@ First, install the general dependencies:
 
     sudo apt update
     sudo apt upgrade
-    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git python3 cmake     
+    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git python3 cmake
 
 A host toolchain (`build-essential`) is necessary because some dependency
 packages need to build host utilities that are used in the build process.
@@ -61,7 +61,7 @@ Acquire the source in the usual way:
     git clone https://github.com/dashpay/dash.git
     cd dash
 
-## Building for 64-bit Windows
+### Building for 64-bit Windows
 
 The first step is to install the mingw-w64 cross-compilation tool chain:
 
@@ -87,19 +87,9 @@ Build using:
     CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
     make
 
-## Depends system
+### Depends system
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-
-Footnotes
----------
-
-<a name="footnote1">1</a>: Starting from Ubuntu Xenial 16.04, both the 32 and 64 bit Mingw-w64 packages install two different
-compiler options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
-efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
-required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
-It's not possible to build the Dash Core code using the win32 version of the Mingw-w64 cross compilers (at least not without
-modifying headers in the Dash Core source code).
 
 ARM-Linux Cross-compilation
 -------------------
@@ -120,3 +110,13 @@ When building Dash Core, use
 ```bash
 $ ./configure --prefix=`pwd`/depends/arm-linux-gnueabihf
 ```
+
+Footnotes
+---------
+
+<a name="footnote1">1</a>: Starting from Ubuntu Xenial 16.04, both the 32 and 64 bit Mingw-w64 packages install two different
+compiler options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
+efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
+required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
+It's not possible to build the Dash Core code using the win32 version of the Mingw-w64 cross compilers (at least not without
+modifying headers in the Dash Core source code).

--- a/doc/build-cross.md
+++ b/doc/build-cross.md
@@ -35,7 +35,7 @@ When building Dash Core, use
 $ ./configure --prefix=`pwd`/depends/x86_64-apple-darwin11
 ```
 
-Windows 64bit/32bit Cross-compilation
+Windows 64bit Cross-compilation
 -------------------------------
 The steps below can be performed on Ubuntu (including in a VM) or WSL. The depends system
 will also work on other Linux distributions, however the commands for

--- a/doc/build-cross.md
+++ b/doc/build-cross.md
@@ -37,57 +37,69 @@ $ ./configure --prefix=`pwd`/depends/x86_64-apple-darwin11
 
 Windows 64bit/32bit Cross-compilation
 -------------------------------
-Cross-compiling to Windows requires a few additional packages to be installed:
+The steps below can be performed on Ubuntu (including in a VM) or WSL. The depends system
+will also work on other Linux distributions, however the commands for
+installing the toolchain will be different.
 
-```bash
-$ sudo apt-get install nsis wine-stable wine64 bc
-```
+First, install the general dependencies:
 
-For Windows 64bit, install :
-```bash
-$ sudo apt-get install g++-mingw-w64-x86-64
-```
+    sudo apt update
+    sudo apt upgrade
+    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git python3 cmake     
 
-If you're building on Ubuntu 17.04 or later, run these two commands, selecting the 'posix' variant for both,
-to work around issues with mingw-w64. See issue [8732](https://github.com/bitcoin/bitcoin/issues/8732) for more information.
-This also fixes linker issues related to std::thread and other threading related standard C++ libraries.
-```
-sudo update-alternatives --config x86_64-w64-mingw32-g++
-sudo update-alternatives --config x86_64-w64-mingw32-gcc
-```
+A host toolchain (`build-essential`) is necessary because some dependency
+packages need to build host utilities that are used in the build process.
 
-For Windows 32bit, install:
-```bash
-$ sudo apt-get install g++-mingw-w64-i686
-```
+See [dependencies.md](dependencies.md) for a complete overview.
 
-If you're building on Ubuntu 17.04 or later, run these two commands, selecting the 'posix' variant for both,
-to fix linker issues related to std::thread and other threading related standard C++ libraries.
-```
-sudo update-alternatives --config x86_64-w64-mingw32-g++
-sudo update-alternatives --config x86_64-w64-mingw32-gcc
-```
+If you want to build the windows installer with `make deploy` you need [NSIS](https://nsis.sourceforge.io/Main_Page):
 
-Before building for Windows 32bit or 64bit, run
+    sudo apt install nsis
 
-```
-$ PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
-```
+Acquire the source in the usual way:
 
-When building the dependencies, as described in [build-generic](build-generic.md), use
+    git clone https://github.com/dashpay/dash.git
+    cd dash
 
-```bash
-$ make HOST=x86_64-w64-mingw32 -j4
-```
+## Building for 64-bit Windows
 
-When building Dash Core, use
+The first step is to install the mingw-w64 cross-compilation tool chain:
 
-```bash
-$ ./configure --prefix=`pwd`/depends/x86_64-w64-mingw32
-```
+    sudo apt install g++-mingw-w64-x86-64
 
-These commands will build for Windows 64bit. If you want to compile for 32bit,
-replace `x86_64-w64-mingw32` with `i686-w64-mingw32`.
+Ubuntu Bionic 18.04 <sup>[1](#footnote1)</sup>:
+
+    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
+
+Once the toolchain is installed the build steps are common:
+
+Note that for WSL the Dash Core source path MUST be somewhere in the default mount file system, for
+example /usr/src/dash, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
+This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
+
+Build using:
+
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
+    cd depends
+    make HOST=x86_64-w64-mingw32
+    cd ..
+    ./autogen.sh # not required when building from tarball
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
+    make
+
+## Depends system
+
+For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
+
+Footnotes
+---------
+
+<a name="footnote1">1</a>: Starting from Ubuntu Xenial 16.04, both the 32 and 64 bit Mingw-w64 packages install two different
+compiler options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
+efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
+required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
+It's not possible to build the Dash Core code using the win32 version of the Mingw-w64 cross compilers (at least not without
+modifying headers in the Dash Core source code).
 
 ARM-Linux Cross-compilation
 -------------------

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -3,62 +3,128 @@ WINDOWS BUILD NOTES
 
 Below are some notes on how to build Dash Core for Windows.
 
-Most developers use cross-compilation from Ubuntu to build executables for
-Windows. Cross-compilation is also used to build the release binaries.
+The options known to work for building Dash Core on Windows are:
 
-Currently only building on Ubuntu Trusty 14.04 or Ubuntu Zesty 17.04 or later is supported.
-Building on Ubuntu Xenial 16.04 is known to be broken, see extensive discussion in issue [8732](https://github.com/bitcoin/bitcoin/issues/8732).
-While it may be possible to do so with work arounds, it's potentially dangerous and not recommended.
+* On Linux, using the [Mingw-w64](https://mingw-w64.org/doku.php) cross compiler tool chain. Ubuntu Bionic 18.04 is required
+and is the platform used to build the Dash Core Windows release binaries.
+* On Windows, using [Windows
+Subsystem for Linux (WSL)](https://docs.microsoft.com/windows/wsl/about) and the Mingw-w64 cross compiler tool chain.
+* On Windows, using a native compiler tool chain such as [Visual Studio](https://www.visualstudio.com).
 
-While there are potentially a number of ways to build on Windows (for example using msys / mingw-w64),
-using the Windows Subsystem For Linux is the most straightforward. If you are building with
-another method, please contribute the instructions here for others who are running versions
-of Windows that are not compatible with the Windows Subsystem for Linux.
+Other options which may work, but which have not been extensively tested are (please contribute instructions):
 
-Compiling with Windows Subsystem For Linux
--------------------------------------------
+* On Windows, using a POSIX compatibility layer application such as [cygwin](https://www.cygwin.com/) or [msys2](https://www.msys2.org/).
+
+Installing Windows Subsystem for Linux
+---------------------------------------
 
 With Windows 10, Microsoft has released a new feature named the [Windows
-Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about). This
+Subsystem for Linux (WSL)](https://docs.microsoft.com/windows/wsl/about). This
 feature allows you to run a bash shell directly on Windows in an Ubuntu-based
 environment. Within this environment you can cross compile for Windows without
-the need for a separate Linux VM or server.
+the need for a separate Linux VM or server. Note that while WSL can be installed with
+other Linux variants, such as OpenSUSE, the following instructions have only been
+tested with Ubuntu.
 
 This feature is not supported in versions of Windows prior to Windows 10 or on
 Windows Server SKUs. In addition, it is available [only for 64-bit versions of
-Windows](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
+Windows](https://docs.microsoft.com/windows/wsl/install-win10).
 
-To get the bash shell, you must first activate the feature in Windows.
+Full instructions to install WSL are available on the above link.
+To install WSL on Windows 10 with Fall Creators Update installed (version >= 16215.0) do the following:
 
-1. Turn on Developer Mode
-  * Open Settings -> Update and Security -> For developers
-  * Select the Developer Mode radio button
-  * Restart if necessary
-2. Enable the Windows Subsystem for Linux feature
-  * From Start, search for "Turn Windows features on or off" (type 'turn')
-  * Select Windows Subsystem for Linux (beta)
-  * Click OK
-  * Restart if necessary
+1. Enable the Windows Subsystem for Linux feature
+  * Open the Windows Features dialog (`OptionalFeatures.exe`)
+  * Enable 'Windows Subsystem for Linux'
+  * Click 'OK' and restart if necessary
+2. Install Ubuntu
+  * Open Microsoft Store and search for "Ubuntu 18.04" or use [this link](https://www.microsoft.com/store/productId/9N9TNGVNDL3Q)
+  * Click Install
 3. Complete Installation
-  * Open a cmd prompt and type "bash"
-  * Accept the license
+  * Open a cmd prompt and type "Ubuntu1804"
   * Create a new UNIX user account (this is a separate account from your Windows account)
 
 After the bash shell is active, you can follow the instructions below, starting
 with the "Cross-compilation" section. Compiling the 64-bit version is
-recommended but it is possible to compile the 32-bit version.
+recommended, but it is possible to compile the 32-bit version.
 
-Cross-compilation
--------------------
+Cross-compilation for Ubuntu and Windows Subsystem for Linux
+------------------------------------------------------------
 
-Follow the instructions for Windows in [build-cross](build-cross.md)
+The steps below can be performed on Ubuntu (including in a VM) or WSL. The depends system
+will also work on other Linux distributions, however the commands for
+installing the toolchain will be different.
+
+First, install the general dependencies:
+
+    sudo apt update
+    sudo apt upgrade
+    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git python3 cmake     
+
+A host toolchain (`build-essential`) is necessary because some dependency
+packages need to build host utilities that are used in the build process.
+
+See [dependencies.md](dependencies.md) for a complete overview.
+
+If you want to build the windows installer with `make deploy` you need [NSIS](https://nsis.sourceforge.io/Main_Page):
+
+    sudo apt install nsis
+
+Acquire the source in the usual way:
+
+    git clone https://github.com/dashpay/dash.git
+    cd dash
+
+## Building for 64-bit Windows
+
+The first step is to install the mingw-w64 cross-compilation tool chain:
+
+    sudo apt install g++-mingw-w64-x86-64
+
+Ubuntu Bionic 18.04 <sup>[1](#footnote1)</sup>:
+
+    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
+
+Once the toolchain is installed the build steps are common:
+
+Note that for WSL the Dash Core source path MUST be somewhere in the default mount file system, for
+example /usr/src/dash, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
+This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
+
+Build using:
+
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
+    cd depends
+    make HOST=x86_64-w64-mingw32
+    cd ..
+    ./autogen.sh # not required when building from tarball
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
+    make
+
+## Depends system
+
+For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
 
 Installation
 -------------
 
 After building using the Windows subsystem it can be useful to copy the compiled
-executables to a directory on the windows drive in the same directory structure
+executables to a directory on the Windows drive in the same directory structure
 as they appear in the release `.zip` archive. This can be done in the following
 way. This will install to `c:\workspace\dash`, for example:
 
     make install DESTDIR=/mnt/c/workspace/dash
+
+You can also create an installer using:
+
+    make deploy
+
+Footnotes
+---------
+
+<a name="footnote1">1</a>: Starting from Ubuntu Xenial 16.04, both the 32 and 64 bit Mingw-w64 packages install two different
+compiler options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
+efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
+required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
+It's not possible to build the Dash Core code using the win32 version of the Mingw-w64 cross compilers (at least not without
+modifying headers in the Dash Core source code).

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -48,62 +48,10 @@ After the bash shell is active, you can follow the instructions below, starting
 with the "Cross-compilation" section. Compiling the 64-bit version is
 recommended, but it is possible to compile the 32-bit version.
 
-Cross-compilation for Ubuntu and Windows Subsystem for Linux
-------------------------------------------------------------
+Cross-compilation
+-------------------
 
-The steps below can be performed on Ubuntu (including in a VM) or WSL. The depends system
-will also work on other Linux distributions, however the commands for
-installing the toolchain will be different.
-
-First, install the general dependencies:
-
-    sudo apt update
-    sudo apt upgrade
-    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git python3 cmake     
-
-A host toolchain (`build-essential`) is necessary because some dependency
-packages need to build host utilities that are used in the build process.
-
-See [dependencies.md](dependencies.md) for a complete overview.
-
-If you want to build the windows installer with `make deploy` you need [NSIS](https://nsis.sourceforge.io/Main_Page):
-
-    sudo apt install nsis
-
-Acquire the source in the usual way:
-
-    git clone https://github.com/dashpay/dash.git
-    cd dash
-
-## Building for 64-bit Windows
-
-The first step is to install the mingw-w64 cross-compilation tool chain:
-
-    sudo apt install g++-mingw-w64-x86-64
-
-Ubuntu Bionic 18.04 <sup>[1](#footnote1)</sup>:
-
-    sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
-
-Once the toolchain is installed the build steps are common:
-
-Note that for WSL the Dash Core source path MUST be somewhere in the default mount file system, for
-example /usr/src/dash, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
-This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
-
-Build using:
-
-    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
-    cd depends
-    make HOST=x86_64-w64-mingw32
-    cd ..
-    ./autogen.sh # not required when building from tarball
-    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
-    make
-
-## Depends system
-
-For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
+Follow the instructions for Windows in [build-cross](build-cross.md)
 
 Installation
 -------------
@@ -118,13 +66,3 @@ way. This will install to `c:\workspace\dash`, for example:
 You can also create an installer using:
 
     make deploy
-
-Footnotes
----------
-
-<a name="footnote1">1</a>: Starting from Ubuntu Xenial 16.04, both the 32 and 64 bit Mingw-w64 packages install two different
-compiler options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
-efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
-required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
-It's not possible to build the Dash Core code using the win32 version of the Mingw-w64 cross compilers (at least not without
-modifying headers in the Dash Core source code).


### PR DESCRIPTION
Update the windows build instructions, based on https://github.com/bitcoin/bitcoin/blob/master/doc/build-windows.md making sure to be compatible

Tested all the steps and worked. The old build instructions don't work anymore. This also fix #3351