### PR TITLE
Streamline processing of pool state updates

### DIFF
--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -115,13 +115,11 @@ private:
     /// step 2: send denominated inputs and outputs prepared in step 1
     bool SendDenominate(const std::vector<std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, CConnman& connman);
 
-    /// Get Masternode updates about the progress of mixing
-    bool CheckPoolStateUpdate(CPrivateSendStatusUpdate psssup);
+    /// Process Masternode updates about the progress of mixing
+    void ProcessPoolStateUpdate(CPrivateSendStatusUpdate psssup);
     // Set the 'state' value, with some logging and capturing when the state changed
     void SetState(PoolState nStateNew);
 
-    /// Check for process
-    void CheckPool();
     void CompletedTransaction(PoolMessage nMessageID);
 
     /// As a client, check and sign the final transaction

--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -857,8 +857,8 @@ void CPrivateSendServer::SetState(PoolState nStateNew)
 {
     if (!fMasternodeMode) return;
 
-    if (nStateNew == POOL_STATE_ERROR || nStateNew == POOL_STATE_SUCCESS) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::SetState -- Can't set state to ERROR or SUCCESS as a Masternode. \n");
+    if (nStateNew == POOL_STATE_ERROR) {
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::SetState -- Can't set state to ERROR as a Masternode. \n");
         return;
     }
 

--- a/src/privatesend/privatesend.cpp
+++ b/src/privatesend/privatesend.cpp
@@ -217,8 +217,6 @@ std::string CPrivateSendBaseSession::GetStateString() const
         return "SIGNING";
     case POOL_STATE_ERROR:
         return "ERROR";
-    case POOL_STATE_SUCCESS:
-        return "SUCCESS";
     default:
         return "UNKNOWN";
     }

--- a/src/privatesend/privatesend.h
+++ b/src/privatesend/privatesend.h
@@ -65,9 +65,8 @@ enum PoolState : int32_t {
     POOL_STATE_ACCEPTING_ENTRIES,
     POOL_STATE_SIGNING,
     POOL_STATE_ERROR,
-    POOL_STATE_SUCCESS,
     POOL_STATE_MIN = POOL_STATE_IDLE,
-    POOL_STATE_MAX = POOL_STATE_SUCCESS
+    POOL_STATE_MAX = POOL_STATE_ERROR
 };
 template<> struct is_serializable_enum<PoolState> : std::true_type {};
 


### PR DESCRIPTION
Changes in behaviour:
- unlock coins, return keys to keypool and set state to POOL_STATE_ERROR on error, reset session on timeout later
- drop POOL_STATE_SUCCESS (wasn't really used)