### PR TITLE
Introduce ONLY_PRIVATESEND coin type to select fully mixed coins only

### DIFF
--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -14,8 +14,8 @@
 enum class CoinType
 {
     ALL_COINS,
-    ONLY_PRIVATESEND,
-    ONLY_DENOMINATED,
+    ONLY_FULLY_MIXED,
+    ONLY_READY_TO_MIX,
     ONLY_NONDENOMINATED,
     ONLY_1000, // find masternode outputs including locked ones (use with caution)
     ONLY_PRIVATESEND_COLLATERAL,
@@ -96,12 +96,12 @@ public:
 
     void UsePrivateSend(bool fUsePrivateSend)
     {
-        nCoinType = fUsePrivateSend ? CoinType::ONLY_PRIVATESEND : CoinType::ALL_COINS;
+        nCoinType = fUsePrivateSend ? CoinType::ONLY_FULLY_MIXED : CoinType::ALL_COINS;
     }
 
     bool IsUsingPrivateSend() const
     {
-        return nCoinType == CoinType::ONLY_PRIVATESEND;
+        return nCoinType == CoinType::ONLY_FULLY_MIXED;
     }
 
 private:

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -14,6 +14,7 @@
 enum class CoinType
 {
     ALL_COINS,
+    ONLY_PRIVATESEND,
     ONLY_DENOMINATED,
     ONLY_NONDENOMINATED,
     ONLY_1000, // find masternode outputs including locked ones (use with caution)
@@ -95,12 +96,12 @@ public:
 
     void UsePrivateSend(bool fUsePrivateSend)
     {
-        nCoinType = fUsePrivateSend ? CoinType::ONLY_DENOMINATED : CoinType::ALL_COINS;
+        nCoinType = fUsePrivateSend ? CoinType::ONLY_PRIVATESEND : CoinType::ALL_COINS;
     }
 
     bool IsUsingPrivateSend() const
     {
-        return nCoinType == CoinType::ONLY_DENOMINATED;
+        return nCoinType == CoinType::ONLY_PRIVATESEND;
     }
 
 private:

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2779,8 +2779,14 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
 
             for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
                 bool found = false;
-                if(nCoinType == CoinType::ONLY_DENOMINATED) {
-                    found = CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
+                if (nCoinType == CoinType::ONLY_PRIVATESEND) {
+                    if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
+                    int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
+                    found = nRounds >= privateSendClient.nPrivateSendRounds;
+                } else if(nCoinType == CoinType::ONLY_DENOMINATED) {
+                    if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
+                    int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
+                    found = nRounds < privateSendClient.nPrivateSendRounds;
                 } else if(nCoinType == CoinType::ONLY_NONDENOMINATED) {
                     if (CPrivateSend::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts
                     found = !CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
@@ -2989,7 +2995,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     int tryDenomStart = 0;
     CAmount nMinChange = MIN_CHANGE;
 
-    if (nCoinType == CoinType::ONLY_DENOMINATED) {
+    if (nCoinType == CoinType::ONLY_PRIVATESEND) {
         // larger denoms first
         std::sort(vCoins.rbegin(), vCoins.rend(), CompareByPriority());
         // we actually want denoms only, so let's skip "non-denom only" step
@@ -3030,7 +3036,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
             if (tryDenom == 0 && CPrivateSend::IsDenominatedAmount(coin.txout.nValue)) continue; // we don't want denom values on first run
 
-            if (nCoinType == CoinType::ONLY_DENOMINATED) {
+            if (nCoinType == CoinType::ONLY_PRIVATESEND) {
                 // Make sure it's actually mixed
                 COutPoint outpoint = COutPoint(pcoin->GetHash(), i);
                 int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
@@ -3079,7 +3085,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
             nValueRet += coinLowestLarger->txout.nValue;
             // There is no change in PS, so we know the fee beforehand,
             // can see if we exceeded the max fee and thus fail quickly.
-            return (nCoinType == CoinType::ONLY_DENOMINATED) ? (nValueRet - nTargetValue <= maxTxFee) : true;
+            return (nCoinType == CoinType::ONLY_PRIVATESEND) ? (nValueRet - nTargetValue <= maxTxFee) : true;
         }
 
         // nTotalLower > nTargetValue
@@ -3120,7 +3126,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
     // There is no change in PS, so we know the fee beforehand,
     // can see if we exceeded the max fee and thus fail quickly.
-    return (nCoinType == CoinType::ONLY_DENOMINATED) ? (nValueRet - nTargetValue <= maxTxFee) : true;
+    return (nCoinType == CoinType::ONLY_PRIVATESEND) ? (nValueRet - nTargetValue <= maxTxFee) : true;
 }
 
 bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl) const
@@ -3138,7 +3144,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
             if(!out.fSpendable)
                 continue;
 
-            if(nCoinType == CoinType::ONLY_DENOMINATED) {
+            if(nCoinType == CoinType::ONLY_PRIVATESEND) {
                 COutPoint outpoint = COutPoint(out.tx->GetHash(),out.i);
                 int nRounds = GetCappedOutpointPrivateSendRounds(outpoint);
                 // make sure it's actually mixed
@@ -3172,7 +3178,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
             // Clearly invalid input, fail
             if (pcoin->tx->vout.size() <= outpoint.n)
                 return false;
-            if (nCoinType == CoinType::ONLY_DENOMINATED) {
+            if (nCoinType == CoinType::ONLY_PRIVATESEND) {
                 // Make sure to include mixed preset inputs only,
                 // even if some non-mixed inputs were manually selected via CoinControl
                 int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
@@ -3434,9 +3440,6 @@ bool CWallet::SelectDenominatedAmounts(CAmount nValueMax, std::set<CAmount>& set
 
     for (const auto& out : vCoins) {
         CAmount nValue = out.tx->tx->vout[out.i].nValue;
-        COutPoint outpoint(out.tx->GetHash(), out.i);
-        int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
-        if (nRounds < 0 || nRounds >= privateSendClient.nPrivateSendRounds) continue;
         if (nValueTotal + nValue <= nValueMax) {
             nValueTotal += nValue;
             setAmountsRet.emplace(nValue);
@@ -3649,7 +3652,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
     wtxNew.fTimeReceivedIsTxTime = true;
     wtxNew.BindWallet(this);
-    if (coin_control.nCoinType == CoinType::ONLY_DENOMINATED) {
+    if (coin_control.nCoinType == CoinType::ONLY_PRIVATESEND) {
         wtxNew.mapValue["DS"] = "1";
     }
 
@@ -3785,7 +3788,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     if (!SelectCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, &coin_control)) {
                         if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
                             strFailReason = _("Unable to locate enough PrivateSend non-denominated funds for this transaction.");
-                        } else if (coin_control.nCoinType == CoinType::ONLY_DENOMINATED) {
+                        } else if (coin_control.nCoinType == CoinType::ONLY_PRIVATESEND) {
                             strFailReason = _("Unable to locate enough PrivateSend denominated funds for this transaction.");
                             strFailReason += " " + _("PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.");
                         } else if (nValueIn < nValueToSelect) {
@@ -3801,7 +3804,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 if (nChange > 0)
                 {
                     //over pay for denominated transactions
-                    if (coin_control.nCoinType == CoinType::ONLY_DENOMINATED) {
+                    if (coin_control.nCoinType == CoinType::ONLY_PRIVATESEND) {
                         nChangePosInOut = -1;
                         nFeeRet += nChange;
                     } else {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3036,13 +3036,6 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
             if (tryDenom == 0 && CPrivateSend::IsDenominatedAmount(coin.txout.nValue)) continue; // we don't want denom values on first run
 
-            if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
-                // Make sure it's actually mixed
-                COutPoint outpoint = COutPoint(pcoin->GetHash(), i);
-                int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
-                if (nRounds < privateSendClient.nPrivateSendRounds) continue;
-            }
-
             if (coin.txout.nValue == nTargetValue)
             {
                 setCoinsRet.insert(coin);
@@ -3144,12 +3137,6 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
             if(!out.fSpendable)
                 continue;
 
-            if(nCoinType == CoinType::ONLY_FULLY_MIXED) {
-                COutPoint outpoint = COutPoint(out.tx->GetHash(),out.i);
-                int nRounds = GetCappedOutpointPrivateSendRounds(outpoint);
-                // make sure it's actually mixed
-                if(nRounds < privateSendClient.nPrivateSendRounds) continue;
-            }
             nValueRet += out.tx->tx->vout[out.i].nValue;
             setCoinsRet.insert(CInputCoin(out.tx, out.i));
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2779,11 +2779,11 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
 
             for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
                 bool found = false;
-                if (nCoinType == CoinType::ONLY_PRIVATESEND) {
+                if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
                     if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
                     int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
                     found = nRounds >= privateSendClient.nPrivateSendRounds;
-                } else if(nCoinType == CoinType::ONLY_DENOMINATED) {
+                } else if(nCoinType == CoinType::ONLY_READY_TO_MIX) {
                     if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
                     int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
                     found = nRounds < privateSendClient.nPrivateSendRounds;
@@ -2995,7 +2995,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     int tryDenomStart = 0;
     CAmount nMinChange = MIN_CHANGE;
 
-    if (nCoinType == CoinType::ONLY_PRIVATESEND) {
+    if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
         // larger denoms first
         std::sort(vCoins.rbegin(), vCoins.rend(), CompareByPriority());
         // we actually want denoms only, so let's skip "non-denom only" step
@@ -3036,7 +3036,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
             if (tryDenom == 0 && CPrivateSend::IsDenominatedAmount(coin.txout.nValue)) continue; // we don't want denom values on first run
 
-            if (nCoinType == CoinType::ONLY_PRIVATESEND) {
+            if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
                 // Make sure it's actually mixed
                 COutPoint outpoint = COutPoint(pcoin->GetHash(), i);
                 int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
@@ -3085,7 +3085,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
             nValueRet += coinLowestLarger->txout.nValue;
             // There is no change in PS, so we know the fee beforehand,
             // can see if we exceeded the max fee and thus fail quickly.
-            return (nCoinType == CoinType::ONLY_PRIVATESEND) ? (nValueRet - nTargetValue <= maxTxFee) : true;
+            return (nCoinType == CoinType::ONLY_FULLY_MIXED) ? (nValueRet - nTargetValue <= maxTxFee) : true;
         }
 
         // nTotalLower > nTargetValue
@@ -3126,7 +3126,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
     // There is no change in PS, so we know the fee beforehand,
     // can see if we exceeded the max fee and thus fail quickly.
-    return (nCoinType == CoinType::ONLY_PRIVATESEND) ? (nValueRet - nTargetValue <= maxTxFee) : true;
+    return (nCoinType == CoinType::ONLY_FULLY_MIXED) ? (nValueRet - nTargetValue <= maxTxFee) : true;
 }
 
 bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl) const
@@ -3144,7 +3144,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
             if(!out.fSpendable)
                 continue;
 
-            if(nCoinType == CoinType::ONLY_PRIVATESEND) {
+            if(nCoinType == CoinType::ONLY_FULLY_MIXED) {
                 COutPoint outpoint = COutPoint(out.tx->GetHash(),out.i);
                 int nRounds = GetCappedOutpointPrivateSendRounds(outpoint);
                 // make sure it's actually mixed
@@ -3178,7 +3178,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
             // Clearly invalid input, fail
             if (pcoin->tx->vout.size() <= outpoint.n)
                 return false;
-            if (nCoinType == CoinType::ONLY_PRIVATESEND) {
+            if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
                 // Make sure to include mixed preset inputs only,
                 // even if some non-mixed inputs were manually selected via CoinControl
                 int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
@@ -3293,7 +3293,7 @@ bool CWallet::SelectPSInOutPairsByDenominations(int nDenom, CAmount nValueMax, s
     CAmount nDenomAmount = CPrivateSend::DenominationToAmount(nDenom);
 
     CCoinControl coin_control;
-    coin_control.nCoinType = CoinType::ONLY_DENOMINATED;
+    coin_control.nCoinType = CoinType::ONLY_READY_TO_MIX;
     AvailableCoins(vCoins, true, &coin_control);
     LogPrint(BCLog::PRIVATESEND, "CWallet::%s -- vCoins.size(): %d\n", __func__, vCoins.size());
 
@@ -3432,7 +3432,7 @@ bool CWallet::SelectDenominatedAmounts(CAmount nValueMax, std::set<CAmount>& set
 
     std::vector<COutput> vCoins;
     CCoinControl coin_control;
-    coin_control.nCoinType = CoinType::ONLY_DENOMINATED;
+    coin_control.nCoinType = CoinType::ONLY_READY_TO_MIX;
     AvailableCoins(vCoins, true, &coin_control);
     // larger denoms first
     std::sort(vCoins.rbegin(), vCoins.rend(), CompareByPriority());
@@ -3651,7 +3651,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
     wtxNew.fTimeReceivedIsTxTime = true;
     wtxNew.BindWallet(this);
-    if (coin_control.nCoinType == CoinType::ONLY_PRIVATESEND) {
+    if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
         wtxNew.mapValue["DS"] = "1";
     }
 
@@ -3787,7 +3787,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     if (!SelectCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, &coin_control)) {
                         if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
                             strFailReason = _("Unable to locate enough PrivateSend non-denominated funds for this transaction.");
-                        } else if (coin_control.nCoinType == CoinType::ONLY_PRIVATESEND) {
+                        } else if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
                             strFailReason = _("Unable to locate enough PrivateSend denominated funds for this transaction.");
                             strFailReason += " " + _("PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.");
                         } else if (nValueIn < nValueToSelect) {
@@ -3803,7 +3803,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 if (nChange > 0)
                 {
                     //over pay for denominated transactions
-                    if (coin_control.nCoinType == CoinType::ONLY_PRIVATESEND) {
+                    if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
                         nChangePosInOut = -1;
                         nFeeRet += nChange;
                     } else {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3308,7 +3308,6 @@ bool CWallet::SelectPSInOutPairsByDenominations(int nDenom, CAmount nValueMax, s
         CTxIn txin = CTxIn(txHash, out.i);
         CScript scriptPubKey = out.tx->tx->vout[out.i].scriptPubKey;
         int nRounds = GetRealOutpointPrivateSendRounds(txin.prevout);
-        if (nRounds >= privateSendClient.nPrivateSendRounds) continue;
 
         if (nValue != nDenomAmount) continue;
         nValueTotal += nValue;


### PR DESCRIPTION
This should make it a bit clearer IMO.

Note: ONLY_DENOMINATED will NOT return fully mixed coins now