### PR TITLE
Remove duplicated mnauth condition check

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -82,7 +82,7 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
             return;
         }
 
-        if (mnauth.proRegTxHash.IsNull() || !mnauth.sig.IsValid()) {
+        if (!mnauth.sig.IsValid()) {
             LOCK(cs_main);
             Misbehaving(pnode->GetId(), 100, "invalid mnauth signature");
             return;


### PR DESCRIPTION
At some point an [additional check](https://github.com/thephez/dash/blob/develop/src/evo/mnauth.cpp#L79-L83) was added before this one (L79) that covers the null proregtx case so this condition should never be reached.