### PR TITLE
Disable qt menu heuristics for openConfEditorAction

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -438,6 +438,8 @@ void BitcoinGUI::createActions()
     openRepairAction->setStatusTip(tr("Show wallet repair options"));
     openConfEditorAction = new QAction(QIcon(":/icons/edit"), tr("Open Wallet &Configuration File"), this);
     openConfEditorAction->setStatusTip(tr("Open configuration file"));
+    // override TextHeuristicRole set by default which confuses this action with application settings
+    openConfEditorAction->setMenuRole(QAction::NoRole);
     showBackupsAction = new QAction(QIcon(":/icons/browse"), tr("Show Automatic &Backups"), this);
     showBackupsAction->setStatusTip(tr("Show automatically created wallet backups"));
     // initially disable the debug window menu items


### PR DESCRIPTION
Thanks to `TextHeuristicRole` set by default qt confuses `openConfEditorAction` with application settings and binds it as if we would set `PreferencesRole` to it. As a result it opens `dash.conf` when user clicks `Preferences...` and not application settings as one would expect. Explicitly setting `NoRole` fixes it.

Note: this issue only appears in some languages e.g. `de`.

@xdustinface