### PR TITLE
Feature request #3425 - Add information to "protx diff"

### DIFF
--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -5,6 +5,8 @@
 #ifndef DASH_QUORUMS_COMMITMENT_H
 #define DASH_QUORUMS_COMMITMENT_H
 
+#include <llmq/quorums_utils.h>
+
 #include <consensus/params.h>
 
 #include <evo/deterministicmns.h>
@@ -94,8 +96,13 @@ public:
         obj.push_back(Pair("llmqType", (int)llmqType));
         obj.push_back(Pair("quorumHash", quorumHash.ToString()));
         obj.push_back(Pair("signersCount", CountSigners()));
+        obj.push_back(Pair("signers", CLLMQUtils::ToHexStr(signers)));
         obj.push_back(Pair("validMembersCount", CountValidMembers()));
+        obj.push_back(Pair("validMembers", CLLMQUtils::ToHexStr(validMembers)));
         obj.push_back(Pair("quorumPublicKey", quorumPublicKey.ToString()));
+        obj.push_back(Pair("quorumVvecHash", quorumVvecHash.ToString()));
+        obj.push_back(Pair("quorumSig", quorumSig.ToString()));
+        obj.push_back(Pair("membersSig", membersSig.ToString()));
     }
 };
 

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -75,7 +75,7 @@ public:
         for (size_t i = 0; i < vBits.size(); i++) {
             vBytes[i / 8] |= vBits[i] << (i % 8);
         }
-        return HexStr(vBytes.rbegin(), vBytes.rend(), false);
+        return HexStr(vBytes);
     }
 };
 

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -69,6 +69,14 @@ public:
             }
         }
     }
+    static std::string ToHexStr(const std::vector<bool>& vBits)
+    {
+        std::vector<uint8_t> vBytes((vBits.size() + 7) / 8);
+        for (size_t i = 0; i < vBits.size(); i++) {
+            vBytes[i / 8] |= vBits[i] << (i % 8);
+        }
+        return HexStr(vBytes.rbegin(), vBytes.rend(), false);
+    }
 };
 
 } // namespace llmq


### PR DESCRIPTION
As requested in #3425 i added the following entries to the json object:

- `signers` -> Bitset representing the aggregated signers of this final commitment
- `validMembers` -> Bitset of valid members in this commitment
- `quorumVvecHash` -> The SHA256 hash of the quorum verification vector
- `quorumSig` -> Recovered threshold signature
- `membersSig` -> Aggregated BLS signatures from all included commitments

Example output:

```
{
    "version": 1,
    "llmqType": 1,
    "quorumHash": "000002a20a35757fc467f0ebe8663f76e4c5df74411cc5f1735cfd92278071fe",
    "signersCount": 49,
    "signers": "fffffffffffb03",
    "validMembersCount": 49,
    "validMembers": "fffffffffffb03",
    "quorumPublicKey": "8db1108b50dd741076b577f6798f0bf382ca4d11dafd55ed14aaaf613f604aa55bf1da1f0469f75105376e440381ee23",
    "quorumVvecHash": "feedb15d5a7ca25a68d9c51036973d37925d8439d4769d7dd7bace7440089071",
    "quorumSig": "1879f6260ef427dc9542088b39e02a8e73e34c0484269cbc12108ab991d438f81e5be80a5b4b5595b6634113fdf060060c8fe190677627fb2d25f6e052c7f93598d36dd415f8f84c693c6a5943098616a1e135522852d8f572bb6e1470df4a94",
    "membersSig": "8ef7d881fcc1e8111dd82c556ab62dad56ea5ecb47a9ac067eb2057d92d27e39530630a7f77d19adc857d33eb485a1b601b2d78ac4c73742f2036089bfb1f25441f1dfcd3cfd1eed6e7d664c0e97bf75b7d7097ebd647791fbcef070fe3e3e91"
}
```

Should be all or is there anything else required?