### PR TITLE
Fix `gobject submit`: replace request params with txidFee

### DIFF
--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -281,7 +281,7 @@ UniValue gobject_submit(const JSONRPCRequest& request)
     CGovernanceObject govobj(hashParent, nRevision, nTime, txidFee, strDataHex);
 
     LogPrint(BCLog::GOBJECT, "gobject_submit -- GetDataAsPlainString = %s, hash = %s, txid = %s\n",
-                govobj.GetDataAsPlainString(), govobj.GetHash().ToString(), request.params[5].get_str());
+                govobj.GetDataAsPlainString(), govobj.GetHash().ToString(), txidFee.ToString());
 
     if (govobj.GetObjectType() == GOVERNANCE_OBJECT_PROPOSAL) {
         CProposalValidator validator(strDataHex, false);


### PR DESCRIPTION
Replaced request.params[5] with txidFee, cause the param could be null at that index when the submit type is a masternode trigger,  triggering a JSON parsing error (expected str, got null).