### PR TITLE
Implement significantly improved createdenominations algorithm

### DIFF
--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -789,7 +789,8 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
             return false;
         }
 
-        if (deterministicMNManager->GetListAtChainTip().GetValidMNsCount() == 0) {
+        if (deterministicMNManager->GetListAtChainTip().GetValidMNsCount() == 0 &&
+            Params().NetworkIDString() != CBaseChainParams::REGTEST) {
             LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::DoAutomaticDenominating -- No Masternodes detected\n");
             strAutoDenomResult = _("No Masternodes detected.");
             return false;

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -661,21 +661,6 @@ void CPrivateSendClientManager::UpdatedSuccessBlock()
     nCachedLastSuccessBlock = nCachedBlockHeight;
 }
 
-bool CPrivateSendClientManager::IsDenomSkipped(const CAmount& nDenomValue)
-{
-    return std::find(vecDenominationsSkipped.begin(), vecDenominationsSkipped.end(), nDenomValue) != vecDenominationsSkipped.end();
-}
-
-void CPrivateSendClientManager::AddSkippedDenom(const CAmount& nDenomValue)
-{
-    vecDenominationsSkipped.push_back(nDenomValue);
-}
-
-void CPrivateSendClientManager::RemoveSkippedDenom(const CAmount& nDenomValue)
-{
-    vecDenominationsSkipped.erase(std::remove(vecDenominationsSkipped.begin(), vecDenominationsSkipped.end(), nDenomValue), vecDenominationsSkipped.end());
-}
-
 bool CPrivateSendClientManager::WaitForAnotherBlock()
 {
     if (!masternodeSync.IsBlockchainSynced()) return true;

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1653,7 +1653,10 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
             int nOutputs = 0;
 
             // Number of denoms we can create given our denom and the amount of funds we have left
-            int denomsToCreate = nValueLeft / nDenomValue;
+            int denomsToCreateValue = nValueLeft / nDenomValue;
+            int denomsToCreateBal = nBalanceToDenominate / nDenomValue;
+            // Use the smaller value
+            int denomsToCreate = denomsToCreateValue > denomsToCreateBal ? denomsToCreateBal : denomsToCreateValue;
             for (int i = 0; i < denomsToCreate; i++) {
                 CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
 

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1543,8 +1543,6 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         mapDenomCount.insert(std::pair<CAmount, int>(nDenomValue, GetWallets()[0]->CountInputsWithAmount(nDenomValue)));
     }
 
-    int debugLoopNum = 0;
-
     // NOTE: We do not allow txes larger than 100kB, so we have to limit the number of outputs here.
     // We still want to create a lot of outputs though.
     // Knowing that each CTxOut is ~35b big, 400 inputs should take 400 x ~35b = ~17.5kb.
@@ -1561,13 +1559,9 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
     // Now, in this system, so long as we don't reach 500 outputs the process repeats in the same transaction,
     // creating up to privatesenddenoms per denomination in a single transaction.
     while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nOutputsTotal <= 500) {
-        assert(debugLoopNum++ < 100);
-        LogPrint(BCLog::PRIVATESEND,
-                 "CPrivateSendClientSession::CreateDenominated -- big loop %d\n",
-                 debugLoopNum);
-
         for (auto it = vecStandardDenoms.rbegin(); it != vecStandardDenoms.rend(); ++it) {
             CAmount nDenomValue = *it;
+            auto currentDenomIt = mapDenomCount.find(nDenomValue);
 
             int nOutputs = 0;
 
@@ -1579,50 +1573,27 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                                && nBalanceToDenominate < nDenomValue);
                 fAddFinal = false; // add final denom only once, only the smalest possible one
 
-                if (fRegular == false && fFinal == false) {
-                    LogPrint(BCLog::PRIVATESEND,
-                             "CPrivateSendClientSession::CreateDenominated -- fRegular false b/c (nValueLeft %d >= nDenomValue %d && nBalanceToDenominate %d >= nDenomValue %d)\n",
-                             nValueLeft, nDenomValue, nBalanceToDenominate, nDenomValue);
-                    LogPrint(BCLog::PRIVATESEND,
-                             "CPrivateSendClientSession::CreateDenominated -- fFinal false b/c %s  nValueLeft: %d nDenomValue: %d nBalanceToD: %d\n",
-                             fAddFinal ? "true" : "false", nValueLeft, nDenomValue, nBalanceToDenominate);
-                }
-
                 return fRegular || fFinal;
             };
 
             // add each output up to 11 times or until it can't be added again or until we reach nPrivateSendDenoms
-            while (needMoreOutputs() && nOutputs <= 10 && mapDenomCount.find(nDenomValue)->second <= privateSendClient.nPrivateSendDenoms) {
-                LogPrint(BCLog::PRIVATESEND,
-                         "CPrivateSendClientSession::CreateDenominated -- CreatedDenom b/c mapDenomCount.find(nDenomValue)->second: %d <= privateSendClient.nPrivateSendDenoms: %d\n",
-                         mapDenomCount.find(nDenomValue)->second, privateSendClient.nPrivateSendDenoms);
+            while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second <= privateSendClient.nPrivateSendDenoms) {
                 CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
 
                 vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
 
                 // increment outputs and subtract denomination amount
                 nOutputs++;
-                mapDenomCount.find(nDenomValue)->second++;
+                currentDenomIt->second++;
                 nValueLeft -= nDenomValue;
                 nBalanceToDenominate -= nDenomValue;
                 LogPrint(BCLog::PRIVATESEND,
                          "CPrivateSendClientSession::CreateDenominated -- 1 - totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n",
                          nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN);
             }
-/*
-            LogPrint(BCLog::PRIVATESEND,
-                     "CPrivateSendClientSession::CreateDenominated -- Stopped CreatedDenom for %d args: %d %s %d %d eval: %s\n",
-                     nDenomValue, needMoreOutputs() ? "true" : "false", nOutputs, mapDenomCount.find(nDenomValue)->second, privateSendClient.nPrivateSendDenoms,
-                     (needMoreOutputs() && nOutputs <= 10 && mapDenomCount.find(nDenomValue)->second <= privateSendClient.nPrivateSendDenoms) ? "true" : "false");
-*/
-            nOutputsTotal += nOutputs;
-            if (nValueLeft == 0 || nBalanceToDenominate <= 0) {
-                LogPrint(BCLog::PRIVATESEND,
-                         "CPrivateSendClientSession::CreateDenominated -- THIS WEIRD BREAK WAS CALLED %d, %d\n",
-                         nValueLeft, nBalanceToDenominate);
 
-                break;
-            }
+            nOutputsTotal += nOutputs;
+            if (nValueLeft == 0 || nBalanceToDenominate <= 0) break;
         }
 
         bool finished = true;
@@ -1630,23 +1601,17 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
             // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenoms of this
             // denom and that our nValueLeft/nBalanceToDenominate is enough to create one of these denoms, if so, loop again.
             if (it.second <= privateSendClient.nPrivateSendDenoms && nValueLeft >= it.first && nBalanceToDenominate >= it.first) {
-                LogPrint(BCLog::PRIVATESEND,
-                         "CPrivateSendClientSession::CreateDenominated -- 1 - decided not finished b/c %d <= %d && %d >= %d\n",
-                         it.second, privateSendClient.nPrivateSendDenoms, nValueLeft, it.first);
                 finished = false;
                 break;
             }
-            LogPrint(BCLog::PRIVATESEND,
-                     "CPrivateSendClientSession::CreateDenominated -- 1 - Okay to finish b/c %d <= %d && %d >= %d\n",
-                     it.second, privateSendClient.nPrivateSendDenoms, nValueLeft, it.first);
-
         }
 
         if (finished) break;
     }
 
     // Now that nPrivateSendDenoms worth of each denom have been created, do something with the remainder.
-    while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nOutputsTotal <= 500) {
+    while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nBalanceToDenominate >= CPrivateSend::GetSmallestDenomination()
+           && nOutputsTotal <= 500) {
 
         // Go big to small
         for (long nDenomValue : vecStandardDenoms) {
@@ -1667,8 +1632,6 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 mapDenomCount.find(nDenomValue)->second++;
                 nValueLeft -= nDenomValue;
                 nBalanceToDenominate -= nDenomValue;
-                LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- Incremented a denom %d. currentDenomCount: %d\n",
-                         mapDenomCount.find(nDenomValue)->first, mapDenomCount.find(nDenomValue)->second);
                 LogPrint(BCLog::PRIVATESEND,
                          "CPrivateSendClientSession::CreateDenominated -- 1 - totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n",
                          nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN);

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1530,7 +1530,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
     // NOTE: We do not allow txes larger than 100kB, so we have to limit the number of outputs here.
     // We still want to create a lot of outputs though.
-    // Knowing that each CTxOut is ~35b big, 400 inputs should take 400 x ~35b = ~17.5kb.
+    // Knowing that each CTxOut is ~35b big, 400 outputs should take 400 x ~35b = ~17.5kb.
     // More than 500 outputs starts to make qt quite laggy.
     // Additionally to need all 500 outputs (assuming a max per denom of 50) you'd need to be trying to
     // create denominations for over 3000 dash!

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -172,8 +172,6 @@ private:
     // Keep track of the used Masternodes
     std::vector<COutPoint> vecMasternodesUsed;
 
-    std::vector<CAmount> vecDenominationsSkipped;
-
     // TODO: or map<denom, CPrivateSendClientSession> ??
     std::deque<CPrivateSendClientSession> deqSessions;
     mutable CCriticalSection cs_deqsessions;
@@ -204,7 +202,6 @@ public:
 
     CPrivateSendClientManager() :
         vecMasternodesUsed(),
-        vecDenominationsSkipped(),
         deqSessions(),
         nCachedLastSuccessBlock(0),
         nMinBlocksToWait(1),
@@ -222,10 +219,6 @@ public:
     }
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
-
-    bool IsDenomSkipped(const CAmount& nDenomValue);
-    void AddSkippedDenom(const CAmount& nDenomValue);
-    void RemoveSkippedDenom(const CAmount& nDenomValue);
 
     void ResetPool();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4102,7 +4102,6 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, CCon
                 coin.BindWallet(this);
                 NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
                 updated_hahes.insert(txin.prevout.hash);
-                privateSendClient.RemoveSkippedDenom(coin.tx->vout[txin.prevout.n].nValue);
             }
         }
 


### PR DESCRIPTION
This works in the way creating PS denoms has traditionally worked with some twists, assuming enough funds, it will start with the smallest denom then create 11 of those, then go up to the next biggest denom create 11 and repeat. Previously, once the largest denom was reached, as many could be created were created and then any remaining funds were put into a change address and denominations were created in the same manner a block later/in another tx. 

Now, in this new system, so long as we don't reach 500 outputs the process repeats in the same transaction, creating up to privatesenddenoms per denomination in a single transaction. Then, once there are privatesenddenoms of each denom, take that leftover/"change" and create as many of the largest denom you can with that amount, then as many of the next largest, down to the smallest. 

This has the change of privatesenddenoms not being a hard cap anymore that won't be exceeded, but instead, the initial "checkpoint" so to speak.
It has a couple of other benefits as well, in the case of privatesenddenoms = 50, receiving a lot of small-ish txes results in you having max number of small denoms, which means you have funds in your wallet, but denoms won't be created from them which means you won't end up mixing all your funds. In this new system, ALL funds, up until the privatesend max_amount will get mixed.

In the old system, receiving lots of small transactions basically clogged your wallet up with tiny inputs, resulting in high fees and other problems (including potential privacy attacks, due to user more inputs than necessary). Under this system, that will still happen in the case of receiving LOTS of tiny transactions, but it will be to a much lesser degree. This is due to the fact that in the old system, 11 smallest denoms were created first, no matter what, under this system, assuming you have privatesenddenoms (50) of the smallest denom, then the wallet will only create as many smallest inputs as it needs to to mix all the funds. As an example, receiving 1.584 Dash in my test (at privatesenddenoms) resulted in only 4 new 0.001 denoms. 

Also, I adjusted DoAutomaticDenominating to allow the creating of denoms on regtest in https://github.com/dashpay/dash/commit/75164e589cbc3b845a3a844144f1914365596369, that made my testing much easier