### PR TITLE
rpc/wallet: Add coinType to queryOptions of listunspent

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -228,7 +228,7 @@ UniValue masternode_outputs(const JSONRPCRequest& request)
     // Find possible candidates
     std::vector<COutput> vPossibleCoins;
     CCoinControl coin_control;
-    coin_control.nCoinType = CoinType::ONLY_1000;
+    coin_control.nCoinType = CoinType::ONLY_MASTERNODE_COLLATERAL;
     pwallet->AvailableCoins(vPossibleCoins, true, &coin_control);
 
     UniValue obj(UniValue::VOBJ);

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -19,7 +19,7 @@ enum class CoinType
     ONLY_NONDENOMINATED,
     ONLY_MASTERNODE_COLLATERAL, // find masternode outputs including locked ones (use with caution)
     ONLY_PRIVATESEND_COLLATERAL,
-    MAX_COIN_TYPE = ONLY_PRIVATESEND_COLLATERAL
+    MAX_COIN_TYPE = ONLY_PRIVATESEND_COLLATERAL,
 };
 
 /** Coin Control Features. */

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -19,6 +19,7 @@ enum class CoinType
     ONLY_NONDENOMINATED,
     ONLY_1000, // find masternode outputs including locked ones (use with caution)
     ONLY_PRIVATESEND_COLLATERAL,
+    MAX_COIN_TYPE = ONLY_PRIVATESEND_COLLATERAL
 };
 
 /** Coin Control Features. */

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -17,7 +17,7 @@ enum class CoinType
     ONLY_FULLY_MIXED,
     ONLY_READY_TO_MIX,
     ONLY_NONDENOMINATED,
-    ONLY_1000, // find masternode outputs including locked ones (use with caution)
+    ONLY_MASTERNODE_COLLATERAL, // find masternode outputs including locked ones (use with caution)
     ONLY_PRIVATESEND_COLLATERAL,
     MAX_COIN_TYPE = ONLY_PRIVATESEND_COLLATERAL
 };

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -19,6 +19,8 @@ enum class CoinType
     ONLY_NONDENOMINATED,
     ONLY_MASTERNODE_COLLATERAL, // find masternode outputs including locked ones (use with caution)
     ONLY_PRIVATESEND_COLLATERAL,
+    // Attributes
+    MIN_COIN_TYPE = ALL_COINS,
     MAX_COIN_TYPE = ONLY_PRIVATESEND_COLLATERAL,
 };
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3090,8 +3090,8 @@ UniValue listunspent(const JSONRPCRequest& request)
         if (options.exists("coinType")) {
             int64_t nCoinType = options["coinType"].get_int64();
 
-            if (nCoinType > static_cast<int64_t>(CoinType::MAX_COIN_TYPE)) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid coinType selected. Available range: %d - %d", static_cast<int64_t>(CoinType::ALL_COINS), static_cast<int64_t>(CoinType::MAX_COIN_TYPE)));
+            if (nCoinType < static_cast<int64_t>(CoinType::MIN_COIN_TYPE) || nCoinType > static_cast<int64_t>(CoinType::MAX_COIN_TYPE)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid coinType selected. Available range: %d - %d", static_cast<int64_t>(CoinType::MIN_COIN_TYPE), static_cast<int64_t>(CoinType::MAX_COIN_TYPE)));
             }
 
             coinControl.nCoinType = static_cast<CoinType>(nCoinType);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2996,7 +2996,7 @@ UniValue listunspent(const JSONRPCRequest& request)
             "      \"maximumAmount\"    (numeric or string, default=unlimited) Maximum value of each UTXO in " + CURRENCY_UNIT + "\n"
             "      \"maximumCount\"     (numeric or string, default=unlimited) Maximum number of UTXOs\n"
             "      \"minimumSumAmount\" (numeric or string, default=unlimited) Minimum sum value of all UTXOs in " + CURRENCY_UNIT + "\n"
-            "      \"coinType\"         (numeric, default=0) Filter coinTypes as followed: 0=ALL_COINS, 1=ONLY_FULLY_MIXED, 2=ONLY_READY_TO_MIX, 3=ONLY_NONDENOMINATED, 4=ONLY_1000, 5=ONLY_PRIVATESEND_COLLATERAL\n"
+            "      \"coinType\"         (numeric, default=0) Filter coinTypes as followed: 0=ALL_COINS, 1=ONLY_FULLY_MIXED, 2=ONLY_READY_TO_MIX, 3=ONLY_NONDENOMINATED, 4=ONLY_MASTERNODE_COLLATERAL, 5=ONLY_PRIVATESEND_COLLATERAL\n"
             "    }\n"
             "\nResult\n"
             "[                   (array of json object)\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2996,6 +2996,7 @@ UniValue listunspent(const JSONRPCRequest& request)
             "      \"maximumAmount\"    (numeric or string, default=unlimited) Maximum value of each UTXO in " + CURRENCY_UNIT + "\n"
             "      \"maximumCount\"     (numeric or string, default=unlimited) Maximum number of UTXOs\n"
             "      \"minimumSumAmount\" (numeric or string, default=unlimited) Minimum sum value of all UTXOs in " + CURRENCY_UNIT + "\n"
+            "      \"coinType\"         (numeric, default=0) Filter coinTypes as followed: 0=ALL_COINS, 1=ONLY_FULLY_MIXED, 2=ONLY_READY_TO_MIX, 3=ONLY_NONDENOMINATED, 4=ONLY_1000, 5=ONLY_PRIVATESEND_COLLATERAL\n"
             "    }\n"
             "\nResult\n"
             "[                   (array of json object)\n"
@@ -3066,6 +3067,8 @@ UniValue listunspent(const JSONRPCRequest& request)
     CAmount nMaximumAmount = MAX_MONEY;
     CAmount nMinimumSumAmount = MAX_MONEY;
     uint64_t nMaximumCount = 0;
+    CCoinControl coinControl;
+    coinControl.nCoinType = CoinType::ALL_COINS;
 
     if (!request.params[4].isNull()) {
         const UniValue& options = request.params[4].get_obj();
@@ -3081,6 +3084,18 @@ UniValue listunspent(const JSONRPCRequest& request)
 
         if (options.exists("maximumCount"))
             nMaximumCount = options["maximumCount"].get_int64();
+
+        if (options.exists("coinType")) {
+
+            int64_t nCoinType = options["coinType"].get_int64();
+
+            if (nCoinType > static_cast<int64_t>(CoinType::MAX_COIN_TYPE)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid coinType selected. Available range: %d - %d", static_cast<int64_t>(CoinType::ALL_COINS), static_cast<int64_t>(CoinType::MAX_COIN_TYPE)));
+            }
+
+            coinControl.nCoinType = static_cast<CoinType>(nCoinType);
+        }
+
     }
 
     // Make sure the results are valid at least up to the most recent block
@@ -3091,7 +3106,7 @@ UniValue listunspent(const JSONRPCRequest& request)
     std::vector<COutput> vecOutputs;
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    pwallet->AvailableCoins(vecOutputs, !include_unsafe, nullptr, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
+    pwallet->AvailableCoins(vecOutputs, !include_unsafe, &coinControl, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
     for (const COutput& out : vecOutputs) {
         CTxDestination address;
         const CScript& scriptPubKey = out.tx->tx->vout[out.i].scriptPubKey;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2996,7 +2996,9 @@ UniValue listunspent(const JSONRPCRequest& request)
             "      \"maximumAmount\"    (numeric or string, default=unlimited) Maximum value of each UTXO in " + CURRENCY_UNIT + "\n"
             "      \"maximumCount\"     (numeric or string, default=unlimited) Maximum number of UTXOs\n"
             "      \"minimumSumAmount\" (numeric or string, default=unlimited) Minimum sum value of all UTXOs in " + CURRENCY_UNIT + "\n"
-            "      \"coinType\"         (numeric, default=0) Filter coinTypes as followed: 0=ALL_COINS, 1=ONLY_FULLY_MIXED, 2=ONLY_READY_TO_MIX, 3=ONLY_NONDENOMINATED, 4=ONLY_MASTERNODE_COLLATERAL, 5=ONLY_PRIVATESEND_COLLATERAL\n"
+            "      \"coinType\"         (numeric, default=0) Filter coinTypes as follows:\n"
+            "                         0=ALL_COINS, 1=ONLY_FULLY_MIXED, 2=ONLY_READY_TO_MIX, 3=ONLY_NONDENOMINATED,\n"
+            "                         4=ONLY_MASTERNODE_COLLATERAL, 5=ONLY_PRIVATESEND_COLLATERAL\n"
             "    }\n"
             "\nResult\n"
             "[                   (array of json object)\n"
@@ -3086,7 +3088,6 @@ UniValue listunspent(const JSONRPCRequest& request)
             nMaximumCount = options["maximumCount"].get_int64();
 
         if (options.exists("coinType")) {
-
             int64_t nCoinType = options["coinType"].get_int64();
 
             if (nCoinType > static_cast<int64_t>(CoinType::MAX_COIN_TYPE)) {
@@ -3095,7 +3096,6 @@ UniValue listunspent(const JSONRPCRequest& request)
 
             coinControl.nCoinType = static_cast<CoinType>(nCoinType);
         }
-
     }
 
     // Make sure the results are valid at least up to the most recent block

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2829,7 +2829,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
                 } else if(nCoinType == CoinType::ONLY_NONDENOMINATED) {
                     if (CPrivateSend::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts
                     found = !CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
-                } else if(nCoinType == CoinType::ONLY_1000) {
+                } else if(nCoinType == CoinType::ONLY_MASTERNODE_COLLATERAL) {
                     found = pcoin->tx->vout[i].nValue == 1000*COIN;
                 } else if(nCoinType == CoinType::ONLY_PRIVATESEND_COLLATERAL) {
                     found = CPrivateSend::IsCollateralAmount(pcoin->tx->vout[i].nValue);
@@ -2844,7 +2844,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
                 if (coinControl && coinControl->HasSelected() && !coinControl->fAllowOtherInputs && !coinControl->IsSelected(COutPoint(wtxid, i)))
                     continue;
 
-                if (IsLockedCoin(wtxid, i) && nCoinType != CoinType::ONLY_1000)
+                if (IsLockedCoin(wtxid, i) && nCoinType != CoinType::ONLY_MASTERNODE_COLLATERAL)
                     continue;
 
                 if (IsSpent(wtxid, i))
@@ -3503,7 +3503,7 @@ bool CWallet::GetMasternodeOutpointAndKeys(COutPoint& outpointRet, CPubKey& pubK
     // Find possible candidates
     std::vector<COutput> vPossibleCoins;
     CCoinControl coin_control;
-    coin_control.nCoinType = CoinType::ONLY_1000;
+    coin_control.nCoinType = CoinType::ONLY_MASTERNODE_COLLATERAL;
     AvailableCoins(vPossibleCoins, true, &coin_control);
     if(vPossibleCoins.empty()) {
         LogPrintf("CWallet::GetMasternodeOutpointAndKeys -- Could not locate any valid masternode vin\n");


### PR DESCRIPTION
This PR allows to filter utxos by `CoinType` when querying them with the `listunspent` rpc command like 

```
listunspent 1 99999 "[]" true "{\"coinType\":3}"
```

to query only non-denominated utxos. 

It also renames the CoinType `ONLY_1000` to `ONLY_MASTERNODE_COLLATERAL` to make it more obvious in the code and the rpc description what that's for.. hope thats ok! 