### PR TITLE
Allow txindex to be off in full mode

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -88,7 +88,7 @@ bool CGovernanceManager::SerializeVoteForHash(const uint256& nHash, CDataStream&
 void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
 {
     // lite mode is not supported
-    if (fLiteMode) return;
+    if (fLiteMode || !fTxIndex) return;
     if (!masternodeSync.IsBlockchainSynced()) return;
 
     // ANOTHER USER IS ASKING US TO HELP THEM SYNC GOVERNANCE OBJECT DATA
@@ -547,7 +547,7 @@ struct sortProposalsByVotes {
 
 void CGovernanceManager::DoMaintenance(CConnman& connman)
 {
-    if (fLiteMode || !masternodeSync.IsSynced() || ShutdownRequested()) return;
+    if (fLiteMode || !fTxIndex || !masternodeSync.IsSynced() || ShutdownRequested()) return;
 
     // CHECK OBJECTS WE'VE ASKED FOR, REMOVE OLD ENTRIES
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1830,11 +1830,6 @@ bool AppInitMain()
                     break;
                 }
 
-                if (!fLiteMode && !fTxIndex
-                   && chainparams.NetworkIDString() != CBaseChainParams::REGTEST) { // TODO remove this when pruning is fixed. See https://github.com/dashpay/dash/pull/1817 and https://github.com/dashpay/dash/pull/1743
-                    return InitError(_("Transaction index can't be disabled in full mode. Either start with -litemode command line switch or enable transaction index."));
-                }
-
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
                 if (!mapBlockIndex.empty() && mapBlockIndex.count(chainparams.GetConsensus().hashGenesisBlock) == 0)


### PR DESCRIPTION
I originally made this change to see how stuff would break... But then I had a problem... Nothing broke!

I'm not sure if the break if actually much deeper, and I just don't see everything breaking, but this change allowed me to start a wallet, with txindex off. When I did so, I expected IS to crash the wallet or something, but it... didn't... IS worked... Chainlocks worked... I think this is a result of the implementation of LLMQ based IS. Under the old IS model, individual inputs received locks, whereas in the new model (If I recall / read the code correctly) the entire tx gets locked. So whereas in the old system, you needed txindex when receiving IS, now you don't.

This also has the added benefit of allowing people to run pruned nodes which have all of Dash's lovely features like privatesend, instantsend and chainlocks enabled automagically

(Assuming everything is good in this PR) Regarding whether to merge into 0.16 or 0.17 I don't have much of a preference, ofc since it is my change I am going to want to see it in 16, however, this isn't a bug fix, and would likely cause more testing to be needed. Basically emotionally I want it in 16, but logically I think it should probably be after 16