### PR TITLE
Reintroduce mixing hard cap for all but the largest denom

### DIFF
--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1557,7 +1557,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
             };
 
             // add each output up to 11 times or until it can't be added again or until we reach nPrivateSendDenomsBatched
-            while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second <= privateSendClient.nPrivateSendDenomsBatched) {
+            while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second < privateSendClient.nPrivateSendDenomsBatched) {
                 CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
 
                 vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
@@ -1581,7 +1581,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         for (auto it : mapDenomCount) {
             // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenomsBatched of this
             // denom and that our nValueLeft/nBalanceToDenominate is enough to create one of these denoms, if so, loop again.
-            if (it.second <= privateSendClient.nPrivateSendDenomsBatched && nValueLeft >= it.first && nBalanceToDenominate >= it.first) {
+            if (it.second < privateSendClient.nPrivateSendDenomsBatched && nValueLeft >= it.first && nBalanceToDenominate >= it.first) {
                 finished = false;
                 break;
             }

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1534,10 +1534,10 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
     // it will start with the smallest denom then create 11 of those, then go up to the next biggest denom create 11
     // and repeat. Previously, once the largest denom was reached, as many would be created were created as possible and
     // then any remaining was put into a change address and denominations were created in the same manner a block later.
-    // Now, in this system, so long as we don't reach MAX_PRIVATESEND_DENOM_OUTPUTS outputs the process repeats in the same transaction,
-    // creating up to privatesenddenoms per denomination in a single transaction.
+    // Now, in this system, so long as we don't reach PRIVATESEND_DENOM_OUTPUTS_THRESHOLD outputs the process repeats in
+    // the same transaction, creating up to nPrivateSendDenomsHardCap per denomination in a single transaction.
 
-    while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nOutputsTotal < MAX_PRIVATESEND_DENOM_OUTPUTS) {
+    while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nOutputsTotal < PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) {
 
         for (auto it = vecStandardDenoms.rbegin(); it != vecStandardDenoms.rend(); ++it) {
             CAmount nDenomValue = *it;
@@ -1575,11 +1575,10 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 LogPrint(BCLog::PRIVATESEND,
                          "CPrivateSendClientSession::CreateDenominated -- 1 - nDenomValue: %f, totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
                          (float) nDenomValue / COIN, nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
-                if (nOutputs + nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
             }
 
             nOutputsTotal += nOutputs;
-            if (nValueLeft == 0 || nBalanceToDenominate <= 0 || nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
+            if (nValueLeft == 0 || nBalanceToDenominate <= 0) break;
         }
 
         bool finished = true;
@@ -1603,7 +1602,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
     // Now that nPrivateSendDenomsGoal worth of each denom have been created or the max number of denoms given the value of the input, do something with the remainder.
     if (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nBalanceToDenominate >= CPrivateSend::GetSmallestDenomination()
-           && nOutputsTotal < MAX_PRIVATESEND_DENOM_OUTPUTS) {
+           && nOutputsTotal < PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) {
 
         CAmount nLargestDenomValue = vecStandardDenoms.front();
 
@@ -1632,10 +1631,10 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 LogPrint(BCLog::PRIVATESEND,
                          "CPrivateSendClientSession::CreateDenominated -- 2 - nDenomValue: %f, totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
                          (float) nDenomValue / COIN, nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
-                if (nOutputs + nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
+                if (nOutputs + nOutputsTotal >= PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) break;
             }
             nOutputsTotal += nOutputs;
-            if (nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
+            if (nOutputsTotal >= PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) break;
         }
     }
 

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1603,7 +1603,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         CAmount nLargestDenomValue = vecStandardDenoms.front();
 
         // Go big to small
-        for (long nDenomValue : vecStandardDenoms) {
+        for (auto nDenomValue : vecStandardDenoms) {
             int nOutputs = 0;
 
             // Number of denoms we can create given our denom and the amount of funds we have left

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1762,8 +1762,8 @@ void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
     obj.push_back(Pair("max_sessions",  nPrivateSendSessions));
     obj.push_back(Pair("max_rounds",    nPrivateSendRounds));
     obj.push_back(Pair("max_amount",    nPrivateSendAmount));
-    obj.push_back(Pair("max_denoms_goal",    nPrivateSendDenomsGoal));
-    obj.push_back(Pair("max_denoms_hardcap",    nPrivateSendDenomsHardCap));
+    obj.push_back(Pair("denoms_goal",   nPrivateSendDenomsGoal));
+    obj.push_back(Pair("denoms_hardcap", nPrivateSendDenomsHardCap));
     obj.push_back(Pair("queue_size",    GetQueueSize()));
 
     UniValue arrSessions(UniValue::VARR);

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1561,8 +1561,8 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 return fRegular || fFinal;
             };
 
-            // add each output up to 11 times or until it can't be added again or until we reach nPrivateSendDenoms
-            while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second <= privateSendClient.nPrivateSendDenoms) {
+            // add each output up to 11 times or until it can't be added again or until we reach nPrivateSendDenomsBatched
+            while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second <= privateSendClient.nPrivateSendDenomsBatched) {
                 CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
 
                 vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
@@ -1583,9 +1583,9 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
         bool finished = true;
         for (auto it : mapDenomCount) {
-            // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenoms of this
+            // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenomsBatched of this
             // denom and that our nValueLeft/nBalanceToDenominate is enough to create one of these denoms, if so, loop again.
-            if (it.second <= privateSendClient.nPrivateSendDenoms && nValueLeft >= it.first && nBalanceToDenominate >= it.first) {
+            if (it.second <= privateSendClient.nPrivateSendDenomsBatched && nValueLeft >= it.first && nBalanceToDenominate >= it.first) {
                 finished = false;
                 break;
             }
@@ -1594,9 +1594,11 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         if (finished) break;
     }
 
-    // Now that nPrivateSendDenoms worth of each denom have been created, do something with the remainder.
-    while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nBalanceToDenominate >= CPrivateSend::GetSmallestDenomination()
-           && nOutputsTotal <= 500) {
+    // Now that nPrivateSendDenomsBatched worth of each denom have been created or the max number of denoms given the value of the input, do something with the remainder.
+    if (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nBalanceToDenominate >= CPrivateSend::GetSmallestDenomination()
+           && nOutputsTotal < 500) {
+
+        CAmount nLargestDenomValue = vecStandardDenoms.front();
 
         // Go big to small
         for (long nDenomValue : vecStandardDenoms) {
@@ -1607,14 +1609,17 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
             int denomsToCreateBal = nBalanceToDenominate / nDenomValue;
             // Use the smaller value
             int denomsToCreate = denomsToCreateValue > denomsToCreateBal ? denomsToCreateBal : denomsToCreateValue;
+            auto it = mapDenomCount.find(nDenomValue);
             for (int i = 0; i < denomsToCreate; i++) {
-                CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
+                // Never go above the cap unless it's the largest denom
+                if (nDenomValue != nLargestDenomValue && it->second >= privateSendClient.nPrivateSendDenomsHardCap) break;
 
+                CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
                 vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
 
                 // increment outputs and subtract denomination amount
                 nOutputs++;
-                mapDenomCount.find(nDenomValue)->second++;
+                it->second++;
                 nValueLeft -= nDenomValue;
                 nBalanceToDenominate -= nDenomValue;
                 LogPrint(BCLog::PRIVATESEND,
@@ -1742,7 +1747,8 @@ void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
     obj.push_back(Pair("max_sessions",  nPrivateSendSessions));
     obj.push_back(Pair("max_rounds",    nPrivateSendRounds));
     obj.push_back(Pair("max_amount",    nPrivateSendAmount));
-    obj.push_back(Pair("max_denoms",    nPrivateSendDenoms));
+    obj.push_back(Pair("max_denoms_batched",    nPrivateSendDenomsBatched));
+    obj.push_back(Pair("max_denoms_hardcap",    nPrivateSendDenomsHardCap));
     obj.push_back(Pair("queue_size",    GetQueueSize()));
 
     UniValue arrSessions(UniValue::VARR);

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1568,8 +1568,8 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 nValueLeft -= nDenomValue;
                 nBalanceToDenominate -= nDenomValue;
                 LogPrint(BCLog::PRIVATESEND,
-                         "CPrivateSendClientSession::CreateDenominated -- 1 - totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n",
-                         nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN);
+                         "CPrivateSendClientSession::CreateDenominated -- 1 - nDenomValue: %f, totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
+                         (float) nDenomValue / COIN, nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
                 if (nOutputs + nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
             }
 
@@ -1578,13 +1578,19 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         }
 
         bool finished = true;
-        for (auto it : mapDenomCount) {
+        for (const auto it : mapDenomCount) {
             // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenomsBatched of this
             // denom and that our nValueLeft/nBalanceToDenominate is enough to create one of these denoms, if so, loop again.
             if (it.second < privateSendClient.nPrivateSendDenomsBatched && nValueLeft >= it.first && nBalanceToDenominate >= it.first) {
                 finished = false;
+                LogPrint(BCLog::PRIVATESEND,
+                        "CPrivateSendClientSession::CreateDenominated -- 1 - NOT finished - nDenomValue: %f, count: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
+                        (float) it.first / COIN, it.second, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
                 break;
             }
+            LogPrint(BCLog::PRIVATESEND,
+                    "CPrivateSendClientSession::CreateDenominated -- 1 - FINSHED - nDenomValue: %f, count: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
+                    (float) it.first / COIN, it.second, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
         }
 
         if (finished) break;
@@ -1619,9 +1625,8 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 nValueLeft -= nDenomValue;
                 nBalanceToDenominate -= nDenomValue;
                 LogPrint(BCLog::PRIVATESEND,
-                         "CPrivateSendClientSession::CreateDenominated -- 1 - totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n",
-                         nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN);
-
+                         "CPrivateSendClientSession::CreateDenominated -- 2 - nDenomValue: %f, totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
+                         (float) nDenomValue / COIN, nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
                 if (nOutputs + nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
             }
             nOutputsTotal += nOutputs;
@@ -1629,7 +1634,14 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         }
     }
 
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- 2 - nOutputsTotal: %d, nValueLeft: %f\n", nOutputsTotal, (float)nValueLeft / COIN);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- 3 - nOutputsTotal: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
+            nOutputsTotal, (float)nValueLeft / COIN, (float)nBalanceToDenominate / COIN);
+
+    for (const auto it : mapDenomCount) {
+        LogPrint(BCLog::PRIVATESEND,
+                "CPrivateSendClientSession::CreateDenominated -- 3 - DONE - nDenomValue: %f, count: %d\n",
+                (float) it.first / COIN, it.second);
+    }
 
     // No reasons to create mixing collaterals if we can't create denoms to mix
     if (nOutputsTotal == 0) return false;

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1561,8 +1561,8 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 return fRegular || fFinal;
             };
 
-            // add each output up to 11 times or until it can't be added again or until we reach nPrivateSendDenomsBatched
-            while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second < privateSendClient.nPrivateSendDenomsBatched) {
+            // add each output up to 11 times or until it can't be added again or until we reach nPrivateSendDenomsGoal
+            while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second < privateSendClient.nPrivateSendDenomsGoal) {
                 CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
 
                 vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
@@ -1584,9 +1584,9 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
         bool finished = true;
         for (const auto it : mapDenomCount) {
-            // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenomsBatched of this
+            // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenomsGoal of this
             // denom and that our nValueLeft/nBalanceToDenominate is enough to create one of these denoms, if so, loop again.
-            if (it.second < privateSendClient.nPrivateSendDenomsBatched && nValueLeft >= it.first && nBalanceToDenominate > 0) {
+            if (it.second < privateSendClient.nPrivateSendDenomsGoal && nValueLeft >= it.first && nBalanceToDenominate > 0) {
                 finished = false;
                 LogPrint(BCLog::PRIVATESEND,
                         "CPrivateSendClientSession::CreateDenominated -- 1 - NOT finished - nDenomValue: %f, count: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
@@ -1601,7 +1601,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         if (finished) break;
     }
 
-    // Now that nPrivateSendDenomsBatched worth of each denom have been created or the max number of denoms given the value of the input, do something with the remainder.
+    // Now that nPrivateSendDenomsGoal worth of each denom have been created or the max number of denoms given the value of the input, do something with the remainder.
     if (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nBalanceToDenominate >= CPrivateSend::GetSmallestDenomination()
            && nOutputsTotal < MAX_PRIVATESEND_DENOM_OUTPUTS) {
 
@@ -1762,7 +1762,7 @@ void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
     obj.push_back(Pair("max_sessions",  nPrivateSendSessions));
     obj.push_back(Pair("max_rounds",    nPrivateSendRounds));
     obj.push_back(Pair("max_amount",    nPrivateSendAmount));
-    obj.push_back(Pair("max_denoms_batched",    nPrivateSendDenomsBatched));
+    obj.push_back(Pair("max_denoms_goal",    nPrivateSendDenomsGoal));
     obj.push_back(Pair("max_denoms_hardcap",    nPrivateSendDenomsHardCap));
     obj.push_back(Pair("queue_size",    GetQueueSize()));
 

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1551,7 +1551,12 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                                && nValueLeft >= nDenomValue
                                && nBalanceToDenominate > 0
                                && nBalanceToDenominate < nDenomValue);
-                fAddFinal = false; // add final denom only once, only the smalest possible one
+                if (fFinal) {
+                    fAddFinal = false; // add final denom only once, only the smalest possible one
+                    LogPrint(BCLog::PRIVATESEND,
+                             "CPrivateSendClientSession::CreateDenominated -- 1 - FINAL - nDenomValue: %f, nValueLeft: %f, nBalanceToDenominate: %f\n",
+                             (float) nDenomValue / COIN, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
+                }
 
                 return fRegular || fFinal;
             };
@@ -1581,7 +1586,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         for (const auto it : mapDenomCount) {
             // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenomsBatched of this
             // denom and that our nValueLeft/nBalanceToDenominate is enough to create one of these denoms, if so, loop again.
-            if (it.second < privateSendClient.nPrivateSendDenomsBatched && nValueLeft >= it.first && nBalanceToDenominate >= it.first) {
+            if (it.second < privateSendClient.nPrivateSendDenomsBatched && nValueLeft >= it.first && nBalanceToDenominate > 0) {
                 finished = false;
                 LogPrint(BCLog::PRIVATESEND,
                         "CPrivateSendClientSession::CreateDenominated -- 1 - NOT finished - nDenomValue: %f, count: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1528,22 +1528,17 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         mapDenomCount.insert(std::pair<CAmount, int>(nDenomValue, GetWallets()[0]->CountInputsWithAmount(nDenomValue)));
     }
 
-    // NOTE: We do not allow txes larger than 100kB, so we have to limit the number of outputs here.
-    // We still want to create a lot of outputs though.
-    // Knowing that each CTxOut is ~35b big, 400 outputs should take 400 x ~35b = ~17.5kb.
-    // More than 500 outputs starts to make qt quite laggy.
-    // Additionally to need all 500 outputs (assuming a max per denom of 50) you'd need to be trying to
-    // create denominations for over 3000 dash!
-
     // Will generate outputs for the createdenoms up to privatesendmaxdenoms per denom
 
     // This works in the way creating PS denoms has traditionally worked, assuming enough funds,
     // it will start with the smallest denom then create 11 of those, then go up to the next biggest denom create 11
     // and repeat. Previously, once the largest denom was reached, as many would be created were created as possible and
     // then any remaining was put into a change address and denominations were created in the same manner a block later.
-    // Now, in this system, so long as we don't reach 500 outputs the process repeats in the same transaction,
+    // Now, in this system, so long as we don't reach MAX_PRIVATESEND_DENOM_OUTPUTS outputs the process repeats in the same transaction,
     // creating up to privatesenddenoms per denomination in a single transaction.
-    while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nOutputsTotal <= 500) {
+
+    while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nOutputsTotal < MAX_PRIVATESEND_DENOM_OUTPUTS) {
+
         for (auto it = vecStandardDenoms.rbegin(); it != vecStandardDenoms.rend(); ++it) {
             CAmount nDenomValue = *it;
             auto currentDenomIt = mapDenomCount.find(nDenomValue);
@@ -1575,10 +1570,11 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 LogPrint(BCLog::PRIVATESEND,
                          "CPrivateSendClientSession::CreateDenominated -- 1 - totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n",
                          nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN);
+                if (nOutputs + nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
             }
 
             nOutputsTotal += nOutputs;
-            if (nValueLeft == 0 || nBalanceToDenominate <= 0) break;
+            if (nValueLeft == 0 || nBalanceToDenominate <= 0 || nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
         }
 
         bool finished = true;
@@ -1596,7 +1592,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
     // Now that nPrivateSendDenomsBatched worth of each denom have been created or the max number of denoms given the value of the input, do something with the remainder.
     if (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nBalanceToDenominate >= CPrivateSend::GetSmallestDenomination()
-           && nOutputsTotal < 500) {
+           && nOutputsTotal < MAX_PRIVATESEND_DENOM_OUTPUTS) {
 
         CAmount nLargestDenomValue = vecStandardDenoms.front();
 
@@ -1626,8 +1622,10 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                          "CPrivateSendClientSession::CreateDenominated -- 1 - totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f\n",
                          nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN);
 
+                if (nOutputs + nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
             }
             nOutputsTotal += nOutputs;
+            if (nOutputsTotal >= MAX_PRIVATESEND_DENOM_OUTPUTS) break;
         }
     }
 

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -19,17 +19,17 @@ class UniValue;
 static const int MIN_PRIVATESEND_SESSIONS = 1;
 static const int MIN_PRIVATESEND_ROUNDS = 2;
 static const int MIN_PRIVATESEND_AMOUNT = 2;
-static const int MIN_PRIVATESEND_DENOMS_BATCHED = 10;
+static const int MIN_PRIVATESEND_DENOMS_GOAL = 10;
 static const int MIN_PRIVATESEND_DENOMS_HARDCAP = 10;
 static const int MAX_PRIVATESEND_SESSIONS = 10;
 static const int MAX_PRIVATESEND_ROUNDS = 16;
-static const int MAX_PRIVATESEND_DENOMS_BATCHED = 100000;
+static const int MAX_PRIVATESEND_DENOMS_GOAL = 100000;
 static const int MAX_PRIVATESEND_DENOMS_HARDCAP = 100000;
 static const int MAX_PRIVATESEND_AMOUNT = MAX_MONEY / COIN;
 static const int DEFAULT_PRIVATESEND_SESSIONS = 4;
 static const int DEFAULT_PRIVATESEND_ROUNDS = 4;
 static const int DEFAULT_PRIVATESEND_AMOUNT = 1000;
-static const int DEFAULT_PRIVATESEND_DENOMS_BATCHED = 50;
+static const int DEFAULT_PRIVATESEND_DENOMS_GOAL = 50;
 static const int DEFAULT_PRIVATESEND_DENOMS_HARDCAP = 300;
 
 static const bool DEFAULT_PRIVATESEND_AUTOSTART = false;
@@ -204,7 +204,7 @@ public:
     int nPrivateSendSessions;
     int nPrivateSendRounds;
     int nPrivateSendAmount;
-    int nPrivateSendDenomsBatched;
+    int nPrivateSendDenomsGoal;
     int nPrivateSendDenomsHardCap;
     bool fEnablePrivateSend;
     bool fPrivateSendRunning;
@@ -222,7 +222,7 @@ public:
         nCachedBlockHeight(0),
         nPrivateSendRounds(DEFAULT_PRIVATESEND_ROUNDS),
         nPrivateSendAmount(DEFAULT_PRIVATESEND_AMOUNT),
-        nPrivateSendDenomsBatched(DEFAULT_PRIVATESEND_DENOMS_BATCHED),
+        nPrivateSendDenomsGoal(DEFAULT_PRIVATESEND_DENOMS_GOAL),
         nPrivateSendDenomsHardCap(DEFAULT_PRIVATESEND_DENOMS_HARDCAP),
         fEnablePrivateSend(false),
         fPrivateSendRunning(false),

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -19,15 +19,18 @@ class UniValue;
 static const int MIN_PRIVATESEND_SESSIONS = 1;
 static const int MIN_PRIVATESEND_ROUNDS = 2;
 static const int MIN_PRIVATESEND_AMOUNT = 2;
-static const int MIN_PRIVATESEND_DENOMS = 10;
+static const int MIN_PRIVATESEND_DENOMS_BATCHED = 10;
+static const int MIN_PRIVATESEND_DENOMS_HARDCAP = 10;
 static const int MAX_PRIVATESEND_SESSIONS = 10;
 static const int MAX_PRIVATESEND_ROUNDS = 16;
-static const int MAX_PRIVATESEND_DENOMS = 100000;
+static const int MAX_PRIVATESEND_DENOMS_BATCHED = 100000;
+static const int MAX_PRIVATESEND_DENOMS_HARDCAP = 100000;
 static const int MAX_PRIVATESEND_AMOUNT = MAX_MONEY / COIN;
 static const int DEFAULT_PRIVATESEND_SESSIONS = 4;
 static const int DEFAULT_PRIVATESEND_ROUNDS = 4;
 static const int DEFAULT_PRIVATESEND_AMOUNT = 1000;
-static const int DEFAULT_PRIVATESEND_DENOMS = 50;
+static const int DEFAULT_PRIVATESEND_DENOMS_BATCHED = 50;
+static const int DEFAULT_PRIVATESEND_DENOMS_HARDCAP = 300;
 
 static const bool DEFAULT_PRIVATESEND_AUTOSTART = false;
 static const bool DEFAULT_PRIVATESEND_MULTISESSION = false;
@@ -192,7 +195,8 @@ public:
     int nPrivateSendSessions;
     int nPrivateSendRounds;
     int nPrivateSendAmount;
-    int nPrivateSendDenoms;
+    int nPrivateSendDenomsBatched;
+    int nPrivateSendDenomsHardCap;
     bool fEnablePrivateSend;
     bool fPrivateSendRunning;
     bool fPrivateSendMultiSession;
@@ -209,7 +213,8 @@ public:
         nCachedBlockHeight(0),
         nPrivateSendRounds(DEFAULT_PRIVATESEND_ROUNDS),
         nPrivateSendAmount(DEFAULT_PRIVATESEND_AMOUNT),
-        nPrivateSendDenoms(DEFAULT_PRIVATESEND_DENOMS),
+        nPrivateSendDenomsBatched(DEFAULT_PRIVATESEND_DENOMS_BATCHED),
+        nPrivateSendDenomsHardCap(DEFAULT_PRIVATESEND_DENOMS_HARDCAP),
         fEnablePrivateSend(false),
         fPrivateSendRunning(false),
         fPrivateSendMultiSession(DEFAULT_PRIVATESEND_MULTISESSION),

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -35,14 +35,15 @@ static const int DEFAULT_PRIVATESEND_DENOMS_HARDCAP = 300;
 static const bool DEFAULT_PRIVATESEND_AUTOSTART = false;
 static const bool DEFAULT_PRIVATESEND_MULTISESSION = false;
 
-// How many denom outputs to create in CreateDenominated
+// How many new denom outputs to create before we consider the "goal" loop in CreateDenominated
+// a final one and start creating an actual tx. Same limit applies for the "hard cap" part of the algo.
 // NOTE: We do not allow txes larger than 100kB, so we have to limit the number of outputs here.
 // We still want to create a lot of outputs though.
 // Knowing that each CTxOut is ~35b big, 400 outputs should take 400 x ~35b = ~17.5kb.
 // More than 500 outputs starts to make qt quite laggy.
 // Additionally to need all 500 outputs (assuming a max per denom of 50) you'd need to be trying to
 // create denominations for over 3000 dash!
-static const int MAX_PRIVATESEND_DENOM_OUTPUTS = 500;
+static const int PRIVATESEND_DENOM_OUTPUTS_THRESHOLD = 500;
 
 // Warn user if mixing in gui or try to create backup if mixing in daemon mode
 // when we have only this many keys left

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -35,6 +35,15 @@ static const int DEFAULT_PRIVATESEND_DENOMS_HARDCAP = 300;
 static const bool DEFAULT_PRIVATESEND_AUTOSTART = false;
 static const bool DEFAULT_PRIVATESEND_MULTISESSION = false;
 
+// How many denom outputs to create in CreateDenominated
+// NOTE: We do not allow txes larger than 100kB, so we have to limit the number of outputs here.
+// We still want to create a lot of outputs though.
+// Knowing that each CTxOut is ~35b big, 400 outputs should take 400 x ~35b = ~17.5kb.
+// More than 500 outputs starts to make qt quite laggy.
+// Additionally to need all 500 outputs (assuming a max per denom of 50) you'd need to be trying to
+// create denominations for over 3000 dash!
+static const int MAX_PRIVATESEND_DENOM_OUTPUTS = 500;
+
 // Warn user if mixing in gui or try to create backup if mixing in daemon mode
 // when we have only this many keys left
 static const int PRIVATESEND_KEYS_THRESHOLD_WARNING = 100;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -380,7 +380,7 @@ void WalletInit::InitPrivateSendSettings()
 
     if (privateSendClient.fEnablePrivateSend) {
         LogPrintf("PrivateSend: autostart=%d, multisession=%d, "
-                  "sessions=%d, rounds=%d, amount=%d, denoms_batched=%d, denoms_hardcap=%d\n",
+                  "sessions=%d, rounds=%d, amount=%d, denoms_goal=%d, denoms_hardcap=%d\n",
                   privateSendClient.fPrivateSendRunning, privateSendClient.fPrivateSendMultiSession,
                   privateSendClient.nPrivateSendSessions, privateSendClient.nPrivateSendRounds,
                   privateSendClient.nPrivateSendAmount,

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -223,7 +223,7 @@ bool WalletInit::ParameterInteraction()
 
     if (gArgs.IsArgSet("-privatesenddenoms")) {
         int nDenomsDeprecated = gArgs.GetArg("-privatesenddenoms", DEFAULT_PRIVATESEND_DENOMS_HARDCAP);
-        InitWarning("Warning: -privatesenddenoms is deprecated, please use -privatesenddenomshardcap instead.\n");
+        InitWarning("Warning: -privatesenddenoms is deprecated, please use -privatesenddenomshardcap or -privatesenddenomsgoal.\n");
         if (gArgs.SoftSetArg("-privatesenddenomshardcap", itostr(nDenomsDeprecated))) {
             LogPrintf("%s: parameter interaction: -privatesenddenoms=%d -> setting -privatesenddenomshardcap=%d\n", __func__, nDenomsDeprecated, nDenomsDeprecated);
         }

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -63,7 +63,7 @@ std::string WalletInit::GetHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-privatesendsessions=<n>", strprintf(_("Use N separate masternodes in parallel to mix funds (%u-%u, default: %u)"), MIN_PRIVATESEND_SESSIONS, MAX_PRIVATESEND_SESSIONS, DEFAULT_PRIVATESEND_SESSIONS));
     strUsage += HelpMessageOpt("-privatesendrounds=<n>", strprintf(_("Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)"), MIN_PRIVATESEND_ROUNDS, MAX_PRIVATESEND_ROUNDS, DEFAULT_PRIVATESEND_ROUNDS));
     strUsage += HelpMessageOpt("-privatesendamount=<n>", strprintf(_("Target PrivateSend balance (%u-%u, default: %u)"), MIN_PRIVATESEND_AMOUNT, MAX_PRIVATESEND_AMOUNT, DEFAULT_PRIVATESEND_AMOUNT));
-    strUsage += HelpMessageOpt("-privatesenddenomsbatched=<n>", strprintf(_("Try to create at least N inputs of each denominated amount in batches (%u-%u, default: %u)"), MIN_PRIVATESEND_DENOMS_BATCHED, MAX_PRIVATESEND_DENOMS_BATCHED, DEFAULT_PRIVATESEND_DENOMS_BATCHED));
+    strUsage += HelpMessageOpt("-privatesenddenomsgoal=<n>", strprintf(_("Try to create at least N inputs of each denominated amount (%u-%u, default: %u)"), MIN_PRIVATESEND_DENOMS_GOAL, MAX_PRIVATESEND_DENOMS_GOAL, DEFAULT_PRIVATESEND_DENOMS_GOAL));
     strUsage += HelpMessageOpt("-privatesenddenomshardcap=<n>", strprintf(_("Create up to N inputs of each denominated amount (%u-%u, default: %u)"), MIN_PRIVATESEND_DENOMS_HARDCAP, MAX_PRIVATESEND_DENOMS_HARDCAP, DEFAULT_PRIVATESEND_DENOMS_HARDCAP));
 
     if (showDebug)
@@ -230,8 +230,8 @@ bool WalletInit::ParameterInteraction()
         gArgs.ForceRemoveArg("-privatesenddenoms");
     }
 
-    if (gArgs.GetArg("-privatesenddenomshardcap", DEFAULT_PRIVATESEND_DENOMS_HARDCAP) < gArgs.GetArg("-privatesenddenomsbatched", DEFAULT_PRIVATESEND_DENOMS_BATCHED)) {
-        return InitError("-privatesenddenomshardcap can't be lower than -privatesenddenomsbatched");
+    if (gArgs.GetArg("-privatesenddenomshardcap", DEFAULT_PRIVATESEND_DENOMS_HARDCAP) < gArgs.GetArg("-privatesenddenomsgoal", DEFAULT_PRIVATESEND_DENOMS_GOAL)) {
+        return InitError("-privatesenddenomshardcap can't be lower than -privatesenddenomsgoal");
     }
 
     return true;
@@ -375,7 +375,7 @@ void WalletInit::InitPrivateSendSettings()
     privateSendClient.nPrivateSendSessions = std::min(std::max((int)gArgs.GetArg("-privatesendsessions", DEFAULT_PRIVATESEND_SESSIONS), MIN_PRIVATESEND_SESSIONS), MAX_PRIVATESEND_SESSIONS);
     privateSendClient.nPrivateSendRounds = std::min(std::max((int)gArgs.GetArg("-privatesendrounds", DEFAULT_PRIVATESEND_ROUNDS), MIN_PRIVATESEND_ROUNDS), MAX_PRIVATESEND_ROUNDS);
     privateSendClient.nPrivateSendAmount = std::min(std::max((int)gArgs.GetArg("-privatesendamount", DEFAULT_PRIVATESEND_AMOUNT), MIN_PRIVATESEND_AMOUNT), MAX_PRIVATESEND_AMOUNT);
-    privateSendClient.nPrivateSendDenomsBatched = std::min(std::max((int)gArgs.GetArg("-privatesenddenomsbatched", DEFAULT_PRIVATESEND_DENOMS_BATCHED), MIN_PRIVATESEND_DENOMS_BATCHED), MAX_PRIVATESEND_DENOMS_BATCHED);
+    privateSendClient.nPrivateSendDenomsGoal = std::min(std::max((int)gArgs.GetArg("-privatesenddenomsgoal", DEFAULT_PRIVATESEND_DENOMS_GOAL), MIN_PRIVATESEND_DENOMS_GOAL), MAX_PRIVATESEND_DENOMS_GOAL);
     privateSendClient.nPrivateSendDenomsHardCap = std::min(std::max((int)gArgs.GetArg("-privatesenddenomshardcap", DEFAULT_PRIVATESEND_DENOMS_HARDCAP), MIN_PRIVATESEND_DENOMS_HARDCAP), MAX_PRIVATESEND_DENOMS_HARDCAP);
 
     if (privateSendClient.fEnablePrivateSend) {
@@ -384,7 +384,7 @@ void WalletInit::InitPrivateSendSettings()
                   privateSendClient.fPrivateSendRunning, privateSendClient.fPrivateSendMultiSession,
                   privateSendClient.nPrivateSendSessions, privateSendClient.nPrivateSendRounds,
                   privateSendClient.nPrivateSendAmount,
-                  privateSendClient.nPrivateSendDenomsBatched, privateSendClient.nPrivateSendDenomsHardCap);
+                  privateSendClient.nPrivateSendDenomsGoal, privateSendClient.nPrivateSendDenomsHardCap);
     }
 
 }


### PR DESCRIPTION
With many txes received on different addresses "nPrivateSendDenoms is not a hard cap but a checkpoint" logic introduced in #3479 creates hundreds of tiny denoms which are not easy to spend safely and user has no control over this behaviour anymore. This PR reverts it back to the original "nPrivateSendDenoms is a hard cap for most denoms". If someone wants "no hard cap for all denoms" in his wallet he should just bump `-privatesenddenoms` instead.