### PR TITLE
Increase max headers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1851,7 +1851,8 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
             nodestate->m_last_block_announcement = GetTime();
         }
 
-        if (nCount == MAX_HEADERS_RESULTS) {
+        int max_headers = pfrom->nVersion < 70218 ? MAX_HEADERS_RESULTS_OLD : MAX_HEADERS_RESULTS;
+        if (nCount == max_headers) {
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.
@@ -1910,7 +1911,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
         }
         // If we're in IBD, we want outbound peers that will serve us a useful
         // chain. Disconnect peers that are on chains with insufficient work.
-        if (IsInitialBlockDownload() && nCount != MAX_HEADERS_RESULTS) {
+        if (IsInitialBlockDownload() && nCount != max_headers) {
             // When nCount < MAX_HEADERS_RESULTS, we know we have no more
             // headers to fetch from this peer.
             if (nodestate->pindexBestKnownBlock && nodestate->pindexBestKnownBlock->nChainWork < nMinimumChainWork) {
@@ -2686,7 +2687,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         // we must use CBlocks, as CBlockHeaders won't include the 0x00 nTx count at the end
         std::vector<CBlock> vHeaders;
-        int nLimit = MAX_HEADERS_RESULTS;
+        int nLimit = pfrom->nVersion < 70218 ? MAX_HEADERS_RESULTS_OLD : MAX_HEADERS_RESULTS;
         LogPrint(BCLog::NET, "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), pfrom->GetId());
         for (; pindex; pindex = chainActive.Next(pindex))
         {
@@ -3201,7 +3202,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
         unsigned int nCount = ReadCompactSize(vRecv);
-        if (nCount > MAX_HEADERS_RESULTS) {
+        int max_headers = pfrom->nVersion < 70218 ? MAX_HEADERS_RESULTS_OLD : MAX_HEADERS_RESULTS;
+        if (nCount > max_headers) {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("headers message size = %u", nCount));
             return false;

--- a/src/validation.h
+++ b/src/validation.h
@@ -88,8 +88,10 @@ static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */
 static const unsigned int BLOCK_STALLING_TIMEOUT = 2;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
- *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
-static const unsigned int MAX_HEADERS_RESULTS = 2000;
+ *  less than this number, we reached its tip. Changing this value is a protocol upgrade.
+ *  TODO remove MAX_HEADERS_RESULTS_OLD once minimum protocol version is 70218 */
+static const unsigned int MAX_HEADERS_RESULTS_OLD = 2000;
+static const unsigned int MAX_HEADERS_RESULTS = 8000;
 /** Maximum depth of blocks we're willing to serve as compact blocks to peers
  *  when requested. For older blocks, a regular BLOCK response will be sent. */
 static const int MAX_CMPCTBLOCK_DEPTH = 5;

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70217;
+static const int PROTOCOL_VERSION = 70218;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
This was requested by @quantumexplorer on the mobile team. He can probably provide a better justification as to why this change is needed/valuable. 8000 was his idea, and the idea behind it was that since we have 4x as many blocks per unit time. However, other values could maybe be better and this should be looked into 