### PR TITLE
Fix chainlock scheduler handling

### DIFF
--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -42,6 +42,8 @@ CChainLocksHandler::CChainLocksHandler()
 
 CChainLocksHandler::~CChainLocksHandler()
 {
+    scheduler_thread->interrupt();
+    scheduler_thread->join();
     delete scheduler_thread;
     delete scheduler;
 }
@@ -59,9 +61,8 @@ void CChainLocksHandler::Start()
 
 void CChainLocksHandler::Stop()
 {
+    scheduler->stop();
     quorumSigningManager->UnregisterRecoveredSigsListener(this);
-    scheduler_thread->interrupt();
-    scheduler_thread->join();
 }
 
 bool CChainLocksHandler::AlreadyHave(const CInv& inv)


### PR DESCRIPTION
Reindexing corrupted chain by clicking "ok" in a corresponding dialog when running qt always fails otherwise. To reproduce this just drop e.g. `regtest/blocks/index/` and try starting qt with/without the patch.