### PR TITLE
UpgradeDBIfNeeded failure should require reindexing

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -673,8 +673,8 @@ public:
 
 public:
     // TODO these can all be removed in a future version
-    bool UpgradeDiff(CDBBatch& batch, const CBlockIndex* pindexNext, const CDeterministicMNList& curMNList, CDeterministicMNList& newMNList);
-    void UpgradeDBIfNeeded();
+    void UpgradeDiff(CDBBatch& batch, const CBlockIndex* pindexNext, const CDeterministicMNList& curMNList, CDeterministicMNList& newMNList);
+    bool UpgradeDBIfNeeded();
 
 private:
     void CleanupCache(int nHeight);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1944,7 +1944,10 @@ bool AppInitMain()
                     assert(chainActive.Tip() != NULL);
                 }
 
-                deterministicMNManager->UpgradeDBIfNeeded();
+                if (!deterministicMNManager->UpgradeDBIfNeeded()) {
+                    strLoadError = _("Error upgrading evo database");
+                    break;
+                }
 
                 if (!is_coinsview_empty) {
                     uiInterface.InitMessage(_("Verifying blocks..."));


### PR DESCRIPTION
Simply logging an error is not enough here, should actually refuse to continue loading - a node with a broken evodb will most likely stuck sooner or later anyway, so it's better to reindex asap instead of waiting for this to happen.