### PR TITLE
qt: Fix label updates in SendCoinsEntry

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -84,7 +84,7 @@ void SendCoinsEntry::on_payTo_textChanged(const QString &address)
         setValue(rcp);
         ui->payTo->blockSignals(false);
     } else {
-        updateLabel(rcp.address);
+        updateLabel(address);
     }
 }
 


### PR DESCRIPTION
Found my own bug (which leads to not assigning the label from the addressbook for an address in the send screen) which was introduced in #3475. 

This is a fix for #3522 