### PR TITLE
Dont skip sendmessages

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2708,20 +2708,11 @@ void CConnman::OpenMasternodeConnection(const CAddress &addrConnect, bool probe)
 
 void CConnman::ThreadMessageHandler()
 {
-    int64_t nLastForceSendMessages = 0;
-
     while (!flagInterruptMsgProc)
     {
         std::vector<CNode*> vNodesCopy = CopyNodeVector();
 
-        int64_t nNow = GetTimeMillis();
-
         bool fMoreWork = false;
-        bool fForceSendMessages = false;
-        if (nNow - nLastForceSendMessages >= 100) {
-            fForceSendMessages = true;
-            nLastForceSendMessages = nNow;
-        }
 
         for (CNode* pnode : vNodesCopy)
         {
@@ -2729,13 +2720,12 @@ void CConnman::ThreadMessageHandler()
                 continue;
 
             // Receive messages
-            bool fDidWork = false;
-            bool fMoreNodeWork = m_msgproc->ProcessMessages(pnode, flagInterruptMsgProc, fDidWork);
+            bool fMoreNodeWork = m_msgproc->ProcessMessages(pnode, flagInterruptMsgProc);
             fMoreWork |= (fMoreNodeWork && !pnode->fPauseSend);
             if (flagInterruptMsgProc)
                 return;
             // Send messages
-            if (fDidWork || fForceSendMessages) {
+            {
                 LOCK(pnode->cs_sendProcessing);
                 m_msgproc->SendMessages(pnode, flagInterruptMsgProc);
             }

--- a/src/net.h
+++ b/src/net.h
@@ -675,7 +675,7 @@ struct CombinerAll
 class NetEventsInterface
 {
 public:
-    virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt, bool &fRetDidWork) = 0;
+    virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
     virtual bool SendMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;
     virtual void FinalizeNode(NodeId id, bool& update_connection_time) = 0;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3597,7 +3597,7 @@ static bool SendRejectsAndCheckIfBanned(CNode* pnode, CConnman* connman, bool en
     return false;
 }
 
-bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc, bool &fRetDidWork)
+bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
 {
     const CChainParams& chainparams = Params();
     //
@@ -3609,17 +3609,13 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     //  (x) data
     //
     bool fMoreWork = false;
-    fRetDidWork = false;
 
-    if (!pfrom->vRecvGetData.empty()) {
+    if (!pfrom->vRecvGetData.empty())
         ProcessGetData(pfrom, chainparams, connman, interruptMsgProc);
-        fRetDidWork = true;
-    }
 
     if (!pfrom->orphan_work_set.empty()) {
         LOCK2(cs_main, g_cs_orphans);
         ProcessOrphanTx(connman, pfrom->orphan_work_set);
-        fRetDidWork = true;
     }
 
     if (pfrom->fDisconnect)
@@ -3643,7 +3639,6 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
         pfrom->nProcessQueueSize -= msgs.front().vRecv.size() + CMessageHeader::HEADER_SIZE;
         pfrom->fPauseRecv = pfrom->nProcessQueueSize > connman->GetReceiveFloodSize();
         fMoreWork = !pfrom->vProcessMsg.empty();
-        fRetDidWork = true;
     }
     CNetMessage& msg(msgs.front());
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -50,7 +50,7 @@ public:
     /** Handle removal of a peer by updating various state and removing it from mapNodeState */
     void FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) override;
     /** Process protocol messages received from a given node */
-    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt, bool &fRetDidWork) override;
+    bool ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt) override;
     /**
     * Send queued protocol messages to be sent to a give node.
     *


### PR DESCRIPTION
This reverts parts of https://github.com/dashpay/dash/pull/3420 (24ead629051233c34eade4cf9c0aea23ba2cb937 to be specific) and implements an alternative skipping mechanism only applied to fMasternode connections.

The reason for the revert is that the old logic did not make sense. Whether the currently processed node needs to send something or not can't be decided solely on the processing of messages for this specific node. Other nodes might actually result in this node having pending messages, e.g. when they relayed some object and inventories need to be relayed.

The alternative implementation simply throttles `SendMessages` calls for fMasternode connections, as these usually don't relay anything.