### PR TITLE
Use exponential backoff timeout for concentrated recovery attempts

### DIFF
--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -364,7 +364,8 @@ class CSigSharesManager : public CRecoveredSigsListener
     // 400 is the maximum quorum size, so this is also the maximum number of sigs we need to support
     const size_t MAX_MSGS_TOTAL_BATCHED_SIGS = 400;
 
-    const int64_t SEND_FOR_RECOVERY_TIMEOUT = 1;
+    const int64_t EXP_SEND_FOR_RECOVERY_TIMEOUT = 2000;
+    const int64_t MAX_SEND_FOR_RECOVERY_TIMEOUT = 10000;
     const size_t MAX_MSGS_SIG_SHARES = 32;
 
 private:

--- a/test/functional/llmq-signing.py
+++ b/test/functional/llmq-signing.py
@@ -117,9 +117,9 @@ class LLMQSigningTest(DashTestFramework):
             # Make sure node0 has received qsendrecsigs from the previously isolated node
             mn.node.ping()
             wait_until(lambda: all('pingwait' not in peer for peer in mn.node.getpeerinfo()))
-            # Let 1 second pass so that the next node is used for recovery, which should succeed
-            self.bump_mocktime(1)
-            wait_for_sigs(True, False, True, 5)
+            # Let 2 seconds pass so that the next node is used for recovery, which should succeed
+            self.bump_mocktime(2)
+            wait_for_sigs(True, False, True, 2)
 
 if __name__ == '__main__':
     LLMQSigningTest().main()


### PR DESCRIPTION
Stress tests in my devnets have shown that 1 second is way too low on high load, as it causes many signatures to be sent to many nodes unnecessarily.