### PR TITLE
Sleep 1 sec in mininode's wait_for_disconnect

### DIFF
--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -373,6 +373,7 @@ class P2PInterface(P2PConnection):
     def wait_for_disconnect(self, timeout=60):
         test_function = lambda: self.state != "connected"
         wait_until(test_function, timeout=timeout, lock=mininode_lock)
+        # This is a hack. The related issues should be fixed by bitcoin 14119 and 14457.
         time.sleep(1)
 
     # Message receiving helper methods

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -373,6 +373,7 @@ class P2PInterface(P2PConnection):
     def wait_for_disconnect(self, timeout=60):
         test_function = lambda: self.state != "connected"
         wait_until(test_function, timeout=timeout, lock=mininode_lock)
+        time.sleep(1)
 
     # Message receiving helper methods
 


### PR DESCRIPTION
This should fix `invalidtxrequest.py`.

EDIT: yes, it's a hack :) the actual issue in this test will be fixed by future backports.