### PR TITLE
Fix CSigningManager::VerifyRecoveredSig

### DIFF
--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -938,14 +938,12 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
 
 bool CSigningManager::VerifyRecoveredSig(Consensus::LLMQType llmqType, int signedAtHeight, const uint256& id, const uint256& msgHash, const CBLSSignature& sig)
 {
-    auto& llmqParams = Params().GetConsensus().llmqs.at(Params().GetConsensus().llmqTypeChainLocks);
-
-    auto quorum = SelectQuorumForSigning(llmqParams.type, signedAtHeight, id);
+    auto quorum = SelectQuorumForSigning(llmqType, signedAtHeight, id);
     if (!quorum) {
         return false;
     }
 
-    uint256 signHash = CLLMQUtils::BuildSignHash(llmqParams.type, quorum->qc.quorumHash, id, msgHash);
+    uint256 signHash = CLLMQUtils::BuildSignHash(llmqType, quorum->qc.quorumHash, id, msgHash);
     return sig.VerifyInsecure(quorum->qc.quorumPublicKey, signHash);
 }
 


### PR DESCRIPTION
Drop useless `llmqParams` calculation, just use `llmqType` arg directly. This calculation is also broken because it always uses `Params().GetConsensus().llmqTypeChainLocks` instead of passed `llmqType` but, thankfully, this doesn't cause any issues cause ChainLock quorums are the only ones this function is used for currently. For any other quorum type this function would fail when you'd expect it to succeed, so it's more of a bug than a typo and it makes sense to backport it to v0.16.x imo.

Fixes #3545 

Thanks to @sidhujag for reporting 👍 