### PR TITLE
Disable new connection handling and concentrated recovery for large LLMQs

### DIFF
--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -446,7 +446,7 @@ void CDKGSession::VerifyAndComplain(CDKGPendingMessages& pendingMessages)
 
 void CDKGSession::VerifyConnectionAndMinProtoVersions()
 {
-    if (!sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+    if (!CLLMQUtils::IsAllMembersConnectedEnabled(params.type)) {
         return;
     }
 

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -530,7 +530,7 @@ void CDKGSessionHandler::HandleDKGRound()
     });
 
     CLLMQUtils::EnsureQuorumConnections(params.type, pindexQuorum, curSession->myProTxHash, gArgs.GetBoolArg("-watchquorums", DEFAULT_WATCH_QUORUMS));
-    if (curSession->AreWeMember() && sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+    if (curSession->AreWeMember() && CLLMQUtils::IsAllMembersConnectedEnabled(params.type)) {
         CLLMQUtils::AddQuorumProbeConnections(params.type, pindexQuorum, curSession->myProTxHash);
     }
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -739,7 +739,7 @@ void CSigSharesManager::ProcessSigShare(NodeId nodeId, const CSigShare& sigShare
 
     // prepare node set for direct-push in case this is our sig share
     std::set<NodeId> quorumNodes;
-    if (!sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+    if (!CLLMQUtils::IsAllMembersConnectedEnabled(llmqType)) {
         if (sigShare.quorumMember == quorum->GetMemberIndex(activeMasternodeInfo.proTxHash)) {
             quorumNodes = connman.GetMasternodeQuorumNodes((Consensus::LLMQType) sigShare.llmqType, sigShare.quorumHash);
         }
@@ -755,7 +755,9 @@ void CSigSharesManager::ProcessSigShare(NodeId nodeId, const CSigShare& sigShare
         if (!sigShares.Add(sigShare.GetKey(), sigShare)) {
             return;
         }
-        sigSharesToAnnounce.Add(sigShare.GetKey(), true);
+        if (!CLLMQUtils::IsAllMembersConnectedEnabled(llmqType)) {
+            sigSharesToAnnounce.Add(sigShare.GetKey(), true);
+        }
 
         // Update the time we've seen the last sigShare
         timeSeenForSessions[sigShare.GetSignHash()] = GetAdjustedTime();
@@ -909,6 +911,10 @@ void CSigSharesManager::CollectSigSharesToRequest(std::unordered_map<NodeId, std
             auto& signHash = p2.first;
             auto& session = p2.second;
 
+            if (CLLMQUtils::IsAllMembersConnectedEnabled(session.llmqType)) {
+                continue;
+            }
+
             if (quorumSigningManager->HasRecoveredSigForSession(signHash)) {
                 continue;
             }
@@ -982,6 +988,10 @@ void CSigSharesManager::CollectSigSharesToSend(std::unordered_map<NodeId, std::u
             auto& signHash = p2.first;
             auto& session = p2.second;
 
+            if (CLLMQUtils::IsAllMembersConnectedEnabled(session.llmqType)) {
+                continue;
+            }
+
             if (quorumSigningManager->HasRecoveredSigForSession(signHash)) {
                 continue;
             }
@@ -1031,6 +1041,10 @@ void CSigSharesManager::CollectSigSharesToSendConcentrated(std::unordered_map<No
     auto curTime = GetTime();
 
     for (auto& p : signedSessions) {
+        if (!CLLMQUtils::IsAllMembersConnectedEnabled(p.second.quorum->params.type)) {
+            continue;
+        }
+
         if (p.second.attempt > p.second.quorum->params.recoveryMembers) {
             continue;
         }
@@ -1137,13 +1151,10 @@ bool CSigSharesManager::SendMessages()
 
     {
         LOCK(cs);
-        if (!sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
-            CollectSigSharesToRequest(sigSharesToRequest);
-            CollectSigSharesToSend(sigShareBatchesToSend);
-            CollectSigSharesToAnnounce(sigSharesToAnnounce);
-        } else {
-            CollectSigSharesToSendConcentrated(sigSharesToSend, vNodesCopy);
-        }
+        CollectSigSharesToRequest(sigSharesToRequest);
+        CollectSigSharesToSend(sigShareBatchesToSend);
+        CollectSigSharesToAnnounce(sigSharesToAnnounce);
+        CollectSigSharesToSendConcentrated(sigSharesToSend, vNodesCopy);
 
         for (auto& p : sigSharesToRequest) {
             for (auto& p2 : p.second) {
@@ -1583,7 +1594,7 @@ void CSigSharesManager::Sign(const CQuorumCPtr& quorum, const uint256& id, const
               signHash.ToString(), sigShare.id.ToString(), sigShare.msgHash.ToString(), quorum->params.type, quorum->qc.quorumHash.ToString(), t.count());
     ProcessSigShare(-1, sigShare, *g_connman, quorum);
 
-    if (sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+    if (CLLMQUtils::IsAllMembersConnectedEnabled(quorum->params.type)) {
         LOCK(cs);
         auto& session = signedSessions[sigShare.GetSignHash()];
         session.sigShare = sigShare;
@@ -1596,6 +1607,10 @@ void CSigSharesManager::Sign(const CQuorumCPtr& quorum, const uint256& id, const
 // causes all known sigShares to be re-announced
 void CSigSharesManager::ForceReAnnouncement(const CQuorumCPtr& quorum, Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash)
 {
+    if (!CLLMQUtils::IsAllMembersConnectedEnabled(llmqType)) {
+        return;
+    }
+
     LOCK(cs);
     auto signHash = CLLMQUtils::BuildSignHash(llmqType, quorum->qc.quorumHash, id, msgHash);
     auto sigs = sigShares.GetAllForSignHash(signHash);

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1016,7 +1016,7 @@ void CSigSharesManager::CollectSigSharesToSend(std::unordered_map<NodeId, std::u
     }
 }
 
-void CSigSharesManager::CollectSigSharesToSend(std::unordered_map<NodeId, std::vector<CSigShare>>& sigSharesToSend, const std::vector<CNode*>& vNodes)
+void CSigSharesManager::CollectSigSharesToSendConcentrated(std::unordered_map<NodeId, std::vector<CSigShare>>& sigSharesToSend, const std::vector<CNode*>& vNodes)
 {
     AssertLockHeld(cs);
 
@@ -1142,7 +1142,7 @@ bool CSigSharesManager::SendMessages()
             CollectSigSharesToSend(sigShareBatchesToSend);
             CollectSigSharesToAnnounce(sigSharesToAnnounce);
         } else {
-            CollectSigSharesToSend(sigSharesToSend, vNodesCopy);
+            CollectSigSharesToSendConcentrated(sigSharesToSend, vNodesCopy);
         }
 
         for (auto& p : sigSharesToRequest) {

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -449,7 +449,7 @@ private:
     bool SendMessages();
     void CollectSigSharesToRequest(std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>>& sigSharesToRequest);
     void CollectSigSharesToSend(std::unordered_map<NodeId, std::unordered_map<uint256, CBatchedSigShares, StaticSaltedHasher>>& sigSharesToSend);
-    void CollectSigSharesToSend(std::unordered_map<NodeId, std::vector<CSigShare>>& sigSharesToSend, const std::vector<CNode*>& vNodes);
+    void CollectSigSharesToSendConcentrated(std::unordered_map<NodeId, std::vector<CSigShare>>& sigSharesToSend, const std::vector<CNode*>& vNodes);
     void CollectSigSharesToAnnounce(std::unordered_map<NodeId, std::unordered_map<uint256, CSigSharesInv, StaticSaltedHasher>>& sigSharesToAnnounce);
     bool SignPendingSigShares();
     void WorkThreadMain();

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -44,6 +44,18 @@ uint256 CLLMQUtils::BuildSignHash(Consensus::LLMQType llmqType, const uint256& q
     return h.GetHash();
 }
 
+bool CLLMQUtils::IsAllMembersConnectedEnabled(Consensus::LLMQType llmqType)
+{
+    auto spork21 = sporkManager.GetSporkValue(SPORK_21_QUORUM_ALL_CONNECTED);
+    if (spork21 == 0) {
+        return true;
+    }
+    if (spork21 == 1 && llmqType != Consensus::LLMQ_400_60 && llmqType != Consensus::LLMQ_400_85) {
+        return true;
+    }
+    return false;
+}
+
 uint256 CLLMQUtils::DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2)
 {
     // We need to deterministically select who is going to initiate the connection. The naive way would be to simply
@@ -70,7 +82,7 @@ std::set<uint256> CLLMQUtils::GetQuorumConnections(Consensus::LLMQType llmqType,
 {
     auto& params = Params().GetConsensus().llmqs.at(llmqType);
 
-    if (sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED)) {
+    if (IsAllMembersConnectedEnabled(llmqType)) {
         auto mns = GetAllQuorumMembers(llmqType, pindexQuorum);
         std::set<uint256> result;
 

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -31,6 +31,7 @@ public:
         return BuildSignHash((Consensus::LLMQType)s.llmqType, s.quorumHash, s.id, s.msgHash);
     }
 
+    static bool IsAllMembersConnectedEnabled(Consensus::LLMQType llmqType);
     static uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2);
     static std::set<uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& forMember, bool onlyOutbound);
     static std::set<uint256> GetQuorumRelayMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& forMember, bool onlyOutbound);


### PR DESCRIPTION
I did many tests with the large quorums a few weeks ago and had to do a lot of optimizations to make it stable with the extremely high amount of connections that dashd has to handle. I believe that most bottlenecks are fixed now, but still don't feel confident enough to enable this for the large quorums as well. The smaller quorums (50 members) worked very good in my tests, so lets only enable it for these now and later, when we feel more confident, enable the larger ones as well.

This PR allows this by setting spork21 to 1 instead of 0.