### PR TITLE
Fix argument handling for devnets

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -616,7 +616,7 @@ public:
 class CDevNetParams : public CChainParams {
 public:
     CDevNetParams() {
-        strNetworkID = "dev";
+        strNetworkID = "devnet";
         consensus.nSubsidyHalvingInterval = 210240;
         consensus.nMasternodePaymentsStartBlock = 4010; // not true, but it's ok as long as it's less then nMasternodePaymentsIncreaseBlock
         consensus.nMasternodePaymentsIncreaseBlock = 4030;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -13,7 +13,7 @@
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
-const std::string CBaseChainParams::DEVNET = "dev";
+const std::string CBaseChainParams::DEVNET = "devnet";
 const std::string CBaseChainParams::REGTEST = "regtest";
 
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -23,7 +23,7 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
     {"test", QAPP_APP_NAME_TESTNET, 190, 20, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
-    {"dev", QAPP_APP_NAME_DEVNET, 190, 20, "[devnet: %s]"},
+    {"devnet", QAPP_APP_NAME_DEVNET, 190, 20, "[devnet: %s]"},
     {"regtest", QAPP_APP_NAME_REGTEST, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -620,7 +620,7 @@ public:
     /* Special test for -testnet and -regtest args, because we
      * don't want to be confused by craziness like "[regtest] testnet=1"
      */
-    static inline bool GetNetBoolArg(const ArgsManager &am, const std::string& net_arg)
+    static inline bool GetNetBoolArg(const ArgsManager &am, const std::string& net_arg, bool interpret_bool)
     {
         std::pair<bool,std::string> found_result(false,std::string());
         found_result = GetArgHelper(am.m_override_args, net_arg, true);
@@ -630,7 +630,7 @@ public:
                 return false; // not set
             }
         }
-        return InterpretBool(found_result.second); // is set, so evaluate
+        return !interpret_bool || InterpretBool(found_result.second); // is set, so evaluate
     }
 };
 
@@ -1031,9 +1031,9 @@ void ArgsManager::ReadConfigFile(const std::string& confPath)
 
 std::string ArgsManager::GetChainName() const
 {
-    bool fRegTest = ArgsManagerHelper::GetNetBoolArg(*this, "-regtest");
-    bool fDevNet = ArgsManagerHelper::GetNetBoolArg(*this, "-devnet");
-    bool fTestNet = ArgsManagerHelper::GetNetBoolArg(*this, "-testnet");
+    bool fRegTest = ArgsManagerHelper::GetNetBoolArg(*this, "-regtest", true);
+    bool fDevNet = ArgsManagerHelper::GetNetBoolArg(*this, "-devnet", false);
+    bool fTestNet = ArgsManagerHelper::GetNetBoolArg(*this, "-testnet", true);
 
     int nameParamsCount = (fRegTest ? 1 : 0) + (fDevNet ? 1 : 0) + (fTestNet ? 1 : 0);
     if (nameParamsCount > 1)


### PR DESCRIPTION
Backporting bitcoin#11862 has broken `-devnet=devnetname`, which is fixed by this PR.