### PR TITLE
chore: bump version of CFinalCommitment

### DIFF
--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -22,7 +22,7 @@ namespace llmq
 class CFinalCommitment
 {
 public:
-    static const uint16_t CURRENT_VERSION = 1;
+    static const uint16_t CURRENT_VERSION = 2;
 
 public:
     uint16_t nVersion{CURRENT_VERSION};


### PR DESCRIPTION
To reflect the change in the RPC output (e.g. `protx diff`) between versions 0.15 and 0.16 introduced in this PR
https://github.com/dashpay/dash/commit/ae152991174b9578c4ca4553fc17dad0c653b9e0
it would be nice to bump the version here as well.