### PR TITLE
qt: Disable macOS system focus rectangles for dash themes

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -33,6 +33,8 @@ AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent) :
 
     GUIUtil::updateFonts();
 
+    GUIUtil::disableMacFocusRect(this);
+
     ui->passEdit1->setMinimumSize(ui->passEdit1->sizeHint());
     ui->passEdit2->setMinimumSize(ui->passEdit2->sizeHint());
     ui->passEdit3->setMinimumSize(ui->passEdit3->sizeHint());

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -65,6 +65,8 @@ CoinControlDialog::CoinControlDialog(const PlatformStyle *_platformStyle, QWidge
 
     GUIUtil::updateFonts();
 
+    GUIUtil::disableMacFocusRect(this);
+
     // context menu actions
     QAction *copyAddressAction = new QAction(tr("Copy address"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);

--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -21,6 +21,8 @@ EditAddressDialog::EditAddressDialog(Mode _mode, QWidget *parent) :
 {
     ui->setupUi(this);
 
+    GUIUtil::disableMacFocusRect(this);
+
     GUIUtil::setupAddressWidget(ui->addressEdit, this);
 
     switch(mode)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1410,6 +1410,19 @@ bool dashThemeActive()
     return theme != traditionalTheme;
 }
 
+void disableMacFocusRect(const QWidget* w)
+{
+#ifdef Q_OS_MAC
+    for (const auto& c : w->findChildren<QWidget*>()) {
+        if (c->testAttribute(Qt::WA_MacShowFocusRect)) {
+            c->setAttribute(Qt::WA_MacShowFocusRect, !dashThemeActive());
+        }
+    }
+#else
+    return;
+#endif
+}
+
 void setClipboard(const QString& str)
 {
     QApplication::clipboard()->setText(str, QClipboard::Clipboard);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1418,8 +1418,6 @@ void disableMacFocusRect(const QWidget* w)
             c->setAttribute(Qt::WA_MacShowFocusRect, !dashThemeActive());
         }
     }
-#else
-    return;
 #endif
 }
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -307,6 +307,10 @@ namespace GUIUtil
     /** Check if a dash specific theme is activated (light/dark) */
     bool dashThemeActive();
 
+    /** Disable the OS default focus rect for macOS because we have custom focus rects
+     * set in the css files */
+    void disableMacFocusRect(const QWidget* w);
+
     /* Convert QString to OS specific boost path through UTF-8 */
     fs::path qstringToBoostPath(const QString &path);
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -205,6 +205,7 @@ bool Intro::pickDataDirectory()
     {
         /* Let the user choose one */
         Intro intro;
+        GUIUtil::disableMacFocusRect(&intro);
         intro.setDataDirectory(dataDirDefaultCurrent);
         intro.setWindowIcon(QIcon(":icons/bitcoin"));
 

--- a/src/qt/openuridialog.cpp
+++ b/src/qt/openuridialog.cpp
@@ -17,6 +17,7 @@ OpenURIDialog::OpenURIDialog(QWidget *parent) :
 {
     ui->setupUi(this);
     GUIUtil::updateFonts();
+    GUIUtil::disableMacFocusRect(this);
     ui->uriEdit->setPlaceholderText("dash:");
 }
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -40,6 +40,8 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
 
     GUIUtil::updateFonts();
 
+    GUIUtil::disableMacFocusRect(this);
+
     /* Main elements init */
     ui->databaseCache->setMinimum(nMinDbCache);
     ui->databaseCache->setMaximum(nMaxDbCache);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -473,6 +473,8 @@ RPCConsole::RPCConsole(const PlatformStyle *_platformStyle, QWidget *parent) :
                       ui->banHeading
                      }, GUIUtil::FontWeight::Bold, 16);
 
+    GUIUtil::disableMacFocusRect(this);
+
     QSettings settings;
     if (!restoreGeometry(settings.value("RPCConsoleWindowGeometry").toByteArray())) {
         // Restore failed (perhaps missing setting), center the window

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -23,6 +23,8 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
 {
     ui->setupUi(this);
 
+    GUIUtil::disableMacFocusRect(this);
+
     setCurrentWidget(ui->SendCoins);
 
     if (platformStyle->getUseExtraSpacing())

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -67,6 +67,8 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformS
     GUIUtil::setFont({ui->statusLabel_SM, ui->statusLabel_VM}, GUIUtil::FontWeight::Bold);
 
     GUIUtil::updateFonts();
+
+    GUIUtil::disableMacFocusRect(this);
 }
 
 SignVerifyMessageDialog::~SignVerifyMessageDialog()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -112,6 +112,8 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
 
     // Pass through messages from transactionView
     connect(transactionView, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
+
+    GUIUtil::disableMacFocusRect(this);
 }
 
 WalletView::~WalletView()


### PR DESCRIPTION
This PR ist part of a series of +-25 PRs related to UI redesigns. Its ancestor is #3555, its successor is #3557. I did not screenshot every single PR and its changes, instead i made "walk through all screen" videos with the result of this PR series and also with the 0.15 UI. If there are any concrete screenshots wanted, just let me know. To build with the full set of changes you can build from the branch [xdustinface:pr-ui-redesign](https://github.com/xdustinface/dash/tree/pr-ui-redesign) which always contains all changes.

[ -> Walk through 0.15](https://youtu.be/cWQeHj5tWR0)
[ -> Walk through Redesign](https://youtu.be/0QeSyXo1aao)

I tried to give the commits enough text to make things obvious without a lot description for each PR. Also here, if you want more description for this specific PR, let me know.
### About this PR

This PR disables all focus rects drawn by macOS for dash themes. The focus rects drawn by macOS are in the color the user selected in the OS settings as selection color. This just doesn't always fit into the coloring of the dash specific themes.