### PR TITLE
qt: Introduce runtime theme changes

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -125,8 +125,6 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
     spinnerFrame(0),
     platformStyle(_platformStyle)
 {
-    GUIUtil::loadStyleSheet(this);
-
     QSettings settings;
     if (!restoreGeometry(settings.value("MainWindowGeometry").toByteArray())) {
         // Restore failed (perhaps missing setting), center the window
@@ -844,6 +842,7 @@ void BitcoinGUI::optionsClicked()
 
     OptionsDialog dlg(this, enableWallet);
     dlg.setModel(clientModel->getOptionsModel());
+    connect(&dlg, &OptionsDialog::themeChanged, [=]() { GUIUtil::loadTheme(); });
     dlg.exec();
 }
 

--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -395,6 +395,8 @@ void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 {
     window = new BitcoinGUI(platformStyle, networkStyle, 0);
 
+    GUIUtil::loadTheme(window);
+
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window, SLOT(detectShutdown()));
 }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -132,6 +132,11 @@ static std::set<QWidget*> setFixedPitchFontUpdates;
 // Contains all widgets where a non-default fontsize has been seet with GUIUtil::setFont
 static std::map<QWidget*, int> mapFontSizeUpdates;
 
+#ifdef Q_OS_MAC
+// Contains all widgets where the macOS focus rect has been disabled.
+static std::set<QWidget*> setRectsDisabled;
+#endif
+
 static const std::map<ThemedColor, QColor> themedColors = {
     { ThemedColor::DEFAULT, QColor(85, 85, 85) },
     { ThemedColor::UNCONFIRMED, QColor(128, 128, 128) },
@@ -1528,6 +1533,23 @@ void disableMacFocusRect(const QWidget* w)
     for (const auto& c : w->findChildren<QWidget*>()) {
         if (c->testAttribute(Qt::WA_MacShowFocusRect)) {
             c->setAttribute(Qt::WA_MacShowFocusRect, !dashThemeActive());
+            setRectsDisabled.emplace(c);
+        }
+    }
+#endif
+}
+
+void updateMacFocusRects()
+{
+#ifdef Q_OS_MAC
+    QWidgetList allWidgets = QApplication::allWidgets();
+    auto it = setRectsDisabled.begin();
+    while (it != setRectsDisabled.end()) {
+        if (allWidgets.contains(*it)) {
+            (*it)->setAttribute(Qt::WA_MacShowFocusRect, !dashThemeActive());
+            ++it;
+        } else {
+            it = setRectsDisabled.erase(it);
         }
     }
 #endif

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1025,6 +1025,11 @@ const std::vector<QString> listThemes()
     return vecThemes;
 }
 
+const QString getDefaultTheme()
+{
+    return defaultTheme;
+}
+
 void loadStyleSheet(QWidget* widget, bool fDebugWidget)
 {
     AssertLockNotHeld(cs_css);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -342,6 +342,9 @@ namespace GUIUtil
      * set in the css files */
     void disableMacFocusRect(const QWidget* w);
 
+    /** Enable/Disable the macOS focus rects depending on the current theme. */
+    void updateMacFocusRects();
+
     /* Convert QString to OS specific boost path through UTF-8 */
     fs::path qstringToBoostPath(const QString &path);
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -253,6 +253,9 @@ namespace GUIUtil
     /** Return a list of all theme css files */
     const std::vector<QString> listThemes();
 
+    /** Return the name of the default theme `*/
+    const QString getDefaultTheme();
+
     /** Updates the widgets stylesheet and adds it to the list of ui debug elements
         if fDebugWidget is true. Beeing on that list means the stylesheet of the
         widget gets updated if the related css files has been changed if -debug-ui mode is active. */

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -256,10 +256,10 @@ namespace GUIUtil
     /** Return the name of the default theme `*/
     const QString getDefaultTheme();
 
-    /** Updates the widgets stylesheet and adds it to the list of ui debug elements
-        if fDebugWidget is true. Beeing on that list means the stylesheet of the
-        widget gets updated if the related css files has been changed if -debug-ui mode is active. */
-    void loadStyleSheet(QWidget* widget = nullptr, bool fDebugWidget = true);
+    /** Updates the widgets stylesheet and adds it to the list of ui debug elements.
+    Beeing on that list means the stylesheet of the widget gets updated if the
+    related css files has been changed if -debug-ui mode is active. */
+    void loadStyleSheet(QWidget* widget = nullptr, bool fForceUpdate = false);
 
     enum class FontFamily {
         SystemDefault,
@@ -337,6 +337,9 @@ namespace GUIUtil
 
     /** Check if a dash specific theme is activated (light/dark).*/
     bool dashThemeActive();
+
+    /** Load the theme and update all UI elements according to the appearance settings. */
+    void loadTheme(QWidget* widget = nullptr, bool fForce = true);
 
     /** Disable the OS default focus rect for macOS because we have custom focus rects
      * set in the css files */

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -26,6 +26,7 @@
 #include <QIntValidator>
 #include <QLocale>
 #include <QMessageBox>
+#include <QSettings>
 #include <QTimer>
 
 OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
@@ -35,6 +36,8 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     mapper(0)
 {
     ui->setupUi(this);
+
+    previousTheme = GUIUtil::getActiveTheme();
 
     GUIUtil::setFont({ui->statusLabel}, GUIUtil::FontWeight::Bold, 16);
 
@@ -104,6 +107,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     for (const QString& entry : GUIUtil::listThemes()) {
         ui->theme->addItem(entry, QVariant(entry));
     }
+    connect(ui->theme, SIGNAL(valueChanged()), this, SLOT(updateTheme()));
 
     /* Language selector */
     QDir translations(":translations");
@@ -188,7 +192,6 @@ void OptionsDialog::setModel(OptionsModel *_model)
     connect(ui->connectSocksTor, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
     /* Display */
     connect(ui->digits, SIGNAL(valueChanged()), this, SLOT(showRestartWarning()));
-    connect(ui->theme, SIGNAL(valueChanged()), this, SLOT(showRestartWarning()));
     connect(ui->lang, SIGNAL(valueChanged()), this, SLOT(showRestartWarning()));
     connect(ui->thirdPartyTxUrls, SIGNAL(textChanged(const QString &)), this, SLOT(showRestartWarning()));
 }
@@ -293,6 +296,9 @@ void OptionsDialog::on_okButton_clicked()
 
 void OptionsDialog::on_cancelButton_clicked()
 {
+    if (previousTheme != GUIUtil::getActiveTheme()) {
+        updateTheme(previousTheme);
+    }
     reject();
 }
 
@@ -371,6 +377,16 @@ void OptionsDialog::updateDefaultProxyNets()
     strProxy = proxy.proxy.ToStringIP() + ":" + proxy.proxy.ToStringPort();
     strDefaultProxyGUI = ui->proxyIp->text() + ":" + ui->proxyPort->text();
     (strProxy == strDefaultProxyGUI.toStdString()) ? ui->proxyReachTor->setChecked(true) : ui->proxyReachTor->setChecked(false);
+}
+
+void OptionsDialog::updateTheme(const QString& theme)
+{
+    QString newValue = theme.isEmpty() ? ui->theme->value().toString() : theme;
+    if (GUIUtil::getActiveTheme() != newValue) {
+        QSettings().setValue("theme", newValue);
+        QSettings().sync();
+        Q_EMIT themeChanged();
+    }
 }
 
 ProxyAddressValidator::ProxyAddressValidator(QObject *parent) :

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -60,15 +60,18 @@ private Q_SLOTS:
     void updateProxyValidationState();
     /* query the networks, for which the default proxy is used */
     void updateDefaultProxyNets();
+    void updateTheme(const QString& toTheme = QString());
 
 Q_SIGNALS:
     void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
+    void themeChanged();
 
 private:
     Ui::OptionsDialog *ui;
     OptionsModel *model;
     QDataWidgetMapper *mapper;
     QButtonGroup pageButtons;
+    QString previousTheme;
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -85,7 +85,7 @@ void OptionsModel::Init(bool resetSettings)
     strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "").toString();
 
     if (!settings.contains("theme"))
-        settings.setValue("theme", "");
+        settings.setValue("theme", GUIUtil::getDefaultTheme());
 
 #ifdef ENABLE_WALLET
     if (!settings.contains("fCoinControlFeatures"))

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -510,10 +510,8 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             break;
 #endif // ENABLE_WALLET
         case Theme:
-            if (settings.value("theme") != value) {
-                settings.setValue("theme", value);
-                setRestartRequired(true);
-            }
+            // Set in OptionsDialog::updateTheme slot now
+            // to allow instant theme changes.
             break;
         case Language:
             if (settings.value("language") != value) {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1263,6 +1263,16 @@ void RPCConsole::hideEvent(QHideEvent *event)
     clientModel->getPeerTableModel()->stopAutoRefresh();
 }
 
+void RPCConsole::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::StyleChange) {
+        clear();
+        ui->promptIcon->setHidden(GUIUtil::dashThemeActive());
+    }
+
+    QWidget::changeEvent(e);
+}
+
 void RPCConsole::showPeersTableContextMenu(const QPoint& point)
 {
     QModelIndex index = ui->peerWidget->indexAt(point);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -79,6 +79,7 @@ private Q_SLOTS:
     void resizeEvent(QResizeEvent *event);
     void showEvent(QShowEvent *event);
     void hideEvent(QHideEvent *event);
+    void changeEvent(QEvent* e);
     /** Show custom context menu on Peers tab */
     void showPeersTableContextMenu(const QPoint& point);
     /** Show custom context menu on Bans tab */

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -211,7 +211,7 @@ ShutdownWindow::ShutdownWindow(QWidget *parent, Qt::WindowFlags f):
 {
     setObjectName("ShutdownWindow");
 
-    GUIUtil::loadStyleSheet(this, false);
+    GUIUtil::loadStyleSheet(this);
 
     QVBoxLayout *layout = new QVBoxLayout();
     layout->addWidget(new QLabel(


### PR DESCRIPTION
This PR ist part of a series of +-25 PRs related to UI redesigns. Its ancestor is #3558, its successor is  #3560. I did not screenshot every single PR and its changes, instead i made "walk through all screen" videos with the result of this PR series and also with the 0.15 UI. If there are any concrete screenshots wanted, just let me know. To build with the full set of changes you can build from the branch [xdustinface:pr-ui-redesign](https://github.com/xdustinface/dash/tree/pr-ui-redesign) which always contains all changes.

[ -> Walk through 0.15](https://youtu.be/cWQeHj5tWR0)
[ -> Walk through Redesign](https://youtu.be/0QeSyXo1aao)

I tried to give the commits enough text to make things obvious without a lot description for each PR. Also here, if you want more description for this specific PR, let me know.
### About this PR

This PR enables runtime theme changes. Means no more client restart required if the theme gets changed in the options dialog.