### PR TITLE
qt: Replace usage of QTabBar with custom replacement

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -15,14 +15,77 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QTabWidget" name="tabWidget">
+    <layout class="QHBoxLayout" name="horizontalLayout_Buttons_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="btnInfo">
+       <property name="text">
+        <string>&amp;Information</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnConsole">
+       <property name="text">
+        <string>&amp;Console</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnNetTraffic">
+       <property name="text">
+        <string>&amp;Network Traffic</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnPeers">
+       <property name="text">
+        <string>&amp;Peers</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnRepair">
+       <property name="text">
+        <string>&amp;Wallet Repair</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="stackedWidgetRPC">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tab_info">
-      <attribute name="title">
-       <string>&amp;Information</string>
-      </attribute>
+     <widget class="QWidget" name="pageInfo">
       <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
        <property name="horizontalSpacing">
         <number>12</number>
@@ -159,11 +222,11 @@
         </widget>
        </item>
        <item row="6" column="0">
-           <widget class="QLabel" name="labelNetwork">
-               <property name="text">
-                   <string>Network</string>
-               </property>
-           </widget>
+        <widget class="QLabel" name="labelNetwork">
+         <property name="text">
+          <string>Network</string>
+         </property>
+        </widget>
        </item>
        <item row="7" column="0">
         <widget class="QLabel" name="label_8">
@@ -418,10 +481,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_console">
-      <attribute name="title">
-       <string>&amp;Console</string>
-      </attribute>
+     <widget class="QWidget" name="pageConsole">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="spacing">
         <number>3</number>
@@ -455,14 +515,14 @@
              <height>24</height>
             </size>
            </property>
-           <property name="text">
-            <string/>
-           </property>
            <property name="toolTip">
             <string>Decrease font size</string>
            </property>
+           <property name="text">
+            <string/>
+           </property>
            <property name="icon">
-            <iconset resource="../bitcoin.qrc">
+            <iconset>
              <normaloff>:/icons/fontsmaller</normaloff>:/icons/fontsmaller</iconset>
            </property>
            <property name="iconSize">
@@ -494,7 +554,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset resource="../bitcoin.qrc">
+            <iconset>
              <normaloff>:/icons/fontbigger</normaloff>:/icons/fontbigger</iconset>
            </property>
            <property name="iconSize">
@@ -529,7 +589,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset resource="../bitcoin.qrc">
+            <iconset>
              <normaloff>:/icons/console_remove</normaloff>:/icons/console_remove</iconset>
            </property>
            <property name="shortcut">
@@ -584,7 +644,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset resource="../dash.qrc">
+            <iconset>
              <normaloff>:/icons/prompticon</normaloff>
              <disabledoff>:/icons/prompticon</disabledoff>:/icons/prompticon</iconset>
            </property>
@@ -613,10 +673,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_nettraffic">
-      <attribute name="title">
-       <string>&amp;Network Traffic</string>
-      </attribute>
+     <widget class="QWidget" name="pageNetTraffic">
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -866,10 +923,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_peers">
-      <attribute name="title">
-       <string>&amp;Peers</string>
-      </attribute>
+     <widget class="QWidget" name="pagePeers">
       <layout class="QGridLayout" name="gridLayout_2">
        <item row="0" column="0" rowspan="2">
         <layout class="QVBoxLayout" name="verticalLayout_101">
@@ -1428,10 +1482,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_repair">
-      <attribute name="title">
-       <string>&amp;Wallet Repair</string>
-      </attribute>
+     <widget class="QWidget" name="pageRepair">
       <widget class="QPushButton" name="btn_salvagewallet">
        <property name="geometry">
         <rect>
@@ -1697,8 +1748,6 @@
    </slots>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../dash.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -18,14 +18,77 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTabWidget" name="tabWidget">
+    <layout class="QHBoxLayout" name="horizontalLayout_Buttons_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="btnMain">
+       <property name="text">
+        <string>&amp;Main</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnWallet">
+       <property name="text">
+        <string>W&amp;allet</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnNetwork">
+       <property name="text">
+        <string>&amp;Network</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnWindow">
+       <property name="text">
+        <string>&amp;Window</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnDisplay">
+       <property name="text">
+        <string>&amp;Display</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="stackedWidgetOptions">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tabMain">
-      <attribute name="title">
-       <string>&amp;Main</string>
-      </attribute>
+     <widget class="QWidget" name="pageMain">
       <layout class="QVBoxLayout" name="verticalLayout_Main">
        <item>
         <widget class="QCheckBox" name="bitcoinAtStartup">
@@ -132,10 +195,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabWallet">
-      <attribute name="title">
-       <string>W&amp;allet</string>
-      </attribute>
+     <widget class="QWidget" name="pageWallet">
       <layout class="QVBoxLayout" name="verticalLayout_Wallet">
        <item>
         <widget class="QGroupBox" name="groupBox">
@@ -300,10 +360,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabNetwork">
-      <attribute name="title">
-       <string>&amp;Network</string>
-      </attribute>
+     <widget class="QWidget" name="pageNetwork">
       <layout class="QVBoxLayout" name="verticalLayout_Network">
        <item>
         <widget class="QCheckBox" name="mapPortUpnp">
@@ -618,10 +675,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabWindow">
-      <attribute name="title">
-       <string>&amp;Window</string>
-      </attribute>
+     <widget class="QWidget" name="pageWindow">
       <layout class="QVBoxLayout" name="verticalLayout_Window">
        <item>
         <widget class="QCheckBox" name="hideTrayIcon">
@@ -668,10 +722,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabDisplay">
-      <attribute name="title">
-       <string>&amp;Display</string>
-      </attribute>
+     <widget class="QWidget" name="pageDisplay">
       <layout class="QVBoxLayout" name="verticalLayout_Display">
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_1_Display">

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -18,14 +18,47 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTabWidget" name="tabWidget">
+    <layout class="QHBoxLayout" name="horizontalLayout_Buttons_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="btnSignMessage">
+       <property name="text">
+        <string>&amp;Sign Message</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnVerifyMessage">
+       <property name="text">
+        <string>&amp;Verify Message</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="stackedWidgetSig">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tabSignMessage">
-      <attribute name="title">
-       <string>&amp;Sign Message</string>
-      </attribute>
+     <widget class="QWidget" name="pageSignMessage">
       <layout class="QVBoxLayout" name="verticalLayout_SM">
        <item>
         <widget class="QLabel" name="infoLabel_SM">
@@ -198,10 +231,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabVerifyMessage">
-      <attribute name="title">
-       <string>&amp;Verify Message</string>
-      </attribute>
+     <widget class="QWidget" name="pageVerifyMessage">
       <layout class="QVBoxLayout" name="verticalLayout_VM">
        <item>
         <widget class="QLabel" name="infoLabel_VM">

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -69,16 +69,27 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     connect(ui->connectSocksTor, SIGNAL(toggled(bool)), ui->proxyPortTor, SLOT(setEnabled(bool)));
     connect(ui->connectSocksTor, SIGNAL(toggled(bool)), this, SLOT(updateProxyValidationState()));
 
-    /* Window elements init */
-#ifdef Q_OS_MAC
-    /* remove Window tab on Mac */
-    ui->tabWidget->removeTab(ui->tabWidget->indexOf(ui->tabWindow));
-#endif
-
+    pageButtons.addButton(ui->btnMain, pageButtons.buttons().size());
     /* remove Wallet tab in case of -disablewallet */
     if (!enableWallet) {
-        ui->tabWidget->removeTab(ui->tabWidget->indexOf(ui->tabWallet));
+        ui->stackedWidgetOptions->removeWidget(ui->pageWallet);
+        ui->btnWallet->hide();
+    } else {
+        pageButtons.addButton(ui->btnWallet, pageButtons.buttons().size());
     }
+    pageButtons.addButton(ui->btnNetwork, pageButtons.buttons().size());
+#ifdef Q_OS_MAC
+    /* remove Window tab on Mac */
+    ui->stackedWidgetOptions->removeWidget(ui->pageWindow);
+    ui->btnWindow->hide();
+#else
+    pageButtons.addButton(ui->btnWindow, pageButtons.buttons().size());
+#endif
+    pageButtons.addButton(ui->btnDisplay, pageButtons.buttons().size());
+
+    connect(&pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
+
+    showPage(0);
 
     /* Display elements init */
 
@@ -226,6 +237,23 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->thirdPartyTxUrls, OptionsModel::ThirdPartyTxUrls);
 
+}
+
+void OptionsDialog::showPage(int index)
+{
+    std::vector<QWidget*> vecNormal;
+    QAbstractButton* btnActive = pageButtons.button(index);
+    for (QAbstractButton* button : pageButtons.buttons()) {
+        if (button != btnActive) {
+            vecNormal.push_back(button);
+        }
+    }
+
+    GUIUtil::setFont({btnActive}, GUIUtil::FontWeight::Bold, 16);
+    GUIUtil::setFont(vecNormal, GUIUtil::FontWeight::Normal, 16);
+
+    ui->stackedWidgetOptions->setCurrentIndex(index);
+    btnActive->setChecked(true);
 }
 
 void OptionsDialog::setOkButtonState(bool fState)

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_QT_OPTIONSDIALOG_H
 #define BITCOIN_QT_OPTIONSDIALOG_H
 
+#include <QButtonGroup>
 #include <QDialog>
 #include <QValidator>
 
@@ -44,6 +45,8 @@ public:
     void setMapper();
 
 private Q_SLOTS:
+    /** custom tab buttons clicked */
+    void showPage(int index);
     /* set OK button state (enabled / disabled) */
     void setOkButtonState(bool fState);
     void on_resetButton_clicked();
@@ -65,6 +68,7 @@ private:
     Ui::OptionsDialog *ui;
     OptionsModel *model;
     QDataWidgetMapper *mapper;
+    QButtonGroup pageButtons;
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -203,6 +203,86 @@ QDialog#SignVerifyMessageDialog QPushButton#clearButton_VM:disabled {
 }
 
 /******************************************************
+QPushButton - Special case, tabbar replacement buttons
+******************************************************/
+
+/* Debug window buttons */
+#btnInfo,
+#btnConsole,
+#btnNetTraffic,
+#btnPeers,
+#btnRepair,
+/* Options dialog buttons */
+#btnMain,
+#btnWallet,
+#btnNetwork,
+#btnWindow,
+#btnDisplay,
+/* Sign/Verify dialog buttons */
+#btnSignMessage,
+#btnVerifyMessage {
+    border-color: #205a96;
+    color: #818181;
+}
+
+/* Debug window buttons */
+#btnInfo:hover:checked,
+#btnConsole:hover:checked,
+#btnNetTraffic:hover:checked,
+#btnPeers:hover:checked,
+#btnRepair:hover:checked,
+/* Options dialog buttons */
+#btnMain:hover:checked,
+#btnWallet:hover:checked,
+#btnNetwork:hover:checked,
+#btnWindow:hover:checked,
+#btnDisplay:hover:checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:checked,
+#btnVerifyMessage:hover:checked {
+    border-color: #c7c7c7;
+    color: #c7c7c7;
+}
+
+/* Debug window buttons */
+#btnInfo:hover:!checked,
+#btnConsole:hover:!checked,
+#btnNetTraffic:hover:!checked,
+#btnPeers:hover:!checked,
+#btnRepair:hover:!checked,
+/* Options dialog buttons */
+#btnMain:hover:!checked,
+#btnWallet:hover:!checked,
+#btnNetwork:hover:!checked,
+#btnWindow:hover:!checked,
+#btnDisplay:hover:!checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:!checked,
+#btnVerifyMessage:hover:!checked {
+    border-color: #205a96;
+    color: #c7c7c7;
+}
+
+/* Debug window buttons */
+#btnInfo:checked,
+#btnConsole:checked,
+#btnNetTraffic:checked,
+#btnPeers:checked,
+#btnRepair:checked,
+/* Options dialog buttons */
+#btnMain:checked,
+#btnWallet:checked,
+#btnNetwork:checked,
+#btnWindow:checked,
+#btnDisplay:checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:checked,
+#btnVerifyMessage:checked {
+    border-color: #c7c7c7;
+    color: #c7c7c7;
+}
+
+/******************************************************
 QRadioButton
 ******************************************************/
 

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -493,6 +493,118 @@ QDialog#SignVerifyMessageDialog QPushButton#clearButton_VM:disabled {
 }
 
 /******************************************************
+QPushButton - Special case, tabbar replacement buttons
+******************************************************/
+
+/* Debug window buttons */
+#btnInfo,
+#btnConsole,
+#btnNetTraffic,
+#btnPeers,
+#btnRepair,
+/* Options dialog buttons */
+#btnMain,
+#btnWallet,
+#btnNetwork,
+#btnWindow,
+#btnDisplay,
+/* Sign/Verify dialog buttons */
+#btnSignMessage,
+#btnVerifyMessage {
+    background: none;
+    border-radius: 0px;
+    color: red;
+    border-bottom: 2px solid red;
+    background-color: transparent;
+}
+
+/* Debug window buttons */
+#btnInfo:hover:checked,
+#btnConsole:hover:checked,
+#btnNetTraffic:hover:checked,
+#btnPeers:hover:checked,
+#btnRepair:hover:checked,
+/* Options dialog buttons */
+#btnMain:hover:checked,
+#btnWallet:hover:checked,
+#btnNetwork:hover:checked,
+#btnWindow:hover:checked,
+#btnDisplay:hover:checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:checked,
+#btnVerifyMessage:hover:checked {
+    border: none;
+    color: red;
+    border-radius: 0px;
+    border-bottom: 2px solid red;
+    background-color:transparent;
+}
+
+/* Debug window buttons */
+#btnInfo:hover:!checked,
+#btnConsole:hover:!checked,
+#btnNetTraffic:hover:!checked,
+#btnPeers:hover:!checked,
+#btnRepair:hover:!checked,
+/* Options dialog buttons */
+#btnMain:hover:!checked,
+#btnWallet:hover:!checked,
+#btnNetwork:hover:!checked,
+#btnWindow:hover:!checked,
+#btnDisplay:hover:!checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:!checked,
+#btnVerifyMessage:hover:!checked {
+    border: none;
+    color: red;
+    border-radius: 0px;
+    border-bottom: 2px solid red;
+    background-color:transparent;
+}
+
+/* Debug window buttons */
+#btnInfo:checked,
+#btnConsole:checked,
+#btnNetwork:checked,
+#btnPeers:checked,
+#btnRepair:checked,
+/* Options dialog buttons */
+#btnMain:checked,
+#btnWallet:checked,
+#btnNetwork:checked,
+#btnWindow:checked,
+#btnDisplay:checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:checked,
+#btnVerifyMessage:checked {
+    border: none;
+    color: red;
+    border-radius: 0px;
+    border-bottom: 2px solid red;
+    background-color:transparent;
+}
+
+/* Debug window buttons */
+#btnShowInfo:hover:pressed,
+#btnShowConsole:hover:pressed,
+#btnShowNetwork:hover:pressed,
+#btnShowPeers:hover:pressed,
+/* Options dialog buttons */
+#btnMain:hover:pressed,
+#btnWallet:hover:pressed,
+#btnNetwork:hover:pressed,
+#btnWindow:hover:pressed,
+#btnDisplay:hover:pressed,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:pressed,
+#btnVerifyMessage:hover:pressed {
+    border: none;
+    border-radius: 0px;
+    border-bottom: 2px solid red;
+    background-color:transparent;
+}
+
+/******************************************************
 QRadioButton
 ******************************************************/
 

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -201,6 +201,86 @@ QDialog#SignVerifyMessageDialog QPushButton#clearButton_VM:disabled {
 }
 
 /******************************************************
+QPushButton - Special case, tabbar replacement buttons
+******************************************************/
+
+/* Debug window buttons */
+#btnInfo,
+#btnConsole,
+#btnNetTraffic,
+#btnPeers,
+#btnRepair,
+/* Options dialog buttons */
+#btnMain,
+#btnWallet,
+#btnNetwork,
+#btnWindow,
+#btnDisplay,
+/* Sign/Verify dialog buttons */
+#btnSignMessage,
+#btnVerifyMessage {
+    border-color: #008de4;
+    color: #a7a7a7;
+}
+
+/* Debug window buttons */
+#btnInfo:hover:checked,
+#btnConsole:hover:checked,
+#btnNetTraffic:hover:checked,
+#btnPeers:hover:checked,
+#btnRepair:hover:checked,
+/* Options dialog buttons */
+#btnMain:hover:checked,
+#btnWallet:hover:checked,
+#btnNetwork:hover:checked,
+#btnWindow:hover:checked,
+#btnDisplay:hover:checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:checked,
+#btnVerifyMessage:hover:checked {
+    border-color: #008de4;
+    color: #555;
+}
+
+/* Debug window buttons */
+#btnInfo:hover:!checked,
+#btnConsole:hover:!checked,
+#btnNetTraffic:hover:!checked,
+#btnPeers:hover:!checked,
+#btnRepair:hover:!checked,
+/* Options dialog buttons */
+#btnMain:hover:!checked,
+#btnWallet:hover:!checked,
+#btnNetwork:hover:!checked,
+#btnWindow:hover:!checked,
+#btnDisplay:hover:!checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:!checked,
+#btnVerifyMessage:hover:!checked {
+    border-color: #047ac2;
+    color: #555;
+}
+
+/* Debug window buttons */
+#btnInfo:checked,
+#btnConsole:checked,
+#btnNetTraffic:checked,
+#btnPeers:checked,
+#btnRepair:checked,
+/* Options dialog buttons */
+#btnMain:checked,
+#btnWallet:checked,
+#btnNetwork:checked,
+#btnWindow:checked,
+#btnDisplay:checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:checked,
+#btnVerifyMessage:checked {
+    border-color: #008de4;
+    color: #555;
+}
+
+/******************************************************
 QRadioButton
 ******************************************************/
 

--- a/src/qt/res/css/traditional.css
+++ b/src/qt/res/css/traditional.css
@@ -36,6 +36,107 @@ QToolBar QLabel#lblToolbarLogo {
 }
 
 /******************************************************
+QPushButton - Special case, tabbar replacement buttons
+******************************************************/
+
+/* Debug window buttons */
+#btnInfo,
+#btnConsole,
+#btnNetTraffic,
+#btnPeers,
+#btnRepair,
+/* Options dialog buttons */
+#btnMain,
+#btnWallet,
+#btnNetwork,
+#btnWindow,
+#btnDisplay,
+/* Sign/Verify dialog buttons */
+#btnSignMessage,
+#btnVerifyMessage {
+    background: none;
+    border-radius: 0px;
+    color: red;
+    border-bottom: 3px solid red;
+    padding-bottom: 5px;
+    background-color: transparent;
+    border-color: #008de4;
+    color: #333;
+}
+
+/* Debug window buttons */
+#btnInfo:hover:checked,
+#btnConsole:hover:checked,
+#btnNetTraffic:hover:checked,
+#btnPeers:hover:checked,
+#btnRepair:hover:checked,
+/* Options dialog buttons */
+#btnMain:hover:checked,
+#btnWallet:hover:checked,
+#btnNetwork:hover:checked,
+#btnWindow:hover:checked,
+#btnDisplay:hover:checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:checked,
+#btnVerifyMessage:hover:checked {
+    border: none;
+    color: red;
+    border-radius: 0px;
+    border-bottom: 3px solid red;
+    background-color:transparent;
+    border-color: #333;
+    color: #333;
+}
+
+/* Debug window buttons */
+#btnInfo:hover:!checked,
+#btnConsole:hover:!checked,
+#btnNetTraffic:hover:!checked,
+#btnPeers:hover:!checked,
+#btnRepair:hover:!checked,
+/* Options dialog buttons */
+#btnMain:hover:!checked,
+#btnWallet:hover:!checked,
+#btnNetwork:hover:!checked,
+#btnWindow:hover:!checked,
+#btnDisplay:hover:!checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:hover:!checked,
+#btnVerifyMessage:hover:!checked {
+    border: none;
+    color: red;
+    border-radius: 0px;
+    border-bottom: 3px solid red;
+    background-color:transparent;
+    border-color: #047ac2;
+    color: #666;
+}
+
+/* Debug window buttons */
+#btnInfo:checked,
+#btnConsole:checked,
+#btnNetwork:checked,
+#btnPeers:checked,
+#btnRepair:checked,
+/* Options dialog buttons */
+#btnMain:checked,
+#btnWallet:checked,
+#btnNetwork:checked,
+#btnWindow:checked,
+#btnDisplay:checked,
+/* Sign/Verify dialog buttons */
+#btnSignMessage:checked,
+#btnVerifyMessage:checked {
+    border: none;
+    color: red;
+    border-radius: 0px;
+    border-bottom: 3px solid red;
+    background-color:transparent;
+    border-color: #333;
+    color: #333;
+}
+
+/******************************************************
 ModalOverlay
 ******************************************************/
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -531,6 +531,14 @@ RPCConsole::RPCConsole(const PlatformStyle *_platformStyle, QWidget *parent) :
     ui->peerHeading->setText(tr("Select a peer to view detailed information."));
 
     consoleFontSize = settings.value(fontSizeSettingsKey, QFontInfo(GUIUtil::getFontNormal()).pointSize()).toInt();
+
+    pageButtons.addButton(ui->btnInfo, pageButtons.buttons().size());
+    pageButtons.addButton(ui->btnConsole, pageButtons.buttons().size());
+    pageButtons.addButton(ui->btnNetTraffic, pageButtons.buttons().size());
+    pageButtons.addButton(ui->btnPeers, pageButtons.buttons().size());
+    pageButtons.addButton(ui->btnRepair, pageButtons.buttons().size());
+    connect(&pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
+
     clear();
 }
 
@@ -968,6 +976,23 @@ void RPCConsole::setInstantSendLockCount(size_t count)
     ui->instantSendLockCount->setText(QString::number(count));
 }
 
+void RPCConsole::showPage(int index)
+{
+    std::vector<QWidget*> vecNormal;
+    QAbstractButton* btnActive = pageButtons.button(index);
+    for (QAbstractButton* button : pageButtons.buttons()) {
+        if (button != btnActive) {
+            vecNormal.push_back(button);
+        }
+    }
+
+    GUIUtil::setFont({btnActive}, GUIUtil::FontWeight::Bold, 16);
+    GUIUtil::setFont(vecNormal, GUIUtil::FontWeight::Normal, 16);
+
+    ui->stackedWidgetRPC->setCurrentIndex(index);
+    btnActive->setChecked(true);
+}
+
 void RPCConsole::on_lineEdit_returnPressed()
 {
     QString cmd = ui->lineEdit->text();
@@ -1052,11 +1077,11 @@ void RPCConsole::startExecutor()
     thread.start();
 }
 
-void RPCConsole::on_tabWidget_currentChanged(int index)
+void RPCConsole::on_stackedWidgetRPC_currentChanged(int index)
 {
-    if (ui->tabWidget->widget(index) == ui->tab_console)
+    if (ui->stackedWidgetRPC->widget(index) == ui->pageConsole)
         ui->lineEdit->setFocus();
-    else if (ui->tabWidget->widget(index) != ui->tab_peers)
+    else if (ui->stackedWidgetRPC->widget(index) != ui->pagePeers)
         clearSelectedNode();
 }
 
@@ -1341,5 +1366,5 @@ void RPCConsole::showOrHideBanTableIfRequired()
 
 void RPCConsole::setTabFocus(enum TabTypes tabType)
 {
-    ui->tabWidget->setCurrentIndex(tabType);
+    showPage(tabType);
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -11,6 +11,7 @@
 
 #include <net.h>
 
+#include <QButtonGroup>
 #include <QWidget>
 #include <QCompleter>
 #include <QThread>
@@ -65,8 +66,10 @@ protected:
     void keyPressEvent(QKeyEvent *);
 
 private Q_SLOTS:
+    /** custom tab buttons clicked */
+    void showPage(int index);
     void on_lineEdit_returnPressed();
-    void on_tabWidget_currentChanged(int index);
+    void on_stackedWidgetRPC_currentChanged(int index);
     /** open the debug.log from the current datadir */
     void on_openDebugLogfileButton_clicked();
     /** change the time range of the network traffic graph */
@@ -158,6 +161,7 @@ private:
     };
 
     Ui::RPCConsole *ui;
+    QButtonGroup pageButtons;
     ClientModel *clientModel;
     QStringList history;
     int historyPtr;

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -29,6 +29,10 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformS
 {
     ui->setupUi(this);
 
+    pageButtons.addButton(ui->btnSignMessage, pageButtons.buttons().size());
+    pageButtons.addButton(ui->btnVerifyMessage, pageButtons.buttons().size());
+    connect(&pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
+
     ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Message\" to generate signature"));
 
 #ifdef Q_OS_MAC // Icons on push buttons are very uncommon on Mac
@@ -95,16 +99,33 @@ void SignVerifyMessageDialog::setAddress_VM(const QString &address)
 
 void SignVerifyMessageDialog::showTab_SM(bool fShow)
 {
-    ui->tabWidget->setCurrentIndex(0);
+    showPage(0);
     if (fShow)
         this->show();
 }
 
 void SignVerifyMessageDialog::showTab_VM(bool fShow)
 {
-    ui->tabWidget->setCurrentIndex(1);
+    showPage(1);
     if (fShow)
         this->show();
+}
+
+void SignVerifyMessageDialog::showPage(int index)
+{
+    std::vector<QWidget*> vecNormal;
+    QAbstractButton* btnActive = pageButtons.button(index);
+    for (QAbstractButton* button : pageButtons.buttons()) {
+        if (button != btnActive) {
+            vecNormal.push_back(button);
+        }
+    }
+
+    GUIUtil::setFont({btnActive}, GUIUtil::FontWeight::Bold, 16);
+    GUIUtil::setFont(vecNormal, GUIUtil::FontWeight::Normal, 16);
+
+    ui->stackedWidgetSig->setCurrentIndex(index);
+    btnActive->setChecked(true);
 }
 
 void SignVerifyMessageDialog::on_addressBookButton_SM_clicked()
@@ -272,8 +293,7 @@ bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
 {
     if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::FocusIn)
     {
-        if (ui->tabWidget->currentIndex() == 0)
-        {
+        if (ui->stackedWidgetSig->currentIndex() == 0) {
             /* Clear status message on focus change */
             ui->statusLabel_SM->clear();
 
@@ -283,9 +303,7 @@ bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
                 ui->signatureOut_SM->selectAll();
                 return true;
             }
-        }
-        else if (ui->tabWidget->currentIndex() == 1)
-        {
+        } else if (ui->stackedWidgetSig->currentIndex() == 1) {
             /* Clear status message on focus change */
             ui->statusLabel_VM->clear();
         }

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_QT_SIGNVERIFYMESSAGEDIALOG_H
 #define BITCOIN_QT_SIGNVERIFYMESSAGEDIALOG_H
 
+#include <QButtonGroup>
 #include <QDialog>
 
 class PlatformStyle;
@@ -36,8 +37,11 @@ private:
     Ui::SignVerifyMessageDialog *ui;
     WalletModel *model;
     const PlatformStyle *platformStyle;
+    QButtonGroup pageButtons;
 
 private Q_SLOTS:
+    /** custom tab buttons clicked */
+    void showPage(int index);
     /* sign message */
     void on_addressBookButton_SM_clicked();
     void on_pasteButton_SM_clicked();


### PR DESCRIPTION
This PR ist part of a series of +-25 PRs related to UI redesigns. Its ancestor is #3559, its successor is  #3561. I did not screenshot every single PR and its changes, instead i made "walk through all screen" videos with the result of this PR series and also with the 0.15 UI. If there are any concrete screenshots wanted, just let me know. To build with the full set of changes you can build from the branch [xdustinface:pr-ui-redesign](https://github.com/xdustinface/dash/tree/pr-ui-redesign) which always contains all changes.

[ -> Walk through 0.15](https://youtu.be/cWQeHj5tWR0)
[ -> Walk through Redesign](https://youtu.be/0QeSyXo1aao)

I tried to give the commits enough text to make things obvious without a lot description for each PR. Also here, if you want more description for this specific PR, let me know.
### About this PR

This PR removes all occurences of `QTabBar` (SignVerifyMessageDialog, OptionsDialog, RPCConsole). Instead it adds a `QStackedWidget` as replacement with `QPushButtons` in a `QHBoxLayout` grouped into a `QButtonGroup` above it to simulate the tabs. This is because the `QTabBar` items can't be stretched and styled the way it's possible with the `QPushButtons`. It also adds stylesheets to give the buttons a nice look.