### PR TITLE
qt: Redesign BitcoinAmountField

### DIFF
--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -7,9 +7,11 @@
 
 #include <amount.h>
 
+#include <QValidator>
 #include <QWidget>
 
-class AmountSpinBox;
+class AmountLineEdit;
+class BitcoinUnits;
 
 QT_BEGIN_NAMESPACE
 class QValueComboBox;
@@ -30,9 +32,6 @@ public:
 
     CAmount value(bool *value=0) const;
     void setValue(const CAmount& value);
-
-    /** Set single step in satoshis **/
-    void setSingleStep(const CAmount& step);
 
     /** Make read-only **/
     void setReadOnly(bool fReadOnly);
@@ -64,12 +63,10 @@ protected:
     bool eventFilter(QObject *object, QEvent *event);
 
 private:
-    AmountSpinBox *amount;
-    QValueComboBox *unit;
+    AmountLineEdit *amount;
+    BitcoinUnits *units;
 
-private Q_SLOTS:
     void unitChanged(int idx);
-
 };
 
 #endif // BITCOIN_QT_BITCOINAMOUNTFIELD_H

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -246,7 +246,11 @@ int BitcoinUnits::rowCount(const QModelIndex &parent) const
 
 QVariant BitcoinUnits::data(const QModelIndex &index, int role) const
 {
-    int row = index.row();
+    return data(index.row(), role);
+}
+
+QVariant BitcoinUnits::data(const int &row, int role) const
+{
     if(row >= 0 && row < unitlist.size())
     {
         Unit unit = unitlist.at(row);

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -111,6 +111,7 @@ public:
     };
     int rowCount(const QModelIndex &parent) const;
     QVariant data(const QModelIndex &index, int role) const;
+    QVariant data(const int &row, int role) const;
     ///@}
 
     static QString removeSpaces(QString text)

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -99,12 +99,6 @@
         </item>
         <item row="5" column="2">
          <widget class="BitcoinAmountField" name="reqAmount">
-          <property name="minimumSize">
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
           <property name="toolTip">
            <string>An optional amount to request. Leave this empty or zero to not request a specific amount.</string>
           </property>
@@ -291,8 +285,6 @@
   <tabstop>showRequestButton</tabstop>
   <tabstop>removeRequestButton</tabstop>
  </tabstops>
- <resources>
-  <include location="../dash.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -97,13 +97,6 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
-         <widget class="BitcoinAmountField" name="reqAmount">
-          <property name="toolTip">
-           <string>An optional amount to request. Leave this empty or zero to not request a specific amount.</string>
-          </property>
-         </widget>
-        </item>
         <item row="7" column="2">
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
@@ -159,6 +152,36 @@
            <string/>
           </property>
          </widget>
+        </item>
+        <item row="5" column="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="BitcoinAmountField" name="reqAmount">
+            <property name="toolTip">
+             <string>An optional amount to request. Leave this empty or zero to not request a specific amount.</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1071,11 +1071,6 @@ BitcoinAmountField
 ******************************************************/
 
 BitcoinAmountField{
-    /* This is a hacky way to make sure BitcoinAmountField's
-    * shows completely.
-    * TODO: Fix the issue properly.
-    */
-    margin-bottom: 5px;
 }
 
 /******************************************************

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -217,7 +217,7 @@ void SendCoinsDialog::setModel(WalletModel *_model)
         connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(setMinimumFee()));
         connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(updateFeeSectionControls()));
         connect(ui->checkBoxMinimumFee, SIGNAL(stateChanged(int)), this, SLOT(coinControlUpdateLabels()));
-        ui->customFee->setSingleStep(GetRequiredFee(1000));
+
         updateFeeSectionControls();
         updateMinFeeLabel();
         updateSmartFeeLabel();


### PR DESCRIPTION
This PR ist part of a series of +-25 PRs related to UI redesigns. Its ancestor is #3568, its successor is  #3570. I did not screenshot every single PR and its changes, instead i made "walk through all screen" videos with the result of this PR series and also with the 0.15 UI. If there are any concrete screenshots wanted, just let me know. To build with the full set of changes you can build from the branch [xdustinface:pr-ui-redesign](https://github.com/xdustinface/dash/tree/pr-ui-redesign) which always contains all changes.

[ -> Walk through 0.15](https://youtu.be/cWQeHj5tWR0)
[ -> Walk through Redesign](https://youtu.be/0QeSyXo1aao)

I tried to give the commits enough text to make things obvious without a lot description for each PR. Also here, if you want more description for this specific PR, let me know.
### About this PR

This PR gives the BitcoinAmountField a redesign. It removes the spinbox and the unit selector. Result is just a line edit with the same validation and background functionality. Its still possible to change the input unit by changing the global unit selector to the desired unit.