### PR TITLE
qt: Introduce platform specific css sections

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1070,7 +1070,12 @@ void loadStyleSheet(QWidget* widget, bool fDebugWidget)
                 QString strStyle = QLatin1String(qFile.readAll());
                 // Process all <os=...></os> groups in the stylesheet first
                 QRegularExpressionMatch osStyleMatch;
-                QRegularExpression osStyleExp("^(<os=(?:'|\").+(?:'|\")>)((?:.|\n)+?)(</os>?)$");
+                QRegularExpression osStyleExp(
+                        "^"
+                        "(<os=(?:'|\").+(?:'|\")>)" // group 1
+                        "((?:.|\n)+?)"              // group 2
+                        "(</os>?)"                  // group 3
+                        "$");
                 osStyleExp.setPatternOptions(QRegularExpression::MultilineOption);
                 QRegularExpressionMatchIterator it = osStyleExp.globalMatch(strStyle);
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1058,6 +1058,7 @@ void loadStyleSheet(QWidget* widget, bool fDebugWidget)
                 return false;
             }
 
+            std::string platformName = gArgs.GetArg("-uiplatform", BitcoinGUI::DEFAULT_UIPLATFORM);
             stylesheet = std::make_unique<QString>();
 
             for (const auto& file : vecFiles) {
@@ -1083,7 +1084,7 @@ void loadStyleSheet(QWidget* widget, bool fDebugWidget)
                     }
 
                     for (int i = 0; i < listMatches.size(); i += 4) {
-                        if (!listMatches[i + 1].contains(QString::fromStdString(BitcoinGUI::DEFAULT_UIPLATFORM))) {
+                        if (!listMatches[i + 1].contains(QString::fromStdString(platformName))) {
                             // If os is not supported for this styles
                             // just remove the full match
                             strStyle.replace(listMatches[i], "");

--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -784,3 +784,38 @@ TransactionView
 ******************************************************/
 
 /***** No dark.css specific coloring here yet *****/
+
+
+/******************************************************
+*******************************************************
+STYLING OF OS SPECIFIC UI PARTS
+
+NOTE: GUIUtil::loadStyleSheet treats css code between <os="<os_list>"> and </os>
+different. It will only become added for operating systems provided in the list
+of the sections start tag.
+
+There may be multiple entries per section. Possible entries:
+
+- macosx
+- windows
+- other
+
+<os_list> must be a combination of the three options above separated by
+comma like in "windows,macosx".
+
+Its ok to have multiple <os="...">...</os> sections in a file with
+arbitrary OS combinations. They will all become added to the end of the
+file though. Means even putting an <os> section in the top of the file
+would become appended to the end of the file during loading which should
+be kept in mind when adding sections to avoid unexpected overwriting.
+*******************************************************
+******************************************************/
+
+<os="macosx, windows, other">
+
+/* Example section to add styles for all operating systems
+   Remove any to exclude it.
+*/
+
+</os>
+

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1849,3 +1849,39 @@ TransactionView QComboBox {
     min-height: 30px;
     margin-top: 15px;
 }
+
+
+/******************************************************
+*******************************************************
+STYLING OF OS SPECIFIC UI PARTS
+
+NOTE: GUIUtil::loadStyleSheet treats css code between <os="<os_list>"> and </os>
+different. It will only become added for operating systems provided in the list
+of the sections start tag.
+
+There may be multiple entries per section. Possible entries:
+
+- macosx
+- windows
+- other
+
+<os_list> must be a combination of the three options above separated by
+comma like in "windows,macosx".
+
+Its ok to have multiple <os="...">...</os> sections in a file with
+arbitrary OS combinations. They will all become added to the end of the
+file though. Means even putting an <os> section in the top of the file
+would become appended to the end of the file during loading which should
+be kept in mind when adding sections to avoid unexpected overwriting.
+*******************************************************
+******************************************************/
+
+
+<os="macosx, windows, other">
+
+/* Example section to add styles for all operating systems
+   Remove any to exclude it.
+*/
+
+</os>
+

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -766,3 +766,39 @@ TransactionView
 ******************************************************/
 
 /***** No light.css specific coloring here yet *****/
+
+
+/******************************************************
+*******************************************************
+STYLING OF OS SPECIFIC UI PARTS
+
+NOTE: GUIUtil::loadStyleSheet treats css code between <os="<os_list>"> and </os>
+different. It will only become added for operating systems provided in the list
+of the sections start tag.
+
+There may be multiple entries per section. Possible entries:
+
+- macosx
+- windows
+- other
+
+<os_list> must be a combination of the three options above separated by
+comma like in "windows,macosx".
+
+Its ok to have multiple <os="...">...</os> sections in a file with
+arbitrary OS combinations. They will all become added to the end of the
+file though. Means even putting an <os> section in the top of the file
+would become appended to the end of the file during loading which should
+be kept in mind when adding sections to avoid unexpected overwriting.
+*******************************************************
+******************************************************/
+
+
+<os="macosx, windows, other">
+
+/* Example section to add styles for all operating systems
+   Remove any to exclude it.
+*/
+
+</os>
+


### PR DESCRIPTION
This PR ist part of a series of +-25 PRs related to UI redesigns. Its ancestor is #3569, its successor is  #3571. I did not screenshot every single PR and its changes, instead i made "walk through all screen" videos with the result of this PR series and also with the 0.15 UI. If there are any concrete screenshots wanted, just let me know. To build with the full set of changes you can build from the branch [xdustinface:pr-ui-redesign](https://github.com/xdustinface/dash/tree/pr-ui-redesign) which always contains all changes.

[ -> Walk through 0.15](https://youtu.be/cWQeHj5tWR0)
[ -> Walk through Redesign](https://youtu.be/0QeSyXo1aao)

I tried to give the commits enough text to make things obvious without a lot description for each PR. Also here, if you want more description for this specific PR, let me know.
### About this PR

See commit message.