### PR TITLE
qt: Add missing placeholders

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -77,6 +77,8 @@ MasternodeList::MasternodeList(QWidget* parent) :
 
     ui->tableWidgetMasternodesDIP3->setContextMenuPolicy(Qt::CustomContextMenu);
 
+    ui->filterLineEditDIP3->setPlaceholderText(tr("Filter by any property (e.g. address or protx hash)"));
+
     QAction* copyProTxHashAction = new QAction(tr("Copy ProTx Hash"), this);
     QAction* copyCollateralOutpointAction = new QAction(tr("Copy Collateral Outpoint"), this);
     contextMenuDIP3 = new QMenu(this);

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -32,6 +32,9 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) :
                       ui->label_2,
                       ui->label_3}, GUIUtil::FontWeight::Normal, 15);
 
+    ui->reqLabel->setPlaceholderText(tr("Enter a label for this request to add its address to your address book"));
+    ui->reqMessage->setPlaceholderText(tr("Enter a message which gets added to this request."));
+
     // context menu actions
     QAction *copyURIAction = new QAction(tr("Copy URI"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -32,8 +32,8 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) :
                       ui->label_2,
                       ui->label_3}, GUIUtil::FontWeight::Normal, 15);
 
-    ui->reqLabel->setPlaceholderText(tr("Enter a label which gets assigned to the generated address in your address book"));
-    ui->reqMessage->setPlaceholderText(tr("Enter a message which gets added to this request"));
+    ui->reqLabel->setPlaceholderText(tr("Enter a label to associate with the new receiving address"));
+    ui->reqMessage->setPlaceholderText(tr("Enter a message to attach to the payment request"));
 
     // context menu actions
     QAction *copyURIAction = new QAction(tr("Copy URI"), this);

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -32,7 +32,7 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) :
                       ui->label_2,
                       ui->label_3}, GUIUtil::FontWeight::Normal, 15);
 
-    ui->reqLabel->setPlaceholderText(tr("Enter a label for this request to add its address to your address book"));
+    ui->reqLabel->setPlaceholderText(tr("Enter a label which gets assigned to the generated address in your address book"));
     ui->reqMessage->setPlaceholderText(tr("Enter a message which gets added to this request"));
 
     // context menu actions

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -33,7 +33,7 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) :
                       ui->label_3}, GUIUtil::FontWeight::Normal, 15);
 
     ui->reqLabel->setPlaceholderText(tr("Enter a label for this request to add its address to your address book"));
-    ui->reqMessage->setPlaceholderText(tr("Enter a message which gets added to this request."));
+    ui->reqMessage->setPlaceholderText(tr("Enter a message which gets added to this request"));
 
     // context menu actions
     QAction *copyURIAction = new QAction(tr("Copy URI"), this);

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -31,8 +31,13 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget* parent) :
     pageButtons.addButton(ui->btnVerifyMessage, pageButtons.buttons().size());
     connect(&pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
 
+    ui->messageIn_SM->setPlaceholderText(tr("Enter a message to be signed"));
     ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Message\" to generate signature"));
 
+    ui->messageIn_VM->setPlaceholderText(tr("Enter a message to be verified"));
+    ui->signatureIn_VM->setPlaceholderText(tr("Enter a signature to be verified"));
+
+    // These icons are needed on Mac also
     ui->addressBookButton_SM->setIcon(QIcon(":/icons/address-book"));
     ui->pasteButton_SM->setIcon(QIcon(":/icons/editpaste"));
     ui->copySignatureButton_SM->setIcon(QIcon(":/icons/editcopy"));

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -35,7 +35,7 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget* parent) :
     ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Message\" to generate signature"));
 
     ui->messageIn_VM->setPlaceholderText(tr("Enter a message to be verified"));
-    ui->signatureIn_VM->setPlaceholderText(tr("Enter a signature to be verified"));
+    ui->signatureIn_VM->setPlaceholderText(tr("Enter a signature for the message to be verified"));
 
     // These icons are needed on Mac also
     ui->addressBookButton_SM->setIcon(QIcon(":/icons/address-book"));


### PR DESCRIPTION
This PR ist part of a series of +-25 PRs related to UI redesigns. Its ancestor is #3574, its successor is  #3613. I did not screenshot every single PR and its changes, instead i made "walk through all screen" videos with the result of this PR series and also with the 0.15 UI. If there are any concrete screenshots wanted, just let me know. To build with the full set of changes you can build from the branch [xdustinface:pr-ui-redesign](https://github.com/xdustinface/dash/tree/pr-ui-redesign) which always contains all changes.

[ -> Walk through 0.15](https://youtu.be/cWQeHj5tWR0)
[ -> Walk through Redesign](https://youtu.be/0QeSyXo1aao)

I tried to give the commits enough text to make things obvious without a lot description for each PR. Also here, if you want more description for this specific PR, let me know.
### About this PR

See individual commit messages.