### PR TITLE
Add few missing locks after backporting 12333

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -225,6 +225,8 @@ UniValue masternode_outputs(const JSONRPCRequest& request)
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
+    LOCK2(cs_main, pwallet->cs_wallet);
+
     // Find possible candidates
     std::vector<COutput> vPossibleCoins;
     CCoinControl coin_control;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3313,6 +3313,8 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
 
 bool CWallet::SelectPSInOutPairsByDenominations(int nDenom, CAmount nValueMax, std::vector< std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet)
 {
+    LOCK2(cs_main, cs_wallet);
+
     CAmount nValueTotal{0};
 
     std::set<uint256> setRecentTxIds;
@@ -3460,6 +3462,8 @@ bool CWallet::SelectCoinsGroupedByAddresses(std::vector<CompactTallyItem>& vecTa
 
 bool CWallet::SelectDenominatedAmounts(CAmount nValueMax, std::set<CAmount>& setAmountsRet) const
 {
+    LOCK2(cs_main, cs_wallet);
+
     CAmount nValueTotal{0};
     setAmountsRet.clear();
 
@@ -3503,6 +3507,8 @@ bool CWallet::GetCollateralTxDSIn(CTxDSIn& txdsinRet, CAmount& nValueRet) const
 
 bool CWallet::GetMasternodeOutpointAndKeys(COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet, const std::string& strTxHash, const std::string& strOutputIndex)
 {
+    LOCK2(cs_main, cs_wallet);
+
     // wait for reindex and/or import to finish
     if (fImporting || fReindex) return false;
 
@@ -3579,6 +3585,8 @@ int CWallet::CountInputsWithAmount(CAmount nInputAmount) const
 
 bool CWallet::HasCollateralInputs(bool fOnlyConfirmed) const
 {
+    LOCK2(cs_main, cs_wallet);
+
     std::vector<COutput> vCoins;
     CCoinControl coin_control;
     coin_control.nCoinType = CoinType::ONLY_PRIVATESEND_COLLATERAL;


### PR DESCRIPTION
12333 (which was backported via #3518) replaced `cs_main` and `cs_wallet` locks in `CWallet::AvailableCoins` with corresponding assertions and added these locks to callers. We missed a couple of places in Dash-specific parts of code where these locks should be added too and binaries compiled with `DDEBUG_LOCKORDER` are crashing now. This should fix it.