### PR TITLE
qt: Call GUIUtil::loadFonts earlier

### DIFF
--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -692,9 +692,9 @@ int main(int argc, char *argv[])
     app.createOptionsModel(gArgs.GetBoolArg("-resetguisettings", false));
     // Load custom application fonts and setup font management
     if (!GUIUtil::loadFonts()) {
-            QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
-                                  QObject::tr("Error: Failed to load application fonts."));
-            return EXIT_FAILURE;
+        QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
+                              QObject::tr("Error: Failed to load application fonts."));
+        return EXIT_FAILURE;
     }
     // Validate/set font family
     if (gArgs.IsArgSet("-font-family")) {

--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -272,9 +272,6 @@ bool BitcoinCore::baseInitialize()
     {
         return false;
     }
-    if (!GUIUtil::loadFonts()) {
-        return false;
-    }
     return true;
 }
 
@@ -693,7 +690,12 @@ int main(int argc, char *argv[])
     app.parameterSetup();
     // Load GUI settings from QSettings
     app.createOptionsModel(gArgs.GetBoolArg("-resetguisettings", false));
-
+    // Load custom application fonts and setup font management
+    if (!GUIUtil::loadFonts()) {
+            QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
+                                  QObject::tr("Error: Failed to load application fonts."));
+            return EXIT_FAILURE;
+    }
     // Validate/set font family
     if (gArgs.IsArgSet("-font-family")) {
         GUIUtil::FontFamily family;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1183,7 +1183,7 @@ bool loadFonts()
 
     // Fail if an added id is -1 which means QFontDatabase::addApplicationFont failed.
     if (std::find(vecFontIds.begin(), vecFontIds.end(), -1) != vecFontIds.end()) {
-        return InitError("Font loading failed.");
+        return false;
     }
 
     // Print debug logs for added fonts fetched by the added ids


### PR DESCRIPTION
This was added in #3555 but i just realised `BitcoinCore::baseInitialize` isn't the best place to load the fonts. Reason why i moved it to where is is with this PR:

- It's after the creation of `OptionsModel` which is required because we will later have font realted settings and their defaults should be set before the call of `GUIUtil::loadFonts`.
- It's before the first call of any font related helper as they depend on `GUIUtil::loadFonts`.