### PR TITLE
ci: Disable rpcbind_test in gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,7 +113,7 @@ builder-image:
   stage: test
   extends: .base-template
   script:
-    - ./ci/test_integrationtests.sh --extended --exclude pruning,dbcrash
+    - ./ci/test_integrationtests.sh --extended --exclude pruning,dbcrash,rpcbind_test
   after_script:
     - mkdir -p $CI_PROJECT_DIR/testlogs
   artifacts:


### PR DESCRIPTION
Its not possible to setup default gitlab-ci integration since rpcbind_test.py fails for shared runners in gitlab ci. As this test is also always skipped by our gitlab ci (`TestFramework (WARNING): Test Skipped: This test requires IPv6 support.`) i guess its ok to disable it in the gitlab ci for now?

Might to be related to https://github.com/bitcoin/bitcoin/issues/17765