### PR TITLE
llmq: Fix thread handling in CDKGSessionManager and CDKGSessionHandler

### DIFF
--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -95,18 +95,10 @@ CDKGSessionHandler::CDKGSessionHandler(const Consensus::LLMQParams& _params, ctp
     pendingJustifications((size_t)_params.size * 2, MSG_QUORUM_JUSTIFICATION),
     pendingPrematureCommitments((size_t)_params.size * 2, MSG_QUORUM_PREMATURE_COMMITMENT)
 {
-    phaseHandlerThread = std::thread([this] {
-        RenameThread(strprintf("dash-q-phase-%d", (uint8_t)params.type).c_str());
-        PhaseHandlerThread();
-    });
 }
 
 CDKGSessionHandler::~CDKGSessionHandler()
 {
-    stopRequested = true;
-    if (phaseHandlerThread.joinable()) {
-        phaseHandlerThread.join();
-    }
 }
 
 void CDKGSessionHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
@@ -142,6 +134,35 @@ void CDKGSessionHandler::ProcessMessage(CNode* pfrom, const std::string& strComm
         pendingJustifications.PushPendingMessage(pfrom->GetId(), vRecv);
     } else if (strCommand == NetMsgType::QPCOMMITMENT) {
         pendingPrematureCommitments.PushPendingMessage(pfrom->GetId(), vRecv);
+    }
+}
+
+void CDKGSessionHandler::StartThread()
+{
+    auto threadName = [&]() -> auto {
+        switch (params.type) {
+            case Consensus::LLMQ_50_60:
+                return "q-phase-1";
+            case Consensus::LLMQ_400_60:
+                return "q-phase-2";
+            case Consensus::LLMQ_400_85:
+                return "q-phase-3";
+            case Consensus::LLMQ_TEST:
+                return "q-phase-100";
+            case Consensus::LLMQ_DEVNET:
+                return "q-phase-101";
+            default:
+                throw std::runtime_error("Tried to start a CDKGSessionHandler thread for LLMQ_NONE.");
+        }
+    };
+    phaseHandlerThread = std::thread(&TraceThread<std::function<void()> >, threadName(), std::function<void()>(std::bind(&CDKGSessionHandler::PhaseHandlerThread, this)));
+}
+
+void CDKGSessionHandler::StopThread()
+{
+    stopRequested = true;
+    if (phaseHandlerThread.joinable()) {
+        phaseHandlerThread.join();
     }
 }
 

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -84,9 +84,8 @@ void CDKGPendingMessages::Clear()
 
 //////
 
-CDKGSessionHandler::CDKGSessionHandler(const Consensus::LLMQParams& _params, ctpl::thread_pool& _messageHandlerPool, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager) :
+CDKGSessionHandler::CDKGSessionHandler(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager) :
     params(_params),
-    messageHandlerPool(_messageHandlerPool),
     blsWorker(_blsWorker),
     dkgManager(_dkgManager),
     curSession(std::make_shared<CDKGSession>(_params, _blsWorker, _dkgManager)),

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -138,6 +138,10 @@ void CDKGSessionHandler::ProcessMessage(CNode* pfrom, const std::string& strComm
 
 void CDKGSessionHandler::StartThread()
 {
+    if (phaseHandlerThread.joinable()) {
+        throw std::runtime_error("Tried to start an already started CDKGSessionHandler thread.");
+    }
+
     auto threadName = [&]() -> auto {
         switch (params.type) {
             case Consensus::LLMQ_50_60:
@@ -150,8 +154,10 @@ void CDKGSessionHandler::StartThread()
                 return "q-phase-100";
             case Consensus::LLMQ_DEVNET:
                 return "q-phase-101";
-            default:
+            case Consensus::LLMQ_NONE:
                 throw std::runtime_error("Tried to start a CDKGSessionHandler thread for LLMQ_NONE.");
+            default:
+                throw std::runtime_error("Tried to start a CDKGSessionHandler thread for an unknown LLMQ type.");
         }
     };
     phaseHandlerThread = std::thread(&TraceThread<std::function<void()> >, threadName(), std::function<void()>(std::bind(&CDKGSessionHandler::PhaseHandlerThread, this)));

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -94,6 +94,9 @@ CDKGSessionHandler::CDKGSessionHandler(const Consensus::LLMQParams& _params, CBL
     pendingJustifications((size_t)_params.size * 2, MSG_QUORUM_JUSTIFICATION),
     pendingPrematureCommitments((size_t)_params.size * 2, MSG_QUORUM_PREMATURE_COMMITMENT)
 {
+    if (params.type == Consensus::LLMQ_NONE) {
+        throw std::runtime_error("Can't initialize CDKGSessionHandler with LLMQ_NONE type.");
+    }
 }
 
 CDKGSessionHandler::~CDKGSessionHandler()

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -142,25 +142,8 @@ void CDKGSessionHandler::StartThread()
         throw std::runtime_error("Tried to start an already started CDKGSessionHandler thread.");
     }
 
-    auto threadName = [&]() -> auto {
-        switch (params.type) {
-            case Consensus::LLMQ_50_60:
-                return "q-phase-1";
-            case Consensus::LLMQ_400_60:
-                return "q-phase-2";
-            case Consensus::LLMQ_400_85:
-                return "q-phase-3";
-            case Consensus::LLMQ_TEST:
-                return "q-phase-100";
-            case Consensus::LLMQ_DEVNET:
-                return "q-phase-101";
-            case Consensus::LLMQ_NONE:
-                throw std::runtime_error("Tried to start a CDKGSessionHandler thread for LLMQ_NONE.");
-            default:
-                throw std::runtime_error("Tried to start a CDKGSessionHandler thread for an unknown LLMQ type.");
-        }
-    };
-    phaseHandlerThread = std::thread(&TraceThread<std::function<void()> >, threadName(), std::function<void()>(std::bind(&CDKGSessionHandler::PhaseHandlerThread, this)));
+    std::string threadName = strprintf("q-phase-%d", params.type);
+    phaseHandlerThread = std::thread(&TraceThread<std::function<void()> >, threadName, std::function<void()>(std::bind(&CDKGSessionHandler::PhaseHandlerThread, this)));
 }
 
 void CDKGSessionHandler::StopThread()

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -103,7 +103,6 @@ private:
     std::atomic<bool> stopRequested{false};
 
     const Consensus::LLMQParams& params;
-    ctpl::thread_pool& messageHandlerPool;
     CBLSWorker& blsWorker;
     CDKGSessionManager& dkgManager;
 
@@ -120,7 +119,7 @@ private:
     CDKGPendingMessages pendingPrematureCommitments;
 
 public:
-    CDKGSessionHandler(const Consensus::LLMQParams& _params, ctpl::thread_pool& _messageHandlerPool, CBLSWorker& blsWorker, CDKGSessionManager& _dkgManager);
+    CDKGSessionHandler(const Consensus::LLMQParams& _params, CBLSWorker& blsWorker, CDKGSessionManager& _dkgManager);
     ~CDKGSessionHandler();
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew);

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -126,6 +126,9 @@ public:
     void UpdatedBlockTip(const CBlockIndex *pindexNew);
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 
+    void StartThread();
+    void StopThread();
+
 private:
     bool InitNewQuorum(const CBlockIndex* pindexQuorum);
 

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -27,7 +27,7 @@ CDKGSessionManager::CDKGSessionManager(CDBWrapper& _llmqDb, CBLSWorker& _blsWork
     for (const auto& qt : Params().GetConsensus().llmqs) {
         dkgSessionHandlers.emplace(std::piecewise_construct,
                 std::forward_as_tuple(qt.first),
-                std::forward_as_tuple(qt.second, messageHandlerPool, blsWorker, *this));
+                std::forward_as_tuple(qt.second, blsWorker, *this));
     }
 }
 
@@ -40,9 +40,6 @@ void CDKGSessionManager::StartThreads()
     for (auto& it : dkgSessionHandlers) {
         it.second.StartThread();
     }
-
-    messageHandlerPool.resize(2);
-    RenameThreadPool(messageHandlerPool, "dash-q-msg");
 }
 
 void CDKGSessionManager::StopThreads()
@@ -50,8 +47,6 @@ void CDKGSessionManager::StopThreads()
     for (auto& it : dkgSessionHandlers) {
         it.second.StopThread();
     }
-
-    messageHandlerPool.stop(true);
 }
 
 void CDKGSessionManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fInitialDownload)

--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -24,26 +24,33 @@ CDKGSessionManager::CDKGSessionManager(CDBWrapper& _llmqDb, CBLSWorker& _blsWork
     llmqDb(_llmqDb),
     blsWorker(_blsWorker)
 {
+    for (const auto& qt : Params().GetConsensus().llmqs) {
+        dkgSessionHandlers.emplace(std::piecewise_construct,
+                std::forward_as_tuple(qt.first),
+                std::forward_as_tuple(qt.second, messageHandlerPool, blsWorker, *this));
+    }
 }
 
 CDKGSessionManager::~CDKGSessionManager()
 {
 }
 
-void CDKGSessionManager::StartMessageHandlerPool()
+void CDKGSessionManager::StartThreads()
 {
-    for (const auto& qt : Params().GetConsensus().llmqs) {
-        dkgSessionHandlers.emplace(std::piecewise_construct,
-                std::forward_as_tuple(qt.first),
-                std::forward_as_tuple(qt.second, messageHandlerPool, blsWorker, *this));
+    for (auto& it : dkgSessionHandlers) {
+        it.second.StartThread();
     }
 
     messageHandlerPool.resize(2);
     RenameThreadPool(messageHandlerPool, "dash-q-msg");
 }
 
-void CDKGSessionManager::StopMessageHandlerPool()
+void CDKGSessionManager::StopThreads()
 {
+    for (auto& it : dkgSessionHandlers) {
+        it.second.StopThread();
+    }
+
     messageHandlerPool.stop(true);
 }
 

--- a/src/llmq/quorums_dkgsessionmgr.h
+++ b/src/llmq/quorums_dkgsessionmgr.h
@@ -23,7 +23,6 @@ class CDKGSessionManager
 private:
     CDBWrapper& llmqDb;
     CBLSWorker& blsWorker;
-    ctpl::thread_pool messageHandlerPool;
 
     std::map<Consensus::LLMQType, CDKGSessionHandler> dkgSessionHandlers;
 

--- a/src/llmq/quorums_dkgsessionmgr.h
+++ b/src/llmq/quorums_dkgsessionmgr.h
@@ -50,8 +50,8 @@ public:
     CDKGSessionManager(CDBWrapper& _llmqDb, CBLSWorker& _blsWorker);
     ~CDKGSessionManager();
 
-    void StartMessageHandlerPool();
-    void StopMessageHandlerPool();
+    void StartThreads();
+    void StopThreads();
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload);
 

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -70,7 +70,7 @@ void StartLLMQSystem()
         blsWorker->Start();
     }
     if (quorumDKGSessionManager) {
-        quorumDKGSessionManager->StartMessageHandlerPool();
+        quorumDKGSessionManager->StartThreads();
     }
     if (quorumSigSharesManager) {
         quorumSigSharesManager->RegisterAsRecoveredSigsListener();
@@ -97,7 +97,7 @@ void StopLLMQSystem()
         quorumSigSharesManager->UnregisterAsRecoveredSigsListener();
     }
     if (quorumDKGSessionManager) {
-        quorumDKGSessionManager->StopMessageHandlerPool();
+        quorumDKGSessionManager->StopThreads();
     }
     if (blsWorker) {
         blsWorker->Stop();


### PR DESCRIPTION
This is inspired by this CI test failure https://gitlab.com/dashpay/dash/-/jobs/614306340.

`p2p-instantsend.py` failed with a `Segmentation fault`

https://gitlab.com/dashpay/dash/-/jobs/614306340#L3201

```
node5 2020-06-28 03:20:00.184954 (mocktime: 2014-12-04 17:17:21) Posix Signal: Segmentation fault
  0#: (0x56BC7A5A) stl_vector.h:466                  - std::vector<unsigned long long, std::allocator<unsigned long long> >::operator=(std::vector<unsigned long long, std::allocator<unsigned long long> >&&)
  1#: (0x56BC7A5A) stacktraces.cpp:779               - HandlePosixSignal
  2#: (0xF76DEBC0) <unknown-file>                    - ???
  3#: (0xF76B6B06) <unknown-file>                    - ???
  4#: (0x56AF007B) mutex:110                         - std::recursive_mutex::lock()
  5#: (0x56AF007B) sync.h:59                         - AnnotatedMixin<std::recursive_mutex>::lock()
  6#: (0x56AF007B) std_mutex.h:267                   - std::unique_lock<CCriticalSection>::lock()
  7#: (0x56AF007B) sync.h:128                        - CCriticalBlock::Enter(char const*, char const*, int)
  8#: (0x56AF007B) sync.h:149                        - CCriticalBlock::CCriticalBlock(CCriticalSection&, char const*, char const*, int, bool)
  9#: (0x56AF007B) net.h:294                         - ForEachNode<CConnman::CFullyConnectedOnly, llmq::CDKGSession::RelayInvToParticipants(const CInv&) const::<lambda(CNode*)>&>
 10#: (0x56AF007B) net.h:304                         - ForEachNode<llmq::CDKGSession::RelayInvToParticipants(const CInv&) const::<lambda(CNode*)> >
 11#: (0x56AF007B) quorums_dkgsession.cpp:1314       - llmq::CDKGSession::RelayInvToParticipants(CInv const&) const
 12#: (0x56AF2B49) std_function.h:694                - function<llmq::CDKGSession::ReceiveMessage(const uint256&, const llmq::CDKGContribution&, bool&)::<lambda(llmq::CDKGDebugMemberStatus&)> >
 13#: (0x56AF2B49) quorums_dkgsession.cpp:288        - llmq::CDKGSession::ReceiveMessage(uint256 const&, llmq::CDKGContribution const&, bool&)
 14#: (0x56B42EA3) quorums_dkgsessionhandler.cpp:485 - bool llmq::ProcessPendingMessageBatch<llmq::CDKGContribution, 23>(llmq::CDKGSession&, llmq::CDKGPendingMessages&, unsigned int)
 15#: (0x56B30914) std_function.h:303                - _M_invoke
 16#: (0x56B2B1BD) quorums_dkgsessionhandler.cpp:204 - llmq::CDKGSessionHandler::WaitForNextPhase(llmq::QuorumPhase, llmq::QuorumPhase, uint256 const&, std::function<bool ()> const&)
 17#: (0x56B2C17E) atomic_base.h:396                 - std::__atomic_base<unsigned long long>::load(std::memory_order) const
 18#: (0x56B2C17E) util.h:154                        - LogAcceptCategory
 19#: (0x56B2C17E) quorums_dkgsessionhandler.cpp:322 - llmq::CDKGSessionHandler::HandlePhase(llmq::QuorumPhase, llmq::QuorumPhase, uint256 const&, double, std::function<void ()> const&, std::function<bool ()> const&)
 20#: (0x56B2E637) std_function.h:275                - std::_Function_base::~_Function_base()
 21#: (0x56B2E637) std_function.h:389                - std::function<void ()>::~function()
 22#: (0x56B2E637) quorums_dkgsessionhandler.cpp:546 - llmq::CDKGSessionHandler::HandleDKGRound()
 23#: (0x56B2EC58) quorums_dkgsessionhandler.cpp:586 - llmq::CDKGSessionHandler::PhaseHandlerThread()
 24#: (0x56B2F376) thread:186                        - _M_run
 25#: (0x571877CD) <unknown-file>                    - ???
 26#: (0xF76B43BD) <unknown-file>                    - ???
 27#: (0xF74A0E16) <unknown-file>                    - ???
```

### My understanding of this issue: 

`phaseHandlerThread.join()` is only called in the destructor of `CDKGSessionHandler`. https://github.com/dashpay/dash/blob/a7f4f95f108395a7600d4c39fc5dfa298c07a9bc/src/llmq/quorums_dkgsessionhandler.cpp#L104-L110

This happens here https://github.com/dashpay/dash/blob/a7f4f95f108395a7600d4c39fc5dfa298c07a9bc/src/init.cpp#L326

which is after the networking threads have been stopped already which happens some lines above due to https://github.com/dashpay/dash/blob/a7f4f95f108395a7600d4c39fc5dfa298c07a9bc/src/init.cpp#L287

So it seems like if `CDKGSessionHandler::PhaseHandlerThread` has pending messages its possible that the code before the next `ShutdownRequested()` check ends up in `CDKGSession::ReceiveMessage` where it tries to relay a message even though the networking threads are stopped already. Unfortunately i couldn't figure the exact line where the segmentation fault happens but as trace ends with a `LOCK` after `ForEachNode<llmq::CDKGSession::RelayInvToParticipants(const CInv&) const::<lambda(CNode*)> >` it does probably end somewhere in here https://github.com/dashpay/dash/blob/3f7553a711abdff511817ed60a83918393b147ba/src/llmq/quorums_dkgsession.cpp#L1314-L1323

If i would have to choose one it would be https://github.com/dashpay/dash/blob/3f7553a711abdff511817ed60a83918393b147ba/src/llmq/quorums_dkgsession.cpp#L1322
If someone has an exact line and the explanation why please let me know! 

No matter what line it is.. i would say this just happens because the dkg threads do run longer than the networking threads and this will be fixed with this PR due to an earlier `join()` for all dkg threads which happens here https://github.com/dashpay/dash/blob/3f7553a711abdff511817ed60a83918393b147ba/src/init.cpp#L247 before stopping the network threads.

### Questions i still have now
1. Which line is it and why?
2. What is the point of the thread pool (`messageHandlerPool`) which i removed from `CDKGSessionManager` in f3db650?  For me this looked like a leftover or some unfinished stuff unless this is some crazy magic which has an impact which i can't see yet. So i removed it. If there is some reason to revoke this please tell me! 