### PR TITLE
test: Introduce scaled timeouts 

### DIFF
--- a/test/functional/llmq-signing.py
+++ b/test/functional/llmq-signing.py
@@ -3,8 +3,6 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-import time
-
 from test_framework.mininode import *
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import *
@@ -49,18 +47,10 @@ class LLMQSigningTest(DashTestFramework):
             return True
 
         def wait_for_sigs(hasrecsigs, isconflicting1, isconflicting2, timeout):
-            t = time.time()
-            while time.time() - t < timeout:
-                if check_sigs(hasrecsigs, isconflicting1, isconflicting2):
-                    return
-                time.sleep(0.1)
-            raise AssertionError("wait_for_sigs timed out")
+            wait_until(lambda: check_sigs(hasrecsigs, isconflicting1, isconflicting2), timeout = timeout)
 
         def assert_sigs_nochange(hasrecsigs, isconflicting1, isconflicting2, timeout):
-            t = time.time()
-            while time.time() - t < timeout:
-                assert(check_sigs(hasrecsigs, isconflicting1, isconflicting2))
-                time.sleep(0.1)
+            assert(not wait_until(lambda: not check_sigs(hasrecsigs, isconflicting1, isconflicting2), timeout = timeout, do_assert = False))
 
         # Initial state
         wait_for_sigs(False, False, False, 1)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -34,6 +34,7 @@ from .util import (
     initialize_datadir,
     p2p_port,
     set_node_times,
+    set_timeout_scale,
     satoshi_round,
     sync_blocks,
     sync_mempools,
@@ -108,8 +109,15 @@ class BitcoinTestFramework():
                           help="use dash-cli instead of RPC for all commands")
         parser.add_option("--dashd-arg", dest="dashd_extra_args", default=[], type='string', action='append',
                           help="Pass extra args to all dashd instances")
+        parser.add_option("--timeoutscale", dest="timeout_scale", default=1, type='int' ,
+                          help="Scale the test timeouts by multiplying them with the here provided value (defaul: 1)")
         self.add_options(parser)
         (self.options, self.args) = parser.parse_args()
+
+        if self.options.timeout_scale < 1:
+            raise RuntimeError("--timeoutscale can't be less than 1")
+
+        set_timeout_scale(self.options.timeout_scale)
 
         PortSeed.n = self.options.port_seed
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -24,6 +24,15 @@ from .authproxy import AuthServiceProxy, JSONRPCException
 
 logger = logging.getLogger("TestFramework.utils")
 
+# Util options
+##############
+
+class Options:
+    timeout_scale = 1
+
+def set_timeout_scale(_timeout_scale):
+    Options.timeout_scale = _timeout_scale
+
 # Assert functions
 ##################
 
@@ -207,6 +216,7 @@ def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), sleep=
     if attempts == float('inf') and timeout == float('inf'):
         timeout = 60
     attempt = 0
+    timeout *= Options.timeout_scale
     time_end = time.time() + timeout
 
     while attempt < attempts and time.time() < time_end:
@@ -420,6 +430,7 @@ def sync_blocks(rpc_connections, *, wait=1, timeout=60):
     # earlier.
     maxheight = max(x.getblockcount() for x in rpc_connections)
     start_time = cur_time = time.time()
+    timeout *= Options.timeout_scale
     while cur_time <= start_time + timeout:
         tips = [r.waitforblockheight(maxheight, int(wait * 1000)) for r in rpc_connections]
         if all(t["height"] == maxheight for t in tips):
@@ -435,6 +446,7 @@ def sync_chain(rpc_connections, *, wait=1, timeout=60):
     """
     Wait until everybody has the same best block
     """
+    timeout *= Options.timeout_scale
     while timeout > 0:
         best_hash = [x.getbestblockhash() for x in rpc_connections]
         if best_hash == [best_hash[0]] * len(best_hash):
@@ -448,6 +460,7 @@ def sync_mempools(rpc_connections, *, wait=1, timeout=60, flush_scheduler=True, 
     Wait until everybody has the same transactions in their memory
     pools
     """
+    timeout *= Options.timeout_scale
     while timeout > 0:
         pool = set(rpc_connections[0].getrawmempool())
         num_match = 1


### PR DESCRIPTION
This PR introduces `--timeoutscale=<value>` in the test framework. This allows to scale the test timeouts by multiplying them with `<value>`. This is mostly meant to be used by CI where time seems to be rare from time to time.