### PR TITLE
Backport 12610 + PrivateSend multiwallet support.

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -62,7 +62,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
     CPrivateSend::UpdatedBlockTip(pindexNew);
 #ifdef ENABLE_WALLET
-    privateSendClient.UpdatedBlockTip(pindexNew);
+    privateSendClientManager.UpdatedBlockTip(pindexNew);
 #endif // ENABLE_WALLET
 
     llmq::quorumInstantSendManager->UpdatedBlockTip(pindexNew);

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -62,7 +62,9 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
     CPrivateSend::UpdatedBlockTip(pindexNew);
 #ifdef ENABLE_WALLET
-    privateSendClientManager.UpdatedBlockTip(pindexNew);
+    for (auto& pair : privateSendClientManagers) {
+        pair.second->UpdatedBlockTip(pindexNew);
+    }
 #endif // ENABLE_WALLET
 
     llmq::quorumInstantSendManager->UpdatedBlockTip(pindexNew);

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -258,6 +258,9 @@ void StopHTTPRPC()
 {
     LogPrint(BCLog::RPC, "Stopping HTTP RPC server\n");
     UnregisterHTTPHandler("/", true);
+#ifdef ENABLE_WALLET
+    UnregisterHTTPHandler("/wallet/", false);
+#endif
     if (httpRPCTimerInterface) {
         RPCUnsetTimerInterface(httpRPCTimerInterface.get());
         httpRPCTimerInterface.reset();

--- a/src/masternode/masternode-utils.cpp
+++ b/src/masternode/masternode-utils.cpp
@@ -24,7 +24,7 @@ void CMasternodeUtils::ProcessMasternodeConnections(CConnman& connman)
 {
     std::vector<CDeterministicMNCPtr> vecDmns; // will be empty when no wallet
 #ifdef ENABLE_WALLET
-    privateSendClient.GetMixingMasternodesInfo(vecDmns);
+    privateSendClientManager.GetMixingMasternodesInfo(vecDmns);
 #endif // ENABLE_WALLET
 
     // Don't disconnect masternode connections when we have less then the desired amount of outbound nodes

--- a/src/masternode/masternode-utils.cpp
+++ b/src/masternode/masternode-utils.cpp
@@ -24,7 +24,9 @@ void CMasternodeUtils::ProcessMasternodeConnections(CConnman& connman)
 {
     std::vector<CDeterministicMNCPtr> vecDmns; // will be empty when no wallet
 #ifdef ENABLE_WALLET
-    privateSendClientManager.GetMixingMasternodesInfo(vecDmns);
+    for (const auto& pair : privateSendClientManagers) {
+        pair.second->GetMixingMasternodesInfo(vecDmns);
+    }
 #endif // ENABLE_WALLET
 
     // Don't disconnect masternode connections when we have less then the desired amount of outbound nodes

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3543,7 +3543,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         //probably one the extensions
 #ifdef ENABLE_WALLET
         privateSendClientQueueManager.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
-        privateSendClientManager.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
+        for (auto& pair : privateSendClientManagers) {
+            pair.second->ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
+        }
 #endif // ENABLE_WALLET
         privateSendServer.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
         sporkManager.ProcessSpork(pfrom, strCommand, vRecv, *connman);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3542,6 +3542,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     {
         //probably one the extensions
 #ifdef ENABLE_WALLET
+        privateSendClientQueueManager.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
         privateSendClientManager.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
 #endif // ENABLE_WALLET
         privateSendServer.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3542,7 +3542,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     {
         //probably one the extensions
 #ifdef ENABLE_WALLET
-        privateSendClient.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
+        privateSendClientManager.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
 #endif // ENABLE_WALLET
         privateSendServer.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
         sporkManager.ProcessSpork(pfrom, strCommand, vRecv, *connman);

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -23,18 +23,17 @@
 #include <univalue.h>
 
 CPrivateSendClientManager privateSendClientManager;
+CPrivateSendClientQueueManager privateSendClientQueueManager;
 CPrivateSendClientOptions privateSendClientOptions;
 
-void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CPrivateSendClientQueueManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
     if (fMasternodeMode) return;
     if (!privateSendClientOptions.fEnablePrivateSend) return;
     if (!masternodeSync.IsBlockchainSynced()) return;
 
     if (!CheckDiskSpace()) {
-        ResetPool();
-        StopMixing();
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::ProcessMessage -- Not enough disk space, disabling PrivateSend.\n");
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientQueueManager::ProcessMessage -- Not enough disk space, disabling PrivateSend.\n");
         return;
     }
 
@@ -85,14 +84,9 @@ void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& 
 
         // if the queue is ready, submit if we can
         if (dsq.fReady) {
-            LOCK(cs_deqsessions);
-            for (auto& session : deqSessions) {
-                CDeterministicMNCPtr mnMixing;
-                if (session.GetMixingMasternodeInfo(mnMixing) && mnMixing->pdmnState->addr == dmn->pdmnState->addr && session.GetState() == POOL_STATE_QUEUE) {
-                    LogPrint(BCLog::PRIVATESEND, "DSQUEUE -- PrivateSend queue (%s) is ready on masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
-                    session.SubmitDenominate(connman);
-                    return;
-                }
+            if (privateSendClientManager.TrySubmitDenominate(dmn->pdmnState->addr, connman)) {
+                LogPrint(BCLog::PRIVATESEND, "DSQUEUE -- PrivateSend queue (%s) is ready on masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
+                return;
             }
         } else {
             int64_t nLastDsq = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastDsq();
@@ -108,13 +102,7 @@ void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& 
 
             LogPrint(BCLog::PRIVATESEND, "DSQUEUE -- new PrivateSend queue (%s) from masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
 
-            LOCK(cs_deqsessions);
-            for (auto& session : deqSessions) {
-                CDeterministicMNCPtr mnMixing;
-                if (session.GetMixingMasternodeInfo(mnMixing) && mnMixing->collateralOutpoint == dsq.masternodeOutpoint) {
-                    dsq.fTried = true;
-                }
-            }
+            privateSendClientManager.MarkAlreadyJoinedQueueAsTried(dsq);
 
             TRY_LOCK(cs_vecqueue, lockRecv);
             if (!lockRecv) return;
@@ -122,7 +110,23 @@ void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& 
             dsq.Relay(connman);
         }
 
-    } else if (strCommand == NetMsgType::DSSTATUSUPDATE ||
+    }
+}
+
+void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+{
+    if (fMasternodeMode) return;
+    if (!privateSendClientOptions.fEnablePrivateSend) return;
+    if (!masternodeSync.IsBlockchainSynced()) return;
+
+    if (!CheckDiskSpace()) {
+        ResetPool();
+        StopMixing();
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::ProcessMessage -- Not enough disk space, disabling PrivateSend.\n");
+        return;
+    }
+
+    if (strCommand == NetMsgType::DSSTATUSUPDATE ||
                strCommand == NetMsgType::DSFINALTX ||
                strCommand == NetMsgType::DSCOMPLETE) {
         LOCK(cs_deqsessions);
@@ -427,8 +431,6 @@ bool CPrivateSendClientSession::CheckTimeout()
 void CPrivateSendClientManager::CheckTimeout()
 {
     if (fMasternodeMode) return;
-
-    CheckQueue();
 
     if (!privateSendClientOptions.fEnablePrivateSend || !IsMixing()) return;
 
@@ -1049,7 +1051,7 @@ bool CPrivateSendClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymize
 
     // Look through the queues and see if anything matches
     CPrivateSendQueue dsq;
-    while (privateSendClientManager.GetQueueItemAndTry(dsq)) {
+    while (privateSendClientQueueManager.GetQueueItemAndTry(dsq)) {
         auto dmn = mnList.GetValidMNByCollateral(dsq.masternodeOutpoint);
 
         if (!dmn) {
@@ -1212,6 +1214,32 @@ void CPrivateSendClientManager::ProcessPendingDsaRequest(CConnman& connman)
             strAutoDenomResult = _("Mixing in progress...");
         }
     }
+}
+
+bool CPrivateSendClientManager::TrySubmitDenominate(const CService& mnAddr, CConnman& connman)
+{
+    LOCK(cs_deqsessions);
+    for (auto& session : deqSessions) {
+        CDeterministicMNCPtr mnMixing;
+        if (session.GetMixingMasternodeInfo(mnMixing) && mnMixing->pdmnState->addr == mnAddr && session.GetState() == POOL_STATE_QUEUE) {
+            session.SubmitDenominate(connman);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CPrivateSendClientManager::MarkAlreadyJoinedQueueAsTried(CPrivateSendQueue& dsq) const
+{
+    LOCK(cs_deqsessions);
+    for (const auto& session : deqSessions) {
+        CDeterministicMNCPtr mnMixing;
+        if (session.GetMixingMasternodeInfo(mnMixing) && mnMixing->collateralOutpoint == dsq.masternodeOutpoint) {
+            dsq.fTried = true;
+            return true;
+        }
+    }
+    return false;
 }
 
 bool CPrivateSendClientSession::SubmitDenominate(CConnman& connman)
@@ -1760,6 +1788,16 @@ void CPrivateSendClientManager::UpdatedBlockTip(const CBlockIndex* pindex)
     LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::UpdatedBlockTip -- nCachedBlockHeight: %d\n", nCachedBlockHeight);
 }
 
+void CPrivateSendClientQueueManager::DoMaintenance()
+{
+    if (!privateSendClientOptions.fEnablePrivateSend) return;
+    if (fMasternodeMode) return; // no client-side mixing on masternodes
+
+    if (!masternodeSync.IsBlockchainSynced() || ShutdownRequested()) return;
+
+    CheckQueue();
+}
+
 void CPrivateSendClientManager::DoMaintenance(CConnman& connman)
 {
     if (!privateSendClientOptions.fEnablePrivateSend) return;
@@ -1800,7 +1838,6 @@ void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
     obj.clear();
     obj.setObject();
     obj.pushKV("running",       IsMixing());
-    obj.pushKV("queue_size",    GetQueueSize());
 
     UniValue arrSessions(UniValue::VARR);
     for (const auto& session : deqSessions) {
@@ -1811,4 +1848,10 @@ void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
         }
     }
     obj.pushKV("sessions",  arrSessions);
+}
+
+void DoPrivateSendMaintenance(CConnman& connman)
+{
+    privateSendClientQueueManager.DoMaintenance();
+    privateSendClientManager.DoMaintenance(connman);
 }

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1814,8 +1814,7 @@ void CPrivateSendClientManager::DoMaintenance(CConnman& connman)
 
 void CPrivateSendClientSession::GetJsonInfo(UniValue& obj) const
 {
-    obj.clear();
-    obj.setObject();
+    assert(obj.isObject());
     if (mixingMasternode != nullptr) {
         assert(mixingMasternode->pdmnState);
         obj.pushKV("protxhash", mixingMasternode->proTxHash.ToString());
@@ -1830,8 +1829,7 @@ void CPrivateSendClientSession::GetJsonInfo(UniValue& obj) const
 void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
 {
     LOCK(cs_deqsessions);
-    obj.clear();
-    obj.setObject();
+    assert(obj.isObject());
     obj.pushKV("running",       IsMixing());
 
     UniValue arrSessions(UniValue::VARR);

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1843,6 +1843,18 @@ void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
     obj.pushKV("sessions",  arrSessions);
 }
 
+void CPrivateSendClientOptions::GetJsonInfo(UniValue& obj) const
+{
+    assert(obj.isObject());
+    obj.pushKV("enabled",           privateSendClientOptions.fEnablePrivateSend);
+    obj.pushKV("multisession",      privateSendClientOptions.fPrivateSendMultiSession);
+    obj.pushKV("max_sessions",      privateSendClientOptions.nPrivateSendSessions);
+    obj.pushKV("max_rounds",        privateSendClientOptions.nPrivateSendRounds);
+    obj.pushKV("max_amount",        privateSendClientOptions.nPrivateSendAmount);
+    obj.pushKV("denoms_goal",       privateSendClientOptions.nPrivateSendDenomsGoal);
+    obj.pushKV("denoms_hardcap",    privateSendClientOptions.nPrivateSendDenomsHardCap);
+}
+
 void DoPrivateSendMaintenance(CConnman& connman)
 {
     privateSendClientQueueManager.DoMaintenance();

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -22,7 +22,7 @@
 #include <memory>
 #include <univalue.h>
 
-CPrivateSendClientManager privateSendClientManager;
+std::map<const std::string, CPrivateSendClientManager*> privateSendClientManagers;
 CPrivateSendClientQueueManager privateSendClientQueueManager;
 CPrivateSendClientOptions privateSendClientOptions;
 
@@ -84,9 +84,11 @@ void CPrivateSendClientQueueManager::ProcessMessage(CNode* pfrom, const std::str
 
         // if the queue is ready, submit if we can
         if (dsq.fReady) {
-            if (privateSendClientManager.TrySubmitDenominate(dmn->pdmnState->addr, connman)) {
-                LogPrint(BCLog::PRIVATESEND, "DSQUEUE -- PrivateSend queue (%s) is ready on masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
-                return;
+            for (auto& pair : privateSendClientManagers) {
+                if (pair.second->TrySubmitDenominate(dmn->pdmnState->addr, connman)) {
+                    LogPrint(BCLog::PRIVATESEND, "DSQUEUE -- PrivateSend queue (%s) is ready on masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
+                    return;
+                }
             }
         } else {
             int64_t nLastDsq = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastDsq();
@@ -102,7 +104,11 @@ void CPrivateSendClientQueueManager::ProcessMessage(CNode* pfrom, const std::str
 
             LogPrint(BCLog::PRIVATESEND, "DSQUEUE -- new PrivateSend queue (%s) from masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
 
-            privateSendClientManager.MarkAlreadyJoinedQueueAsTried(dsq);
+            for (const auto& pair : privateSendClientManagers) {
+                if (pair.second->MarkAlreadyJoinedQueueAsTried(dsq)) {
+                    break;
+                }
+            }
 
             TRY_LOCK(cs_vecqueue, lockRecv);
             if (!lockRecv) return;
@@ -666,7 +672,7 @@ void CPrivateSendClientSession::CompletedTransaction(PoolMessage nMessageID)
 
     if (nMessageID == MSG_SUCCESS) {
         LogPrint(BCLog::PRIVATESEND, "CompletedTransaction -- success\n");
-        privateSendClientManager.UpdatedSuccessBlock();
+        privateSendClientManagers.at(mixingWallet->GetName())->UpdatedSuccessBlock();
         keyHolderStorage.KeepAll();
     } else {
         LogPrint(BCLog::PRIVATESEND, "CompletedTransaction -- error\n");
@@ -1068,7 +1074,7 @@ bool CPrivateSendClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymize
             continue;
         }
 
-        privateSendClientManager.AddUsedMasternode(dsq.masternodeOutpoint);
+        privateSendClientManagers.at(mixingWallet->GetName())->AddUsedMasternode(dsq.masternodeOutpoint);
 
         if (connman.IsMasternodeOrDisconnectRequested(dmn->pdmnState->addr)) {
             LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::JoinExistingQueue -- skipping masternode connection, addr=%s\n", dmn->pdmnState->addr.ToString());
@@ -1111,7 +1117,7 @@ bool CPrivateSendClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, C
 
     // otherwise, try one randomly
     while (nTries < 10) {
-        auto dmn = privateSendClientManager.GetRandomNotUsedMasternode();
+        auto dmn = privateSendClientManagers.at(mixingWallet->GetName())->GetRandomNotUsedMasternode();
 
         if (!dmn) {
             LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::StartNewQueue -- Can't find random masternode!\n");
@@ -1119,7 +1125,7 @@ bool CPrivateSendClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, C
             return false;
         }
 
-        privateSendClientManager.AddUsedMasternode(dmn->collateralOutpoint);
+        privateSendClientManagers.at(mixingWallet->GetName())->AddUsedMasternode(dmn->collateralOutpoint);
 
         // skip next mn payments winners
         if (dmn->pdmnState->nLastPaidHeight + nMnCount < mnList.GetHeight() + 8) {
@@ -1496,12 +1502,12 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
 
     // use the same nCachedLastSuccessBlock as for DS mixing to prevent race
     CValidationState state;
-    if (!GetMixingWallet()->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
+    if (!mixingWallet->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- CommitTransaction failed! Reason given: %s\n", state.GetRejectReason());
         return false;
     }
 
-    privateSendClientManager.UpdatedSuccessBlock();
+    privateSendClientManagers.at(mixingWallet->GetName())->UpdatedSuccessBlock();
 
     return true;
 }
@@ -1741,13 +1747,13 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
     keyHolderStorageDenom.KeepAll();
 
     CValidationState state;
-    if (!GetMixingWallet()->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
+    if (!mixingWallet->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- CommitTransaction failed! Reason given: %s\n", state.GetRejectReason());
         return false;
     }
 
     // use the same nCachedLastSuccessBlock as for DS mixing to prevent race
-    privateSendClientManager.UpdatedSuccessBlock();
+    privateSendClientManagers.at(mixingWallet->GetName())->UpdatedSuccessBlock();
     LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- txid=%s\n", wtx.GetHash().GetHex());
 
     return true;
@@ -1842,5 +1848,7 @@ void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
 void DoPrivateSendMaintenance(CConnman& connman)
 {
     privateSendClientQueueManager.DoMaintenance();
-    privateSendClientManager.DoMaintenance(connman);
+    for (auto& pair : privateSendClientManagers) {
+        pair.second->DoMaintenance(connman);
+    }
 }

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -32,7 +32,7 @@ void CPrivateSendClientManager::ProcessMessage(CNode* pfrom, const std::string& 
 
     if (!CheckDiskSpace()) {
         ResetPool();
-        fPrivateSendRunning = false;
+        StopMixing();
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::ProcessMessage -- Not enough disk space, disabling PrivateSend.\n");
         return;
     }
@@ -225,6 +225,24 @@ void CPrivateSendClientSession::ProcessMessage(CNode* pfrom, const std::string& 
     }
 }
 
+bool CPrivateSendClientManager::StartMixing(CWallet* pwallet) {
+    if (IsMixing()) {
+        return false;
+    }
+    assert(pwallet != nullptr);
+    mixingWallet = pwallet;
+    return true;
+}
+
+void CPrivateSendClientManager::StopMixing() {
+    mixingWallet = nullptr;
+}
+
+bool CPrivateSendClientManager::IsMixing() const
+{
+    return mixingWallet != nullptr;
+}
+
 void CPrivateSendClientSession::ResetPool()
 {
     txMyCollateral = CMutableTransaction();
@@ -261,13 +279,13 @@ void CPrivateSendClientSession::UnlockCoins()
     if (!privateSendClient.fEnablePrivateSend) return;
 
     while (true) {
-        TRY_LOCK(GetWallets()[0]->cs_wallet, lockWallet);
+        TRY_LOCK(GetMixingWallet()->cs_wallet, lockWallet);
         if (!lockWallet) {
             MilliSleep(50);
             continue;
         }
         for (const auto& outpoint : vecOutPointLocked)
-            GetWallets()[0]->UnlockCoin(outpoint);
+            GetMixingWallet()->UnlockCoin(outpoint);
         break;
     }
 
@@ -355,6 +373,17 @@ bool CPrivateSendClientManager::GetMixingMasternodesInfo(std::vector<CDeterminis
     return !vecDmnsRet.empty();
 }
 
+CWallet* CPrivateSendClientSession::GetMixingWallet() const
+{
+    return privateSendClient.GetMixingWallet();
+}
+
+CWallet* CPrivateSendClientManager::GetMixingWallet() const
+{
+    assert(mixingWallet != nullptr);
+    return mixingWallet;
+}
+
 //
 // Check session timeouts
 //
@@ -400,7 +429,7 @@ void CPrivateSendClientManager::CheckTimeout()
 
     CheckQueue();
 
-    if (!fEnablePrivateSend || !fPrivateSendRunning) return;
+    if (!fEnablePrivateSend || !IsMixing()) return;
 
     LOCK(cs_deqsessions);
     for (auto& session : deqSessions) {
@@ -524,7 +553,7 @@ void CPrivateSendClientSession::ProcessPoolStateUpdate(CPrivateSendStatusUpdate 
 //
 bool CPrivateSendClientSession::SignFinalTransaction(const CTransaction& finalTransactionNew, CNode* pnode, CConnman& connman)
 {
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
 
     if (fMasternodeMode || pnode == nullptr) return false;
     if (!mixingMasternode) return false;
@@ -604,7 +633,7 @@ bool CPrivateSendClientSession::SignFinalTransaction(const CTransaction& finalTr
                 return false;
             }
 
-            const CKeyStore& keystore = *GetWallets()[0];
+            const CKeyStore& keystore = *GetMixingWallet();
 
             LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- Signing my input %i\n", __func__, nMyInputIndex);
             // TODO we're using amount=0 here but we should use the correct amount. This works because Dash ignores the amount while signing/verifying (only used in Bitcoin/Segwit)
@@ -673,14 +702,14 @@ bool CPrivateSendClientManager::WaitForAnotherBlock()
 
 bool CPrivateSendClientManager::CheckAutomaticBackup()
 {
-    if (!fEnablePrivateSend || !fPrivateSendRunning) return false;
+    if (!fEnablePrivateSend || !IsMixing()) return false;
 
     switch (nWalletBackups) {
     case 0:
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- Automatic backups disabled, no mixing available.\n");
         strAutoDenomResult = _("Automatic backups disabled") + ", " + _("no mixing available.");
-        fPrivateSendRunning = false;               // stop mixing
-        GetWallets()[0]->nKeysLeftSinceAutoBackup = 0; // no backup, no "keys since last backup"
+        StopMixing();
+        GetMixingWallet()->nKeysLeftSinceAutoBackup = 0; // no backup, no "keys since last backup"
         return false;
     case -1:
         // Automatic backup failed, nothing else we can do until user fixes the issue manually.
@@ -698,24 +727,24 @@ bool CPrivateSendClientManager::CheckAutomaticBackup()
         return false;
     }
 
-    if (GetWallets()[0]->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_STOP) {
+    if (GetMixingWallet()->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_STOP) {
         // We should never get here via mixing itself but probably something else is still actively using keypool
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- Very low number of keys left: %d, no mixing available.\n", GetWallets()[0]->nKeysLeftSinceAutoBackup);
-        strAutoDenomResult = strprintf(_("Very low number of keys left: %d") + ", " + _("no mixing available."), GetWallets()[0]->nKeysLeftSinceAutoBackup);
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- Very low number of keys left: %d, no mixing available.\n", GetMixingWallet()->nKeysLeftSinceAutoBackup);
+        strAutoDenomResult = strprintf(_("Very low number of keys left: %d") + ", " + _("no mixing available."), GetMixingWallet()->nKeysLeftSinceAutoBackup);
         // It's getting really dangerous, stop mixing
-        fPrivateSendRunning = false;
+        StopMixing();
         return false;
-    } else if (GetWallets()[0]->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING) {
+    } else if (GetMixingWallet()->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING) {
         // Low number of keys left but it's still more or less safe to continue
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- Very low number of keys left: %d\n", GetWallets()[0]->nKeysLeftSinceAutoBackup);
-        strAutoDenomResult = strprintf(_("Very low number of keys left: %d"), GetWallets()[0]->nKeysLeftSinceAutoBackup);
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- Very low number of keys left: %d\n", GetMixingWallet()->nKeysLeftSinceAutoBackup);
+        strAutoDenomResult = strprintf(_("Very low number of keys left: %d"), GetMixingWallet()->nKeysLeftSinceAutoBackup);
 
         if (fCreateAutoBackups) {
             LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- Trying to create new backup.\n");
             std::string warningString;
             std::string errorString;
 
-            if (!GetWallets()[0]->AutoBackupWallet("", warningString, errorString)) {
+            if (!GetMixingWallet()->AutoBackupWallet("", warningString, errorString)) {
                 if (!warningString.empty()) {
                     // There were some issues saving backup but yet more or less safe to continue
                     LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- WARNING! Something went wrong on automatic backup: %s\n", warningString);
@@ -733,7 +762,7 @@ bool CPrivateSendClientManager::CheckAutomaticBackup()
         }
     }
 
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- Keys left since latest backup: %d\n", GetWallets()[0]->nKeysLeftSinceAutoBackup);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientManager::CheckAutomaticBackup -- Keys left since latest backup: %d\n", GetMixingWallet()->nKeysLeftSinceAutoBackup);
 
     return true;
 }
@@ -751,15 +780,15 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
         return false;
     }
 
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
 
     CAmount nBalanceNeedsAnonymized;
 
     {
         LOCK2(cs_main, mempool.cs);
-        LOCK(GetWallets()[0]->cs_wallet);
+        LOCK(GetMixingWallet()->cs_wallet);
 
-        if (!fDryRun && GetWallets()[0]->IsLocked(true)) {
+        if (!fDryRun && GetMixingWallet()->IsLocked(true)) {
             strAutoDenomResult = _("Wallet is locked.");
             return false;
         }
@@ -783,7 +812,7 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
         }
 
         // check if there is anything left to do
-        CAmount nBalanceAnonymized = GetWallets()[0]->GetAnonymizedBalance();
+        CAmount nBalanceAnonymized = GetMixingWallet()->GetAnonymizedBalance();
         nBalanceNeedsAnonymized = privateSendClient.nPrivateSendAmount*COIN - nBalanceAnonymized;
 
         if (nBalanceNeedsAnonymized < 0) {
@@ -795,13 +824,13 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
         CAmount nValueMin = CPrivateSend::GetSmallestDenomination();
 
         // if there are no confirmed DS collateral inputs yet
-        if (!GetWallets()[0]->HasCollateralInputs()) {
+        if (!GetMixingWallet()->HasCollateralInputs()) {
             // should have some additional amount for them
             nValueMin += CPrivateSend::GetMaxCollateralAmount();
         }
 
         // including denoms but applying some restrictions
-        CAmount nBalanceAnonymizable = GetWallets()[0]->GetAnonymizableBalance();
+        CAmount nBalanceAnonymizable = GetMixingWallet()->GetAnonymizableBalance();
 
         // mixable balance is way too small
         if (nBalanceAnonymizable < nValueMin) {
@@ -811,10 +840,10 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
         }
 
         // excluding denoms
-        CAmount nBalanceAnonimizableNonDenom = GetWallets()[0]->GetAnonymizableBalance(true);
+        CAmount nBalanceAnonimizableNonDenom = GetMixingWallet()->GetAnonymizableBalance(true);
         // denoms
-        CAmount nBalanceDenominatedConf = GetWallets()[0]->GetDenominatedBalance();
-        CAmount nBalanceDenominatedUnconf = GetWallets()[0]->GetDenominatedBalance(true);
+        CAmount nBalanceDenominatedConf = GetMixingWallet()->GetDenominatedBalance();
+        CAmount nBalanceDenominatedUnconf = GetMixingWallet()->GetDenominatedBalance(true);
         CAmount nBalanceDenominated = nBalanceDenominatedConf + nBalanceDenominatedUnconf;
         CAmount nBalanceToDenominate = privateSendClient.nPrivateSendAmount * COIN - nBalanceDenominated;
 
@@ -863,8 +892,8 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
         }
 
         //check if we have the collateral sized inputs
-        if (!GetWallets()[0]->HasCollateralInputs()) {
-            return !GetWallets()[0]->HasCollateralInputs(false) && MakeCollateralAmounts(connman);
+        if (!GetMixingWallet()->HasCollateralInputs()) {
+            return !GetMixingWallet()->HasCollateralInputs(false) && MakeCollateralAmounts(connman);
         }
 
         if (nSessionID) {
@@ -888,14 +917,14 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
         //check our collateral and create new if needed
         std::string strReason;
         if (txMyCollateral == CMutableTransaction()) {
-            if (!GetWallets()[0]->CreateCollateralTransaction(txMyCollateral, strReason)) {
+            if (!GetMixingWallet()->CreateCollateralTransaction(txMyCollateral, strReason)) {
                 LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::DoAutomaticDenominating -- create collateral error:%s\n", strReason);
                 return false;
             }
         } else {
             if (!CPrivateSend::IsCollateralValid(txMyCollateral)) {
                 LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::DoAutomaticDenominating -- invalid collateral, recreating...\n");
-                if (!GetWallets()[0]->CreateCollateralTransaction(txMyCollateral, strReason)) {
+                if (!GetMixingWallet()->CreateCollateralTransaction(txMyCollateral, strReason)) {
                     LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::DoAutomaticDenominating -- create collateral error: %s\n", strReason);
                     return false;
                 }
@@ -903,10 +932,10 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
         }
         // lock the funds we're going to use for our collateral
         for (const auto& txin : txMyCollateral.vin) {
-            GetWallets()[0]->LockCoin(txin.prevout);
+            GetMixingWallet()->LockCoin(txin.prevout);
             vecOutPointLocked.push_back(txin.prevout);
         }
-    } // LOCK2(cs_main, GetWallets()[0]->cs_wallet);
+    } // LOCK2(cs_main, GetMixingWallet()->cs_wallet);
 
     // Always attempt to join an existing queue
     if (JoinExistingQueue(nBalanceNeedsAnonymized, connman)) {
@@ -923,14 +952,14 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
 bool CPrivateSendClientManager::DoAutomaticDenominating(CConnman& connman, bool fDryRun)
 {
     if (fMasternodeMode) return false; // no client-side mixing on masternodes
-    if (!fEnablePrivateSend || !fPrivateSendRunning) return false;
+    if (!fEnablePrivateSend || !IsMixing()) return false;
 
     if (!masternodeSync.IsBlockchainSynced()) {
         strAutoDenomResult = _("Can't mix while sync in progress.");
         return false;
     }
 
-    if (!fDryRun && GetWallets()[0]->IsLocked(true)) {
+    if (!fDryRun && GetMixingWallet()->IsLocked(true)) {
         strAutoDenomResult = _("Wallet is locked.");
         return false;
     }
@@ -1013,7 +1042,7 @@ CDeterministicMNCPtr CPrivateSendClientManager::GetRandomNotUsedMasternode()
 
 bool CPrivateSendClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman)
 {
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
 
     auto mnList = deterministicMNManager->GetListAtChainTip();
 
@@ -1042,7 +1071,7 @@ bool CPrivateSendClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymize
         std::vector<std::pair<CTxDSIn, CTxOut> > vecPSInOutPairsTmp;
 
         // Try to match their denominations if possible, select exact number of denominations
-        if (!GetWallets()[0]->SelectPSInOutPairsByDenominations(dsq.nDenom, nBalanceNeedsAnonymized, vecPSInOutPairsTmp)) {
+        if (!GetMixingWallet()->SelectPSInOutPairsByDenominations(dsq.nDenom, nBalanceNeedsAnonymized, vecPSInOutPairsTmp)) {
             LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::JoinExistingQueue -- Couldn't match denomination %d (%s)\n", dsq.nDenom, CPrivateSend::DenominationToString(dsq.nDenom));
             continue;
         }
@@ -1072,7 +1101,7 @@ bool CPrivateSendClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymize
 
 bool CPrivateSendClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman)
 {
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
     if (nBalanceNeedsAnonymized <= 0) return false;
 
     int nTries = 0;
@@ -1081,7 +1110,7 @@ bool CPrivateSendClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, C
 
     // find available denominated amounts
     std::set<CAmount> setAmounts;
-    if (!GetWallets()[0]->SelectDenominatedAmounts(nBalanceNeedsAnonymized, setAmounts)) {
+    if (!GetMixingWallet()->SelectDenominatedAmounts(nBalanceNeedsAnonymized, setAmounts)) {
         // this should never happen
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::StartNewQueue -- Can't mix: no compatible inputs found!\n");
         strAutoDenomResult = _("Can't mix: no compatible inputs found!");
@@ -1187,7 +1216,7 @@ void CPrivateSendClientManager::ProcessPendingDsaRequest(CConnman& connman)
 bool CPrivateSendClientSession::SubmitDenominate(CConnman& connman)
 {
     LOCK2(cs_main, mempool.cs);
-    LOCK(GetWallets()[0]->cs_wallet);
+    LOCK(GetMixingWallet()->cs_wallet);
 
     std::string strError;
     std::vector<std::pair<CTxDSIn, CTxOut> > vecPSInOutPairs, vecPSInOutPairsTmp;
@@ -1238,9 +1267,9 @@ bool CPrivateSendClientSession::SubmitDenominate(CConnman& connman)
 
 bool CPrivateSendClientSession::SelectDenominate(std::string& strErrorRet, std::vector<std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet)
 {
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
 
-    if (GetWallets()[0]->IsLocked(true)) {
+    if (GetMixingWallet()->IsLocked(true)) {
         strErrorRet = "Wallet locked, unable to create transaction!";
         return false;
     }
@@ -1252,7 +1281,7 @@ bool CPrivateSendClientSession::SelectDenominate(std::string& strErrorRet, std::
 
     vecPSInOutPairsRet.clear();
 
-    bool fSelected = GetWallets()[0]->SelectPSInOutPairsByDenominations(nSessionDenom, CPrivateSend::GetMaxPoolAmount(), vecPSInOutPairsRet);
+    bool fSelected = GetMixingWallet()->SelectPSInOutPairsByDenominations(nSessionDenom, CPrivateSend::GetMaxPoolAmount(), vecPSInOutPairsRet);
     if (!fSelected) {
         strErrorRet = "Can't select current denominated inputs";
         return false;
@@ -1264,7 +1293,7 @@ bool CPrivateSendClientSession::SelectDenominate(std::string& strErrorRet, std::
 bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds, std::string& strErrorRet, const std::vector<std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsIn, std::vector<std::pair<CTxDSIn, CTxOut> >& vecPSInOutPairsRet, bool fDryRun)
 {
     AssertLockHeld(cs_main);
-    AssertLockHeld(GetWallets()[0]->cs_wallet);
+    AssertLockHeld(GetMixingWallet()->cs_wallet);
 
     if (!CPrivateSend::IsValidDenomination(nSessionDenom)) {
         strErrorRet = "Incorrect session denom";
@@ -1295,7 +1324,7 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
                 ++nSteps;
                 continue;
             }
-            scriptDenom = keyHolderStorage.AddKey(GetWallets()[0]);
+            scriptDenom = keyHolderStorage.AddKey(GetMixingWallet());
         }
         vecPSInOutPairsRet.emplace_back(pair.first, CTxOut(nDenomAmount, scriptDenom));
         // step is complete
@@ -1313,7 +1342,7 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
     }
 
     for (const auto& pair : vecPSInOutPairsRet) {
-        GetWallets()[0]->LockCoin(pair.first.prevout);
+        GetMixingWallet()->LockCoin(pair.first.prevout);
         vecOutPointLocked.push_back(pair.first.prevout);
     }
 
@@ -1323,17 +1352,17 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
 // Create collaterals by looping through inputs grouped by addresses
 bool CPrivateSendClientSession::MakeCollateralAmounts(CConnman& connman)
 {
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
 
     LOCK2(cs_main, mempool.cs);
-    LOCK(GetWallets()[0]->cs_wallet);
+    LOCK(GetMixingWallet()->cs_wallet);
 
     // NOTE: We do not allow txes larger than 100kB, so we have to limit number of inputs here.
     // We still want to consume a lot of inputs to avoid creating only smaller denoms though.
     // Knowing that each CTxIn is at least 148b big, 400 inputs should take 400 x ~148b = ~60kB.
     // This still leaves more than enough room for another data of typical MakeCollateralAmounts tx.
     std::vector<CompactTallyItem> vecTally;
-    if (!GetWallets()[0]->SelectCoinsGroupedByAddresses(vecTally, false, false, true, 400)) {
+    if (!GetMixingWallet()->SelectCoinsGroupedByAddresses(vecTally, false, false, true, 400)) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- SelectCoinsGroupedByAddresses can't find any inputs!\n");
         return false;
     }
@@ -1365,9 +1394,9 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(mempool.cs);
-    AssertLockHeld(GetWallets()[0]->cs_wallet);
+    AssertLockHeld(GetMixingWallet()->cs_wallet);
 
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
 
     // Skip way too tiny amounts
     if (tallyItem.nAmount < CPrivateSend::GetCollateralAmount()) {
@@ -1391,9 +1420,9 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
     std::vector<CRecipient> vecSend;
 
     // make our collateral address
-    CReserveKey reservekeyCollateral(GetWallets()[0]);
+    CReserveKey reservekeyCollateral(GetMixingWallet());
     // make our change address
-    CReserveKey reservekeyChange(GetWallets()[0]);
+    CReserveKey reservekeyChange(GetMixingWallet());
 
     CScript scriptCollateral;
     CPubKey vchPubKey;
@@ -1422,7 +1451,7 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
         coinControl.Select(outpoint);
     }
 
-    bool fSuccess = GetWallets()[0]->CreateTransaction(vecSend, wtx, reservekeyChange,
+    bool fSuccess = GetMixingWallet()->CreateTransaction(vecSend, wtx, reservekeyChange,
         nFeeRet, nChangePosRet, strFail, coinControl);
     if (!fSuccess) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- ONLY_NONDENOMINATED: %s\n", strFail);
@@ -1430,7 +1459,7 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
         if (fTryDenominated) {
             // Try to also use denominated coins (we can't mix denominated without collaterals anyway).
             coinControl.nCoinType = CoinType::ALL_COINS;
-            if (!GetWallets()[0]->CreateTransaction(vecSend, wtx, reservekeyChange,
+            if (!GetMixingWallet()->CreateTransaction(vecSend, wtx, reservekeyChange,
                     nFeeRet, nChangePosRet, strFail, coinControl)) {
                 LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- ALL_COINS Error: %s\n", strFail);
                 reservekeyCollateral.ReturnKey();
@@ -1449,7 +1478,7 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
 
     // use the same nCachedLastSuccessBlock as for DS mixing to prevent race
     CValidationState state;
-    if (!GetWallets()[0]->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
+    if (!GetMixingWallet()->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- CommitTransaction failed! Reason given: %s\n", state.GetRejectReason());
         return false;
     }
@@ -1462,17 +1491,17 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
 // Create denominations by looping through inputs grouped by addresses
 bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, CConnman& connman)
 {
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
 
     LOCK2(cs_main, mempool.cs);
-    LOCK(GetWallets()[0]->cs_wallet);
+    LOCK(GetMixingWallet()->cs_wallet);
 
     // NOTE: We do not allow txes larger than 100kB, so we have to limit number of inputs here.
     // We still want to consume a lot of inputs to avoid creating only smaller denoms though.
     // Knowing that each CTxIn is at least 148b big, 400 inputs should take 400 x ~148b = ~60kB.
     // This still leaves more than enough room for another data of typical CreateDenominated tx.
     std::vector<CompactTallyItem> vecTally;
-    if (!GetWallets()[0]->SelectCoinsGroupedByAddresses(vecTally, true, true, true, 400)) {
+    if (!GetMixingWallet()->SelectCoinsGroupedByAddresses(vecTally, true, true, true, 400)) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- SelectCoinsGroupedByAddresses can't find any inputs!\n");
         return false;
     }
@@ -1482,7 +1511,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         return a.nAmount > b.nAmount;
     });
 
-    bool fCreateMixingCollaterals = !GetWallets()[0]->HasCollateralInputs();
+    bool fCreateMixingCollaterals = !GetMixingWallet()->HasCollateralInputs();
 
     for (const auto& item : vecTally) {
         if (!CreateDenominated(nBalanceToDenominate, item, fCreateMixingCollaterals, connman)) continue;
@@ -1498,9 +1527,9 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(mempool.cs);
-    AssertLockHeld(GetWallets()[0]->cs_wallet);
+    AssertLockHeld(GetMixingWallet()->cs_wallet);
 
-    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.fPrivateSendRunning) return false;
+    if (!privateSendClient.fEnablePrivateSend || !privateSendClient.IsMixing()) return false;
 
     std::vector<CRecipient> vecSend;
     CKeyHolderStorage keyHolderStorageDenom;
@@ -1520,7 +1549,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
     // ****** Add an output for mixing collaterals ************ /
 
     if (fCreateMixingCollaterals) {
-        CScript scriptCollateral = keyHolderStorageDenom.AddKey(GetWallets()[0]);
+        CScript scriptCollateral = keyHolderStorageDenom.AddKey(GetMixingWallet());
         vecSend.push_back((CRecipient){scriptCollateral, CPrivateSend::GetMaxCollateralAmount(), false});
         nValueLeft -= CPrivateSend::GetMaxCollateralAmount() + nOutputFee;
     }
@@ -1533,7 +1562,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
     std::map<CAmount, int> mapDenomCount;
     for (auto nDenomValue : vecStandardDenoms) {
-        mapDenomCount.insert(std::pair<CAmount, int>(nDenomValue, GetWallets()[0]->CountInputsWithAmount(nDenomValue)));
+        mapDenomCount.insert(std::pair<CAmount, int>(nDenomValue, GetMixingWallet()->CountInputsWithAmount(nDenomValue)));
     }
 
     // Will generate outputs for the createdenoms up to privatesendmaxdenoms per denom
@@ -1571,7 +1600,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
             // add each output up to 11 times or until it can't be added again or until we reach nPrivateSendDenomsGoal
             while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second < privateSendClient.nPrivateSendDenomsGoal) {
-                CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
+                CScript scriptDenom = keyHolderStorageDenom.AddKey(GetMixingWallet());
 
                 vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
 
@@ -1635,7 +1664,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                 // Never go above the cap unless it's the largest denom
                 if (nDenomValue != nLargestDenomValue && it->second >= privateSendClient.nPrivateSendDenomsHardCap) break;
 
-                CScript scriptDenom = keyHolderStorageDenom.AddKey(GetWallets()[0]);
+                CScript scriptDenom = keyHolderStorageDenom.AddKey(GetMixingWallet());
                 vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
 
                 // increment outputs and subtract denomination amount
@@ -1681,9 +1710,9 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
     int nChangePosRet = -1;
     std::string strFail = "";
     // make our change address
-    CReserveKey reservekeyChange(GetWallets()[0]);
+    CReserveKey reservekeyChange(GetMixingWallet());
 
-    bool fSuccess = GetWallets()[0]->CreateTransaction(vecSend, wtx, reservekeyChange,
+    bool fSuccess = GetMixingWallet()->CreateTransaction(vecSend, wtx, reservekeyChange,
         nFeeRet, nChangePosRet, strFail, coinControl);
     if (!fSuccess) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- Error: %s\n", strFail);
@@ -1694,7 +1723,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
     keyHolderStorageDenom.KeepAll();
 
     CValidationState state;
-    if (!GetWallets()[0]->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
+    if (!GetMixingWallet()->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- CommitTransaction failed! Reason given: %s\n", state.GetRejectReason());
         return false;
     }
@@ -1770,7 +1799,7 @@ void CPrivateSendClientManager::GetJsonInfo(UniValue& obj) const
     obj.clear();
     obj.setObject();
     obj.pushKV("enabled",       fEnablePrivateSend);
-    obj.pushKV("running",       fPrivateSendRunning);
+    obj.pushKV("running",       IsMixing());
     obj.pushKV("multisession",  fPrivateSendMultiSession);
     obj.pushKV("max_sessions",  nPrivateSendSessions);
     obj.pushKV("max_rounds",    nPrivateSendRounds);

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -163,6 +163,7 @@ public:
     std::string GetStatus(bool fWaitForBlock);
 
     bool GetMixingMasternodeInfo(CDeterministicMNCPtr& ret) const;
+    CWallet* GetMixingWallet() const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun = false);
@@ -193,6 +194,8 @@ private:
     int nMinBlocksToWait; // how many blocks to wait after one successful mixing tx in non-multisession mode
     std::string strAutoDenomResult;
 
+    CWallet* mixingWallet;
+
     // Keep track of current block height
     int nCachedBlockHeight;
 
@@ -208,7 +211,6 @@ public:
     int nPrivateSendDenomsGoal;
     int nPrivateSendDenomsHardCap;
     bool fEnablePrivateSend;
-    bool fPrivateSendRunning;
     bool fPrivateSendMultiSession;
 
     int nCachedNumBlocks;    //used for the overview screen
@@ -226,21 +228,28 @@ public:
         nPrivateSendDenomsGoal(DEFAULT_PRIVATESEND_DENOMS_GOAL),
         nPrivateSendDenomsHardCap(DEFAULT_PRIVATESEND_DENOMS_HARDCAP),
         fEnablePrivateSend(false),
-        fPrivateSendRunning(false),
         fPrivateSendMultiSession(DEFAULT_PRIVATESEND_MULTISESSION),
         nCachedNumBlocks(std::numeric_limits<int>::max()),
-        fCreateAutoBackups(true)
+        fCreateAutoBackups(true),
+        mixingWallet(nullptr)
     {
     }
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
 
+
+
+    bool StartMixing(CWallet* pwallet);
+    void StopMixing();
+    bool IsMixing() const;
     void ResetPool();
 
     std::string GetStatuses();
     std::string GetSessionDenoms();
 
     bool GetMixingMasternodesInfo(std::vector<CDeterministicMNCPtr>& vecDmnsRet) const;
+
+    CWallet* GetMixingWallet() const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun = false);

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -61,9 +61,6 @@ extern std::map<const std::string, CPrivateSendClientManager*> privateSendClient
 // The object to track mixing queues
 extern CPrivateSendClientQueueManager privateSendClientQueueManager;
 
-// The object to store application wide mixing options
-extern CPrivateSendClientOptions privateSendClientOptions;
-
 class CPendingDsaRequest
 {
 private:
@@ -281,6 +278,27 @@ public:
 class CPrivateSendClientOptions
 {
 public:
+    static int GetSessions() { return CPrivateSendClientOptions::Get().nPrivateSendSessions; }
+    static int GetRounds() { return CPrivateSendClientOptions::Get().nPrivateSendRounds; }
+    static int GetAmount() { return CPrivateSendClientOptions::Get().nPrivateSendAmount; }
+    static int GetDenomsGoal() { return CPrivateSendClientOptions::Get().nPrivateSendDenomsGoal; }
+    static int GetDenomsHardCap() { return CPrivateSendClientOptions::Get().nPrivateSendDenomsHardCap; }
+
+    static void SetEnabled(bool fEnabled);
+    static void SetMultiSessionEnabled(bool fEnabled);
+    static void SetRounds(int nRounds);
+    static void SetAmount(CAmount amount);
+
+    static int IsEnabled() { return CPrivateSendClientOptions::Get().fEnablePrivateSend; }
+    static int IsMultiSessionEnabled() { return CPrivateSendClientOptions::Get().fPrivateSendMultiSession; }
+
+    static void GetJsonInfo(UniValue& obj);
+
+private:
+    static CPrivateSendClientOptions* _instance;
+    static std::once_flag onceFlag;
+
+    CCriticalSection cs_ps_options;
     int nPrivateSendSessions;
     int nPrivateSendRounds;
     int nPrivateSendAmount;
@@ -299,7 +317,11 @@ public:
     {
     }
 
-    void GetJsonInfo(UniValue& obj) const;
+    CPrivateSendClientOptions(const CPrivateSendClientOptions& other) = delete;
+    CPrivateSendClientOptions& operator=(const CPrivateSendClientOptions&) = delete;
+
+    static CPrivateSendClientOptions& Get();
+    static void Init();
 };
 
 void DoPrivateSendMaintenance(CConnman& connman);

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -120,6 +120,8 @@ private:
 
     CKeyHolderStorage keyHolderStorage; // storage for keys used in PrepareDenominate
 
+    CWallet* mixingWallet;
+
     /// Create denominations
     bool CreateDenominated(CAmount nBalanceToDenominate, CConnman& connman);
     bool CreateDenominated(CAmount nBalanceToDenominate, const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals, CConnman& connman);
@@ -153,14 +155,15 @@ private:
     void SetNull();
 
 public:
-    CPrivateSendClientSession() :
+    CPrivateSendClientSession(CWallet* pwallet) :
         vecOutPointLocked(),
         strLastMessage(),
         strAutoDenomResult(),
         mixingMasternode(),
         txMyCollateral(),
         pendingDsaRequest(),
-        keyHolderStorage()
+        keyHolderStorage(),
+        mixingWallet(pwallet)
     {
     }
 
@@ -173,7 +176,6 @@ public:
     std::string GetStatus(bool fWaitForBlock);
 
     bool GetMixingMasternodeInfo(CDeterministicMNCPtr& ret) const;
-    CWallet* GetMixingWallet() const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun = false);
@@ -252,8 +254,6 @@ public:
     std::string GetSessionDenoms();
 
     bool GetMixingMasternodesInfo(std::vector<CDeterministicMNCPtr>& vecDmnsRet) const;
-
-    CWallet* GetMixingWallet() const;
 
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun = false);

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -298,6 +298,8 @@ public:
         fPrivateSendMultiSession(DEFAULT_PRIVATESEND_MULTISESSION)
     {
     }
+
+    void GetJsonInfo(UniValue& obj) const;
 };
 
 void DoPrivateSendMaintenance(CConnman& connman);

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -56,7 +56,7 @@ static const int PRIVATESEND_KEYS_THRESHOLD_WARNING = 100;
 static const int PRIVATESEND_KEYS_THRESHOLD_STOP = 50;
 
 // The main object for accessing mixing
-extern CPrivateSendClientManager privateSendClientManager;
+extern std::map<const std::string, CPrivateSendClientManager*> privateSendClientManagers;
 
 // The object to track mixing queues
 extern CPrivateSendClientQueueManager privateSendClientQueueManager;

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -11,10 +11,13 @@
 
 #include <evo/deterministicmns.h>
 
-class CPrivateSendClientManager;
 class CPrivateSendClientOptions;
+class CPrivateSendClientManager;
+class CPrivateSendClientQueueManager;
+
 class CConnman;
 class CNode;
+
 class UniValue;
 
 static const int MIN_PRIVATESEND_SESSIONS = 1;
@@ -54,6 +57,9 @@ static const int PRIVATESEND_KEYS_THRESHOLD_STOP = 50;
 
 // The main object for accessing mixing
 extern CPrivateSendClientManager privateSendClientManager;
+
+// The object to track mixing queues
+extern CPrivateSendClientQueueManager privateSendClientQueueManager;
 
 // The object to store application wide mixing options
 extern CPrivateSendClientOptions privateSendClientOptions;
@@ -182,9 +188,19 @@ public:
     void GetJsonInfo(UniValue& obj) const;
 };
 
+/** Used to keep track of mixing queues
+ */
+class CPrivateSendClientQueueManager : public CPrivateSendBaseManager
+{
+public:
+    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+
+    void DoMaintenance();
+};
+
 /** Used to keep track of current status of mixing pool
  */
-class CPrivateSendClientManager : public CPrivateSendBaseManager
+class CPrivateSendClientManager
 {
 private:
     // Keep track of the used Masternodes
@@ -242,6 +258,9 @@ public:
     /// Passively run mixing in the background according to the configuration in settings
     bool DoAutomaticDenominating(CConnman& connman, bool fDryRun = false);
 
+    bool TrySubmitDenominate(const CService& mnAddr, CConnman& connman);
+    bool MarkAlreadyJoinedQueueAsTried(CPrivateSendQueue& dsq) const;
+
     void CheckTimeout();
 
     void ProcessPendingDsaRequest(CConnman& connman);
@@ -280,5 +299,7 @@ public:
     {
     }
 };
+
+void DoPrivateSendMaintenance(CConnman& connman);
 
 #endif // BITCOIN_PRIVATESEND_PRIVATESEND_CLIENT_H

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -12,6 +12,7 @@
 #include <evo/deterministicmns.h>
 
 class CPrivateSendClientManager;
+class CPrivateSendClientOptions;
 class CConnman;
 class CNode;
 class UniValue;
@@ -52,7 +53,10 @@ static const int PRIVATESEND_KEYS_THRESHOLD_WARNING = 100;
 static const int PRIVATESEND_KEYS_THRESHOLD_STOP = 50;
 
 // The main object for accessing mixing
-extern CPrivateSendClientManager privateSendClient;
+extern CPrivateSendClientManager privateSendClientManager;
+
+// The object to store application wide mixing options
+extern CPrivateSendClientOptions privateSendClientOptions;
 
 class CPendingDsaRequest
 {
@@ -205,14 +209,6 @@ private:
     bool CheckAutomaticBackup();
 
 public:
-    int nPrivateSendSessions;
-    int nPrivateSendRounds;
-    int nPrivateSendAmount;
-    int nPrivateSendDenomsGoal;
-    int nPrivateSendDenomsHardCap;
-    bool fEnablePrivateSend;
-    bool fPrivateSendMultiSession;
-
     int nCachedNumBlocks;    //used for the overview screen
     bool fCreateAutoBackups; //builtin support for automatic backups
 
@@ -223,12 +219,6 @@ public:
         nMinBlocksToWait(1),
         strAutoDenomResult(),
         nCachedBlockHeight(0),
-        nPrivateSendRounds(DEFAULT_PRIVATESEND_ROUNDS),
-        nPrivateSendAmount(DEFAULT_PRIVATESEND_AMOUNT),
-        nPrivateSendDenomsGoal(DEFAULT_PRIVATESEND_DENOMS_GOAL),
-        nPrivateSendDenomsHardCap(DEFAULT_PRIVATESEND_DENOMS_HARDCAP),
-        fEnablePrivateSend(false),
-        fPrivateSendMultiSession(DEFAULT_PRIVATESEND_MULTISESSION),
         nCachedNumBlocks(std::numeric_limits<int>::max()),
         fCreateAutoBackups(true),
         mixingWallet(nullptr)
@@ -236,8 +226,6 @@ public:
     }
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
-
-
 
     bool StartMixing(CWallet* pwallet);
     void StopMixing();
@@ -268,6 +256,29 @@ public:
     void DoMaintenance(CConnman& connman);
 
     void GetJsonInfo(UniValue& obj) const;
+};
+
+/* Application wide mixing options */
+class CPrivateSendClientOptions
+{
+public:
+    int nPrivateSendSessions;
+    int nPrivateSendRounds;
+    int nPrivateSendAmount;
+    int nPrivateSendDenomsGoal;
+    int nPrivateSendDenomsHardCap;
+    bool fEnablePrivateSend;
+    bool fPrivateSendMultiSession;
+
+    CPrivateSendClientOptions() :
+        nPrivateSendRounds(DEFAULT_PRIVATESEND_ROUNDS),
+        nPrivateSendAmount(DEFAULT_PRIVATESEND_AMOUNT),
+        nPrivateSendDenomsGoal(DEFAULT_PRIVATESEND_DENOMS_GOAL),
+        nPrivateSendDenomsHardCap(DEFAULT_PRIVATESEND_DENOMS_HARDCAP),
+        fEnablePrivateSend(false),
+        fPrivateSendMultiSession(DEFAULT_PRIVATESEND_MULTISESSION)
+    {
+    }
 };
 
 #endif // BITCOIN_PRIVATESEND_PRIVATESEND_CLIENT_H

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -615,6 +615,7 @@ void BitcoinGUI::createToolBars()
 
 #ifdef ENABLE_WALLET
         m_wallet_selector = new QComboBox(this);
+        m_wallet_selector->setHidden(true);
         connect(m_wallet_selector, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(setCurrentWallet(const QString&)));
 #endif
 
@@ -743,6 +744,7 @@ bool BitcoinGUI::addWallet(WalletModel *walletModel)
     setWalletActionsEnabled(true);
     m_wallet_selector->addItem(name);
     if (m_wallet_selector->count() == 2) {
+        m_wallet_selector->setHidden(false);
         QVBoxLayout* layout = new QVBoxLayout(this);
         layout->addWidget(m_wallet_selector);
         layout->setSpacing(0);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1049,7 +1049,9 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     // Disabling macOS App Nap on initial sync, disk, reindex operations and mixing.
     bool disableAppNap = !masternodeSync.IsSynced();
 #ifdef ENABLE_WALLET
-    disableAppNap |= privateSendClientManager.IsMixing();
+    for (const auto& pair : privateSendClientManagers) {
+        disableAppNap |= pair.second->IsMixing();
+    }
 #endif // ENABLE_WALLET
     if (disableAppNap) {
         m_app_nap_inhibitor->disableAppNap();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -780,8 +780,8 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     sendCoinsAction->setEnabled(enabled);
     sendCoinsMenuAction->setEnabled(enabled);
 #ifdef ENABLE_WALLET
-    privateSendCoinsAction->setEnabled(enabled && privateSendClientOptions.fEnablePrivateSend);
-    privateSendCoinsMenuAction->setEnabled(enabled && privateSendClientOptions.fEnablePrivateSend);
+    privateSendCoinsAction->setEnabled(enabled && CPrivateSendClientOptions::IsEnabled());
+    privateSendCoinsMenuAction->setEnabled(enabled && CPrivateSendClientOptions::IsEnabled());
 #else
     privateSendCoinsAction->setEnabled(enabled);
     privateSendCoinsMenuAction->setEnabled(enabled);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1049,7 +1049,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     // Disabling macOS App Nap on initial sync, disk, reindex operations and mixing.
     bool disableAppNap = !masternodeSync.IsSynced();
 #ifdef ENABLE_WALLET
-    disableAppNap |= privateSendClient.fPrivateSendRunning;
+    disableAppNap |= privateSendClient.IsMixing();
 #endif // ENABLE_WALLET
     if (disableAppNap) {
         m_app_nap_inhibitor->disableAppNap();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -87,6 +87,7 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
     progressDialog(0),
     appMenuBar(0),
     appToolBar(0),
+    appToolBarLogoAction(0),
     overviewAction(0),
     historyAction(0),
     masternodeAction(0),
@@ -613,11 +614,7 @@ void BitcoinGUI::createToolBars()
         overviewAction->setChecked(true);
 
 #ifdef ENABLE_WALLET
-        QWidget *spacer = new QWidget();
-        spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-        toolbar->addWidget(spacer);
-
-        m_wallet_selector = new QComboBox();
+        m_wallet_selector = new QComboBox(this);
         connect(m_wallet_selector, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(setCurrentWallet(const QString&)));
 #endif
 
@@ -625,7 +622,7 @@ void BitcoinGUI::createToolBars()
         logoLabel->setObjectName("lblToolbarLogo");
         logoLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
-        toolbar->addWidget(logoLabel);
+        appToolBarLogoAction = toolbar->addWidget(logoLabel);
 
         /** Create additional container for toolbar and walletFrame and make it the central widget.
             This is a workaround mostly for toolbar styling on Mac OS but should work fine for every other OSes too.
@@ -746,11 +743,16 @@ bool BitcoinGUI::addWallet(WalletModel *walletModel)
     setWalletActionsEnabled(true);
     m_wallet_selector->addItem(name);
     if (m_wallet_selector->count() == 2) {
-        m_wallet_selector_label = new QLabel();
-        m_wallet_selector_label->setText(tr("Wallet:") + " ");
-        m_wallet_selector_label->setBuddy(m_wallet_selector);
-        appToolBar->addWidget(m_wallet_selector_label);
-        appToolBar->addWidget(m_wallet_selector);
+        QVBoxLayout* layout = new QVBoxLayout(this);
+        layout->addWidget(m_wallet_selector);
+        layout->setSpacing(0);
+        layout->setMargin(0);
+        layout->setContentsMargins(5, 0, 5, 0);
+        QWidget* walletSelector = new QWidget(this);
+        walletSelector->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+        walletSelector->setObjectName("walletSelector");
+        walletSelector->setLayout(layout);
+        appToolBar->insertWidget(appToolBarLogoAction, walletSelector);
     }
     rpcConsole->addWallet(walletModel);
     return walletFrame->addWallet(walletModel);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1339,7 +1339,7 @@ void BitcoinGUI::showEvent(QShowEvent *event)
 void BitcoinGUI::incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName)
 {
     IncomingTransactionMessage itx = {
-            date, unit, amount, type, address, label
+            date, unit, amount, type, address, label, walletName
     };
     incomingTransactions.emplace_back(itx);
 
@@ -1406,8 +1406,8 @@ void BitcoinGUI::showIncomingTransactions()
             // On new transaction, make an info balloon
             QString msg = tr("Date: %1\n").arg(itx.date) +
                           tr("Amount: %1\n").arg(BitcoinUnits::formatWithUnit(itx.unit, itx.amount, true));
-            if (WalletModel::isMultiwallet() && !walletName.isEmpty()) {
-                msg += tr("Wallet: %1\n").arg(walletName);
+            if (WalletModel::isMultiwallet() && !itx.walletName.isEmpty()) {
+                msg += tr("Wallet: %1\n").arg(itx.walletName);
             }
             msg += tr("Type: %1\n").arg(itx.type);
             if (!itx.label.isEmpty())

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -23,6 +23,7 @@
 #include <privatesend/privatesend-client.h>
 #include <qt/walletframe.h>
 #include <qt/walletmodel.h>
+#include <qt/walletview.h>
 #endif // ENABLE_WALLET
 
 #ifdef Q_OS_MAC
@@ -41,6 +42,7 @@
 #include <QAction>
 #include <QApplication>
 #include <QButtonGroup>
+#include <QComboBox>
 #include <QDateTime>
 #include <QDesktopWidget>
 #include <QDragEnterEvent>
@@ -70,10 +72,6 @@ const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #endif
         ;
 
-/** Display name for default wallet name. Uses tilde to avoid name
- * collisions in the future with additional wallets */
-const QString BitcoinGUI::DEFAULT_WALLET = "~Default";
-
 BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *networkStyle, QWidget *parent) :
     QMainWindow(parent),
     enableWallet(false),
@@ -88,6 +86,7 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
     progressBar(0),
     progressDialog(0),
     appMenuBar(0),
+    appToolBar(0),
     overviewAction(0),
     historyAction(0),
     masternodeAction(0),
@@ -588,6 +587,7 @@ void BitcoinGUI::createToolBars()
     if(walletFrame)
     {
         QToolBar *toolbar = new QToolBar(tr("Tabs toolbar"));
+        appToolBar = toolbar;
         toolbar->setContextMenuPolicy(Qt::PreventContextMenu);
         toolbar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         toolbar->setToolButtonStyle(Qt::ToolButtonTextOnly);
@@ -611,6 +611,15 @@ void BitcoinGUI::createToolBars()
         }
         toolbar->setMovable(false); // remove unused icon in upper left corner
         overviewAction->setChecked(true);
+
+#ifdef ENABLE_WALLET
+        QWidget *spacer = new QWidget();
+        spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        toolbar->addWidget(spacer);
+
+        m_wallet_selector = new QComboBox();
+        connect(m_wallet_selector, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(setCurrentWallet(const QString&)));
+#endif
 
         QLabel *logoLabel = new QLabel();
         logoLabel->setObjectName("lblToolbarLogo");
@@ -729,12 +738,22 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel)
 }
 
 #ifdef ENABLE_WALLET
-bool BitcoinGUI::addWallet(const QString& name, WalletModel *walletModel)
+bool BitcoinGUI::addWallet(WalletModel *walletModel)
 {
     if(!walletFrame)
         return false;
+    const QString name = walletModel->getWalletName();
     setWalletActionsEnabled(true);
-    return walletFrame->addWallet(name, walletModel);
+    m_wallet_selector->addItem(name);
+    if (m_wallet_selector->count() == 2) {
+        m_wallet_selector_label = new QLabel();
+        m_wallet_selector_label->setText(tr("Wallet:") + " ");
+        m_wallet_selector_label->setBuddy(m_wallet_selector);
+        appToolBar->addWidget(m_wallet_selector_label);
+        appToolBar->addWidget(m_wallet_selector);
+    }
+    rpcConsole->addWallet(walletModel);
+    return walletFrame->addWallet(walletModel);
 }
 
 bool BitcoinGUI::setCurrentWallet(const QString& name)
@@ -1317,7 +1336,7 @@ void BitcoinGUI::showEvent(QShowEvent *event)
 }
 
 #ifdef ENABLE_WALLET
-void BitcoinGUI::incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label)
+void BitcoinGUI::incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName)
 {
     IncomingTransactionMessage itx = {
             date, unit, amount, type, address, label
@@ -1386,8 +1405,11 @@ void BitcoinGUI::showIncomingTransactions()
         for (auto& itx : txs) {
             // On new transaction, make an info balloon
             QString msg = tr("Date: %1\n").arg(itx.date) +
-                          tr("Amount: %1\n").arg(BitcoinUnits::formatWithUnit(itx.unit, itx.amount, true)) +
-                          tr("Type: %1\n").arg(itx.type);
+                          tr("Amount: %1\n").arg(BitcoinUnits::formatWithUnit(itx.unit, itx.amount, true));
+            if (WalletModel::isMultiwallet() && !walletName.isEmpty()) {
+                msg += tr("Wallet: %1\n").arg(walletName);
+            }
+            msg += tr("Type: %1\n").arg(itx.type);
             if (!itx.label.isEmpty())
                 msg += tr("Label: %1\n").arg(itx.label);
             else if (!itx.address.isEmpty())
@@ -1495,6 +1517,20 @@ void BitcoinGUI::setEncryptionStatus(int status)
         encryptWalletAction->setEnabled(false); // TODO: decrypt currently not supported
         break;
     }
+}
+
+void BitcoinGUI::updateWalletStatus()
+{
+    if (!walletFrame) {
+        return;
+    }
+    WalletView * const walletView = walletFrame->currentWalletView();
+    if (!walletView) {
+        return;
+    }
+    WalletModel * const walletModel = walletView->getWalletModel();
+    setEncryptionStatus(walletModel->getEncryptionStatus());
+    setHDStatus(walletModel->hdEnabled());
 }
 #endif // ENABLE_WALLET
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -780,8 +780,8 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     sendCoinsAction->setEnabled(enabled);
     sendCoinsMenuAction->setEnabled(enabled);
 #ifdef ENABLE_WALLET
-    privateSendCoinsAction->setEnabled(enabled && privateSendClient.fEnablePrivateSend);
-    privateSendCoinsMenuAction->setEnabled(enabled && privateSendClient.fEnablePrivateSend);
+    privateSendCoinsAction->setEnabled(enabled && privateSendClientOptions.fEnablePrivateSend);
+    privateSendCoinsMenuAction->setEnabled(enabled && privateSendClientOptions.fEnablePrivateSend);
 #else
     privateSendCoinsAction->setEnabled(enabled);
     privateSendCoinsMenuAction->setEnabled(enabled);
@@ -1049,7 +1049,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVer
     // Disabling macOS App Nap on initial sync, disk, reindex operations and mixing.
     bool disableAppNap = !masternodeSync.IsSynced();
 #ifdef ENABLE_WALLET
-    disableAppNap |= privateSendClient.IsMixing();
+    disableAppNap |= privateSendClientManager.IsMixing();
 #endif // ENABLE_WALLET
     if (disableAppNap) {
         m_app_nap_inhibitor->disableAppNap();

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -159,6 +159,7 @@ private:
         QString type;
         QString address;
         QString label;
+        QString walletName;
     };
     std::list<IncomingTransactionMessage> incomingTransactions;
     QTimer* incomingTransactionsTimer;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -96,6 +96,7 @@ private:
 
     QMenuBar *appMenuBar;
     QToolBar *appToolBar;
+    QAction* appToolBarLogoAction;
     QToolButton *overviewAction;
     QToolButton *historyAction;
     QToolButton *masternodeAction;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -38,6 +38,7 @@ class ModalOverlay;
 
 QT_BEGIN_NAMESPACE
 class QAction;
+class QComboBox;
 class QProgressBar;
 class QProgressDialog;
 class QToolButton;
@@ -52,7 +53,6 @@ class BitcoinGUI : public QMainWindow
     Q_OBJECT
 
 public:
-    static const QString DEFAULT_WALLET;
     static const std::string DEFAULT_UIPLATFORM;
 
     explicit BitcoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *networkStyle, QWidget *parent = 0);
@@ -68,8 +68,7 @@ public:
         The wallet model represents a bitcoin wallet, and offers access to the list of transactions, address book and sending
         functionality.
     */
-    bool addWallet(const QString& name, WalletModel *walletModel);
-    bool setCurrentWallet(const QString& name);
+    bool addWallet(WalletModel *walletModel);
     void removeAllWallets();
 #endif // ENABLE_WALLET
     bool enableWallet;
@@ -96,6 +95,7 @@ private:
     QProgressDialog *progressDialog;
 
     QMenuBar *appMenuBar;
+    QToolBar *appToolBar;
     QToolButton *overviewAction;
     QToolButton *historyAction;
     QToolButton *masternodeAction;
@@ -129,6 +129,9 @@ private:
     QAction *openAction;
     QAction *showHelpMessageAction;
     QAction *showPrivateSendHelpAction;
+
+    QLabel *m_wallet_selector_label;
+    QComboBox *m_wallet_selector;
 
     QSystemTrayIcon *trayIcon;
     QMenu *trayIconMenu;
@@ -212,22 +215,29 @@ public Q_SLOTS:
     void message(const QString &title, const QString &message, unsigned int style, bool *ret = nullptr);
 
 #ifdef ENABLE_WALLET
-    /** Set the hd-enabled status as shown in the UI.
-     @param[in] status            current hd enabled status
-     @see WalletModel::EncryptionStatus
-     */
-    void setHDStatus(int hdEnabled);
+    bool setCurrentWallet(const QString& name);
+    /** Set the UI status indicators based on the currently selected wallet.
+    */
+    void updateWalletStatus();
 
+private:
     /** Set the encryption status as shown in the UI.
        @param[in] status            current encryption status
        @see WalletModel::EncryptionStatus
     */
     void setEncryptionStatus(int status);
 
+    /** Set the hd-enabled status as shown in the UI.
+     @param[in] status            current hd enabled status
+     @see WalletModel::EncryptionStatus
+     */
+    void setHDStatus(int hdEnabled);
+
+public Q_SLOTS:
     bool handlePaymentRequest(const SendCoinsRecipient& recipient);
 
     /** Show incoming transaction notification for new transactions. */
-    void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label);
+    void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName);
     void showIncomingTransactions();
 #endif // ENABLE_WALLET
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -501,7 +501,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         // unselect non-fully-mixed, this can happen when users switch from Send to PrivateSend
         if (coinControl()->IsUsingPrivateSend()) {
             int nRounds = model->getRealOutpointPrivateSendRounds(outpt);
-            if (nRounds < privateSendClientOptions.nPrivateSendRounds) {
+            if (nRounds < CPrivateSendClientOptions::GetRounds()) {
                 coinControl()->UnSelect(outpt);
                 fUnselectedNonMixed = true;
                 continue;
@@ -707,7 +707,7 @@ void CoinControlDialog::updateView()
             COutPoint outpoint = COutPoint(out.tx->tx->GetHash(), out.i);
             int nRounds = model->getRealOutpointPrivateSendRounds(outpoint);
 
-            if ((coinControl()->IsUsingPrivateSend() && nRounds >= privateSendClientOptions.nPrivateSendRounds) || !(coinControl()->IsUsingPrivateSend())) {
+            if ((coinControl()->IsUsingPrivateSend() && nRounds >= CPrivateSendClientOptions::GetRounds()) || !(coinControl()->IsUsingPrivateSend())) {
                 nSum += out.tx->tx->vout[out.i].nValue;
                 nChildren++;
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -501,7 +501,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         // unselect non-fully-mixed, this can happen when users switch from Send to PrivateSend
         if (coinControl()->IsUsingPrivateSend()) {
             int nRounds = model->getRealOutpointPrivateSendRounds(outpt);
-            if (nRounds < privateSendClient.nPrivateSendRounds) {
+            if (nRounds < privateSendClientOptions.nPrivateSendRounds) {
                 coinControl()->UnSelect(outpt);
                 fUnselectedNonMixed = true;
                 continue;
@@ -707,7 +707,7 @@ void CoinControlDialog::updateView()
             COutPoint outpoint = COutPoint(out.tx->tx->GetHash(), out.i);
             int nRounds = model->getRealOutpointPrivateSendRounds(outpoint);
 
-            if ((coinControl()->IsUsingPrivateSend() && nRounds >= privateSendClient.nPrivateSendRounds) || !(coinControl()->IsUsingPrivateSend())) {
+            if ((coinControl()->IsUsingPrivateSend() && nRounds >= privateSendClientOptions.nPrivateSendRounds) || !(coinControl()->IsUsingPrivateSend())) {
                 nSum += out.tx->tx->vout[out.i].nValue;
                 nChildren++;
 

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -495,6 +495,22 @@
           <number>4</number>
          </property>
          <item>
+          <widget class="QLabel" name="WalletSelectorLabel">
+           <property name="text">
+            <string>Wallet: </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="WalletSelector">
+           <item>
+            <property name="text">
+             <string>(none)</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -288,7 +288,7 @@ void OptionsDialog::on_okButton_clicked()
 {
     mapper->submit();
 #ifdef ENABLE_WALLET
-    privateSendClient.nCachedNumBlocks = std::numeric_limits<int>::max();
+    privateSendClientManager.nCachedNumBlocks = std::numeric_limits<int>::max();
     if(HasWallets())
         GetWallets()[0]->MarkDirty();
 #endif // ENABLE_WALLET

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -288,9 +288,10 @@ void OptionsDialog::on_okButton_clicked()
 {
     mapper->submit();
 #ifdef ENABLE_WALLET
-    privateSendClientManager.nCachedNumBlocks = std::numeric_limits<int>::max();
-    if(HasWallets())
-        GetWallets()[0]->MarkDirty();
+    for (auto& pwallet : GetWallets()) {
+        privateSendClientManagers.at(pwallet->GetName())->nCachedNumBlocks = std::numeric_limits<int>::max();
+        pwallet->MarkDirty();
+    }
 #endif // ENABLE_WALLET
     accept();
     updateDefaultProxyNets();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -138,7 +138,7 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("nPrivateSendRounds", DEFAULT_PRIVATESEND_ROUNDS);
     if (!gArgs.SoftSetArg("-privatesendrounds", settings.value("nPrivateSendRounds").toString().toStdString()))
         addOverriddenOption("-privatesendrounds");
-    privateSendClient.nPrivateSendRounds = settings.value("nPrivateSendRounds").toInt();
+    privateSendClientOptions.nPrivateSendRounds = settings.value("nPrivateSendRounds").toInt();
 
     if (!settings.contains("nPrivateSendAmount")) {
         // for migration from old settings
@@ -149,13 +149,13 @@ void OptionsModel::Init(bool resetSettings)
     }
     if (!gArgs.SoftSetArg("-privatesendamount", settings.value("nPrivateSendAmount").toString().toStdString()))
         addOverriddenOption("-privatesendamount");
-    privateSendClient.nPrivateSendAmount = settings.value("nPrivateSendAmount").toInt();
+    privateSendClientOptions.nPrivateSendAmount = settings.value("nPrivateSendAmount").toInt();
 
     if (!settings.contains("fPrivateSendMultiSession"))
         settings.setValue("fPrivateSendMultiSession", DEFAULT_PRIVATESEND_MULTISESSION);
     if (!gArgs.SoftSetBoolArg("-privatesendmultisession", settings.value("fPrivateSendMultiSession").toBool()))
         addOverriddenOption("-privatesendmultisession");
-    privateSendClient.fPrivateSendMultiSession = settings.value("fPrivateSendMultiSession").toBool();
+    privateSendClientOptions.fPrivateSendMultiSession = settings.value("fPrivateSendMultiSession").toBool();
 #endif
 
     // Network
@@ -470,24 +470,24 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case PrivateSendRounds:
             if (settings.value("nPrivateSendRounds") != value)
             {
-                privateSendClient.nPrivateSendRounds = value.toInt();
-                settings.setValue("nPrivateSendRounds", privateSendClient.nPrivateSendRounds);
+                privateSendClientOptions.nPrivateSendRounds = value.toInt();
+                settings.setValue("nPrivateSendRounds", privateSendClientOptions.nPrivateSendRounds);
                 Q_EMIT privateSendRoundsChanged();
             }
             break;
         case PrivateSendAmount:
             if (settings.value("nPrivateSendAmount") != value)
             {
-                privateSendClient.nPrivateSendAmount = value.toInt();
-                settings.setValue("nPrivateSendAmount", privateSendClient.nPrivateSendAmount);
+                privateSendClientOptions.nPrivateSendAmount = value.toInt();
+                settings.setValue("nPrivateSendAmount", privateSendClientOptions.nPrivateSendAmount);
                 Q_EMIT privateSentAmountChanged();
             }
             break;
         case PrivateSendMultiSession:
             if (settings.value("fPrivateSendMultiSession") != value)
             {
-                privateSendClient.fPrivateSendMultiSession = value.toBool();
-                settings.setValue("fPrivateSendMultiSession", privateSendClient.fPrivateSendMultiSession);
+                privateSendClientOptions.fPrivateSendMultiSession = value.toBool();
+                settings.setValue("fPrivateSendMultiSession", privateSendClientOptions.fPrivateSendMultiSession);
             }
             break;
 #endif

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -138,7 +138,7 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("nPrivateSendRounds", DEFAULT_PRIVATESEND_ROUNDS);
     if (!gArgs.SoftSetArg("-privatesendrounds", settings.value("nPrivateSendRounds").toString().toStdString()))
         addOverriddenOption("-privatesendrounds");
-    privateSendClientOptions.nPrivateSendRounds = settings.value("nPrivateSendRounds").toInt();
+    CPrivateSendClientOptions::SetRounds(settings.value("nPrivateSendRounds").toInt());
 
     if (!settings.contains("nPrivateSendAmount")) {
         // for migration from old settings
@@ -149,13 +149,13 @@ void OptionsModel::Init(bool resetSettings)
     }
     if (!gArgs.SoftSetArg("-privatesendamount", settings.value("nPrivateSendAmount").toString().toStdString()))
         addOverriddenOption("-privatesendamount");
-    privateSendClientOptions.nPrivateSendAmount = settings.value("nPrivateSendAmount").toInt();
+    CPrivateSendClientOptions::SetAmount(settings.value("nPrivateSendAmount").toInt());
 
     if (!settings.contains("fPrivateSendMultiSession"))
         settings.setValue("fPrivateSendMultiSession", DEFAULT_PRIVATESEND_MULTISESSION);
     if (!gArgs.SoftSetBoolArg("-privatesendmultisession", settings.value("fPrivateSendMultiSession").toBool()))
         addOverriddenOption("-privatesendmultisession");
-    privateSendClientOptions.fPrivateSendMultiSession = settings.value("fPrivateSendMultiSession").toBool();
+    CPrivateSendClientOptions::SetMultiSessionEnabled(settings.value("fPrivateSendMultiSession").toBool());
 #endif
 
     // Network
@@ -470,24 +470,24 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case PrivateSendRounds:
             if (settings.value("nPrivateSendRounds") != value)
             {
-                privateSendClientOptions.nPrivateSendRounds = value.toInt();
-                settings.setValue("nPrivateSendRounds", privateSendClientOptions.nPrivateSendRounds);
+                CPrivateSendClientOptions::SetRounds(value.toInt());
+                settings.setValue("nPrivateSendRounds", CPrivateSendClientOptions::GetRounds());
                 Q_EMIT privateSendRoundsChanged();
             }
             break;
         case PrivateSendAmount:
             if (settings.value("nPrivateSendAmount") != value)
             {
-                privateSendClientOptions.nPrivateSendAmount = value.toInt();
-                settings.setValue("nPrivateSendAmount", privateSendClientOptions.nPrivateSendAmount);
+                CPrivateSendClientOptions::SetAmount(value.toInt());
+                settings.setValue("nPrivateSendAmount", CPrivateSendClientOptions::GetAmount());
                 Q_EMIT privateSentAmountChanged();
             }
             break;
         case PrivateSendMultiSession:
             if (settings.value("fPrivateSendMultiSession") != value)
             {
-                privateSendClientOptions.fPrivateSendMultiSession = value.toBool();
-                settings.setValue("fPrivateSendMultiSession", privateSendClientOptions.fPrivateSendMultiSession);
+                CPrivateSendClientOptions::SetMultiSessionEnabled(value.toBool());
+                settings.setValue("fPrivateSendMultiSession", CPrivateSendClientOptions::IsMultiSessionEnabled());
             }
             break;
 #endif

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -181,7 +181,7 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
             ui->labelPrivateSendEnabled->setToolTip(tr("Automatic backups are disabled, no mixing available!"));
         }
     } else {
-        if(!privateSendClient.fPrivateSendRunning){
+        if(!privateSendClient.IsMixing()){
             ui->togglePrivateSend->setText(tr("Start Mixing"));
         } else {
             ui->togglePrivateSend->setText(tr("Stop Mixing"));
@@ -500,7 +500,7 @@ void OverviewPage::privateSendStatus(bool fForce)
     }
     ui->labelPrivateSendEnabled->setToolTip(strKeysLeftText);
 
-    if (!privateSendClient.fPrivateSendRunning) {
+    if (!privateSendClient.IsMixing()) {
         if (nBestHeight != privateSendClient.nCachedNumBlocks) {
             privateSendClient.nCachedNumBlocks = nBestHeight;
             updatePrivateSendProgress();
@@ -557,7 +557,7 @@ void OverviewPage::privateSendStatus(bool fForce)
         }
     }
 
-    QString strEnabled = privateSendClient.fPrivateSendRunning ? tr("Enabled") : tr("Disabled");
+    QString strEnabled = privateSendClient.IsMixing() ? tr("Enabled") : tr("Disabled");
     // Show how many keys left in advanced PS UI mode only
     if(fShowAdvancedPSUI) strEnabled += ", " + strKeysLeftText;
     ui->labelPrivateSendEnabled->setText(strEnabled);
@@ -600,7 +600,7 @@ void OverviewPage::togglePrivateSend(){
                 QMessageBox::Ok, QMessageBox::Ok);
         settings.setValue("hasMixed", "hasMixed");
     }
-    if(!privateSendClient.fPrivateSendRunning){
+    if(!privateSendClient.IsMixing()){
         const CAmount nMinAmount = CPrivateSend::GetSmallestDenomination() + CPrivateSend::GetMaxCollateralAmount();
         if(currentBalance < nMinAmount){
             QString strMinAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, nMinAmount));
@@ -628,14 +628,15 @@ void OverviewPage::togglePrivateSend(){
 
     }
 
-    privateSendClient.fPrivateSendRunning = !privateSendClient.fPrivateSendRunning;
     privateSendClient.nCachedNumBlocks = std::numeric_limits<int>::max();
 
-    if(!privateSendClient.fPrivateSendRunning){
+    if (privateSendClient.IsMixing()) {
         ui->togglePrivateSend->setText(tr("Start Mixing"));
         privateSendClient.ResetPool();
+        privateSendClient.StopMixing();
     } else {
         ui->togglePrivateSend->setText(tr("Stop Mixing"));
+        privateSendClient.StartMixing(walletModel->getWallet());
     }
 }
 
@@ -663,5 +664,5 @@ void OverviewPage::DisablePrivateSendCompletely() {
     if (nWalletBackups <= 0) {
         ui->labelPrivateSendEnabled->setText("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>(" + tr("Disabled") + ")</span>");
     }
-    privateSendClient.fPrivateSendRunning = false;
+    privateSendClient.StopMixing();
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -492,7 +492,12 @@ void OverviewPage::privateSendStatus(bool fForce)
     static int64_t nLastDSProgressBlockTime = 0;
     int nBestHeight = clientModel->getNumBlocks();
 
-    CPrivateSendClientManager* privateSendClientManager = privateSendClientManagers.find(walletModel->getWallet()->GetName())->second;
+    auto it = privateSendClientManagers.find(walletModel->getWallet()->GetName());
+    if (it == privateSendClientManagers.end()) {
+        // nothing to do
+        return;
+    }
+    CPrivateSendClientManager* privateSendClientManager = it->second;
 
     // We are processing more than 1 block per second, we'll just leave
     if(nBestHeight > privateSendClientManager->nCachedNumBlocks && GetTime() - nLastDSProgressBlockTime <= 1) return;
@@ -605,7 +610,12 @@ void OverviewPage::togglePrivateSend(){
         settings.setValue("hasMixed", "hasMixed");
     }
 
-    CPrivateSendClientManager* privateSendClientManager = privateSendClientManagers.find(walletModel->getWallet()->GetName())->second;
+    auto it = privateSendClientManagers.find(walletModel->getWallet()->GetName());
+    if (it == privateSendClientManagers.end()) {
+        // nothing to do
+        return;
+    }
+    CPrivateSendClientManager* privateSendClientManager = it->second;
 
     if (!privateSendClientManager->IsMixing()) {
         const CAmount nMinAmount = CPrivateSend::GetSmallestDenomination() + CPrivateSend::GetMaxCollateralAmount();
@@ -671,5 +681,10 @@ void OverviewPage::DisablePrivateSendCompletely() {
     if (nWalletBackups <= 0) {
         ui->labelPrivateSendEnabled->setText("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>(" + tr("Disabled") + ")</span>");
     }
-    privateSendClientManagers.at(walletModel->getWallet()->GetName())->StopMixing();
+    auto it = privateSendClientManagers.find(walletModel->getWallet()->GetName());
+    if (it == privateSendClientManagers.end()) {
+        // nothing to do
+        return;
+    }
+    it->second->StopMixing();
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -181,14 +181,16 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
             ui->labelPrivateSendEnabled->setToolTip(tr("Automatic backups are disabled, no mixing available!"));
         }
     } else {
-        if(!privateSendClientManager.IsMixing()){
-            ui->togglePrivateSend->setText(tr("Start Mixing"));
-        } else {
-            ui->togglePrivateSend->setText(tr("Stop Mixing"));
-        }
         // Disable privateSendClient builtin support for automatic backups while we are in GUI,
         // we'll handle automatic backups and user warnings in privateSendStatus()
-        privateSendClientManager.fCreateAutoBackups = false;
+        for (auto& pair : privateSendClientManagers) {
+            if (!pair.second->IsMixing()) {
+                ui->togglePrivateSend->setText(tr("Start Mixing"));
+            } else {
+                ui->togglePrivateSend->setText(tr("Stop Mixing"));
+            }
+            pair.second->fCreateAutoBackups = false;
+        }
 
         timer = new QTimer(this);
         connect(timer, SIGNAL(timeout()), this, SLOT(privateSendStatus()));
@@ -490,8 +492,10 @@ void OverviewPage::privateSendStatus(bool fForce)
     static int64_t nLastDSProgressBlockTime = 0;
     int nBestHeight = clientModel->getNumBlocks();
 
+    CPrivateSendClientManager* privateSendClientManager = privateSendClientManagers.find(walletModel->getWallet()->GetName())->second;
+
     // We are processing more than 1 block per second, we'll just leave
-    if(nBestHeight > privateSendClientManager.nCachedNumBlocks && GetTime() - nLastDSProgressBlockTime <= 1) return;
+    if(nBestHeight > privateSendClientManager->nCachedNumBlocks && GetTime() - nLastDSProgressBlockTime <= 1) return;
     nLastDSProgressBlockTime = GetTime();
 
     QString strKeysLeftText(tr("keys left: %1").arg(walletModel->getKeysLeftSinceAutoBackup()));
@@ -500,9 +504,9 @@ void OverviewPage::privateSendStatus(bool fForce)
     }
     ui->labelPrivateSendEnabled->setToolTip(strKeysLeftText);
 
-    if (!privateSendClientManager.IsMixing()) {
-        if (nBestHeight != privateSendClientManager.nCachedNumBlocks) {
-            privateSendClientManager.nCachedNumBlocks = nBestHeight;
+    if (!privateSendClientManager->IsMixing()) {
+        if (nBestHeight != privateSendClientManager->nCachedNumBlocks) {
+            privateSendClientManager->nCachedNumBlocks = nBestHeight;
             updatePrivateSendProgress();
         }
 
@@ -557,7 +561,7 @@ void OverviewPage::privateSendStatus(bool fForce)
         }
     }
 
-    QString strEnabled = privateSendClientManager.IsMixing() ? tr("Enabled") : tr("Disabled");
+    QString strEnabled = privateSendClientManager->IsMixing() ? tr("Enabled") : tr("Disabled");
     // Show how many keys left in advanced PS UI mode only
     if(fShowAdvancedPSUI) strEnabled += ", " + strKeysLeftText;
     ui->labelPrivateSendEnabled->setText(strEnabled);
@@ -579,15 +583,15 @@ void OverviewPage::privateSendStatus(bool fForce)
     }
 
     // check privatesend status and unlock if needed
-    if(nBestHeight != privateSendClientManager.nCachedNumBlocks) {
+    if(nBestHeight != privateSendClientManager->nCachedNumBlocks) {
         // Balance and number of transactions might have changed
-        privateSendClientManager.nCachedNumBlocks = nBestHeight;
+        privateSendClientManager->nCachedNumBlocks = nBestHeight;
         updatePrivateSendProgress();
     }
 
     setWidgetsVisible(true);
 
-    ui->labelSubmittedDenom->setText(QString(privateSendClientManager.GetSessionDenoms().c_str()));
+    ui->labelSubmittedDenom->setText(QString(privateSendClientManager->GetSessionDenoms().c_str()));
 }
 
 void OverviewPage::togglePrivateSend(){
@@ -600,7 +604,10 @@ void OverviewPage::togglePrivateSend(){
                 QMessageBox::Ok, QMessageBox::Ok);
         settings.setValue("hasMixed", "hasMixed");
     }
-    if(!privateSendClientManager.IsMixing()){
+
+    CPrivateSendClientManager* privateSendClientManager = privateSendClientManagers.find(walletModel->getWallet()->GetName())->second;
+
+    if (!privateSendClientManager->IsMixing()) {
         const CAmount nMinAmount = CPrivateSend::GetSmallestDenomination() + CPrivateSend::GetMaxCollateralAmount();
         if(currentBalance < nMinAmount){
             QString strMinAmount(BitcoinUnits::formatWithUnit(nDisplayUnit, nMinAmount));
@@ -617,7 +624,7 @@ void OverviewPage::togglePrivateSend(){
             if(!ctx.isValid())
             {
                 //unlock was cancelled
-                privateSendClientManager.nCachedNumBlocks = std::numeric_limits<int>::max();
+                privateSendClientManager->nCachedNumBlocks = std::numeric_limits<int>::max();
                 QMessageBox::warning(this, tr("PrivateSend"),
                     tr("Wallet is locked and user declined to unlock. Disabling PrivateSend."),
                     QMessageBox::Ok, QMessageBox::Ok);
@@ -628,15 +635,15 @@ void OverviewPage::togglePrivateSend(){
 
     }
 
-    privateSendClientManager.nCachedNumBlocks = std::numeric_limits<int>::max();
+    privateSendClientManager->nCachedNumBlocks = std::numeric_limits<int>::max();
 
-    if (privateSendClientManager.IsMixing()) {
+    if (privateSendClientManager->IsMixing()) {
         ui->togglePrivateSend->setText(tr("Start Mixing"));
-        privateSendClientManager.ResetPool();
-        privateSendClientManager.StopMixing();
+        privateSendClientManager->ResetPool();
+        privateSendClientManager->StopMixing();
     } else {
         ui->togglePrivateSend->setText(tr("Stop Mixing"));
-        privateSendClientManager.StartMixing(walletModel->getWallet());
+        privateSendClientManager->StartMixing(walletModel->getWallet());
     }
 }
 
@@ -664,5 +671,5 @@ void OverviewPage::DisablePrivateSendCompletely() {
     if (nWalletBackups <= 0) {
         ui->labelPrivateSendEnabled->setText("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>(" + tr("Disabled") + ")</span>");
     }
-    privateSendClientManager.StopMixing();
+    privateSendClientManagers.at(walletModel->getWallet()->GetName())->StopMixing();
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -172,7 +172,7 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
     // start with displaying the "out of sync" warnings
     showOutOfSyncWarning(true);
 
-    if(!privateSendClientOptions.fEnablePrivateSend) return;
+    if (!CPrivateSendClientOptions::IsEnabled()) return;
 
     // Disable any PS UI for masternode or when autobackup is disabled or failed for whatever reason
     if(fMasternodeMode || nWalletBackups <= 0){
@@ -310,7 +310,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         // Initialize PS UI
         privateSendStatus(true);
 
-        if(!privateSendClientOptions.fEnablePrivateSend) return;
+        if (!CPrivateSendClientOptions::IsEnabled()) return;
 
         connect(model->getOptionsModel(), SIGNAL(privateSendRoundsChanged()), this, SLOT(updatePrivateSendProgress()));
         connect(model->getOptionsModel(), SIGNAL(privateSentAmountChanged()), this, SLOT(updatePrivateSendProgress()));
@@ -359,7 +359,7 @@ void OverviewPage::updatePrivateSendProgress()
     if(!walletModel) return;
 
     QString strAmountAndRounds;
-    QString strPrivateSendAmount = BitcoinUnits::formatHtmlWithUnit(nDisplayUnit, privateSendClientOptions.nPrivateSendAmount * COIN, false, BitcoinUnits::separatorAlways);
+    QString strPrivateSendAmount = BitcoinUnits::formatHtmlWithUnit(nDisplayUnit, CPrivateSendClientOptions::GetAmount() * COIN, false, BitcoinUnits::separatorAlways);
 
     if(currentBalance == 0)
     {
@@ -368,7 +368,7 @@ void OverviewPage::updatePrivateSendProgress()
 
         // when balance is zero just show info from settings
         strPrivateSendAmount = strPrivateSendAmount.remove(strPrivateSendAmount.indexOf("."), BitcoinUnits::decimals(nDisplayUnit) + 1);
-        strAmountAndRounds = strPrivateSendAmount + " / " + tr("%n Rounds", "", privateSendClientOptions.nPrivateSendRounds);
+        strAmountAndRounds = strPrivateSendAmount + " / " + tr("%n Rounds", "", CPrivateSendClientOptions::GetRounds());
 
         ui->labelAmountRounds->setToolTip(tr("No inputs detected"));
         ui->labelAmountRounds->setText(strAmountAndRounds);
@@ -380,15 +380,15 @@ void OverviewPage::updatePrivateSendProgress()
     CAmount nMaxToAnonymize = nAnonymizableBalance + currentAnonymizedBalance;
 
     // If it's more than the anon threshold, limit to that.
-    if(nMaxToAnonymize > privateSendClientOptions.nPrivateSendAmount*COIN) nMaxToAnonymize = privateSendClientOptions.nPrivateSendAmount*COIN;
+    if (nMaxToAnonymize > CPrivateSendClientOptions::GetAmount() * COIN) nMaxToAnonymize = CPrivateSendClientOptions::GetAmount() * COIN;
 
     if(nMaxToAnonymize == 0) return;
 
-    if(nMaxToAnonymize >= privateSendClientOptions.nPrivateSendAmount * COIN) {
+    if (nMaxToAnonymize >= CPrivateSendClientOptions::GetAmount() * COIN) {
         ui->labelAmountRounds->setToolTip(tr("Found enough compatible inputs to mix %1")
                                           .arg(strPrivateSendAmount));
         strPrivateSendAmount = strPrivateSendAmount.remove(strPrivateSendAmount.indexOf("."), BitcoinUnits::decimals(nDisplayUnit) + 1);
-        strAmountAndRounds = strPrivateSendAmount + " / " + tr("%n Rounds", "", privateSendClientOptions.nPrivateSendRounds);
+        strAmountAndRounds = strPrivateSendAmount + " / " + tr("%n Rounds", "", CPrivateSendClientOptions::GetRounds());
     } else {
         QString strMaxToAnonymize = BitcoinUnits::formatHtmlWithUnit(nDisplayUnit, nMaxToAnonymize, false, BitcoinUnits::separatorAlways);
         ui->labelAmountRounds->setToolTip(tr("Not enough compatible inputs to mix <span style='%1'>%2</span>,<br>"
@@ -399,7 +399,7 @@ void OverviewPage::updatePrivateSendProgress()
         strMaxToAnonymize = strMaxToAnonymize.remove(strMaxToAnonymize.indexOf("."), BitcoinUnits::decimals(nDisplayUnit) + 1);
         strAmountAndRounds = "<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>" +
                 QString(BitcoinUnits::factor(nDisplayUnit) == 1 ? "" : "~") + strMaxToAnonymize +
-                " / " + tr("%n Rounds", "", privateSendClientOptions.nPrivateSendRounds) + "</span>";
+                " / " + tr("%n Rounds", "", CPrivateSendClientOptions::GetRounds()) + "</span>";
     }
     ui->labelAmountRounds->setText(strAmountAndRounds);
 
@@ -438,7 +438,7 @@ void OverviewPage::updatePrivateSendProgress()
 
     // apply some weights to them ...
     float denomWeight = 1;
-    float anonNormWeight = privateSendClientOptions.nPrivateSendRounds;
+    float anonNormWeight = CPrivateSendClientOptions::GetRounds();
     float anonFullWeight = 2;
     float fullWeight = denomWeight + anonNormWeight + anonFullWeight;
     // ... and calculate the whole progress
@@ -454,7 +454,7 @@ void OverviewPage::updatePrivateSendProgress()
                           tr("Denominated") + ": %2%<br/>" +
                           tr("Partially mixed") + ": %3%<br/>" +
                           tr("Mixed") + ": %4%<br/>" +
-                          tr("Denominated inputs have %5 of %n rounds on average", "", privateSendClientOptions.nPrivateSendRounds))
+                          tr("Denominated inputs have %5 of %n rounds on average", "", CPrivateSendClientOptions::GetRounds()))
             .arg(progress).arg(denomPart).arg(anonNormPart).arg(anonFullPart)
             .arg(nAverageAnonymizedRounds);
     ui->privateSendProgress->setToolTip(strToolPip);
@@ -462,10 +462,10 @@ void OverviewPage::updatePrivateSendProgress()
 
 void OverviewPage::updateAdvancedPSUI(bool fShowAdvancedPSUI) {
     this->fShowAdvancedPSUI = fShowAdvancedPSUI;
-    int nNumItems = (!privateSendClientOptions.fEnablePrivateSend || !fShowAdvancedPSUI) ? NUM_ITEMS : NUM_ITEMS_ADV;
+    int nNumItems = (!CPrivateSendClientOptions::IsEnabled() || !fShowAdvancedPSUI) ? NUM_ITEMS : NUM_ITEMS_ADV;
     SetupTransactionList(nNumItems);
 
-    if (!privateSendClientOptions.fEnablePrivateSend) return;
+    if (!CPrivateSendClientOptions::IsEnabled()) return;
 
     ui->framePrivateSend->setVisible(true);
     ui->labelCompletitionText->setVisible(fShowAdvancedPSUI);

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -143,7 +143,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
         ui->reqAmount->value(), ui->reqMessage->text());
     ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
-    dialog->setModel(model->getOptionsModel());
+    dialog->setModel(model);
     dialog->setInfo(info);
     dialog->show();
     clear();
@@ -156,7 +156,7 @@ void ReceiveCoinsDialog::on_recentRequestsView_doubleClicked(const QModelIndex &
 {
     const RecentRequestsTableModel *submodel = model->getRecentRequestsTableModel();
     ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
-    dialog->setModel(model->getOptionsModel());
+    dialog->setModel(model);
     dialog->setInfo(submodel->entry(index.row()).recipient);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -107,12 +107,12 @@ ReceiveRequestDialog::~ReceiveRequestDialog()
     delete ui;
 }
 
-void ReceiveRequestDialog::setModel(OptionsModel *_model)
+void ReceiveRequestDialog::setModel(WalletModel *_model)
 {
     this->model = _model;
 
     if (_model)
-        connect(_model, SIGNAL(displayUnitChanged(int)), this, SLOT(update()));
+        connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(update()));
 
     // update the display unit if necessary
     update();
@@ -143,11 +143,14 @@ void ReceiveRequestDialog::update()
             uri + "\">" + GUIUtil::HtmlEscape(uri) + "</a><br>";
     html += "<b>"+tr("Address")+"</b>: " + GUIUtil::HtmlEscape(info.address) + "<br>";
     if(info.amount)
-        html += "<b>"+tr("Amount")+"</b>: " + BitcoinUnits::formatHtmlWithUnit(model->getDisplayUnit(), info.amount) + "<br>";
+        html += "<b>"+tr("Amount")+"</b>: " + BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), info.amount) + "<br>";
     if(!info.label.isEmpty())
         html += "<b>"+tr("Label")+"</b>: " + GUIUtil::HtmlEscape(info.label) + "<br>";
     if(!info.message.isEmpty())
         html += "<b>"+tr("Message")+"</b>: " + GUIUtil::HtmlEscape(info.message) + "<br>";
+    if(model->isMultiwallet()) {
+        html += "<b>"+tr("Wallet")+"</b>: " + GUIUtil::HtmlEscape(model->getWalletName()) + "<br>";
+    }
     ui->outUri->setText(html);
 
 #ifdef USE_QRCODE

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -12,8 +12,6 @@
 #include <QLabel>
 #include <QPainter>
 
-class OptionsModel;
-
 namespace Ui {
     class ReceiveRequestDialog;
 }
@@ -53,7 +51,7 @@ public:
     explicit ReceiveRequestDialog(QWidget *parent = 0);
     ~ReceiveRequestDialog();
 
-    void setModel(OptionsModel *model);
+    void setModel(WalletModel *model);
     void setInfo(const SendCoinsRecipient &info);
 
 private Q_SLOTS:
@@ -64,7 +62,7 @@ private Q_SLOTS:
 
 private:
     Ui::ReceiveRequestDialog *ui;
-    OptionsModel *model;
+    WalletModel *model;
     SendCoinsRecipient info;
 };
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -19,6 +19,7 @@
 class ClientModel;
 class PlatformStyle;
 class RPCTimerInterface;
+class WalletModel;
 
 namespace Ui {
     class RPCConsole;
@@ -38,12 +39,13 @@ public:
     explicit RPCConsole(const PlatformStyle *platformStyle, QWidget *parent);
     ~RPCConsole();
 
-    static bool RPCParseCommandLine(std::string &strResult, const std::string &strCommand, bool fExecute, std::string * const pstrFilteredOut = nullptr);
-    static bool RPCExecuteCommandLine(std::string &strResult, const std::string &strCommand, std::string * const pstrFilteredOut = nullptr) {
-        return RPCParseCommandLine(strResult, strCommand, true, pstrFilteredOut);
+    static bool RPCParseCommandLine(std::string &strResult, const std::string &strCommand, bool fExecute, std::string * const pstrFilteredOut = nullptr, const std::string *walletID = nullptr);
+    static bool RPCExecuteCommandLine(std::string &strResult, const std::string &strCommand, std::string * const pstrFilteredOut = nullptr, const std::string *walletID = nullptr) {
+        return RPCParseCommandLine(strResult, strCommand, true, pstrFilteredOut, walletID);
     }
 
     void setClientModel(ClientModel *model);
+    void addWallet(WalletModel * const walletModel);
 
     enum MessageClass {
         MC_ERROR,
@@ -94,7 +96,7 @@ public Q_SLOTS:
     void fontBigger();
     void fontSmaller();
     void setFontSize(int newSize);
-    
+
     /** Wallet repair options */
     void walletSalvage();
     void walletRescan();
@@ -102,7 +104,7 @@ public Q_SLOTS:
     void walletZaptxes2();
     void walletUpgrade();
     void walletReindex();
-    
+
     /** Append the message to the message widget */
     void message(int category, const QString &message, bool html = false);
     /** Set number of connections shown in the UI */
@@ -139,7 +141,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     // For RPC command executor
     void stopExecutor();
-    void cmdRequest(const QString &command);
+    void cmdRequest(const QString &command, const QString &walletID);
     /** Get restart command-line parameters and handle restart */
     void handleRestart(QStringList args);
 
@@ -175,6 +177,7 @@ private:
     int consoleFontSize;
     QCompleter *autoCompleter;
     QThread thread;
+    QString m_last_wallet_id;
 
     /** Update UI with latest network info from model. */
     void updateNetworkState();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -331,10 +331,12 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients)
     QStringList formatted;
     for (const SendCoinsRecipient &rcp : currentTransaction.getRecipients())
     {
-        // generate bold amount string
+        // generate bold amount string with wallet name in case of multiwallet
         QString amount = "<b>" + BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount);
+        if (model->isMultiwallet()) {
+            amount.append(" <u>"+tr("from wallet %1").arg(GUIUtil::HtmlEscape(model->getWalletName()))+"</u> ");
+        }
         amount.append("</b> ");
-
         // generate monospace address string
         QString address = "<span style='font-family: monospace;'>" + rcp.address;
         address.append("</span>");

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qt/walletframe.h>
+#include <qt/walletmodel.h>
 
 #include <qt/bitcoingui.h>
 #include <qt/walletview.h>
@@ -39,10 +40,16 @@ void WalletFrame::setClientModel(ClientModel *_clientModel)
     this->clientModel = _clientModel;
 }
 
-bool WalletFrame::addWallet(const QString& name, WalletModel *walletModel)
+bool WalletFrame::addWallet(WalletModel *walletModel)
 {
-    if (!gui || !clientModel || !walletModel || mapWalletViews.count(name) > 0)
+    if (!gui || !clientModel || !walletModel) {
         return false;
+    }
+
+    const QString name = walletModel->getWalletName();
+    if (mapWalletViews.count(name) > 0) {
+        return false;
+    }
 
     WalletView *walletView = new WalletView(platformStyle, this);
     walletView->setBitcoinGUI(gui);

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -36,7 +36,7 @@ public:
 
     void setClientModel(ClientModel *clientModel);
 
-    bool addWallet(const QString& name, WalletModel *walletModel);
+    bool addWallet(WalletModel *walletModel);
     bool setCurrentWallet(const QString& name);
     bool removeWallet(const QString &name);
     void removeAllWallets();
@@ -59,6 +59,7 @@ private:
 
     const PlatformStyle *platformStyle;
 
+public:
     WalletView *currentWalletView();
 
 public Q_SLOTS:

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -155,13 +155,12 @@ void WalletModel::pollBalanceChanged()
     if(!lockWallet)
         return;
 
-    if(fForceCheckBalanceChanged || chainActive.Height() != cachedNumBlocks || privateSendClientOptions.nPrivateSendRounds != cachedPrivateSendRounds)
-    {
+    if (fForceCheckBalanceChanged || chainActive.Height() != cachedNumBlocks || CPrivateSendClientOptions::GetRounds() != cachedPrivateSendRounds) {
         fForceCheckBalanceChanged = false;
 
         // Balance and number of transactions might have changed
         cachedNumBlocks = chainActive.Height();
-        cachedPrivateSendRounds = privateSendClientOptions.nPrivateSendRounds;
+        cachedPrivateSendRounds = CPrivateSendClientOptions::GetRounds();
 
         checkBalanceChanged();
         if(transactionTableModel)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -138,8 +138,9 @@ void WalletModel::updateStatus()
 {
     EncryptionStatus newEncryptionStatus = getEncryptionStatus();
 
-    if(cachedEncryptionStatus != newEncryptionStatus)
-        Q_EMIT encryptionStatusChanged(newEncryptionStatus);
+    if(cachedEncryptionStatus != newEncryptionStatus) {
+        Q_EMIT encryptionStatusChanged();
+    }
 }
 
 void WalletModel::pollBalanceChanged()
@@ -807,4 +808,19 @@ bool WalletModel::hdEnabled() const
 int WalletModel::getDefaultConfirmTarget() const
 {
     return nTxConfirmTarget;
+}
+
+QString WalletModel::getWalletName() const
+{
+    LOCK(wallet->cs_wallet);
+    QString walletName = QString::fromStdString(wallet->GetName());
+    if (walletName.endsWith(".dat")) {
+        walletName.truncate(walletName.size() - 4);
+    }
+    return walletName;
+}
+
+bool WalletModel::isMultiwallet()
+{
+    return gArgs.GetArgs("-wallet").size() > 1;
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -155,13 +155,13 @@ void WalletModel::pollBalanceChanged()
     if(!lockWallet)
         return;
 
-    if(fForceCheckBalanceChanged || chainActive.Height() != cachedNumBlocks || privateSendClient.nPrivateSendRounds != cachedPrivateSendRounds)
+    if(fForceCheckBalanceChanged || chainActive.Height() != cachedNumBlocks || privateSendClientOptions.nPrivateSendRounds != cachedPrivateSendRounds)
     {
         fForceCheckBalanceChanged = false;
 
         // Balance and number of transactions might have changed
         cachedNumBlocks = chainActive.Height();
-        cachedPrivateSendRounds = privateSendClient.nPrivateSendRounds;
+        cachedPrivateSendRounds = privateSendClientOptions.nPrivateSendRounds;
 
         checkBalanceChanged();
         if(transactionTableModel)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -133,6 +133,8 @@ public:
     TransactionTableModel *getTransactionTableModel();
     RecentRequestsTableModel *getRecentRequestsTableModel();
 
+    CWallet *getWallet() const { return wallet; };
+
     CAmount getBalance(const CCoinControl *coinControl = nullptr) const;
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;
@@ -232,6 +234,9 @@ public:
 
     int getRealOutpointPrivateSendRounds(const COutPoint& outpoint) const;
 
+    QString getWalletName() const;
+
+    static bool isMultiwallet();
 private:
     CWallet *wallet;
     bool fHaveWatchOnly;
@@ -270,7 +275,7 @@ Q_SIGNALS:
                         const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
 
     // Encryption status of wallet changed
-    void encryptionStatusChanged(int status);
+    void encryptionStatusChanged();
 
     // Signal emitted when wallet needs to be unlocked
     // It is valid behaviour for listeners to keep the wallet locked after this signal;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -134,13 +134,13 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
         connect(this, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));
 
         // Pass through encryption status changed signals
-        connect(this, SIGNAL(encryptionStatusChanged(int)), gui, SLOT(setEncryptionStatus(int)));
+        connect(this, SIGNAL(encryptionStatusChanged()), gui, SLOT(updateWalletStatus()));
 
         // Pass through transaction notifications
-        connect(this, SIGNAL(incomingTransaction(QString,int,CAmount,QString,QString,QString)), gui, SLOT(incomingTransaction(QString,int,CAmount,QString,QString,QString)));
+        connect(this, SIGNAL(incomingTransaction(QString,int,CAmount,QString,QString,QString,QString)), gui, SLOT(incomingTransaction(QString,int,CAmount,QString,QString,QString,QString)));
 
         // Connect HD enabled state signal
-        connect(this, SIGNAL(hdEnabledStatusChanged(int)), gui, SLOT(setHDStatus(int)));
+        connect(this, SIGNAL(hdEnabledStatusChanged()), gui, SLOT(updateWalletStatus()));
     }
 }
 
@@ -178,11 +178,11 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
         connect(_walletModel, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
 
         // Handle changes in encryption status
-        connect(_walletModel, SIGNAL(encryptionStatusChanged(int)), this, SIGNAL(encryptionStatusChanged(int)));
+        connect(_walletModel, SIGNAL(encryptionStatusChanged()), this, SIGNAL(encryptionStatusChanged()));
         updateEncryptionStatus();
 
         // update HD status
-        Q_EMIT hdEnabledStatusChanged(_walletModel->hdEnabled());
+        Q_EMIT hdEnabledStatusChanged();
 
         // Balloon pop-up for new transaction
         connect(_walletModel->getTransactionTableModel(), SIGNAL(rowsInserted(QModelIndex,int,int)),
@@ -222,7 +222,7 @@ void WalletView::processNewTransaction(const QModelIndex& parent, int start, int
     QString address = ttm->data(index, TransactionTableModel::AddressRole).toString();
     QString label = ttm->data(index, TransactionTableModel::LabelRole).toString();
 
-    Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address, label);
+    Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address, label, walletModel->getWalletName());
 }
 
 void WalletView::gotoOverviewPage()
@@ -303,7 +303,7 @@ void WalletView::showOutOfSyncWarning(bool fShow)
 
 void WalletView::updateEncryptionStatus()
 {
-    Q_EMIT encryptionStatusChanged(walletModel->getEncryptionStatus());
+    Q_EMIT encryptionStatusChanged();
 }
 
 void WalletView::encryptWallet(bool status)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -46,6 +46,7 @@ public:
         The client model represents the part of the core that communicates with the P2P network, and is wallet-agnostic.
     */
     void setClientModel(ClientModel *clientModel);
+    WalletModel *getWalletModel() { return walletModel; }
     /** Set the wallet model.
         The wallet model represents a bitcoin wallet, and offers access to the list of transactions, address book and sending
         functionality.
@@ -132,11 +133,11 @@ Q_SIGNALS:
     /**  Fired when a message should be reported to the user */
     void message(const QString &title, const QString &message, unsigned int style);
     /** Encryption status of wallet changed */
-    void encryptionStatusChanged(int status);
+    void encryptionStatusChanged();
     /** HD-Enabled status of wallet changed (only possible during startup) */
-    void hdEnabledStatusChanged(int hdEnabled);
+    void hdEnabledStatusChanged();
     /** Notify that a new transaction appeared */
-    void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label);
+    void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label, const QString& walletName);
     /** Notify that the out of sync warning icon has been pressed */
     void outOfSyncWarningClicked();
 };

--- a/src/rpc/privatesend.cpp
+++ b/src/rpc/privatesend.cpp
@@ -136,14 +136,9 @@ UniValue getprivatesendinfo(const JSONRPCRequest& request)
 
 #ifdef ENABLE_WALLET
 
-    obj.pushKV("enabled",           privateSendClientOptions.fEnablePrivateSend);
-    obj.pushKV("multisession",      privateSendClientOptions.fPrivateSendMultiSession);
-    obj.pushKV("max_sessions",      privateSendClientOptions.nPrivateSendSessions);
-    obj.pushKV("max_rounds",        privateSendClientOptions.nPrivateSendRounds);
-    obj.pushKV("max_amount",        privateSendClientOptions.nPrivateSendAmount);
-    obj.pushKV("denoms_goal",       privateSendClientOptions.nPrivateSendDenomsGoal);
-    obj.pushKV("denoms_hardcap",    privateSendClientOptions.nPrivateSendDenomsHardCap);
-    obj.pushKV("queue_size",        privateSendClientQueueManager.GetQueueSize());
+    privateSendClientOptions.GetJsonInfo(obj);
+
+    obj.pushKV("queue_size", privateSendClientQueueManager.GetQueueSize());
 
     CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) {

--- a/src/rpc/privatesend.cpp
+++ b/src/rpc/privatesend.cpp
@@ -50,13 +50,16 @@ UniValue privatesend(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please unlock wallet for mixing with walletpassphrase first.");
         }
 
-        privateSendClient.fPrivateSendRunning = true;
+        if (!privateSendClient.StartMixing(pwallet)) {
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing has been started already.");
+        }
+
         bool result = privateSendClient.DoAutomaticDenominating(*g_connman);
         return "Mixing " + (result ? "started successfully" : ("start failed: " + privateSendClient.GetStatuses() + ", will retry"));
     }
 
     if (request.params[0].get_str() == "stop") {
-        privateSendClient.fPrivateSendRunning = false;
+        privateSendClient.StopMixing();
         return "Mixing was stopped";
     }
 

--- a/src/rpc/privatesend.cpp
+++ b/src/rpc/privatesend.cpp
@@ -32,7 +32,7 @@ UniValue privatesend(const JSONRPCRequest& request)
     if (fMasternodeMode)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Client-side mixing is not supported on masternodes");
 
-    if (!privateSendClientOptions.fEnablePrivateSend) {
+    if (!CPrivateSendClientOptions::IsEnabled()) {
         if (!gArgs.GetBoolArg("-enableprivatesend", true)) {
             // otherwise it's on by default, unless cmd line option says otherwise
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing is disabled via -enableprivatesend=0 command line option, remove it to enable mixing again");
@@ -136,7 +136,7 @@ UniValue getprivatesendinfo(const JSONRPCRequest& request)
 
 #ifdef ENABLE_WALLET
 
-    privateSendClientOptions.GetJsonInfo(obj);
+    CPrivateSendClientOptions::GetJsonInfo(obj);
 
     obj.pushKV("queue_size", privateSendClientQueueManager.GetQueueSize());
 

--- a/src/rpc/privatesend.cpp
+++ b/src/rpc/privatesend.cpp
@@ -32,7 +32,7 @@ UniValue privatesend(const JSONRPCRequest& request)
     if (fMasternodeMode)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Client-side mixing is not supported on masternodes");
 
-    if (!privateSendClient.fEnablePrivateSend) {
+    if (!privateSendClientOptions.fEnablePrivateSend) {
         if (!gArgs.GetBoolArg("-enableprivatesend", true)) {
             // otherwise it's on by default, unless cmd line option says otherwise
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing is disabled via -enableprivatesend=0 command line option, remove it to enable mixing again");
@@ -50,21 +50,21 @@ UniValue privatesend(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please unlock wallet for mixing with walletpassphrase first.");
         }
 
-        if (!privateSendClient.StartMixing(pwallet)) {
+        if (!privateSendClientManager.StartMixing(pwallet)) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing has been started already.");
         }
 
-        bool result = privateSendClient.DoAutomaticDenominating(*g_connman);
-        return "Mixing " + (result ? "started successfully" : ("start failed: " + privateSendClient.GetStatuses() + ", will retry"));
+        bool result = privateSendClientManager.DoAutomaticDenominating(*g_connman);
+        return "Mixing " + (result ? "started successfully" : ("start failed: " + privateSendClientManager.GetStatuses() + ", will retry"));
     }
 
     if (request.params[0].get_str() == "stop") {
-        privateSendClient.StopMixing();
+        privateSendClientManager.StopMixing();
         return "Mixing was stopped";
     }
 
     if (request.params[0].get_str() == "reset") {
-        privateSendClient.ResetPool();
+        privateSendClientManager.ResetPool();
         return "Mixing was reset";
     }
 
@@ -89,13 +89,13 @@ UniValue getprivatesendinfo(const JSONRPCRequest& request)
                 "\nResult (for regular nodes):\n"
                 "{\n"
                 "  \"enabled\": true|false,             (bool) Whether mixing functionality is enabled\n"
-                "  \"running\": true|false,             (bool) Whether mixing is currently running\n"
                 "  \"multisession\": true|false,        (bool) Whether PrivateSend Multisession option is enabled\n"
                 "  \"max_sessions\": xxx,               (numeric) How many parallel mixing sessions can there be at once\n"
                 "  \"max_rounds\": xxx,                 (numeric) How many rounds to mix\n"
                 "  \"max_amount\": xxx,                 (numeric) Target PrivateSend balance in " + CURRENCY_UNIT + "\n"
                 "  \"max_denoms\": xxx,                 (numeric) How many inputs of each denominated amount to create\n"
                 "  \"queue_size\": xxx,                 (numeric) How many queues there are currently on the network\n"
+                "  \"running\": true|false,             (bool) Whether mixing is currently running\n"
                 "  \"sessions\":                        (array of json objects)\n"
                 "    [\n"
                 "      {\n"
@@ -133,12 +133,21 @@ UniValue getprivatesendinfo(const JSONRPCRequest& request)
 
 
 #ifdef ENABLE_WALLET
-    privateSendClient.GetJsonInfo(obj);
+
+    obj.pushKV("enabled",           privateSendClientOptions.fEnablePrivateSend);
+    obj.pushKV("multisession",      privateSendClientOptions.fPrivateSendMultiSession);
+    obj.pushKV("max_sessions",      privateSendClientOptions.nPrivateSendSessions);
+    obj.pushKV("max_rounds",        privateSendClientOptions.nPrivateSendRounds);
+    obj.pushKV("max_amount",        privateSendClientOptions.nPrivateSendAmount);
+    obj.pushKV("denoms_goal",       privateSendClientOptions.nPrivateSendDenomsGoal);
+    obj.pushKV("denoms_hardcap",    privateSendClientOptions.nPrivateSendDenomsHardCap);
 
     CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) {
         return obj;
     }
+
+     privateSendClientManager.GetJsonInfo(obj);
 
     obj.pushKV("keys_left",     pwallet->nKeysLeftSinceAutoBackup);
     obj.push_back(Pair("warnings",      pwallet->nKeysLeftSinceAutoBackup < PRIVATESEND_KEYS_THRESHOLD_WARNING

--- a/src/rpc/privatesend.cpp
+++ b/src/rpc/privatesend.cpp
@@ -141,6 +141,7 @@ UniValue getprivatesendinfo(const JSONRPCRequest& request)
     obj.pushKV("max_amount",        privateSendClientOptions.nPrivateSendAmount);
     obj.pushKV("denoms_goal",       privateSendClientOptions.nPrivateSendDenomsGoal);
     obj.pushKV("denoms_hardcap",    privateSendClientOptions.nPrivateSendDenomsHardCap);
+    obj.pushKV("queue_size",        privateSendClientQueueManager.GetQueueSize());
 
     CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) {

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -365,8 +365,7 @@ void WalletInit::Start(CScheduler& scheduler)
     scheduler.scheduleEvery(MaybeCompactWalletDB, 500);
 
     if (!fMasternodeMode && privateSendClientOptions.fEnablePrivateSend) {
-        scheduler.scheduleEvery(std::bind(&CPrivateSendClientManager::DoMaintenance, std::ref(privateSendClientManager),
-                                            std::ref(*g_connman)), 1 * 1000);
+        scheduler.scheduleEvery(std::bind(&DoPrivateSendMaintenance, std::ref(*g_connman)), 1 * 1000);
     }
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2682,7 +2682,7 @@ UniValue setprivatesendrounds(const JSONRPCRequest& request)
     if (nRounds > MAX_PRIVATESEND_ROUNDS || nRounds < MIN_PRIVATESEND_ROUNDS)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid number of rounds");
 
-    privateSendClient.nPrivateSendRounds = nRounds;
+    privateSendClientOptions.nPrivateSendRounds = nRounds;
 
     return NullUniValue;
 }
@@ -2710,7 +2710,7 @@ UniValue setprivatesendamount(const JSONRPCRequest& request)
     if (nAmount > MAX_PRIVATESEND_AMOUNT || nAmount < MIN_PRIVATESEND_AMOUNT)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid amount of " + CURRENCY_UNIT + " as mixing goal amount");
 
-    privateSendClient.nPrivateSendAmount = nAmount;
+    privateSendClientOptions.nPrivateSendAmount = nAmount;
 
     return NullUniValue;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2682,7 +2682,7 @@ UniValue setprivatesendrounds(const JSONRPCRequest& request)
     if (nRounds > MAX_PRIVATESEND_ROUNDS || nRounds < MIN_PRIVATESEND_ROUNDS)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid number of rounds");
 
-    privateSendClientOptions.nPrivateSendRounds = nRounds;
+    CPrivateSendClientOptions::SetRounds(nRounds);
 
     return NullUniValue;
 }
@@ -2710,7 +2710,7 @@ UniValue setprivatesendamount(const JSONRPCRequest& request)
     if (nAmount > MAX_PRIVATESEND_AMOUNT || nAmount < MIN_PRIVATESEND_AMOUNT)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid amount of " + CURRENCY_UNIT + " as mixing goal amount");
 
-    privateSendClientOptions.nPrivateSendAmount = nAmount;
+    CPrivateSendClientOptions::SetAmount(nAmount);
 
     return NullUniValue;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1662,7 +1662,7 @@ int CWallet::GetCappedOutpointPrivateSendRounds(const COutPoint& outpoint) const
 {
     LOCK(cs_wallet);
     int realPrivateSendRounds = GetRealOutpointPrivateSendRounds(outpoint);
-    return realPrivateSendRounds > privateSendClientOptions.nPrivateSendRounds ? privateSendClientOptions.nPrivateSendRounds : realPrivateSendRounds;
+    return realPrivateSendRounds > CPrivateSendClientOptions::GetRounds() ? CPrivateSendClientOptions::GetRounds() : realPrivateSendRounds;
 }
 
 bool CWallet::IsDenominated(const COutPoint& outpoint) const
@@ -2364,7 +2364,7 @@ CAmount CWalletTx::GetAnonymizedCredit(bool fUseCache) const
         if (pwallet->IsSpent(hashTx, i) || !CPrivateSend::IsDenominatedAmount(txout.nValue)) continue;
 
         const int nRounds = pwallet->GetCappedOutpointPrivateSendRounds(outpoint);
-        if (nRounds >= privateSendClientOptions.nPrivateSendRounds){
+        if (nRounds >= CPrivateSendClientOptions::GetRounds()) {
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error(std::string(__func__) + ": value out of range");
@@ -2573,7 +2573,7 @@ CAmount CWallet::GetBalance() const
 
 CAmount CWallet::GetAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfirmed) const
 {
-    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
+    if (!CPrivateSendClientOptions::IsEnabled()) return 0;
 
     std::vector<CompactTallyItem> vecTally;
     if(!SelectCoinsGroupedByAddresses(vecTally, fSkipDenominated, true, fSkipUnconfirmed)) return 0;
@@ -2595,7 +2595,7 @@ CAmount CWallet::GetAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfi
 
 CAmount CWallet::GetAnonymizedBalance() const
 {
-    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
+    if (!CPrivateSendClientOptions::IsEnabled()) return 0;
 
     CAmount nTotal = 0;
 
@@ -2612,7 +2612,7 @@ CAmount CWallet::GetAnonymizedBalance() const
 // that's ok as long as we use it for informational purposes only
 float CWallet::GetAverageAnonymizedRounds() const
 {
-    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
+    if (!CPrivateSendClientOptions::IsEnabled()) return 0;
 
     int nTotal = 0;
     int nCount = 0;
@@ -2634,7 +2634,7 @@ float CWallet::GetAverageAnonymizedRounds() const
 // that's ok as long as we use it for informational purposes only
 CAmount CWallet::GetNormalizedAnonymizedBalance() const
 {
-    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
+    if (!CPrivateSendClientOptions::IsEnabled()) return 0;
 
     CAmount nTotal = 0;
 
@@ -2648,7 +2648,7 @@ CAmount CWallet::GetNormalizedAnonymizedBalance() const
         if (it->second.GetDepthInMainChain() < 0) continue;
 
         int nRounds = GetCappedOutpointPrivateSendRounds(outpoint);
-        nTotal += nValue * nRounds / privateSendClientOptions.nPrivateSendRounds;
+        nTotal += nValue * nRounds / CPrivateSendClientOptions::GetRounds();
     }
 
     return nTotal;
@@ -2656,7 +2656,7 @@ CAmount CWallet::GetNormalizedAnonymizedBalance() const
 
 CAmount CWallet::GetDenominatedBalance(bool unconfirmed) const
 {
-    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
+    if (!CPrivateSendClientOptions::IsEnabled()) return 0;
 
     CAmount nTotal = 0;
 
@@ -2831,11 +2831,11 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
             if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
                 if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
                 int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
-                found = nRounds >= privateSendClientOptions.nPrivateSendRounds;
+                found = nRounds >= CPrivateSendClientOptions::GetRounds();
             } else if(nCoinType == CoinType::ONLY_READY_TO_MIX) {
                 if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
                 int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
-                found = nRounds < privateSendClientOptions.nPrivateSendRounds;
+                found = nRounds < CPrivateSendClientOptions::GetRounds();
             } else if(nCoinType == CoinType::ONLY_NONDENOMINATED) {
                 if (CPrivateSend::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts
                 found = !CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
@@ -3217,7 +3217,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
                 // Make sure to include mixed preset inputs only,
                 // even if some non-mixed inputs were manually selected via CoinControl
                 int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
-                if (nRounds < privateSendClientOptions.nPrivateSendRounds) continue;
+                if (nRounds < CPrivateSendClientOptions::GetRounds()) continue;
             }
             nValueFromPresetInputs += pcoin->tx->vout[outpoint.n].nValue;
             setPresetCoins.insert(CInputCoin(pcoin, outpoint.n));
@@ -3420,7 +3420,7 @@ bool CWallet::SelectCoinsGroupedByAddresses(std::vector<CompactTallyItem>& vecTa
                 // otherwise they will just lead to higher fee / lower priority
                 if(wtx.tx->vout[i].nValue <= nSmallestDenom/10) continue;
                 // ignore mixed
-                if(GetCappedOutpointPrivateSendRounds(COutPoint(outpoint.hash, i)) >= privateSendClientOptions.nPrivateSendRounds) continue;
+                if (GetCappedOutpointPrivateSendRounds(COutPoint(outpoint.hash, i)) >= CPrivateSendClientOptions::GetRounds()) continue;
             }
 
             if (itTallyItem == mapTally.end()) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -53,6 +53,7 @@ bool AddWallet(CWallet* wallet)
     std::vector<CWallet*>::const_iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
     if (i != vpwallets.end()) return false;
     vpwallets.push_back(wallet);
+    privateSendClientManagers.emplace(std::make_pair(wallet->GetName(), new CPrivateSendClientManager()));
     return true;
 }
 
@@ -63,6 +64,10 @@ bool RemoveWallet(CWallet* wallet)
     std::vector<CWallet*>::iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
     if (i == vpwallets.end()) return false;
     vpwallets.erase(i);
+    auto it = privateSendClientManagers.find(wallet->GetName());
+    delete it->second;
+    it->second = nullptr;
+    privateSendClientManagers.erase(it);
     return true;
 }
 
@@ -4342,7 +4347,7 @@ bool CWallet::NewKeyPool()
             batch.ErasePool(nIndex);
         }
         setExternalKeyPool.clear();
-        privateSendClientManager.StopMixing();
+        privateSendClientManagers.at(GetName())->StopMixing();
         nKeysLeftSinceAutoBackup = 0;
 
         m_pool_key_to_index.clear();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1657,7 +1657,7 @@ int CWallet::GetCappedOutpointPrivateSendRounds(const COutPoint& outpoint) const
 {
     LOCK(cs_wallet);
     int realPrivateSendRounds = GetRealOutpointPrivateSendRounds(outpoint);
-    return realPrivateSendRounds > privateSendClient.nPrivateSendRounds ? privateSendClient.nPrivateSendRounds : realPrivateSendRounds;
+    return realPrivateSendRounds > privateSendClientOptions.nPrivateSendRounds ? privateSendClientOptions.nPrivateSendRounds : realPrivateSendRounds;
 }
 
 bool CWallet::IsDenominated(const COutPoint& outpoint) const
@@ -2359,7 +2359,7 @@ CAmount CWalletTx::GetAnonymizedCredit(bool fUseCache) const
         if (pwallet->IsSpent(hashTx, i) || !CPrivateSend::IsDenominatedAmount(txout.nValue)) continue;
 
         const int nRounds = pwallet->GetCappedOutpointPrivateSendRounds(outpoint);
-        if (nRounds >= privateSendClient.nPrivateSendRounds){
+        if (nRounds >= privateSendClientOptions.nPrivateSendRounds){
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error(std::string(__func__) + ": value out of range");
@@ -2568,7 +2568,7 @@ CAmount CWallet::GetBalance() const
 
 CAmount CWallet::GetAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfirmed) const
 {
-    if(!privateSendClient.fEnablePrivateSend) return 0;
+    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
 
     std::vector<CompactTallyItem> vecTally;
     if(!SelectCoinsGroupedByAddresses(vecTally, fSkipDenominated, true, fSkipUnconfirmed)) return 0;
@@ -2590,7 +2590,7 @@ CAmount CWallet::GetAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfi
 
 CAmount CWallet::GetAnonymizedBalance() const
 {
-    if(!privateSendClient.fEnablePrivateSend) return 0;
+    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
 
     CAmount nTotal = 0;
 
@@ -2607,7 +2607,7 @@ CAmount CWallet::GetAnonymizedBalance() const
 // that's ok as long as we use it for informational purposes only
 float CWallet::GetAverageAnonymizedRounds() const
 {
-    if(!privateSendClient.fEnablePrivateSend) return 0;
+    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
 
     int nTotal = 0;
     int nCount = 0;
@@ -2629,7 +2629,7 @@ float CWallet::GetAverageAnonymizedRounds() const
 // that's ok as long as we use it for informational purposes only
 CAmount CWallet::GetNormalizedAnonymizedBalance() const
 {
-    if(!privateSendClient.fEnablePrivateSend) return 0;
+    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
 
     CAmount nTotal = 0;
 
@@ -2643,7 +2643,7 @@ CAmount CWallet::GetNormalizedAnonymizedBalance() const
         if (it->second.GetDepthInMainChain() < 0) continue;
 
         int nRounds = GetCappedOutpointPrivateSendRounds(outpoint);
-        nTotal += nValue * nRounds / privateSendClient.nPrivateSendRounds;
+        nTotal += nValue * nRounds / privateSendClientOptions.nPrivateSendRounds;
     }
 
     return nTotal;
@@ -2651,7 +2651,7 @@ CAmount CWallet::GetNormalizedAnonymizedBalance() const
 
 CAmount CWallet::GetDenominatedBalance(bool unconfirmed) const
 {
-    if(!privateSendClient.fEnablePrivateSend) return 0;
+    if(!privateSendClientOptions.fEnablePrivateSend) return 0;
 
     CAmount nTotal = 0;
 
@@ -2826,11 +2826,11 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
             if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
                 if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
                 int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
-                found = nRounds >= privateSendClient.nPrivateSendRounds;
+                found = nRounds >= privateSendClientOptions.nPrivateSendRounds;
             } else if(nCoinType == CoinType::ONLY_READY_TO_MIX) {
                 if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
                 int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
-                found = nRounds < privateSendClient.nPrivateSendRounds;
+                found = nRounds < privateSendClientOptions.nPrivateSendRounds;
             } else if(nCoinType == CoinType::ONLY_NONDENOMINATED) {
                 if (CPrivateSend::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts
                 found = !CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
@@ -3212,7 +3212,7 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
                 // Make sure to include mixed preset inputs only,
                 // even if some non-mixed inputs were manually selected via CoinControl
                 int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
-                if (nRounds < privateSendClient.nPrivateSendRounds) continue;
+                if (nRounds < privateSendClientOptions.nPrivateSendRounds) continue;
             }
             nValueFromPresetInputs += pcoin->tx->vout[outpoint.n].nValue;
             setPresetCoins.insert(CInputCoin(pcoin, outpoint.n));
@@ -3415,7 +3415,7 @@ bool CWallet::SelectCoinsGroupedByAddresses(std::vector<CompactTallyItem>& vecTa
                 // otherwise they will just lead to higher fee / lower priority
                 if(wtx.tx->vout[i].nValue <= nSmallestDenom/10) continue;
                 // ignore mixed
-                if(GetCappedOutpointPrivateSendRounds(COutPoint(outpoint.hash, i)) >= privateSendClient.nPrivateSendRounds) continue;
+                if(GetCappedOutpointPrivateSendRounds(COutPoint(outpoint.hash, i)) >= privateSendClientOptions.nPrivateSendRounds) continue;
             }
 
             if (itTallyItem == mapTally.end()) {
@@ -4342,7 +4342,7 @@ bool CWallet::NewKeyPool()
             batch.ErasePool(nIndex);
         }
         setExternalKeyPool.clear();
-        privateSendClient.StopMixing();
+        privateSendClientManager.StopMixing();
         nKeysLeftSinceAutoBackup = 0;
 
         m_pool_key_to_index.clear();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4342,7 +4342,7 @@ bool CWallet::NewKeyPool()
             batch.ErasePool(nIndex);
         }
         setExternalKeyPool.clear();
-        privateSendClient.fPrivateSendRunning = false;
+        privateSendClient.StopMixing();
         nKeysLeftSinceAutoBackup = 0;
 
         m_pool_key_to_index.clear();


### PR DESCRIPTION
Currently when trying to mix, it fails at `assert(mixingWallet != nullptr);` in `GetMixingWallet()` with below stack trace. However, I don't really understand how that happens... Because, mixingWallet and fPrivateSendRunning should be changed in tandem, when fPrivateSendRunning gets set to false mixingWallet gets set to nullPtr and anytime fPrivateSendRunning gets set to true mixingWallet gets set to a valid wallet pointer. Yet somehow, GetMixingWallet() is getting called in `DoAutomaticDenominating` when mixingWallet == nullptr yet that is protected behind `    if (!fEnablePrivateSend || !fPrivateSendRunning) return false;`

I'm done trying to figure it out for today. So if you have any thoughts (on either the backport or the wip privatesend stuff) let me know.

```
ubuntu@ubuntu-Ryzen:~/workspace/dash$ ./src/qt/dash-qt --testnet --wallet=wallet.dat --wallet=wallet2
dash-qt: privatesend/privatesend-client.cpp:378: CWallet* CPrivateSendClientManager::GetMixingWallet() const: Assertion `mixingWallet != nullptr' failed.
Posix Signal: Aborted
   0#: (0x564D98F93765) stl_vector.h:466            - std::vector<unsigned long, std::allocator<unsigned long> >::operator=(std::vector<unsigned long, std::allocator<unsigned long> >&&)
   1#: (0x564D98F93765) stacktraces.cpp:775         - HandlePosixSignal
   2#: (0x7F03B87DC8A0) <unknown-file>              - ???
   3#: (0x7F03B7889F47) <unknown-file>              - ???
   4#: (0x7F03B788B8B1) <unknown-file>              - ???
   5#: (0x7F03B787B42A) <unknown-file>              - ???
   6#: (0x7F03B787B4A2) <unknown-file>              - ???
   7#: (0x564D98DA5B76) privatesend-client.cpp:378  - ???
   8#: (0x564D98DC9571) std_mutex.h:232             - CPrivateSendClientManager::GetMixingWallet() const
   9#: (0x564D98DC9571) privatesend-client.cpp:957  - CPrivateSendClientManager::DoAutomaticDenominating(CConnman&, bool)
  10#: (0x564D98DC9BE5) privatesend-client.cpp:1759 - CPrivateSendClientManager::DoMaintenance(CConnman&)
  11#: (0x564D98F5C024) scheduler.cpp:123           - Repeat
  12#: (0x564D98F5DCD5) std_function.h:275          - std::_Function_base::~_Function_base()
  13#: (0x564D98F5DCD5) std_function.h:389          - std::function<void ()>::~function()
  14#: (0x564D98F5DCD5) bind.hpp:398                - void boost::_bi::list3<boost::_bi::value<CScheduler*>, boost::_bi::value<std::function<void ()> >, boost::_bi::value<long> >::operator()<void (*)(CScheduler*, std::function<void ()>, long), boost::_bi::list0>(boost::_bi::type<void>, void (*&)(CScheduler*, std::function<void ()>, long), boost::_bi::list0&, int)
  15#: (0x564D98F5DCD5) bind.hpp:1294               - boost::_bi::bind_t<void, void (*)(CScheduler*, std::function<void ()>, long), boost::_bi::list3<boost::_bi::value<CScheduler*>, boost::_bi::value<std::function<void ()> >, boost::_bi::value<long> > >::operator()()
  16#: (0x564D98F5DCD5) std_function.h:316          - std::_Function_handler<void (), boost::_bi::bind_t<void, void (*)(CScheduler*, std::function<void ()>, long), boost::_bi::list3<boost::_bi::value<CScheduler*>, boost::_bi::value<std::function<void ()> >, boost::_bi::value<long> > > >::_M_invoke(std::_Any_data const&)
  17#: (0x564D98F5CC1C) lock_types.hpp:336          - boost::unique_lock<boost::mutex>::lock()
  18#: (0x564D98F5CC1C) reverselock.h:22            - reverse_lock<boost::unique_lock<boost::mutex> >::~reverse_lock()
  19#: (0x564D98F5CC1C) scheduler.cpp:82            - CScheduler::serviceQueue()
  20#: (0x564D989B0EDD) util.h:445                  - void TraceThread<std::function<void ()> >(char const*, std::function<void ()>)
  21#: (0x564D989B2EF7) std_function.h:275          - std::_Function_base::~_Function_base()
  22#: (0x564D989B2EF7) std_function.h:389          - std::function<void ()>::~function()
  23#: (0x564D989B2EF7) bind.hpp:319                - void boost::_bi::list2<boost::_bi::value<char const*>, boost::_bi::value<std::function<void ()> > >::operator()<void (*)(char const*, std::function<void ()>), boost::_bi::list0>(boost::_bi::type<void>, void (*&)(char const*, std::function<void ()>), boost::_bi::list0&, int)
  24#: (0x564D989B2EF7) bind.hpp:1294               - boost::_bi::bind_t<void, void (*)(char const*, std::function<void ()>), boost::_bi::list2<boost::_bi::value<char const*>, boost::_bi::value<std::function<void ()> > > >::operator()()
  25#: (0x564D989B2EF7) thread.hpp:116              - boost::detail::thread_data<boost::_bi::bind_t<void, void (*)(char const*, std::function<void ()>), boost::_bi::list2<boost::_bi::value<char const*>, boost::_bi::value<std::function<void ()> > > > >::run()
  26#: (0x564D990CD77D) <unknown-file>              - ???
Aborted (core dumped)
```