### PR TITLE
Add INTEGRATION_TESTS_ARGS gitlab-ci variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,8 +112,11 @@ builder-image:
 .test-template:
   stage: test
   extends: .base-template
+  variables:
+    INTEGRATION_TESTS_ARGS: "--extended --exclude pruning,dbcrash"
   script:
-    - ./ci/test_integrationtests.sh --extended --exclude pruning,dbcrash
+    - echo "INTEGRATION_TESTS_ARGS=${INTEGRATION_TESTS_ARGS}"
+    - ./ci/test_integrationtests.sh $INTEGRATION_TESTS_ARGS
   after_script:
     - mkdir -p $CI_PROJECT_DIR/testlogs
   artifacts:


### PR DESCRIPTION
This allows tweaking integration tests params on the fly (in Gitlab GUI https://docs.gitlab.com/ee/ci/variables/#create-a-custom-variable-in-the-ui).

Replaces #3603 (if I understand the idea behind it correctly).