### PR TITLE
Fail GetTransaction when the block from txindex is not in mapBlockIndex

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -977,6 +977,9 @@ bool GetTransaction(const uint256& hash, CTransactionRef& txOut, const Consensus
                 hashBlock = header.GetHash();
                 if (txOut->GetHash() != hash)
                     return error("%s: txid mismatch", __func__);
+                if (!mapBlockIndex.count(hashBlock)) {
+                    return error("%s: hashBlock %s not in mapBlockIndex", __func__, hashBlock.ToString());
+                }
                 return true;
             }
 


### PR DESCRIPTION
This indicates a previous crash where the TX made it into the txindex but
the block was not flushed to disk. When dashd is restarted then, there is
a short time where GetTransaction would return a non-existant block, while
callers very often assume that the returned block hash is known.