### PR TITLE
util: Change TraceThread's "name" type: "const char*" -> "const std::string"

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -434,9 +434,9 @@ void RenameThreadPool(ctpl::thread_pool& tp, const char* baseName);
 /**
  * .. and a wrapper that just calls func once
  */
-template <typename Callable> void TraceThread(const char* name,  Callable func)
+template <typename Callable> void TraceThread(const std::string name,  Callable func)
 {
-    std::string s = strprintf("dash-%s", name);
+    std::string s = "dash-" + name;
     RenameThread(s.c_str());
     try
     {
@@ -450,7 +450,7 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
         throw;
     }
     catch (...) {
-        PrintExceptionContinue(std::current_exception(), name);
+        PrintExceptionContinue(std::current_exception(), name.c_str());
         throw;
     }
 }


### PR DESCRIPTION
Having `const char*` leads to undefined behaviour if the `const char*` is deallocated before the thread used it.

This wasn't an issue so far since there were no dynamic thread names but #3601 kind of requires this and i thought that should rather be a separate PR then. 