### PR TITLE
test: p2p_timeouts - Wait a second longer before timeout validations

### DIFF
--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -74,7 +74,7 @@ class TimeoutsTest(BitcoinTestFramework):
         ]
 
         with self.nodes[0].assert_debug_log(expected_msgs=expected_timeout_logs):
-            sleep(3)
+            sleep(3 + 1) # Sleep one second more than peertimeout
             assert not no_verack_node.connected
             assert not no_version_node.connected
             assert not no_send_node.connected


### PR DESCRIPTION
I saw this test failing many times now at this point and it always looked like (if i did not missread the logs) that the expected messages and so the disconnects did pop up right after it failed. So this might help to avoid some red crosses. 

I tested this a bit in my CI before with a `+5` where i did somewhat more than 100 test runs without a failure of `p2p_timeouts`. Sure, it may still fail as 100 runs are probably not very representative but chances are good! :D Still at the end i guess `+1` is enough and i would like to watch this in our CI for a while. 