### PR TITLE
qt: Make sure stylesheet updates of -debug-ui are activated

### DIFF
--- a/src/qt/appearancewidget.cpp
+++ b/src/qt/appearancewidget.cpp
@@ -102,7 +102,8 @@ void AppearanceWidget::updateTheme(const QString& theme)
     QString newValue = theme.isEmpty() ? ui->theme->currentData().toString() : theme;
     if (GUIUtil::getActiveTheme() != newValue) {
         QSettings().setValue("theme", newValue);
-        GUIUtil::loadTheme();
+        // Force loading the theme
+        GUIUtil::loadTheme(nullptr, true);
     }
 }
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -351,7 +351,7 @@ namespace GUIUtil
     bool dashThemeActive();
 
     /** Load the theme and update all UI elements according to the appearance settings. */
-    void loadTheme(QWidget* widget = nullptr, bool fForce = true);
+    void loadTheme(QWidget* widget = nullptr, bool fForce = false);
 
     /** Disable the OS default focus rect for macOS because we have custom focus rects
      * set in the css files */


### PR DESCRIPTION
This reverses force logic of `GUIUtil::loadTheme` to not force by default and instead forces it explicit in appearance widgets call.

Due to `fForce` beeing default the ui debug timer wasn't started properly after #3559 because there was no call of `GUIUtil::loadStylesheet` without `fForce=true` which is a requirement to start the debug timer.

Currently based on #3568