### PR TITLE
Fix `-resetguisettings`

### DIFF
--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -369,7 +369,7 @@ BitcoinApplication::~BitcoinApplication()
 #endif
     // Delete Qt-settings if user clicked on "Reset Options"
     QSettings settings;
-    if(optionsModel && optionsModel->resetSettings){
+    if(optionsModel && optionsModel->resetSettingsOnShutdown){
         settings.clear();
         settings.sync();
     }

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -278,6 +278,7 @@ void OptionsDialog::on_resetButton_clicked()
 
         /* reset all options and close GUI */
         model->Reset();
+        model->resetSettingsOnShutdown = true;
         QApplication::quit();
     }
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -52,8 +52,6 @@ void OptionsModel::Init(bool resetSettings)
 
     checkAndMigrate();
 
-    this->resetSettings = resetSettings;
-
     QSettings settings;
 
     // Ensure restart flag is unset on client startup
@@ -226,7 +224,6 @@ void OptionsModel::Reset()
 
     // Remove all entries from our QSettings object
     settings.clear();
-    resetSettings = true; // Needed in dash.cpp during shotdown to also remove the window positions
 
     // default setting for OptionsModel::StartAtStartup - disabled
     if (GUIUtil::GetStartOnSystemStartup())

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -84,7 +84,7 @@ public:
     /* Restart flag helper */
     void setRestartRequired(bool fRequired);
     bool isRestartRequired() const;
-    bool resetSettings;
+    bool resetSettingsOnShutdown{false};
 
 private:
     /* Qt-only settings */


### PR DESCRIPTION
Starting with `-resetguisettings` results in settings being cleared not only on start but on shutdown too. The bug was introduced in #569 (5+ years ago 🙈 ). This should fix it by only setting the flag to `true` when the "Reset Options" button was clicked. I also renamed `OptionsModel::resetSettings` while at it to make it clearer what it's used for.