### PR TITLE
qt: Give PrivateSend separate instances of SendCoinsDialog + CCoinControl

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -34,6 +34,7 @@
 
 QList<CAmount> CoinControlDialog::payAmounts;
 bool CoinControlDialog::fSubtractFeeFromAmount = false;
+CoinControlDialog::Mode CoinControlDialog::mode{CoinControlDialog::Mode::NORMAL};
 
 bool CCoinControlWidgetItem::operator<(const QTreeWidgetItem &other) const {
     int column = treeWidget()->sortColumn();
@@ -496,16 +497,6 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
             continue;
         }
 
-        // unselect non-fully-mixed, this can happen when users switch from Send to PrivateSend
-        if (coinControl()->IsUsingPrivateSend()) {
-            int nRounds = model->getRealOutpointPrivateSendRounds(outpt);
-            if (nRounds < CPrivateSendClientOptions::GetRounds()) {
-                coinControl()->UnSelect(outpt);
-                fUnselectedNonMixed = true;
-                continue;
-            }
-        }
-
         // Quantity
         nQuantity++;
 
@@ -651,10 +642,22 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     }
 }
 
+void CoinControlDialog::usePrivateSend(bool fUsePrivateSend)
+{
+    CoinControlDialog::mode = fUsePrivateSend ? CoinControlDialog::Mode::PRIVATESEND : CoinControlDialog::Mode::NORMAL;
+}
+
 CCoinControl* CoinControlDialog::coinControl()
 {
-    static CCoinControl coin_control;
-    return &coin_control;
+    if (CoinControlDialog::mode == CoinControlDialog::Mode::NORMAL) {
+        static CCoinControl coinControlNormal;
+        coinControlNormal.UsePrivateSend(false);
+        return &coinControlNormal;
+    } else {
+        static CCoinControl coinControlPrivateSend;
+        coinControlPrivateSend.UsePrivateSend(true);
+        return &coinControlPrivateSend;
+    }
 }
 
 void CoinControlDialog::updateView()

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -53,6 +53,7 @@ public:
     static QList<CAmount> payAmounts;
     static CCoinControl *coinControl();
     static bool fSubtractFeeFromAmount;
+    static void usePrivateSend(bool fUsePrivateSend);
 
 private:
     Ui::CoinControlDialog *ui;
@@ -82,6 +83,13 @@ private:
         COLUMN_VOUT_INDEX,
     };
     friend class CCoinControlWidgetItem;
+
+    enum class Mode {
+        NORMAL,
+        PRIVATESEND,
+    };
+
+    static CoinControlDialog::Mode mode;
 
 private Q_SLOTS:
     void showMenu(const QPoint &);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -51,14 +51,14 @@ int getIndexForConfTarget(int target) {
     return confTargets.size() - 1;
 }
 
-SendCoinsDialog::SendCoinsDialog(QWidget* parent) :
+SendCoinsDialog::SendCoinsDialog(bool _fPrivateSend, QWidget* parent) :
     QDialog(parent),
     ui(new Ui::SendCoinsDialog),
     clientModel(0),
     model(0),
     fNewRecipientAllowed(true),
     fFeeMinimized(true),
-    fPrivateSend(false)
+    fPrivateSend(_fPrivateSend)
 {
     ui->setupUi(this);
 
@@ -155,6 +155,14 @@ SendCoinsDialog::SendCoinsDialog(QWidget* parent) :
     ui->customFee->setValue(settings.value("nTransactionFee").toLongLong());
     ui->checkBoxMinimumFee->setChecked(settings.value("fPayOnlyMinFee").toBool());
     minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());
+
+    if (fPrivateSend) {
+        ui->sendButton->setText("PrivateS&end");
+        ui->sendButton->setToolTip("Confirm the PrivateSend action");
+    } else {
+        ui->sendButton->setText("S&end");
+        ui->sendButton->setToolTip("Confirm the send action");
+    }
 }
 
 void SendCoinsDialog::setClientModel(ClientModel *_clientModel)
@@ -632,7 +640,6 @@ void SendCoinsDialog::updateDisplayUnit()
 {
     setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(), model->getAnonymizedBalance(),
                    model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
-    CoinControlDialog::coinControl()->UsePrivateSend(fPrivateSend);
     coinControlUpdateLabels();
     ui->customFee->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
     updateMinFeeLabel();
@@ -791,19 +798,11 @@ void SendCoinsDialog::updateCoinControlState(CCoinControl& ctrl)
     ctrl.m_confirm_target = getConfTargetForIndex(ui->confTargetSelector->currentIndex());
 }
 
-void SendCoinsDialog::setPrivateSend(bool privateSend)
+void SendCoinsDialog::showEvent(QShowEvent* event)
 {
-    if (fPrivateSend != privateSend) {
-        fPrivateSend = privateSend;
-        coinControlUpdateLabels();
-        updateDisplayUnit();
-        if (privateSend) {
-            ui->sendButton->setText("PrivateS&end");
-            ui->sendButton->setToolTip("Confirm the PrivateSend action");
-        } else {
-            ui->sendButton->setText("S&end");
-            ui->sendButton->setToolTip("Confirm the send action");
-        }
+    QWidget::showEvent(event);
+    if (!event->spontaneous()) {
+        CoinControlDialog::usePrivateSend(fPrivateSend);
     }
 }
 

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -9,6 +9,7 @@
 
 #include <QDialog>
 #include <QMessageBox>
+#include <QShowEvent>
 #include <QString>
 #include <QTimer>
 
@@ -32,7 +33,7 @@ class SendCoinsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SendCoinsDialog(QWidget* parent = 0);
+    explicit SendCoinsDialog(bool fPrivateSend = false, QWidget* parent = 0);
     ~SendCoinsDialog();
 
     void setClientModel(ClientModel *clientModel);
@@ -45,7 +46,6 @@ public:
     void setAddress(const QString &address);
     void pasteEntry(const SendCoinsRecipient &rv);
     bool handlePaymentRequest(const SendCoinsRecipient &recipient);
-    void setPrivateSend(bool privateSend);
 
 public Q_SLOTS:
     void clear();
@@ -76,6 +76,8 @@ private:
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
+
+    void showEvent(QShowEvent* event);
 
 private Q_SLOTS:
     void on_sendButton_clicked();

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -71,6 +71,7 @@ WalletView::WalletView(QWidget* parent) :
 
     receiveCoinsPage = new ReceiveCoinsDialog();
     sendCoinsPage = new SendCoinsDialog();
+    privateSendCoinsPage = new SendCoinsDialog(true);
 
     usedSendingAddressesPage = new AddressBookPage(AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
     usedReceivingAddressesPage = new AddressBookPage(AddressBookPage::ForEditing, AddressBookPage::ReceivingTab, this);
@@ -79,6 +80,7 @@ WalletView::WalletView(QWidget* parent) :
     addWidget(transactionsPage);
     addWidget(receiveCoinsPage);
     addWidget(sendCoinsPage);
+    addWidget(privateSendCoinsPage);
 
     QSettings settings;
     if (settings.value("fShowMasternodesTab").toBool()) {
@@ -92,6 +94,7 @@ WalletView::WalletView(QWidget* parent) :
 
     // Highlight transaction after send
     connect(sendCoinsPage, SIGNAL(coinsSent(uint256)), transactionView, SLOT(focusTransaction(uint256)));
+    connect(privateSendCoinsPage, SIGNAL(coinsSent(uint256)), transactionView, SLOT(focusTransaction(uint256)));
 
     // Double-clicking on a transaction on the transaction history page shows details
     connect(transactionView, SIGNAL(doubleClicked(QModelIndex)), transactionView, SLOT(showDetails()));
@@ -102,8 +105,9 @@ WalletView::WalletView(QWidget* parent) :
     // Clicking on "Export" allows to export the transaction list
     connect(exportButton, SIGNAL(clicked()), transactionView, SLOT(exportClicked()));
 
-    // Pass through messages from sendCoinsPage
+    // Pass through messages from SendCoinsDialog
     connect(sendCoinsPage, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
+    connect(privateSendCoinsPage, SIGNAL(message(QString, QString, unsigned int)), this, SIGNAL(message(QString, QString, unsigned int)));
 
     // Pass through messages from transactionView
     connect(transactionView, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
@@ -124,6 +128,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
 
         // Navigate to transaction history page after send
         connect(sendCoinsPage, SIGNAL(coinsSent(uint256)), gui, SLOT(gotoHistoryPage()));
+        connect(privateSendCoinsPage, SIGNAL(coinsSent(uint256)), gui, SLOT(gotoHistoryPage()));
 
         // Receive and report messages
         connect(this, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));
@@ -145,6 +150,7 @@ void WalletView::setClientModel(ClientModel *_clientModel)
 
     overviewPage->setClientModel(_clientModel);
     sendCoinsPage->setClientModel(_clientModel);
+    privateSendCoinsPage->setClientModel(_clientModel);
     QSettings settings;
     if (settings.value("fShowMasternodesTab").toBool()) {
         masternodeListPage->setClientModel(_clientModel);
@@ -164,6 +170,7 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
     }
     receiveCoinsPage->setModel(_walletModel);
     sendCoinsPage->setModel(_walletModel);
+    privateSendCoinsPage->setModel(_walletModel);
     usedReceivingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
     usedSendingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
 
@@ -245,7 +252,6 @@ void WalletView::gotoReceiveCoinsPage()
 
 void WalletView::gotoSendCoinsPage(QString addr)
 {
-    sendCoinsPage->setPrivateSend(false);
     setCurrentWidget(sendCoinsPage);
 
     if (!addr.isEmpty()) {
@@ -255,11 +261,10 @@ void WalletView::gotoSendCoinsPage(QString addr)
 
 void WalletView::gotoPrivateSendCoinsPage(QString addr)
 {
-    sendCoinsPage->setPrivateSend(true);
-    setCurrentWidget(sendCoinsPage);
+    setCurrentWidget(privateSendCoinsPage);
 
     if (!addr.isEmpty())
-        sendCoinsPage->setAddress(addr);
+        privateSendCoinsPage->setAddress(addr);
 }
 
 void WalletView::gotoSignMessageTab(QString addr)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -64,6 +64,7 @@ private:
     QWidget *transactionsPage;
     ReceiveCoinsDialog *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
+    SendCoinsDialog* privateSendCoinsPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
     MasternodeList *masternodeListPage;


### PR DESCRIPTION
Prior to this PR there are (imo) flaws in the behaviour of the PrivateSend tab.

- If you enter an address, label, add a recipient, do whatever in the normal Send tab its also reflected in
the PrivateSend tab
- If you select fully mixed coins in the Send tab's CoinControl they are also selected
in the PrivateSend tab if you switch over.
- If you select non-fully mixed coins in the Send tab's CoinControl you
get a warning when switching over to PrivateSend tab due to non-fully
mixed coins selected in CoinControl.

With giving the private send tab separate instances of `SendCoinsDialog` and `CCoinControl` they are independent from each other which just makes more sense imo and by doing this the points above are solved. I would say this just better reflects the actual behaviour of a tab.