### PR TITLE
init: Fix crash due to -litemode and improve its deprecation warning

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1518,9 +1518,7 @@ bool AppInitParameterInteraction()
     }
 
     if (gArgs.IsArgSet("-litemode")) {
-        if (gArgs.GetBoolArg("-litemode", false)) {
-            InitWarning(_("Warning: -litemode is deprecated, please use -disablegovernance.\n"));
-        }
+        InitWarning(_("-litemode is deprecated.") + (gArgs.GetBoolArg("-litemode", false) ? (" "  + _("Its replacement -disablegovernance has been forced instead.")) : ( " " + _("It has been replaced by -disablegovernance."))));
         gArgs.ForceRemoveArg("-litemode");
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -974,11 +974,9 @@ void InitParameterInteraction()
     }
 
     if (gArgs.GetBoolArg("-litemode", false)) {
-        InitWarning(_("Warning: -litemode is deprecated, please use -disablegovernance.\n"));
         if (gArgs.SoftSetBoolArg("-disablegovernance", true)) {
             LogPrintf("%s: parameter interaction: -litemode=true -> setting -disablegovernance=true\n", __func__);
         }
-        gArgs.ForceRemoveArg("-litemode");
     }
 
     if (gArgs.GetArg("-prune", 0) > 0) {
@@ -1517,6 +1515,13 @@ bool AppInitParameterInteraction()
         if (gArgs.GetBoolArg("-disablegovernance", false)) {
             return InitError(_("You can not disable governance validation on a masternode."));
         }
+    }
+
+    if (gArgs.IsArgSet("-litemode")) {
+        if (gArgs.GetBoolArg("-litemode", false)) {
+            InitWarning(_("Warning: -litemode is deprecated, please use -disablegovernance.\n"));
+        }
+        gArgs.ForceRemoveArg("-litemode");
     }
 
     fDisableGovernance = gArgs.GetBoolArg("-disablegovernance", false);


### PR DESCRIPTION
Prior to this PR the signal `CClientUIInterface::ThreadSafeMessageBox` is not connected to a slot in Qt at the time its emitted when `-litemode` is used. The signal gets emitted from `InitWarning`, in `InitParameterInteraction`. This happens currently before `BitcoinGUI` gets created by `app.createWindow(networkStyle.data())` in `dash.cpp` where the signal becomes  connected to the slot. After this commit the litemode `InitWarning` will be called in `AppInitParameterInteraction` which runs after `BitcoinGUI` has been created, means the signal will be connected then at that point and the crash introduced in #3579  is fixed.

This also brings some changes to the deprecation warning message if `-litemode` is still used.

- Always show a basic warning if `-litemode` gets used no matter if its
activated or not.
- Let the user know when `-disablegovernance` gets forced by `-litemode`.