### PR TITLE
qt: Fix appearancewidget.h to make lint-include-guards.sh happy

### DIFF
--- a/src/qt/appearancewidget.h
+++ b/src/qt/appearancewidget.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef DASH_QT_APPEARANCE_WIDGET_H
-#define DASH_QT_APPEARANCE_WIDGET_H
+#ifndef BITCOIN_QT_APPEARANCEWIDGET_H
+#define BITCOIN_QT_APPEARANCEWIDGET_H
 
 #include <QWidget>
 
@@ -53,4 +53,4 @@ private:
     void updateWeightSlider();
 };
 
-#endif // DASH_QT_APPEARANCE_WIDGET_H
+#endif // BITCOIN_QT_APPEARANCEWIDGET_H


### PR DESCRIPTION
Seems like that wasn't an issue pre-merge because the related branch wasn't on the latest develop. 