### PR TITLE
Fix a crash on splash screen when wallet fails to load

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4197,8 +4197,6 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
     if (nLoadWalletRet != DBErrors::LOAD_OK)
         return nLoadWalletRet;
 
-    uiInterface.LoadWallet(this);
-
     return DBErrors::LOAD_OK;
 }
 
@@ -5253,6 +5251,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
                 InitError(_("Failed to rescan the wallet during initialization"));
                 return nullptr;
             }
+            uiInterface.LoadWallet(walletInstance); // TODO: move it up when backporting 13063
             walletInstance->ScanForWalletTransactions(pindexRescan, nullptr, reserver, true);
         }
         LogPrintf(" rescan      %15dms\n", GetTimeMillis() - nStart);


### PR DESCRIPTION
Discovered by @xdustinface:
> Happens because this unique_ptr  https://github.com/dashpay/dash/blob/develop/src/wallet/wallet.cpp#L5102 gets added to the list of wallets in splashscreen inside https://github.com/dashpay/dash/blob/develop/src/wallet/wallet.cpp#L5104 which calls SplashScreen::ConnectWallet due to the uiInterface if general wallet loading fails. But if the further wallet validation in CreateWalletFromFile fails the unique ptr is deallocated but the splashscreen still hold a reference to its former address. Then it tries to disconnect the signal here https://github.com/dashpay/dash/blob/develop/src/qt/splashscreen.cpp#L182 and crashes.

This is fixed in https://github.com/bitcoin/bitcoin/pull/13063 which depends on a HUGE gui/node/wallet separation PR https://github.com/bitcoin/bitcoin/pull/10244 and there is no way we backport these to 0.16. However the only thing that uses `ShowProgress` on splash screen is `ScanForWalletTransactions()`, so we can just call `uiInterface.LoadWallet()` right next to it (instead of doing it in `CWallet:LoadWallet()`) as a workaround.