### PR TITLE
Include protocol version into MNAUTH

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -34,7 +34,15 @@ void CMNAuth::PushMNAUTH(CNode* pnode, CConnman& connman)
         // It does not protect against:
         //   node1 -> Eve -> node2
         // This is ok as we only use MNAUTH as a DoS protection and not for sensitive stuff
-        signHash = ::SerializeHash(std::make_tuple(*activeMasternodeInfo.blsPubKeyOperator, pnode->receivedMNAuthChallenge, pnode->fInbound));
+        int nOurNodeVersion{PROTOCOL_VERSION};
+        if (Params().NetworkIDString() != CBaseChainParams::MAIN && gArgs.IsArgSet("-pushversion")) {
+            nOurNodeVersion = gArgs.GetArg("-pushversion", PROTOCOL_VERSION);
+        }
+        if (pnode->nVersion < MIN_MASTERNODE_PROTO_VERSION || nOurNodeVersion < MIN_MASTERNODE_PROTO_VERSION) {
+            signHash = ::SerializeHash(std::make_tuple(*activeMasternodeInfo.blsPubKeyOperator, pnode->receivedMNAuthChallenge, pnode->fInbound));
+        } else {
+            signHash = ::SerializeHash(std::make_tuple(*activeMasternodeInfo.blsPubKeyOperator, pnode->receivedMNAuthChallenge, pnode->fInbound, nOurNodeVersion));
+        }
     }
 
     CMNAuth mnauth;
@@ -102,8 +110,17 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
         uint256 signHash;
         {
             LOCK(pnode->cs_mnauth);
+            int nOurNodeVersion{PROTOCOL_VERSION};
+            if (Params().NetworkIDString() != CBaseChainParams::MAIN && gArgs.IsArgSet("-pushversion")) {
+                nOurNodeVersion = gArgs.GetArg("-pushversion", PROTOCOL_VERSION);
+            }
             // See comment in PushMNAUTH (fInbound is negated here as we're on the other side of the connection)
-            signHash = ::SerializeHash(std::make_tuple(dmn->pdmnState->pubKeyOperator, pnode->sentMNAuthChallenge, !pnode->fInbound));
+            if (pnode->nVersion < MIN_MASTERNODE_PROTO_VERSION || nOurNodeVersion < MIN_MASTERNODE_PROTO_VERSION) {
+                signHash = ::SerializeHash(std::make_tuple(dmn->pdmnState->pubKeyOperator, pnode->sentMNAuthChallenge, !pnode->fInbound));
+            } else {
+                signHash = ::SerializeHash(std::make_tuple(dmn->pdmnState->pubKeyOperator, pnode->sentMNAuthChallenge, !pnode->fInbound, pnode->nVersion.load()));
+            }
+            LogPrint(BCLog::NET_NETCONN, "CMNAuth::%s -- constructed signHash for nVersion %d, peer=%d\n", __func__, pnode->nVersion, pnode->GetId());
         }
 
         if (!mnauth.sig.VerifyInsecure(dmn->pdmnState->pubKeyOperator.Get(), signHash)) {

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -38,7 +38,7 @@ void CMNAuth::PushMNAUTH(CNode* pnode, CConnman& connman)
         if (Params().NetworkIDString() != CBaseChainParams::MAIN && gArgs.IsArgSet("-pushversion")) {
             nOurNodeVersion = gArgs.GetArg("-pushversion", PROTOCOL_VERSION);
         }
-        if (pnode->nVersion < MIN_MASTERNODE_PROTO_VERSION || nOurNodeVersion < MIN_MASTERNODE_PROTO_VERSION) {
+        if (pnode->nVersion < MNAUTH_NODE_VER_VERSION || nOurNodeVersion < MNAUTH_NODE_VER_VERSION) {
             signHash = ::SerializeHash(std::make_tuple(*activeMasternodeInfo.blsPubKeyOperator, pnode->receivedMNAuthChallenge, pnode->fInbound));
         } else {
             signHash = ::SerializeHash(std::make_tuple(*activeMasternodeInfo.blsPubKeyOperator, pnode->receivedMNAuthChallenge, pnode->fInbound, nOurNodeVersion));
@@ -115,7 +115,7 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataS
                 nOurNodeVersion = gArgs.GetArg("-pushversion", PROTOCOL_VERSION);
             }
             // See comment in PushMNAUTH (fInbound is negated here as we're on the other side of the connection)
-            if (pnode->nVersion < MIN_MASTERNODE_PROTO_VERSION || nOurNodeVersion < MIN_MASTERNODE_PROTO_VERSION) {
+            if (pnode->nVersion < MNAUTH_NODE_VER_VERSION || nOurNodeVersion < MNAUTH_NODE_VER_VERSION) {
                 signHash = ::SerializeHash(std::make_tuple(dmn->pdmnState->pubKeyOperator, pnode->sentMNAuthChallenge, !pnode->fInbound));
             } else {
                 signHash = ::SerializeHash(std::make_tuple(dmn->pdmnState->pubKeyOperator, pnode->sentMNAuthChallenge, !pnode->fInbound, pnode->nVersion.load()));

--- a/src/version.h
+++ b/src/version.h
@@ -54,4 +54,7 @@ static const int LLMQS_PROTO_VERSION = 70214;
 //! TODO we can remove this in 0.15.0.0
 static const int SENDDSQUEUE_PROTO_VERSION = 70214;
 
+//! protocol version is included in MNAUTH starting with this version
+static const int MNAUTH_NODE_VER_VERSION = 70218;
+
 #endif // BITCOIN_VERSION_H

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70217;
+static const int PROTOCOL_VERSION = 70218;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -23,7 +23,7 @@ static const int GETHEADERS_VERSION = 70077;
 static const int MIN_PEER_PROTO_VERSION = 70213;
 
 //! minimum proto version of masternode to accept in DKGs
-static const int MIN_MASTERNODE_PROTO_VERSION = 70217;
+static const int MIN_MASTERNODE_PROTO_VERSION = 70218;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
(As discussed in Slack a couple days ago) now that PoSe relies on a protocol version send by other MNs, it makes sense to include it into `MNAUTH` message to make sure it wasn't forged by a mitm attacker somehow.

Note: bumping `MIN_MASTERNODE_PROTO_VERSION` will trigger another PoSe-score increase/ban wave for currently deployed testnet nodes running on 70217 once enough nodes are upgraded to this commit which is fine and might even be a desirable thing cause it allows us to test PoSe during protocol bumps once again.