### PR TITLE
ci: Introduce FAST_MODE Gitlab variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,19 +135,6 @@ builder-image:
 
 ###
 
-i686-pc-linux-gnu:
-  extends:
-    - .build-depends-template
-    - .skip-in-fast-mode-template
-  variables:
-    HOST: i686-pc-linux-gnu
-
-x86_64-unknown-linux-gnu-debug:
-  extends: .build-depends-template
-  variables:
-    HOST: x86_64-unknown-linux-gnu
-    DEP_OPTS: "DEBUG=1"
-
 arm-linux-gnueabihf:
   extends: .build-depends-template
   variables:
@@ -167,10 +154,23 @@ x86_64-w64-mingw32:
   variables:
     HOST: x86_64-w64-mingw32
 
+i686-pc-linux-gnu:
+  extends:
+    - .build-depends-template
+    - .skip-in-fast-mode-template
+  variables:
+    HOST: i686-pc-linux-gnu
+
 x86_64-unknown-linux-gnu:
   extends: .build-depends-template
   variables:
     HOST: x86_64-unknown-linux-gnu
+
+x86_64-unknown-linux-gnu-debug:
+  extends: .build-depends-template
+  variables:
+    HOST: x86_64-unknown-linux-gnu
+    DEP_OPTS: "DEBUG=1"
 
 x86_64-unknown-linux-gnu-nowalet:
   extends:
@@ -197,22 +197,6 @@ x86_64-apple-darwin11:
 
 ###
 
-linux32-build:
-  extends:
-    - .build-template
-    - .skip-in-fast-mode-template
-  needs:
-    - i686-pc-linux-gnu
-  variables:
-    BUILD_TARGET: linux32
-
-linux64-build:
-  extends: .build-template
-  needs:
-    - x86_64-unknown-linux-gnu-debug
-  variables:
-    BUILD_TARGET: linux64
-
 arm-linux-build:
   extends: .build-template
   needs:
@@ -237,6 +221,22 @@ win64-build:
     - x86_64-w64-mingw32
   variables:
     BUILD_TARGET: win64
+
+linux32-build:
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
+  needs:
+    - i686-pc-linux-gnu
+  variables:
+    BUILD_TARGET: linux32
+
+linux64-build:
+  extends: .build-template
+  needs:
+    - x86_64-unknown-linux-gnu-debug
+  variables:
+    BUILD_TARGET: linux64
 
 linux64_nowallet-build:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,11 +161,6 @@ i686-pc-linux-gnu:
   variables:
     HOST: i686-pc-linux-gnu
 
-x86_64-unknown-linux-gnu:
-  extends: .build-depends-template
-  variables:
-    HOST: x86_64-unknown-linux-gnu
-
 x86_64-unknown-linux-gnu-debug:
   extends: .build-depends-template
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ image: "ubuntu:bionic"
 
 variables:
   DOCKER_DRIVER: overlay2
+  FAST_MODE: "false" # when "true", only run linter on arm and unit/functional tests on linux64, skip everything else
 
 stages:
   - builder-image
@@ -126,32 +127,20 @@ builder-image:
       - $CI_PROJECT_DIR/testlogs
     expire_in: 3 days
 
+.skip-in-fast-mode-template:
+  rules:
+    - if: '$FAST_MODE == "true"'
+      when: never
+    - when: always
+
 ###
 
-arm-linux-gnueabihf:
-  extends: .build-depends-template
-  variables:
-    HOST: arm-linux-gnueabihf
-
-i686-w64-mingw32:
-  extends: .build-depends-template
-  variables:
-    HOST: i686-w64-mingw32
-
-x86_64-w64-mingw32:
-  extends: .build-depends-template
-  variables:
-    HOST: x86_64-w64-mingw32
-
 i686-pc-linux-gnu:
-  extends: .build-depends-template
+  extends:
+    - .build-depends-template
+    - .skip-in-fast-mode-template
   variables:
     HOST: i686-pc-linux-gnu
-
-x86_64-unknown-linux-gnu:
-  extends: .build-depends-template
-  variables:
-    HOST: x86_64-unknown-linux-gnu
 
 x86_64-unknown-linux-gnu-debug:
   extends: .build-depends-template
@@ -159,48 +148,59 @@ x86_64-unknown-linux-gnu-debug:
     HOST: x86_64-unknown-linux-gnu
     DEP_OPTS: "DEBUG=1"
 
-x86_64-unknown-linux-gnu-nowalet:
+arm-linux-gnueabihf:
   extends: .build-depends-template
+  variables:
+    HOST: arm-linux-gnueabihf
+
+i686-w64-mingw32:
+  extends:
+    - .build-depends-template
+    - .skip-in-fast-mode-template
+  variables:
+    HOST: i686-w64-mingw32
+
+x86_64-w64-mingw32:
+  extends:
+    - .build-depends-template
+    - .skip-in-fast-mode-template
+  variables:
+    HOST: x86_64-w64-mingw32
+
+x86_64-unknown-linux-gnu:
+  extends: .build-depends-template
+  variables:
+    HOST: x86_64-unknown-linux-gnu
+
+x86_64-unknown-linux-gnu-nowalet:
+  extends:
+    - .build-depends-template
+    - .skip-in-fast-mode-template
   variables:
     HOST: x86_64-unknown-linux-gnu
     DEP_OPTS: "NO_WALLET=1"
 
 x86_64-unknown-linux-gnu-release:
-  extends: .build-depends-template
+  extends:
+    - .build-depends-template
+    - .skip-in-fast-mode-template
   variables:
     HOST: x86_64-unknown-linux-gnu
     DEP_OPTS: "NO_UPNP=1"
 
 x86_64-apple-darwin11:
-  extends: .build-depends-template
+  extends:
+    - .build-depends-template
+    - .skip-in-fast-mode-template
   variables:
     HOST: x86_64-apple-darwin11
 
 ###
 
-arm-linux-build:
-  extends: .build-template
-  needs:
-    - arm-linux-gnueabihf
-  variables:
-    BUILD_TARGET: arm-linux
-
-win32-build:
-  extends: .build-template
-  needs:
-    - i686-w64-mingw32
-  variables:
-    BUILD_TARGET: win32
-
-win64-build:
-  extends: .build-template
-  needs:
-    - x86_64-w64-mingw32
-  variables:
-    BUILD_TARGET: win64
-
 linux32-build:
-  extends: .build-template
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
   needs:
     - i686-pc-linux-gnu
   variables:
@@ -213,22 +213,53 @@ linux64-build:
   variables:
     BUILD_TARGET: linux64
 
-linux64_nowallet-build:
+arm-linux-build:
   extends: .build-template
+  needs:
+    - arm-linux-gnueabihf
+  variables:
+    BUILD_TARGET: arm-linux
+
+win32-build:
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
+  needs:
+    - i686-w64-mingw32
+  variables:
+    BUILD_TARGET: win32
+
+win64-build:
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
+  needs:
+    - x86_64-w64-mingw32
+  variables:
+    BUILD_TARGET: win64
+
+linux64_nowallet-build:
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
   needs:
     - x86_64-unknown-linux-gnu-nowalet
   variables:
     BUILD_TARGET: linux64_nowallet
 
 linux64_release-build:
-  extends: .build-template
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
   needs:
     - x86_64-unknown-linux-gnu-release
   variables:
     BUILD_TARGET: linux64_release
 
 mac-build:
-  extends: .build-template
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
   needs:
     - x86_64-apple-darwin11
   variables:
@@ -237,7 +268,9 @@ mac-build:
 ###
 
 linux32-test:
-  extends: .test-template
+  extends:
+    - .test-template
+    - .skip-in-fast-mode-template
   needs:
     - linux32-build
   variables:


### PR DESCRIPTION
This adds a custom .gitlab-short-ci.yml which only does Linux64 and arm (for linting). I plan on using this in conjunction with travis. Such that my gitlab should be very quick and finish / get me good info very quick, travis will take a bit longer, but will run the full suite of builds. 

There might be a better way to do this because there is a bit of duplication happening now between .gitlab-ci.yml and .gitlab-short-ci.yml