### PR TITLE
privatesend: Make sure change in MakeCollateralAmounts has min value

### DIFF
--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1498,6 +1498,11 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
         }
     }
 
+    if(wtx.tx->vout[nChangePosRet].nValue < CPrivateSend::GetCollateralAmount()) {
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- Not enough change in tx: %s\n", wtx.tx->ToString());
+        return false;
+    }
+
     reservekeyCollateral.KeepKey();
 
     LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- txid=%s\n", wtx.GetHash().GetHex());


### PR DESCRIPTION
This PR is a fix for #3597. The issue there is that we run in cases where the change output in `CPrivateSendClientSession::MakeCollateralAmounts` is too small to be considered as private send collateral. This leads to those change outputs returning `false` for `CPrivateSend::IsCollateralAmount` in https://github.com/dashpay/dash/blob/0fbfd9ba96585852b078bad3c2900264f738b52d/src/qt/transactionrecord.cpp#L159-L160 Then the transaction will not become seen as “PrivateSend Make Collateral Inputs” transaction but instead it ends up being seen as “Payment to yourself” transaction. Those are the unexpected transaction popping up in the issue. 

As fix `CPrivateSendClientSession::MakeCollateralAmounts` simply skips “PrivateSend Make Collateral Inputs” transactions with change outputs smaller than  `GetCollateralAmount()`. This way we also don’t leave tiny outputs in the wallet but instead a bit bigger ones if they don’t contain enough.. i guess that makes sense? 

a19583279401fb92d2be1f1ecf6cc80d165396a3 is alternative GUI only fix which also allows change outputs smaller than `GetCollateralAmount()` by setting the minimum required value to `GetMaxCollateralAmount()` in `TransactionRecord::decomposeTransaction` https://github.com/dashpay/dash/blob/a19583279401fb92d2be1f1ecf6cc80d165396a3/src/qt/transactionrecord.cpp#L159-L160 By doing this we still end up parsing the “PrivateSend Make Collateral Input" transactions with too small changes properly and not see them as “Payment to yourself" transactions like with the issue.  

I tested a19583279401fb92d2be1f1ecf6cc80d165396a3 and it works but i couldn’t verify 0fbfd9ba96585852b078bad3c2900264f738b52d since its not so easy to reproduce the issue. But just from looking at the code, it should make sense and we should go with 0fbfd9ba96585852b078bad3c2900264f738b52d, no? 