### PR TITLE
docs/trivial: replace `inter-quorum` with `intra-quorum`

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -111,7 +111,7 @@ struct LLMQParams {
     // Number of quorums to consider "active" for signing sessions
     int signingActiveQuorumCount;
 
-    // Used for inter-quorum communication. This is the number of quorums for which we should keep old connections. This
+    // Used for intra-quorum communication. This is the number of quorums for which we should keep old connections. This
     // should be at least one more then the active quorums set.
     int keepOldConnections;
 

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -76,7 +76,7 @@ typedef std::shared_ptr<const CQuorum> CQuorumCPtr;
  * The quorum manager maintains quorums which were mined on chain. When a quorum is requested from the manager,
  * it will lookup the commitment (through CQuorumBlockProcessor) and build a CQuorum object from it.
  *
- * It is also responsible for initialization of the inter-quorum connections for new quorums.
+ * It is also responsible for initialization of the intra-quorum connections for new quorums.
  */
 class CQuorumManager
 {


### PR DESCRIPTION
Inter means between two groups, intra means inside of a group. For example, communication between two different quorums would be inter-quorum communication, communication between two different MNs in a quorum would be intra-quorum communication, yet would be inter-masternode communications.