### PR TITLE
[RPC] Show address of fundDest when no funds

### DIFF
--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -226,7 +226,7 @@ static void FundSpecialTx(CWallet* pwallet, CMutableTransaction& tx, const Speci
     }
 
     if (!coinControl.HasSelected()) {
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "No funds at specified address");
+        throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("No funds at specified address %s", EncodeDestination(fundDest)));
     }
 
     CWalletTx wtx;


### PR DESCRIPTION
When doing a protx register_prepare it can be confusing to find out which address has no funds.This PR change shows the address where the funds are not available to make it simpler to find the addr to add funds to.