### PR TITLE
llmq: Fix spork check in CSigSharesManager::ForceReAnnouncement

### DIFF
--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1609,7 +1609,7 @@ void CSigSharesManager::Sign(const CQuorumCPtr& quorum, const uint256& id, const
 // causes all known sigShares to be re-announced
 void CSigSharesManager::ForceReAnnouncement(const CQuorumCPtr& quorum, Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash)
 {
-    if (!CLLMQUtils::IsAllMembersConnectedEnabled(llmqType)) {
+    if (CLLMQUtils::IsAllMembersConnectedEnabled(llmqType)) {
         return;
     }
 


### PR DESCRIPTION
It seems like the idea here was to avoid announcing already available sigshares for a signhash to everyone if concentrated recovery is enabled. But by returning there if `IsAllMembersConnectedEnabled` equals to `false` we disable the re-announcements prior to the spork activation, where we want to still have them and re-enable if the spork is enabled where we don't want to have them.