### PR TITLE
Stage specific Travis job names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     # DOCKER_HUB_PASSWORD
     - secure: "RLzlMhfLqwSBrZqJOVOd61suXBn+HtUR3vOZfuFYF/Qmjjj5TE41+rObZmzc54hP/ZL+OH6blnibpvfDXlX+eN38ivFQfuxkJIGL68SJsEwNBRwW39Yw6Hl5RdI41MLCH7ByN15wifLp1JKBilHJ7XGMOUjI7P0yl7JjX8GBXUCtJbVLRugo80/yn+XQ1NdnlpbpYHNjMEQFWSODPa3pSK5McWvyQjDZDgS+IkdrZmIYJPMa7bmKH5I/edUPSmXQT905FgEwq9u8XR0SyBopli21EK9l6GkXIIvmDTYz5vT26Apvi2B4Aoazlklg+KNRUJuLGerpt6kbnU0gMSUChVkFfFhOk6GRSN3a/AUfD2FOudvMhet2QvlPHx+GYdEUr5XVo5HW42pHsqfD6eDtHd8VLTsHP0q4C8V85fNMv21lkkehy2ry8fx/RRy6x4O2wg2mua+79UkGKXp75gMKzWEcth34PCFCOu37l2F8R/ANnrQ52K/8vIQ88TtU2OpYX89fHjLojBxu+WKEBGZH2LRPsZBOUHeeO5C/xKDrhZU24ORnMW8wg66Qg5GIX1KI4a8yp73Mpues5hzpJ6wkMuRrQt40ymKndLCjv8KSd+5BfP6Or/KIrzDNYdZaasjk7JNi6rcZmm9d3fTAo+Ja/mjpUCIOo3SX14luzVCJIig="
     - DOCKER_BUILD=false
-    - BUILD_TARGET=$TRAVIS_JOB_NAME
 
 stages:
   - build depends
@@ -61,58 +60,85 @@ jobs:
   include:
     # build depends
     - <<: *builddepends
-      name: arm-linux
+      name: depends-arm-linux
+      env: BUILD_TARGET=arm-linux
     - <<: *builddepends
-      name: win32
+      name: depends-win32
+      env: BUILD_TARGET=win32
     - <<: *builddepends
-      name: win64
+      name: depends-win64
+      env: BUILD_TARGET=win64
     - <<: *builddepends
-      name: linux32
+      name: depends-linux32
+      env: BUILD_TARGET=linux32
     - <<: *builddepends
-      name: linux64
+      name: depends-linux64
+      env: BUILD_TARGET=linux64
     - <<: *builddepends
-      name: linux64_nowallet
+      name: depends-linux64_nowallet
+      env: BUILD_TARGET=linux64_nowallet
     - <<: *builddepends
-      name: linux64_release
-      env: DOCKER_BUILD=true
+      name: depends-linux64_release
+      env:
+        - BUILD_TARGET=linux64_release
+        - DOCKER_BUILD=true
     - <<: *builddepends
-      name: mac
+      name: depends-mac
+      env: BUILD_TARGET=mac
     # build source
     - <<: *buildsrc
-      name: arm-linux
+      name: src-arm-linux
+      env: BUILD_TARGET=arm-linux
     - <<: *buildsrc
-      name: win32
+      name: src-win32
+      env: BUILD_TARGET=win32
     - <<: *buildsrc
-      name: win64
+      name: src-win64
+      env: BUILD_TARGET=win64
     - <<: *buildsrc
-      name: linux32
+      name: src-linux32
+      env: BUILD_TARGET=linux32
     - <<: *buildsrc
-      name: linux64
+      name: src-linux64
+      env: BUILD_TARGET=linux64
     - <<: *buildsrc
-      name: linux64_nowallet
+      name: src-linux64_nowallet
+      env: BUILD_TARGET=linux64_nowallet
     - <<: *buildsrc
-      name: linux64_release
-      env: DOCKER_BUILD=true
+      name: src-linux64_release
+      env:
+        - BUILD_TARGET=linux64_release
+        - DOCKER_BUILD=true
     - <<: *buildsrc
-      name: mac
+      name: src-mac
+      env: BUILD_TARGET=mac
     # run tests (no tests for arm-linux and mac)
     - <<: *runtests
-      name: win32
+      name: tests-win32
+      env: BUILD_TARGET=win32
     - <<: *runtests
-      name: win64
+      name: tests-win64
+      env: BUILD_TARGET=win64
     - <<: *runtests
-      name: linux32
+      name: tests-linux32
+      env: BUILD_TARGET=linux32
     - <<: *runtests
-      name: linux64
+      name: tests-linux64
+      env: BUILD_TARGET=linux64
     - <<: *runtests
-      name: linux64_nowallet
+      name: tests-linux64_nowallet
+      env: BUILD_TARGET=linux64_nowallet
     - <<: *runtests
-      name: linux64_release
-      env: DOCKER_BUILD=true
+      name: tests-linux64_release
+      env:
+        - BUILD_TARGET=linux64_release
+        - DOCKER_BUILD=true
     # build docker
     - <<: *builddocker
-      name: linux64_release
-      env: DOCKER_BUILD=true
+      name: docker-linux64_release
+      env:
+        - BUILD_TARGET=linux64_release
+        - DOCKER_BUILD=true
 
 before_cache:
   # Save builder image


### PR DESCRIPTION
For some reason Travis doesn't seem to like having the same name on different stages and ignores the cache that was built earlier _sometimes_ (?), see recent builds https://travis-ci.org/github/dashpay/dash/builds. Making job names stage specific should fix these issues (see this branch build https://travis-ci.com/github/UdjinM6/dash/builds/178267096 and a couple of other builds where branches where rebased on top of this one instead of `develop`: https://travis-ci.com/github/UdjinM6/dash/builds/178234894, https://travis-ci.com/github/UdjinM6/dash/builds/178234948).

(Note: Travis job names were introduced in https://github.com/dashpay/dash/pull/3632)