### PR TITLE
Print exception origin in crash messages

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -576,14 +576,9 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n\n");
 }
 
-static std::string FormatException(const std::exception_ptr pex, const char* pszThread)
+void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExceptionOrigin)
 {
-    return GetPrettyExceptionStr(pex);
-}
-
-void PrintExceptionContinue(const std::exception_ptr pex, const char* pszThread)
-{
-    std::string message = FormatException(pex, pszThread);
+    std::string message = strprintf("\"%s\" rised an exception\n%s", pszExceptionOrigin, GetPrettyExceptionStr(pex));
     LogPrintf("\n\n************************\n%s\n", message);
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -578,7 +578,7 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
 
 void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExceptionOrigin)
 {
-    std::string message = strprintf("\"%s\" rised an exception\n%s", pszExceptionOrigin, GetPrettyExceptionStr(pex));
+    std::string message = strprintf("\"%s\" raised an exception\n%s", pszExceptionOrigin, GetPrettyExceptionStr(pex));
     LogPrintf("\n\n************************\n%s\n", message);
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
 }

--- a/src/util.h
+++ b/src/util.h
@@ -90,7 +90,7 @@ bool error(const char* fmt, const Args&... args)
     return false;
 }
 
-void PrintExceptionContinue(const std::exception_ptr pex, const char* pszThread);
+void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExceptionOrigin);
 void FileCommit(FILE *file);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);


### PR DESCRIPTION
We use `PrintExceptionContinue` in many places and we pass crash origin to it as a param but we never use it. Also, change the param name to better match its current meaning.