### PR TITLE
privatesend|wallet|qt: Improve calculations in CreateDenominated/MakeCollateralAmounts

### DIFF
--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1647,7 +1647,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
         auto countPossibleOutputs = [&](CAmount nAmount) -> int {
             std::vector<CAmount> vecOutputs;
-            while(true) {
+            while (true) {
                 // Create an potential output
                 vecOutputs.push_back(nAmount);
                 if (!txBuilder.CouldAddOutputs(vecOutputs) || txBuilder.CountOutputs() + vecOutputs.size() > PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) {

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1685,7 +1685,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
                     it->second++;
                     nBalanceToDenominate -= nDenomValue;
                 } else {
-                    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 2 - Error: AddOutput failed: denomsToCreate: %d/%d, %s\n", __func__, i, denomsToCreate, txBuilder.ToString());
+                    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 2 - Error: AddOutput failed at %d/%d, %s\n", __func__, i + 1, denomsToCreate, txBuilder.ToString());
                     break;
                 }
                 LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 2 - nDenomValue: %f, nBalanceToDenominate: %f, nOutputs: %d, %s\n",

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1650,10 +1650,17 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
         auto countPossibleOutputs = [&](CAmount nAmount) -> int {
             std::vector<CAmount> vecOutputs;
-            while (txBuilder.TryAddOutputs(vecOutputs)) {
+            while(true) {
+                // Create an potential output
                 vecOutputs.push_back(nAmount);
+                if (!txBuilder.TryAddOutputs(vecOutputs) || txBuilder.CountOutputs() + vecOutputs.size() > PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) {
+                    // If its not possible to add it due to insufficient amount left or total number of outputs exceeds
+                    // PRIVATESEND_DENOM_OUTPUTS_THRESHOLD drop the output again and stop trying.
+                    vecOutputs.pop_back();
+                    break;
+                }
             }
-            return vecOutputs.size();
+            return static_cast<int>(vecOutputs.size());
         };
 
         // Go big to small

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1557,32 +1557,24 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
     if (!CPrivateSendClientOptions::IsEnabled() || !mixingWallet) return false;
 
-    std::vector<CRecipient> vecSend;
-    CKeyHolderStorage keyHolderStorageDenom;
+    // denominated input is always a single one, so we can check its amount directly and return early
+    if (tallyItem.vecOutPoints.size() == 1 && CPrivateSend::IsDenominatedAmount(tallyItem.nAmount)) {
+        return false;
+    }
 
-    CCoinControl coinControl;
-    // Every input will require at least this much fees in duffs
-    const CAmount nInputFee = GetMinimumFee(148, coinControl, ::mempool, ::feeEstimator, nullptr /* feeCalc */);
-    // Every output will require at least this much fees in duffs
-    const CAmount nOutputFee = GetMinimumFee(34, coinControl, ::mempool, ::feeEstimator, nullptr /* feeCalc */);
+    CTransactionBuilder txBuilder(mixingWallet, tallyItem);
 
-    CAmount nValueLeft = tallyItem.nAmount;
-    // Leave some room for fees, assuming we are going to spend all the outpoints
-    nValueLeft -= tallyItem.vecOutPoints.size() * nInputFee;
-
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- 0 - %s nValueLeft: %f\n", EncodeDestination(tallyItem.txdest), (float)nValueLeft / COIN);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- Start %s\n", __func__, txBuilder.ToString());
 
     // ****** Add an output for mixing collaterals ************ /
 
-    if (fCreateMixingCollaterals) {
-        CScript scriptCollateral = keyHolderStorageDenom.AddKey(mixingWallet);
-        vecSend.push_back((CRecipient){scriptCollateral, CPrivateSend::GetMaxCollateralAmount(), false});
-        nValueLeft -= CPrivateSend::GetMaxCollateralAmount() + nOutputFee;
+    if (fCreateMixingCollaterals && !txBuilder.AddOutput(CPrivateSend::GetMaxCollateralAmount())) {
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- Failed to add collateral output\n", __func__);
+        return false;
     }
 
     // ****** Add outputs for denoms ************ /
 
-    int nOutputsTotal = 0;
     bool fAddFinal = true;
     std::vector<CAmount> vecStandardDenoms = CPrivateSend::GetStandardDenominations();
 
@@ -1600,8 +1592,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
     // Now, in this system, so long as we don't reach PRIVATESEND_DENOM_OUTPUTS_THRESHOLD outputs the process repeats in
     // the same transaction, creating up to nPrivateSendDenomsHardCap per denomination in a single transaction.
 
-    while (nValueLeft >= CPrivateSend::GetSmallestDenomination() && nOutputsTotal < PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) {
-
+    while (txBuilder.TryAddOutput(CPrivateSend::GetSmallestDenomination()) && txBuilder.CountOutputs() < PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) {
         for (auto it = vecStandardDenoms.rbegin(); it != vecStandardDenoms.rend(); ++it) {
             CAmount nDenomValue = *it;
             auto currentDenomIt = mapDenomCount.find(nDenomValue);
@@ -1609,72 +1600,76 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
             int nOutputs = 0;
 
             auto needMoreOutputs = [&]() {
-                bool fRegular = ((nValueLeft >= nDenomValue + nOutputFee) && nBalanceToDenominate >= nDenomValue);
-                bool fFinal = (fAddFinal
-                               && nValueLeft >= nDenomValue + nOutputFee
-                               && nBalanceToDenominate > 0
-                               && nBalanceToDenominate < nDenomValue);
-                if (fFinal) {
-                    fAddFinal = false; // add final denom only once, only the smalest possible one
-                    LogPrint(BCLog::PRIVATESEND, /* Continued */
-                             "CPrivateSendClientSession::CreateDenominated -- 1 - FINAL - nDenomValue: %f, nValueLeft: %f, nBalanceToDenominate: %f\n",
-                             (float) nDenomValue / COIN, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
+                if (txBuilder.TryAddOutput(nDenomValue)) {
+                    if (fAddFinal && nBalanceToDenominate > 0 && nBalanceToDenominate < nDenomValue) {
+                        fAddFinal = false; // add final denom only once, only the smalest possible one
+                        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 1 - FINAL - nDenomValue: %f, nBalanceToDenominate: %f, nOutputs: %d, %s\n",
+                                                     __func__, (float) nDenomValue / COIN, (float) nBalanceToDenominate / COIN, nOutputs, txBuilder.ToString());
+                        return true;
+                    } else if (nBalanceToDenominate >= nDenomValue) {
+                        return true;
+                    }
                 }
-
-                return fRegular || fFinal;
+                return false;
             };
 
             // add each output up to 11 times or until it can't be added again or until we reach nPrivateSendDenomsGoal
             while (needMoreOutputs() && nOutputs <= 10 && currentDenomIt->second < CPrivateSendClientOptions::GetDenomsGoal()) {
-                CScript scriptDenom = keyHolderStorageDenom.AddKey(mixingWallet);
+                // Add output and subtract denomination amount
+                if (txBuilder.AddOutput(nDenomValue)) {
+                    ++nOutputs;
+                    ++currentDenomIt->second;
+                    nBalanceToDenominate -= nDenomValue;
+                    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 1 - nDenomValue: %f, nBalanceToDenominate: %f, nOutputs: %d, %s\n",
+                                                 __func__, (float) nDenomValue / COIN, (float) nBalanceToDenominate / COIN, nOutputs, txBuilder.ToString());
+                } else {
+                    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 1 - Error: AddOutput failed for nDenomValue: %f, nBalanceToDenominate: %f, nOutputs: %d, %s\n",
+                                                 __func__, (float) nDenomValue / COIN, (float) nBalanceToDenominate / COIN, nOutputs, txBuilder.ToString());
+                    return false;
+                }
 
-                vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
-
-                // increment outputs and subtract denomination amount
-                nOutputs++;
-                currentDenomIt->second++;
-                nValueLeft -= nDenomValue + nOutputFee;
-                nBalanceToDenominate -= nDenomValue;
-                LogPrint(BCLog::PRIVATESEND, /* Continued */
-                         "CPrivateSendClientSession::CreateDenominated -- 1 - nDenomValue: %f, totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
-                         (float) nDenomValue / COIN, nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
             }
 
-            nOutputsTotal += nOutputs;
-            if (nValueLeft == 0 || nBalanceToDenominate <= 0) break;
+            if (txBuilder.GetAmountLeft() == 0 || nBalanceToDenominate <= 0) break;
         }
 
         bool finished = true;
         for (const auto it : mapDenomCount) {
             // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenomsGoal of this
             // denom and that our nValueLeft/nBalanceToDenominate is enough to create one of these denoms, if so, loop again.
-            if (it.second < CPrivateSendClientOptions::GetDenomsGoal() && (nValueLeft >= it.first + nOutputFee) && nBalanceToDenominate > 0) {
+            if (it.second < CPrivateSendClientOptions::GetDenomsGoal() && txBuilder.TryAddOutput(it.first) && nBalanceToDenominate >= it.first) {
                 finished = false;
-                LogPrint(BCLog::PRIVATESEND, /* Continued */
-                        "CPrivateSendClientSession::CreateDenominated -- 1 - NOT finished - nDenomValue: %f, count: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
-                        (float) it.first / COIN, it.second, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
+                LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 1 - NOT finished - nDenomValue: %f, count: %d, nBalanceToDenominate: %f, %s\n",
+                                             __func__, (float) it.first / COIN, it.second, (float) nBalanceToDenominate / COIN, txBuilder.ToString());
                 break;
             }
-            LogPrint(BCLog::PRIVATESEND, /* Continued */
-                    "CPrivateSendClientSession::CreateDenominated -- 1 - FINSHED - nDenomValue: %f, count: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
-                    (float) it.first / COIN, it.second, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
+            LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 1 - FINSHED - nDenomValue: %f, count: %d, nBalanceToDenominate: %f, %s\n",
+                                         __func__, (float) it.first / COIN, it.second, (float) nBalanceToDenominate / COIN, txBuilder.ToString());
         }
 
         if (finished) break;
     }
 
     // Now that nPrivateSendDenomsGoal worth of each denom have been created or the max number of denoms given the value of the input, do something with the remainder.
-    if ((nValueLeft >= CPrivateSend::GetSmallestDenomination() + nOutputFee) && nBalanceToDenominate >= CPrivateSend::GetSmallestDenomination()
-           && nOutputsTotal < PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) {
-
+    if (txBuilder.TryAddOutput(CPrivateSend::GetSmallestDenomination()) && nBalanceToDenominate >= CPrivateSend::GetSmallestDenomination() && txBuilder.CountOutputs() < PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) {
         CAmount nLargestDenomValue = vecStandardDenoms.front();
+
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 2 - Process remainder: %s\n", __func__, txBuilder.ToString());
+
+        auto countPossibleOutputs = [&](CAmount nAmount) -> int {
+            std::vector<CAmount> vecOutputs;
+            while (txBuilder.TryAddOutputs(vecOutputs)) {
+                vecOutputs.push_back(nAmount);
+            }
+            return vecOutputs.size();
+        };
 
         // Go big to small
         for (auto nDenomValue : vecStandardDenoms) {
             int nOutputs = 0;
 
             // Number of denoms we can create given our denom and the amount of funds we have left
-            int denomsToCreateValue = nValueLeft / (nDenomValue + nOutputFee);
+            int denomsToCreateValue = countPossibleOutputs(nDenomValue);
             // Prefer overshooting the targed balance by larger denoms (hence `+1`) instead of a more
             // accurate approximation by many smaller denoms. This is ok because when we get here we
             // should have nPrivateSendDenomsGoal of each smaller denom already. Also, without `+1`
@@ -1685,78 +1680,51 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
             int denomsToCreateBal = (nBalanceToDenominate / nDenomValue) + 1;
             // Use the smaller value
             int denomsToCreate = denomsToCreateValue > denomsToCreateBal ? denomsToCreateBal : denomsToCreateValue;
+            LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 2 - nBalanceToDenominate: %f, nDenomValue: %f, denomsToCreateValue: %d, denomsToCreateBal: %d\n",
+                                         __func__, (float) nBalanceToDenominate / COIN, (float) nDenomValue / COIN, denomsToCreateValue, denomsToCreateBal);
             auto it = mapDenomCount.find(nDenomValue);
             for (int i = 0; i < denomsToCreate; i++) {
                 // Never go above the cap unless it's the largest denom
                 if (nDenomValue != nLargestDenomValue && it->second >= CPrivateSendClientOptions::GetDenomsHardCap()) break;
 
-                CScript scriptDenom = keyHolderStorageDenom.AddKey(mixingWallet);
-                vecSend.push_back((CRecipient) {scriptDenom, nDenomValue, false});
-
-                // increment outputs and subtract denomination amount
-                nOutputs++;
-                it->second++;
-                nValueLeft -= nDenomValue + nOutputFee;
-                nBalanceToDenominate -= nDenomValue;
-                LogPrint(BCLog::PRIVATESEND, /* Continued */
-                         "CPrivateSendClientSession::CreateDenominated -- 2 - nDenomValue: %f, totalOutputs: %d, nOutputsTotal: %d, nOutputs: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
-                         (float) nDenomValue / COIN, nOutputsTotal + nOutputs, nOutputsTotal, nOutputs, (float) nValueLeft / COIN, (float) nBalanceToDenominate / COIN);
-                if (nOutputs + nOutputsTotal >= PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) break;
+                // Increment helpers, add output and subtract denomination amount
+                if (txBuilder.AddOutput(nDenomValue)) {
+                    nOutputs++;
+                    it->second++;
+                    nBalanceToDenominate -= nDenomValue;
+                } else {
+                    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 2 - Error: AddOutput failed: denomsToCreate: %d/%d, %s\n", __func__, i, denomsToCreate, txBuilder.ToString());
+                    break;
+                }
+                LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 2 - nDenomValue: %f, nBalanceToDenominate: %f, nOutputs: %d, %s\n",
+                                             __func__, (float) nDenomValue / COIN, (float) nBalanceToDenominate / COIN, nOutputs, txBuilder.ToString());
+                if (txBuilder.CountOutputs() >= PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) break;
             }
-            nOutputsTotal += nOutputs;
-            if (nOutputsTotal >= PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) break;
+            if (txBuilder.CountOutputs() >= PRIVATESEND_DENOM_OUTPUTS_THRESHOLD) break;
         }
     }
 
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- 3 - nOutputsTotal: %d, nValueLeft: %f, nBalanceToDenominate: %f\n",
-            nOutputsTotal, (float)nValueLeft / COIN, (float)nBalanceToDenominate / COIN);
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 3 - nBalanceToDenominate: %f, %s\n", __func__, (float) nBalanceToDenominate / COIN, txBuilder.ToString());
 
     for (const auto it : mapDenomCount) {
-        LogPrint(BCLog::PRIVATESEND, /* Continued */
-                "CPrivateSendClientSession::CreateDenominated -- 3 - DONE - nDenomValue: %f, count: %d\n",
-                (float) it.first / COIN, it.second);
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 3 - DONE - nDenomValue: %f, count: %d\n", __func__, (float) it.first / COIN, it.second);
     }
 
     // No reasons to create mixing collaterals if we can't create denoms to mix
-    if (nOutputsTotal == 0) return false;
-
-    // if we have anything left over, it will be automatically send back as change - there is no need to send it manually
-
-    coinControl.fAllowOtherInputs = false;
-    coinControl.fAllowWatchOnly = false;
-    coinControl.nCoinType = CoinType::ONLY_NONDENOMINATED;
-    // send change to the same address so that we were able create more denoms out of it later
-    coinControl.destChange = tallyItem.txdest;
-    for (const auto& outpoint : tallyItem.vecOutPoints) {
-        coinControl.Select(outpoint);
-    }
-
-    CWalletTx wtx;
-    CAmount nFeeRet = 0;
-    int nChangePosRet = -1;
-    std::string strFail;
-    // make our change address
-    CReserveKey reservekeyChange(mixingWallet);
-
-    bool fSuccess = mixingWallet->CreateTransaction(vecSend, wtx, reservekeyChange,
-        nFeeRet, nChangePosRet, strFail, coinControl);
-    if (!fSuccess) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- Error: %s\n", strFail);
-        keyHolderStorageDenom.ReturnAll();
+    if ((fCreateMixingCollaterals && txBuilder.CountOutputs() == 1) || txBuilder.CountOutputs() == 0) {
         return false;
     }
 
-    keyHolderStorageDenom.KeepAll();
-
-    CValidationState state;
-    if (!mixingWallet->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- CommitTransaction failed! Reason given: %s\n", state.GetRejectReason());
+    std::string strResult;
+    if (!txBuilder.Commit(strResult)) {
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- Commit failed: %s\n", __func__, strResult);
         return false;
     }
 
     // use the same nCachedLastSuccessBlock as for DS mixing to prevent race
     privateSendClientManagers.at(mixingWallet->GetName())->UpdatedSuccessBlock();
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::CreateDenominated -- txid=%s\n", wtx.GetHash().GetHex());
+
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- txid: %s\n", __func__, strResult);
 
     return true;
 }

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1444,7 +1444,7 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
     }
 
     auto getAdjustedAmount = [&](CAmount nAmount) -> CAmount {
-        // If amount is denominated remove one duff, this will to into fees!
+        // If amount is denominated remove one duff, this will go into fees!
         return CPrivateSend::IsDenominatedAmount(nAmount) ? nAmount - 1 : nAmount;
     };
 

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1629,7 +1629,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
         for (const auto it : mapDenomCount) {
             // Check if this specific denom could use another loop, check that there aren't nPrivateSendDenomsGoal of this
             // denom and that our nValueLeft/nBalanceToDenominate is enough to create one of these denoms, if so, loop again.
-            if (it.second < CPrivateSendClientOptions::GetDenomsGoal() && txBuilder.TryAddOutput(it.first) && nBalanceToDenominate >= it.first) {
+            if (it.second < CPrivateSendClientOptions::GetDenomsGoal() && txBuilder.TryAddOutput(it.first) && nBalanceToDenominate > 0) {
                 finished = false;
                 LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 1 - NOT finished - nDenomValue: %f, count: %d, nBalanceToDenominate: %f, %s\n",
                                              __func__, (float) it.first / COIN, it.second, (float) nBalanceToDenominate / COIN, txBuilder.ToString());

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1424,8 +1424,8 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
 
     if (!CPrivateSendClientOptions::IsEnabled() || !mixingWallet) return false;
 
-    // Skip way too tiny amounts
-    if (tallyItem.nAmount < CPrivateSend::GetCollateralAmount()) {
+    // Denominated input is always a single one, so we can check its amount directly and return early
+    if (!fTryDenominated && tallyItem.vecOutPoints.size() == 1 && CPrivateSend::IsDenominatedAmount(tallyItem.nAmount)) {
         return false;
     }
 
@@ -1434,82 +1434,74 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
         return false;
     }
 
-    // denominated input is always a single one, so we can check its amount directly and return early
-    if (!fTryDenominated && tallyItem.vecOutPoints.size() == 1 && CPrivateSend::IsDenominatedAmount(tallyItem.nAmount)) {
+    CTransactionBuilder txBuilder(mixingWallet, tallyItem);
+
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- Start %s\n", __func__, txBuilder.ToString());
+
+    // Skip way too tiny amounts. Smallest we want is minimum collateral amount in a one output tx
+    if (!txBuilder.TryAddOutput(CPrivateSend::GetCollateralAmount())) {
         return false;
     }
 
-    CWalletTx wtx;
-    CAmount nFeeRet = 0;
-    int nChangePosRet = -1;
-    std::string strFail;
-    std::vector<CRecipient> vecSend;
+    auto getAdjustedAmount = [&](CAmount nAmount) -> CAmount {
+        // If amount is denominated remove one duff, this will to into fees!
+        return CPrivateSend::IsDenominatedAmount(nAmount) ? nAmount - 1 : nAmount;
+    };
 
-    // make our collateral address
-    CReserveKey reservekeyCollateral(mixingWallet);
-    // make our change address
-    CReserveKey reservekeyChange(mixingWallet);
+    int nCase{0}; // Just for debug logs
+    if (txBuilder.TryAddOutputs({CPrivateSend::GetMaxCollateralAmount(), CPrivateSend::GetCollateralAmount()})) {
+        nCase = 1;
+        // <case1>, see TransactionRecord::decomposeTransaction
+        // Out1 == CPrivateSend::GetMaxCollateralAmount()
+        // Out2 >= CPrivateSend::GetCollateralAmount()
 
-    CScript scriptCollateral;
-    CPubKey vchPubKey;
-    assert(reservekeyCollateral.GetReservedKey(vchPubKey, false)); // should never fail, as we just unlocked
-    scriptCollateral = GetScriptForDestination(vchPubKey.GetID());
+        txBuilder.AddOutput(CPrivateSend::GetMaxCollateralAmount());
+        // Note, here we first add a zero amount output to get the remainder after all fees and then assign it
+        CTransactionBuilderOutput* out = txBuilder.AddOutput();
+        out->UpdateAmount(getAdjustedAmount(txBuilder.GetAmountLeft()));
 
-    CAmount nCollateralAmount{0};
-    if (tallyItem.nAmount > CPrivateSend::GetMaxCollateralAmount() + CPrivateSend::GetCollateralAmount()*2) {
-        // Change output will be large enough to be valid as a collateral or a source input for another run
-        nCollateralAmount = CPrivateSend::GetMaxCollateralAmount();
-    } else {
-        // Change output might be too small for another collateral if we try to create the largest collateral
-        // here, create a slightly smaller one instead
-        nCollateralAmount = CPrivateSend::GetMaxCollateralAmount() - CPrivateSend::GetCollateralAmount();
-    }
-    vecSend.push_back((CRecipient){scriptCollateral, nCollateralAmount, false});
+    } else if (txBuilder.TryAddOutputs({CPrivateSend::GetCollateralAmount(), CPrivateSend::GetCollateralAmount()})) {
+        nCase = 2;
+        // <case2>, see TransactionRecord::decomposeTransaction
+        // Out1 CPrivateSend::IsCollateralAmount()
+        // Out2 CPrivateSend::IsCollateralAmount()
 
-    // try to use non-denominated and not mn-like funds first, select them explicitly
-    CCoinControl coinControl;
-    coinControl.fAllowOtherInputs = false;
-    coinControl.fAllowWatchOnly = false;
-    coinControl.nCoinType = CoinType::ONLY_NONDENOMINATED;
-    // send change to the same address so that we were able create more denoms out of it later
-    coinControl.destChange = tallyItem.txdest;
-    for (const auto& outpoint : tallyItem.vecOutPoints) {
-        coinControl.Select(outpoint);
-    }
+        // First add two outputs to get the available value after all fees
+        CTransactionBuilderOutput* out1 = txBuilder.AddOutput();
+        CTransactionBuilderOutput* out2 = txBuilder.AddOutput();
 
-    bool fSuccess = mixingWallet->CreateTransaction(vecSend, wtx, reservekeyChange,
-        nFeeRet, nChangePosRet, strFail, coinControl);
-    if (!fSuccess) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- ONLY_NONDENOMINATED: %s\n", strFail);
-        // If we failed then most likely there are not enough funds on this address.
-        if (fTryDenominated) {
-            // Try to also use denominated coins (we can't mix denominated without collaterals anyway).
-            coinControl.nCoinType = CoinType::ALL_COINS;
-            if (!mixingWallet->CreateTransaction(vecSend, wtx, reservekeyChange,
-                    nFeeRet, nChangePosRet, strFail, coinControl)) {
-                LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- ALL_COINS Error: %s\n", strFail);
-                reservekeyCollateral.ReturnKey();
-                return false;
-            }
-        } else {
-            // Nothing else we can do.
-            reservekeyCollateral.ReturnKey();
-            return false;
-        }
+        // Create two equal outputs from the available value. This adds one duff to the fee if txBuilder.GetAmountLeft() is odd.
+        CAmount nAmountOutputs = getAdjustedAmount(txBuilder.GetAmountLeft() / 2);
+
+        assert(CPrivateSend::IsCollateralAmount(nAmountOutputs));
+
+        out1->UpdateAmount(nAmountOutputs);
+        out2->UpdateAmount(nAmountOutputs);
+
+    } else { // still at least possible to add one CPrivateSend::GetCollateralAmount() output
+        nCase = 3;
+        // <case3>, see TransactionRecord::decomposeTransaction
+        // Out1 CPrivateSend::IsCollateralAmount()
+        // Out2 Skipped
+        CTransactionBuilderOutput* out = txBuilder.AddOutput();
+        out->UpdateAmount(getAdjustedAmount(txBuilder.GetAmountLeft()));
+
+        assert(CPrivateSend::IsCollateralAmount(out->GetAmount()));
     }
 
-    reservekeyCollateral.KeepKey();
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- Done with case %d: %s\n", __func__, nCase, txBuilder.ToString());
 
-    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- txid=%s\n", wtx.GetHash().GetHex());
+    assert(txBuilder.IsDust(txBuilder.GetAmountLeft()));
 
-    // use the same nCachedLastSuccessBlock as for DS mixing to prevent race
-    CValidationState state;
-    if (!mixingWallet->CommitTransaction(wtx, reservekeyChange, &connman, state)) {
-        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::MakeCollateralAmounts -- CommitTransaction failed! Reason given: %s\n", state.GetRejectReason());
+    std::string strResult;
+    if (!txBuilder.Commit(strResult)) {
+        LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- Commit failed: %s\n", __func__, strResult);
         return false;
     }
 
     privateSendClientManagers.at(mixingWallet->GetName())->UpdatedSuccessBlock();
+
+    LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- txid: %s\n", __func__, strResult);
 
     return true;
 }

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -888,12 +888,12 @@ bool CPrivateSendClientSession::DoAutomaticDenominating(CConnman& connman, bool 
         // there are funds to denominate and denominated balance does not exceed
         // max amount to mix yet.
         if (nBalanceAnonimizableNonDenom >= nValueMin + CPrivateSend::GetCollateralAmount() && nBalanceToDenominate > 0) {
-            CreateDenominated(nBalanceToDenominate, connman);
+            CreateDenominated(nBalanceToDenominate);
         }
 
         //check if we have the collateral sized inputs
         if (!mixingWallet->HasCollateralInputs()) {
-            return !mixingWallet->HasCollateralInputs(false) && MakeCollateralAmounts(connman);
+            return !mixingWallet->HasCollateralInputs(false) && MakeCollateralAmounts();
         }
 
         if (nSessionID) {
@@ -1376,7 +1376,7 @@ bool CPrivateSendClientSession::PrepareDenominate(int nMinRounds, int nMaxRounds
 }
 
 // Create collaterals by looping through inputs grouped by addresses
-bool CPrivateSendClientSession::MakeCollateralAmounts(CConnman& connman)
+bool CPrivateSendClientSession::MakeCollateralAmounts()
 {
     if (!CPrivateSendClientOptions::IsEnabled() || !mixingWallet) return false;
 
@@ -1400,13 +1400,13 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(CConnman& connman)
 
     // First try to use only non-denominated funds
     for (const auto& item : vecTally) {
-        if (!MakeCollateralAmounts(item, false, connman)) continue;
+        if (!MakeCollateralAmounts(item, false)) continue;
         return true;
     }
 
     // There should be at least some denominated funds we should be able to break in pieces to continue mixing
     for (const auto& item : vecTally) {
-        if (!MakeCollateralAmounts(item, true, connman)) continue;
+        if (!MakeCollateralAmounts(item, true)) continue;
         return true;
     }
 
@@ -1416,7 +1416,7 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(CConnman& connman)
 }
 
 // Split up large inputs or create fee sized inputs
-bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& tallyItem, bool fTryDenominated, CConnman& connman)
+bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& tallyItem, bool fTryDenominated)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(mempool.cs);
@@ -1504,7 +1504,7 @@ bool CPrivateSendClientSession::MakeCollateralAmounts(const CompactTallyItem& ta
 }
 
 // Create denominations by looping through inputs grouped by addresses
-bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, CConnman& connman)
+bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate)
 {
     if (!CPrivateSendClientOptions::IsEnabled() || !mixingWallet) return false;
 
@@ -1529,7 +1529,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
     bool fCreateMixingCollaterals = !mixingWallet->HasCollateralInputs();
 
     for (const auto& item : vecTally) {
-        if (!CreateDenominated(nBalanceToDenominate, item, fCreateMixingCollaterals, connman)) continue;
+        if (!CreateDenominated(nBalanceToDenominate, item, fCreateMixingCollaterals)) continue;
         return true;
     }
 
@@ -1538,7 +1538,7 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 }
 
 // Create denominations
-bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals, CConnman& connman)
+bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(mempool.cs);

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1588,12 +1588,13 @@ bool CPrivateSendClientSession::CreateDenominated(CAmount nBalanceToDenominate, 
 
             int nOutputs = 0;
 
+            const auto& strFunc = __func__;
             auto needMoreOutputs = [&]() {
                 if (txBuilder.CouldAddOutput(nDenomValue)) {
                     if (fAddFinal && nBalanceToDenominate > 0 && nBalanceToDenominate < nDenomValue) {
                         fAddFinal = false; // add final denom only once, only the smalest possible one
                         LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::%s -- 1 - FINAL - nDenomValue: %f, nBalanceToDenominate: %f, nOutputs: %d, %s\n",
-                                                     __func__, (float) nDenomValue / COIN, (float) nBalanceToDenominate / COIN, nOutputs, txBuilder.ToString());
+                                                     strFunc, (float) nDenomValue / COIN, (float) nBalanceToDenominate / COIN, nOutputs, txBuilder.ToString());
                         return true;
                     } else if (nBalanceToDenominate >= nDenomValue) {
                         return true;

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -120,12 +120,12 @@ private:
     CWallet* mixingWallet;
 
     /// Create denominations
-    bool CreateDenominated(CAmount nBalanceToDenominate, CConnman& connman);
-    bool CreateDenominated(CAmount nBalanceToDenominate, const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals, CConnman& connman);
+    bool CreateDenominated(CAmount nBalanceToDenominate);
+    bool CreateDenominated(CAmount nBalanceToDenominate, const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals);
 
     /// Split up large inputs or make fee sized inputs
-    bool MakeCollateralAmounts(CConnman& connman);
-    bool MakeCollateralAmounts(const CompactTallyItem& tallyItem, bool fTryDenominated, CConnman& connman);
+    bool MakeCollateralAmounts();
+    bool MakeCollateralAmounts(const CompactTallyItem& tallyItem, bool fTryDenominated);
 
     bool JoinExistingQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman);
     bool StartNewQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman);

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -180,7 +180,8 @@ bool CTransactionBuilder::CouldAddOutput(CAmount nAmountOutput) const
 bool CTransactionBuilder::CouldAddOutputs(const std::vector<CAmount>& vecOutputAmounts) const
 {
     CAmount nAmountAdditional{0};
-    int nBytesAdditional = nBytesOutput * vecOutputAmounts.size();
+    assert(vecOutputAmounts.size() < INT_MAX);
+    int nBytesAdditional = nBytesOutput * (int)vecOutputAmounts.size();
     for (const auto nAmountOutput : vecOutputAmounts) {
         if (nAmountOutput < 0) {
             return false;
@@ -238,7 +239,9 @@ CAmount CTransactionBuilder::GetFee(unsigned int nBytes) const
 int CTransactionBuilder::GetSizeOfCompactSizeDiff(size_t nAdd) const
 {
     size_t nSize = vecOutputs.size();
-    return ::GetSizeOfCompactSizeDiff(nSize, nSize + nAdd);
+    unsigned int ret = ::GetSizeOfCompactSizeDiff(nSize, nSize + nAdd);
+    assert(ret <= INT_MAX);
+    return (int)ret;
 }
 
 bool CTransactionBuilder::IsDust(CAmount nAmount) const

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -172,14 +172,14 @@ void CTransactionBuilder::Clear()
     dummyReserveKey.ReturnKey();
 }
 
-bool CTransactionBuilder::TryAddOutput(CAmount nAmountOutput) const
+bool CTransactionBuilder::CouldAddOutput(CAmount nAmountOutput) const
 {
     // Adding another output can change the serialized size of the vout size hence + GetSizeOfCompactSizeDiff()
     unsigned int nBytes = GetBytesTotal() + nBytesOutput + GetSizeOfCompactSizeDiff(1);
     return GetAmountLeft(GetAmountInitial(), GetAmountUsed() + nAmountOutput, GetFee(nBytes)) >= 0;
 }
 
-bool CTransactionBuilder::TryAddOutputs(const std::vector<CAmount>& vecOutputAmounts) const
+bool CTransactionBuilder::CouldAddOutputs(const std::vector<CAmount>& vecOutputAmounts) const
 {
     CAmount nAmountAdditional{0};
     int nBytesAdditional = nBytesOutput * vecOutputAmounts.size();
@@ -194,7 +194,7 @@ bool CTransactionBuilder::TryAddOutputs(const std::vector<CAmount>& vecOutputAmo
 CTransactionBuilderOutput* CTransactionBuilder::AddOutput(CAmount nAmountOutput)
 {
     LOCK(cs_outputs);
-    if (TryAddOutput(nAmountOutput)) {
+    if (CouldAddOutput(nAmountOutput)) {
         vecOutputs.push_back(std::make_unique<CTransactionBuilderOutput>(this, pwallet, nAmountOutput));
         return vecOutputs.back().get();
     }

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -136,7 +136,7 @@ CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyI
     SignatureData dummySignature;
     ProduceSignature(DummySignatureCreator(pwallet), dummyScript, dummySignature);
     for (auto out : tallyItem.vecOutPoints) {
-        dummyTx.vin.push_back(CTxIn(out, dummySignature.scriptSig));
+        dummyTx.vin.emplace_back(out, dummySignature.scriptSig);
     }
     // Calculate required bytes for the dummy tx with tallyItem's inputs only
     nBytesBase = ::GetSerializeSize(dummyTx, SER_NETWORK, PROTOCOL_VERSION);

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -257,7 +257,7 @@ bool CTransactionBuilder::Commit(std::string& strResult)
     CAmount nFeeRet = 0;
     int nChangePosRet = -1;
 
-    // Transfor the outputs to the format CWallet::CreateTransaction requires
+    // Transform the outputs to the format CWallet::CreateTransaction requires
     std::vector<CRecipient> vecSend;
     {
         LOCK(cs_outputs);

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -10,6 +10,12 @@
 #include <validation.h>
 #include <wallet/fees.h>
 
+inline unsigned int GetSizeOfCompactSizeDiff(uint64_t nSizePrev, uint64_t nSizeNew)
+{
+    assert(nSizePrev <= nSizeNew);
+    return ::GetSizeOfCompactSize(nSizeNew) - ::GetSizeOfCompactSize(nSizePrev);
+}
+
 CKeyHolder::CKeyHolder(CWallet* pwallet) :
     reserveKey(pwallet)
 {
@@ -168,7 +174,9 @@ void CTransactionBuilder::Clear()
 
 bool CTransactionBuilder::TryAddOutput(CAmount nAmountOutput) const
 {
-    return GetAmountLeft(GetAmountInitial(), GetAmountUsed() + nAmountOutput, GetFee(GetBytesTotal() + nBytesOutput)) >= 0;
+    // Adding another output can change the serialized size of the vout size hence + GetSizeOfCompactSizeDiff()
+    unsigned int nBytes = GetBytesTotal() + nBytesOutput + GetSizeOfCompactSizeDiff(1);
+    return GetAmountLeft(GetAmountInitial(), GetAmountUsed() + nAmountOutput, GetFee(nBytes)) >= 0;
 }
 
 bool CTransactionBuilder::TryAddOutputs(const std::vector<CAmount>& vecOutputAmounts) const
@@ -178,7 +186,9 @@ bool CTransactionBuilder::TryAddOutputs(const std::vector<CAmount>& vecOutputAmo
     for (const auto nAmountOutput : vecOutputAmounts) {
         nAmountAdditional += nAmountOutput;
     }
-    return GetAmountLeft(GetAmountInitial(), GetAmountUsed() + nAmountAdditional, GetFee(GetBytesTotal() + nBytesAdditional)) >= 0;
+    // Adding other outputs can change the serialized size of the vout size hence + GetSizeOfCompactSizeDiff()
+    unsigned int nBytes = GetBytesTotal() + nBytesAdditional + GetSizeOfCompactSizeDiff(vecOutputAmounts.size());
+    return GetAmountLeft(GetAmountInitial(), GetAmountUsed() + nAmountAdditional, GetFee(nBytes)) >= 0;
 }
 
 CTransactionBuilderOutput* CTransactionBuilder::AddOutput(CAmount nAmountOutput)
@@ -193,10 +203,8 @@ CTransactionBuilderOutput* CTransactionBuilder::AddOutput(CAmount nAmountOutput)
 
 unsigned int CTransactionBuilder::GetBytesTotal() const
 {
-    unsigned int nBytesAll = nBytesBase + vecOutputs.size() * nBytesOutput;
-    // Adding outputs can change the serialized size of the vout size
-    unsigned int nBytesCompactSizeDiff = GetSizeOfCompactSize(vecOutputs.size()) - GetSizeOfCompactSize(0);
-    return nBytesAll + nBytesCompactSizeDiff;
+    // Adding other outputs can change the serialized size of the vout size hence + GetSizeOfCompactSizeDiff()
+   return nBytesBase + vecOutputs.size() * nBytesOutput + ::GetSizeOfCompactSizeDiff(0, vecOutputs.size());
 }
 
 CAmount CTransactionBuilder::GetAmountLeft(const CAmount nAmountInitial, const CAmount nAmountUsed, const CAmount nFee)
@@ -224,6 +232,12 @@ CAmount CTransactionBuilder::GetFee(unsigned int nBytes) const
         nFeeCalc = ::maxTxFee;
     }
     return nFeeCalc;
+}
+
+int CTransactionBuilder::GetSizeOfCompactSizeDiff(size_t nAdd) const
+{
+    size_t nSize = vecOutputs.size();
+    return ::GetSizeOfCompactSizeDiff(nSize, nSize + nAdd);
 }
 
 bool CTransactionBuilder::IsDust(CAmount nAmount) const
@@ -271,9 +285,8 @@ bool CTransactionBuilder::Commit(std::string& strResult)
     if (fDust) {
         nFeeAdditional = nAmountLeft;
     } else {
-        // Adding another output can change the serialized size of the vout size
-        unsigned int nBytesCompactSizeDiff = GetSizeOfCompactSize(vecOutputs.size() + 1) - GetSizeOfCompactSize(vecOutputs.size());
-        nBytesAdditional = nBytesOutput + nBytesCompactSizeDiff;
+        // Add a change output and GetSizeOfCompactSizeDiff(1) as another output can changes the serialized size of the vout size in CTransaction
+        nBytesAdditional = nBytesOutput + GetSizeOfCompactSizeDiff(1);
     }
 
     // If the calculated fee does not match the fee returned by CreateTransaction aka if this check fails something is messed!

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -134,9 +134,8 @@ CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyI
     }
     // Calculate required bytes for the dummy tx with tallyItem's inputs only
     nBytesBase = ::GetSerializeSize(dummyTx, SER_NETWORK, PROTOCOL_VERSION);
-    // Add one output and use the size difference to calculate the output size
-    dummyTx.vout.push_back(CTxOut(0, dummyScript));
-    nBytesOutput = ::GetSerializeSize(dummyTx, SER_NETWORK, PROTOCOL_VERSION) - nBytesBase;
+    // Calculate the output size
+    nBytesOutput = ::GetSerializeSize(CTxOut(0, dummyScript), SER_NETWORK, PROTOCOL_VERSION);
     // Just to make sure..
     Clear();
 }

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -108,7 +108,7 @@ CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyI
     dummyReserveKey(pwalletIn),
     tallyItem(tallyItemIn)
 {
-    // Generate d feerate which will be used to consider if the remainder is dust and will go into fees or not
+    // Generate a feerate which will be used to consider if the remainder is dust and will go into fees or not
     coinControl.m_discard_feerate = ::GetDiscardRate(::feeEstimator);
     // Generate a feerate which will be used by calculations of this class and also by CWallet::CreateTransaction
     coinControl.m_feerate = ::feeEstimator.estimateSmartFee(::nTxConfirmTarget, nullptr, true);

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -213,7 +213,7 @@ CAmount CTransactionBuilder::GetAmountUsed() const
     return nAmountUsed;
 }
 
-CAmount CTransactionBuilder::GetFee(int nBytes) const
+CAmount CTransactionBuilder::GetFee(unsigned int nBytes) const
 {
     CAmount nFeeCalc = coinControl.m_feerate->GetFee(nBytes);
     CAmount nRequiredFee = GetRequiredFee(nBytes);

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -2,7 +2,13 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/validation.h>
+#include <policy/fees.h>
+#include <policy/policy.h>
 #include <privatesend/privatesend-util.h>
+#include <script/sign.h>
+#include <validation.h>
+#include <wallet/fees.h>
 
 CKeyHolder::CKeyHolder(CWallet* pwallet) :
     reserveKey(pwallet)
@@ -69,4 +75,224 @@ void CKeyHolderStorage::ReturnAll()
         }
         LogPrintf("CKeyHolderStorage::%s -- %lld keys returned\n", __func__, tmp.size());
     }
+}
+
+CTransactionBuilderOutput::CTransactionBuilderOutput(CTransactionBuilder* pTxBuilderIn, CWallet* pwalletIn, CAmount nAmountIn) :
+    pTxBuilder(pTxBuilderIn),
+    key(pwalletIn),
+    nAmount(nAmountIn)
+{
+    assert(pTxBuilder);
+    CPubKey pubKey;
+    key.GetReservedKey(pubKey, false);
+    script = ::GetScriptForDestination(pubKey.GetID());
+}
+
+bool CTransactionBuilderOutput::UpdateAmount(const CAmount nNewAmount)
+{
+    LOCK(pTxBuilder->cs_outputs);
+
+    const CAmount nAmountDiff = nNewAmount - nAmount;
+
+    if (nNewAmount > 0 && nAmountDiff <= pTxBuilder->GetAmountLeft()) {
+        if (nAmountDiff != 0) {
+            nAmount = nNewAmount;
+        }
+        return true;
+    }
+    return false;
+}
+
+CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyItem& tallyItemIn) :
+    pwallet(pwalletIn),
+    dummyReserveKey(pwalletIn),
+    tallyItem(tallyItemIn)
+{
+    // Generate d feerate which will be used to consider if the remainder is dust and will go into fees or not
+    coinControl.m_dust_feerate = ::GetDiscardRate(::feeEstimator);
+    // Generate a feerate which will be used by calculations of this class and also by CWallet::CreateTransaction
+    coinControl.m_feerate = ::feeEstimator.estimateSmartFee(::nTxConfirmTarget, nullptr, true);
+    // Fee will always go back to origin
+    coinControl.destChange = tallyItemIn.txdest;
+    // Only allow tallyItems inputs for tx creation
+    coinControl.fAllowOtherInputs = false;
+    // Select all tallyItem outputs in the coinControl so that CreateTransaction knows what to use
+    for (const auto& outpoint : tallyItem.vecOutPoints) {
+        coinControl.Select(outpoint);
+    }
+    // Create dummy tx to calculate the exact required fees upfront for accurate amount and fee calculations
+    CMutableTransaction dummyTx;
+    // Get a comparable dummy scriptPubKey
+    CTransactionBuilderOutput dummyOutput(this, pwallet, 0);
+    CScript dummyScript = dummyOutput.GetScript();
+    dummyOutput.ReturnKey();
+    // And create dummy signatures for all inputs
+    SignatureData dummySignature;
+    ProduceSignature(DummySignatureCreator(pwallet), dummyScript, dummySignature);
+    for (auto out : tallyItem.vecOutPoints) {
+        dummyTx.vin.push_back(CTxIn(out, dummySignature.scriptSig));
+    }
+    // Calculate required bytes for the dummy tx with tallyItem's inputs only
+    nBytesBase = ::GetSerializeSize(dummyTx, SER_NETWORK, PROTOCOL_VERSION);
+    // Add one output and use the size difference to calculate the output size
+    dummyTx.vout.push_back(CTxOut(0, dummyScript));
+    nBytesOutput = ::GetSerializeSize(dummyTx, SER_NETWORK, PROTOCOL_VERSION) - nBytesBase;
+    // Just to make sure..
+    Clear();
+}
+
+CTransactionBuilder::~CTransactionBuilder()
+{
+    Clear();
+}
+
+void CTransactionBuilder::Clear()
+{
+    std::vector<std::unique_ptr<CTransactionBuilderOutput>> vecOutputsTmp;
+    {
+        // Don't hold cs_outputs while clearing the outputs which might indirectly call lock cs_wallet
+        LOCK(cs_outputs);
+        std::swap(vecOutputs, vecOutputsTmp);
+        vecOutputs.clear();
+    }
+
+    for (auto& key : vecOutputsTmp) {
+        if (fKeepKeys) {
+            key->KeepKey();
+        } else {
+            key->ReturnKey();
+        }
+    }
+    // Always return this key just to make sure..
+    dummyReserveKey.ReturnKey();
+}
+
+bool CTransactionBuilder::TryAddOutput(CAmount nAmount) const
+{
+    return GetAmountLeft(tallyItem.nAmount, GetAmountUsed() + nAmount, GetFee(GetBytesTotal() + nBytesOutput, coinControl.m_feerate.get())) >= 0;
+}
+
+bool CTransactionBuilder::TryAddOutputs(const std::vector<CAmount>& vecAmounts) const
+{
+    CAmount nAmountSum{0};
+    for (auto nAmount : vecAmounts) {
+        nAmountSum += nAmount;
+    }
+    return GetAmountLeft(tallyItem.nAmount, GetAmountUsed() + nAmountSum, GetFee(GetBytesTotal() + nBytesOutput * vecAmounts.size(), coinControl.m_feerate.get())) >= 0;
+}
+
+CTransactionBuilderOutput* CTransactionBuilder::AddOutput(CAmount nAmount)
+{
+    LOCK(cs_outputs);
+    if (TryAddOutput(nAmount)) {
+        vecOutputs.push_back(std::make_unique<CTransactionBuilderOutput>(this, pwallet, nAmount));
+        return vecOutputs.back().get();
+    }
+    return nullptr;
+}
+
+CAmount CTransactionBuilder::GetAmountLeft(const CAmount nAmount, const CAmount nAmountUsed, const CAmount nFee)
+{
+    return nAmount - nAmountUsed - nFee;
+}
+
+CAmount CTransactionBuilder::GetAmountUsed() const
+{
+    CAmount nAmountUsed{0};
+    for (const auto& out : vecOutputs) {
+        nAmountUsed += out->GetAmount();
+    }
+    return nAmountUsed;
+}
+
+CAmount CTransactionBuilder::GetFee(int nBytes, const CFeeRate& feeRate)
+{
+    CAmount nFeeCalc = feeRate.GetFee(nBytes);
+    CAmount nRequiredFee = GetRequiredFee(nBytes);
+    if (nRequiredFee > nFeeCalc) {
+        nFeeCalc = nRequiredFee;
+    }
+    if (nFeeCalc > ::maxTxFee) {
+        nFeeCalc = ::maxTxFee;
+    }
+    return nFeeCalc;
+}
+
+CAmount CTransactionBuilder::GetFee() const
+{
+    return GetFee(GetBytesTotal(), coinControl.m_feerate.get());
+}
+
+bool CTransactionBuilder::IsDust(CAmount nAmount) const
+{
+    return ::IsDust(CTxOut(nAmount, ::GetScriptForDestination(tallyItem.txdest)), coinControl.m_dust_feerate.get());
+}
+
+bool CTransactionBuilder::Commit(std::string& strResult)
+{
+    CWalletTx wtx;
+    CAmount nFeeRet = 0;
+    int nChangePosRet = -1;
+
+    // Transfor the outputs to the format CWallet::CreateTransaction requires
+    std::vector<CRecipient> vecSend;
+    {
+        LOCK(cs_outputs);
+        vecSend.reserve(vecOutputs.size());
+        for (const auto& out : vecOutputs) {
+            vecSend.push_back((CRecipient){out->GetScript(), out->GetAmount(), false});
+        }
+    }
+
+    if (!pwallet->CreateTransaction(vecSend, wtx, dummyReserveKey, nFeeRet, nChangePosRet, strResult, coinControl)) {
+        return false;
+    }
+
+    CAmount nAmountLeft = GetAmountLeft();
+    CAmount nFeeAdditional = nAmountLeft && IsDust(nAmountLeft) ? nAmountLeft : 0;
+    int nBytesAdditional = !IsDust(nAmountLeft) ? nBytesOutput : 0;
+    CAmount nFeeCalc = GetFee(GetBytesTotal() + nBytesAdditional, coinControl.m_feerate.get()) + nFeeAdditional;
+
+    // If there is a either remainder which is considered to be dust (will be added to fee in this case) or no amount left there should be no change output, return if there is a change output.
+    if (nChangePosRet != -1 && IsDust(nAmountLeft)) {
+        strResult = strprintf("Unexpected change output %s at position %d", wtx.tx->vout[nChangePosRet].ToString(), nChangePosRet);
+        return false;
+    }
+
+    // If there is a remainder which is not considered to be dust it should end up in a change output, return if not.
+    if (!IsDust(nAmountLeft) && nChangePosRet == -1) {
+        strResult = strprintf("Change output missing: %d", GetAmountLeft());
+        return false;
+    }
+
+    // If the calculated fee does not match the fee returned by CreateTransaction aka if this check fails something is messed!
+    if (nFeeRet != nFeeCalc) {
+        strResult = strprintf("Fee validation failed -> nFeeRet: %d, nFeeCalc: %d, nFeeAdditional: %d, nBytesAdditional: %d, %s", nFeeRet, nFeeCalc, nFeeAdditional, nBytesAdditional, ToString());
+        return false;
+    }
+
+    CValidationState state;
+    if (!pwallet->CommitTransaction(wtx, dummyReserveKey, g_connman.get(), state)) {
+        strResult = state.GetRejectReason();
+        return false;
+    }
+
+    fKeepKeys = true;
+
+    strResult = wtx.GetHash().ToString();
+
+    return true;
+}
+
+std::string CTransactionBuilder::ToString()
+{
+    return strprintf("CTransactionBuilder(Amount left: %d, Bytes base: %d, Bytes output %d, Bytes total: %d, Amount used: %d, Outputs: %d, Fee rate: %d, Fee: %d)",
+        GetAmountLeft(),
+        nBytesBase,
+        nBytesOutput,
+        GetBytesTotal(),
+        GetAmountUsed(),
+        CountOutputs(),
+        coinControl.m_feerate->GetFeePerK(),
+        GetFee());
 }

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -97,16 +97,11 @@ CTransactionBuilderOutput::CTransactionBuilderOutput(CTransactionBuilder* pTxBui
 bool CTransactionBuilderOutput::UpdateAmount(const CAmount nNewAmount)
 {
     LOCK(pTxBuilder->cs_outputs);
-
-    const CAmount nAmountDiff = nNewAmount - nAmount;
-
-    if (nNewAmount > 0 && nAmountDiff <= pTxBuilder->GetAmountLeft()) {
-        if (nAmountDiff != 0) {
-            nAmount = nNewAmount;
-        }
-        return true;
+    if (nNewAmount <= 0 || nNewAmount - nAmount > pTxBuilder->GetAmountLeft()) {
+        return false;
     }
-    return false;
+    nAmount = nNewAmount;
+    return true;
 }
 
 CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyItem& tallyItemIn) :

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -112,7 +112,7 @@ CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyI
     // Generate a feerate which will be used to consider if the remainder is dust and will go into fees or not
     coinControl.m_discard_feerate = ::GetDiscardRate(::feeEstimator);
     // Generate a feerate which will be used by calculations of this class and also by CWallet::CreateTransaction
-    coinControl.m_feerate = std::max(::feeEstimator.estimateSmartFee(::nTxConfirmTarget, nullptr, true), payTxFee);
+    coinControl.m_feerate = std::max(::feeEstimator.estimateSmartFee((int)::nTxConfirmTarget, nullptr, true), payTxFee);
     // Change always goes back to origin
     coinControl.destChange = tallyItemIn.txdest;
     // Only allow tallyItems inputs for tx creation

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -117,7 +117,7 @@ CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyI
     // Generate a feerate which will be used to consider if the remainder is dust and will go into fees or not
     coinControl.m_discard_feerate = ::GetDiscardRate(::feeEstimator);
     // Generate a feerate which will be used by calculations of this class and also by CWallet::CreateTransaction
-    coinControl.m_feerate = ::feeEstimator.estimateSmartFee(::nTxConfirmTarget, nullptr, true);
+    coinControl.m_feerate = std::max(::feeEstimator.estimateSmartFee(::nTxConfirmTarget, nullptr, true), payTxFee);
     // Change always goes back to origin
     coinControl.destChange = tallyItemIn.txdest;
     // Only allow tallyItems inputs for tx creation

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -112,7 +112,7 @@ CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyI
     coinControl.m_discard_feerate = ::GetDiscardRate(::feeEstimator);
     // Generate a feerate which will be used by calculations of this class and also by CWallet::CreateTransaction
     coinControl.m_feerate = ::feeEstimator.estimateSmartFee(::nTxConfirmTarget, nullptr, true);
-    // Fee will always go back to origin
+    // Change always goes back to origin
     coinControl.destChange = tallyItemIn.txdest;
     // Only allow tallyItems inputs for tx creation
     coinControl.fAllowOtherInputs = false;
@@ -298,7 +298,8 @@ bool CTransactionBuilder::Commit(std::string& strResult)
 
 std::string CTransactionBuilder::ToString() const
 {
-    return strprintf("CTransactionBuilder(Amount left: %d, Bytes base: %d, Bytes output %d, Bytes total: %d, Amount used: %d, Outputs: %d, Fee rate: %d, Fee: %d)",
+    return strprintf("CTransactionBuilder(Amount initial: %d, Amount left: %d, Bytes base: %d, Bytes output: %d, Bytes total: %d, Amount used: %d, Outputs: %d, Fee rate: %d, Discard fee rate: %d, Fee: %d)",
+        GetAmountInitial(),
         GetAmountLeft(),
         nBytesBase,
         nBytesOutput,
@@ -306,5 +307,6 @@ std::string CTransactionBuilder::ToString() const
         GetAmountUsed(),
         CountOutputs(),
         coinControl.m_feerate->GetFeePerK(),
+        coinControl.m_discard_feerate->GetFeePerK(),
         GetFee(GetBytesTotal()));
 }

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -174,6 +174,9 @@ void CTransactionBuilder::Clear()
 
 bool CTransactionBuilder::CouldAddOutput(CAmount nAmountOutput) const
 {
+    if (nAmountOutput < 0) {
+        return false;
+    }
     // Adding another output can change the serialized size of the vout size hence + GetSizeOfCompactSizeDiff()
     unsigned int nBytes = GetBytesTotal() + nBytesOutput + GetSizeOfCompactSizeDiff(1);
     return GetAmountLeft(GetAmountInitial(), GetAmountUsed() + nAmountOutput, GetFee(nBytes)) >= 0;
@@ -184,6 +187,9 @@ bool CTransactionBuilder::CouldAddOutputs(const std::vector<CAmount>& vecOutputA
     CAmount nAmountAdditional{0};
     int nBytesAdditional = nBytesOutput * vecOutputAmounts.size();
     for (const auto nAmountOutput : vecOutputAmounts) {
+        if (nAmountOutput < 0) {
+            return false;
+        }
         nAmountAdditional += nAmountOutput;
     }
     // Adding other outputs can change the serialized size of the vout size hence + GetSizeOfCompactSizeDiff()

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -204,7 +204,7 @@ CTransactionBuilderOutput* CTransactionBuilder::AddOutput(CAmount nAmountOutput)
 unsigned int CTransactionBuilder::GetBytesTotal() const
 {
     // Adding other outputs can change the serialized size of the vout size hence + GetSizeOfCompactSizeDiff()
-   return nBytesBase + vecOutputs.size() * nBytesOutput + ::GetSizeOfCompactSizeDiff(0, vecOutputs.size());
+    return nBytesBase + vecOutputs.size() * nBytesOutput + ::GetSizeOfCompactSizeDiff(0, vecOutputs.size());
 }
 
 CAmount CTransactionBuilder::GetAmountLeft(const CAmount nAmountInitial, const CAmount nAmountUsed, const CAmount nFee)
@@ -289,7 +289,7 @@ bool CTransactionBuilder::Commit(std::string& strResult)
         nBytesAdditional = nBytesOutput + GetSizeOfCompactSizeDiff(1);
     }
 
-    // If the calculated fee does not match the fee returned by CreateTransaction aka if this check fails something is messed!
+    // If the calculated fee does not match the fee returned by CreateTransaction aka if this check fails something is wrong!
     CAmount nFeeCalc = GetFee(GetBytesTotal() + nBytesAdditional) + nFeeAdditional;
     if (nFeeRet != nFeeCalc) {
         strResult = strprintf("Fee validation failed -> nFeeRet: %d, nFeeCalc: %d, nFeeAdditional: %d, nBytesAdditional: %d, %s", nFeeRet, nFeeCalc, nFeeAdditional, nBytesAdditional, ToString());

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -278,7 +278,7 @@ bool CTransactionBuilder::Commit(std::string& strResult)
     return true;
 }
 
-std::string CTransactionBuilder::ToString()
+std::string CTransactionBuilder::ToString() const
 {
     return strprintf("CTransactionBuilder(Amount left: %d, Bytes base: %d, Bytes output %d, Bytes total: %d, Amount used: %d, Outputs: %d, Fee rate: %d, Fee: %d)",
         GetAmountLeft(),

--- a/src/privatesend/privatesend-util.cpp
+++ b/src/privatesend/privatesend-util.cpp
@@ -109,7 +109,7 @@ CTransactionBuilder::CTransactionBuilder(CWallet* pwalletIn, const CompactTallyI
     tallyItem(tallyItemIn)
 {
     // Generate d feerate which will be used to consider if the remainder is dust and will go into fees or not
-    coinControl.m_dust_feerate = ::GetDiscardRate(::feeEstimator);
+    coinControl.m_discard_feerate = ::GetDiscardRate(::feeEstimator);
     // Generate a feerate which will be used by calculations of this class and also by CWallet::CreateTransaction
     coinControl.m_feerate = ::feeEstimator.estimateSmartFee(::nTxConfirmTarget, nullptr, true);
     // Fee will always go back to origin
@@ -219,7 +219,7 @@ CAmount CTransactionBuilder::GetFee(int nBytes) const
 
 bool CTransactionBuilder::IsDust(CAmount nAmount) const
 {
-    return ::IsDust(CTxOut(nAmount, ::GetScriptForDestination(tallyItem.txdest)), coinControl.m_dust_feerate.get());
+    return ::IsDust(CTxOut(nAmount, ::GetScriptForDestination(tallyItem.txdest)), coinControl.m_discard_feerate.get());
 }
 
 bool CTransactionBuilder::Commit(std::string& strResult)

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -57,7 +57,7 @@ public:
     // Get the amount of this output
     CAmount GetAmount() const { return nAmount; }
     // Try update the amount of this output. Returns true if it was successful and false if not (e.g. insufficient amount left).
-    bool UpdateAmount(const CAmount nAmount);
+    bool UpdateAmount(CAmount nAmount);
     // Tell the wallet to remove the key used by this output from the keypool
     void KeepKey() { key.KeepKey(); }
     // Tell the wallet to return the key used by this output to the keypool
@@ -117,7 +117,7 @@ private:
     // Get the total number of bytes used already by this transaction
     unsigned int GetBytesTotal() const;
     // Helper to calculate static amount left by simply subtracting an used amount and a fee from a provided initial amount.
-    static CAmount GetAmountLeft(const CAmount nAmountInitial, const CAmount nAmountUsed, const CAmount nFee);
+    static CAmount GetAmountLeft(CAmount nAmountInitial, CAmount nAmountUsed, CAmount nFee);
     // Get the amount currently used by added outputs. Does not include fees.
     CAmount GetAmountUsed() const;
     // Get fees based on the number of bytes and the feerate set in CoinControl.

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -124,6 +124,8 @@ private:
     // NOTE: To get the total transaction fee this should only be called once with the total number of bytes for the transaction to avoid
     // calling CFeeRate::GetFee multiple times with subtotals as this may add rounding errors with each further call.
     CAmount GetFee(unsigned int nBytes) const;
+    // Helper to get GetSizeOfCompactSizeDiff(vecOutputs.size(), vecOutputs.size() + nAdd)
+    int GetSizeOfCompactSizeDiff(size_t nAdd) const;
 };
 
 #endif // BITCOIN_PRIVATESEND_PRIVATESEND_UTIL_H

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -100,8 +100,6 @@ public:
     bool TryAddOutputs(const std::vector<CAmount>& vecAmounts) const;
     // Add an output with the amount nAmount. Returns a pointer to the output if it could be added and nullptr if not due to insufficient amomunt left.
     CTransactionBuilderOutput* AddOutput(CAmount nAmount = 0);
-    // Get a reference to the coinControl
-    const CCoinControl& GetCoinControl() const { return coinControl; }
     // Get amount we had available when we started
     CAmount GetAmountInitial() const { return tallyItem.nAmount; }
     // Helper to calculate static remainders for output trying

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -55,7 +55,7 @@ public:
     // Get the scriptPubKey of this output
     CScript GetScript() { return script; }
     // Get the amount of this output
-    CAmount GetAmount() { return nAmount; }
+    CAmount GetAmount() const { return nAmount; }
     // Try update the amount of this output. Returns true if it was successful and false if not (e.g. insufficient amount left).
     bool UpdateAmount(const CAmount nAmount);
     // Tell the wallet to remove the key used by this output from the keypool

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -37,6 +37,10 @@ public:
     void ReturnAll();
 };
 
+/**
+ * @brief Used by CTransactionBuilder to represent its transaction outputs.
+ * It creates a CReserveKey for the given CWallet as destination.
+ */
 class CTransactionBuilderOutput
 {
     /// Used for amount updates
@@ -64,6 +68,11 @@ public:
     void ReturnKey() { key.ReturnKey(); }
 };
 
+/**
+ * @brief Enables simple transaction generation for a given CWallet object. The resulting
+ * transaction's inputs are defined by the given CompactTallyItem. The outputs are
+ * defined by CTransactionBuilderOutput.
+ */
 class CTransactionBuilder
 {
     /// Wallet the transaction will be build for

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -113,7 +113,7 @@ public:
     // Create and Commit the transaction to the wallet
     bool Commit(std::string& strResult);
     // Convert to a string
-    std::string ToString();
+    std::string ToString() const;
 
 private:
     // Clear the output vector and keep/return the included keys depending on the value of fKeepKeys

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -114,8 +114,6 @@ public:
     CAmount GetAmountUsed() const;
     // Get the total number of bytes used already by this transaction
     int GetBytesTotal() const { return nBytesBase + vecOutputs.size() * nBytesOutput; }
-    // Get the number of bytes added by a single output
-    int GetBytesOutput() const { return nBytesOutput; }
     // Check if an amounts should be considered as dust
     bool IsDust(CAmount nAmount) const;
     // Get the total number of added outputs

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -94,8 +94,6 @@ class CTransactionBuilder
 public:
     CTransactionBuilder(CWallet* pwalletIn, const CompactTallyItem& tallyItemIn);
     ~CTransactionBuilder();
-    // Clear the output vector and keep/return the included keys depending on the value of fKeepKeys
-    void Clear();
     // Try to add a single output with the amount nAmount. Returns true if its possble and false if not.
     bool TryAddOutput(CAmount nAmount) const;
     // Try to add multiple outputs as vector of amounts. Returns true if its possible to add all of them and false if not.
@@ -110,10 +108,6 @@ public:
     static CAmount GetAmountLeft(const CAmount nAmount, const CAmount nAmountUsed, const CAmount nFee);
     // Get the amount currently left to add more outputs. Does respect fees.
     CAmount GetAmountLeft() const { return GetAmountInitial() - GetAmountUsed() - GetFee(GetBytesTotal()); }
-    // Get the amount currently used by added outputs. Does not include fees.
-    CAmount GetAmountUsed() const;
-    // Get the total number of bytes used already by this transaction
-    int GetBytesTotal() const { return nBytesBase + vecOutputs.size() * nBytesOutput; }
     // Check if an amounts should be considered as dust
     bool IsDust(CAmount nAmount) const;
     // Get the total number of added outputs
@@ -124,6 +118,12 @@ public:
     std::string ToString();
 
 private:
+    // Clear the output vector and keep/return the included keys depending on the value of fKeepKeys
+    void Clear();
+    // Get the total number of bytes used already by this transaction
+    int GetBytesTotal() const { return nBytesBase + vecOutputs.size() * nBytesOutput; }
+    // Get the amount currently used by added outputs. Does not include fees.
+    CAmount GetAmountUsed() const;
     // Get fees based on the number of bytes and the feerate set in CoinControl
     CAmount GetFee(int nBytes) const;
 };

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -109,13 +109,9 @@ public:
     // Helper to calculate static remainders for output trying
     static CAmount GetAmountLeft(const CAmount nAmount, const CAmount nAmountUsed, const CAmount nFee);
     // Get the amount currently left to add more outputs. Does respect fees.
-    CAmount GetAmountLeft() const { return GetAmountInitial() - GetAmountUsed() - GetFee(GetBytesTotal(), coinControl.m_feerate.get()); }
+    CAmount GetAmountLeft() const { return GetAmountInitial() - GetAmountUsed() - GetFee(GetBytesTotal()); }
     // Get the amount currently used by added outputs. Does not include fees.
     CAmount GetAmountUsed() const;
-    // Helper to calculate static fees for output tryingd
-    static CAmount GetFee(int nBytes, const CFeeRate& feeRate);
-    // Get fees based on the number of total used byes and the feerate set in CoinControl
-    CAmount GetFee() const;
     // Get the total number of bytes used already by this transaction
     int GetBytesTotal() const { return nBytesBase + vecOutputs.size() * nBytesOutput; }
     // Get the number of bytes added by a single output
@@ -128,6 +124,10 @@ public:
     bool Commit(std::string& strResult);
     // Convert to a string
     std::string ToString();
+
+private:
+    // Get fees based on the number of bytes and the feerate set in CoinControl
+    CAmount GetFee(int nBytes) const;
 };
 
 #endif // BITCOIN_PRIVATESEND_PRIVATESEND_UTIL_H

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -80,7 +80,7 @@ class CTransactionBuilder
     int nBytesBase{0};
     // Contains the number of bytes required to add one output
     int nBytesOutput{0};
-    // Call KeepKey for all keys in desctructor if fKeepKeys is true, call ReturnKey for all key if its false.
+    // Call KeepKey for all keys in destructor if fKeepKeys is true, call ReturnKey for all key if its false.
     bool fKeepKeys{false};
     // Protect vecOutputs
     mutable CCriticalSection cs_outputs;
@@ -96,7 +96,7 @@ public:
     bool CouldAddOutput(CAmount nAmountOutput) const;
     // Check if its possible to add multiple outputs as vector of amounts. Returns true if its possible to add all of them and false if not.
     bool CouldAddOutputs(const std::vector<CAmount>& vecOutputAmounts) const;
-    // Add an output with the amount nAmount. Returns a pointer to the output if it could be added and nullptr if not due to insufficient amomunt left.
+    // Add an output with the amount nAmount. Returns a pointer to the output if it could be added and nullptr if not due to insufficient amount left.
     CTransactionBuilderOutput* AddOutput(CAmount nAmountOutput = 0);
     // Get amount we had available when we started
     CAmount GetAmountInitial() const { return tallyItem.nAmount; }

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -115,7 +115,7 @@ private:
     // Clear the output vector and keep/return the included keys depending on the value of fKeepKeys
     void Clear();
     // Get the total number of bytes used already by this transaction
-    int GetBytesTotal() const { return nBytesBase + vecOutputs.size() * nBytesOutput; }
+    unsigned int GetBytesTotal() const;
     // Helper to calculate static amount left by simply subtracting an used amount and a fee from a provided initial amount.
     static CAmount GetAmountLeft(const CAmount nAmountInitial, const CAmount nAmountUsed, const CAmount nFee);
     // Get the amount currently used by added outputs. Does not include fees.

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -92,10 +92,10 @@ class CTransactionBuilder
 public:
     CTransactionBuilder(CWallet* pwalletIn, const CompactTallyItem& tallyItemIn);
     ~CTransactionBuilder();
-    // Try to add a single output with the amount nAmount. Returns true if its possble and false if not.
-    bool TryAddOutput(CAmount nAmountOutput) const;
-    // Try to add multiple outputs as vector of amounts. Returns true if its possible to add all of them and false if not.
-    bool TryAddOutputs(const std::vector<CAmount>& vecOutputAmounts) const;
+    // Check it would be possible to add a single output with the amount nAmount. Returns true if its possible and false if not.
+    bool CouldAddOutput(CAmount nAmountOutput) const;
+    // Check if its possible to add multiple outputs as vector of amounts. Returns true if its possible to add all of them and false if not.
+    bool CouldAddOutputs(const std::vector<CAmount>& vecOutputAmounts) const;
     // Add an output with the amount nAmount. Returns a pointer to the output if it could be added and nullptr if not due to insufficient amomunt left.
     CTransactionBuilderOutput* AddOutput(CAmount nAmountOutput = 0);
     // Get amount we had available when we started

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -53,7 +53,7 @@ public:
     CTransactionBuilderOutput(CTransactionBuilderOutput&&) = delete;
     CTransactionBuilderOutput& operator=(CTransactionBuilderOutput&&) = delete;
     // Get the scriptPubKey of this output
-    CScript GetScript() { return script; }
+    CScript GetScript() const { return script; }
     // Get the amount of this output
     CAmount GetAmount() const { return nAmount; }
     // Try update the amount of this output. Returns true if it was successful and false if not (e.g. insufficient amount left).

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -100,8 +100,6 @@ public:
     CTransactionBuilderOutput* AddOutput(CAmount nAmountOutput = 0);
     // Get amount we had available when we started
     CAmount GetAmountInitial() const { return tallyItem.nAmount; }
-    // Helper to calculate static amount left by simply subtracting an used amount and a fee from a provided initial amount.
-    static CAmount GetAmountLeft(const CAmount nAmountInitial, const CAmount nAmountUsed, const CAmount nFee);
     // Get the amount currently left to add more outputs. Does respect fees.
     CAmount GetAmountLeft() const { return GetAmountInitial() - GetAmountUsed() - GetFee(GetBytesTotal()); }
     // Check if an amounts should be considered as dust
@@ -118,6 +116,8 @@ private:
     void Clear();
     // Get the total number of bytes used already by this transaction
     int GetBytesTotal() const { return nBytesBase + vecOutputs.size() * nBytesOutput; }
+    // Helper to calculate static amount left by simply subtracting an used amount and a fee from a provided initial amount.
+    static CAmount GetAmountLeft(const CAmount nAmountInitial, const CAmount nAmountUsed, const CAmount nFee);
     // Get the amount currently used by added outputs. Does not include fees.
     CAmount GetAmountUsed() const;
     // Get fees based on the number of bytes and the feerate set in CoinControl.

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -93,15 +93,15 @@ public:
     CTransactionBuilder(CWallet* pwalletIn, const CompactTallyItem& tallyItemIn);
     ~CTransactionBuilder();
     // Try to add a single output with the amount nAmount. Returns true if its possble and false if not.
-    bool TryAddOutput(CAmount nAmount) const;
+    bool TryAddOutput(CAmount nAmountOutput) const;
     // Try to add multiple outputs as vector of amounts. Returns true if its possible to add all of them and false if not.
-    bool TryAddOutputs(const std::vector<CAmount>& vecAmounts) const;
+    bool TryAddOutputs(const std::vector<CAmount>& vecOutputAmounts) const;
     // Add an output with the amount nAmount. Returns a pointer to the output if it could be added and nullptr if not due to insufficient amomunt left.
-    CTransactionBuilderOutput* AddOutput(CAmount nAmount = 0);
+    CTransactionBuilderOutput* AddOutput(CAmount nAmountOutput = 0);
     // Get amount we had available when we started
     CAmount GetAmountInitial() const { return tallyItem.nAmount; }
-    // Helper to calculate static remainders for output trying
-    static CAmount GetAmountLeft(const CAmount nAmount, const CAmount nAmountUsed, const CAmount nFee);
+    // Helper to calculate static amount left by simply subtracting an used amount and a fee from a provided initial amount.
+    static CAmount GetAmountLeft(const CAmount nAmountInitial, const CAmount nAmountUsed, const CAmount nFee);
     // Get the amount currently left to add more outputs. Does respect fees.
     CAmount GetAmountLeft() const { return GetAmountInitial() - GetAmountUsed() - GetFee(GetBytesTotal()); }
     // Check if an amounts should be considered as dust
@@ -120,7 +120,9 @@ private:
     int GetBytesTotal() const { return nBytesBase + vecOutputs.size() * nBytesOutput; }
     // Get the amount currently used by added outputs. Does not include fees.
     CAmount GetAmountUsed() const;
-    // Get fees based on the number of bytes and the feerate set in CoinControl
+    // Get fees based on the number of bytes and the feerate set in CoinControl.
+    // NOTE: To get the total transaction fee this should only be called once with the total number of bytes for the transaction to avoid
+    // calling CFeeRate::GetFee multiple times with subtotals as this may add rounding errors with each further call.
     CAmount GetFee(int nBytes) const;
 };
 

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -123,7 +123,7 @@ private:
     // Get fees based on the number of bytes and the feerate set in CoinControl.
     // NOTE: To get the total transaction fee this should only be called once with the total number of bytes for the transaction to avoid
     // calling CFeeRate::GetFee multiple times with subtotals as this may add rounding errors with each further call.
-    CAmount GetFee(int nBytes) const;
+    CAmount GetFee(unsigned int nBytes) const;
 };
 
 #endif // BITCOIN_PRIVATESEND_PRIVATESEND_UTIL_H

--- a/src/privatesend/privatesend-util.h
+++ b/src/privatesend/privatesend-util.h
@@ -74,8 +74,6 @@ class CTransactionBuilder
     // Its a member just to make sure ReturnKey can be called in destructor just in case it gets generated/kept
     // somewhere in CWallet code.
     CReserveKey dummyReserveKey;
-    // Fee rate used to evaluate if an amount should be considered as dust or not
-    CFeeRate dustFeeRate;
     // Contains all utxos available to generate this transactions. They are all from the same address.
     CompactTallyItem tallyItem;
     // Contains the number of bytes required for a transaction with only the inputs of tallyItems, no outputs

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -157,10 +157,10 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                         fMakeCollateral = (nAmount0 == CPrivateSend::GetMaxCollateralAmount() && !CPrivateSend::IsDenominatedAmount(nAmount1) && nAmount1 >= CPrivateSend::GetCollateralAmount()) ||
                                           (nAmount1 == CPrivateSend::GetMaxCollateralAmount() && !CPrivateSend::IsDenominatedAmount(nAmount0) && nAmount0 >= CPrivateSend::GetCollateralAmount()) ||
                         // <case2>, see CPrivateSendClientSession::MakeCollateralAmounts
-                                          (nAmount0 == nAmount1 && !CPrivateSend::IsDenominatedAmount(nAmount0) && CPrivateSend::IsCollateralAmount(nAmount0));
+                                          (nAmount0 == nAmount1 && CPrivateSend::IsCollateralAmount(nAmount0));
                     } else if (wtx.tx->vout.size() == 1) {
                         // <case3>, see CPrivateSendClientSession::MakeCollateralAmounts
-                        fMakeCollateral = !CPrivateSend::IsDenominatedAmount(wtx.tx->vout[0].nValue) && CPrivateSend::IsCollateralAmount(wtx.tx->vout[0].nValue);
+                        fMakeCollateral = CPrivateSend::IsCollateralAmount(wtx.tx->vout[0].nValue);
                     }
                     if (fMakeCollateral) {
                         sub.type = TransactionRecord::PrivateSendMakeCollaterals;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -150,14 +150,14 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     sub.type = TransactionRecord::PrivateSendCollateralPayment;
                 } else {
                     bool fMakeCollateral{false};
-                    if (wtx.tx->vout.size() == 2) {
-                        CAmount nMaxCollateralAmount = CPrivateSend::GetMaxCollateralAmount();
-                        CAmount nPreMaxCollateralAmount = nMaxCollateralAmount  - CPrivateSend::GetCollateralAmount();
-                        fMakeCollateral =
-                            wtx.tx->vout[0].nValue == nMaxCollateralAmount ||
-                            wtx.tx->vout[1].nValue == nMaxCollateralAmount ||
-                            (wtx.tx->vout[0].nValue == nPreMaxCollateralAmount && CPrivateSend::IsCollateralAmount(wtx.tx->vout[1].nValue)) ||
-                            (wtx.tx->vout[1].nValue == nPreMaxCollateralAmount && CPrivateSend::IsCollateralAmount(wtx.tx->vout[0].nValue));
+                    if (wtx.tx->vout.size() == 1) {
+                        fMakeCollateral = !CPrivateSend::IsDenominatedAmount(wtx.tx->vout[0].nValue) && CPrivateSend::IsCollateralAmount(wtx.tx->vout[0].nValue); // <case3>, see CPrivateSendClientSession::MakeCollateralAmounts;
+                    } else if (wtx.tx->vout.size() == 2) {
+                        CAmount nAmount0 = wtx.tx->vout[0].nValue;
+                        CAmount nAmount1 = wtx.tx->vout[1].nValue;
+                        fMakeCollateral = (nAmount0 == CPrivateSend::GetMaxCollateralAmount() && !CPrivateSend::IsDenominatedAmount(nAmount1) && nAmount1 >= CPrivateSend::GetCollateralAmount()) ||
+                                          (nAmount1 == CPrivateSend::GetMaxCollateralAmount() && !CPrivateSend::IsDenominatedAmount(nAmount0) && nAmount0 >= CPrivateSend::GetCollateralAmount()) || // <case1>, see CPrivateSendClientSession::MakeCollateralAmounts
+                                          (nAmount0 == nAmount1 && !CPrivateSend::IsDenominatedAmount(nAmount0) && CPrivateSend::IsCollateralAmount(nAmount0)); // <case2>, see CPrivateSendClientSession::MakeCollateralAmounts
                     }
                     if (fMakeCollateral) {
                         sub.type = TransactionRecord::PrivateSendMakeCollaterals;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -150,14 +150,17 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     sub.type = TransactionRecord::PrivateSendCollateralPayment;
                 } else {
                     bool fMakeCollateral{false};
-                    if (wtx.tx->vout.size() == 1) {
-                        fMakeCollateral = !CPrivateSend::IsDenominatedAmount(wtx.tx->vout[0].nValue) && CPrivateSend::IsCollateralAmount(wtx.tx->vout[0].nValue); // <case3>, see CPrivateSendClientSession::MakeCollateralAmounts;
-                    } else if (wtx.tx->vout.size() == 2) {
+                    if (wtx.tx->vout.size() == 2) {
                         CAmount nAmount0 = wtx.tx->vout[0].nValue;
                         CAmount nAmount1 = wtx.tx->vout[1].nValue;
+                        // <case1>, see CPrivateSendClientSession::MakeCollateralAmounts
                         fMakeCollateral = (nAmount0 == CPrivateSend::GetMaxCollateralAmount() && !CPrivateSend::IsDenominatedAmount(nAmount1) && nAmount1 >= CPrivateSend::GetCollateralAmount()) ||
-                                          (nAmount1 == CPrivateSend::GetMaxCollateralAmount() && !CPrivateSend::IsDenominatedAmount(nAmount0) && nAmount0 >= CPrivateSend::GetCollateralAmount()) || // <case1>, see CPrivateSendClientSession::MakeCollateralAmounts
-                                          (nAmount0 == nAmount1 && !CPrivateSend::IsDenominatedAmount(nAmount0) && CPrivateSend::IsCollateralAmount(nAmount0)); // <case2>, see CPrivateSendClientSession::MakeCollateralAmounts
+                                          (nAmount1 == CPrivateSend::GetMaxCollateralAmount() && !CPrivateSend::IsDenominatedAmount(nAmount0) && nAmount0 >= CPrivateSend::GetCollateralAmount()) ||
+                        // <case2>, see CPrivateSendClientSession::MakeCollateralAmounts
+                                          (nAmount0 == nAmount1 && !CPrivateSend::IsDenominatedAmount(nAmount0) && CPrivateSend::IsCollateralAmount(nAmount0));
+                    } else if (wtx.tx->vout.size() == 1) {
+                        // <case3>, see CPrivateSendClientSession::MakeCollateralAmounts
+                        fMakeCollateral = !CPrivateSend::IsDenominatedAmount(wtx.tx->vout[0].nValue) && CPrivateSend::IsCollateralAmount(wtx.tx->vout[0].nValue);
                     }
                     if (fMakeCollateral) {
                         sub.type = TransactionRecord::PrivateSendMakeCollaterals;

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -39,6 +39,8 @@ public:
     bool fOverrideFeeRate;
     //! Override the default payTxFee if set
     boost::optional<CFeeRate> m_feerate;
+    //! Override the dust feerate estimation with m_dust_feerate in CreateTransaction if set
+    boost::optional<CFeeRate> m_dust_feerate;
     //! Override the default confirmation target if set
     boost::optional<unsigned int> m_confirm_target;
     //! Fee estimation mode to control arguments to estimateSmartFee

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -39,8 +39,8 @@ public:
     bool fOverrideFeeRate;
     //! Override the default payTxFee if set
     boost::optional<CFeeRate> m_feerate;
-    //! Override the dust feerate estimation with m_dust_feerate in CreateTransaction if set
-    boost::optional<CFeeRate> m_dust_feerate;
+    //! Override the discard feerate estimation with m_discard_feerate in CreateTransaction if set
+    boost::optional<CFeeRate> m_discard_feerate;
     //! Override the default confirmation target if set
     boost::optional<unsigned int> m_confirm_target;
     //! Fee estimation mode to control arguments to estimateSmartFee

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -61,6 +61,7 @@ public:
         fAllowWatchOnly = false;
         setSelected.clear();
         m_feerate.reset();
+        m_discard_feerate.reset();
         fOverrideFeeRate = false;
         m_confirm_target.reset();
         m_fee_mode = FeeEstimateMode::UNSET;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3809,7 +3809,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         }
                     }
 
-                    if (IsDust(txout, ::dustRelayFee)) {
+                    if (IsDust(txout, ::dustRelayFee))
+                    {
                         if (recipient.fSubtractFeeFromAmount && nFeeRet > 0)
                         {
                             if (txout.nValue < 0)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3734,7 +3734,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
     assert(txNew.nLockTime <= (unsigned int)chainActive.Height());
     assert(txNew.nLockTime < LOCKTIME_THRESHOLD);
     FeeCalculation feeCalc;
-    CFeeRate discard_rate = coin_control.m_dust_feerate ? *coin_control.m_dust_feerate : GetDiscardRate(::feeEstimator);
+    CFeeRate discard_rate = coin_control.m_discard_feerate ? *coin_control.m_discard_feerate : GetDiscardRate(::feeEstimator);
     CAmount nFeeNeeded;
     unsigned int nBytes;
     {
@@ -3809,7 +3809,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         }
                     }
 
-                    if (IsDust(txout, discard_rate)) {
+                    if (IsDust(txout, ::dustRelayFee)) {
                         if (recipient.fSubtractFeeFromAmount && nFeeRet > 0)
                         {
                             if (txout.nValue < 0)


### PR DESCRIPTION
While the idea of respecting fees in calculations brought up in #3588 and #3640 makes totally sense i still noticed while reviewing/testing the latter that the estimation of just saying use min fee for `148` bytes for inputs and min fee for `34` bytes for outputs and then sum it up isn’t good enough imo.

1. It doen’t respect the general tx overhead
2. It introduces rounding errors with the increasing numbers of inputs/outputs

So even with those estimations we end up in cases where the calculations are slightly off from the expected. This brings inaccuracy to transaction generation and leads to issues (e.g. the. one in `TransactionRecord::decomposeTransaction`).

As solution this PR introduces `CTransactionBuilder` in 13fa395eeb0050225ce2f1a77418d1af96137b0e, a class which wraps transaction creation and allows a simple and failproof creation of transactions with inputs defined by `CompactTallyItem` while also respecting the logics implemented in `CWallet::CreateTransaction`. For output generation it takes care of key generation, provides methods e.g. to add/try to add outputs, get the remaining amount available, and methods to create/commit the transaction to the wallet. To avoid running into the issues described above it does not calculate a seperate fee for the amount of bytes for input/outputs like it was before. Instead it uses bytes for all calculations and calculates a total fee for the transaction when required. This way it’s possible now to calculate the correct amounts/fees used for the created transactions. 

Further on top this PR brings also some small fixes/modifications to the logic behind `CreateDenominated` and `MakeCollateralAmounts` in fba14a11411639d15700e8b658a03b5d0611ff65 and 8e0191ca83b23ff76ca87f8a45daec2a3cd1d74d so please review very carefully there that we can be sure i didn’t mess something here :) 

3d0060165fab3e930a11dae85066d6eb1e36d264 finally makes sure #3597 is not longer an issue. As it now should cover all the cases produced by `MakeCollateralAmounts` correctly.