### PR TITLE
trivial: return bool instead of int in CPrivateSendClientOptions

### DIFF
--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -289,8 +289,8 @@ public:
     static void SetRounds(int nRounds);
     static void SetAmount(CAmount amount);
 
-    static int IsEnabled() { return CPrivateSendClientOptions::Get().fEnablePrivateSend; }
-    static int IsMultiSessionEnabled() { return CPrivateSendClientOptions::Get().fPrivateSendMultiSession; }
+    static bool IsEnabled() { return CPrivateSendClientOptions::Get().fEnablePrivateSend; }
+    static bool IsMultiSessionEnabled() { return CPrivateSendClientOptions::Get().fPrivateSendMultiSession; }
 
     static void GetJsonInfo(UniValue& obj);
 


### PR DESCRIPTION
Signed-off-by: pasta <pasta@dashboost.org>