### PR TITLE
privatesend: Implement Random Round Mixing

### DIFF
--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1259,7 +1259,7 @@ bool CPrivateSendClientSession::SubmitDenominate(CConnman& connman)
 
     std::vector<std::pair<int, size_t> > vecInputsByRounds;
 
-    for (int i = 0; i < CPrivateSendClientOptions::GetRounds(); i++) {
+    for (int i = 0; i < CPrivateSendClientOptions::GetRounds() + CPrivateSendClientOptions::GetRandomRounds(); i++) {
         if (PrepareDenominate(i, i, strError, vecPSInOutPairs, vecPSInOutPairsTmp, true)) {
             LogPrint(BCLog::PRIVATESEND, "CPrivateSendClientSession::SubmitDenominate -- Running PrivateSend denominate for %d rounds, success\n", i);
             vecInputsByRounds.emplace_back(i, vecPSInOutPairsTmp.size());

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -244,11 +244,6 @@ bool CPrivateSendClientManager::StartMixing(CWallet* pwallet) {
     }
     assert(pwallet != nullptr);
     mixingWallet = pwallet;
-    nSalt = mixingWallet->GetPrivateSendSalt();
-    if (nSalt.IsNull()) {
-        nSalt = GetRandHash();
-        pwallet->WritePrivateSendSalt(nSalt);
-    }
     return true;
 }
 

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -244,6 +244,11 @@ bool CPrivateSendClientManager::StartMixing(CWallet* pwallet) {
     }
     assert(pwallet != nullptr);
     mixingWallet = pwallet;
+    nSalt = mixingWallet->GetPrivateSendSalt();
+    if (nSalt.IsNull()) {
+        nSalt = GetRandHash();
+        pwallet->WritePrivateSendSalt(nSalt);
+    }
     return true;
 }
 

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -224,8 +224,12 @@ private:
     bool CheckAutomaticBackup();
 
 public:
-    int nCachedNumBlocks;    //used for the overview screen
-    bool fCreateAutoBackups; //builtin support for automatic backups
+    // used for the overview screen
+    int nCachedNumBlocks;
+    // builtin support for automatic backups
+    bool fCreateAutoBackups;
+    // Pulled from wallet DB ("ps_salt") and used when mixing a random number of rounds
+    uint256 nSalt;
 
     CPrivateSendClientManager() :
         vecMasternodesUsed(),

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -54,6 +54,8 @@ static const int PRIVATESEND_DENOM_OUTPUTS_THRESHOLD = 500;
 static const int PRIVATESEND_KEYS_THRESHOLD_WARNING = 100;
 // Stop mixing completely, it's too dangerous to continue when we have only this many keys left
 static const int PRIVATESEND_KEYS_THRESHOLD_STOP = 50;
+// Pseudorandomly mix up to this many times in addition to base round count
+static const int PRIVATESEND_RANDOM_ROUNDS = 3;
 
 // The main object for accessing mixing
 extern std::map<const std::string, CPrivateSendClientManager*> privateSendClientManagers;
@@ -284,6 +286,7 @@ class CPrivateSendClientOptions
 public:
     static int GetSessions() { return CPrivateSendClientOptions::Get().nPrivateSendSessions; }
     static int GetRounds() { return CPrivateSendClientOptions::Get().nPrivateSendRounds; }
+    static int GetRandomRounds() { return CPrivateSendClientOptions::Get().nPrivateSendRandomRounds; }
     static int GetAmount() { return CPrivateSendClientOptions::Get().nPrivateSendAmount; }
     static int GetDenomsGoal() { return CPrivateSendClientOptions::Get().nPrivateSendDenomsGoal; }
     static int GetDenomsHardCap() { return CPrivateSendClientOptions::Get().nPrivateSendDenomsHardCap; }
@@ -305,6 +308,7 @@ private:
     CCriticalSection cs_ps_options;
     int nPrivateSendSessions;
     int nPrivateSendRounds;
+    int nPrivateSendRandomRounds;
     int nPrivateSendAmount;
     int nPrivateSendDenomsGoal;
     int nPrivateSendDenomsHardCap;
@@ -313,6 +317,7 @@ private:
 
     CPrivateSendClientOptions() :
         nPrivateSendRounds(DEFAULT_PRIVATESEND_ROUNDS),
+        nPrivateSendRandomRounds(PRIVATESEND_RANDOM_ROUNDS),
         nPrivateSendAmount(DEFAULT_PRIVATESEND_AMOUNT),
         nPrivateSendDenomsGoal(DEFAULT_PRIVATESEND_DENOMS_GOAL),
         nPrivateSendDenomsHardCap(DEFAULT_PRIVATESEND_DENOMS_HARDCAP),

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -230,8 +230,6 @@ public:
     int nCachedNumBlocks;
     // builtin support for automatic backups
     bool fCreateAutoBackups;
-    // Pulled from wallet DB ("ps_salt") and used when mixing a random number of rounds
-    uint256 nSalt;
 
     CPrivateSendClientManager() :
         vecMasternodesUsed(),

--- a/src/privatesend/privatesend-client.h
+++ b/src/privatesend/privatesend-client.h
@@ -226,10 +226,8 @@ private:
     bool CheckAutomaticBackup();
 
 public:
-    // used for the overview screen
-    int nCachedNumBlocks;
-    // builtin support for automatic backups
-    bool fCreateAutoBackups;
+    int nCachedNumBlocks;    // used for the overview screen
+    bool fCreateAutoBackups; // builtin support for automatic backups
 
     CPrivateSendClientManager() :
         vecMasternodesUsed(),

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -706,9 +706,8 @@ void CoinControlDialog::updateView()
         int nChildren = 0;
         for (const COutput& out : coins.second) {
             COutPoint outpoint = COutPoint(out.tx->tx->GetHash(), out.i);
-            int nRounds = model->getRealOutpointPrivateSendRounds(outpoint);
 
-            if ((coinControl()->IsUsingPrivateSend() && nRounds >= CPrivateSendClientOptions::GetRounds()) || !(coinControl()->IsUsingPrivateSend())) {
+            if ((coinControl()->IsUsingPrivateSend() && model->isFullyMixed(outpoint)) || !(coinControl()->IsUsingPrivateSend())) {
                 nSum += out.tx->tx->vout[out.i].nValue;
                 nChildren++;
 
@@ -759,6 +758,7 @@ void CoinControlDialog::updateView()
                 itemOutput->setData(COLUMN_DATE, Qt::UserRole, QVariant((qlonglong)out.tx->GetTxTime()));
 
                 // PrivateSend rounds
+                int nRounds = model->getRealOutpointPrivateSendRounds(outpoint);
                 if (nRounds >= 0 || LogAcceptCategory(BCLog::PRIVATESEND)) {
                     itemOutput->setText(COLUMN_PRIVATESEND_ROUNDS, QString::number(nRounds));
                 } else {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -229,6 +229,11 @@ int WalletModel::getRealOutpointPrivateSendRounds(const COutPoint& outpoint) con
     return wallet->GetRealOutpointPrivateSendRounds(outpoint);
 }
 
+bool WalletModel::isFullyMixed(const COutPoint& outpoint) const
+{
+    return wallet->IsFullyMixed(outpoint);
+}
+
 void WalletModel::updateAddressBook(const QString &address, const QString &label,
         bool isMine, const QString &purpose, int status)
 {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -232,6 +232,7 @@ public:
     int getNumISLocks() const;
 
     int getRealOutpointPrivateSendRounds(const COutPoint& outpoint) const;
+    bool isFullyMixed(const COutPoint& outpoint) const;
 
     QString getWalletName() const;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3167,7 +3167,7 @@ UniValue listunspent(const JSONRPCRequest& request)
         entry.pushKV("spendable", out.fSpendable);
         entry.pushKV("solvable", out.fSolvable);
         entry.pushKV("safe", out.fSafe);
-        entry.pushKV("ps_rounds", pwallet->GetCappedOutpointPrivateSendRounds(COutPoint(out.tx->GetHash(), out.i)));
+        entry.pushKV("ps_rounds", pwallet->GetRealOutpointPrivateSendRounds(COutPoint(out.tx->GetHash(), out.i)));
         results.push_back(entry);
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1693,8 +1693,9 @@ bool CWallet::IsFullyMixed(const COutPoint& outpoint) const
     // If we have already mixed N + MaxOffset rounds, don't mix again.
     // Otherwise, we should mix again 50% of the time, this results in an exponential decay
     // N rounds 50% N+1 25% N+2 12.5%... until we reach N + GetRandomRounds() rounds where we stop.
+    uint256 outpointHash = SerializeHash(outpoint);
     if (nRounds < CPrivateSendClientOptions::GetRounds() + CPrivateSendClientOptions::GetRandomRounds()) {
-        if (Hash(outpoint.hash.begin(), outpoint.hash.end(), nPrivateSendSalt.begin(), nPrivateSendSalt.end()).GetCheapHash() % 2 == 0) {
+        if (Hash(outpointHash.begin(), outpointHash.end(), nPrivateSendSalt.begin(), nPrivateSendSalt.end()).GetCheapHash() % 2 == 0) {
             return false;
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2830,11 +2830,11 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
             bool found = false;
             if (nCoinType == CoinType::ONLY_FULLY_MIXED) {
                 if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
-                int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
+                int nRounds = GetRealOutpointPrivateSendRounds(COutPoint(wtxid, i));
                 found = nRounds >= CPrivateSendClientOptions::GetRounds();
             } else if(nCoinType == CoinType::ONLY_READY_TO_MIX) {
                 if (!CPrivateSend::IsDenominatedAmount(pcoin->tx->vout[i].nValue)) continue;
-                int nRounds = GetCappedOutpointPrivateSendRounds(COutPoint(wtxid, i));
+                int nRounds = GetRealOutpointPrivateSendRounds(COutPoint(wtxid, i));
                 found = nRounds < CPrivateSendClientOptions::GetRounds();
             } else if(nCoinType == CoinType::ONLY_NONDENOMINATED) {
                 if (CPrivateSend::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2970,7 +2970,7 @@ const CTxOut& CWallet::FindNonChangeParentOutput(const CTransaction& tx, int out
     return ptx->vout[n];
 }
 
-void CWallet::GetPrivateSendSalt()
+void CWallet::InitPrivateSendSalt()
 {
     // Avoid fetching it multiple times
     assert(nPrivateSendSalt.IsNull());
@@ -4227,7 +4227,7 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
         }
     }
 
-    GetPrivateSendSalt();
+    InitPrivateSendSalt();
 
     if (nLoadWalletRet != DBErrors::LOAD_OK)
         return nLoadWalletRet;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1583,9 +1583,11 @@ int CWallet::GetRealOutpointPrivateSendRounds(const COutPoint& outpoint, int nRo
 {
     LOCK(cs_wallet);
 
-    if (nRounds >= MAX_PRIVATESEND_ROUNDS) {
-        // there can only be MAX_PRIVATESEND_ROUNDS rounds max
-        return MAX_PRIVATESEND_ROUNDS - 1;
+    const int nRoundsMax = MAX_PRIVATESEND_ROUNDS + CPrivateSendClientOptions::GetRandomRounds();
+
+    if (nRounds >= nRoundsMax) {
+        // there can only be nRoundsMax rounds max
+        return nRoundsMax - 1;
     }
 
     auto pair = mapOutpointRoundsCache.emplace(outpoint, -10);
@@ -1651,7 +1653,7 @@ int CWallet::GetRealOutpointPrivateSendRounds(const COutPoint& outpoint, int nRo
         }
     }
     *nRoundsRef = fDenomFound
-            ? (nShortest >= MAX_PRIVATESEND_ROUNDS - 1 ? MAX_PRIVATESEND_ROUNDS : nShortest + 1) // good, we a +1 to the shortest one but only MAX_PRIVATESEND_ROUNDS rounds max allowed
+            ? (nShortest >= nRoundsMax - 1 ? nRoundsMax : nShortest + 1) // good, we a +1 to the shortest one but only nRoundsMax rounds max allowed
             : 0;            // too bad, we are the fist one in that chain
     LogPrint(BCLog::PRIVATESEND, "%s UPDATED   %-70s %3d\n", __func__, outpoint.ToStringShort(), *nRoundsRef);
     return *nRoundsRef;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1685,8 +1685,8 @@ bool CWallet::IsDenominated(const COutPoint& outpoint) const
 
 bool CWallet::IsFullyMixed(const COutPoint& outpoint) const
 {
-    // Mix again if we don't have N rounds yet
     int nRounds = GetRealOutpointPrivateSendRounds(outpoint);
+    // Mix again if we don't have N rounds yet
     if (nRounds < CPrivateSendClientOptions::GetRounds()) return false;
 
     // Try to mix a "random" number of rounds more than minimum.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2951,6 +2951,20 @@ const CTxOut& CWallet::FindNonChangeParentOutput(const CTransaction& tx, int out
     return ptx->vout[n];
 }
 
+const uint256 CWallet::GetPrivateSendSalt()
+{
+    uint256 ps_salt;
+    WalletBatch batch(*database);
+    batch.ReadPrivateSendSalt(ps_salt);
+    return ps_salt;
+}
+
+bool CWallet::WritePrivateSendSalt(uint256 &salt)
+{
+    WalletBatch batch(*database);
+    return batch.WritePrivateSendSalt(salt);
+}
+
 static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const CAmount& nTotalLower, const CAmount& nTargetValue,
                                   std::vector<char>& vfBest, CAmount& nBest, int iterations = 1000)
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1693,9 +1693,12 @@ bool CWallet::IsFullyMixed(const COutPoint& outpoint) const
     // If we have already mixed N + MaxOffset rounds, don't mix again.
     // Otherwise, we should mix again 50% of the time, this results in an exponential decay
     // N rounds 50% N+1 25% N+2 12.5%... until we reach N + GetRandomRounds() rounds where we stop.
-    uint256 outpointHash = SerializeHash(outpoint);
     if (nRounds < CPrivateSendClientOptions::GetRounds() + CPrivateSendClientOptions::GetRandomRounds()) {
-        if (Hash(outpointHash.begin(), outpointHash.end(), nPrivateSendSalt.begin(), nPrivateSendSalt.end()).GetCheapHash() % 2 == 0) {
+        CDataStream ss(SER_GETHASH, PROTOCOL_VERSION);
+        ss << outpoint << nPrivateSendSalt;
+        uint256 nHash;
+        CSHA256().Write((const unsigned char*)ss.data(), ss.size()).Finalize(nHash.begin());
+        if (nHash.GetCheapHash() % 2 == 0) {
             return false;
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -922,6 +922,7 @@ public:
     int GetCappedOutpointPrivateSendRounds(const COutPoint& outpoint) const;
 
     bool IsDenominated(const COutPoint& outpoint) const;
+    bool IsFullyMixed(const COutPoint& outpoint) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1222,6 +1222,16 @@ public:
     void NotifyChainLock(const CBlockIndex* pindexChainLock, const llmq::CChainLockSig& clsig) override;
 
     /**
+     * Fetches PrivateSend salt from database
+     */
+    const uint256 GetPrivateSendSalt();
+
+    /**
+    * Writes PrivateSend salt to database
+    */
+    bool WritePrivateSendSalt(uint256& salt);
+
+    /**
      * Blocks until the wallet state is up-to-date to /at least/ the current
      * chain at the time this function is entered
      * Obviously holding cs_main/cs_wallet when going into this call may cause

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -811,7 +811,7 @@ private:
     /**
      * Fetches PrivateSend salt from database or generates and saves a new one if no salt was found in the db
      */
-    void GetPrivateSendSalt();
+    void InitPrivateSendSalt();
 
 public:
     /*

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -802,6 +802,16 @@ private:
      */
     const CBlockIndex* m_last_block_processed = nullptr;
 
+    // Pulled from wallet DB ("ps_salt") and used when mixing a random number of rounds.
+    // This salt is needed to prevent an attacker from learning how many extra times
+    // the input was mixed based only on information in the blockchain.
+    uint256 nPrivateSendSalt;
+
+    /**
+     * Fetches PrivateSend salt from database or generates and saves a new one if no salt was found in the db
+     */
+    void GetPrivateSendSalt();
+
 public:
     /*
      * Main wallet lock.
@@ -1220,16 +1230,6 @@ public:
 
     void NotifyTransactionLock(const CTransaction &tx, const llmq::CInstantSendLock& islock) override;
     void NotifyChainLock(const CBlockIndex* pindexChainLock, const llmq::CChainLockSig& clsig) override;
-
-    /**
-     * Fetches PrivateSend salt from database
-     */
-    const uint256 GetPrivateSendSalt();
-
-    /**
-    * Writes PrivateSend salt to database
-    */
-    bool WritePrivateSendSalt(uint256& salt);
 
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -802,9 +802,10 @@ private:
      */
     const CBlockIndex* m_last_block_processed = nullptr;
 
-    // Pulled from wallet DB ("ps_salt") and used when mixing a random number of rounds.
-    // This salt is needed to prevent an attacker from learning how many extra times
-    // the input was mixed based only on information in the blockchain.
+    /** Pulled from wallet DB ("ps_salt") and used when mixing a random number of rounds.
+     *  This salt is needed to prevent an attacker from learning how many extra times
+     *  the input was mixed based only on information in the blockchain.
+     */
     uint256 nPrivateSendSalt;
 
     /**

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -168,6 +168,16 @@ bool WalletBatch::WriteAccountingEntry(const uint64_t nAccEntryNum, const CAccou
     return WriteIC(std::make_pair(std::string("acentry"), std::make_pair(acentry.strAccount, nAccEntryNum)), acentry);
 }
 
+bool WalletBatch::ReadPrivateSendSalt(uint256& salt)
+{
+    return m_batch.Read(std::string("ps_salt"), salt);
+}
+
+bool WalletBatch::WritePrivateSendSalt(uint256& salt)
+{
+    return WriteIC(std::string("ps_salt"), salt);
+}
+
 CAmount WalletBatch::GetAccountCreditDebit(const std::string& strAccount)
 {
     std::list<CAccountingEntry> entries;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -173,7 +173,7 @@ bool WalletBatch::ReadPrivateSendSalt(uint256& salt)
     return m_batch.Read(std::string("ps_salt"), salt);
 }
 
-bool WalletBatch::WritePrivateSendSalt(uint256& salt)
+bool WalletBatch::WritePrivateSendSalt(const uint256& salt)
 {
     return WriteIC(std::string("ps_salt"), salt);
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -160,6 +160,9 @@ public:
     bool ReadAccount(const std::string& strAccount, CAccount& account);
     bool WriteAccount(const std::string& strAccount, const CAccount& account);
 
+    bool WritePrivateSendSalt(uint256& salt);
+    bool ReadPrivateSendSalt(uint256& salt);
+
     /// Write destination data key,value tuple to database
     bool WriteDestData(const std::string &address, const std::string &key, const std::string &value);
     /// Erase destination data tuple from wallet database

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -160,8 +160,8 @@ public:
     bool ReadAccount(const std::string& strAccount, CAccount& account);
     bool WriteAccount(const std::string& strAccount, const CAccount& account);
 
-    bool WritePrivateSendSalt(uint256& salt);
     bool ReadPrivateSendSalt(uint256& salt);
+    bool WritePrivateSendSalt(const uint256& salt);
 
     /// Write destination data key,value tuple to database
     bool WriteDestData(const std::string &address, const std::string &key, const std::string &value);


### PR DESCRIPTION
The first commit simply uses "GetRealOutpointPrivateSendRounds" in a few behind the scenes places where I saw it

The second commit:

Add "ps_salt" value to walletdb
This value is used to deterministically pick a random number of rounds to mix, between N and N + GetRandomRounds. A salt is needed in addition to the inputs hash to ensure that an attacker learns nothing from looking at the blockchain.

Third Commit:
Implement Random Round Mixing

This implements "Random Round Mixing." Previously, attempted attacks on PrivateSend assumed that all inputs had been mixed for the same number of rounds. Normally assuming 2,4,8 or 16.

While none of these attacks have been successful, they still teach what we can do to make our system more robust, and one of those ways is to implement "Random Round Mixing".

Under the previous system, inputs were mixed up until N rounds (configured by user). At this point, the input was considered mixed, and could be private-sent. Under this new system, an input will be mixed to N rounds like prior. However, at this point, Sha256d(input, salt) will be calculated (note: this likely could be a more efficient hash function than double sha256, but that can be done in another PR / version if needed). If (hash % 2 == 0), then the input will be mixed for one more round.
This results in an exponential decay where if you mix a set of inputs, half of those inputs will be mixed for N rounds, 1/4 will be mixed N+1, 1/8 will be mixed N+2, etc. This current implementation caps it at N+2. This results in mixing an average of N+0.875 rounds. If you removed the cap, you would mix on average N+1 rounds.



I tested this by starting three wallets mixing, and the distribution (while not perfect) was exactly how I would expect with about 50%, 25%, 12.5%, 12.5%. This also fixes #3525 