### PR TITLE
docs: Adjust developer-notes.md to use signed ints normally

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -414,7 +414,7 @@ class A
    a non-negative one, use an assertion or exception instead.
    - *Rationale*: When signed ints are mixed with unsigned ints, the signed int is converted to a unsigned
    int. If the signed int is some negative `N`, it'll become `INT_MAX - N`  which might cause unexpected consequences.
- 
+
 
 Strings and formatting
 ------------------------

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -407,7 +407,6 @@ class A
 
   - *Rationale*: Easier to understand what is happening, thus easier to spot mistakes, even for those
   that are not language lawyers
-  
  - Prefer signed ints and do not mix signed and unsigned integers. If an unsigned int is used, it should have a good
    reason. The fact a value will never be negative is not a good reason. The most common reason will be that mod two
    arithmetic is needed, such as in cryptographic primitives. If you need to make sure that some value is always

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -410,9 +410,10 @@ class A
   
  - Prefer signed ints and do not mix signed and unsigned integers. If an unsigned int is used, it should have a good 
    reason. The fact a value will never be negative is not a good reason. The most common reason will be that mod two 
-   arithmetic is needed, such as in cryptographic primitives.
+   arithmetic is needed, such as in cryptographic primitives. If you need to make sure that some value is always
+   a non-negative one, use an assertion or exception instead.
    - *Rationale*: When signed ints are mixed with unsigned ints, the signed int is converted to a unsigned
-   int. If the signed int is some negative `N`, it'll become `INT_MAX - N` 
+   int. If the signed int is some negative `N`, it'll become `INT_MAX - N`  which might cause unexpected consequences.
  
 
 Strings and formatting

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -407,6 +407,13 @@ class A
 
   - *Rationale*: Easier to understand what is happening, thus easier to spot mistakes, even for those
   that are not language lawyers
+  
+ - Prefer signed ints and do not mix signed and unsigned integers. If an unsigned int is used, it should have a good 
+   reason. The fact a value will never be negative is not a good reason. The most common reason will be that mod two 
+   arithmetic is needed, such as in cryptographic primitives.
+   - *Rationale*: When signed ints are mixed with unsigned ints, the signed int is converted to a unsigned
+   int. If the signed int is some negative `N`, it'll become `INT_MAX - N` 
+ 
 
 Strings and formatting
 ------------------------

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -408,8 +408,8 @@ class A
   - *Rationale*: Easier to understand what is happening, thus easier to spot mistakes, even for those
   that are not language lawyers
   
- - Prefer signed ints and do not mix signed and unsigned integers. If an unsigned int is used, it should have a good 
-   reason. The fact a value will never be negative is not a good reason. The most common reason will be that mod two 
+ - Prefer signed ints and do not mix signed and unsigned integers. If an unsigned int is used, it should have a good
+   reason. The fact a value will never be negative is not a good reason. The most common reason will be that mod two
    arithmetic is needed, such as in cryptographic primitives. If you need to make sure that some value is always
    a non-negative one, use an assertion or exception instead.
    - *Rationale*: When signed ints are mixed with unsigned ints, the signed int is converted to a unsigned


### PR DESCRIPTION
I actually learned more about this when I went to try to convert some ints that should never be negative into uints. However, I researched it a bit and found out it's actually a quite bad idea due to what happens when signed integers and unsigned ints get mixed up. I think it'd be valuable to formalize and put into developer docs.

(also change some unsigned ints to ints that were used in arithmetic with signed ints)