### PR TITLE
Merge #13007: test: Fix dangling wallet pointer in vpwallets

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -479,6 +479,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.push_back((pathTemp / "wallet.backup").string());
         AddWallet(&wallet);
         ::dumpwallet(request);
+        RemoveWallet(&wallet);
     }
 
     // Call importwallet RPC and verify all blocks with timestamps >= BLOCK_TIME

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -492,6 +492,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.push_back((pathTemp / "wallet.backup").string());
         AddWallet(&wallet);
         ::importwallet(request);
+        RemoveWallet(&wallet);
 
         LOCK(wallet.cs_wallet);
         BOOST_CHECK_EQUAL(wallet.mapWallet.size(), 3);
@@ -501,7 +502,6 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
             bool expected = i >= 100;
             BOOST_CHECK_EQUAL(found, expected);
         }
-        RemoveWallet(&wallet);
     }
 
     SetMockTime(0);


### PR DESCRIPTION
The wallet should be removed after the `dumpwallet()` call otherwise it 
may lead to unepexted behaviour in other wallet tests since the wallet 
stays in `vpwallets` then.