### PR TITLE
wallet: Fix and improve CWallet::CreateTransaction

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3820,7 +3820,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
             bool pick_new_inputs = true;
             CAmount nValueIn = 0;
             CAmount nAmountToSelectAdditional{0};
-            // Start with no fee and loop until there is enough fee, try it 500 times.
+            // Start with nAmountToSelectAdditional=0 and loop until there is enough to cover the request + fees, try it 500 times.
             int nMaxTries = 500;
             while (--nMaxTries)
             {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4031,7 +4031,20 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 // If subtracting fee from recipients, we now know what fee we
                 // need to subtract, we have no reason to reselect inputs
                 if (nSubtractFeeFromAmount > 0) {
+                    // If we are in here the second time it means we already subtracted the fee from the
+                    // output(s) and there weren't any issues while doing that. So the transaction is ready now
+                    // and we can break.
+                    if (!pick_new_inputs) {
+                        break;
+                    }
                     pick_new_inputs = false;
+                }
+
+                // If nAmountLeft == nFeeRet it means we either added nChange to nFeeRet since nChange was considered to be dust
+                // or the input exactly matches output + fee.
+                // Either way, we used the total amount of the inputs we picked and the transaction is ready.
+                if (nAmountLeft == nFeeRet) {
+                    break;
                 }
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4018,6 +4018,18 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     nChangePosInOut = -1;
                 }
 
+                if (nAmountAvailable == 0 || (!nSubtractFeeFromAmount && nValueIn < nValue)) {
+                    if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
+                        strFailReason = _("Unable to locate enough PrivateSend non-denominated funds for this transaction.");
+                    } else if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
+                        strFailReason = _("Unable to locate enough PrivateSend denominated funds for this transaction.");
+                        strFailReason += " " + _("PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.");
+                    } else {
+                        strFailReason = _("Insufficient funds.");
+                    }
+                    return false;
+                }
+
                 if (getChange() < 0) {
                     if (!nSubtractFeeFromAmount) {
                         // nValueIn is not enough to cover nValue + nFeeRet. Add the missing amount abs(nChange) to the fee

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3892,9 +3892,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 // nLockTime set above actually works.
                 txNew.vin.clear();
                 for (const auto& coin : vecCoins) {
-                    CTxIn txin = CTxIn(coin.outpoint,CScript(),
-                                              CTxIn::SEQUENCE_FINAL - 1);
-                    txNew.vin.push_back(txin);
+                    txNew.vin.emplace_back(coin.outpoint, CScript(), CTxIn::SEQUENCE_FINAL - 1);
                 }
 
                 auto calculateFee = [&](CAmount& nFee) -> bool {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3812,6 +3812,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
             nFeeRet = 0;
             bool pick_new_inputs = true;
             CAmount nValueIn = 0;
+            CAmount nAmountToSelectAdditional{0};
             // Start with no fee and loop until there is enough fee
             while (true)
             {
@@ -3822,8 +3823,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 bool fFirst = true;
 
                 CAmount nValueToSelect = nValue;
-                if (nSubtractFeeFromAmount == 0)
-                    nValueToSelect += nFeeRet;
+                if (nSubtractFeeFromAmount == 0) {
+                    nValueToSelect += nAmountToSelectAdditional;
+                }
                 // vouts to the payees
                 for (const auto& recipient : vecSend)
                 {
@@ -3939,7 +3941,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
 
                 CTxOut newTxOut;
-                const CAmount nAmountLeft = nValueIn - nValueToSelect;
+                const CAmount nAmountLeft = nValueIn - nValue;
                 CAmount nChange = nAmountLeft - nFeeRet;
 
                 if (nChange > 0)
@@ -3997,9 +3999,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
 
                 if (nChange < 0 && !nSubtractFeeFromAmount) {
-                    // nValueIn is not enough to cover nValueToSelect + nFeeRet. Add the missing amount abs(nChange) to the fee
+                    // nValueIn is not enough to cover nValue + nFeeRet. Add the missing amount abs(nChange) to the fee
                     // and try to select other inputs in the next loop to cover the full required amount.
-                    nFeeRet += abs(nChange);
+                    nAmountToSelectAdditional += abs(nChange);
                     continue;
                 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3773,7 +3773,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
     CFeeRate discard_rate = coin_control.m_discard_feerate ? *coin_control.m_discard_feerate : GetDiscardRate(::feeEstimator);
     unsigned int nBytes;
     {
-        std::set<CInputCoin> setCoins;
+        std::vector<CInputCoin> vecCoins;
         LOCK2(cs_main, mempool.cs);
         LOCK(cs_wallet);
         {
@@ -3876,8 +3876,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 // Choose coins to use
                 if (pick_new_inputs) {
                     nValueIn = 0;
-                    setCoins.clear();
-                    if (!SelectCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, &coin_control)) {
+                    std::set<CInputCoin> setCoinsTmp;
+                    if (!SelectCoins(vAvailableCoins, nValueToSelect, setCoinsTmp, nValueIn, &coin_control)) {
                         if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
                             strFailReason = _("Unable to locate enough PrivateSend non-denominated funds for this transaction.");
                         } else if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
@@ -3888,6 +3888,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         }
                         return false;
                     }
+                    vecCoins.assign(setCoinsTmp.begin(), setCoinsTmp.end());
                 }
 
                 // Fill vin
@@ -3895,7 +3896,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 // Note how the sequence number is set to max()-1 so that the
                 // nLockTime set above actually works.
                 txNew.vin.clear();
-                for (const auto& coin : setCoins) {
+                for (const auto& coin : vecCoins) {
                     CTxIn txin = CTxIn(coin.outpoint,CScript(),
                                               CTxIn::SEQUENCE_FINAL - 1);
                     txNew.vin.push_back(txin);
@@ -3904,7 +3905,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 auto calculateFee = [&](CAmount& nFee) -> bool {
                     // Fill in dummy signatures for fee calculation.
                     int nIn = 0;
-                    for (const auto& coin : setCoins)
+                    for (const auto& coin : vecCoins)
                     {
                         const CScript& scriptPubKey = coin.txout.scriptPubKey;
                         SignatureData sigdata;
@@ -4039,6 +4040,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                 // If no specific change position was requested, apply BIP69
                 if (nChangePosRequest == -1) {
+                    std::sort(vecCoins.begin(), vecCoins.end(), CompareInputCoinBIP69());
                     std::sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());
                     std::sort(txNew.vout.begin(), txNew.vout.end(), CompareOutputBIP69());
                 }
@@ -4094,7 +4096,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
         {
             CTransaction txNewConst(txNew);
             int nIn = 0;
-            for(const auto& coin : setCoins)
+            for(const auto& coin : vecCoins)
             {
                 const CScript& scriptPubKey = coin.txout.scriptPubKey;
                 SignatureData sigdata;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3820,8 +3820,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
             bool pick_new_inputs = true;
             CAmount nValueIn = 0;
             CAmount nAmountToSelectAdditional{0};
-            // Start with no fee and loop until there is enough fee
-            while (true)
+            // Start with no fee and loop until there is enough fee, try it 500 times.
+            int nMaxTries = 500;
+            while (--nMaxTries)
             {
                 nChangePosInOut = nChangePosRequest;
                 txNew.vin.clear();
@@ -4066,6 +4067,11 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 if (nAmountLeft == nFeeRet) {
                     break;
                 }
+            }
+
+            if (!nMaxTries) {
+                strFailReason = _("Exceeded max tries.");
+                return false;
             }
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3822,7 +3822,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
             CAmount nAmountToSelectAdditional{0};
             // Start with nAmountToSelectAdditional=0 and loop until there is enough to cover the request + fees, try it 500 times.
             int nMaxTries = 500;
-            while (--nMaxTries)
+            while (--nMaxTries > 0)
             {
                 nChangePosInOut = std::numeric_limits<int>::max();
                 txNew.vin.clear();
@@ -3953,7 +3953,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 CTxOut newTxOut;
                 const CAmount nAmountLeft = nValueIn - nValue;
                 auto getChange = [&]() {
-                    if (nSubtractFeeFromAmount) {
+                    if (nSubtractFeeFromAmount > 0) {
                         return nAmountLeft;
                     } else {
                         return nAmountLeft - nFeeRet;
@@ -4075,7 +4075,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
             }
 
-            if (!nMaxTries) {
+            if (nMaxTries == 0) {
                 strFailReason = _("Exceeded max tries.");
                 return false;
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3900,12 +3900,10 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 auto calculateFee = [&](CAmount& nFee) -> bool {
                     // Fill in dummy signatures for fee calculation.
                     int nIn = 0;
-                    for (const auto& coin : vecCoins)
-                    {
+                    for (const auto& coin : vecCoins) {
                         const CScript& scriptPubKey = coin.txout.scriptPubKey;
                         SignatureData sigdata;
-                        if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))
-                        {
+                        if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata)) {
                             strFailReason = _("Signing transaction failed");
                             return false;
                         } else {
@@ -3937,8 +3935,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                     // If we made it here and we aren't even able to meet the relay fee on the next pass, give up
                     // because we must be at the maximum allowed fee.
-                    if (nFee < ::minRelayTxFee.GetFee(nBytes))
-                    {
+                    if (nFee < ::minRelayTxFee.GetFee(nBytes)) {
                         strFailReason = _("Transaction too large for fee policy");
                         return false;
                     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3820,7 +3820,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
             bool pick_new_inputs = true;
             CAmount nValueIn = 0;
             CAmount nAmountToSelectAdditional{0};
-            // Start with no nAmountToSelectAdditional and loop until there is enough to cover the request, try it 500 times.
+            // Start with no fee and loop until there is enough fee, try it 500 times.
             int nMaxTries = 500;
             while (--nMaxTries)
             {
@@ -4092,18 +4092,11 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
         if (sign)
         {
-            auto getScriptPubKey = [&](const CTxIn& txin) -> const CScript& {
-                for (const auto& coin : setCoins) {
-                    if (txin.prevout == coin.outpoint) {
-                        return coin.txout.scriptPubKey;
-                    }
-                }
-                assert(false);
-            };
             CTransaction txNewConst(txNew);
-            for (int nIn = 0; nIn < txNew.vin.size(); ++nIn)
+            int nIn = 0;
+            for(const auto& coin : setCoins)
             {
-                const CScript& scriptPubKey = getScriptPubKey(txNew.vin[nIn]);
+                const CScript& scriptPubKey = coin.txout.scriptPubKey;
                 SignatureData sigdata;
 
                 if (!ProduceSignature(TransactionSignatureCreator(this, &txNewConst, nIn, SIGHASH_ALL), scriptPubKey, sigdata))
@@ -4113,6 +4106,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 } else {
                     UpdateTransaction(txNew, nIn, sigdata);
                 }
+
+                nIn++;
             }
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4034,19 +4034,19 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     std::sort(vecCoins.begin(), vecCoins.end(), CompareInputCoinBIP69());
                     std::sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());
                     std::sort(txNew.vout.begin(), txNew.vout.end(), CompareOutputBIP69());
-                }
 
-                // If there was change output added before, we must update its position now
-                if (nChangePosInOut != -1) {
-                    int i = 0;
-                    for (const CTxOut& txOut : txNew.vout)
-                    {
-                        if (txOut == newTxOut)
+                    // If there was a change output added before, we must update its position now
+                    if (nChangePosInOut != -1) {
+                        int i = 0;
+                        for (const CTxOut& txOut : txNew.vout)
                         {
-                            nChangePosInOut = i;
-                            break;
+                            if (txOut == newTxOut)
+                            {
+                                nChangePosInOut = i;
+                                break;
+                            }
+                            i++;
                         }
-                        i++;
                     }
                 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3771,7 +3771,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
     assert(txNew.nLockTime < LOCKTIME_THRESHOLD);
     FeeCalculation feeCalc;
     CFeeRate discard_rate = coin_control.m_discard_feerate ? *coin_control.m_discard_feerate : GetDiscardRate(::feeEstimator);
-    CAmount nFeeNeeded;
     unsigned int nBytes;
     {
         std::set<CInputCoin> setCoins;
@@ -3809,8 +3808,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                 scriptChange = GetScriptForDestination(vchPubKey.GetID());
             }
-            CTxOut change_prototype_txout(0, scriptChange);
-            size_t change_prototype_size = GetSerializeSize(change_prototype_txout, SER_DISK, 0);
 
             nFeeRet = 0;
             bool pick_new_inputs = true;
@@ -3937,13 +3934,13 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     return true;
                 };
 
-                if (!calculateFee(nFeeNeeded)) {
+                if (!calculateFee(nFeeRet)) {
                     return false;
                 }
 
                 CTxOut newTxOut;
                 const CAmount nAmountLeft = nValueIn - nValueToSelect;
-                CAmount nChange = nAmountLeft - nFeeNeeded;
+                CAmount nChange = nAmountLeft - nFeeRet;
 
                 if (nChange > 0)
                 {
@@ -3991,8 +3988,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                             std::vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
                             txNew.vout.insert(position, newTxOut);
-                            nFeeNeeded = nFeeNeededWithChange;
-                            nChange = nAmountLeft - nFeeNeeded;
+                            nFeeRet = nFeeNeededWithChange;
+                            nChange = nAmountLeft - nFeeRet;
                         }
                     }
                 } else {
@@ -4019,56 +4016,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     }
                 }
 
-                if (nFeeRet >= nFeeNeeded) {
-                    // Reduce fee to only the needed amount if possible. This
-                    // prevents potential overpayment in fees if the coins
-                    // selected to meet nFeeNeeded result in a transaction that
-                    // requires less fee than the prior iteration.
-
-                    // If we have no change and a big enough excess fee, then
-                    // try to construct transaction again only without picking
-                    // new inputs. We now know we only need the smaller fee
-                    // (because of reduced tx size) and so we should add a
-                    // change output. Only try this once.
-                    if (nChangePosInOut == -1 && nSubtractFeeFromAmount == 0 && pick_new_inputs) {
-                        unsigned int tx_size_with_change = nBytes + change_prototype_size + 2; // Add 2 as a buffer in case increasing # of outputs changes compact size
-                        CAmount fee_needed_with_change = GetMinimumFee(tx_size_with_change, coin_control, ::mempool, ::feeEstimator, nullptr);
-                        CAmount minimum_value_for_change = GetDustThreshold(change_prototype_txout, discard_rate);
-                        if (nFeeRet >= fee_needed_with_change + minimum_value_for_change) {
-                            pick_new_inputs = false;
-                            nFeeRet = fee_needed_with_change;
-                            continue;
-                        }
-                    }
-
-                    // If we have change output already, just increase it
-                    if (nFeeRet > nFeeNeeded && nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
-                        CAmount extraFeePaid = nFeeRet - nFeeNeeded;
-                        std::vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
-                        change_position->nValue += extraFeePaid;
-                        nFeeRet -= extraFeePaid;
-                    }
-                    break; // Done, enough fee included.
-                }
-                else if (!pick_new_inputs) {
-                    // This shouldn't happen, we should have had enough excess
-                    // fee to pay for the new output and still meet nFeeNeeded
-                    // Or we should have just subtracted fee from recipients and
-                    // nFeeNeeded should not have changed
-                    strFailReason = _("Transaction fee and change calculation failed");
-                    return false;
-                }
-
-                // Try to reduce change to include necessary fee
+                // We have a change output, means we can just break as the transaction is done.
                 if (nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
-                    CAmount additionalFeeNeeded = nFeeNeeded - nFeeRet;
-                    std::vector<CTxOut>::iterator change_position = txNew.vout.begin()+nChangePosInOut;
-                    // Only reduce change if remaining amount is still a large enough output.
-                    if (change_position->nValue >= MIN_FINAL_CHANGE + additionalFeeNeeded) {
-                        change_position->nValue -= additionalFeeNeeded;
-                        nFeeRet += additionalFeeNeeded;
-                        break; // Done, able to increase fee from change
-                    }
+                    break;
                 }
 
                 // If subtracting fee from recipients, we now know what fee we
@@ -4076,10 +4026,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 if (nSubtractFeeFromAmount > 0) {
                     pick_new_inputs = false;
                 }
-
-                // Include more fee and try again.
-                nFeeRet = nFeeNeeded;
-                continue;
             }
         }
 
@@ -4126,8 +4072,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
         }
     }
 
-    LogPrintf("Fee Calculation: Fee:%d Bytes:%u Needed:%d Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
-              nFeeRet, nBytes, nFeeNeeded, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
+    LogPrintf("Fee Calculation: Fee:%d Bytes:%u Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
+              nFeeRet, nBytes, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
               feeCalc.est.pass.start, feeCalc.est.pass.end,
               100 * feeCalc.est.pass.withinTarget / (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool),
               feeCalc.est.pass.withinTarget, feeCalc.est.pass.totalConfirmed, feeCalc.est.pass.inMempool, feeCalc.est.pass.leftMempool,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3996,6 +3996,13 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     nChangePosInOut = -1;
                 }
 
+                if (nChange < 0 && !nSubtractFeeFromAmount) {
+                    // nValueIn is not enough to cover nValueToSelect + nFeeRet. Add the missing amount abs(nChange) to the fee
+                    // and try to select other inputs in the next loop to cover the full required amount.
+                    nFeeRet += abs(nChange);
+                    continue;
+                }
+
                 // If no specific change position was requested, apply BIP69
                 if (nChangePosRequest == -1) {
                     std::sort(txNew.vin.begin(), txNew.vin.end(), CompareInputBIP69());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3956,22 +3956,30 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                 CTxOut newTxOut;
                 const CAmount nAmountLeft = nValueIn - nValue;
-                CAmount nChange = nAmountLeft - nFeeRet;
+                auto getChange = [&]() {
+                    if (nSubtractFeeFromAmount) {
+                        return nAmountLeft;
+                    } else {
+                        return nAmountLeft - nFeeRet;
+                    }
+                };
 
-                if (nChange > 0)
+                if (getChange() > 0)
                 {
                     //over pay for denominated transactions
                     if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
                         nChangePosInOut = -1;
-                        nFeeRet += nChange;
+                        nFeeRet += getChange();
                     } else {
                         // Fill a vout to ourself with zero amount until we know the correct change
                         newTxOut = CTxOut(0, scriptChange);
                         txNew.vout.push_back(newTxOut);
 
-                        // Calculate the fee with the change output added
-                        CAmount nFeeNeededWithChange{0};
-                        if (!calculateFee(nFeeNeededWithChange)) {
+                        // Calculate the fee with the change output added, store the
+                        // current fee to reset it in case the remainder is dust and we
+                        // don't need to fee with change output added.
+                        CAmount nFeePrev = nFeeRet;
+                        if (!calculateFee(nFeeRet)) {
                             return false;
                         }
 
@@ -3979,15 +3987,15 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         txNew.vout.pop_back();
 
                         // Set the change amount properly
-                        newTxOut.nValue = nAmountLeft - nFeeNeededWithChange;
+                        newTxOut.nValue = getChange();
 
                         // Never create dust outputs; if we would, just
                         // add the dust to the fee.
                         if (IsDust(newTxOut, discard_rate))
                         {
+                            nFeeRet = nFeePrev;
                             nChangePosInOut = -1;
-                            nFeeRet += nChange;
-
+                            nFeeRet += getChange();
                         }
                         else
                         {
@@ -4004,19 +4012,17 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                             std::vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
                             txNew.vout.insert(position, newTxOut);
-                            nFeeRet = nFeeNeededWithChange;
-                            nChange = nAmountLeft - nFeeRet;
                         }
                     }
                 } else {
                     nChangePosInOut = -1;
                 }
 
-                if (nChange < 0) {
+                if (getChange() < 0) {
                     if (!nSubtractFeeFromAmount) {
                         // nValueIn is not enough to cover nValue + nFeeRet. Add the missing amount abs(nChange) to the fee
                         // and try to select other inputs in the next loop to cover the full required amount.
-                        nAmountToSelectAdditional += abs(nChange);
+                        nAmountToSelectAdditional += abs(getChange());
                         continue;
                     } else if (nAmountToSelectAdditional && nValueToSelect == nAmountAvailable) {
                         strFailReason = _("Insufficient funds.");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3877,8 +3877,73 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     }
                 }
 
-                const CAmount nChange = nValueIn - nValueToSelect;
+                // Fill vin
+                //
+                // Note how the sequence number is set to max()-1 so that the
+                // nLockTime set above actually works.
+                txNew.vin.clear();
+                for (const auto& coin : setCoins) {
+                    CTxIn txin = CTxIn(coin.outpoint,CScript(),
+                                              CTxIn::SEQUENCE_FINAL - 1);
+                    txNew.vin.push_back(txin);
+                }
+
+                auto calculateFee = [&](CAmount& nFee) -> bool {
+                    // Fill in dummy signatures for fee calculation.
+                    int nIn = 0;
+                    for (const auto& coin : setCoins)
+                    {
+                        const CScript& scriptPubKey = coin.txout.scriptPubKey;
+                        SignatureData sigdata;
+                        if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))
+                        {
+                            strFailReason = _("Signing transaction failed");
+                            return false;
+                        } else {
+                            UpdateTransaction(txNew, nIn, sigdata);
+                        }
+
+                        nIn++;
+                    }
+
+                    nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
+
+                    if (nExtraPayloadSize != 0) {
+                        // account for extra payload in fee calculation
+                        nBytes += GetSizeOfCompactSize(nExtraPayloadSize) + nExtraPayloadSize;
+                    }
+
+                    if (nBytes > MAX_STANDARD_TX_SIZE) {
+                        // Do not create oversized transactions (bad-txns-oversize).
+                        strFailReason = _("Transaction too large");
+                        return false;
+                    }
+
+                    // Remove scriptSigs to eliminate the fee calculation dummy signatures
+                    for (auto& txin : txNew.vin) {
+                        txin.scriptSig = CScript();
+                    }
+
+                    nFee = GetMinimumFee(nBytes, coin_control, ::mempool, ::feeEstimator, &feeCalc);
+
+                    // If we made it here and we aren't even able to meet the relay fee on the next pass, give up
+                    // because we must be at the maximum allowed fee.
+                    if (nFee < ::minRelayTxFee.GetFee(nBytes))
+                    {
+                        strFailReason = _("Transaction too large for fee policy");
+                        return false;
+                    }
+
+                    return true;
+                };
+
+                if (!calculateFee(nFeeNeeded)) {
+                    return false;
+                }
+
                 CTxOut newTxOut;
+                const CAmount nAmountLeft = nValueIn - nValueToSelect;
+                CAmount nChange = nAmountLeft - nFeeNeeded;
 
                 if (nChange > 0)
                 {
@@ -3887,8 +3952,21 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         nChangePosInOut = -1;
                         nFeeRet += nChange;
                     } else {
-                        // Fill a vout to ourself
-                        newTxOut = CTxOut(nChange, scriptChange);
+                        // Fill a vout to ourself with zero amount until we know the correct change
+                        newTxOut = CTxOut(0, scriptChange);
+                        txNew.vout.push_back(newTxOut);
+
+                        // Calculate the fee with the change output added
+                        CAmount nFeeNeededWithChange{0};
+                        if (!calculateFee(nFeeNeededWithChange)) {
+                            return false;
+                        }
+
+                        // Remove the change output again, it will be added later again if required
+                        txNew.vout.pop_back();
+
+                        // Set the change amount properly
+                        newTxOut.nValue = nAmountLeft - nFeeNeededWithChange;
 
                         // Never create dust outputs; if we would, just
                         // add the dust to the fee.
@@ -3913,21 +3991,12 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                             std::vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
                             txNew.vout.insert(position, newTxOut);
+                            nFeeNeeded = nFeeNeededWithChange;
+                            nChange = nAmountLeft - nFeeNeeded;
                         }
                     }
                 } else {
                     nChangePosInOut = -1;
-                }
-
-                // Fill vin
-                //
-                // Note how the sequence number is set to max()-1 so that the
-                // nLockTime set above actually works.
-                txNew.vin.clear();
-                for (const auto& coin : setCoins) {
-                    CTxIn txin = CTxIn(coin.outpoint,CScript(),
-                                              CTxIn::SEQUENCE_FINAL - 1);
-                    txNew.vin.push_back(txin);
                 }
 
                 // If no specific change position was requested, apply BIP69
@@ -3948,51 +4017,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         }
                         i++;
                     }
-                }
-
-                // Fill in dummy signatures for fee calculation.
-                int nIn = 0;
-                for (const auto& coin : setCoins)
-                {
-                    const CScript& scriptPubKey = coin.txout.scriptPubKey;
-                    SignatureData sigdata;
-                    if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata))
-                    {
-                        strFailReason = _("Signing transaction failed");
-                        return false;
-                    } else {
-                        UpdateTransaction(txNew, nIn, sigdata);
-                    }
-
-                    nIn++;
-                }
-
-                nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
-
-                if (nExtraPayloadSize != 0) {
-                    // account for extra payload in fee calculation
-                    nBytes += GetSizeOfCompactSize(nExtraPayloadSize) + nExtraPayloadSize;
-                }
-
-                if (nBytes > MAX_STANDARD_TX_SIZE) {
-                    // Do not create oversized transactions (bad-txns-oversize).
-                    strFailReason = _("Transaction too large");
-                    return false;
-                }
-
-                // Remove scriptSigs to eliminate the fee calculation dummy signatures
-                for (auto& txin : txNew.vin) {
-                    txin.scriptSig = CScript();
-                }
-
-                nFeeNeeded = GetMinimumFee(nBytes, coin_control, ::mempool, ::feeEstimator, &feeCalc);
-
-                // If we made it here and we aren't even able to meet the relay fee on the next pass, give up
-                // because we must be at the maximum allowed fee.
-                if (nFeeNeeded < ::minRelayTxFee.GetFee(nBytes))
-                {
-                    strFailReason = _("Transaction too large for fee policy");
-                    return false;
                 }
 
                 if (nFeeRet >= nFeeNeeded) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4018,26 +4018,21 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     nChangePosInOut = -1;
                 }
 
-                if (nAmountAvailable == 0 || (!nSubtractFeeFromAmount && nValueIn < nValue)) {
-                    if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
-                        strFailReason = _("Unable to locate enough PrivateSend non-denominated funds for this transaction.");
-                    } else if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
-                        strFailReason = _("Unable to locate enough PrivateSend denominated funds for this transaction.");
-                        strFailReason += " " + _("PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.");
-                    } else {
-                        strFailReason = _("Insufficient funds.");
-                    }
-                    return false;
-                }
-
-                if (getChange() < 0) {
-                    if (!nSubtractFeeFromAmount) {
+                if (nAmountAvailable == 0 || getChange() < 0) {
+                    if (!nSubtractFeeFromAmount && nValueToSelect < nAmountAvailable) {
                         // nValueIn is not enough to cover nValue + nFeeRet. Add the missing amount abs(nChange) to the fee
                         // and try to select other inputs in the next loop to cover the full required amount.
                         nAmountToSelectAdditional += abs(getChange());
                         continue;
-                    } else if (nAmountToSelectAdditional && nValueToSelect == nAmountAvailable) {
-                        strFailReason = _("Insufficient funds.");
+                    } else {
+                        if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
+                            strFailReason = _("Unable to locate enough PrivateSend non-denominated funds for this transaction.");
+                        } else if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
+                            strFailReason = _("Unable to locate enough PrivateSend denominated funds for this transaction.");
+                            strFailReason += " " + _("PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.");
+                        } else {
+                            strFailReason = _("Insufficient funds.");
+                        }
                         return false;
                     }
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3832,13 +3832,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
 
                 CAmount nValueToSelect = nValue;
                 if (nSubtractFeeFromAmount == 0) {
+                    assert(nAmountToSelectAdditional >= 0);
                     nValueToSelect += nAmountToSelectAdditional;
-                }
-                // If the resulting amount to select exceeds the
-                // balance from the available coins just try it one
-                // last time with whole available amount.
-                if (nValueToSelect > nAmountAvailable) {
-                    nValueToSelect = nAmountAvailable;
                 }
                 // vouts to the payees
                 for (const auto& recipient : vecSend)
@@ -4021,23 +4016,17 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     nChangePosInOut = -1;
                 }
 
-                if (nAmountAvailable == 0 || getChange() < 0) {
-                    if (!nSubtractFeeFromAmount && nValueToSelect < nAmountAvailable) {
+                if (getChange() < 0) {
+                    if (nSubtractFeeFromAmount == 0) {
                         // nValueIn is not enough to cover nValue + nFeeRet. Add the missing amount abs(nChange) to the fee
-                        // and try to select other inputs in the next loop to cover the full required amount.
+                        // and try to select other inputs in the next loop step to cover the full required amount.
                         nAmountToSelectAdditional += abs(getChange());
-                        continue;
-                    } else {
-                        if (coin_control.nCoinType == CoinType::ONLY_NONDENOMINATED) {
-                            strFailReason = _("Unable to locate enough PrivateSend non-denominated funds for this transaction.");
-                        } else if (coin_control.nCoinType == CoinType::ONLY_FULLY_MIXED) {
-                            strFailReason = _("Unable to locate enough PrivateSend denominated funds for this transaction.");
-                            strFailReason += " " + _("PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.");
-                        } else {
-                            strFailReason = _("Insufficient funds.");
-                        }
-                        return false;
+                    } else if (nAmountToSelectAdditional > 0 && nValueToSelect == nAmountAvailable) {
+                        // We tried selecting more and failed. We have no extra funds left,
+                        // so just add 1 duff to fail in the next loop step with a correct reason
+                        nAmountToSelectAdditional += 1;
                     }
+                    continue;
                 }
 
                 // If no specific change position was requested, apply BIP69

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3824,7 +3824,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
             int nMaxTries = 500;
             while (--nMaxTries)
             {
-                nChangePosInOut = nChangePosRequest;
+                nChangePosInOut = std::numeric_limits<int>::max();
                 txNew.vin.clear();
                 txNew.vout.clear();
                 wtxNew.fFromMe = true;
@@ -4000,15 +4000,17 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         }
                         else
                         {
-                            if (nChangePosInOut == -1)
+                            if (nChangePosRequest == -1)
                             {
                                 // Insert change txn at random position:
                                 nChangePosInOut = GetRandInt(txNew.vout.size()+1);
                             }
-                            else if ((unsigned int)nChangePosInOut > txNew.vout.size())
+                            else if ((unsigned int)nChangePosRequest > txNew.vout.size())
                             {
                                 strFailReason = _("Change index out of range");
                                 return false;
+                            } else {
+                                nChangePosInOut = nChangePosRequest;
                             }
 
                             std::vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosInOut;
@@ -4089,6 +4091,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 return false;
             }
         }
+
+        // Make sure change position was updated one way or another
+        assert(nChangePosInOut != std::numeric_limits<int>::max());
 
         if (nChangePosInOut == -1) reservekey.ReturnKey(); // Return any reserved key if we don't have change
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4050,7 +4050,14 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     }
                 }
 
-                // We have a change output, means we can just break as the transaction is done.
+                if (nAmountLeft == nFeeRet) {
+                    // We either added the change amount to nFeeRet because the change amount was considered
+                    // to be dust or the input exactly matches output + fee.
+                    // Either way, we used the total amount of the inputs we picked and the transaction is ready.
+                    break;
+                }
+
+                // We have a change output and we don't need to subtruct fees, which means the transaction is ready.
                 if (nChangePosInOut != -1 && nSubtractFeeFromAmount == 0) {
                     break;
                 }
@@ -4065,13 +4072,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         break;
                     }
                     pick_new_inputs = false;
-                }
-
-                // If nAmountLeft == nFeeRet it means we either added nChange to nFeeRet since nChange was considered to be dust
-                // or the input exactly matches output + fee.
-                // Either way, we used the total amount of the inputs we picked and the transaction is ready.
-                if (nAmountLeft == nFeeRet) {
-                    break;
                 }
             }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -547,6 +547,16 @@ public:
     }
 };
 
+struct CompareInputCoinBIP69
+{
+    inline bool operator()(const CInputCoin& a, const CInputCoin& b) const
+    {
+        // Note: CInputCoin-s are essentially inputs, their txouts are used for informational purposes only
+        // that's why we use CompareInputBIP69 to sort them in a BIP69 compliant way.
+        return CompareInputBIP69()(CTxIn(a.outpoint), CTxIn(b.outpoint));
+    }
+};
+
 class COutput
 {
 public:


### PR DESCRIPTION
This PR fixes/improves fee calculation and with that reasons for the failing test case 2/4 of `CreateTransactionTest` unit tests introduced in #3667.

@UdjinM6 Test 2/4 is the issue we discovered in #3657 aka the previous logic did not subtract fees from change before checking if it’s dust or not. If fees are much higher than the discard/dust rate and the change after fee was actually dust, it still tried to add a change output which then caused it to fail if only given inputs were allowed. 