### PR TITLE
test: Implement unit tests for CTransactionBuilder

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -72,7 +72,6 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
-  test/privatesend_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \
   test/ratecheck_tests.cpp \
@@ -106,6 +105,7 @@ BITCOIN_TESTS =\
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \
+  test/privatesend_tests.cpp \
   wallet/test/wallet_test_fixture.cpp \
   wallet/test/wallet_test_fixture.h \
   wallet/test/accounting_tests.cpp \

--- a/src/test/privatesend_tests.cpp
+++ b/src/test/privatesend_tests.cpp
@@ -132,6 +132,8 @@ BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
 
         CTransactionBuilderOutput* output = txBuilder.AddOutput();
         BOOST_CHECK(output->UpdateAmount(txBuilder.GetAmountLeft()));
+        BOOST_CHECK(output->UpdateAmount(1));
+        BOOST_CHECK(output->UpdateAmount(output->GetAmount() + txBuilder.GetAmountLeft()));
         BOOST_CHECK(!output->UpdateAmount(output->GetAmount() + 1));
         BOOST_CHECK(!output->UpdateAmount(0));
         BOOST_CHECK(!output->UpdateAmount(-1));

--- a/src/test/privatesend_tests.cpp
+++ b/src/test/privatesend_tests.cpp
@@ -5,7 +5,11 @@
 #include <test/test_dash.h>
 
 #include <amount.h>
+#include <consensus/validation.h>
+#include <privatesend/privatesend-util.h>
 #include <privatesend/privatesend.h>
+#include <validation.h>
+#include <wallet/wallet.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -24,6 +28,148 @@ BOOST_AUTO_TEST_CASE(ps_collatoral_tests)
     BOOST_CHECK(!CPrivateSend::IsCollateralAmount(0.00040001 * COIN));
     BOOST_CHECK(!CPrivateSend::IsCollateralAmount(0.00100000 * COIN));
     BOOST_CHECK(!CPrivateSend::IsCollateralAmount(0.00100001 * COIN));
+}
+
+class CTransactionBuilderTestSetup : public TestChain100Setup
+{
+public:
+    CTransactionBuilderTestSetup()
+    {
+        CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        wallet = MakeUnique<CWallet>("mock", WalletDatabase::CreateMock());
+        bool firstRun;
+        wallet->LoadWallet(firstRun);
+        AddWallet(wallet.get());
+        {
+            LOCK(wallet->cs_wallet);
+            wallet->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
+        }
+        WalletRescanReserver reserver(wallet.get());
+        reserver.reserve();
+        wallet->ScanForWalletTransactions(chainActive.Genesis(), nullptr, reserver);
+    }
+
+    ~CTransactionBuilderTestSetup()
+    {
+        RemoveWallet(wallet.get());
+    }
+
+    std::unique_ptr<CWallet> wallet;
+
+    CWalletTx& AddTxToChain(uint256 nTxHash)
+    {
+        assert(wallet->mapWallet.find(nTxHash) != wallet->mapWallet.end());
+        CMutableTransaction blocktx;
+        {
+            LOCK(wallet->cs_wallet);
+            blocktx = CMutableTransaction(*wallet->mapWallet.at(nTxHash).tx);
+        }
+        CreateAndProcessBlock({blocktx}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        LOCK(cs_main);
+        LOCK(wallet->cs_wallet);
+        auto it = wallet->mapWallet.find(blocktx.GetHash());
+        BOOST_CHECK(it != wallet->mapWallet.end());
+        it->second.SetMerkleBranch(chainActive.Tip(), 1);
+        return it->second;
+    }
+    CompactTallyItem GetTallyItem(const std::vector<CAmount>& vecAmounts)
+    {
+        CompactTallyItem tallyItem;
+        CWalletTx tx;
+        CReserveKey destKey(wallet.get());
+        CReserveKey reserveKey(wallet.get());
+        CAmount nFeeRet;
+        int nChangePosRet = -1;
+        std::string strError;
+        CCoinControl coinControl;
+        CPubKey pubKey;
+        BOOST_CHECK(destKey.GetReservedKey(pubKey, false));
+        tallyItem.txdest = pubKey.GetID();
+
+        for (CAmount nAmount : vecAmounts) {
+            BOOST_CHECK(wallet->CreateTransaction({{GetScriptForDestination(tallyItem.txdest), nAmount, false}}, tx, reserveKey, nFeeRet, nChangePosRet, strError, coinControl));
+            CValidationState state;
+            BOOST_CHECK(wallet->CommitTransaction(tx, reserveKey, nullptr, state));
+            CWalletTx& wtx = AddTxToChain(tx.GetHash());
+            for (size_t n = 0; n < wtx.tx->vout.size(); ++n) {
+                if (nChangePosRet != -1 && n == nChangePosRet) {
+                    // Skip the change output to only return the requested coins
+                    continue;
+                }
+                tallyItem.vecOutPoints.push_back(COutPoint(wtx.GetHash(), n));
+                tallyItem.nAmount += wtx.tx->vout[n].nValue;
+            }
+        }
+        assert(tallyItem.vecOutPoints.size() == vecAmounts.size());
+        destKey.KeepKey();
+        return tallyItem;
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
+{
+    minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
+    // Tests with single outpoint tallyItem
+    {
+        CompactTallyItem tallyItem = GetTallyItem({5000});
+        CTransactionBuilder txBuilder(wallet.get(), tallyItem);
+
+        BOOST_CHECK_EQUAL(txBuilder.CountOutputs(), 0);
+        BOOST_CHECK_EQUAL(tallyItem.nAmount, txBuilder.GetAmountInitial());
+        BOOST_CHECK_EQUAL(txBuilder.GetAmountLeft(), 4810);
+
+        BOOST_CHECK(txBuilder.CouldAddOutput(4776));
+        BOOST_CHECK(!txBuilder.CouldAddOutput(4777));
+
+        BOOST_CHECK(txBuilder.CouldAddOutput(0));
+        BOOST_CHECK(!txBuilder.CouldAddOutput(-1));
+
+        BOOST_CHECK(txBuilder.CouldAddOutputs({1000, 1000, 2708}));
+        BOOST_CHECK(!txBuilder.CouldAddOutputs({1000, 1000, 2709}));
+
+        BOOST_CHECK_EQUAL(txBuilder.AddOutput(5000), nullptr);
+        BOOST_CHECK_EQUAL(txBuilder.AddOutput(-1), nullptr);
+
+        CTransactionBuilderOutput* output = txBuilder.AddOutput();
+        BOOST_CHECK(output->UpdateAmount(txBuilder.GetAmountLeft()));
+        BOOST_CHECK(!output->UpdateAmount(output->GetAmount() + 1));
+        BOOST_CHECK(!output->UpdateAmount(0));
+        BOOST_CHECK(!output->UpdateAmount(-1));
+        BOOST_CHECK_EQUAL(txBuilder.CountOutputs(), 1);
+
+        std::string strResult;
+        BOOST_CHECK(txBuilder.Commit(strResult));
+        CWalletTx& wtx = AddTxToChain(uint256S(strResult));
+        BOOST_CHECK_EQUAL(wtx.tx->vout[0].nValue, output->GetAmount());
+        BOOST_CHECK(wtx.tx->vout[0].scriptPubKey == output->GetScript());
+    }
+    // Tests with multiple outpoint tallyItem
+    {
+        CompactTallyItem tallyItem = GetTallyItem({10000, 20000, 30000, 40000, 50000});
+        CTransactionBuilder txBuilder(wallet.get(), tallyItem);
+        std::vector<CTransactionBuilderOutput*> vecOutputs;
+        std::string strResult;
+
+        vecOutputs.push_back(txBuilder.AddOutput(100));
+        BOOST_CHECK(!txBuilder.Commit(strResult));
+
+        vecOutputs.back()->UpdateAmount(1000);
+        while (vecOutputs.size() < 100) {
+            vecOutputs.push_back(txBuilder.AddOutput(1000 + vecOutputs.size()));
+        }
+        BOOST_CHECK_EQUAL(vecOutputs.size(), 100);
+        BOOST_CHECK(txBuilder.Commit(strResult));
+        CWalletTx& wtx = AddTxToChain(uint256S(strResult));
+        for (const auto& out : wtx.tx->vout) {
+            auto it = std::find_if(vecOutputs.begin(), vecOutputs.end(), [&](CTransactionBuilderOutput* output) -> bool {
+                return output->GetAmount() == out.nValue && output->GetScript() == out.scriptPubKey;
+            });
+            if (it != vecOutputs.end()) {
+                vecOutputs.erase(it);
+            }
+        }
+        BOOST_CHECK(vecOutputs.size() == 0);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/privatesend_tests.cpp
+++ b/src/test/privatesend_tests.cpp
@@ -121,7 +121,7 @@ BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
         CTransactionBuilder txBuilder(wallet.get(), tallyItem);
 
         BOOST_CHECK_EQUAL(txBuilder.CountOutputs(), 0);
-        BOOST_CHECK_EQUAL(tallyItem.nAmount, txBuilder.GetAmountInitial());
+        BOOST_CHECK_EQUAL(txBuilder.GetAmountInitial(), tallyItem.nAmount);
         BOOST_CHECK_EQUAL(txBuilder.GetAmountLeft(), 4810);         // 5000 - 190
 
         BOOST_CHECK(txBuilder.CouldAddOutput(4776));                // 4810 - 34


### PR DESCRIPTION
Currently based on #3657 where the class to test - `CTransactionBuilder` - gets introduced.