### PR TITLE
qt: Ignore GUIUtil::updateFont calls until GUIUtil::loadFonts was called

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1516,6 +1516,11 @@ void setFixedPitchFont(const std::vector<QWidget*>& vecWidgets)
 
 void updateFonts()
 {
+    // Fonts need to be loaded by GUIIUtil::loadFonts(), if not just return.
+    if (!osDefaultFont) {
+        return;
+    }
+
     setApplicationFont();
 
     auto getKey = [](QWidget* w) -> QString {


### PR DESCRIPTION
Fixes #3686