### PR TITLE
masternode|rpc: Remove unused code

### DIFF
--- a/src/masternode/masternode-sync.h
+++ b/src/masternode/masternode-sync.h
@@ -9,7 +9,6 @@
 
 class CMasternodeSync;
 
-static const int MASTERNODE_SYNC_FAILED          = -1;
 static const int MASTERNODE_SYNC_INITIAL         = 0; // sync just started, was reset recently or still in IDB
 static const int MASTERNODE_SYNC_WAITING         = 1; // waiting after initial to see if we can get more headers/blocks
 static const int MASTERNODE_SYNC_GOVERNANCE      = 4;
@@ -38,16 +37,12 @@ private:
     int64_t nTimeAssetSyncStarted;
     // ... last bumped
     int64_t nTimeLastBumped;
-    // ... or failed
-    int64_t nTimeLastFailure;
 
 public:
     CMasternodeSync() { Reset(); }
 
-
     static void SendGovernanceSyncRequest(CNode* pnode, CConnman& connman);
 
-    bool IsFailed() const { return nCurrentAsset == MASTERNODE_SYNC_FAILED; }
     bool IsBlockchainSynced() const { return nCurrentAsset > MASTERNODE_SYNC_WAITING; }
     bool IsSynced() const { return nCurrentAsset == MASTERNODE_SYNC_FINISHED; }
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -97,7 +97,6 @@ UniValue mnsync(const JSONRPCRequest& request)
         objStatus.pushKV("Attempt", masternodeSync.GetAttempt());
         objStatus.pushKV("IsBlockchainSynced", masternodeSync.IsBlockchainSynced());
         objStatus.pushKV("IsSynced", masternodeSync.IsSynced());
-        objStatus.pushKV("IsFailed", masternodeSync.IsFailed());
         return objStatus;
     }
 


### PR DESCRIPTION
Removes `MASTERNODE_SYNC_FAILED` state in `CMasternodeSync` and its dependencies . That stuff is not longer used since #2600 and #3097.