### PR TITLE
masternode|net|rpc: Improve masternode sync process

### DIFF
--- a/src/masternode/masternode-sync.cpp
+++ b/src/masternode/masternode-sync.cpp
@@ -199,6 +199,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                     //    the number of connected peers).
                     // We must be at the tip already, let's move to the next asset.
                     SwitchToNextAsset(connman);
+                    uiInterface.NotifyAdditionalDataSyncProgressChanged(nSyncProgress);
                 }
             }
 

--- a/src/masternode/masternode-sync.cpp
+++ b/src/masternode/masternode-sync.cpp
@@ -14,13 +14,16 @@
 class CMasternodeSync;
 CMasternodeSync masternodeSync;
 
-void CMasternodeSync::Reset()
+void CMasternodeSync::Reset(bool fNotifyReset)
 {
     nCurrentAsset = MASTERNODE_SYNC_BLOCKCHAIN;
     nTriedPeerCount = 0;
     nTimeAssetSyncStarted = GetTime();
     nTimeLastBumped = GetTime();
     fReachedBestHeader = false;
+    if (fNotifyReset) {
+        uiInterface.NotifyAdditionalDataSyncProgressChanged(-1);
+    }
 }
 
 void CMasternodeSync::BumpAssetLastTime(const std::string& strFuncName)

--- a/src/masternode/masternode-sync.cpp
+++ b/src/masternode/masternode-sync.cpp
@@ -188,13 +188,15 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                     LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- syncing mempool from peer=%d\n", nTick, nCurrentAsset, pnode->GetId());
                 }
 
-                if (fReachedBestHeader && GetTime() - nTimeLastBumped > MASTERNODE_SYNC_TIMEOUT_SECONDS) {
+                if (fReachedBestHeader && GetTime() - nTimeLastBumped > (vNodesCopy.size() > 3 ? MASTERNODE_SYNC_TICK_SECONDS : MASTERNODE_SYNC_TIMEOUT_SECONDS)) {
                     // At this point we know that:
                     // a) there are peers (because we are looping on at least one of them);
-                    // b) we waited for at least MASTERNODE_SYNC_TIMEOUT_SECONDS since we reached
-                    //    the headers tip the last time (i.e. since fReachedBestHeader has been set to true);
+                    // b) we waited for at least MASTERNODE_SYNC_TICK_SECONDS/MASTERNODE_SYNC_TIMEOUT_SECONDS
+                    //    (depending on the number of connected peers) since we reached the headers tip the last
+                    //    time (i.e. since fReachedBestHeader has been set to true);
                     // c) there were no blocks (UpdatedBlockTip, NotifyHeaderTip) or headers (AcceptedBlockHeader)
-                    //    for at least MASTERNODE_SYNC_TIMEOUT_SECONDS.
+                    //    for at least MASTERNODE_SYNC_TICK_SECONDS/MASTERNODE_SYNC_TIMEOUT_SECONDS (depending on
+                    //    the number of connected peers).
                     // We must be at the tip already, let's move to the next asset.
                     SwitchToNextAsset(connman);
                 }

--- a/src/masternode/masternode-sync.cpp
+++ b/src/masternode/masternode-sync.cpp
@@ -17,7 +17,7 @@ CMasternodeSync masternodeSync;
 void CMasternodeSync::Reset(bool fForce, bool fNotifyReset)
 {
     // Avoid resetting the sync process if we just "recently" received a new block
-    if (fForce || !nTimeLastUpdateBlockTip || ((GetTime() - nTimeLastUpdateBlockTip) > MASTERNODE_SYNC_RESET_SECONDS)) {
+    if (fForce || (GetTime() - nTimeLastUpdateBlockTip > MASTERNODE_SYNC_RESET_SECONDS)) {
         nCurrentAsset = MASTERNODE_SYNC_BLOCKCHAIN;
         nTriedPeerCount = 0;
         nTimeAssetSyncStarted = GetTime();
@@ -195,7 +195,8 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                     LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- syncing mempool from peer=%d\n", nTick, nCurrentAsset, pnode->GetId());
                 }
 
-                if (fReachedBestHeader && GetTime() - nTimeLastBumped > (vNodesCopy.size() > 3 ? MASTERNODE_SYNC_TICK_SECONDS : MASTERNODE_SYNC_TIMEOUT_SECONDS)) {
+                int64_t nTimeSyncTimeout = vNodesCopy.size() > 3 ? MASTERNODE_SYNC_TICK_SECONDS : MASTERNODE_SYNC_TIMEOUT_SECONDS;
+                if (fReachedBestHeader && (GetTime() - nTimeLastBumped > nTimeSyncTimeout)) {
                     // At this point we know that:
                     // a) there are peers (because we are looping on at least one of them);
                     // b) we waited for at least MASTERNODE_SYNC_TICK_SECONDS/MASTERNODE_SYNC_TIMEOUT_SECONDS

--- a/src/masternode/masternode-sync.h
+++ b/src/masternode/masternode-sync.h
@@ -9,8 +9,7 @@
 
 class CMasternodeSync;
 
-static const int MASTERNODE_SYNC_INITIAL         = 0; // sync just started, was reset recently or still in IDB
-static const int MASTERNODE_SYNC_WAITING         = 1; // waiting after initial to see if we can get more headers/blocks
+static const int MASTERNODE_SYNC_BLOCKCHAIN      = 1;
 static const int MASTERNODE_SYNC_GOVERNANCE      = 4;
 static const int MASTERNODE_SYNC_GOVOBJ          = 10;
 static const int MASTERNODE_SYNC_GOVOBJ_VOTE     = 11;
@@ -38,12 +37,15 @@ private:
     // ... last bumped
     int64_t nTimeLastBumped;
 
+    /// Set to true if best header is reached in CMasternodeSync::UpdatedBlockTip
+    bool fReachedBestHeader{false};
+
 public:
     CMasternodeSync() { Reset(); }
 
     static void SendGovernanceSyncRequest(CNode* pnode, CConnman& connman);
 
-    bool IsBlockchainSynced() const { return nCurrentAsset > MASTERNODE_SYNC_WAITING; }
+    bool IsBlockchainSynced() const { return nCurrentAsset > MASTERNODE_SYNC_BLOCKCHAIN; }
     bool IsSynced() const { return nCurrentAsset == MASTERNODE_SYNC_FINISHED; }
 
     int GetAssetID() const { return nCurrentAsset; }

--- a/src/masternode/masternode-sync.h
+++ b/src/masternode/masternode-sync.h
@@ -17,6 +17,7 @@ static const int MASTERNODE_SYNC_FINISHED        = 999;
 
 static const int MASTERNODE_SYNC_TICK_SECONDS    = 6;
 static const int MASTERNODE_SYNC_TIMEOUT_SECONDS = 30; // our blocks are 2.5 minutes so 30 seconds should be fine
+static const int MASTERNODE_SYNC_RESET_SECONDS = 600; // Reset fReachedBestHeader in CMasternodeSync::Reset if UpdateBlockTip hasn't been called for this seconds
 
 extern CMasternodeSync masternodeSync;
 
@@ -39,9 +40,11 @@ private:
 
     /// Set to true if best header is reached in CMasternodeSync::UpdatedBlockTip
     bool fReachedBestHeader{false};
+    /// Last time UpdateBlockTip has been called
+    int64_t nTimeLastUpdateBlockTip{0};
 
 public:
-    CMasternodeSync() { Reset(false); }
+    CMasternodeSync() { Reset(true, false); }
 
     static void SendGovernanceSyncRequest(CNode* pnode, CConnman& connman);
 
@@ -55,7 +58,7 @@ public:
     std::string GetAssetName() const;
     std::string GetSyncStatus() const;
 
-    void Reset(bool fNotifyReset = true);
+    void Reset(bool fForce = false, bool fNotifyReset = true);
     void SwitchToNextAsset(CConnman& connman);
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv) const;

--- a/src/masternode/masternode-sync.h
+++ b/src/masternode/masternode-sync.h
@@ -41,7 +41,7 @@ private:
     bool fReachedBestHeader{false};
 
 public:
-    CMasternodeSync() { Reset(); }
+    CMasternodeSync() { Reset(false); }
 
     static void SendGovernanceSyncRequest(CNode* pnode, CConnman& connman);
 
@@ -55,7 +55,7 @@ public:
     std::string GetAssetName() const;
     std::string GetSyncStatus() const;
 
-    void Reset();
+    void Reset(bool fNotifyReset = true);
     void SwitchToNextAsset(CConnman& connman);
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv) const;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1394,7 +1394,7 @@ void CConnman::NotifyNumConnectionsChanged()
 
     // If we had zero connections before and new connections now or if we just dropped
     // to zero connections reset the sync process if its outdated.
-    if (vNodesSize && !nPrevNodeCount || !vNodesSize && nPrevNodeCount) {
+    if ((vNodesSize > 0 && nPrevNodeCount == 0) || (vNodesSize == 0 && nPrevNodeCount > 0)) {
         masternodeSync.Reset();
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2516,7 +2516,7 @@ void CConnman::ThreadOpenMasternodeConnections()
 
         didConnect = false;
 
-        if (!fNetworkActive)
+        if (!fNetworkActive || !masternodeSync.IsBlockchainSynced())
             continue;
 
         std::set<CService> connectedNodes;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1391,6 +1391,13 @@ void CConnman::NotifyNumConnectionsChanged()
         LOCK(cs_vNodes);
         vNodesSize = vNodes.size();
     }
+
+    // If we had zero connections before and new connections now or if we just dropped
+    // to zero connections reset the sync process if its outdated.
+    if (vNodesSize && !nPrevNodeCount || !vNodesSize && nPrevNodeCount) {
+        masternodeSync.Reset();
+    }
+
     if(vNodesSize != nPrevNodeCount) {
         nPrevNodeCount = vNodesSize;
         if(clientInterface)
@@ -2898,6 +2905,10 @@ void CConnman::SetNetworkActive(bool active)
     }
 
     fNetworkActive = active;
+
+    // Always call the Reset() if the network gets enabled/disabled to make sure the sync process
+    // gets a reset if its outdated..
+    masternodeSync.Reset();
 
     uiInterface.NotifyNetworkActiveChanged(fNetworkActive);
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -108,7 +108,7 @@ UniValue mnsync(const JSONRPCRequest& request)
 
     if(strMode == "reset")
     {
-        masternodeSync.Reset();
+        masternodeSync.Reset(true);
         return "success";
     }
     return "failure";

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -109,7 +109,6 @@ UniValue mnsync(const JSONRPCRequest& request)
     if(strMode == "reset")
     {
         masternodeSync.Reset();
-        masternodeSync.SwitchToNextAsset(*g_connman);
         return "success";
     }
     return "failure";

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -113,6 +113,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
             mn.node.setnetworkactive(False)
             wait_until(lambda: mn.node.getconnectioncount() == 0)
             mn.node.setnetworkactive(True)
+            force_finish_mnsync(mn.node)
             connect_nodes(mn.node, 0)
 
     def reset_probe_timeouts(self):


### PR DESCRIPTION
This PR fixes some inconsistency issues in the masternode sync process e.g. if connections dropped or network has been disabled. It also combines the two states  

- `MASTERNODE_SYNC_INITIAL`
-  `MASTERNODE_SYNC_WAITING` 

into one: `MASTERNODE_SYNC_BLOCKCHAIN`. 

Just didn't see a reason to stick with the initial state as it seems simpler to me with only having states representing what actually happens at the time. If that has some deeper idea i didn't see yet, let me know. 


7d9ab2199869e177ce111ecac71160bb8303eee2 decreases the timeout (30s to 6s) between the transition `MASTERNODE_SYNC_BLOCKCHAIN -> MASTERNODE_SYNC_GOVERNANCE` if the client has more than three connected peers. Idea is that i guess we can assume, if one has more than 3 connections and there was no update for 6 seconds chances are very low that there is more to come, no? And if there is more to come the process will either get a reset or will just catch up properly later. Will still be 30s for less than three tried peers.

bcafa734f078cf2ca86dd7394f99560d60bc34bc makes sure the UI gets an update if the masterrnode sync receives a reset. This is a preparation for a Qt-PR i have to come next. If someone feels this should rather be moved to the Qt-PR then, please cry. For me it felt better to put it in here.

Rest should be obvious, see commits.