### PR TITLE
chainparams: Remove llmq_50_60 from regtest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -896,7 +896,6 @@ public:
 
         // long living quorum params
         consensus.llmqs[Consensus::LLMQ_TEST] = llmq_test;
-        consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
         consensus.llmqTypeChainLocks = Consensus::LLMQ_TEST;
         consensus.llmqTypeInstantSend = Consensus::LLMQ_TEST;
     }


### PR DESCRIPTION
Its just not used anywhere so there is no point in starting the thread 
for it imo since it just spams the test logs with tries/failures.