### PR TITLE
qt: Finetune ModalOverlay

### DIFF
--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -79,10 +79,7 @@
               <number>0</number>
              </property>
              <item>
-              <widget class="QPushButton" name="warningIcon">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
+              <widget class="QLabel" name="warningIcon">
                <property name="text">
                 <string/>
                </property>

--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -169,6 +169,9 @@
            <property name="fieldGrowthPolicy">
             <enum>QFormLayout::FieldsStayAtSizeHint</enum>
            </property>
+           <property name="formAlignment">
+            <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           </property>
            <property name="horizontalSpacing">
             <number>6</number>
            </property>

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -31,7 +31,7 @@ foreverHidden(false)
                       ui->labelEstimatedTimeLeft,
                      }, GUIUtil::FontWeight::Bold);
 
-    GUIUtil::setIcon(ui->warningIcon, "warning", GUIUtil::ThemedColor::ORANGE, QSize(48, 48));
+    ui->warningIcon->setPixmap(GUIUtil::getIcon("warning", GUIUtil::ThemedColor::ORANGE).pixmap(48, 48));
 
     connect(ui->closeButton, SIGNAL(clicked()), this, SLOT(closeClicked()));
     if (parent) {

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1231,11 +1231,10 @@ QWidget#bgWidget { /* The frame overlaying the overview-page */
     padding-right: 10px;
 }
 
-QWidget#bgWidget .QPushButton#warningIcon {
+QWidget#bgWidget .QLabel#warningIcon {
     background-color: #00000000;
-    width: 64px;
-    height: 64px;
-    padding: 5px;
+    margin-left: 10px;
+    margin-right: 10px;
 }
 
 QWidget#contentWidget { /* The actual content with the text/buttons/etc... */


### PR DESCRIPTION
Just make sure the icon is aligned properly besides the text. Also align the main information in the center instead of having it stick at the left which looks weird imo. 