### PR TITLE
qt|wallet: Fix "Use available balance" for PrivateSend 

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -728,7 +728,7 @@ void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
     // Calculate available amount to send.
     CAmount amount;
     if (fPrivateSend) {
-        amount = model->getAnonymizedBalance();
+        amount = model->getAnonymizedBalance(&coin_control);
     } else {
         amount = model->getBalance(&coin_control);
     }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -84,9 +84,9 @@ CAmount WalletModel::getAnonymizableBalance(bool fSkipDenominated, bool fSkipUnc
     return wallet->GetAnonymizableBalance(fSkipDenominated, fSkipUnconfirmed);
 }
 
-CAmount WalletModel::getAnonymizedBalance() const
+CAmount WalletModel::getAnonymizedBalance(const CCoinControl* coinControl) const
 {
-    return wallet->GetAnonymizedBalance();
+    return wallet->GetAnonymizedBalance(coinControl);
 }
 
 CAmount WalletModel::getDenominatedBalance(bool unconfirmed) const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -138,7 +138,7 @@ public:
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;
     CAmount getAnonymizableBalance(bool fSkipDenominated, bool fSkipUnconfirmed) const;
-    CAmount getAnonymizedBalance() const;
+    CAmount getAnonymizedBalance(const CCoinControl* coinControl = nullptr) const;
     CAmount getDenominatedBalance(bool unconfirmed) const;
     CAmount getNormalizedAnonymizedBalance() const;
     CAmount getAverageAnonymizedRounds() const;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2367,7 +2367,7 @@ CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool fUseCache) const
     return nCredit;
 }
 
-CAmount CWalletTx::GetAnonymizedCredit(bool fUseCache, const CCoinControl* coinControl) const
+CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
 {
     if (!pwallet)
         return 0;
@@ -2376,7 +2376,7 @@ CAmount CWalletTx::GetAnonymizedCredit(bool fUseCache, const CCoinControl* coinC
     if (IsCoinBase() || GetDepthInMainChain() < 0)
         return 0;
 
-    if (fUseCache && fAnonymizedCreditCached)
+    if (coinControl == nullptr && fAnonymizedCreditCached)
         return nAnonymizedCreditCached;
 
     CAmount nCredit = 0;
@@ -2399,8 +2399,11 @@ CAmount CWalletTx::GetAnonymizedCredit(bool fUseCache, const CCoinControl* coinC
         }
     }
 
-    nAnonymizedCreditCached = nCredit;
-    fAnonymizedCreditCached = true;
+    if (coinControl == nullptr) {
+        nAnonymizedCreditCached = nCredit;
+        fAnonymizedCreditCached = true;
+    }
+
     return nCredit;
 }
 
@@ -2630,7 +2633,7 @@ CAmount CWallet::GetAnonymizedBalance(const CCoinControl* coinControl) const
     LOCK2(cs_main, cs_wallet);
 
     for (auto pcoin : GetSpendableTXs()) {
-        nTotal += pcoin->GetAnonymizedCredit(coinControl == nullptr, coinControl);
+        nTotal += pcoin->GetAnonymizedCredit(coinControl);
     }
 
     return nTotal;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -480,7 +480,7 @@ public:
     CAmount GetAvailableWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetChange() const;
 
-    CAmount GetAnonymizedCredit(bool fUseCache = true, const CCoinControl* coinControl = nullptr) const;
+    CAmount GetAnonymizedCredit(const CCoinControl* coinControl = nullptr) const;
     CAmount GetDenominatedCredit(bool unconfirmed, bool fUseCache=true) const;
 
     void GetAmounts(std::list<COutputEntry>& listReceived,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -480,7 +480,7 @@ public:
     CAmount GetAvailableWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetChange() const;
 
-    CAmount GetAnonymizedCredit(bool fUseCache=true) const;
+    CAmount GetAnonymizedCredit(bool fUseCache = true, const CCoinControl* coinControl = nullptr) const;
     CAmount GetDenominatedCredit(bool unconfirmed, bool fUseCache=true) const;
 
     void GetAmounts(std::list<COutputEntry>& listReceived,
@@ -1045,7 +1045,7 @@ public:
     CAmount GetLegacyBalance(const isminefilter& filter, int minDepth, const std::string* account, const bool fAddLocked) const;
 
     CAmount GetAnonymizableBalance(bool fSkipDenominated = false, bool fSkipUnconfirmed = true) const;
-    CAmount GetAnonymizedBalance() const;
+    CAmount GetAnonymizedBalance(const CCoinControl* coinControl = nullptr) const;
     float GetAverageAnonymizedRounds() const;
     CAmount GetNormalizedAnonymizedBalance() const;
     CAmount GetDenominatedBalance(bool unconfirmed=false) const;


### PR DESCRIPTION
Fixes the "Use available balance" feature in the PrivateSend tab which doesn't work before this PR if specific UTXOs are selected in the CoinControl. It just selects the total PrivateSend balance instead.. 