### PR TITLE
qt: Finetune CoinControlDialog + bitcoin#14828

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -135,12 +135,12 @@ CoinControlDialog::CoinControlDialog(QWidget* parent) :
     // Toggle lock state
     connect(ui->pushButtonToggleLock, SIGNAL(clicked()), this, SLOT(buttonToggleLockClicked()));
 
-    ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 84);
+    ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 94);
     ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 100);
     ui->treeWidget->setColumnWidth(COLUMN_LABEL, 170);
     ui->treeWidget->setColumnWidth(COLUMN_PRIVATESEND_ROUNDS, 88);
-    ui->treeWidget->setColumnWidth(COLUMN_DATE, 80);
-    ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 100);
+    ui->treeWidget->setColumnWidth(COLUMN_DATE, 120);
+    ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 110);
 
     ui->treeWidget->header()->setStretchLastSection(false);
     ui->treeWidget->header()->setSectionResizeMode(COLUMN_ADDRESS, QHeaderView::Stretch);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -665,6 +665,8 @@ void CoinControlDialog::updateView()
     if (!model || !model->getOptionsModel() || !model->getAddressTableModel())
         return;
 
+    ui->treeWidget->setColumnHidden(COLUMN_PRIVATESEND_ROUNDS, mode == Mode::NORMAL);
+
     bool treeMode = ui->radioTreeMode->isChecked();
     ui->treeWidget->clear();
     ui->treeWidget->setEnabled(false); // performance, otherwise updateLabels would be called for every checked checkbox

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -138,10 +138,12 @@ CoinControlDialog::CoinControlDialog(QWidget* parent) :
     ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 84);
     ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 100);
     ui->treeWidget->setColumnWidth(COLUMN_LABEL, 170);
-    ui->treeWidget->setColumnWidth(COLUMN_ADDRESS, 190);
     ui->treeWidget->setColumnWidth(COLUMN_PRIVATESEND_ROUNDS, 88);
     ui->treeWidget->setColumnWidth(COLUMN_DATE, 80);
     ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 100);
+
+    ui->treeWidget->header()->setStretchLastSection(false);
+    ui->treeWidget->header()->setSectionResizeMode(COLUMN_ADDRESS, QHeaderView::Stretch);
 
     // default view is sorted by amount desc
     sortView(COLUMN_AMOUNT, Qt::DescendingOrder);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -676,7 +676,13 @@ void CoinControlDialog::updateView()
     if (!model || !model->getOptionsModel() || !model->getAddressTableModel())
         return;
 
-    ui->treeWidget->setColumnHidden(COLUMN_PRIVATESEND_ROUNDS, mode == Mode::NORMAL);
+    bool fNormalMode = mode == Mode::NORMAL;
+    ui->treeWidget->setColumnHidden(COLUMN_PRIVATESEND_ROUNDS, fNormalMode);
+    ui->radioTreeMode->setVisible(fNormalMode);
+    ui->radioListMode->setVisible(fNormalMode);
+    if (mode == Mode::PRIVATESEND) {
+        ui->radioListMode->setChecked(true);
+    }
 
     QString strHideButton;
     switch (mode) {

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -138,7 +138,7 @@ CoinControlDialog::CoinControlDialog(QWidget* parent) :
     ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 94);
     ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 100);
     ui->treeWidget->setColumnWidth(COLUMN_LABEL, 170);
-    ui->treeWidget->setColumnWidth(COLUMN_PRIVATESEND_ROUNDS, 88);
+    ui->treeWidget->setColumnWidth(COLUMN_PRIVATESEND_ROUNDS, 110);
     ui->treeWidget->setColumnWidth(COLUMN_DATE, 120);
     ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 110);
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -678,6 +678,7 @@ void CoinControlDialog::updateView()
 
     bool fNormalMode = mode == Mode::NORMAL;
     ui->treeWidget->setColumnHidden(COLUMN_PRIVATESEND_ROUNDS, fNormalMode);
+    ui->treeWidget->setColumnHidden(COLUMN_LABEL, !fNormalMode);
     ui->radioTreeMode->setVisible(fNormalMode);
     ui->radioListMode->setVisible(fNormalMode);
     if (mode == Mode::PRIVATESEND) {

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -852,12 +852,15 @@ void CoinControlDialog::updateView()
         }
     }
 
-    // expand all partially selected
+    // expand all partially selected and hide the empty
     if (treeMode)
     {
-        for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++)
-            if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) == Qt::PartiallyChecked)
-                ui->treeWidget->topLevelItem(i)->setExpanded(true);
+        for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++) {
+            QTreeWidgetItem* topLevelItem = ui->treeWidget->topLevelItem(i);
+            topLevelItem->setHidden(topLevelItem->childCount() == 0);
+            if (topLevelItem->checkState(COLUMN_CHECKBOX) == Qt::PartiallyChecked)
+                topLevelItem->setExpanded(true);
+        }
     }
 
     // sort view

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -681,9 +681,6 @@ void CoinControlDialog::updateView()
     ui->treeWidget->setColumnHidden(COLUMN_LABEL, !fNormalMode);
     ui->radioTreeMode->setVisible(fNormalMode);
     ui->radioListMode->setVisible(fNormalMode);
-    if (mode == Mode::PRIVATESEND) {
-        ui->radioListMode->setChecked(true);
-    }
 
     QString strHideButton;
     switch (mode) {
@@ -700,6 +697,7 @@ void CoinControlDialog::updateView()
         } else {
             strHideButton = tr("Show spendable coins only");
         }
+        ui->radioListMode->setChecked(true);
         break;
     }
     ui->hideButton->setText(strHideButton);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -682,6 +682,11 @@ void CoinControlDialog::updateView()
     ui->radioTreeMode->setVisible(fNormalMode);
     ui->radioListMode->setVisible(fNormalMode);
 
+    if (!CPrivateSendClientOptions::IsEnabled()) {
+        fHideAdditional = false;
+        ui->hideButton->setVisible(false);
+    }
+
     QString strHideButton;
     switch (mode) {
     case Mode::NORMAL:

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -67,6 +67,8 @@ private:
     QAction *lockAction;
     QAction *unlockAction;
 
+    bool fHideAdditional{true};
+
     void sortView(int, Qt::SortOrder);
     void updateView();
 
@@ -119,6 +121,7 @@ private Q_SLOTS:
     void buttonSelectAllClicked();
     void buttonToggleLockClicked();
     void updateLabelLocked();
+    void on_hideButton_clicked();
 };
 
 #endif // BITCOIN_QT_COINCONTROLDIALOG_H

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -79,9 +79,14 @@ private:
         COLUMN_PRIVATESEND_ROUNDS,
         COLUMN_DATE,
         COLUMN_CONFIRMATIONS,
-        COLUMN_TXHASH,
-        COLUMN_VOUT_INDEX,
     };
+
+    enum
+    {
+        TxHashRole = Qt::UserRole,
+        VOutRole
+    };
+
     friend class CCoinControlWidgetItem;
 
     enum class Mode {

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -422,7 +422,7 @@
      </column>
      <column>
       <property name="text">
-       <string>PS Rounds</string>
+       <string>Mixing Rounds</string>
       </property>
      </column>
      <column>

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -277,7 +277,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0">
+       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0,0">
         <property name="spacing">
          <number>14</number>
         </property>
@@ -307,6 +307,22 @@
           </property>
           <property name="text">
            <string>toggle lock state</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="hideButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
           </property>
           <property name="autoDefault">
            <bool>false</bool>

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -376,7 +376,7 @@
       <bool>false</bool>
      </property>
      <property name="columnCount">
-      <number>11</number>
+      <number>7</number>
      </property>
      <attribute name="headerShowSortIndicator" stdset="0">
       <bool>true</bool>

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -438,26 +438,6 @@
        <string>Confirmed</string>
       </property>
      </column>
-     <column>
-      <property name="text">
-       <string/>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string/>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string/>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string/>
-      </property>
-     </column>
     </widget>
    </item>
    <item>

--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -798,6 +798,10 @@ AskPassphraseDialog
 CoinControlDialog
 ******************************************************/
 
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
+    border-color: #4a4a4b;
+}
+
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:selected,
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:checked,
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:selected,

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1098,10 +1098,6 @@ BitcoinAmountField{
 CoinControlDialog
 ******************************************************/
 
-QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
-    border-bottom: 1px solid red;
-}
-
 QDialog#CoinControlDialog .QLabel#labelCoinControlQuantityText { /* Coin Control Quantity Label */
     min-height: 30px;
     padding-left: 15px;
@@ -1165,6 +1161,7 @@ QDialog#CoinControlDialog QHeaderView::section:first { /* Bug Fix: the number 1 
 }
 
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
+    border-bottom: 1px solid red;
     min-height: 25px;
 }
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:hover {

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1161,6 +1161,7 @@ QDialog#CoinControlDialog QHeaderView::section:first { /* Bug Fix: the number 1 
 }
 
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
+    min-height: 25px;
 }
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:selected { /* Coin Control Item (selected) */
 }

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1163,6 +1163,9 @@ QDialog#CoinControlDialog QHeaderView::section:first { /* Bug Fix: the number 1 
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
     min-height: 25px;
 }
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:hover {
+    background-color: #00000000;
+}
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:selected { /* Coin Control Item (selected) */
 }
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:checked { /* Coin Control Item (checked) */

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1098,6 +1098,10 @@ BitcoinAmountField{
 CoinControlDialog
 ******************************************************/
 
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
+    border-bottom: 1px solid red;
+}
+
 QDialog#CoinControlDialog .QLabel#labelCoinControlQuantityText { /* Coin Control Quantity Label */
     min-height: 30px;
     padding-left: 15px;

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -783,6 +783,10 @@ AskPassphraseDialog
 CoinControlDialog
 ******************************************************/
 
+QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item {
+    border-color: #c7c7c7;
+}
+
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:selected,
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::item:checked,
 QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::branch:selected,


### PR DESCRIPTION
The rows resize without it if they get locked and the lock icon appears besides the checkbox. Looks weird.. and especially if you press the lock all button its just not nice.

#### Update
The scope has been expanded during review, see https://github.com/dashpay/dash/pull/3701#issuecomment-693697063 for the final result. 