### PR TITLE
qt: Make sure font size in TransactionDescDialog is adjusted properly

### DIFF
--- a/src/qt/transactiondescdialog.cpp
+++ b/src/qt/transactiondescdialog.cpp
@@ -17,6 +17,7 @@ TransactionDescDialog::TransactionDescDialog(const QModelIndex &idx, QWidget *pa
     ui(new Ui::TransactionDescDialog)
 {
     ui->setupUi(this);
+    GUIUtil::updateFonts();
     setWindowTitle(tr("Details for %1").arg(idx.data(TransactionTableModel::TxHashRole).toString()));
     QString desc = idx.data(TransactionTableModel::LongDescriptionRole).toString();
     ui->detailText->setHtml(desc);


### PR DESCRIPTION
Without this the font size in the dialog will only become adjusted to the set size scale if `GUIUtil::updateFonts` gets invoked somewhere else e.g. when opening the options dialog. 