### PR TITLE
qt: Make sure send confirmation dialog uses correct font settings

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -1010,6 +1010,7 @@ SendConfirmationDialog::SendConfirmationDialog(const QString &title, const QStri
     QWidget *parent) :
     QMessageBox(QMessageBox::Question, title, text, QMessageBox::Yes | QMessageBox::Cancel, parent), secDelay(_secDelay)
 {
+    GUIUtil::updateFonts();
     setDefaultButton(QMessageBox::Cancel);
     yesButton = button(QMessageBox::Yes);
     updateYesButton();


### PR DESCRIPTION
| Before | After |
|-|-|
| <img width="915" alt="Screenshot 2020-09-16 at 00 20 03" src="https://user-images.githubusercontent.com/1935069/93266272-7c4ecd80-f7b2-11ea-940a-dcdab7b08f48.png"> | <img width="928" alt="Screenshot 2020-09-16 at 00 20 34" src="https://user-images.githubusercontent.com/1935069/93266285-82dd4500-f7b2-11ea-8408-c5ad73fd5a49.png"> |

