### PR TITLE
qt: Finetune OverviewPage

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -656,19 +656,6 @@
          </layout>
         </widget>
        </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
      </item>
      <item>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -40,7 +40,23 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,1">
+     <item>
+      <spacer name="horizontalSpacerLeft">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
@@ -564,6 +580,19 @@
       </layout>
      </item>
      <item>
+      <spacer name="horizontalSpacerCenter">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <widget class="QFrame" name="frame_2">
@@ -647,6 +676,22 @@
         </spacer>
        </item>
       </layout>
+     </item>
+     <item>
+      <spacer name="horizontalSpacerRight">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -639,9 +639,6 @@
           </item>
           <item>
            <widget class="QListView" name="listTransactions">
-            <property name="styleSheet">
-             <string notr="true">QListView { background: transparent; }</string>
-            </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -25,9 +25,6 @@
      <property name="visible">
       <bool>false</bool>
      </property>
-     <property name="styleSheet">
-      <string notr="true">QLabel { background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop:0 #F0D0A0, stop:1 #F8D488); color:#000000; }</string>
-     </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -690,6 +690,10 @@ void OverviewPage::SetupTransactionList(int nNumItems)
         ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
     }
 
+    if (filter->rowCount() == nNumItems) {
+        return;
+    }
+
     filter->setLimit(nNumItems);
     ui->listTransactions->setMinimumHeight(nNumItems * ITEM_HEIGHT);
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -677,13 +677,17 @@ void OverviewPage::SetupTransactionList(int nNumItems) {
 
     if(walletModel && walletModel->getOptionsModel()) {
         // Set up transaction list
-        filter.reset(new TransactionFilterProxy());
-        filter->setSourceModel(walletModel->getTransactionTableModel());
-        filter->setLimit(nNumItems);
-        filter->setDynamicSortFilter(true);
-        filter->setSortRole(Qt::EditRole);
-        filter->setShowInactive(false);
-        filter->sort(TransactionTableModel::Date, Qt::DescendingOrder);
+        if (filter == nullptr) {
+            filter.reset(new TransactionFilterProxy());
+            filter->setSourceModel(walletModel->getTransactionTableModel());
+            filter->setLimit(nNumItems);
+            filter->setDynamicSortFilter(true);
+            filter->setSortRole(Qt::EditRole);
+            filter->setShowInactive(false);
+            filter->sort(TransactionTableModel::Date, Qt::DescendingOrder);
+        } else {
+            filter->setLimit(nNumItems);
+        }
 
         ui->listTransactions->setModel(filter.get());
         ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -26,8 +26,9 @@
 #include <QTimer>
 
 #define DECORATION_SIZE 54
-#define NUM_ITEMS 5
-#define NUM_ITEMS_ADV 7
+#define NUM_ITEMS_DISABLED 5
+#define NUM_ITEMS_ENABLED_NORMAL 7
+#define NUM_ITEMS_ENABLED_ADVANCED 9
 
 class TxViewDelegate : public QAbstractItemDelegate
 {
@@ -480,6 +481,12 @@ void OverviewPage::privateSendStatus(bool fForce)
     auto tempWidgets = {ui->labelSubmittedDenomText,
                         ui->labelSubmittedDenom};
 
+    bool fIsEnabled = CPrivateSendClientOptions::IsEnabled();
+    if (!fIsEnabled) {
+        SetupTransactionList(NUM_ITEMS_DISABLED);
+        return;
+    }
+
     auto setWidgetsVisible = [&](bool fVisible) {
         for (const auto& it : tempWidgets) {
             it->setVisible(fVisible);
@@ -520,7 +527,13 @@ void OverviewPage::privateSendStatus(bool fForce)
         if (fShowAdvancedPSUI) strEnabled += ", " + strKeysLeftText;
         ui->labelPrivateSendEnabled->setText(strEnabled);
 
+        // If mixing isn't active always show the lower number of txes because there are
+        // anyway the most PS widgets hidden.
+        SetupTransactionList(NUM_ITEMS_ENABLED_NORMAL);
+
         return;
+    } else {
+        SetupTransactionList(fShowAdvancedPSUI ? NUM_ITEMS_ENABLED_ADVANCED : NUM_ITEMS_ENABLED_NORMAL);
     }
 
     // Warn user that wallet is running out of keys

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -694,7 +694,6 @@ void OverviewPage::SetupTransactionList(int nNumItems)
     }
 
     filter->setLimit(nNumItems);
-    ui->listTransactions->setMinimumHeight(nNumItems * ITEM_HEIGHT);
     // Workaround to make sure the number of transactions always equals nNumItems.
     // For details about the unsolved issue see https://github.com/dashpay/dash/pull/3715#issuecomment-698038707
     ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -673,25 +673,25 @@ void OverviewPage::togglePrivateSend(){
 }
 
 void OverviewPage::SetupTransactionList(int nNumItems) {
-    ui->listTransactions->setMinimumHeight(nNumItems * ITEM_HEIGHT);
 
-    if(walletModel && walletModel->getTransactionTableModel()) {
-        // Set up transaction list
-        if (filter == nullptr) {
-            filter.reset(new TransactionFilterProxy());
-            filter->setSourceModel(walletModel->getTransactionTableModel());
-            filter->setLimit(nNumItems);
-            filter->setDynamicSortFilter(true);
-            filter->setSortRole(Qt::EditRole);
-            filter->setShowInactive(false);
-            filter->sort(TransactionTableModel::Date, Qt::DescendingOrder);
-        } else {
-            filter->setLimit(nNumItems);
-        }
+    if(walletModel == nullptr || walletModel->getTransactionTableModel() == nullptr) {
+        return;
+    }
 
+    // Set up transaction list
+    if (filter == nullptr) {
+        filter.reset(new TransactionFilterProxy());
+        filter->setSourceModel(walletModel->getTransactionTableModel());
+        filter->setDynamicSortFilter(true);
+        filter->setSortRole(Qt::EditRole);
+        filter->setShowInactive(false);
+        filter->sort(TransactionTableModel::Date, Qt::DescendingOrder);
         ui->listTransactions->setModel(filter.get());
         ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
     }
+
+    filter->setLimit(nNumItems);
+    ui->listTransactions->setMinimumHeight(nNumItems * ITEM_HEIGHT);
 }
 
 void OverviewPage::DisablePrivateSendCompletely() {

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -672,9 +672,9 @@ void OverviewPage::togglePrivateSend(){
     }
 }
 
-void OverviewPage::SetupTransactionList(int nNumItems) {
-
-    if(walletModel == nullptr || walletModel->getTransactionTableModel() == nullptr) {
+void OverviewPage::SetupTransactionList(int nNumItems)
+{
+    if (walletModel == nullptr || walletModel->getTransactionTableModel() == nullptr) {
         return;
     }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -694,9 +694,6 @@ void OverviewPage::SetupTransactionList(int nNumItems)
     }
 
     filter->setLimit(nNumItems);
-    // Workaround to make sure the number of transactions always equals nNumItems.
-    // For details about the unsolved issue see https://github.com/dashpay/dash/pull/3715#issuecomment-698038707
-    ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
 }
 
 void OverviewPage::DisablePrivateSendCompletely() {

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -687,7 +687,6 @@ void OverviewPage::SetupTransactionList(int nNumItems)
         filter->setShowInactive(false);
         filter->sort(TransactionTableModel::Date, Qt::DescendingOrder);
         ui->listTransactions->setModel(filter.get());
-        ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
     }
 
     if (filter->rowCount() == nNumItems) {
@@ -696,6 +695,9 @@ void OverviewPage::SetupTransactionList(int nNumItems)
 
     filter->setLimit(nNumItems);
     ui->listTransactions->setMinimumHeight(nNumItems * ITEM_HEIGHT);
+    // Workaround to make sure the number of transactions always equals nNumItems.
+    // For details about the unsolved issue see https://github.com/dashpay/dash/pull/3715#issuecomment-698038707
+    ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
 }
 
 void OverviewPage::DisablePrivateSendCompletely() {

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -673,7 +673,7 @@ void OverviewPage::togglePrivateSend(){
 }
 
 void OverviewPage::SetupTransactionList(int nNumItems) {
-    ui->listTransactions->setMinimumHeight(nNumItems * (ITEM_HEIGHT + 4));
+    ui->listTransactions->setMinimumHeight(nNumItems * ITEM_HEIGHT);
 
     if(walletModel && walletModel->getOptionsModel()) {
         // Set up transaction list

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -675,7 +675,7 @@ void OverviewPage::togglePrivateSend(){
 void OverviewPage::SetupTransactionList(int nNumItems) {
     ui->listTransactions->setMinimumHeight(nNumItems * ITEM_HEIGHT);
 
-    if(walletModel && walletModel->getOptionsModel()) {
+    if(walletModel && walletModel->getTransactionTableModel()) {
         // Set up transaction list
         if (filter == nullptr) {
             filter.reset(new TransactionFilterProxy());

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -46,10 +46,10 @@ public:
 
         QRect mainRect = option.rect;
         int xspace = 8;
-        int ypad = 6;
+        int ypad = 8;
         int halfheight = (mainRect.height() - 2*ypad)/2;
         QRect amountRect(mainRect.left() + xspace, mainRect.top()+ypad, mainRect.width() - xspace, halfheight);
-        QRect addressRect(mainRect.left() + xspace, mainRect.top()+ypad+halfheight, mainRect.width() - xspace, halfheight);
+        QRect addressRect(mainRect.left() + xspace, mainRect.top()+ypad+halfheight + 5, mainRect.width() - xspace, halfheight);
 
         QDateTime date = index.data(TransactionTableModel::DateRole).toDateTime();
         QString address = index.data(Qt::DisplayRole).toString();
@@ -93,6 +93,11 @@ public:
             foreground = GUIUtil::getThemedQColor(GUIUtil::ThemedColor::UNCONFIRMED);
             amountText = QString("[") + amountText + QString("]");
         }
+
+        QFont font = painter->font();
+        font.setPointSize(font.pointSize() * 1.17);
+        painter->setFont(font);
+
         painter->drawText(amountRect, Qt::AlignRight|Qt::AlignVCenter, amountText);
 
         painter->setPen(GUIUtil::getThemedQColor(GUIUtil::ThemedColor::DEFAULT));

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -33,6 +33,7 @@ in the <theme.css> file.
 # Used colors in general.css for commit 44de8a93f2
 
 #00000000
+#222222
 #5e8c41
 #a84832
 #c79304
@@ -1299,6 +1300,17 @@ QDialog#OptionsDialog #frame {
 QDialog#OptionsDialog QGroupBox {
     margin-top: 10px;
 }
+
+/******************************************************
+ OverviewPage
+ ******************************************************/
+
+QWidget#OverviewPage QLabel#labelAlerts {
+     background-color: #c79304;
+     color: #222222;
+     border-radius: 5px;
+     padding: 5px;
+ }
 
 /******************************************************
 OverviewPage Balances

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1309,21 +1309,18 @@ QWidget .QFrame#frame { /* Wallet Balance */
 }
 
 QWidget .QFrame#frame > .QLabel {
-    min-width: 100px;
-    min-height: 25px;
+    min-width: 60px;
+    min-height: 26px;
 }
 
 QWidget .QFrame#frame .QLabel#label_5 { /* Wallet Label */
-    min-width: 180px;
     margin-top: 0;
     margin-right: 5px;
-    padding-right: 5px;
 }
 
 QWidget .QFrame#frame .QLabel#labelWalletStatus { /* Wallet Sync Status */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
     color: #a84832;
-    margin-left: 3px;
 }
 
 QWidget .QFrame#frame .QLabel#labelSpendable { /* Spendable Header */
@@ -1419,25 +1416,22 @@ OverviewPage PrivateSend
 QWidget .QFrame#framePrivateSend { /* PrivateSend Widget */
     background-color: #00000000;
     max-width: 451px;
-    min-width: 451px;
     max-height: 350px;
 }
 
 QWidget .QFrame#framePrivateSend  > .QLabel {
-    min-width: 175px;
+    min-width: 100px;
     min-height: 26px;
 }
 
 QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendHeader { /* PrivateSend Header */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
-    margin-right: 10px;
+    margin-right: 5px;
 }
 
 QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendSyncStatus { /* PrivateSend Sync Status */
     qproperty-alignment: 'AlignVCenter | AlignLeft';
     color: #a84832;
-    margin-left: 2px;
-    padding-right: 5px;
 }
 
 QWidget .QFrame#framePrivateSend  .QLabel#labelPrivateSendEnabledText { /* PrivateSend Enabled Status Label */
@@ -1515,34 +1509,22 @@ OverviewPage RecentTransactions
 ******************************************************/
 
 QWidget .QFrame#frame_2 { /* Transactions Widget */
-    min-width: 510px;
-    margin-right: 20px;
-    margin-left: 0;
-    margin-top: 0;
+    min-width: 430;
 }
 
 QWidget .QFrame#frame_2 .QLabel#label_4 { /* Recent Transactions Label */
-    min-width: 180px;
-    margin-top: 0;
-    margin-right: 5px;
-    padding-right: 5px;
+    margin-right: 0px;
     min-height: 30px;
 }
 
 QWidget .QFrame#frame_2 .QLabel#labelTransactionsStatus { /* Recent Transactions Sync Status */
-    qproperty-alignment: 'AlignBottom | AlignRight';
+    qproperty-alignment: 'AlignVCenter | AlignLeft';
     color: #a84832;
-    min-width: 93px;
-    margin-top: 0;
-    margin-left: 16px;
-    margin-right: 5px;
-    min-height: 16px;
 }
 
 QWidget .QFrame#frame_2 QListView { /* Transaction List */
-    max-width: 369px;
-    margin-top: 12px;
-    margin-left: 0px; /* CSS Voodoo - set to -66px to hide default transaction icons */
+    max-width: 430px;
+    margin-right: 10px;
 }
 
 /******************************************************

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1523,7 +1523,6 @@ QWidget .QFrame#frame_2 { /* Transactions Widget */
 
 QWidget .QFrame#frame_2 .QLabel#label_4 { /* Recent Transactions Label */
     min-width: 180px;
-    margin-left: 18px;
     margin-top: 0;
     margin-right: 5px;
     padding-right: 5px;

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1535,6 +1535,7 @@ QWidget .QFrame#frame_2 .QLabel#labelTransactionsStatus { /* Recent Transactions
 }
 
 QWidget .QFrame#frame_2 QListView { /* Transaction List */
+    background: #00000000;
     max-width: 430px;
     margin-right: 10px;
 }

--- a/src/qt/res/css/traditional.css
+++ b/src/qt/res/css/traditional.css
@@ -20,6 +20,7 @@ Loaded in GUIUtil::loadStyleSheet() in guitil.cpp.
 # Used colors in traditional.css for commit 44de8a93f2
 
 #00000000
+#222222
 #333
 #fff
 #008de4
@@ -227,6 +228,13 @@ AppearanceWidget #lblFontWeightBold {
 /******************************************************
 OverviewPage
 ******************************************************/
+
+QWidget#OverviewPage QLabel#labelAlerts {
+     background-color: #c79304;
+     color: #222222;
+     border-radius: 5px;
+     padding: 5px;
+ }
 
 QWidget .QFrame#frame .QLabel#labelWalletStatus, /* Wallet Sync Status */
 QWidget .QFrame#framePrivateSend .QLabel#labelPrivateSendSyncStatus, /* PrivateSend Sync Status */

--- a/src/qt/res/css/traditional.css
+++ b/src/qt/res/css/traditional.css
@@ -242,6 +242,12 @@ QWidget .QFrame#frame_2 .QLabel#labelTransactionsStatus { /* Recent Transactions
     color: #a84832;
 }
 
+QWidget .QFrame#frame_2 QListView { /* Transaction List */
+    background: #00000000;
+    min-width: 430px;
+    margin-right: 10px;
+}
+
 /******************************************************
 SendCoinsDialog
 ******************************************************/

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -110,7 +110,9 @@ void TransactionFilterProxy::setInstantSendFilter(InstantSendFilter filter)
 
 void TransactionFilterProxy::setLimit(int limit)
 {
+    Q_EMIT layoutAboutToBeChanged();
     this->limitRows = limit;
+    Q_EMIT layoutChanged();
 }
 
 void TransactionFilterProxy::setShowInactive(bool _showInactive)


### PR DESCRIPTION
This PR brings the following changes to the `OverviewPage`:

- Make sure that the "Balances", "Recent Transactions" and "PrivateSend" frames are aligned properly around the window center it gets resized.
- Give the transaction the same coloring/highlighting like in the transaction tab
- Adjust the warning box
- Make sure PrivateSend related widgets show/hide as expected based on its settings/state
- Finetune the overall css layouts and remove obsolete entries

@UdjinM6 68b3e36 and 876fffd are inspired by 55c0f40, thanks for that 👍 let me know if you would like to see more of it in here.

Requires #3710 to make sense / look good.

### Preview

| Before | With this PR | 
| - | - | 
| <img width="1072" alt="Bildschirmfoto 2020-09-16 um 03 06 53" src="https://user-images.githubusercontent.com/35775977/93287163-16c20780-f7d9-11ea-9bc6-8dad8a9527ec.png"> | <img width="1072" alt="Bildschirmfoto 2020-09-16 um 02 56 50" src="https://user-images.githubusercontent.com/35775977/93287146-10cc2680-f7d9-11ea-80ba-8af57d78e06f.png"> | 
| <img width="1552" alt="Bildschirmfoto 2020-09-16 um 03 06 48" src="https://user-images.githubusercontent.com/35775977/93287162-16297100-f7d9-11ea-8444-23ae4dfe227b.png"> | <img width="1552" alt="Bildschirmfoto 2020-09-16 um 02 56 54" src="https://user-images.githubusercontent.com/35775977/93287157-14f84400-f7d9-11ea-9f91-4a4c10fbe4f2.png"> |