### PR TITLE
qt: Add PrivateSend tab in OptionsDialog, allow to show/hide PS UI

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -760,6 +760,8 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel)
 
             // initialize the disable state of the tray icon with the current value in the model.
             setTrayIconVisible(optionsModel->getHideTrayIcon());
+
+            connect(optionsModel, SIGNAL(privateSendEnabledChanged()), this, SLOT(updatePrivateSendVisibility()));
         }
     } else {
         // Disable possibility to show main window via action

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -198,8 +198,6 @@ private:
 
     void updateProgressBarVisibility();
 
-    void updatePrivateSendVisibility();
-
     void updateToolBarShortcuts();
 
 Q_SIGNALS:
@@ -331,6 +329,8 @@ private Q_SLOTS:
     void toggleNetworkActive();
 
     void showModalOverlay();
+
+    void updatePrivateSendVisibility();
 };
 
 class UnitDisplayStatusBarControl : public QLabel

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>583</width>
-    <height>537</height>
+    <height>420</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -52,6 +52,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="btnPrivateSend">
+       <property name="text">
+        <string>PrivateSend</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnNetwork">
        <property name="text">
         <string>&amp;Network</string>
@@ -234,25 +244,66 @@
      <widget class="QWidget" name="pageWallet">
       <layout class="QVBoxLayout" name="verticalLayout_Wallet">
        <item>
-        <widget class="QCheckBox" name="coinControlFeatures">
-         <property name="toolTip">
-          <string>Whether to show coin control features or not.</string>
-         </property>
-         <property name="text">
-          <string>Enable coin &amp;control features</string>
-         </property>
-        </widget>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="coinControlFeatures">
+            <property name="toolTip">
+             <string>Whether to show coin control features or not.</string>
+            </property>
+            <property name="text">
+             <string>Enable coin &amp;control features</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="showMasternodesTab">
+            <property name="toolTip">
+             <string>Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</string>
+            </property>
+            <property name="text">
+             <string>Show Masternodes Tab</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="spendZeroConfChange">
+            <property name="toolTip">
+             <string>If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</string>
+            </property>
+            <property name="text">
+             <string>&amp;Spend unconfirmed change</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="privateSendEnabled">
+            <property name="toolTip">
+             <string>Show additional information and buttons for PrivateSend on overview screen.</string>
+            </property>
+            <property name="text">
+             <string>Enable PrivateSend interface</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="showMasternodesTab">
-         <property name="toolTip">
-          <string>Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</string>
+        <spacer name="verticalSpacer_Wallet">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="text">
-          <string>Show Masternodes Tab</string>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
          </property>
-        </widget>
+        </spacer>
        </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="pagePrivateSend">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <widget class="QCheckBox" name="showAdvancedPSUI">
          <property name="toolTip">
@@ -264,12 +315,12 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="spendZeroConfChange">
+        <widget class="QCheckBox" name="showPrivateSendPopups">
          <property name="toolTip">
-          <string>If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</string>
+          <string>Show system popups for PrivateSend mixing transactions&lt;br/&gt;just like for all other transaction types.</string>
          </property>
          <property name="text">
-          <string>&amp;Spend unconfirmed change</string>
+          <string>Show popups for PrivateSend transactions</string>
          </property>
         </widget>
        </item>
@@ -290,16 +341,6 @@
          </property>
          <property name="text">
           <string>Enable PrivateSend &amp;multi-session</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="showPrivateSendPopups">
-         <property name="toolTip">
-          <string>Show system popups for PrivateSend mixing transactions&lt;br/&gt;just like for all other transaction types.</string>
-         </property>
-         <property name="text">
-          <string>Show popups for PrivateSend transactions</string>
          </property>
         </widget>
        </item>
@@ -373,7 +414,7 @@
         </layout>
        </item>
        <item>
-        <spacer name="verticalSpacer_Wallet">
+        <spacer name="verticalSpacerPS">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -278,7 +278,7 @@
           <item>
            <widget class="QCheckBox" name="privateSendEnabled">
             <property name="toolTip">
-             <string>Show mixing interface on Overview screen and reveal PrivateSend screen which allows to spend fully mixed coins only. A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</string>
+             <string>Show mixing interface on Overview screen and reveal PrivateSend screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</string>
             </property>
             <property name="text">
              <string>Enable PrivateSend features</string>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -278,10 +278,10 @@
           <item>
            <widget class="QCheckBox" name="privateSendEnabled">
             <property name="toolTip">
-             <string>Show additional information and buttons for PrivateSend on overview screen.</string>
+             <string>Show mixing interface on Overview screen and reveal PrivateSend screen which allows to spend fully mixed coins only. A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</string>
             </property>
             <property name="text">
-             <string>Enable PrivateSend interface</string>
+             <string>Enable PrivateSend features</string>
             </property>
            </widget>
           </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -217,10 +217,14 @@ void OptionsDialog::setModel(OptionsModel *_model)
     connect(ui->lang, SIGNAL(valueChanged()), this, SLOT(showRestartWarning()));
     connect(ui->thirdPartyTxUrls, SIGNAL(textChanged(const QString &)), this, SLOT(showRestartWarning()));
 
-    connect(ui->privateSendEnabled, &QCheckBox::clicked, [=]() {
-        const QSignalBlocker blocker(ui->privateSendEnabled);
-        _model->togglePrivateSendEnabledChanged();
+    connect(ui->privateSendEnabled, &QCheckBox::clicked, [=](bool fChecked) {
+#ifdef ENABLE_WALLET
+        CPrivateSendClientOptions::SetEnabled(fChecked);
+#endif
         updatePrivateSendVisibility();
+        if (_model != nullptr) {
+            _model->emitPrivateSendEnabledChanged();
+        }
     });
 }
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -190,6 +190,9 @@ void OptionsDialog::setModel(OptionsModel *_model)
 
 #ifdef ENABLE_WALLET
         if (strLabel.contains("-enableprivatesend")) {
+        // If -enableprivatesend was passed in on the command line, set the checkbox
+        // to the value given via commandline and disable it (make it unclickable).
+        // Note: Check without "-" to make it work with the "no" prefix commandline feature.
             bool fEnabled = CPrivateSendClientOptions::IsEnabled();
             ui->privateSendEnabled->setChecked(fEnabled);
             ui->privateSendEnabled->setEnabled(false);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -415,20 +415,7 @@ void OptionsDialog::updatePrivateSendVisibility()
 #else
     bool fEnabled = false;
 #endif
-    std::vector<QWidget*> vecWidgets{
-        ui->btnPrivateSend,
-        ui->showAdvancedPSUI,
-        ui->showPrivateSendPopups,
-        ui->lowKeysWarning,
-        ui->privateSendMultiSession,
-        ui->privateSendAmount,
-        ui->lblPrivateSendAmountText,
-        ui->lblPrivateSendRoundsText,
-        ui->privateSendRounds,
-    };
-    for (auto w : vecWidgets) {
-        w->setVisible(fEnabled);
-    }
+    ui->btnPrivateSend->setVisible(fEnabled);
 }
 
 ProxyAddressValidator::ProxyAddressValidator(QObject *parent) :

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -189,9 +189,9 @@ void OptionsDialog::setModel(OptionsModel *_model)
 
 
 #ifdef ENABLE_WALLET
-        if (strLabel.contains("-enableprivatesend")) {
         // If -enableprivatesend was passed in on the command line, set the checkbox
         // to the value given via commandline and disable it (make it unclickable).
+        if (strLabel.contains("-enableprivatesend")) {
             bool fEnabled = CPrivateSendClientOptions::IsEnabled();
             ui->privateSendEnabled->setChecked(fEnabled);
             ui->privateSendEnabled->setEnabled(false);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -162,6 +162,11 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     // Store the current PrivateSend enabled state to recover it if it gets changed but the dialog gets not accepted but declined.
 #ifdef ENABLE_WALLET
     fPrivateSendEnabledPrev = CPrivateSendClientOptions::IsEnabled();
+    connect(this, &OptionsDialog::rejected, [=]() {
+        if (fPrivateSendEnabledPrev != CPrivateSendClientOptions::IsEnabled()) {
+            ui->privateSendEnabled->click();
+        }
+    });
 #endif
 }
 
@@ -340,11 +345,6 @@ void OptionsDialog::on_okButton_clicked()
 void OptionsDialog::on_cancelButton_clicked()
 {
     reject();
-#ifdef ENABLE_WALLET
-    if (fPrivateSendEnabledPrev != CPrivateSendClientOptions::IsEnabled()) {
-        ui->privateSendEnabled->click();
-    }
-#endif
 }
 
 void OptionsDialog::on_hideTrayIcon_stateChanged(int fState)

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -192,7 +192,6 @@ void OptionsDialog::setModel(OptionsModel *_model)
         if (strLabel.contains("-enableprivatesend")) {
         // If -enableprivatesend was passed in on the command line, set the checkbox
         // to the value given via commandline and disable it (make it unclickable).
-        // Note: Check without "-" to make it work with the "no" prefix commandline feature.
             bool fEnabled = CPrivateSendClientOptions::IsEnabled();
             ui->privateSendEnabled->setChecked(fEnabled);
             ui->privateSendEnabled->setEnabled(false);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -158,6 +158,11 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->widgetAppearance->setLayout(appearanceLayout);
 
     updatePrivateSendVisibility();
+
+    // Store the current PrivateSend enabled state to recover it if it gets changed but the dialog gets not accepted but declined.
+#ifdef ENABLE_WALLET
+    fPrivateSendEnabledPrev = CPrivateSendClientOptions::IsEnabled();
+#endif
 }
 
 OptionsDialog::~OptionsDialog()
@@ -333,6 +338,11 @@ void OptionsDialog::on_okButton_clicked()
 void OptionsDialog::on_cancelButton_clicked()
 {
     reject();
+#ifdef ENABLE_WALLET
+    if (fPrivateSendEnabledPrev != CPrivateSendClientOptions::IsEnabled()) {
+        ui->privateSendEnabled->click();
+    }
+#endif
 }
 
 void OptionsDialog::on_hideTrayIcon_stateChanged(int fState)

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -74,6 +74,7 @@ private:
     QButtonGroup pageButtons;
     QString previousTheme;
     AppearanceWidget* appearance;
+    bool fPrivateSendEnabledPrev{false};
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -494,7 +494,10 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             }
             break;
         case PrivateSendEnabled:
-            // Set in togglePrivateSendEnabled()
+            if (settings.value("fPrivateSendEnabled") != value) {
+                settings.setValue("fPrivateSendEnabled", value.toBool());
+                Q_EMIT privateSendEnabledChanged();
+            }
             break;
         case ShowAdvancedPSUI:
             if (settings.value("fShowAdvancedPSUI") != value) {
@@ -650,15 +653,9 @@ bool OptionsModel::getProxySettings(QNetworkProxy& proxy) const
     return false;
 }
 
-void OptionsModel::togglePrivateSendEnabledChanged()
+void OptionsModel::emitPrivateSendEnabledChanged()
 {
-#ifdef ENABLE_WALLET
-    QSettings settings;
-    bool fToggled = !settings.value("fPrivateSendEnabled").toBool();
-    settings.setValue("fPrivateSendEnabled", fToggled);
-    CPrivateSendClientOptions::SetEnabled(fToggled);
     Q_EMIT privateSendEnabledChanged();
-#endif
 }
 
 void OptionsModel::setRestartRequired(bool fRequired)

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -497,9 +497,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             // Set in togglePrivateSendEnabled()
             break;
         case ShowAdvancedPSUI:
-            fShowAdvancedPSUI = value.toBool();
-            settings.setValue("fShowAdvancedPSUI", fShowAdvancedPSUI);
-            Q_EMIT advancedPSUIChanged(fShowAdvancedPSUI);
+            if (settings.value("fShowAdvancedPSUI") != value) {
+                fShowAdvancedPSUI = value.toBool();
+                settings.setValue("fShowAdvancedPSUI", fShowAdvancedPSUI);
+                Q_EMIT advancedPSUIChanged(fShowAdvancedPSUI);
+            }
             break;
         case ShowPrivateSendPopups:
             settings.setValue("fShowPrivateSendPopups", value);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -113,10 +113,12 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("digits", "2");
 
     // PrivateSend
-    if (!settings.contains("fPrivateSendEnabled"))
+    if (!settings.contains("fPrivateSendEnabled")) {
         settings.setValue("fPrivateSendEnabled", true);
-    if (!gArgs.SoftSetBoolArg("-enableprivatesend", settings.value("fPrivateSendEnabled").toBool()))
+    }
+    if (!gArgs.SoftSetBoolArg("-enableprivatesend", settings.value("fPrivateSendEnabled").toBool())) {
         addOverriddenOption("-enableprivatesend");
+    }
 
     if (!settings.contains("fShowAdvancedPSUI"))
         settings.setValue("fShowAdvancedPSUI", false);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -114,7 +114,7 @@ void OptionsModel::Init(bool resetSettings)
 
     // PrivateSend
     if (!settings.contains("fPrivateSendEnabled"))
-        settings.setValue("fPrivateSendEnabled", false);
+        settings.setValue("fPrivateSendEnabled", true);
     if (!gArgs.SoftSetBoolArg("-enableprivatesend", settings.value("fPrivateSendEnabled").toBool()))
         addOverriddenOption("-enableprivatesend");
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -85,7 +85,7 @@ public:
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     bool getShowAdvancedPSUI() { return fShowAdvancedPSUI; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
-    void togglePrivateSendEnabledChanged();
+    void emitPrivateSendEnabledChanged();
 
     /* Restart flag helper */
     void setRestartRequired(bool fRequired);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -55,6 +55,7 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         ShowMasternodesTab,     // bool
+        PrivateSendEnabled,     // bool
         ShowAdvancedPSUI,       // bool
         ShowPrivateSendPopups,  // bool
         LowKeysWarning,         // bool
@@ -84,6 +85,7 @@ public:
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     bool getShowAdvancedPSUI() { return fShowAdvancedPSUI; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
+    void togglePrivateSendEnabledChanged();
 
     /* Restart flag helper */
     void setRestartRequired(bool fRequired);
@@ -110,6 +112,7 @@ private:
     void checkAndMigrate();
 Q_SIGNALS:
     void displayUnitChanged(int unit);
+    void privateSendEnabledChanged();
     void privateSendRoundsChanged();
     void privateSentAmountChanged();
     void advancedPSUIChanged(bool);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -285,7 +285,9 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(model->getOptionsModel(), SIGNAL(privateSendRoundsChanged()), this, SLOT(updatePrivateSendProgress()));
         connect(model->getOptionsModel(), SIGNAL(privateSentAmountChanged()), this, SLOT(updatePrivateSendProgress()));
         connect(model->getOptionsModel(), SIGNAL(advancedPSUIChanged(bool)), this, SLOT(updateAdvancedPSUI(bool)));
-        connect(model->getOptionsModel(), SIGNAL(privateSendEnabledChanged()), this, SLOT(privateSendStatus(true)));
+        connect(model->getOptionsModel(), &OptionsModel::privateSendEnabledChanged, [=]() {
+            privateSendStatus(true);
+        });
 
         connect(ui->togglePrivateSend, SIGNAL(clicked()), this, SLOT(togglePrivateSend()));
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -163,30 +163,14 @@ OverviewPage::OverviewPage(QWidget* parent) :
     // start with displaying the "out of sync" warnings
     showOutOfSyncWarning(true);
 
-    if (!CPrivateSendClientOptions::IsEnabled()) return;
-
-    // Disable any PS UI for masternode or when autobackup is disabled or failed for whatever reason
-    if(fMasternodeMode || nWalletBackups <= 0){
-        DisablePrivateSendCompletely();
-        if (nWalletBackups <= 0) {
-            ui->labelPrivateSendEnabled->setToolTip(tr("Automatic backups are disabled, no mixing available!"));
-        }
-    } else {
-        // Disable privateSendClient builtin support for automatic backups while we are in GUI,
-        // we'll handle automatic backups and user warnings in privateSendStatus()
-        for (auto& pair : privateSendClientManagers) {
-            if (!pair.second->IsMixing()) {
-                ui->togglePrivateSend->setText(tr("Start Mixing"));
-            } else {
-                ui->togglePrivateSend->setText(tr("Stop Mixing"));
-            }
-            pair.second->fCreateAutoBackups = false;
-        }
-
-        timer = new QTimer(this);
-        connect(timer, SIGNAL(timeout()), this, SLOT(privateSendStatus()));
-        timer->start(1000);
+    // Disable privateSendClient builtin support for automatic backups while we are in GUI,
+    // we'll handle automatic backups and user warnings in privateSendStatus()
+    for (auto& pair : privateSendClientManagers) {
+        pair.second->fCreateAutoBackups = false;
     }
+
+    timer = new QTimer(this);
+    connect(timer, SIGNAL(timeout()), this, SLOT(privateSendStatus()));
 }
 
 void OverviewPage::handleTransactionClicked(const QModelIndex &index)
@@ -297,8 +281,6 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         // explicitly update PS frame and transaction list to reflect actual settings
         updateAdvancedPSUI(model->getOptionsModel()->getShowAdvancedPSUI());
-
-        if (!CPrivateSendClientOptions::IsEnabled()) return;
 
         connect(model->getOptionsModel(), SIGNAL(privateSendRoundsChanged()), this, SLOT(updatePrivateSendProgress()));
         connect(model->getOptionsModel(), SIGNAL(privateSentAmountChanged()), this, SLOT(updatePrivateSendProgress()));
@@ -460,11 +442,27 @@ void OverviewPage::privateSendStatus(bool fForce)
 
     if(!walletModel) return;
 
+    // Disable any PS UI for masternode or when autobackup is disabled or failed for whatever reason
+    if (fMasternodeMode || nWalletBackups <= 0) {
+        DisablePrivateSendCompletely();
+        if (nWalletBackups <= 0) {
+            ui->labelPrivateSendEnabled->setToolTip(tr("Automatic backups are disabled, no mixing available!"));
+        }
+        return;
+    }
+
     bool fIsEnabled = CPrivateSendClientOptions::IsEnabled();
     ui->framePrivateSend->setVisible(fIsEnabled);
     if (!fIsEnabled) {
         SetupTransactionList(NUM_ITEMS_DISABLED);
+        if (timer != nullptr) {
+            timer->stop();
+        }
         return;
+    }
+
+    if (timer != nullptr && !timer->isActive()) {
+        timer->start(1000);
     }
 
     // Wrap all privatesend related widgets we want to show/hide state based.

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -303,6 +303,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(model->getOptionsModel(), SIGNAL(privateSendRoundsChanged()), this, SLOT(updatePrivateSendProgress()));
         connect(model->getOptionsModel(), SIGNAL(privateSentAmountChanged()), this, SLOT(updatePrivateSendProgress()));
         connect(model->getOptionsModel(), SIGNAL(advancedPSUIChanged(bool)), this, SLOT(updateAdvancedPSUI(bool)));
+        connect(model->getOptionsModel(), SIGNAL(privateSendEnabledChanged()), this, SLOT(privateSendStatus(true)));
 
         connect(ui->togglePrivateSend, SIGNAL(clicked()), this, SLOT(togglePrivateSend()));
 

--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -477,6 +477,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain,
 #btnWallet,
+#btnPrivateSend,
 #btnNetwork,
 #btnDisplay,
 #btnAppearance,
@@ -496,6 +497,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:checked,
 #btnWallet:hover:checked,
+#btnPrivateSend:hover:checked,
 #btnNetwork:hover:checked,
 #btnDisplay:hover:checked,
 #btnAppearance:hover:checked,
@@ -515,6 +517,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:!checked,
 #btnWallet:hover:!checked,
+#btnPrivateSend:hover:!checked,
 #btnNetwork:hover:!checked,
 #btnDisplay:hover:!checked,
 #btnAppearance:hover:!checked,
@@ -534,6 +537,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:checked,
 #btnWallet:checked,
+#btnPrivateSend:checked,
 #btnNetwork:checked,
 #btnDisplay:checked,
 #btnAppearance:checked,

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -621,6 +621,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain,
 #btnWallet,
+#btnPrivateSend,
 #btnNetwork,
 #btnDisplay,
 #btnAppearance,
@@ -643,6 +644,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:checked,
 #btnWallet:hover:checked,
+#btnPrivateSend:hover:checked,
 #btnNetwork:hover:checked,
 #btnDisplay:hover:checked,
 #btnAppearance:hover:checked,
@@ -665,6 +667,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:!checked,
 #btnWallet:hover:!checked,
+#btnPrivateSend:hover:!checked,
 #btnNetwork:hover:!checked,
 #btnDisplay:hover:!checked,
 #btnAppearance:hover:!checked,
@@ -687,6 +690,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:checked,
 #btnWallet:checked,
+#btnPrivateSend:checked,
 #btnNetwork:checked,
 #btnDisplay:checked,
 #btnAppearance:checked,
@@ -708,6 +712,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:pressed,
 #btnWallet:hover:pressed,
+#btnPrivateSend:hover:pressed,
 #btnNetwork:hover:pressed,
 #btnDisplay:hover:pressed,
 #btnAppearance:hover:pressed,

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -459,6 +459,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain,
 #btnWallet,
+#btnPrivateSend,
 #btnNetwork,
 #btnDisplay,
 #btnAppearance,
@@ -478,6 +479,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:checked,
 #btnWallet:hover:checked,
+#btnPrivateSend:hover:checked,
 #btnNetwork:hover:checked,
 #btnDisplay:hover:checked,
 #btnAppearance:hover:checked,
@@ -497,6 +499,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:!checked,
 #btnWallet:hover:!checked,
+#btnPrivateSend:hover:!checked,
 #btnNetwork:hover:!checked,
 #btnDisplay:hover:!checked,
 #btnAppearance:hover:!checked,
@@ -516,6 +519,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:checked,
 #btnWallet:checked,
+#btnPrivateSend:checked,
 #btnNetwork:checked,
 #btnDisplay:checked,
 #btnAppearance:checked,

--- a/src/qt/res/css/traditional.css
+++ b/src/qt/res/css/traditional.css
@@ -54,6 +54,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain,
 #btnWallet,
+#btnPrivateSend,
 #btnNetwork,
 #btnDisplay,
 #btnAppearance,
@@ -77,6 +78,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:checked,
 #btnWallet:hover:checked,
+#btnPrivateSend:hover:checked,
 #btnNetwork:hover:checked,
 #btnDisplay:hover:checked,
 #btnAppearance:hover:checked,
@@ -99,6 +101,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:hover:!checked,
 #btnWallet:hover:!checked,
+#btnPrivateSend:hover:!checked,
 #btnNetwork:hover:!checked,
 #btnDisplay:hover:!checked,
 #btnAppearance:hover:!checked,
@@ -121,6 +124,7 @@ QPushButton - Special case, tabbar replacement buttons
 /* Options dialog buttons */
 #btnMain:checked,
 #btnWallet:checked,
+#btnPrivateSend:checked,
 #btnNetwork:checked,
 #btnDisplay:checked,
 #btnAppearance:checked,

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -250,6 +250,8 @@ void TransactionView::setModel(WalletModel *_model)
                     mapperThirdPartyTxUrls->setMapping(thirdPartyTxUrlAction, listUrls[i].trimmed());
                 }
             }
+
+            connect(_model->getOptionsModel(), SIGNAL(privateSendEnabledChanged()), this, SLOT(updatePrivateSendVisibility()));
         }
 
         // show/hide column Watch-only


### PR DESCRIPTION
- Move PrivateSend related settings from `Options -> Wallet` into a new tab `Options -> PrivateSend`
- Add `Enable PrivateSend interface` in `Options ->Wallet`. This checkbox allows to dynamically show/hide the PrivateSend related UI elements all over the place

Based on #3716 and #3715 

### Before
<img width="695" alt="Bildschirmfoto 2020-09-16 um 17 10 45" src="https://user-images.githubusercontent.com/35775977/93357004-232d7b00-f840-11ea-9812-7e89f2fc443c.png">

### With this PR

| PrivateSend UI hidden | PrivateSend options tab  |
| - | - |
| <img width="695" alt="Bildschirmfoto 2020-09-16 um 17 17 54" src="https://user-images.githubusercontent.com/35775977/93357573-c088af00-f840-11ea-8f8f-57edf1fa5131.png"> | <img width="695" alt="Bildschirmfoto 2020-09-16 um 17 18 01" src="https://user-images.githubusercontent.com/35775977/93357567-bff01880-f840-11ea-8c8a-83e19f8889ea.png"> |