### PR TITLE
rpc: Add chainlock BLS signature to getbestchainlock

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -215,11 +215,12 @@ UniValue getbestchainlock(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
             "getbestchainlock\n"
-            "\nReturns the block hash of the best chainlock. Throws an error if there is no known chainlock yet. "
+            "\nReturns information about the best chainlock. Throws an error if there is no known chainlock yet."
             "\nResult:\n"
             "{\n"
             "  \"blockhash\" : \"hash\",      (string) The block hash hex encoded\n"
             "  \"height\" : n,              (numeric) The block height or index\n"
+            "  \"signature\" : \"hash\",    (string) The chainlock's BLS signature.\n"
             "  \"known_block\" : true|false (boolean) True if the block is known by our node\n"
             "}\n"
             "\nExamples:\n"
@@ -234,6 +235,8 @@ UniValue getbestchainlock(const JSONRPCRequest& request)
     }
     result.pushKV("blockhash", clsig.blockHash.GetHex());
     result.pushKV("height", clsig.nHeight);
+    result.pushKV("signature", clsig.sig.ToString());
+
     LOCK(cs_main);
     result.pushKV("known_block", mapBlockIndex.count(clsig.blockHash) > 0);
     return result;


### PR DESCRIPTION
Implements requested feature in #3712 

#### Example 
```
getbestchainlock
{
    "blockhash": "00000105df60caca6a257d8f2f90d422f2d1abf6658555650d5c2c8ecd209e25", 
    "height": 382312,
    "signature": "17b7b6008df6725a5b89bd114c89a2d650b3fcb33fc127c29763c15a3cf110d7e32aa5108223b0b31597be0953d37c6c06545ed28e71be7d6420e1b24e54ae66eb40b932f453ddc811af37b38d364bd1a9df7da31c60be4728b84150558516f2",
    "known_block": true
}
```