### PR TITLE
Handle situations when we have evodb records but no blocks anymore

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1127,7 +1127,7 @@ bool CDeterministicMNManager::UpgradeDBIfNeeded()
 
     if (chainActive.Tip() == nullptr) {
         // should have no records
-        return !evoDb.GetRawDB().Exists(std::string("b_b")) && !evoDb.GetRawDB().Exists(EVODB_BEST_BLOCK);
+        return evoDb.IsEmpty();
     }
 
     if (evoDb.GetRawDB().Exists(EVODB_BEST_BLOCK)) {

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1126,7 +1126,8 @@ bool CDeterministicMNManager::UpgradeDBIfNeeded()
     LOCK(cs_main);
 
     if (chainActive.Tip() == nullptr) {
-        return true;
+        // should have no records
+        return !evoDb.GetRawDB().Exists(std::string("b_b")) && !evoDb.GetRawDB().Exists(EVODB_BEST_BLOCK);
     }
 
     if (evoDb.GetRawDB().Exists(EVODB_BEST_BLOCK)) {

--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -98,6 +98,7 @@ public:
 
     bool CommitRootTransaction();
 
+    bool HasSomeBestBlock() { return db.Exists(EVODB_BEST_BLOCK); }
     bool VerifyBestBlock(const uint256& hash);
     void WriteBestBlock(const uint256& hash);
 

--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -98,7 +98,8 @@ public:
 
     bool CommitRootTransaction();
 
-    bool HasSomeBestBlock() { return db.Exists(EVODB_BEST_BLOCK); }
+    bool IsEmpty() { return db.IsEmpty(); }
+
     bool VerifyBestBlock(const uint256& hash);
     void WriteBestBlock(const uint256& hash);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -62,6 +62,7 @@
 
 #include <evo/deterministicmns.h>
 #include <llmq/quorums_init.h>
+#include <llmq/quorums_blockprocessor.h>
 
 #include <stdint.h>
 #include <stdio.h>
@@ -1981,7 +1982,13 @@ bool AppInitMain()
                     assert(chainActive.Tip() != NULL);
                 }
 
-                if (!deterministicMNManager->UpgradeDBIfNeeded()) {
+                if (is_coinsview_empty && evoDb->HasSomeBestBlock()) {
+                    // EvoDB processed some blocks earlier but we have no blocks anymore, something is wrong
+                    strLoadError = _("Error initializing block database");
+                    break;
+                }
+
+                if (!deterministicMNManager->UpgradeDBIfNeeded() || !llmq::quorumBlockProcessor->UpgradeDB()) {
                     strLoadError = _("Error upgrading evo database");
                     break;
                 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1982,7 +1982,7 @@ bool AppInitMain()
                     assert(chainActive.Tip() != NULL);
                 }
 
-                if (is_coinsview_empty && evoDb->HasSomeBestBlock()) {
+                if (is_coinsview_empty && !evoDb->IsEmpty()) {
                     // EvoDB processed some blocks earlier but we have no blocks anymore, something is wrong
                     strLoadError = _("Error initializing block database");
                     break;

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -268,12 +268,18 @@ bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, const CBlockIndex* pi
 }
 
 // TODO remove this with 0.15.0
-void CQuorumBlockProcessor::UpgradeDB()
+bool CQuorumBlockProcessor::UpgradeDB()
 {
     LOCK(cs_main);
+
+    if (chainActive.Tip() == nullptr) {
+        // should have no records
+        return !evoDb.GetRawDB().Exists(DB_MINED_COMMITMENT) && !evoDb.GetRawDB().Exists(DB_BEST_BLOCK_UPGRADE);
+    }
+
     uint256 bestBlock;
     if (evoDb.GetRawDB().Read(DB_BEST_BLOCK_UPGRADE, bestBlock) && bestBlock == chainActive.Tip()->GetBlockHash()) {
-        return;
+        return true;
     }
 
     LogPrintf("CQuorumBlockProcessor::%s -- Upgrading DB...\n", __func__);
@@ -283,7 +289,7 @@ void CQuorumBlockProcessor::UpgradeDB()
         while (pindex) {
             if (fPruneMode && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
                 // Too late, we already pruned blocks we needed to reprocess commitments
-                throw std::runtime_error(std::string(__func__) + ": Quorum Commitments DB upgrade failed, you need to re-download the blockchain");
+                return false;
             }
             CBlock block;
             bool r = ReadBlockFromDisk(block, pindex, Params().GetConsensus());
@@ -310,6 +316,7 @@ void CQuorumBlockProcessor::UpgradeDB()
     }
 
     LogPrintf("CQuorumBlockProcessor::%s -- Upgrade done...\n", __func__);
+    return true;
 }
 
 bool CQuorumBlockProcessor::GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindex, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state)

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -274,7 +274,7 @@ bool CQuorumBlockProcessor::UpgradeDB()
 
     if (chainActive.Tip() == nullptr) {
         // should have no records
-        return !evoDb.GetRawDB().Exists(DB_MINED_COMMITMENT) && !evoDb.GetRawDB().Exists(DB_BEST_BLOCK_UPGRADE);
+        return evoDb.IsEmpty();
     }
 
     uint256 bestBlock;

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -37,7 +37,7 @@ private:
 public:
     explicit CQuorumBlockProcessor(CEvoDB& _evoDb) : evoDb(_evoDb) {}
 
-    void UpgradeDB();
+    bool UpgradeDB();
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
 

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -64,8 +64,6 @@ void DestroyLLMQSystem()
 
 void StartLLMQSystem()
 {
-    quorumBlockProcessor->UpgradeDB();
-
     if (blsWorker) {
         blsWorker->Start();
     }


### PR DESCRIPTION
This kind of situations are unlikely to happen in normal conditions but can be unintentionally caused by advanced users/3-rd party developers messing with datadir. Currently the node would simply crash, with this PR it follows the usual chain corruption flow.