### PR TITLE
Fix mempool sync

### DIFF
--- a/src/masternode/masternode-sync.cpp
+++ b/src/masternode/masternode-sync.cpp
@@ -189,12 +189,6 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
             }
 
             if (nCurrentAsset == MASTERNODE_SYNC_BLOCKCHAIN) {
-                if(pnode->nVersion >= 70216 && !pnode->fInbound && gArgs.GetBoolArg("-syncmempool", DEFAULT_SYNC_MEMPOOL) && !netfulfilledman.HasFulfilledRequest(pnode->addr, "mempool-sync")) {
-                    netfulfilledman.AddFulfilledRequest(pnode->addr, "mempool-sync");
-                    connman.PushMessage(pnode, msgMaker.Make(NetMsgType::MEMPOOL));
-                    LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- syncing mempool from peer=%d\n", nTick, nCurrentAsset, pnode->GetId());
-                }
-
                 int64_t nTimeSyncTimeout = vNodesCopy.size() > 3 ? MASTERNODE_SYNC_TICK_SECONDS : MASTERNODE_SYNC_TIMEOUT_SECONDS;
                 if (fReachedBestHeader && (GetTime() - nTimeLastBumped > nTimeSyncTimeout)) {
                     // At this point we know that:
@@ -208,6 +202,19 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                     // We must be at the tip already, let's move to the next asset.
                     SwitchToNextAsset(connman);
                     uiInterface.NotifyAdditionalDataSyncProgressChanged(nSyncProgress);
+
+                    // Now that the blockchain is synced request the mempool from the connected outbound nodes if possible
+                    for (auto pNodeTmp : vNodesCopy) {
+                        if (pNodeTmp->nVersion >= 70216 &&
+                            !pNodeTmp->fInbound &&
+                            gArgs.GetBoolArg("-syncmempool", DEFAULT_SYNC_MEMPOOL) &&
+                            !netfulfilledman.HasFulfilledRequest(pNodeTmp->addr, "mempool-sync")) {
+
+                            netfulfilledman.AddFulfilledRequest(pNodeTmp->addr, "mempool-sync");
+                            connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::MEMPOOL));
+                            LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- syncing mempool from peer=%d\n", nTick, nCurrentAsset, pNodeTmp->GetId());
+                        }
+                    }
                 }
             }
 

--- a/src/masternode/masternode-sync.cpp
+++ b/src/masternode/masternode-sync.cpp
@@ -203,16 +203,15 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                     SwitchToNextAsset(connman);
                     uiInterface.NotifyAdditionalDataSyncProgressChanged(nSyncProgress);
 
-                    // Now that the blockchain is synced request the mempool from the connected outbound nodes if possible
-                    for (auto pNodeTmp : vNodesCopy) {
-                        if (pNodeTmp->nVersion >= 70216 &&
-                            !pNodeTmp->fInbound &&
-                            gArgs.GetBoolArg("-syncmempool", DEFAULT_SYNC_MEMPOOL) &&
-                            !netfulfilledman.HasFulfilledRequest(pNodeTmp->addr, "mempool-sync")) {
-
-                            netfulfilledman.AddFulfilledRequest(pNodeTmp->addr, "mempool-sync");
-                            connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::MEMPOOL));
-                            LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- syncing mempool from peer=%d\n", nTick, nCurrentAsset, pNodeTmp->GetId());
+                    if (gArgs.GetBoolArg("-syncmempool", DEFAULT_SYNC_MEMPOOL)) {
+                        // Now that the blockchain is synced request the mempool from the connected outbound nodes if possible
+                        for (auto pNodeTmp : vNodesCopy) {
+                            bool fRequestedEarlier = netfulfilledman.HasFulfilledRequest(pNodeTmp->addr, "mempool-sync");
+                            if (pNodeTmp->nVersion >= 70216 && !pNodeTmp->fInbound && !fRequestedEarlier) {
+                                netfulfilledman.AddFulfilledRequest(pNodeTmp->addr, "mempool-sync");
+                                connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::MEMPOOL));
+                                LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- syncing mempool from peer=%d\n", nTick, nCurrentAsset, pNodeTmp->GetId());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Currently mempool sync isn't quite helpful because we ask for it while still syncing the chain and mempool might look completely different by the time we finish syncing blocks. This PR ensures we do it at the right time.

~(build fails because of the issue fixed by #3724 , will rebase later)~