### PR TITLE
Make the coinjoin input warning less scary

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -407,6 +407,9 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients)
             questionString.append("<br />");
             questionString.append("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>");
             questionString.append(tr("Warning: Using %1 with %2 or more inputs can harm your privacy and is not recommended").arg("CoinJoin").arg(10));
+            questionString.append("<a style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_COMMAND) + "' href=\"https://docs.dash.org/en/stable/wallets/dashcore/privatesend-instantsend.html#inputs\">");
+            questionString.append(tr("Click to learn more"));
+            questionString.append("</a>");
             questionString.append("</span> ");
         }
     }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -407,7 +407,7 @@ void SendCoinsDialog::send(QList<SendCoinsRecipient> recipients)
             questionString.append("<br />");
             questionString.append("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>");
             questionString.append(tr("Warning: Using %1 with %2 or more inputs can harm your privacy and is not recommended").arg("CoinJoin").arg(10));
-            questionString.append("<a style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_COMMAND) + "' href=\"https://docs.dash.org/en/stable/wallets/dashcore/privatesend-instantsend.html#inputs\">");
+            questionString.append("<a style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_COMMAND) + "' href=\"https://docs.dash.org/en/stable/wallets/dashcore/coinjoin-instantsend.html#inputs\">");
             questionString.append(tr("Click to learn more"));
             questionString.append("</a>");
             questionString.append("</span> ");


### PR DESCRIPTION
I'm not sure how much of a fan I am of the warning text I propose, I'm open to suggestions, however, I think this kind of a modification is quite needed.

Milestone should probably be 17 b/c translation changes, however, it'd probably be fine to include in 16 

Scary Warning
![more scary](https://user-images.githubusercontent.com/6443210/93967422-afff9980-fd56-11ea-9083-61fc63013387.png)
Less Scary Warning
![less scary](https://user-images.githubusercontent.com/6443210/93967438-b5f57a80-fd56-11ea-826f-5c79f1ddc747.png)

