### PR TITLE
Do not try to access new tx in `WalletModel::prepareTransaction` if it wasn't really created

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -351,8 +351,10 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         if (fSubtractFeeFromAmount && fCreated)
             transaction.reassignAmounts();
 
-        nValueOut = newTx->GetValueOut();
-        nVinSize = newTx->vin.size();
+        if (fCreated) {
+            nValueOut = newTx->GetValueOut();
+            nVinSize = newTx->vin.size();
+        }
     }
 
     if(!fCreated)


### PR DESCRIPTION
... or we'll just crash otherwise. This part wasn't crashing before #3680 (which switched `CreateTransaction` from using `CWalletTx` to `CTransactionRef`), so no need to backport to v0.16.

Thanks @thephez for reporting the issue