### PR TITLE
qt: Fix font size and scaling issues

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -216,7 +216,7 @@ QVariant AddressTableModel::data(const QModelIndex &index, int role) const
         QFont font;
         if(index.column() == Address)
         {
-            font = GUIUtil::fixedPitchFont();
+            font = GUIUtil::getFontNormal();
         }
         return font;
     }

--- a/src/qt/appearancewidget.cpp
+++ b/src/qt/appearancewidget.cpp
@@ -51,6 +51,12 @@ AppearanceWidget::AppearanceWidget(QWidget* parent) :
     connect(ui->fontScaleSlider, SIGNAL(valueChanged(int)), this, SLOT(updateFontScale(int)));
     connect(ui->fontWeightNormalSlider, SIGNAL(valueChanged(int)), this, SLOT(updateFontWeightNormal(int)));
     connect(ui->fontWeightBoldSlider, SIGNAL(valueChanged(int)), this, SLOT(updateFontWeightBold(int)));
+
+    connect(ui->theme, &QComboBox::currentTextChanged, [=]() { Q_EMIT appearanceChanged(); });
+    connect(ui->fontFamily, &QComboBox::currentTextChanged, [=]() { Q_EMIT appearanceChanged(); });
+    connect(ui->fontScaleSlider, &QSlider::sliderReleased, [=]() { Q_EMIT appearanceChanged(); });
+    connect(ui->fontWeightNormalSlider, &QSlider::sliderReleased, [=]() { Q_EMIT appearanceChanged(); });
+    connect(ui->fontWeightBoldSlider, &QSlider::sliderReleased, [=]() { Q_EMIT appearanceChanged(); });
 }
 
 AppearanceWidget::~AppearanceWidget()

--- a/src/qt/appearancewidget.h
+++ b/src/qt/appearancewidget.h
@@ -29,6 +29,9 @@ public:
 
     void setModel(OptionsModel* model);
 
+Q_SIGNALS:
+    void appearanceChanged();
+
 public Q_SLOTS:
     void accept();
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1194,6 +1194,10 @@ void BitcoinGUI::updateWidth()
     int nWidth = std::max<int>(980, (nWidthWidestButton + 30) * (nButtonsVisible + 1));
     setMinimumWidth(nWidth);
     setMaximumWidth(nWidth);
+    // Reset the max width after it has been set to still allow window resizing
+    QTimer::singleShot(0, this, [=]() {
+        setMaximumWidth(std::numeric_limits<int>::max());
+    });
 }
 
 void BitcoinGUI::updateToolBarShortcuts()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -453,6 +453,8 @@ void BitcoinGUI::createActions()
     for (auto button : tabGroup->buttons()) {
         GUIUtil::setFont({button}, GUIUtil::FontWeight::Normal, 16);
     }
+    GUIUtil::updateFonts();
+
     // Give the selected tab button a bolder font.
     connect(tabGroup, SIGNAL(buttonToggled(QAbstractButton *, bool)), this, SLOT(highlightTabButton(QAbstractButton *, bool)));
 #endif // ENABLE_WALLET
@@ -1013,6 +1015,7 @@ void BitcoinGUI::openClicked()
 void BitcoinGUI::highlightTabButton(QAbstractButton *button, bool checked)
 {
     GUIUtil::setFont({button}, checked ? GUIUtil::FontWeight::Bold : GUIUtil::FontWeight::Normal, 16);
+    GUIUtil::updateFonts();
 }
 
 void BitcoinGUI::gotoOverviewPage()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1193,11 +1193,7 @@ void BitcoinGUI::updateWidth()
     // Use nButtonsVisible + 1 <- for the dash logo
     int nWidth = std::max<int>(980, (nWidthWidestButton + 30) * (nButtonsVisible + 1));
     setMinimumWidth(nWidth);
-    setMaximumWidth(nWidth);
-    // Reset the max width after it has been set to still allow window resizing
-    QTimer::singleShot(0, this, [=]() {
-        setMaximumWidth(std::numeric_limits<int>::max());
-    });
+    resize(nWidth, height());
 }
 
 void BitcoinGUI::updateToolBarShortcuts()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -924,6 +924,9 @@ void BitcoinGUI::optionsClicked()
 
     OptionsDialog dlg(this, enableWallet);
     dlg.setModel(clientModel->getOptionsModel());
+    connect(&dlg, &OptionsDialog::appearanceChanged, [=]() {
+        updateWidth();
+    });
     dlg.exec();
 
     updatePrivateSendVisibility();
@@ -1171,6 +1174,26 @@ void BitcoinGUI::updatePrivateSendVisibility()
     privateSendCoinsMenuAction->setVisible(fEnabled);
     showPrivateSendHelpAction->setVisible(fEnabled);
     updateToolBarShortcuts();
+    updateWidth();
+}
+
+void BitcoinGUI::updateWidth()
+{
+    int nWidthWidestButton{0};
+    int nButtonsVisible{0};
+    for (QAbstractButton* button : tabGroup->buttons()) {
+        if (!button->isEnabled()) {
+            continue;
+        }
+        QFontMetrics fm(button->font());
+        nWidthWidestButton = std::max<int>(nWidthWidestButton, fm.width(button->text()));
+        ++nButtonsVisible;
+    }
+    // Add 30 per button as padding and use minimum 980 which is the minimum required to show all tab's contents
+    // Use nButtonsVisible + 1 <- for the dash logo
+    int nWidth = std::max<int>(980, (nWidthWidestButton + 30) * (nButtonsVisible + 1));
+    setMinimumWidth(nWidth);
+    setMaximumWidth(nWidth);
 }
 
 void BitcoinGUI::updateToolBarShortcuts()
@@ -1490,6 +1513,10 @@ void BitcoinGUI::showEvent(QShowEvent *event)
     openRepairAction->setEnabled(true);
     aboutAction->setEnabled(true);
     optionsAction->setEnabled(true);
+
+    if (!event->spontaneous()) {
+        updateWidth();
+    }
 }
 
 #ifdef ENABLE_WALLET

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -331,6 +331,8 @@ private Q_SLOTS:
     void showModalOverlay();
 
     void updatePrivateSendVisibility();
+
+    void updateWidth();
 };
 
 class UnitDisplayStatusBarControl : public QLabel

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1545,7 +1545,7 @@ void updateFonts()
         std::vector<QString> vecIgnore{
             "QWidget", "QDialog", "QFrame", "QStackedWidget", "QDesktopWidget", "QDesktopScreenWidget",
             "QTipLabel", "QMessageBox", "QMenu", "QComboBoxPrivateScroller", "QComboBoxPrivateContainer",
-            "QScrollBar", "BitcoinGUI", "WalletView", "WalletFrame"
+            "QScrollBar", "QListView", "BitcoinGUI", "WalletView", "WalletFrame"
         };
         if (std::find(vecIgnore.begin(), vecIgnore.end(), w->metaObject()->className()) != vecIgnore.end()) {
             continue;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1574,6 +1574,12 @@ void updateFonts()
     std::map<QWidget*, QFont> mapWidgetFonts;
 
     for (QWidget* w : qApp->allWidgets()) {
+        if (strcmp(w->metaObject()->className(), "QTipLabel") == 0 ||
+            strcmp(w->metaObject()->className(), "QMessageBox") == 0 ||
+            strcmp(w->metaObject()->className(), "QMenu") == 0) {
+            // Ignore any of those because their font is set through application fonts later.
+            continue;
+        }
         QFont font = w->font();
         font.setFamily(qApp->font().family());
         font.setWeight(getFontWeightNormal());

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1537,7 +1537,10 @@ void setFont(const std::vector<QWidget*>& vecWidgets, FontWeight weight, int nPo
 
     for (auto it : vecWidgets) {
         auto fontAttributes = std::make_tuple(weight, fItalic, nPointSize);
-        mapNormalFontUpdates.emplace(std::make_pair(it, fontAttributes));
+        auto itFontUpdate = mapNormalFontUpdates.emplace(std::make_pair(it, fontAttributes));
+        if (!itFontUpdate.second) {
+            itFontUpdate.first->second = fontAttributes;
+        }
         it->setFont(font);
     }
 }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1385,7 +1385,7 @@ void setFontScale(int nScale)
 
 double getScaledFontSize(int nSize)
 {
-    return (nSize * (1 + (fontScale * fontScaleSteps)));
+    return std::round(nSize * (1 + (fontScale * fontScaleSteps)) * 4) / 4.0;
 }
 
 bool loadFonts()

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1624,15 +1624,27 @@ void updateFonts()
         it.first->setFont(it.second);
     }
 
-    // Get the global font for QToolTip labels
+    // Scale the global font for QToolTip labels, QMenu and QMessageBox instances
     QFont fontToolTip = qApp->font("QTipLabel");
-    // Store the default QToolTip font size before ever applying any scale to it
+    QFont fontMenu = qApp->font("QMenu");
+    QFont fontMessageBox = qApp->font("QMessageBox");
+    // Store their default font sizes before ever applying any scale to it
     if (!mapDefaultFontSizes.count("QTipLabel")) {
         mapDefaultFontSizes.emplace("QTipLabel", fontToolTip.pointSize());
     }
-    // And give it the proper scaled size based on its default size
+    if (!mapDefaultFontSizes.count("QMenu")) {
+        mapDefaultFontSizes.emplace("QMenu", fontMenu.pointSize());
+    }
+    if (!mapDefaultFontSizes.count("QMessageBox")) {
+        mapDefaultFontSizes.emplace("QMessageBox", fontMessageBox.pointSize());
+    }
     fontToolTip.setPointSizeF(getScaledFontSize(mapDefaultFontSizes["QTipLabel"]));
+    fontMenu.setPointSizeF(getScaledFontSize(mapDefaultFontSizes["QMenu"]));
+    fontMessageBox.setPointSizeF(getScaledFontSize(mapDefaultFontSizes["QMessageBox"]));
     qApp->setFont(fontToolTip, "QTipLabel");
+    qApp->setFont(fontMenu, "QMenu");
+    qApp->setFont(fontMessageBox, "QMessageBox");
+    // And give them the proper scaled size based on their default sizes if required
 }
 
 QFont getFont(FontFamily family, QFont::Weight qWeight, bool fItalic, int nPointSize)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1586,9 +1586,8 @@ void updateFonts()
         }
         bool fDefaultFont = mapNormalFontUpdates.find(w) == mapNormalFontUpdates.end() &&
                             setFixedPitchFontUpdates.find(w) == setFixedPitchFontUpdates.end();
-        bool fDefaultFontChanged = font.pointSizeF() != getScaledFontSize(mapDefaultFontSizes[key]);
         font.setPointSizeF(getScaledFontSize(mapDefaultFontSizes[key]));
-        mapWidgetFonts.emplace(w, std::make_pair(font, fAdded || (fDefaultFont && fDefaultFontChanged)));
+        mapWidgetFonts.emplace(w, std::make_pair(font, fAdded || (fDefaultFont && font != w->font())));
     }
 
     auto itn = mapNormalFontUpdates.begin();

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1566,8 +1566,6 @@ void updateFonts()
         return;
     }
 
-    setApplicationFont();
-
     auto getKey = [](QWidget* w) -> QString {
         return w->parent() ? w->parent()->objectName() + w->objectName() : w->objectName();
     };

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1565,10 +1565,12 @@ void updateFonts()
     std::map<QWidget*, std::pair<QFont, bool>> mapWidgetFonts;
 
     for (QWidget* w : qApp->allWidgets()) {
-        if (strcmp(w->metaObject()->className(), "QTipLabel") == 0 ||
-            strcmp(w->metaObject()->className(), "QMessageBox") == 0 ||
-            strcmp(w->metaObject()->className(), "QMenu") == 0) {
-            // Ignore any of those because their font is set through application fonts later.
+        std::vector<QString> vecIgnore{
+            "QWidget", "QDialog", "QFrame", "QStackedWidget", "QDesktopWidget", "QDesktopScreenWidget",
+            "QTipLabel", "QMessageBox", "QMenu", "QComboBoxPrivateScroller", "QComboBoxPrivateContainer",
+            "QScrollBar", "BitcoinGUI", "WalletView", "WalletFrame"
+        };
+        if (std::find(vecIgnore.begin(), vecIgnore.end(), w->metaObject()->className()) != vecIgnore.end()) {
             continue;
         }
         QFont font = w->font();

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1521,15 +1521,12 @@ void setApplicationFont()
 
 void setFont(const std::vector<QWidget*>& vecWidgets, FontWeight weight, int nPointSize, bool fItalic)
 {
-    QFont font = getFont(weight, fItalic, nPointSize);
-
     for (auto it : vecWidgets) {
         auto fontAttributes = std::make_tuple(weight, fItalic, nPointSize);
         auto itFontUpdate = mapNormalFontUpdates.emplace(std::make_pair(it, fontAttributes));
         if (!itFontUpdate.second) {
             itFontUpdate.first->second = fontAttributes;
         }
-        it->setFont(font);
     }
 }
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -102,9 +102,6 @@ namespace GUIUtil
     QString dateTimeStr(const QDateTime &datetime);
     QString dateTimeStr(qint64 nTime);
 
-    // Return a monospace font
-    QFont fixedPitchFont();
-
     // Set up widgets for address and amounts
     void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent, bool fAllowURI = false);
     void setupAmountWidget(QLineEdit *widget, QWidget *parent);
@@ -331,9 +328,6 @@ namespace GUIUtil
         issues loading variations of montserrat in css it also keeps track of the set fonts to update on
         theme changes. */
     void setFont(const std::vector<QWidget*>& vecWidgets, FontWeight weight, int nPointSize = -1, bool fItalic = false);
-
-    /** Workaround to set a fixed pitch font in traditional theme while keeping track of font updates */
-    void setFixedPitchFont(const std::vector<QWidget*>& vecWidgets);
 
     /** Update the font of all widgets where a custom font has been set with
         GUIUtil::setFont */

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -92,6 +92,8 @@ MasternodeList::MasternodeList(QWidget* parent) :
     timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(updateDIP3ListScheduled()));
     timer->start(1000);
+
+    GUIUtil::updateFonts();
 }
 
 MasternodeList::~MasternodeList()

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -41,6 +41,8 @@ foreverHidden(false)
 
     blockProcessTime.clear();
     setVisible(false);
+
+    GUIUtil::updateFonts();
 }
 
 ModalOverlay::~ModalOverlay()

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -160,6 +160,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
 
     connect(appearance, &AppearanceWidget::appearanceChanged, [=](){
         updateWidth();
+        Q_EMIT appearanceChanged();
     });
 
     updatePrivateSendVisibility();

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -306,6 +306,7 @@ void OptionsDialog::showPage(int index)
 
     GUIUtil::setFont({btnActive}, GUIUtil::FontWeight::Bold, 16);
     GUIUtil::setFont(vecNormal, GUIUtil::FontWeight::Normal, 16);
+    GUIUtil::updateFonts();
 
     ui->stackedWidgetOptions->setCurrentIndex(index);
     btnActive->setChecked(true);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -463,6 +463,7 @@ void OptionsDialog::showEvent(QShowEvent* event)
     if (!event->spontaneous()) {
         updateWidth();
     }
+    QDialog::showEvent(event);
 }
 
 ProxyAddressValidator::ProxyAddressValidator(QObject *parent) :

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -157,6 +157,10 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     appearanceLayout->addWidget(appearance);
     ui->widgetAppearance->setLayout(appearanceLayout);
 
+    connect(appearance, &AppearanceWidget::appearanceChanged, [=](){
+        updateWidth();
+    });
+
     updatePrivateSendVisibility();
 
     // Store the current PrivateSend enabled state to recover it if it gets changed but the dialog gets not accepted but declined.

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -168,6 +168,8 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
         }
     });
 #endif
+
+    updateWidth();
 }
 
 OptionsDialog::~OptionsDialog()
@@ -237,6 +239,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
         if (_model != nullptr) {
             _model->emitPrivateSendEnabledChanged();
         }
+        updateWidth();
     });
 }
 
@@ -432,6 +435,24 @@ void OptionsDialog::updatePrivateSendVisibility()
     bool fEnabled = false;
 #endif
     ui->btnPrivateSend->setVisible(fEnabled);
+}
+
+void OptionsDialog::updateWidth()
+{
+    int nWidthWidestButton{0};
+    int nButtonsVisible{0};
+    for (QAbstractButton* button : pageButtons.buttons()) {
+        if (!button->isVisible()) {
+            continue;
+        }
+        QFontMetrics fm(button->font());
+        nWidthWidestButton = std::max<int>(nWidthWidestButton, fm.width(button->text()));
+        ++nButtonsVisible;
+    }
+    // Add 10 per button as padding and use minimum 585 which is what we used in css before
+    int nWidth = std::max<int>(585, (nWidthWidestButton + 10) * nButtonsVisible);
+    setMinimumWidth(nWidth);
+    setMaximumWidth(nWidth);
 }
 
 ProxyAddressValidator::ProxyAddressValidator(QObject *parent) :

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -457,6 +457,10 @@ void OptionsDialog::updateWidth()
     int nWidth = std::max<int>(585, (nWidthWidestButton + 10) * nButtonsVisible);
     setMinimumWidth(nWidth);
     setMaximumWidth(nWidth);
+    // Reset the max width after it has been set to still allow window resizing
+    QTimer::singleShot(0, this, [=]() {
+        setMaximumWidth(std::numeric_limits<int>::max());
+    });
 }
 
 void OptionsDialog::showEvent(QShowEvent* event)

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -28,6 +28,7 @@
 #include <QLocale>
 #include <QMessageBox>
 #include <QSettings>
+#include <QShowEvent>
 #include <QTimer>
 
 OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
@@ -172,8 +173,6 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
         }
     });
 #endif
-
-    updateWidth();
 }
 
 OptionsDialog::~OptionsDialog()
@@ -457,6 +456,13 @@ void OptionsDialog::updateWidth()
     int nWidth = std::max<int>(585, (nWidthWidestButton + 10) * nButtonsVisible);
     setMinimumWidth(nWidth);
     setMaximumWidth(nWidth);
+}
+
+void OptionsDialog::showEvent(QShowEvent* event)
+{
+    if (!event->spontaneous()) {
+        updateWidth();
+    }
 }
 
 ProxyAddressValidator::ProxyAddressValidator(QObject *parent) :

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -456,11 +456,7 @@ void OptionsDialog::updateWidth()
     // Add 10 per button as padding and use minimum 585 which is what we used in css before
     int nWidth = std::max<int>(585, (nWidthWidestButton + 10) * nButtonsVisible);
     setMinimumWidth(nWidth);
-    setMaximumWidth(nWidth);
-    // Reset the max width after it has been set to still allow window resizing
-    QTimer::singleShot(0, this, [=]() {
-        setMaximumWidth(std::numeric_limits<int>::max());
-    });
+    resize(nWidth, height());
 }
 
 void OptionsDialog::showEvent(QShowEvent* event)

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -64,6 +64,8 @@ private Q_SLOTS:
 
     void updatePrivateSendVisibility();
 
+    void updateWidth();
+
 Q_SIGNALS:
     void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
 

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -77,6 +77,8 @@ private:
     QString previousTheme;
     AppearanceWidget* appearance;
     bool fPrivateSendEnabledPrev{false};
+
+    void showEvent(QShowEvent* event);
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -67,6 +67,7 @@ private Q_SLOTS:
     void updateWidth();
 
 Q_SIGNALS:
+    void appearanceChanged();
     void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
 
 private:

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -78,7 +78,7 @@ private:
     AppearanceWidget* appearance;
     bool fPrivateSendEnabledPrev{false};
 
-    void showEvent(QShowEvent* event);
+    void showEvent(QShowEvent* event) override;
 };
 
 #endif // BITCOIN_QT_OPTIONSDIALOG_H

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -62,7 +62,7 @@ public:
         // Draw first line (with slightly bigger font than the second line will get)
         // Content: Date/Time, Optional IS indicator, Amount
         QFont font = fontInitial;
-        font.setPointSize(font.pointSize() * 1.17);
+        font.setPointSizeF(GUIUtil::getScaledFontSize(font.pointSizeF() * 1.17));
         painter->setFont(font);
         // Date/Time
         colorForeground = qvariant_cast<QColor>(indexDate.data(Qt::ForegroundRole));
@@ -83,6 +83,7 @@ public:
 
         // Draw second line (with the initial font)
         // Content: Address/label, Optional Watchonly indicator
+        fontInitial.setPointSizeF(GUIUtil::getScaledFontSize(fontInitial.pointSizeF()));
         painter->setFont(fontInitial);
         // Address/Label
         colorForeground = qvariant_cast<QColor>(indexAddress.data(Qt::ForegroundRole));

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -144,6 +144,8 @@ OverviewPage::OverviewPage(QWidget* parent) :
                       ui->labelSpendable
                      }, GUIUtil::FontWeight::Bold);
 
+    GUIUtil::updateFonts();
+
     // Recent transactions
     ui->listTransactions->setItemDelegate(txdelegate);
     // Note: minimum height of listTransactions will be set later in updateAdvancedPSUI() to reflect actual settings

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -31,6 +31,7 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) :
     GUIUtil::setFont({ui->label,
                       ui->label_2,
                       ui->label_3}, GUIUtil::FontWeight::Normal, 15);
+    GUIUtil::updateFonts();
 
     ui->reqLabel->setPlaceholderText(tr("Enter a label to associate with the new receiving address"));
     ui->reqMessage->setPlaceholderText(tr("Enter a message to attach to the payment request"));

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -194,7 +194,7 @@ void ReceiveRequestDialog::update()
             painter.fillRect(paddedRect, GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BACKGROUND_WIDGET));
             painter.drawImage(2, 2, qrImage.scaled(QR_IMAGE_SIZE - 4, QR_IMAGE_SIZE - 4));
             // calculate ideal font size
-            QFont font = GUIUtil::fixedPitchFont();
+            QFont font = GUIUtil::getFontNormal();
             qreal font_size = GUIUtil::calculateIdealFontSize((paddedRect.width() - 20), info.address, font);
             font.setPointSizeF(font_size);
             // paint the address

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1259,7 +1259,6 @@ OptionsDialog
 ******************************************************/
 
 QDialog#OptionsDialog {
-    min-width: 585px;
 }
 
 QDialog#OptionsDialog QValueComboBox,

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -850,7 +850,7 @@ void RPCConsole::clear(bool clearHistory)
     ui->lineEdit->setFocus();
 
     // Set default style sheet
-    QFontInfo fixedFontInfo(GUIUtil::fixedPitchFont());
+    QFontInfo fixedFontInfo(GUIUtil::getFontNormal());
     ui->messagesWidget->document()->setDefaultStyleSheet(
         QString(
                 "table { }"

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -858,7 +858,7 @@ void RPCConsole::clear(bool clearHistory)
                 "td.message { " + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_PRIMARY) + " font-family: %1; font-size: %2; white-space:pre-wrap; } "
                 "td.cmd-request, b { " + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_COMMAND) + " } "
                 "td.cmd-error, .secwarning { " + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + " }"
-            ).arg(fixedFontInfo.family(), QString("%1pt").arg(consoleFontSize)).arg(consoleFontSize * 0.1)
+            ).arg(fixedFontInfo.family(), QString("%1pt").arg(consoleFontSize))
         );
 
 #ifdef Q_OS_MAC

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -458,6 +458,8 @@ RPCConsole::RPCConsole(QWidget* parent) :
                       ui->banHeading
                      }, GUIUtil::FontWeight::Bold, 16);
 
+    GUIUtil::updateFonts();
+
     GUIUtil::disableMacFocusRect(this);
 
     QSettings settings;
@@ -974,6 +976,7 @@ void RPCConsole::showPage(int index)
 
     GUIUtil::setFont({btnActive}, GUIUtil::FontWeight::Bold, 16);
     GUIUtil::setFont(vecNormal, GUIUtil::FontWeight::Normal, 16);
+    GUIUtil::updateFonts();
 
     ui->stackedWidgetRPC->setCurrentIndex(index);
     btnActive->setChecked(true);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -86,6 +86,8 @@ SendCoinsDialog::SendCoinsDialog(bool _fPrivateSend, QWidget* parent) :
 
     addEntry();
 
+    GUIUtil::updateFonts();
+
     connect(ui->addButton, SIGNAL(clicked()), this, SLOT(addEntry()));
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -32,7 +32,7 @@ SendCoinsEntry::SendCoinsEntry(QWidget* parent) :
     // normal dash address field
     GUIUtil::setupAddressWidget(ui->payTo, this, true);
     // just a label for displaying dash address(es)
-    ui->payTo_is->setFont(GUIUtil::fixedPitchFont());
+    GUIUtil::setFixedPitchFont({ui->payToLabel_is});
 
     GUIUtil::setFont({ui->payToLabel,
                      ui->labellLabel,

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -31,8 +31,6 @@ SendCoinsEntry::SendCoinsEntry(QWidget* parent) :
 
     // normal dash address field
     GUIUtil::setupAddressWidget(ui->payTo, this, true);
-    // just a label for displaying dash address(es)
-    GUIUtil::setFixedPitchFont({ui->payToLabel_is});
 
     GUIUtil::setFont({ui->payToLabel,
                      ui->labellLabel,

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -53,9 +53,7 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget* parent) :
     ui->messageIn_VM->installEventFilter(this);
     ui->signatureIn_VM->installEventFilter(this);
 
-    GUIUtil::setFixedPitchFont({ui->signatureOut_SM, ui->signatureIn_VM});
-
-    GUIUtil::setFont({ui->signatureOut_SM}, GUIUtil::FontWeight::Normal, 11, true);
+    GUIUtil::setFont({ui->signatureOut_SM, ui->signatureIn_VM}, GUIUtil::FontWeight::Normal, 11, true);
     GUIUtil::setFont({ui->signatureLabel_SM}, GUIUtil::FontWeight::Bold, 16);
     GUIUtil::setFont({ui->statusLabel_SM, ui->statusLabel_VM}, GUIUtil::FontWeight::Bold);
 

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -110,6 +110,7 @@ void SignVerifyMessageDialog::showPage(int index)
 
     GUIUtil::setFont({btnActive}, GUIUtil::FontWeight::Bold, 16);
     GUIUtil::setFont(vecNormal, GUIUtil::FontWeight::Normal, 16);
+    GUIUtil::updateFonts();
 
     ui->stackedWidgetSig->setCurrentIndex(index);
     btnActive->setChecked(true);

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -159,16 +159,24 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     }
 
     // Draw statistic rect on top of everything else
-    const int nScale = GUIUtil::getFontScale() / 2;
-    const int nMarginStats = 20;
     const int nPadding = 5;
-    const int nWidthStats = 160 + nScale * 3 - 2 * nPadding;
-    const int nHeightStats = 110 + nScale - 2 * nPadding;
-    const int nSizeMark = nWidthStats * 0.15;
-    const int nWidthText = nWidthStats * 0.45;
-    const int nWidthBytes = nWidthStats * 0.4;
-    const int nHeightTotals = nHeightStats * 0.3;
-    const int nHeightInOut = nHeightStats * 0.35;
+    const int nMarginStats = 20;
+    const QString strTotal = tr("Total");
+    const QString strReceived = tr("Received");
+    const QString strSent = tr("Sent");
+    // Get a bold font for the title and a normal one for the rest
+    QFont fontTotal = GUIUtil::getFont(GUIUtil::FontWeight::Bold, false, 16);
+    QFont fontInOut = GUIUtil::getFont(GUIUtil::FontWeight::Normal, false, 12);
+    // Use font metrics to determine minimum rect sizes depending on the font scale
+    QFontMetrics fmTotal(fontTotal);
+    QFontMetrics fmInOut(fontInOut);
+    const int nSizeMark = fmInOut.height() + 2 * nPadding;
+    const int nWidthText = fmInOut.width(strReceived) + 2 * nPadding;
+    const int nWidthBytes = fmInOut.width("1000 GB") + 2 * nPadding;
+    const int nHeightTotals = fmTotal.height() + 2 * nPadding;
+    const int nHeightInOut = fmInOut.height() + 2 * nPadding;
+    const int nWidthStats = nSizeMark + nWidthText + nWidthBytes + 2 * nPadding;
+    const int nHeightStats = nHeightTotals + 2 * nHeightInOut + 2 * nPadding;
     auto addPadding = [&](QRect& rect, int nPadding) {
         rect.adjust(nPadding, nPadding, -nPadding, -nPadding);
     };
@@ -177,26 +185,23 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     QRect rectContent = rectOuter;
     QRect rectContentPadded = rectContent;
     addPadding(rectContentPadded, nPadding);
-    QRect rectTotals(rectContentPadded.topLeft(), QSize(nWidthStats, nHeightTotals));
-    QRect rectIn(rectTotals.bottomLeft(), QSize(nWidthStats, nHeightInOut));
-    QRect rectOut(rectIn.bottomLeft(), QSize(nWidthStats, nHeightInOut));
+    QRect rectTotals(rectContentPadded.topLeft(), QSize(rectContentPadded.width(), nHeightTotals));
+    QRect rectIn(rectTotals.bottomLeft(), QSize(rectContentPadded.width(), nHeightInOut));
+    QRect rectOut(rectIn.bottomLeft(), QSize(rectContentPadded.width(), nHeightInOut));
     // Create subrects for received
     QRect rectInMark(rectIn.topLeft(), QSize(nSizeMark, nSizeMark));
     QRect rectInText(rectInMark.topRight(), QSize(nWidthText, nHeightInOut));
-    QRect rectInBytes(rectInText.topRight(), QSize(nWidthBytes - nPadding, nHeightInOut));
+    QRect rectInBytes(rectInText.topRight(), QSize(nWidthBytes, nHeightInOut));
     // Create subrects for sent
     QRect rectOutMark(rectOut.topLeft(), QSize(nSizeMark, nSizeMark));
     QRect rectOutText(rectOutMark.topRight(), QSize(nWidthText, nHeightInOut));
-    QRect rectOutBytes(rectOutText.topRight(), QSize(nWidthBytes - nPadding, nHeightInOut));
-    // Get a bold font for the title and a normal one for the rest
-    QFont fontTotal = GUIUtil::getFont(GUIUtil::FontWeight::Bold, false, 16);
-    QFont fontInOut = GUIUtil::getFont(GUIUtil::FontWeight::Normal, false, 12);
+    QRect rectOutBytes(rectOutText.topRight(), QSize(nWidthBytes, nHeightInOut));
     // Add padding where required
     addPadding(rectTotals, nPadding);
-    addPadding(rectInMark, nPadding);
+    addPadding(rectInMark, 1.6 * nPadding);
     addPadding(rectInText, nPadding);
     addPadding(rectInBytes, nPadding);
-    addPadding(rectOutMark, nPadding);
+    addPadding(rectOutMark, 1.6 * nPadding);
     addPadding(rectOutText, nPadding);
     addPadding(rectOutBytes, nPadding);
     // Finally draw it all
@@ -205,11 +210,11 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     painter.fillRect(rectContent, GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BACKGROUND_NETSTATS));
     painter.setPen(axisCol);
     painter.setFont(fontTotal);
-    painter.drawText(rectTotals, Qt::AlignLeft, tr("Totals"));
+    painter.drawText(rectTotals, Qt::AlignLeft, strTotal);
     painter.setFont(fontInOut);
-    painter.drawText(rectInText, Qt::AlignLeft, tr("Received"));
+    painter.drawText(rectInText, Qt::AlignLeft, strReceived);
     painter.drawText(rectInBytes, Qt::AlignRight, GUIUtil::formatBytes(trafficGraphData.getLastBytesIn()));
-    painter.drawText(rectOutText, Qt::AlignLeft, tr("Sent"));
+    painter.drawText(rectOutText, Qt::AlignLeft, strSent);
     painter.drawText(rectOutBytes, Qt::AlignRight, GUIUtil::formatBytes(trafficGraphData.getLastBytesOut()));
     painter.setPen(green);
     painter.setBrush(green);

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -218,6 +218,8 @@ ShutdownWindow::ShutdownWindow(QWidget *parent, Qt::WindowFlags f):
         tr("%1 is shutting down...").arg(tr(PACKAGE_NAME)) + "<br /><br />" +
         tr("Do not shut down the computer until this window disappears.")));
     setLayout(layout);
+
+    GUIUtil::updateFonts();
 }
 
 QWidget *ShutdownWindow::showShutdownWindow(BitcoinGUI *window)

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -62,6 +62,7 @@ WalletView::WalletView(QWidget* parent) :
     GUIUtil::setFont({transactionSumLabel,
                       transactionSum,
                      }, GUIUtil::FontWeight::Bold, 14);
+    GUIUtil::updateFonts();
 
     hbox_buttons->addWidget(transactionSum);
 


### PR DESCRIPTION
This PR should fix all remaining places where the font scale wasn't applied yet (besides the splashscreen which probably also should follow anytime later). It also in general improves the font-scaling process and from now on it only updates fonts where really required. See commit messages. 

@thephez This should fix all the issues you pointed out in slack
@PastaPastaPasta 64ce1b5 might fix the one you sent me. At least it makes it better here on mac where i had it similar like you with a low font scale though.  
@strophy 82c1612 could be a fix for your "I can't get the same menu size like in other applications" thing