### PR TITLE
qt: Fix Recent transactions list height

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -26,8 +26,8 @@
 
 #define ITEM_HEIGHT 54
 #define NUM_ITEMS_DISABLED 5
-#define NUM_ITEMS_ENABLED_NORMAL 7
-#define NUM_ITEMS_ENABLED_ADVANCED 9
+#define NUM_ITEMS_ENABLED_NORMAL 6
+#define NUM_ITEMS_ENABLED_ADVANCED 8
 
 class TxViewDelegate : public QAbstractItemDelegate
 {

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -695,6 +695,7 @@ void OverviewPage::SetupTransactionList(int nNumItems)
     }
 
     filter->setLimit(nNumItems);
+    ui->listTransactions->setMinimumHeight(nNumItems * ITEM_HEIGHT);
 }
 
 void OverviewPage::DisablePrivateSendCompletely() {


### PR DESCRIPTION
This partially reverts https://github.com/dashpay/dash/pull/3715/commits/a3604f5c7c85689f816c063066ff48fe3e89f93c I suggested in #3715. Turns out that we still need `setMinimumHeight` at least on Windows (not sure why but tx list looks clipped there atm while it looks just fine on mac).