### PR TITLE
Always harden osx binaries when creating detached sigs

### DIFF
--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -23,7 +23,7 @@ fi
 rm -rf ${TEMPDIR} ${TEMPLIST}
 mkdir -p ${TEMPDIR}
 
-${CODESIGN} -f --file-list ${TEMPLIST} "$@" "${BUNDLE}"
+${CODESIGN} -f --file-list ${TEMPLIST} -o runtime "$@" "${BUNDLE}"
 
 grep -v CodeResources < "${TEMPLIST}" | while read i; do
   TARGETFILE="${BUNDLE}/`echo "${i}" | sed "s|.*${BUNDLE}/||"`"


### PR DESCRIPTION
This is required for macos app notarization https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution