### PR TITLE
qt: Make sure there is a valid theme set in the options

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1123,6 +1123,11 @@ const QString getDefaultTheme()
     return defaultTheme;
 }
 
+const bool isValidTheme(const QString& strTheme)
+{
+    return strTheme == defaultTheme || strTheme == darkThemePrefix || strTheme == traditionalTheme;
+}
+
 void loadStyleSheet(QWidget* widget, bool fForceUpdate)
 {
     AssertLockNotHeld(cs_css);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -270,6 +270,9 @@ namespace GUIUtil
     /** Return the name of the default theme `*/
     const QString getDefaultTheme();
 
+    /** Check if the given theme name is valid or not */
+    const bool isValidTheme(const QString& strTheme);
+
     /** Updates the widgets stylesheet and adds it to the list of ui debug elements.
     Beeing on that list means the stylesheet of the widget gets updated if the
     related css files has been changed if -debug-ui mode is active. */

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -701,4 +701,10 @@ void OptionsModel::checkAndMigrate()
     if (settings.contains("addrSeparateProxyTor") && settings.value("addrSeparateProxyTor").toString().endsWith("%2")) {
         settings.setValue("addrSeparateProxyTor", GetDefaultProxyAddress());
     }
+
+    // Make sure there is a valid theme set in the options.
+    QString strActiveTheme = settings.value("theme", GUIUtil::getDefaultTheme()).toString();
+    if (!GUIUtil::isValidTheme(strActiveTheme)) {
+        settings.setValue("theme", GUIUtil::getDefaultTheme());
+    }
 }


### PR DESCRIPTION
Dash-Qt versions `0.12` up to `0.14` may fail to start when upgrading to `0.16.0.1` due to potential invalid names set in the `theme` option. This PR makes sure the `theme` option will become overwritten with a valid theme in that case.