### PR TITLE
qt: Fix --disable-wallet build and --disablewallet mode

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1193,7 +1193,7 @@ void BitcoinGUI::updatePrivateSendVisibility()
 
 void BitcoinGUI::updateWidth()
 {
-    if (!walletFrame) return;
+    if (walletFrame == nullptr) return;
     if (windowState() & (Qt::WindowMaximized | Qt::WindowFullScreen)) {
         return;
     }
@@ -1216,7 +1216,7 @@ void BitcoinGUI::updateWidth()
 
 void BitcoinGUI::updateToolBarShortcuts()
 {
-    if (!walletFrame) return;
+    if (walletFrame == nullptr) return;
 #ifdef Q_OS_MAC
     auto modifier = Qt::CTRL;
 #else

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -147,7 +147,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     setWindowIcon(networkStyle->getTrayAndWindowIcon());
     setWindowTitle(windowTitle);
 
-    rpcConsole = new RPCConsole(node, 0);
+    rpcConsole = new RPCConsole(node, nullptr);
     helpMessageDialog = new HelpMessageDialog(node, this, HelpMessageDialog::cmdline);
 #ifdef ENABLE_WALLET
     if(enableWallet)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -147,14 +147,13 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     setWindowIcon(networkStyle->getTrayAndWindowIcon());
     setWindowTitle(windowTitle);
 
-    rpcConsole = new RPCConsole(node, nullptr);
+    rpcConsole = new RPCConsole(node, this, enableWallet ? Qt::Window : Qt::Widget);
     helpMessageDialog = new HelpMessageDialog(node, this, HelpMessageDialog::cmdline);
 #ifdef ENABLE_WALLET
     if(enableWallet)
     {
         /** Create wallet frame*/
         walletFrame = new WalletFrame(this);
-        GUIUtil::loadStyleSheet(rpcConsole);
     } else
 #endif // ENABLE_WALLET
     {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -154,6 +154,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     {
         /** Create wallet frame*/
         walletFrame = new WalletFrame(this);
+        GUIUtil::loadStyleSheet(rpcConsole);
     } else
 #endif // ENABLE_WALLET
     {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -147,7 +147,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     setWindowIcon(networkStyle->getTrayAndWindowIcon());
     setWindowTitle(windowTitle);
 
-    rpcConsole = new RPCConsole(node, this);
+    rpcConsole = new RPCConsole(node, 0);
     helpMessageDialog = new HelpMessageDialog(node, this, HelpMessageDialog::cmdline);
 #ifdef ENABLE_WALLET
     if(enableWallet)
@@ -431,6 +431,7 @@ void BitcoinGUI::createActions()
         connect(masternodeAction, SIGNAL(clicked()), this, SLOT(showNormalIfMinimized()));
         connect(masternodeAction, SIGNAL(clicked()), this, SLOT(gotoMasternodePage()));
     }
+#endif // ENABLE_WALLET
 
     // These showNormalIfMinimized are needed because Send Coins and Receive Coins
     // can be triggered from the tray menu, and need to show the GUI to be useful.
@@ -453,12 +454,15 @@ void BitcoinGUI::createActions()
 
     for (auto button : tabGroup->buttons()) {
         GUIUtil::setFont({button}, GUIUtil::FontWeight::Normal, 16);
+        if (walletFrame == nullptr) {
+            // hide buttons when there is no wallet
+            button->setVisible(false);
+        }
     }
     GUIUtil::updateFonts();
 
     // Give the selected tab button a bolder font.
     connect(tabGroup, SIGNAL(buttonToggled(QAbstractButton *, bool)), this, SLOT(highlightTabButton(QAbstractButton *, bool)));
-#endif // ENABLE_WALLET
 
     quitAction = new QAction(tr("E&xit"), this);
     quitAction->setStatusTip(tr("Quit application"));
@@ -1177,7 +1181,9 @@ void BitcoinGUI::updatePrivateSendVisibility()
 #endif
     // PrivateSend button is the third QToolButton, show/hide the underlying QAction
     // Hiding the QToolButton itself doesn't work.
-    appToolBar->actions()[2]->setVisible(fEnabled);
+    if (appToolBar != nullptr) {
+        appToolBar->actions()[2]->setVisible(fEnabled);
+    }
     privateSendCoinsMenuAction->setVisible(fEnabled);
     showPrivateSendHelpAction->setVisible(fEnabled);
     updateToolBarShortcuts();
@@ -1186,6 +1192,7 @@ void BitcoinGUI::updatePrivateSendVisibility()
 
 void BitcoinGUI::updateWidth()
 {
+    if (!walletFrame) return;
     if (windowState() & (Qt::WindowMaximized | Qt::WindowFullScreen)) {
         return;
     }
@@ -1208,6 +1215,7 @@ void BitcoinGUI::updateWidth()
 
 void BitcoinGUI::updateToolBarShortcuts()
 {
+    if (!walletFrame) return;
 #ifdef Q_OS_MAC
     auto modifier = Qt::CTRL;
 #else

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1192,7 +1192,9 @@ void BitcoinGUI::updatePrivateSendVisibility()
 
 void BitcoinGUI::updateWidth()
 {
-    if (walletFrame == nullptr) return;
+    if (walletFrame == nullptr) {
+        return;
+    }
     if (windowState() & (Qt::WindowMaximized | Qt::WindowFullScreen)) {
         return;
     }
@@ -1215,7 +1217,9 @@ void BitcoinGUI::updateWidth()
 
 void BitcoinGUI::updateToolBarShortcuts()
 {
-    if (walletFrame == nullptr) return;
+    if (walletFrame == nullptr) {
+        return;
+    }
 #ifdef Q_OS_MAC
     auto modifier = Qt::CTRL;
 #else

--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -41,12 +41,10 @@ Loaded in GUIUtil::loadStyleSheet() in guitil.cpp.
 Common stuff
 ******************************************************/
 
-WalletFrame,
-QDialog {
-    background-color: #323233;
-}
-
-QMessageBox {
+QDialog,
+QMainWindow,
+QMessageBox
+WalletFrame {
     background-color: #323233;
 }
 

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -39,12 +39,10 @@ Loaded in GUIUtil::loadStyleSheet() in guitil.cpp.
 Common stuff
 ******************************************************/
 
-WalletFrame,
-QDialog {
-    background-color: #f2f2f4;
-}
-
-QMessageBox {
+QDialog,
+QMainWindow,
+QMessageBox
+WalletFrame {
     background-color: #f2f2f4;
 }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -466,9 +466,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent) :
                       ui->banHeading
                      }, GUIUtil::FontWeight::Bold, 16);
 
-    GUIUtil::updateFonts();
-
-    GUIUtil::disableMacFocusRect(this);
+    GUIUtil::loadTheme(this, false);
 
     QSettings settings;
     if (!restoreGeometry(settings.value("RPCConsoleWindowGeometry").toByteArray())) {
@@ -531,6 +529,8 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent) :
     pageButtons.addButton(ui->btnPeers, pageButtons.buttons().size());
     pageButtons.addButton(ui->btnRepair, pageButtons.buttons().size());
     connect(&pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
+
+    showPage(TAB_INFO);
 
     clear();
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -445,8 +445,8 @@ void RPCExecutor::request(const QString &command, const QString &walletID)
     }
 }
 
-RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent) :
-    QWidget(parent, Qt::Window),
+RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent, Qt::WindowFlags flags) :
+    QWidget(parent, flags),
     m_node(node),
     ui(new Ui::RPCConsole),
     clientModel(0),

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -466,7 +466,9 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent) :
                       ui->banHeading
                      }, GUIUtil::FontWeight::Bold, 16);
 
-    GUIUtil::loadTheme(this, false);
+    GUIUtil::updateFonts();
+
+    GUIUtil::disableMacFocusRect(this);
 
     QSettings settings;
     if (!restoreGeometry(settings.value("RPCConsoleWindowGeometry").toByteArray())) {

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -39,7 +39,7 @@ class RPCConsole: public QWidget
     Q_OBJECT
 
 public:
-    explicit RPCConsole(interfaces::Node& node, QWidget* parent);
+    explicit RPCConsole(interfaces::Node& node, QWidget* parent, Qt::WindowFlags flags);
     ~RPCConsole();
 
     static bool RPCParseCommandLine(interfaces::Node* node, std::string &strResult, const std::string &strCommand, bool fExecute, std::string * const pstrFilteredOut = nullptr, const std::string *walletID = nullptr);

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -200,7 +200,9 @@ void SplashScreen::unsubscribeFromCoreSignals()
     // Disconnect signals from client
     m_handler_init_message->disconnect();
     m_handler_show_progress->disconnect();
+#ifdef ENABLE_WALLET
     m_handler_load_wallet->disconnect();
+#endif // ENABLE_WALLET
     for (auto& handler : m_connected_wallet_handlers) {
         handler->disconnect();
     }


### PR DESCRIPTION
Console is not showing up in `--disable-wallet` build and dash-qt is crashing in `--disablewallet` mode currently. This PR should fix both issues.