### PR TITLE
qt: add shortcuts for tabs in more dialogs

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1154,10 +1154,10 @@ void BitcoinGUI::updatePrivateSendVisibility()
     if (appToolBar != nullptr) {
         appToolBar->actions()[2]->setVisible(fEnabled);
         privateSendCoinsButton->setVisible(fEnabled);
+        GUIUtil::updateButtonGroupShortcuts(tabGroup);
     }
     privateSendCoinsMenuAction->setVisible(fEnabled);
     showPrivateSendHelpAction->setVisible(fEnabled);
-    updateToolBarShortcuts();
     updateWidth();
 }
 
@@ -1184,26 +1184,6 @@ void BitcoinGUI::updateWidth()
     int nWidth = std::max<int>(980, (nWidthWidestButton + 30) * (nButtonsVisible + 1));
     setMinimumWidth(nWidth);
     resize(nWidth, height());
-}
-
-void BitcoinGUI::updateToolBarShortcuts()
-{
-    if (walletFrame == nullptr) {
-        return;
-    }
-#ifdef Q_OS_MAC
-    auto modifier = Qt::CTRL;
-#else
-    auto modifier = Qt::ALT;
-#endif
-    int nKey = 0;
-    for (auto button : tabGroup->buttons()) {
-        if (button->isVisible()) {
-            button->setShortcut(QKeySequence(modifier + Qt::Key_1 + nKey++));
-        } else {
-            button->setShortcut(QKeySequence());
-        }
-    }
 }
 
 void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QString& blockHash, double nVerificationProgress, bool header)

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -209,8 +209,6 @@ private:
 
     void updateProgressBarVisibility();
 
-    void updateToolBarShortcuts();
-
 Q_SIGNALS:
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString &uri);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -44,6 +44,7 @@ class Node;
 
 QT_BEGIN_NAMESPACE
 class QAction;
+class QButtonGroup;
 class QComboBox;
 class QProgressBar;
 class QProgressDialog;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -45,6 +45,7 @@
 #include <QAbstractButton>
 #include <QAbstractItemView>
 #include <QApplication>
+#include <QButtonGroup>
 #include <QClipboard>
 #include <QDateTime>
 #include <QDebug>
@@ -1788,6 +1789,26 @@ void updateMacFocusRects()
         }
     }
 #endif
+}
+
+void updateButtonGroupShortcuts(QButtonGroup* buttonGroup)
+{
+    if (buttonGroup == nullptr) {
+        return;
+    }
+#ifdef Q_OS_MAC
+    auto modifier = Qt::CTRL;
+#else
+    auto modifier = Qt::ALT;
+#endif
+    int nKey = 0;
+    for (auto button : buttonGroup->buttons()) {
+        if (button->isVisible()) {
+            button->setShortcut(QKeySequence(modifier + Qt::Key_1 + nKey++));
+        } else {
+            button->setShortcut(QKeySequence());
+        }
+    }
 }
 
 void setClipboard(const QString& str)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -31,6 +31,7 @@ class Node;
 QT_BEGIN_NAMESPACE
 class QAbstractButton;
 class QAbstractItemView;
+class QButtonGroup;
 class QDateTime;
 class QFont;
 class QLineEdit;
@@ -374,6 +375,9 @@ namespace GUIUtil
 
     /** Enable/Disable the macOS focus rects depending on the current theme. */
     void updateMacFocusRects();
+
+    /** Update shortcuts for individual buttons in QButtonGroup based on their visibility. */
+    void updateButtonGroupShortcuts(QButtonGroup* buttonGroup);
 
     /* Convert QString to OS specific boost path through UTF-8 */
     fs::path qstringToBoostPath(const QString &path);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -20,6 +20,7 @@
 #include <netbase.h>
 #include <txdb.h> // for -dbcache defaults
 
+#include <QButtonGroup>
 #include <QDataWidgetMapper>
 #include <QDir>
 #include <QIntValidator>
@@ -33,7 +34,8 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     QDialog(parent),
     ui(new Ui::OptionsDialog),
     model(0),
-    mapper(0)
+    mapper(0),
+    pageButtons(0)
 {
     ui->setupUi(this);
 
@@ -77,7 +79,8 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     connect(ui->connectSocksTor, SIGNAL(toggled(bool)), ui->proxyPortTor, SLOT(setEnabled(bool)));
     connect(ui->connectSocksTor, SIGNAL(toggled(bool)), this, SLOT(updateProxyValidationState()));
 
-    pageButtons.addButton(ui->btnMain, pageButtons.buttons().size());
+    pageButtons = new QButtonGroup(this);
+    pageButtons->addButton(ui->btnMain, pageButtons->buttons().size());
     /* Remove Wallet/PrivateSend tabs in case of -disablewallet */
     if (!enableWallet) {
         ui->stackedWidgetOptions->removeWidget(ui->pageWallet);
@@ -85,14 +88,14 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
         ui->stackedWidgetOptions->removeWidget(ui->pagePrivateSend);
         ui->btnPrivateSend->hide();
     } else {
-        pageButtons.addButton(ui->btnWallet, pageButtons.buttons().size());
-        pageButtons.addButton(ui->btnPrivateSend, pageButtons.buttons().size());
+        pageButtons->addButton(ui->btnWallet, pageButtons->buttons().size());
+        pageButtons->addButton(ui->btnPrivateSend, pageButtons->buttons().size());
     }
-    pageButtons.addButton(ui->btnNetwork, pageButtons.buttons().size());
-    pageButtons.addButton(ui->btnDisplay, pageButtons.buttons().size());
-    pageButtons.addButton(ui->btnAppearance, pageButtons.buttons().size());
+    pageButtons->addButton(ui->btnNetwork, pageButtons->buttons().size());
+    pageButtons->addButton(ui->btnDisplay, pageButtons->buttons().size());
+    pageButtons->addButton(ui->btnAppearance, pageButtons->buttons().size());
 
-    connect(&pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
+    connect(pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
 
     showPage(0);
 
@@ -164,6 +167,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
 
 OptionsDialog::~OptionsDialog()
 {
+    delete pageButtons;
     delete ui;
 }
 
@@ -294,8 +298,8 @@ void OptionsDialog::setMapper()
 void OptionsDialog::showPage(int index)
 {
     std::vector<QWidget*> vecNormal;
-    QAbstractButton* btnActive = pageButtons.button(index);
-    for (QAbstractButton* button : pageButtons.buttons()) {
+    QAbstractButton* btnActive = pageButtons->button(index);
+    for (QAbstractButton* button : pageButtons->buttons()) {
         if (button != btnActive) {
             vecNormal.push_back(button);
         }
@@ -443,7 +447,7 @@ void OptionsDialog::updateWidth()
 {
     int nWidthWidestButton{0};
     int nButtonsVisible{0};
-    for (QAbstractButton* button : pageButtons.buttons()) {
+    for (QAbstractButton* button : pageButtons->buttons()) {
         if (!button->isVisible()) {
             continue;
         }

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -441,6 +441,7 @@ void OptionsDialog::updatePrivateSendVisibility()
     bool fEnabled = false;
 #endif
     ui->btnPrivateSend->setVisible(fEnabled);
+    GUIUtil::updateButtonGroupShortcuts(pageButtons);
 }
 
 void OptionsDialog::updateWidth()
@@ -465,6 +466,7 @@ void OptionsDialog::showEvent(QShowEvent* event)
 {
     if (!event->spontaneous()) {
         updateWidth();
+        GUIUtil::updateButtonGroupShortcuts(pageButtons);
     }
     QDialog::showEvent(event);
 }

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_QT_OPTIONSDIALOG_H
 #define BITCOIN_QT_OPTIONSDIALOG_H
 
-#include <QButtonGroup>
 #include <QDialog>
 #include <QValidator>
 
@@ -14,6 +13,7 @@ class OptionsModel;
 class QValidatedLineEdit;
 
 QT_BEGIN_NAMESPACE
+class QButtonGroup;
 class QDataWidgetMapper;
 QT_END_NAMESPACE
 
@@ -74,7 +74,7 @@ private:
     Ui::OptionsDialog *ui;
     OptionsModel *model;
     QDataWidgetMapper *mapper;
-    QButtonGroup pageButtons;
+    QButtonGroup* pageButtons;
     QString previousTheme;
     AppearanceWidget* appearance;
     bool fPrivateSendEnabledPrev{false};

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -28,6 +28,7 @@
 #include <db_cxx.h>
 #endif
 
+#include <QButtonGroup>
 #include <QDir>
 #include <QDesktopWidget>
 #include <QKeyEvent>
@@ -453,7 +454,8 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent, Qt::WindowFlags 
     historyPtr(0),
     peersTableContextMenu(0),
     banTableContextMenu(0),
-    consoleFontSize(0)
+    consoleFontSize(0),
+    pageButtons(0)
 {
     ui->setupUi(this);
 
@@ -525,12 +527,13 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent, Qt::WindowFlags 
 
     consoleFontSize = settings.value(fontSizeSettingsKey, QFontInfo(GUIUtil::getFontNormal()).pointSize()).toInt();
 
-    pageButtons.addButton(ui->btnInfo, pageButtons.buttons().size());
-    pageButtons.addButton(ui->btnConsole, pageButtons.buttons().size());
-    pageButtons.addButton(ui->btnNetTraffic, pageButtons.buttons().size());
-    pageButtons.addButton(ui->btnPeers, pageButtons.buttons().size());
-    pageButtons.addButton(ui->btnRepair, pageButtons.buttons().size());
-    connect(&pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
+    pageButtons = new QButtonGroup(this);
+    pageButtons->addButton(ui->btnInfo, pageButtons->buttons().size());
+    pageButtons->addButton(ui->btnConsole, pageButtons->buttons().size());
+    pageButtons->addButton(ui->btnNetTraffic, pageButtons->buttons().size());
+    pageButtons->addButton(ui->btnPeers, pageButtons->buttons().size());
+    pageButtons->addButton(ui->btnRepair, pageButtons->buttons().size());
+    connect(pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
 
     showPage(TAB_INFO);
 
@@ -543,6 +546,7 @@ RPCConsole::~RPCConsole()
     settings.setValue("RPCConsoleWindowGeometry", saveGeometry());
     m_node.rpcUnsetTimerInterface(rpcTimerInterface);
     delete rpcTimerInterface;
+    delete pageButtons;
     delete ui;
 }
 
@@ -978,8 +982,8 @@ void RPCConsole::setInstantSendLockCount(size_t count)
 void RPCConsole::showPage(int index)
 {
     std::vector<QWidget*> vecNormal;
-    QAbstractButton* btnActive = pageButtons.button(index);
-    for (QAbstractButton* button : pageButtons.buttons()) {
+    QAbstractButton* btnActive = pageButtons->button(index);
+    for (QAbstractButton* button : pageButtons->buttons()) {
         if (button != btnActive) {
             vecNormal.push_back(button);
         }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1271,6 +1271,8 @@ void RPCConsole::showEvent(QShowEvent *event)
 {
     QWidget::showEvent(event);
 
+    GUIUtil::updateButtonGroupShortcuts(pageButtons);
+
     if (!clientModel || !clientModel->getPeerTableModel())
         return;
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -11,7 +11,6 @@
 
 #include <net.h>
 
-#include <QButtonGroup>
 #include <QWidget>
 #include <QCompleter>
 #include <QThread>
@@ -29,6 +28,7 @@ namespace Ui {
 }
 
 QT_BEGIN_NAMESPACE
+class QButtonGroup;
 class QMenu;
 class QItemSelection;
 QT_END_NAMESPACE
@@ -168,7 +168,7 @@ private:
 
     interfaces::Node& m_node;
     Ui::RPCConsole *ui;
-    QButtonGroup pageButtons;
+    QButtonGroup* pageButtons;
     ClientModel *clientModel;
     QStringList history;
     int historyPtr;

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -302,3 +302,11 @@ bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
     }
     return QDialog::eventFilter(object, event);
 }
+
+void SignVerifyMessageDialog::showEvent(QShowEvent* event)
+{
+    if (!event->spontaneous()) {
+        GUIUtil::updateButtonGroupShortcuts(pageButtons);
+    }
+    QDialog::showEvent(event);
+}

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -18,18 +18,21 @@
 #include <string>
 #include <vector>
 
+#include <QButtonGroup>
 #include <QClipboard>
 
 SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget* parent) :
     QDialog(parent),
     ui(new Ui::SignVerifyMessageDialog),
-    model(0)
+    model(0),
+    pageButtons(0)
 {
     ui->setupUi(this);
 
-    pageButtons.addButton(ui->btnSignMessage, pageButtons.buttons().size());
-    pageButtons.addButton(ui->btnVerifyMessage, pageButtons.buttons().size());
-    connect(&pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
+    pageButtons = new QButtonGroup(this);
+    pageButtons->addButton(ui->btnSignMessage, pageButtons->buttons().size());
+    pageButtons->addButton(ui->btnVerifyMessage, pageButtons->buttons().size());
+    connect(pageButtons, SIGNAL(buttonClicked(int)), this, SLOT(showPage(int)));
 
     ui->messageIn_SM->setPlaceholderText(tr("Enter a message to be signed"));
     ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Message\" to generate signature"));
@@ -64,6 +67,7 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget* parent) :
 
 SignVerifyMessageDialog::~SignVerifyMessageDialog()
 {
+    delete pageButtons;
     delete ui;
 }
 
@@ -101,8 +105,8 @@ void SignVerifyMessageDialog::showTab_VM(bool fShow)
 void SignVerifyMessageDialog::showPage(int index)
 {
     std::vector<QWidget*> vecNormal;
-    QAbstractButton* btnActive = pageButtons.button(index);
-    for (QAbstractButton* button : pageButtons.buttons()) {
+    QAbstractButton* btnActive = pageButtons->button(index);
+    for (QAbstractButton* button : pageButtons->buttons()) {
         if (button != btnActive) {
             vecNormal.push_back(button);
         }

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -40,6 +40,8 @@ private:
     WalletModel *model;
     QButtonGroup* pageButtons;
 
+    void showEvent(QShowEvent* event) override;
+
 private Q_SLOTS:
     /** custom tab buttons clicked */
     void showPage(int index);

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -5,10 +5,13 @@
 #ifndef BITCOIN_QT_SIGNVERIFYMESSAGEDIALOG_H
 #define BITCOIN_QT_SIGNVERIFYMESSAGEDIALOG_H
 
-#include <QButtonGroup>
 #include <QDialog>
 
 class WalletModel;
+
+QT_BEGIN_NAMESPACE
+class QButtonGroup;
+QT_END_NAMESPACE
 
 namespace Ui {
     class SignVerifyMessageDialog;
@@ -35,7 +38,7 @@ protected:
 private:
     Ui::SignVerifyMessageDialog *ui;
     WalletModel *model;
-    QButtonGroup pageButtons;
+    QButtonGroup* pageButtons;
 
 private Q_SLOTS:
     /** custom tab buttons clicked */


### PR DESCRIPTION
This adds shortcuts for tabs in options, rpcconsole/debug window and sign/verify dialogs to unify UX.

~Based on #3763~