### PR TITLE
build: create mountpoint for named volume

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,28 @@
-FROM debian:stretch
+FROM phusion/baseimage:bionic-1.0.0
 LABEL maintainer="Dash Developers <dev@dash.org>"
 LABEL description="Dockerised DashCore, built from Travis"
 
-RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -fr /var/cache/apt/*
+ARG USER_ID
+ARG GROUP_ID
 
-COPY bin/* /usr/bin/
+ENV HOME /dash
+
+# add user with specified (or default) user/group ids
+ENV USER_ID ${USER_ID:-1000}
+ENV GROUP_ID ${GROUP_ID:-1000}
+RUN groupadd -g ${GROUP_ID} dash
+RUN useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /dash dash
+RUN mkdir /dash/.dashcore
+RUN chown dash:dash -R /dash
+
+COPY bin/* /usr/local/bin/
+
+RUN chmod a+x /usr/local/bin/*
+
+USER dash
+
+VOLUME ["/dash"]
+
+EXPOSE 9998 9999 19998 19999
+
+WORKDIR /dash


### PR DESCRIPTION
This PR is a backport of [PR](https://github.com/dashpay/docker-dashd/pull/33).
The problem is that to make [mn-bootstrap](https://github.com/dashevo/mn-bootstrap) work with dev docker image of dash core, we need to have the data directory, located at /~/.dashcore instead of /root/.dashcore. This PR should fix this.