### PR TITLE
Fix IS-locks sync via `mempool` p2p command

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4201,8 +4201,8 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                     CInv islockInv(MSG_ISLOCK, islockHash);
                     pto->filterInventoryKnown.insert(islockHash);
 
-                    LogPrint(BCLog::NET, "SendMessages -- queued inv: %s  index=%d peer=%d\n", inv.ToString(), vInv.size(), pto->GetId());
-                    vInv.push_back(inv);
+                    LogPrint(BCLog::NET, "SendMessages -- queued inv: %s  index=%d peer=%d\n", islockInv.ToString(), vInv.size(), pto->GetId());
+                    vInv.push_back(islockInv);
                     if (vInv.size() == MAX_INV_SZ) {
                         LogPrint(BCLog::NET, "SendMessages -- pushing inv's: count=%d peer=%d\n", vInv.size(), pto->GetId());
                         connman->PushMessage(pto, msgMaker.Make(NetMsgType::INV, vInv));


### PR DESCRIPTION
Should send `islockInv`, not `inv` here. Basically, instead of sending 1 tx inv and 1 IS-lock inv we send 2 tx invs currently...