### PR TITLE
qt: Handle fonts of deleted widgets properly, streamline the flow in `GUIUtil::updateFonts`

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1545,7 +1545,6 @@ void updateFonts()
     }
 
     static std::map<QPointer<QWidget>, int> mapWidgetDefaultFontSizes;
-    static std::map<QString, int> mapClassDefaultFontSizes;
 
     // QPointer becomes nullptr for objects that were deleted.
     // Remove them from mapDefaultFontSize and mapFontUpdates
@@ -1623,35 +1622,20 @@ void updateFonts()
         it.first->setFont(it.second);
     }
 
-    // Scale the global font for QToolTip labels, QMenu and QMessageBox instances
-    QFont fontToolTip = qApp->font("QTipLabel");
-    QFont fontMenu = qApp->font("QMenu");
-    QFont fontMessageBox = qApp->font("QMessageBox");
-    // Store their default font sizes before ever applying any scale to it
-    if (!mapClassDefaultFontSizes.count("QTipLabel")) {
-        mapClassDefaultFontSizes.emplace("QTipLabel", fontToolTip.pointSize());
-    }
-    if (!mapClassDefaultFontSizes.count("QMenu")) {
-        mapClassDefaultFontSizes.emplace("QMenu", fontMenu.pointSize());
-    }
-    if (!mapClassDefaultFontSizes.count("QMessageBox")) {
-        mapClassDefaultFontSizes.emplace("QMessageBox", fontMessageBox.pointSize());
-    }
-    // And give them the proper scaled size based on their default sizes if required
-    double dSize = getScaledFontSize(mapClassDefaultFontSizes["QTipLabel"]);
-    if (fontToolTip.pointSizeF() != dSize) {
-        fontToolTip.setPointSizeF(dSize);
-        qApp->setFont(fontToolTip, "QTipLabel");
-    }
-    dSize = getScaledFontSize(mapClassDefaultFontSizes["QMenu"]);
-    if (fontMenu.pointSizeF() != dSize) {
-        fontMenu.setPointSizeF(dSize);
-        qApp->setFont(fontMenu, "QMenu");
-    }
-    dSize = getScaledFontSize(getScaledFontSize(mapClassDefaultFontSizes["QMessageBox"]));
-    if (fontMessageBox.pointSizeF() != dSize) {
-        fontMessageBox.setPointSizeF(dSize);
-        qApp->setFont(fontMessageBox, "QMessageBox");
+    // Scale the global font size for the classes in the map below
+    static std::map<std::string, int> mapClassFontUpdates{
+        {"QTipLabel", -1}, {"QMenu", -1}, {"QMessageBox", -1}
+    };
+    for (auto& it : mapClassFontUpdates) {
+        QFont fontClass = qApp->font(it.first.c_str());
+        if (it.second == -1) {
+            it.second = fontClass.pointSize();
+        }
+        double dSize = getScaledFontSize(it.second);
+        if (fontClass.pointSizeF() != dSize) {
+            fontClass.setPointSizeF(dSize);
+            qApp->setFont(fontClass, it.first.c_str());
+        }
     }
 }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -134,7 +134,7 @@ static QFont::Weight fontWeightNormal = defaultFontWeightNormal;
 static QFont::Weight fontWeightBold = defaultFontWeightBold;
 
 // Contains all widgets and its font attributes (weight, italic, size) with font changes due to GUIUtil::setFont
-static std::map<QPointer<QWidget>, std::tuple<FontWeight, bool, int>> mapNormalFontUpdates;
+static std::map<QPointer<QWidget>, std::tuple<FontWeight, bool, int>> mapFontUpdates;
 // Contains a list of supported font weights for all members of GUIUtil::FontFamily
 static std::map<FontFamily, std::vector<QFont::Weight>> mapSupportedWeights;
 
@@ -1530,7 +1530,7 @@ void setFont(const std::vector<QWidget*>& vecWidgets, FontWeight weight, int nPo
 {
     for (auto it : vecWidgets) {
         auto fontAttributes = std::make_tuple(weight, fItalic, nPointSize);
-        auto itFontUpdate = mapNormalFontUpdates.emplace(std::make_pair(it, fontAttributes));
+        auto itFontUpdate = mapFontUpdates.emplace(std::make_pair(it, fontAttributes));
         if (!itFontUpdate.second) {
             itFontUpdate.first->second = fontAttributes;
         }
@@ -1548,7 +1548,7 @@ void updateFonts()
     static std::map<QString, int> mapClassDefaultFontSizes;
 
     // QPointer becomes nullptr for objects that were deleted.
-    // Remove them from mapDefaultFontSize and mapNormalFontUpdates
+    // Remove them from mapDefaultFontSize and mapFontUpdates
     // before proceeding any further.
     size_t nMapSize = mapWidgetDefaultFontSizes.size();
     auto itd = mapWidgetDefaultFontSizes.begin();
@@ -1564,18 +1564,18 @@ void updateFonts()
                  << "nullptr items from mapWidgetDefaultFontSizes";
     }
 
-    nMapSize = mapNormalFontUpdates.size();
-    auto itn = mapNormalFontUpdates.begin();
-    while (itn != mapNormalFontUpdates.end()) {
+    nMapSize = mapFontUpdates.size();
+    auto itn = mapFontUpdates.begin();
+    while (itn != mapFontUpdates.end()) {
         if (itn->first.isNull()) {
-            itn = mapNormalFontUpdates.erase(itn);
+            itn = mapFontUpdates.erase(itn);
         } else {
             ++itn;
         }
     }
-    if (nMapSize - mapNormalFontUpdates.size() > 0) {
-        qDebug() << __func__ << ": removed" << nMapSize - mapNormalFontUpdates.size()
-                 << "nullptr items from mapNormalFontUpdates";
+    if (nMapSize - mapFontUpdates.size() > 0) {
+        qDebug() << __func__ << ": removed" << nMapSize - mapFontUpdates.size()
+                 << "nullptr items from mapFontUpdates";
     }
 
     size_t nUpdatable{0}, nUpdated{0};
@@ -1602,8 +1602,8 @@ void updateFonts()
         int pointSizeStored = mapWidgetDefaultFontSizes.at(w);
         font.setPointSizeF(getScaledFontSize(pointSizeStored));
 
-        auto it = mapNormalFontUpdates.find(w);
-        if (it != mapNormalFontUpdates.end()) {
+        auto it = mapFontUpdates.find(w);
+        if (it != mapFontUpdates.end()) {
             int nSize = std::get<2>(it->second);
             if (nSize == -1) {
                 nSize = pointSizeStored;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1594,8 +1594,7 @@ void updateFonts()
         font.setStyle(qApp->font().style());
 
         // Insert/Get the default font size of the widget
-        int pointSize = font.pointSize() > 0 ? font.pointSize() : defaultFontSize;
-        auto itDefault = mapWidgetDefaultFontSizes.emplace(std::make_pair(w, pointSize));
+        auto itDefault = mapWidgetDefaultFontSizes.emplace(w, font.pointSize());
 
         auto it = mapFontUpdates.find(w);
         if (it != mapFontUpdates.end()) {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1550,6 +1550,7 @@ void updateFonts()
     // QPointer becomes nullptr for objects that were deleted.
     // Remove them from mapDefaultFontSize and mapNormalFontUpdates
     // before proceeding any further.
+    size_t nMapSize = mapWidgetDefaultFontSizes.size();
     auto itd = mapWidgetDefaultFontSizes.begin();
     while (itd != mapWidgetDefaultFontSizes.end()) {
         if (itd->first.isNull()) {
@@ -1558,7 +1559,12 @@ void updateFonts()
             ++itd;
         }
     }
+    if (nMapSize - mapWidgetDefaultFontSizes.size() > 0) {
+        qDebug() << __func__ << ": removed" << nMapSize - mapWidgetDefaultFontSizes.size()
+                 << "nullptr items from mapWidgetDefaultFontSizes";
+    }
 
+    nMapSize = mapNormalFontUpdates.size();
     auto itn = mapNormalFontUpdates.begin();
     while (itn != mapNormalFontUpdates.end()) {
         if (itn->first.isNull()) {
@@ -1567,7 +1573,12 @@ void updateFonts()
             ++itn;
         }
     }
+    if (nMapSize - mapNormalFontUpdates.size() > 0) {
+        qDebug() << __func__ << ": removed" << nMapSize - mapNormalFontUpdates.size()
+                 << "nullptr items from mapNormalFontUpdates";
+    }
 
+    size_t nUpdatable{0}, nUpdated{0};
     // Loop through all widgets
     for (QWidget* w : qApp->allWidgets()) {
         std::vector<QString> vecIgnore{
@@ -1578,6 +1589,7 @@ void updateFonts()
         if (std::find(vecIgnore.begin(), vecIgnore.end(), w->metaObject()->className()) != vecIgnore.end()) {
             continue;
         }
+        ++nUpdatable;
         QFont font = w->font();
         font.setFamily(qApp->font().family());
         font.setWeight(getFontWeightNormal());
@@ -1599,11 +1611,15 @@ void updateFonts()
             QFont&& fontUpd = getFont(std::get<0>(it->second), std::get<1>(it->second), nSize);
             if (w->font() != fontUpd) {
                 w->setFont(fontUpd);
+                ++nUpdated;
             }
         } else if (w->font() != font) {
             w->setFont(font);
+            ++nUpdated;
         }
     }
+    qDebug() << __func__ << ": updated:" << nUpdated << "/" << nUpdatable
+             << ": total:" << qApp->allWidgets().size();
 
     // Scale the global font for QToolTip labels, QMenu and QMessageBox instances
     QFont fontToolTip = qApp->font("QTipLabel");

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1550,32 +1550,26 @@ void updateFonts()
     // QPointer becomes nullptr for objects that were deleted.
     // Remove them from mapDefaultFontSize and mapFontUpdates
     // before proceeding any further.
-    size_t nMapSize = mapWidgetDefaultFontSizes.size();
+    size_t nRemovedDefaultFonts{0};
     auto itd = mapWidgetDefaultFontSizes.begin();
     while (itd != mapWidgetDefaultFontSizes.end()) {
         if (itd->first.isNull()) {
             itd = mapWidgetDefaultFontSizes.erase(itd);
+            ++nRemovedDefaultFonts;
         } else {
             ++itd;
         }
     }
-    if (nMapSize - mapWidgetDefaultFontSizes.size() > 0) {
-        qDebug() << __func__ << ": removed" << nMapSize - mapWidgetDefaultFontSizes.size()
-                 << "nullptr items from mapWidgetDefaultFontSizes";
-    }
 
-    nMapSize = mapFontUpdates.size();
+    size_t nRemovedFontUpdates{0};
     auto itn = mapFontUpdates.begin();
     while (itn != mapFontUpdates.end()) {
         if (itn->first.isNull()) {
             itn = mapFontUpdates.erase(itn);
+            ++nRemovedFontUpdates;
         } else {
             ++itn;
         }
-    }
-    if (nMapSize - mapFontUpdates.size() > 0) {
-        qDebug() << __func__ << ": removed" << nMapSize - mapFontUpdates.size()
-                 << "nullptr items from mapFontUpdates";
     }
 
     size_t nUpdatable{0}, nUpdated{0};
@@ -1618,8 +1612,8 @@ void updateFonts()
             ++nUpdated;
         }
     }
-    qDebug() << __func__ << ": updated:" << nUpdated << "/" << nUpdatable
-             << ": total:" << qApp->allWidgets().size();
+    qDebug().nospace() << __func__ << " - widget counts: updated/updatable/total(" << nUpdated << "/" << nUpdatable << "/" << qApp->allWidgets().size() << ")"
+             << ", removed items: mapWidgetDefaultFontSizes/mapFontUpdates(" << nRemovedDefaultFonts << "/" << nRemovedFontUpdates << ")";
 
     // Scale the global font for QToolTip labels, QMenu and QMessageBox instances
     QFont fontToolTip = qApp->font("QTipLabel");

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1592,15 +1592,14 @@ void updateFonts()
 
         // Set the font size based on the widgets default font size + the font scale
         int pointSize = font.pointSize() > 0 ? font.pointSize() : defaultFontSize;
-        mapWidgetDefaultFontSizes.emplace(std::make_pair(w, pointSize));
-        int pointSizeStored = mapWidgetDefaultFontSizes.at(w);
-        font.setPointSizeF(getScaledFontSize(pointSizeStored));
+        auto itDefault = mapWidgetDefaultFontSizes.emplace(std::make_pair(w, pointSize));
+        font.setPointSizeF(getScaledFontSize(itDefault.first->second));
 
         auto it = mapFontUpdates.find(w);
         if (it != mapFontUpdates.end()) {
             int nSize = std::get<2>(it->second);
             if (nSize == -1) {
-                nSize = pointSizeStored;
+                nSize = itDefault.first->second;
             }
             QFont&& fontUpd = getFont(std::get<0>(it->second), std::get<1>(it->second), nSize);
             if (w->font() != fontUpd) {


### PR DESCRIPTION
Fixes #3767 