### PR TITLE
Backport 18894: gui: Fix manual coin control with multiple wallets loaded

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -422,9 +422,9 @@ public:
     {
         return m_wallet.GetAverageAnonymizedRounds();
     }
-    CAmount getAvailableBalance(const CCoinControl& coin_control, bool fAnonymized) override
+    CAmount getAvailableBalance(const CCoinControl& coin_control) override
     {
-        if (fAnonymized) {
+        if (coin_control.IsUsingPrivateSend()) {
             return m_wallet.GetAnonymizedBalance(&coin_control);
         } else {
             return m_wallet.GetAvailableBalance(&coin_control);

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -218,7 +218,7 @@ public:
     virtual CAmount getAverageAnonymizedRounds() = 0;
 
     //! Get available balance.
-    virtual CAmount getAvailableBalance(const CCoinControl& coin_control, bool fAnonymized = false) = 0;
+    virtual CAmount getAvailableBalance(const CCoinControl& coin_control) = 0;
 
     //! Return whether transaction input belongs to wallet.
     virtual isminetype txinIsMine(const CTxIn& txin) = 0;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -32,7 +32,6 @@
 
 QList<CAmount> CoinControlDialog::payAmounts;
 bool CoinControlDialog::fSubtractFeeFromAmount = false;
-CoinControlDialog::Mode CoinControlDialog::mode{CoinControlDialog::Mode::NORMAL};
 
 bool CCoinControlWidgetItem::operator<(const QTreeWidgetItem &other) const {
     int column = treeWidget()->sortColumn();
@@ -41,10 +40,11 @@ bool CCoinControlWidgetItem::operator<(const QTreeWidgetItem &other) const {
     return QTreeWidgetItem::operator<(other);
 }
 
-CoinControlDialog::CoinControlDialog(QWidget* parent) :
+CoinControlDialog::CoinControlDialog(CCoinControl& coin_control, WalletModel* _model, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::CoinControlDialog),
-    model(0)
+    m_coin_control(coin_control),
+    model(_model)
 {
     ui->setupUi(this);
 
@@ -152,6 +152,13 @@ CoinControlDialog::CoinControlDialog(QWidget* parent) :
         ui->radioTreeMode->click();
     if (settings.contains("nCoinControlSortColumn") && settings.contains("nCoinControlSortOrder"))
         sortView(settings.value("nCoinControlSortColumn").toInt(), (static_cast<Qt::SortOrder>(settings.value("nCoinControlSortOrder").toInt())));
+
+    if(_model->getOptionsModel() && _model->getAddressTableModel())
+    {
+        updateView();
+        updateLabelLocked();
+        CoinControlDialog::updateLabels(m_coin_control, _model, this);
+    }
 }
 
 CoinControlDialog::~CoinControlDialog()
@@ -162,18 +169,6 @@ CoinControlDialog::~CoinControlDialog()
     settings.setValue("nCoinControlSortOrder", (int)sortOrder);
 
     delete ui;
-}
-
-void CoinControlDialog::setModel(WalletModel *_model)
-{
-    this->model = _model;
-
-    if(_model && _model->getOptionsModel() && _model->getAddressTableModel())
-    {
-        updateView();
-        updateLabelLocked();
-        CoinControlDialog::updateLabels(_model, this);
-    }
 }
 
 // ok button
@@ -201,8 +196,8 @@ void CoinControlDialog::buttonSelectAllClicked()
                 ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
     ui->treeWidget->setEnabled(true);
     if (state == Qt::Unchecked)
-        coinControl()->UnSelectAll(); // just to be sure
-    CoinControlDialog::updateLabels(model, this);
+        m_coin_control.UnSelectAll(); // just to be sure
+    CoinControlDialog::updateLabels(m_coin_control, model, this);
 }
 
 // Toggle lock state
@@ -216,7 +211,7 @@ void CoinControlDialog::buttonToggleLockClicked()
             item = ui->treeWidget->topLevelItem(i);
             COutPoint outpt(uint256S(item->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), item->data(COLUMN_ADDRESS, VOutRole).toUInt());
             // Don't toggle the lock state of partially mixed coins if they are not hidden in PrivateSend mode
-            if (coinControl()->IsUsingPrivateSend() && !fHideAdditional && !model->isFullyMixed(outpt)) {
+            if (m_coin_control.IsUsingPrivateSend() && !fHideAdditional && !model->isFullyMixed(outpt)) {
                 continue;
             }
             if (model->wallet().isLockedCoin(outpt)) {
@@ -232,7 +227,7 @@ void CoinControlDialog::buttonToggleLockClicked()
             updateLabelLocked();
         }
         ui->treeWidget->setEnabled(true);
-        CoinControlDialog::updateLabels(model, this);
+        CoinControlDialog::updateLabels(m_coin_control, model, this);
     }
     else{
         QMessageBox msgBox(this);
@@ -424,16 +419,16 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
         COutPoint outpt(uint256S(item->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), item->data(COLUMN_ADDRESS, VOutRole).toUInt());
 
         if (item->checkState(COLUMN_CHECKBOX) == Qt::Unchecked)
-            coinControl()->UnSelect(outpt);
+            m_coin_control.UnSelect(outpt);
         else if (item->isDisabled()) // locked (this happens if "check all" through parent node)
             item->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
         else {
-            coinControl()->Select(outpt);
+            m_coin_control.Select(outpt);
         }
 
         // selection changed -> update labels
         if (ui->treeWidget->isEnabled()) // do not update on every click for (un)select all
-            CoinControlDialog::updateLabels(model, this);
+            CoinControlDialog::updateLabels(m_coin_control, model, this);
     }
 }
 
@@ -454,10 +449,10 @@ void CoinControlDialog::on_hideButton_clicked()
 {
     fHideAdditional = !fHideAdditional;
     updateView();
-    CoinControlDialog::updateLabels(model, this);
+    CoinControlDialog::updateLabels(m_coin_control, model, this);
 }
 
-void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
+void CoinControlDialog::updateLabels(CCoinControl& m_coin_control, WalletModel *model, QDialog* dialog)
 {
     if (!model)
         return;
@@ -490,7 +485,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     bool fUnselectedNonMixed{false};
 
     std::vector<COutPoint> vCoinControl;
-    coinControl()->ListSelected(vCoinControl);
+    m_coin_control.ListSelected(vCoinControl);
 
     size_t i = 0;
     for (const auto& out : model->wallet().getCoins(vCoinControl)) {
@@ -501,7 +496,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         const COutPoint& outpt = vCoinControl[i++];
         if (out.is_spent)
         {
-            coinControl()->UnSelect(outpt);
+            m_coin_control.UnSelect(outpt);
             fUnselectedSpent = true;
             continue;
         }
@@ -540,14 +535,14 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
                 nBytes -= 34;
 
         // Fee
-        nPayFee = model->node().getMinimumFee(nBytes, *coinControl(), nullptr /* returned_target */, nullptr /* reason */);
+        nPayFee = model->node().getMinimumFee(nBytes, m_coin_control, nullptr /* returned_target */, nullptr /* reason */);
 
         if (nPayAmount > 0)
         {
             nChange = nAmount - nPayAmount;
 
             // PrivateSend Fee = overpay
-            if(coinControl()->IsUsingPrivateSend() && nChange > 0)
+            if(m_coin_control.IsUsingPrivateSend() && nChange > 0)
             {
                 nPayFee = std::max(nChange, nPayFee);
                 nChange = 0;
@@ -651,30 +646,12 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     }
 }
 
-void CoinControlDialog::usePrivateSend(bool fUsePrivateSend)
-{
-    CoinControlDialog::mode = fUsePrivateSend ? CoinControlDialog::Mode::PRIVATESEND : CoinControlDialog::Mode::NORMAL;
-}
-
-CCoinControl* CoinControlDialog::coinControl()
-{
-    if (CoinControlDialog::mode == CoinControlDialog::Mode::NORMAL) {
-        static CCoinControl coinControlNormal;
-        coinControlNormal.UsePrivateSend(false);
-        return &coinControlNormal;
-    } else {
-        static CCoinControl coinControlPrivateSend;
-        coinControlPrivateSend.UsePrivateSend(true);
-        return &coinControlPrivateSend;
-    }
-}
-
 void CoinControlDialog::updateView()
 {
     if (!model || !model->getOptionsModel() || !model->getAddressTableModel())
         return;
 
-    bool fNormalMode = mode == Mode::NORMAL;
+    bool fNormalMode = !m_coin_control.IsUsingPrivateSend();
     ui->treeWidget->setColumnHidden(COLUMN_PRIVATESEND_ROUNDS, fNormalMode);
     ui->treeWidget->setColumnHidden(COLUMN_LABEL, !fNormalMode);
     ui->radioTreeMode->setVisible(fNormalMode);
@@ -686,22 +663,19 @@ void CoinControlDialog::updateView()
     }
 
     QString strHideButton;
-    switch (mode) {
-    case Mode::NORMAL:
+    if (fNormalMode) {
         if (fHideAdditional) {
             strHideButton = tr("Show all coins");
         } else {
             strHideButton = tr("Hide PrivateSend coins");
         }
-        break;
-    case Mode::PRIVATESEND:
+    } else {
         if (fHideAdditional) {
             strHideButton = tr("Show all PrivateSend coins");
         } else {
             strHideButton = tr("Show spendable coins only");
         }
         ui->radioListMode->setChecked(true);
-        break;
     }
     ui->hideButton->setText(strHideButton);
 
@@ -748,15 +722,15 @@ void CoinControlDialog::updateView()
             CAmount nAmount = out.txout.nValue;
             bool fPrivateSendAmount = model->node().privateSendOptions().isDenominated(nAmount) || model->node().privateSendOptions().isCollateralAmount(nAmount);
 
-            if (coinControl()->IsUsingPrivateSend()) {
+            if (m_coin_control.IsUsingPrivateSend()) {
                 fFullyMixed = model->isFullyMixed(output);
                 if ((fHideAdditional && !fFullyMixed) || (!fHideAdditional && !fPrivateSendAmount)) {
-                    coinControl()->UnSelect(output);
+                    m_coin_control.UnSelect(output);
                     continue;
                 }
             } else {
                 if (fHideAdditional && fPrivateSendAmount) {
-                    coinControl()->UnSelect(output);
+                    m_coin_control.UnSelect(output);
                     continue;
                 }
             }
@@ -831,17 +805,17 @@ void CoinControlDialog::updateView()
 
             // disable locked coins
             if (model->wallet().isLockedCoin(output)) {
-                coinControl()->UnSelect(output); // just to be sure
+                m_coin_control.UnSelect(output); // just to be sure
                 itemOutput->setDisabled(true);
                 itemOutput->setIcon(COLUMN_CHECKBOX, GUIUtil::getIcon("lock_closed", GUIUtil::ThemedColor::RED));
             }
 
             // set checkbox
-            if (coinControl()->IsSelected(output)) {
+            if (m_coin_control.IsSelected(output)) {
                 itemOutput->setCheckState(COLUMN_CHECKBOX, Qt::Checked);
             }
 
-            if (coinControl()->IsUsingPrivateSend() && !fHideAdditional && !fFullyMixed) {
+            if (m_coin_control.IsUsingPrivateSend() && !fHideAdditional && !fFullyMixed) {
                 itemOutput->setDisabled(true);
             }
         }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -40,7 +40,7 @@ bool CCoinControlWidgetItem::operator<(const QTreeWidgetItem &other) const {
     return QTreeWidgetItem::operator<(other);
 }
 
-CoinControlDialog::CoinControlDialog(CCoinControl& coin_control, WalletModel* _model, QWidget *parent) :
+CoinControlDialog::CoinControlDialog(CCoinControl& coin_control, WalletModel* _model, QWidget* parent) :
     QDialog(parent),
     ui(new Ui::CoinControlDialog),
     m_coin_control(coin_control),

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -42,21 +42,18 @@ class CoinControlDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit CoinControlDialog(QWidget* parent = 0);
+    explicit CoinControlDialog(CCoinControl& coin_control, WalletModel* model, QWidget *parent = nullptr);
     ~CoinControlDialog();
 
-    void setModel(WalletModel *model);
-
     // static because also called from sendcoinsdialog
-    static void updateLabels(WalletModel*, QDialog*);
+    static void updateLabels(CCoinControl& m_coin_control, WalletModel*, QDialog*);
 
     static QList<CAmount> payAmounts;
-    static CCoinControl *coinControl();
     static bool fSubtractFeeFromAmount;
-    static void usePrivateSend(bool fUsePrivateSend);
 
 private:
     Ui::CoinControlDialog *ui;
+    CCoinControl& m_coin_control;
     WalletModel *model;
     int sortColumn;
     Qt::SortOrder sortOrder;
@@ -90,13 +87,6 @@ private:
     };
 
     friend class CCoinControlWidgetItem;
-
-    enum class Mode {
-        NORMAL,
-        PRIVATESEND,
-    };
-
-    static CoinControlDialog::Mode mode;
 
 private Q_SLOTS:
     void showMenu(const QPoint &);

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -15,6 +15,7 @@
 
 static const int MAX_SEND_POPUP_ENTRIES = 10;
 
+class CCoinControl;
 class ClientModel;
 class SendCoinsEntry;
 class SendCoinsRecipient;
@@ -62,10 +63,10 @@ private:
     Ui::SendCoinsDialog *ui;
     ClientModel *clientModel;
     WalletModel *model;
+    std::unique_ptr<CCoinControl> m_coin_control;
     bool fNewRecipientAllowed;
     void send(QList<SendCoinsRecipient> recipients);
     bool fFeeMinimized;
-    bool fPrivateSend;
 
     // Process WalletModel::SendCoinsReturn and generate a pair consisting
     // of a message and message flags for use in Q_EMIT message().
@@ -75,8 +76,6 @@ private:
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
-
-    void showEvent(QShowEvent* event);
 
 private Q_SLOTS:
     void on_sendButton_clicked();

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -53,7 +53,7 @@ public:
         SetNull();
     }
 
-    void SetNull()
+    void SetNull(bool fResetCoinType = true)
     {
         destChange = CNoDestination();
         fAllowOtherInputs = false;
@@ -65,7 +65,9 @@ public:
         fOverrideFeeRate = false;
         m_confirm_target.reset();
         m_fee_mode = FeeEstimateMode::UNSET;
-        nCoinType = CoinType::ALL_COINS;
+        if (fResetCoinType) {
+            nCoinType = CoinType::ALL_COINS;
+        }
     }
 
     bool HasSelected() const


### PR DESCRIPTION
It's pretty hard to follow the logic in SendCoins and CoinControl dialogs, especially now that we have two send tabs. Turned out that there is also another issue - manual coin control isn't quite working with multiple wallets loaded but there is a patch in BTC which actually fixes both of them at once. Should not introduce any changes in the actual behaviour. Future merge conflicts are minimal and trivial as far as I can tell.