### PR TITLE
Always hold cs lock while accessing quorumHash and phase in CDKGSessionHandler

### DIFF
--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -131,8 +131,6 @@ public:
 private:
     bool InitNewQuorum(const CBlockIndex* pindexQuorum);
 
-    std::pair<QuorumPhase, uint256> GetPhaseAndQuorumHash() const;
-
     typedef std::function<void()> StartPhaseFunc;
     typedef std::function<bool()> WhileWaitFunc;
     void WaitForNextPhase(QuorumPhase curPhase, QuorumPhase nextPhase, const uint256& expectedQuorumHash, const WhileWaitFunc& runWhileWaiting);


### PR DESCRIPTION
This is just one of the reasons why `feature_llmq_simplepose.py` fails sometime but it's a bug in general which should be fixed regardless.