### PR TITLE
Avoid accessing pendingContributionVerifications from VerifyPendingContributions while ReceiveMessage is still doing its job

### DIFF
--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -257,6 +257,8 @@ bool CDKGSession::PreVerifyMessage(const uint256& hash, const CDKGContribution& 
 
 void CDKGSession::ReceiveMessage(const uint256& hash, const CDKGContribution& qc, bool& retBan)
 {
+    LOCK(cs_pending);
+
     CDKGLogger logger(*this, __func__);
 
     retBan = false;
@@ -356,6 +358,8 @@ void CDKGSession::ReceiveMessage(const uint256& hash, const CDKGContribution& qc
 // See CBLSWorker::VerifyContributionShares for more details.
 void CDKGSession::VerifyPendingContributions()
 {
+    AssertLockHeld(cs_pending);
+
     CDKGLogger logger(*this, __func__);
 
     cxxtimer::Timer t1(true);
@@ -409,7 +413,10 @@ void CDKGSession::VerifyAndComplain(CDKGPendingMessages& pendingMessages)
         return;
     }
 
-    VerifyPendingContributions();
+    {
+        LOCK(cs_pending);
+        VerifyPendingContributions();
+    }
 
     CDKGLogger logger(*this, __func__);
 

--- a/src/llmq/quorums_dkgsession.h
+++ b/src/llmq/quorums_dkgsession.h
@@ -277,6 +277,7 @@ private:
     std::map<uint256, CDKGJustification> justifications;
     std::map<uint256, CDKGPrematureCommitment> prematureCommitments;
 
+    mutable CCriticalSection cs_pending;
     std::vector<size_t> pendingContributionVerifications;
 
     // filled by ReceivePrematureCommitment and used by FinalizeCommitments


### PR DESCRIPTION
Another locking bug. This one causes `did not send any contribution` errors in `feature_llmq_simplepose.py` because we switch `receivedContribution` to `true` which lets it move forward to the next phase and `VerifyAndComplain`  fires `VerifyPendingContributions` before `ReceiveMessage` had any chance to populate `pendingContributionVerifications` with contributions it was processing at that time.