### PR TITLE
contrib: Update makeseeds.py

### DIFF
--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -17,4 +17,5 @@ that the list is as expected.
 
 Ubuntu:
 
-    sudo apt-get install python3-dnspython
+    sudo apt-get install python3-pip
+    pip3 install dnspython

--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -91,7 +91,7 @@ def filtermultipayoutaddress(mns):
     return [mn for mn in mns if len(hist[mn['state']['payoutAddress']]) == 1]
 
 def resolveasn(resolver, ip):
-    asn = int([x.to_text() for x in resolver.query('.'.join(reversed(ip.split('.'))) + '.origin.asn.cymru.com', 'TXT').response.answer][0].split('\"')[1].split(' ')[0])
+    asn = int([x.to_text() for x in resolver.resolve('.'.join(reversed(ip.split('.'))) + '.origin.asn.cymru.com', 'TXT').response.answer][0].split('\"')[1].split(' ')[0])
     return asn
 
 # Based on Greg Maxwell's seed_filter.py


### PR DESCRIPTION
The `dnspython` package complained about  `dns.resolver.Resolver.query()` being deprecated and suggested to use `dns.resolver.Resolver.resolve()` instead.