### PR TITLE
governance: Notify main signals in ProcessVote instead ProcessMessage

### DIFF
--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -12,6 +12,7 @@
 #include <messagesigner.h>
 #include <spork.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 #include <string>
 
@@ -210,6 +211,8 @@ bool CGovernanceObject::ProcessVote(CNode* pfrom,
     voteInstanceRef = vote_instance_t(vote.GetOutcome(), nVoteTimeUpdate, vote.GetTimestamp());
     fileVotes.AddVote(vote);
     fDirtyCache = true;
+    // SEND NOTIFICATION TO SCRIPT/ZMQ
+    GetMainSignals().NotifyGovernanceVote(vote);
     return true;
 }
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -15,7 +15,6 @@
 #include <netmessagemaker.h>
 #include <spork.h>
 #include <validation.h>
-#include <validationinterface.h>
 
 CGovernanceManager governance;
 
@@ -255,8 +254,6 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
             }
             return;
         }
-        // SEND NOTIFICATION TO SCRIPT/ZMQ
-        GetMainSignals().NotifyGovernanceVote(vote);
     }
 }
 


### PR DESCRIPTION
Thats to also call `NotifyGovernanceVote` for votes added by RPC not only the ones coming from P2P.