### PR TITLE
Fix a couple of issues with `-rescan`

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1257,7 +1257,7 @@
         <string>Salvage wallet</string>
        </property>
       </widget>
-      <widget class="QPushButton" name="btn_rescan">
+      <widget class="QPushButton" name="btn_rescan1">
        <property name="geometry">
         <rect>
          <x>10</x>
@@ -1273,14 +1273,33 @@
         </size>
        </property>
        <property name="text">
-        <string>Rescan blockchain files</string>
+        <string>Rescan blockchain files 1</string>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="btn_rescan2">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>200</y>
+         <width>301</width>
+         <height>23</height>
+        </rect>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>180</width>
+         <height>23</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Rescan blockchain files 2</string>
        </property>
       </widget>
       <widget class="QPushButton" name="btn_zapwallettxes1">
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>200</y>
+         <y>250</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1299,7 +1318,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>250</y>
+         <y>300</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1318,7 +1337,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>300</y>
+         <y>350</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1365,7 +1384,7 @@
         <bool>true</bool>
        </property>
       </widget>
-      <widget class="QLabel" name="label_repair_rescan">
+      <widget class="QLabel" name="label_repair_rescan1">
        <property name="geometry">
         <rect>
          <x>330</x>
@@ -1375,7 +1394,23 @@
         </rect>
        </property>
        <property name="text">
-        <string>-rescan: Rescan the block chain for missing wallet transactions.</string>
+        <string>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_repair_rescan2">
+       <property name="geometry">
+        <rect>
+         <x>330</x>
+         <y>190</y>
+         <width>411</width>
+         <height>41</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -1385,7 +1420,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>190</y>
+         <y>240</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1401,7 +1436,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>240</y>
+         <y>290</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1417,7 +1452,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>290</y>
+         <y>340</y>
          <width>411</width>
          <height>41</height>
         </rect>
@@ -1449,7 +1484,7 @@
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>350</y>
+         <y>400</y>
          <width>301</width>
          <height>23</height>
         </rect>
@@ -1462,7 +1497,7 @@
        <property name="geometry">
         <rect>
          <x>330</x>
-         <y>340</y>
+         <y>390</y>
          <width>411</width>
          <height>41</height>
         </rect>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -53,7 +53,8 @@ const TrafficGraphData::GraphRange INITIAL_TRAFFIC_GRAPH_SETTING = TrafficGraphD
 
 // Repair parameters
 const QString SALVAGEWALLET("-salvagewallet");
-const QString RESCAN("-rescan");
+const QString RESCAN1("-rescan=1");
+const QString RESCAN2("-rescan=2");
 const QString ZAPTXES1("-zapwallettxes=1 -persistmempool=0");
 const QString ZAPTXES2("-zapwallettxes=2 -persistmempool=0");
 const QString UPGRADEWALLET("-upgradewallet");
@@ -497,7 +498,8 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent, Qt::WindowFlags 
     // connect(ui->btn_salvagewallet, SIGNAL(clicked()), this, SLOT(walletSalvage()));
     // Disable salvage option in GUI, it's way too powerful and can lead to funds loss
     ui->btn_salvagewallet->setEnabled(false);
-    connect(ui->btn_rescan, SIGNAL(clicked()), this, SLOT(walletRescan()));
+    connect(ui->btn_rescan1, SIGNAL(clicked()), this, SLOT(walletRescan1()));
+    connect(ui->btn_rescan2, SIGNAL(clicked()), this, SLOT(walletRescan2()));
     connect(ui->btn_zapwallettxes1, SIGNAL(clicked()), this, SLOT(walletZaptxes1()));
     connect(ui->btn_zapwallettxes2, SIGNAL(clicked()), this, SLOT(walletZaptxes2()));
     connect(ui->btn_upgradewallet, SIGNAL(clicked()), this, SLOT(walletUpgrade()));
@@ -799,10 +801,16 @@ void RPCConsole::walletSalvage()
     buildParameterlist(SALVAGEWALLET);
 }
 
-/** Restart wallet with "-rescan" */
-void RPCConsole::walletRescan()
+/** Restart wallet with "-rescan=1" */
+void RPCConsole::walletRescan1()
 {
-    buildParameterlist(RESCAN);
+    buildParameterlist(RESCAN1);
+}
+
+/** Restart wallet with "-rescan=2" */
+void RPCConsole::walletRescan2()
+{
+    buildParameterlist(RESCAN2);
 }
 
 /** Restart wallet with "-zapwallettxes=1" */
@@ -838,7 +846,8 @@ void RPCConsole::buildParameterlist(QString arg)
 
     // Remove existing repair-options
     args.removeAll(SALVAGEWALLET);
-    args.removeAll(RESCAN);
+    args.removeAll(RESCAN1);
+    args.removeAll(RESCAN2);
     args.removeAll(ZAPTXES1);
     args.removeAll(ZAPTXES2);
     args.removeAll(UPGRADEWALLET);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -100,7 +100,8 @@ public Q_SLOTS:
 
     /** Wallet repair options */
     void walletSalvage();
-    void walletRescan();
+    void walletRescan1();
+    void walletRescan2();
     void walletZaptxes1();
     void walletZaptxes2();
     void walletUpgrade();

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -177,6 +177,13 @@ bool WalletInit::ParameterInteraction()
         }
     }
 
+    int rescan_mode = gArgs.GetArg("-rescan", 0);
+    if (rescan_mode < 0 || rescan_mode > 2) {
+        LogPrintf("%s: Warning: incorrect -rescan mode, falling back to default value.\n", __func__);
+        InitWarning(_("Incorrect -rescan mode, falling back to default value"));
+        gArgs.ForceRemoveArg("-rescan");
+    }
+
     if (is_multiwallet) {
         if (gArgs.GetBoolArg("-upgradewallet", false)) {
             return InitError(strprintf("%s is only allowed with a single wallet file", "-upgradewallet"));

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -67,7 +67,8 @@ std::string WalletInit::GetHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-createwalletbackups=<n>", strprintf(_("Number of automatic wallet backups (default: %u)"), nWalletBackups));
     strUsage += HelpMessageOpt("-disablewallet", _("Do not load the wallet and disable wallet RPC calls"));
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), DEFAULT_KEYPOOL_SIZE));
-    strUsage += HelpMessageOpt("-rescan", _("Rescan the block chain for missing wallet transactions on startup"));
+    strUsage += HelpMessageOpt("-rescan=<mode>", _("Rescan the block chain for missing wallet transactions on startup") +
+                                            " " + _("(1 = start from wallet creation time, 2 = start from genesis block)"));
     strUsage += HelpMessageOpt("-salvagewallet", _("Attempt to recover private keys from a corrupt wallet on startup"));
     strUsage += HelpMessageOpt("-spendzeroconfchange", strprintf(_("Spend unconfirmed change when sending transactions (default: %u)"), DEFAULT_SPEND_ZEROCONF_CHANGE));
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format on startup"));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2739,6 +2739,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"unconfirmed_balance\": xxx, (numeric) the total unconfirmed balance of the wallet in " + CURRENCY_UNIT + "\n"
             "  \"immature_balance\": xxxxxx, (numeric) the total immature balance of the wallet in " + CURRENCY_UNIT + "\n"
             "  \"txcount\": xxxxxxx,         (numeric) the total number of transactions in the wallet\n"
+            "  \"timefirstkey\": xxxxxx,     (numeric) the timestamp (seconds since Unix epoch) of the oldest known key in the wallet\n"
             "  \"keypoololdest\": xxxxxx,    (numeric) the timestamp (seconds since Unix epoch) of the oldest pre-generated key in the key pool\n"
             "  \"keypoolsize\": xxxx,        (numeric) how many new keys are pre-generated (only counts external keys)\n"
             "  \"keypoolsize_hd_internal\": xxxx, (numeric) how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)\n"
@@ -2783,6 +2784,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     obj.pushKV("unconfirmed_balance", ValueFromAmount(pwallet->GetUnconfirmedBalance()));
     obj.pushKV("immature_balance",    ValueFromAmount(pwallet->GetImmatureBalance()));
     obj.pushKV("txcount",       (int)pwallet->mapWallet.size());
+    obj.pushKV("timefirstkey", pwallet->GetTimeFirstKey());
     obj.pushKV("keypoololdest", pwallet->GetOldestKeyPoolTime());
     obj.pushKV("keypoolsize",   (int64_t)pwallet->KeypoolCountExternalKeys());
     if (fHDEnabled) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1247,9 +1247,10 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlockI
              * the mostly recently created transactions from newer versions of the wallet.
              */
 
+            WalletBatch batch(*database);
             // loop though all outputs
             for (const CTxOut& txout: tx.vout) {
-                // extract addresses and check if they match with an unused keypool key
+                // extract addresses, check if they match with an unused keypool key, update metadata if needed
                 std::vector<CKeyID> vAffected;
                 CAffectedKeysVisitor(*this, vAffected).Process(txout.scriptPubKey);
                 for (const CKeyID &keyid : vAffected) {
@@ -1261,6 +1262,15 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlockI
                         if (!TopUpKeyPool()) {
                             LogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
                         }
+                    }
+                    if (mapKeyMetadata[keyid].nCreateTime > pIndex->nTime) {
+                        LogPrintf("%s: Found a key which appears to be used earlier than we expected, updating metadata\n", __func__);
+                        CPubKey vchPubKey;
+                        bool res = GetPubKey(keyid, vchPubKey);
+                        assert(res); // this should never fail
+                        mapKeyMetadata[keyid].nCreateTime = pIndex->nTime;
+                        batch.WriteKeyMeta(vchPubKey, mapKeyMetadata[keyid]);
+                        UpdateTimeFirstKey(pIndex->nTime);
                     }
                 }
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -463,6 +463,12 @@ void CWallet::UpdateTimeFirstKey(int64_t nCreateTime)
     }
 }
 
+int64_t CWallet::GetTimeFirstKey() const
+{
+    AssertLockHeld(cs_wallet);
+    return nTimeFirstKey;
+}
+
 bool CWallet::AddCScript(const CScript& redeemScript)
 {
     if (!CCryptoKeyStore::AddCScript(redeemScript))
@@ -5328,6 +5334,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
         LogPrintf("setInternalKeyPool.size() = %u\n",   walletInstance->KeypoolCountInternalKeys());
         LogPrintf("mapWallet.size() = %u\n",            walletInstance->mapWallet.size());
         LogPrintf("mapAddressBook.size() = %u\n",       walletInstance->mapAddressBook.size());
+        LogPrintf("nTimeFirstKey = %u\n",               walletInstance->nTimeFirstKey);
     }
 
     return walletInstance;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1269,7 +1269,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlockI
                             LogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
                         }
                     }
-                    if (mapKeyMetadata[keyid].nCreateTime > pIndex->nTime) {
+                    if (pIndex != nullptr && mapKeyMetadata[keyid].nCreateTime > pIndex->nTime) {
                         LogPrintf("%s: Found a key which appears to be used earlier than we expected, updating metadata\n", __func__);
                         CPubKey vchPubKey;
                         bool res = GetPubKey(keyid, vchPubKey);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5271,8 +5271,11 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
 
         // No need to read and scan block if block was created before
         // our wallet birthday (as adjusted for block time variability)
-        while (pindexRescan && walletInstance->nTimeFirstKey && (pindexRescan->GetBlockTime() < (walletInstance->nTimeFirstKey - TIMESTAMP_WINDOW))) {
-            pindexRescan = chainActive.Next(pindexRescan);
+        // unless a full rescan was requested
+        if (gArgs.GetArg("-rescan", 0) != 2) {
+            while (pindexRescan && walletInstance->nTimeFirstKey && (pindexRescan->GetBlockTime() < (walletInstance->nTimeFirstKey - TIMESTAMP_WINDOW))) {
+                pindexRescan = chainActive.Next(pindexRescan);
+            }
         }
 
         nStart = GetTimeMillis();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -978,6 +978,7 @@ public:
 
     bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
     void UpdateTimeFirstKey(int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    int64_t GetTimeFirstKey() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Adds an encrypted key to the store, and saves it to disk.
     bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret) override;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -58,6 +58,11 @@ bool WalletBatch::EraseTx(uint256 hash)
     return EraseIC(std::make_pair(std::string("tx"), hash));
 }
 
+bool WalletBatch::WriteKeyMeta(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta)
+{
+    return WriteIC(std::make_pair(std::string("keymeta"), vchPubKey), keyMeta, true);
+}
+
 bool WalletBatch::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata& keyMeta)
 {
     if (!WriteIC(std::make_pair(std::string("keymeta"), vchPubKey), keyMeta, false)) {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -134,6 +134,8 @@ public:
     bool WriteTx(const CWalletTx& wtx);
     bool EraseTx(uint256 hash);
 
+    bool WriteKeyMeta(const CPubKey& vchPubKey, const CKeyMetadata &keyMeta);
+
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);


### PR DESCRIPTION
When a wallet is created we set `nTimeFirstKey = GetTime()` which allows `-rescan` to save time by fast-forwarding to a block around this time and ignoring all the older blocks. This works fine for non-HD wallets with random keys but HD wallets are special - because of their deterministic nature they might have keys which were used in txes before the wallet file was even created. This PR fixes it by updating key metadata when a key which appears to be used earlier than we expected is found db8b129 and by letting users to rescan from genesis block via `-rescan=2` fa06123. For qt users there is a new corresponding repair option on Repair tab c93b18d58b. I also tweaked `CreateWalletFromFile` logs and `getwalletinfo` rpc to make it easier to track `nTimeFirstKey` changes 2d2fb11a00.

<img width="936" alt="Screenshot 2020-11-10 at 01 05 52" src="https://user-images.githubusercontent.com/1935069/98606377-3f0d4480-22f8-11eb-8c61-818850c0e57d.png">
