### PR TITLE
test: Fix default value of COutPoint.n to match C++

### DIFF
--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -297,7 +297,7 @@ class CBlockLocator():
 
 
 class COutPoint():
-    def __init__(self, hash=0, n=0):
+    def __init__(self, hash=0, n=0xFFFFFFFF):
         self.hash = hash
         self.n = n
 


### PR DESCRIPTION
`n` gets a `(uint32_t) -1` default which is `4294967295` or `0xFFFFFFFF`.

 https://github.com/dashpay/dash/blob/develop/src/primitives/transaction.h#L32
