### PR TITLE
wallet: Add methods to store governance objects

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5492,11 +5492,27 @@ void CWallet::NotifyChainLock(const CBlockIndex* pindexChainLock, const llmq::CC
     NotifyChainLockReceived(pindexChainLock->nHeight);
 }
 
+bool CWallet::LoadGovernanceObject(const CGovernanceObject& obj)
+{
+    return m_gobjects.emplace(obj.GetHash(), obj).second;
+}
+
 bool CWallet::WriteGovernanceObject(const CGovernanceObject& obj)
 {
     AssertLockHeld(cs_wallet);
     WalletBatch batch(*database);
-    return batch.WriteGovernanceObject(obj);
+    return batch.WriteGovernanceObject(obj) && LoadGovernanceObject(obj);
+}
+
+std::vector<const CGovernanceObject*> CWallet::GetGovernanceObjects()
+{
+    AssertLockHeld(cs_wallet);
+    std::vector<const CGovernanceObject*> vecObjects;
+    vecObjects.reserve(m_gobjects.size());
+    for (auto& obj : m_gobjects) {
+        vecObjects.push_back(&obj.second);
+    }
+    return vecObjects;
 }
 
 CKeyPool::CKeyPool()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5494,6 +5494,7 @@ void CWallet::NotifyChainLock(const CBlockIndex* pindexChainLock, const llmq::CC
 
 bool CWallet::LoadGovernanceObject(const CGovernanceObject& obj)
 {
+    AssertLockHeld(cs_wallet);
     return m_gobjects.emplace(obj.GetHash(), obj).second;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5492,6 +5492,13 @@ void CWallet::NotifyChainLock(const CBlockIndex* pindexChainLock, const llmq::CC
     NotifyChainLockReceived(pindexChainLock->nHeight);
 }
 
+bool CWallet::WriteGovernanceObject(const CGovernanceObject& obj)
+{
+    AssertLockHeld(cs_wallet);
+    WalletBatch batch(*database);
+    return batch.WriteGovernanceObject(obj);
+}
+
 CKeyPool::CKeyPool()
 {
     nTime = GetTime();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -851,6 +851,9 @@ public:
     // Map from Script ID to key metadata (for watch-only keys).
     std::map<CScriptID, CKeyMetadata> m_script_metadata;
 
+    // Map from governance object hash to governance object, they are added by gobject_prepare.
+    std::map<uint256, CGovernanceObject> m_gobjects;
+
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID = 0;
@@ -1235,8 +1238,12 @@ public:
     void NotifyTransactionLock(const CTransaction &tx, const llmq::CInstantSendLock& islock) override;
     void NotifyChainLock(const CBlockIndex* pindexChainLock, const llmq::CChainLockSig& clsig) override;
 
+    /** Load a CGovernanceObject into m_gobjects. */
+    bool LoadGovernanceObject(const CGovernanceObject& obj);
     /** Store a CGovernanceObject in the wallet database. */
     bool WriteGovernanceObject(const CGovernanceObject& obj);
+    /** Returns a vector containing pointers to the governance objects in m_gobjects */
+    std::vector<const CGovernanceObject*> GetGovernanceObjects();
 
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -23,6 +23,7 @@
 #include <wallet/walletdb.h>
 #include <wallet/rpcwallet.h>
 
+#include <governance/governance-object.h>
 #include <privatesend/privatesend.h>
 
 #include <algorithm>
@@ -1233,6 +1234,9 @@ public:
 
     void NotifyTransactionLock(const CTransaction &tx, const llmq::CInstantSendLock& islock) override;
     void NotifyChainLock(const CBlockIndex* pindexChainLock, const llmq::CChainLockSig& clsig) override;
+
+    /** Store a CGovernanceObject in the wallet database. */
+    bool WriteGovernanceObject(const CGovernanceObject& obj);
 
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1240,7 +1240,7 @@ public:
 
     /** Load a CGovernanceObject into m_gobjects. */
     bool LoadGovernanceObject(const CGovernanceObject& obj);
-    /** Store a CGovernanceObject in the wallet database. */
+    /** Store a CGovernanceObject in the wallet database. This should only be used by governance objects that are created by this wallet via `gobject prepare`. */
     bool WriteGovernanceObject(const CGovernanceObject& obj);
     /** Returns a vector containing pointers to the governance objects in m_gobjects */
     std::vector<const CGovernanceObject*> GetGovernanceObjects();

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -10,6 +10,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <fs.h>
+#include <governance/governance-object.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>
@@ -176,6 +177,11 @@ bool WalletBatch::ReadPrivateSendSalt(uint256& salt)
 bool WalletBatch::WritePrivateSendSalt(const uint256& salt)
 {
     return WriteIC(std::string("ps_salt"), salt);
+}
+
+bool WalletBatch::WriteGovernanceObject(const CGovernanceObject& obj)
+{
+    return WriteIC(std::make_pair(std::string("gobject"), obj.GetHash()), obj, false);
 }
 
 CAmount WalletBatch::GetAccountCreditDebit(const std::string& strAccount)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -552,6 +552,21 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 strErr = "Error reading wallet database: LoadHDPubKey failed";
                 return false;
             }
+        } else if (strType == "gobject") {
+            uint256 nObjectHash;
+            CGovernanceObject obj;
+            ssKey >> nObjectHash;
+            ssValue >> obj;
+
+            if (obj.GetHash() != nObjectHash) {
+                strErr = "Invalid governance object: Hash mismatch";
+                return false;
+            }
+
+            if (!pwallet->LoadGovernanceObject(obj)) {
+                strErr = "Invalid governance object: LoadGovernanceObject";
+                return false;
+            }
         }
     } catch (...)
     {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -34,6 +34,7 @@ static const bool DEFAULT_FLUSHWALLET = true;
 class CAccount;
 class CAccountingEntry;
 struct CBlockLocator;
+class CGovernanceObject;
 class CKeyPool;
 class CMasterKey;
 class CScript;
@@ -162,6 +163,9 @@ public:
 
     bool ReadPrivateSendSalt(uint256& salt);
     bool WritePrivateSendSalt(const uint256& salt);
+
+    /** Write a CGovernanceObject to the database */
+    bool WriteGovernanceObject(const CGovernanceObject& obj);
 
     /// Write destination data key,value tuple to database
     bool WriteDestData(const std::string &address, const std::string &key, const std::string &value);


### PR DESCRIPTION
Preparation for `gobject list-prepared` RPC command.