### PR TITLE
rpc|governance|test: Store prepared governance objects and implement "gobject list-prepared" 

### DIFF
--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -419,6 +419,28 @@ std::string CGovernanceObject::GetDataAsPlainString() const
     return std::string(vchData.begin(), vchData.end());
 }
 
+UniValue CGovernanceObject::ToJson() const
+{
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("objectHash", GetHash().ToString());
+    obj.pushKV("parentHash", nHashParent.ToString());
+    obj.pushKV("collateralHash", GetCollateralHash().ToString());
+    obj.pushKV("createdAt", GetCreationTime());
+    obj.pushKV("revision", nRevision);
+    obj.pushKV("type", nObjectType);
+    UniValue data;
+    if (!data.read(GetDataAsPlainString())) {
+        data.clear();
+        data.setObject();
+        data.pushKV("plain", GetDataAsPlainString());
+        data.pushKV("hex", GetDataAsHexString());
+    } else {
+        data.pushKV("hex", GetDataAsHexString());
+    }
+    obj.pushKV("data", data);
+    return obj;
+}
+
 void CGovernanceObject::UpdateLocalValidity()
 {
     LOCK(cs_main);

--- a/src/governance/governance-object.h
+++ b/src/governance/governance-object.h
@@ -336,6 +336,8 @@ public:
         // AFTER DESERIALIZATION OCCURS, CACHED VARIABLES MUST BE CALCULATED MANUALLY
     }
 
+    UniValue ToJson() const;
+
     // FUNCTIONS FOR DEALING WITH DATA STRING
     void LoadData();
     void GetData(UniValue& objResult);

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -238,7 +238,7 @@ void gobject_list_prepared_help(CWallet* const pwallet)
                 "Returns a list of governance objects prepared by this wallet with \"gobject prepare\" sorted by their creation time.\n"
                 + HelpRequiringPassphrase(pwallet) + "\n"
                 "\nArguments:\n"
-                "1. count (numeric, optional) Maximal number of objects to return.\n"
+                "1. count (numeric, optional) Maximum number of objects to return.\n"
                 );
 }
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -238,7 +238,7 @@ void gobject_list_prepared_help(CWallet* const pwallet)
                 "Returns a list of governance objects prepared by this wallet with \"gobject prepare\" sorted by their creation time.\n"
                 + HelpRequiringPassphrase(pwallet) + "\n"
                 "\nArguments:\n"
-                "1. count (numeric, optional) Maximum number of objects to return.\n"
+                "1. count (numeric, optional, default=10) Maximum number of objects to return.\n"
                 );
 }
 
@@ -254,7 +254,7 @@ UniValue gobject_list_prepared(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    int64_t nCount = request.params.size() > 1 ? ParseInt64V(request.params[1], "count") : std::numeric_limits<int64_t>::max();
+    int64_t nCount = request.params.size() > 1 ? ParseInt64V(request.params[1], "count") : 10;
     if (nCount <= 0) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "count needs to be greater 0");
     }

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -270,11 +270,9 @@ UniValue gobject_list_prepared(const JSONRPCRequest& request)
     });
 
     UniValue jsonArray(UniValue::VARR);
-    for (auto& object : vecObjects) {
-        if (jsonArray.size() >= nCount) {
-            break;
-        }
-        jsonArray.push_back(object->ToJson());
+    auto it = vecObjects.rbegin() + std::max<int>(0, vecObjects.size() - nCount);
+    while (it != vecObjects.rend()) {
+        jsonArray.push_back((*it++)->ToJson());
     }
 
     return jsonArray;

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -234,11 +234,11 @@ UniValue gobject_prepare(const JSONRPCRequest& request)
 void gobject_list_prepared_help(CWallet* const pwallet)
 {
     throw std::runtime_error(
-                "gobject list-prepared <limit>\n"
+                "gobject list-prepared <count>\n"
                 "Returns a list of governance objects prepared by this wallet with \"gobject prepare\" sorted by their creation time.\n"
                 + HelpRequiringPassphrase(pwallet) + "\n"
                 "\nArguments:\n"
-                "1. limit (numeric, optional) Maximal number of objects to return.\n"
+                "1. count (numeric, optional) Maximal number of objects to return.\n"
                 );
 }
 
@@ -254,9 +254,9 @@ UniValue gobject_list_prepared(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    int64_t nLimit = request.params.size() > 1 ? ParseInt64V(request.params[1], "limit") : std::numeric_limits<int64_t>::max();
-    if (nLimit <= 0) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "limit needs to be greater 0");
+    int64_t nCount = request.params.size() > 1 ? ParseInt64V(request.params[1], "count") : std::numeric_limits<int64_t>::max();
+    if (nCount <= 0) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "count needs to be greater 0");
     }
     // Get a list of all prepared governance objects stored in the wallet
     LOCK(pwallet->cs_wallet);
@@ -272,7 +272,7 @@ UniValue gobject_list_prepared(const JSONRPCRequest& request)
     UniValue jsonArray(UniValue::VARR);
     for (auto& object : vecObjects) {
         jsonArray.push_back(object->ToJson());
-        if (jsonArray.size() >= nLimit) {
+        if (jsonArray.size() >= nCount) {
             break;
         }
     }

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -255,8 +255,8 @@ UniValue gobject_list_prepared(const JSONRPCRequest& request)
     EnsureWalletIsUnlocked(pwallet);
 
     int64_t nCount = request.params.size() > 1 ? ParseInt64V(request.params[1], "count") : 10;
-    if (nCount <= 0) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "count needs to be greater 0");
+    if (nCount < 0) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Negative count");
     }
     // Get a list of all prepared governance objects stored in the wallet
     LOCK(pwallet->cs_wallet);
@@ -271,10 +271,10 @@ UniValue gobject_list_prepared(const JSONRPCRequest& request)
 
     UniValue jsonArray(UniValue::VARR);
     for (auto& object : vecObjects) {
-        jsonArray.push_back(object->ToJson());
         if (jsonArray.size() >= nCount) {
             break;
         }
+        jsonArray.push_back(object->ToJson());
     }
 
     return jsonArray;

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -213,6 +213,10 @@ UniValue gobject_prepare(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INTERNAL_ERROR, err);
     }
 
+    if (!pwallet->WriteGovernanceObject({hashParent, nRevision, nTime, tx->GetHash(), strDataHex})) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "WriteGovernanceObject failed");
+    }
+
     // -- make our change address
     CReserveKey reservekey(pwallet);
     // -- send the tx to the network

--- a/test/functional/feature_governance_objects.py
+++ b/test/functional/feature_governance_objects.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2020 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests around dash governance objects."""
+
+from test_framework.test_framework import DashTestFramework
+from test_framework.util import *
+from test_framework.messages import *
+
+
+def validate_object(prepared, rpc_prepared):
+    assert_equal(prepared["parentHash"], rpc_prepared["parentHash"])
+    assert_equal(prepared["collateralHash"], rpc_prepared["collateralHash"])
+    assert_equal(prepared["createdAt"], rpc_prepared["createdAt"])
+    assert_equal(prepared["revision"], rpc_prepared["revision"])
+    assert_equal(prepared["type"], rpc_prepared["type"])
+    assert_equal(prepared["hex"], rpc_prepared["data"]["hex"])
+    del rpc_prepared["data"]["hex"]
+    assert_equal(prepared["data"], rpc_prepared["data"])
+
+
+class DashGovernanceTest (DashTestFramework):
+    def set_test_params(self):
+        self.set_dash_test_params(2, 1)
+
+    def prepare_object(self, object_type, parent_hash, creation_time, revision, name, amount):
+        proposal_rev = revision
+        proposal_time = int(creation_time)
+        proposal_template = {
+            "type": object_type,
+            "name": name,
+            "start_epoch": proposal_time,
+            "end_epoch": proposal_time + 24 * 60 * 60,
+            "payment_amount": amount,
+            "payment_address": self.nodes[0].getnewaddress(),
+            "url": "https://dash.org"
+        }
+        proposal_hex = ''.join(format(x, '02x') for x in json.dumps(proposal_template).encode())
+        collateral_hash = self.nodes[0].gobject("prepare", parent_hash, proposal_rev, proposal_time, proposal_hex)
+        return {
+            "parentHash": parent_hash,
+            "collateralHash": collateral_hash,
+            "createdAt": proposal_time,
+            "revision": proposal_rev,
+            "type": object_type,
+            "hex": proposal_hex,
+            "data": proposal_template,
+        }
+
+    def run_test(self):
+
+        time_start = time.time()
+        object_type = 1  # GOVERNANCE PROPOSAL
+
+        # At start there should be no prepared objects available
+        assert_equal(len(self.nodes[0].gobject("list-prepared")), 0)
+        # Create 5 proposals with different creation times and validate their ordered like expected
+        p1 = self.prepare_object(object_type, uint256_to_string(0), time_start, 0, "SortByTime1", 1)
+        p2 = self.prepare_object(object_type, uint256_to_string(0), time_start + 10, 1000, "SortByTime2", 10)
+        p3 = self.prepare_object(object_type, uint256_to_string(0), time_start - 10, 1000000000, "SortByTime3", 20)
+        p4 = self.prepare_object(object_type, uint256_to_string(0), time_start + 1, -20, "SortByTime4", 400)
+        p5 = self.prepare_object(object_type, uint256_to_string(0), time_start + 30, 1, "SortByTime5", 100000000)
+
+        rpc_list_prepared = self.nodes[0].gobject("list-prepared")
+        assert_equal(len(rpc_list_prepared), 5)
+
+        expected_order = [p5, p2, p4, p1, p3]
+        for i in range(len(expected_order)):
+            validate_object(expected_order[i], rpc_list_prepared[i])
+
+        # Create two more with the same time
+        self.prepare_object(object_type, uint256_to_string(0), time_start + 60, 1, "SameTime1", 2)
+        self.prepare_object(object_type, uint256_to_string(0), time_start + 60, 2, "SameTime2", 2)
+        # Query them with limit=2
+        rpc_list_prepared = self.nodes[0].gobject("list-prepared", 2)
+        # And make sure it does only return 2 of the 7 available
+        assert_equal(len(rpc_list_prepared), 2)
+        # Since they have the same time they should be sorted by hex data, in this case, the first should be greater
+        assert_greater_than(rpc_list_prepared[0]["data"]["hex"], rpc_list_prepared[1]["data"]["hex"])
+        # Restart node0 and make sure it still contains all valid proposals after restart
+        rpc_full_list_pre_restart = self.nodes[0].gobject("list-prepared")
+        self.restart_node(0)
+        rpc_full_list_post_restart = self.nodes[0].gobject("list-prepared")
+        assert_equal(rpc_full_list_pre_restart, rpc_full_list_post_restart)
+        # And test some invalid limit values
+        assert_raises_rpc_error(-8, "limit needs to be greater 0", self.nodes[0].gobject, "list-prepared", 0)
+        assert_raises_rpc_error(-8, "limit needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1)
+        assert_raises_rpc_error(-8, "limit needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1000)
+
+
+if __name__ == '__main__':
+    DashGovernanceTest().main()

--- a/test/functional/feature_governance_objects.py
+++ b/test/functional/feature_governance_objects.py
@@ -72,7 +72,7 @@ class DashGovernanceTest (DashTestFramework):
         # Create two more with the same time
         self.prepare_object(object_type, uint256_to_string(0), time_start + 60, 1, "SameTime1", 2)
         self.prepare_object(object_type, uint256_to_string(0), time_start + 60, 2, "SameTime2", 2)
-        # Query them with limit=2
+        # Query them with count=2
         rpc_list_prepared = self.nodes[0].gobject("list-prepared", 2)
         # And make sure it does only return 2 of the 7 available
         assert_equal(len(rpc_list_prepared), 2)
@@ -83,10 +83,10 @@ class DashGovernanceTest (DashTestFramework):
         self.restart_node(0)
         rpc_full_list_post_restart = self.nodes[0].gobject("list-prepared")
         assert_equal(rpc_full_list_pre_restart, rpc_full_list_post_restart)
-        # And test some invalid limit values
-        assert_raises_rpc_error(-8, "limit needs to be greater 0", self.nodes[0].gobject, "list-prepared", 0)
-        assert_raises_rpc_error(-8, "limit needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1)
-        assert_raises_rpc_error(-8, "limit needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1000)
+        # And test some invalid count values
+        assert_raises_rpc_error(-8, "count needs to be greater 0", self.nodes[0].gobject, "list-prepared", 0)
+        assert_raises_rpc_error(-8, "count needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1)
+        assert_raises_rpc_error(-8, "count needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1000)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_governance_objects.py
+++ b/test/functional/feature_governance_objects.py
@@ -65,7 +65,7 @@ class DashGovernanceTest (DashTestFramework):
         rpc_list_prepared = self.nodes[0].gobject("list-prepared")
         assert_equal(len(rpc_list_prepared), 5)
 
-        expected_order = [p5, p2, p4, p1, p3]
+        expected_order = [p3, p1, p4, p2, p5]
         for i in range(len(expected_order)):
             validate_object(expected_order[i], rpc_list_prepared[i])
 
@@ -76,8 +76,8 @@ class DashGovernanceTest (DashTestFramework):
         rpc_list_prepared = self.nodes[0].gobject("list-prepared", 2)
         # And make sure it does only return 2 of the 7 available
         assert_equal(len(rpc_list_prepared), 2)
-        # Since they have the same time they should be sorted by hex data, in this case, the first should be greater
-        assert_greater_than(rpc_list_prepared[0]["data"]["hex"], rpc_list_prepared[1]["data"]["hex"])
+        # Since they have the same time they should be sorted by hex data, in this case, the second should be greater
+        assert_greater_than(rpc_list_prepared[1]["data"]["hex"], rpc_list_prepared[0]["data"]["hex"])
         # Restart node0 and make sure it still contains all valid proposals after restart
         rpc_full_list_pre_restart = self.nodes[0].gobject("list-prepared")
         self.restart_node(0)

--- a/test/functional/feature_governance_objects.py
+++ b/test/functional/feature_governance_objects.py
@@ -83,6 +83,14 @@ class DashGovernanceTest (DashTestFramework):
         self.restart_node(0)
         rpc_full_list_post_restart = self.nodes[0].gobject("list-prepared")
         assert_equal(rpc_full_list_pre_restart, rpc_full_list_post_restart)
+        # Create more objects so that we have a total of 11
+        self.prepare_object(object_type, uint256_to_string(0), time_start, 0, "More1", 1)
+        self.prepare_object(object_type, uint256_to_string(0), time_start, 0, "More2", 1)
+        self.prepare_object(object_type, uint256_to_string(0), time_start, 0, "More3", 1)
+        self.prepare_object(object_type, uint256_to_string(0), time_start, 0, "More4", 1)
+        # Make sure default count is 10 while there are 11 in total
+        assert_equal(len(self.nodes[0].gobject("list-prepared")), 10)
+        assert_equal(len(self.nodes[0].gobject("list-prepared", 12)), 11)
         # And test some invalid count values
         assert_raises_rpc_error(-8, "count needs to be greater 0", self.nodes[0].gobject, "list-prepared", 0)
         assert_raises_rpc_error(-8, "count needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1)

--- a/test/functional/feature_governance_objects.py
+++ b/test/functional/feature_governance_objects.py
@@ -91,10 +91,11 @@ class DashGovernanceTest (DashTestFramework):
         # Make sure default count is 10 while there are 11 in total
         assert_equal(len(self.nodes[0].gobject("list-prepared")), 10)
         assert_equal(len(self.nodes[0].gobject("list-prepared", 12)), 11)
+        # Make sure it returns 0 objects with count=0
+        assert_equal(len(self.nodes[0].gobject("list-prepared", 0)), 0)
         # And test some invalid count values
-        assert_raises_rpc_error(-8, "count needs to be greater 0", self.nodes[0].gobject, "list-prepared", 0)
-        assert_raises_rpc_error(-8, "count needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1)
-        assert_raises_rpc_error(-8, "count needs to be greater 0", self.nodes[0].gobject, "list-prepared", -1000)
+        assert_raises_rpc_error(-8, "Negative count", self.nodes[0].gobject, "list-prepared", -1)
+        assert_raises_rpc_error(-8, "Negative count", self.nodes[0].gobject, "list-prepared", -1000)
 
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -147,6 +147,7 @@ BASE_SCRIPTS= [
     'wallet_encryption.py',
     'feature_dersig.py',
     'feature_cltv.py',
+    'feature_governance_objects.py',
     'rpc_uptime.py',
     'wallet_resendwallettransactions.py',
     'feature_minchainwork.py',


### PR DESCRIPTION
1ffc410 Makes sure governance objects prepared by `gobject prepare` are stored in the wallet database before the fee transaction gets broadcasted to the network so that it in the future it should be impossible for someone to lose the required data.

0d41a73 Adds the RPC call `gobject list-prepared` to access the governance objects stored in the wallet database.

Based on #3810 