### PR TITLE
Backport #17249: rpc: Add missing deque include to fix build

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -14,6 +14,7 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <deque>
 #include <memory>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This fixes build issues on Fedora 33 (https://pastebin.com/6m7X4mvM) reported by t0dd on Discord.

Original pull request description:

  Regressed by boostorg/filesystem@9a14c37d6f95. See [error log](https://github.com/bitcoin/bitcoin/files/3772177/bitcoin-0.18.1.log).

  ```c++
  httpserver.cpp:74:10: error: no template named 'deque' in namespace 'std'
      std::deque<std::unique_ptr<WorkItem>> queue;
      ~~~~~^
  ```