### PR TITLE
Fix a crash when a new devnet is started/joined

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3836,7 +3836,9 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
         return AbortNode(state, std::string("System error: ") + e.what());
     }
 
-    FlushStateToDisk(chainparams, state, FlushStateMode::NONE);
+    if (pcoinsTip != nullptr) {
+        FlushStateToDisk(chainparams, state, FlushStateMode::NONE);
+    }
 
     CheckBlockIndex(chainparams.GetConsensus());
 


### PR DESCRIPTION
The issue was introduced by https://github.com/dashpay/dash/pull/3786/commits/da0e1360b222ccbbee7f91f574b503c36f6113f7#diff-97c3a52bc5fad452d82670a7fd291800bae20c7bc35bb82686c2c0a4ea7b5b98R3832