### PR TITLE
tests: Make sure txes are actually included in blocks we mine in feature_llmq_is_retroactive.py

### DIFF
--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -98,6 +98,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # Make node0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
         block = self.nodes[0].generate(1)[0]
+        assert(txid in self.nodes[0].getblock(block, 1)['tx'])
         self.wait_for_chainlocked_block_all_nodes(block)
 
         self.log.info("testing retroactive signing with partially known TX and all nodes session timeout")
@@ -143,6 +144,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # Make node 0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
         block = self.nodes[0].generate(1)[0]
+        assert(txid in self.nodes[0].getblock(block, 1)['tx'])
         self.wait_for_chainlocked_block_all_nodes(block)
 
     def test_single_node_session_timeout(self, do_cycle_llmqs):
@@ -174,6 +176,7 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # Make node 0 consider the TX as safe
         self.bump_mocktime(10 * 60 + 1)
         block = self.nodes[0].generate(1)[0]
+        assert(txid in self.nodes[0].getblock(block, 1)['tx'])
         self.wait_for_chainlocked_block_all_nodes(block)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I was wondering why tests were still passing even when I broke "safe tx" conditions (while playing with some other changes locally). Turned out we never actually check txes here, we just check CLs for whatever blocks are mined...

Note: This is a test only issue, the CL logic/code is ok.