### PR TITLE
Fix `Node::getLogCategories()` to work with Dash-specific log categories

### DIFF
--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -172,7 +172,7 @@ class NodeImpl : public Node
     void initLogging() override { InitLogging(); }
     void initParameterInteraction() override { InitParameterInteraction(); }
     std::string getWarnings(const std::string& type) override { return GetWarnings(type); }
-    uint32_t getLogCategories() override { return ::logCategories; }
+    uint64_t getLogCategories() override { return ::logCategories; }
     bool baseInitialize() override
     {
         return AppInitBasicSetup() && AppInitParameterInteraction() && AppInitSanityChecks() &&

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -123,7 +123,7 @@ public:
     virtual std::string getWarnings(const std::string& type) = 0;
 
     // Get log flags.
-    virtual uint32_t getLogCategories() = 0;
+    virtual uint64_t getLogCategories() = 0;
 
     //! Initialize app dependencies.
     virtual bool baseInitialize() = 0;


### PR DESCRIPTION
We use top 32 bits of uint64_t for Dash-specific log categories, see logging.h