### PR TITLE
qt: Lower the number of data samples in TrafficGraphData to make it move much smoother

### DIFF
--- a/src/qt/trafficgraphdata.cpp
+++ b/src/qt/trafficgraphdata.cpp
@@ -1,7 +1,7 @@
 #include <qt/trafficgraphdata.h>
 
 const int TrafficGraphData::RangeMinutes[] = {5,10,15,30,60,120,180,360,720,1440};
-const int TrafficGraphData::DESIRED_DATA_SAMPLES = 800;
+const int TrafficGraphData::DESIRED_DATA_SAMPLES = TrafficGraphData::RangeMinutes[TrafficGraphData::Range_5m] * 60; // i.e. one data sample per second for Range_5m
 const int TrafficGraphData::DesiredQueueSizes[] = {
         TrafficGraphData::DESIRED_DATA_SAMPLES,     //Range_5m
         TrafficGraphData::DESIRED_DATA_SAMPLES/2,   //Range_10m


### PR DESCRIPTION
Having too many data samples causes graph inconsistencies with each update. Not sure how to describe it precisely, you have to see it yourself (most notable in 5m range) :) Not attaching screenshots because you won't see any difference there, it's smth about the way this graph behaves in dynamics. With this patch it's all nice and smooth for me in all ranges as far as I can tell, pls test.