### PR TITLE
IsTxSafeForMining should not fail if ChainLocks are enabled but not enforced

### DIFF
--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -469,7 +469,7 @@ bool CChainLocksHandler::IsTxSafeForMining(const uint256& txid)
     int64_t txAge = 0;
     {
         LOCK(cs);
-        if (!isSporkActive) {
+        if (!isSporkActive || !isEnforced) {
             return true;
         }
         auto it = txFirstSeenTime.find(txid);


### PR DESCRIPTION
This should not affect live networks because ChainLocks are enforced already but technically speaking it's a bug. You can reproduce it in tests if you enable spork19 before dip8 is activated.