### PR TITLE
qt: Fix the direction of some arrows in light theme

### DIFF
--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -118,7 +118,7 @@ QAbstractSpinBox::up-arrow {
     border-image: url(':/images/arrow_up_light');
 }
 QAbstractSpinBox::up-arrow:hover {
-    border-image: url(':/images/arrow_down_dark');
+    border-image: url(':/images/arrow_up_dark');
 }
 QAbstractSpinBox::up-arrow:pressed {
     border-image: url(':/images/arrow_up_light');
@@ -127,13 +127,13 @@ QAbstractSpinBox::up-arrow:disabled {
     border-image: url(':/images/arrow_light_up_normal');
 }
 QAbstractSpinBox::down-arrow {
-    border-image: url(':/images/arrow_up_light');
+    border-image: url(':/images/arrow_down_light');
 }
 QAbstractSpinBox::down-arrow:hover {
     border-image: url(':/images/arrow_down_dark');
 }
 QAbstractSpinBox::down-arrow:pressed {
-    border-image: url(':/images/arrow_up_light');
+    border-image: url(':/images/arrow_down_light');
 }
 QAbstractSpinBox::down-arrow:disabled {
     border-image: url(':/images/arrow_light_down_normal');


### PR DESCRIPTION
Partially fixes #3850 (The arrow direction part but not `and the bold border around the field is pushing the arrows out of alignment with the field below`)