### PR TITLE
Send islock notifications for txes received after their islocks were received

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -958,18 +958,13 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
 
     RemoveMempoolConflictsForLock(hash, islock);
     ResolveBlockConflicts(hash, islock);
-    UpdateWalletTransaction(tx, islock);
-}
 
-void CInstantSendManager::UpdateWalletTransaction(const CTransactionRef& tx, const CInstantSendLock& islock)
-{
-    if (tx == nullptr) {
-        return;
+    if (tx != nullptr) {
+        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about an in-time lock for tx %s\n", __func__, tx->GetHash().ToString().c_str());
+        GetMainSignals().NotifyTransactionLock(*tx, islock);
+        // bump mempool counter to make sure newly locked txes are picked up by getblocktemplate
+        mempool.AddTransactionsUpdated(1);
     }
-
-    GetMainSignals().NotifyTransactionLock(*tx, islock);
-    // bump mempool counter to make sure newly mined txes are picked up by getblocktemplate
-    mempool.AddTransactionsUpdated(1);
 }
 
 void CInstantSendManager::ProcessNewTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, bool allowReSigning)
@@ -1015,7 +1010,24 @@ void CInstantSendManager::ProcessNewTransaction(const CTransactionRef& tx, const
 
 void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
 {
+    if (!IsInstantSendEnabled()) {
+        return;
+    }
+
+    CInstantSendLockPtr islock{nullptr};
+    {
+        LOCK(cs);
+        islock = db.GetInstantSendLockByTxid(tx->GetHash());
+    }
+
     ProcessNewTransaction(tx, nullptr, false);
+
+    if (islock != nullptr) {
+        // If the islock was received before the TX, we know we were not able to send
+        // the notification at that time, we need to do it now.
+        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about an earlier received lock for tx %s\n", __func__, tx->GetHash().ToString().c_str());
+        GetMainSignals().NotifyTransactionLock(*tx, *islock);
+    }
 }
 
 void CInstantSendManager::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted)

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -960,7 +960,7 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
     ResolveBlockConflicts(hash, islock);
 
     if (tx != nullptr) {
-        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about an in-time lock for tx %s\n", __func__, tx->GetHash().ToString().c_str());
+        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about an in-time lock for tx %s\n", __func__, tx->GetHash().ToString());
         GetMainSignals().NotifyTransactionLock(*tx, islock);
         // bump mempool counter to make sure newly locked txes are picked up by getblocktemplate
         mempool.AddTransactionsUpdated(1);
@@ -1025,7 +1025,7 @@ void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
     if (islock != nullptr) {
         // If the islock was received before the TX, we know we were not able to send
         // the notification at that time, we need to do it now.
-        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about an earlier received lock for tx %s\n", __func__, tx->GetHash().ToString().c_str());
+        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about an earlier received lock for tx %s\n", __func__, tx->GetHash().ToString());
         GetMainSignals().NotifyTransactionLock(*tx, *islock);
     }
 }

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -139,7 +139,6 @@ public:
     bool ProcessPendingInstantSendLocks();
     std::unordered_set<uint256> ProcessPendingInstantSendLocks(int signOffset, const std::unordered_map<uint256, std::pair<NodeId, CInstantSendLock>, StaticSaltedHasher>& pend, bool ban);
     void ProcessInstantSendLock(NodeId from, const uint256& hash, const CInstantSendLock& islock);
-    static void UpdateWalletTransaction(const CTransactionRef& tx, const CInstantSendLock& islock);
 
     void ProcessNewTransaction(const CTransactionRef& tx, const CBlockIndex* pindex, bool allowReSigning);
     void TransactionAddedToMempool(const CTransactionRef& tx);

--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -285,25 +285,5 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
         clsig = msg_clsig(height, block.sha256, hex_str_to_bytes(recSig['sig']))
         return clsig
 
-    def create_islock(self, hextx):
-        tx = FromHex(CTransaction(), hextx)
-        tx.rehash()
-
-        request_id_buf = ser_string(b"islock") + ser_compact_size(len(tx.vin))
-        inputs = []
-        for txin in tx.vin:
-            request_id_buf += txin.prevout.serialize()
-            inputs.append(txin.prevout)
-        request_id = hash256(request_id_buf)[::-1].hex()
-        message_hash = tx.hash
-
-        for mn in self.mninfo:
-            mn.node.quorum('sign', 100, request_id, message_hash)
-
-        recSig = self.get_recovered_sig(request_id, message_hash)
-        islock = msg_islock(inputs, tx.sha256, hex_str_to_bytes(recSig['sig']))
-        return islock
-
-
 if __name__ == '__main__':
     LLMQ_IS_CL_Conflicts().main()

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -284,9 +284,7 @@ class DashZMQTest (DashTestFramework):
             # this is expected
             pass
         # Now send the tx itself
-        tx = FromHex(CTransaction(), rpc_raw_tx_3['hex'])
-        tx.rehash()
-        self.test_node.send_tx(msg_tx(tx))
+        self.test_node.send_tx(FromHex(msg_tx(), rpc_raw_tx_3['hex']))
         self.wait_for_instantlock(rpc_raw_tx_3['txid'], self.nodes[0])
         # Validate hashtxlock
         zmq_tx_lock_hash = bytes_to_hex_str(self.receive(ZMQPublisher.hash_tx_lock).read(32))

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -14,10 +14,11 @@ import time
 import zmq
 
 from test_framework.test_framework import DashTestFramework, SkipTest
-from test_framework.util import assert_equal, assert_raises_rpc_error, bytes_to_hex_str
-from test_framework.messages import (CBlock, CGovernanceObject, CGovernanceVote, COutPoint, CRecoveredSig, CTransaction,
-                                    msg_clsig, msg_islock,
-                                    hash256, ser_string, uint256_to_string)
+from test_framework.mininode import P2PInterface, network_thread_start
+from test_framework.util import assert_equal, assert_raises_rpc_error, bytes_to_hex_str, hex_str_to_bytes
+from test_framework.messages import (CBlock, CGovernanceObject, CGovernanceVote, CInv, COutPoint, CRecoveredSig, CTransaction,
+                                    msg_clsig, msg_inv, msg_islock, msg_tx,
+                                    FromHex, hash256, ser_compact_size, ser_string, uint256_from_str, uint256_to_string)
 
 
 class ZMQPublisher(Enum):
@@ -35,6 +36,33 @@ class ZMQPublisher(Enum):
     raw_governance_object = "rawgovernanceobject"
     raw_instantsend_doublespend = "rawinstantsenddoublespend"
     raw_recovered_sig = "rawrecoveredsig"
+
+class TestP2PConn(P2PInterface):
+    def __init__(self):
+        super().__init__()
+        self.islocks = {}
+        self.txes = {}
+
+    def send_islock(self, islock):
+        hash = uint256_from_str(hash256(islock.serialize()))
+        self.islocks[hash] = islock
+
+        inv = msg_inv([CInv(30, hash)])
+        self.send_message(inv)
+
+    def send_tx(self, tx):
+        hash = uint256_from_str(hash256(tx.serialize()))
+        self.txes[hash] = tx
+
+        inv = msg_inv([CInv(30, hash)])
+        self.send_message(inv)
+
+    def on_getdata(self, message):
+        for inv in message.inv:
+            if inv.hash in self.islocks:
+                self.send_message(self.islocks[inv.hash])
+            if inv.hash in self.txes:
+                self.send_message(self.txes[inv.hash])
 
 class DashZMQTest (DashTestFramework):
     def set_test_params(self):
@@ -97,12 +125,31 @@ class DashZMQTest (DashTestFramework):
         for pub in publishers:
             self.socket.unsubscribe(pub.value)
 
-    def receive(self, publisher):
+    def receive(self, publisher, flags=0):
         # Receive a ZMQ message and validate it's sent from the correct ZMQPublisher
-        topic, body, seq = self.socket.recv_multipart()
+        topic, body, seq = self.socket.recv_multipart(flags)
         # Topic should match the publisher value
         assert_equal(topic.decode(), publisher.value)
         return io.BytesIO(body)
+
+    def create_islock(self, hextx):
+        tx = FromHex(CTransaction(), hextx)
+        tx.rehash()
+
+        request_id_buf = ser_string(b"islock") + ser_compact_size(len(tx.vin))
+        inputs = []
+        for txin in tx.vin:
+            request_id_buf += txin.prevout.serialize()
+            inputs.append(txin.prevout)
+        request_id = hash256(request_id_buf)[::-1].hex()
+        message_hash = tx.hash
+
+        for mn in self.mninfo:
+            mn.node.quorum('sign', 100, request_id, message_hash)
+
+        recSig = self.get_recovered_sig(request_id, message_hash)
+        islock = msg_islock(inputs, tx.sha256, hex_str_to_bytes(recSig['sig']))
+        return islock
 
     def test_recovered_signature_publishers(self):
 
@@ -196,6 +243,10 @@ class DashZMQTest (DashTestFramework):
         self.log.info("Testing %d InstantSend publishers" % len(instantsend_publishers))
         # Subscribe to InstantSend messages
         self.subscribe(instantsend_publishers)
+        # Initialize test node
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
+        network_thread_start()
+        self.nodes[0].p2p.wait_for_verack()
         # Make sure all nodes agree
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
         # Create two raw TXs, they will conflict with each other
@@ -238,6 +289,28 @@ class DashZMQTest (DashTestFramework):
         zmq_double_spend_tx_1.deserialize(self.receive(ZMQPublisher.raw_instantsend_doublespend))
         assert(zmq_double_spend_tx_1.is_valid())
         assert_equal(zmq_double_spend_tx_1.hash, rpc_raw_tx_1['txid'])
+        # No islock notifications when tx is not received yet
+        self.nodes[0].generate(1)
+        rpc_raw_tx_3 = self.create_raw_tx(self.nodes[0], self.nodes[0], 1, 1, 100)
+        islock = self.create_islock(rpc_raw_tx_3['hex'])
+        self.test_node.send_islock(islock)
+        # Validate NO hashtxlock
+        time.sleep(1)
+        try:
+            data = self.receive(ZMQPublisher.hash_tx_lock, zmq.NOBLOCK)
+        except zmq.ZMQError:
+            # this is expected
+            pass
+        # Now send the tx itself
+        tx = FromHex(CTransaction(), rpc_raw_tx_3['hex'])
+        tx.rehash()
+        self.test_node.send_tx(msg_tx(tx))
+        self.wait_for_instantlock(rpc_raw_tx_3['txid'], self.nodes[0])
+        # Validate hashtxlock
+        zmq_tx_lock_hash = bytes_to_hex_str(self.receive(ZMQPublisher.hash_tx_lock).read(32))
+        assert_equal(zmq_tx_lock_hash, rpc_raw_tx_3['txid'])
+        # Drop test node connection
+        self.nodes[0].disconnect_p2ps()
         # Unsubscribe from InstantSend messages
         self.unsubscribe(instantsend_publishers)
 

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -297,7 +297,8 @@ class DashZMQTest (DashTestFramework):
         # Validate NO hashtxlock
         time.sleep(1)
         try:
-            data = self.receive(ZMQPublisher.hash_tx_lock, zmq.NOBLOCK)
+            self.receive(ZMQPublisher.hash_tx_lock, zmq.NOBLOCK)
+            assert(False)
         except zmq.ZMQError:
             # this is expected
             pass

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -16,9 +16,24 @@ import zmq
 from test_framework.test_framework import DashTestFramework, SkipTest
 from test_framework.mininode import P2PInterface, network_thread_start
 from test_framework.util import assert_equal, assert_raises_rpc_error, bytes_to_hex_str
-from test_framework.messages import (CBlock, CGovernanceObject, CGovernanceVote, CInv, COutPoint, CRecoveredSig, CTransaction,
-                                    msg_clsig, msg_inv, msg_islock, msg_tx,
-                                    FromHex, hash256, ser_string, uint256_from_str, uint256_to_string)
+from test_framework.messages import (
+    CBlock,
+    CGovernanceObject,
+    CGovernanceVote,
+    CInv,
+    COutPoint,
+    CRecoveredSig,
+    CTransaction,
+    FromHex,
+    hash256,
+    msg_clsig,
+    msg_inv,
+    msg_islock,
+    msg_tx,
+    ser_string,
+    uint256_from_str,
+    uint256_to_string
+)
 
 
 class ZMQPublisher(Enum):
@@ -36,6 +51,7 @@ class ZMQPublisher(Enum):
     raw_governance_object = "rawgovernanceobject"
     raw_instantsend_doublespend = "rawinstantsenddoublespend"
     raw_recovered_sig = "rawrecoveredsig"
+
 
 class TestP2PConn(P2PInterface):
     def __init__(self):
@@ -63,6 +79,7 @@ class TestP2PConn(P2PInterface):
                 self.send_message(self.islocks[inv.hash])
             if inv.hash in self.txes:
                 self.send_message(self.txes[inv.hash])
+
 
 class DashZMQTest (DashTestFramework):
     def set_test_params(self):


### PR DESCRIPTION
Islocks can be received/processed before corresponding txes sometimes. We do not send islock notifications in this case (`tx == nullptr`) because the tx itself should be a part of that message. With this PR we will send an islock notification in case we had a corresponding islock for a tx that was just added to our mempool (we know there was no islock notification earlier, see above). This basically makes tx->islock notifications flow a bit more consistent.

Also drop UpdateWalletTransaction - its name makes no sense and it's only used once.

9d539b7 will cause tests to timeout without this patch.