### PR TITLE
tests: Enable InstantSend and ChainLocks by default

### DIFF
--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -37,7 +37,6 @@ class TestP2PConn(P2PInterface):
 class LLMQCoinbaseCommitmentsTest(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
-        self.set_dash_dip8_activation(200)
 
     def run_test(self):
         self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
@@ -83,6 +82,9 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
 
         self.nodes[0].generate(1)
         oldhash = self.nodes[0].getbestblockhash()
+        # Have to disable ChainLocks here because they won't let you to invalidate already locked blocks
+        self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 4070908800)
+        self.wait_for_sporks_same()
         # Test DIP8 activation once with a pre-existing quorum and once without (we don't know in which order it will activate on mainnet)
         self.test_dip8_quorum_merkle_root_activation(True)
         for n in self.nodes:
@@ -90,6 +92,8 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         self.sync_all()
         first_quorum = self.test_dip8_quorum_merkle_root_activation(False)
 
+        # Re-enable ChainLocks again
+        self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.wait_for_sporks_same()
 

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -102,11 +102,6 @@ class LLMQChainLocksTest(DashTestFramework):
         self.wait_for_chainlocked_block(self.nodes[0], self.nodes[1].getbestblockhash())
         assert(self.nodes[0].getbestblockhash() == self.nodes[1].getbestblockhash())
 
-        self.log.info("Enable LLMQ bases InstantSend, which also enables checks for \"safe\" transactions")
-        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
-        self.nodes[0].spork("SPORK_3_INSTANTSEND_BLOCK_FILTERING", 0)
-        self.wait_for_sporks_same()
-
         self.log.info("Isolate a node and let it create some transactions which won't get IS locked")
         isolate_node(self.nodes[0])
         txs = []

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -19,7 +19,6 @@ Checks LLMQs based ChainLocks
 class LLMQChainLocksTest(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
-        self.set_dash_dip8_activation(10)
 
     def run_test(self):
 
@@ -42,9 +41,6 @@ class LLMQChainLocksTest(DashTestFramework):
         self.log.info("Mining 4 quorums")
         for i in range(4):
             self.mine_quorum()
-
-        self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
-        self.wait_for_sporks_same()
 
         self.log.info("Mine single block, wait for chainlock")
         self.nodes[0].generate(1)

--- a/test/functional/feature_llmq_dkgerrors.py
+++ b/test/functional/feature_llmq_dkgerrors.py
@@ -15,7 +15,6 @@ Simulate and check DKG errors
 class LLMQDKGErrors(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(4, 3, [["-whitelist=127.0.0.1"]] * 4, fast_dip3_enforcement=True)
-        self.set_dash_dip8_activation(10)
 
     def run_test(self):
 

--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -48,7 +48,6 @@ class TestP2PConn(P2PInterface):
 class LLMQ_IS_CL_Conflicts(DashTestFramework):
     def set_test_params(self):
         self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
-        self.set_dash_dip8_activation(10)
         #disable_mocktime()
 
     def run_test(self):
@@ -62,7 +61,6 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
         self.nodes[0].p2p.wait_for_verack()
 
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
-        self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
         self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
         self.nodes[0].spork("SPORK_3_INSTANTSEND_BLOCK_FILTERING", 0)
         self.wait_for_sporks_same()

--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -61,8 +61,6 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
         self.nodes[0].p2p.wait_for_verack()
 
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
-        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
-        self.nodes[0].spork("SPORK_3_INSTANTSEND_BLOCK_FILTERING", 0)
         self.wait_for_sporks_same()
 
         self.mine_quorum()

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -22,7 +22,6 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         # -whitelist is needed to avoid the trickling logic on node0
         self.set_dash_test_params(6, 5, [["-whitelist=127.0.0.1"], [], [], [], ["-minrelaytxfee=0.001"], ["-minrelaytxfee=0.001"]], fast_dip3_enforcement=True)
         self.set_dash_llmq_test_params(5, 3)
-        self.set_dash_dip8_activation(10)
 
     def run_test(self):
         while self.nodes[0].getblockchaininfo()["bip9_softforks"]["dip0008"]["status"] != "active":
@@ -30,7 +29,6 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.sync_blocks(self.nodes, timeout=60*5)
 
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
-        self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
         self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
         self.nodes[0].spork("SPORK_3_INSTANTSEND_BLOCK_FILTERING", 0)
         self.wait_for_sporks_same()

--- a/test/functional/feature_llmq_is_retroactive.py
+++ b/test/functional/feature_llmq_is_retroactive.py
@@ -29,8 +29,6 @@ class LLMQ_IS_RetroactiveSigning(DashTestFramework):
         self.sync_blocks(self.nodes, timeout=60*5)
 
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
-        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
-        self.nodes[0].spork("SPORK_3_INSTANTSEND_BLOCK_FILTERING", 0)
         self.wait_for_sporks_same()
 
         self.mine_quorum()

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -110,6 +110,8 @@ class LLMQSimplePoSeTest(DashTestFramework):
                 addr = self.nodes[0].getnewaddress()
                 self.nodes[0].sendtoaddress(addr, 0.1)
                 self.nodes[0].protx('update_service', mn.proTxHash, '127.0.0.1:%d' % p2p_port(mn.node.index), mn.keyOperator, "", addr)
+                # Make sure this tx "safe" to mine even when InstantSend and ChainLocks are no longer functional
+                self.bump_mocktime(60 * 10 + 1)
                 self.nodes[0].generate(1)
                 assert(not self.check_banned(mn))
 

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -45,7 +45,6 @@ class DashZMQTest (DashTestFramework):
         node0_extra_args.append("-whitelist=127.0.0.1")
 
         self.set_dash_test_params(4, 3, fast_dip3_enforcement=True, extra_args=[node0_extra_args, [], [], []])
-        self.set_dash_dip8_activation(10)
 
     def run_test(self):
         # Check that dashd has been built with ZMQ enabled.
@@ -67,7 +66,6 @@ class DashZMQTest (DashTestFramework):
             self.sync_blocks()
             self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
             self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
-            self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
             self.wait_for_sporks_same()
             # Create an LLMQ for testing
             self.quorum_type = 100  # llmq_test

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -64,7 +64,6 @@ class DashZMQTest (DashTestFramework):
             while self.nodes[0].getblockchaininfo()["bip9_softforks"]["dip0008"]["status"] != "active":
                 self.nodes[0].generate(10)
             self.sync_blocks()
-            self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
             self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
             self.wait_for_sporks_same()
             # Create an LLMQ for testing

--- a/test/functional/p2p_instantsend.py
+++ b/test/functional/p2p_instantsend.py
@@ -27,10 +27,6 @@ class InstantSendTest(DashTestFramework):
         self.wait_for_sporks_same()
         self.mine_quorum()
 
-        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
-        self.nodes[0].spork("SPORK_3_INSTANTSEND_BLOCK_FILTERING", 0)
-        self.wait_for_sporks_same()
-
         self.test_mempool_doublespend()
         self.test_block_doublespend()
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -526,6 +526,9 @@ class DashTestFramework(BitcoinTestFramework):
             for i in range(0, num_nodes):
                 self.extra_args[i].append("-dip3params=30:50")
 
+        # make sure to activate dip8 after prepare_masternodes has finished its job already
+        self.set_dash_dip8_activation(200)
+
         # LLMQ default test params (no need to pass -llmqtestparams)
         self.llmq_size = 3
         self.llmq_threshold = 2
@@ -696,6 +699,9 @@ class DashTestFramework(BitcoinTestFramework):
         self.nodes[0].generate(1)
         # sync nodes
         self.sync_all()
+        # Enable ChainLocks by default
+        self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
+        self.wait_for_sporks_same()
         self.bump_mocktime(1)
 
         mn_info = self.nodes[0].masternodelist("status")

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -699,7 +699,9 @@ class DashTestFramework(BitcoinTestFramework):
         self.nodes[0].generate(1)
         # sync nodes
         self.sync_all()
-        # Enable ChainLocks by default
+        # Enable InstantSend (including block filtering) and ChainLocks by default
+        self.nodes[0].spork("SPORK_2_INSTANTSEND_ENABLED", 0)
+        self.nodes[0].spork("SPORK_3_INSTANTSEND_BLOCK_FILTERING", 0)
         self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
         self.wait_for_sporks_same()
         self.bump_mocktime(1)


### PR DESCRIPTION
That's how mainnet and testnet operate for a long time already, so it makes sense to test this scenario as the default one imo. ~This is also a preparation for #3845 - it makes sure that everything behaves as expected before any related changes in c++ code.~

Note: This PR is expected to fail in multiple tests without #3846  

https://github.com/dashpay/dash/pull/3853/commits/b0b7ab33ad3774f12d05325382d11f2b529ca7b6 failed: https://gitlab.com/dashpay/dash/-/pipelines/225785896