### PR TITLE
rpc: Fix filtering in `masternode winners`

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -319,6 +319,7 @@ UniValue masternode_winners(const JSONRPCRequest& request)
     UniValue obj(UniValue::VOBJ);
     auto mapPayments = GetRequiredPaymentsStrings(nHeight - nLast, nHeight + 20);
     for (const auto &p : mapPayments) {
+        if (strFilter != "" && p.second.find(strFilter) == std::string::npos) continue;
         obj.pushKV(strprintf("%d", p.first), p.second);
     }
 


### PR DESCRIPTION
Was broken by https://github.com/dashpay/dash/commit/44706dc88acf2eab07695f5093bda31ab278d2bf#diff-244e87df3ed336aadc56ec7c8fc521954751f3c3f66b3eb3832bcbcc87996c51L807