### PR TITLE
interfaces: Add isSpendable wallet interface method that accepts CScript

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -208,6 +208,7 @@ public:
     }
     bool getPubKey(const CKeyID& address, CPubKey& pub_key) override { return m_wallet.GetPubKey(address, pub_key); }
     bool getPrivKey(const CKeyID& address, CKey& key) override { return m_wallet.GetKey(address, key); }
+    bool isSpendable(const CScript& script) override { return IsMine(m_wallet, script) & ISMINE_SPENDABLE; }
     bool isSpendable(const CTxDestination& dest) override { return IsMine(m_wallet, dest) & ISMINE_SPENDABLE; }
     bool haveWatchOnly() override { return m_wallet.HaveWatchOnly(); };
     bool setAddressBook(const CTxDestination& dest, const std::string& name, const std::string& purpose) override

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -111,6 +111,7 @@ public:
     virtual bool getPrivKey(const CKeyID& address, CKey& key) = 0;
 
     //! Return whether wallet has private key.
+    virtual bool isSpendable(const CScript& script) = 0;
     virtual bool isSpendable(const CTxDestination& dest) = 0;
 
     //! Return whether wallet has watch only keys.


### PR DESCRIPTION
This fixes masternode list tab which would not show "my" masternodes in the list despite wallet having keys for [`scriptPayout` or `scriptOperatorPayout`](https://github.com/dashpay/dash/blob/develop/src/qt/masternodelist.cpp#L225-L226). The bug was introduced via https://github.com/dashpay/dash/pull/3682/commits/bda6fc4be9cf339175ccbe76a6b2d18903a92578.