### PR TITLE
wallet|init: Fix forcing -disablewallet if -masternodeblsprivkey is set

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1003,6 +1003,10 @@ void InitParameterInteraction()
         LogPrintf("%s: parameter interaction: additional indexes -> setting -checklevel=4\n", __func__);
     }
 
+    if (gArgs.IsArgSet("-masternodeblsprivkey") && gArgs.SoftSetBoolArg("-disablewallet", true)) {
+        LogPrintf("%s: parameter interaction: -masternodeblsprivkey set -> setting -disablewallet=1\n", __func__);
+    }
+
     // Warn if network-specific options (-addnode, -connect, etc) are
     // specified in default section of config file, but not overridden
     // on the command line or in this network's section of the config file.

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -129,10 +129,6 @@ std::string WalletInit::GetHelpString(bool showDebug) const
 
 bool WalletInit::ParameterInteraction() const
 {
-    if (gArgs.IsArgSet("-masternodeblsprivkey") && gArgs.SoftSetBoolArg("-disablewallet", true)) {
-        LogPrintf("%s: parameter interaction: -masternodeblsprivkey set -> setting -disablewallet=1\n", __func__);
-    }
-
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         for (const std::string& wallet : gArgs.GetArgs("-wallet")) {
             LogPrintf("%s: parameter interaction: -disablewallet -> ignoring -wallet=%s\n", __func__, wallet);


### PR DESCRIPTION
Prior to this `-disablewallet` is getting forced after the UI has been initialised if a `-masternodeblsprivkey` is set. This leads to the application running with a "Wallet UI" with undefined behaviour and not with the the expected "Node only UI".