### PR TITLE
rpc: `masternode winners` results should also include operator addresses

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -291,6 +291,12 @@ std::string GetRequiredPaymentsString(int nBlockHeight, const CDeterministicMNCP
             assert(false);
         }
         strPayments = EncodeDestination(dest);
+        if (payee->nOperatorReward != 0 && payee->pdmnState->scriptOperatorPayout != CScript()) {
+            if (!ExtractDestination(payee->pdmnState->scriptOperatorPayout, dest)) {
+                assert(false);
+            }
+            strPayments += ", " + EncodeDestination(dest);
+        }
     }
     if (CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
         std::vector<CTxOut> voutSuperblock;

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -506,7 +506,7 @@ MASTERNODE_COLLATERAL = 1000
 
 
 class MasternodeInfo:
-    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout):
+    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, ipAndPort, operatorReward, operatorPayoutAddress, collateral_address, collateral_txid, collateral_vout):
         self.proTxHash = proTxHash
         self.ownerAddr = ownerAddr
         self.votingAddr = votingAddr
@@ -587,14 +587,18 @@ class DashTestFramework(BitcoinTestFramework):
         rewardsAddr = self.nodes[0].getnewaddress()
 
         port = p2p_port(len(self.nodes) + idx)
+        ipAndPort = '127.0.0.1:%d' % port
+        operatorReward = idx
+        operatorPayoutAddress = self.nodes[0].getnewaddress()
+
         submit = (idx % 4) < 2
 
         if (idx % 2) == 0 :
             self.nodes[0].lockunspent(True, [{'txid': txid, 'vout': collateral_vout}])
-            protx_result = self.nodes[0].protx('register_fund', address, '127.0.0.1:%d' % port, ownerAddr, bls['public'], votingAddr, 0, rewardsAddr, address, submit)
+            protx_result = self.nodes[0].protx('register_fund', address, ipAndPort, ownerAddr, bls['public'], votingAddr, operatorReward, rewardsAddr, address, submit)
         else:
             self.nodes[0].generate(1)
-            protx_result = self.nodes[0].protx('register', txid, collateral_vout, '127.0.0.1:%d' % port, ownerAddr, bls['public'], votingAddr, 0, rewardsAddr, address, submit)
+            protx_result = self.nodes[0].protx('register', txid, collateral_vout, ipAndPort, ownerAddr, bls['public'], votingAddr, operatorReward, rewardsAddr, address, submit)
 
         if submit:
             proTxHash = protx_result
@@ -603,7 +607,10 @@ class DashTestFramework(BitcoinTestFramework):
 
         self.nodes[0].generate(1)
 
-        self.mninfo.append(MasternodeInfo(proTxHash, ownerAddr, votingAddr, bls['public'], bls['secret'], address, txid, collateral_vout))
+        if operatorReward > 0:
+            self.nodes[0].protx('update_service', proTxHash, ipAndPort, bls['secret'], operatorPayoutAddress, address)
+
+        self.mninfo.append(MasternodeInfo(proTxHash, ownerAddr, votingAddr, bls['public'], bls['secret'], ipAndPort, operatorReward, operatorPayoutAddress, address, txid, collateral_vout))
         self.sync_all()
 
         self.log.info("Prepared masternode %d: collateral_txid=%s, collateral_vout=%d, protxHash=%s" % (idx, txid, collateral_vout, proTxHash))

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -506,7 +506,7 @@ MASTERNODE_COLLATERAL = 1000
 
 
 class MasternodeInfo:
-    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, ipAndPort, operatorReward, operatorPayoutAddress, collateral_address, collateral_txid, collateral_vout):
+    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout):
         self.proTxHash = proTxHash
         self.ownerAddr = ownerAddr
         self.votingAddr = votingAddr
@@ -610,7 +610,7 @@ class DashTestFramework(BitcoinTestFramework):
         if operatorReward > 0:
             self.nodes[0].protx('update_service', proTxHash, ipAndPort, bls['secret'], operatorPayoutAddress, address)
 
-        self.mninfo.append(MasternodeInfo(proTxHash, ownerAddr, votingAddr, bls['public'], bls['secret'], ipAndPort, operatorReward, operatorPayoutAddress, address, txid, collateral_vout))
+        self.mninfo.append(MasternodeInfo(proTxHash, ownerAddr, votingAddr, bls['public'], bls['secret'], address, txid, collateral_vout))
         self.sync_all()
 
         self.log.info("Prepared masternode %d: collateral_txid=%s, collateral_vout=%d, protxHash=%s" % (idx, txid, collateral_vout, proTxHash))


### PR DESCRIPTION
~Based on #3861 atm~