### PR TITLE
privatesend: Drop redundant CBLSSignature.IsValid() checks

### DIFF
--- a/src/privatesend/privatesend.cpp
+++ b/src/privatesend/privatesend.cpp
@@ -63,7 +63,7 @@ bool CPrivateSendQueue::CheckSignature(const CBLSPublicKey& blsPubKey) const
 
     CBLSSignature sig;
     sig.SetBuf(vchSig);
-    if (!sig.IsValid() || !sig.VerifyInsecure(blsPubKey, hash)) {
+    if (!sig.VerifyInsecure(blsPubKey, hash)) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendQueue::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }
@@ -113,7 +113,7 @@ bool CPrivateSendBroadcastTx::CheckSignature(const CBLSPublicKey& blsPubKey) con
 
     CBLSSignature sig;
     sig.SetBuf(vchSig);
-    if (!sig.IsValid() || !sig.VerifyInsecure(blsPubKey, hash)) {
+    if (!sig.VerifyInsecure(blsPubKey, hash)) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendBroadcastTx::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }


### PR DESCRIPTION
It's checked in `VerifyInsecure` already