### PR TITLE
bls: Refactor CBLSWrapper::SetBuf and CBLSWrapper::GetBuf

### DIFF
--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -14,18 +14,6 @@
 #include <assert.h>
 #include <string.h>
 
-bool CBLSId::InternalSetBuf(const void* buf)
-{
-    memcpy(impl.begin(), buf, sizeof(uint256));
-    return true;
-}
-
-bool CBLSId::InternalGetBuf(void* buf) const
-{
-    memcpy(buf, impl.begin(), sizeof(uint256));
-    return true;
-}
-
 void CBLSId::SetInt(int x)
 {
     impl.SetHex(strprintf("%x", x));
@@ -52,22 +40,6 @@ CBLSId CBLSId::FromHash(const uint256& hash)
     CBLSId id;
     id.SetHash(hash);
     return id;
-}
-
-bool CBLSSecretKey::InternalSetBuf(const void* buf)
-{
-    try {
-        impl = bls::PrivateKey::FromBytes((const uint8_t*)buf);
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
-bool CBLSSecretKey::InternalGetBuf(void* buf) const
-{
-    impl.Serialize((uint8_t*)buf);
-    return true;
 }
 
 void CBLSSecretKey::AggregateInsecure(const CBLSSecretKey& o)
@@ -171,22 +143,6 @@ CBLSSignature CBLSSecretKey::Sign(const uint256& hash) const
     return sigRet;
 }
 
-bool CBLSPublicKey::InternalSetBuf(const void* buf)
-{
-    try {
-        impl = bls::PublicKey::FromBytes((const uint8_t*)buf);
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
-bool CBLSPublicKey::InternalGetBuf(void* buf) const
-{
-    impl.Serialize((uint8_t*)buf);
-    return true;
-}
-
 void CBLSPublicKey::AggregateInsecure(const CBLSPublicKey& o)
 {
     assert(IsValid() && o.IsValid());
@@ -254,22 +210,6 @@ bool CBLSPublicKey::DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& 
     impl = bls::BLS::DHKeyExchange(sk.impl, pk.impl);
     fValid = true;
     UpdateHash();
-    return true;
-}
-
-bool CBLSSignature::InternalSetBuf(const void* buf)
-{
-    try {
-        impl = bls::InsecureSignature::FromBytes((const uint8_t*)buf);
-        return true;
-    } catch (...) {
-        return false;
-    }
-}
-
-bool CBLSSignature::InternalGetBuf(void* buf) const
-{
-    impl.Serialize((uint8_t*)buf);
     return true;
 }
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -106,8 +106,10 @@ public:
         if (std::all_of((const char*)buf, (const char*)buf + SerSize, [](char c) { return c == 0; })) {
             Reset();
         } else {
-            fValid = InternalSetBuf(buf);
-            if (!fValid) {
+            try {
+                impl = ImplType::FromBytes((const uint8_t*)buf);
+                fValid = true;
+            } catch (...) {
                 Reset();
             }
         }

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -220,15 +220,15 @@ struct CBLSIdImplicit : public uint256
     {
         memcpy(begin(), id.begin(), sizeof(uint256));
     }
-    static uint256 FromBytes(const uint8_t* buffer)
+    static CBLSIdImplicit FromBytes(const uint8_t* buffer)
     {
-        uint256 instance;
-        memcpy(instance.begin(), buffer, sizeof(uint256));
+        CBLSIdImplicit instance;
+        memcpy(instance.begin(), buffer, sizeof(CBLSIdImplicit));
         return instance;
     }
     void Serialize(uint8_t* buffer) const
     {
-        memcpy(buffer, data, sizeof(uint256));
+        memcpy(buffer, data, sizeof(CBLSIdImplicit));
     }
 };
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -128,8 +128,7 @@ public:
         if (!fValid) {
             memset(buf, 0, SerSize);
         } else {
-            bool ok = InternalGetBuf(buf);
-            assert(ok);
+            impl.Serialize(static_cast<uint8_t*>(buf));
         }
     }
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -44,9 +44,6 @@ protected:
 
     inline constexpr size_t GetSerSize() const { return SerSize; }
 
-    virtual bool InternalSetBuf(const void* buf) = 0;
-    virtual bool InternalGetBuf(void* buf) const = 0;
-
 public:
     static const size_t SerSize = _SerSize;
 
@@ -249,10 +246,6 @@ public:
 
     static CBLSId FromInt(int64_t i);
     static CBLSId FromHash(const uint256& hash);
-
-protected:
-    bool InternalSetBuf(const void* buf);
-    bool InternalGetBuf(void* buf) const;
 };
 
 class CBLSSecretKey : public CBLSWrapper<bls::PrivateKey, BLS_CURVE_SECKEY_SIZE, CBLSSecretKey>
@@ -274,10 +267,6 @@ public:
 
     CBLSPublicKey GetPublicKey() const;
     CBLSSignature Sign(const uint256& hash) const;
-
-protected:
-    bool InternalSetBuf(const void* buf);
-    bool InternalGetBuf(void* buf) const;
 };
 
 class CBLSPublicKey : public CBLSWrapper<bls::PublicKey, BLS_CURVE_PUBKEY_SIZE, CBLSPublicKey>
@@ -298,9 +287,6 @@ public:
     bool PublicKeyShare(const std::vector<CBLSPublicKey>& mpk, const CBLSId& id);
     bool DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& pk);
 
-protected:
-    bool InternalSetBuf(const void* buf);
-    bool InternalGetBuf(void* buf) const;
 };
 
 class CBLSSignature : public CBLSWrapper<bls::InsecureSignature, BLS_CURVE_SIG_SIZE, CBLSSignature>
@@ -328,10 +314,6 @@ public:
     bool VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash) const;
 
     bool Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids);
-
-protected:
-    bool InternalSetBuf(const void* buf);
-    bool InternalGetBuf(void* buf) const;
 };
 
 #ifndef BUILD_BITCOIN_INTERNAL

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -215,6 +215,25 @@ public:
     }
 };
 
+struct CBLSIdImplicit : public uint256
+{
+    CBLSIdImplicit() {}
+    CBLSIdImplicit(const uint256& id)
+    {
+        memcpy(begin(), id.begin(), sizeof(uint256));
+    }
+    static uint256 FromBytes(const uint8_t* buffer)
+    {
+        uint256 instance;
+        memcpy(instance.begin(), buffer, sizeof(uint256));
+        return instance;
+    }
+    void Serialize(uint8_t* buffer) const
+    {
+        memcpy(buffer, data, sizeof(uint256));
+    }
+};
+
 class CBLSId : public CBLSWrapper<uint256, BLS_CURVE_ID_SIZE, CBLSId>
 {
 public:

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -234,7 +234,7 @@ struct CBLSIdImplicit : public uint256
     }
 };
 
-class CBLSId : public CBLSWrapper<uint256, BLS_CURVE_ID_SIZE, CBLSId>
+class CBLSId : public CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>
 {
 public:
     using CBLSWrapper::operator=;


### PR DESCRIPTION
Some refactoring of `CBLSWrapper::GetBuf`/`CBLSWrapper::SetBuf` to simplify the BLS classes a bit. 

`uint256` was implicit type of `CBLSId` but it doesn't provide `FromBytes` and the correct required `Serialize` to match the BLS primitives from `dashpay/bls-signatures` which are used by `CBLSWrapper`.

So 73d3271 + 2de99db are required to make 1df1d8b and 2c2e29d possible and b936f17 just drops not longer needed code.