### PR TITLE
refactor: Add/Use byte vector constructor for CBLSWrapper

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -242,6 +242,7 @@ public:
     using CBLSWrapper::operator=;
     using CBLSWrapper::operator==;
     using CBLSWrapper::operator!=;
+    using CBLSWrapper::CBLSWrapper;
 
     CBLSId() {}
 
@@ -258,6 +259,7 @@ public:
     using CBLSWrapper::operator=;
     using CBLSWrapper::operator==;
     using CBLSWrapper::operator!=;
+    using CBLSWrapper::CBLSWrapper;
 
     CBLSSecretKey() {}
 
@@ -282,6 +284,7 @@ public:
     using CBLSWrapper::operator=;
     using CBLSWrapper::operator==;
     using CBLSWrapper::operator!=;
+    using CBLSWrapper::CBLSWrapper;
 
     CBLSPublicKey() {}
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -62,6 +62,10 @@ public:
         static NullHash nullHash;
         cachedHash = nullHash.hash;
     }
+    CBLSWrapper(const std::vector<unsigned char>& vecBytes) : CBLSWrapper<ImplType, _SerSize, C>()
+    {
+        SetBuf(vecBytes);
+    }
 
     CBLSWrapper(const CBLSWrapper& ref) = default;
     CBLSWrapper& operator=(const CBLSWrapper& ref) = default;

--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -315,9 +315,7 @@ bool CGovernanceObject::Sign(const CBLSSecretKey& key)
 
 bool CGovernanceObject::CheckSignature(const CBLSPublicKey& pubKey) const
 {
-    CBLSSignature sig;
-    sig.SetBuf(vchSig);
-    if (!sig.VerifyInsecure(pubKey, GetSignatureHash())) {
+    if (!CBLSSignature(vchSig).VerifyInsecure(pubKey, GetSignatureHash())) {
         LogPrintf("CGovernanceObject::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }

--- a/src/governance/governance-vote.cpp
+++ b/src/governance/governance-vote.cpp
@@ -235,10 +235,7 @@ bool CGovernanceVote::Sign(const CBLSSecretKey& key)
 
 bool CGovernanceVote::CheckSignature(const CBLSPublicKey& pubKey) const
 {
-    uint256 hash = GetSignatureHash();
-    CBLSSignature sig;
-    sig.SetBuf(vchSig);
-    if (!sig.VerifyInsecure(pubKey, hash)) {
+    if (!CBLSSignature(vchSig).VerifyInsecure(pubKey, GetSignatureHash())) {
         LogPrintf("CGovernanceVote::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2113,8 +2113,7 @@ bool AppInitMain()
     std::string strMasterNodeBLSPrivKey = gArgs.GetArg("-masternodeblsprivkey", "");
     if (!strMasterNodeBLSPrivKey.empty()) {
         auto binKey = ParseHex(strMasterNodeBLSPrivKey);
-        CBLSSecretKey keyOperator;
-        keyOperator.SetBuf(binKey);
+        CBLSSecretKey keyOperator(binKey);
         if (!keyOperator.IsValid()) {
             return InitError(_("Invalid masternodeblsprivkey. Please see documentation."));
         }

--- a/src/privatesend/privatesend.cpp
+++ b/src/privatesend/privatesend.cpp
@@ -59,11 +59,7 @@ bool CPrivateSendQueue::Sign()
 
 bool CPrivateSendQueue::CheckSignature(const CBLSPublicKey& blsPubKey) const
 {
-    uint256 hash = GetSignatureHash();
-
-    CBLSSignature sig;
-    sig.SetBuf(vchSig);
-    if (!sig.VerifyInsecure(blsPubKey, hash)) {
+    if (!CBLSSignature(vchSig).VerifyInsecure(blsPubKey, GetSignatureHash())) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendQueue::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }
@@ -109,11 +105,7 @@ bool CPrivateSendBroadcastTx::Sign()
 
 bool CPrivateSendBroadcastTx::CheckSignature(const CBLSPublicKey& blsPubKey) const
 {
-    uint256 hash = GetSignatureHash();
-
-    CBLSSignature sig;
-    sig.SetBuf(vchSig);
-    if (!sig.VerifyInsecure(blsPubKey, hash)) {
+    if (!CBLSSignature(vchSig).VerifyInsecure(blsPubKey, GetSignatureHash())) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendBroadcastTx::CheckSignature -- VerifyInsecure() failed\n");
         return false;
     }

--- a/src/test/evo_simplifiedmns_tests.cpp
+++ b/src/test/evo_simplifiedmns_tests.cpp
@@ -23,13 +23,10 @@ BOOST_AUTO_TEST_CASE(simplifiedmns_merkleroots)
         std::string ip = strprintf("%d.%d.%d.%d", 0, 0, 0, i);
         Lookup(ip.c_str(), smle.service, i, false);
 
-        uint8_t skBuf[CBLSSecretKey::SerSize];
-        memset(skBuf, 0, sizeof(skBuf));
-        skBuf[0] = (uint8_t)i;
-        CBLSSecretKey sk;
-        sk.SetBuf(skBuf, sizeof(skBuf));
+        std::vector<unsigned char> vecBytes{static_cast<unsigned char>(i)};
+        vecBytes.resize(CBLSSecretKey::SerSize);
 
-        smle.pubKeyOperator.Set(sk.GetPublicKey());
+        smle.pubKeyOperator.Set(CBLSSecretKey(vecBytes).GetPublicKey());
         smle.keyIDVoting.SetHex(strprintf("%040x", i));
         smle.isValid = true;
 


### PR DESCRIPTION
Adds `CBLSWrapper(const std::vector<unsigned char>& vecBytes)` constructor and makes use of it in several places.

~Requires #3867 to work.~ Merged