### PR TITLE
refactor: Use constructors instead of static initialiser in CBLSId

### DIFF
--- a/src/bench/bls_dkg.cpp
+++ b/src/bench/bls_dkg.cpp
@@ -25,17 +25,19 @@ struct DKG
 
     BLSVerificationVectorPtr quorumVvec;
 
-    DKG(int quorumSize)
+    DKG(size_t quorumSize)
     {
         members.reserve(quorumSize);
-        ids.resize(quorumSize);
+        ids.reserve(quorumSize);
 
-        for (int i = 0; i < quorumSize; i++) {
-            members.push_back({CBLSId(i + 1), {}, {}});
-            ids[i] = members[i].id;
+        for (size_t i = 0; i < quorumSize; i++) {
+            uint256 id;
+            WriteLE64(id.begin(), i + 1);
+            members.push_back({id, {}, {}});
+            ids.emplace_back(id);
         }
 
-        for (int i = 0; i < quorumSize; i++) {
+        for (size_t i = 0; i < quorumSize; i++) {
             blsWorker.GenerateContributions(quorumSize / 2 + 1, ids, members[i].vvec, members[i].skShares);
         }
 

--- a/src/bench/bls_dkg.cpp
+++ b/src/bench/bls_dkg.cpp
@@ -27,11 +27,11 @@ struct DKG
 
     DKG(int quorumSize)
     {
-        members.resize(quorumSize);
+        members.reserve(quorumSize);
         ids.resize(quorumSize);
 
         for (int i = 0; i < quorumSize; i++) {
-            members[i].id.SetInt(i + 1);
+            members.push_back({CBLSId(i + 1), {}, {}});
             ids[i] = members[i].id;
         }
 

--- a/src/bench/bls_dkg.cpp
+++ b/src/bench/bls_dkg.cpp
@@ -25,19 +25,19 @@ struct DKG
 
     BLSVerificationVectorPtr quorumVvec;
 
-    DKG(size_t quorumSize)
+    DKG(int quorumSize)
     {
         members.reserve(quorumSize);
         ids.reserve(quorumSize);
 
-        for (size_t i = 0; i < quorumSize; i++) {
+        for (int i = 0; i < quorumSize; i++) {
             uint256 id;
             WriteLE64(id.begin(), i + 1);
             members.push_back({id, {}, {}});
             ids.emplace_back(id);
         }
 
-        for (size_t i = 0; i < quorumSize; i++) {
+        for (int i = 0; i < quorumSize; i++) {
             blsWorker.GenerateContributions(quorumSize / 2 + 1, ids, members[i].vvec, members[i].skShares);
         }
 

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -14,6 +14,20 @@
 #include <assert.h>
 #include <string.h>
 
+CBLSId::CBLSId(const int64_t n) : CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>()
+{
+    impl.SetHex(strprintf("%x", n));
+    fValid = true;
+    UpdateHash();
+}
+
+CBLSId::CBLSId(const uint256& nHash) : CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>()
+{
+    impl = nHash;
+    fValid = true;
+    UpdateHash();
+}
+
 void CBLSId::SetInt(int x)
 {
     impl.SetHex(strprintf("%x", x));

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -14,13 +14,6 @@
 #include <assert.h>
 #include <string.h>
 
-CBLSId::CBLSId(const int64_t n) : CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>()
-{
-    impl.SetHex(strprintf("%x", n));
-    fValid = true;
-    UpdateHash();
-}
-
 CBLSId::CBLSId(const uint256& nHash) : CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>()
 {
     impl = nHash;

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -28,34 +28,6 @@ CBLSId::CBLSId(const uint256& nHash) : CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_
     UpdateHash();
 }
 
-void CBLSId::SetInt(int x)
-{
-    impl.SetHex(strprintf("%x", x));
-    fValid = true;
-    UpdateHash();
-}
-
-void CBLSId::SetHash(const uint256& hash)
-{
-    impl = hash;
-    fValid = true;
-    UpdateHash();
-}
-
-CBLSId CBLSId::FromInt(int64_t i)
-{
-    CBLSId id;
-    id.SetInt(i);
-    return id;
-}
-
-CBLSId CBLSId::FromHash(const uint256& hash)
-{
-    CBLSId id;
-    id.SetHash(hash);
-    return id;
-}
-
 void CBLSSecretKey::AggregateInsecure(const CBLSSecretKey& o)
 {
     assert(IsValid() && o.IsValid());

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -242,12 +242,6 @@ public:
     CBLSId() {}
     CBLSId(const int64_t n);
     CBLSId(const uint256& nHash);
-    
-    void SetInt(int x);
-    void SetHash(const uint256& hash);
-
-    static CBLSId FromInt(int64_t i);
-    static CBLSId FromHash(const uint256& hash);
 };
 
 class CBLSSecretKey : public CBLSWrapper<bls::PrivateKey, BLS_CURVE_SECKEY_SIZE, CBLSSecretKey>

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -240,7 +240,6 @@ public:
     using CBLSWrapper::operator!=;
 
     CBLSId() {}
-    CBLSId(const int64_t n);
     CBLSId(const uint256& nHash);
 };
 

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -240,7 +240,9 @@ public:
     using CBLSWrapper::operator!=;
 
     CBLSId() {}
-
+    CBLSId(const int64_t n);
+    CBLSId(const uint256& nHash);
+    
     void SetInt(int x);
     void SetHash(const uint256& hash);
 

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -84,7 +84,7 @@ CBLSPublicKey CQuorum::GetPubKeyShare(size_t memberIdx) const
         return CBLSPublicKey();
     }
     auto& m = members[memberIdx];
-    return blsCache.BuildPubKeyShare(m->proTxHash, quorumVvec, CBLSId::FromHash(m->proTxHash));
+    return blsCache.BuildPubKeyShare(m->proTxHash, quorumVvec, CBLSId(m->proTxHash));
 }
 
 CBLSSecretKey CQuorum::GetSkShare() const

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -84,7 +84,7 @@ CDKGPrematureCommitment::CDKGPrematureCommitment(const Consensus::LLMQParams& pa
 CDKGMember::CDKGMember(CDeterministicMNCPtr _dmn, size_t _idx) :
     dmn(_dmn),
     idx(_idx),
-    id(CBLSId::FromHash(_dmn->proTxHash))
+    id(_dmn->proTxHash)
 {
 
 }

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -807,7 +807,7 @@ void CSigSharesManager::TryRecoverSig(const CQuorumCPtr& quorum, const uint256& 
         for (auto it = sigShares->begin(); it != sigShares->end() && sigSharesForRecovery.size() < quorum->params.threshold; ++it) {
             auto& sigShare = it->second;
             sigSharesForRecovery.emplace_back(sigShare.sigShare.Get());
-            idsForRecovery.emplace_back(CBLSId::FromHash(quorum->members[sigShare.quorumMember]->proTxHash));
+            idsForRecovery.emplace_back(quorum->members[sigShare.quorumMember]->proTxHash);
         }
 
         // check if we can recover the final signature


### PR DESCRIPTION
Adds ~`CBLSId(const int64_t n)` and~ `CBLSId(const uint256& nHash)` constructor and makes use of it in several places.

~Based on #3867~ Merged 