### PR TITLE
tests: Rework feature_new_quorum_type_activation.py using `-vbparams`

### DIFF
--- a/test/functional/feature_new_quorum_type_activation.py
+++ b/test/functional/feature_new_quorum_type_activation.py
@@ -15,16 +15,24 @@ Tests the activation of a new quorum type in v17 via a bip9-like hardfork
 
 class NewQuorumTypeActivationTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.setup_clean_chain = True
         self.num_nodes = 1
+        self.extra_args = [["-vbparams=v17:0:999999999999:10:8:6:5"]]
 
     def run_test(self):
+        assert_equal(get_bip9_status(self.nodes[0], 'v17')['status'], 'defined')
+        self.nodes[0].generate(9)
+        assert_equal(get_bip9_status(self.nodes[0], 'v17')['status'], 'started')
+        ql = self.nodes[0].quorum("list")
+        assert_equal(len(ql), 1)
+        assert("llmq_test_v17" not in ql)
+        self.nodes[0].generate(10)
         assert_equal(get_bip9_status(self.nodes[0], 'v17')['status'], 'locked_in')
         ql = self.nodes[0].quorum("list")
         assert_equal(len(ql), 1)
         assert("llmq_test_v17" not in ql)
-        self.nodes[0].generate(99)
+        self.nodes[0].generate(10)
         assert_equal(get_bip9_status(self.nodes[0], 'v17')['status'], 'active')
-        self.nodes[0].generate(1)
         ql = self.nodes[0].quorum("list")
         assert_equal(len(ql), 2)
         assert("llmq_test_v17" in ql)


### PR DESCRIPTION
Block cache isn't really needed for this test. Test duration drops from 26s to 2s when running this test only.

This is expected to fail without #3872 