### PR TITLE
rpc: fix help for gobject_list_prepared

### DIFF
--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -246,7 +246,7 @@ UniValue gobject_list_prepared(const JSONRPCRequest& request)
 {
     CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
     if (request.fHelp || (request.params.size() > 2)) {
-        gobject_prepare_help(pwallet);
+        gobject_list_prepared_help(pwallet);
     }
 
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp))


### PR DESCRIPTION
`gobject list_prepared` was incorrectly showing the help for `gobject prepare` since introduced in #3811