### PR TITLE
rpc: remove duplicated type field from gobject list-prepared

### DIFF
--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -425,7 +425,6 @@ UniValue CGovernanceObject::ToJson() const
     obj.pushKV("collateralHash", GetCollateralHash().ToString());
     obj.pushKV("createdAt", GetCreationTime());
     obj.pushKV("revision", nRevision);
-    obj.pushKV("type", nObjectType);
     UniValue data;
     if (!data.read(GetDataAsPlainString())) {
         data.clear();

--- a/test/functional/feature_governance_objects.py
+++ b/test/functional/feature_governance_objects.py
@@ -14,7 +14,6 @@ def validate_object(prepared, rpc_prepared):
     assert_equal(prepared["collateralHash"], rpc_prepared["collateralHash"])
     assert_equal(prepared["createdAt"], rpc_prepared["createdAt"])
     assert_equal(prepared["revision"], rpc_prepared["revision"])
-    assert_equal(prepared["type"], rpc_prepared["type"])
     assert_equal(prepared["hex"], rpc_prepared["data"]["hex"])
     del rpc_prepared["data"]["hex"]
     assert_equal(prepared["data"], rpc_prepared["data"])

--- a/test/functional/feature_governance_objects.py
+++ b/test/functional/feature_governance_objects.py
@@ -42,7 +42,6 @@ class DashGovernanceTest (DashTestFramework):
             "collateralHash": collateral_hash,
             "createdAt": proposal_time,
             "revision": proposal_rev,
-            "type": object_type,
             "hex": proposal_hex,
             "data": proposal_template,
         }


### PR DESCRIPTION
The `type` is already included in the `data` object so it shouldn't be necessary here.

Without this change:
``` json
[
  {
    "objectHash": "307cde2e485968548cd1a19473bf48f788c16178d82f63cbe849c33988d9592b",
    "parentHash": "0000000000000000000000000000000000000000000000000000000000000000",
    "collateralHash": "987570add8979576cb8a4ee510df448fd2ae7097628b7980559489ecb116b0fa",
    "createdAt": 1608143561,
    "revision": 1,
    "type": 1,
    "data": {
      "end_epoch": 1608151237,
      "name": "test",
      "payment_address": "yd5KMREs3GLMe6mTJYr3YrH1juwNwrFCfB",
      "payment_amount": 5,
      "start_epoch": 1608147672,
      "type": 1,
      "url": "https://www.dash.org",
      "hex": "7b22656e645f65706f6368223a313630383135313233372c226e616d65223a2274657374222c227061796d656e745f61646472657373223a227964354b4d52457333474c4d65366d544a597233597248316a75774e777246436642222c227061796d656e745f616d6f756e74223a352c2273746172745f65706f6368223a313630383134373637322c2274797065223a312c2275726c223a2268747470733a2f2f7777772e646173682e6f7267227d"
    }
  }
]
```

With it:
``` json
[
  {
    "objectHash": "307cde2e485968548cd1a19473bf48f788c16178d82f63cbe849c33988d9592b",
    "parentHash": "0000000000000000000000000000000000000000000000000000000000000000",
    "collateralHash": "987570add8979576cb8a4ee510df448fd2ae7097628b7980559489ecb116b0fa",
    "createdAt": 1608143561,
    "revision": 1,
    "data": {
      "end_epoch": 1608151237,
      "name": "test",
      "payment_address": "yd5KMREs3GLMe6mTJYr3YrH1juwNwrFCfB",
      "payment_amount": 5,
      "start_epoch": 1608147672,
      "type": 1,
      "url": "https://www.dash.org",
      "hex": "7b22656e645f65706f6368223a313630383135313233372c226e616d65223a2274657374222c227061796d656e745f61646472657373223a227964354b4d52457333474c4d65366d544a597233597248316a75774e777246436642222c227061796d656e745f616d6f756e74223a352c2273746172745f65706f6368223a313630383134373637322c2274797065223a312c2275726c223a2268747470733a2f2f7777772e646173682e6f7267227d"
    }
  }
]
```