### PR TITLE
Revert "Merge bitcoin#13782: Fix osslsigncode compile issue in gitian-build"

### DIFF
--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -5,8 +5,7 @@ suites:
 architectures:
 - "amd64"
 packages:
-# Once osslsigncode supports openssl 1.1, we can change this back to libssl-dev
-- "libssl1.0-dev"
+- "libssl-dev"
 - "autoconf"
 - "automake"
 - "libtool"


### PR DESCRIPTION
We use osslsigncode 2.0 already due to dashpay#3258 so this commit reverts backport of bitcoin#13782 (https://github.com/dashpay/dash/commit/619f7fb862c196b22e4b222b5bc2ff1f56411c12)