### PR TITLE
Fix CDKGSessionHandler thread names

### DIFF
--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -142,7 +142,7 @@ void CDKGSessionHandler::StartThread()
         throw std::runtime_error("Tried to start an already started CDKGSessionHandler thread.");
     }
 
-    std::string threadName = strprintf("q-phase-%d", params.type);
+    std::string threadName = strprintf("q-phase-%d", (uint8_t)params.type);
     phaseHandlerThread = std::thread(&TraceThread<std::function<void()> >, threadName, std::function<void()>(std::bind(&CDKGSessionHandler::PhaseHandlerThread, this)));
 }
 


### PR DESCRIPTION
Some compilers seems to have an issue with this implicit conversion producing garbage instead of numbers.

We had an explicit conversion [here](https://github.com/dashpay/dash/commit/62c3fb57484fca6b3ab8f2f0e16474d4527868e7#diff-92a8ac27d98265e048cdb614638aac53d080b34d39fb60ea2a1985a15218e7e2L100) initially but it was dropped [here](https://github.com/dashpay/dash/commit/62c3fb57484fca6b3ab8f2f0e16474d4527868e7#diff-92a8ac27d98265e048cdb614638aac53d080b34d39fb60ea2a1985a15218e7e2R149) accidentally.

(thanks to @mrdefacto for reporting an issue)