### PR TITLE
Change thread names to fit into 15 symbols

### DIFF
--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -63,7 +63,7 @@ void CBLSWorker::Start()
     int workerCount = std::thread::hardware_concurrency() / 2;
     workerCount = std::max(std::min(1, workerCount), 4);
     workerPool.resize(workerCount);
-    RenameThreadPool(workerPool, "dash-bls-worker");
+    RenameThreadPool(workerPool, "dash-bls-work");
 }
 
 void CBLSWorker::Stop()

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -35,7 +35,7 @@ CChainLocksHandler::CChainLocksHandler()
 {
     scheduler = new CScheduler();
     CScheduler::Function serviceLoop = boost::bind(&CScheduler::serviceQueue, scheduler);
-    scheduler_thread = new boost::thread(boost::bind(&TraceThread<CScheduler::Function>, "cl-scheduler", serviceLoop));
+    scheduler_thread = new boost::thread(boost::bind(&TraceThread<CScheduler::Function>, "cl-schdlr", serviceLoop));
 }
 
 CChainLocksHandler::~CChainLocksHandler()

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -142,7 +142,7 @@ void CDKGSessionHandler::StartThread()
         throw std::runtime_error("Tried to start an already started CDKGSessionHandler thread.");
     }
 
-    std::string threadName = strprintf("q-phase-%d", (uint8_t)params.type);
+    std::string threadName = strprintf("llmq-%d", (uint8_t)params.type);
     phaseHandlerThread = std::thread(&TraceThread<std::function<void()> >, threadName, std::function<void()>(std::bind(&CDKGSessionHandler::PhaseHandlerThread, this)));
 }
 

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -352,7 +352,7 @@ void CInstantSendManager::Start()
         assert(false);
     }
 
-    workThread = std::thread(&TraceThread<std::function<void()> >, "instantsend", std::function<void()>(std::bind(&CInstantSendManager::WorkThreadMain, this)));
+    workThread = std::thread(&TraceThread<std::function<void()> >, "isman", std::function<void()>(std::bind(&CInstantSendManager::WorkThreadMain, this)));
 
     quorumSigningManager->RegisterRecoveredSigsListener(this);
 }


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="111" alt="Screenshot 2020-12-23 at 16 48 12" src="https://user-images.githubusercontent.com/1935069/103002224-90d3fc00-453f-11eb-96b0-702b5d4b751f.png">|<img width="103" alt="Screenshot 2020-12-23 at 16 55 32" src="https://user-images.githubusercontent.com/1935069/103002398-e01a2c80-453f-11eb-99ae-bd91cec5341c.png">|

The reason to touch `dash-q-phase` (even though it looks ok on screenshots above) is the way it works on regtest.
Before:
```
dash-q-phase-10 | RenameThread: thread new name dash-q-phase-100
dash-q-phase-10 | q-phase-100 thread start
dash-q-phase-10 | RenameThread: thread new name dash-q-phase-102
dash-q-phase-10 | q-phase-102 thread start
```
After:
```
  dash-llmq-100 | RenameThread: thread new name dash-llmq-100
  dash-llmq-100 | llmq-100 thread start
  dash-llmq-102 | RenameThread: thread new name dash-llmq-102
  dash-llmq-102 | llmq-102 thread start
```

~Based on #3896 atm due to merge conflicts.~