### PR TITLE
Fix versionbits cache usage in IsQuorumTypeEnabled

### DIFF
--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -13,6 +13,7 @@
 #include <llmq/quorums_instantsend.h>
 #include <llmq/quorums_signing.h>
 #include <llmq/quorums_signing_shares.h>
+#include <llmq/quorums_utils.h>
 
 #include <dbwrapper.h>
 
@@ -60,6 +61,8 @@ void DestroyLLMQSystem()
     blsWorker = nullptr;
     delete llmqDb;
     llmqDb = nullptr;
+    LOCK(cs_llmq_vbc);
+    llmq_versionbitscache.Clear();
 }
 
 void StartLLMQSystem()

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -15,6 +15,9 @@
 namespace llmq
 {
 
+CCriticalSection cs_llmq_vbc;
+VersionBitsCache llmq_versionbitscache;
+
 std::vector<CDeterministicMNCPtr> CLLMQUtils::GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum)
 {
     if (!IsQuorumTypeEnabled(llmqType, pindexQuorum->pprev)) {
@@ -259,8 +262,10 @@ bool CLLMQUtils::IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quo
 
 bool CLLMQUtils::IsQuorumTypeEnabled(Consensus::LLMQType llmqType, const CBlockIndex* pindex)
 {
+    LOCK(cs_llmq_vbc);
+
     const Consensus::Params& consensusParams = Params().GetConsensus();
-    bool f_v17_Active =  VersionBitsState(pindex, consensusParams, Consensus::DEPLOYMENT_V17, versionbitscache) == ThresholdState::ACTIVE;
+    bool f_v17_Active = VersionBitsState(pindex, consensusParams, Consensus::DEPLOYMENT_V17, llmq_versionbitscache) == ThresholdState::ACTIVE;
 
     switch (llmqType)
     {

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -12,8 +12,15 @@
 
 #include <vector>
 
+class VersionBitsCache;
+
 namespace llmq
 {
+
+// Use a separate cache instance instead of versionbitscache to avoid locking cs_main
+// and dealing with all kinds of deadlocks.
+extern CCriticalSection cs_llmq_vbc;
+extern VersionBitsCache llmq_versionbitscache;
 
 class CLLMQUtils
 {


### PR DESCRIPTION
Not protecting it causes random crashes and protecting it with `cs_main` opens a can of worms (various deadlocks). Having a separate cache instance seems like a good compromise with a tiny overhead which _shouldn't_ cause any issues as far as I'm aware.