### PR TITLE
rpc: Introduce `quorum verify`

### DIFF
--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -303,7 +303,7 @@ void quorum_verify_help()
 {
     throw std::runtime_error(
             "quorum verify llmqType \"id\" \"msgHash\" \"signature\" ( \"quorumHash\" signHeight )\n"
-            "Test if a quorum signature is valid for a message\n"
+            "Test if a quorum signature is valid for a request id and a message hash\n"
             "\nArguments:\n"
             "1. llmqType              (int, required) LLMQ type.\n"
             "2. \"id\"                  (string, required) Request id.\n"
@@ -534,7 +534,7 @@ UniValue quorum_dkgsimerror(const JSONRPCRequest& request)
             "  dkgstatus         - Return the status of the current DKG process\n"
             "  memberof          - Checks which quorums the given masternode is a member of\n"
             "  sign              - Threshold-sign a message\n"
-            "  verify            - Test if a quorum signature is valid for a message\n"
+            "  verify            - Test if a quorum signature is valid for a request id and a message hash\n"
             "  hasrecsig         - Test if a valid recovered signature is present\n"
             "  getrecsig         - Get a recovered signature\n"
             "  isconflicting     - Test if a conflict exists\n"

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -299,6 +299,23 @@ void quorum_sign_help()
     );
 }
 
+void quorum_verify_help()
+{
+    throw std::runtime_error(
+            "quorum verify llmqType \"id\" \"msgHash\" \"signature\" ( \"quorumHash\" signHeight )\n"
+            "Test if a quorum signature is valid for a message\n"
+            "\nArguments:\n"
+            "1. llmqType              (int, required) LLMQ type.\n"
+            "2. \"id\"                  (string, required) Request id.\n"
+            "3. \"msgHash\"             (string, required) Message hash.\n"
+            "4. \"signature\"           (string, required) Quorum signature to verify.\n"
+            "5. \"quorumHash\"          (string, optional) The quorum identifier.\n"
+            "                             Set to \"\" if you want to specify signHeight instead.\n"
+            "6. signHeight                (int, optional) The height at which the message was signed.\n"
+            "                             Only works when quorumHash is \"\".\n"
+    );
+}
+
 void quorum_hasrecsig_help()
 {
     throw std::runtime_error(
@@ -343,6 +360,10 @@ UniValue quorum_sigs_cmd(const JSONRPCRequest& request)
             if ((request.params.size() < 4) || (request.params.size() > 5)) {
                 quorum_sign_help();
             }
+        } else if (cmd == "verify") {
+            if (request.params.size() < 5 || request.params.size() > 7) {
+                quorum_verify_help();
+            }
         } else if (cmd == "hasrecsig") {
             quorum_hasrecsig_help();
         } else if (cmd == "getrecsig") {
@@ -375,6 +396,39 @@ UniValue quorum_sigs_cmd(const JSONRPCRequest& request)
         } else {
             return llmq::quorumSigningManager->AsyncSignIfMember(llmqType, id, msgHash);
         }
+    } else if (cmd == "verify") {
+        CBLSSignature sig;
+        if (!sig.SetHexStr(request.params[4].get_str())) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
+        }
+
+        llmq::CQuorumCPtr quorum{nullptr};
+        if (request.params[5].isNull() || (request.params[5].get_str().empty() && !request.params[6].isNull())) {
+            int signHeight{-1};
+            if (!request.params[6].isNull()) {
+                signHeight = ParseInt32V(request.params[6], "signHeight");
+            }
+            // First check against the current active set
+            quorum = llmq::quorumSigningManager->SelectQuorumForSigning(llmqType, id, signHeight, 0);
+            if (!quorum) {
+                // Then check against the previous active set in case it changed recently
+                auto signOffset = Params().GetConsensus().llmqs.at(llmqType).dkgInterval;
+                quorum = llmq::quorumSigningManager->SelectQuorumForSigning(llmqType, id, signHeight, signOffset);
+                if (!quorum) {
+                    // None of the above
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "quorum not found");
+                }
+            }
+        } else {
+            uint256 quorumHash = ParseHashV(request.params[5], "quorumHash");
+            quorum = llmq::quorumManager->GetQuorum(llmqType, quorumHash);
+            if (!quorum) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "quorum not found");
+            }
+        }
+
+        uint256 signHash = llmq::CLLMQUtils::BuildSignHash(llmqType, quorum->qc.quorumHash, id, msgHash);
+        return sig.VerifyInsecure(quorum->qc.quorumPublicKey, signHash);
     } else if (cmd == "hasrecsig") {
         return llmq::quorumSigningManager->HasRecoveredSig(llmqType, id, msgHash);
     } else if (cmd == "getrecsig") {
@@ -483,6 +537,7 @@ UniValue quorum_dkgsimerror(const JSONRPCRequest& request)
             "  dkgstatus         - Return the status of the current DKG process\n"
             "  memberof          - Checks which quorums the given masternode is a member of\n"
             "  sign              - Threshold-sign a message\n"
+            "  verify            - Test if a quorum signature is valid for a message\n"
             "  hasrecsig         - Test if a valid recovered signature is present\n"
             "  getrecsig         - Get a recovered signature\n"
             "  isconflicting     - Test if a conflict exists\n"
@@ -509,7 +564,7 @@ UniValue quorum(const JSONRPCRequest& request)
         return quorum_dkgstatus(request);
     } else if (command == "memberof") {
         return quorum_memberof(request);
-    } else if (command == "sign" || command == "hasrecsig" || command == "getrecsig" || command == "isconflicting") {
+    } else if (command == "sign" || command == "verify" || command == "hasrecsig" || command == "getrecsig" || command == "isconflicting") {
         return quorum_sigs_cmd(request);
     } else if (command == "selectquorum") {
         return quorum_selectquorum(request);

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -414,17 +414,14 @@ UniValue quorum_sigs_cmd(const JSONRPCRequest& request)
                 // Then check against the previous active set in case it changed recently
                 auto signOffset = Params().GetConsensus().llmqs.at(llmqType).dkgInterval;
                 quorum = llmq::quorumSigningManager->SelectQuorumForSigning(llmqType, id, signHeight, signOffset);
-                if (!quorum) {
-                    // None of the above
-                    throw JSONRPCError(RPC_INVALID_PARAMETER, "quorum not found");
-                }
             }
         } else {
             uint256 quorumHash = ParseHashV(request.params[5], "quorumHash");
             quorum = llmq::quorumManager->GetQuorum(llmqType, quorumHash);
-            if (!quorum) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "quorum not found");
-            }
+        }
+
+        if (!quorum) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "quorum not found");
         }
 
         uint256 signHash = llmq::CLLMQUtils::BuildSignHash(llmqType, quorum->qc.quorumHash, id, msgHash);

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -412,7 +412,7 @@ UniValue quorum_sigs_cmd(const JSONRPCRequest& request)
             quorum = llmq::quorumSigningManager->SelectQuorumForSigning(llmqType, id, signHeight, 0);
             if (!quorum) {
                 // Then check against the previous active set in case it changed recently
-                auto signOffset = Params().GetConsensus().llmqs.at(llmqType).dkgInterval;
+                int signOffset = Params().GetConsensus().llmqs.at(llmqType).dkgInterval;
                 quorum = llmq::quorumSigningManager->SelectQuorumForSigning(llmqType, id, signHeight, signOffset);
             }
         } else {

--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -64,6 +64,20 @@ class LLMQSigningTest(DashTestFramework):
         self.mninfo[2].node.quorum("sign", 100, id, msgHash)
         wait_for_sigs(True, False, True, 15)
 
+        # Test `quorum verify` rpc
+        node = self.nodes[0]
+        recsig = node.quorum("getrecsig", 100, id, msgHash)
+        # Find quorum automatically
+        height = node.getblockcount()
+        height_bad = node.getblockheader(recsig["quorumHash"])["height"]
+        assert(node.quorum("verify", 100, id, msgHash, recsig["sig"]))
+        assert(node.quorum("verify", 100, id, msgHash, recsig["sig"], "", height))
+        assert(not node.quorum("verify", 100, id, msgHashConflict, recsig["sig"]))
+        assert_raises_rpc_error(-8, "quorum not found", node.quorum, "verify", 100, id, msgHash, recsig["sig"], "", height_bad)
+        # Use specifc quorum
+        assert(node.quorum("verify", 100, id, msgHash, recsig["sig"], recsig["quorumHash"]))
+        assert(not node.quorum("verify", 100, id, msgHashConflict, recsig["sig"], recsig["quorumHash"]))
+
         recsig_time = self.mocktime
 
         # Mine one more quorum, so that we have 2 active ones, nothing should change

--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -70,6 +70,7 @@ class LLMQSigningTest(DashTestFramework):
         # Find quorum automatically
         height = node.getblockcount()
         height_bad = node.getblockheader(recsig["quorumHash"])["height"]
+        hash_bad = node.getblockhash(0)
         assert(node.quorum("verify", 100, id, msgHash, recsig["sig"]))
         assert(node.quorum("verify", 100, id, msgHash, recsig["sig"], "", height))
         assert(not node.quorum("verify", 100, id, msgHashConflict, recsig["sig"]))
@@ -77,6 +78,7 @@ class LLMQSigningTest(DashTestFramework):
         # Use specifc quorum
         assert(node.quorum("verify", 100, id, msgHash, recsig["sig"], recsig["quorumHash"]))
         assert(not node.quorum("verify", 100, id, msgHashConflict, recsig["sig"], recsig["quorumHash"]))
+        assert_raises_rpc_error(-8, "quorum not found", node.quorum, "verify", 100, id, msgHash, recsig["sig"], hash_bad)
 
         recsig_time = self.mocktime
 


### PR DESCRIPTION
Example: verifying islock sig for tx 8b5174d0e95b5642ebec23c3fe8f0bbf8f6993502f4210322871bba0e818ff3b on testnet
```
> dash-cli quorum verify 1 2ceeaa7ff20de327ef65b14de692199d15b67b9458d0ded7d68735cce98dd039 8b5174d0e95b5642ebec23c3fe8f0bbf8f6993502f4210322871bba0e818ff3b 99cf2a0deb08286a2d1ffdd2564b35522fd748c8802e561abed330dea20df5cb5a5dffeddbe627ea32cb36de13d5b4a516fdfaebae9886b2f7969a5d112416cf8d1983ebcbf1463a64f7522505627e08b9c76c036616fbb1649271a2773a1653 000000583a348d1a0a5f753ef98e6a69f9bcd9b27919f10eb1a1c3edb6c79182
true
```