### PR TITLE
Use build badges provided by Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Dash Core staging tree 0.17
 ===========================
 
-`master:` [![Build Status](https://travis-ci.org/dashpay/dash.svg?branch=master)](https://travis-ci.org/dashpay/dash) `develop:` [![Build Status](https://travis-ci.org/dashpay/dash.svg?branch=develop)](https://travis-ci.org/dashpay/dash/branches)
+|CI|master|develop|
+|-|-|-|
+|Gitlab|[![Build Status](https://gitlab.com/dashpay/dash/badges/master/pipeline.svg)](https://gitlab.com/dashpay/dash/-/tree/master)|[![Build Status](https://gitlab.com/dashpay/dash/badges/develop/pipeline.svg)](https://gitlab.com/dashpay/dash/-/tree/develop)|
 
 https://www.dash.org
 


### PR DESCRIPTION
Looks like this:

<img width="599" alt="Screenshot 2021-01-06 at 20 15 18" src="https://user-images.githubusercontent.com/1935069/103799303-f655db80-505b-11eb-9dd4-bb3b764f7775.png">

Live: https://github.com/UdjinM6/dash/tree/fixbadges