### PR TITLE
llmq|rpc|test: Add optional "submit" parameter to "quorum sign"

### DIFF
--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -406,7 +406,7 @@ public:
     void ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv);
 
     void AsyncSign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
-    void Sign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
+    CSigShare CreateSigShare(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
     void ForceReAnnouncement(const CQuorumCPtr& quorum, Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash);
 
     void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -975,6 +975,34 @@ class CRecoveredSig:
         r += self.sig
         return r
 
+
+class CSigShare:
+    def __init__(self):
+        self.llmqType = 0
+        self.quorumHash = 0
+        self.quorumMember = 0
+        self.id = 0
+        self.msgHash = 0
+        self.sigShare = b'\\x0' * 96
+
+    def deserialize(self, f):
+        self.llmqType = struct.unpack("<B", f.read(1))[0]
+        self.quorumHash = deser_uint256(f)
+        self.quorumMember = struct.unpack("<H", f.read(2))[0]
+        self.id = deser_uint256(f)
+        self.msgHash = deser_uint256(f)
+        self.sigShare = f.read(96)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.llmqType)
+        r += ser_uint256(self.quorumHash)
+        r += struct.pack("<H", self.quorumMember)
+        r += ser_uint256(self.id)
+        r += ser_uint256(self.msgHash)
+        r += self.sigShare
+        return r
+
 # Objects that correspond to messages on the wire
 class msg_version():
     command = b"version"
@@ -1517,3 +1545,21 @@ class msg_islock():
 
     def __repr__(self):
         return "msg_islock(inputs=%s, txid=%064x)" % (repr(self.inputs), self.txid)
+
+
+class msg_qsigshare():
+    command = b"qsigshare"
+
+    def __init__(self, sig_shares=[]):
+        self.sig_shares = sig_shares
+
+    def deserialize(self, f):
+        self.sig_shares = deser_vector(f, CSigShare)
+
+    def serialize(self):
+        r = b""
+        r += ser_vector(self.sig_shares)
+        return r
+
+    def __repr__(self):
+        return "msg_qsigshare(sigShares=%d)" % (len(self.sig_shares))


### PR DESCRIPTION
This PR is based on a requirement of platform. They want to handle the validation of the individual signature shares as well as the threshold recovery completely in tenderdash without relaying them in dash core P2P. Having the `submit` parameter for `quorum sign` allows to just create a signature share and return it as JSON object instead of triggering  `AsyncSignIfMember` (the "create and submit to others" workflow) which happens for `submit=true` (the default case like before).

The resulting object for `submit=false` contains all information included in the class `CSigShare`. Example output:

```
{
  "llmqType": 100,
  "quorumHash": "53d959f609a654cf4e5e3c083fd6c47b7ec6cb73af4ac7329149688337b8ef9a",
  "quorumMember": 2,
  "id": "0000000000000000000000000000000000000000000000000000000000000001",
  "msgHash", "0000000000000000000000000000000000000000000000000000000000000002",
  "signHash", "39458221939396a45a2e348caada646eabd52849990827d40e33eb1399097b3c",
  "signature": "9716545a0c28ff70900a71fabbadf3c13e4ae562032122902405365f1ebf3da813c8a97d765eb8b167ff339c1638550c13822217cf06b609ba6a78f0035684ca7b4afdb7146ce74a30cfb6770f852aade8c27ffec67c79f85be31964573fb51c"
}
```

Based on #3914 