### PR TITLE
rpc|test: Improve platform restrictions, add new commands to the whitelist

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1748,6 +1748,8 @@ bool AppInitMain()
     GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
     GetMainSignals().RegisterWithMempoolSignals(mempool);
 
+    tableRPC.InitPlatformRestrictions();
+
     /* Register RPC commands regardless of -server setting so they will be
      * available in the GUI RPC console even if external calls are disabled.
      */

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -34,10 +34,10 @@ static RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */
 static std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers;
 
-// Any commands submitted by this user will have their commands filtered based on the platformAllowedCommands
+// Any commands submitted by this user will have their commands filtered based on the mapPlatformRestrictions
 static const std::string defaultPlatformUser = "platform-user";
 
-static const std::map<std::string, std::set<std::string>> platformAllowedCommands{
+static const std::map<std::string, std::set<std::string>> mapPlatformRestrictions{
     {"getbestblockhash", {}},
     {"getblockhash", {}},
     {"getblockcount", {}},
@@ -563,9 +563,9 @@ UniValue CRPCTable::execute(const JSONRPCRequest &request) const
     // Before executing the RPC Command, filter commands from platform rpc user
     if (fMasternodeMode && request.authUser == gArgs.GetArg("-platform-user", defaultPlatformUser)) {
 
-        auto it = platformAllowedCommands.find(request.strMethod);
-        // If the requested method is not available in platformAllowedCommands
-        if (it == platformAllowedCommands.end()) {
+        auto it = mapPlatformRestrictions.find(request.strMethod);
+        // If the requested method is not available in mapPlatformRestrictions
+        if (it == mapPlatformRestrictions.end()) {
             throw JSONRPCError(RPC_PLATFORM_RESTRICTION, strprintf("Method \"%s\" prohibited", request.strMethod));
         }
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -269,6 +269,8 @@ void CRPCTable::InitPlatformRestrictions()
         {"getblockhash", {}},
         {"getblockcount", {}},
         {"getbestchainlock", {}},
+        {"quorum", {"sign", Params().GetConsensus().llmqTypePlatform}},
+        {"quorum", {"verify"}},
     };
 }
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -37,13 +37,6 @@ static std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers;
 // Any commands submitted by this user will have their commands filtered based on the mapPlatformRestrictions
 static const std::string defaultPlatformUser = "platform-user";
 
-static const std::multimap<std::string, std::set<std::string>> mapPlatformRestrictions{
-    {"getbestblockhash", {}},
-    {"getblockhash", {}},
-    {"getblockcount", {}},
-    {"getbestchainlock", {}},
-};
-
 static struct CRPCSignals
 {
     boost::signals2::signal<void ()> Started;
@@ -267,6 +260,16 @@ std::string CRPCTable::help(const std::string& strCommand, const std::string& st
         strRet = strprintf("help: unknown command: %s\n", strCommand);
     strRet = strRet.substr(0,strRet.size()-1);
     return strRet;
+}
+
+void CRPCTable::InitPlatformRestrictions()
+{
+    mapPlatformRestrictions = {
+        {"getbestblockhash", {}},
+        {"getblockhash", {}},
+        {"getblockcount", {}},
+        {"getbestchainlock", {}},
+    };
 }
 
 UniValue help(const JSONRPCRequest& jsonRequest)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -271,6 +271,7 @@ void CRPCTable::InitPlatformRestrictions()
         {"getbestchainlock", {}},
         {"quorum", {"sign", Params().GetConsensus().llmqTypePlatform}},
         {"quorum", {"verify"}},
+        {"verifyislock", {}},
     };
 }
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -12,6 +12,7 @@
 
 #include <list>
 #include <map>
+#include <set>
 #include <stdint.h>
 #include <string>
 
@@ -142,10 +143,13 @@ class CRPCTable
 {
 private:
     std::map<std::string, const CRPCCommand*> mapCommands;
+    std::multimap<std::string, std::set<std::string>> mapPlatformRestrictions;
 public:
     CRPCTable();
     const CRPCCommand* operator[](const std::string& name) const;
     std::string help(const std::string& name, const std::string& strSubCommand, const JSONRPCRequest& helpreq) const;
+
+    void InitPlatformRestrictions();
 
     /**
      * Execute a method.

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -12,7 +12,6 @@
 
 #include <list>
 #include <map>
-#include <set>
 #include <stdint.h>
 #include <string>
 
@@ -143,7 +142,7 @@ class CRPCTable
 {
 private:
     std::map<std::string, const CRPCCommand*> mapCommands;
-    std::multimap<std::string, std::set<std::string>> mapPlatformRestrictions;
+    std::multimap<std::string, std::vector<UniValue>> mapPlatformRestrictions;
 public:
     CRPCTable();
     const CRPCCommand* operator[](const std::string& name) const;

--- a/test/functional/rpc_platform_filter.py
+++ b/test/functional/rpc_platform_filter.py
@@ -52,7 +52,13 @@ class HTTPBasicsTest(BitcoinTestFramework):
                 assert_equal(resp.status, expexted_status)
             conn.close()
 
-        whitelisted = ["getbestblockhash", "getblockhash", "getblockcount", "getbestchainlock", "quorum"]
+        whitelisted = ["getbestblockhash",
+                       "getblockhash",
+                       "getblockcount",
+                       "getbestchainlock",
+                       "quorum",
+                       "verifyislock"]
+
         help_output = self.nodes[0].help().split('\n')
         nonwhitelisted = set()
 
@@ -82,6 +88,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
                                 "0000000000000000000000000000000000000000000000000000000000000001"],
                                 rpcuser_authpair_platform, 200)
         test_command("quorum", ["verify"], rpcuser_authpair_platform, 500)
+        test_command("verifyislock", [], rpcuser_authpair_platform, 500)
 
         self.log.info('Try using some invalid combinations for platform-user')
         test_command("quorum", [], rpcuser_authpair_platform, 403)

--- a/test/functional/rpc_platform_filter.py
+++ b/test/functional/rpc_platform_filter.py
@@ -52,7 +52,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
                 assert_equal(resp.status, expexted_status)
             conn.close()
 
-        whitelisted = ["getbestblockhash", "getblockhash", "getblockcount", "getbestchainlock"]
+        whitelisted = ["getbestblockhash", "getblockhash", "getblockcount", "getbestchainlock", "quorum"]
         help_output = self.nodes[0].help().split('\n')
         nonwhitelisted = set()
 
@@ -77,6 +77,18 @@ class HTTPBasicsTest(BitcoinTestFramework):
         test_command("getblockhash", [0], rpcuser_authpair_platform, 200)
         test_command("getblockcount", [], rpcuser_authpair_platform, 200)
         test_command("getbestchainlock", [], rpcuser_authpair_platform, 500)
+        test_command("quorum", ["sign", 100], rpcuser_authpair_platform, 500)
+        test_command("quorum", ["sign", 100, "0000000000000000000000000000000000000000000000000000000000000000",
+                                "0000000000000000000000000000000000000000000000000000000000000001"],
+                                rpcuser_authpair_platform, 200)
+        test_command("quorum", ["verify"], rpcuser_authpair_platform, 500)
+
+        self.log.info('Try using some invalid combinations for platform-user')
+        test_command("quorum", [], rpcuser_authpair_platform, 403)
+        test_command("quorum", ["sign"], rpcuser_authpair_platform, 403)
+        test_command("quorum", ["sign", 102], rpcuser_authpair_platform, 403)
+        test_command("quorum", ["sign", "100"], rpcuser_authpair_platform, 403)
+        test_command("quorum", ["dkgsimerror"], rpcuser_authpair_platform, 403)
 
         self.log.info('Try running all non-whitelisted commands as each user...')
         for command in nonwhitelisted:


### PR DESCRIPTION
This PR changes the platform restriction code to use `std::multimap` instead of `std::map` to store the restrictions which allows to have multiple entries for one command but with a different parameter set. This is required for example to allow different subsets of `quorum <subcommand> <params>`. 

It also changes the parameter holding container from `std::set` to `std::vector` with a change of the value type from `std::string` to `UniValue` which lets us define full subsets of parameter with different types available from `UniValue` like 

```
{"quorum", {"sign", Params().GetConsensus().llmqTypePlatform}},
```

It also introduces new whitelisted commands.

Based on #3913 and requires #3906 to pass