### PR TITLE
Add runtime error for Generate commands when the build compiles without mining support

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -194,6 +194,11 @@ UniValue generatetoaddress(const JSONRPCRequest& request)
 
     return generateBlocks(coinbaseScript, nGenerate, nMaxTries, false);
 }
+#else
+UniValue generatetoaddress(const JSONRPCRequest& request)
+{
+    throw std::runtime_error("Error RPC miner isn't compiled");
+}
 #endif // ENABLE_MINER
 
 UniValue getmininginfo(const JSONRPCRequest& request)
@@ -966,6 +971,8 @@ static const CRPCCommand commands[] =
 
 #if ENABLE_MINER
     { "generating",         "generatetoaddress",      &generatetoaddress,      {"nblocks","address","maxtries"} },
+#else
+    { "hidden",             "generatetoaddress",      &generatetoaddress,      {"nblocks","address","maxtries"} }, // Hidden as it isn't functional, just an error to let people know if miner isn't compiled
 #endif // ENABLE_MINER
 
     { "hidden",             "estimatefee",            &estimatefee,            {} },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -197,7 +197,7 @@ UniValue generatetoaddress(const JSONRPCRequest& request)
 #else
 UniValue generatetoaddress(const JSONRPCRequest& request)
 {
-    throw std::runtime_error("Error RPC miner isn't compiled");
+    throw JSONRPCError(RPC_METHOD_NOT_FOUND, "This call is not available because RPC miner isn't compiled");
 }
 #endif // ENABLE_MINER
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3740,7 +3740,7 @@ UniValue generate(const JSONRPCRequest& request)
 #else
 UniValue generate(const JSONRPCRequest& request)
 {
-    throw std::runtime_error("Error RPC miner isn't compiled");
+    throw JSONRPCError(RPC_METHOD_NOT_FOUND, "This call is not available because RPC miner isn't compiled");
 }
 #endif //ENABLE_MINING
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3737,6 +3737,11 @@ UniValue generate(const JSONRPCRequest& request)
 
     return generateBlocks(coinbase_script, num_generate, max_tries, true);
 }
+#else
+UniValue generate(const JSONRPCRequest& request)
+{
+    throw std::runtime_error("Error RPC miner isn't compiled");
+}
 #endif //ENABLE_MINING
 
 UniValue rescanblockchain(const JSONRPCRequest& request)
@@ -4180,6 +4185,8 @@ static const CRPCCommand commands[] =
 
 #if ENABLE_MINER
     { "generating",         "generate",                         &generate,                      {"nblocks","maxtries"} },
+#else
+    { "hidden",             "generate",                         &generate,                      {"nblocks","maxtries"} }, // Hidden as it isn't functional, just an error to let people know if miner isn't compiled
 #endif //ENABLE_MINER
     { "wallet",             "keepass",                  &keepass,                  {} },
     { "hidden",             "instantsendtoaddress",     &instantsendtoaddress,     {} },


### PR DESCRIPTION
This PR solves this issue #3648 

This PR makes it so if you haven't compiled with mining support and run a generate command it will throw a runtime error saying `Error RPC miner isn't compiled`

My Dash address as this is for a bounty XbJDGK4qzXesmtoVfFSLhe8juHQsxhJDGK