### PR TITLE
Partial merge bitcoin#14624: Some simple improvements to the RNG code

### DIFF
--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -35,7 +35,8 @@ static void BuildTestVectors(size_t count, size_t invalidCount,
     for (size_t i = 0; i < invalidCount; i++) {
         invalid[i] = true;
     }
-    std::shuffle(invalid.begin(), invalid.end());
+    
+    Shuffle(invalid.begin(), invalid.end(), FastRandomContext());
 
     for (size_t i = 0; i < count; i++) {
         secKeys[i].MakeNewKey();

--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -35,7 +35,6 @@ static void BuildTestVectors(size_t count, size_t invalidCount,
     for (size_t i = 0; i < invalidCount; i++) {
         invalid[i] = true;
     }
-    
     Shuffle(invalid.begin(), invalid.end(), FastRandomContext());
 
     for (size_t i = 0; i < count; i++) {

--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -35,7 +35,7 @@ static void BuildTestVectors(size_t count, size_t invalidCount,
     for (size_t i = 0; i < invalidCount; i++) {
         invalid[i] = true;
     }
-    std::random_shuffle(invalid.begin(), invalid.end());
+    std::shuffle(invalid.begin(), invalid.end());
 
     for (size_t i = 0; i < count; i++) {
         secKeys[i].MakeNewKey();

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1012,9 +1012,8 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::RequestGovernanceObjectVotes -- start: vTriggerObjHashes %d vOtherObjHashes %d mapAskedRecently %d\n",
         vTriggerObjHashes.size(), vOtherObjHashes.size(), mapAskedRecently.size());
 
-    FastRandomContext insecure_rand;
-    std::random_shuffle(vTriggerObjHashes.begin(), vTriggerObjHashes.end(), insecure_rand);
-    std::random_shuffle(vOtherObjHashes.begin(), vOtherObjHashes.end(), insecure_rand);
+    Shuffle(vTriggerObjHashes.begin(), vTriggerObjHashes.end(), FastRandomContext());
+    Shuffle(vOtherObjHashes.begin(), vOtherObjHashes.end(), FastRandomContext());
 
     for (int i = 0; i < nMaxObjRequestsPerNode; ++i) {
         uint256 nHashGovobj;

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -884,7 +884,8 @@ void CSigSharesManager::CollectSigSharesToRequest(std::unordered_map<NodeId, std
         }
         shuffledNodeIds.emplace_back(p.first);
     }
-    std::random_shuffle(shuffledNodeIds.begin(), shuffledNodeIds.end(), rnd);
+    
+    Shuffle(shuffledNodeIds.begin(), shuffledNodeIds.end(), FastRandomContext());
 
     for (auto& nodeId : shuffledNodeIds) {
         auto& nodeState = nodeStates[nodeId];

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -884,8 +884,7 @@ void CSigSharesManager::CollectSigSharesToRequest(std::unordered_map<NodeId, std
         }
         shuffledNodeIds.emplace_back(p.first);
     }
-    
-    Shuffle(shuffledNodeIds.begin(), shuffledNodeIds.end(), FastRandomContext());
+    Shuffle(shuffledNodeIds.begin(), shuffledNodeIds.end(), rnd);
 
     for (auto& nodeId : shuffledNodeIds) {
         auto& nodeState = nodeStates[nodeId];

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -63,7 +63,7 @@ public:
         if (rndNodes.empty()) {
             return;
         }
-        Shuffle(rndNodes.begin(), rndNodes.end(), FastRandomContext());
+        Shuffle(rndNodes.begin(), rndNodes.end(), rnd);
 
         size_t idx = 0;
         while (!rndNodes.empty() && cont()) {

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -63,7 +63,7 @@ public:
         if (rndNodes.empty()) {
             return;
         }
-        std::random_shuffle(rndNodes.begin(), rndNodes.end(), rnd);
+        Shuffle(rndNodes.begin(), rndNodes.end(), FastRandomContext());
 
         size_t idx = 0;
         while (!rndNodes.empty() && cont()) {

--- a/src/privatesend/privatesend-client.cpp
+++ b/src/privatesend/privatesend-client.cpp
@@ -1016,9 +1016,8 @@ CDeterministicMNCPtr CPrivateSendClientManager::GetRandomNotUsedMasternode()
         vpMasternodesShuffled.emplace_back(dmn);
     });
 
-    FastRandomContext insecure_rand;
     // shuffle pointers
-    std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), insecure_rand);
+    Shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), FastRandomContext());
 
     std::set<COutPoint> excludeSet(vecMasternodesUsed.begin(), vecMasternodesUsed.end());
 

--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -414,7 +414,7 @@ void CPrivateSendServer::ChargeFees(CConnman& connman)
     if ((int)vecOffendersCollaterals.size() >= vecSessionCollaterals.size()) return;
 
     //charge one of the offenders randomly
-    std::shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end());
+    Shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end(), FastRandomContext());
 
     if (nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_SIGNING) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s", /* Continued */

--- a/src/privatesend/privatesend-server.cpp
+++ b/src/privatesend/privatesend-server.cpp
@@ -414,7 +414,7 @@ void CPrivateSendServer::ChargeFees(CConnman& connman)
     if ((int)vecOffendersCollaterals.size() >= vecSessionCollaterals.size()) return;
 
     //charge one of the offenders randomly
-    std::random_shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end());
+    std::shuffle(vecOffendersCollaterals.begin(), vecOffendersCollaterals.end());
 
     if (nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_SIGNING) {
         LogPrint(BCLog::PRIVATESEND, "CPrivateSendServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s", /* Continued */

--- a/src/random.h
+++ b/src/random.h
@@ -142,6 +142,29 @@ public:
     inline uint64_t operator()() { return rand64(); }
 };
 
+/** More efficient than using std::shuffle on a FastRandomContext.
+ *
+ * This is more efficient as std::shuffle will consume entropy in groups of
+ * 64 bits at the time and throw away most.
+ *
+ * This also works around a bug in libstdc++ std::shuffle that may cause
+ * type::operator=(type&&) to be invoked on itself, which the library's
+ * debug mode detects and panics on. This is a known issue, see
+ * https://stackoverflow.com/questions/22915325/avoiding-self-assignment-in-stdshuffle
+ */
+template<typename I, typename R>
+void Shuffle(I first, I last, R&& rng)
+{
+    while (first != last) {
+        size_t j = rng.randrange(last - first);
+        if (j) {
+            using std::swap;
+            swap(*first, *(first + j));
+        }
+        ++first;
+    }
+}
+
 /* Number of random bytes returned by GetOSRand.
  * When changing this constant make sure to change all call sites, and make
  * sure that the underlying OS APIs for all platforms support the number.

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -85,8 +85,42 @@ BOOST_AUTO_TEST_CASE(stdrandom_test)
         for (int j = 1; j <= 10; ++j) {
             BOOST_CHECK(std::find(test.begin(), test.end(), j) != test.end());
         }
+        Shuffle(test.begin(), test.end(), ctx);
+        for (int j = 1; j <= 10; ++j) {
+            BOOST_CHECK(std::find(test.begin(), test.end(), j) != test.end());
+        }
     }
 
+}
+
+/** Test that Shuffle reaches every permutation with equal probability. */
+BOOST_AUTO_TEST_CASE(shuffle_stat_test)
+{
+    FastRandomContext ctx(true);
+    uint32_t counts[5 * 5 * 5 * 5 * 5] = {0};
+    for (int i = 0; i < 12000; ++i) {
+        int data[5] = {0, 1, 2, 3, 4};
+        Shuffle(std::begin(data), std::end(data), ctx);
+        int pos = data[0] + data[1] * 5 + data[2] * 25 + data[3] * 125 + data[4] * 625;
+        ++counts[pos];
+    }
+    unsigned int sum = 0;
+    double chi_score = 0.0;
+    for (int i = 0; i < 5 * 5 * 5 * 5 * 5; ++i) {
+        int i1 = i % 5, i2 = (i / 5) % 5, i3 = (i / 25) % 5, i4 = (i / 125) % 5, i5 = i / 625;
+        uint32_t count = counts[i];
+        if (i1 == i2 || i1 == i3 || i1 == i4 || i1 == i5 || i2 == i3 || i2 == i4 || i2 == i5 || i3 == i4 || i3 == i5 || i4 == i5) {
+            BOOST_CHECK(count == 0);
+        } else {
+            chi_score += ((count - 100.0) * (count - 100.0)) / 100.0;
+            BOOST_CHECK(count > 50);
+            BOOST_CHECK(count < 150);
+            sum += count;
+        }
+    }
+    BOOST_CHECK(chi_score > 58.1411); // 99.9999% confidence interval
+    BOOST_CHECK(chi_score < 210.275);
+    BOOST_CHECK_EQUAL(sum, 12000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -261,7 +261,7 @@ bool KnapsackSolver(const CAmount& nTargetValue, std::vector<CInputCoin>& vCoins
     std::vector<CInputCoin> vValue;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    Shuffle(vCoins.begin(), vCoins.end(), FastRandomContext());
 
     int tryDenomStart = 0;
     CAmount nMinChange = MIN_CHANGE;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3253,7 +3253,7 @@ bool CWallet::SelectPSInOutPairsByDenominations(int nDenom, CAmount nValueMax, s
     AvailableCoins(vCoins, true, &coin_control);
     LogPrint(BCLog::PRIVATESEND, "CWallet::%s -- vCoins.size(): %d\n", __func__, vCoins.size());
 
-    std::random_shuffle(vCoins.rbegin(), vCoins.rend(), GetRandInt);
+    Shuffle(vCoins.rbegin(), vCoins.rend(), FastRandomContext());
 
     for (const auto& out : vCoins) {
         uint256 txHash = out.tx->GetHash();


### PR DESCRIPTION
## Overview

`std::random_shuffle` has been deprecated and Bitcoin has opted to implement an alternative to `std::shuffle` for `FastRandomContext` due to a bug specific to `libstdc++` named `Shuffle`. 

Unlike `std::random_shuffle`, `std::shuffle` does not accept only two arguments so those invocations now use `FastRandomContext`.

Replicating the commit would only implement changes to Bitcoin-derived logic while leaving Dash-specific logic using the deprecated call, changes have been made for LLMQ, Governance and Privatesend accordingly.

## Disclosure

Dash-specific changes have not been tested, only compilation has been ensured. Running the client on (a) testnet may be necessary.

## Resources

* https://github.com/bitcoin/bitcoin/commit/3db746beb407f7cdd9cd6a605a195bef1254b4c0 (Introduce a Shuffle for FastRandomContext and use it in wallet and coinselection, Dec 13, 2018 by sipa)
* https://en.cppreference.com/w/cpp/algorithm/random_shuffle 
* https://stackoverflow.com/questions/22915325/avoiding-self-assignment-in-stdshuffle (mentioned in sipa's commit)