### PR TITLE
rpc|test:  Introduce "mnauth" RPC command to override masternode authentications

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -427,7 +427,7 @@ UniValue mnauth(const JSONRPCRequest& request)
     if (request.fHelp || (request.params.size() != 3))
         throw std::runtime_error(
             "mnauth nodeId \"proTxHash\" \"publicKey\"\n"
-            "\nFake a MNAUTH for a connected node in regression test (-regtest only).\n"
+            "\nOverride MNAUTH processing results for the specified node with a user provided data (-regtest only).\n"
             "\nArguments:\n"
             "1. nodeId          (integer, required) Internal peer id of the node the mock data gets added to.\n"
             "2. \"proTxHash\"     (string, required) The authenticated proTxHash as hex string.\n"

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -7,6 +7,7 @@
 #include <chain.h>
 #include <clientversion.h>
 #include <core_io.h>
+#include <evo/mnauth.h>
 #include <init.h>
 #include <httpserver.h>
 #include <key_io.h>
@@ -419,6 +420,42 @@ UniValue setmocktime(const JSONRPCRequest& request)
     SetMockTime(request.params[0].get_int64());
 
     return NullUniValue;
+}
+
+UniValue mnauth(const JSONRPCRequest& request)
+{
+    if (request.fHelp || (request.params.size() != 3))
+        throw std::runtime_error(
+            "mnauth nodeId \"proTxHash\" \"publicKey\"\n"
+            "\nFake a MNAUTH for a connected node in regression test (-regtest only).\n"
+            "\nArguments:\n"
+            "1. nodeId          (integer, required) Internal peer id of the node the mock data gets added to.\n"
+            "2. \"proTxHash\"     (string, required) The authenticated proTxHash as hex string.\n"
+            "3. \"publicKey\"     (string, required) The authenticated public key as hex string.\n"
+            );
+
+    if (!Params().MineBlocksOnDemand())
+        throw std::runtime_error("mnauth for regression testing (-regtest mode) only");
+
+    int nodeId = ParseInt64V(request.params[0], "nodeId");
+    uint256 proTxHash = ParseHashV(request.params[1], "proTxHash");
+    if (proTxHash.IsNull()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "proTxHash invalid");
+    }
+    CBLSPublicKey publicKey;
+    publicKey.SetHexStr(request.params[2].get_str());
+    if (!publicKey.IsValid()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "publicKey invalid");
+    }
+
+    bool fSuccess = g_connman->ForNode(nodeId, [&](CNode* pNode){
+        LOCK(pNode->cs_mnauth);
+        pNode->verifiedProRegTxHash = proTxHash;
+        pNode->verifiedPubKeyHash = publicKey.GetHash();
+        return true;
+    });
+
+    return fSuccess;
 }
 
 bool getAddressFromIndex(const int &type, const uint160 &hash, std::string &address)
@@ -1123,6 +1160,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "echo",                   &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "echojson",               &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "getinfo",                &getinfo_deprecated,     {}},
+    { "hidden",             "mnauth",                 &mnauth,                 {"nodeId", "proTxHash", "publicKey"}},
 };
 
 void RegisterMiscRPCCommands(CRPCTable &t)

--- a/test/functional/rpc_mnauth.py
+++ b/test/functional/rpc_mnauth.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.mininode import *
+from test_framework.test_framework import DashTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+'''
+rpc_mnauth.py
+
+Tests mnauth RPC command
+'''
+
+
+class FakeMNAUTHTest(DashTestFramework):
+    def set_test_params(self):
+        self.set_dash_test_params(2, 1, fast_dip3_enforcement=True)
+
+    def run_test(self):
+
+        masternode = self.mninfo[0]
+        p2p_masternode = masternode.node.add_p2p_connection(P2PInterface())
+        network_thread_start()
+        p2p_masternode.wait_for_verack()
+
+        protx_hash = masternode.proTxHash
+        public_key = masternode.pubKeyOperator
+
+        # The peerinfo should not yet contain verified_proregtx_hash/verified_pubkey_hash
+        assert("verified_proregtx_hash" not in masternode.node.getpeerinfo()[-1])
+        assert("verified_pubkey_hash" not in masternode.node.getpeerinfo()[-1])
+        # Fake-Authenticate the P2P connection to the masternode
+        node_id = masternode.node.getpeerinfo()[-1]["id"]
+        assert(masternode.node.mnauth(node_id, protx_hash, public_key))
+        # The peerinfo should now contain verified_proregtx_hash and verified_pubkey_hash
+        peerinfo = masternode.node.getpeerinfo()[-1]
+        assert("verified_proregtx_hash" in peerinfo)
+        assert("verified_pubkey_hash" in peerinfo)
+        assert_equal(peerinfo["verified_proregtx_hash"], protx_hash)
+        assert_equal(peerinfo["verified_pubkey_hash"], bytes_to_hex_str(hash256(hex_str_to_bytes(public_key))[::-1]))
+        # Test some error cases
+        null_hash = "0000000000000000000000000000000000000000000000000000000000000000"
+        assert_raises_rpc_error(-8, "proTxHash invalid", masternode.node.mnauth,
+                                                         node_id,
+                                                         null_hash,
+                                                         public_key)
+        assert_raises_rpc_error(-8, "publicKey invalid", masternode.node.mnauth,
+                                                         node_id,
+                                                         protx_hash,
+                                                         null_hash)
+        assert(not masternode.node.mnauth(-1, protx_hash, public_key))
+
+if __name__ == '__main__':
+    FakeMNAUTHTest().main()

--- a/test/functional/rpc_mnauth.py
+++ b/test/functional/rpc_mnauth.py
@@ -52,5 +52,6 @@ class FakeMNAUTHTest(DashTestFramework):
                                                          null_hash)
         assert(not masternode.node.mnauth(-1, protx_hash, public_key))
 
+
 if __name__ == '__main__':
     FakeMNAUTHTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -157,6 +157,7 @@ BASE_SCRIPTS= [
     'feature_shutdown.py',
     'rpc_privatesend.py',
     'rpc_masternode.py',
+    'rpc_mnauth.py',
     'rpc_verifyislock.py',
     'p2p_fingerprint.py',
     'rpc_platform_filter.py',


### PR DESCRIPTION
Allows to fake verified MN P2P connections. Something i need for an other test. If someone has a better idea how to archive this, let me know :)

Based on #3929 