### PR TITLE
wallet: Upgrade path for non-HD wallets to HD

### DIFF
--- a/src/hdchain.cpp
+++ b/src/hdchain.cpp
@@ -79,6 +79,10 @@ bool CHDChain::SetMnemonic(const SecureString& ssMnemonic, const SecureString& s
         if (!IsNull())
             return false;
 
+        if (ssMnemonicPassphrase.size() > 256) {
+            throw std::runtime_error(std::string(__func__) + "Mnemonic passphrase is too long, must be at most 256 characters");
+        }
+
         // empty mnemonic i.e. "generate a new one"
         if (ssMnemonic.empty()) {
             ssMnemonicTmp = CMnemonic::Generate(256);

--- a/src/hdchain.cpp
+++ b/src/hdchain.cpp
@@ -80,7 +80,7 @@ bool CHDChain::SetMnemonic(const SecureString& ssMnemonic, const SecureString& s
             return false;
 
         if (ssMnemonicPassphrase.size() > 256) {
-            throw std::runtime_error(std::string(__func__) + "Mnemonic passphrase is too long, must be at most 256 characters");
+            throw std::runtime_error(std::string(__func__) + ": Mnemonic passphrase is too long, must be at most 256 characters");
         }
 
         // empty mnemonic i.e. "generate a new one"

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -408,7 +408,7 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
     return true;
 }
 
-bool CCryptoKeyStore::EncryptHDChain(const CKeyingMaterial& vMasterKeyIn)
+bool CCryptoKeyStore::EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain)
 {
     LOCK(cs_KeyStore);
     // should call EncryptKeys first
@@ -420,6 +420,11 @@ bool CCryptoKeyStore::EncryptHDChain(const CKeyingMaterial& vMasterKeyIn)
 
     if (cryptedHDChain.IsCrypted())
         return true;
+
+    if (hdChain.IsNull() && !chain.IsNull()) {
+        // Encrypting a new HDChain for an already encrypted non-HD wallet
+        hdChain = chain;
+    }
 
     // make sure seed matches this chain
     if (hdChain.GetID() != hdChain.GetSeedHash())

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -141,7 +141,7 @@ protected:
     //! will encrypt previously unencrypted keys
     bool EncryptKeys(CKeyingMaterial& vMasterKeyIn);
 
-    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn);
+    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
     bool DecryptHDChain(CHDChain& hdChainRet) const;
     bool SetHDChain(const CHDChain& chain);
     bool SetCryptedHDChain(const CHDChain& chain);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3059,6 +3059,109 @@ UniValue listwallets(const JSONRPCRequest& request)
     return obj;
 }
 
+UniValue upgradetohd(const JSONRPCRequest& request)
+{
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    if (request.fHelp)
+        throw std::runtime_error(
+                "upgradetohd\n"
+                "\nUpgrades non-HD wallets to HD.\n"
+                "\nNote that you will need to MAKE A NEW BACKUP of your wallet after setting the HD wallet mnemonic.\n"
+                "\nArguments:\n"
+                "1. \"mnemonic\"             (string, optional, default=\"\") Mnemonic as defined in BIP39 to use for the new HD wallet."
+                "                          Use an empty string \"\" to generate a new random mnemonic.\n"
+                "2. \"mnemonicpassphrase\"   (string, optional, default=\"\") Optional mnemonic passphrase as defined in BIP39\n"
+                "3. \"walletpassphrase\"     (string, optional) If your wallet is encrypted you must have your wallet passphrase here\n"
+                "                          If your wallet is not encrypted specifying wallet passphrase will trigger wallet encryption.\n"
+
+                "\nExamples:\n"
+                + HelpExampleCli("upgradetohd", "")
+                + HelpExampleCli("upgradetohd", "\"mnemonicword1 ... mnemonicwordN\"")
+                + HelpExampleCli("upgradetohd", "\"mnemonicword1 ... mnemonicwordN\" \"mnemonicpassphrase\"")
+                + HelpExampleCli("upgradetohd", "\"mnemonicword1 ... mnemonicwordN\" \"mnemonicpassphrase\" \"walletpassphrase\""));
+
+    LOCK2(cs_main, pwallet->cs_wallet);
+
+    // Do not do anything to HD wallets
+    if (pwallet->IsHDEnabled()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade a wallet to HD if it is already upgraded to HD.");
+    }
+
+    if (!pwallet->SetMaxVersion(FEATURE_HD)) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Cannot downgrade wallet");
+    }
+
+    bool prev_encrypted = pwallet->IsCrypted();
+
+    SecureString secureWalletPassphrase;
+    secureWalletPassphrase.reserve(100);
+    // TODO: get rid of this .c_str() by implementing SecureString::operator=(std::string)
+    // Alternately, find a way to make request.params[0] mlock()'d to begin with.
+    if (request.params[2].isNull()) {
+        if (prev_encrypted) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade encrypted wallet to HD without the wallet passphrase");
+        }
+    } else {
+        secureWalletPassphrase = request.params[2].get_str().c_str();
+    }
+
+    bool generate_mnemonic = request.params[0].isNull() || request.params[0].get_str().empty();
+
+    SecureString secureMnemonic;
+    secureMnemonic.reserve(256);
+    if (!generate_mnemonic) {
+        if (IsInitialBlockDownload()) {
+            throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Cannot set mnemonic while still in Initial Block Download");
+        }
+        secureMnemonic = request.params[0].get_str().c_str();
+    }
+
+    SecureString secureMnemonicPassphrase;
+    secureMnemonicPassphrase.reserve(256);
+    if (!request.params[1].isNull()) {
+        secureMnemonicPassphrase = request.params[1].get_str().c_str();
+    }
+
+    LogPrintf("Upgrading wallet to HD\n");
+    pwallet->SetMinVersion(FEATURE_HD);
+
+    if (prev_encrypted) {
+        if (!pwallet->GenerateNewHDChainEncrypted(secureMnemonic, secureMnemonicPassphrase, secureWalletPassphrase)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Failed to generate encrypted HD wallet");
+        }
+    } else {
+        pwallet->GenerateNewHDChain(secureMnemonic, secureMnemonicPassphrase);
+        if (!secureWalletPassphrase.empty()) {
+            if (!pwallet->EncryptWallet(secureWalletPassphrase)) {
+                throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Failed to encrypt HD wallet");
+            }
+        }
+    }
+
+    // If you are generating new mnemonic it is assumed that the addresses have never gotten a transaction before, so you don't need to rescan for transactions
+    if (!generate_mnemonic) {
+        WalletRescanReserver reserver(pwallet);
+        if (!reserver.reserve()) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait.");
+        }
+        pwallet->ScanForWalletTransactions(chainActive.Genesis(), nullptr, reserver, true);
+    }
+
+    if (!prev_encrypted && pwallet->IsCrypted()) {
+        // BDB seems to have a bad habit of writing old data into
+        // slack space in .dat files; that is bad if the old data is
+        // unencrypted private keys. So:
+        StartShutdown();
+        return "Wallet encrypted; Dash Core server stopping, restart to run with encrypted HD wallet. The keypool has been flushed. You need to MAKE A NEW BACKUP.";
+    }
+
+    return NullUniValue;
+}
+
 UniValue keepass(const JSONRPCRequest& request)
 {
     CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
@@ -4158,6 +4261,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "setprivatesendamount",     &setprivatesendamount,     {"amount"} },
     { "wallet",             "signmessage",                      &signmessage,                   {"address","message"} },
     { "wallet",             "signrawtransactionwithwallet",     &signrawtransactionwithwallet,  {"hexstring","prevtxs","sighashtype"} },
+    { "wallet",             "upgradetohd",                      &upgradetohd,                   {"mnemonic", "mnemonicpassphrase", "walletpassphrase"} },
     { "wallet",             "walletlock",                       &walletlock,                    {} },
     { "wallet",             "walletpassphrasechange",           &walletpassphrasechange,        {"oldpassphrase","newpassphrase"} },
     { "wallet",             "walletpassphrase",                 &walletpassphrase,              {"passphrase","timeout","mixingonly"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3103,10 +3103,13 @@ UniValue upgradetohd(const JSONRPCRequest& request)
     // Alternately, find a way to make request.params[0] mlock()'d to begin with.
     if (request.params[2].isNull()) {
         if (prev_encrypted) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "Cannot upgrade encrypted wallet to HD without the wallet passphrase");
+            throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Cannot upgrade encrypted wallet to HD without the wallet passphrase");
         }
     } else {
         secureWalletPassphrase = request.params[2].get_str().c_str();
+        if (!pwallet->Unlock(secureWalletPassphrase)) {
+            throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "The wallet passphrase entered was incorrect");
+        }
     }
 
     bool generate_mnemonic = request.params[0].isNull() || request.params[0].get_str().empty();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3070,7 +3070,7 @@ UniValue upgradetohd(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "upgradetohd\n"
                 "\nUpgrades non-HD wallets to HD.\n"
-                "\Warning: You will need to make a new backup of your wallet after setting the HD wallet mnemonic.\n"
+                "\nWarning: You will need to make a new backup of your wallet after setting the HD wallet mnemonic.\n"
                 "\nArguments:\n"
                 "1. \"mnemonic\"             (string, optional, default=\"\") Mnemonic as defined in BIP39 to use for the new HD wallet."
                 "                          Use an empty string \"\" to generate a new random mnemonic.\n"
@@ -3159,7 +3159,7 @@ UniValue upgradetohd(const JSONRPCRequest& request)
         // slack space in .dat files; that is bad if the old data is
         // unencrypted private keys. So:
         StartShutdown();
-        return "Wallet successfully upgraded and encrypted, Dash Core server is stopping. Remember to make a backup before restarting."
+        return "Wallet successfully upgraded and encrypted, Dash Core server is stopping. Remember to make a backup before restarting.";
     }
 
     return true;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3061,7 +3061,7 @@ UniValue listwallets(const JSONRPCRequest& request)
 
 UniValue upgradetohd(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
         return NullUniValue;
     }
@@ -3070,7 +3070,7 @@ UniValue upgradetohd(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "upgradetohd\n"
                 "\nUpgrades non-HD wallets to HD.\n"
-                "\nNote that you will need to MAKE A NEW BACKUP of your wallet after setting the HD wallet mnemonic.\n"
+                "\Warning: You will need to make a new backup of your wallet after setting the HD wallet mnemonic.\n"
                 "\nArguments:\n"
                 "1. \"mnemonic\"             (string, optional, default=\"\") Mnemonic as defined in BIP39 to use for the new HD wallet."
                 "                          Use an empty string \"\" to generate a new random mnemonic.\n"
@@ -3159,10 +3159,10 @@ UniValue upgradetohd(const JSONRPCRequest& request)
         // slack space in .dat files; that is bad if the old data is
         // unencrypted private keys. So:
         StartShutdown();
-        return "Wallet encrypted; Dash Core server stopping, restart to run with encrypted HD wallet. The keypool has been flushed. You need to MAKE A NEW BACKUP.";
+        return "Wallet successfully upgraded and encrypted, Dash Core server is stopping. Remember to make a backup before restarting."
     }
 
-    return NullUniValue;
+    return true;
 }
 
 UniValue keepass(const JSONRPCRequest& request)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5051,9 +5051,6 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
     {
         // Create new keyUser and set as default key
         if (gArgs.GetBoolArg("-usehd", DEFAULT_USE_HD_WALLET) && !walletInstance->IsHDEnabled()) {
-            if (gArgs.GetArg("-mnemonicpassphrase", "").size() > 256) {
-                return error(_("Mnemonic passphrase is too long, must be at most 256 characters"));
-            }
             // generate a new master key
             walletInstance->GenerateNewHDChain();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1810,7 +1810,7 @@ bool CWallet::GenerateNewHDChainEncrypted(const SecureString& secureMnemonic, co
         if (!crypter.SetKeyFromPassphrase(secureWalletPassphrase, pMasterKey.second.vchSalt, pMasterKey.second.nDeriveIterations, pMasterKey.second.nDerivationMethod)) {
             return false;
         }
-        //get VMasterKey to encrypt new hdChain
+        // get vMasterKey to encrypt new hdChain
         if (!crypter.Decrypt(pMasterKey.second.vchCryptedKey, vMasterKey)) {
             continue; // try another master key
         }
@@ -5101,7 +5101,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
         if (gArgs.GetBoolArg("-usehd", DEFAULT_USE_HD_WALLET) && !walletInstance->IsHDEnabled()) {
             std::string strSeed = gArgs.GetArg("-hdseed", "not hex");
 
-            if(gArgs.IsArgSet("-hdseed") && IsHex(strSeed)) {
+            if (gArgs.IsArgSet("-hdseed") && IsHex(strSeed)) {
                 CHDChain newHdChain;
                 std::vector<unsigned char> vchSeed = ParseHex(strSeed);
                 if (!newHdChain.SetSeed(SecureVector(vchSeed.begin(), vchSeed.end()), true)) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1233,6 +1233,7 @@ public:
     bool IsHDEnabled() const;
     /* Generates a new HD chain */
     void GenerateNewHDChain(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase);
+    bool GenerateNewHDChainEncrypted(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase, const SecureString& secureWalletPassphrase);
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
     bool SetCryptedHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1232,7 +1232,7 @@ public:
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const;
     /* Generates a new HD chain */
-    void GenerateNewHDChain();
+    void GenerateNewHDChain(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase);
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
     bool SetCryptedHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -145,6 +145,7 @@ BASE_SCRIPTS= [
     'feature_sporks.py',
     'rpc_getblockstats.py',
     'wallet_encryption.py',
+    'wallet_upgradetohd.py',
     'feature_dersig.py',
     'feature_cltv.py',
     'feature_new_quorum_type_activation.py',

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -42,7 +42,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         self.log.info("No mnemonic, no mnemonic passphrase, no wallet passphrase")
         assert('hdchainid' not in node.getwalletinfo())
         balance_before = node.getbalance()
-        node.upgradetohd()
+        assert(node.upgradetohd())
         mnemonic = node.dumphdinfo()['mnemonic']
         chainid = node.getwalletinfo()['hdchainid']
         assert_equal(len(chainid), 64)
@@ -76,7 +76,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         assert(balance_before != balance_non_HD)
 
         self.log.info("No mnemonic, no mnemonic passphrase, no wallet passphrase, should result in completely different keys")
-        node.upgradetohd()
+        assert(node.upgradetohd())
         assert(mnemonic != node.dumphdinfo()['mnemonic'])
         assert(chainid != node.getwalletinfo()['hdchainid'])
         assert_equal(balance_non_HD, node.getbalance())
@@ -89,7 +89,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
 
         self.log.info("Same mnemonic, another mnemonic passphrase, no wallet passphrase, should result in a different set of keys")
         new_mnemonic_passphrase = "somewords"
-        node.upgradetohd(mnemonic, new_mnemonic_passphrase)
+        assert(node.upgradetohd(mnemonic, new_mnemonic_passphrase))
         assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
         new_chainid = node.getwalletinfo()['hdchainid']
         assert(chainid != new_chainid)
@@ -103,7 +103,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         self.recover_non_hd()
 
         self.log.info("Same mnemonic, another mnemonic passphrase, no wallet passphrase, should result in a different set of keys (again)")
-        node.upgradetohd(mnemonic, new_mnemonic_passphrase)
+        assert(node.upgradetohd(mnemonic, new_mnemonic_passphrase))
         assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
         assert_equal(new_chainid, node.getwalletinfo()['hdchainid'])
         assert_equal(balance_non_HD, node.getbalance())
@@ -116,7 +116,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         self.recover_non_hd()
 
         self.log.info("Same mnemonic, no mnemonic passphrase, no wallet passphrase, should recover all coins after rescan")
-        node.upgradetohd(mnemonic)
+        assert(node.upgradetohd(mnemonic))
         assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
         assert_equal(chainid, node.getwalletinfo()['hdchainid'])
         node.keypoolrefill(5)
@@ -128,7 +128,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         self.log.info("Same mnemonic, no mnemonic passphrase, no wallet passphrase, large enough keepool, should recover all coins with no extra rescan")
         self.stop_node(0)
         self.start_node(0, extra_args=['-keypool=10'])
-        node.upgradetohd(mnemonic)
+        assert(node.upgradetohd(mnemonic))
         assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
         assert_equal(chainid, node.getwalletinfo()['hdchainid'])
         # All coins should be recovered
@@ -138,7 +138,8 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
 
         self.log.info("Same mnemonic, same mnemonic passphrase, encrypt wallet on upgrade, should recover all coins after rescan")
         walletpass = "111pass222"
-        node.upgradetohd(mnemonic, "", walletpass)
+        # Upgrading and encrypting at the saame time results in a warning
+        assert_equal(node.upgradetohd(mnemonic, "", walletpass), "Wallet successfully upgraded and encrypted, Dash Core server is stopping. Remember to make a backup before restarting.")
         # Wallet encryption results in node shutdown
         node.wait_until_stopped()
         self.start_node(0, extra_args=['-rescan'])
@@ -165,7 +166,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         self.start_node(0, extra_args=['-rescan'])
         assert_raises_rpc_error(-14, "Cannot upgrade encrypted wallet to HD without the wallet passphrase", node.upgradetohd, mnemonic)
         assert_raises_rpc_error(-14, "The wallet passphrase entered was incorrect", node.upgradetohd, mnemonic, "", "wrongpass")
-        node.upgradetohd(mnemonic, "", walletpass)
+        assert(node.upgradetohd(mnemonic, "", walletpass))
         # Note: upgrading an already encrypted wallet does not result in node shutdown
         assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.", node.dumphdinfo)
         node.walletpassphrase(walletpass, 100)

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+wallet_upgradetohd.py
+
+Test upgrade to a Hierarchical Deterministic wallet via upgradetohd rpc
+"""
+
+import sys
+import shutil
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class WalletUpgradeToHDTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes, stderr=sys.stdout)
+        self.start_nodes()
+
+    def recover_non_hd(self):
+        self.log.info("Recover non-HD wallet to check different upgrade paths")
+        node = self.nodes[0]
+        self.stop_node(0)
+        shutil.copyfile(os.path.join(node.datadir, "non_hd.bak"), os.path.join(node.datadir, "regtest", "wallets", "wallet.dat"))
+        self.start_node(0)
+        assert('hdchainid' not in node.getwalletinfo())
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.backupwallet(os.path.join(node.datadir, "non_hd.bak"))
+
+        self.log.info("No mnemonic, no mnemonic passphrase, no wallet passphrase")
+        assert('hdchainid' not in node.getwalletinfo())
+        balance_before = node.getbalance()
+        node.upgradetohd()
+        mnemonic = node.dumphdinfo()['mnemonic']
+        chainid = node.getwalletinfo()['hdchainid']
+        assert_equal(len(chainid), 64)
+        assert_equal(balance_before, node.getbalance())
+
+        self.log.info("Should be spendable and should use correct paths")
+        for i in range(5):
+            txid = node.sendtoaddress(node.getnewaddress(), 1)
+            outs = node.decoderawtransaction(node.gettransaction(txid)['hex'])['vout']
+            for out in outs:
+                if out['value'] == 1:
+                    keypath = node.getaddressinfo(out['scriptPubKey']['addresses'][0])['hdkeypath']
+                    assert_equal(keypath, "m/44'/1'/0'/0/%d" % i)
+                else:
+                    keypath = node.getaddressinfo(out['scriptPubKey']['addresses'][0])['hdkeypath']
+                    assert_equal(keypath, "m/44'/1'/0'/1/%d" % i)
+
+        self.bump_mocktime(1)
+        node.generate(1)
+
+        self.log.info("Should no longer be able to start it with HD disabled")
+        self.stop_node(0)
+        node.assert_start_raises_init_error(['-usehd=0'], "Error: Error loading : You can't disable HD on an already existing HD wallet")
+        self.start_node(0)
+        balance_after = node.getbalance()
+
+        self.recover_non_hd()
+
+        # We spent some coins from non-HD keys to HD ones earlier
+        balance_non_HD = node.getbalance()
+        assert(balance_before != balance_non_HD)
+
+        self.log.info("No mnemonic, no mnemonic passphrase, no wallet passphrase, should result in completely different keys")
+        node.upgradetohd()
+        assert(mnemonic != node.dumphdinfo()['mnemonic'])
+        assert(chainid != node.getwalletinfo()['hdchainid'])
+        assert_equal(balance_non_HD, node.getbalance())
+        node.keypoolrefill(5)
+        node.rescanblockchain()
+        # Completely different keys, no HD coins should be recovered
+        assert_equal(balance_non_HD, node.getbalance())
+
+        self.recover_non_hd()
+
+        self.log.info("Same mnemonic, another mnemonic passphrase, no wallet passphrase, should result in a different set of keys")
+        new_mnemonic_passphrase = "somewords"
+        node.upgradetohd(mnemonic, new_mnemonic_passphrase)
+        assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
+        new_chainid = node.getwalletinfo()['hdchainid']
+        assert(chainid != new_chainid)
+        assert_equal(balance_non_HD, node.getbalance())
+        node.keypoolrefill(5)
+        node.rescanblockchain()
+        # A different set of keys, no HD coins should be recovered
+        new_addresses = (node.getnewaddress(), node.getrawchangeaddress())
+        assert_equal(balance_non_HD, node.getbalance())
+
+        self.recover_non_hd()
+
+        self.log.info("Same mnemonic, another mnemonic passphrase, no wallet passphrase, should result in a different set of keys (again)")
+        node.upgradetohd(mnemonic, new_mnemonic_passphrase)
+        assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
+        assert_equal(new_chainid, node.getwalletinfo()['hdchainid'])
+        assert_equal(balance_non_HD, node.getbalance())
+        node.keypoolrefill(5)
+        node.rescanblockchain()
+        # A different set of keys, no HD coins should be recovered, keys should be the same as they were the previous time
+        assert_equal(new_addresses, (node.getnewaddress(), node.getrawchangeaddress()))
+        assert_equal(balance_non_HD, node.getbalance())
+
+        self.recover_non_hd()
+
+        self.log.info("Same mnemonic, no mnemonic passphrase, no wallet passphrase, should recover all coins after rescan")
+        node.upgradetohd(mnemonic)
+        assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
+        assert_equal(chainid, node.getwalletinfo()['hdchainid'])
+        node.keypoolrefill(5)
+        node.rescanblockchain()
+        assert_equal(balance_after, node.getbalance())
+
+        self.recover_non_hd()
+
+        self.log.info("Same mnemonic, no mnemonic passphrase, no wallet passphrase, large enough keepool, should recover all coins with no extra rescan")
+        self.stop_node(0)
+        self.start_node(0, extra_args=['-keypool=10'])
+        node.upgradetohd(mnemonic)
+        assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
+        assert_equal(chainid, node.getwalletinfo()['hdchainid'])
+        # All coins should be recovered
+        assert_equal(balance_after, node.getbalance())
+
+        self.recover_non_hd()
+
+        self.log.info("Same mnemonic, same mnemonic passphrase, encrypt wallet on upgrade, should recover all coins after rescan")
+        walletpass = "111pass222"
+        node.upgradetohd(mnemonic, "", walletpass)
+        # Wallet encryption results in node shutdown
+        node.wait_until_stopped()
+        self.start_node(0, extra_args=['-rescan'])
+        assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.", node.dumphdinfo)
+        node.walletpassphrase(walletpass, 100)
+        assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
+        assert_equal(chainid, node.getwalletinfo()['hdchainid'])
+        # Note: wallet encryption results in additonal keypool topup,
+        # so we can't compare new balance to balance_non_HD here,
+        # assert_equal(balance_non_HD, node.getbalance())  # won't work
+        assert(balance_non_HD != node.getbalance())
+        node.keypoolrefill(4)
+        node.rescanblockchain()
+        # All coins should be recovered
+        assert_equal(balance_after, node.getbalance())
+
+        self.recover_non_hd()
+
+        self.log.info("Same mnemonic, same mnemonic passphrase, encrypt wallet first, should recover all coins on upgrade after rescan")
+        walletpass = "111pass222"
+        node.encryptwallet(walletpass)
+        # Wallet encryption results in node shutdown
+        node.wait_until_stopped()
+        self.start_node(0, extra_args=['-rescan'])
+        assert_raises_rpc_error(-14, "Cannot upgrade encrypted wallet to HD without the wallet passphrase", node.upgradetohd, mnemonic)
+        assert_raises_rpc_error(-14, "The wallet passphrase entered was incorrect", node.upgradetohd, mnemonic, "", "wrongpass")
+        node.upgradetohd(mnemonic, "", walletpass)
+        # Note: upgrading an already encrypted wallet does not result in node shutdown
+        assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.", node.dumphdinfo)
+        node.walletpassphrase(walletpass, 100)
+        assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
+        assert_equal(chainid, node.getwalletinfo()['hdchainid'])
+        # Note: wallet encryption results in additonal keypool topup,
+        # so we can't compare new balance to balance_non_HD here,
+        # assert_equal(balance_non_HD, node.getbalance())  # won't work
+        assert(balance_non_HD != node.getbalance())
+        node.keypoolrefill(4)
+        node.rescanblockchain()
+        # All coins should be recovered
+        assert_equal(balance_after, node.getbalance())
+
+
+if __name__ == '__main__':
+    WalletUpgradeToHDTest().main ()


### PR DESCRIPTION
This PR is an alternative attempt to fix #3740. It borrows some ideas and code snippets from #3932 (thanks @KolbyML! 👍 ) but it takes a step back to refactor things first and then uses these results to actually fix the issue, specifically:
a) move an already existing code around to ensure data consistency (9ed6a18) and split responsibility for different steps/paths of generating a HD wallet (b3066e7),
b) implement missing wallet functionality for generating an encrypted HD chain in an encrypted wallet (4c8797c) - `GenerateNewHDChainEncrypted` - which not only covers the non-HD->HD upgrade path but can also be used later to replace one encrypted HD chain with another (just like `GenerateNewHDChain` can be used for non-encrypted wallets),
c) implement a different version (comparing to #3932) of the `upgradetohd` rpc (fe54252) which uses (a) and (b) instead of pulling wallet/bip39 logic into `rpcwallet.cpp` and utilises `SetMnemonic` implementation details (empty mnemonic == generate a new random one) to simplify rpc interface.