### PR TITLE
test: Check for the actual llmq_test session, not just for any

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -849,7 +849,7 @@ class DashTestFramework(BitcoinTestFramework):
             all_ok = True
             for node in nodes:
                 s = node.quorum("dkgstatus")
-                if s["session"] == {}:
+                if 'llmq_test' not in s["session"]:
                     continue
                 if "quorumConnections" not in s:
                     all_ok = False
@@ -879,7 +879,7 @@ class DashTestFramework(BitcoinTestFramework):
 
             for mn in mninfos:
                 s = mn.node.quorum('dkgstatus')
-                if s["session"] == {}:
+                if 'llmq_test' not in s["session"]:
                     continue
                 if "quorumConnections" not in s:
                     return ret()


### PR DESCRIPTION
If `v17` version bit is active `mine_quorum` fails (stucks while connecting nodes in contribution phase) if there are more masternodes than the quorum size because we then don't `continue` for members of an active `llmq_test_v17` session because we don't check if the masternode has an active session for `llmq_test`, we just check if there is any session. Means no issues for `masternode_count == quorum_size` but chances of failures for `masternode_count > quorum_size` .

f88244847209d833c7622ca644523074debc03ac fails without this PR. Didn't add it here because it's probably not worth the extra time overhead which MN creation and DKG brings with. 