### PR TITLE
bls: Modify CBLSIES classes - Introduce individually encrypted objects

### DIFF
--- a/src/bls/bls_ies.cpp
+++ b/src/bls/bls_ies.cpp
@@ -29,12 +29,20 @@ static bool DecryptBlob(const void* in, size_t inSize, Out& out, const void* sym
     return w == (int)inSize;
 }
 
-bool CBLSIESEncryptedBlob::Encrypt(const CBLSPublicKey& peerPubKey, const void* plainTextData, size_t dataSize)
+uint256 CBLSIESEncryptedBlob::GetIV(size_t idx) const
+{
+    uint256 iv = ivSeed;
+    for (size_t i = 0; i < idx; i++) {
+        iv = ::SerializeHash(iv);
+    }
+    return iv;
+}
+
+bool CBLSIESEncryptedBlob::Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const void* plainTextData, size_t dataSize)
 {
     CBLSSecretKey ephemeralSecretKey;
     ephemeralSecretKey.MakeNewKey();
     ephemeralPubKey = ephemeralSecretKey.GetPublicKey();
-    GetStrongRandBytes(iv, sizeof(iv));
 
     CBLSPublicKey pk;
     if (!pk.DHKeyExchange(ephemeralSecretKey, peerPubKey)) {
@@ -45,10 +53,11 @@ bool CBLSIESEncryptedBlob::Encrypt(const CBLSPublicKey& peerPubKey, const void* 
     pk.GetBuf(symKey);
     symKey.resize(32);
 
-    return EncryptBlob(plainTextData, dataSize, data, symKey.data(), iv);
+    uint256 iv = GetIV(idx);
+    return EncryptBlob(plainTextData, dataSize, data, symKey.data(), iv.begin());
 }
 
-bool CBLSIESEncryptedBlob::Decrypt(const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const
+bool CBLSIESEncryptedBlob::Decrypt(size_t idx, const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const
 {
     CBLSPublicKey pk;
     if (!pk.DHKeyExchange(secretKey, ephemeralPubKey)) {
@@ -59,7 +68,13 @@ bool CBLSIESEncryptedBlob::Decrypt(const CBLSSecretKey& secretKey, CDataStream& 
     pk.GetBuf(symKey);
     symKey.resize(32);
 
-    return DecryptBlob(data.data(), data.size(), decryptedDataRet, symKey.data(), iv);
+    uint256 iv = GetIV(idx);
+    return DecryptBlob(data.data(), data.size(), decryptedDataRet, symKey.data(), iv.begin());
+}
+
+bool CBLSIESEncryptedBlob::IsValid() const
+{
+    return ephemeralPubKey.IsValid() && data.size() > 0 && !ivSeed.IsNull();
 }
 
 

--- a/src/bls/bls_ies.h
+++ b/src/bls/bls_ies.h
@@ -160,6 +160,11 @@ public:
             return false;
         }
     }
+
+    CBLSIESEncryptedObject<Object> Get(const size_t idx)
+    {
+        return {ephemeralPubKey, ivSeed, blobs[idx]};
+    }
 };
 
 #endif // DASH_CRYPTO_BLS_IES_H

--- a/src/bls/bls_ies.h
+++ b/src/bls/bls_ies.h
@@ -42,8 +42,7 @@ public:
     {
     }
 
-    CBLSIESEncryptedObject(const CBLSPublicKey& ephemeralPubKeyIn, const uint256& ivSeedIn, const std::vector<unsigned char>& dataIn) :
-        CBLSIESEncryptedBlob()
+    CBLSIESEncryptedObject(const CBLSPublicKey& ephemeralPubKeyIn, const uint256& ivSeedIn, const std::vector<unsigned char>& dataIn)
     {
         ephemeralPubKey = ephemeralPubKeyIn;
         ivSeed = ivSeedIn;

--- a/src/bls/bls_ies.h
+++ b/src/bls/bls_ies.h
@@ -42,6 +42,14 @@ public:
     {
     }
 
+    CBLSIESEncryptedObject(const CBLSPublicKey& ephemeralPubKeyIn, const uint256& ivSeedIn, const std::vector<unsigned char>& dataIn) :
+        CBLSIESEncryptedBlob()
+    {
+        ephemeralPubKey = ephemeralPubKeyIn;
+        ivSeed = ivSeedIn;
+        data = dataIn;
+    }
+
     bool Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const Object& obj, int nVersion)
     {
         try {

--- a/src/bls/bls_ies.h
+++ b/src/bls/bls_ies.h
@@ -12,10 +12,10 @@ class CBLSIESEncryptedBlob
 {
 public:
     CBLSPublicKey ephemeralPubKey;
-    unsigned char iv[16];
+    uint256 ivSeed;
     std::vector<unsigned char> data;
 
-    bool valid{false};
+    uint256 GetIV(size_t idx) const;
 
 public:
     ADD_SERIALIZE_METHODS
@@ -23,22 +23,15 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        if (!ser_action.ForRead()) {
-            assert(valid);
-        } else {
-            valid = false;
-        }
         READWRITE(ephemeralPubKey);
-        READWRITE(iv);
+        READWRITE(ivSeed);
         READWRITE(data);
-        if (ser_action.ForRead()) {
-            valid = true;
-        }
-    };
+    }
 
 public:
-    bool Encrypt(const CBLSPublicKey& peerPubKey, const void* data, size_t dataSize);
-    bool Decrypt(const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const;
+    bool Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const void* data, size_t dataSize);
+    bool Decrypt(size_t idx, const CBLSSecretKey& secretKey, CDataStream& decryptedDataRet) const;
+    bool IsValid() const;
 };
 
 template <typename Object>
@@ -49,21 +42,21 @@ public:
     {
     }
 
-    bool Encrypt(const CBLSPublicKey& peerPubKey, const Object& obj, int nVersion)
+    bool Encrypt(size_t idx, const CBLSPublicKey& peerPubKey, const Object& obj, int nVersion)
     {
         try {
             CDataStream ds(SER_NETWORK, nVersion);
             ds << obj;
-            return CBLSIESEncryptedBlob::Encrypt(peerPubKey, ds.data(), ds.size());
+            return CBLSIESEncryptedBlob::Encrypt(idx, peerPubKey, ds.data(), ds.size());
         } catch (std::exception&) {
             return false;
         }
     }
 
-    bool Decrypt(const CBLSSecretKey& secretKey, Object& objRet, int nVersion) const
+    bool Decrypt(size_t idx, const CBLSSecretKey& secretKey, Object& objRet, int nVersion) const
     {
         CDataStream ds(SER_NETWORK, nVersion);
-        if (!CBLSIESEncryptedBlob::Decrypt(secretKey, ds)) {
+        if (!CBLSIESEncryptedBlob::Decrypt(idx, secretKey, ds)) {
             return false;
         }
         try {


### PR DESCRIPTION
Allows to use `CBLSIESEncryptedObject` as single encrypted object separated from `CBLSIESMultiRecipientObjects` which contains a list of encrypted objects. The classes `CBLSIESEncryptedBlob` and `CBLSIESEncryptedObject` are currently not used anywhere.. the reason for this PR is just preparation for one/more PR(s) which i will have ready _soon_ so we can just leave this here opened until the others are there,  will probably help to better understand the reasons :) 