### PR TITLE
spork: implement spork caching

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -36,7 +36,7 @@ CSporkManager::CSporkManager()
     }
 }
 
-bool CSporkManager::SporkValueIsActive(SporkId nSporkID, int64_t &nActiveValueRet)
+bool CSporkManager::SporkValueIsActive(SporkId nSporkID, int64_t &nActiveValueRet) const
 {
     LOCK(cs);
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -224,6 +224,7 @@ bool CSporkManager::UpdateSpork(SporkId nSporkID, int64_t nValue, CConnman& conn
 
 bool CSporkManager::IsSporkActive(SporkId nSporkID)
 {
+    LOCK(cs);
     // If nSporkID is cached, and the cached value is true, then return early true
     auto it = mapSporksCachedActive.find(nSporkID);
     if (it != mapSporksCachedActive.end() && it->second) {

--- a/src/spork.h
+++ b/src/spork.h
@@ -157,7 +157,7 @@ private:
     std::unordered_map<std::string, CSporkDef*> sporkDefsByName;
 
     std::unordered_map<SporkId, bool> mapSporksCachedActive;
-    std::unordered_map<SporkId, int64_t> mapSporksCachedValues;
+    mutable std::unordered_map<SporkId, int64_t> mapSporksCachedValues;
 
     mutable CCriticalSection cs;
     std::unordered_map<uint256, CSporkMessage> mapSporksByHash;
@@ -171,7 +171,7 @@ private:
      * SporkValueIsActive is used to get the value agreed upon by the majority
      * of signed spork messages for a given Spork ID.
      */
-    bool SporkValueIsActive(SporkId nSporkID, int64_t& nActiveValueRet);
+    bool SporkValueIsActive(SporkId nSporkID, int64_t& nActiveValueRet) const;
 
 public:
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -156,6 +156,9 @@ private:
     std::unordered_map<SporkId, CSporkDef*> sporkDefsById;
     std::unordered_map<std::string, CSporkDef*> sporkDefsByName;
 
+    std::unordered_map<SporkId, bool> mapSporksCachedActive;
+    std::unordered_map<SporkId, int64_t> mapSporksCachedValues;
+
     mutable CCriticalSection cs;
     std::unordered_map<uint256, CSporkMessage> mapSporksByHash;
     std::unordered_map<SporkId, std::map<CKeyID, CSporkMessage> > mapSporksActive;
@@ -168,7 +171,7 @@ private:
      * SporkValueIsActive is used to get the value agreed upon by the majority
      * of signed spork messages for a given Spork ID.
      */
-    bool SporkValueIsActive(SporkId nSporkID, int64_t& nActiveValueRet) const;
+    bool SporkValueIsActive(SporkId nSporkID, int64_t& nActiveValueRet);
 
 public:
 


### PR DESCRIPTION
I was looking through the flow to check if a spork is active or not, and based on my view, it seems extremely wasteful, especially considering that checking if a spork is activate happens extremely often (for example it happens in almost every single IS method).

So this implements caching for spork values and whether a spork is active. 

Whenever a new spork of a given SporkId is processed, all related caching is cleared.

Currently, spork activity is only cached if the activity is "true" this is because false values could be based  on a timestamp, which means we can't really cache false values.

Maybe this change isn't actually really an improvement... LMK