### PR TITLE
llmq|rpc|test|version: Implement P2P messages QGETDATA <-> QDATA 

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -422,6 +422,11 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
 
     if (strCommand == NetMsgType::QGETDATA) {
 
+        if (!fMasternodeMode || pFrom == nullptr || pFrom->verifiedProRegTxHash.IsNull()) {
+            error("Not a masternode");
+            return;
+        }
+
         CQuorumDataRequest request;
         vRecv >> request;
 
@@ -487,6 +492,11 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
     }
 
     if (strCommand == NetMsgType::QDATA) {
+
+        if (!fMasternodeMode || pFrom == nullptr || pFrom->verifiedProRegTxHash.IsNull()) {
+            error("Not a masternode");
+            return;
+        }
 
         CQuorumDataRequest request;
         vRecv >> request;

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -325,7 +325,7 @@ bool CQuorumManager::RequestQuorumData(CNode* pFrom, Consensus::LLMQType llmqTyp
         return false;
     }
     if (pFrom == nullptr || (pFrom->verifiedProRegTxHash.IsNull() && !pFrom->qwatch)) {
-        LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- pFrom is not neither a verified masternode nor qwatch connection\n", __func__);
+        LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- pFrom is neither a verified masternode nor a qwatch connection\n", __func__);
         return false;
     }
     if (Params().GetConsensus().llmqs.count(llmqType) == 0) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -591,12 +591,10 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
         CQuorumPtr pQuorum;
         {
             LOCK(quorumsCacheCs);
-            auto itQuorum = quorumsCache.find(std::make_pair(request.GetLLMQType(), request.GetQuorumHash()));
-            if (itQuorum == quorumsCache.end()) {
+            if (!mapQuorumsCache[request.GetLLMQType()].get(request.GetQuorumHash(), pQuorum)) {
                 error("Quorum not found", false); // Don't bump score because we asked for it
                 return;
             }
-            pQuorum = itQuorum->second;
         }
 
         if (request.GetDataMask() & CQuorumDataRequest::QUORUM_VERIFICATION_VECTOR) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -524,6 +524,7 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
 
         CDataStream ssResponseData(SER_NETWORK, pFrom->GetSendVersion());
 
+        // Check if request wants QUORUM_VERIFICATION_VECTOR data
         if (request.GetDataMask() & CQuorumDataRequest::QUORUM_VERIFICATION_VECTOR) {
 
             if (!pQuorum->quorumVvec) {
@@ -534,6 +535,7 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
             ssResponseData << *pQuorum->quorumVvec;
         }
 
+        // Check if request wants ENCRYPTED_CONTRIBUTIONS data
         if (request.GetDataMask() & CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS) {
 
             int memberIdx = pQuorum->GetMemberIndex(request.GetProTxHash());
@@ -598,6 +600,7 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
             }
         }
 
+        // Check if request has QUORUM_VERIFICATION_VECTOR data
         if (request.GetDataMask() & CQuorumDataRequest::QUORUM_VERIFICATION_VECTOR) {
 
             BLSVerificationVector verficationVector;
@@ -611,6 +614,7 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
             }
         }
 
+        // Check if request has ENCRYPTED_CONTRIBUTIONS data
         if (request.GetDataMask() & CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS) {
 
             if (pQuorum->quorumVvec->size() != pQuorum->params.threshold) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -272,7 +272,7 @@ CQuorumPtr CQuorumManager::BuildQuorumFromCommitment(const Consensus::LLMQType l
         CQuorum::StartCachePopulatorThread(quorum);
     }
 
-    mapQuorumsCache[llmqType].emplace(quorumHash, quorum);
+    mapQuorumsCache[llmqType].insert(quorumHash, quorum);
 
     return quorum;
 }
@@ -452,7 +452,7 @@ CQuorumCPtr CQuorumManager::GetQuorum(Consensus::LLMQType llmqType, const CBlock
     }
 
     LOCK(quorumsCacheCs);
-    CQuorumCPtr pQuorum;
+    CQuorumPtr pQuorum;
     if (mapQuorumsCache[llmqType].get(quorumHash, pQuorum)) {
         return pQuorum;
     }

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -324,8 +324,8 @@ bool CQuorumManager::RequestQuorumData(CNode* pFrom, Consensus::LLMQType llmqTyp
         LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Version must be %d or greater.\n", __func__, LLMQ_DATA_MESSAGES_VERSION);
         return false;
     }
-    if (pFrom == nullptr || pFrom->verifiedProRegTxHash.IsNull()) {
-        LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- pFrom is no masternode\n", __func__);
+    if (pFrom == nullptr || (pFrom->verifiedProRegTxHash.IsNull() && !pFrom->qwatch)) {
+        LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- pFrom is not neither a verified masternode nor qwatch connection\n", __func__);
         return false;
     }
     if (Params().GetConsensus().llmqs.count(llmqType) == 0) {
@@ -473,8 +473,8 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
 
     if (strCommand == NetMsgType::QGETDATA) {
 
-        if (!fMasternodeMode || pFrom == nullptr || pFrom->verifiedProRegTxHash.IsNull()) {
-            error("Not a masternode");
+        if (!fMasternodeMode || pFrom == nullptr || (pFrom->verifiedProRegTxHash.IsNull() && !pFrom->qwatch)) {
+            error("Not a verified masternode or a qwatch connection");
             return;
         }
 
@@ -557,8 +557,8 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
 
     if (strCommand == NetMsgType::QDATA) {
 
-        if (!fMasternodeMode || pFrom == nullptr || pFrom->verifiedProRegTxHash.IsNull()) {
-            error("Not a masternode");
+        if (!fMasternodeMode || pFrom == nullptr || (pFrom->verifiedProRegTxHash.IsNull() && !pFrom->qwatch)) {
+            error("Not a verified masternode or a qwatch connection");
             return;
         }
 

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -53,6 +53,24 @@ void CQuorum::Init(const CFinalCommitment& _qc, const CBlockIndex* _pindexQuorum
     minedBlockHash = _minedBlockHash;
 }
 
+bool CQuorum::SetVerificationVector(const BLSVerificationVector& quorumVecIn)
+{
+    if (::SerializeHash(quorumVecIn) != qc.quorumVvecHash) {
+        return false;
+    }
+    quorumVvec = std::make_shared<BLSVerificationVector>(quorumVecIn);
+    return true;
+}
+
+bool CQuorum::SetSecretKeyShare(const CBLSSecretKey& secretKeyShare)
+{
+    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(GetMemberIndex(activeMasternodeInfo.proTxHash)))) {
+        return false;
+    }
+    skShare = secretKeyShare;
+    return true;
+}
+
 bool CQuorum::IsMember(const uint256& proTxHash) const
 {
     for (auto& dmn : members) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -557,7 +557,8 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
 
     if (strCommand == NetMsgType::QDATA) {
 
-        if (!fMasternodeMode || pFrom == nullptr || (pFrom->verifiedProRegTxHash.IsNull() && !pFrom->qwatch)) {
+        bool fIsWatching = gArgs.GetBoolArg("-watchquorums", DEFAULT_WATCH_QUORUMS);
+        if ((!fMasternodeMode && !fIsWatching) || pFrom == nullptr || (pFrom->verifiedProRegTxHash.IsNull() && !pFrom->qwatch)) {
             errorHandler("Not a verified masternode or a qwatch connection");
             return;
         }

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -23,6 +23,106 @@ namespace llmq
 class CDKGSessionManager;
 
 /**
+ * An object of this class represents a QGETDATA request or a QDATA response header
+ */
+class CQuorumDataRequest
+{
+public:
+
+    enum Flags : uint16_t {
+        QUORUM_VERIFICATION_VECTOR = 0x0001,
+        ENCRYPTED_CONTRIBUTIONS = 0x0002,
+    };
+    enum Errors : uint8_t {
+        NONE = 0x00,
+        QUORUM_TYPE_INVALID = 0x01,
+        QUORUM_BLOCK_NOT_FOUND = 0x02,
+        QUORUM_NOT_FOUND = 0x03,
+        MASTERNODE_IS_NO_MEMBER = 0x04,
+        QUORUM_VERIFICATION_VECTOR_MISSING = 0x05,
+        ENCRYPTED_CONTRIBUTIONS_MISSING = 0x06,
+        UNDEFINED = 0xFF,
+    };
+
+private:
+    Consensus::LLMQType llmqType;
+    uint256 quorumHash;
+    uint16_t nDataMask;
+    uint256 proTxHash;
+    Errors nError;
+
+    int64_t nTime;
+    bool fProcessed;
+
+    static const int64_t nExpirySeconds{300};
+
+public:
+
+    CQuorumDataRequest() : nTime(GetAdjustedTime()) {}
+    CQuorumDataRequest(const Consensus::LLMQType llmqTypeIn, const uint256& quorumHashIn, const uint16_t nDataMaskIn, const uint256& proTxHashIn = uint256()) :
+        llmqType(llmqTypeIn),
+        quorumHash(quorumHashIn),
+        nDataMask(nDataMaskIn),
+        proTxHash(proTxHashIn),
+        nError(UNDEFINED),
+        nTime(GetAdjustedTime()),
+        fProcessed(false) {}
+
+    ADD_SERIALIZE_METHODS
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(llmqType);
+        READWRITE(quorumHash);
+        READWRITE(nDataMask);
+        READWRITE(proTxHash);
+        if (ser_action.ForRead()) {
+            try {
+                READWRITE(nError);
+            } catch (...) {
+                nError = UNDEFINED;
+            }
+        } else if (nError != UNDEFINED) {
+            READWRITE(nError);
+        }
+    }
+
+    const Consensus::LLMQType GetLLMQType() const { return llmqType; }
+    const uint256& GetQuorumHash() const { return quorumHash; }
+    const uint16_t GetDataMask() const { return nDataMask; }
+    const uint256& GetProTxHash() const { return proTxHash; }
+
+    void SetError(Errors nErrorIn) { nError = nErrorIn; }
+    const Errors GetError() const { return nError; }
+
+    bool IsExpired() const
+    {
+        return (GetAdjustedTime() - nTime) >= nExpirySeconds;
+    }
+    bool IsProcessed() const
+    {
+        return fProcessed;
+    }
+    void SetProcessed()
+    {
+        fProcessed = true;
+    }
+
+    bool operator==(const CQuorumDataRequest& other)
+    {
+        return llmqType == other.llmqType &&
+               quorumHash == other.quorumHash &&
+               nDataMask == other.nDataMask &&
+               proTxHash == other.proTxHash;
+    }
+    bool operator!=(const CQuorumDataRequest& other)
+    {
+        return !(*this == other);
+    }
+};
+
+/**
  * An object of this class represents a quorum which was mined on-chain (through a quorum commitment)
  * It at least contains information about the members and the quorum public key which is needed to verify recovered
  * signatures from this quorum.
@@ -116,5 +216,7 @@ private:
 extern CQuorumManager* quorumManager;
 
 } // namespace llmq
+
+template<> struct is_serializable_enum<llmq::CQuorumDataRequest::Errors> : std::true_type {};
 
 #endif // BITCOIN_LLMQ_QUORUMS_H

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -54,7 +54,7 @@ private:
     int64_t nTime;
     bool fProcessed;
 
-    static const int64_t nExpirySeconds{300};
+    static const int64_t EXPIRATION_TIMEOUT{300};
 
 public:
 
@@ -98,7 +98,7 @@ public:
 
     bool IsExpired() const
     {
-        return (GetTime() - nTime) >= nExpirySeconds;
+        return (GetTime() - nTime) >= EXPIRATION_TIMEOUT;
     }
     bool IsProcessed() const
     {

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -58,14 +58,14 @@ private:
 
 public:
 
-    CQuorumDataRequest() : nTime(GetAdjustedTime()) {}
+    CQuorumDataRequest() : nTime(GetTime()) {}
     CQuorumDataRequest(const Consensus::LLMQType llmqTypeIn, const uint256& quorumHashIn, const uint16_t nDataMaskIn, const uint256& proTxHashIn = uint256()) :
         llmqType(llmqTypeIn),
         quorumHash(quorumHashIn),
         nDataMask(nDataMaskIn),
         proTxHash(proTxHashIn),
         nError(UNDEFINED),
-        nTime(GetAdjustedTime()),
+        nTime(GetTime()),
         fProcessed(false) {}
 
     ADD_SERIALIZE_METHODS
@@ -98,7 +98,7 @@ public:
 
     bool IsExpired() const
     {
-        return (GetAdjustedTime() - nTime) >= nExpirySeconds;
+        return (GetTime() - nTime) >= nExpirySeconds;
     }
     bool IsProcessed() const
     {

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -189,7 +189,7 @@ private:
     CDKGSessionManager& dkgManager;
 
     mutable CCriticalSection quorumsCacheCs;
-    mutable std::map<Consensus::LLMQType, unordered_lru_cache<uint256, CQuorumCPtr, StaticSaltedHasher>> mapQuorumsCache;
+    mutable std::map<Consensus::LLMQType, unordered_lru_cache<uint256, CQuorumPtr, StaticSaltedHasher>> mapQuorumsCache;
     mutable std::map<Consensus::LLMQType, unordered_lru_cache<uint256, std::vector<CQuorumCPtr>, StaticSaltedHasher>> scanQuorumsCache;
 
 public:

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -157,6 +157,9 @@ public:
     ~CQuorum();
     void Init(const CFinalCommitment& _qc, const CBlockIndex* _pindexQuorum, const uint256& _minedBlockHash, const std::vector<CDeterministicMNCPtr>& _members);
 
+    bool SetVerificationVector(const BLSVerificationVector& quorumVecIn);
+    bool SetSecretKeyShare(const CBLSSecretKey& secretKeyShare);
+
     bool IsMember(const uint256& proTxHash) const;
     bool IsValidMember(const uint256& proTxHash) const;
     int GetMemberIndex(const uint256& proTxHash) const;

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -201,6 +201,8 @@ public:
 
     static bool HasQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash);
 
+    bool RequestQuorumData(CNode* pFrom, Consensus::LLMQType llmqType, const CBlockIndex* pQuorumIndex, uint16_t nDataMask, const uint256& proTxHash = uint256());
+
     // all these methods will lock cs_main for a short period of time
     CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
     std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, size_t nCountRequested) const;

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -197,6 +197,8 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload) const;
 
+    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
+
     static bool HasQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash);
 
     // all these methods will lock cs_main for a short period of time

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3584,6 +3584,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         CMNAuth::ProcessMessage(pfrom, strCommand, vRecv, *connman);
         llmq::quorumBlockProcessor->ProcessMessage(pfrom, strCommand, vRecv);
         llmq::quorumDKGSessionManager->ProcessMessage(pfrom, strCommand, vRecv);
+        llmq::quorumManager->ProcessMessage(pfrom, strCommand, vRecv);
         llmq::quorumSigSharesManager->ProcessMessage(pfrom, strCommand, vRecv);
         llmq::quorumSigningManager->ProcessMessage(pfrom, strCommand, vRecv);
         llmq::chainLocksHandler->ProcessMessage(pfrom, strCommand, vRecv);

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -72,6 +72,8 @@ const char *QGETSIGSHARES="qgetsigs";
 const char *QBSIGSHARES="qbsigs";
 const char *QSIGREC="qsigrec";
 const char *QSIGSHARE="qsigshare";
+const char* QGETDATA = "qgetdata";
+const char* QDATA = "qdata";
 const char *CLSIG="clsig";
 const char *ISLOCK="islock";
 const char *MNAUTH="mnauth";
@@ -139,6 +141,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::QBSIGSHARES,
     NetMsgType::QSIGREC,
     NetMsgType::QSIGSHARE,
+    NetMsgType::QGETDATA,
+    NetMsgType::QDATA,
     NetMsgType::CLSIG,
     NetMsgType::ISLOCK,
     NetMsgType::MNAUTH,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -268,6 +268,8 @@ extern const char *QGETSIGSHARES;
 extern const char *QBSIGSHARES;
 extern const char *QSIGREC;
 extern const char *QSIGSHARE;
+extern const char* QGETDATA;
+extern const char* QDATA;
 extern const char *CLSIG;
 extern const char *ISLOCK;
 extern const char *MNAUTH;

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -577,6 +577,7 @@ UniValue quorum_getdata(const JSONRPCRequest& request)
     uint16_t nDataMask = static_cast<uint16_t>(ParseInt32V(request.params[4], "dataMask"));
     uint256 proTxHash;
 
+    // Check if request wants ENCRYPTED_CONTRIBUTIONS data
     if (nDataMask & llmq::CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS) {
         if (!request.params[5].isNull()) {
             proTxHash = ParseHashV(request.params[5], "proTxHash");

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -567,7 +567,7 @@ void quorum_getdata_help()
 
 UniValue quorum_getdata(const JSONRPCRequest& request)
 {
-    if (request.fHelp || (request.params.size() != 6)) {
+    if (request.fHelp || (request.params.size() < 5 || request.params.size() > 6)) {
         quorum_getdata_help();
     }
 

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -551,8 +551,8 @@ UniValue quorum_dkgsimerror(const JSONRPCRequest& request)
 void quorum_getdata_help()
 {
     throw std::runtime_error(
-        "quorum getdata nodeId llmqType \"quorumHash\" dataMask \"proTxHash\"\n"
-        "This allows to trigger sending a QGETDATA messages to a connected peer.\n"
+        "quorum getdata nodeId llmqType \"quorumHash\" dataMask ( \"proTxHash\" )\n"
+        "Send a QGETDATA message to the specified peer.\n"
         "\nArguments:\n"
         "1. nodeId          (integer, required) The internal nodeId of the peer to receive the QGETDATA message.\n"
         "2. llmqType        (integer, required) The quorum type the data will be request from.\n"

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -554,14 +554,14 @@ void quorum_getdata_help()
         "quorum getdata nodeId llmqType \"quorumHash\" dataMask ( \"proTxHash\" )\n"
         "Send a QGETDATA message to the specified peer.\n"
         "\nArguments:\n"
-        "1. nodeId          (integer, required) The internal nodeId of the peer to receive the QGETDATA message.\n"
-        "2. llmqType        (integer, required) The quorum type the data will be request from.\n"
-        "3. \"quorumHash\"    (string, required) The quorum hash the data will be request from.\n"
-        "4. dataMask        (integer, required) Defined which data will be requested.\n"
+        "1. nodeId          (integer, required) The internal nodeId of the peer to request quorum data from.\n"
+        "2. llmqType        (integer, required) The quorum type related to the quorum data being requested.\n"
+        "3. \"quorumHash\"    (string, required) The quorum hash related to the quorum data being requested.\n"
+        "4. dataMask        (integer, required) Specify what data to request.\n"
         "                                       Possible values: 1 - Request quorum verification vector\n"
         "                                                        2 - Request encrypted contributions for member defined by \"proTxHash\"\n"
         "                                                        3 - Request both, 1 and 2\n"
-        "5. \"proTxHash\"     (string, optional) The proTxHash the contributions will be requested for. Must be member of the provided LLMQ.\n"
+        "5. \"proTxHash\"     (string, optional) The proTxHash the contributions will be requested for. Must be member of the specified LLMQ.\n"
         );
 }
 

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -575,7 +575,19 @@ UniValue quorum_getdata(const JSONRPCRequest& request)
     Consensus::LLMQType llmqType = static_cast<Consensus::LLMQType>(ParseInt32V(request.params[2], "llmqType"));
     uint256 quorumHash = ParseHashV(request.params[3], "quorumHash");
     uint16_t nDataMask = static_cast<uint16_t>(ParseInt32V(request.params[4], "dataMask"));
-    uint256 proTxHash = ParseHashV(request.params[5], "proTxHash");
+    uint256 proTxHash;
+
+    if (nDataMask & llmq::CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS) {
+        if (!request.params[5].isNull()) {
+            proTxHash = ParseHashV(request.params[5], "proTxHash");
+            if (proTxHash.IsNull()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "proTxHash invalid");
+            }
+        } else {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "proTxHash missing");
+        }
+    }
+
     const CBlockIndex* pQuorumIndex{nullptr};
     {
         LOCK(cs_main);

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -559,7 +559,7 @@ void quorum_getdata_help()
         "3. \"quorumHash\"    (string, required) The quorum hash related to the quorum data being requested.\n"
         "4. dataMask        (integer, required) Specify what data to request.\n"
         "                                       Possible values: 1 - Request quorum verification vector\n"
-        "                                                        2 - Request encrypted contributions for member defined by \"proTxHash\"\n"
+        "                                                        2 - Request encrypted contributions for member defined by \"proTxHash\". \"proTxHash\" must be specified if this option is used.\n"
         "                                                        3 - Request both, 1 and 2\n"
         "5. \"proTxHash\"     (string, optional) The proTxHash the contributions will be requested for. Must be member of the specified LLMQ.\n"
         );

--- a/src/version.h
+++ b/src/version.h
@@ -36,4 +36,7 @@ static const int SENDDSQUEUE_PROTO_VERSION = 70214;
 //! protocol version is included in MNAUTH starting with this version
 static const int MNAUTH_NODE_VER_VERSION = 70218;
 
+//! introduction of QGETDATA/QDATA messages
+static const int LLMQ_DATA_MESSAGES_VERSION = 70219;
+
 #endif // BITCOIN_VERSION_H

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70218;
+static const int PROTOCOL_VERSION = 70219;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -20,7 +20,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION = 70213;
 
 //! minimum proto version of masternode to accept in DKGs
-static const int MIN_MASTERNODE_PROTO_VERSION = 70218;
+static const int MIN_MASTERNODE_PROTO_VERSION = 70219;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -5,7 +5,7 @@
 
 from test_framework.mininode import *
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import force_finish_mnsync, assert_equal, connect_nodes
+from test_framework.util import assert_raises_rpc_error, force_finish_mnsync, assert_equal, connect_nodes
 
 '''
 p2p_quorum_data.py
@@ -383,6 +383,12 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_for_banscore(mn1.node, id_p2p_mn1, 50)
         mn1.node.disconnect_p2ps()
         network_thread_join()
+        # Test optional proTxHash of `quorum getdata`
+        assert_raises_rpc_error(-8, "proTxHash missing",
+                                mn1.node.quorum, "getdata", 0, 100, quorum_hash, 0x02)
+        assert_raises_rpc_error(-8, "proTxHash invalid",
+                                mn1.node.quorum, "getdata", 0, 100, quorum_hash, 0x03,
+                                "0000000000000000000000000000000000000000000000000000000000000000")
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -35,6 +35,16 @@ MASTERNODE_IS_NO_MEMBER = 4
 QUORUM_VERIFICATION_VECTOR_MISSING = 5
 ENCRYPTED_CONTRIBUTIONS_MISSING = 6
 
+# Used to overwrite MNAUTH for mininode connections
+fake_mnauth_1 = ["cecf37bf0ec05d2d22cb8227f88074bb882b94cd2081ba318a5a444b1b15b9fd",
+                 "087ba00bf61135f3860c4944a0debabe186ef82628fbe4ceaed1ad51d672c58dde14ea4b321efe0b89257a40322bc972"]
+fake_mnauth_2 = ["6ad7ed7a2d6c2c1db30fc364114602b36b2730a9aa96d8f11f1871a9cee37378",
+                 "122463411a86362966a5161805f24cf6a0eef08a586b8e00c4f0ad0b084c5bb3f5c9a60ee5ffc78db2313897e3ab2223"]
+
+# Used to distinguish mininode connections
+uacomment_m3_1 = "MN3_1"
+uacomment_m3_2 = "MN3_2"
+
 
 def assert_qdata(qdata, qgetdata, error, len_vvec=0, len_contributions=0):
     assert qdata is not None and qgetdata is not None
@@ -434,11 +444,6 @@ class QuorumDataMessagesTest(DashTestFramework):
         mn2 = self.mninfo[1]
         mn3 = self.mninfo[2]
 
-        fake_mnauth_1 = ["cecf37bf0ec05d2d22cb8227f88074bb882b94cd2081ba318a5a444b1b15b9fd",
-                         "087ba00bf61135f3860c4944a0debabe186ef82628fbe4ceaed1ad51d672c58dde14ea4b321efe0b89257a40322bc972"]
-        fake_mnauth_2 = ["6ad7ed7a2d6c2c1db30fc364114602b36b2730a9aa96d8f11f1871a9cee37378",
-                         "122463411a86362966a5161805f24cf6a0eef08a586b8e00c4f0ad0b084c5bb3f5c9a60ee5ffc78db2313897e3ab2223"]
-
         # Convert the hex values into integer values
         quorum_hash_int = int(quorum_hash, 16)
         protx_hash_int = int(mn1.proTxHash, 16)
@@ -447,9 +452,6 @@ class QuorumDataMessagesTest(DashTestFramework):
         qgetdata_vvec = msg_qgetdata(quorum_hash_int, 100, 0x01, protx_hash_int)
         qgetdata_contributions = msg_qgetdata(quorum_hash_int, 100, 0x02, protx_hash_int)
         qgetdata_all = msg_qgetdata(quorum_hash_int, 100, 0x03, protx_hash_int)
-
-        uacomment_m3_1 = "MN3_1"
-        uacomment_m3_2 = "MN3_2"
 
         test_basics()
         test_request_limit()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -71,20 +71,16 @@ def p2p_connection(node, uacomment=None):
 
 
 def get_mininode_id(node, uacomment=None):
-    tries = 0
-    node_id = None
-    while tries < 200 and node_id is None:
+    def get_id():
         for p in node.getpeerinfo():
             for p2p in node.p2ps:
                 if uacomment is not None and p2p.uacomment != uacomment:
                     continue
                 if p["subver"] == p2p.strSubVer.decode():
-                    node_id = p["id"]
-                    break
-        tries += 1
-        time.sleep(0.05)
-    assert node_id is not None
-    return node_id
+                    return p["id"]
+        return None
+    wait_until(lambda: get_id() != None, timeout=10)
+    return get_id()
 
 
 def mnauth(node, node_id, protx_hash, operator_pubkey):

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -339,12 +339,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         # QWATCH connections share one request limit slot
         def test_qwatch_connections():
             self.log.info("Test QWATCH connections")
-
-            # Restart mns to clear previous ratelimiting
-            self.restart_mn(mn1)
-            self.restart_mn(mn2)
-            self.restart_mn(mn3)
-
+            force_request_expire()
             p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
             p2p_mn3_2 = p2p_connection(mn3.node, uacomment_m3_2)
             network_thread_start()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -198,8 +198,6 @@ class QuorumDataMessagesTest(DashTestFramework):
             qgetdata_invalid_quorum = msg_qgetdata(int(mn1.node.getblockhash(0), 16), 100, 0x01, protx_hash_int)
             qgetdata_invalid_no_member = msg_qgetdata(quorum_hash_int, 100, 0x02, quorum_hash_int)
 
-            mn1.node.disconnect_p2ps()
-            network_thread_join()
             p2p_mn1 = p2p_connection(mn1.node)
             network_thread_start()
             p2p_mn1.wait_for_verack()
@@ -310,28 +308,6 @@ class QuorumDataMessagesTest(DashTestFramework):
             wait_for_banscore(mn3.node, id_p2p_mn3_1, 75)
             # mn2 should be "banned" now
             wait_until(lambda: not p2p_mn3_2.is_connected, timeout=10)
-            mn3.node.disconnect_p2ps()
-            network_thread_join()
-            # Test that QWATCH connections are also allowed to query data but
-            # all QWATCH connections share one request limit slot
-            p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
-            p2p_mn3_2 = p2p_connection(mn3.node, uacomment_m3_2)
-            network_thread_start()
-            p2p_mn3_1.wait_for_verack()
-            p2p_mn3_2.wait_for_verack()
-            id_p2p_mn3_1 = get_mininode_id(mn3.node, uacomment_m3_1)
-            id_p2p_mn3_2 = get_mininode_id(mn3.node, uacomment_m3_2)
-            assert id_p2p_mn3_1 != id_p2p_mn3_2
-            # Send QWATCH for both connections
-            p2p_mn3_1.send_message(msg_qwatch())
-            p2p_mn3_2.send_message(msg_qwatch())
-            # Now send alternating and make sure they share the same request limit
-            p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
-            wait_for_banscore(mn3.node, id_p2p_mn3_1, 0)
-            p2p_mn3_2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
-            wait_for_banscore(mn3.node, id_p2p_mn3_2, 25)
-            p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
-            wait_for_banscore(mn3.node, id_p2p_mn3_1, 25)
             mn3.node.disconnect_p2ps()
             network_thread_join()
 

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -300,7 +300,7 @@ class QuorumDataMessagesTest(DashTestFramework):
             self.wait_for_quorum_data([mn1], 100, quorum_hash, recover=False)
 
         # Test request limiting / banscore increase
-        def test_ratelimiting_banscore():
+        def test_request_limit():
 
             def test_send_from_two_to_one(send_1, expected_banscore_1, send_2, expected_banscore_2, clear_requests=False):
                 if clear_requests:
@@ -452,7 +452,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         uacomment_m3_2 = "MN3_2"
 
         test_basics()
-        test_ratelimiting_banscore()
+        test_request_limit()
         test_qwatch_connections()
         test_watchquorums()
         test_rpc_quorum_getdata_proTxHash()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.mininode import *
+from test_framework.test_framework import DashTestFramework
+from test_framework.util import force_finish_mnsync, assert_equal, connect_nodes
+
+'''
+p2p_quorum_data.py
+
+Tests QGETDATA/QDATA functionality
+'''
+
+
+def assert_qdata(qdata, qgetdata, error, len_vvec=0, len_contributions=0):
+    assert qdata is not None and qgetdata is not None
+    assert_equal(qdata.quorum_type, qgetdata.quorum_type)
+    assert_equal(qdata.quorum_hash, qgetdata.quorum_hash)
+    assert_equal(qdata.data_mask, qgetdata.data_mask)
+    assert_equal(qdata.protx_hash, qgetdata.protx_hash)
+    assert_equal(qdata.error, error)
+    assert_equal(len(qdata.quorum_vvec), len_vvec)
+    assert_equal(len(qdata.enc_contributions), len_contributions)
+
+
+def wait_for_banscore(node, peer_id, expexted_score):
+    def get_score():
+        for peer in node.getpeerinfo():
+            if peer["id"] == peer_id:
+                return peer["banscore"]
+        return None
+    wait_until(lambda: get_score() == expexted_score, timeout=6, sleep=2)
+
+
+def p2p_connection(node, subversion=MY_SUBVERSION):
+    connection = node.add_p2p_connection(QuorumDataInterface(), send_version=False)
+    version_message = msg_version()
+    version_message.strSubVer = subversion
+    connection.sendbuf = connection.build_message(version_message)
+    return connection
+
+
+def get_mininode_id(node, subversion=MY_SUBVERSION):
+    tries = 0
+    node_id = None
+    while tries < 10 and node_id is None:
+        for p in node.getpeerinfo():
+            if p["subver"] == subversion.decode():
+                node_id = p["id"]
+                break
+        tries += 1
+        time.sleep(1)
+    assert(node_id is not None)
+    return node_id
+
+
+def mnauth(node, node_id, protx_hash, operator_pubkey):
+    assert(node.mnauth(node_id, protx_hash, operator_pubkey))
+    mnauth_peer_id = None
+    for peer in node.getpeerinfo():
+        if "verified_proregtx_hash" in peer and peer["verified_proregtx_hash"] == protx_hash:
+            assert_equal(mnauth_peer_id, None)
+            mnauth_peer_id = peer["id"]
+    assert_equal(mnauth_peer_id, node_id)
+
+class QuorumDataInterface(P2PInterface):
+    def __init__(self):
+        super().__init__()
+
+    def test_qgetdata(self, qgetdata, expected_error=0, len_vvec=0, len_contributions=0, response_expected=True):
+        self.send_message(qgetdata)
+        self.wait_for_qdata(message_expected=response_expected)
+        if response_expected:
+            assert_qdata(self.get_qdata(), qgetdata, expected_error, len_vvec, len_contributions)
+
+    def get_qgetdata(self):
+        return self.last_message["qdata"]
+
+    def wait_for_qgetdata(self, timeout=3, message_expected=True):
+        def test_function():
+            return self.message_count["qgetdata"]
+        wait_until(test_function, timeout=timeout, lock=mininode_lock, do_assert=message_expected)
+        self.message_count["qgetdata"] = 0
+        if not message_expected:
+            assert (not self.message_count["qgetdata"])
+
+    def get_qdata(self):
+        return self.last_message["qdata"]
+
+    def wait_for_qdata(self, timeout=10, message_expected=True):
+        def test_function():
+            return self.message_count["qdata"]
+        wait_until(test_function, timeout=timeout, lock=mininode_lock, do_assert=message_expected)
+        self.message_count["qdata"] = 0
+        if not message_expected:
+            assert (not self.message_count["qdata"])
+
+
+class QuorumDataMessagesTest(DashTestFramework):
+    def set_test_params(self):
+        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
+
+    def restart_mn(self, mn, reindex=False):
+        args = self.extra_args[mn.nodeIdx] + ['-masternodeblsprivkey=%s' % mn.keyOperator]
+        if reindex:
+            args.append('-reindex')
+        self.restart_node(mn.nodeIdx, args)
+        force_finish_mnsync(mn.node)
+        connect_nodes(mn.node, 0)
+        self.sync_blocks()
+
+    def run_test(self):
+
+        def test_send_from_two_to_one(send_1, expected_banscore_1, send_2, expected_banscore_2, clear_requests=False):
+            if clear_requests:
+                force_request_expire()
+            if send_1:
+                p2p_mn3_1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+            if send_2:
+                p2p_mn3_2.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+            wait_for_banscore(mn3.node, id_p2p_mn3_1, expected_banscore_1)
+            wait_for_banscore(mn3.node, id_p2p_mn3_2, expected_banscore_2)
+
+        def force_request_expire(bump_seconds=self.quorum_data_request_expiry_seconds + 1):
+            self.bump_mocktime(bump_seconds)
+            if node0.getblockcount() % 2:  # Test with/without expired request cleanup
+                node0.generate(1)
+                self.sync_blocks()
+
+        self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 4070908800)
+
+        self.wait_for_sporks_same()
+        quorum_hash = self.mine_quorum()
+
+        node0 = self.nodes[0]
+        mn1 = self.mninfo[0]
+        mn2 = self.mninfo[1]
+        mn3 = self.mninfo[2]
+
+        fake_mnauth_1 = ["cecf37bf0ec05d2d22cb8227f88074bb882b94cd2081ba318a5a444b1b15b9fd",
+                    "087ba00bf61135f3860c4944a0debabe186ef82628fbe4ceaed1ad51d672c58dde14ea4b321efe0b89257a40322bc972"]
+        fake_mnauth_2 = ["6ad7ed7a2d6c2c1db30fc364114602b36b2730a9aa96d8f11f1871a9cee37378",
+                    "122463411a86362966a5161805f24cf6a0eef08a586b8e00c4f0ad0b084c5bb3f5c9a60ee5ffc78db2313897e3ab2223"]
+
+        p2p_node0 = p2p_connection(node0)
+        p2p_mn1 = p2p_connection(mn1.node)
+        network_thread_start()
+        p2p_node0.wait_for_verack()
+        p2p_mn1.wait_for_verack()
+        id_p2p_node0 = get_mininode_id(node0)
+        id_p2p_mn1 = get_mininode_id(mn1.node)
+
+        wait_for_banscore(node0, id_p2p_node0, 0)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 0)
+
+        quorum_hash_int = int(quorum_hash, 16)
+        protx_hash_int = int(mn1.proTxHash, 16)
+
+        # Valid requests
+        qgetdata_vvec = msg_qgetdata(quorum_hash_int, 100, 0x01, protx_hash_int)
+        qgetdata_contributions = msg_qgetdata(quorum_hash_int, 100, 0x02, protx_hash_int)
+        qgetdata_all = msg_qgetdata(quorum_hash_int, 100, 0x03, protx_hash_int)
+        # The normal node should not respond to qgetdata
+        p2p_node0.test_qgetdata(qgetdata_all, response_expected=False)
+        wait_for_banscore(node0, id_p2p_node0, 10)
+        # The masternode should not respond to qgetdata for non-masternode connections
+        p2p_mn1.test_qgetdata(qgetdata_all, response_expected=False)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 10)
+        # Open a fake MNAUTH authenticated P2P connection to the masternode to allow qgetdata
+        node0.disconnect_p2ps()
+        mn1.node.disconnect_p2ps()
+        network_thread_join()
+        p2p_mn1 = p2p_connection(mn1.node)
+        network_thread_start()
+        p2p_mn1.wait_for_verack()
+        id_p2p_mn1 = get_mininode_id(mn1.node)
+        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+        # The masternode should now respond to qgetdata requests
+        # Request verification vector
+        p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 0)
+        # Request encrypted contributions
+        p2p_mn1.test_qgetdata(qgetdata_contributions, 0, 0, self.llmq_size)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 25)
+        # Request both
+        p2p_mn1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 50)
+        # Create invalid messages for all error cases
+        qgetdata_invalid_type = msg_qgetdata(quorum_hash_int, 103, 0x01, protx_hash_int)
+        qgetdata_invalid_block = msg_qgetdata(protx_hash_int, 100, 0x01, protx_hash_int)
+        qgetdata_invalid_quorum = msg_qgetdata(int(mn1.node.getblockhash(0), 16), 100, 0x01, protx_hash_int)
+        qgetdata_invalid_no_member = msg_qgetdata(quorum_hash_int, 100, 0x02, quorum_hash_int)
+        # Possible error values of QDATA
+        QUORUM_TYPE_INVALID = 1
+        QUORUM_BLOCK_NOT_FOUND = 2
+        QUORUM_NOT_FOUND = 3
+        MASTERNODE_IS_NO_MEMBER = 4
+        QUORUM_VERIFICATION_VECTOR_MISSING = 5
+        ENCRYPTED_CONTRIBUTIONS_MISSING = 6
+        # Test all invalid messages
+        mn1.node.disconnect_p2ps()
+        network_thread_join()
+        p2p_mn1 = p2p_connection(mn1.node)
+        network_thread_start()
+        p2p_mn1.wait_for_verack()
+        id_p2p_mn1 = get_mininode_id(mn1.node)
+        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+        p2p_mn1.test_qgetdata(qgetdata_invalid_type, QUORUM_TYPE_INVALID)
+        p2p_mn1.test_qgetdata(qgetdata_invalid_block, QUORUM_BLOCK_NOT_FOUND)
+        p2p_mn1.test_qgetdata(qgetdata_invalid_quorum, QUORUM_NOT_FOUND)
+        p2p_mn1.test_qgetdata(qgetdata_invalid_no_member, MASTERNODE_IS_NO_MEMBER)
+        # The last two error case require the node to miss its DKG data so we just reindex the node.
+        mn1.node.disconnect_p2ps()
+        network_thread_join()
+        self.restart_mn(mn1, reindex=True)
+        # Re-connect to the masternode
+        p2p_mn1 = p2p_connection(mn1.node)
+        p2p_mn2 = p2p_connection(mn2.node)
+        network_thread_start()
+        p2p_mn1.wait_for_verack()
+        p2p_mn2.wait_for_verack()
+        id_p2p_mn1 = get_mininode_id(mn1.node)
+        id_p2p_mn2 = get_mininode_id(mn2.node)
+        assert(id_p2p_mn1 is not None)
+        assert(id_p2p_mn2 is not None)
+        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+        mnauth(mn2.node, id_p2p_mn2, fake_mnauth_2[0], fake_mnauth_2[1])
+        # Validate the DKG data is missing
+        p2p_mn1.test_qgetdata(qgetdata_vvec, QUORUM_VERIFICATION_VECTOR_MISSING)
+        p2p_mn1.test_qgetdata(qgetdata_contributions, ENCRYPTED_CONTRIBUTIONS_MISSING)
+        # Now that mn1 is missing its DKG data try to recover it by querying the data from mn2 and then sending it to
+        # mn1 with a direct QDATA message.
+        #
+        # mininode - QGETDATA -> mn2 - QDATA -> mininode - QDATA -> mn1
+        #
+        # However, mn1 only accepts self requested QDATA messages, that's why we trigger mn1 - QGETDATA -> mininode
+        # via the RPC command "quorum getdata".
+        #
+        # Get the required DKG data for mn1
+        p2p_mn2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+        # Trigger mn1 - QGETDATA -> p2p_mn1
+        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        # Wait until mn1 sent the QGETDATA to p2p_mn1
+        p2p_mn1.wait_for_qgetdata()
+        # Send the QDATA received from mn2 to mn1
+        p2p_mn1.send_message(p2p_mn2.get_qdata())
+        # Now mn1 should have its data back!
+        self.wait_for_quorum_data([mn1], 100, quorum_hash, recover=False)
+        # Restart one more time and make sure data gets saved to db
+        mn1.node.disconnect_p2ps()
+        mn2.node.disconnect_p2ps()
+        network_thread_join()
+        self.restart_mn(mn1)
+        self.wait_for_quorum_data([mn1], 100, quorum_hash, recover=False)
+        # Test request limiting / banscore increase
+        p2p_mn1 = p2p_connection(mn1.node)
+        network_thread_start()
+        p2p_mn1.wait_for_verack()
+        id_p2p_mn1 = get_mininode_id(mn1.node)
+        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+        p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 0)
+        force_request_expire(299)  # This shouldn't clear requests, next request should bump score
+        p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 25)
+        force_request_expire(1)  # This should clear the requests now, next request should not bump score
+        p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 25)
+        mn1.node.disconnect_p2ps()
+        network_thread_join()
+        # Requesting one QDATA with mn1 and mn2 from mn3 should not result in banscore increase
+        # for either of both.
+        version_m3_1 = MY_SUBVERSION + b"MN3_1"
+        version_m3_2 = MY_SUBVERSION + b"MN3_2"
+        p2p_mn3_1 = p2p_connection(mn3.node, subversion=version_m3_1)
+        p2p_mn3_2 = p2p_connection(mn3.node, subversion=version_m3_2)
+        network_thread_start()
+        p2p_mn3_1.wait_for_verack()
+        p2p_mn3_2.wait_for_verack()
+        id_p2p_mn3_1 = get_mininode_id(mn3.node, version_m3_1)
+        id_p2p_mn3_2 = get_mininode_id(mn3.node, version_m3_2)
+        assert(id_p2p_mn3_1 != id_p2p_mn3_2)
+        mnauth(mn3.node, id_p2p_mn3_1, fake_mnauth_1[0], fake_mnauth_1[1])
+        mnauth(mn3.node, id_p2p_mn3_2, fake_mnauth_2[0], fake_mnauth_2[1])
+        # Now try some {mn1, mn2} - QGETDATA -> mn3 combinations to make sure request limit works connection based
+        test_send_from_two_to_one(False, 0, True, 0, True)
+        test_send_from_two_to_one(True, 0, True, 25)
+        test_send_from_two_to_one(True, 25, False, 25)
+        test_send_from_two_to_one(False, 25, True, 25, True)
+        test_send_from_two_to_one(True, 25, True, 50)
+        test_send_from_two_to_one(True, 50, True, 75)
+        test_send_from_two_to_one(True, 50, True, 75, True)
+        test_send_from_two_to_one(True, 75, False, 75)
+        test_send_from_two_to_one(False, 75, True, None)
+        # mn1 should still have a score of 75
+        wait_for_banscore(mn3.node, id_p2p_mn3_1, 75)
+        # mn2 should be "banned" now
+        wait_until(lambda: not p2p_mn3_2.is_connected, timeout=10)
+        mn3.node.disconnect_p2ps()
+        network_thread_join()
+        # Test ban score increase for invalid/unexpected QDATA
+        p2p_mn1 = p2p_connection(mn1.node)
+        network_thread_start()
+        p2p_mn1.wait_for_verack()
+        id_p2p_mn1 = get_mininode_id(mn1.node)
+        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+        wait_for_banscore(mn1.node, id_p2p_mn1, 0)
+        qdata_valid = p2p_mn2.get_qdata()
+        # - Not requested
+        p2p_mn1.send_message(qdata_valid)
+        time.sleep(1)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 10)
+        # - Already received
+        force_request_expire()
+        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        p2p_mn1.wait_for_qgetdata()
+        p2p_mn1.send_message(qdata_valid)
+        time.sleep(1)
+        p2p_mn1.send_message(qdata_valid)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 20)
+        # - Not like requested
+        force_request_expire()
+        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        p2p_mn1.wait_for_qgetdata()
+        qdata_invalid_request = qdata_valid
+        qdata_invalid_request.data_mask = 2
+        p2p_mn1.send_message(qdata_invalid_request)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 30)
+        # - Invalid verification vector
+        force_request_expire()
+        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        p2p_mn1.wait_for_qgetdata()
+        qdata_invalid_vvec = qdata_valid
+        qdata_invalid_vvec.quorum_vvec.pop()
+        p2p_mn1.send_message(qdata_invalid_vvec)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 40)
+        # - Invalid contributions
+        force_request_expire()
+        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        p2p_mn1.wait_for_qgetdata()
+        qdata_invalid_contribution = qdata_valid
+        qdata_invalid_contribution.enc_contributions.pop()
+        p2p_mn1.send_message(qdata_invalid_contribution)
+        wait_for_banscore(mn1.node, id_p2p_mn1, 50)
+
+
+if __name__ == '__main__':
+    QuorumDataMessagesTest().main()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -321,6 +321,20 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_for_banscore(mn3.node, id_p2p_mn3_1, 25)
         mn3.node.disconnect_p2ps()
         network_thread_join()
+        # Test -watchquorums support
+        for extra_args in [[], ["-watchquorums"]]:
+            self.restart_node(0, self.extra_args[0] + extra_args)
+            p2p_node0 = p2p_connection(node0)
+            network_thread_start()
+            p2p_node0.wait_for_verack()
+            id_p2p_node0 = get_mininode_id(node0)
+            mnauth(node0, id_p2p_node0, fake_mnauth_1[0], fake_mnauth_1[1])
+            assert(node0.quorum("getdata", id_p2p_node0, 100, quorum_hash, 0x03, mn1.proTxHash))
+            p2p_node0.wait_for_qgetdata()
+            p2p_node0.send_message(p2p_mn2.get_qdata())
+            wait_for_banscore(node0, id_p2p_node0, (1 - len(extra_args)) * 10)
+            node0.disconnect_p2ps()
+            network_thread_join()
         # Test ban score increase for invalid/unexpected QDATA
         p2p_mn1 = p2p_connection(mn1.node)
         network_thread_start()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -47,13 +47,13 @@ def assert_qdata(qdata, qgetdata, error, len_vvec=0, len_contributions=0):
     assert_equal(len(qdata.enc_contributions), len_contributions)
 
 
-def wait_for_banscore(node, peer_id, expexted_score):
+def wait_for_banscore(node, peer_id, expected_score):
     def get_score():
         for peer in node.getpeerinfo():
             if peer["id"] == peer_id:
                 return peer["banscore"]
         return None
-    wait_until(lambda: get_score() == expexted_score, timeout=6, sleep=2)
+    wait_until(lambda: get_score() == expected_score, timeout=6, sleep=2)
 
 
 def p2p_connection(node, uacomment=None):

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -13,6 +13,14 @@ p2p_quorum_data.py
 Tests QGETDATA/QDATA functionality
 '''
 
+# Possible error values of QDATA
+QUORUM_TYPE_INVALID = 1
+QUORUM_BLOCK_NOT_FOUND = 2
+QUORUM_NOT_FOUND = 3
+MASTERNODE_IS_NO_MEMBER = 4
+QUORUM_VERIFICATION_VECTOR_MISSING = 5
+ENCRYPTED_CONTRIBUTIONS_MISSING = 6
+
 
 def assert_qdata(qdata, qgetdata, error, len_vvec=0, len_contributions=0):
     assert qdata is not None and qgetdata is not None
@@ -190,13 +198,6 @@ class QuorumDataMessagesTest(DashTestFramework):
         qgetdata_invalid_block = msg_qgetdata(protx_hash_int, 100, 0x01, protx_hash_int)
         qgetdata_invalid_quorum = msg_qgetdata(int(mn1.node.getblockhash(0), 16), 100, 0x01, protx_hash_int)
         qgetdata_invalid_no_member = msg_qgetdata(quorum_hash_int, 100, 0x02, quorum_hash_int)
-        # Possible error values of QDATA
-        QUORUM_TYPE_INVALID = 1
-        QUORUM_BLOCK_NOT_FOUND = 2
-        QUORUM_NOT_FOUND = 3
-        MASTERNODE_IS_NO_MEMBER = 4
-        QUORUM_VERIFICATION_VECTOR_MISSING = 5
-        ENCRYPTED_CONTRIBUTIONS_MISSING = 6
         # Test all invalid messages
         mn1.node.disconnect_p2ps()
         network_thread_join()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -128,7 +128,7 @@ class QuorumDataMessagesTest(DashTestFramework):
             wait_for_banscore(mn3.node, id_p2p_mn3_1, expected_banscore_1)
             wait_for_banscore(mn3.node, id_p2p_mn3_2, expected_banscore_2)
 
-        def force_request_expire(bump_seconds=self.quorum_data_request_expiry_seconds + 1):
+        def force_request_expire(bump_seconds=self.quorum_data_request_expiration_timeout + 1):
             self.bump_mocktime(bump_seconds)
             if node0.getblockcount() % 2:  # Test with/without expired request cleanup
                 node0.generate(1)

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -381,6 +381,8 @@ class QuorumDataMessagesTest(DashTestFramework):
         qdata_invalid_contribution.enc_contributions.pop()
         p2p_mn1.send_message(qdata_invalid_contribution)
         wait_for_banscore(mn1.node, id_p2p_mn1, 50)
+        mn1.node.disconnect_p2ps()
+        network_thread_join()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -86,6 +86,7 @@ def mnauth(node, node_id, protx_hash, operator_pubkey):
             mnauth_peer_id = peer["id"]
     assert_equal(mnauth_peer_id, node_id)
 
+
 class QuorumDataInterface(P2PInterface):
     def __init__(self):
         super().__init__()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -63,7 +63,7 @@ def wait_for_banscore(node, peer_id, expected_score):
             if peer["id"] == peer_id:
                 return peer["banscore"]
         return None
-    wait_until(lambda: get_score() == expected_score, timeout=6, sleep=2)
+    wait_until(lambda: get_score() == expected_score, timeout=6)
 
 
 def p2p_connection(node, uacomment=None):
@@ -73,7 +73,7 @@ def p2p_connection(node, uacomment=None):
 def get_mininode_id(node, uacomment=None):
     tries = 0
     node_id = None
-    while tries < 10 and node_id is None:
+    while tries < 200 and node_id is None:
         for p in node.getpeerinfo():
             for p2p in node.p2ps:
                 if uacomment is not None and p2p.uacomment != uacomment:
@@ -82,7 +82,7 @@ def get_mininode_id(node, uacomment=None):
                     node_id = p["id"]
                     break
         tries += 1
-        time.sleep(1)
+        time.sleep(0.05)
     assert node_id is not None
     return node_id
 

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -73,12 +73,12 @@ def get_mininode_id(node, uacomment=None):
                     break
         tries += 1
         time.sleep(1)
-    assert(node_id is not None)
+    assert node_id is not None
     return node_id
 
 
 def mnauth(node, node_id, protx_hash, operator_pubkey):
-    assert(node.mnauth(node_id, protx_hash, operator_pubkey))
+    assert node.mnauth(node_id, protx_hash, operator_pubkey)
     mnauth_peer_id = None
     for peer in node.getpeerinfo():
         if "verified_proregtx_hash" in peer and peer["verified_proregtx_hash"] == protx_hash:
@@ -106,7 +106,7 @@ class QuorumDataInterface(P2PInterface):
         wait_until(test_function, timeout=timeout, lock=mininode_lock, do_assert=message_expected)
         self.message_count["qgetdata"] = 0
         if not message_expected:
-            assert (not self.message_count["qgetdata"])
+            assert not self.message_count["qgetdata"]
 
     def get_qdata(self):
         return self.last_message["qdata"]
@@ -117,7 +117,7 @@ class QuorumDataInterface(P2PInterface):
         wait_until(test_function, timeout=timeout, lock=mininode_lock, do_assert=message_expected)
         self.message_count["qdata"] = 0
         if not message_expected:
-            assert (not self.message_count["qdata"])
+            assert not self.message_count["qdata"]
 
 
 class QuorumDataMessagesTest(DashTestFramework):
@@ -239,8 +239,8 @@ class QuorumDataMessagesTest(DashTestFramework):
         p2p_mn2.wait_for_verack()
         id_p2p_mn1 = get_mininode_id(mn1.node)
         id_p2p_mn2 = get_mininode_id(mn2.node)
-        assert(id_p2p_mn1 is not None)
-        assert(id_p2p_mn2 is not None)
+        assert id_p2p_mn1 is not None
+        assert id_p2p_mn2 is not None
         mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
         mnauth(mn2.node, id_p2p_mn2, fake_mnauth_2[0], fake_mnauth_2[1])
         # Validate the DKG data is missing
@@ -257,7 +257,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         # Get the required DKG data for mn1
         p2p_mn2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
         # Trigger mn1 - QGETDATA -> p2p_mn1
-        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
         # Wait until mn1 sent the QGETDATA to p2p_mn1
         p2p_mn1.wait_for_qgetdata()
         # Send the QDATA received from mn2 to mn1
@@ -297,7 +297,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         p2p_mn3_2.wait_for_verack()
         id_p2p_mn3_1 = get_mininode_id(mn3.node, uacomment_m3_1)
         id_p2p_mn3_2 = get_mininode_id(mn3.node, uacomment_m3_2)
-        assert(id_p2p_mn3_1 != id_p2p_mn3_2)
+        assert id_p2p_mn3_1 != id_p2p_mn3_2
         mnauth(mn3.node, id_p2p_mn3_1, fake_mnauth_1[0], fake_mnauth_1[1])
         mnauth(mn3.node, id_p2p_mn3_2, fake_mnauth_2[0], fake_mnauth_2[1])
         # Now try some {mn1, mn2} - QGETDATA -> mn3 combinations to make sure request limit works connection based
@@ -325,7 +325,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         p2p_mn3_2.wait_for_verack()
         id_p2p_mn3_1 = get_mininode_id(mn3.node, uacomment_m3_1)
         id_p2p_mn3_2 = get_mininode_id(mn3.node, uacomment_m3_2)
-        assert (id_p2p_mn3_1 != id_p2p_mn3_2)
+        assert id_p2p_mn3_1 != id_p2p_mn3_2
         # Send QWATCH for both connections
         p2p_mn3_1.send_message(msg_qwatch())
         p2p_mn3_2.send_message(msg_qwatch())
@@ -346,7 +346,7 @@ class QuorumDataMessagesTest(DashTestFramework):
             p2p_node0.wait_for_verack()
             id_p2p_node0 = get_mininode_id(node0)
             mnauth(node0, id_p2p_node0, fake_mnauth_1[0], fake_mnauth_1[1])
-            assert(node0.quorum("getdata", id_p2p_node0, 100, quorum_hash, 0x03, mn1.proTxHash))
+            assert node0.quorum("getdata", id_p2p_node0, 100, quorum_hash, 0x03, mn1.proTxHash)
             p2p_node0.wait_for_qgetdata()
             p2p_node0.send_message(p2p_mn2.get_qdata())
             wait_for_banscore(node0, id_p2p_node0, (1 - len(extra_args)) * 10)
@@ -366,7 +366,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_for_banscore(mn1.node, id_p2p_mn1, 10)
         # - Already received
         force_request_expire()
-        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
         p2p_mn1.wait_for_qgetdata()
         p2p_mn1.send_message(qdata_valid)
         time.sleep(1)
@@ -374,7 +374,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_for_banscore(mn1.node, id_p2p_mn1, 20)
         # - Not like requested
         force_request_expire()
-        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
         p2p_mn1.wait_for_qgetdata()
         qdata_invalid_request = qdata_valid
         qdata_invalid_request.data_mask = 2
@@ -382,7 +382,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_for_banscore(mn1.node, id_p2p_mn1, 30)
         # - Invalid verification vector
         force_request_expire()
-        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
         p2p_mn1.wait_for_qgetdata()
         qdata_invalid_vvec = qdata_valid
         qdata_invalid_vvec.quorum_vvec.pop()
@@ -390,7 +390,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_for_banscore(mn1.node, id_p2p_mn1, 40)
         # - Invalid contributions
         force_request_expire()
-        assert(mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash))
+        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
         p2p_mn1.wait_for_qgetdata()
         qdata_invalid_contribution = qdata_valid
         qdata_invalid_contribution.enc_contributions.pop()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -41,8 +41,10 @@ def wait_for_banscore(node, peer_id, expexted_score):
         return None
     wait_until(lambda: get_score() == expexted_score, timeout=6, sleep=2)
 
+
 def p2p_connection(node, uacomment=None):
     return node.add_p2p_connection(QuorumDataInterface(), uacomment=uacomment)
+
 
 def get_mininode_id(node, uacomment=None):
     tries = 0

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -79,7 +79,7 @@ def get_mininode_id(node, uacomment=None):
                 if p["subver"] == p2p.strSubVer.decode():
                     return p["id"]
         return None
-    wait_until(lambda: get_id() != None, timeout=10)
+    wait_until(lambda: get_id() is not None, timeout=10)
     return get_id()
 
 

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -286,8 +286,8 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_for_banscore(mn1.node, id_p2p_mn1, 25)
         mn1.node.disconnect_p2ps()
         network_thread_join()
-        # Requesting one QDATA with mn1 and mn2 from mn3 should not result in banscore increase
-        # for either of both.
+        # Requesting one QDATA with mn1 and mn2 from mn3 should not result in
+        # banscore increase for either of both.
         uacomment_m3_1 = "MN3_1"
         uacomment_m3_2 = "MN3_2"
         p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
@@ -316,8 +316,8 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_until(lambda: not p2p_mn3_2.is_connected, timeout=10)
         mn3.node.disconnect_p2ps()
         network_thread_join()
-        # Test that QWATCH connections are also allowed to query data but all QWATCH connections share
-        # one request limit slot
+        # Test that QWATCH connections are also allowed to query data but all
+        # QWATCH connections share one request limit slot
         p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
         p2p_mn3_2 = p2p_connection(mn3.node, uacomment_m3_2)
         network_thread_start()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -414,7 +414,7 @@ class QuorumDataMessagesTest(DashTestFramework):
                 mn2.node.disconnect_p2ps()
                 network_thread_join()
 
-        def test_rpc_quorum_getdata_proTxHash():
+        def test_rpc_quorum_getdata_protx_hash():
             self.log.info("Test optional proTxHash of `quorum getdata`")
             assert_raises_rpc_error(-8, "proTxHash missing",
                                     mn1.node.quorum, "getdata", 0, 100, quorum_hash, 0x02)
@@ -455,7 +455,7 @@ class QuorumDataMessagesTest(DashTestFramework):
         test_request_limit()
         test_qwatch_connections()
         test_watchquorums()
-        test_rpc_quorum_getdata_proTxHash()
+        test_rpc_quorum_getdata_protx_hash()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -274,8 +274,8 @@ class QuorumDataMessagesTest(DashTestFramework):
             p2p_mn1.test_qgetdata(qgetdata_vvec, QUORUM_VERIFICATION_VECTOR_MISSING)
             p2p_mn1.test_qgetdata(qgetdata_contributions, ENCRYPTED_CONTRIBUTIONS_MISSING)
             self.log.info("Test DKG data recovery with QDATA")
-            # Now that mn1 is missing its DKG data try to recover it by querying the data from mn2 and then sending it to
-            # mn1 with a direct QDATA message.
+            # Now that mn1 is missing its DKG data try to recover it by querying the data from mn2 and then sending it
+            # to mn1 with a direct QDATA message.
             #
             # mininode - QGETDATA -> mn2 - QDATA -> mininode - QDATA -> mn1
             #
@@ -302,15 +302,15 @@ class QuorumDataMessagesTest(DashTestFramework):
         # Test request limiting / banscore increase
         def test_request_limit():
 
-            def test_send_from_two_to_one(send_1, expected_banscore_1, send_2, expected_banscore_2, clear_requests=False):
+            def test_send_from_two_to_one(send_1, expected_score_1, send_2, expected_score_2, clear_requests=False):
                 if clear_requests:
                     force_request_expire()
                 if send_1:
                     p2p_mn3_1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
                 if send_2:
                     p2p_mn3_2.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
-                wait_for_banscore(mn3.node, id_p2p_mn3_1, expected_banscore_1)
-                wait_for_banscore(mn3.node, id_p2p_mn3_2, expected_banscore_2)
+                wait_for_banscore(mn3.node, id_p2p_mn3_1, expected_score_1)
+                wait_for_banscore(mn3.node, id_p2p_mn3_2, expected_score_2)
 
             self.log.info("Test request limiting / banscore increases")
 

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -301,6 +301,28 @@ class QuorumDataMessagesTest(DashTestFramework):
         wait_until(lambda: not p2p_mn3_2.is_connected, timeout=10)
         mn3.node.disconnect_p2ps()
         network_thread_join()
+        # Test that QWATCH connections are also allowed to query data but all QWATCH connections share
+        # one request limit slot
+        p2p_mn3_1 = p2p_connection(mn3.node, subversion=version_m3_1)
+        p2p_mn3_2 = p2p_connection(mn3.node, subversion=version_m3_2)
+        network_thread_start()
+        p2p_mn3_1.wait_for_verack()
+        p2p_mn3_2.wait_for_verack()
+        id_p2p_mn3_1 = get_mininode_id(mn3.node, version_m3_1)
+        id_p2p_mn3_2 = get_mininode_id(mn3.node, version_m3_2)
+        assert (id_p2p_mn3_1 != id_p2p_mn3_2)
+        # Send QWATCH for both connections
+        p2p_mn3_1.send_message(msg_qwatch())
+        p2p_mn3_2.send_message(msg_qwatch())
+        # Now send alternating and make sure they share the same request limit
+        p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+        wait_for_banscore(mn3.node, id_p2p_mn3_1, 0)
+        p2p_mn3_2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+        wait_for_banscore(mn3.node, id_p2p_mn3_2, 25)
+        p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+        wait_for_banscore(mn3.node, id_p2p_mn3_1, 25)
+        mn3.node.disconnect_p2ps()
+        network_thread_join()
         # Test ban score increase for invalid/unexpected QDATA
         p2p_mn1 = p2p_connection(mn1.node)
         network_thread_start()

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -3,9 +3,23 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-from test_framework.mininode import *
+import time
+
+from test_framework.messages import msg_qgetdata, msg_qwatch
+from test_framework.mininode import (
+    mininode_lock,
+    network_thread_start,
+    network_thread_join,
+    P2PInterface,
+)
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import assert_raises_rpc_error, force_finish_mnsync, assert_equal, connect_nodes
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    connect_nodes,
+    force_finish_mnsync,
+    wait_until,
+)
 
 '''
 p2p_quorum_data.py

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -97,9 +97,6 @@ class QuorumDataInterface(P2PInterface):
         if response_expected:
             assert_qdata(self.get_qdata(), qgetdata, expected_error, len_vvec, len_contributions)
 
-    def get_qgetdata(self):
-        return self.last_message["qdata"]
-
     def wait_for_qgetdata(self, timeout=3, message_expected=True):
         def test_function():
             return self.message_count["qgetdata"]
@@ -135,22 +132,332 @@ class QuorumDataMessagesTest(DashTestFramework):
 
     def run_test(self):
 
-        def test_send_from_two_to_one(send_1, expected_banscore_1, send_2, expected_banscore_2, clear_requests=False):
-            if clear_requests:
-                force_request_expire()
-            if send_1:
-                p2p_mn3_1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
-            if send_2:
-                p2p_mn3_2.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
-            wait_for_banscore(mn3.node, id_p2p_mn3_1, expected_banscore_1)
-            wait_for_banscore(mn3.node, id_p2p_mn3_2, expected_banscore_2)
-
         def force_request_expire(bump_seconds=self.quorum_data_request_expiration_timeout + 1):
             self.bump_mocktime(bump_seconds)
-            if node0.getblockcount() % 2:  # Test with/without expired request cleanup
+            # Test with/without expired request cleanup
+            if node0.getblockcount() % 2:
                 node0.generate(1)
                 self.sync_blocks()
 
+        def test_mnauth_restriction():
+            self.log.info("Testing mnauth restriction")
+            p2p_node0 = p2p_connection(node0)
+            p2p_mn1 = p2p_connection(mn1.node)
+            network_thread_start()
+            p2p_node0.wait_for_verack()
+            p2p_mn1.wait_for_verack()
+            id_p2p_node0 = get_mininode_id(node0)
+            id_p2p_mn1 = get_mininode_id(mn1.node)
+
+            # Ensure that both nodes start with zero ban score
+            wait_for_banscore(node0, id_p2p_node0, 0)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 0)
+
+            self.log.info("Check that normal node doesn't respond to qgetdata "
+                          "and does bump our score")
+            p2p_node0.test_qgetdata(qgetdata_all, response_expected=False)
+            wait_for_banscore(node0, id_p2p_node0, 10)
+            # The masternode should not respond to qgetdata for non-masternode connections
+            self.log.info("Check that masternode doesn't respond to "
+                          "non-masternode connection. Doesn't bump score.")
+            p2p_mn1.test_qgetdata(qgetdata_all, response_expected=False)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 10)
+            # Open a fake MNAUTH authenticated P2P connection to the masternode to allow qgetdata
+            node0.disconnect_p2ps()
+            mn1.node.disconnect_p2ps()
+            network_thread_join()
+            p2p_mn1 = p2p_connection(mn1.node)
+            network_thread_start()
+            p2p_mn1.wait_for_verack()
+            id_p2p_mn1 = get_mininode_id(mn1.node)
+            mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+            # The masternode should now respond to qgetdata requests
+            self.log.info("Request verification vector")
+            p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 0)
+            # Note: our banscore is bumped as we are requesting too rapidly,
+            # however the node still returns the data
+            self.log.info("Request encrypted contributions")
+            p2p_mn1.test_qgetdata(qgetdata_contributions, 0, 0, self.llmq_size)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 25)
+            # Request both
+            # Note: our banscore is bumped as we are requesting too rapidly,
+            # however the node still returns the data
+            self.log.info("Request both")
+            p2p_mn1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 50)
+            mn1.node.disconnect_p2ps()
+            network_thread_join()
+
+        # Test all invalid messages
+        def test_invalid_messages():
+            self.log.info("Test all invalid messages")
+            # Create invalid messages for all error cases
+            qgetdata_invalid_type = msg_qgetdata(quorum_hash_int, 103, 0x01, protx_hash_int)
+            qgetdata_invalid_block = msg_qgetdata(protx_hash_int, 100, 0x01, protx_hash_int)
+            qgetdata_invalid_quorum = msg_qgetdata(int(mn1.node.getblockhash(0), 16), 100, 0x01, protx_hash_int)
+            qgetdata_invalid_no_member = msg_qgetdata(quorum_hash_int, 100, 0x02, quorum_hash_int)
+
+            mn1.node.disconnect_p2ps()
+            network_thread_join()
+            p2p_mn1 = p2p_connection(mn1.node)
+            network_thread_start()
+            p2p_mn1.wait_for_verack()
+            id_p2p_mn1 = get_mininode_id(mn1.node)
+            mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+            p2p_mn1.test_qgetdata(qgetdata_invalid_type, QUORUM_TYPE_INVALID)
+            p2p_mn1.test_qgetdata(qgetdata_invalid_block, QUORUM_BLOCK_NOT_FOUND)
+            p2p_mn1.test_qgetdata(qgetdata_invalid_quorum, QUORUM_NOT_FOUND)
+            p2p_mn1.test_qgetdata(qgetdata_invalid_no_member, MASTERNODE_IS_NO_MEMBER)
+            # The last two error case require the node to miss its DKG data so we just reindex the node.
+            mn1.node.disconnect_p2ps()
+            network_thread_join()
+            self.restart_mn(mn1, reindex=True)
+            # Re-connect to the masternode
+            p2p_mn1 = p2p_connection(mn1.node)
+            p2p_mn2 = p2p_connection(mn2.node)
+            network_thread_start()
+            p2p_mn1.wait_for_verack()
+            p2p_mn2.wait_for_verack()
+            id_p2p_mn1 = get_mininode_id(mn1.node)
+            id_p2p_mn2 = get_mininode_id(mn2.node)
+            assert id_p2p_mn1 is not None
+            assert id_p2p_mn2 is not None
+            mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+            mnauth(mn2.node, id_p2p_mn2, fake_mnauth_2[0], fake_mnauth_2[1])
+            # Validate the DKG data is missing
+            p2p_mn1.test_qgetdata(qgetdata_vvec, QUORUM_VERIFICATION_VECTOR_MISSING)
+            p2p_mn1.test_qgetdata(qgetdata_contributions, ENCRYPTED_CONTRIBUTIONS_MISSING)
+            # Now that mn1 is missing its DKG data try to recover it by querying the data from mn2 and then sending it to
+            # mn1 with a direct QDATA message.
+            #
+            # mininode - QGETDATA -> mn2 - QDATA -> mininode - QDATA -> mn1
+            #
+            # However, mn1 only accepts self requested QDATA messages, that's why we trigger mn1 - QGETDATA -> mininode
+            # via the RPC command "quorum getdata".
+            #
+            # Get the required DKG data for mn1
+            p2p_mn2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            # Trigger mn1 - QGETDATA -> p2p_mn1
+            assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
+            # Wait until mn1 sent the QGETDATA to p2p_mn1
+            p2p_mn1.wait_for_qgetdata()
+            # Send the QDATA received from mn2 to mn1
+            p2p_mn1.send_message(p2p_mn2.get_qdata())
+            # Now mn1 should have its data back!
+            self.wait_for_quorum_data([mn1], 100, quorum_hash, recover=False)
+            # Restart one more time and make sure data gets saved to db
+            mn1.node.disconnect_p2ps()
+            mn2.node.disconnect_p2ps()
+            network_thread_join()
+            self.restart_mn(mn1)
+            self.wait_for_quorum_data([mn1], 100, quorum_hash, recover=False)
+
+        # Test request limiting / banscore increase
+        def test_ratelimiting_banscore():
+
+            def test_send_from_two_to_one(send_1, expected_banscore_1, send_2, expected_banscore_2, clear_requests=False):
+                if clear_requests:
+                    force_request_expire()
+                if send_1:
+                    p2p_mn3_1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+                if send_2:
+                    p2p_mn3_2.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+                wait_for_banscore(mn3.node, id_p2p_mn3_1, expected_banscore_1)
+                wait_for_banscore(mn3.node, id_p2p_mn3_2, expected_banscore_2)
+
+            self.log.info("Test request limiting / banscore increases")
+
+            p2p_mn1 = p2p_connection(mn1.node)
+            network_thread_start()
+            p2p_mn1.wait_for_verack()
+            id_p2p_mn1 = get_mininode_id(mn1.node)
+            mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+            p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 0)
+            force_request_expire(299)  # This shouldn't clear requests, next request should bump score
+            p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 25)
+            force_request_expire(1)  # This should clear the requests now, next request should not bump score
+            p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 25)
+            mn1.node.disconnect_p2ps()
+            network_thread_join()
+            # Requesting one QDATA with mn1 and mn2 from mn3 should not result
+            # in banscore increase for either of both.
+            p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
+            p2p_mn3_2 = p2p_connection(mn3.node, uacomment_m3_2)
+            network_thread_start()
+            p2p_mn3_1.wait_for_verack()
+            p2p_mn3_2.wait_for_verack()
+            id_p2p_mn3_1 = get_mininode_id(mn3.node, uacomment_m3_1)
+            id_p2p_mn3_2 = get_mininode_id(mn3.node, uacomment_m3_2)
+            assert id_p2p_mn3_1 != id_p2p_mn3_2
+            mnauth(mn3.node, id_p2p_mn3_1, fake_mnauth_1[0], fake_mnauth_1[1])
+            mnauth(mn3.node, id_p2p_mn3_2, fake_mnauth_2[0], fake_mnauth_2[1])
+            # Now try some {mn1, mn2} - QGETDATA -> mn3 combinations to make
+            # sure request limit works connection based
+            test_send_from_two_to_one(False, 0, True, 0, True)
+            test_send_from_two_to_one(True, 0, True, 25)
+            test_send_from_two_to_one(True, 25, False, 25)
+            test_send_from_two_to_one(False, 25, True, 25, True)
+            test_send_from_two_to_one(True, 25, True, 50)
+            test_send_from_two_to_one(True, 50, True, 75)
+            test_send_from_two_to_one(True, 50, True, 75, True)
+            test_send_from_two_to_one(True, 75, False, 75)
+            test_send_from_two_to_one(False, 75, True, None)
+            # mn1 should still have a score of 75
+            wait_for_banscore(mn3.node, id_p2p_mn3_1, 75)
+            # mn2 should be "banned" now
+            wait_until(lambda: not p2p_mn3_2.is_connected, timeout=10)
+            mn3.node.disconnect_p2ps()
+            network_thread_join()
+            # Test that QWATCH connections are also allowed to query data but
+            # all QWATCH connections share one request limit slot
+            p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
+            p2p_mn3_2 = p2p_connection(mn3.node, uacomment_m3_2)
+            network_thread_start()
+            p2p_mn3_1.wait_for_verack()
+            p2p_mn3_2.wait_for_verack()
+            id_p2p_mn3_1 = get_mininode_id(mn3.node, uacomment_m3_1)
+            id_p2p_mn3_2 = get_mininode_id(mn3.node, uacomment_m3_2)
+            assert id_p2p_mn3_1 != id_p2p_mn3_2
+            # Send QWATCH for both connections
+            p2p_mn3_1.send_message(msg_qwatch())
+            p2p_mn3_2.send_message(msg_qwatch())
+            # Now send alternating and make sure they share the same request limit
+            p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            wait_for_banscore(mn3.node, id_p2p_mn3_1, 0)
+            p2p_mn3_2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            wait_for_banscore(mn3.node, id_p2p_mn3_2, 25)
+            p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            wait_for_banscore(mn3.node, id_p2p_mn3_1, 25)
+            mn3.node.disconnect_p2ps()
+            network_thread_join()
+
+        # Test that QWATCH connections are also allowed to query data but all
+        # QWATCH connections share one request limit slot
+        def test_qwatch_connections():
+            self.log.info("Test QWATCH connections")
+
+            # Restart mns to clear previous ratelimiting
+            self.restart_mn(mn1)
+            self.restart_mn(mn2)
+            self.restart_mn(mn3)
+
+            p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
+            p2p_mn3_2 = p2p_connection(mn3.node, uacomment_m3_2)
+            network_thread_start()
+            p2p_mn3_1.wait_for_verack()
+            p2p_mn3_2.wait_for_verack()
+            id_p2p_mn3_1 = get_mininode_id(mn3.node, uacomment_m3_1)
+            id_p2p_mn3_2 = get_mininode_id(mn3.node, uacomment_m3_2)
+            assert id_p2p_mn3_1 != id_p2p_mn3_2
+
+            wait_for_banscore(mn3.node, id_p2p_mn3_1, 0)
+            wait_for_banscore(mn3.node, id_p2p_mn3_2, 0)
+
+            # Send QWATCH for both connections
+            p2p_mn3_1.send_message(msg_qwatch())
+            p2p_mn3_2.send_message(msg_qwatch())
+
+            # Now send alternating and make sure they share the same request limit
+            p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            wait_for_banscore(mn3.node, id_p2p_mn3_1, 0)
+            p2p_mn3_2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            wait_for_banscore(mn3.node, id_p2p_mn3_2, 25)
+            p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            wait_for_banscore(mn3.node, id_p2p_mn3_1, 25)
+            mn3.node.disconnect_p2ps()
+            network_thread_join()
+
+        def test_watchquorums():
+            self.log.info("Test -watchquorums support")
+            for extra_args in [[], ["-watchquorums"]]:
+                self.restart_node(0, self.extra_args[0] + extra_args)
+                for i in range(self.num_nodes - 1):
+                    connect_nodes(node0, i + 1)
+                p2p_node0 = p2p_connection(node0)
+                p2p_mn2 = p2p_connection(mn2.node)
+                network_thread_start()
+                p2p_node0.wait_for_verack()
+                p2p_mn2.wait_for_verack()
+                id_p2p_node0 = get_mininode_id(node0)
+                id_p2p_mn2 = get_mininode_id(mn2.node)
+                mnauth(node0, id_p2p_node0, fake_mnauth_1[0], fake_mnauth_1[1])
+                mnauth(mn2.node, id_p2p_mn2, fake_mnauth_2[0], fake_mnauth_2[1])
+                p2p_mn2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+                assert node0.quorum("getdata", id_p2p_node0, 100, quorum_hash, 0x03, mn1.proTxHash)
+                p2p_node0.wait_for_qgetdata()
+                p2p_node0.send_message(p2p_mn2.get_qdata())
+                wait_for_banscore(node0, id_p2p_node0, (1 - len(extra_args)) * 10)
+                node0.disconnect_p2ps()
+                mn2.node.disconnect_p2ps()
+                network_thread_join()
+
+        def test_invalid_unexpected_qdata():
+            self.log.info("Test ban score increase for invalid / unexpected QDATA")
+            p2p_mn1 = p2p_connection(mn1.node)
+            p2p_mn2 = p2p_connection(mn2.node)
+            network_thread_start()
+            p2p_mn1.wait_for_verack()
+            p2p_mn2.wait_for_verack()
+            id_p2p_mn1 = get_mininode_id(mn1.node)
+            id_p2p_mn2 = get_mininode_id(mn2.node)
+            mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
+            mnauth(mn2.node, id_p2p_mn2, fake_mnauth_2[0], fake_mnauth_2[1])
+            wait_for_banscore(mn1.node, id_p2p_mn1, 0)
+            p2p_mn2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
+            qdata_valid = p2p_mn2.get_qdata()
+            # - Not requested
+            p2p_mn1.send_message(qdata_valid)
+            time.sleep(1)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 10)
+            # - Already received
+            force_request_expire()
+            assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
+            p2p_mn1.wait_for_qgetdata()
+            p2p_mn1.send_message(qdata_valid)
+            time.sleep(1)
+            p2p_mn1.send_message(qdata_valid)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 20)
+            # - Not like requested
+            force_request_expire()
+            assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
+            p2p_mn1.wait_for_qgetdata()
+            qdata_invalid_request = qdata_valid
+            qdata_invalid_request.data_mask = 2
+            p2p_mn1.send_message(qdata_invalid_request)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 30)
+            # - Invalid verification vector
+            force_request_expire()
+            assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
+            p2p_mn1.wait_for_qgetdata()
+            qdata_invalid_vvec = qdata_valid
+            qdata_invalid_vvec.quorum_vvec.pop()
+            p2p_mn1.send_message(qdata_invalid_vvec)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 40)
+            # - Invalid contributions
+            force_request_expire()
+            assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
+            p2p_mn1.wait_for_qgetdata()
+            qdata_invalid_contribution = qdata_valid
+            qdata_invalid_contribution.enc_contributions.pop()
+            p2p_mn1.send_message(qdata_invalid_contribution)
+            wait_for_banscore(mn1.node, id_p2p_mn1, 50)
+            mn1.node.disconnect_p2ps()
+            mn2.node.disconnect_p2ps()
+            network_thread_join()
+
+        def test_rpc_quorum_getdata_proTxHash():
+            self.log.info("Test optional proTxHash of `quorum getdata`")
+            assert_raises_rpc_error(-8, "proTxHash missing",
+                                    mn1.node.quorum, "getdata", 0, 100, quorum_hash, 0x02)
+            assert_raises_rpc_error(-8, "proTxHash invalid",
+                                    mn1.node.quorum, "getdata", 0, 100, quorum_hash, 0x03,
+                                    "0000000000000000000000000000000000000000000000000000000000000000")
+
+        # Enable DKG and disable ChainLocks
         self.nodes[0].spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 4070908800)
 
@@ -163,21 +470,11 @@ class QuorumDataMessagesTest(DashTestFramework):
         mn3 = self.mninfo[2]
 
         fake_mnauth_1 = ["cecf37bf0ec05d2d22cb8227f88074bb882b94cd2081ba318a5a444b1b15b9fd",
-                    "087ba00bf61135f3860c4944a0debabe186ef82628fbe4ceaed1ad51d672c58dde14ea4b321efe0b89257a40322bc972"]
+                         "087ba00bf61135f3860c4944a0debabe186ef82628fbe4ceaed1ad51d672c58dde14ea4b321efe0b89257a40322bc972"]
         fake_mnauth_2 = ["6ad7ed7a2d6c2c1db30fc364114602b36b2730a9aa96d8f11f1871a9cee37378",
-                    "122463411a86362966a5161805f24cf6a0eef08a586b8e00c4f0ad0b084c5bb3f5c9a60ee5ffc78db2313897e3ab2223"]
+                         "122463411a86362966a5161805f24cf6a0eef08a586b8e00c4f0ad0b084c5bb3f5c9a60ee5ffc78db2313897e3ab2223"]
 
-        p2p_node0 = p2p_connection(node0)
-        p2p_mn1 = p2p_connection(mn1.node)
-        network_thread_start()
-        p2p_node0.wait_for_verack()
-        p2p_mn1.wait_for_verack()
-        id_p2p_node0 = get_mininode_id(node0)
-        id_p2p_mn1 = get_mininode_id(mn1.node)
-
-        wait_for_banscore(node0, id_p2p_node0, 0)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 0)
-
+        # Convert the hex values into integer values
         quorum_hash_int = int(quorum_hash, 16)
         protx_hash_int = int(mn1.proTxHash, 16)
 
@@ -185,225 +482,17 @@ class QuorumDataMessagesTest(DashTestFramework):
         qgetdata_vvec = msg_qgetdata(quorum_hash_int, 100, 0x01, protx_hash_int)
         qgetdata_contributions = msg_qgetdata(quorum_hash_int, 100, 0x02, protx_hash_int)
         qgetdata_all = msg_qgetdata(quorum_hash_int, 100, 0x03, protx_hash_int)
-        # The normal node should not respond to qgetdata
-        p2p_node0.test_qgetdata(qgetdata_all, response_expected=False)
-        wait_for_banscore(node0, id_p2p_node0, 10)
-        # The masternode should not respond to qgetdata for non-masternode connections
-        p2p_mn1.test_qgetdata(qgetdata_all, response_expected=False)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 10)
-        # Open a fake MNAUTH authenticated P2P connection to the masternode to allow qgetdata
-        node0.disconnect_p2ps()
-        mn1.node.disconnect_p2ps()
-        network_thread_join()
-        p2p_mn1 = p2p_connection(mn1.node)
-        network_thread_start()
-        p2p_mn1.wait_for_verack()
-        id_p2p_mn1 = get_mininode_id(mn1.node)
-        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
-        # The masternode should now respond to qgetdata requests
-        # Request verification vector
-        p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 0)
-        # Request encrypted contributions
-        p2p_mn1.test_qgetdata(qgetdata_contributions, 0, 0, self.llmq_size)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 25)
-        # Request both
-        p2p_mn1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 50)
-        # Create invalid messages for all error cases
-        qgetdata_invalid_type = msg_qgetdata(quorum_hash_int, 103, 0x01, protx_hash_int)
-        qgetdata_invalid_block = msg_qgetdata(protx_hash_int, 100, 0x01, protx_hash_int)
-        qgetdata_invalid_quorum = msg_qgetdata(int(mn1.node.getblockhash(0), 16), 100, 0x01, protx_hash_int)
-        qgetdata_invalid_no_member = msg_qgetdata(quorum_hash_int, 100, 0x02, quorum_hash_int)
-        # Test all invalid messages
-        mn1.node.disconnect_p2ps()
-        network_thread_join()
-        p2p_mn1 = p2p_connection(mn1.node)
-        network_thread_start()
-        p2p_mn1.wait_for_verack()
-        id_p2p_mn1 = get_mininode_id(mn1.node)
-        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
-        p2p_mn1.test_qgetdata(qgetdata_invalid_type, QUORUM_TYPE_INVALID)
-        p2p_mn1.test_qgetdata(qgetdata_invalid_block, QUORUM_BLOCK_NOT_FOUND)
-        p2p_mn1.test_qgetdata(qgetdata_invalid_quorum, QUORUM_NOT_FOUND)
-        p2p_mn1.test_qgetdata(qgetdata_invalid_no_member, MASTERNODE_IS_NO_MEMBER)
-        # The last two error case require the node to miss its DKG data so we just reindex the node.
-        mn1.node.disconnect_p2ps()
-        network_thread_join()
-        self.restart_mn(mn1, reindex=True)
-        # Re-connect to the masternode
-        p2p_mn1 = p2p_connection(mn1.node)
-        p2p_mn2 = p2p_connection(mn2.node)
-        network_thread_start()
-        p2p_mn1.wait_for_verack()
-        p2p_mn2.wait_for_verack()
-        id_p2p_mn1 = get_mininode_id(mn1.node)
-        id_p2p_mn2 = get_mininode_id(mn2.node)
-        assert id_p2p_mn1 is not None
-        assert id_p2p_mn2 is not None
-        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
-        mnauth(mn2.node, id_p2p_mn2, fake_mnauth_2[0], fake_mnauth_2[1])
-        # Validate the DKG data is missing
-        p2p_mn1.test_qgetdata(qgetdata_vvec, QUORUM_VERIFICATION_VECTOR_MISSING)
-        p2p_mn1.test_qgetdata(qgetdata_contributions, ENCRYPTED_CONTRIBUTIONS_MISSING)
-        # Now that mn1 is missing its DKG data try to recover it by querying the data from mn2 and then sending it to
-        # mn1 with a direct QDATA message.
-        #
-        # mininode - QGETDATA -> mn2 - QDATA -> mininode - QDATA -> mn1
-        #
-        # However, mn1 only accepts self requested QDATA messages, that's why we trigger mn1 - QGETDATA -> mininode
-        # via the RPC command "quorum getdata".
-        #
-        # Get the required DKG data for mn1
-        p2p_mn2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
-        # Trigger mn1 - QGETDATA -> p2p_mn1
-        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
-        # Wait until mn1 sent the QGETDATA to p2p_mn1
-        p2p_mn1.wait_for_qgetdata()
-        # Send the QDATA received from mn2 to mn1
-        p2p_mn1.send_message(p2p_mn2.get_qdata())
-        # Now mn1 should have its data back!
-        self.wait_for_quorum_data([mn1], 100, quorum_hash, recover=False)
-        # Restart one more time and make sure data gets saved to db
-        mn1.node.disconnect_p2ps()
-        mn2.node.disconnect_p2ps()
-        network_thread_join()
-        self.restart_mn(mn1)
-        self.wait_for_quorum_data([mn1], 100, quorum_hash, recover=False)
-        # Test request limiting / banscore increase
-        p2p_mn1 = p2p_connection(mn1.node)
-        network_thread_start()
-        p2p_mn1.wait_for_verack()
-        id_p2p_mn1 = get_mininode_id(mn1.node)
-        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
-        p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 0)
-        force_request_expire(299)  # This shouldn't clear requests, next request should bump score
-        p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 25)
-        force_request_expire(1)  # This should clear the requests now, next request should not bump score
-        p2p_mn1.test_qgetdata(qgetdata_vvec, 0, self.llmq_threshold, 0)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 25)
-        mn1.node.disconnect_p2ps()
-        network_thread_join()
-        # Requesting one QDATA with mn1 and mn2 from mn3 should not result in
-        # banscore increase for either of both.
+
         uacomment_m3_1 = "MN3_1"
         uacomment_m3_2 = "MN3_2"
-        p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
-        p2p_mn3_2 = p2p_connection(mn3.node, uacomment_m3_2)
-        network_thread_start()
-        p2p_mn3_1.wait_for_verack()
-        p2p_mn3_2.wait_for_verack()
-        id_p2p_mn3_1 = get_mininode_id(mn3.node, uacomment_m3_1)
-        id_p2p_mn3_2 = get_mininode_id(mn3.node, uacomment_m3_2)
-        assert id_p2p_mn3_1 != id_p2p_mn3_2
-        mnauth(mn3.node, id_p2p_mn3_1, fake_mnauth_1[0], fake_mnauth_1[1])
-        mnauth(mn3.node, id_p2p_mn3_2, fake_mnauth_2[0], fake_mnauth_2[1])
-        # Now try some {mn1, mn2} - QGETDATA -> mn3 combinations to make sure request limit works connection based
-        test_send_from_two_to_one(False, 0, True, 0, True)
-        test_send_from_two_to_one(True, 0, True, 25)
-        test_send_from_two_to_one(True, 25, False, 25)
-        test_send_from_two_to_one(False, 25, True, 25, True)
-        test_send_from_two_to_one(True, 25, True, 50)
-        test_send_from_two_to_one(True, 50, True, 75)
-        test_send_from_two_to_one(True, 50, True, 75, True)
-        test_send_from_two_to_one(True, 75, False, 75)
-        test_send_from_two_to_one(False, 75, True, None)
-        # mn1 should still have a score of 75
-        wait_for_banscore(mn3.node, id_p2p_mn3_1, 75)
-        # mn2 should be "banned" now
-        wait_until(lambda: not p2p_mn3_2.is_connected, timeout=10)
-        mn3.node.disconnect_p2ps()
-        network_thread_join()
-        # Test that QWATCH connections are also allowed to query data but all
-        # QWATCH connections share one request limit slot
-        p2p_mn3_1 = p2p_connection(mn3.node, uacomment_m3_1)
-        p2p_mn3_2 = p2p_connection(mn3.node, uacomment_m3_2)
-        network_thread_start()
-        p2p_mn3_1.wait_for_verack()
-        p2p_mn3_2.wait_for_verack()
-        id_p2p_mn3_1 = get_mininode_id(mn3.node, uacomment_m3_1)
-        id_p2p_mn3_2 = get_mininode_id(mn3.node, uacomment_m3_2)
-        assert id_p2p_mn3_1 != id_p2p_mn3_2
-        # Send QWATCH for both connections
-        p2p_mn3_1.send_message(msg_qwatch())
-        p2p_mn3_2.send_message(msg_qwatch())
-        # Now send alternating and make sure they share the same request limit
-        p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
-        wait_for_banscore(mn3.node, id_p2p_mn3_1, 0)
-        p2p_mn3_2.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
-        wait_for_banscore(mn3.node, id_p2p_mn3_2, 25)
-        p2p_mn3_1.test_qgetdata(qgetdata_all, 0, self.llmq_threshold, self.llmq_size)
-        wait_for_banscore(mn3.node, id_p2p_mn3_1, 25)
-        mn3.node.disconnect_p2ps()
-        network_thread_join()
-        # Test -watchquorums support
-        for extra_args in [[], ["-watchquorums"]]:
-            self.restart_node(0, self.extra_args[0] + extra_args)
-            p2p_node0 = p2p_connection(node0)
-            network_thread_start()
-            p2p_node0.wait_for_verack()
-            id_p2p_node0 = get_mininode_id(node0)
-            mnauth(node0, id_p2p_node0, fake_mnauth_1[0], fake_mnauth_1[1])
-            assert node0.quorum("getdata", id_p2p_node0, 100, quorum_hash, 0x03, mn1.proTxHash)
-            p2p_node0.wait_for_qgetdata()
-            p2p_node0.send_message(p2p_mn2.get_qdata())
-            wait_for_banscore(node0, id_p2p_node0, (1 - len(extra_args)) * 10)
-            node0.disconnect_p2ps()
-            network_thread_join()
-        # Test ban score increase for invalid/unexpected QDATA
-        p2p_mn1 = p2p_connection(mn1.node)
-        network_thread_start()
-        p2p_mn1.wait_for_verack()
-        id_p2p_mn1 = get_mininode_id(mn1.node)
-        mnauth(mn1.node, id_p2p_mn1, fake_mnauth_1[0], fake_mnauth_1[1])
-        wait_for_banscore(mn1.node, id_p2p_mn1, 0)
-        qdata_valid = p2p_mn2.get_qdata()
-        # - Not requested
-        p2p_mn1.send_message(qdata_valid)
-        time.sleep(1)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 10)
-        # - Already received
-        force_request_expire()
-        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
-        p2p_mn1.wait_for_qgetdata()
-        p2p_mn1.send_message(qdata_valid)
-        time.sleep(1)
-        p2p_mn1.send_message(qdata_valid)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 20)
-        # - Not like requested
-        force_request_expire()
-        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
-        p2p_mn1.wait_for_qgetdata()
-        qdata_invalid_request = qdata_valid
-        qdata_invalid_request.data_mask = 2
-        p2p_mn1.send_message(qdata_invalid_request)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 30)
-        # - Invalid verification vector
-        force_request_expire()
-        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
-        p2p_mn1.wait_for_qgetdata()
-        qdata_invalid_vvec = qdata_valid
-        qdata_invalid_vvec.quorum_vvec.pop()
-        p2p_mn1.send_message(qdata_invalid_vvec)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 40)
-        # - Invalid contributions
-        force_request_expire()
-        assert mn1.node.quorum("getdata", id_p2p_mn1, 100, quorum_hash, 0x03, mn1.proTxHash)
-        p2p_mn1.wait_for_qgetdata()
-        qdata_invalid_contribution = qdata_valid
-        qdata_invalid_contribution.enc_contributions.pop()
-        p2p_mn1.send_message(qdata_invalid_contribution)
-        wait_for_banscore(mn1.node, id_p2p_mn1, 50)
-        mn1.node.disconnect_p2ps()
-        network_thread_join()
-        # Test optional proTxHash of `quorum getdata`
-        assert_raises_rpc_error(-8, "proTxHash missing",
-                                mn1.node.quorum, "getdata", 0, 100, quorum_hash, 0x02)
-        assert_raises_rpc_error(-8, "proTxHash invalid",
-                                mn1.node.quorum, "getdata", 0, 100, quorum_hash, 0x03,
-                                "0000000000000000000000000000000000000000000000000000000000000000")
+
+        test_mnauth_restriction()
+        test_invalid_messages()
+        test_ratelimiting_banscore()
+        test_qwatch_connections()
+        test_watchquorums()
+        test_invalid_unexpected_qdata()
+        test_rpc_quorum_getdata_proTxHash()
 
 
 if __name__ == '__main__':

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1036,6 +1036,7 @@ class CBLSIESEncryptedSecretKey:
         r += self.data
         return r
 
+
 # Objects that correspond to messages on the wire
 class msg_version():
     command = b"version"

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -27,7 +27,7 @@ from test_framework.util import hex_str_to_bytes, bytes_to_hex_str
 import dash_hash
 
 MIN_VERSION_SUPPORTED = 60001
-MY_VERSION = 70214  # MIN_PEER_PROTO_VERSION
+MY_VERSION = 70219  # LLMQ_DATA_MESSAGES_VERSION
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3%s/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1002,6 +1002,40 @@ class CSigShare:
         r += self.sigShare
         return r
 
+
+class CBLSPublicKey:
+    def __init__(self):
+        self.data = b'\\x0' * 48
+
+    def deserialize(self, f):
+        self.data = f.read(48)
+
+    def serialize(self):
+        r = b""
+        r += self.data
+        return r
+
+
+class CBLSIESEncryptedSecretKey:
+    def __init__(self):
+        self.ephemeral_pubKey = b'\\x0' * 48
+        self.iv = b'\\x0' * 32
+        self.data = b'\\x0' * 32
+
+    def deserialize(self, f):
+        self.ephemeral_pubKey = f.read(48)
+        self.iv = f.read(32)
+        data_size = deser_compact_size(f)
+        self.data = f.read(data_size)
+
+    def serialize(self):
+        r = b""
+        r += self.ephemeral_pubKey
+        r += self.iv
+        r += ser_compact_size(len(self.data))
+        r += self.data
+        return r
+
 # Objects that correspond to messages on the wire
 class msg_version():
     command = b"version"
@@ -1562,3 +1596,77 @@ class msg_qsigshare():
 
     def __repr__(self):
         return "msg_qsigshare(sigShares=%d)" % (len(self.sig_shares))
+
+
+class msg_qgetdata():
+    command = b"qgetdata"
+
+    def __init__(self, quorum_hash=0, quorum_type=-1, data_mask=0, protx_hash=0):
+        self.quorum_hash = quorum_hash
+        self.quorum_type = quorum_type
+        self.data_mask = data_mask
+        self.protx_hash = protx_hash
+
+    def deserialize(self, f):
+        self.quorum_type = struct.unpack("<B", f.read(1))[0]
+        self.quorum_hash = deser_uint256(f)
+        self.data_mask = struct.unpack("<H", f.read(2))[0]
+        self.protx_hash = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.quorum_type)
+        r += ser_uint256(self.quorum_hash)
+        r += struct.pack("<H", self.data_mask)
+        r += ser_uint256(self.protx_hash)
+        return r
+
+    def __repr__(self):
+        return "msg_qgetdata(quorum_hash=%064x, quorum_type=%d, data_mask=%d, protx_hash=%064x)" % (
+                                                                                self.quorum_hash,
+                                                                                self.quorum_type,
+                                                                                self.data_mask,
+                                                                                self.protx_hash)
+
+
+class msg_qdata():
+    command = b"qdata"
+
+    def __init__(self):
+        self.quorum_type = 0
+        self.quorum_hash = 0
+        self.data_mask = 0
+        self.protx_hash = 0
+        self.error = 0
+        self.quorum_vvec = list()
+        self.enc_contributions = list()
+
+    def deserialize(self, f):
+        self.quorum_type = struct.unpack("<B", f.read(1))[0]
+        self.quorum_hash = deser_uint256(f)
+        self.data_mask = struct.unpack("<H", f.read(2))[0]
+        self.protx_hash = deser_uint256(f)
+        self.error = struct.unpack("<B", f.read(1))[0]
+        if self.error == 0:
+            if self.data_mask & 0x01:
+                self.quorum_vvec = deser_vector(f, CBLSPublicKey)
+            if self.data_mask & 0x02:
+                self.enc_contributions = deser_vector(f, CBLSIESEncryptedSecretKey)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.quorum_type)
+        r += ser_uint256(self.quorum_hash)
+        r += struct.pack("<H", self.data_mask)
+        r += ser_uint256(self.protx_hash)
+        r += struct.pack("<B", self.error)
+        if self.error == 0:
+            if self.data_mask & 0x01:
+                r += ser_vector(self.quorum_vvec)
+            if self.data_mask & 0x02:
+                r += ser_vector(self.enc_contributions)
+        return r
+
+    def __repr__(self):
+        return "msg_qdata(error=%d, quorum_vvec=%d, enc_contributions=%d)" % (self.error, len(self.quorum_vvec),
+                                                                                          len(self.enc_contributions))

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1598,6 +1598,22 @@ class msg_qsigshare():
         return "msg_qsigshare(sigShares=%d)" % (len(self.sig_shares))
 
 
+class msg_qwatch():
+    command = b"qwatch"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_qwatch()"
+
+
 class msg_qgetdata():
     command = b"qgetdata"
 

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -65,6 +65,7 @@ MESSAGEMAP = {
     b"qsendrecsigs": None,
     b"qgetdata": msg_qgetdata,
     b"qdata": msg_qdata,
+    b"qwatch" : None,
     b"senddsq": None,
     b"spork": None,
 }
@@ -378,6 +379,7 @@ class P2PInterface(P2PConnection):
 
     def on_qgetdata(self, message): pass
     def on_qdata(self, message): pass
+    def on_qwatch(self, message): pass
 
     def on_verack(self, message):
         self.verack_received = True

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -63,6 +63,8 @@ MESSAGEMAP = {
     b"notfound": None,
     b"qfcommit": None,
     b"qsendrecsigs": None,
+    b"qgetdata": msg_qgetdata,
+    b"qdata": msg_qdata,
     b"senddsq": None,
     b"spork": None,
 }
@@ -373,6 +375,9 @@ class P2PInterface(P2PConnection):
     def on_mnlistdiff(self, message): pass
     def on_clsig(self, message): pass
     def on_islock(self, message): pass
+
+    def on_qgetdata(self, message): pass
+    def on_qdata(self, message): pass
 
     def on_verack(self, message):
         self.verack_received = True

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1091,7 +1091,7 @@ class DashTestFramework(BitcoinTestFramework):
         quorum_info = test_mn.node.quorum("info", quorum_type_in, quorum_hash_in, expect_secret)
         if expect_secret and "secretKeyShare" not in quorum_info:
             return False
-        if "members" not in quorum_info or len(quorum_info["members"]) <= 0:
+        if "members" not in quorum_info or len(quorum_info["members"]) == 0:
             return False
         pubkey_count = 0
         valid_count = 0

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -545,8 +545,8 @@ class DashTestFramework(BitcoinTestFramework):
         self.llmq_size = 3
         self.llmq_threshold = 2
 
-        # This is nExpirySeconds in CQuorumDataRequest
-        self.quorum_data_request_expiry_seconds = 300
+        # This is EXPIRATION_TIMEOUT in CQuorumDataRequest
+        self.quorum_data_request_expiration_timeout = 300
 
     def set_dash_dip8_activation(self, activate_after_block):
         self.dip8_activation_height = activate_after_block
@@ -1105,7 +1105,7 @@ class DashTestFramework(BitcoinTestFramework):
             valid = 0
             if recover:
                 if self.mocktime % 2:
-                    self.bump_mocktime(self.quorum_data_request_expiry_seconds + 1)
+                    self.bump_mocktime(self.quorum_data_request_expire_timeout + 1)
                     self.nodes[0].generate(1)
 
             for test_mn in mns:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -545,6 +545,9 @@ class DashTestFramework(BitcoinTestFramework):
         self.llmq_size = 3
         self.llmq_threshold = 2
 
+        # This is nExpirySeconds in CQuorumDataRequest
+        self.quorum_data_request_expiry_seconds = 300
+
     def set_dash_dip8_activation(self, activate_after_block):
         self.dip8_activation_height = activate_after_block
         for i in range(0, self.num_nodes):
@@ -1083,6 +1086,35 @@ class DashTestFramework(BitcoinTestFramework):
             if mn.proTxHash == proTxHash:
                 return mn
         return None
+
+    def test_mn_quorum_data(self, test_mn, quorum_type_in, quorum_hash_in, expect_secret=True):
+        quorum_info = test_mn.node.quorum("info", quorum_type_in, quorum_hash_in, expect_secret)
+        if expect_secret and "secretKeyShare" not in quorum_info:
+            return False
+        if "members" not in quorum_info or len(quorum_info["members"]) <= 0:
+            return False
+        pubkey_count = 0
+        valid_count = 0
+        for quorum_member in quorum_info["members"]:
+            valid_count += quorum_member["valid"]
+            pubkey_count += "pubKeyShare" in quorum_member
+        return pubkey_count == valid_count
+
+    def wait_for_quorum_data(self, mns, quorum_type_in, quorum_hash_in, expect_secret=True, recover=False, timeout=60):
+        def test_mns():
+            valid = 0
+            if recover:
+                if self.mocktime % 2:
+                    self.bump_mocktime(self.quorum_data_request_expiry_seconds + 1)
+                    self.nodes[0].generate(1)
+
+            for test_mn in mns:
+                valid += self.test_mn_quorum_data(test_mn, quorum_type_in, quorum_hash_in, expect_secret)
+            self.log.debug("wait_for_quorum_data: %d/%d - quorum_type=%d quorum_hash=%s" %
+                           (valid, len(mns), quorum_type_in, quorum_hash_in))
+            return valid == len(mns)
+
+        wait_until(test_mns, timeout=timeout, sleep=0.5)
 
     def wait_for_mnauth(self, node, count, timeout=10):
         def test():

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -67,6 +67,7 @@ BASE_SCRIPTS= [
     'rpc_fundrawtransaction.py',
     'rpc_fundrawtransaction_hd.py',
     'wallet_multiwallet.py --usecli',
+    'p2p_quorum_data.py',
     # vv Tests less than 2m vv
     'p2p_instantsend.py',
     'wallet_basic.py',


### PR DESCRIPTION
This PR introduces two new P2P messages and with that it bumps the protocol version to `70219`. They will in a follow up PR be used for DKG data sharing between masternodes. Means this PR only contains the implementation of the messages and their tests.

The messages:
- `QGETDATA` - Ask a masternode for DKG data. Can be both or either of the following: 
   - The quorum verification vector a specific quorum
   - The encrypted DKG contributions from member of the quorum
- `QDATA` - Respond with the requested DKG data.


5e858cf, 269ce38 and 38bde3f Contain the most part of the messages implementation 

6b55815 Implements tests

285c9bd Introduces a RPC wrapper around `QGETDATA` called `quorum getdata` (I actually only did that to be able to test everything related to the new messages independently in this PR) 

The other commits are mostly helper around the implementation.

This PR is based on #3929 #3930 #3937 #3943 #3948 