### PR TITLE
chainparams|init: Add -llmqinstantsend command line parameter for devnets

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -128,6 +128,10 @@ void CChainParams::UpdateLLMQChainLocks(Consensus::LLMQType llmqType) {
     consensus.llmqTypeChainLocks = llmqType;
 }
 
+void CChainParams::UpdateLLMQInstantSend(Consensus::LLMQType llmqType) {
+    consensus.llmqTypeInstantSend = llmqType;
+}
+
 void CChainParams::UpdateLLMQTestParams(int size, int threshold) {
     auto& params = consensus.llmqs.at(Consensus::LLMQ_TEST);
     params.size = size;
@@ -1080,6 +1084,11 @@ void UpdateDevnetSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSub
 void UpdateDevnetLLMQChainLocks(Consensus::LLMQType llmqType)
 {
     globalChainParams->UpdateLLMQChainLocks(llmqType);
+}
+
+void UpdateDevnetLLMQInstantSend(Consensus::LLMQType llmqType)
+{
+    globalChainParams->UpdateLLMQInstantSend(llmqType);
 }
 
 void UpdateLLMQTestParams(int size, int threshold)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -93,6 +93,7 @@ public:
     void UpdateBudgetParameters(int nMasternodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock);
     void UpdateSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor);
     void UpdateLLMQChainLocks(Consensus::LLMQType llmqType);
+    void UpdateLLMQInstantSend(Consensus::LLMQType llmqType);
     void UpdateLLMQTestParams(int size, int threshold);
     void UpdateLLMQDevnetParams(int size, int threshold);
     int PoolMinParticipants() const { return nPoolMinParticipants; }
@@ -180,6 +181,11 @@ void UpdateDevnetSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSub
  * Allows modifying the LLMQ type for ChainLocks.
  */
 void UpdateDevnetLLMQChainLocks(Consensus::LLMQType llmqType);
+
+/**
+ * Allows modifying the LLMQ type for InstantSend.
+ */
+void UpdateDevnetLLMQInstantSend(Consensus::LLMQType llmqType);
 
 /**
  * Allows modifying parameters of the test LLMQ

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1537,20 +1537,30 @@ bool AppInitParameterInteraction()
     }
 
     if (chainparams.NetworkIDString() == CBaseChainParams::DEVNET) {
-        std::string llmqTypeChainLocks = gArgs.GetArg("-llmqchainlocks", Params().GetConsensus().llmqs.at(Params().GetConsensus().llmqTypeChainLocks).name);
-        Consensus::LLMQType llmqType = Consensus::LLMQ_NONE;
+        std::string strLLMQTypeChainLocks = gArgs.GetArg("-llmqchainlocks", Params().GetConsensus().llmqs.at(Params().GetConsensus().llmqTypeChainLocks).name);
+        std::string strLLMQTypeInstantSend = gArgs.GetArg("-llmqinstantsend", Params().GetConsensus().llmqs.at(Params().GetConsensus().llmqTypeInstantSend).name);
+        Consensus::LLMQType llmqTypeChainLocks = Consensus::LLMQ_NONE;
+        Consensus::LLMQType llmqTypeInstantSend = Consensus::LLMQ_NONE;
         for (const auto& p : Params().GetConsensus().llmqs) {
-            if (p.second.name == llmqTypeChainLocks) {
-                llmqType = p.first;
-                break;
+            if (p.second.name == strLLMQTypeChainLocks) {
+                llmqTypeChainLocks = p.first;
+            }
+            if (p.second.name == strLLMQTypeInstantSend) {
+                llmqTypeInstantSend = p.first;
             }
         }
-        if (llmqType == Consensus::LLMQ_NONE) {
+        if (llmqTypeChainLocks == Consensus::LLMQ_NONE) {
             return InitError("Invalid LLMQ type specified for -llmqchainlocks.");
         }
-        UpdateDevnetLLMQChainLocks(llmqType);
+        if (llmqTypeInstantSend == Consensus::LLMQ_NONE) {
+            return InitError("Invalid LLMQ type specified for -llmqinstantsend.");
+        }
+        UpdateDevnetLLMQChainLocks(llmqTypeChainLocks);
+        UpdateDevnetLLMQInstantSend(llmqTypeInstantSend);
     } else if (gArgs.IsArgSet("-llmqchainlocks")) {
         return InitError("LLMQ type for ChainLocks can only be overridden on devnet.");
+    } else if (gArgs.IsArgSet("-llmqinstantsend")) {
+        return InitError("LLMQ type for InstantSend can only be overridden on devnet.");
     }
 
     if (chainparams.NetworkIDString() == CBaseChainParams::DEVNET) {


### PR DESCRIPTION
Adds the command line parameter `-llmqinstantsend` to adjust LLMQ type for InstantSend for devnets in the same way like we have it already for ChainLocks with `-llmqchainlocks`.