### PR TITLE
Flush callbacks one more time at shutdown

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -307,6 +307,10 @@ void PrepareShutdown()
         FlushStateToDisk();
     }
 
+    // After there are no more peers/RPC left to give us new data which may generate
+    // CValidationInterface callbacks, flush them...
+    GetMainSignals().FlushBackgroundCallbacks();
+
     // Any future callbacks will be dropped. This should absolutely be safe - if
     // missing a callback results in an unrecoverable situation, unclean shutdown
     // would too. The only reason to do the above flushes is to let the wallet catch


### PR DESCRIPTION
This is needed to be able to process `SetBestChain` callback generated by the first `FlushStateToDisk` call in `PrepareShutdown`. Not doing this leaves the wallet in an inconsistent state which is one of the reasons why `feature_pruning.py` fails atm.

Partially reverts #3378