### PR TITLE
llmq|init|test: Implement DKG data recovery / quorum verification vector sync

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -64,6 +64,7 @@
 #include <evo/deterministicmns.h>
 #include <llmq/quorums_init.h>
 #include <llmq/quorums_blockprocessor.h>
+#include <llmq/quorums_utils.h>
 
 #include <statsd_client.h>
 
@@ -1595,6 +1596,16 @@ bool AppInitParameterInteraction()
         }
     } else if (gArgs.IsArgSet("-llmqtestparams")) {
         return InitError("LLMQ test params can only be overridden on regtest.");
+    }
+
+    try {
+        const bool fRecoveryEnabled{llmq::CLLMQUtils::QuorumDataRecoveryEnabled()};
+        const bool fQuorumVvecRequestsEnabled{llmq::CLLMQUtils::GetEnabledQuorumVvecSyncTypes().size() > 0};
+        if (!fRecoveryEnabled && fQuorumVvecRequestsEnabled) {
+            InitWarning("-llmq-qvvec-sync set but recovery is disabled due to -llmq-data-recovery=0");
+        }
+    } catch (const std::invalid_argument& e) {
+        return InitError(e.what());
     }
 
     if (gArgs.IsArgSet("-maxorphantx")) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -44,10 +44,15 @@ static uint256 MakeQuorumKey(const CQuorum& q)
     return hw.GetHash();
 }
 
+CQuorum::CQuorum(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker) : params(_params), blsCache(_blsWorker), stopQuorumThreads(false)
+{
+    interruptQuorumDataReceived.reset();
+}
+
 CQuorum::~CQuorum()
 {
-    // most likely the thread is already done
-    stopCachePopulatorThread = true;
+    interruptQuorumDataReceived();
+    stopQuorumThreads = true;
 }
 
 void CQuorum::Init(const CFinalCommitment& _qc, const CBlockIndex* _pindexQuorum, const uint256& _minedBlockHash, const std::vector<CDeterministicMNCPtr>& _members)
@@ -163,7 +168,7 @@ void CQuorum::StartCachePopulatorThread(std::shared_ptr<CQuorum> _this)
     // when then later some other thread tries to get keys, it will be much faster
     _this->cachePopulatorThread = std::thread([_this, t]() {
         RenameThread("dash-q-cachepop");
-        for (size_t i = 0; i < _this->members.size() && !_this->stopCachePopulatorThread && !ShutdownRequested(); i++) {
+        for (size_t i = 0; i < _this->members.size() && !_this->stopQuorumThreads && !ShutdownRequested(); i++) {
             if (_this->qc.validMembers[i]) {
                 _this->GetPubKeyShare(i);
             }
@@ -173,6 +178,154 @@ void CQuorum::StartCachePopulatorThread(std::shared_ptr<CQuorum> _this)
     _this->cachePopulatorThread.detach();
 }
 
+size_t CQuorum::GetQuorumRecoveryStartOffset(const CBlockIndex* pIndex) const
+{
+    const size_t nActiveQuorums = params.signingActiveQuorumCount + 1;
+    const std::vector<CQuorumCPtr> vecQuorums = quorumManager->ScanQuorums(qc.llmqType, pIndex, nActiveQuorums);
+    assert(vecQuorums.size() > 0);
+    std::set<uint256> setAllTypeMembers;
+    for (auto& pQuorum : vecQuorums) {
+        auto& vecValid = pQuorum->qc.validMembers;
+        for (size_t i = 0; i< vecValid.size(); ++i) {
+            if (vecValid[i]) {
+                setAllTypeMembers.emplace(pQuorum->members[i]->proTxHash);
+            }
+        }
+    }
+    std::vector<uint256> vecAllTypeMembers{setAllTypeMembers.begin(), setAllTypeMembers.end()};
+    std::sort(vecAllTypeMembers.begin(), vecAllTypeMembers.end());
+    size_t nMyIndex{0};
+    for (size_t i = 0; i< vecAllTypeMembers.size(); ++i) {
+        if (activeMasternodeInfo.proTxHash == vecAllTypeMembers[i]) {
+            nMyIndex = i;
+            break;
+        }
+    }
+    return nMyIndex % qc.validMembers.size();
+}
+
+void CQuorum::StartQuorumDataRecoveryThread(std::shared_ptr<CQuorum> _this, const CBlockIndex* pIndex, uint16_t nDataMaskIn)
+{
+    if (_this->fQuorumDataRecoveryThreadRunning) {
+        LogPrint(BCLog::LLMQ, "CQuorum::%s -- Already running\n", __func__);
+        return;
+    }
+    _this->fQuorumDataRecoveryThreadRunning = true;
+
+    std::thread([_this, pIndex, nDataMaskIn]() {
+        const auto& strThreadName = "dash-q-recovery";
+        RenameThread(strThreadName);
+
+        size_t nTries{0};
+        uint16_t nDataMask{nDataMaskIn};
+        int64_t nTimeLastSuccess{Params().NetworkIDString() == CBaseChainParams::REGTEST ? GetAdjustedTime() : 0};
+        uint256* pCurrentMemberHash{nullptr};
+        std::vector<uint256> vecMemberHashes;
+        const size_t nMyStartOffset{_this->GetQuorumRecoveryStartOffset(pIndex)};
+        const int64_t nRequestTimeout{10};
+
+        auto printLog = [&](const std::string& strMessage) {
+            const std::string strMember{pCurrentMemberHash == nullptr ? "nullptr" : pCurrentMemberHash->ToString()};
+            LogPrint(BCLog::LLMQ, "%s -- %s - for llmqType %d, quorumHash %s, nDataMask (%d/%d), pCurrentMemberHash %s, nTries %d\n",
+                strThreadName, strMessage, _this->qc.llmqType, _this->qc.quorumHash.ToString(), nDataMask, nDataMaskIn, strMember, nTries);
+        };
+        printLog("Start");
+
+        while (!masternodeSync.IsBlockchainSynced() && !_this->stopQuorumThreads && !ShutdownRequested()) {
+            _this->interruptQuorumDataReceived.reset();
+            _this->interruptQuorumDataReceived.sleep_for(std::chrono::seconds(nRequestTimeout));
+        }
+
+        if (_this->stopQuorumThreads || ShutdownRequested()) {
+            printLog("Aborted");
+            return;
+        }
+
+        vecMemberHashes.reserve(_this->qc.validMembers.size());
+        for (auto& member : _this->members) {
+            if (_this->IsValidMember(member->proTxHash) && member->proTxHash != activeMasternodeInfo.proTxHash) {
+                vecMemberHashes.push_back(member->proTxHash);
+            }
+        }
+        std::sort(vecMemberHashes.begin(), vecMemberHashes.end());
+
+        printLog("Try to request");
+
+        while (nDataMask > 0 && !_this->stopQuorumThreads && !ShutdownRequested()) {
+
+            if (nDataMask & llmq::CQuorumDataRequest::QUORUM_VERIFICATION_VECTOR && _this->quorumVvec != nullptr) {
+                nDataMask &= ~llmq::CQuorumDataRequest::QUORUM_VERIFICATION_VECTOR;
+                printLog("Received quorumVvec");
+            }
+
+            if (nDataMask & llmq::CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS && _this->skShare.IsValid()) {
+                nDataMask &= ~llmq::CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS;
+                printLog("Received skShare");
+            }
+
+            if (nDataMask == 0) {
+                printLog("Success");
+                break;
+            }
+
+            if ((GetAdjustedTime() - nTimeLastSuccess) > nRequestTimeout) {
+                if (nTries >= vecMemberHashes.size()) {
+                    printLog("All tried but failed");
+                    break;
+                }
+                // Access the member list of the quorum with the calculated offset applied to balance the load equally
+                pCurrentMemberHash = &vecMemberHashes[(nMyStartOffset + nTries++) % vecMemberHashes.size()];
+                {
+                    LOCK(cs_data_requests);
+                    auto it = mapQuorumDataRequests.find(std::make_pair(*pCurrentMemberHash, true));
+                    if (it != mapQuorumDataRequests.end() && !it->second.IsExpired()) {
+                        printLog("Already asked");
+                        continue;
+                    }
+                }
+                // Sleep a bit depending on the start offset to balance out multiple requests to same masternode
+                _this->interruptQuorumDataReceived.sleep_for(std::chrono::milliseconds(nMyStartOffset * 100));
+                nTimeLastSuccess = GetAdjustedTime();
+                g_connman->AddPendingMasternode(*pCurrentMemberHash);
+                printLog("Connect");
+            }
+
+            g_connman->ForEachNode([&](CNode* pNode) {
+
+                if (pCurrentMemberHash == nullptr || pNode->verifiedProRegTxHash != *pCurrentMemberHash) {
+                    return;
+                }
+
+                if (quorumManager->RequestQuorumData(pNode, _this->qc.llmqType, _this->pindexQuorum, nDataMask, activeMasternodeInfo.proTxHash)) {
+                    nTimeLastSuccess = GetAdjustedTime();
+                    printLog("Requested");
+                } else {
+                    LOCK(cs_data_requests);
+                    auto it = mapQuorumDataRequests.find(std::make_pair(pNode->verifiedProRegTxHash, true));
+                    if (it == mapQuorumDataRequests.end()) {
+                        printLog("Failed");
+                        pNode->fDisconnect = true;
+                        pCurrentMemberHash = nullptr;
+                        return;
+                    } else if (it->second.IsProcessed()) {
+                        printLog("Processed");
+                        pNode->fDisconnect = true;
+                        pCurrentMemberHash = nullptr;
+                        return;
+                    } else {
+                        printLog("Waiting");
+                        return;
+                    }
+                }
+            });
+            _this->interruptQuorumDataReceived.reset();
+            _this->interruptQuorumDataReceived.sleep_for(std::chrono::seconds(nRequestTimeout));
+        }
+        _this->fQuorumDataRecoveryThreadRunning = false;
+        printLog("Done");
+    }).detach();
+}
+
 CQuorumManager::CQuorumManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager) :
     evoDb(_evoDb),
     blsWorker(_blsWorker),
@@ -180,6 +333,54 @@ CQuorumManager::CQuorumManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker, CDKGSessi
 {
     CLLMQUtils::InitQuorumsCache(mapQuorumsCache);
     CLLMQUtils::InitQuorumsCache(scanQuorumsCache);
+}
+
+void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex) const
+{
+    if (!fMasternodeMode || !CLLMQUtils::QuorumDataRecoveryEnabled() || pIndex == nullptr) {
+        return;
+    }
+
+    LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Process block %s\n", __func__, pIndex->GetBlockHash().ToString());
+
+    for (auto& llmq : Params().GetConsensus().llmqs) {
+        // Process signingActiveQuorumCount + 1 quorums for all available llmqTypes
+        const auto vecQuorums = ScanQuorums(llmq.first, pIndex, llmq.second.signingActiveQuorumCount + 1);
+
+        for (const auto& pQuorum : vecQuorums) {
+            // If there is already a thread running for this specific quorum skip it
+            if (pQuorum->fQuorumDataRecoveryThreadRunning) {
+                continue;
+            }
+
+            uint16_t nDataMask{0};
+            const bool fWeAreQuorumMember = pQuorum->IsValidMember(activeMasternodeInfo.proTxHash);
+
+            if (fWeAreQuorumMember && pQuorum->quorumVvec == nullptr) {
+                nDataMask |= llmq::CQuorumDataRequest::QUORUM_VERIFICATION_VECTOR;
+            }
+
+            if (fWeAreQuorumMember && !pQuorum->skShare.IsValid()) {
+                nDataMask |= llmq::CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS;
+            }
+
+            if (nDataMask == 0) {
+                LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- No data needed from (%d, %s) at height %d\n",
+                    __func__, pQuorum->qc.llmqType, pQuorum->qc.quorumHash.ToString(), pIndex->nHeight);
+                continue;
+            }
+
+            LOCK(quorumsCacheCs);
+            CQuorumPtr pQuorumMutable;
+            if (!mapQuorumsCache[pQuorum->qc.llmqType].get(pQuorum->qc.quorumHash, pQuorumMutable)) {
+                // Shouldn't happen?
+                LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Quorum not found in cache\n", __func__);
+                continue;
+            }
+            // Finally start the thread which triggers the requests for this quorum
+            CQuorum::StartQuorumDataRecoveryThread(pQuorumMutable, pIndex, nDataMask);
+        }
+    }
 }
 
 void CQuorumManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fInitialDownload) const
@@ -202,6 +403,8 @@ void CQuorumManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fInitial
             ++it;
         }
     }
+
+    TriggerQuorumDataRecoveryThreads(pindexNew);
 }
 
 void CQuorumManager::EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexNew) const
@@ -647,6 +850,7 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
             }
         }
         pQuorum->WriteContributions(evoDb);
+        pQuorum->interruptQuorumDataReceived();
         return;
     }
 }

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -218,7 +218,7 @@ void CQuorum::StartQuorumDataRecoveryThread(std::shared_ptr<CQuorum> _this, cons
 
         size_t nTries{0};
         uint16_t nDataMask{nDataMaskIn};
-        int64_t nTimeLastSuccess{Params().NetworkIDString() == CBaseChainParams::REGTEST ? GetAdjustedTime() : 0};
+        int64_t nTimeLastSuccess{0};
         uint256* pCurrentMemberHash{nullptr};
         std::vector<uint256> vecMemberHashes;
         const size_t nMyStartOffset{_this->GetQuorumRecoveryStartOffset(pIndex)};

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -204,7 +204,7 @@ size_t CQuorum::GetQuorumRecoveryStartOffset(const CBlockIndex* pIndex) const
     return nMyIndex % qc.validMembers.size();
 }
 
-void CQuorum::StartQuorumDataRecoveryThread(std::shared_ptr<CQuorum> _this, const CBlockIndex* pIndex, uint16_t nDataMaskIn)
+void CQuorum::StartQuorumDataRecoveryThread(const CQuorumCPtr _this, const CBlockIndex* pIndex, uint16_t nDataMaskIn)
 {
     if (_this->fQuorumDataRecoveryThreadRunning) {
         LogPrint(BCLog::LLMQ, "CQuorum::%s -- Already running\n", __func__);
@@ -382,15 +382,8 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
                 continue;
             }
 
-            LOCK(quorumsCacheCs);
-            CQuorumPtr pQuorumMutable;
-            if (!mapQuorumsCache[pQuorum->qc.llmqType].get(pQuorum->qc.quorumHash, pQuorumMutable)) {
-                // Shouldn't happen?
-                LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Quorum not found in cache\n", __func__);
-                continue;
-            }
             // Finally start the thread which triggers the requests for this quorum
-            CQuorum::StartQuorumDataRecoveryThread(pQuorumMutable, pIndex, nDataMask);
+            CQuorum::StartQuorumDataRecoveryThread(pQuorum, pIndex, nDataMask);
         }
     }
 }

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -313,6 +313,15 @@ std::vector<Consensus::LLMQType> CLLMQUtils::GetEnabledQuorumTypes(const CBlockI
     return ret;
 }
 
+bool CLLMQUtils::QuorumDataRecoveryEnabled()
+{
+    int nDataRecovery = gArgs.GetArg("-llmq-data-recovery", DEFAULT_ENABLE_QUORUM_DATA_RECOVERY);
+    if ((nDataRecovery < 0) || (nDataRecovery > 1)) {
+        throw std::invalid_argument("Invalid value for -llmq-data-recovery, 1: Enabled, 0: Disabled");
+    }
+    return nDataRecovery > 0;
+}
+
 const Consensus::LLMQParams& GetLLMQParams(Consensus::LLMQType llmqType)
 {
     return Params().GetConsensus().llmqs.at(llmqType);

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -315,11 +315,7 @@ std::vector<Consensus::LLMQType> CLLMQUtils::GetEnabledQuorumTypes(const CBlockI
 
 bool CLLMQUtils::QuorumDataRecoveryEnabled()
 {
-    int nDataRecovery = gArgs.GetArg("-llmq-data-recovery", DEFAULT_ENABLE_QUORUM_DATA_RECOVERY);
-    if ((nDataRecovery < 0) || (nDataRecovery > 1)) {
-        throw std::invalid_argument("Invalid value for -llmq-data-recovery, 1: Enabled, 0: Disabled");
-    }
-    return nDataRecovery > 0;
+    return gArgs.GetBoolArg("-llmq-data-recovery", DEFAULT_ENABLE_QUORUM_DATA_RECOVERY);
 }
 
 std::set<Consensus::LLMQType> CLLMQUtils::GetEnabledQuorumVvecSyncTypes()

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -322,6 +322,28 @@ bool CLLMQUtils::QuorumDataRecoveryEnabled()
     return nDataRecovery > 0;
 }
 
+std::set<Consensus::LLMQType> CLLMQUtils::GetEnabledQuorumVvecSyncTypes()
+{
+    std::set<Consensus::LLMQType> setQuorumVvecSyncTypes;
+    for (const std::string& strLLMQType : gArgs.GetArgs("-llmq-qvvec-sync")) {
+        Consensus::LLMQType llmqType = Consensus::LLMQ_NONE;
+        for (const auto& p : Params().GetConsensus().llmqs) {
+            if (p.second.name == strLLMQType) {
+                llmqType = p.first;
+                break;
+            }
+        }
+        if (llmqType == Consensus::LLMQ_NONE) {
+            throw std::invalid_argument(strprintf("Invalid llmqType in -llmq-qvvec-sync: %s", strLLMQType));
+        }
+        if (setQuorumVvecSyncTypes.count(llmqType) > 0) {
+            throw std::invalid_argument(strprintf("Duplicated llmqType in -llmq-qvvec-sync: %s", strLLMQType));
+        }
+        setQuorumVvecSyncTypes.emplace(llmqType);
+    }
+    return setQuorumVvecSyncTypes;
+}
+
 const Consensus::LLMQParams& GetLLMQParams(Consensus::LLMQType llmqType)
 {
     return Params().GetConsensus().llmqs.at(llmqType);

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -22,7 +22,7 @@ namespace llmq
 extern CCriticalSection cs_llmq_vbc;
 extern VersionBitsCache llmq_versionbitscache;
 
-static const int DEFAULT_ENABLE_QUORUM_DATA_RECOVERY = 1;
+static const bool DEFAULT_ENABLE_QUORUM_DATA_RECOVERY = true;
 
 class CLLMQUtils
 {

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -22,6 +22,8 @@ namespace llmq
 extern CCriticalSection cs_llmq_vbc;
 extern VersionBitsCache llmq_versionbitscache;
 
+static const int DEFAULT_ENABLE_QUORUM_DATA_RECOVERY = 1;
+
 class CLLMQUtils
 {
 public:
@@ -51,6 +53,9 @@ public:
     static bool IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quorumHash);
     static bool IsQuorumTypeEnabled(Consensus::LLMQType llmqType, const CBlockIndex* pindex);
     static std::vector<Consensus::LLMQType> GetEnabledQuorumTypes(const CBlockIndex* pindex);
+
+    /// Returns the state of `-llmq-data-recovery`
+    static bool QuorumDataRecoveryEnabled();
 
     template<typename NodesContainer, typename Continue, typename Callback>
     static void IterateNodesRandom(NodesContainer& nodeStates, Continue&& cont, Callback&& callback, FastRandomContext& rnd)

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -57,6 +57,9 @@ public:
     /// Returns the state of `-llmq-data-recovery`
     static bool QuorumDataRecoveryEnabled();
 
+    /// Returns the values given by `-llmq-qvvec-sync`
+    static std::set<Consensus::LLMQType> GetEnabledQuorumVvecSyncTypes();
+
     template<typename NodesContainer, typename Continue, typename Callback>
     static void IterateNodesRandom(NodesContainer& nodeStates, Continue&& cont, Callback&& callback, FastRandomContext& rnd)
     {

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -48,10 +48,9 @@ class QuorumDataRecoveryTest(DashTestFramework):
 
     def test_mns(self, quorum_type_in, quorum_hash_in, valid_mns=[], all_mns=[], expect_secret=True,
                  recover=False, timeout=120):
-        for invalid_mn in all_mns:
-            if invalid_mn in valid_mns:
-                continue
-            assert not self.test_mn_quorum_data(invalid_mn, quorum_type_in, quorum_hash_in, False)
+        for mn in all_mns:
+            if mn not in valid_mns:
+                assert not self.test_mn_quorum_data(mn, quorum_type_in, quorum_hash_in, False)
         self.wait_for_quorum_data(valid_mns, quorum_type_in, quorum_hash_in, expect_secret, recover, timeout)
 
     def get_mn(self, protx_hash):

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import time
+from test_framework.mininode import logger
+from test_framework.test_framework import DashTestFramework
+from test_framework.util import force_finish_mnsync, connect_nodes
+
+'''
+feature_llmq_data_recovery.py
+
+Tests automated recovery of DKG data and the related command line parameters:
+ -llmq-data-recovery
+ -llmq-qvvec-sync
+'''
+
+# LLMQ types available in regtest
+llmq_test = 100
+llmq_test_v17 = 102
+llmq_type_strings = {llmq_test: 'llmq_test', llmq_test_v17: 'llmq_test_v17'}
+
+
+class QuorumDataRecoveryTest(DashTestFramework):
+    def set_test_params(self):
+        extra_args = [["-vbparams=v17:0:999999999999:10:8:6:5"] for _ in range(9)]
+        self.set_dash_test_params(9, 7, fast_dip3_enforcement=True, extra_args=extra_args)
+        self.set_dash_llmq_test_params(4, 3)
+
+    def restart_mn(self, mn, reindex=False, qvvec_sync=[], qdata_recovery_enabled=True):
+        args = self.extra_args[mn.nodeIdx] + ['-masternodeblsprivkey=%s' % mn.keyOperator,
+                                              '-llmq-data-recovery=%d' % qdata_recovery_enabled]
+        if reindex:
+            args.append('-reindex')
+        for llmq_type in qvvec_sync:
+            args.append('-llmq-qvvec-sync=%s' % llmq_type_strings[llmq_type])
+        self.restart_node(mn.nodeIdx, args)
+        force_finish_mnsync(mn.node)
+        connect_nodes(mn.node, 0)
+        self.sync_blocks()
+
+    def restart_mns(self, mns=None, exclude=[], reindex=False, qvvec_sync=[], qdata_recovery_enabled=True):
+        for mn in self.mninfo if mns is None else mns:
+            if mn not in exclude:
+                self.restart_mn(mn, reindex, qvvec_sync, qdata_recovery_enabled)
+        self.wait_for_sporks_same()
+
+    def test_mns(self, quorum_type_in, quorum_hash_in, valid_mns=[], all_mns=[], expect_secret=True,
+                 recover=False, timeout=120):
+        for invalid_mn in all_mns:
+            if invalid_mn in valid_mns:
+                continue
+            assert not self.test_mn_quorum_data(invalid_mn, quorum_type_in, quorum_hash_in, False)
+        self.wait_for_quorum_data(valid_mns, quorum_type_in, quorum_hash_in, expect_secret, recover, timeout)
+
+    def get_mn(self, protx_hash):
+        for mn in self.mninfo:
+            if mn.proTxHash == protx_hash:
+                return mn
+        return None
+
+    def get_member_mns(self, quorum_type, quorum_hash):
+        members = self.nodes[0].quorum("info", quorum_type, quorum_hash)["members"]
+        mns = []
+        for member in members:
+            if member["valid"]:
+                mns.append(self.get_mn(member["proTxHash"]))
+        return mns
+
+    def get_subset_only_in_left(self, quorum_members_left, quorum_members_right):
+        quorum_members_subset = quorum_members_left.copy()
+        for mn in list(set(quorum_members_left) & set(quorum_members_right)):
+            quorum_members_subset.remove(mn)
+        return quorum_members_subset
+
+    def test_llmq_qvvec_sync(self, llmq_types):
+        self.log.info("Test with %d -llmq-qvvec-sync option(s)" % len(llmq_types))
+        for llmq_type in llmq_types:
+            self.log.info("Validate -llmq-qvvec-sync=%s" % llmq_type_strings[llmq_type])
+            # First restart with recovery thread triggering disabled
+            self.restart_mns(qdata_recovery_enabled=False)
+            # Create quorum_1 and a quorum_2 so that we have subsets (members_only_in_1, members_only_in_2) where each
+            # only contains nodes that are members of quorum_1 but not quorum_2 and vice versa
+            quorum_hash_1 = None
+            quorum_hash_2 = None
+            members_only_in_1 = []
+            members_only_in_2 = []
+            while len(members_only_in_1) == 0 or len(members_only_in_2) == 0:
+                quorum_hash_1 = self.mine_quorum()
+                quorum_hash_2 = self.mine_quorum()
+                member_mns_1 = self.get_member_mns(llmq_type, quorum_hash_1)
+                member_mns_2 = self.get_member_mns(llmq_type, quorum_hash_2)
+                members_only_in_1 = self.get_subset_only_in_left(member_mns_1, member_mns_2)
+                members_only_in_2 = self.get_subset_only_in_left(member_mns_2, member_mns_1)
+            # So far the nodes of quorum_1 shouldn't have the quorum verification vector of quorum_2 and vice versa
+            self.test_mns(llmq_type, quorum_hash_2, valid_mns=[], all_mns=members_only_in_1, expect_secret=False)
+            self.test_mns(llmq_type, quorum_hash_1, valid_mns=[], all_mns=members_only_in_2, expect_secret=False)
+            # Now restart with recovery enabled
+            self.restart_mns(qvvec_sync=llmq_types)
+            # Members which are only in quorum 2 should request the qvvec from quorum 1 from the members of quorum 1
+            self.test_mns(llmq_type, quorum_hash_1, valid_mns=members_only_in_2, expect_secret=False, recover=True)
+            # Members which are only in quorum 1 should request the qvvec from quorum 2 from the members of quorum 2
+            self.test_mns(llmq_type, quorum_hash_2, valid_mns=members_only_in_1, expect_secret=False, recover=True)
+
+    def run_test(self):
+
+        node = self.nodes[0]
+        node.spork("SPORK_17_QUORUM_DKG_ENABLED", 0)
+        node.spork("SPORK_21_QUORUM_ALL_CONNECTED", 0)
+        self.wait_for_sporks_same()
+        self.activate_dip8()
+
+        logger.info("Test automated DGK data recovery")
+        # This two nodes will remain the only ones with valid DKG data
+        last_resort_test = None
+        last_resort_v17 = None
+        while True:
+            # Mine the quorums used for the recovery test
+            quorum_hash_recover = self.mine_quorum()
+            # Get all their member masternodes
+            member_mns_recover_test = self.get_member_mns(llmq_test, quorum_hash_recover)
+            member_mns_recover_v17 = self.get_member_mns(llmq_test_v17, quorum_hash_recover)
+            # All members should initially be valid
+            self.test_mns(llmq_test, quorum_hash_recover, valid_mns=member_mns_recover_test)
+            self.test_mns(llmq_test_v17, quorum_hash_recover, valid_mns=member_mns_recover_v17)
+            try:
+                # As last resorts find one node which is in llmq_test but not in llmq_test_v17 and one other vice versa
+                last_resort_test = self.get_subset_only_in_left(member_mns_recover_test, member_mns_recover_v17)[0]
+                last_resort_v17 = self.get_subset_only_in_left(member_mns_recover_v17, member_mns_recover_test)[0]
+                break
+            except IndexError:
+                continue
+        assert last_resort_test != last_resort_v17
+        # Reindex all other nodes the to drop their DKG data, first run with recovery disabled to make sure disabling
+        # works as expected
+        recover_members = member_mns_recover_test + member_mns_recover_v17
+        exclude_members = [last_resort_test, last_resort_v17]
+        # Reindex all masternodes but exclude the last_resort for both testing quorums
+        self.restart_mns(exclude=exclude_members, reindex=True, qdata_recovery_enabled=False)
+        # Validate all but one are invalid members now
+        self.test_mns(llmq_test, quorum_hash_recover, valid_mns=[last_resort_test], all_mns=member_mns_recover_test)
+        self.test_mns(llmq_test_v17, quorum_hash_recover, valid_mns=[last_resort_v17], all_mns=member_mns_recover_v17)
+        # If recovery would be enabled it would trigger after the mocktime bump / mined block
+        self.bump_mocktime(self.quorum_data_request_expiration_timeout + 1)
+        node.generate(1)
+        time.sleep(10)
+        # Make sure they are still invalid
+        self.test_mns(llmq_test, quorum_hash_recover, valid_mns=[last_resort_test], all_mns=member_mns_recover_test)
+        self.test_mns(llmq_test_v17, quorum_hash_recover, valid_mns=[last_resort_v17], all_mns=member_mns_recover_v17)
+        # Mining a block should not result in a chainlock now because the responsible quorum shouldn't have enough
+        # valid members.
+        self.wait_for_chainlocked_block(node, node.generate(1)[0], False, 5)
+        # Now restart with recovery enabled
+        self.restart_mns(mns=recover_members, exclude=exclude_members, reindex=True, qdata_recovery_enabled=True)
+        # Validate that all invalid members recover. Note: recover=True leads to mocktime bumps and mining while waiting
+        # which trigger CQuorumManger::TriggerQuorumDataRecoveryThreads()
+        self.test_mns(llmq_test, quorum_hash_recover, valid_mns=member_mns_recover_test, recover=True)
+        self.test_mns(llmq_test_v17, quorum_hash_recover, valid_mns=member_mns_recover_v17, recover=True)
+        # Mining a block should result in a chainlock now because the quorum should be healed
+        self.wait_for_chainlocked_block(node, node.getbestblockhash())
+        logger.info("Test -llmq-qvvec-sync command line parameter")
+        # Run with one type separated and then both possible (for regtest) together, both calls generate new quorums
+        # and are restarting the nodes with the other parameters
+        self.test_llmq_qvvec_sync([llmq_test])
+        self.test_llmq_qvvec_sync([llmq_test, llmq_test_v17])
+        logger.info("Test invalid command line parameter values")
+        node.stop_node()
+        node.wait_until_stopped()
+        node.assert_start_raises_init_error(["-llmq-qvvec-sync=0"],
+                                            "Error: Invalid llmqType in -llmq-qvvec-sync: 0")
+        node.assert_start_raises_init_error(["-llmq-qvvec-sync=llmq-test"],
+                                            "Error: Invalid llmqType in -llmq-qvvec-sync: llmq-test")
+        node.assert_start_raises_init_error(["-llmq-qvvec-sync="],
+                                            "Error: Invalid llmqType in -llmq-qvvec-sync:")
+        node.assert_start_raises_init_error(["-llmq-qvvec-sync=100", "-llmq-qvvec-sync=0"],
+                                            "Error: Invalid llmqType in -llmq-qvvec-sync: 100")
+        node.assert_start_raises_init_error(["-llmq-qvvec-sync=llmq_test", "-llmq-qvvec-sync=llmq_test"],
+                                            "Error: Duplicated llmqType in -llmq-qvvec-sync: llmq_test")
+        node.assert_start_raises_init_error(["-llmq-data-recovery=-1"],
+                                            "Error: Invalid value for -llmq-data-recovery"
+                                            ", 1: Enabled, 0: Disabled")
+        node.assert_start_raises_init_error(["-llmq-data-recovery=2"],
+                                            "Error: Invalid value for -llmq-data-recovery"
+                                            ", 1: Enabled, 0: Disabled")
+
+
+if __name__ == '__main__':
+    QuorumDataRecoveryTest().main()

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -177,12 +177,6 @@ class QuorumDataRecoveryTest(DashTestFramework):
                                             "Error: Invalid llmqType in -llmq-qvvec-sync: 100")
         node.assert_start_raises_init_error(["-llmq-qvvec-sync=llmq_test", "-llmq-qvvec-sync=llmq_test"],
                                             "Error: Duplicated llmqType in -llmq-qvvec-sync: llmq_test")
-        node.assert_start_raises_init_error(["-llmq-data-recovery=-1"],
-                                            "Error: Invalid value for -llmq-data-recovery"
-                                            ", 1: Enabled, 0: Disabled")
-        node.assert_start_raises_init_error(["-llmq-data-recovery=2"],
-                                            "Error: Invalid value for -llmq-data-recovery"
-                                            ", 1: Enabled, 0: Disabled")
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -125,7 +125,8 @@ class QuorumDataInterface(P2PInterface):
 
 class QuorumDataMessagesTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
+        extra_args = [["-llmq-data-recovery=0"]] * 4
+        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True, extra_args=extra_args)
 
     def restart_mn(self, mn, reindex=False):
         args = self.extra_args[mn.nodeIdx] + ['-masternodeblsprivkey=%s' % mn.keyOperator]

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -545,7 +545,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.llmq_size = 3
         self.llmq_threshold = 2
 
-        # This is nRequestTimeout in dash-q-getdata thread
+        # This is nRequestTimeout in dash-q-recovery thread
         self.quorum_data_thread_request_timeout_seconds = 10
         # This is EXPIRATION_TIMEOUT in CQuorumDataRequest
         self.quorum_data_request_expiration_timeout = 300

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -545,6 +545,8 @@ class DashTestFramework(BitcoinTestFramework):
         self.llmq_size = 3
         self.llmq_threshold = 2
 
+        # This is nRequestTimeout in dash-q-getdata thread
+        self.quorum_data_thread_request_timeout_seconds = 10
         # This is EXPIRATION_TIMEOUT in CQuorumDataRequest
         self.quorum_data_request_expiration_timeout = 300
 
@@ -1107,6 +1109,8 @@ class DashTestFramework(BitcoinTestFramework):
                 if self.mocktime % 2:
                     self.bump_mocktime(self.quorum_data_request_expire_timeout + 1)
                     self.nodes[0].generate(1)
+                else:
+                    self.bump_mocktime(self.quorum_data_thread_request_timeout_seconds + 1)
 
             for test_mn in mns:
                 valid += self.test_mn_quorum_data(test_mn, quorum_type_in, quorum_hash_in, expect_secret)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1090,8 +1090,8 @@ class DashTestFramework(BitcoinTestFramework):
         return None
 
     def test_mn_quorum_data(self, test_mn, quorum_type_in, quorum_hash_in, expect_secret=True):
-        quorum_info = test_mn.node.quorum("info", quorum_type_in, quorum_hash_in, expect_secret)
-        if expect_secret and "secretKeyShare" not in quorum_info:
+        quorum_info = test_mn.node.quorum("info", quorum_type_in, quorum_hash_in, True)
+        if expect_secret != ("secretKeyShare" in quorum_info):
             return False
         if "members" not in quorum_info or len(quorum_info["members"]) == 0:
             return False

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1107,7 +1107,7 @@ class DashTestFramework(BitcoinTestFramework):
             valid = 0
             if recover:
                 if self.mocktime % 2:
-                    self.bump_mocktime(self.quorum_data_request_expire_timeout + 1)
+                    self.bump_mocktime(self.quorum_data_request_expiration_timeout + 1)
                     self.nodes[0].generate(1)
                 else:
                     self.bump_mocktime(self.quorum_data_thread_request_timeout_seconds + 1)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -60,6 +60,7 @@ BASE_SCRIPTS= [
     # Longest test should go first, to favor running tests in parallel
     'feature_dip3_deterministicmns.py', # NOTE: needs dash_hash to pass
     'feature_block_reward_reallocation.py',
+    'feature_llmq_data_recovery.py',
     'wallet_hd.py',
     'wallet_backup.py',
     # vv Tests less than 5m vv


### PR DESCRIPTION
This PR implements DKG data recovery in 4d54892127a9d139e1e3042e90c1c520030de396 which allows a member of  `LLMQx` which looses it's required DKG data (quorum verification vector and secret key share) e.g. due to unexpected loss/corruption of the database to recover itself with the help of the other members of `LLMQx` and the P2P messages `QGETDATA`/`QDATA`. Before this PR such an invalid member would just stay invalid for the remaining "active time" of the LLMQ.

To solve a requirement of platform/tenderdash it also introduces quorum verification vector sync in eef2691defeb3e903db28eaf8afd247a7810961b which enables to configure a masternode to request the quorum verification vectors of all existing/new LLMQs with the type `llmqType` if the masternode itself is a member of any other active LLMQ with the type `llmqType`.

### New command line parameter (hidden?):
- `-llmq-data-recovery` - Enable `1`, Disable `0` automated data recovery/qvvec requests.
- `-llmq-qvvec-sync` - Defines from which LLMQ type the masternode should sync quorum verification vectors (Can be used multiple times with different LLMQ types.

### New thread
- `dash-q-recovery` This new thread can exist exactly one time for each quorum (llmqType, quorumHash) and its job is to query the missing DKG data from related quorum members. This is done in a loop like: Calculate the next masternode to try, connect to it, send the `QGETDATA` request and wait until the `QDATA` message comes in with a timeout of 10 seconds before we try the next member. This is continues until the required data has been received successfully or until all members of the quorum were asked without success. 

The recovery threads are getting started by `CQuorumManager::TriggerQuorumDataRecoveryThreads()` if required which gets called with every block update in `CQuorumManager::UpdatedBlockTip()`.

The masternode decides based on `CQuourm::GetQuorumRecoveryStartOffset()` and the sorted protx hashes from all members of the quorum to which member of the quorum it tries to connect first. It also sleeps `offset * 100ms` before it tries to connect to the next member. I implemented those two as attempt to balance the incoming requests equally for each member of the target quorum. This means if `-llmq-qvvec-sync=llmq_100_67` is used on all masternodes by platform and a new `llmq_100_67` quorum just formed we will have in worst case ~2400 nodes asking ~100 members for their quorum verification vectors which means each member will then in best case get 24 requests and then all nodes should have the verification vector. Should be just good or do i miss something?

Let me know your thoughts! 

Based on #3953 