### PR TITLE
Fix two issues with ResetBlockFailureFlags, add tests

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3413,6 +3413,16 @@ bool CChainState::ResetBlockFailureFlags(CBlockIndex *pindex) {
             pindex->nStatus &= ~BLOCK_FAILED_MASK;
             setDirtyBlockIndex.insert(pindex);
             m_failed_blocks.erase(pindex);
+            // Mark all nearest BLOCK_FAILED_CHILD descendants (if any) as BLOCK_FAILED_VALID
+            auto itp = mapPrevBlockIndex.equal_range(pindex->GetBlockHash());
+            for (auto jt = itp.first; jt != itp.second; ++jt) {
+                if (jt->second->nStatus & BLOCK_FAILED_CHILD) {
+                    jt->second->nStatus |= BLOCK_FAILED_VALID;
+                    m_failed_blocks.insert(jt->second);
+                    setDirtyBlockIndex.insert(jt->second);
+                    setBlockIndexCandidates.erase(jt->second);
+                }
+            }
         }
         pindex = pindex->pprev;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3412,6 +3412,7 @@ bool CChainState::ResetBlockFailureFlags(CBlockIndex *pindex) {
         if (pindex->nStatus & BLOCK_FAILED_MASK) {
             pindex->nStatus &= ~BLOCK_FAILED_MASK;
             setDirtyBlockIndex.insert(pindex);
+            m_failed_blocks.erase(pindex);
         }
         pindex = pindex->pprev;
     }

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -83,7 +83,8 @@ class InvalidateTest(BitcoinTestFramework):
 
         assert_equal(self.nodes[1].getblockcount(), newheight)
         self.restart_node(1, extra_args=["-checkblocks=5"])
-        assert_equal(self.nodes[1].getblockcount(), newheight + 20)
+        wait_until(lambda: self.nodes[1].getblockcount() == newheight + 20)
+        assert_equal(tip, self.nodes[1].getbestblockhash())
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -60,5 +60,31 @@ class InvalidateTest(BitcoinTestFramework):
         if node1height < 4:
             raise AssertionError("Node 1 reorged to a lower height: %d"%node1height)
 
+        self.log.info("Make sure ResetBlockFailureFlags does the job correctly")
+        self.restart_node(0, extra_args=["-checkblocks=5"])
+        self.restart_node(1, extra_args=["-checkblocks=5"])
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.nodes[0].generate(10)
+        self.sync_blocks(self.nodes[0:2])
+        newheight = self.nodes[0].getblockcount()
+        for j in range(2):
+            self.restart_node(0, extra_args=["-checkblocks=5"])
+            tip = self.nodes[0].generate(10)[-1]
+            self.nodes[1].generate(9)
+            connect_nodes(self.nodes[0], 1)
+            self.sync_blocks(self.nodes[0:2])
+            assert_equal(self.nodes[0].getblockcount(), newheight + 10 * (j + 1))
+            assert_equal(self.nodes[1].getblockcount(), newheight + 10 * (j + 1))
+            assert_equal(self.nodes[1].getbestblockhash(), tip)
+
+        tip = self.nodes[1].getbestblockhash()
+        self.nodes[1].invalidateblock(self.nodes[1].getblockhash(newheight + 1))
+        self.nodes[1].invalidateblock(self.nodes[1].getblockhash(newheight + 1))
+
+        assert_equal(self.nodes[1].getblockcount(), newheight)
+        self.restart_node(1, extra_args=["-checkblocks=5"])
+        assert_equal(self.nodes[1].getblockcount(), newheight + 20)
+
+
 if __name__ == '__main__':
     InvalidateTest().main()


### PR DESCRIPTION
Without fe38ff9 new test crashes with errors like
```
Assertion failure:
  assertion: (pindex->nStatus & BLOCK_FAILED_MASK) == 0
  file: validation.cpp, line: 5013
  function: CheckBlockIndex
   0#: (0x10E526E65) stacktraces.cpp:651        - __assert_rtn
   1#: (0x10E2BBBD0) validation.cpp:5013        - CheckBlockIndex
   2#: (0x10E2BA6DC) microsec_time_clock.hpp:70 - ActivateBestChain
   3#: (0x10E2BBF34) validation.cpp             - ???
   4#: (0x10E181B2A) memory:4521                - reconsiderblock
   5#: (0x10E21B72B) server.cpp:626             - execute
   6#: (0x10DE65A0D) httprpc.cpp:197            - HTTPReq_JSONRPC
   7#: (0x10DE73178) functional:1799            - operator()
   8#: (0x10DE746BD) memory:2651                - Run
   9#: (0x10DE74C8A) memory:2649                - __thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (*)(WorkQueue<HTTPClosure> *), WorkQueue<HTTPClosure> *> >
  10#: (0x7FFF6DDC82EB) <unknown-file>             - ???
  11#: (0x7FFF6DDCB249) <unknown-file>             - ???
  12#: (0x7FFF6DDC740D) <unknown-file>             - ???
Assertion failed: ((pindex->nStatus & BLOCK_FAILED_MASK) == 0), function CheckBlockIndex, file validation.cpp, line 5013.
```