### PR TITLE
governance: Fix signature check in CGovernanceObject::Sign

### DIFF
--- a/src/governance/governance-object.cpp
+++ b/src/governance/governance-object.cpp
@@ -305,7 +305,7 @@ void CGovernanceObject::SetMasternodeOutpoint(const COutPoint& outpoint)
 bool CGovernanceObject::Sign(const CBLSSecretKey& key)
 {
     CBLSSignature sig = key.Sign(GetSignatureHash());
-    if (!key.IsValid()) {
+    if (!sig.IsValid()) {
         return false;
     }
     sig.GetBuf(vchSig);


### PR DESCRIPTION
This shouldn't make a difference but i still think it should be rather checked like this otherwise `if (!key.IsValid())` could be above the `key.Sign` call.