### PR TITLE
chainlocks: Rely more on clsigs with known blocks instead of pure clsigs

### DIFF
--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -119,7 +119,7 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CCha
             return;
         }
 
-        if (!bestChainLock.IsNull() && clsig.nHeight <= bestChainLock.nHeight) {
+        if (!bestChainLockWithKnownBlock.IsNull() && clsig.nHeight <= bestChainLockWithKnownBlock.nHeight) {
             // no need to process/relay older CLSIGs
             return;
         }
@@ -272,7 +272,7 @@ void CChainLocksHandler::TrySignChainTip()
             return;
         }
 
-        if (bestChainLock.nHeight >= pindex->nHeight) {
+        if (bestChainLockWithKnownBlock.nHeight >= pindex->nHeight) {
             // already got the same CLSIG or a better one
             return;
         }
@@ -337,7 +337,7 @@ void CChainLocksHandler::TrySignChainTip()
 
     {
         LOCK(cs);
-        if (bestChainLock.nHeight >= pindex->nHeight) {
+        if (bestChainLockWithKnownBlock.nHeight >= pindex->nHeight) {
             // might have happened while we didn't hold cs
             return;
         }
@@ -571,7 +571,7 @@ void CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recove
             // this is not what we signed, so lets not create a CLSIG for it
             return;
         }
-        if (bestChainLock.nHeight >= lastSignedHeight) {
+        if (bestChainLockWithKnownBlock.nHeight >= lastSignedHeight) {
             // already got the same or a better CLSIG through the CLSIG message
             return;
         }

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -3,11 +3,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+import struct
 import time
 
-from test_framework.mininode import *
+from test_framework.blocktools import (create_block, create_coinbase)
+from test_framework.messages import CInv, hash256, msg_clsig, msg_inv, ser_string, uint256_from_str
+from test_framework.mininode import P2PInterface, network_thread_join, network_thread_start
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import *
+from test_framework.util import connect_nodes, hex_str_to_bytes, isolate_node, reconnect_isolated_node
 
 '''
 feature_llmq_chainlocks.py
@@ -15,6 +18,23 @@ feature_llmq_chainlocks.py
 Checks LLMQs based ChainLocks
 
 '''
+
+class TestP2PConn(P2PInterface):
+    def __init__(self):
+        super().__init__()
+        self.clsigs = {}
+
+    def send_clsig(self, clsig):
+        clhash = uint256_from_str(hash256(clsig.serialize()))
+        self.clsigs[clhash] = clsig
+
+        inv = msg_inv([CInv(29, clhash)])
+        self.send_message(inv)
+
+    def on_getdata(self, message):
+        for inv in message.inv:
+            if inv.hash in self.clsigs:
+                self.send_message(self.clsigs[inv.hash])
 
 class LLMQChainLocksTest(DashTestFramework):
     def set_test_params(self):
@@ -156,6 +176,48 @@ class LLMQChainLocksTest(DashTestFramework):
         self.log.info("Reenable network on first node and wait for chainlock")
         reconnect_isolated_node(self.nodes[0], 1)
         self.wait_for_chainlocked_block(self.nodes[0], self.nodes[0].getbestblockhash(), timeout=30)
+
+        self.log.info("Send fake future clsigs and see if this breaks ChainLocks")
+        SIGN_HEIGHT_OFFSET = 8
+        p2p_node = self.nodes[0].add_p2p_connection(TestP2PConn())
+        network_thread_start()
+        p2p_node.wait_for_verack()
+        self.log.info("Should accept fake clsig but won't sign the same height twice (normally)")
+        (fake_clsig1, fake_block_hash1) = self.create_fake_clsig(1)
+        p2p_node.send_clsig(fake_clsig1)
+        for node in self.nodes:
+            self.wait_for_best_chainlock(node, fake_block_hash1, timeout=5)
+        tip = self.nodes[0].generate(1)[-1]
+        for node in self.nodes:
+            self.wait_for_chainlocked_block(node, tip, expected=False, timeout=5)
+        self.log.info("Shouldn't accept fake clsig for 'tip + SIGN_HEIGHT_OFFSET + 1' block height")
+        (fake_clsig2, fake_block_hash2) = self.create_fake_clsig(SIGN_HEIGHT_OFFSET + 1)
+        p2p_node.send_clsig(fake_clsig2)
+        time.sleep(5)
+        # Note: fake_block_hash1 is a blockhash for the fake_clsig1 we accepted initially, not for the new fake_clsig2
+        assert(self.nodes[0].getbestchainlock()["blockhash"] == fake_block_hash1)
+        self.log.info("Should accept fake clsig for 'tip + SIGN_HEIGHT_OFFSET' but new clsigs should still be formed")
+        (fake_clsig3, fake_block_hash3) = self.create_fake_clsig(SIGN_HEIGHT_OFFSET)
+        p2p_node.send_clsig(fake_clsig3)
+        for node in self.nodes:
+            self.wait_for_best_chainlock(node, fake_block_hash3, timeout=5)
+        tip = self.nodes[0].generate(1)[-1]
+        self.wait_for_chainlocked_block_all_nodes(tip, timeout=5)
+        self.nodes[0].disconnect_p2ps()
+        network_thread_join()
+
+    def create_fake_clsig(self, height_offset):
+        # create a fake block height_offset blocks ahead of the tip
+        height = self.nodes[0].getblockcount() + height_offset
+        fake_block = create_block(0xff, create_coinbase(height, dip4_activated=True))
+        # create a fake clsig for that block
+        request_id_buf = ser_string(b"clsig") + struct.pack("<I", height)
+        request_id = hash256(request_id_buf)[::-1].hex()
+        for mn in self.mninfo:
+            mn.node.quorum('sign', 100, request_id, fake_block.hash)
+        recSig = self.get_recovered_sig(request_id, fake_block.hash)
+        fake_clsig = msg_clsig(height, fake_block.sha256, hex_str_to_bytes(recSig['sig']))
+        return (fake_clsig, fake_block.hash)
 
     def create_chained_txs(self, node, amount):
         txid = node.sendtoaddress(node.getnewaddress(), amount)


### PR DESCRIPTION
A malicious quorum can sign a clsig with some (random) hash and some future height, up to `tip + SIGN_HEIGHT_OFFSET` (anything above it won't pass `VerifyRecoveredSig`/`SelectQuorumForSigning`, see tests for `fake_clsig2`). Such a clsig not only does not lock the chain but it also prevents new clsigs (for heights up to that future one) from forming or being accepted, see tests for `fake_clsig3` (fails without b010bc9). Chances to form such a quorum are close to 0 e.g. 1.29e-38 if you control 1500 MNs (see `Success probability of creating a malicious ChainLock` [here](https://github.com/dashpay/dips/blob/master/dip-0008.md#calculations) for more info), so it's not a critical issue by any means but I feel like it still makes sense to reduce any potential impact of such an event when possible.

Note: the issue is only for _future_ clsigs, the best clsig with a known block is not affected, no reorgs _below_ the already locked block are possible. 