### PR TITLE
instantsend: Ignore IS while reindexing/loading blocks from file, bail out early when IS is off

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1520,12 +1520,12 @@ void CInstantSendManager::WorkThreadMain()
 
 bool IsInstantSendEnabled()
 {
-    return sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED);
+    return !fReindex && !fImporting && sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED);
 }
 
 bool RejectConflictingBlocks()
 {
-    return sporkManager.IsSporkActive(SPORK_3_INSTANTSEND_BLOCK_FILTERING);
+    return !fReindex && !fImporting && sporkManager.IsSporkActive(SPORK_3_INSTANTSEND_BLOCK_FILTERING);
 }
 
 } // namespace llmq

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -214,7 +214,7 @@ size_t CInstantSendDb::GetInstantSendLockCount() const
 
 CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByHash(const uint256& hash) const
 {
-    if (hash.IsNull() || !IsInstantSendEnabled()) {
+    if (hash.IsNull()) {
         return nullptr;
     }
 
@@ -234,9 +234,6 @@ CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByHash(const uint256& hash
 
 uint256 CInstantSendDb::GetInstantSendLockHashByTxid(const uint256& txid) const
 {
-    if (!IsInstantSendEnabled()) {
-        return {};
-    }
     uint256 islockHash;
     if (!txidCache.get(txid, islockHash)) {
         db.Read(std::make_tuple(std::string(DB_HASH_BY_TXID), txid), islockHash);
@@ -252,9 +249,6 @@ CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByTxid(const uint256& txid
 
 CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByInput(const COutPoint& outpoint) const
 {
-    if (!IsInstantSendEnabled()) {
-        return nullptr;
-    }
     uint256 islockHash;
     if (!outpointCache.get(outpoint, islockHash)) {
         db.Read(std::make_tuple(std::string(DB_HASH_BY_OUTPOINT), outpoint), islockHash);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2386,7 +2386,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                                  REJECT_INVALID, "conflict-tx-lock");
             }
         }
-    } else {
+    } else if (!fReindex && !fImporting) {
         LogPrintf("ConnectBlock(DASH): spork is off, skipping transaction locking checks\n");
     }
 


### PR DESCRIPTION
Please see individual commits.

Extracted from #3970, ~based on #3984 atm~