### PR TITLE
instantsend: Mark blocks as conflicting when there is a CL vs IS conflict

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1304,8 +1304,8 @@ void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const
         CValidationState state;
         // need non-const pointer
         auto pindex2 = LookupBlockIndex(pindex->GetBlockHash());
-        if (!InvalidateBlock(state, Params(), pindex2)) {
-            LogPrintf("CInstantSendManager::%s -- InvalidateBlock failed: %s\n", __func__, FormatStateMessage(state));
+        if (!MarkConflictingBlock(state, Params(), pindex2)) {
+            LogPrintf("CInstantSendManager::%s -- MarkConflictingBlock failed: %s\n", __func__, FormatStateMessage(state));
             // This should not have happened and we are in a state were it's not safe to continue anymore
             assert(false);
         }


### PR DESCRIPTION
A followup for https://github.com/dashpay/dash/pull/3924

Extracted from #3970