### PR TITLE
llmq: Sleep less in quorum data recovery threads

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -319,7 +319,7 @@ void CQuorum::StartQuorumDataRecoveryThread(const CQuorumCPtr _this, const CBloc
                 }
             });
             _this->interruptQuorumDataReceived.reset();
-            _this->interruptQuorumDataReceived.sleep_for(std::chrono::seconds(nRequestTimeout));
+            _this->interruptQuorumDataReceived.sleep_for(std::chrono::seconds(1));
         }
         _this->fQuorumDataRecoveryThreadRunning = false;
         printLog("Done");


### PR DESCRIPTION
Speeds up feature_llmq_data_recovery.py test by ~25% (at least on my local machine) and makes sense overall imo (should free resources by dropping failed/processed connections faster).