### PR TITLE
chainlocks: Relay clsig inv only after bestChainLock(Hash) are assigned

### DIFF
--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -135,12 +135,12 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CCha
         return;
     }
 
-    g_connman->RelayInv(clsigInv, LLMQS_PROTO_VERSION);
-
     {
         LOCK2(cs_main, cs);
         bestChainLockHash = hash;
         bestChainLock = clsig;
+
+        g_connman->RelayInv(clsigInv, LLMQS_PROTO_VERSION);
 
         const CBlockIndex* pindex = LookupBlockIndex(clsig.blockHash);
         if (!pindex) {


### PR DESCRIPTION
Fixes a race condition when we could reply with `notfound` to other nodes after they ask for a clsig corresponding to this inv because we might still be waiting for locks here.