### PR TITLE
qt: Decouple transaction label updates from transaction status updates

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -26,7 +26,7 @@ bool TransactionRecord::showTransaction()
 /*
  * Decompose CWallet transaction to model transaction records.
  */
-QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interfaces::WalletTx& wtx)
+QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Wallet& wallet, const interfaces::WalletTx& wtx)
 {
     QList<TransactionRecord> parts;
     int64_t nTime = wtx.time;
@@ -59,6 +59,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                     sub.type = TransactionRecord::RecvWithAddress;
                     sub.strAddress = EncodeDestination(wtx.txout_address[i]);
                     sub.txDest = wtx.txout_address[i];
+                    sub.updateLabel(wallet);
                 }
                 else
                 {
@@ -118,6 +119,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                     // Sent to Dash Address
                     sub.strAddress = EncodeDestination(address);
                     sub.txDest = address;
+                    sub.updateLabel(wallet);
                 }
                 else
                 {
@@ -210,6 +212,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                     sub.type = TransactionRecord::SendToAddress;
                     sub.strAddress = EncodeDestination(wtx.txout_address[nOut]);
                     sub.txDest = wtx.txout_address[nOut];
+                    sub.updateLabel(wallet);
                 }
                 else
                 {
@@ -328,6 +331,18 @@ bool TransactionRecord::statusUpdateNeeded(int numBlocks, int chainLockHeight) c
 {
     return status.cur_num_blocks != numBlocks || status.needsUpdate
         || (!status.lockedByChainLocks && status.cachedChainLockHeight != chainLockHeight);
+}
+
+void TransactionRecord::updateLabel(interfaces::Wallet& wallet)
+{
+    if (IsValidDestination(txDest)) {
+        std::string name;
+        if (wallet.getAddress(txDest, &name)) {
+            label = QString::fromStdString(name);
+        } else{
+            label = "";
+        }
+    }
 }
 
 QString TransactionRecord::getTxHash() const

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -339,7 +339,7 @@ void TransactionRecord::updateLabel(interfaces::Wallet& wallet)
         std::string name;
         if (wallet.getAddress(txDest, &name)) {
             label = QString::fromStdString(name);
-        } else{
+        } else {
             label = "";
         }
     }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -52,8 +52,6 @@ public:
     bool lockedByChainLocks;
     /// Sorting key based on status
     std::string sortKey;
-    /// Label
-    QString label;
 
     /** @name Generated (mined) transactions
        @{*/
@@ -129,7 +127,7 @@ public:
     /** Decompose CWallet transaction to model transaction records.
      */
     static bool showTransaction();
-    static QList<TransactionRecord> decomposeTransaction(const interfaces::WalletTx& wtx);
+    static QList<TransactionRecord> decomposeTransaction(interfaces::Wallet& wallet, const interfaces::WalletTx& wtx);
 
     /** @name Immutable transaction attributes
       @{*/
@@ -152,6 +150,9 @@ public:
     /** Whether the transaction was sent/received with a watch-only address */
     bool involvesWatchAddress;
 
+    /// Label
+    QString label;
+
     /** Return the unique identifier for this transaction (part) */
     QString getTxHash() const;
 
@@ -165,6 +166,10 @@ public:
     /** Return whether a status update is needed.
      */
     bool statusUpdateNeeded(int numBlocks, int chainLockHeight) const;
+
+    /** Update label from address book.
+     */
+    void updateLabel(interfaces::Wallet& wallet);
 };
 
 #endif // BITCOIN_QT_TRANSACTIONRECORD_H

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -77,7 +77,7 @@ public:
         {
             for (const auto& wtx : wallet.getWalletTxs()) {
                 if (TransactionRecord::showTransaction()) {
-                    cachedWallet.append(TransactionRecord::decomposeTransaction(wtx));
+                    cachedWallet.append(TransactionRecord::decomposeTransaction(wallet, wtx));
                 }
             }
         }
@@ -132,7 +132,7 @@ public:
                 }
                 // Added -- insert at the right position
                 QList<TransactionRecord> toInsert =
-                        TransactionRecord::decomposeTransaction(wtx);
+                        TransactionRecord::decomposeTransaction(wallet, wtx);
                 if(!toInsert.isEmpty()) /* only if something to insert */
                 {
                     parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex+toInsert.size()-1);
@@ -169,13 +169,13 @@ public:
         }
     }
 
-    void updateAddressBook(const QString& address, const QString& label, bool isMine, const QString& purpose, int status)
+    void updateAddressBook(interfaces::Wallet& wallet, const QString& address, const QString& label, bool isMine, const QString& purpose, int status)
     {
         std::string address2 = address.toStdString();
         int index = 0;
         for (auto& rec : cachedWallet) {
             if (rec.strAddress == address2) {
-                rec.status.needsUpdate = true;
+                rec.updateLabel(wallet);
                 Q_EMIT parent->dataChanged(parent->index(index, TransactionTableModel::ToAddress), parent->index(index, TransactionTableModel::ToAddress));
             }
             index++;
@@ -204,15 +204,6 @@ public:
             int64_t adjustedTime;
             if (rec->statusUpdateNeeded(numBlocks, parent->getChainLockHeight()) && wallet.tryGetTxStatus(rec->hash, wtx, adjustedTime)) {
                 rec->updateStatus(wtx, numBlocks, adjustedTime, parent->getChainLockHeight());
-                // Update label
-                if (IsValidDestination(rec->txDest)) {
-                    std::string name;
-                    if (wallet.getAddress(rec->txDest, &name)) {
-                        rec->status.label = QString::fromStdString(name);
-                    } else {
-                        rec->status.label = "";
-                    }
-                }
             }
             return rec;
         }
@@ -274,7 +265,7 @@ void TransactionTableModel::updateTransaction(const QString &hash, int status, b
 void TransactionTableModel::updateAddressBook(const QString& address, const QString& label, bool isMine,
                                               const QString& purpose, int status)
 {
-    priv->updateAddressBook(address, label, isMine, purpose, status);
+    priv->updateAddressBook(walletModel->wallet(), address, label, isMine, purpose, status);
 }
 
 void TransactionTableModel::updateConfirmations()
@@ -439,7 +430,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::SendToAddress:
     case TransactionRecord::Generated:
     case TransactionRecord::PrivateSend:
-        return formatAddressLabel(wtx->strAddress, wtx->status.label, tooltip) + watchAddress;
+        return formatAddressLabel(wtx->strAddress, wtx->label, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->strAddress) + watchAddress;
     case TransactionRecord::SendToSelf:
@@ -459,7 +450,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::PrivateSend:
     case TransactionRecord::RecvWithPrivateSend:
         {
-        if (wtx->status.label.isEmpty()) {
+        if (wtx->label.isEmpty()) {
             return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BAREADDRESS);
         }
         } break;
@@ -653,7 +644,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
     case AddressRole:
         return QString::fromStdString(rec->strAddress);
     case LabelRole:
-        return rec->status.label;
+        return rec->label;
     case AmountRole:
         return qint64(rec->credit + rec->debit);
     case TxHashRole:
@@ -663,7 +654,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
     case TxPlainTextRole:
         {
             QString details;
-            QString txLabel = rec->status.label;
+            QString txLabel = rec->label;
 
             details.append(formatTxDate(rec));
             details.append(" ");


### PR DESCRIPTION
I doesn't really make much sense to check/update status on address book updates and vice versa.

~Based on #3993 atm~