### PR TITLE
bench: Tweak BLS benchmarks

### DIFF
--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -81,6 +81,21 @@ static void BLS_SecKeyAggregate_Normal(benchmark::State& state)
     }
 }
 
+static void BLS_SignatureAggregate_Normal(benchmark::State& state)
+{
+    uint256 hash = GetRandHash();
+    CBLSSecretKey secKey1, secKey2;
+    secKey1.MakeNewKey();
+    secKey2.MakeNewKey();
+    CBLSSignature sig1 = secKey1.Sign(hash);
+    CBLSSignature sig2 = secKey2.Sign(hash);
+
+    // Benchmark.
+    while (state.KeepRunning()) {
+        sig1.AggregateInsecure(sig2);
+    }
+}
+
 static void BLS_Sign_Normal(benchmark::State& state)
 {
     CBLSSecretKey secKey;
@@ -350,6 +365,7 @@ static void BLS_Verify_BatchedParallel(benchmark::State& state)
 
 BENCHMARK(BLS_PubKeyAggregate_Normal, 300 * 1000)
 BENCHMARK(BLS_SecKeyAggregate_Normal, 700 * 1000)
+BENCHMARK(BLS_SignatureAggregate_Normal, 100 * 1000)
 BENCHMARK(BLS_Sign_Normal, 600)
 BENCHMARK(BLS_Verify_Normal, 350)
 BENCHMARK(BLS_Verify_LargeBlock1000, 1)

--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -359,8 +359,8 @@ static void BLS_Verify_BatchedParallel(benchmark::State& state)
     }
 }
 
-BENCHMARK(BLS_PubKeyAggregate_Normal, 300 * 1000)
-BENCHMARK(BLS_SecKeyAggregate_Normal, 700 * 1000)
+BENCHMARK(BLS_PubKeyAggregate_Normal, 140 * 1000)
+BENCHMARK(BLS_SecKeyAggregate_Normal, 800 * 1000)
 BENCHMARK(BLS_SignatureAggregate_Normal, 100 * 1000)
 BENCHMARK(BLS_Sign_Normal, 600)
 BENCHMARK(BLS_Verify_Normal, 350)

--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -61,8 +61,7 @@ static void BLS_PubKeyAggregate_Normal(benchmark::State& state)
 
     // Benchmark.
     while (state.KeepRunning()) {
-        CBLSPublicKey k(pubKey1);
-        k.AggregateInsecure(pubKey2);
+        pubKey1.AggregateInsecure(pubKey2);
     }
 }
 
@@ -71,13 +70,10 @@ static void BLS_SecKeyAggregate_Normal(benchmark::State& state)
     CBLSSecretKey secKey1, secKey2;
     secKey1.MakeNewKey();
     secKey2.MakeNewKey();
-    CBLSPublicKey pubKey1 = secKey1.GetPublicKey();
-    CBLSPublicKey pubKey2 = secKey2.GetPublicKey();
 
     // Benchmark.
     while (state.KeepRunning()) {
-        CBLSSecretKey k(secKey1);
-        k.AggregateInsecure(secKey2);
+        secKey1.AggregateInsecure(secKey2);
     }
 }
 

--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -147,14 +147,14 @@ static void BLS_Verify_LargeBlock(size_t txCount, benchmark::State& state)
     }
 }
 
+static void BLS_Verify_LargeBlock100(benchmark::State& state)
+{
+    BLS_Verify_LargeBlock(100, state);
+}
+
 static void BLS_Verify_LargeBlock1000(benchmark::State& state)
 {
     BLS_Verify_LargeBlock(1000, state);
-}
-
-static void BLS_Verify_LargeBlock10000(benchmark::State& state)
-{
-    BLS_Verify_LargeBlock(10000, state);
 }
 
 static void BLS_Verify_LargeBlockSelfAggregated(size_t txCount, benchmark::State& state)
@@ -173,14 +173,14 @@ static void BLS_Verify_LargeBlockSelfAggregated(size_t txCount, benchmark::State
     }
 }
 
+static void BLS_Verify_LargeBlockSelfAggregated100(benchmark::State& state)
+{
+    BLS_Verify_LargeBlockSelfAggregated(100, state);
+}
+
 static void BLS_Verify_LargeBlockSelfAggregated1000(benchmark::State& state)
 {
     BLS_Verify_LargeBlockSelfAggregated(1000, state);
-}
-
-static void BLS_Verify_LargeBlockSelfAggregated10000(benchmark::State& state)
-{
-    BLS_Verify_LargeBlockSelfAggregated(10000, state);
 }
 
 static void BLS_Verify_LargeAggregatedBlock(size_t txCount, benchmark::State& state)
@@ -200,14 +200,14 @@ static void BLS_Verify_LargeAggregatedBlock(size_t txCount, benchmark::State& st
     }
 }
 
+static void BLS_Verify_LargeAggregatedBlock100(benchmark::State& state)
+{
+    BLS_Verify_LargeAggregatedBlock(100, state);
+}
+
 static void BLS_Verify_LargeAggregatedBlock1000(benchmark::State& state)
 {
     BLS_Verify_LargeAggregatedBlock(1000, state);
-}
-
-static void BLS_Verify_LargeAggregatedBlock10000(benchmark::State& state)
-{
-    BLS_Verify_LargeAggregatedBlock(10000, state);
 }
 
 static void BLS_Verify_LargeAggregatedBlock1000PreVerified(benchmark::State& state)
@@ -364,11 +364,12 @@ BENCHMARK(BLS_SecKeyAggregate_Normal, 800 * 1000)
 BENCHMARK(BLS_SignatureAggregate_Normal, 100 * 1000)
 BENCHMARK(BLS_Sign_Normal, 600)
 BENCHMARK(BLS_Verify_Normal, 350)
+BENCHMARK(BLS_Verify_LargeBlock100, 3)
 BENCHMARK(BLS_Verify_LargeBlock1000, 1)
+BENCHMARK(BLS_Verify_LargeBlockSelfAggregated100, 7)
 BENCHMARK(BLS_Verify_LargeBlockSelfAggregated1000, 1)
-BENCHMARK(BLS_Verify_LargeBlockSelfAggregated10000, 1)
+BENCHMARK(BLS_Verify_LargeAggregatedBlock100, 7)
 BENCHMARK(BLS_Verify_LargeAggregatedBlock1000, 1)
-BENCHMARK(BLS_Verify_LargeAggregatedBlock10000, 1)
 BENCHMARK(BLS_Verify_LargeAggregatedBlock1000PreVerified, 5)
 BENCHMARK(BLS_Verify_Batched, 500)
 BENCHMARK(BLS_Verify_BatchedParallel, 1000)


### PR DESCRIPTION
The main idea of this PR was to "purify" `CBLSPublicKey` and `CBLSSecretKey` simple benchmarks by dropping unrelated actions. For `CBLSPublicKey` however this resulted in ~2x worse numbers which I _guess_ is a result of using an aggregated pubkey (which holds a new value at every step) as a base one instead of using the same `pubKey1` each time. This PR also adds a similar benchmark for `CBLSSignature` and replaces `LargeBlock*10000`s with `LargeBlock*100`s while at it.

develop:
```
# Benchmark, evals, iterations, total, min, max, median
BLS_PubKeyAggregate_Normal, 5, 300000, 5.25894, 3.46108e-06, 3.53267e-06, 3.52481e-06
BLS_SecKeyAggregate_Normal, 5, 700000, 5.00097, 1.4178e-06, 1.44469e-06, 1.42675e-06
```

before 0339711:
```
# Benchmark, evals, iterations, total, min, max, median
BLS_PubKeyAggregate_Normal, 5, 300000, 10.9057, 7.18349e-06, 7.54132e-06, 7.21579e-06
BLS_SecKeyAggregate_Normal, 5, 700000, 4.52316, 1.26873e-06, 1.34298e-06, 1.27715e-06
BLS_SignatureAggregate_Normal, 5, 100000, 5.30105, 1.04112e-05, 1.09907e-05, 1.05486e-05
```

after 0339711:
```
# Benchmark, evals, iterations, total, min, max, median
BLS_PubKeyAggregate_Normal, 5, 140000, 5.08675, 7.13055e-06, 7.70252e-06, 7.15043e-06
BLS_SecKeyAggregate_Normal, 5, 800000, 5.26039, 1.30286e-06, 1.33599e-06, 1.30964e-06
BLS_SignatureAggregate_Normal, 5, 100000, 5.24772, 1.04197e-05, 1.0596e-05, 1.04735e-05
```

LargeBlock part after 1b7f9aa:
```
# Benchmark, evals, iterations, total, min, max, median
BLS_Verify_LargeAggregatedBlock100, 5, 7, 4.96194, 0.141337, 0.142906, 0.141484
BLS_Verify_LargeAggregatedBlock1000, 5, 1, 6.98894, 1.39548, 1.40355, 1.39589
BLS_Verify_LargeAggregatedBlock1000PreVerified, 5, 5, 3.74757, 0.149304, 0.150337, 0.150061
BLS_Verify_LargeBlock100, 5, 3, 4.55061, 0.302694, 0.304299, 0.303265
BLS_Verify_LargeBlock1000, 5, 1, 15.2369, 3.03189, 3.08571, 3.03827
BLS_Verify_LargeBlockSelfAggregated100, 5, 7, 4.94675, 0.140552, 0.142535, 0.140887
BLS_Verify_LargeBlockSelfAggregated1000, 5, 1, 7.00312, 1.39942, 1.40283, 1.40029
```