### PR TITLE
chainlocks: Implement Multi-Quorum ChainLocks

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -187,9 +187,9 @@ static Consensus::LLMQParams llmq_test = {
         .dkgMiningWindowEnd = 18,
         .dkgBadVotesThreshold = 2,
 
-        .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
+        .signingActiveQuorumCount = 4, // just a few ones to allow easier testing
 
-        .keepOldConnections = 3,
+        .keepOldConnections = 5,
         .recoveryMembers = 3,
 };
 

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -579,6 +579,8 @@ void CChainLocksHandler::CheckActiveState()
 
 void CChainLocksHandler::TrySignChainTip()
 {
+    const static int attempt_start{-2}; // let a couple of extra attempts to wait for busy/slow quorums
+    static int attempt{attempt_start};
     static int lastSignedHeight{-1};
 
     Cleanup();
@@ -614,7 +616,9 @@ void CChainLocksHandler::TrySignChainTip()
         }
 
         if (bestChainLockWithKnownBlock.nHeight >= pindex->nHeight) {
-            // already got the same CLSIG or a better one
+            // already got the same CLSIG or a better one, reset and bail out
+            lastSignedHeight = bestChainLockWithKnownBlock.nHeight;
+            attempt = attempt_start;
             return;
         }
 
@@ -688,8 +692,6 @@ void CChainLocksHandler::TrySignChainTip()
                 mapSharesAtTip = it->second;
             }
         }
-        const static int attempt_start{-2}; // let a couple of extra attempts to wait for busy/slow quorums
-        static int attempt{attempt_start};
         bool fMemberOfSomeQuorum{false};
         ++attempt;
         for (size_t i = 0; i < quorums_scanned.size(); ++i) {

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -415,7 +415,7 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, CChainLockSig& c
                         LOCK(pnode->cs_filter);
                         fSPV = pnode->pfilter != nullptr;
                     }
-                    if (pnode->nVersion >= MULTI_QUORUM_CHAINLOCKS_VERSION && !fSPV && !pnode->m_masternode_connection) {
+                    if (pnode->nVersion >= MULTI_QUORUM_CHAINLOCKS_VERSION && !fSPV && pnode->CanRelay()) {
                         pnode->PushInventory(clsigInv);
                     }
                 });

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -419,6 +419,8 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, CChainLockSig& c
                         pnode->PushInventory(clsigInv);
                     }
                 });
+                // Try signing the tip ourselves
+                TrySignChainTip();
             }
         } else {
             // An aggregated CLSIG

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -117,6 +117,21 @@ const CChainLockSig CChainLocksHandler::GetBestChainLock()
     return bestChainLockWithKnownBlock;
 }
 
+const std::map<CQuorumCPtr, CChainLockSigCPtr> CChainLocksHandler::GetBestChainLockShares()
+{
+    if (!AreMultiQuorumChainLocksEnabled()) {
+        return {};
+    }
+
+    LOCK(cs);
+    auto it = bestChainLockShares.find(bestChainLockWithKnownBlock.nHeight);
+    if (it == bestChainLockShares.end()) {
+        return {};
+    }
+
+    return it->second;
+}
+
 bool CChainLocksHandler::TryUpdateBestChainLock(const CBlockIndex* pindex)
 {
     AssertLockHeld(cs);

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -122,7 +122,7 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CCha
             return;
         }
 
-        if (!bestChainLock.IsNull() && clsig.nHeight <= bestChainLock.nHeight) {
+        if (!bestChainLockWithKnownBlock.IsNull() && clsig.nHeight <= bestChainLockWithKnownBlock.nHeight) {
             // no need to process/relay older CLSIGs
             return;
         }
@@ -288,7 +288,7 @@ void CChainLocksHandler::TrySignChainTip()
             return;
         }
 
-        if (bestChainLock.nHeight >= pindex->nHeight) {
+        if (bestChainLockWithKnownBlock.nHeight >= pindex->nHeight) {
             // already got the same CLSIG or a better one
             return;
         }
@@ -353,7 +353,7 @@ void CChainLocksHandler::TrySignChainTip()
 
     {
         LOCK(cs);
-        if (bestChainLock.nHeight >= pindex->nHeight) {
+        if (bestChainLockWithKnownBlock.nHeight >= pindex->nHeight) {
             // might have happened while we didn't hold cs
             return;
         }
@@ -587,7 +587,7 @@ void CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recove
             // this is not what we signed, so lets not create a CLSIG for it
             return;
         }
-        if (bestChainLock.nHeight >= lastSignedHeight) {
+        if (bestChainLockWithKnownBlock.nHeight >= lastSignedHeight) {
             // already got the same or a better CLSIG through the CLSIG message
             return;
         }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -313,10 +313,9 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, CChainLockSig& c
 
     CheckActiveState();
 
-    CInv clsigInv(clsig.nVersion == 1 ? MSG_CLSIGMQ : MSG_CLSIG, hash);
-
     if (from != -1) {
         LOCK(cs_main);
+        CInv clsigInv(clsig.nVersion == 1 ? MSG_CLSIGMQ : MSG_CLSIG, hash);
         EraseObjectRequest(from, clsigInv);
     }
 
@@ -410,6 +409,7 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, CChainLockSig& c
                 g_connman->RelayInv(clsigAggInv, MULTI_QUORUM_CHAINLOCKS_VERSION);
             } else {
                 // Relay partial CLSIGs to full nodes only, SPV wallets should wait for the aggregated CLSIG.
+                CInv clsigInv(MSG_CLSIGMQ, ::SerializeHash(clsig));
                 g_connman->ForEachNode([&](CNode* pnode) {
                     bool fSPV{false};
                     {
@@ -441,6 +441,7 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, CChainLockSig& c
             }
             // Note: do not hold cs while calling RelayInv
             AssertLockNotHeld(cs);
+            CInv clsigInv(MSG_CLSIGMQ, hash);
             g_connman->RelayInv(clsigInv, MULTI_QUORUM_CHAINLOCKS_VERSION);
         }
     } else {
@@ -497,6 +498,7 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, CChainLockSig& c
         }
         // Note: do not hold cs while calling RelayInv
         AssertLockNotHeld(cs);
+        CInv clsigInv(MSG_CLSIG, hash);
         g_connman->RelayInv(clsigInv, LLMQS_PROTO_VERSION);
     }
 

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -9,6 +9,7 @@
 
 #include <chain.h>
 #include <consensus/validation.h>
+#include <masternode/activemasternode.h>
 #include <masternode/masternode-sync.h>
 #include <net_processing.h>
 #include <scheduler.h>
@@ -661,11 +662,73 @@ void CChainLocksHandler::TrySignChainTip()
     if (AreMultiQuorumChainLocksEnabled()) {
         // Use multiple ChainLocks quorums
         const auto quorums_scanned = llmq::quorumManager->ScanQuorums(llmqType, pindex, signingActiveQuorumCount);
+        std::map<CQuorumCPtr, CChainLockSigCPtr> mapSharesAtTip;
+        {
+            LOCK(cs);
+            const auto it = bestChainLockShares.find(pindex->nHeight);
+            if (it != bestChainLockShares.end()) {
+                mapSharesAtTip = it->second;
+            }
+        }
+        const static int attempt_start{-2}; // let a couple of extra attempts to wait for busy/slow quorums
+        static int attempt{attempt_start};
+        bool fMemberOfSomeQuorum{false};
+        ++attempt;
         for (size_t i = 0; i < quorums_scanned.size(); ++i) {
-            const CQuorumCPtr& quorum = quorums_scanned[i];
+            int nQuorumIndex = (pindex->nHeight + i) % quorums_scanned.size();
+            const CQuorumCPtr& quorum = quorums_scanned[nQuorumIndex];
             if (quorum == nullptr) {
                 return;
             }
+            if (!quorum->IsValidMember(activeMasternodeInfo.proTxHash)) {
+                continue;
+            }
+            fMemberOfSomeQuorum = true;
+            if (i > 0) {
+                int nQuorumIndexPrev = (nQuorumIndex + 1) % quorums_scanned.size();
+                auto it2 = mapSharesAtTip.find(quorums_scanned[nQuorumIndexPrev]);
+                if (it2 == mapSharesAtTip.end() && attempt > i) {
+                    // look deeper after 'i' attempts
+                    while (nQuorumIndexPrev != nQuorumIndex) {
+                        nQuorumIndexPrev = (nQuorumIndexPrev + 1) % quorums_scanned.size();
+                        it2 = mapSharesAtTip.find(quorums_scanned[nQuorumIndexPrev]);
+                        if (it2 != mapSharesAtTip.end()) {
+                            break;
+                        }
+                        LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) didn't sign a chainlock at height %d yet\n",
+                                __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc.quorumHash.ToString(), pindex->nHeight);
+                    }
+                }
+                if (it2 == mapSharesAtTip.end()) {
+                    if (attempt <= i) {
+                        // previous quorum did not sign a chainlock, bail out for now
+                        LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum did not sign a chainlock at height %d yet\n", __func__, pindex->nHeight);
+                        return;
+                    }
+                    // else
+                    // waiting for previous quorum(s) to sign anything for too long already,
+                    // just sign whatever we think is a good tip
+                } else if (it2->second->blockHash != pindex->GetBlockHash()) {
+                    LOCK(cs_main);
+                    auto shareBlockIndex = LookupBlockIndex(it2->second->blockHash);
+                    if (shareBlockIndex != nullptr && shareBlockIndex->nHeight == pindex->nHeight) {
+                        // previous quorum signed an alternative chain tip, sign it too instead
+                        LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) signed an altenative chaintip (%s != %s) at height %d, join it\n",
+                                __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc.quorumHash.ToString(), it2->second->blockHash.ToString(), pindex->GetBlockHash().ToString(), pindex->nHeight);
+                        pindex = shareBlockIndex;
+                    } else if (attempt <= i) {
+                        // previous quorum signed some different hash we have no idea about, bail out for now
+                        LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) signed an unknown or an invalid blockHash (%s != %s) at height %d\n",
+                                __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc.quorumHash.ToString(), it2->second->blockHash.ToString(), pindex->GetBlockHash().ToString(), pindex->nHeight);
+                        return;
+                    }
+                    // else
+                    // waiting the unknown/invalid hash for too long already,
+                    // just sign whatever we think is a good tip
+                }
+            }
+            LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- use quorum (%d, %s) and try to sign %s at height %d\n",
+                    __func__, nQuorumIndex, quorums_scanned[nQuorumIndex]->qc.quorumHash.ToString(), pindex->GetBlockHash().ToString(), pindex->nHeight);
             uint256 requestId = ::SerializeHash(std::make_tuple(CLSIG_REQUESTID_PREFIX, pindex->nHeight, quorum->qc.quorumHash));
             {
                 LOCK(cs);
@@ -676,7 +739,11 @@ void CChainLocksHandler::TrySignChainTip()
                 mapSignedRequestIds.emplace(requestId, std::make_pair(pindex->nHeight, pindex->GetBlockHash()));
             }
             quorumSigningManager->AsyncSignIfMember(llmqType, requestId, pindex->GetBlockHash(), quorum->qc.quorumHash);
+        }
+        if (!fMemberOfSomeQuorum || attempt >= quorums_scanned.size()) {
+            // not a member or tried too many times, nothing to do
             lastSignedHeight = pindex->nHeight;
+            attempt = attempt_start;
         }
     } else {
         // Use single ChainLocks quorum

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -208,6 +208,19 @@ bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const 
                 __func__, clsig.ToString(), requestId.ToString(), signHash.ToString());
 
         if (clsig.sig.VerifyInsecure(quorum->qc.quorumPublicKey, signHash)) {
+            if (idIn.IsNull() && !quorumSigningManager->HasRecoveredSigForId(llmqType, requestId)) {
+                // We can reconstruct the CRecoveredSig from the clsig and pass it to the signing manager, which
+                // avoids unnecessary double-verification of the signature. We can do this here because we just
+                // verified the sig.
+                std::shared_ptr<CRecoveredSig> rs = std::make_shared<CRecoveredSig>();
+                rs->llmqType = llmqType;
+                rs->quorumHash = quorum->qc.quorumHash;
+                rs->id = requestId;
+                rs->msgHash = clsig.blockHash;
+                rs->sig.Set(clsig.sig);
+                rs->UpdateHash();
+                quorumSigningManager->PushReconstructedRecoveredSig(rs);
+            }
             ret = std::make_pair(i, quorum);
             return true;
         }
@@ -426,6 +439,20 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, CChainLockSig& c
                 Misbehaving(from, 10);
             }
             return;
+        }
+
+        if (idIn.IsNull() && !quorumSigningManager->HasRecoveredSigForId(llmqType, requestId)) {
+            // We can reconstruct the CRecoveredSig from the clsig and pass it to the signing manager, which
+            // avoids unnecessary double-verification of the signature. We can do this here because we just
+            // verified the sig.
+            std::shared_ptr<CRecoveredSig> rs = std::make_shared<CRecoveredSig>();
+            rs->llmqType = llmqType;
+            rs->quorumHash = quorum->qc.quorumHash;
+            rs->id = requestId;
+            rs->msgHash = clsig.blockHash;
+            rs->sig.Set(clsig.sig);
+            rs->UpdateHash();
+            quorumSigningManager->PushReconstructedRecoveredSig(rs);
         }
 
         {

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -74,19 +74,53 @@ bool CChainLocksHandler::GetChainLockByHash(const uint256& hash, llmq::CChainLoc
 {
     LOCK(cs);
 
-    if (hash != bestChainLockHash) {
-        // we only propagate the best one and ditch all the old ones
-        return false;
+    if (::SerializeHash(mostRecentChainLockShare) == hash) {
+        ret = mostRecentChainLockShare;
+        return true;
     }
 
-    ret = bestChainLock;
-    return true;
+    if (::SerializeHash(bestChainLockWithKnownBlock) == hash) {
+        ret = bestChainLockWithKnownBlock;
+        return true;
+    }
+
+    for (const auto& pair : bestChainLockCandidates) {
+        if (::SerializeHash(*pair.second) == hash) {
+            ret = *pair.second;
+            return true;
+        }
+    }
+
+    return false;
 }
 
-CChainLockSig CChainLocksHandler::GetBestChainLock()
+const CChainLockSig CChainLocksHandler::GetMostRecentChainLock()
 {
     LOCK(cs);
-    return bestChainLock;
+    return mostRecentChainLockShare;
+}
+
+const CChainLockSig CChainLocksHandler::GetBestChainLock()
+{
+    LOCK(cs);
+    return bestChainLockWithKnownBlock;
+}
+
+void CChainLocksHandler::TryUpdateBestChainLock(const CBlockIndex* pindex)
+{
+    AssertLockHeld(cs);
+
+    if (pindex == nullptr || pindex->nHeight <= bestChainLockWithKnownBlock.nHeight) {
+        return;
+    }
+
+    auto it1 = bestChainLockCandidates.find(pindex->nHeight);
+    if (it1 != bestChainLockCandidates.end()) {
+        bestChainLockWithKnownBlock = *it1->second;
+        bestChainLockBlockIndex = pindex;
+        LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- CLSIG from candidates (%s)\n", __func__, bestChainLockWithKnownBlock.ToString());
+        return;
+    }
 }
 
 void CChainLocksHandler::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
@@ -128,8 +162,40 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CCha
         }
     }
 
-    const uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, clsig.nHeight));
-    if (!quorumSigningManager->VerifyRecoveredSig(Params().GetConsensus().llmqTypeChainLocks, clsig.nHeight, requestId, clsig.blockHash, clsig.sig)) {
+    CBlockIndex* pindexSig;
+    CBlockIndex* pindexScan;
+    {
+        LOCK(cs_main);
+        if (clsig.nHeight > chainActive.Height() + CSigningManager::SIGN_HEIGHT_OFFSET) {
+            // too far into the future
+            LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- future CLSIG (%s), peer=%d\n", __func__, clsig.ToString(), from);
+            return;
+        }
+        pindexSig = pindexScan = LookupBlockIndex(clsig.blockHash);
+        if (pindexScan == nullptr) {
+            // we don't know the block/header for this CLSIG yet, try scanning quorums at chain tip
+            pindexScan = chainActive.Tip();
+        }
+        if (pindexSig != nullptr && pindexSig->nHeight != clsig.nHeight) {
+            // Should not happen
+            LogPrintf("CChainLocksHandler::%s -- height of CLSIG (%s) does not match the expected block's height (%d)\n",
+                    __func__, clsig.ToString(), pindexSig->nHeight);
+            return;
+        }
+    }
+
+    const auto llmqType = Params().GetConsensus().llmqTypeChainLocks;
+
+    uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, clsig.nHeight));
+    auto quorum = CSigningManager::SelectQuorumForSigning(llmqType, requestId, clsig.nHeight);
+    if (quorum == nullptr) {
+        return;
+    }
+    uint256 signHash = CLLMQUtils::BuildSignHash(llmqType, quorum->qc.quorumHash, requestId, clsig.blockHash);
+    LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- CLSIG (%s) requestId=%s, signHash=%s, peer=%d\n",
+            __func__, clsig.ToString(), requestId.ToString(), signHash.ToString(), from);
+
+    if (!clsig.sig.VerifyInsecure(quorum->qc.quorumPublicKey, signHash)) {
         LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- invalid CLSIG (%s), peer=%d\n", __func__, clsig.ToString(), from);
         if (from != -1) {
             LOCK(cs_main);
@@ -138,48 +204,28 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CCha
         return;
     }
 
-    CBlockIndex* pindex;
-    {
-        LOCK(cs_main);
-        pindex = LookupBlockIndex(clsig.blockHash);
-    }
-
     {
         LOCK(cs);
-        bestChainLockHash = hash;
-        bestChainLock = clsig;
-
-        if (pindex != nullptr) {
-
-            if (pindex->nHeight != clsig.nHeight) {
-                // Should not happen, same as the conflict check from above.
-                LogPrintf("CChainLocksHandler::%s -- height of CLSIG (%s) does not match the specified block's height (%d)\n",
-                        __func__, clsig.ToString(), pindex->nHeight);
-                // Note: not relaying clsig here
-                return;
-            }
-
-            bestChainLockWithKnownBlock = bestChainLock;
-            bestChainLockBlockIndex = pindex;
-        }
-        // else if (pindex == nullptr)
-        // Note: make sure to still relay clsig further.
+        bestChainLockCandidates[clsig.nHeight] = std::make_shared<const CChainLockSig>(clsig);
+        mostRecentChainLockShare = clsig;
+        TryUpdateBestChainLock(pindexSig);
     }
-
     // Note: do not hold cs while calling RelayInv
     AssertLockNotHeld(cs);
     g_connman->RelayInv(clsigInv, LLMQS_PROTO_VERSION);
 
-    if (pindex == nullptr) {
+    if (pindexSig == nullptr) {
         // we don't know the block/header for this CLSIG yet, so bail out for now
         // when the block or the header later comes in, we will enforce the correct chain
         return;
     }
 
-    scheduler->scheduleFromNow([&]() {
-        CheckActiveState();
-        EnforceBestChainLock();
-    }, 0);
+    if (bestChainLockBlockIndex == pindexSig) {
+        scheduler->scheduleFromNow([&]() {
+            CheckActiveState();
+            EnforceBestChainLock();
+        }, 0);
+    }
 
     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- processed new CLSIG (%s), peer=%d\n",
               __func__, clsig.ToString(), from);
@@ -189,22 +235,17 @@ void CChainLocksHandler::AcceptedBlockHeader(const CBlockIndex* pindexNew)
 {
     LOCK(cs);
 
-    if (pindexNew->GetBlockHash() == bestChainLock.blockHash) {
-        LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- block header %s came in late, updating and enforcing\n", __func__, pindexNew->GetBlockHash().ToString());
-
-        if (bestChainLock.nHeight != pindexNew->nHeight) {
-            // Should not happen, same as the conflict check from ProcessNewChainLock.
-            LogPrintf("CChainLocksHandler::%s -- height of CLSIG (%s) does not match the specified block's height (%d)\n",
-                      __func__, bestChainLock.ToString(), pindexNew->nHeight);
-            return;
-        }
-
-        // when EnforceBestChainLock is called later, it might end up invalidating other chains but not activating the
-        // CLSIG locked chain. This happens when only the header is known but the block is still missing yet. The usual
-        // block processing logic will handle this when the block arrives
-        bestChainLockWithKnownBlock = bestChainLock;
-        bestChainLockBlockIndex = pindexNew;
+    auto it = bestChainLockCandidates.find(pindexNew->nHeight);
+    if (it == bestChainLockCandidates.end()) {
+        return;
     }
+
+    LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- block header %s came in late, updating and enforcing\n", __func__, pindexNew->GetBlockHash().ToString());
+
+    // when EnforceBestChainLock is called later, it might end up invalidating other chains but not activating the
+    // CLSIG locked chain. This happens when only the header is known but the block is still missing yet. The usual
+    // block processing logic will handle this when the block arrives
+    TryUpdateBestChainLock(pindexNew);
 }
 
 void CChainLocksHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
@@ -243,14 +284,16 @@ void CChainLocksHandler::CheckActiveState()
         // ChainLocks got activated just recently, but it's possible that it was already running before, leaving
         // us with some stale values which we should not try to enforce anymore (there probably was a good reason
         // to disable spork19)
-        bestChainLockHash = uint256();
-        bestChainLock = bestChainLockWithKnownBlock = CChainLockSig();
+        mostRecentChainLockShare = bestChainLockWithKnownBlock = CChainLockSig();
         bestChainLockBlockIndex = lastNotifyChainLockBlockIndex = nullptr;
+        bestChainLockCandidates.clear();
     }
 }
 
 void CChainLocksHandler::TrySignChainTip()
 {
+    static int lastSignedHeight{-1};
+
     Cleanup();
 
     if (!fMasternodeMode) {
@@ -348,21 +391,20 @@ void CChainLocksHandler::TrySignChainTip()
         }
     }
 
-    uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, pindex->nHeight));
-    uint256 msgHash = pindex->GetBlockHash();
+    const auto llmqType = Params().GetConsensus().llmqTypeChainLocks;
+    mapSignedRequestIds.clear();
 
+    uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, pindex->nHeight));
     {
         LOCK(cs);
         if (bestChainLockWithKnownBlock.nHeight >= pindex->nHeight) {
             // might have happened while we didn't hold cs
             return;
         }
-        lastSignedHeight = pindex->nHeight;
-        lastSignedRequestId = requestId;
-        lastSignedMsgHash = msgHash;
+        mapSignedRequestIds.emplace(requestId, std::make_pair(pindex->nHeight, pindex->GetBlockHash()));
     }
-
-    quorumSigningManager->AsyncSignIfMember(Params().GetConsensus().llmqTypeChainLocks, requestId, msgHash);
+    quorumSigningManager->AsyncSignIfMember(llmqType, requestId, pindex->GetBlockHash());
+    lastSignedHeight = pindex->nHeight;
 }
 
 void CChainLocksHandler::TransactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime)
@@ -583,18 +625,20 @@ void CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recove
             return;
         }
 
-        if (recoveredSig.id != lastSignedRequestId || recoveredSig.msgHash != lastSignedMsgHash) {
+        auto it = mapSignedRequestIds.find(recoveredSig.id);
+        if (it == mapSignedRequestIds.end() || recoveredSig.msgHash != it->second.second) {
             // this is not what we signed, so lets not create a CLSIG for it
             return;
         }
-        if (bestChainLockWithKnownBlock.nHeight >= lastSignedHeight) {
+        if (bestChainLockWithKnownBlock.nHeight >= it->second.first) {
             // already got the same or a better CLSIG through the CLSIG message
             return;
         }
 
-        clsig.nHeight = lastSignedHeight;
-        clsig.blockHash = lastSignedMsgHash;
+        clsig.nHeight = it->second.first;
+        clsig.blockHash = it->second.second;
         clsig.sig = recoveredSig.sig.Get();
+        mapSignedRequestIds.erase(recoveredSig.id);
     }
     ProcessNewChainLock(-1, clsig, ::SerializeHash(clsig));
 }
@@ -714,6 +758,16 @@ void CChainLocksHandler::Cleanup()
             }
         } else {
             ++it;
+        }
+    }
+
+    if (bestChainLockBlockIndex != nullptr) {
+        for (auto it = bestChainLockCandidates.begin(); it != bestChainLockCandidates.end(); ) {
+            if (it->first == bestChainLockBlockIndex->nHeight) {
+                it = bestChainLockCandidates.erase(++it, bestChainLockCandidates.end());
+            } else {
+                ++it;
+            }
         }
     }
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -40,7 +40,13 @@ public:
         READWRITE(nHeight);
         READWRITE(blockHash);
         READWRITE(sig);
-        if (!(s.GetType() & SER_GETHASH) && (s.GetVersion() >= MULTI_QUORUM_CHAINLOCKS_VERSION)) {
+        if (s.GetVersion() >= MULTI_QUORUM_CHAINLOCKS_VERSION) {
+            if ((s.GetType() & SER_GETHASH) && !ser_action.ForRead()) {
+                size_t signers_count = std::count(signers.begin(), signers.end(), true);
+                if (signers.empty() || signers_count == 0) {
+                    return;
+                }
+            }
             READWRITE(DYNBITSET(signers));
         }
     }

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -105,6 +105,7 @@ public:
     bool GetChainLockByHash(const uint256& hash, CChainLockSig& ret);
     const CChainLockSig GetMostRecentChainLock();
     const CChainLockSig GetBestChainLock();
+    const std::map<CQuorumCPtr, CChainLockSigCPtr> GetBestChainLockShares();
 
     void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
     void ProcessNewChainLock(NodeId from, CChainLockSig& clsig, const uint256& hash, const uint256& idIn = uint256());

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -127,6 +127,7 @@ class CSigningManager
 {
     friend class CSigSharesManager;
 
+public:
     // when selecting a quorum for signing and verification, we use CQuorumManager::SelectQuorum with this offset as
     // starting height for scanning. This is because otherwise the resulting signatures would not be verifiable by nodes
     // which are not 100% at the chain tip.

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -75,6 +75,7 @@ const char *QSIGSHARE="qsigshare";
 const char* QGETDATA = "qgetdata";
 const char* QDATA = "qdata";
 const char *CLSIG="clsig";
+const char *CLSIGMQ="clsigmq";
 const char *ISLOCK="islock";
 const char *MNAUTH="mnauth";
 }; // namespace NetMsgType
@@ -144,6 +145,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::QGETDATA,
     NetMsgType::QDATA,
     NetMsgType::CLSIG,
+    NetMsgType::CLSIGMQ,
     NetMsgType::ISLOCK,
     NetMsgType::MNAUTH,
 };
@@ -269,6 +271,7 @@ const char* CInv::GetCommandInternal() const
         case MSG_QUORUM_PREMATURE_COMMITMENT:   return NetMsgType::QPCOMMITMENT;
         case MSG_QUORUM_RECOVERED_SIG:          return NetMsgType::QSIGREC;
         case MSG_CLSIG:                         return NetMsgType::CLSIG;
+        case MSG_CLSIGMQ:                       return NetMsgType::CLSIGMQ;
         case MSG_ISLOCK:                        return NetMsgType::ISLOCK;
         default:
             return nullptr;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -271,6 +271,7 @@ extern const char *QSIGSHARE;
 extern const char* QGETDATA;
 extern const char* QDATA;
 extern const char *CLSIG;
+extern const char *CLSIGMQ;
 extern const char *ISLOCK;
 extern const char *MNAUTH;
 };
@@ -425,6 +426,7 @@ enum GetDataMsg {
     MSG_QUORUM_RECOVERED_SIG = 28,
     MSG_CLSIG = 29,
     MSG_ISLOCK = 30,
+    MSG_CLSIGMQ = 31,
 };
 
 /** inv message data */

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -231,7 +231,7 @@ UniValue getbestchainlock(const JSONRPCRequest& request)
         );
     UniValue result(UniValue::VOBJ);
 
-    llmq::CChainLockSig clsig = llmq::chainLocksHandler->GetBestChainLock();
+    llmq::CChainLockSig clsig = llmq::chainLocksHandler->GetMostRecentChainLock();
     if (clsig.IsNull()) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to find any chainlock");
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -241,6 +241,97 @@ UniValue getbestchainlock(const JSONRPCRequest& request)
 
     LOCK(cs_main);
     result.pushKV("known_block", mapBlockIndex.count(clsig.blockHash) > 0);
+
+    return result;
+}
+
+UniValue getchainlocks(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0) {
+        throw std::runtime_error(
+            "getchainlocks\n"
+            "\nReturns information about the active and the most recent chainlocks.\n"
+            "The active chainlock is the one that has enough signatures and the block\n"
+            "it tries to lock is known by our node. The recent chainlock might not have\n"
+            "enough signatures or its block might not be known by our node yet.\n"
+            "Throws an error if there is no known chainlock yet.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"recent_chainlock\" : {       (object)\n"
+            "    \"blockhash\" : \"hash\",      (string) The block hash hex encoded\n"
+            "    \"height\" : n,              (numeric) The block height or index\n"
+            "    \"signature\" : \"hash\",      (string) The chainlock's BLS signature.\n"
+            "    \"known_block\" : true|false (boolean) True if the block is known by our node\n"
+            "  },\n"
+            "  \"active_chainlock\" : {       (object) Only shown when Multi-Quorum ChainLocks are enabled\n"
+            "    \"blockhash\" : \"hash\",      (string) The block hash hex encoded\n"
+            "    \"height\" : n,              (numeric) The block height or index\n"
+            "    \"signers\" : \"hex\",         (string) The hex representation of a combined signer index\n"
+            "    \"signature\" : \"hash\",      (string) The chainlock's BLS aggregated signature\n"
+            "    \"shares\" : [               (array) The chainlock's BLS signatures produced by various quorums\n"
+            "      {\n"
+            "        \"quorumHash\" : \"hash\", (string) The quorum voted for this chainlock\n"
+            "        \"signers\" : \"hex\",     (string) The hex representation of the quorum signer index\n"
+            "        \"signature\" : \"hex\",   (string) The chainlock's BLS signature produced by that quorum\n"
+            "      }\n"
+            "    ... ],\n"
+            "  }\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getchainlocks", "")
+            + HelpExampleRpc("getchainlocks", "")
+        );
+    }
+
+    UniValue result(UniValue::VOBJ);
+    UniValue recentChainlock(UniValue::VOBJ);
+    UniValue activeChainlock(UniValue::VOBJ);
+    UniValue activeChainlockShares(UniValue::VARR);
+
+    llmq::CChainLockSig clsig = llmq::chainLocksHandler->GetMostRecentChainLock();
+    if (clsig.IsNull()) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to find any chainlock");
+    }
+    recentChainlock.pushKV("blockhash", clsig.blockHash.GetHex());
+    recentChainlock.pushKV("height", clsig.nHeight);
+    recentChainlock.pushKV("signature", clsig.sig.ToString());
+
+    {
+        LOCK(cs_main);
+        recentChainlock.pushKV("known_block", mapBlockIndex.count(clsig.blockHash) > 0);
+    }
+    result.pushKV("recent_chainlock", recentChainlock);
+
+    clsig = llmq::chainLocksHandler->GetBestChainLock();
+
+    if (clsig.IsNull()) {
+        activeChainlock.pushKV("shares", activeChainlockShares);
+        result.pushKV("active_chainlock", activeChainlock);
+        return result;
+    }
+
+    activeChainlock.pushKV("blockhash", clsig.blockHash.GetHex());
+    activeChainlock.pushKV("height", clsig.nHeight);
+    activeChainlock.pushKV("signers", llmq::CLLMQUtils::ToHexStr(clsig.signers));
+    activeChainlock.pushKV("signature", clsig.sig.ToString());
+
+    const auto& clsigsShares = llmq::chainLocksHandler->GetBestChainLockShares();
+    if (clsigsShares.empty()) {
+        activeChainlock.pushKV("shares", activeChainlockShares);
+        result.pushKV("active_chainlock", activeChainlock);
+        return result;
+    }
+
+    for (const auto& pair : clsigsShares) {
+        UniValue sig(UniValue::VOBJ);
+        sig.pushKV("quorumHash", pair.first->qc.quorumHash.GetHex());
+        sig.pushKV("signers", llmq::CLLMQUtils::ToHexStr(pair.second->signers));
+        sig.pushKV("signature", pair.second->sig.ToString());
+        activeChainlockShares.push_back(sig);
+    }
+    activeChainlock.pushKV("shares", activeChainlockShares);
+    result.pushKV("active_chainlock", activeChainlock);
+
     return result;
 }
 
@@ -2238,6 +2329,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "getblockheaders",        &getblockheaders,        {"blockhash","count","verbose"} },
     { "blockchain",         "getmerkleblocks",        &getmerkleblocks,        {"filter","blockhash","count"} },
     { "blockchain",         "getchaintips",           &getchaintips,           {"count","branchlen"} },
+    { "blockchain",         "getchainlocks",          &getchainlocks,          {} },
     { "blockchain",         "getdifficulty",          &getdifficulty,          {} },
     { "blockchain",         "getmempoolancestors",    &getmempoolancestors,    {"txid","verbose"} },
     { "blockchain",         "getmempooldescendants",  &getmempooldescendants,  {"txid","verbose"} },

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -32,8 +32,12 @@
 #include <evo/specialtx.h>
 #include <evo/cbtx.h>
 
+#include <llmq/quorums.h>
 #include <llmq/quorums_chainlocks.h>
+#include <llmq/quorums_commitment.h>
 #include <llmq/quorums_instantsend.h>
+#include <llmq/quorums_signing.h>
+#include <llmq/quorums_utils.h>
 
 #include <stdint.h>
 
@@ -335,7 +339,7 @@ UniValue getchainlocks(const JSONRPCRequest& request)
 
     for (const auto& pair : clsigsShares) {
         UniValue sig(UniValue::VOBJ);
-        sig.pushKV("quorumHash", pair.first->qc.quorumHash.GetHex());
+        sig.pushKV("quorumHash", pair.first->qc->quorumHash.GetHex());
         sig.pushKV("signers", llmq::CLLMQUtils::ToHexStr(pair.second->signers));
         sig.pushKV("signature", pair.second->sig.ToString());
         activeChainlockShares.push_back(sig);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -265,12 +265,14 @@ UniValue getchainlocks(const JSONRPCRequest& request)
             "\nResult:\n"
             "{\n"
             "  \"recent_chainlock\" : {       (object)\n"
+            "    \"version\" : n,             (numeric) The chainlock's version\n"
             "    \"blockhash\" : \"hash\",      (string) The block hash hex encoded\n"
             "    \"height\" : n,              (numeric) The block height or index\n"
             "    \"signature\" : \"hash\",      (string) The chainlock's BLS signature.\n"
             "    \"known_block\" : true|false (boolean) True if the block is known by our node\n"
             "  },\n"
             "  \"active_chainlock\" : {       (object) Only shown when Multi-Quorum ChainLocks are enabled\n"
+            "    \"version\" : n,             (numeric) The chainlock's version\n"
             "    \"blockhash\" : \"hash\",      (string) The block hash hex encoded\n"
             "    \"height\" : n,              (numeric) The block height or index\n"
             "    \"signers\" : \"hex\",         (string) The hex representation of a combined signer index\n"
@@ -299,6 +301,7 @@ UniValue getchainlocks(const JSONRPCRequest& request)
     if (clsig.IsNull()) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to find any chainlock");
     }
+    recentChainlock.pushKV("version", clsig.nVersion);
     recentChainlock.pushKV("blockhash", clsig.blockHash.GetHex());
     recentChainlock.pushKV("height", clsig.nHeight);
     recentChainlock.pushKV("signature", clsig.sig.ToString());
@@ -317,6 +320,7 @@ UniValue getchainlocks(const JSONRPCRequest& request)
         return result;
     }
 
+    activeChainlock.pushKV("version", clsig.nVersion);
     activeChainlock.pushKV("blockhash", clsig.blockHash.GetHex());
     activeChainlock.pushKV("height", clsig.nHeight);
     activeChainlock.pushKV("signers", llmq::CLLMQUtils::ToHexStr(clsig.signers));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -217,7 +217,7 @@ UniValue getbestchainlock(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
             "getbestchainlock\n"
-            "\nReturns information about the best chainlock. Throws an error if there is no known chainlock yet."
+            "\nDEPRECATED. Returns information about the best chainlock. Throws an error if there is no known chainlock yet."
             "\nResult:\n"
             "{\n"
             "  \"blockhash\" : \"hash\",      (string) The block hash hex encoded\n"
@@ -229,6 +229,13 @@ UniValue getbestchainlock(const JSONRPCRequest& request)
             + HelpExampleCli("getbestchainlock", "")
             + HelpExampleRpc("getbestchainlock", "")
         );
+
+    if (!IsDeprecatedRPCEnabled("getbestchainlock")) {
+        throw JSONRPCError(RPC_METHOD_DEPRECATED, "getbestchainlock is deprecated and will be fully removed in v0.18. "
+            "To use getbestchainlock in v0.17, restart dashd with -deprecatedrpc=getbestchainlock.\n"
+            "Projects should transition to using getchainlocks before upgrading to v0.18");
+    }
+
     UniValue result(UniValue::VOBJ);
 
     llmq::CChainLockSig clsig = llmq::chainLocksHandler->GetMostRecentChainLock();

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -269,6 +269,7 @@ void CRPCTable::InitPlatformRestrictions()
         {"getblockhash", {}},
         {"getblockcount", {}},
         {"getbestchainlock", {}},
+        {"getchainlocks", {}},
         {"quorum", {"sign", Params().GetConsensus().llmqTypePlatform}},
         {"quorum", {"verify"}},
         {"verifyislock", {}},

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70219;
+static const int PROTOCOL_VERSION = 70220;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -20,7 +20,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION = 70213;
 
 //! minimum proto version of masternode to accept in DKGs
-static const int MIN_MASTERNODE_PROTO_VERSION = 70219;
+static const int MIN_MASTERNODE_PROTO_VERSION = 70220;
 
 //! minimum proto version for governance sync and messages
 static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70213;

--- a/src/version.h
+++ b/src/version.h
@@ -48,4 +48,7 @@ static const int MNAUTH_NODE_VER_VERSION = 70218;
 //! introduction of QGETDATA/QDATA messages
 static const int LLMQ_DATA_MESSAGES_VERSION = 70219;
 
+//! introduction of Multi-Quorum ChainLocks
+static const int MULTI_QUORUM_CHAINLOCKS_VERSION = 70220;
+
 #endif // BITCOIN_VERSION_H

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -36,7 +36,7 @@ class TestP2PConn(P2PInterface):
 
 class LLMQCoinbaseCommitmentsTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
+        self.set_dash_test_params(4, 3, extra_args=[["-vbparams=v17:999999999999:999999999999"]] * 4, fast_dip3_enforcement=True)
 
     def run_test(self):
         self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
@@ -108,25 +108,38 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         # Verify that the second quorum appears in MNLISTDIFF
         expectedDeleted = []
         expectedNew = [QuorumId(100, int(second_quorum, 16))]
-        quorums_before_third = self.test_getmnlistdiff_quorums(baseBlockHash, self.nodes[0].getbestblockhash(), quorumList, expectedDeleted, expectedNew)
-        block_before_third = self.nodes[0].getbestblockhash()
+        quorumList = self.test_getmnlistdiff_quorums(baseBlockHash, self.nodes[0].getbestblockhash(), quorumList, expectedDeleted, expectedNew)
+        baseBlockHash = self.nodes[0].getbestblockhash()
 
         third_quorum = self.mine_quorum()
-
-        # Verify that the first quorum is deleted and the third quorum is added in MNLISTDIFF (the first got inactive)
-        expectedDeleted = [QuorumId(100, int(first_quorum, 16))]
-        expectedNew = [QuorumId(100, int(third_quorum, 16))]
-        self.test_getmnlistdiff_quorums(block_before_third, self.nodes[0].getbestblockhash(), quorums_before_third, expectedDeleted, expectedNew)
-
-        # Verify that the diff between genesis and best block is the current active set (second and third quorum)
         expectedDeleted = []
-        expectedNew = [QuorumId(100, int(second_quorum, 16)), QuorumId(100, int(third_quorum, 16))]
+        expectedNew = [QuorumId(100, int(third_quorum, 16))]
+        quorumList = self.test_getmnlistdiff_quorums(baseBlockHash, self.nodes[0].getbestblockhash(), quorumList, expectedDeleted, expectedNew)
+        baseBlockHash = self.nodes[0].getbestblockhash()
+
+        fourth_quorum = self.mine_quorum()
+        expectedDeleted = []
+        expectedNew = [QuorumId(100, int(fourth_quorum, 16))]
+
+        quorums_before_fifth = self.test_getmnlistdiff_quorums(baseBlockHash, self.nodes[0].getbestblockhash(), quorumList, expectedDeleted, expectedNew)
+        block_before_fifth = self.nodes[0].getbestblockhash()
+
+        fifth_quorum = self.mine_quorum()
+
+        # Verify that the first quorum is deleted and the fifth quorum is added in MNLISTDIFF (the first got inactive)
+        expectedDeleted = [QuorumId(100, int(first_quorum, 16))]
+        expectedNew = [QuorumId(100, int(fifth_quorum, 16))]
+        self.test_getmnlistdiff_quorums(block_before_fifth, self.nodes[0].getbestblockhash(), quorums_before_fifth, expectedDeleted, expectedNew)
+
+        # Verify that the diff between genesis and best block is the current active set (second and fifth quorum)
+        expectedDeleted = []
+        expectedNew = [QuorumId(100, int(second_quorum, 16)), QuorumId(100, int(third_quorum, 16)), QuorumId(100, int(fourth_quorum, 16)), QuorumId(100, int(fifth_quorum, 16))]
         self.test_getmnlistdiff_quorums(null_hash, self.nodes[0].getbestblockhash(), {}, expectedDeleted, expectedNew)
 
-        # Now verify that diffs are correct around the block that mined the third quorum.
+        # Now verify that diffs are correct around the block that mined the fifth quorum.
         # This tests the logic in CalcCbTxMerkleRootQuorums, which has to manually add the commitment from the current
         # block
-        mined_in_block = self.nodes[0].quorum("info", 100, third_quorum)["minedBlock"]
+        mined_in_block = self.nodes[0].quorum("info", 100, fifth_quorum)["minedBlock"]
         prev_block = self.nodes[0].getblock(mined_in_block)["previousblockhash"]
         prev_block2 = self.nodes[0].getblock(prev_block)["previousblockhash"]
         next_block = self.nodes[0].getblock(mined_in_block)["nextblockhash"]
@@ -134,27 +147,27 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         # The 2 block before the quorum was mined should both give an empty diff
         expectedDeleted = []
         expectedNew = []
-        self.test_getmnlistdiff_quorums(block_before_third, prev_block2, quorums_before_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(block_before_third, prev_block, quorums_before_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(block_before_fifth, prev_block2, quorums_before_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(block_before_fifth, prev_block, quorums_before_fifth, expectedDeleted, expectedNew)
         # The block in which the quorum was mined and the 2 after that should all give the same diff
         expectedDeleted = [QuorumId(100, int(first_quorum, 16))]
-        expectedNew = [QuorumId(100, int(third_quorum, 16))]
-        quorums_with_third = self.test_getmnlistdiff_quorums(block_before_third, mined_in_block, quorums_before_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(block_before_third, next_block, quorums_before_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(block_before_third, next_block2, quorums_before_third, expectedDeleted, expectedNew)
+        expectedNew = [QuorumId(100, int(fifth_quorum, 16))]
+        quorums_with_fifth = self.test_getmnlistdiff_quorums(block_before_fifth, mined_in_block, quorums_before_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(block_before_fifth, next_block, quorums_before_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(block_before_fifth, next_block2, quorums_before_fifth, expectedDeleted, expectedNew)
         # A diff between the two block that happened after the quorum was mined should give an empty diff
         expectedDeleted = []
         expectedNew = []
-        self.test_getmnlistdiff_quorums(mined_in_block, next_block, quorums_with_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(mined_in_block, next_block2, quorums_with_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(next_block, next_block2, quorums_with_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(mined_in_block, next_block, quorums_with_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(mined_in_block, next_block2, quorums_with_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(next_block, next_block2, quorums_with_fifth, expectedDeleted, expectedNew)
 
         # Using the same block for baseBlockHash and blockHash should give empty diffs
-        self.test_getmnlistdiff_quorums(prev_block, prev_block, quorums_before_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(prev_block2, prev_block2, quorums_before_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(mined_in_block, mined_in_block, quorums_with_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(next_block, next_block, quorums_with_third, expectedDeleted, expectedNew)
-        self.test_getmnlistdiff_quorums(next_block2, next_block2, quorums_with_third, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(prev_block, prev_block, quorums_before_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(prev_block2, prev_block2, quorums_before_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(mined_in_block, mined_in_block, quorums_with_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(next_block, next_block, quorums_with_fifth, expectedDeleted, expectedNew)
+        self.test_getmnlistdiff_quorums(next_block2, next_block2, quorums_with_fifth, expectedDeleted, expectedNew)
 
 
     def test_getmnlistdiff(self, baseBlockHash, blockHash, baseMNList, expectedDeleted, expectedUpdated):

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -60,6 +60,20 @@ class LLMQChainLocksTest(DashTestFramework):
         for i in range(4):
             self.mine_quorum()
 
+        self.test_steps(False)
+        self.test_steps(True)
+
+    def test_steps(self, multi_quorum):
+        self.bump_mocktime(1)
+        if multi_quorum:
+            self.log.info("Testing multi-quorum ChainLocks")
+            self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 1)
+            self.wait_for_sporks_same()
+        else:
+            self.log.info("Testing single-quorum ChainLocks")
+            self.nodes[0].spork("SPORK_19_CHAINLOCKS_ENABLED", 0)
+            self.wait_for_sporks_same()
+
         self.log.info("Mine single block, wait for chainlock")
         self.nodes[0].generate(1)
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
@@ -184,22 +198,36 @@ class LLMQChainLocksTest(DashTestFramework):
         p2p_node = self.nodes[0].add_p2p_connection(TestP2PConn())
         network_thread_start()
         p2p_node.wait_for_verack()
-        self.log.info("Should accept fake clsig but won't sign the same height twice (normally)")
-        fake_clsig1, fake_block_hash1 = self.create_fake_clsig(1)
+        if multi_quorum:
+            self.log.info("Should accept fake clsig but other quorums should sign the actual block on the same height and override the malicious one")
+        else:
+            self.log.info("Should accept fake clsig but won't sign the same height twice (normally)")
+        fake_clsig1, fake_block_hash1 = self.create_fake_clsig(1, multi_quorum)
         p2p_node.send_clsig(fake_clsig1)
         for node in self.nodes:
             self.wait_for_best_chainlock(node, fake_block_hash1, timeout=5)
         tip = self.nodes[0].generate(1)[-1]
-        for node in self.nodes:
-            self.wait_for_chainlocked_block(node, tip, expected=False, timeout=5)
+        if multi_quorum:
+            # Honest nodes win
+            self.wait_for_chainlocked_block_all_nodes(tip, timeout=5)
+        else:
+            # No new clsig for the same height
+            time.sleep(5)
+            for node in self.nodes:
+                assert(self.nodes[0].getchainlocks()["recent_chainlock"]["blockhash"] != tip)
         self.log.info("Shouldn't accept fake clsig for 'tip + SIGN_HEIGHT_OFFSET + 1' block height")
-        fake_clsig2, fake_block_hash2 = self.create_fake_clsig(SIGN_HEIGHT_OFFSET + 1)
+        fake_clsig2, fake_block_hash2 = self.create_fake_clsig(SIGN_HEIGHT_OFFSET + 1, multi_quorum)
         p2p_node.send_clsig(fake_clsig2)
-        time.sleep(5)
-        # Note: fake_block_hash1 is a blockhash for the fake_clsig1 we accepted initially, not for the new fake_clsig2
-        assert(self.nodes[0].getbestchainlock()["blockhash"] == fake_block_hash1)
+        if multi_quorum:
+            time.sleep(5)
+            for node in self.nodes:
+                assert(node.getchainlocks()["recent_chainlock"]["blockhash"] == tip)
+                assert(node.getchainlocks()["active_chainlock"]["blockhash"] == tip)
+        else:
+            # Note: fake_block_hash1 is a blockhash for the fake_clsig1 we accepted initially, not for the new fake_clsig2
+            assert(self.nodes[0].getchainlocks()["recent_chainlock"]["blockhash"] == fake_block_hash1)
         self.log.info("Should accept fake clsig for 'tip + SIGN_HEIGHT_OFFSET' but new clsigs should still be formed")
-        fake_clsig3, fake_block_hash3 = self.create_fake_clsig(SIGN_HEIGHT_OFFSET)
+        fake_clsig3, fake_block_hash3 = self.create_fake_clsig(SIGN_HEIGHT_OFFSET, multi_quorum)
         p2p_node.send_clsig(fake_clsig3)
         for node in self.nodes:
             self.wait_for_best_chainlock(node, fake_block_hash3, timeout=5)
@@ -208,15 +236,18 @@ class LLMQChainLocksTest(DashTestFramework):
         self.nodes[0].disconnect_p2ps()
         network_thread_join()
 
-    def create_fake_clsig(self, height_offset):
+    def create_fake_clsig(self, height_offset, multi_quorum):
         # create a fake block height_offset blocks ahead of the tip
         height = self.nodes[0].getblockcount() + height_offset
         fake_block = create_block(0xff, create_coinbase(height, dip4_activated=True))
         # create a fake clsig for that block
+        quorum_hash = self.nodes[0].quorum('list', 1)["llmq_test"][0]
         request_id_buf = ser_string(b"clsig") + struct.pack("<I", height)
+        if multi_quorum:
+            request_id_buf += hex_str_to_bytes(quorum_hash)[::-1]
         request_id = hash256(request_id_buf)[::-1].hex()
         for mn in self.mninfo:
-            mn.node.quorum('sign', 100, request_id, fake_block.hash)
+            mn.node.quorum('sign', 100, request_id, fake_block.hash, quorum_hash if multi_quorum else None)
         rec_sig = self.get_recovered_sig(request_id, fake_block.hash)
         fake_clsig = msg_clsig(height, fake_block.sha256, hex_str_to_bytes(rec_sig['sig']))
         return fake_clsig, fake_block.hash

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -249,7 +249,7 @@ class LLMQChainLocksTest(DashTestFramework):
         for mn in self.mninfo:
             mn.node.quorum('sign', 100, request_id, fake_block.hash, quorum_hash if multi_quorum else None)
         rec_sig = self.get_recovered_sig(request_id, fake_block.hash)
-        fake_clsig = msg_clsig(height, fake_block.sha256, hex_str_to_bytes(rec_sig['sig']))
+        fake_clsig = msg_clsig(height, fake_block.sha256, hex_str_to_bytes(rec_sig['sig']), [1,0,0,0] if multi_quorum else [])
         return fake_clsig, fake_block.hash
 
     def create_chained_txs(self, node, amount):

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -205,7 +205,7 @@ class LLMQChainLocksTest(DashTestFramework):
         fake_clsig1, fake_block_hash1 = self.create_fake_clsig(1, multi_quorum)
         p2p_node.send_clsig(fake_clsig1)
         for node in self.nodes:
-            self.wait_for_best_chainlock(node, fake_block_hash1, timeout=5)
+            self.wait_for_most_recent_chainlock(node, fake_block_hash1, timeout=5)
         tip = self.nodes[0].generate(1)[-1]
         if multi_quorum:
             # Honest nodes win
@@ -230,7 +230,7 @@ class LLMQChainLocksTest(DashTestFramework):
         fake_clsig3, fake_block_hash3 = self.create_fake_clsig(SIGN_HEIGHT_OFFSET, multi_quorum)
         p2p_node.send_clsig(fake_clsig3)
         for node in self.nodes:
-            self.wait_for_best_chainlock(node, fake_block_hash3, timeout=5)
+            self.wait_for_most_recent_chainlock(node, fake_block_hash3, timeout=5)
         tip = self.nodes[0].generate(1)[-1]
         self.wait_for_chainlocked_block_all_nodes(tip, timeout=5)
         self.nodes[0].disconnect_p2ps()

--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -115,7 +115,7 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
         self.test_node.send_clsig(cl)
 
         for node in self.nodes:
-            self.wait_for_best_chainlock(node, block.hash)
+            self.wait_for_most_recent_chainlock(node, block.hash)
 
         self.sync_blocks()
 

--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -129,6 +129,10 @@ class LLMQSigningTest(DashTestFramework):
         self.mine_quorum()
         assert_sigs_nochange(True, False, True, 3)
 
+        # Mine 2 more quorums, so that we have a full set
+        self.mine_quorum()
+        self.mine_quorum()
+
         # Create a recovered sig for the oldest quorum i.e. the active quorum which will be moved
         # out of the active set when a new quorum appears
         request_id = 2

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -199,7 +199,7 @@ class DashZMQTest (DashTestFramework):
         # Generate ChainLock
         generated_hash = self.nodes[0].generate(1)[0]
         self.wait_for_chainlocked_block_all_nodes(generated_hash)
-        rpc_best_chain_lock = self.nodes[0].getbestchainlock()
+        rpc_best_chain_lock = self.nodes[0].getchainlocks()["recent_chainlock"]
         rpc_best_chain_lock_hash = rpc_best_chain_lock["blockhash"]
         rpc_best_chain_lock_sig = rpc_best_chain_lock["signature"]
         assert_equal(generated_hash, rpc_best_chain_lock_hash)

--- a/test/functional/rpc_platform_filter.py
+++ b/test/functional/rpc_platform_filter.py
@@ -56,6 +56,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
                        "getblockhash",
                        "getblockcount",
                        "getbestchainlock",
+                       "getchainlocks",
                        "quorum",
                        "verifyislock"]
 
@@ -83,6 +84,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
         test_command("getblockhash", [0], rpcuser_authpair_platform, 200)
         test_command("getblockcount", [], rpcuser_authpair_platform, 200)
         test_command("getbestchainlock", [], rpcuser_authpair_platform, 500)
+        test_command("getchainlocks", [], rpcuser_authpair_platform, 500)
         test_command("quorum", ["sign", 100], rpcuser_authpair_platform, 500)
         test_command("quorum", ["sign", 100, "0000000000000000000000000000000000000000000000000000000000000000",
                                 "0000000000000000000000000000000000000000000000000000000000000001"],

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -28,7 +28,7 @@ class RPCVerifyChainLockTest(DashTestFramework):
         self.wait_for_sporks_same()
         self.mine_quorum()
         self.wait_for_chainlocked_block(node0, node0.generate(1)[0])
-        chainlock = node0.getbestchainlock()
+        chainlock = node0.getchainlocks()["recent_chainlock"]
         block_hash = chainlock["blockhash"]
         height = chainlock["height"]
         chainlock_signature = chainlock["signature"]
@@ -45,8 +45,8 @@ class RPCVerifyChainLockTest(DashTestFramework):
         node1.setnetworkactive(False)
         node0.generate(1)
         self.wait_for_chainlocked_block(node0, node0.generate(1)[0])
-        chainlock = node0.getbestchainlock()
-        assert chainlock != node1.getbestchainlock()
+        chainlock = node0.getchainlocks()["recent_chainlock"]
+        assert chainlock != node1.getchainlocks()["recent_chainlock"]
         block_hash = chainlock["blockhash"]
         height = chainlock["height"]
         chainlock_signature = chainlock["signature"]

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -27,7 +27,7 @@ from test_framework.util import hex_str_to_bytes, bytes_to_hex_str
 import dash_hash
 
 MIN_VERSION_SUPPORTED = 60001
-MY_VERSION = 70219  # LLMQ_DATA_MESSAGES_VERSION
+MY_VERSION = 70220  # MULTI_QUORUM_CHAINLOCKS_VERSION
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3%s/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
@@ -1536,21 +1536,24 @@ class msg_mnlistdiff():
 class msg_clsig():
     command = b"clsig"
 
-    def __init__(self, height=0, blockHash=0, sig=b'\\x0' * 96):
+    def __init__(self, height=0, blockHash=0, sig=b'\\x0' * 96, signers=[]):
         self.height = height
         self.blockHash = blockHash
         self.sig = sig
+        self.signers = signers
 
     def deserialize(self, f):
         self.height = struct.unpack('<i', f.read(4))[0]
         self.blockHash = deser_uint256(f)
         self.sig = f.read(96)
+        self.signers = deser_dyn_bitset(f, False)
 
     def serialize(self):
         r = b""
         r += struct.pack('<i', self.height)
         r += ser_uint256(self.blockHash)
         r += self.sig
+        r += ser_dyn_bitset(self.signers, False)
         return r
 
     def __repr__(self):

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1536,13 +1536,39 @@ class msg_mnlistdiff():
 class msg_clsig():
     command = b"clsig"
 
-    def __init__(self, height=0, blockHash=0, sig=b'\\x0' * 96, signers=[]):
+    def __init__(self, height=0, blockHash=0, sig=b'\\x0' * 96):
+        self.height = height
+        self.blockHash = blockHash
+        self.sig = sig
+
+    def deserialize(self, f):
+        self.height = struct.unpack('<i', f.read(4))[0]
+        self.blockHash = deser_uint256(f)
+        self.sig = f.read(96)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack('<i', self.height)
+        r += ser_uint256(self.blockHash)
+        r += self.sig
+        return r
+
+    def __repr__(self):
+        return "msg_clsig(height=%d, blockHash=%064x)" % (self.height, self.blockHash)
+
+
+class msg_clsigmq():
+    command = b"clsigmq"
+
+    def __init__(self, nVersion=0, height=0, blockHash=0, sig=b'\\x0' * 96, signers=[]):
+        self.nVersion = nVersion
         self.height = height
         self.blockHash = blockHash
         self.sig = sig
         self.signers = signers
 
     def deserialize(self, f):
+        self.nVersion = struct.unpack("<B", f.read(1))[0]
         self.height = struct.unpack('<i', f.read(4))[0]
         self.blockHash = deser_uint256(f)
         self.sig = f.read(96)
@@ -1550,6 +1576,7 @@ class msg_clsig():
 
     def serialize(self):
         r = b""
+        r += struct.pack("<B", self.nVersion)
         r += struct.pack('<i', self.height)
         r += ser_uint256(self.blockHash)
         r += self.sig
@@ -1557,7 +1584,7 @@ class msg_clsig():
         return r
 
     def __repr__(self):
-        return "msg_clsig(height=%d, blockHash=%064x)" % (self.height, self.blockHash)
+        return "msg_clsigmq(nVersion=%d, height=%d, blockHash=%064x)" % (self.nVersion, self.height, self.blockHash)
 
 
 class msg_islock():

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -55,6 +55,7 @@ MESSAGEMAP = {
     b"version": msg_version,
     # Dash Specific
     b"clsig": msg_clsig,
+    b"clsigmq": msg_clsigmq,
     b"getmnlistd": msg_getmnlistd,
     b"getsporks": None,
     b"govsync": None,
@@ -375,6 +376,7 @@ class P2PInterface(P2PConnection):
 
     def on_mnlistdiff(self, message): pass
     def on_clsig(self, message): pass
+    def on_clsigmq(self, message): pass
     def on_islock(self, message): pass
 
     def on_qgetdata(self, message): pass

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -846,8 +846,8 @@ class DashTestFramework(BitcoinTestFramework):
         for node in self.nodes:
             self.wait_for_chainlocked_block(node, block_hash, timeout=timeout)
 
-    def wait_for_best_chainlock(self, node, block_hash, timeout=15):
-        wait_until(lambda: node.getbestchainlock()["blockhash"] == block_hash, timeout=timeout, sleep=0.1)
+    def wait_for_most_recent_chainlock(self, node, block_hash, timeout=15):
+        wait_until(lambda: node.getchainlocks()["recent_chainlock"]["blockhash"] == block_hash, timeout=timeout, sleep=0.1)
 
     def wait_for_sporks_same(self, timeout=30):
         def check_sporks_same():

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -116,7 +116,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "coinjoin/coinjoin -> masternode/activemasternode -> net -> coinjoin/coinjoin"
     "evo/deterministicmns -> validationinterface -> txmempool -> evo/deterministicmns"
     "llmq/quorums -> validation -> llmq/quorums_chainlocks -> llmq/quorums"
-    "llmq/quorums_chainlocks -> llmq/quorums_instantsend -> validation -> llmq/quorums_chainlocks"
+    "llmq/quorums_chainlocks -> llmq/quorums_commitment -> validation -> llmq/quorums_chainlocks"
     "evo/deterministicmns -> evo/simplifiedmns -> llmq/quorums_blockprocessor -> net_processing -> masternode/masternode-payments -> evo/deterministicmns"
     "core_io -> evo/cbtx -> llmq/quorums_blockprocessor -> net_processing -> masternode/masternode-payments -> governance/governance-classes -> core_io"
     "evo/deterministicmns -> evo/simplifiedmns -> llmq/quorums_blockprocessor -> net_processing -> masternode/masternode-payments -> masternode/activemasternode -> evo/deterministicmns"


### PR DESCRIPTION
This PR is a Proof of Concept for the Multi-Quorum ChainLocks idea. To be merged _after_ corresponding [DIP8 modifications](https://github.com/dashpay/dips/pull/85) only.

The main idea is to let all active ChainLock quorums create new CLSIG messages at every block and to require the majority of these quorums to vote for the same hash to actually lock the chain. Unlike in current system, having a malicious quorum will no longer be enough to disrupt ChainLocks (see tests as an example where 3 honest quorums override the "fake" ChainLock produced by a malicious quorum).

The new mode is activated by setting `SPORK_19_CHAINLOCKS_ENABLED` to `1`. This PR changes CLSIG structure, bumps protocol version to `70220`, introduces new rpc `getchainlocks` , deprecates `getbestchainlock` (as less functional and more confusing in new mode), tweaks test quorum params and related tests accordingly. Please see individual commits.

Based on #3978 atm.