### PR TITLE
net: Use Intra-Quorum Relay connections for other messages too

### DIFF
--- a/src/masternode/masternode-sync.cpp
+++ b/src/masternode/masternode-sync.cpp
@@ -142,11 +142,10 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
     {
         CNetMsgMaker msgMaker(pnode->GetSendVersion());
 
-        // Don't try to sync any data from outbound "masternode" connections -
-        // they are temporary and should be considered unreliable for a sync process.
+        // Don't try to sync any data from outbound non-relay "masternode" connections.
         // Inbound connection this early is most likely a "masternode" connection
         // initiated from another node, so skip it too.
-        if(pnode->m_masternode_connection || (fMasternodeMode && pnode->fInbound)) continue;
+        if (!pnode->CanRelay() || (fMasternodeMode && pnode->fInbound)) continue;
 
         // QUICK MODE (REGTEST ONLY!)
         if(Params().NetworkIDString() == CBaseChainParams::REGTEST)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3688,29 +3688,23 @@ void CConnman::RelayTransaction(const CTransaction& tx)
         nInv = MSG_DSTX;
     }
     CInv inv(nInv, hash);
-    LOCK(cs_vNodes);
-    for (CNode* pnode : vNodes)
-    {
-        if (pnode->m_masternode_connection)
-            continue;
-        pnode->PushInventory(inv);
-    }
+    RelayInv(inv);
 }
 
-void CConnman::RelayInv(CInv &inv, const int minProtoVersion, bool fAllowMasternodeConnections) {
+void CConnman::RelayInv(CInv &inv, const int minProtoVersion) {
     LOCK(cs_vNodes);
     for (const auto& pnode : vNodes) {
-        if (pnode->nVersion < minProtoVersion || (pnode->m_masternode_connection && !fAllowMasternodeConnections))
+        if (pnode->nVersion < minProtoVersion || !pnode->CanRelay())
             continue;
         pnode->PushInventory(inv);
     }
 }
 
-void CConnman::RelayInvFiltered(CInv &inv, const CTransaction& relatedTx, const int minProtoVersion, bool fAllowMasternodeConnections)
+void CConnman::RelayInvFiltered(CInv &inv, const CTransaction& relatedTx, const int minProtoVersion)
 {
     LOCK(cs_vNodes);
     for (const auto& pnode : vNodes) {
-        if (pnode->nVersion < minProtoVersion || (pnode->m_masternode_connection && !fAllowMasternodeConnections))
+        if (pnode->nVersion < minProtoVersion || !pnode->CanRelay())
             continue;
         {
             LOCK(pnode->cs_filter);
@@ -3721,11 +3715,11 @@ void CConnman::RelayInvFiltered(CInv &inv, const CTransaction& relatedTx, const 
     }
 }
 
-void CConnman::RelayInvFiltered(CInv &inv, const uint256& relatedTxHash, const int minProtoVersion, bool fAllowMasternodeConnections)
+void CConnman::RelayInvFiltered(CInv &inv, const uint256& relatedTxHash, const int minProtoVersion)
 {
     LOCK(cs_vNodes);
     for (const auto& pnode : vNodes) {
-        if (pnode->nVersion < minProtoVersion || (pnode->m_masternode_connection && !fAllowMasternodeConnections))
+        if (pnode->nVersion < minProtoVersion || !pnode->CanRelay())
             continue;
         {
             LOCK(pnode->cs_filter);

--- a/src/net.h
+++ b/src/net.h
@@ -362,10 +362,10 @@ public:
     void ReleaseNodeVector(const std::vector<CNode*>& vecNodes);
 
     void RelayTransaction(const CTransaction& tx);
-    void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION, bool fAllowMasternodeConnections = false);
-    void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion = MIN_PEER_PROTO_VERSION, bool fAllowMasternodeConnections = false);
+    void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
+    void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
     // This overload will not update node filters,  so use it only for the cases when other messages will update related transaction data in filters
-    void RelayInvFiltered(CInv &inv, const uint256 &relatedTxHash, const int minProtoVersion = MIN_PEER_PROTO_VERSION, bool fAllowMasternodeConnections = false);
+    void RelayInvFiltered(CInv &inv, const uint256 &relatedTxHash, const int minProtoVersion = MIN_PEER_PROTO_VERSION);
 
     // Addrman functions
     size_t GetAddressCount() const;
@@ -1128,6 +1128,8 @@ public:
     void MaybeSetAddrName(const std::string& addrNameIn);
 
     std::string GetLogString() const;
+
+    bool CanRelay() const { return !m_masternode_connection || m_masternode_iqr_connection; }
 };
 
 class CExplicitNetCleanup


### PR DESCRIPTION
Make intra-quorum data delivery more robust.

We stopped relaying this data (https://github.com/dashpay/dash/pull/3368) when we were preparing to implement Concentrated Recovery (https://github.com/dashpay/dash/pull/3389) one part of which was spork21 ("all connected" mode) (https://github.com/dashpay/dash/pull/3380) because relaying all the data via 50+ connections from each member to everyone else in the quorum at once could be wasteful potentially. But I _think_ it should still be fine for quorum masternodes to re-use a small subset (in case of "all connected" mode) of intra-quorum connections to relay the data inside quorums. Syncing via these connections should also be safe (unlike syncing via potentially short-living pure "masternode" connections). Not having to rely on non-maliciousness of (regular) nodes surrounding each quorum member is yet another good thing imo.

Thoughts?

~Based on #4020 atm.~