### PR TITLE
partial #8149 and merge #19845, #19954: Complete the BIP155 implementation and upgrade to TORv3

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -262,6 +262,7 @@ BITCOIN_CORE_H = \
   utilasmap.h \
   utilmemory.h \
   utilmoneystr.h \
+  utilstring.h \
   utiltime.h \
   validation.h \
   validationinterface.h \
@@ -587,6 +588,7 @@ libdash_util_a_SOURCES = \
   utilmoneystr.cpp \
   utilstrencodings.cpp \
   utiltime.cpp \
+  utilstring.cpp \
   $(BITCOIN_CORE_H)
 
 if GLIBC_BACK_COMPAT

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -6,6 +6,8 @@
 
 #include <hash.h>
 #include <uint256.h>
+#include <utilstrencodings.h>
+#include <utilstring.h>
 
 #include <assert.h>
 #include <stdint.h>
@@ -127,6 +129,9 @@ std::string EncodeBase58(const std::vector<unsigned char>& vch)
 
 bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet)
 {
+    if (!ValidAsCString(str)) {
+        return false;
+    }
     return DecodeBase58(str.c_str(), vchRet);
 }
 
@@ -158,6 +163,9 @@ bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet)
 
 bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet)
 {
+    if (!ValidAsCString(str)) {
+        return false;
+    }
     return DecodeBase58Check(str.c_str(), vchRet);
 }
 

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -53,6 +53,13 @@ void static inline WriteLE64(unsigned char* ptr, uint64_t x)
     memcpy(ptr, (char*)&v, 8);
 }
 
+uint16_t static inline ReadBE16(const unsigned char* ptr)
+{
+    uint16_t x;
+    memcpy((char*)&x, ptr, 2);
+    return be16toh(x);
+}
+
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
     uint32_t x;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -22,6 +22,7 @@
 #include <random.h>
 #include <reverse_iterator.h>
 #include <scheduler.h>
+#include <streams.h>
 #include <tinyformat.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -2248,7 +2249,11 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
         }
 
-        connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::VERACK));
+        const CNetMsgMaker msg_maker(INIT_PROTO_VERSION);
+        connman->PushMessage(pfrom, msg_maker.Make(NetMsgType::VERACK));
+
+        // Signal ADDRv2 support (BIP155).
+        connman->PushMessage(pfrom, msg_maker.Make(NetMsgType::SENDADDRV2));
 
         pfrom->nServices = nServices;
         pfrom->SetAddrLocal(addrMe);
@@ -2409,17 +2414,27 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
     }
 
-    if (strCommand == NetMsgType::ADDR) {
+    if (strCommand == NetMsgType::ADDR || strCommand == NetMsgType::ADDRV2) {
+        int stream_version = vRecv.GetVersion();
+        if (strCommand == NetMsgType::ADDRV2) {
+            // Add ADDRV2_FORMAT to the version so that the CNetAddr and CAddress
+            // unserialize methods know that an address in v2 format is coming.
+            stream_version |= ADDRV2_FORMAT;
+        }
+
+        OverrideStream<CDataStream> s(&vRecv, vRecv.GetType(), stream_version);
         std::vector<CAddress> vAddr;
-        vRecv >> vAddr;
+
+        s >> vAddr;
 
         // Don't want addr from older versions unless seeding
         if (pfrom->nVersion < CADDR_TIME_VERSION && connman->GetAddressCount() > 1000)
             return true;
+
         if (vAddr.size() > 1000)
         {
             LOCK(cs_main);
-            Misbehaving(pfrom->GetId(), 20, strprintf("message addr size() = %u", vAddr.size()));
+            Misbehaving(pfrom->GetId(), 20, strprintf("%s message size = %u", strCommand, vAddr.size()));
             return false;
         }
 
@@ -2456,6 +2471,11 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         if (pfrom->fOneShot)
             pfrom->fDisconnect = true;
         statsClient.gauge("peers.knownAddresses", connman->GetAddressCount(), 1.0f);
+        return true;
+    }
+
+    if (strCommand == NetMsgType::SENDADDRV2) {
+        pfrom->m_wants_addrv2 = true;
         return true;
     }
 
@@ -3963,6 +3983,17 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
             pto->nNextAddrSend = PoissonNextSend(nNow, AVG_ADDRESS_BROADCAST_INTERVAL);
             std::vector<CAddress> vAddr;
             vAddr.reserve(pto->vAddrToSend.size());
+
+            const char* strCommand;
+            int make_flags;
+            if (pto->m_wants_addrv2) {
+                strCommand = NetMsgType::ADDRV2;
+                make_flags = ADDRV2_FORMAT;
+            } else {
+                strCommand = NetMsgType::ADDR;
+                make_flags = 0;
+            }
+
             for (const CAddress& addr : pto->vAddrToSend)
             {
                 if (!pto->addrKnown.contains(addr.GetKey()))
@@ -3972,14 +4003,14 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                     // receiver rejects addr messages larger than 1000
                     if (vAddr.size() >= 1000)
                     {
-                        connman->PushMessage(pto, msgMaker.Make(NetMsgType::ADDR, vAddr));
+                        connman->PushMessage(pto, msgMaker.Make(make_flags, strCommand, vAddr));
                         vAddr.clear();
                     }
                 }
             }
             pto->vAddrToSend.clear();
             if (!vAddr.empty())
-                connman->PushMessage(pto, msgMaker.Make(NetMsgType::ADDR, vAddr));
+                connman->PushMessage(pto, msgMaker.Make(make_flags, strCommand, vAddr));
             // we only send the big addr message once
             if (pto->vAddrToSend.capacity() > 40)
                 pto->vAddrToSend.shrink_to_fit();

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -5,18 +5,112 @@
 
 #include <netaddress.h>
 #include <netbase.h>
+#include <crypto/common.h>
+#include <crypto/sha3.h>
 #include <hash.h>
+#include <prevector.h>
+#include <tinyformat.h>
 #include <utilasmap.h>
 #include <utilstrencodings.h>
-#include <tinyformat.h>
+#include <utilstring.h>
 
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <ios>
 #include <iterator>
 #include <tuple>
 
 constexpr size_t CNetAddr::V1_SERIALIZATION_SIZE;
+constexpr size_t CNetAddr::MAX_ADDRV2_SIZE;
+
+CNetAddr::BIP155Network CNetAddr::GetBIP155Network() const
+{
+    switch (m_net) {
+    case NET_IPV4:
+        return BIP155Network::IPV4;
+    case NET_IPV6:
+        return BIP155Network::IPV6;
+    case NET_ONION:
+        switch (m_addr.size()) {
+        case ADDR_TORV2_SIZE:
+            return BIP155Network::TORV2;
+        case ADDR_TORV3_SIZE:
+            return BIP155Network::TORV3;
+        default:
+            assert(false);
+        }
+    case NET_I2P:
+        return BIP155Network::I2P;
+    case NET_CJDNS:
+        return BIP155Network::CJDNS;
+    case NET_INTERNAL:   // should have been handled before calling this function
+    case NET_UNROUTABLE: // m_net is never and should not be set to NET_UNROUTABLE
+    case NET_MAX:        // m_net is never and should not be set to NET_MAX
+        assert(false);
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}
+
+bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t address_size)
+{
+    switch (possible_bip155_net) {
+    case BIP155Network::IPV4:
+        if (address_size == ADDR_IPV4_SIZE) {
+            m_net = NET_IPV4;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 IPv4 address with length %u (should be %u)", address_size,
+                      ADDR_IPV4_SIZE));
+    case BIP155Network::IPV6:
+        if (address_size == ADDR_IPV6_SIZE) {
+            m_net = NET_IPV6;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 IPv6 address with length %u (should be %u)", address_size,
+                      ADDR_IPV6_SIZE));
+    case BIP155Network::TORV2:
+        if (address_size == ADDR_TORV2_SIZE) {
+            m_net = NET_ONION;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 TORv2 address with length %u (should be %u)", address_size,
+                      ADDR_TORV2_SIZE));
+    case BIP155Network::TORV3:
+        if (address_size == ADDR_TORV3_SIZE) {
+            m_net = NET_ONION;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 TORv3 address with length %u (should be %u)", address_size,
+                      ADDR_TORV3_SIZE));
+    case BIP155Network::I2P:
+        if (address_size == ADDR_I2P_SIZE) {
+            m_net = NET_I2P;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 I2P address with length %u (should be %u)", address_size,
+                      ADDR_I2P_SIZE));
+    case BIP155Network::CJDNS:
+        if (address_size == ADDR_CJDNS_SIZE) {
+            m_net = NET_CJDNS;
+            return true;
+        }
+        throw std::ios_base::failure(
+            strprintf("BIP155 CJDNS address with length %u (should be %u)", address_size,
+                      ADDR_CJDNS_SIZE));
+    }
+
+    // Don't throw on addresses with unknown network ids (maybe from the future).
+    // Instead silently drop them and have the unserialization code consume
+    // subsequent ones which may be known to us.
+    return false;
+}
 
 bool fAllowPrivateNet = DEFAULT_ALLOWPRIVATENET;
 
@@ -38,7 +132,13 @@ void CNetAddr::SetIP(const CNetAddr& ipIn)
         assert(ipIn.m_addr.size() == ADDR_IPV6_SIZE);
         break;
     case NET_ONION:
-        assert(ipIn.m_addr.size() == ADDR_TORV2_SIZE);
+        assert(ipIn.m_addr.size() == ADDR_TORV2_SIZE || ipIn.m_addr.size() == ADDR_TORV3_SIZE);
+        break;
+    case NET_I2P:
+        assert(ipIn.m_addr.size() == ADDR_I2P_SIZE);
+        break;
+    case NET_CJDNS:
+        assert(ipIn.m_addr.size() == ADDR_CJDNS_SIZE);
         break;
     case NET_INTERNAL:
         assert(ipIn.m_addr.size() == ADDR_INTERNAL_SIZE);
@@ -50,13 +150,6 @@ void CNetAddr::SetIP(const CNetAddr& ipIn)
 
     m_net = ipIn.m_net;
     m_addr = ipIn.m_addr;
-}
-
-template <typename T1, size_t PREFIX_LEN>
-inline bool HasPrefix(const T1& obj, const std::array<uint8_t, PREFIX_LEN>& prefix)
-{
-    return obj.size() >= PREFIX_LEN &&
-           std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
 }
 
 void CNetAddr::SetLegacyIPv6(Span<const uint8_t> ipv6)
@@ -103,24 +196,80 @@ bool CNetAddr::SetInternal(const std::string &name)
     return true;
 }
 
+namespace torv3 {
+// https://gitweb.torproject.org/torspec.git/tree/rend-spec-v3.txt#n2135
+static constexpr size_t CHECKSUM_LEN = 2;
+static const unsigned char VERSION[] = {3};
+static constexpr size_t TOTAL_LEN = ADDR_TORV3_SIZE + CHECKSUM_LEN + sizeof(VERSION);
+
+static void Checksum(Span<const uint8_t> addr_pubkey, uint8_t (&checksum)[CHECKSUM_LEN])
+{
+    // TORv3 CHECKSUM = H(".onion checksum" | PUBKEY | VERSION)[:2]
+    static const unsigned char prefix[] = ".onion checksum";
+    static constexpr size_t prefix_len = 15;
+
+    SHA3_256 hasher;
+
+    hasher.Write(MakeSpan(prefix).first(prefix_len));
+    hasher.Write(addr_pubkey);
+    hasher.Write(VERSION);
+
+    uint8_t checksum_full[SHA3_256::OUTPUT_SIZE];
+
+    hasher.Finalize(checksum_full);
+
+    memcpy(checksum, checksum_full, sizeof(checksum));
+}
+
+}; // namespace torv3
+
 /**
- * Parse a TORv2 address and set this object to it.
+ * Parse a TOR address and set this object to it.
  *
  * @returns Whether or not the operation was successful.
  *
  * @see CNetAddr::IsTor()
  */
-bool CNetAddr::SetSpecial(const std::string &strName)
+bool CNetAddr::SetSpecial(const std::string& str)
 {
-    if (strName.size()>6 && strName.substr(strName.size() - 6, 6) == ".onion") {
-        std::vector<unsigned char> vchAddr = DecodeBase32(strName.substr(0, strName.size() - 6).c_str());
-        if (vchAddr.size() != ADDR_TORV2_SIZE) {
+    static const char* suffix{".onion"};
+    static constexpr size_t suffix_len{6};
+
+    if (!ValidAsCString(str) || str.size() <= suffix_len ||
+        str.substr(str.size() - suffix_len) != suffix) {
+        return false;
+    }
+
+    bool invalid;
+    const auto& input = DecodeBase32(str.substr(0, str.size() - suffix_len).c_str(), &invalid);
+
+    if (invalid) {
+        return false;
+    }
+
+    switch (input.size()) {
+    case ADDR_TORV2_SIZE:
+        m_net = NET_ONION;
+        m_addr.assign(input.begin(), input.end());
+        return true;
+    case torv3::TOTAL_LEN: {
+        Span<const uint8_t> input_pubkey{input.data(), ADDR_TORV3_SIZE};
+        Span<const uint8_t> input_checksum{input.data() + ADDR_TORV3_SIZE, torv3::CHECKSUM_LEN};
+        Span<const uint8_t> input_version{input.data() + ADDR_TORV3_SIZE + torv3::CHECKSUM_LEN, sizeof(torv3::VERSION)};
+
+        uint8_t calculated_checksum[torv3::CHECKSUM_LEN];
+        torv3::Checksum(input_pubkey, calculated_checksum);
+
+        if (input_checksum != calculated_checksum || input_version != torv3::VERSION) {
             return false;
         }
+
         m_net = NET_ONION;
-        m_addr.assign(vchAddr.begin(), vchAddr.end());
+        m_addr.assign(input_pubkey.begin(), input_pubkey.end());
         return true;
     }
+    }
+
     return false;
 }
 
@@ -231,12 +380,26 @@ bool CNetAddr::IsRFC7343() const
            (m_addr[3] & 0xF0) == 0x20;
 }
 
-bool CNetAddr::IsTor() const { return m_net == NET_ONION; }
-
 bool CNetAddr::IsHeNet() const
 {
     return IsIPv6() && HasPrefix(m_addr, std::array<uint8_t, 4>{0x20, 0x01, 0x04, 0x70});
 }
+
+/**
+ * Check whether this object represents a TOR address.
+ * @see CNetAddr::SetSpecial(const std::string &)
+ */
+bool CNetAddr::IsTor() const { return m_net == NET_ONION; }
+
+/**
+ * Check whether this object represents an I2P address.
+ */
+bool CNetAddr::IsI2P() const { return m_net == NET_I2P; }
+
+/**
+ * Check whether this object represents a CJDNS address.
+ */
+bool CNetAddr::IsCJDNS() const { return m_net == NET_CJDNS; }
 
 bool CNetAddr::IsLocal() const
 {
@@ -320,11 +483,67 @@ enum Network CNetAddr::GetNetwork() const
     return m_net;
 }
 
+static std::string IPv6ToString(Span<const uint8_t> a)
+{
+    assert(a.size() == ADDR_IPV6_SIZE);
+    // clang-format off
+    return strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
+                     ReadBE16(&a[0]),
+                     ReadBE16(&a[2]),
+                     ReadBE16(&a[4]),
+                     ReadBE16(&a[6]),
+                     ReadBE16(&a[8]),
+                     ReadBE16(&a[10]),
+                     ReadBE16(&a[12]),
+                     ReadBE16(&a[14]));
+    // clang-format on
+}
+
 std::string CNetAddr::ToStringIP(bool fUseGetnameinfo) const
 {
-    if (IsTor())
-        return EncodeBase32(m_addr) + ".onion";
-    if (IsInternal())
+    switch (m_net) {
+    case NET_IPV4:
+    case NET_IPV6: {
+        if (fUseGetnameinfo) {
+            CService serv(*this, 0);
+            struct sockaddr_storage sockaddr;
+            socklen_t socklen = sizeof(sockaddr);
+            if (serv.GetSockAddr((struct sockaddr*)&sockaddr, &socklen)) {
+                char name[1025] = "";
+                if (!getnameinfo((const struct sockaddr*)&sockaddr, socklen, name,
+                                 sizeof(name), nullptr, 0, NI_NUMERICHOST))
+                    return std::string(name);
+            }
+        }
+        if (m_net == NET_IPV4) {
+            return strprintf("%u.%u.%u.%u", m_addr[0], m_addr[1], m_addr[2], m_addr[3]);
+        }
+        return IPv6ToString(m_addr);
+    }
+    case NET_ONION:
+        switch (m_addr.size()) {
+        case ADDR_TORV2_SIZE:
+            return EncodeBase32(m_addr) + ".onion";
+        case ADDR_TORV3_SIZE: {
+
+            uint8_t checksum[torv3::CHECKSUM_LEN];
+            torv3::Checksum(m_addr, checksum);
+
+            // TORv3 onion_address = base32(PUBKEY | CHECKSUM | VERSION) + ".onion"
+            prevector<torv3::TOTAL_LEN, uint8_t> address{m_addr.begin(), m_addr.end()};
+            address.insert(address.end(), checksum, checksum + torv3::CHECKSUM_LEN);
+            address.insert(address.end(), torv3::VERSION, torv3::VERSION + sizeof(torv3::VERSION));
+
+            return EncodeBase32(address) + ".onion";
+        }
+        default:
+            assert(false);
+        }
+    case NET_I2P:
+        return EncodeBase32(m_addr, false /* don't pad with = */) + ".b32.i2p";
+    case NET_CJDNS:
+        return IPv6ToString(m_addr);
+    case NET_INTERNAL:
         return EncodeBase32(m_addr) + ".internal";
     if (fUseGetnameinfo)
     {
@@ -338,14 +557,12 @@ std::string CNetAddr::ToStringIP(bool fUseGetnameinfo) const
             }
         }
     }
-    if (IsIPv4())
-        return strprintf("%u.%u.%u.%u", m_addr[0], m_addr[1], m_addr[2], m_addr[3]);
-    assert(IsIPv6());
-    return strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
-                     m_addr[0] << 8 | m_addr[1], m_addr[2] << 8 | m_addr[3],
-                     m_addr[4] << 8 | m_addr[5], m_addr[6] << 8 | m_addr[7],
-                     m_addr[8] << 8 | m_addr[9], m_addr[10] << 8 | m_addr[11],
-                     m_addr[12] << 8 | m_addr[13], m_addr[14] << 8 | m_addr[15]);
+    case NET_UNROUTABLE: // m_net is never and should not be set to NET_UNROUTABLE
+    case NET_MAX:        // m_net is never and should not be set to NET_MAX
+        assert(false);
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
 }
 
 std::string CNetAddr::ToString() const
@@ -404,21 +621,22 @@ uint32_t CNetAddr::GetLinkedIPv4() const
     assert(false);
 }
 
-uint32_t CNetAddr::GetNetClass() const {
-    uint32_t net_class = NET_IPV6;
-    if (IsLocal()) {
-        net_class = 255;
-    }
+uint32_t CNetAddr::GetNetClass() const
+{
+    // Make sure that if we return NET_IPV6, then IsIPv6() is true. The callers expect that.
+
+    // Check for "internal" first because such addresses are also !IsRoutable()
+    // and we don't want to return NET_UNROUTABLE in that case.
     if (IsInternal()) {
-        net_class = NET_INTERNAL;
-    } else if (!IsRoutable()) {
-        net_class = NET_UNROUTABLE;
-    } else if (HasLinkedIPv4()) {
-        net_class = NET_IPV4;
-    } else if (IsTor()) {
-        net_class = NET_ONION;
+        return NET_INTERNAL;
     }
-    return net_class;
+    if (!IsRoutable()) {
+        return NET_UNROUTABLE;
+    }
+    if (HasLinkedIPv4()) {
+        return NET_IPV4;
+    }
+    return m_net;
 }
 
 uint32_t CNetAddr::GetMappedAS(const std::vector<bool> &asmap) const {
@@ -493,7 +711,7 @@ std::vector<unsigned char> CNetAddr::GetGroup(const std::vector<bool> &asmap) co
         vchRet.push_back((ipv4 >> 24) & 0xFF);
         vchRet.push_back((ipv4 >> 16) & 0xFF);
         return vchRet;
-    } else if (IsTor()) {
+    } else if (IsTor() || IsI2P() || IsCJDNS()) {
         nBits = 4;
     } else if (IsHeNet()) {
         // for he.net, use /36 groups
@@ -703,7 +921,7 @@ std::string CService::ToStringPort() const
 
 std::string CService::ToStringIPPort(bool fUseGetnameinfo) const
 {
-    if (IsIPv4() || IsTor() || IsInternal()) {
+    if (IsIPv4() || IsTor() || IsI2P() || IsInternal()) {
         return ToStringIP(fUseGetnameinfo) + ":" + ToStringPort();
     } else {
         return "[" + ToStringIP(fUseGetnameinfo) + "]:" + ToStringPort();

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -472,6 +472,26 @@ bool CNetAddr::IsInternal() const
    return m_net == NET_INTERNAL;
 }
 
+bool CNetAddr::IsAddrV1Compatible() const
+{
+    switch (m_net) {
+    case NET_IPV4:
+    case NET_IPV6:
+    case NET_INTERNAL:
+        return true;
+    case NET_ONION:
+        return m_addr.size() == ADDR_TORV2_SIZE;
+    case NET_I2P:
+    case NET_CJDNS:
+        return false;
+    case NET_UNROUTABLE: // m_net is never and should not be set to NET_UNROUTABLE
+    case NET_MAX:        // m_net is never and should not be set to NET_MAX
+        assert(false);
+    } // no default case, so the compiler can warn about missing cases
+
+    assert(false);
+}
+
 enum Network CNetAddr::GetNetwork() const
 {
     if (IsInternal())
@@ -736,9 +756,12 @@ std::vector<unsigned char> CNetAddr::GetGroup(const std::vector<bool> &asmap) co
 
 std::vector<unsigned char> CNetAddr::GetAddrBytes() const
 {
-    uint8_t serialized[V1_SERIALIZATION_SIZE];
-    SerializeV1Array(serialized);
-    return {std::begin(serialized), std::end(serialized)};
+    if (IsAddrV1Compatible()) {
+        uint8_t serialized[V1_SERIALIZATION_SIZE];
+        SerializeV1Array(serialized);
+        return {std::begin(serialized), std::end(serialized)};
+    }
+    return std::vector<unsigned char>(m_addr.begin(), m_addr.end());
 }
 
 uint64_t CNetAddr::GetHash() const

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -14,13 +14,25 @@
 #include <prevector.h>
 #include <serialize.h>
 #include <span.h>
+#include <tinyformat.h>
+#include <utilstrencodings.h>
+#include <utilstring.h>
 
 #include <array>
 #include <cstdint>
+#include <ios>
 #include <string>
 #include <vector>
 
 extern bool fAllowPrivateNet;
+
+/**
+ * A flag that is ORed into the protocol version to designate that addresses
+ * should be serialized in (unserialized from) v2 format (BIP155).
+ * Make sure that this does not collide with any of the values in `version.h`
+ * or with `SERIALIZE_TRANSACTION_NO_WITNESS`.
+ */
+static const int ADDRV2_FORMAT = 0x20000000;
 
 /**
  * A network type.
@@ -42,8 +54,14 @@ enum Network
     /// IPv6
     NET_IPV6,
 
-    /// TORv2
+    /// TOR (v2 or v3)
     NET_ONION,
+
+    /// I2P
+    NET_I2P,
+
+    /// CJDNS
+    NET_CJDNS,
 
     /// A set of addresses that represent the hash of a string or FQDN. We use
     /// them in CAddrMan to keep track of which DNS seeds were used.
@@ -84,6 +102,16 @@ static constexpr size_t ADDR_IPV6_SIZE = 16;
 
 /// Size of TORv2 address (in bytes).
 static constexpr size_t ADDR_TORV2_SIZE = 10;
+
+/// Size of TORv3 address (in bytes). This is the length of just the address
+/// as used in BIP155, without the checksum and the version byte.
+static constexpr size_t ADDR_TORV3_SIZE = 32;
+
+/// Size of I2P address (in bytes).
+static constexpr size_t ADDR_I2P_SIZE = 32;
+
+/// Size of CJDNS address (in bytes).
+static constexpr size_t ADDR_CJDNS_SIZE = 16;
 
 /// Size of "internal" (NET_INTERNAL) address (in bytes).
 static constexpr size_t ADDR_INTERNAL_SIZE = 10;
@@ -154,6 +182,8 @@ class CNetAddr
         bool IsRFC6145() const; // IPv6 IPv4-translated address (::FFFF:0:0:0/96) (actually defined in RFC2765)
         bool IsHeNet() const;   // IPv6 Hurricane Electric - https://he.net (2001:0470::/36)
         bool IsTor() const;
+        bool IsI2P() const;
+        bool IsCJDNS() const;
         bool IsLocal() const;
         bool IsRoutable() const;
         bool IsInternal() const;
@@ -191,7 +221,11 @@ class CNetAddr
         template <typename Stream>
         void Serialize(Stream& s) const
         {
-            SerializeV1Stream(s);
+            if (s.GetVersion() & ADDRV2_FORMAT) {
+                SerializeV2Stream(s);
+            } else {
+                SerializeV1Stream(s);
+            }
         }
 
         /**
@@ -200,20 +234,58 @@ class CNetAddr
         template <typename Stream>
         void Unserialize(Stream& s)
         {
-            UnserializeV1Stream(s);
+            if (s.GetVersion() & ADDRV2_FORMAT) {
+                UnserializeV2Stream(s);
+            } else {
+                UnserializeV1Stream(s);
+            }
         }
 
         friend class CSubNet;
 
     private:
         /**
+         * BIP155 network ids recognized by this software.
+         */
+        enum BIP155Network : uint8_t {
+            IPV4 = 1,
+            IPV6 = 2,
+            TORV2 = 3,
+            TORV3 = 4,
+            I2P = 5,
+            CJDNS = 6,
+        };
+
+        /**
          * Size of CNetAddr when serialized as ADDRv1 (pre-BIP155) (in bytes).
          */
         static constexpr size_t V1_SERIALIZATION_SIZE = ADDR_IPV6_SIZE;
 
         /**
+         * Maximum size of an address as defined in BIP155 (in bytes).
+         * This is only the size of the address, not the entire CNetAddr object
+         * when serialized.
+         */
+        static constexpr size_t MAX_ADDRV2_SIZE = 512;
+
+        /**
+         * Get the BIP155 network id of this address.
+         * Must not be called for IsInternal() objects.
+         * @returns BIP155 network id
+         */
+        BIP155Network GetBIP155Network() const;
+
+        /**
+         * Set `m_net` from the provided BIP155 network id and size after validation.
+         * @retval true the network was recognized, is valid and `m_net` was set
+         * @retval false not recognised (from future?) and should be silently ignored
+         * @throws std::ios_base::failure if the network is one of the BIP155 founding
+         * networks (id 1..6) with wrong address size.
+         */
+        bool SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t address_size);
+
+        /**
          * Serialize in pre-ADDRv2/BIP155 format to an array.
-         * Some addresses (e.g. TORv3) cannot be serialized in pre-BIP155 format.
          */
         void SerializeV1Array(uint8_t (&arr)[V1_SERIALIZATION_SIZE]) const
         {
@@ -231,6 +303,9 @@ class CNetAddr
                 memcpy(arr + prefix_size, m_addr.data(), m_addr.size());
                 return;
             case NET_ONION:
+                if (m_addr.size() == ADDR_TORV3_SIZE) {
+                    break;
+                }
                 prefix_size = sizeof(TORV2_IN_IPV6_PREFIX);
                 assert(prefix_size + m_addr.size() == sizeof(arr));
                 memcpy(arr, TORV2_IN_IPV6_PREFIX.data(), prefix_size);
@@ -242,18 +317,22 @@ class CNetAddr
                 memcpy(arr, INTERNAL_IN_IPV6_PREFIX.data(), prefix_size);
                 memcpy(arr + prefix_size, m_addr.data(), m_addr.size());
                 return;
+            case NET_I2P:
+                break;
+            case NET_CJDNS:
+                break;
             case NET_UNROUTABLE:
             case NET_MAX:
                 assert(false);
             } // no default case, so the compiler can warn about missing cases
 
-            assert(false);
+            // Serialize TORv3, I2P and CJDNS as all-zeros.
+            memset(arr, 0x0, V1_SERIALIZATION_SIZE);
         }
 
     public:
         /**
          * Serialize in pre-ADDRv2/BIP155 format to a stream.
-         * Some addresses (e.g. TORv3) cannot be serialized in pre-BIP155 format.
          */
         template <typename Stream>
         void SerializeV1Stream(Stream& s) const
@@ -263,6 +342,25 @@ class CNetAddr
             SerializeV1Array(serialized);
 
             s << serialized;
+        }
+
+        /**
+         * Serialize as ADDRv2 / BIP155.
+         */
+        template <typename Stream>
+        void SerializeV2Stream(Stream& s) const
+        {
+            if (IsInternal()) {
+                // Serialize NET_INTERNAL as embedded in IPv6. We need to
+                // serialize such addresses from addrman.
+                s << static_cast<uint8_t>(BIP155Network::IPV6);
+                s << COMPACTSIZE(ADDR_IPV6_SIZE);
+                SerializeV1Stream(s);
+                return;
+            }
+
+            s << static_cast<uint8_t>(GetBIP155Network());
+            s << m_addr;
         }
 
         /**
@@ -286,6 +384,65 @@ class CNetAddr
             s >> serialized;
 
             UnserializeV1Array(serialized);
+        }
+
+        /**
+         * Unserialize from a ADDRv2 / BIP155 format.
+         */
+        template <typename Stream>
+        void UnserializeV2Stream(Stream& s)
+        {
+            uint8_t bip155_net;
+            s >> bip155_net;
+
+            size_t address_size;
+            s >> COMPACTSIZE(address_size);
+
+            if (address_size > MAX_ADDRV2_SIZE) {
+                throw std::ios_base::failure(strprintf(
+                    "Address too long: %u > %u", address_size, MAX_ADDRV2_SIZE));
+            }
+
+            scopeId = 0;
+
+            if (SetNetFromBIP155Network(bip155_net, address_size)) {
+                m_addr.resize(address_size);
+                s >> MakeSpan(m_addr);
+
+                if (m_net != NET_IPV6) {
+                    return;
+                }
+
+                // Do some special checks on IPv6 addresses.
+
+                // Recognize NET_INTERNAL embedded in IPv6, such addresses are not
+                // gossiped but could be coming from addrman, when unserializing from
+                // disk.
+                if (HasPrefix(m_addr, INTERNAL_IN_IPV6_PREFIX)) {
+                    m_net = NET_INTERNAL;
+                    memmove(m_addr.data(), m_addr.data() + INTERNAL_IN_IPV6_PREFIX.size(),
+                            ADDR_INTERNAL_SIZE);
+                    m_addr.resize(ADDR_INTERNAL_SIZE);
+                    return;
+                }
+
+                if (!HasPrefix(m_addr, IPV4_IN_IPV6_PREFIX) &&
+                    !HasPrefix(m_addr, TORV2_IN_IPV6_PREFIX)) {
+                    return;
+                }
+
+                // IPv4 and TORv2 are not supposed to be embedded in IPv6 (like in V1
+                // encoding). Unserialize as !IsValid(), thus ignoring them.
+            } else {
+                // If we receive an unknown BIP155 network id (from the future?) then
+                // ignore the address - unserialize as !IsValid().
+                s.ignore(address_size);
+            }
+
+            // Mimic a default-constructed CNetAddr object which is !IsValid() and thus
+            // will not be gossiped, but continue reading next addresses from the stream.
+            m_net = NET_IPV6;
+            m_addr.assign(ADDR_IPV6_SIZE, 0x0);
         }
 };
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -188,6 +188,12 @@ class CNetAddr
         bool IsRoutable() const;
         bool IsInternal() const;
         bool IsValid() const;
+
+        /**
+         * Check if the current object can be serialized in pre-ADDRv2/BIP155 format.
+         */
+        bool IsAddrV1Compatible() const;
+
         enum Network GetNetwork() const;
         std::string ToString() const;
         std::string ToStringIP(bool fUseGetnameinfo = true) const;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -10,6 +10,7 @@
 #include <script/script.h>
 #include <serialize.h>
 #include <uint256.h>
+#include <tuple>
 
 /** Transaction types */
 enum {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -18,6 +18,8 @@ namespace NetMsgType {
 const char *VERSION="version";
 const char *VERACK="verack";
 const char *ADDR="addr";
+const char *ADDRV2="addrv2";
+const char *SENDADDRV2="sendaddrv2";
 const char *INV="inv";
 const char *GETDATA="getdata";
 const char *MERKLEBLOCK="merkleblock";
@@ -86,6 +88,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::VERSION,
     NetMsgType::VERACK,
     NetMsgType::ADDR,
+    NetMsgType::ADDRV2,
+    NetMsgType::SENDADDRV2,
     NetMsgType::INV,
     NetMsgType::GETDATA,
     NetMsgType::MERKLEBLOCK,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -85,6 +85,18 @@ extern const char *VERACK;
  */
 extern const char *ADDR;
 /**
+ * The addrv2 message relays connection information for peers on the network just
+ * like the addr message, but is extended to allow gossiping of longer node
+ * addresses (see BIP155).
+ */
+extern const char *ADDRV2;
+/**
+ * The sendaddrv2 message signals support for receiving ADDRV2 messages (BIP155).
+ * It also implies that its sender can encode as ADDRV2 and would send ADDRV2
+ * instead of ADDR to a peer that has signaled ADDRV2 support by sending SENDADDRV2.
+ */
+extern const char *SENDADDRV2;
+/**
  * The inv message (inventory message) transmits one or more inventories of
  * objects known to the transmitting peer.
  * @see https://bitcoin.org/en/developer-reference#inv

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -27,7 +27,11 @@
 #include <prevector.h>
 #include <span.h>
 
-static const unsigned int MAX_SIZE = 0x02000000;
+/**
+ * The maximum size of a serialized object in bytes or number of elements
+ * (for eg vectors) when the size is encoded as CompactSize.
+ */
+static constexpr uint64_t MAX_SIZE = 0x02000000;
 
 /** Maximum amount of memory (in bytes) to allocate at once when deserializing vectors. */
 static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
@@ -339,8 +343,14 @@ void WriteCompactSize(Stream& os, uint64_t nSize)
     return;
 }
 
+/**
+ * Decode a CompactSize-encoded variable-length integer.
+ *
+ * As these are primarily used to encode the size of vector-like serializations, by default a range
+ * check is performed. When used as a generic number encoding, range_check should be set to false.
+ */
 template<typename Stream>
-uint64_t ReadCompactSize(Stream& is)
+uint64_t ReadCompactSize(Stream& is, bool range_check = true)
 {
     uint8_t chSize = ser_readdata8(is);
     uint64_t nSizeRet = 0;
@@ -366,8 +376,9 @@ uint64_t ReadCompactSize(Stream& is)
         if (nSizeRet < 0x100000000ULL)
             throw std::ios_base::failure("non-canonical ReadCompactSize()");
     }
-    if (nSizeRet > (uint64_t)MAX_SIZE)
+    if (range_check && nSizeRet > MAX_SIZE) {
         throw std::ios_base::failure("ReadCompactSize(): size too large");
+    }
     return nSizeRet;
 }
 
@@ -504,7 +515,7 @@ static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&
 #define FIXEDVARINTSBITSET(obj, size) CFixedVarIntsBitSet(REF(obj), (size))
 #define AUTOBITSET(obj, size) CAutoBitSet(REF(obj), (size))
 #define VARINT(obj, ...) Using<VarIntFormatter<__VA_ARGS__>>(obj)
-#define COMPACTSIZE(obj) Using<CompactSizeFormatter>(obj)
+#define COMPACTSIZE(obj) Using<CompactSizeFormatter<true>>(obj)
 #define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))
 
 class CFixedBitSet
@@ -735,12 +746,13 @@ public:
 };
 
 /** Formatter for integers in CompactSize format. */
+template<bool RangeCheck>
 struct CompactSizeFormatter
 {
     template<typename Stream, typename I>
     void Unser(Stream& s, I& v)
     {
-        uint64_t n = ReadCompactSize<Stream>(s);
+        uint64_t n = ReadCompactSize<Stream>(s, RangeCheck);
         if (n < std::numeric_limits<I>::min() || n > std::numeric_limits<I>::max()) {
             throw std::ios_base::failure("CompactSize exceeds limit of type");
         }

--- a/src/streams.h
+++ b/src/streams.h
@@ -168,6 +168,39 @@ public:
         }
     }
 };
+template<typename Stream>
+class OverrideStream
+{
+    Stream* stream;
+public:
+    const int nType;
+    const int nVersion;
+
+    OverrideStream(Stream* stream_, int nType_, int nVersion_) : stream(stream_), nType(nType_), nVersion(nVersion_) {}
+
+    template<typename T>
+    OverrideStream<Stream>& operator<<(const T& obj)
+    {
+        // Serialize to this stream
+        ::Serialize(*this->stream, obj);
+        return (*this);
+    }
+
+    template<typename T>
+    OverrideStream<Stream>& operator>>(T& obj)
+    {
+        // Unserialize from this stream
+        ::Unserialize(*this->stream, obj);
+        return (*this);
+    }
+};
+
+template<typename S>
+OverrideStream<S> WithOrVersion(S* s, int nVersionFlag)
+{
+    return OverrideStream<S>(s, s->GetType(), s->GetVersion() | nVersionFlag);
+}
+
 
 /** Double ended buffer combining vector and stream-like interfaces.
  *

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -13,10 +13,13 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
 {
     static const std::string vstrIn[]  = {"","f","fo","foo","foob","fooba","foobar"};
     static const std::string vstrOut[] = {"","my======","mzxq====","mzxw6===","mzxw6yq=","mzxw6ytb","mzxw6ytboi======"};
+    static const std::string vstrOutNoPadding[] = {"","my","mzxq","mzxw6","mzxw6yq","mzxw6ytb","mzxw6ytboi"};
     for (unsigned int i=0; i<sizeof(vstrIn)/sizeof(vstrIn[0]); i++)
     {
         std::string strEnc = EncodeBase32(vstrIn[i]);
         BOOST_CHECK_EQUAL(strEnc, vstrOut[i]);
+        strEnc = EncodeBase32(vstrIn[i], false);
+        BOOST_CHECK_EQUAL(strEnc, vstrOutNoPadding[i]);
         std::string strDec = DecodeBase32(vstrOut[i]);
         BOOST_CHECK_EQUAL(strDec, vstrIn[i]);
     }

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -58,12 +58,25 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
     }
 
     BOOST_CHECK(!DecodeBase58("invalid", result));
+    BOOST_CHECK(!DecodeBase58("invalid", result));
+    BOOST_CHECK(!DecodeBase58(std::string("invalid"), result));
+    BOOST_CHECK(!DecodeBase58(std::string("\0invalid", 8), result));
+
+    BOOST_CHECK(DecodeBase58(std::string("good", 4), result));
+    BOOST_CHECK(!DecodeBase58(std::string("bad0IOl", 7), result));
+    BOOST_CHECK(!DecodeBase58(std::string("goodbad0IOl", 11), result));
+    BOOST_CHECK(!DecodeBase58(std::string("good\0bad0IOl", 12), result));
 
     // check that DecodeBase58 skips whitespace, but still fails with unexpected non-whitespace at the end.
     BOOST_CHECK(!DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t a", result));
     BOOST_CHECK( DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t ", result));
     std::vector<unsigned char> expected = ParseHex("971a55");
     BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+
+    BOOST_CHECK(DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh", 21), result));
+    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oi", 21), result));
+    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh0IOl", 25), result));
+    BOOST_CHECK(!DecodeBase58Check(std::string("3vQB7B6MrGQZaxCuFg4oh\00IOl", 26), result));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -28,17 +28,6 @@
 
 BOOST_FIXTURE_TEST_SUITE(miner_tests, TestingSetup)
 
-// BOOST_CHECK_EXCEPTION predicates to check the specific validation error
-class HasReason {
-public:
-    HasReason(const std::string& reason) : m_reason(reason) {}
-    bool operator() (const std::runtime_error& e) const {
-        return std::string(e.what()).find(m_reason) != std::string::npos;
-    };
-private:
-    const std::string m_reason;
-};
-
 static CFeeRate blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
 
 static BlockAssembler AssemblerForTest(const CChainParams& params) {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -217,6 +217,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsIPv4());
 
     BOOST_CHECK(addr.IsBindAny());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "0.0.0.0");
 
     // IPv4, INADDR_NONE
@@ -225,6 +226,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsIPv4());
 
     BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "255.255.255.255");
 
     // IPv4, casual
@@ -233,6 +235,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsIPv4());
 
     BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "12.34.56.78");
 
     // IPv6, in6addr_any
@@ -241,6 +244,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsIPv6());
 
     BOOST_CHECK(addr.IsBindAny());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "::");
 
     // IPv6, casual
@@ -249,6 +253,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsIPv6());
 
     BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "1122:3344:5566:7788:9900:aabb:ccdd:eeff");
 
     // TORv2
@@ -257,6 +262,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsTor());
 
     BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "6hzph5hv6337r6p2.onion");
 
     // TORv3
@@ -266,6 +272,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsTor());
 
     BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK(!addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), torv3_addr);
 
     // TORv3, broken, with wrong checksum
@@ -290,6 +297,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_REQUIRE(addr.IsInternal());
 
     BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "esffpvrt3wpeaygy.internal");
 
     // Totally bogus
@@ -384,6 +392,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
     s >> addr;
     BOOST_CHECK(addr.IsValid());
     BOOST_CHECK(addr.IsIPv4());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "1.2.3.4");
     BOOST_REQUIRE(s.empty());
 
@@ -420,6 +429,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
     s >> addr;
     BOOST_CHECK(addr.IsValid());
     BOOST_CHECK(addr.IsIPv6());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "102:304:506:708:90a:b0c:d0e:f10");
     BOOST_REQUIRE(s.empty());
 
@@ -431,6 +441,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
                                               // sha256(name)[0:10]
     s >> addr;
     BOOST_CHECK(addr.IsInternal());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "zklycewkdo64v6wc.internal");
     BOOST_REQUIRE(s.empty());
 
@@ -466,6 +477,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
     s >> addr;
     BOOST_CHECK(addr.IsValid());
     BOOST_CHECK(addr.IsTor());
+    BOOST_CHECK(addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "6hzph5hv6337r6p2.onion");
     BOOST_REQUIRE(s.empty());
 
@@ -487,6 +499,7 @@ BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
     s >> addr;
     BOOST_CHECK(addr.IsValid());
     BOOST_CHECK(addr.IsTor());
+    BOOST_CHECK(!addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(),
                       "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion");
     BOOST_REQUIRE(s.empty());
@@ -508,6 +521,8 @@ BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
                            "f98232ae42d4b6fd2fa81952dfe36a87"));
     s >> addr;
     BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsI2P());
+    BOOST_CHECK(!addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(),
                       "ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p");
     BOOST_REQUIRE(s.empty());
@@ -529,6 +544,8 @@ BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
                            ));
     s >> addr;
     BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsCJDNS());
+    BOOST_CHECK(!addr.IsAddrV1Compatible());
     BOOST_CHECK_EQUAL(addr.ToString(), "fc00:1:2:3:4:5:6:7");
     BOOST_REQUIRE(s.empty());
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -7,6 +7,7 @@
 #include <boost/test/unit_test.hpp>
 #include <hash.h>
 #include <serialize.h>
+#include <span.h>
 #include <streams.h>
 #include <net.h>
 #include <netbase.h>
@@ -15,6 +16,7 @@
 #include <utilstrencodings.h>
 #include <version.h>
 
+#include <ios>
 #include <memory>
 
 class CAddrManSerializationMock : public CAddrMan
@@ -250,12 +252,37 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
     BOOST_CHECK_EQUAL(addr.ToString(), "1122:3344:5566:7788:9900:aabb:ccdd:eeff");
 
     // TORv2
-    addr.SetSpecial("6hzph5hv6337r6p2.onion");
+    BOOST_REQUIRE(addr.SetSpecial("6hzph5hv6337r6p2.onion"));
     BOOST_REQUIRE(addr.IsValid());
     BOOST_REQUIRE(addr.IsTor());
 
     BOOST_CHECK(!addr.IsBindAny());
     BOOST_CHECK_EQUAL(addr.ToString(), "6hzph5hv6337r6p2.onion");
+
+    // TORv3
+    const char* torv3_addr = "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion";
+    BOOST_REQUIRE(addr.SetSpecial(torv3_addr));
+    BOOST_REQUIRE(addr.IsValid());
+    BOOST_REQUIRE(addr.IsTor());
+
+    BOOST_CHECK(!addr.IsBindAny());
+    BOOST_CHECK_EQUAL(addr.ToString(), torv3_addr);
+
+    // TORv3, broken, with wrong checksum
+    BOOST_CHECK(!addr.SetSpecial("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscsad.onion"));
+
+    // TORv3, broken, with wrong version
+    BOOST_CHECK(!addr.SetSpecial("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscrye.onion"));
+
+    // TORv3, malicious
+    BOOST_CHECK(!addr.SetSpecial(std::string{
+        "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd\0wtf.onion", 66}));
+
+    // TOR, bogus length
+    BOOST_CHECK(!addr.SetSpecial(std::string{"mfrggzak.onion"}));
+
+    // TOR, invalid base32
+    BOOST_CHECK(!addr.SetSpecial(std::string{"mf*g zak.onion"}));
 
     // Internal
     addr.SetInternal("esffpp");
@@ -264,17 +291,284 @@ BOOST_AUTO_TEST_CASE(cnetaddr_basic)
 
     BOOST_CHECK(!addr.IsBindAny());
     BOOST_CHECK_EQUAL(addr.ToString(), "esffpvrt3wpeaygy.internal");
+
+    // Totally bogus
+    BOOST_CHECK(!addr.SetSpecial("totally bogus"));
 }
 
-BOOST_AUTO_TEST_CASE(cnetaddr_serialize)
+BOOST_AUTO_TEST_CASE(cnetaddr_serialize_v1)
 {
     CNetAddr addr;
     CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "00000000000000000000000000000000");
+    s.clear();
+
+    BOOST_REQUIRE(LookupHost("1.2.3.4", addr, false));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "00000000000000000000ffff01020304");
+    s.clear();
+
+    BOOST_REQUIRE(LookupHost("1a1b:2a2b:3a3b:4a4b:5a5b:6a6b:7a7b:8a8b", addr, false));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "1a1b2a2b3a3b4a4b5a5b6a6b7a7b8a8b");
+    s.clear();
+
+    BOOST_REQUIRE(addr.SetSpecial("6hzph5hv6337r6p2.onion"));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "fd87d87eeb43f1f2f3f4f5f6f7f8f9fa");
+    s.clear();
+
+    BOOST_REQUIRE(addr.SetSpecial("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion"));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "00000000000000000000000000000000");
+    s.clear();
 
     addr.SetInternal("a");
     s << addr;
     BOOST_CHECK_EQUAL(HexStr(s), "fd6b88c08724ca978112ca1bbdcafac2");
     s.clear();
+}
+
+BOOST_AUTO_TEST_CASE(cnetaddr_serialize_v2)
+{
+    CNetAddr addr;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    // Add ADDRV2_FORMAT to the version so that the CNetAddr
+    // serialize method produces an address in v2 format.
+    s.SetVersion(s.GetVersion() | ADDRV2_FORMAT);
+
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "021000000000000000000000000000000000");
+    s.clear();
+
+    BOOST_REQUIRE(LookupHost("1.2.3.4", addr, false));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "010401020304");
+    s.clear();
+
+    BOOST_REQUIRE(LookupHost("1a1b:2a2b:3a3b:4a4b:5a5b:6a6b:7a7b:8a8b", addr, false));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "02101a1b2a2b3a3b4a4b5a5b6a6b7a7b8a8b");
+    s.clear();
+
+    BOOST_REQUIRE(addr.SetSpecial("6hzph5hv6337r6p2.onion"));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "030af1f2f3f4f5f6f7f8f9fa");
+    s.clear();
+
+    BOOST_REQUIRE(addr.SetSpecial("kpgvmscirrdqpekbqjsvw5teanhatztpp2gl6eee4zkowvwfxwenqaid.onion"));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "042053cd5648488c4707914182655b7664034e09e66f7e8cbf1084e654eb56c5bd88");
+    s.clear();
+
+    BOOST_REQUIRE(addr.SetInternal("a"));
+    s << addr;
+    BOOST_CHECK_EQUAL(HexStr(s), "0210fd6b88c08724ca978112ca1bbdcafac2");
+    s.clear();
+}
+
+BOOST_AUTO_TEST_CASE(cnetaddr_unserialize_v2)
+{
+    CNetAddr addr;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    // Add ADDRV2_FORMAT to the version so that the CNetAddr
+    // unserialize method expects an address in v2 format.
+    s.SetVersion(s.GetVersion() | ADDRV2_FORMAT);
+
+    // Valid IPv4.
+    s << MakeSpan(ParseHex("01"          // network type (IPv4)
+                           "04"          // address length
+                           "01020304")); // address
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsIPv4());
+    BOOST_CHECK_EQUAL(addr.ToString(), "1.2.3.4");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid IPv4, valid length but address itself is shorter.
+    s << MakeSpan(ParseHex("01"      // network type (IPv4)
+                           "04"      // address length
+                           "0102")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure, HasReason("end of data"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Invalid IPv4, with bogus length.
+    s << MakeSpan(ParseHex("01"          // network type (IPv4)
+                           "05"          // address length
+                           "01020304")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 IPv4 address with length 5 (should be 4)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Invalid IPv4, with extreme length.
+    s << MakeSpan(ParseHex("01"          // network type (IPv4)
+                           "fd0102"      // address length (513 as CompactSize)
+                           "01020304")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("Address too long: 513 > 512"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Valid IPv6.
+    s << MakeSpan(ParseHex("02"                                  // network type (IPv6)
+                           "10"                                  // address length
+                           "0102030405060708090a0b0c0d0e0f10")); // address
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsIPv6());
+    BOOST_CHECK_EQUAL(addr.ToString(), "102:304:506:708:90a:b0c:d0e:f10");
+    BOOST_REQUIRE(s.empty());
+
+    // Valid IPv6, contains embedded "internal".
+    s << MakeSpan(ParseHex(
+        "02"                                  // network type (IPv6)
+        "10"                                  // address length
+        "fd6b88c08724ca978112ca1bbdcafac2")); // address: 0xfd + sha256("bitcoin")[0:5] +
+                                              // sha256(name)[0:10]
+    s >> addr;
+    BOOST_CHECK(addr.IsInternal());
+    BOOST_CHECK_EQUAL(addr.ToString(), "zklycewkdo64v6wc.internal");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid IPv6, with bogus length.
+    s << MakeSpan(ParseHex("02"    // network type (IPv6)
+                           "04"    // address length
+                           "00")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 IPv6 address with length 4 (should be 16)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Invalid IPv6, contains embedded IPv4.
+    s << MakeSpan(ParseHex("02"                                  // network type (IPv6)
+                           "10"                                  // address length
+                           "00000000000000000000ffff01020304")); // address
+    s >> addr;
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid IPv6, contains embedded TORv2.
+    s << MakeSpan(ParseHex("02"                                  // network type (IPv6)
+                           "10"                                  // address length
+                           "fd87d87eeb430102030405060708090a")); // address
+    s >> addr;
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
+
+    // Valid TORv2.
+    s << MakeSpan(ParseHex("03"                      // network type (TORv2)
+                           "0a"                      // address length
+                           "f1f2f3f4f5f6f7f8f9fa")); // address
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsTor());
+    BOOST_CHECK_EQUAL(addr.ToString(), "6hzph5hv6337r6p2.onion");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid TORv2, with bogus length.
+    s << MakeSpan(ParseHex("03"    // network type (TORv2)
+                           "07"    // address length
+                           "00")); // address
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 TORv2 address with length 7 (should be 10)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Valid TORv3.
+    s << MakeSpan(ParseHex("04"                               // network type (TORv3)
+                           "20"                               // address length
+                           "79bcc625184b05194975c28b66b66b04" // address
+                           "69f7f6556fb1ac3189a79b40dda32f1f"
+                           ));
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK(addr.IsTor());
+    BOOST_CHECK_EQUAL(addr.ToString(),
+                      "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid TORv3, with bogus length.
+    s << MakeSpan(ParseHex("04" // network type (TORv3)
+                           "00" // address length
+                           "00" // address
+                           ));
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 TORv3 address with length 0 (should be 32)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Valid I2P.
+    s << MakeSpan(ParseHex("05"                               // network type (I2P)
+                           "20"                               // address length
+                           "a2894dabaec08c0051a481a6dac88b64" // address
+                           "f98232ae42d4b6fd2fa81952dfe36a87"));
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK_EQUAL(addr.ToString(),
+                      "ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid I2P, with bogus length.
+    s << MakeSpan(ParseHex("05" // network type (I2P)
+                           "03" // address length
+                           "00" // address
+                           ));
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 I2P address with length 3 (should be 32)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Valid CJDNS.
+    s << MakeSpan(ParseHex("06"                               // network type (CJDNS)
+                           "10"                               // address length
+                           "fc000001000200030004000500060007" // address
+                           ));
+    s >> addr;
+    BOOST_CHECK(addr.IsValid());
+    BOOST_CHECK_EQUAL(addr.ToString(), "fc00:1:2:3:4:5:6:7");
+    BOOST_REQUIRE(s.empty());
+
+    // Invalid CJDNS, with bogus length.
+    s << MakeSpan(ParseHex("06" // network type (CJDNS)
+                           "01" // address length
+                           "00" // address
+                           ));
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("BIP155 CJDNS address with length 1 (should be 16)"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Unknown, with extreme length.
+    s << MakeSpan(ParseHex("aa"             // network type (unknown)
+                           "fe00000002"     // address length (CompactSize's MAX_SIZE)
+                           "01020304050607" // address
+                           ));
+    BOOST_CHECK_EXCEPTION(s >> addr, std::ios_base::failure,
+                          HasReason("Address too long: 33554432 > 512"));
+    BOOST_REQUIRE(!s.empty()); // The stream is not consumed on invalid input.
+    s.clear();
+
+    // Unknown, with reasonable length.
+    s << MakeSpan(ParseHex("aa"       // network type (unknown)
+                           "04"       // address length
+                           "01020304" // address
+                           ));
+    s >> addr;
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
+
+    // Unknown, with zero length.
+    s << MakeSpan(ParseHex("aa" // network type (unknown)
+                           "00" // address length
+                           ""   // address
+                           ));
+    s >> addr;
+    BOOST_CHECK(!addr.IsValid());
+    BOOST_REQUIRE(s.empty());
 }
 
 // prior to PR #14728, this test triggers an undefined behavior

--- a/src/test/test_dash.h
+++ b/src/test/test_dash.h
@@ -150,4 +150,15 @@ struct TestMemPoolEntryHelper
 
 CBlock getBlock13b8a();
 
+// BOOST_CHECK_EXCEPTION predicates to check the specific validation error
+class HasReason {
+public:
+    HasReason(const std::string& reason) : m_reason(reason) {}
+    bool operator() (const std::runtime_error& e) const {
+        return std::string(e.what()).find(m_reason) != std::string::npos;
+    };
+private:
+    const std::string m_reason;
+};
+
 #endif

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -8,6 +8,7 @@
 #include <primitives/transaction.h>
 #include <sync.h>
 #include <utilstrencodings.h>
+#include <utilstring.h>
 #include <utilmoneystr.h>
 #include <test/test_dash.h>
 
@@ -95,6 +96,13 @@ BOOST_AUTO_TEST_CASE(util_HexStr)
     );
 }
 
+BOOST_AUTO_TEST_CASE(util_Join)
+{
+    // Normal version
+    BOOST_CHECK_EQUAL(Join({}, ", "), "");
+    BOOST_CHECK_EQUAL(Join({"foo"}, ", "), "foo");
+    BOOST_CHECK_EQUAL(Join({"foo", "bar"}, ", "), "foo, bar");
+}
 
 BOOST_AUTO_TEST_CASE(util_FormatISO8601DateTime)
 {

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -533,8 +533,9 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
         }
 
         // Finally - now create the service
-        if (private_key.empty()) // No private key, generate one
-            private_key = "NEW:RSA1024"; // Explicitly request RSA1024 - see issue #9214
+        if (private_key.empty()) { // No private key, generate one
+            private_key = "NEW:ED25519-V3"; // Explicitly request key type - see issue #9214
+        }
         // Request hidden service, redirect port.
         // Note that the 'virtual' port doesn't have to be the same as our internal port, but this is just a convenient
         // choice.  TODO; refactor the shutdown sequence some day.
@@ -720,7 +721,7 @@ void TorController::Reconnect()
 
 fs::path TorController::GetPrivateKeyFile()
 {
-    return GetDataDir() / "onion_private_key";
+    return GetDataDir() / "onion_v3_private_key";
 }
 
 void TorController::reconnect_cb(evutil_socket_t fd, short what, void *arg)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -193,20 +193,24 @@ std::string DecodeBase64(const std::string& str, bool* pf_invalid)
     return std::string((const char*)vchRet.data(), vchRet.size());
 }
 
-std::string EncodeBase32(Span<const unsigned char> input)
+std::string EncodeBase32(Span<const unsigned char> input, bool pad)
 {
     static const char *pbase32 = "abcdefghijklmnopqrstuvwxyz234567";
 
     std::string str;
     str.reserve(((input.size() + 4) / 5) * 8);
     ConvertBits<8, 5, true>([&](int v) { str += pbase32[v]; }, input.begin(), input.end());
-    while (str.size() % 8) str += '=';
+    if (pad) {
+        while (str.size() % 8) {
+            str += '=';
+        }
+    }
     return str;
 }
 
-std::string EncodeBase32(const std::string& str)
+std::string EncodeBase32(const std::string& str, bool pad)
 {
-    return EncodeBase32(MakeUCharSpan(str));
+    return EncodeBase32(MakeUCharSpan(str), pad);
 }
 
 std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <utilstrencodings.h>
+#include <utilstring.h>
 
 #include <tinyformat.h>
 
@@ -267,7 +268,7 @@ NODISCARD static bool ParsePrechecks(const std::string& str)
         return false;
     if (str.size() >= 1 && (isspace(str[0]) || isspace(str[str.size()-1]))) // No padding allowed
         return false;
-    if (str.size() != strlen(str.c_str())) // No embedded NUL characters allowed
+    if (!ValidAsCString(str)) // No embedded NUL characters allowed
         return false;
     return true;
 }

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -55,8 +55,20 @@ std::string EncodeBase64(const std::string& str);
 
 std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid = nullptr);
 std::string DecodeBase32(const std::string& str, bool* pf_invalid = nullptr);
-std::string EncodeBase32(Span<const unsigned char> input);
-std::string EncodeBase32(const std::string& str);
+
+/**
+ * Base32 encode.
+ * If `pad` is true, then the output will be padded with '=' so that its length
+ * is a multiple of 8.
+ */
+std::string EncodeBase32(Span<const unsigned char> input, bool pad = true);
+
+/**
+ * Base32 encode.
+ * If `pad` is true, then the output will be padded with '=' so that its length
+ * is a multiple of 8.
+ */
+std::string EncodeBase32(const std::string& str, bool pad = true);
 
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
 std::string i64tostr(int64_t n);

--- a/src/utilstring.cpp
+++ b/src/utilstring.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <utilstring.h>

--- a/src/utilstring.h
+++ b/src/utilstring.h
@@ -5,7 +5,9 @@
 #ifndef BITCOIN_UTILSTRING_H
 #define BITCOIN_UTILSTRING_H
 
-#include <functional>
+#include <attributes.h>
+
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -30,6 +32,14 @@ std::string Join(const std::vector<T>& list, const std::string& separator, Unary
 inline std::string Join(const std::vector<std::string>& list, const std::string& separator)
 {
     return Join(list, separator, [](const std::string& i) { return i; });
+}
+
+/**
+ * Check if a string does not contain any embedded NUL (\0) characters
+ */
+NODISCARD inline bool ValidAsCString(const std::string& str) noexcept
+{
+    return str.size() == strlen(str.c_str());
 }
 
 #endif // BITCOIN_UTILSTRING_H

--- a/src/utilstring.h
+++ b/src/utilstring.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,7 +7,11 @@
 
 #include <attributes.h>
 
+#include <algorithm>
+#include <array>
 #include <cstring>
+#include <locale>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -58,6 +62,17 @@ inline std::string Join(const std::vector<std::string>& list, const std::string&
 NODISCARD inline bool ValidAsCString(const std::string& str) noexcept
 {
     return str.size() == strlen(str.c_str());
+}
+
+/**
+ * Check whether a container begins with the given prefix.
+ */
+template <typename T1, size_t PREFIX_LEN>
+NODISCARD inline bool HasPrefix(const T1& obj,
+                                const std::array<uint8_t, PREFIX_LEN>& prefix)
+{
+    return obj.size() >= PREFIX_LEN &&
+           std::equal(std::begin(prefix), std::end(prefix), std::begin(obj));
 }
 
 #endif // BITCOIN_UTILSTRING_H

--- a/src/utilstring.h
+++ b/src/utilstring.h
@@ -28,10 +28,11 @@ NODISCARD inline std::string TrimString(const std::string& str, const std::strin
  * @param separator  The separator
  * @param unary_op   Apply this operator to each item in the list
  */
-template <typename T, typename UnaryOp>
-std::string Join(const std::vector<T>& list, const std::string& separator, UnaryOp unary_op)
+template <typename T, typename BaseType, typename UnaryOp>
+auto Join(const std::vector<T>& list, const BaseType& separator, UnaryOp unary_op)
+    -> decltype(unary_op(list.at(0)))
 {
-    std::string ret;
+    decltype(unary_op(list.at(0))) ret;
     for (size_t i = 0; i < list.size(); ++i) {
         if (i > 0) ret += separator;
         ret += unary_op(list.at(i));
@@ -39,9 +40,16 @@ std::string Join(const std::vector<T>& list, const std::string& separator, Unary
     return ret;
 }
 
+template <typename T>
+T Join(const std::vector<T>& list, const T& separator)
+{
+    return Join(list, separator, [](const T& i) { return i; });
+}
+
+// Explicit overload needed for c_str arguments, which would otherwise cause a substitution failure in the template above.
 inline std::string Join(const std::vector<std::string>& list, const std::string& separator)
 {
-    return Join(list, separator, [](const std::string& i) { return i; });
+    return Join<std::string>(list, separator);
 }
 
 /**

--- a/src/utilstring.h
+++ b/src/utilstring.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTILSTRING_H
+#define BITCOIN_UTILSTRING_H
+
+#include <functional>
+#include <string>
+#include <vector>
+
+/**
+ * Join a list of items
+ *
+ * @param list       The list to join
+ * @param separator  The separator
+ * @param unary_op   Apply this operator to each item in the list
+ */
+template <typename T, typename UnaryOp>
+std::string Join(const std::vector<T>& list, const std::string& separator, UnaryOp unary_op)
+{
+    std::string ret;
+    for (size_t i = 0; i < list.size(); ++i) {
+        if (i > 0) ret += separator;
+        ret += unary_op(list.at(i));
+    }
+    return ret;
+}
+
+inline std::string Join(const std::vector<std::string>& list, const std::string& separator)
+{
+    return Join(list, separator, [](const std::string& i) { return i; });
+}
+
+#endif // BITCOIN_UTILSTRING_H

--- a/src/utilstring.h
+++ b/src/utilstring.h
@@ -11,6 +11,16 @@
 #include <string>
 #include <vector>
 
+NODISCARD inline std::string TrimString(const std::string& str, const std::string& pattern = " \f\n\r\t\v")
+{
+    std::string::size_type front = str.find_first_not_of(pattern);
+    if (front == std::string::npos) {
+        return std::string();
+    }
+    std::string::size_type end = str.find_last_not_of(pattern);
+    return str.substr(front, end - front + 1);
+}
+
 /**
  * Join a list of items
  *

--- a/src/version.h
+++ b/src/version.h
@@ -48,4 +48,7 @@ static const int MNAUTH_NODE_VER_VERSION = 70218;
 //! introduction of QGETDATA/QDATA messages
 static const int LLMQ_DATA_MESSAGES_VERSION = 70219;
 
+// Make sure that none of the values above collide with
+// `SERIALIZE_TRANSACTION_NO_WITNESS` or `ADDRV2_FORMAT`.
+
 #endif // BITCOIN_VERSION_H

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test addrv2 relay
+"""
+
+import time
+
+from test_framework.messages import (
+    CAddress,
+    msg_addrv2,
+    NODE_NETWORK,
+    NODE_WITNESS,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+ADDRS = []
+for i in range(10):
+    addr = CAddress()
+    addr.time = int(time.time()) + i
+    addr.nServices = NODE_NETWORK | NODE_WITNESS
+    addr.ip = "123.123.123.{}".format(i % 256)
+    addr.port = 8333 + i
+    ADDRS.append(addr)
+
+
+class AddrReceiver(P2PInterface):
+    addrv2_received_and_checked = False
+
+    def __init__(self):
+        super().__init__(support_addrv2 = True)
+
+    def on_addrv2(self, message):
+        for addr in message.addrs:
+            assert_equal(addr.nServices, 9)
+            assert addr.ip.startswith('123.123.123.')
+            assert (8333 <= addr.port < 8343)
+        self.addrv2_received_and_checked = True
+
+    def wait_for_addrv2(self):
+        self.wait_until(lambda: "addrv2" in self.last_message)
+
+
+class AddrTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.log.info('Create connection that sends addrv2 messages')
+        addr_source = self.nodes[0].add_p2p_connection(P2PInterface())
+        msg = msg_addrv2()
+
+        self.log.info('Send too-large addrv2 message')
+        msg.addrs = ADDRS * 101
+        with self.nodes[0].assert_debug_log(['addrv2 message size = 1010']):
+            addr_source.send_and_ping(msg)
+
+        self.log.info('Check that addrv2 message content is relayed and added to addrman')
+        addr_receiver = self.nodes[0].add_p2p_connection(AddrReceiver())
+        msg.addrs = ADDRS
+        with self.nodes[0].assert_debug_log([
+                'Added 10 addresses from 127.0.0.1: 0 tried',
+                'received: addrv2 (131 bytes) peer=0',
+                'sending addrv2 (131 bytes) peer=1',
+        ]):
+            addr_source.send_and_ping(msg)
+            self.nodes[0].setmocktime(int(time.time()) + 30 * 60)
+            addr_receiver.wait_for_addrv2()
+
+        assert addr_receiver.addrv2_received_and_checked
+
+
+if __name__ == '__main__':
+    AddrTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -117,12 +117,17 @@ def uint256_from_compact(c):
     return v
 
 
-def deser_vector(f, c):
+# deser_function_name: Allow for an alternate deserialization function on the
+# entries in the vector.
+def deser_vector(f, c, deser_function_name=None):
     nit = deser_compact_size(f)
     r = []
     for i in range(nit):
         t = c()
-        t.deserialize(f)
+        if deser_function_name:
+            getattr(t, deser_function_name)(f)
+        else:
+            t.deserialize(f)
         r.append(t)
     return r
 
@@ -224,34 +229,82 @@ class CService():
 
 
 class CAddress():
+    __slots__ = ("net", "ip", "nServices", "port", "time")
+
+    # see https://github.com/bitcoin/bips/blob/master/bip-0155.mediawiki
+    NET_IPV4 = 1
+
+    ADDRV2_NET_NAME = {
+        NET_IPV4: "IPv4"
+    }
+
+    ADDRV2_ADDRESS_LENGTH = {
+        NET_IPV4: 4
+    }
+
     def __init__(self):
         self.time = 0
         self.nServices = 1
-        self.pchReserved = b"\x00" * 10 + b"\xff" * 2
+        self.net = self.NET_IPV4
         self.ip = "0.0.0.0"
         self.port = 0
 
-    def deserialize(self, f, with_time=True):
+    def deserialize(self, f, *, with_time=True):
+        """Deserialize from addrv1 format (pre-BIP155)"""
         if with_time:
-            self.time = struct.unpack("<i", f.read(4))[0]
+            # VERSION messages serialize CAddress objects without time
+            self.time = struct.unpack("<I", f.read(4))[0]
         self.nServices = struct.unpack("<Q", f.read(8))[0]
-        self.pchReserved = f.read(12)
+        # We only support IPv4 which means skip 12 bytes and read the next 4 as IPv4 address.
+        f.read(12)
+        self.net = self.NET_IPV4
         self.ip = socket.inet_ntoa(f.read(4))
         self.port = struct.unpack(">H", f.read(2))[0]
 
-    def serialize(self, with_time=True):
+    def serialize(self, *, with_time=True):
+        """Serialize in addrv1 format (pre-BIP155)"""
+        assert self.net == self.NET_IPV4
         r = b""
         if with_time:
-            r += struct.pack("<i", self.time)
+            # VERSION messages serialize CAddress objects without time
+            r += struct.pack("<I", self.time)
         r += struct.pack("<Q", self.nServices)
-        r += self.pchReserved
+        r += b"\x00" * 10 + b"\xff" * 2
+        r += socket.inet_aton(self.ip)
+        r += struct.pack(">H", self.port)
+        return r
+
+    def deserialize_v2(self, f):
+        """Deserialize from addrv2 format (BIP155)"""
+        self.time = struct.unpack("<I", f.read(4))[0]
+
+        self.nServices = deser_compact_size(f)
+
+        self.net = struct.unpack("B", f.read(1))[0]
+        assert self.net == self.NET_IPV4
+
+        address_length = deser_compact_size(f)
+        assert address_length == self.ADDRV2_ADDRESS_LENGTH[self.net]
+
+        self.ip = socket.inet_ntoa(f.read(4))
+
+        self.port = struct.unpack(">H", f.read(2))[0]
+
+    def serialize_v2(self):
+        """Serialize in addrv2 format (BIP155)"""
+        assert self.net == self.NET_IPV4
+        r = b""
+        r += struct.pack("<I", self.time)
+        r += ser_compact_size(self.nServices)
+        r += struct.pack("B", self.net)
+        r += ser_compact_size(self.ADDRV2_ADDRESS_LENGTH[self.net])
         r += socket.inet_aton(self.ip)
         r += struct.pack(">H", self.port)
         return r
 
     def __repr__(self):
-        return "CAddress(nServices=%i ip=%s port=%i)" % (self.nServices,
-                                                         self.ip, self.port)
+        return ("CAddress(nServices=%i net=%s addr=%s port=%i)"
+                % (self.nServices, self.ADDRV2_NET_NAME[self.net], self.ip, self.port))
 
 
 class CInv():
@@ -1129,9 +1182,43 @@ class msg_addr():
     def __repr__(self):
         return "msg_addr(addrs=%s)" % (repr(self.addrs))
 
+class msg_addrv2:
+    __slots__ = ("addrs",)
+    msgtype = b"addrv2"
 
-class msg_inv():
-    command = b"inv"
+    def __init__(self):
+        self.addrs = []
+
+    def deserialize(self, f):
+        self.addrs = deser_vector(f, CAddress, "deserialize_v2")
+
+    def serialize(self):
+        return ser_vector(self.addrs, "serialize_v2")
+
+    def __repr__(self):
+        return "msg_addrv2(addrs=%s)" % (repr(self.addrs))
+
+
+class msg_sendaddrv2:
+    __slots__ = ()
+    msgtype = b"sendaddrv2"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_sendaddrv2()"
+
+
+class msg_inv:
+    __slots__ = ("inv",)
+    msgtype = b"inv"
 
     def __init__(self, inv=None):
         if inv is None:

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -114,6 +114,7 @@ BASE_SCRIPTS = [
     'rpc_users.py',
     'feature_proxy.py',
     'rpc_signrawtransaction.py',
+    'p2p_addrv2_relay.py',
     'p2p_disconnect_ban.py',
     'feature_addressindex.py',
     'feature_timestampindex.py',


### PR DESCRIPTION
## Overview

Continuing the work from https://github.com/dashpay/dash/pull/3939 to ensure that Tor support is available after the deprecation of Torv2 ([source](https://blog.torproject.org/v2-deprecation-timeline)). More information about it is available at https://github.com/bitcoin/bitcoin/issues/18884.

This PR attempts to implement https://github.com/bitcoin/bitcoin/pull/19031 (which were split into various pull requests for ease of review) so that Torv3 support is available in Core. 

## Contents

The PR heavily relies upon functionality that _wasn't been implemented then, requiring multiple dependencies_. Therefore, those features have also been backported and logged accordingly.

### Dependencies needed by https://github.com/bitcoin/bitcoin/pull/19031

* ~~Merge https://github.com/bitcoin/bitcoin/pull/16702 ("p2p: supplying and using asmap to improve IP bucketing in addrman" by naumenkogs)~~

* ~~Merge https://github.com/bitcoin/bitcoin/pull/17812 ("config, net, test: asmap feature refinements and functional tests" by fanquake)~~

* ~~Merge https://github.com/bitcoin/bitcoin/pull/16730 ("Support serialization of std::vector<bool>" by sipa)~~

  * **Segmented and available for review as https://github.com/dashpay/dash/pull/4028**

* ~~Merge https://github.com/bitcoin/bitcoin/pull/13815 ("util: Add [[nodiscard]] to all {Decode,Parse}[...](...) functions returning bool" by practicalswift)~~

  *  **Segmented and available for review as https://github.com/dashpay/dash/pull/4035**

* ~~Partial merge https://github.com/bitcoin/bitcoin/pull/13697 ("Support output descriptors in scantxoutset" by sipa)~~
* ~~Mostly merge https://github.com/bitcoin/bitcoin/pull/18591 ("Add C++17 build to Travis" by sipa)~~
* ~~Mostly merge https://github.com/bitcoin/bitcoin/pull/19387 ("span: update constructors to match c++20 draft spec and add lifetimebound attribute" by theuni)~~

  *  **Segmented and available for review as https://github.com/dashpay/dash/pull/4036**

* ~~Mostly merge https://github.com/bitcoin/bitcoin/pull/18112 ("Serialization improvements step 5 (blockencodings)" by sipa)~~
* ~~Partial merge https://github.com/bitcoin/bitcoin/pull/18021 ("Serialization improvements step 4 (undo.h)" by sipa)~~
  *  **Segmented and available for review as https://github.com/dashpay/dash/pull/4037**

* ~~Merge  https://github.com/bitcoin/bitcoin/pull/19660 ("refactor: Make HexStr take a span" by laanwj)~~
* ~~Merge https://github.com/bitcoin/bitcoin/pull/19373 ("refactor: Replace HexStr(o.begin(), o.end()) with HexStr(o)" by laanwj, using script documented by [MarcoFalke](https://github.com/bitcoin/bitcoin/pull/19373#issuecomment-648988027))~~
* ~~Merge https://github.com/bitcoin/bitcoin/pull/19841 ("Implement Keccak and SHA3_256" by laanwj)~~
   *  **Segmented and available for review as https://github.com/dashpay/dash/pull/4164**
 
* ~~Merge https://github.com/bitcoin/bitcoin/pull/19687 ("refactor: make EncodeBase{32,64} consume Spans" by theStack)~~
  *  **Segmented and available for review as https://github.com/dashpay/dash/pull/4166**

### As part of https://github.com/bitcoin/bitcoin/pull/19031

* ~~https://github.com/bitcoin/bitcoin/pull/19954 ("Complete the BIP155 implementation and upgrade to TORv3" by vasild)~~
* ~~https://github.com/bitcoin/bitcoin/pull/19845 ("net: CNetAddr: add support to (un)serialize as ADDRv2" by vasild)~~
  * **Segmented and available for review as #4025 (this pull request)**

* ~~https://github.com/bitcoin/bitcoin/pull/19628 ("net: change CNetAddr::ip to have flexible size" by vasild)~~
  *  **Segmented and available for review as https://github.com/dashpay/dash/pull/4166**
# Disclosures

* **This is a work in progress**. Dash-specific changes have not been tested, only compilation and unit test success has been ensured. Running the client on a testnet _is_ necessary.
* ~~Tests fail. I do not know why, I do not know how. They fail.~~ No, they don't :)
* I am not too familiar with serialization logic and it is _possible_ that some of the code will break.

## Changes that need review

* `SerializationOp`'s handling of `nServices` in `CAddress` https://github.com/dashpay/dash/commit/28878d3712829c0d58d97c67d49eb745185be0b4#diff-8e2ffc8fe0e0847a6aac311a93b2faeebd2d76ddb2c81741bb8cf7448287807eR381

