### PR TITLE
bugfix: Add missing return in TrySignInputLocks

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -518,6 +518,7 @@ bool CInstantSendManager::TrySignInputLocks(const CTransaction& tx, bool fRetroa
         }
     }
 
+    return true;
 }
 
 bool CInstantSendManager::CheckCanLock(const CTransaction& tx, bool printDebug, const Consensus::Params& params) const


### PR DESCRIPTION
A follow-up to #4024 