### PR TITLE
bls|depends: Upgrade to bls-signatures version 1.0.0

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -23,7 +23,6 @@ packages:
 - "autoconf"
 - "libtool"
 - "automake"
-- "cmake"
 - "faketime"
 - "bsdmainutils"
 - "ca-certificates"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -18,7 +18,6 @@ packages:
 - "automake"
 - "faketime"
 - "bsdmainutils"
-- "cmake"
 - "imagemagick"
 - "libcap-dev"
 - "libz-dev"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -13,7 +13,6 @@ packages:
 - "autoconf"
 - "libtool"
 - "automake"
-- "cmake"
 - "faketime"
 - "bsdmainutils"
 - "mingw-w64"

--- a/depends/README.md
+++ b/depends/README.md
@@ -35,7 +35,7 @@ Install the required dependencies: Ubuntu & Debian
 
 For macOS cross compilation:
 
-    sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
+    sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
 
 For Win32/Win64 cross compilation:
 

--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -9,6 +9,7 @@ define $(package)_set_vars
   $(package)_config_opts=-DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix)
   $(package)_config_opts+= -DCMAKE_PREFIX_PATH=$($(package)_staging_dir)/$(host_prefix)
   $(package)_config_opts+= -DSTLIB=ON -DSHLIB=OFF -DSTBIN=ON
+  $(package)_config_opts+= -DBUILD_BLS_PYTHON_BINDINGS=0 -DBUILD_BLS_TESTS=0 -DBUILD_BLS_BENCHMARKS=0
   $(package)_config_opts_linux=-DOPSYS=LINUX -DCMAKE_SYSTEM_NAME=Linux
   $(package)_config_opts_darwin=-DOPSYS=MACOSX -DCMAKE_SYSTEM_NAME=Darwin
   $(package)_config_opts_mingw32=-DOPSYS=WINDOWS -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS="" -DCMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS=""

--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -1,4 +1,4 @@
-package=chia_bls
+package=bls-dash
 $(package)_version=1.0.0
 $(package)_download_path=https://github.com/dashpay/bls-signatures/archive
 $(package)_file_name=$($(package)_version).tar.gz

--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -12,7 +12,7 @@ define $(package)_set_vars
   $(package)_config_opts+= -DBUILD_BLS_PYTHON_BINDINGS=0 -DBUILD_BLS_TESTS=0 -DBUILD_BLS_BENCHMARKS=0
   $(package)_config_opts_linux=-DOPSYS=LINUX -DCMAKE_SYSTEM_NAME=Linux
   $(package)_config_opts_darwin=-DOPSYS=MACOSX -DCMAKE_SYSTEM_NAME=Darwin
-  $(package)_config_opts_mingw32=-DOPSYS=WINDOWS -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS="" -DCMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS=""
+  $(package)_config_opts_mingw32=-DOPSYS=WINDOWS -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS=""
   $(package)_config_opts_i686+= -DWSIZE=32
   $(package)_config_opts_x86_64+= -DWSIZE=64
   $(package)_config_opts_arm+= -DWSIZE=32

--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -1,9 +1,34 @@
 package=bls-dash
 $(package)_version=1.0.0
 $(package)_download_path=https://github.com/dashpay/bls-signatures/archive
-$(package)_file_name=$($(package)_version).tar.gz
+$(package)_download_file=$($(package)_version).tar.gz
+$(package)_file_name=$(package)-$($(package)_download_file)
+$(package)_build_subdir=build
 $(package)_sha256_hash=ecbc51457dd3de153af27333038f149ba585e16fe46351b763938cb6ef0f2d9a
 $(package)_dependencies=gmp cmake
+
+$(package)_relic_version=186a15da6d07ef436dd8f00a4345838310a0aad3
+$(package)_relic_download_path=https://github.com/relic-toolkit/relic/archive
+$(package)_relic_download_file=$($(package)_relic_version).tar.gz
+$(package)_relic_file_name=relic-toolkit-$($(package)_relic_download_file)
+$(package)_relic_build_subdir=relic
+$(package)_relic_sha256_hash=70fb36acfd206f2128f6da38bda9f9ef070062d50adb97b053d98477bf0112fc
+
+$(package)_extra_sources=$($(package)_relic_file_name)
+
+define $(package)_fetch_cmds
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_relic_download_path),$($(package)_relic_download_file),$($(package)_relic_file_name),$($(package)_relic_sha256_hash))
+endef
+
+define $(package)_extract_cmds
+  mkdir -p $($(package)_extract_dir) && \
+  echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_relic_sha256_hash)  $($(package)_source_dir)/$($(package)_relic_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  tar --strip-components=1 -xf $($(package)_source) -C . && \
+  cp $($(package)_source_dir)/$($(package)_relic_file_name) .
+endef
 
 define $(package)_set_vars
   $(package)_config_opts=-DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix)
@@ -25,22 +50,24 @@ define $(package)_set_vars
   endif
 endef
 
+define $(package)_preprocess_cmds
+  sed -i.old "s|GIT_REPOSITORY https://github.com/relic-toolkit/relic.git|URL \"../../relic-toolkit-$($(package)_relic_version).tar.gz\"|" src/CMakeLists.txt && \
+  sed -i.old "s|GIT_TAG        .*RELIC_GIT_TAG.*|URL_HASH SHA256=$($(package)_relic_sha256_hash)|" src/CMakeLists.txt
+endef
+
 define $(package)_config_cmds
   export CC="$($(package)_cc)" && \
   export CXX="$($(package)_cxx)" && \
   export CFLAGS="$($(package)_cflags) $($(package)_cppflags)" && \
   export CXXFLAGS="$($(package)_cxxflags) $($(package)_cppflags)" && \
   export LDFLAGS="$($(package)_ldflags)" && \
-  mkdir -p build && cd build && \
   $(host_prefix)/bin/cmake ../ $($(package)_config_opts)
 endef
 
 define $(package)_build_cmds
-  cd build && \
   $(MAKE) $($(package)_build_opts)
 endef
 
 define $(package)_stage_cmds
-  cd build && \
   $(MAKE) install
 endef

--- a/depends/packages/chia_bls.mk
+++ b/depends/packages/chia_bls.mk
@@ -4,7 +4,7 @@ $(package)_version=v20181101
 $(package)_download_path=https://github.com/dashpay/bls-signatures/archive
 $(package)_file_name=$($(package)_version).tar.gz
 $(package)_sha256_hash=b3ec74a77a7b6795f84b05e051a0824ef8d9e05b04b2993f01040f35689aa87c
-$(package)_dependencies=gmp
+$(package)_dependencies=gmp cmake
 #$(package)_patches=...TODO (when we switch back to https://github.com/Chia-Network/bls-signatures)
 
 #define $(package)_preprocess_cmds
@@ -37,7 +37,7 @@ define $(package)_config_cmds
   export CXXFLAGS="$($(package)_cxxflags) $($(package)_cppflags)" && \
   export LDFLAGS="$($(package)_ldflags)" && \
   mkdir -p build && cd build && \
-  cmake ../ $($(package)_config_opts)
+  $(host_prefix)/bin/cmake ../ $($(package)_config_opts)
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/chia_bls.mk
+++ b/depends/packages/chia_bls.mk
@@ -1,15 +1,9 @@
 package=chia_bls
-$(package)_version=v20181101
-# It's actually from https://github.com/Chia-Network/bls-signatures, but we have so many patches atm that it's forked
+$(package)_version=1.0.0
 $(package)_download_path=https://github.com/dashpay/bls-signatures/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=b3ec74a77a7b6795f84b05e051a0824ef8d9e05b04b2993f01040f35689aa87c
+$(package)_sha256_hash=ecbc51457dd3de153af27333038f149ba585e16fe46351b763938cb6ef0f2d9a
 $(package)_dependencies=gmp cmake
-#$(package)_patches=...TODO (when we switch back to https://github.com/Chia-Network/bls-signatures)
-
-#define $(package)_preprocess_cmds
-#  for i in $($(package)_patches); do patch -N -p1 < $($(package)_patch_dir)/$$$$i; done
-#endef
 
 define $(package)_set_vars
   $(package)_config_opts=-DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix)

--- a/depends/packages/cmake.mk
+++ b/depends/packages/cmake.mk
@@ -1,0 +1,17 @@
+package=cmake
+$(package)_version=3.14.7
+$(package)_download_path=https://cmake.org/files/v3.14/
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=9221993e0af3e6d10124d840ff24f5b2f3b884416fca04d3312cb0388dec1385
+
+define $(package)_config_cmds
+  ./bootstrap --prefix=$(host_prefix)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef

--- a/depends/packages/native_cdrkit.mk
+++ b/depends/packages/native_cdrkit.mk
@@ -4,13 +4,14 @@ $(package)_download_path=http://distro.ibiblio.org/fatdog/source/600/c
 $(package)_file_name=cdrkit-$($(package)_version).tar.bz2
 $(package)_sha256_hash=b50d64c214a65b1a79afe3a964c691931a4233e2ba605d793eb85d0ac3652564
 $(package)_patches=cdrkit-deterministic.patch
+$(package)_dependencies=cmake
 
 define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/cdrkit-deterministic.patch
 endef
 
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX=$(build_prefix)
+  $(host_prefix)/bin/cmake -DCMAKE_INSTALL_PREFIX=$(build_prefix)
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/native_libdmg-hfsplus.mk
+++ b/depends/packages/native_libdmg-hfsplus.mk
@@ -4,13 +4,14 @@ $(package)_download_path=https://github.com/theuni/libdmg-hfsplus/archive
 $(package)_file_name=libdmg-hfsplus-v$($(package)_version).tar.gz
 $(package)_sha256_hash=6569a02eb31c2827080d7d59001869ea14484c281efab0ae7f2b86af5c3120b3
 $(package)_build_subdir=build
+$(package)_dependencies=cmake
 
 define $(package)_preprocess_cmds
   mkdir build
 endef
 
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix)/bin ..
+  $(host_prefix)/bin/cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix)/bin ..
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl libevent zeromq gmp chia_bls backtrace
+packages:=boost openssl libevent zeromq gmp chia_bls backtrace cmake
 
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl libevent zeromq gmp chia_bls backtrace cmake
+packages:=boost openssl libevent zeromq gmp bls-dash backtrace cmake
 
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib

--- a/doc/build-cross.md
+++ b/doc/build-cross.md
@@ -45,7 +45,7 @@ First, install the general dependencies:
 
     sudo apt update
     sudo apt upgrade
-    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git python3 cmake
+    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git python3
 
 A host toolchain (`build-essential`) is necessary because some dependency
 packages need to build host utilities that are used in the build process.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -12,27 +12,27 @@ Run the following commands to install required packages:
 
 ##### Debian/Ubuntu:
 ```bash
-$ sudo apt-get install curl build-essential libtool autotools-dev automake pkg-config python3 bsdmainutils cmake
+$ sudo apt-get install curl build-essential libtool autotools-dev automake pkg-config python3 bsdmainutils
 ```
 
 ##### Fedora:
 ```bash
-$ sudo dnf install gcc-c++ libtool make autoconf automake python3 cmake libstdc++-static patch
+$ sudo dnf install gcc-c++ libtool make autoconf automake python3 libstdc++-static patch
 ```
 
 ##### Arch Linux:
 ```bash
-$ pacman -S base-devel python3 cmake
+$ pacman -S base-devel python3
 ```
 
 ##### Alpine Linux:
 ```sh
-$ sudo apk --update --no-cache add autoconf automake cmake curl g++ gcc libexecinfo-dev libexecinfo-static libtool make perl pkgconfig python3 patch linux-headers
+$ sudo apk --update --no-cache add autoconf automake curl g++ gcc libexecinfo-dev libexecinfo-static libtool make perl pkgconfig python3 patch linux-headers
 ```
 
 ##### FreeBSD/OpenBSD:
 ```bash
-pkg_add gmake cmake libtool
+pkg_add gmake libtool
 pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.15)
 pkg_add python # (select highest version, e.g. 3.5)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,7 +45,7 @@ BITCOIN_INCLUDES=-I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFL
 BITCOIN_INCLUDES += -I$(srcdir)/secp256k1/include
 BITCOIN_INCLUDES += $(UNIVALUE_CFLAGS)
 
-BLS_LIBS=-lchiabls -lgmp
+BLS_LIBS=-lbls-dash -lgmp
 
 LIBBITCOIN_SERVER=libdash_server.a
 LIBBITCOIN_COMMON=libdash_common.a

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -14,6 +14,14 @@
 #include <assert.h>
 #include <string.h>
 
+static std::unique_ptr<bls::CoreMPL> pSchemeLegacy(new bls::LegacySchemeMPL);
+static std::unique_ptr<bls::CoreMPL> pScheme(new bls::BasicSchemeMPL);
+
+static std::unique_ptr<bls::CoreMPL>& Scheme(const bool fLegacy)
+{
+    return fLegacy ? pSchemeLegacy : pScheme;
+}
+
 CBLSId::CBLSId(const uint256& nHash) : CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_SIZE, CBLSId>()
 {
     impl = nHash;
@@ -24,7 +32,7 @@ CBLSId::CBLSId(const uint256& nHash) : CBLSWrapper<CBLSIdImplicit, BLS_CURVE_ID_
 void CBLSSecretKey::AggregateInsecure(const CBLSSecretKey& o)
 {
     assert(IsValid() && o.IsValid());
-    impl = bls::PrivateKey::AggregateInsecure({impl, o.impl});
+    impl = bls::PrivateKey::Aggregate({impl, o.impl});
     cachedHash.SetNull();
 }
 
@@ -41,7 +49,7 @@ CBLSSecretKey CBLSSecretKey::AggregateInsecure(const std::vector<CBLSSecretKey>&
     }
 
     CBLSSecretKey ret;
-    ret.impl = bls::PrivateKey::AggregateInsecure(v);
+    ret.impl = bls::PrivateKey::Aggregate(v);
     ret.fValid = true;
     ret.cachedHash.SetNull();
     return ret;
@@ -54,7 +62,7 @@ void CBLSSecretKey::MakeNewKey()
     while (true) {
         GetStrongRandBytes(buf, sizeof(buf));
         try {
-            impl = bls::PrivateKey::FromBytes((const uint8_t*)buf);
+            impl = bls::PrivateKey::FromBytes(bls::Bytes((const uint8_t*)buf, SerSize));
             break;
         } catch (...) {
         }
@@ -83,7 +91,7 @@ bool CBLSSecretKey::SecretKeyShare(const std::vector<CBLSSecretKey>& msk, const 
     }
 
     try {
-        impl = bls::BLS::PrivateKeyShare(mskVec, (const uint8_t*)_id.impl.begin());
+        impl = bls::Threshold::PrivateKeyShare(mskVec, bls::Bytes(_id.impl.begin(), _id.impl.size()));
     } catch (...) {
         return false;
     }
@@ -100,7 +108,7 @@ CBLSPublicKey CBLSSecretKey::GetPublicKey() const
     }
 
     CBLSPublicKey pubKey;
-    pubKey.impl = impl.GetPublicKey();
+    pubKey.impl = impl.GetG1Element();
     pubKey.fValid = true;
     pubKey.cachedHash.SetNull();
     return pubKey;
@@ -113,7 +121,7 @@ CBLSSignature CBLSSecretKey::Sign(const uint256& hash) const
     }
 
     CBLSSignature sigRet;
-    sigRet.impl = impl.SignInsecurePrehashed((const uint8_t*)hash.begin());
+    sigRet.impl = Scheme(fLegacy)->Sign(impl, bls::Bytes(hash.begin(), hash.size()));
 
     sigRet.fValid = true;
     sigRet.cachedHash.SetNull();
@@ -124,24 +132,24 @@ CBLSSignature CBLSSecretKey::Sign(const uint256& hash) const
 void CBLSPublicKey::AggregateInsecure(const CBLSPublicKey& o)
 {
     assert(IsValid() && o.IsValid());
-    impl = bls::PublicKey::AggregateInsecure({impl, o.impl});
+    impl = Scheme(fLegacy)->Aggregate({impl, o.impl});
     cachedHash.SetNull();
 }
 
-CBLSPublicKey CBLSPublicKey::AggregateInsecure(const std::vector<CBLSPublicKey>& pks)
+CBLSPublicKey CBLSPublicKey::AggregateInsecure(const std::vector<CBLSPublicKey>& pks, const bool fLegacy)
 {
     if (pks.empty()) {
         return CBLSPublicKey();
     }
 
-    std::vector<bls::PublicKey> v;
-    v.reserve(pks.size());
+    std::vector<bls::G1Element> vecPublicKeys;
+    vecPublicKeys.reserve(pks.size());
     for (auto& pk : pks) {
-        v.emplace_back(pk.impl);
+        vecPublicKeys.emplace_back(pk.impl);
     }
 
     CBLSPublicKey ret;
-    ret.impl = bls::PublicKey::AggregateInsecure(v);
+    ret.impl = Scheme(fLegacy)->Aggregate(vecPublicKeys);
     ret.fValid = true;
     ret.cachedHash.SetNull();
     return ret;
@@ -156,7 +164,7 @@ bool CBLSPublicKey::PublicKeyShare(const std::vector<CBLSPublicKey>& mpk, const 
         return false;
     }
 
-    std::vector<bls::PublicKey> mpkVec;
+    std::vector<bls::G1Element> mpkVec;
     mpkVec.reserve(mpk.size());
     for (const CBLSPublicKey& pk : mpk) {
         if (!pk.IsValid()) {
@@ -166,7 +174,7 @@ bool CBLSPublicKey::PublicKeyShare(const std::vector<CBLSPublicKey>& mpk, const 
     }
 
     try {
-        impl = bls::BLS::PublicKeyShare(mpkVec, (const uint8_t*)_id.impl.begin());
+        impl = bls::Threshold::PublicKeyShare(mpkVec, bls::Bytes(_id.impl.begin(), _id.impl.size()));
     } catch (...) {
         return false;
     }
@@ -184,7 +192,7 @@ bool CBLSPublicKey::DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& 
     if (!sk.IsValid() || !pk.IsValid()) {
         return false;
     }
-    impl = bls::BLS::DHKeyExchange(sk.impl, pk.impl);
+    impl = sk.impl * pk.impl;
     fValid = true;
     cachedHash.SetNull();
     return true;
@@ -193,24 +201,24 @@ bool CBLSPublicKey::DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& 
 void CBLSSignature::AggregateInsecure(const CBLSSignature& o)
 {
     assert(IsValid() && o.IsValid());
-    impl = bls::InsecureSignature::Aggregate({impl, o.impl});
+    impl = Scheme(fLegacy)->Aggregate({impl, o.impl});
     cachedHash.SetNull();
 }
 
-CBLSSignature CBLSSignature::AggregateInsecure(const std::vector<CBLSSignature>& sigs)
+CBLSSignature CBLSSignature::AggregateInsecure(const std::vector<CBLSSignature>& sigs, const bool fLegacy)
 {
     if (sigs.empty()) {
         return CBLSSignature();
     }
 
-    std::vector<bls::InsecureSignature> v;
+    std::vector<bls::G2Element> v;
     v.reserve(sigs.size());
     for (auto& pk : sigs) {
         v.emplace_back(pk.impl);
     }
 
     CBLSSignature ret;
-    ret.impl = bls::InsecureSignature::Aggregate(v);
+    ret.impl = Scheme(fLegacy)->Aggregate(v);
     ret.fValid = true;
     ret.cachedHash.SetNull();
     return ret;
@@ -218,22 +226,27 @@ CBLSSignature CBLSSignature::AggregateInsecure(const std::vector<CBLSSignature>&
 
 CBLSSignature CBLSSignature::AggregateSecure(const std::vector<CBLSSignature>& sigs,
                                              const std::vector<CBLSPublicKey>& pks,
-                                             const uint256& hash)
+                                             const uint256& hash,
+                                             const bool fLegacy)
 {
     if (sigs.size() != pks.size() || sigs.empty()) {
         return CBLSSignature();
     }
 
-    std::vector<bls::Signature> v;
-    v.reserve(sigs.size());
+    std::vector<bls::G1Element> vecPublicKeys;
+    vecPublicKeys.reserve(pks.size());
+    for (auto& pk : pks) {
+        vecPublicKeys.push_back(pk.impl);
+    }
 
-    for (size_t i = 0; i < sigs.size(); i++) {
-        bls::AggregationInfo aggInfo = bls::AggregationInfo::FromMsgHash(pks[i].impl, hash.begin());
-        v.emplace_back(bls::Signature::FromInsecureSig(sigs[i].impl, aggInfo));
+    std::vector<bls::G2Element> vecSignatures;
+    vecSignatures.reserve(pks.size());
+    for (auto& sig : sigs) {
+        vecSignatures.push_back(sig.impl);
     }
 
     CBLSSignature ret;
-    ret.impl = bls::Signature::AggregateSigs(v).GetInsecureSig();
+    ret.impl = Scheme(fLegacy)->AggregateSecure(vecPublicKeys, vecSignatures, bls::Bytes(hash.begin(), hash.size()));
     ret.fValid = true;
     ret.cachedHash.SetNull();
     return ret;
@@ -242,7 +255,7 @@ CBLSSignature CBLSSignature::AggregateSecure(const std::vector<CBLSSignature>& s
 void CBLSSignature::SubInsecure(const CBLSSignature& o)
 {
     assert(IsValid() && o.IsValid());
-    impl = impl.DivideBy({o.impl});
+    impl = impl + o.impl.Negate();
     cachedHash.SetNull();
 }
 
@@ -253,7 +266,7 @@ bool CBLSSignature::VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& h
     }
 
     try {
-        return impl.Verify({(const uint8_t*)hash.begin()}, {pubKey.impl});
+        return Scheme(fLegacy)->Verify(pubKey.impl, bls::Bytes(hash.begin(), hash.size()), impl);
     } catch (...) {
         return false;
     }
@@ -266,8 +279,8 @@ bool CBLSSignature::VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& p
     }
     assert(!pubKeys.empty() && !hashes.empty() && pubKeys.size() == hashes.size());
 
-    std::vector<bls::PublicKey> pubKeyVec;
-    std::vector<const uint8_t*> hashes2;
+    std::vector<bls::G1Element> pubKeyVec;
+    std::vector<bls::Bytes> hashes2;
     hashes2.reserve(hashes.size());
     pubKeyVec.reserve(pubKeys.size());
     for (size_t i = 0; i < pubKeys.size(); i++) {
@@ -276,11 +289,11 @@ bool CBLSSignature::VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& p
             return false;
         }
         pubKeyVec.push_back(p.impl);
-        hashes2.push_back((uint8_t*)hashes[i].begin());
+        hashes2.emplace_back(hashes[i].begin(), hashes[i].size());
     }
 
     try {
-        return impl.Verify(hashes2, pubKeyVec);
+        return Scheme(fLegacy)->AggregateVerify(pubKeyVec, hashes2, impl);
     } catch (...) {
         return false;
     }
@@ -292,16 +305,13 @@ bool CBLSSignature::VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks
         return false;
     }
 
-    std::vector<bls::AggregationInfo> v;
-    v.reserve(pks.size());
-    for (auto& pk : pks) {
-        auto aggInfo = bls::AggregationInfo::FromMsgHash(pk.impl, hash.begin());
-        v.emplace_back(aggInfo);
+    std::vector<bls::G1Element> vecPublicKeys;
+    vecPublicKeys.reserve(pks.size());
+    for (const auto& pk : pks) {
+        vecPublicKeys.push_back(pk.impl);
     }
 
-    bls::AggregationInfo aggInfo = bls::AggregationInfo::MergeInfos(v);
-    bls::Signature aggSig = bls::Signature::FromInsecureSig(impl, aggInfo);
-    return aggSig.Verify();
+    return Scheme(fLegacy)->VerifySecure(vecPublicKeys, impl, bls::Bytes(hash.begin(), hash.size()));
 }
 
 bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids)
@@ -313,8 +323,8 @@ bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::v
         return false;
     }
 
-    std::vector<bls::InsecureSignature> sigsVec;
-    std::vector<const uint8_t*> idsVec;
+    std::vector<bls::G2Element> sigsVec;
+    std::vector<bls::Bytes> idsVec;
     sigsVec.reserve(sigs.size());
     idsVec.reserve(sigs.size());
 
@@ -323,11 +333,11 @@ bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::v
             return false;
         }
         sigsVec.emplace_back(sigs[i].impl);
-        idsVec.emplace_back(ids[i].impl.begin());
+        idsVec.emplace_back(ids[i].impl.begin(), ids[i].impl.size());
     }
 
     try {
-        impl = bls::BLS::RecoverSig(sigsVec, idsVec);
+        impl = bls::Threshold::SignatureRecover(sigsVec, idsVec);
     } catch (...) {
         return false;
     }


### PR DESCRIPTION
This PR upgrades the codebase to support the new version of `dashpay/bls-signatures`. 
- Adds `cmake` to depends because version `3.14` is required by the new version
- Bump and modifies `chia-bls.mk` to support `dashpay/bls-signatures@1.0.0`
- Rename `chia-bls.mk` to `bls-dash.mk`
- Integrates the new version into the codebase.

--- 

**Notes**
See 36c25da which is to show that everything is working when running nodes with the new version of the library together with nodes with the old version running binaries from this pipeline https://gitlab.com/dashpay/dash/-/pipelines/272304135.