### PR TITLE
llmq|init|test: Add "mode" to -llmq-qvvec-sync parameter 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -640,7 +640,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += HelpMessageGroup(_("Masternode options:"));
     strUsage += HelpMessageOpt("-llmq-data-recovery=<n>", strprintf(_("Enable automated quorum data recovery (default: %u)"), llmq::DEFAULT_ENABLE_QUORUM_DATA_RECOVERY));
-    strUsage += HelpMessageOpt("-llmq-qvvec-sync=<quorum_name:mode>", strprintf(_("Defines from which LLMQ type the masternode should sync quorum verification vectors. Can be used multiple times with different LLMQ types. (mode: %d (sync always from all quorums of the type defined by \"quorum_name\"), %d (sync from all quorums of the type defined by \"quorum_name\") if member of any of the quorums"), llmq::SyncAlways, llmq::SyncOnlyIfTypeMember));
+    strUsage += HelpMessageOpt("-llmq-qvvec-sync=<quorum_name:mode>", strprintf(_("Defines from which LLMQ type the masternode should sync quorum verification vectors. Can be used multiple times with different LLMQ types. (mode: %d (sync always from all quorums of the type defined by \"quorum_name\"), %d (sync from all quorums of the type defined by \"quorum_name\") if member of any of the quorums"), (int32_t)llmq::QvvecSyncMode::Always, (int32_t)llmq::QvvecSyncMode::OnlyIfTypeMember));
     strUsage += HelpMessageOpt("-masternodeblsprivkey=<hex>", _("Set the masternode BLS private key and enable the client to act as a masternode"));
     strUsage += HelpMessageOpt("-platform-user=<user>", _("Set the username for the \"platform user\", a restricted user intended to be used by Dash Platform, to the specified username."));
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -640,7 +640,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += HelpMessageGroup(_("Masternode options:"));
     strUsage += HelpMessageOpt("-llmq-data-recovery=<n>", strprintf(_("Enable automated quorum data recovery (default: %u)"), llmq::DEFAULT_ENABLE_QUORUM_DATA_RECOVERY));
-    strUsage += HelpMessageOpt("-llmq-qvvec-sync=<quorum name>", _("Defines from which LLMQ type the masternode should sync quorum verification vectors. Can be used multiple times with different LLMQ types."));
+    strUsage += HelpMessageOpt("-llmq-qvvec-sync=<quorum_name:mode>", strprintf(_("Defines from which LLMQ type the masternode should sync quorum verification vectors. Can be used multiple times with different LLMQ types. (mode: %d (sync always from all quorums of the type defined by \"quorum_name\"), %d (sync from all quorums of the type defined by \"quorum_name\") if member of any of the quorums"), llmq::SyncAlways, llmq::SyncOnlyIfTypeMember));
     strUsage += HelpMessageOpt("-masternodeblsprivkey=<hex>", _("Set the masternode BLS private key and enable the client to act as a masternode"));
     strUsage += HelpMessageOpt("-platform-user=<user>", _("Set the username for the \"platform user\", a restricted user intended to be used by Dash Platform, to the specified username."));
 
@@ -1618,7 +1618,7 @@ bool AppInitParameterInteraction()
 
     try {
         const bool fRecoveryEnabled{llmq::CLLMQUtils::QuorumDataRecoveryEnabled()};
-        const bool fQuorumVvecRequestsEnabled{llmq::CLLMQUtils::GetEnabledQuorumVvecSyncTypes().size() > 0};
+        const bool fQuorumVvecRequestsEnabled{llmq::CLLMQUtils::GetEnabledQuorumVvecSyncEntries().size() > 0};
         if (!fRecoveryEnabled && fQuorumVvecRequestsEnabled) {
             InitWarning("-llmq-qvvec-sync set but recovery is disabled due to -llmq-data-recovery=0");
         }

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -212,8 +212,8 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
             uint16_t nDataMask{0};
             const bool fWeAreQuorumMember = pQuorum->IsValidMember(activeMasternodeInfo.proTxHash);
             const bool fSyncForTypeEnabled = mapQuorumVvecSync.count(pQuorum->qc.llmqType) > 0;
-            const QvvecSyncMode syncMode = fSyncForTypeEnabled ? mapQuorumVvecSync.at(pQuorum->qc.llmqType) : Invalid;
-            const bool fSyncCurrent = syncMode == SyncAlways || (syncMode == SyncOnlyIfTypeMember && fWeAreQuorumTypeMember);
+            const QvvecSyncMode syncMode = fSyncForTypeEnabled ? mapQuorumVvecSync.at(pQuorum->qc.llmqType) : QvvecSyncMode::Invalid;
+            const bool fSyncCurrent = syncMode == QvvecSyncMode::Always || (syncMode == QvvecSyncMode::OnlyIfTypeMember && fWeAreQuorumTypeMember);
 
             if ((fWeAreQuorumMember || (fSyncForTypeEnabled && fSyncCurrent)) && pQuorum->quorumVvec == nullptr) {
                 nDataMask |= llmq::CQuorumDataRequest::QUORUM_VERIFICATION_VECTOR;

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -323,7 +323,7 @@ std::map<Consensus::LLMQType, QvvecSyncMode> CLLMQUtils::GetEnabledQuorumVvecSyn
     std::map<Consensus::LLMQType, QvvecSyncMode> mapQuorumVvecSyncEntries;
     for (const auto& strEntry : gArgs.GetArgs("-llmq-qvvec-sync")) {
         Consensus::LLMQType llmqType = Consensus::LLMQ_NONE;
-        QvvecSyncMode mode{Invalid};
+        QvvecSyncMode mode{QvvecSyncMode::Invalid};
         std::istringstream ssEntry(strEntry);
         std::string strLLMQType, strMode, strTest;
         const bool fLLMQTypePresent = std::getline(ssEntry, strLLMQType, ':') && strLLMQType != "";
@@ -345,14 +345,14 @@ std::map<Consensus::LLMQType, QvvecSyncMode> CLLMQUtils::GetEnabledQuorumVvecSyn
             throw std::invalid_argument(strprintf("Duplicated llmqType in -llmq-qvvec-sync: %s", strEntry));
         }
 
-        int32_t nMode{QvvecSyncMode::Invalid};
+        int32_t nMode;
         if (ParseInt32(strMode, &nMode)) {
             switch (nMode) {
-            case QvvecSyncMode::SyncAlways:
-                mode = QvvecSyncMode::SyncAlways;
+            case (int32_t)QvvecSyncMode::Always:
+                mode = QvvecSyncMode::Always;
                 break;
-            case QvvecSyncMode::SyncOnlyIfTypeMember:
-                mode = QvvecSyncMode::SyncOnlyIfTypeMember;
+            case (int32_t)QvvecSyncMode::OnlyIfTypeMember:
+                mode = QvvecSyncMode::OnlyIfTypeMember;
                 break;
             default:
                 mode = QvvecSyncMode::Invalid;

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -318,11 +318,20 @@ bool CLLMQUtils::QuorumDataRecoveryEnabled()
     return gArgs.GetBoolArg("-llmq-data-recovery", DEFAULT_ENABLE_QUORUM_DATA_RECOVERY);
 }
 
-std::set<Consensus::LLMQType> CLLMQUtils::GetEnabledQuorumVvecSyncTypes()
+std::map<Consensus::LLMQType, QvvecSyncMode> CLLMQUtils::GetEnabledQuorumVvecSyncEntries()
 {
-    std::set<Consensus::LLMQType> setQuorumVvecSyncTypes;
-    for (const std::string& strLLMQType : gArgs.GetArgs("-llmq-qvvec-sync")) {
+    std::map<Consensus::LLMQType, QvvecSyncMode> mapQuorumVvecSyncEntries;
+    for (const auto& strEntry : gArgs.GetArgs("-llmq-qvvec-sync")) {
         Consensus::LLMQType llmqType = Consensus::LLMQ_NONE;
+        QvvecSyncMode mode{Invalid};
+        std::istringstream ssEntry(strEntry);
+        std::string strLLMQType, strMode, strTest;
+        const bool fLLMQTypePresent = std::getline(ssEntry, strLLMQType, ':') && strLLMQType != "";
+        const bool fModePresent = std::getline(ssEntry, strMode, ':') && strMode != "";
+        const bool fTooManyEntries = static_cast<bool>(std::getline(ssEntry, strTest, ':'));
+        if (!fLLMQTypePresent || !fModePresent || fTooManyEntries) {
+            throw std::invalid_argument(strprintf("Invalid format in -llmq-qvvec-sync: %s", strEntry));
+        }
         for (const auto& p : Params().GetConsensus().llmqs) {
             if (p.second.name == strLLMQType) {
                 llmqType = p.first;
@@ -330,14 +339,32 @@ std::set<Consensus::LLMQType> CLLMQUtils::GetEnabledQuorumVvecSyncTypes()
             }
         }
         if (llmqType == Consensus::LLMQ_NONE) {
-            throw std::invalid_argument(strprintf("Invalid llmqType in -llmq-qvvec-sync: %s", strLLMQType));
+            throw std::invalid_argument(strprintf("Invalid llmqType in -llmq-qvvec-sync: %s", strEntry));
         }
-        if (setQuorumVvecSyncTypes.count(llmqType) > 0) {
-            throw std::invalid_argument(strprintf("Duplicated llmqType in -llmq-qvvec-sync: %s", strLLMQType));
+        if (mapQuorumVvecSyncEntries.count(llmqType) > 0) {
+            throw std::invalid_argument(strprintf("Duplicated llmqType in -llmq-qvvec-sync: %s", strEntry));
         }
-        setQuorumVvecSyncTypes.emplace(llmqType);
+
+        int32_t nMode{QvvecSyncMode::Invalid};
+        if (ParseInt32(strMode, &nMode)) {
+            switch (nMode) {
+            case QvvecSyncMode::SyncAlways:
+                mode = QvvecSyncMode::SyncAlways;
+                break;
+            case QvvecSyncMode::SyncOnlyIfTypeMember:
+                mode = QvvecSyncMode::SyncOnlyIfTypeMember;
+                break;
+            default:
+                mode = QvvecSyncMode::Invalid;
+                break;
+            }
+        }
+        if (mode == QvvecSyncMode::Invalid) {
+            throw std::invalid_argument(strprintf("Invalid mode in -llmq-qvvec-sync: %s", strEntry));
+        }
+        mapQuorumVvecSyncEntries.emplace(llmqType, mode);
     }
-    return setQuorumVvecSyncTypes;
+    return mapQuorumVvecSyncEntries;
 }
 
 const Consensus::LLMQParams& GetLLMQParams(Consensus::LLMQType llmqType)

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -24,6 +24,12 @@ extern VersionBitsCache llmq_versionbitscache;
 
 static const bool DEFAULT_ENABLE_QUORUM_DATA_RECOVERY = true;
 
+enum QvvecSyncMode {
+    Invalid = -1,
+    SyncAlways = 0,
+    SyncOnlyIfTypeMember = 1,
+};
+
 class CLLMQUtils
 {
 public:
@@ -57,8 +63,8 @@ public:
     /// Returns the state of `-llmq-data-recovery`
     static bool QuorumDataRecoveryEnabled();
 
-    /// Returns the values given by `-llmq-qvvec-sync`
-    static std::set<Consensus::LLMQType> GetEnabledQuorumVvecSyncTypes();
+    /// Returns the parsed entries given by `-llmq-qvvec-sync`
+    static std::map<Consensus::LLMQType, QvvecSyncMode> GetEnabledQuorumVvecSyncEntries();
 
     template<typename NodesContainer, typename Continue, typename Callback>
     static void IterateNodesRandom(NodesContainer& nodeStates, Continue&& cont, Callback&& callback, FastRandomContext& rnd)

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -24,10 +24,10 @@ extern VersionBitsCache llmq_versionbitscache;
 
 static const bool DEFAULT_ENABLE_QUORUM_DATA_RECOVERY = true;
 
-enum QvvecSyncMode {
+enum class QvvecSyncMode {
     Invalid = -1,
-    SyncAlways = 0,
-    SyncOnlyIfTypeMember = 1,
+    Always = 0,
+    OnlyIfTypeMember = 1,
 };
 
 class CLLMQUtils

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1090,9 +1090,9 @@ class DashTestFramework(BitcoinTestFramework):
                 return mn
         return None
 
-    def test_mn_quorum_data(self, test_mn, quorum_type_in, quorum_hash_in, expect_secret=True):
+    def test_mn_quorum_data(self, test_mn, quorum_type_in, quorum_hash_in, test_secret=True, expect_secret=True):
         quorum_info = test_mn.node.quorum("info", quorum_type_in, quorum_hash_in, True)
-        if expect_secret != ("secretKeyShare" in quorum_info):
+        if test_secret and expect_secret != ("secretKeyShare" in quorum_info):
             return False
         if "members" not in quorum_info or len(quorum_info["members"]) == 0:
             return False
@@ -1103,7 +1103,8 @@ class DashTestFramework(BitcoinTestFramework):
             pubkey_count += "pubKeyShare" in quorum_member
         return pubkey_count == valid_count
 
-    def wait_for_quorum_data(self, mns, quorum_type_in, quorum_hash_in, expect_secret=True, recover=False, timeout=60):
+    def wait_for_quorum_data(self, mns, quorum_type_in, quorum_hash_in, test_secret=True, expect_secret=True,
+                             recover=False, timeout=60):
         def test_mns():
             valid = 0
             if recover:
@@ -1114,7 +1115,7 @@ class DashTestFramework(BitcoinTestFramework):
                     self.bump_mocktime(self.quorum_data_thread_request_timeout_seconds + 1)
 
             for test_mn in mns:
-                valid += self.test_mn_quorum_data(test_mn, quorum_type_in, quorum_hash_in, expect_secret)
+                valid += self.test_mn_quorum_data(test_mn, quorum_type_in, quorum_hash_in, test_secret, expect_secret)
             self.log.debug("wait_for_quorum_data: %d/%d - quorum_type=%d quorum_hash=%s" %
                            (valid, len(mns), quorum_type_in, quorum_hash_in))
             return valid == len(mns)


### PR DESCRIPTION
This changes the paramter from `-llmq-qvvec-sync=<quorum_name>` to `-llmq-qvvec-sync=<quorum_name:mode>`

With the following definitions:

- `quorum_name`: Internal name of the quorum type
- `mode=0` - Sync always from all quorums of the type defined by `quorum_name`
- `mode=1` - Sync only if member of any from all other quorum of the type defined by `quorum_name`

`-llmq-qvvec-sync=llmq_100_67:0` To always request qvvec's from all `LLMQ_100_67`.
`-llmq-qvvec-sync=llmq_100_67:1` Only request if type member.

This means, if platform enables this on all MNs with `mode=0` we will
have all nodes asking new quorum for their verification vector instead
of only `24*100` at max.


Follow up of #3964