### PR TITLE
llmq: Move GetAllQuorumMembers into CFinalCommitment::Verify

### DIFF
--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -103,9 +103,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& strC
             }
         }
 
-        auto members = CLLMQUtils::GetAllQuorumMembers(type, pquorumIndex);
-
-        if (!qc.Verify(members, true)) {
+        if (!qc.Verify(pquorumIndex, true)) {
             LOCK(cs_main);
             LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- commitment for quorum %s:%d is not valid, peer=%d\n", __func__,
                       qc.quorumHash.ToString(), qc.llmqType, pfrom->GetId());
@@ -219,9 +217,8 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
     }
 
     auto quorumIndex = LookupBlockIndex(qc.quorumHash);
-    auto members = CLLMQUtils::GetAllQuorumMembers(params.type, quorumIndex);
 
-    if (!qc.Verify(members, true)) {
+    if (!qc.Verify(quorumIndex, true)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
     }
 

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -52,7 +52,7 @@ public:
         return (int)std::count(validMembers.begin(), validMembers.end(), true);
     }
 
-    bool Verify(const std::vector<CDeterministicMNCPtr>& members, bool checkSigs) const;
+    bool Verify(const CBlockIndex* pQuorumIndex, bool checkSigs) const;
     bool VerifyNull() const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;
 


### PR DESCRIPTION
Instead of calling `CLLMQUtils::GetAllQuorumMembers` before each `CFinalCommitment::Verify` call to get the quorum members, just get them inside `CFinalCommitment::Verify`.