### PR TITLE
evo: Fix CEvoDB::VerifyBestBlock

### DIFF
--- a/src/evo/evodb.cpp
+++ b/src/evo/evodb.cpp
@@ -66,11 +66,10 @@ bool CEvoDB::VerifyBestBlock(const uint256& hash)
     // Make sure evodb is consistent.
     // If we already have best block hash saved, the previous block should match it.
     uint256 hashBestBlock;
-    bool fHasBestBlock = Read(EVODB_BEST_BLOCK, hashBestBlock);
-    uint256 hashBlockIndex = fHasBestBlock ? hash : uint256();
-    assert(hashBestBlock == hashBlockIndex);
-
-    return fHasBestBlock;
+    if (!Read(EVODB_BEST_BLOCK, hashBestBlock)) {
+        return false;
+    }
+    return hashBestBlock == hash;
 }
 
 void CEvoDB::WriteBestBlock(const uint256& hash)


### PR DESCRIPTION
Just return the result of the comparison in case there is a block and false otherwise. This should allow to reach the currently unreachable two error cases below instead of crashing because the assert doesn't pass in case of inconsistency. 

https://github.com/dashpay/dash/blob/c2d7d0cab4f83692db5a6003ae387c4f821fcabd/src/validation.cpp#L1687-L1691
https://github.com/dashpay/dash/blob/c2d7d0cab4f83692db5a6003ae387c4f821fcabd/src/validation.cpp#L2094-L2098