### PR TITLE
chainlocks: Run CheckActiveState before processing new CLSIG

### DIFF
--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -106,6 +106,8 @@ void CChainLocksHandler::ProcessMessage(CNode* pfrom, const std::string& strComm
 
 void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CChainLockSig& clsig, const uint256& hash)
 {
+    CheckActiveState();
+
     CInv clsigInv(MSG_CLSIG, hash);
 
     if (from != -1) {


### PR DESCRIPTION
This fixes a rare race condition for "spork19 off, spork 19 on" conditions when some nodes might call `CheckActiveState` already, create new clsig and send it so that other nodes processed it BUT these other nodes will call `CheckActiveState` after that (because it's done every 5 sec) and reset the best chainlock to null. This bug is the reason why `feature_llmq_is_retroactive.py` fails to find a chainlocked block sometimes even though every node received and successfully processed clsig earlier (according to logs).

Example build failure:
https://gitlab.com/dashpay/dash/-/jobs/1098622516#L2818

clsigs:
node0 https://gitlab.com/dashpay/dash/-/jobs/1098622516#L1715,
node1 https://gitlab.com/dashpay/dash/-/jobs/1098622516#L1603,
node2 https://gitlab.com/dashpay/dash/-/jobs/1098622516#L1674,
node3 https://gitlab.com/dashpay/dash/-/jobs/1098622516#L1697,
node4 https://gitlab.com/dashpay/dash/-/jobs/1098622516#L1616,
node5 https://gitlab.com/dashpay/dash/-/jobs/1098622516#L1595.

Extracted from #4016 