### PR TITLE
partial/logic backport #18544: net: limit BIP37 filter lifespan (active between 'filterload'..'filterclear')

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3913,7 +3913,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nNextAddrSend = 0;
     fRelayTxes = false;
     fSentAddr = false;
-    pfilter = MakeUnique<CBloomFilter>();
+    pfilter = nullptr;
     timeLastMempoolReq = 0;
     nLastBlockTime = 0;
     nLastTXTime = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3913,7 +3913,6 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nNextAddrSend = 0;
     fRelayTxes = false;
     fSentAddr = false;
-    pfilter = nullptr;
     timeLastMempoolReq = 0;
     nLastBlockTime = 0;
     nLastTXTime = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -900,7 +900,7 @@ public:
     bool m_masternode_iqr_connection{false};
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
-    std::unique_ptr<CBloomFilter> pfilter PT_GUARDED_BY(cs_filter);
+    std::unique_ptr<CBloomFilter> pfilter PT_GUARDED_BY(cs_filter){nullptr};
     std::atomic<int> nRefCount;
 
     const uint64_t nKeyedNetGroup;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3493,7 +3493,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     if (strCommand == NetMsgType::FILTERCLEAR) {
         LOCK(pfrom->cs_filter);
         if (pfrom->GetLocalServices() & NODE_BLOOM) {
-            pfrom->pfilter.reset(new CBloomFilter());
+            pfrom->pfilter = nullptr;
         }
         pfrom->fRelayTxes = true;
         return true;


### PR DESCRIPTION
This backports https://github.com/bitcoin/bitcoin/pull/18544/commits/5eae034996b340c19cebab9efb6c89d20fe051ef
```
Previously, a default match-everything bloom filter was set for every peer,
i.e. even before receiving a 'filterload' message and after receiving a
'filterclear' message code branches checking for the existence of the filter
by testing the pointer "pfilter" were _always_ executed.
```

The original PR was merged into btc 0.21, so this "backports" logic, not code. Not backporting test changes because `p2p_filter.py` test simply does not exist in our code base yet, was introduced in btc 0.20.

This is required for #4016 (which is how I found the issue) but even otherwise it's an actual bugfix e.g. for node eviction logic https://github.com/dashpay/dash/blob/develop/src/net.cpp#L1119.