### PR TITLE
llmq: Fix PoSe connection checks

### DIFF
--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -471,6 +471,7 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions()
         protoMap.emplace(pnode->verifiedProRegTxHash, pnode->nVersion);
     });
 
+    bool fShouldAllMembersBeConnected = CLLMQUtils::IsAllMembersConnectedEnabled(params.type);
     for (auto& m : members) {
         if (m->dmn->proTxHash == myProTxHash) {
             continue;
@@ -478,7 +479,7 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions()
 
         auto it = protoMap.find(m->dmn->proTxHash);
         if (it == protoMap.end()) {
-            m->badConnection = true;
+            m->badConnection = fShouldAllMembersBeConnected;
             logger.Batch("%s is not connected to us", m->dmn->proTxHash.ToString());
         } else if (it != protoMap.end() && it->second < MIN_MASTERNODE_PROTO_VERSION) {
             m->badConnection = true;

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -480,7 +480,7 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions()
         auto it = protoMap.find(m->dmn->proTxHash);
         if (it == protoMap.end()) {
             m->badConnection = fShouldAllMembersBeConnected;
-            logger.Batch("%s is not connected to us", m->dmn->proTxHash.ToString());
+            logger.Batch("%s is not connected to us, badConnection=%b", m->dmn->proTxHash.ToString(), m->badConnection);
         } else if (it != protoMap.end() && it->second < MIN_MASTERNODE_PROTO_VERSION) {
             m->badConnection = true;
             logger.Batch("%s does not have min proto version %d (has %d)", m->dmn->proTxHash.ToString(), MIN_MASTERNODE_PROTO_VERSION, it->second);


### PR DESCRIPTION
This was introduced by the `SPORK_21_QUORUM_ALL_CONNECTED` / `SPORK_23_QUORUM_POSE` split in #3907. If PoSe is enabled for a quorum type but all members connected is disabled for the quorum type this would lead to bans because of missing member connections.