### PR TITLE
Move `-instantsendnotify` option help into `wallet/init.cpp`, drop OptionsCategory::INSTANTSEND

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -621,8 +621,6 @@ void SetupServerArgs()
     gArgs.AddArg("-masternodeblsprivkey=<hex>", "Set the masternode BLS private key and enable the client to act as a masternode", false, OptionsCategory::MASTERNODE);
     gArgs.AddArg("-platform-user=<user>", "Set the username for the \"platform user\", a restricted user intended to be used by Dash Platform, to the specified username.", false, OptionsCategory::MASTERNODE);
 
-    gArgs.AddArg("-instantsendnotify=<cmd>", "Execute command when a wallet InstantSend transaction is successfully locked (%s in cmd is replaced by TxID)", false, OptionsCategory::INSTANTSEND);
-
     gArgs.AddArg("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", !testnetChainParams->RequireStandard()), true, OptionsCategory::NODE_RELAY);
     gArgs.AddArg("-dustrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to defined dust, the value of an output such that it will cost more than its value in fees at this fee rate to spend it. (default: %s)", CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)), true, OptionsCategory::NODE_RELAY);
     gArgs.AddArg("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to define cost of relay, used for mempool limiting and BIP 125 replacement. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)), true, OptionsCategory::NODE_RELAY);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -576,8 +576,6 @@ std::string ArgsManager::GetHelpMessage()
                 usage += HelpMessageGroup("Indexing options:");
             else if (last_cat == OptionsCategory::MASTERNODE)
                 usage += HelpMessageGroup("Masternode options:");
-            else if (last_cat == OptionsCategory::INSTANTSEND)
-                usage += HelpMessageGroup("InstantSend options:");
             else if (last_cat == OptionsCategory::STATSD)
                 usage += HelpMessageGroup("Statsd options:");
             else if (last_cat == OptionsCategory::ZMQ)

--- a/src/util.h
+++ b/src/util.h
@@ -146,7 +146,6 @@ enum class OptionsCategory
     CONNECTION,
     INDEXING,
     MASTERNODE,
-    INSTANTSEND,
     STATSD,
     WALLET,
     WALLET_FEE,

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -64,6 +64,7 @@ void WalletInit::AddWalletOptions() const
 {
     gArgs.AddArg("-createwalletbackups=<n>", strprintf("Number of automatic wallet backups (default: %u)", nWalletBackups), false, OptionsCategory::WALLET);
     gArgs.AddArg("-disablewallet", "Do not load the wallet and disable wallet RPC calls", false, OptionsCategory::WALLET);
+    gArgs.AddArg("-instantsendnotify=<cmd>", "Execute command when a wallet InstantSend transaction is successfully locked (%s in cmd is replaced by TxID)", false, OptionsCategory::WALLET);
     gArgs.AddArg("-keypool=<n>", strprintf("Set key pool size to <n> (default: %u)", DEFAULT_KEYPOOL_SIZE), false, OptionsCategory::WALLET);
     gArgs.AddArg("-rescan=<mode>", "Rescan the block chain for missing wallet transactions on startup"
                                             " (1 = start from wallet creation time, 2 = start from genesis block)", false, OptionsCategory::WALLET);


### PR DESCRIPTION
`-instantsendnotify` works for wallet txes only.