### PR TITLE
refactor: Move CCoinJoinClientOptions from coinjoin-client.*

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ BITCOIN_CORE_H = \
   clientversion.h \
   coinjoin/coinjoin.h \
   coinjoin/coinjoin-client.h \
+  coinjoin/coinjoin-client-options.h \
   coinjoin/coinjoin-server.h \
   coinjoin/coinjoin-util.h \
   coins.h \
@@ -393,6 +394,7 @@ libdash_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libdash_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libdash_wallet_a_SOURCES = \
   coinjoin/coinjoin-client.cpp \
+  coinjoin/coinjoin-client-options.cpp \
   coinjoin/coinjoin-util.cpp \
   interfaces/wallet.cpp \
   keepass.cpp \

--- a/src/coinjoin/coinjoin-client-options.cpp
+++ b/src/coinjoin/coinjoin-client-options.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coinjoin/coinjoin-client-options.h>
+
+#include <util.h>
+#include <univalue.h>
+
+#include <cassert>
+
+CCoinJoinClientOptions* CCoinJoinClientOptions::_instance{nullptr};
+std::once_flag CCoinJoinClientOptions::onceFlag;
+
+CCoinJoinClientOptions& CCoinJoinClientOptions::Get()
+{
+    std::call_once(onceFlag, CCoinJoinClientOptions::Init);
+    assert(CCoinJoinClientOptions::_instance);
+    return *CCoinJoinClientOptions::_instance;
+}
+
+void CCoinJoinClientOptions::SetEnabled(bool fEnabled)
+{
+    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
+    LOCK(options.cs_cj_options);
+    options.fEnableCoinJoin = fEnabled;
+}
+
+void CCoinJoinClientOptions::SetMultiSessionEnabled(bool fEnabled)
+{
+    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
+    LOCK(options.cs_cj_options);
+    options.fCoinJoinMultiSession = fEnabled;
+}
+
+void CCoinJoinClientOptions::SetRounds(int nRounds)
+{
+    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
+    LOCK(options.cs_cj_options);
+    options.nCoinJoinRounds = nRounds;
+}
+
+void CCoinJoinClientOptions::SetAmount(CAmount amount)
+{
+    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
+    LOCK(options.cs_cj_options);
+    options.nCoinJoinAmount = amount;
+}
+
+void CCoinJoinClientOptions::Init()
+{
+    assert(!CCoinJoinClientOptions::_instance);
+    static CCoinJoinClientOptions instance;
+    LOCK(instance.cs_cj_options);
+    instance.fCoinJoinMultiSession = gArgs.GetBoolArg("-coinjoinmultisession", DEFAULT_COINJOIN_MULTISESSION);
+    instance.nCoinJoinSessions = std::min(std::max((int)gArgs.GetArg("-coinjoinsessions", DEFAULT_COINJOIN_SESSIONS), MIN_COINJOIN_SESSIONS), MAX_COINJOIN_SESSIONS);
+    instance.nCoinJoinRounds = std::min(std::max((int)gArgs.GetArg("-coinjoinrounds", DEFAULT_COINJOIN_ROUNDS), MIN_COINJOIN_ROUNDS), MAX_COINJOIN_ROUNDS);
+    instance.nCoinJoinAmount = std::min(std::max((int)gArgs.GetArg("-coinjoinamount", DEFAULT_COINJOIN_AMOUNT), MIN_COINJOIN_AMOUNT), MAX_COINJOIN_AMOUNT);
+    instance.nCoinJoinDenomsGoal = std::min(std::max((int)gArgs.GetArg("-coinjoindenomsgoal", DEFAULT_COINJOIN_DENOMS_GOAL), MIN_COINJOIN_DENOMS_GOAL), MAX_COINJOIN_DENOMS_GOAL);
+    instance.nCoinJoinDenomsHardCap = std::min(std::max((int)gArgs.GetArg("-coinjoindenomshardcap", DEFAULT_COINJOIN_DENOMS_HARDCAP), MIN_COINJOIN_DENOMS_HARDCAP), MAX_COINJOIN_DENOMS_HARDCAP);
+    CCoinJoinClientOptions::_instance = &instance;
+}
+
+void CCoinJoinClientOptions::GetJsonInfo(UniValue& obj)
+{
+    assert(obj.isObject());
+    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
+    obj.pushKV("enabled", options.fEnableCoinJoin);
+    obj.pushKV("multisession", options.fCoinJoinMultiSession);
+    obj.pushKV("max_sessions", options.nCoinJoinSessions);
+    obj.pushKV("max_rounds", options.nCoinJoinRounds);
+    obj.pushKV("max_amount", options.nCoinJoinAmount);
+    obj.pushKV("denoms_goal", options.nCoinJoinDenomsGoal);
+    obj.pushKV("denoms_hardcap", options.nCoinJoinDenomsHardCap);
+}

--- a/src/coinjoin/coinjoin-client-options.h
+++ b/src/coinjoin/coinjoin-client-options.h
@@ -8,9 +8,6 @@
 #include <amount.h>
 #include <sync.h>
 
-class CCoinJoinClientOptions;
-
-class CConnman;
 class UniValue;
 
 static const int MIN_COINJOIN_SESSIONS = 1;

--- a/src/coinjoin/coinjoin-client-options.h
+++ b/src/coinjoin/coinjoin-client-options.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2021 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COINJOIN_COINJOIN_CLIENT_OPTIONS_H
+#define BITCOIN_COINJOIN_COINJOIN_CLIENT_OPTIONS_H
+
+#include <amount.h>
+#include <sync.h>
+
+class CCoinJoinClientOptions;
+
+class CConnman;
+class UniValue;
+
+static const int MIN_COINJOIN_SESSIONS = 1;
+static const int MIN_COINJOIN_ROUNDS = 2;
+static const int MIN_COINJOIN_AMOUNT = 2;
+static const int MIN_COINJOIN_DENOMS_GOAL = 10;
+static const int MIN_COINJOIN_DENOMS_HARDCAP = 10;
+static const int MAX_COINJOIN_SESSIONS = 10;
+static const int MAX_COINJOIN_ROUNDS = 16;
+static const int MAX_COINJOIN_DENOMS_GOAL = 100000;
+static const int MAX_COINJOIN_DENOMS_HARDCAP = 100000;
+static const int MAX_COINJOIN_AMOUNT = MAX_MONEY / COIN;
+static const int DEFAULT_COINJOIN_SESSIONS = 4;
+static const int DEFAULT_COINJOIN_ROUNDS = 4;
+static const int DEFAULT_COINJOIN_AMOUNT = 1000;
+static const int DEFAULT_COINJOIN_DENOMS_GOAL = 50;
+static const int DEFAULT_COINJOIN_DENOMS_HARDCAP = 300;
+
+static const bool DEFAULT_COINJOIN_AUTOSTART = false;
+static const bool DEFAULT_COINJOIN_MULTISESSION = false;
+
+// How many new denom outputs to create before we consider the "goal" loop in CreateDenominated
+// a final one and start creating an actual tx. Same limit applies for the "hard cap" part of the algo.
+// NOTE: We do not allow txes larger than 100kB, so we have to limit the number of outputs here.
+// We still want to create a lot of outputs though.
+// Knowing that each CTxOut is ~35b big, 400 outputs should take 400 x ~35b = ~17.5kb.
+// More than 500 outputs starts to make qt quite laggy.
+// Additionally to need all 500 outputs (assuming a max per denom of 50) you'd need to be trying to
+// create denominations for over 3000 dash!
+static const int COINJOIN_DENOM_OUTPUTS_THRESHOLD = 500;
+
+// Warn user if mixing in gui or try to create backup if mixing in daemon mode
+// when we have only this many keys left
+static const int COINJOIN_KEYS_THRESHOLD_WARNING = 100;
+// Stop mixing completely, it's too dangerous to continue when we have only this many keys left
+static const int COINJOIN_KEYS_THRESHOLD_STOP = 50;
+// Pseudorandomly mix up to this many times in addition to base round count
+static const int COINJOIN_RANDOM_ROUNDS = 3;
+
+/* Application wide mixing options */
+class CCoinJoinClientOptions
+{
+public:
+    static int GetSessions() { return CCoinJoinClientOptions::Get().nCoinJoinSessions; }
+    static int GetRounds() { return CCoinJoinClientOptions::Get().nCoinJoinRounds; }
+    static int GetRandomRounds() { return CCoinJoinClientOptions::Get().nCoinJoinRandomRounds; }
+    static int GetAmount() { return CCoinJoinClientOptions::Get().nCoinJoinAmount; }
+    static int GetDenomsGoal() { return CCoinJoinClientOptions::Get().nCoinJoinDenomsGoal; }
+    static int GetDenomsHardCap() { return CCoinJoinClientOptions::Get().nCoinJoinDenomsHardCap; }
+
+    static void SetEnabled(bool fEnabled);
+    static void SetMultiSessionEnabled(bool fEnabled);
+    static void SetRounds(int nRounds);
+    static void SetAmount(CAmount amount);
+
+    static bool IsEnabled() { return CCoinJoinClientOptions::Get().fEnableCoinJoin; }
+    static bool IsMultiSessionEnabled() { return CCoinJoinClientOptions::Get().fCoinJoinMultiSession; }
+
+    static void GetJsonInfo(UniValue& obj);
+
+private:
+    static CCoinJoinClientOptions* _instance;
+    static std::once_flag onceFlag;
+
+    CCriticalSection cs_cj_options;
+    int nCoinJoinSessions;
+    int nCoinJoinRounds;
+    int nCoinJoinRandomRounds;
+    int nCoinJoinAmount;
+    int nCoinJoinDenomsGoal;
+    int nCoinJoinDenomsHardCap;
+    bool fEnableCoinJoin;
+    bool fCoinJoinMultiSession;
+
+    CCoinJoinClientOptions() :
+            nCoinJoinRounds(DEFAULT_COINJOIN_ROUNDS),
+            nCoinJoinRandomRounds(COINJOIN_RANDOM_ROUNDS),
+            nCoinJoinAmount(DEFAULT_COINJOIN_AMOUNT),
+            nCoinJoinDenomsGoal(DEFAULT_COINJOIN_DENOMS_GOAL),
+            nCoinJoinDenomsHardCap(DEFAULT_COINJOIN_DENOMS_HARDCAP),
+            fEnableCoinJoin(false),
+            fCoinJoinMultiSession(DEFAULT_COINJOIN_MULTISESSION)
+    {
+    }
+
+    CCoinJoinClientOptions(const CCoinJoinClientOptions& other) = delete;
+    CCoinJoinClientOptions& operator=(const CCoinJoinClientOptions&) = delete;
+
+    static CCoinJoinClientOptions& Get();
+    static void Init();
+};
+
+#endif // BITCOIN_COINJOIN_COINJOIN_CLIENT_OPTIONS_H

--- a/src/coinjoin/coinjoin-client.cpp
+++ b/src/coinjoin/coinjoin-client.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <coinjoin/coinjoin-client.h>
+#include <coinjoin/coinjoin-client-options.h>
 
 #include <consensus/validation.h>
 #include <core_io.h>
@@ -26,8 +27,6 @@
 std::map<const std::string, std::shared_ptr<CCoinJoinClientManager>> coinJoinClientManagers;
 CCoinJoinClientQueueManager coinJoinClientQueueManager;
 
-CCoinJoinClientOptions* CCoinJoinClientOptions::_instance{nullptr};
-std::once_flag CCoinJoinClientOptions::onceFlag;
 
 void CCoinJoinClientQueueManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
@@ -1882,64 +1881,3 @@ void DoCoinJoinMaintenance(CConnman& connman)
     }
 }
 
-CCoinJoinClientOptions& CCoinJoinClientOptions::Get()
-{
-    std::call_once(onceFlag, CCoinJoinClientOptions::Init);
-    assert(CCoinJoinClientOptions::_instance);
-    return *CCoinJoinClientOptions::_instance;
-}
-
-void CCoinJoinClientOptions::SetEnabled(bool fEnabled)
-{
-    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
-    LOCK(options.cs_cj_options);
-    options.fEnableCoinJoin = fEnabled;
-}
-
-void CCoinJoinClientOptions::SetMultiSessionEnabled(bool fEnabled)
-{
-    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
-    LOCK(options.cs_cj_options);
-    options.fCoinJoinMultiSession = fEnabled;
-}
-
-void CCoinJoinClientOptions::SetRounds(int nRounds)
-{
-    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
-    LOCK(options.cs_cj_options);
-    options.nCoinJoinRounds = nRounds;
-}
-
-void CCoinJoinClientOptions::SetAmount(CAmount amount)
-{
-    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
-    LOCK(options.cs_cj_options);
-    options.nCoinJoinAmount = amount;
-}
-
-void CCoinJoinClientOptions::Init()
-{
-    assert(!CCoinJoinClientOptions::_instance);
-    static CCoinJoinClientOptions instance;
-    LOCK(instance.cs_cj_options);
-    instance.fCoinJoinMultiSession = gArgs.GetBoolArg("-coinjoinmultisession", DEFAULT_COINJOIN_MULTISESSION);
-    instance.nCoinJoinSessions = std::min(std::max((int)gArgs.GetArg("-coinjoinsessions", DEFAULT_COINJOIN_SESSIONS), MIN_COINJOIN_SESSIONS), MAX_COINJOIN_SESSIONS);
-    instance.nCoinJoinRounds = std::min(std::max((int)gArgs.GetArg("-coinjoinrounds", DEFAULT_COINJOIN_ROUNDS), MIN_COINJOIN_ROUNDS), MAX_COINJOIN_ROUNDS);
-    instance.nCoinJoinAmount = std::min(std::max((int)gArgs.GetArg("-coinjoinamount", DEFAULT_COINJOIN_AMOUNT), MIN_COINJOIN_AMOUNT), MAX_COINJOIN_AMOUNT);
-    instance.nCoinJoinDenomsGoal = std::min(std::max((int)gArgs.GetArg("-coinjoindenomsgoal", DEFAULT_COINJOIN_DENOMS_GOAL), MIN_COINJOIN_DENOMS_GOAL), MAX_COINJOIN_DENOMS_GOAL);
-    instance.nCoinJoinDenomsHardCap = std::min(std::max((int)gArgs.GetArg("-coinjoindenomshardcap", DEFAULT_COINJOIN_DENOMS_HARDCAP), MIN_COINJOIN_DENOMS_HARDCAP), MAX_COINJOIN_DENOMS_HARDCAP);
-    CCoinJoinClientOptions::_instance = &instance;
-}
-
-void CCoinJoinClientOptions::GetJsonInfo(UniValue& obj)
-{
-    assert(obj.isObject());
-    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
-    obj.pushKV("enabled", options.fEnableCoinJoin);
-    obj.pushKV("multisession", options.fCoinJoinMultiSession);
-    obj.pushKV("max_sessions", options.nCoinJoinSessions);
-    obj.pushKV("max_rounds", options.nCoinJoinRounds);
-    obj.pushKV("max_amount", options.nCoinJoinAmount);
-    obj.pushKV("denoms_goal", options.nCoinJoinDenomsGoal);
-    obj.pushKV("denoms_hardcap", options.nCoinJoinDenomsHardCap);
-}

--- a/src/coinjoin/coinjoin-client.h
+++ b/src/coinjoin/coinjoin-client.h
@@ -18,42 +18,6 @@ class CNode;
 
 class UniValue;
 
-static const int MIN_COINJOIN_SESSIONS = 1;
-static const int MIN_COINJOIN_ROUNDS = 2;
-static const int MIN_COINJOIN_AMOUNT = 2;
-static const int MIN_COINJOIN_DENOMS_GOAL = 10;
-static const int MIN_COINJOIN_DENOMS_HARDCAP = 10;
-static const int MAX_COINJOIN_SESSIONS = 10;
-static const int MAX_COINJOIN_ROUNDS = 16;
-static const int MAX_COINJOIN_DENOMS_GOAL = 100000;
-static const int MAX_COINJOIN_DENOMS_HARDCAP = 100000;
-static const int MAX_COINJOIN_AMOUNT = MAX_MONEY / COIN;
-static const int DEFAULT_COINJOIN_SESSIONS = 4;
-static const int DEFAULT_COINJOIN_ROUNDS = 4;
-static const int DEFAULT_COINJOIN_AMOUNT = 1000;
-static const int DEFAULT_COINJOIN_DENOMS_GOAL = 50;
-static const int DEFAULT_COINJOIN_DENOMS_HARDCAP = 300;
-
-static const bool DEFAULT_COINJOIN_AUTOSTART = false;
-static const bool DEFAULT_COINJOIN_MULTISESSION = false;
-
-// How many new denom outputs to create before we consider the "goal" loop in CreateDenominated
-// a final one and start creating an actual tx. Same limit applies for the "hard cap" part of the algo.
-// NOTE: We do not allow txes larger than 100kB, so we have to limit the number of outputs here.
-// We still want to create a lot of outputs though.
-// Knowing that each CTxOut is ~35b big, 400 outputs should take 400 x ~35b = ~17.5kb.
-// More than 500 outputs starts to make qt quite laggy.
-// Additionally to need all 500 outputs (assuming a max per denom of 50) you'd need to be trying to
-// create denominations for over 3000 dash!
-static const int COINJOIN_DENOM_OUTPUTS_THRESHOLD = 500;
-
-// Warn user if mixing in gui or try to create backup if mixing in daemon mode
-// when we have only this many keys left
-static const int COINJOIN_KEYS_THRESHOLD_WARNING = 100;
-// Stop mixing completely, it's too dangerous to continue when we have only this many keys left
-static const int COINJOIN_KEYS_THRESHOLD_STOP = 50;
-// Pseudorandomly mix up to this many times in addition to base round count
-static const int COINJOIN_RANDOM_ROUNDS = 3;
 
 // The main object for accessing mixing
 extern std::map<const std::string, std::shared_ptr<CCoinJoinClientManager>> coinJoinClientManagers;
@@ -282,58 +246,6 @@ public:
     void GetJsonInfo(UniValue& obj) const;
 };
 
-/* Application wide mixing options */
-class CCoinJoinClientOptions
-{
-public:
-    static int GetSessions() { return CCoinJoinClientOptions::Get().nCoinJoinSessions; }
-    static int GetRounds() { return CCoinJoinClientOptions::Get().nCoinJoinRounds; }
-    static int GetRandomRounds() { return CCoinJoinClientOptions::Get().nCoinJoinRandomRounds; }
-    static int GetAmount() { return CCoinJoinClientOptions::Get().nCoinJoinAmount; }
-    static int GetDenomsGoal() { return CCoinJoinClientOptions::Get().nCoinJoinDenomsGoal; }
-    static int GetDenomsHardCap() { return CCoinJoinClientOptions::Get().nCoinJoinDenomsHardCap; }
-
-    static void SetEnabled(bool fEnabled);
-    static void SetMultiSessionEnabled(bool fEnabled);
-    static void SetRounds(int nRounds);
-    static void SetAmount(CAmount amount);
-
-    static bool IsEnabled() { return CCoinJoinClientOptions::Get().fEnableCoinJoin; }
-    static bool IsMultiSessionEnabled() { return CCoinJoinClientOptions::Get().fCoinJoinMultiSession; }
-
-    static void GetJsonInfo(UniValue& obj);
-
-private:
-    static CCoinJoinClientOptions* _instance;
-    static std::once_flag onceFlag;
-
-    CCriticalSection cs_cj_options;
-    int nCoinJoinSessions;
-    int nCoinJoinRounds;
-    int nCoinJoinRandomRounds;
-    int nCoinJoinAmount;
-    int nCoinJoinDenomsGoal;
-    int nCoinJoinDenomsHardCap;
-    bool fEnableCoinJoin;
-    bool fCoinJoinMultiSession;
-
-    CCoinJoinClientOptions() :
-        nCoinJoinRounds(DEFAULT_COINJOIN_ROUNDS),
-        nCoinJoinRandomRounds(COINJOIN_RANDOM_ROUNDS),
-        nCoinJoinAmount(DEFAULT_COINJOIN_AMOUNT),
-        nCoinJoinDenomsGoal(DEFAULT_COINJOIN_DENOMS_GOAL),
-        nCoinJoinDenomsHardCap(DEFAULT_COINJOIN_DENOMS_HARDCAP),
-        fEnableCoinJoin(false),
-        fCoinJoinMultiSession(DEFAULT_COINJOIN_MULTISESSION)
-    {
-    }
-
-    CCoinJoinClientOptions(const CCoinJoinClientOptions& other) = delete;
-    CCoinJoinClientOptions& operator=(const CCoinJoinClientOptions&) = delete;
-
-    static CCoinJoinClientOptions& Get();
-    static void Init();
-};
 
 void DoCoinJoinMaintenance(CConnman& connman);
 

--- a/src/coinjoin/coinjoin-client.h
+++ b/src/coinjoin/coinjoin-client.h
@@ -9,7 +9,6 @@
 #include <coinjoin/coinjoin.h>
 #include <evo/deterministicmns.h>
 
-class CCoinJoinClientOptions;
 class CCoinJoinClientManager;
 class CCoinJoinClientQueueManager;
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -35,7 +35,7 @@
 #include <config/dash-config.h>
 #endif
 #ifdef ENABLE_WALLET
-#include <coinjoin/coinjoin-client.h>
+#include <coinjoin/coinjoin-client-options.h>
 #include <wallet/fees.h>
 #include <wallet/wallet.h>
 #define CHECK_WALLET(x) x

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -19,7 +19,7 @@
 #include <txdb.h> // for -dbcache defaults
 
 #ifdef ENABLE_WALLET
-#include <coinjoin/coinjoin-client.h>
+#include <coinjoin/coinjoin-client-options.h>
 #endif
 
 #include <QNetworkProxy>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -16,7 +16,7 @@
 #include <qt/utilitydialog.h>
 #include <qt/walletmodel.h>
 
-#include <coinjoin/coinjoin-client.h>
+#include <coinjoin/coinjoin-client-options.h>
 
 #include <QAbstractItemDelegate>
 #include <QPainter>

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -5,6 +5,7 @@
 #include <validation.h>
 #ifdef ENABLE_WALLET
 #include <coinjoin/coinjoin-client.h>
+#include <coinjoin/coinjoin-client-options.h>
 #endif // ENABLE_WALLET
 #include <coinjoin/coinjoin-server.h>
 #include <rpc/server.h>

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -16,6 +16,7 @@
 #include <wallet/walletutil.h>
 
 #include <coinjoin/coinjoin-client.h>
+#include <coinjoin/coinjoin-client-options.h>
 
 #include <functional>
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -31,6 +31,7 @@
 #include <init.h>  // For StartShutdown
 
 #include <coinjoin/coinjoin-client.h>
+#include <coinjoin/coinjoin-client-options.h>
 #include <llmq/quorums_chainlocks.h>
 #include <llmq/quorums_instantsend.h>
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -31,6 +31,7 @@
 #include <wallet/walletutil.h>
 
 #include <coinjoin/coinjoin-client.h>
+#include <coinjoin/coinjoin-client-options.h>
 #include <governance/governance.h>
 #include <keepass.h>
 #include <spork.h>


### PR DESCRIPTION
We use CCoinJoinClientOptions quite a few places around the codebase where we don't use the rest of coinjoin client. This PR separates CCoinJoinClientOptions out into it's own file. Plus this will be useful to dis-entangle some circular dependencies around the coinjoin codebase and generally make it more modular later on.