### PR TITLE
qt: Delete wallet views when wallets are removed in removeAllWallets

### DIFF
--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -99,8 +99,10 @@ bool WalletFrame::removeWallet(const QString &name)
 void WalletFrame::removeAllWallets()
 {
     QMap<QString, WalletView*>::const_iterator i;
-    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i) {
         walletStack->removeWidget(i.value());
+        delete i.value();
+    }
     mapWalletViews.clear();
 }
 


### PR DESCRIPTION
This fixes a qt wallet crash on shutdown.