### PR TITLE
remove dependency from net on coinjoin

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -25,7 +25,6 @@
 
 #include <masternode/masternode-meta.h>
 #include <masternode/masternode-sync.h>
-#include <coinjoin/coinjoin.h>
 #include <evo/deterministicmns.h>
 
 #include <statsd_client.h>
@@ -3680,13 +3679,10 @@ bool CConnman::DisconnectNode(NodeId id)
     return false;
 }
 
-void CConnman::RelayTransaction(const CTransaction& tx)
+void CConnman::RelayTransaction(const CTransaction& tx, bool dstx)
 {
     uint256 hash = tx.GetHash();
-    int nInv = MSG_TX;
-    if (CCoinJoin::GetDSTX(hash)) {
-        nInv = MSG_DSTX;
-    }
+    int nInv = dstx ? MSG_DSTX : MSG_TX;
     CInv inv(nInv, hash);
     LOCK(cs_vNodes);
     for (CNode* pnode : vNodes)

--- a/src/net.h
+++ b/src/net.h
@@ -361,7 +361,7 @@ public:
     std::vector<CNode*> CopyNodeVector();
     void ReleaseNodeVector(const std::vector<CNode*>& vecNodes);
 
-    void RelayTransaction(const CTransaction& tx);
+    void RelayTransaction(const CTransaction& tx, bool dstx = false);
     void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION, bool fAllowMasternodeConnections = false);
     void RelayInvFiltered(CInv &inv, const CTransaction &relatedTx, const int minProtoVersion = MIN_PEER_PROTO_VERSION, bool fAllowMasternodeConnections = false);
     // This overload will not update node filters,  so use it only for the cases when other messages will update related transaction data in filters

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2879,7 +2879,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
 
             mempool.check(pcoinsTip.get());
-            connman->RelayTransaction(tx);
+            connman->RelayTransaction(tx, nInvType == MSG_DSTX);
 
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
                 auto it_by_prev = mapOrphanTransactionsByPrev.find(COutPoint(inv.hash, i));
@@ -2956,7 +2956,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 int nDoS = 0;
                 if (!state.IsInvalid(nDoS) || nDoS == 0) {
                     LogPrintf("Force relaying tx %s from whitelisted peer=%d\n", tx.GetHash().ToString(), pfrom->GetId());
-                    connman->RelayTransaction(tx);
+                    connman->RelayTransaction(tx, nInvType == MSG_DSTX);
                 } else {
                     LogPrintf("Not relaying invalid transaction %s from whitelisted peer=%d (%s)\n", tx.GetHash().ToString(), pfrom->GetId(), FormatStateMessage(state));
                 }

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -39,7 +39,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     # Dash
     "coinjoin/coinjoin-server -> init -> coinjoin/coinjoin-server"
     "coinjoin/coinjoin-server -> net_processing -> coinjoin/coinjoin-server"
-    "coinjoin/coinjoin -> llmq/quorums_chainlocks -> net -> coinjoin/coinjoin"
     "coinjoin/coinjoin-client -> init -> dsnotificationinterface -> coinjoin/coinjoin-client"
     "coinjoin/coinjoin-client -> init -> masternode/masternode-utils -> coinjoin/coinjoin-client"
     "coinjoin/coinjoin-client -> init -> net_processing -> coinjoin/coinjoin-client"


### PR DESCRIPTION
This should be safe since all validation is done in net_processing anyway and this processing isn't changed at all

https://github.com/dashpay/dash/blob/e0bf689ea25f04b716ee6e3fc61873802e7743a7/src/net_processing.cpp#L2821-L2865