### PR TITLE
wallet: Don't throw in CreateWalletFile

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5059,10 +5059,10 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
                 CHDChain newHdChain;
                 std::vector<unsigned char> vchSeed = ParseHex(strSeed);
                 if (!newHdChain.SetSeed(SecureVector(vchSeed.begin(), vchSeed.end()), true)) {
-                    throw std::runtime_error(std::string(__func__) + ": SetSeed failed");
+                    return error(_("SetSeed failed"));
                 }
                 if (!walletInstance->SetHDChainSingle(newHdChain, false)) {
-                    throw std::runtime_error(std::string(__func__) + ": SetHDChainSingle failed");
+                    return error(_("SetHDChainSingle failed"));
                 }
                 newHdChain.Debug(__func__);
             } else {


### PR DESCRIPTION
To make sure `RemoveWallet` gets called in the `error` lambda.