### PR TITLE
qt: Apply themes globally

### DIFF
--- a/src/qt/appearancewidget.cpp
+++ b/src/qt/appearancewidget.cpp
@@ -110,7 +110,7 @@ void AppearanceWidget::updateTheme(const QString& theme)
         QSettings().setValue("theme", newValue);
         // Force loading the theme
         if (model) {
-            GUIUtil::loadTheme(model->node(), true);
+            GUIUtil::loadTheme(true);
         }
     }
 }

--- a/src/qt/appearancewidget.cpp
+++ b/src/qt/appearancewidget.cpp
@@ -110,7 +110,7 @@ void AppearanceWidget::updateTheme(const QString& theme)
         QSettings().setValue("theme", newValue);
         // Force loading the theme
         if (model) {
-            GUIUtil::loadTheme(model->node(), nullptr, true);
+            GUIUtil::loadTheme(model->node(), true);
         }
     }
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -124,6 +124,8 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     timerConnecting(0),
     timerSpinner(0)
 {
+    GUIUtil::loadTheme(node, true);
+
     QSettings settings;
     if (!restoreGeometry(settings.value("MainWindowGeometry").toByteArray())) {
         // Restore failed (perhaps missing setting), center the window

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -124,7 +124,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     timerConnecting(0),
     timerSpinner(0)
 {
-    GUIUtil::loadTheme(node, true);
+    GUIUtil::loadTheme(true);
 
     QSettings settings;
     if (!restoreGeometry(settings.value("MainWindowGeometry").toByteArray())) {
@@ -267,6 +267,17 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const NetworkStyle* networkStyle,
     incomingTransactionsTimer = new QTimer(this);
     incomingTransactionsTimer->setSingleShot(true);
     connect(incomingTransactionsTimer, SIGNAL(timeout()), SLOT(showIncomingTransactions()));
+
+    bool fDebugCustomStyleSheets = gArgs.GetBoolArg("-debug-ui", false) && GUIUtil::isStyleSheetDirectoryCustom();
+    if (fDebugCustomStyleSheets) {
+        timerCustomCss = new QTimer(this);
+        QObject::connect(timerCustomCss, &QTimer::timeout, [=]() {
+            if (!m_node.shutdownRequested()) {
+                GUIUtil::loadStyleSheet();
+            }
+        });
+        timerCustomCss->start(200);
+    }
 }
 
 BitcoinGUI::~BitcoinGUI()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -184,6 +184,9 @@ private:
     std::list<IncomingTransactionMessage> incomingTransactions;
     QTimer* incomingTransactionsTimer;
 
+    /** Timer to update custom css styling in -debug-ui mode periodically */
+    QTimer* timerCustomCss;
+
     /** Create the main UI actions. */
     void createActions();
     /** Create the menu bar and sub-menus. */

--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -359,9 +359,6 @@ void BitcoinApplication::createOptionsModel(bool resetSettings)
 void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 {
     window = new BitcoinGUI(m_node, networkStyle, 0);
-
-    GUIUtil::loadTheme(m_node, window);
-
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window, SLOT(detectShutdown()));
 }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1082,7 +1082,7 @@ const bool isValidTheme(const QString& strTheme)
     return strTheme == defaultTheme || strTheme == darkThemePrefix || strTheme == traditionalTheme;
 }
 
-void loadStyleSheet(interfaces::Node& node, bool fForceUpdate)
+void loadStyleSheet(bool fForceUpdate)
 {
     AssertLockNotHeld(cs_css);
     LOCK(cs_css);
@@ -1092,11 +1092,7 @@ void loadStyleSheet(interfaces::Node& node, bool fForceUpdate)
     bool fDebugCustomStyleSheets = gArgs.GetBoolArg("-debug-ui", false) && isStyleSheetDirectoryCustom();
     bool fStyleSheetChanged = false;
 
-    if (stylesheet == nullptr) {
-        fForceUpdate = true;
-    }
-
-    if (fForceUpdate || fDebugCustomStyleSheets) {
+    if (stylesheet == nullptr || fForceUpdate || fDebugCustomStyleSheets) {
         auto hasModified = [](const std::vector<QString>& vecFiles) -> bool {
             static std::map<const QString, QDateTime> mapLastModified;
 
@@ -1182,10 +1178,6 @@ void loadStyleSheet(interfaces::Node& node, bool fForceUpdate)
 
     if (fUpdateStyleSheet && stylesheet != nullptr) {
         qApp->setStyleSheet(*stylesheet);
-    }
-
-    if (!node.shutdownRequested() && fDebugCustomStyleSheets && !fForceUpdate) {
-        QTimer::singleShot(200, [&] { loadStyleSheet(node); });
     }
 }
 
@@ -1701,9 +1693,9 @@ bool dashThemeActive()
     return theme != traditionalTheme;
 }
 
-void loadTheme(interfaces::Node& node, bool fForce)
+void loadTheme(bool fForce)
 {
-    loadStyleSheet(node, fForce);
+    loadStyleSheet(fForce);
     updateFonts();
     updateMacFocusRects();
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -277,7 +277,7 @@ namespace GUIUtil
 
     /** Sets the stylesheet of the whole app and updates it if the
     related css files has been changed and -debug-ui mode is active. */
-    void loadStyleSheet(interfaces::Node& node, bool fForceUpdate = false);
+    void loadStyleSheet(bool fForceUpdate = false);
 
     enum class FontFamily {
         SystemDefault,
@@ -362,7 +362,7 @@ namespace GUIUtil
     bool dashThemeActive();
 
     /** Load the theme and update all UI elements according to the appearance settings. */
-    void loadTheme(interfaces::Node& node, bool fForce = false);
+    void loadTheme(bool fForce = false);
 
     /** Disable the OS default focus rect for macOS because we have custom focus rects
      * set in the css files */

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -275,10 +275,9 @@ namespace GUIUtil
     /** Check if the given theme name is valid or not */
     const bool isValidTheme(const QString& strTheme);
 
-    /** Updates the widgets stylesheet and adds it to the list of ui debug elements.
-    Beeing on that list means the stylesheet of the widget gets updated if the
-    related css files has been changed if -debug-ui mode is active. */
-    void loadStyleSheet(interfaces::Node& node, QWidget* widget = nullptr, bool fForceUpdate = false);
+    /** Sets the stylesheet of the whole app and updates it if the
+    related css files has been changed and -debug-ui mode is active. */
+    void loadStyleSheet(interfaces::Node& node, bool fForceUpdate = false);
 
     enum class FontFamily {
         SystemDefault,
@@ -363,7 +362,7 @@ namespace GUIUtil
     bool dashThemeActive();
 
     /** Load the theme and update all UI elements according to the appearance settings. */
-    void loadTheme(interfaces::Node& node, QWidget* widget = nullptr, bool fForce = false);
+    void loadTheme(interfaces::Node& node, bool fForce = false);
 
     /** Disable the OS default focus rect for macOS because we have custom focus rects
      * set in the css files */

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -207,7 +207,7 @@ bool Intro::pickDataDirectory(interfaces::Node& node)
         /* Let the user choose one */
         Intro intro;
         GUIUtil::disableMacFocusRect(&intro);
-        GUIUtil::loadStyleSheet(node);
+        GUIUtil::loadStyleSheet(true);
         intro.setDataDirectory(dataDirDefaultCurrent);
         intro.setWindowIcon(QIcon(":icons/dash"));
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -207,7 +207,7 @@ bool Intro::pickDataDirectory(interfaces::Node& node)
         /* Let the user choose one */
         Intro intro;
         GUIUtil::disableMacFocusRect(&intro);
-        GUIUtil::loadStyleSheet(node, &intro);
+        GUIUtil::loadStyleSheet(node);
         intro.setDataDirectory(dataDirDefaultCurrent);
         intro.setWindowIcon(QIcon(":icons/dash"));
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -541,7 +541,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent, Qt::WindowFlags 
 
     showPage(TAB_INFO);
 
-    clear();
+    reloadThemedWidgets();
 }
 
 RPCConsole::~RPCConsole()
@@ -1293,6 +1293,14 @@ void RPCConsole::setButtonIcons()
     GUIUtil::setIcon(ui->fontSmallerButton, "fontsmaller", GUIUtil::ThemedColor::BLUE, consoleButtonsSize);
 }
 
+void RPCConsole::reloadThemedWidgets()
+{
+    clear();
+    ui->promptLabel->setHidden(GUIUtil::dashThemeActive());
+    // Adjust button icon colors on theme changes
+    setButtonIcons();
+}
+
 void RPCConsole::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
@@ -1325,10 +1333,7 @@ void RPCConsole::hideEvent(QHideEvent *event)
 void RPCConsole::changeEvent(QEvent* e)
 {
     if (e->type() == QEvent::StyleChange) {
-        clear();
-        ui->promptLabel->setHidden(GUIUtil::dashThemeActive());
-        // Adjust button icon colors on theme changes
-        setButtonIcons();
+        reloadThemedWidgets();
     }
 
     QWidget::changeEvent(e);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -723,7 +723,6 @@ void RPCConsole::setClientModel(ClientModel *model)
         autoCompleter = new QCompleter(wordList, this);
         autoCompleter->popup()->setItemDelegate(new QStyledItemDelegate(this));
         autoCompleter->popup()->setObjectName("rpcAutoCompleter");
-        GUIUtil::loadStyleSheet(node, autoCompleter->popup());
         autoCompleter->setModelSorting(QCompleter::CaseSensitivelySortedModel);
         ui->lineEdit->setCompleter(autoCompleter);
         autoCompleter->popup()->installEventFilter(this);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -157,6 +157,8 @@ private:
     void updateNodeDetail(const CNodeCombinedStats *stats);
     /** Set required icons for buttons inside the dialog */
     void setButtonIcons();
+    /** Reload some themes related widgets */
+    void reloadThemedWidgets();
 
     enum ColumnWidths
     {

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -194,8 +194,6 @@ ShutdownWindow::ShutdownWindow(interfaces::Node& node, QWidget *parent, Qt::Wind
 {
     setObjectName("ShutdownWindow");
 
-    GUIUtil::loadStyleSheet(node, this);
-
     QVBoxLayout *layout = new QVBoxLayout();
     layout->addWidget(new QLabel(
         tr("%1 is shutting down...").arg(tr(PACKAGE_NAME)) + "<br /><br />" +


### PR DESCRIPTION
Not sure why we apply themes on a per-widget basis atm (and how/why doing so breaks styling in some cases)... This patch works just fine for me on mac and linux (and fixes comboboxes on mac).