### PR TITLE
ci: Bump CI test timeout

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -52,8 +52,8 @@ if os.name == 'posix':
 TEST_EXIT_PASSED = 0
 TEST_EXIT_SKIPPED = 77
 
-# 20 minutes represented in seconds
-TRAVIS_TIMEOUT_DURATION = 20 * 60
+# 30 minutes represented in seconds
+TRAVIS_TIMEOUT_DURATION = 30 * 60
 
 BASE_SCRIPTS= [
     # Scripts that are run by the travis build process.


### PR DESCRIPTION
`feature_block_reward_reallocation.py` is too heavy for slow gitlab shared runners