### PR TITLE
llmq/rpc: Adjust verify islock, don't err when transaction isn't known locally

### DIFF
--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -684,10 +684,8 @@ UniValue verifyislock(const JSONRPCRequest& request)
         LOCK(cs_main);
         CTransactionRef tx;
         uint256 hash_block;
-        if (GetTransaction(txid, tx, Params().GetConsensus(), hash_block, true)) {
-            if (!hash_block.IsNull()) {
-                pindexMined = LookupBlockIndex(hash_block);
-            }
+        if (GetTransaction(txid, tx, Params().GetConsensus(), hash_block, true) && !hash_block.IsNull()) {
+            pindexMined = LookupBlockIndex(hash_block);
         }
     }
 

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -684,14 +684,10 @@ UniValue verifyislock(const JSONRPCRequest& request)
         LOCK(cs_main);
         CTransactionRef tx;
         uint256 hash_block;
-        if (!GetTransaction(txid, tx, Params().GetConsensus(), hash_block, true)) {
-            std::string errmsg = fTxIndex
-                  ? "No such mempool or blockchain transaction"
-                  : "No such mempool transaction. Use -txindex to enable blockchain transaction queries";
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, errmsg);
-        }
-        if (!hash_block.IsNull()) {
-            pindexMined = LookupBlockIndex(hash_block);
+        if (GetTransaction(txid, tx, Params().GetConsensus(), hash_block, true)) {
+            if (!hash_block.IsNull()) {
+                pindexMined = LookupBlockIndex(hash_block);
+            }
         }
     }
 

--- a/test/functional/rpc_verifyislock.py
+++ b/test/functional/rpc_verifyislock.py
@@ -5,7 +5,7 @@
 
 from test_framework.messages import CTransaction, FromHex, hash256, ser_compact_size, ser_string
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import bytes_to_hex_str, satoshi_round, wait_until
+from test_framework.util import assert_raises_rpc_error, bytes_to_hex_str, satoshi_round, wait_until
 
 '''
 rpc_verifyislock.py
@@ -83,9 +83,14 @@ class RPCVerifyISLockTest(DashTestFramework):
         assert selected_hash == oldest_quorum_hash
         # Create the ISLOCK, then mine a quorum to move the signing quorum out of the active set
         islock = self.create_islock(rawtx)
+        # Mine one block to trigger the "signHeight + dkgInterval" verification for the ISLOCK
         self.mine_quorum()
-        # Send the tx and verify the ISLOCK. This triggers the "signHeight + dkgInterval" verification
-        rawtx_txid = node.sendrawtransaction(rawtx)
+        # Verify the ISLOCK for a transaction that is not yet known by the node
+        rawtx_txid = node.decoderawtransaction(rawtx)["txid"]
+        assert_raises_rpc_error(-5, "No such mempool or blockchain transaction", node.getrawtransaction, rawtx_txid)
+        assert node.verifyislock(request_id, rawtx_txid, bytes_to_hex_str(islock.sig), node.getblockcount())
+        # Send the tx and verify the ISLOCK for a now known transaction
+        assert rawtx_txid == node.sendrawtransaction(rawtx)
         assert node.verifyislock(request_id, rawtx_txid, bytes_to_hex_str(islock.sig), node.getblockcount())
 
 


### PR DESCRIPTION
This is a fix for platform, which is why I'm proposing to backport to 17