### PR TITLE
Implement local PoSe cooldown on updates

### DIFF
--- a/src/masternode/masternode-meta.cpp
+++ b/src/masternode/masternode-meta.cpp
@@ -5,6 +5,7 @@
 #include <masternode/masternode-meta.h>
 
 #include <timedata.h>
+#include <tinyformat.h>
 
 CMasternodeMetaMan mmetaman;
 
@@ -128,9 +129,6 @@ void CMasternodeMetaMan::CheckAndRemove()
 
 std::string CMasternodeMetaMan::ToString() const
 {
-    std::ostringstream info;
-
-    info << "Masternodes: meta infos object count: " << (int)metaInfos.size() <<
-         ", nDsqCount: " << (int)nDsqCount;
-    return info.str();
+    return strprintf("Masternodes: meta infos object count: %ld, nDsqCount: %d, nCurrentVersion: %d, nCurrentVersionStarted: %d",
+            metaInfos.size(), nDsqCount, nCurrentVersion, nCurrentVersionStarted);
 }

--- a/src/masternode/masternode-meta.cpp
+++ b/src/masternode/masternode-meta.cpp
@@ -8,7 +8,7 @@
 
 CMasternodeMetaMan mmetaman;
 
-const std::string CMasternodeMetaMan::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-2";
+const std::string CMasternodeMetaMan::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-3";
 
 UniValue CMasternodeMetaInfo::ToJson() const
 {

--- a/src/masternode/masternode-meta.h
+++ b/src/masternode/masternode-meta.h
@@ -97,6 +97,8 @@ private:
 
     // keep track of dsq count to prevent masternodes from gaming coinjoin queue
     int64_t nDsqCount = 0;
+    int nCurrentVersion = 0;
+    int64_t nCurrentVersionStarted = 0;
 
 public:
     ADD_SERIALIZE_METHODS
@@ -134,6 +136,24 @@ public:
         }
 
         READWRITE(nDsqCount);
+
+        if (ser_action.ForRead()) {
+            READWRITE(nCurrentVersion);
+            READWRITE(nCurrentVersionStarted);
+            if (nCurrentVersion != MIN_MASTERNODE_PROTO_VERSION) {
+                // serialized by previous version
+                nCurrentVersion = MIN_MASTERNODE_PROTO_VERSION;
+                nCurrentVersionStarted = GetTime();
+            }
+        } else {
+            if (nCurrentVersion == 0 && nCurrentVersionStarted == 0) {
+                // first time serialization
+                nCurrentVersion = MIN_MASTERNODE_PROTO_VERSION;
+                nCurrentVersionStarted = GetTime();
+            }
+            READWRITE(nCurrentVersion);
+            READWRITE(nCurrentVersionStarted);
+        }
     }
 
 public:

--- a/src/masternode/masternode-meta.h
+++ b/src/masternode/masternode-meta.h
@@ -161,6 +161,7 @@ public:
 
     int64_t GetDsqCount() { LOCK(cs); return nDsqCount; }
     int64_t GetDsqThreshold(const uint256& proTxHash, int nMnCount);
+    int64_t GetCurrentVersionStarted() { LOCK(cs); return nCurrentVersionStarted; }
 
     void AllowMixing(const uint256& proTxHash);
     void DisallowMixing(const uint256& proTxHash);


### PR DESCRIPTION
This should allow us to smoothly transition to new versions without the need to turn PoSe spork off for a short period of time in order to prevent early PoSe-bans.

Kudos to @codablock for the idea 👍 