### PR TITLE
Initialize `nTime*` members of `CMasternodeSync` with `GetTime()`

### DIFF
--- a/src/masternode/masternode-sync.cpp
+++ b/src/masternode/masternode-sync.cpp
@@ -14,6 +14,12 @@
 class CMasternodeSync;
 CMasternodeSync masternodeSync;
 
+CMasternodeSync::CMasternodeSync()
+{
+    nTimeAssetSyncStarted = GetTime();
+    nTimeLastBumped = GetTime();
+}
+
 void CMasternodeSync::Reset(bool fForce, bool fNotifyReset)
 {
     // Avoid resetting the sync process if we just "recently" received a new block

--- a/src/masternode/masternode-sync.h
+++ b/src/masternode/masternode-sync.h
@@ -49,7 +49,7 @@ private:
     int64_t nTimeLastUpdateBlockTip GUARDED_BY(cs) {0};
 
 public:
-    CMasternodeSync() = default;
+    CMasternodeSync();
 
     static void SendGovernanceSyncRequest(CNode* pnode, CConnman& connman);
 


### PR DESCRIPTION
Need this to match `Reset()` logic that was used in ctor prior to #4124. Fixes issues like `Completed MASTERNODE_SYNC_BLOCKCHAIN in 1619988736s` 🙈 