### PR TITLE
qt: Fix some font weight related issues

### DIFF
--- a/src/qt/appearancewidget.cpp
+++ b/src/qt/appearancewidget.cpp
@@ -47,7 +47,7 @@ AppearanceWidget::AppearanceWidget(QWidget* parent) :
     mapper->setOrientation(Qt::Vertical);
 
     connect(ui->theme, SIGNAL(currentTextChanged(const QString&)), this, SLOT(updateTheme(const QString&)));
-    connect(ui->fontFamily, SIGNAL(activated(int)), this, SLOT(updateFontFamily(int)));
+    connect(ui->fontFamily, SIGNAL(currentIndexChanged(int)), this, SLOT(updateFontFamily(int)));
     connect(ui->fontScaleSlider, SIGNAL(valueChanged(int)), this, SLOT(updateFontScale(int)));
     connect(ui->fontWeightNormalSlider, SIGNAL(valueChanged(int)), this, SLOT(updateFontWeightNormal(int)));
     connect(ui->fontWeightBoldSlider, SIGNAL(valueChanged(int)), this, SLOT(updateFontWeightBold(int)));
@@ -118,7 +118,7 @@ void AppearanceWidget::updateTheme(const QString& theme)
 void AppearanceWidget::updateFontFamily(int index)
 {
     GUIUtil::setFontFamily(static_cast<GUIUtil::FontFamily>(ui->fontFamily->itemData(index).toInt()));
-    updateWeightSlider();
+    updateWeightSlider(true);
 }
 
 void AppearanceWidget::updateFontScale(int nScale)
@@ -148,7 +148,7 @@ void AppearanceWidget::updateFontWeightBold(int nValue, bool fForce)
     GUIUtil::setFontWeightBold(GUIUtil::supportedWeightFromIndex(ui->fontWeightBoldSlider->value()));
 }
 
-void AppearanceWidget::updateWeightSlider()
+void AppearanceWidget::updateWeightSlider(const bool fForce)
 {
     int nMaximum = GUIUtil::getSupportedWeights().size() - 1;
 
@@ -158,9 +158,11 @@ void AppearanceWidget::updateWeightSlider()
     ui->fontWeightBoldSlider->setMinimum(0);
     ui->fontWeightBoldSlider->setMaximum(nMaximum);
 
-    int nIndexNormal = GUIUtil::supportedWeightToIndex(GUIUtil::getSupportedFontWeightNormalDefault());
-    int nIndexBold = GUIUtil::supportedWeightToIndex(GUIUtil::getSupportedFontWeightBoldDefault());
-    assert(nIndexNormal != -1 && nIndexBold != -1);
-    updateFontWeightNormal(nIndexNormal, true);
-    updateFontWeightBold(nIndexBold, true);
+    if (fForce || !GUIUtil::isSupportedWeight(prevWeightNormal) || !GUIUtil::isSupportedWeight(prevWeightBold)) {
+        int nIndexNormal = GUIUtil::supportedWeightToIndex(GUIUtil::getSupportedFontWeightNormalDefault());
+        int nIndexBold = GUIUtil::supportedWeightToIndex(GUIUtil::getSupportedFontWeightBoldDefault());
+        assert(nIndexNormal != -1 && nIndexBold != -1);
+        updateFontWeightNormal(nIndexNormal, true);
+        updateFontWeightBold(nIndexBold, true);
+    }
 }

--- a/src/qt/appearancewidget.cpp
+++ b/src/qt/appearancewidget.cpp
@@ -158,11 +158,9 @@ void AppearanceWidget::updateWeightSlider()
     ui->fontWeightBoldSlider->setMinimum(0);
     ui->fontWeightBoldSlider->setMaximum(nMaximum);
 
-    if (nMaximum < 4) {
-        updateFontWeightNormal(0, true);
-        updateFontWeightBold(nMaximum, true);
-    } else {
-        updateFontWeightNormal(1, true);
-        updateFontWeightBold(4, true);
-    }
+    int nIndexNormal = GUIUtil::supportedWeightToIndex(GUIUtil::getSupportedFontWeightNormalDefault());
+    int nIndexBold = GUIUtil::supportedWeightToIndex(GUIUtil::getSupportedFontWeightBoldDefault());
+    assert(nIndexNormal != -1 && nIndexBold != -1);
+    updateFontWeightNormal(nIndexNormal, true);
+    updateFontWeightBold(nIndexBold, true);
 }

--- a/src/qt/appearancewidget.h
+++ b/src/qt/appearancewidget.h
@@ -53,7 +53,7 @@ private:
     QFont::Weight prevWeightNormal;
     QFont::Weight prevWeightBold;
 
-    void updateWeightSlider();
+    void updateWeightSlider(bool fForce = false);
 };
 
 #endif // BITCOIN_QT_APPEARANCEWIDGET_H

--- a/src/qt/dash.cpp
+++ b/src/qt/dash.cpp
@@ -714,14 +714,14 @@ int main(int argc, char *argv[])
     qInstallMessageHandler(DebugMessageHandler);
     // Allow parameter interaction before we create the options model
     app.parameterSetup();
-    // Load GUI settings from QSettings
-    app.createOptionsModel(gArgs.GetBoolArg("-resetguisettings", false));
     // Load custom application fonts and setup font management
     if (!GUIUtil::loadFonts()) {
         QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
                               QObject::tr("Error: Failed to load application fonts."));
         return EXIT_FAILURE;
     }
+    // Load GUI settings from QSettings
+    app.createOptionsModel(gArgs.GetBoolArg("-resetguisettings", false));
     // Validate/set font family
     if (gArgs.IsArgSet("-font-family")) {
         GUIUtil::FontFamily family;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1658,7 +1658,7 @@ int supportedWeightToIndex(QFont::Weight weight)
             return index;
         }
     }
-    assert(false);
+    return -1;
 }
 
 QString getActiveTheme()

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1379,26 +1379,6 @@ bool loadFonts()
         }
     }
 
-    // Load font related settings
-    QSettings settings;
-    QFont::Weight weight;
-
-    if (!gArgs.IsArgSet("-font-family")) {
-        fontFamily = fontFamilyFromString(settings.value("fontFamily").toString());
-    }
-
-    if (!gArgs.IsArgSet("-font-scale")) {
-        fontScale = settings.value("fontScale").toInt();
-    }
-
-    if (!gArgs.IsArgSet("-font-weight-normal") && weightFromArg(settings.value("fontWeightNormal").toInt(), weight)) {
-        fontWeightNormal = weight;
-    }
-
-    if (!gArgs.IsArgSet("-font-weight-bold") && weightFromArg(settings.value("fontWeightBold").toInt(), weight)) {
-        fontWeightBold = weight;
-    }
-
     setApplicationFont();
 
     // Initialize supported font weights for all available fonts

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1254,7 +1254,7 @@ QFont::Weight toQFontWeight(FontWeight weight)
 QFont::Weight getFontWeightNormal()
 {
     if (!mapWeights.count(fontFamily)) {
-        throw std::runtime_error(strprintf("%s: Font family not loaded: %s", __func__, fontFamilyToString(fontFamily).toStdString()));
+        return defaultFontWeightNormal;
     }
     return mapWeights[fontFamily].first;
 }
@@ -1276,7 +1276,7 @@ QFont::Weight getFontWeightBoldDefault()
 QFont::Weight getFontWeightBold()
 {
     if (!mapWeights.count(fontFamily)) {
-        throw std::runtime_error(strprintf("%s: Font family not loaded: %s", __func__, fontFamilyToString(fontFamily).toStdString()));
+        return defaultFontWeightBold;
     }
     return mapWeights[fontFamily].second;
 }
@@ -1439,8 +1439,17 @@ bool loadFonts()
     return true;
 }
 
+bool fontsLoaded()
+{
+    return osDefaultFont != nullptr;
+}
+
 void setApplicationFont()
 {
+    if (!fontsLoaded()) {
+        return;
+    }
+
     std::unique_ptr<QFont> font;
 
     if (fontFamily == FontFamily::Montserrat) {
@@ -1589,6 +1598,9 @@ void updateFonts()
 QFont getFont(FontFamily family, QFont::Weight qWeight, bool fItalic, int nPointSize)
 {
     QFont font;
+    if (!fontsLoaded()) {
+        return font;
+    }
 
     if (family == FontFamily::Montserrat) {
         static std::map<QFont::Weight, QString> mapMontserratMapping{

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -126,11 +126,9 @@ static const int defaultFontScale = 0;
 static FontFamily fontFamily = defaultFontFamily;
 // Application font scale value. May be overwritten by -font-scale.
 static int fontScale = defaultFontScale;
-// Application font weight for normal text. May be overwritten by -font-weight-normal.
-static QFont::Weight fontWeightNormal = defaultFontWeightNormal;
-// Application font weight for bold text. May be overwritten by -font-weight-bold.
-static QFont::Weight fontWeightBold = defaultFontWeightBold;
-
+// Contains the weight settings separated for all available fonts
+static std::map<FontFamily, std::pair<QFont::Weight, QFont::Weight>> mapDefaultWeights;
+static std::map<FontFamily, std::pair<QFont::Weight, QFont::Weight>> mapWeights;
 // Contains all widgets and its font attributes (weight, italic, size) with font changes due to GUIUtil::setFont
 static std::map<QPointer<QWidget>, std::tuple<FontWeight, bool, int>> mapFontUpdates;
 // Contains a list of supported font weights for all members of GUIUtil::FontFamily
@@ -1255,12 +1253,18 @@ QFont::Weight toQFontWeight(FontWeight weight)
 
 QFont::Weight getFontWeightNormal()
 {
-    return fontWeightNormal;
+    if (!mapWeights.count(fontFamily)) {
+        throw std::runtime_error(strprintf("%s: Font family not loaded: %s", __func__, fontFamilyToString(fontFamily).toStdString()));
+    }
+    return mapWeights[fontFamily].first;
 }
 
 void setFontWeightNormal(QFont::Weight weight)
 {
-    fontWeightNormal = weight;
+    if (!mapWeights.count(fontFamily)) {
+        throw std::runtime_error(strprintf("%s: Font family not loaded: %s", __func__, fontFamilyToString(fontFamily).toStdString()));
+    }
+    mapWeights[fontFamily].first = weight;
     updateFonts();
 }
 
@@ -1271,12 +1275,18 @@ QFont::Weight getFontWeightBoldDefault()
 
 QFont::Weight getFontWeightBold()
 {
-    return fontWeightBold;
+    if (!mapWeights.count(fontFamily)) {
+        throw std::runtime_error(strprintf("%s: Font family not loaded: %s", __func__, fontFamilyToString(fontFamily).toStdString()));
+    }
+    return mapWeights[fontFamily].second;
 }
 
 void setFontWeightBold(QFont::Weight weight)
 {
-    fontWeightBold = weight;
+    if (!mapWeights.count(fontFamily)) {
+        throw std::runtime_error(strprintf("%s: Font family not loaded: %s", __func__, fontFamilyToString(fontFamily).toStdString()));
+    }
+    mapWeights[fontFamily].second = weight;
     updateFonts();
 }
 
@@ -1390,6 +1400,41 @@ bool loadFonts()
 
     mapSupportedWeights.insert(std::make_pair(FontFamily::SystemDefault, supportedWeights(FontFamily::SystemDefault)));
     mapSupportedWeights.insert(std::make_pair(FontFamily::Montserrat, supportedWeights(FontFamily::Montserrat)));
+
+    auto getBestMatch = [&](FontFamily fontFamily, QFont::Weight targetWeight) {
+        auto& vecSupported = mapSupportedWeights[fontFamily];
+        auto it = vecSupported.begin();
+        QFont::Weight bestWeight = *it;
+        int nBestDiff = abs(*it - targetWeight);
+        while (++it != vecSupported.end()) {
+            int nDiff = abs(*it - targetWeight);
+            if (nDiff < nBestDiff) {
+                bestWeight = *it;
+                nBestDiff = nDiff;
+            }
+        }
+        return bestWeight;
+    };
+
+    auto addBestDefaults = [&](FontFamily family) -> auto {
+        QFont::Weight normalWeight = getBestMatch(family, defaultFontWeightNormal);
+        QFont::Weight boldWeight = getBestMatch(family, defaultFontWeightBold);
+        if (normalWeight == boldWeight) {
+            // If the results are the same use the next possible weight for bold font
+            auto& vecSupported = mapSupportedWeights[fontFamily];
+            auto it = std::find(vecSupported.begin(), vecSupported.end(),normalWeight);
+            if (++it != vecSupported.end()) {
+                boldWeight = *it;
+            }
+        }
+        mapDefaultWeights.emplace(family, std::make_pair(normalWeight, boldWeight));
+    };
+
+    addBestDefaults(FontFamily::SystemDefault);
+    addBestDefaults(FontFamily::Montserrat);
+
+    // Load supported defaults. May become overwritten later.
+    mapWeights = mapDefaultWeights;
 
     return true;
 }
@@ -1618,6 +1663,22 @@ QFont getFontNormal()
 QFont getFontBold()
 {
     return getFont(FontWeight::Bold);
+}
+
+QFont::Weight getSupportedFontWeightNormalDefault()
+{
+    if (!mapDefaultWeights.count(fontFamily)) {
+        throw std::runtime_error(strprintf("%s: Font family not loaded: %s", __func__, fontFamilyToString(fontFamily).toStdString()));
+    }
+    return mapDefaultWeights[fontFamily].first;
+}
+
+QFont::Weight getSupportedFontWeightBoldDefault()
+{
+    if (!mapDefaultWeights.count(fontFamily)) {
+        throw std::runtime_error(strprintf("%s: Font family not loaded: %s", __func__, fontFamilyToString(fontFamily).toStdString()));
+    }
+    return mapDefaultWeights[fontFamily].second;
 }
 
 std::vector<QFont::Weight> getSupportedWeights()

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1661,6 +1661,11 @@ int supportedWeightToIndex(QFont::Weight weight)
     return -1;
 }
 
+bool isSupportedWeight(const QFont::Weight weight)
+{
+    return supportedWeightToIndex(weight) != -1;
+}
+
 QString getActiveTheme()
 {
     QSettings settings;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -290,23 +290,6 @@ void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent, bool fAllow
 void setupAppearance(QWidget* parent, OptionsModel* model)
 {
     if (!QSettings().value("fAppearanceSetupDone", false).toBool()) {
-        std::vector<QFont::Weight> vecWeights = getSupportedWeights();
-        // See if the default value for normal weight is available
-        if (std::find(vecWeights.begin(), vecWeights.end(), defaultFontWeightNormal) == vecWeights.end()) {
-            // If not, use the lightest available weight as normal weight
-            fontWeightNormal = vecWeights.front();
-        }
-
-        // See if the default value for bold weight is available
-        if (std::find(vecWeights.begin(), vecWeights.end(), defaultFontWeightBold) == vecWeights.end()) {
-            // If not, use the second lightest available weight as bold weight default or also the lightest if there is only one
-            int nBoldOffset = vecWeights.size() > 1 ? 1 : 0;
-            fontWeightBold = vecWeights[nBoldOffset];
-        }
-
-        QSettings().setValue("fontWeightNormal", weightToArg(fontWeightNormal));
-        QSettings().setValue("fontWeightBold", weightToArg(fontWeightBold));
-
         // Create the dialog
         QDialog dlg(parent);
         dlg.setObjectName("AppearanceSetup");

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1410,7 +1410,7 @@ bool loadFonts()
         };
         std::vector<QFont::Weight> vecWeights{QFont::Thin, QFont::ExtraLight, QFont::Light,
                                               QFont::Normal, QFont::Medium, QFont::DemiBold,
-                                              QFont::Bold, QFont::Black};
+                                              QFont::Bold, QFont::ExtraBold, QFont::Black};
         std::vector<QFont::Weight> vecSupported;
         QFont::Weight prevWeight = vecWeights.front();
         for (auto weight = vecWeights.begin() + 1; weight != vecWeights.end(); ++weight) {

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -348,6 +348,10 @@ namespace GUIUtil
     /** Get the default bold QFont */
     QFont getFontBold();
 
+    /** Return supported normal default for the current font family */
+    QFont::Weight getSupportedFontWeightNormalDefault();
+    /** Return supported bold default for the current font family */
+    QFont::Weight getSupportedFontWeightBoldDefault();
     /** Return supported weights for the current font family */
     std::vector<QFont::Weight> getSupportedWeights();
     /** Convert an index to a weight in the supported weights vector */

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -354,6 +354,8 @@ namespace GUIUtil
     QFont::Weight supportedWeightFromIndex(int nIndex);
     /** Convert a weight to an index in the supported weights vector */
     int supportedWeightToIndex(QFont::Weight weight);
+    /** Check if a weight is supported by the current font family */
+    bool isSupportedWeight(QFont::Weight weight);
 
     /** Return the name of the currently active theme.*/
     QString getActiveTheme();

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -324,6 +324,8 @@ namespace GUIUtil
 
     /** Load dash specific appliciation fonts */
     bool loadFonts();
+    /** Check if the fonts have been loaded successfully */
+    bool fontsLoaded();
 
     /** Set an application wide default font, depends on the selected theme */
     void setApplicationFont();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -86,7 +86,9 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fontFamily"))
         settings.setValue("fontFamily", GUIUtil::fontFamilyToString(GUIUtil::getFontFamilyDefault()));
     if (m_node.softSetArg("-font-family", settings.value("fontFamily").toString().toStdString())) {
-        GUIUtil::setFontFamily(GUIUtil::fontFamilyFromString(settings.value("fontFamily").toString()));
+        if (GUIUtil::fontsLoaded()) {
+            GUIUtil::setFontFamily(GUIUtil::fontFamilyFromString(settings.value("fontFamily").toString()));
+        }
     } else {
         addOverriddenOption("-font-family");
     }
@@ -94,7 +96,9 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fontScale"))
         settings.setValue("fontScale", GUIUtil::getFontScaleDefault());
     if (m_node.softSetArg("-font-scale", settings.value("fontScale").toString().toStdString())) {
-        GUIUtil::setFontScale(settings.value("fontScale").toInt());
+        if (GUIUtil::fontsLoaded()) {
+            GUIUtil::setFontScale(settings.value("fontScale").toInt());
+        }
     } else {
         addOverriddenOption("-font-scale");
     }
@@ -102,14 +106,16 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fontWeightNormal"))
         settings.setValue("fontWeightNormal", GUIUtil::weightToArg(GUIUtil::getFontWeightNormalDefault()));
     if (m_node.softSetArg("-font-weight-normal", settings.value("fontWeightNormal").toString().toStdString())) {
-        QFont::Weight weight;
-        GUIUtil::weightFromArg(settings.value("fontWeightNormal").toInt(), weight);
-        if (!GUIUtil::isSupportedWeight(weight)) {
-            // If the currently selected weight is not supported fallback to the lightest weight for normal font.
-            weight = GUIUtil::getSupportedWeights().front();
-            settings.setValue("fontWeightNormal", GUIUtil::weightToArg(weight));
+        if (GUIUtil::fontsLoaded()) {
+            QFont::Weight weight;
+            GUIUtil::weightFromArg(settings.value("fontWeightNormal").toInt(), weight);
+            if (!GUIUtil::isSupportedWeight(weight)) {
+                // If the currently selected weight is not supported fallback to the lightest weight for normal font.
+                weight = GUIUtil::getSupportedWeights().front();
+                settings.setValue("fontWeightNormal", GUIUtil::weightToArg(weight));
+            }
+            GUIUtil::setFontWeightNormal(weight);
         }
-        GUIUtil::setFontWeightNormal(weight);
     } else {
         addOverriddenOption("-font-weight-normal");
     }
@@ -117,16 +123,18 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fontWeightBold"))
         settings.setValue("fontWeightBold", GUIUtil::weightToArg(GUIUtil::getFontWeightBoldDefault()));
     if (m_node.softSetArg("-font-weight-bold", settings.value("fontWeightBold").toString().toStdString())) {
-        QFont::Weight weight;
-        GUIUtil::weightFromArg(settings.value("fontWeightBold").toInt(), weight);
-        if (!GUIUtil::isSupportedWeight(weight)) {
-            // If the currently selected weight is not supported fallback to the second lightest weight for bold font
-            // or the lightest if there is only one.
-            auto vecSupported = GUIUtil::getSupportedWeights();
-            weight = vecSupported[vecSupported.size() > 1 ? 1 : 0];
-            settings.setValue("fontWeightBold", GUIUtil::weightToArg(weight));
+        if (GUIUtil::fontsLoaded()) {
+            QFont::Weight weight;
+            GUIUtil::weightFromArg(settings.value("fontWeightBold").toInt(), weight);
+            if (!GUIUtil::isSupportedWeight(weight)) {
+                // If the currently selected weight is not supported fallback to the second lightest weight for bold font
+                // or the lightest if there is only one.
+                auto vecSupported = GUIUtil::getSupportedWeights();
+                weight = vecSupported[vecSupported.size() > 1 ? 1 : 0];
+                settings.setValue("fontWeightBold", GUIUtil::weightToArg(weight));
+            }
+            GUIUtil::setFontWeightBold(weight);
         }
-        GUIUtil::setFontWeightBold(weight);
     } else {
         addOverriddenOption("-font-weight-bold");
     }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -85,6 +85,8 @@ void OptionsModel::Init(bool resetSettings)
 
     if (!settings.contains("fontFamily"))
         settings.setValue("fontFamily", GUIUtil::fontFamilyToString(GUIUtil::getFontFamilyDefault()));
+    if (!m_node.softSetArg("-font-family", settings.value("fontFamily").toString().toStdString()))
+        addOverriddenOption("-font-family");
 
     if (!settings.contains("fontScale"))
         settings.setValue("fontScale", GUIUtil::getFontScaleDefault());

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -104,6 +104,11 @@ void OptionsModel::Init(bool resetSettings)
     if (m_node.softSetArg("-font-weight-normal", settings.value("fontWeightNormal").toString().toStdString())) {
         QFont::Weight weight;
         GUIUtil::weightFromArg(settings.value("fontWeightNormal").toInt(), weight);
+        if (!GUIUtil::isSupportedWeight(weight)) {
+            // If the currently selected weight is not supported fallback to the lightest weight for normal font.
+            weight = GUIUtil::getSupportedWeights().front();
+            settings.setValue("fontWeightNormal", GUIUtil::weightToArg(weight));
+        }
         GUIUtil::setFontWeightNormal(weight);
     } else {
         addOverriddenOption("-font-weight-normal");
@@ -114,6 +119,13 @@ void OptionsModel::Init(bool resetSettings)
     if (m_node.softSetArg("-font-weight-bold", settings.value("fontWeightBold").toString().toStdString())) {
         QFont::Weight weight;
         GUIUtil::weightFromArg(settings.value("fontWeightBold").toInt(), weight);
+        if (!GUIUtil::isSupportedWeight(weight)) {
+            // If the currently selected weight is not supported fallback to the second lightest weight for bold font
+            // or the lightest if there is only one.
+            auto vecSupported = GUIUtil::getSupportedWeights();
+            weight = vecSupported[vecSupported.size() > 1 ? 1 : 0];
+            settings.setValue("fontWeightBold", GUIUtil::weightToArg(weight));
+        }
         GUIUtil::setFontWeightBold(weight);
     } else {
         addOverriddenOption("-font-weight-bold");

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -406,12 +406,16 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case FontWeightNormal: {
             QFont::Weight weight;
             GUIUtil::weightFromArg(settings.value("fontWeightNormal").toInt(), weight);
-            return GUIUtil::supportedWeightToIndex(weight);
+            int nIndex = GUIUtil::supportedWeightToIndex(weight);
+            assert(nIndex != -1);
+            return nIndex;
         }
         case FontWeightBold: {
             QFont::Weight weight;
             GUIUtil::weightFromArg(settings.value("fontWeightBold").toInt(), weight);
-            return GUIUtil::supportedWeightToIndex(weight);
+            int nIndex = GUIUtil::supportedWeightToIndex(weight);
+            assert(nIndex != -1);
+            return nIndex;
         }
         case Language:
             return settings.value("language");

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -85,23 +85,39 @@ void OptionsModel::Init(bool resetSettings)
 
     if (!settings.contains("fontFamily"))
         settings.setValue("fontFamily", GUIUtil::fontFamilyToString(GUIUtil::getFontFamilyDefault()));
-    if (!m_node.softSetArg("-font-family", settings.value("fontFamily").toString().toStdString()))
+    if (m_node.softSetArg("-font-family", settings.value("fontFamily").toString().toStdString())) {
+        GUIUtil::setFontFamily(GUIUtil::fontFamilyFromString(settings.value("fontFamily").toString()));
+    } else {
         addOverriddenOption("-font-family");
+    }
 
     if (!settings.contains("fontScale"))
         settings.setValue("fontScale", GUIUtil::getFontScaleDefault());
-    if (!m_node.softSetArg("-font-scale", settings.value("fontScale").toString().toStdString()))
+    if (m_node.softSetArg("-font-scale", settings.value("fontScale").toString().toStdString())) {
+        GUIUtil::setFontScale(settings.value("fontScale").toInt());
+    } else {
         addOverriddenOption("-font-scale");
+    }
 
     if (!settings.contains("fontWeightNormal"))
         settings.setValue("fontWeightNormal", GUIUtil::weightToArg(GUIUtil::getFontWeightNormalDefault()));
-    if (!m_node.softSetArg("-font-weight-normal", settings.value("fontWeightNormal").toString().toStdString()))
+    if (m_node.softSetArg("-font-weight-normal", settings.value("fontWeightNormal").toString().toStdString())) {
+        QFont::Weight weight;
+        GUIUtil::weightFromArg(settings.value("fontWeightNormal").toInt(), weight);
+        GUIUtil::setFontWeightNormal(weight);
+    } else {
         addOverriddenOption("-font-weight-normal");
+    }
 
     if (!settings.contains("fontWeightBold"))
         settings.setValue("fontWeightBold", GUIUtil::weightToArg(GUIUtil::getFontWeightBoldDefault()));
-    if (!m_node.softSetArg("-font-weight-bold", settings.value("fontWeightBold").toString().toStdString()))
+    if (m_node.softSetArg("-font-weight-bold", settings.value("fontWeightBold").toString().toStdString())) {
+        QFont::Weight weight;
+        GUIUtil::weightFromArg(settings.value("fontWeightBold").toInt(), weight);
+        GUIUtil::setFontWeightBold(weight);
+    } else {
         addOverriddenOption("-font-weight-bold");
+    }
 
 #ifdef ENABLE_WALLET
     if (!settings.contains("fCoinControlFeatures"))

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -113,7 +113,6 @@ QModelIndex FindTx(const QAbstractItemModel& model, const uint256& txid)
 //     src/qt/test/test_dash-qt -platform cocoa    # macOS
 void TestGUI()
 {
-    GUIUtil::loadFonts();
     // Set up wallet and chain with 105 blocks (5 mature blocks for spending).
     TestChain100Setup test;
     for (int i = 0; i < 5; ++i) {


### PR DESCRIPTION
This is an attempt to fix some weird behaviors when switching between weights/font families and also crashes like 

```
dash-qt: qt/guiutil.cpp:1700: int GUIUtil::supportedWeightToIndex(QFont::Weight): Assertion `false' failed.
Posix Signal: Aborted
   0#: (0x565085ED8935) stl_vector.h:466       - std::vector<unsigned long, std::allocator<unsigned long> >::operator=(std::vector<unsigned long, std::allocator<unsigned long> >&&)
   1#: (0x565085ED8935) stacktraces.cpp:801    - HandlePosixSignal
   2#: (0x7FE76533C980) <unknown-file>         - ???
   3#: (0x7FE76380EFB7) <unknown-file>         - ???
   4#: (0x7FE763810921) <unknown-file>         - ???
   5#: (0x7FE76380048A) <unknown-file>         - ???
   6#: (0x7FE763800502) <unknown-file>         - ???
   7#: (0x5650858F87EE) guiutil.cpp:1701       - GUIUtil::supportedWeightToIndex(QFont::Weight)
   8#: (0x56508591DEB5) optionsmodel.cpp:374   - OptionsModel::data(QModelIndex const&, int) const
   9#: (0x565086B58B20) <unknown-file>         - ???
  10#: (0x565086B61A33) <unknown-file>         - ???
  11#: (0x565086B61B7F) <unknown-file>         - ???
  12#: (0x56508591479D) optionsdialog.cpp:207  - OptionsDialog::setModel(OptionsModel*)
  13#: (0x5650858E6757) bitcoingui.cpp:901     - BitcoinGUI::optionsClicked()
  14#: (0x56508596D71B) moc_bitcoingui.cpp:308 - BitcoinGUI::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)
  15#: (0x565086849B81) <unknown-file>         - ???
Aborted (core dumped)
```

EDIT: Im not a super fan of my way of fixing tests after the changes in f8d0b77 but it was the fastest/simplest i came up with. If someone has a better idea please provide it :)
