### PR TITLE
evo: Refactor (Add/Update/Remove)MNs to do the job in one go

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -515,7 +515,9 @@ private:
     NODISCARD bool AddUniqueProperty(const CDeterministicMNCPtr& dmn, const T& v)
     {
         static const T nullValue;
-        assert(v != nullValue);
+        if (v == nullValue) {
+            return false;
+        }
 
         auto hash = ::SerializeHash(v);
         auto oldEntry = mnUniquePropertyMap.find(hash);
@@ -533,7 +535,9 @@ private:
     NODISCARD bool DeleteUniqueProperty(const CDeterministicMNCPtr& dmn, const T& oldValue)
     {
         static const T nullValue;
-        assert(oldValue != nullValue);
+        if (oldValue == nullValue) {
+            return false;
+        }
 
         auto oldHash = ::SerializeHash(oldValue);
         auto p = mnUniquePropertyMap.find(oldHash);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -512,50 +512,57 @@ public:
 
 private:
     template <typename T>
-    void AddUniqueProperty(const CDeterministicMNCPtr& dmn, const T& v)
+    NODISCARD bool AddUniqueProperty(const CDeterministicMNCPtr& dmn, const T& v)
     {
         static const T nullValue;
         assert(v != nullValue);
 
         auto hash = ::SerializeHash(v);
         auto oldEntry = mnUniquePropertyMap.find(hash);
-        assert(!oldEntry || oldEntry->first == dmn->proTxHash);
+        if (oldEntry != nullptr && oldEntry->first != dmn->proTxHash) {
+            return false;
+        }
         std::pair<uint256, uint32_t> newEntry(dmn->proTxHash, 1);
-        if (oldEntry) {
+        if (oldEntry != nullptr) {
             newEntry.second = oldEntry->second + 1;
         }
         mnUniquePropertyMap = mnUniquePropertyMap.set(hash, newEntry);
+        return true;
     }
     template <typename T>
-    void DeleteUniqueProperty(const CDeterministicMNCPtr& dmn, const T& oldValue)
+    NODISCARD bool DeleteUniqueProperty(const CDeterministicMNCPtr& dmn, const T& oldValue)
     {
         static const T nullValue;
         assert(oldValue != nullValue);
 
         auto oldHash = ::SerializeHash(oldValue);
         auto p = mnUniquePropertyMap.find(oldHash);
-        assert(p && p->first == dmn->proTxHash);
+        if (p == nullptr || p->first != dmn->proTxHash) {
+            return false;
+        }
         if (p->second == 1) {
             mnUniquePropertyMap = mnUniquePropertyMap.erase(oldHash);
         } else {
             mnUniquePropertyMap = mnUniquePropertyMap.set(oldHash, std::make_pair(dmn->proTxHash, p->second - 1));
         }
+        return true;
     }
     template <typename T>
-    void UpdateUniqueProperty(const CDeterministicMNCPtr& dmn, const T& oldValue, const T& newValue)
+    NODISCARD bool UpdateUniqueProperty(const CDeterministicMNCPtr& dmn, const T& oldValue, const T& newValue)
     {
         if (oldValue == newValue) {
-            return;
+            return true;
         }
         static const T nullValue;
 
-        if (oldValue != nullValue) {
-            DeleteUniqueProperty(dmn, oldValue);
+        if (oldValue != nullValue && !DeleteUniqueProperty(dmn, oldValue)) {
+            return false;
         }
 
-        if (newValue != nullValue) {
-            AddUniqueProperty(dmn, newValue);
+        if (newValue != nullValue && !AddUniqueProperty(dmn, newValue)) {
+            return false;
         }
+        return true;
     }
 };
 


### PR DESCRIPTION
Instead of hashing the value and querying `mnUniquePropertyMap` both 2 or 3 times per property.

Also unify their error messages while at it.