### PR TITLE
llmq: Bump llmq leveldb cache size to 8 MiB

### DIFF
--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -27,7 +27,7 @@ CDBWrapper* llmqDb;
 
 void InitLLMQSystem(CEvoDB& evoDb, bool unitTests, bool fWipe)
 {
-    llmqDb = new CDBWrapper(unitTests ? "" : (GetDataDir() / "llmq"), 1 << 20, unitTests, fWipe);
+    llmqDb = new CDBWrapper(unitTests ? "" : (GetDataDir() / "llmq"), 8 << 20, unitTests, fWipe);
     blsWorker = new CBLSWorker();
 
     quorumDKGDebugManager = new CDKGDebugManager();


### PR DESCRIPTION
The way things work now is that we store islocks temporary and remove them once the corresponding block is chainlocked. They are stored in leveldb cache normally (mirrored by a log file). When cache size is too small to keep all islocks leveldb has to push them to disk BUT the problem here is that it also compresses and sorts them while doing so which results in leveldb touching many files at once while flushing data to tables and then touching them _again_ when we are finally erasing these islocks. Bumping cache size (to 8 MiB) should help to prevent that kind of a behaviour (at current tx/s rate).

<img width="960" alt="Screenshot 2021-05-04 at 21 17 20" src="https://user-images.githubusercontent.com/1935069/117050794-75170880-ad1e-11eb-9046-1be73735c152.png">

(the spike at 05/03  0:00 is when the patch was compiled and applied)