### PR TITLE
tests: Use `wait_for_chainlocked_block_all_nodes` in more places

### DIFF
--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -61,7 +61,7 @@ class LLMQChainLocksTest(DashTestFramework):
         assert(self.nodes[0].getbestblockhash() == node0_tip)
         reconnect_isolated_node(self.nodes[0], 1)
         self.nodes[1].generatetoaddress(1, node0_mining_addr)
-        self.wait_for_chainlocked_block(self.nodes[0], self.nodes[1].getbestblockhash())
+        self.wait_for_chainlocked_block_all_nodes(self.nodes[1].getbestblockhash())
 
         self.log.info("Isolate node, mine on both parts of the network, and reconnect")
         isolate_node(self.nodes[0])
@@ -72,7 +72,7 @@ class LLMQChainLocksTest(DashTestFramework):
         assert(not self.nodes[0].getblock(self.nodes[0].getbestblockhash())["chainlock"])
         reconnect_isolated_node(self.nodes[0], 1)
         self.nodes[1].generatetoaddress(1, node0_mining_addr)
-        self.wait_for_chainlocked_block(self.nodes[0], self.nodes[1].getbestblockhash())
+        self.wait_for_chainlocked_block_all_nodes(self.nodes[1].getbestblockhash())
         assert(self.nodes[0].getblock(self.nodes[0].getbestblockhash())["previousblockhash"] == good_tip)
         assert(self.nodes[1].getblock(self.nodes[1].getbestblockhash())["previousblockhash"] == good_tip)
 
@@ -107,7 +107,7 @@ class LLMQChainLocksTest(DashTestFramework):
         assert(self.nodes[0].getbestblockhash() != good_tip)
         good_fork = good_tip
         good_tip = self.nodes[1].generatetoaddress(1, node0_mining_addr)[-1]  # this should mark bad_tip as conflicting
-        self.wait_for_chainlocked_block(self.nodes[0], good_tip)
+        self.wait_for_chainlocked_block_all_nodes(good_tip)
         assert(self.nodes[0].getbestblockhash() == good_tip)
         found = False
         for tip in self.nodes[0].getchaintips(2):

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -173,7 +173,7 @@ class QuorumDataRecoveryTest(DashTestFramework):
         self.test_mns(llmq_test, quorum_hash_recover, valid_mns=member_mns_recover_test, recover=True)
         self.test_mns(llmq_test_v17, quorum_hash_recover, valid_mns=member_mns_recover_v17, recover=True)
         # Mining a block should result in a chainlock now because the quorum should be healed
-        self.wait_for_chainlocked_block(node, node.getbestblockhash())
+        self.wait_for_chainlocked_block_all_nodes(node.getbestblockhash())
         logger.info("Test -llmq-qvvec-sync command line parameter")
         # Run with one type separated and then both possible (for regtest) together, both calls generate new quorums
         # and are restarting the nodes with the other parameters

--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -142,8 +142,7 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
             # The block should get accepted now, and at the same time prune the conflicting ISLOCKs
             assert(submit_result is None)
 
-        for node in self.nodes:
-            self.wait_for_chainlocked_block(node, block.hash)
+        self.wait_for_chainlocked_block_all_nodes(block.hash)
 
         # Create a chained TX on top of tx2
         inputs = []

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -40,6 +40,7 @@ class RPCVerifyChainLockTest(DashTestFramework):
         assert node0.verifychainlock(block_hash, chainlock_signature, height)
         # Invalid "blockHash"
         assert not node0.verifychainlock(node0.getblockhash(0), chainlock_signature, height)
+        self.wait_for_chainlocked_block_all_nodes(block_hash)
         # Isolate node1, mine a block on node0 and wait for its ChainLock
         node1.setnetworkactive(False)
         node0.generate(1)


### PR DESCRIPTION
Fixes random failures in `rpc_verifychainlock.py` (node1 might not have clsig by the time we call `node1.getbestchainlock()`). For everything else it seems like a good idea in general to make sure clsig actually propagated to other nodes with no issues before moving forward.