### PR TITLE
llmq: Split "llmq" db

### DIFF
--- a/src/llmq/quorums_dkgsessionmgr.cpp
+++ b/src/llmq/quorums_dkgsessionmgr.cpp
@@ -22,10 +22,11 @@ static const std::string DB_VVEC = "qdkg_V";
 static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
-CDKGSessionManager::CDKGSessionManager(CDBWrapper& _llmqDb, CBLSWorker& _blsWorker) :
-    llmqDb(_llmqDb),
+CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, bool unitTests, bool fWipe) :
     blsWorker(_blsWorker)
 {
+    db = std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe);
+
     for (const auto& qt : Params().GetConsensus().llmqs) {
         dkgSessionHandlers.emplace(std::piecewise_construct,
                 std::forward_as_tuple(qt.first),
@@ -199,17 +200,17 @@ bool CDKGSessionManager::GetPrematureCommitment(const uint256& hash, CDKGPrematu
 
 void CDKGSessionManager::WriteVerifiedVvecContribution(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, const BLSVerificationVectorPtr& vvec)
 {
-    llmqDb.Write(std::make_tuple(DB_VVEC, llmqType, pindexQuorum->GetBlockHash(), proTxHash), *vvec);
+    db->Write(std::make_tuple(DB_VVEC, llmqType, pindexQuorum->GetBlockHash(), proTxHash), *vvec);
 }
 
 void CDKGSessionManager::WriteVerifiedSkContribution(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, const CBLSSecretKey& skContribution)
 {
-    llmqDb.Write(std::make_tuple(DB_SKCONTRIB, llmqType, pindexQuorum->GetBlockHash(), proTxHash), skContribution);
+    db->Write(std::make_tuple(DB_SKCONTRIB, llmqType, pindexQuorum->GetBlockHash(), proTxHash), skContribution);
 }
 
 void CDKGSessionManager::WriteEncryptedContributions(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& proTxHash, const CBLSIESMultiRecipientObjects<CBLSSecretKey>& contributions)
 {
-    llmqDb.Write(std::make_tuple(DB_ENC_CONTRIB, llmqType, pindexQuorum->GetBlockHash(), proTxHash), contributions);
+    db->Write(std::make_tuple(DB_ENC_CONTRIB, llmqType, pindexQuorum->GetBlockHash(), proTxHash), contributions);
 }
 
 bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const std::vector<bool>& validMembers, std::vector<uint16_t>& memberIndexesRet, std::vector<BLSVerificationVectorPtr>& vvecsRet, BLSSecretKeyVector& skContributionsRet)
@@ -231,10 +232,10 @@ bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, 
             if (it == contributionsCache.end()) {
                 auto vvecPtr = std::make_shared<BLSVerificationVector>();
                 CBLSSecretKey skContribution;
-                if (!llmqDb.Read(std::make_tuple(DB_VVEC, llmqType, pindexQuorum->GetBlockHash(), proTxHash), *vvecPtr)) {
+                if (!db->Read(std::make_tuple(DB_VVEC, llmqType, pindexQuorum->GetBlockHash(), proTxHash), *vvecPtr)) {
                     return false;
                 }
-                llmqDb.Read(std::make_tuple(DB_SKCONTRIB, llmqType, pindexQuorum->GetBlockHash(), proTxHash), skContribution);
+                db->Read(std::make_tuple(DB_SKCONTRIB, llmqType, pindexQuorum->GetBlockHash(), proTxHash), skContribution);
 
                 it = contributionsCache.emplace(cacheKey, ContributionsCacheEntry{GetTimeMillis(), vvecPtr, skContribution}).first;
             }
@@ -268,7 +269,7 @@ bool CDKGSessionManager::GetEncryptedContributions(Consensus::LLMQType llmqType,
     for (size_t i = 0; i < members.size(); i++) {
         if (validMembers[i]) {
             CBLSIESMultiRecipientObjects<CBLSSecretKey> encryptedContributions;
-            if (!llmqDb.Read(std::make_tuple(DB_ENC_CONTRIB, llmqType, pindexQuorum->GetBlockHash(), members[i]->proTxHash), encryptedContributions)) {
+            if (!db->Read(std::make_tuple(DB_ENC_CONTRIB, llmqType, pindexQuorum->GetBlockHash(), members[i]->proTxHash), encryptedContributions)) {
                 return false;
             }
             vecRet.emplace_back(encryptedContributions.Get(nRequestedMemberIdx));

--- a/src/llmq/quorums_dkgsessionmgr.h
+++ b/src/llmq/quorums_dkgsessionmgr.h
@@ -21,7 +21,7 @@ class CDKGSessionManager
     static const int64_t MAX_CONTRIBUTION_CACHE_TIME = 60 * 1000;
 
 private:
-    CDBWrapper& llmqDb;
+    std::unique_ptr<CDBWrapper> db{nullptr};
     CBLSWorker& blsWorker;
 
     std::map<Consensus::LLMQType, CDKGSessionHandler> dkgSessionHandlers;
@@ -46,7 +46,7 @@ private:
     std::map<ContributionsCacheKey, ContributionsCacheEntry> contributionsCache GUARDED_BY(contributionsCacheCs);
 
 public:
-    CDKGSessionManager(CDBWrapper& _llmqDb, CBLSWorker& _blsWorker);
+    CDKGSessionManager(CBLSWorker& _blsWorker, bool unitTests, bool fWipe);
     ~CDKGSessionManager();
 
     void StartThreads();

--- a/src/llmq/quorums_dkgsessionmgr.h
+++ b/src/llmq/quorums_dkgsessionmgr.h
@@ -71,6 +71,7 @@ public:
     bool GetEncryptedContributions(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const std::vector<bool>& validMembers, const uint256& proTxHash, std::vector<CBLSIESEncryptedObject<CBLSSecretKey>>& vecRet) const;
 
 private:
+    void MigrateDKG();
     void CleanupCache();
 };
 

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -37,7 +37,7 @@ void InitLLMQSystem(CEvoDB& evoDb, bool unitTests, bool fWipe)
     quorumSigSharesManager = new CSigSharesManager();
     quorumSigningManager = new CSigningManager(*llmqDb, unitTests);
     chainLocksHandler = new CChainLocksHandler();
-    quorumInstantSendManager = new CInstantSendManager(*llmqDb);
+    quorumInstantSendManager = new CInstantSendManager(unitTests, fWipe);
 }
 
 void DestroyLLMQSystem()

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -35,7 +35,7 @@ void InitLLMQSystem(CEvoDB& evoDb, bool unitTests, bool fWipe)
     quorumDKGSessionManager = new CDKGSessionManager(*llmqDb, *blsWorker);
     quorumManager = new CQuorumManager(evoDb, *blsWorker, *quorumDKGSessionManager);
     quorumSigSharesManager = new CSigSharesManager();
-    quorumSigningManager = new CSigningManager(*llmqDb, unitTests);
+    quorumSigningManager = new CSigningManager(unitTests, fWipe);
     chainLocksHandler = new CChainLocksHandler();
     quorumInstantSendManager = new CInstantSendManager(unitTests, fWipe);
 }

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -32,7 +32,7 @@ void InitLLMQSystem(CEvoDB& evoDb, bool unitTests, bool fWipe)
 
     quorumDKGDebugManager = new CDKGDebugManager();
     quorumBlockProcessor = new CQuorumBlockProcessor(evoDb);
-    quorumDKGSessionManager = new CDKGSessionManager(*llmqDb, *blsWorker);
+    quorumDKGSessionManager = new CDKGSessionManager(*blsWorker, unitTests, fWipe);
     quorumManager = new CQuorumManager(evoDb, *blsWorker, *quorumDKGSessionManager);
     quorumSigSharesManager = new CSigSharesManager();
     quorumSigningManager = new CSigningManager(unitTests, fWipe);

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -23,11 +23,8 @@ namespace llmq
 
 CBLSWorker* blsWorker;
 
-CDBWrapper* llmqDb;
-
 void InitLLMQSystem(CEvoDB& evoDb, bool unitTests, bool fWipe)
 {
-    llmqDb = new CDBWrapper(unitTests ? "" : (GetDataDir() / "llmq"), 8 << 20, unitTests, fWipe);
     blsWorker = new CBLSWorker();
 
     quorumDKGDebugManager = new CDKGDebugManager();
@@ -38,6 +35,10 @@ void InitLLMQSystem(CEvoDB& evoDb, bool unitTests, bool fWipe)
     quorumSigningManager = new CSigningManager(unitTests, fWipe);
     chainLocksHandler = new CChainLocksHandler();
     quorumInstantSendManager = new CInstantSendManager(unitTests, fWipe);
+
+    // NOTE: we use this only to wipe the old db, do NOT use it for anything else
+    // TODO: remove it in some future version
+    auto llmqDbTmp = std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq"), 1 << 20, unitTests, true);
 }
 
 void DestroyLLMQSystem()
@@ -60,8 +61,6 @@ void DestroyLLMQSystem()
     quorumDKGDebugManager = nullptr;
     delete blsWorker;
     blsWorker = nullptr;
-    delete llmqDb;
-    llmqDb = nullptr;
     LOCK(cs_llmq_vbc);
     llmq_versionbitscache.Clear();
 }

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -45,7 +45,7 @@ private:
 
     int best_confirmed_height{0};
 
-    CDBWrapper& db;
+    std::unique_ptr<CDBWrapper> db{nullptr};
 
     mutable unordered_lru_cache<uint256, CInstantSendLockPtr, StaticSaltedHasher, 10000> islockCache;
     mutable unordered_lru_cache<uint256, uint256, StaticSaltedHasher, 10000> txidCache;
@@ -55,7 +55,7 @@ private:
     void RemoveInstantSendLockMined(CDBBatch& batch, const uint256& hash, int nHeight);
 
 public:
-    explicit CInstantSendDb(CDBWrapper& _db);
+    explicit CInstantSendDb(bool unitTests, bool fWipe);
 
     void Upgrade();
 
@@ -191,7 +191,7 @@ private:
     std::unordered_set<uint256, StaticSaltedHasher> pendingRetryTxs GUARDED_BY(cs);
 
 public:
-    explicit CInstantSendManager(CDBWrapper& _llmqDb);
+    explicit CInstantSendManager(bool unitTests, bool fWipe);
     ~CInstantSendManager();
 
     void Start();

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -37,99 +37,15 @@ UniValue CRecoveredSig::ToJson() const
     return ret;
 }
 
-CRecoveredSigsDb::CRecoveredSigsDb(CDBWrapper& _db) :
-    db(_db)
+CRecoveredSigsDb::CRecoveredSigsDb(bool fMemory, bool fWipe)
 {
-    if (Params().NetworkIDString() == CBaseChainParams::TESTNET) {
-        // TODO this can be completely removed after some time (when we're pretty sure the conversion has been run on most testnet MNs)
-        if (db.Exists(std::string("rs_upgraded"))) {
-            return;
-        }
-
-        ConvertInvalidTimeKeys();
-        AddVoteTimeKeys();
-
-        db.Write(std::string("rs_upgraded"), (uint8_t)1);
-    }
-}
-
-// This converts time values in "rs_t" from host endianness to big endianness, which is required to have proper ordering of the keys
-void CRecoveredSigsDb::ConvertInvalidTimeKeys()
-{
-    LogPrintf("CRecoveredSigsDb::%s -- converting invalid rs_t keys\n", __func__);
-
-    std::unique_ptr<CDBIterator> pcursor(db.NewIterator());
-
-    auto start = std::make_tuple(std::string("rs_t"), (uint32_t)0, (Consensus::LLMQType)0, uint256());
-    pcursor->Seek(start);
-
-    CDBBatch batch(db);
-    size_t cnt = 0;
-    while (pcursor->Valid()) {
-        decltype(start) k;
-
-        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_t") {
-            break;
-        }
-
-        batch.Erase(k);
-        std::get<1>(k) = htobe32(std::get<1>(k));
-        batch.Write(k, (uint8_t)1);
-
-        cnt++;
-
-        pcursor->Next();
-    }
-    pcursor.reset();
-
-    db.WriteBatch(batch);
-
-    LogPrintf("CRecoveredSigsDb::%s -- converted %d invalid rs_t keys\n", __func__, cnt);
-}
-
-// This adds rs_vt keys for every rs_v entry to the DB. The time in the key is set to the current time.
-// This causes cleanup of all these votes a week later.
-void CRecoveredSigsDb::AddVoteTimeKeys()
-{
-    LogPrint(BCLog::LLMQ, "CRecoveredSigsDb::%s -- adding rs_vt keys with current time\n", __func__);
-
-    auto curTime = GetAdjustedTime();
-
-    std::unique_ptr<CDBIterator> pcursor(db.NewIterator());
-
-    auto start = std::make_tuple(std::string("rs_v"), (Consensus::LLMQType)0, uint256());
-    pcursor->Seek(start);
-
-    CDBBatch batch(db);
-    size_t cnt = 0;
-    while (pcursor->Valid()) {
-        decltype(start) k;
-
-        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_v") {
-            break;
-        }
-
-        Consensus::LLMQType llmqType = std::get<1>(k);
-        const uint256& id = std::get<2>(k);
-
-        auto k2 = std::make_tuple(std::string("rs_vt"), (uint32_t)htobe32(curTime), llmqType, id);
-        batch.Write(k2, (uint8_t)1);
-
-        cnt++;
-
-        pcursor->Next();
-    }
-    pcursor.reset();
-
-    db.WriteBatch(batch);
-
-    LogPrint(BCLog::LLMQ, "CRecoveredSigsDb::%s -- added %d rs_vt entries\n", __func__, cnt);
+    db = std::make_unique<CDBWrapper>(fMemory ? "" : (GetDataDir() / "llmq/recsigdb"), 8 << 20, fMemory, fWipe);
 }
 
 bool CRecoveredSigsDb::HasRecoveredSig(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash) const
 {
     auto k = std::make_tuple(std::string("rs_r"), llmqType, id, msgHash);
-    return db.Exists(k);
+    return db->Exists(k);
 }
 
 bool CRecoveredSigsDb::HasRecoveredSigForId(Consensus::LLMQType llmqType, const uint256& id)
@@ -145,7 +61,7 @@ bool CRecoveredSigsDb::HasRecoveredSigForId(Consensus::LLMQType llmqType, const 
 
 
     auto k = std::make_tuple(std::string("rs_r"), llmqType, id);
-    ret = db.Exists(k);
+    ret = db->Exists(k);
 
     LOCK(cs);
     hasSigForIdCache.insert(cacheKey, ret);
@@ -163,7 +79,7 @@ bool CRecoveredSigsDb::HasRecoveredSigForSession(const uint256& signHash)
     }
 
     auto k = std::make_tuple(std::string("rs_s"), signHash);
-    ret = db.Exists(k);
+    ret = db->Exists(k);
 
     LOCK(cs);
     hasSigForSessionCache.insert(signHash, ret);
@@ -181,7 +97,7 @@ bool CRecoveredSigsDb::HasRecoveredSigForHash(const uint256& hash)
     }
 
     auto k = std::make_tuple(std::string("rs_h"), hash);
-    ret = db.Exists(k);
+    ret = db->Exists(k);
 
     LOCK(cs);
     hasSigForHashCache.insert(hash, ret);
@@ -193,7 +109,7 @@ bool CRecoveredSigsDb::ReadRecoveredSig(Consensus::LLMQType llmqType, const uint
     auto k = std::make_tuple(std::string("rs_r"), llmqType, id);
 
     CDataStream ds(SER_DISK, CLIENT_VERSION);
-    if (!db.ReadDataStream(k, ds)) {
+    if (!db->ReadDataStream(k, ds)) {
         return false;
     }
 
@@ -209,7 +125,7 @@ bool CRecoveredSigsDb::GetRecoveredSigByHash(const uint256& hash, CRecoveredSig&
 {
     auto k1 = std::make_tuple(std::string("rs_h"), hash);
     std::pair<Consensus::LLMQType, uint256> k2;
-    if (!db.Read(k1, k2)) {
+    if (!db->Read(k1, k2)) {
         return false;
     }
 
@@ -223,7 +139,7 @@ bool CRecoveredSigsDb::GetRecoveredSigById(Consensus::LLMQType llmqType, const u
 
 void CRecoveredSigsDb::WriteRecoveredSig(const llmq::CRecoveredSig& recSig)
 {
-    CDBBatch batch(db);
+    CDBBatch batch(*db);
 
     uint32_t curTime = GetAdjustedTime();
 
@@ -248,7 +164,7 @@ void CRecoveredSigsDb::WriteRecoveredSig(const llmq::CRecoveredSig& recSig)
     auto k5 = std::make_tuple(std::string("rs_t"), (uint32_t)htobe32(curTime), recSig.llmqType, recSig.id);
     batch.Write(k5, (uint8_t)1);
 
-    db.WriteBatch(batch);
+    db->WriteBatch(batch);
 
     {
         LOCK(cs);
@@ -283,7 +199,7 @@ void CRecoveredSigsDb::RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType l
     if (deleteTimeKey) {
         CDataStream writeTimeDs(SER_DISK, CLIENT_VERSION);
         // TODO remove the size() == sizeof(uint32_t) in a future version (when we stop supporting upgrades from < 0.14.1)
-        if (db.ReadDataStream(k2, writeTimeDs) && writeTimeDs.size() == sizeof(uint32_t)) {
+        if (db->ReadDataStream(k2, writeTimeDs) && writeTimeDs.size() == sizeof(uint32_t)) {
             uint32_t writeTime;
             writeTimeDs >> writeTime;
             auto k5 = std::make_tuple(std::string("rs_t"), (uint32_t) htobe32(writeTime), recSig.llmqType, recSig.id);
@@ -302,9 +218,9 @@ void CRecoveredSigsDb::RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType l
 void CRecoveredSigsDb::RemoveRecoveredSig(Consensus::LLMQType llmqType, const uint256& id)
 {
     LOCK(cs);
-    CDBBatch batch(db);
+    CDBBatch batch(*db);
     RemoveRecoveredSig(batch, llmqType, id, true, true);
-    db.WriteBatch(batch);
+    db->WriteBatch(batch);
 }
 
 // Remove the recovered sig itself and all keys required to get from id -> recSig
@@ -312,14 +228,14 @@ void CRecoveredSigsDb::RemoveRecoveredSig(Consensus::LLMQType llmqType, const ui
 void CRecoveredSigsDb::TruncateRecoveredSig(Consensus::LLMQType llmqType, const uint256& id)
 {
     LOCK(cs);
-    CDBBatch batch(db);
+    CDBBatch batch(*db);
     RemoveRecoveredSig(batch, llmqType, id, false, false);
-    db.WriteBatch(batch);
+    db->WriteBatch(batch);
 }
 
 void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
 {
-    std::unique_ptr<CDBIterator> pcursor(db.NewIterator());
+    std::unique_ptr<CDBIterator> pcursor(db->NewIterator());
 
     auto start = std::make_tuple(std::string("rs_t"), (uint32_t)0, (Consensus::LLMQType)0, uint256());
     uint32_t endTime = (uint32_t)(GetAdjustedTime() - maxAge);
@@ -349,14 +265,14 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
         return;
     }
 
-    CDBBatch batch(db);
+    CDBBatch batch(*db);
     {
         LOCK(cs);
         for (const auto& e : toDelete) {
             RemoveRecoveredSig(batch, e.first, e.second, true, false);
 
             if (batch.SizeEstimate() >= (1 << 24)) {
-                db.WriteBatch(batch);
+                db->WriteBatch(batch);
                 batch.Clear();
             }
         }
@@ -366,7 +282,7 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
         batch.Erase(e);
     }
 
-    db.WriteBatch(batch);
+    db->WriteBatch(batch);
 
     LogPrint(BCLog::LLMQ, "CRecoveredSigsDb::%d -- deleted %d entries\n", __func__, toDelete.size());
 }
@@ -374,13 +290,13 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
 bool CRecoveredSigsDb::HasVotedOnId(Consensus::LLMQType llmqType, const uint256& id) const
 {
     auto k = std::make_tuple(std::string("rs_v"), llmqType, id);
-    return db.Exists(k);
+    return db->Exists(k);
 }
 
 bool CRecoveredSigsDb::GetVoteForId(Consensus::LLMQType llmqType, const uint256& id, uint256& msgHashRet) const
 {
     auto k = std::make_tuple(std::string("rs_v"), llmqType, id);
-    return db.Read(k, msgHashRet);
+    return db->Read(k, msgHashRet);
 }
 
 void CRecoveredSigsDb::WriteVoteForId(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash)
@@ -388,22 +304,22 @@ void CRecoveredSigsDb::WriteVoteForId(Consensus::LLMQType llmqType, const uint25
     auto k1 = std::make_tuple(std::string("rs_v"), llmqType, id);
     auto k2 = std::make_tuple(std::string("rs_vt"), (uint32_t)htobe32(GetAdjustedTime()), llmqType, id);
 
-    CDBBatch batch(db);
+    CDBBatch batch(*db);
     batch.Write(k1, msgHash);
     batch.Write(k2, (uint8_t)1);
 
-    db.WriteBatch(batch);
+    db->WriteBatch(batch);
 }
 
 void CRecoveredSigsDb::CleanupOldVotes(int64_t maxAge)
 {
-    std::unique_ptr<CDBIterator> pcursor(db.NewIterator());
+    std::unique_ptr<CDBIterator> pcursor(db->NewIterator());
 
     auto start = std::make_tuple(std::string("rs_vt"), (uint32_t)0, (Consensus::LLMQType)0, uint256());
     uint32_t endTime = (uint32_t)(GetAdjustedTime() - maxAge);
     pcursor->Seek(start);
 
-    CDBBatch batch(db);
+    CDBBatch batch(*db);
     size_t cnt = 0;
     while (pcursor->Valid()) {
         decltype(start) k;
@@ -431,15 +347,15 @@ void CRecoveredSigsDb::CleanupOldVotes(int64_t maxAge)
         return;
     }
 
-    db.WriteBatch(batch);
+    db->WriteBatch(batch);
 
     LogPrint(BCLog::LLMQ, "CRecoveredSigsDb::%d -- deleted %d entries\n", __func__, cnt);
 }
 
 //////////////////
 
-CSigningManager::CSigningManager(CDBWrapper& llmqDb, bool fMemory) :
-    db(llmqDb)
+CSigningManager::CSigningManager(bool fMemory, bool fWipe) :
+    db(fMemory, fWipe)
 {
 }
 

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -40,6 +40,192 @@ UniValue CRecoveredSig::ToJson() const
 CRecoveredSigsDb::CRecoveredSigsDb(bool fMemory, bool fWipe)
 {
     db = std::make_unique<CDBWrapper>(fMemory ? "" : (GetDataDir() / "llmq/recsigdb"), 8 << 20, fMemory, fWipe);
+    MigrateRecoveredSigs();
+}
+
+void CRecoveredSigsDb::MigrateRecoveredSigs()
+{
+    if (!db->IsEmpty()) return;
+
+    LogPrint(BCLog::LLMQ, "CRecoveredSigsDb::%d -- start\n", __func__);
+
+    CDBBatch batch(*db);
+    auto oldDb = std::make_unique<CDBWrapper>(GetDataDir() / "llmq", 8 << 20);
+    std::unique_ptr<CDBIterator> pcursor(oldDb->NewIterator());
+
+    auto start_h = std::make_tuple(std::string("rs_h"), uint256());
+    pcursor->Seek(start_h);
+
+    while (pcursor->Valid()) {
+        decltype(start_h) k;
+        std::pair<Consensus::LLMQType, uint256> v;
+
+        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_h") {
+            break;
+        }
+        if (!pcursor->GetValue(v)) {
+            break;
+        }
+
+        batch.Write(k, v);
+
+        if (batch.SizeEstimate() >= (1 << 24)) {
+            db->WriteBatch(batch);
+            batch.Clear();
+        }
+
+        pcursor->Next();
+    }
+
+    auto start_r1 = std::make_tuple(std::string("rs_r"), (Consensus::LLMQType)0, uint256());
+    pcursor->Seek(start_r1);
+
+    while (pcursor->Valid()) {
+        decltype(start_r1) k;
+        CRecoveredSig v;
+
+        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_r") {
+            break;
+        }
+        if (!pcursor->GetValue(v)) {
+            break;
+        }
+
+        batch.Write(k, v);
+
+        if (batch.SizeEstimate() >= (1 << 24)) {
+            db->WriteBatch(batch);
+            batch.Clear();
+        }
+
+        pcursor->Next();
+    }
+
+    auto start_r2 = std::make_tuple(std::string("rs_r"), (Consensus::LLMQType)0, uint256(), uint256());
+    pcursor->Seek(start_r2);
+
+    while (pcursor->Valid()) {
+        decltype(start_r2) k;
+        uint32_t v;
+
+        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_r") {
+            break;
+        }
+        if (!pcursor->GetValue(v)) {
+            break;
+        }
+
+        batch.Write(k, v);
+
+        if (batch.SizeEstimate() >= (1 << 24)) {
+            db->WriteBatch(batch);
+            batch.Clear();
+        }
+
+        pcursor->Next();
+    }
+
+    auto start_s = std::make_tuple(std::string("rs_s"), uint256());
+    pcursor->Seek(start_s);
+
+    while (pcursor->Valid()) {
+        decltype(start_s) k;
+        uint8_t v;
+
+        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_s") {
+            break;
+        }
+        if (!pcursor->GetValue(v)) {
+            break;
+        }
+
+        batch.Write(k, v);
+
+        if (batch.SizeEstimate() >= (1 << 24)) {
+            db->WriteBatch(batch);
+            batch.Clear();
+        }
+
+        pcursor->Next();
+    }
+
+    auto start_t = std::make_tuple(std::string("rs_t"), (uint32_t)0, (Consensus::LLMQType)0, uint256());
+    pcursor->Seek(start_t);
+
+    while (pcursor->Valid()) {
+        decltype(start_t) k;
+        uint8_t v;
+
+        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_t") {
+            break;
+        }
+        if (!pcursor->GetValue(v)) {
+            break;
+        }
+
+        batch.Write(k, v);
+
+        if (batch.SizeEstimate() >= (1 << 24)) {
+            db->WriteBatch(batch);
+            batch.Clear();
+        }
+
+        pcursor->Next();
+    }
+
+    auto start_v = std::make_tuple(std::string("rs_v"), (Consensus::LLMQType)0, uint256());
+    pcursor->Seek(start_v);
+
+    while (pcursor->Valid()) {
+        decltype(start_v) k;
+        uint256 v;
+
+        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_v") {
+            break;
+        }
+        if (!pcursor->GetValue(v)) {
+            break;
+        }
+
+        batch.Write(k, v);
+
+        if (batch.SizeEstimate() >= (1 << 24)) {
+            db->WriteBatch(batch);
+            batch.Clear();
+        }
+
+        pcursor->Next();
+    }
+
+    auto start_vt = std::make_tuple(std::string("rs_vt"), (uint32_t)0, (Consensus::LLMQType)0, uint256());
+    pcursor->Seek(start_vt);
+
+    while (pcursor->Valid()) {
+        decltype(start_vt) k;
+        uint8_t v;
+
+        if (!pcursor->GetKey(k) || std::get<0>(k) != "rs_vt") {
+            break;
+        }
+        if (!pcursor->GetValue(v)) {
+            break;
+        }
+
+        batch.Write(k, v);
+
+        if (batch.SizeEstimate() >= (1 << 24)) {
+            db->WriteBatch(batch);
+            batch.Clear();
+        }
+
+        pcursor->Next();
+    }
+
+    db->WriteBatch(batch);
+    pcursor.reset();
+    oldDb.reset();
+
+    LogPrint(BCLog::LLMQ, "CRecoveredSigsDb::%d -- done\n", __func__);
 }
 
 bool CRecoveredSigsDb::HasRecoveredSig(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash) const

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -66,7 +66,7 @@ public:
 class CRecoveredSigsDb
 {
 private:
-    CDBWrapper& db;
+    std::unique_ptr<CDBWrapper> db{nullptr};
 
     CCriticalSection cs;
     unordered_lru_cache<std::pair<Consensus::LLMQType, uint256>, bool, StaticSaltedHasher, 30000> hasSigForIdCache GUARDED_BY(cs);
@@ -74,10 +74,7 @@ private:
     unordered_lru_cache<uint256, bool, StaticSaltedHasher, 30000> hasSigForHashCache GUARDED_BY(cs);
 
 public:
-    explicit CRecoveredSigsDb(CDBWrapper& _db);
-
-    void ConvertInvalidTimeKeys();
-    void AddVoteTimeKeys();
+    explicit CRecoveredSigsDb(bool fMemory, bool fWipe);
 
     bool HasRecoveredSig(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash) const;
     bool HasRecoveredSigForId(Consensus::LLMQType llmqType, const uint256& id);
@@ -136,7 +133,7 @@ private:
     std::vector<CRecoveredSigsListener*> recoveredSigsListeners GUARDED_BY(cs);
 
 public:
-    CSigningManager(CDBWrapper& llmqDb, bool fMemory);
+    CSigningManager(bool fMemory, bool fWipe);
 
     bool AlreadyHave(const CInv& inv);
     bool GetRecoveredSigForGetData(const uint256& hash, CRecoveredSig& ret);

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -96,6 +96,8 @@ public:
     void CleanupOldVotes(int64_t maxAge);
 
 private:
+    void MigrateRecoveredSigs();
+
     bool ReadRecoveredSig(Consensus::LLMQType llmqType, const uint256& id, CRecoveredSig& ret) const;
     void RemoveRecoveredSig(CDBBatch& batch, Consensus::LLMQType llmqType, const uint256& id, bool deleteHashKey, bool deleteTimeKey);
 };


### PR DESCRIPTION
Gives a bit more granular control over each module e.g. we can bump isdb cache to 32 MiB like here in 7baac52 or wipe them individually if needed.