### PR TITLE
instantsend: Partially revert 3987, add more tests for CL vs IS conflicts

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1315,8 +1315,8 @@ void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const
         CValidationState state;
         // need non-const pointer
         auto pindex2 = LookupBlockIndex(pindex->GetBlockHash());
-        if (!MarkConflictingBlock(state, Params(), pindex2)) {
-            LogPrintf("CInstantSendManager::%s -- MarkConflictingBlock failed: %s\n", __func__, FormatStateMessage(state));
+        if (!InvalidateBlock(state, Params(), pindex2)) {
+            LogPrintf("CInstantSendManager::%s -- InvalidateBlock failed: %s\n", __func__, FormatStateMessage(state));
             // This should not have happened and we are in a state were it's not safe to continue anymore
             assert(false);
         }


### PR DESCRIPTION
I think I got it wrong in #3987 - we bail out on CL vs IS conflicts earlier actually and the patched part of `ResolveBlockConflicts` was about IS vs a regular block conflicts only. `develop` works both with and without c3c59e4 which proves the patch did not fix anything, 5e12fb6 extends tests a bit and fails without c3c59e4 which proves the old patch introduced a bug 🙈 