### PR TITLE
instantsend: Do not consider islocks with unknown txes as complete

### DIFF
--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -1118,14 +1118,16 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
     }
 
     ResolveBlockConflicts(hash, *islock);
-    RemoveMempoolConflictsForLock(hash, *islock);
 
     if (tx != nullptr) {
+        RemoveMempoolConflictsForLock(hash, *islock);
         LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about lock %s for tx %s\n", __func__,
                 hash.ToString(), tx->GetHash().ToString());
         GetMainSignals().NotifyTransactionLock(tx, islock);
         // bump mempool counter to make sure newly locked txes are picked up by getblocktemplate
         mempool.AddTransactionsUpdated(1);
+    } else {
+        AskNodesForLockedTx(islock->txid);
     }
 }
 
@@ -1157,6 +1159,8 @@ void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
         ProcessTx(*tx, false, Params().GetConsensus());
         // TX is not locked, so make sure it is tracked
         AddNonLockedTx(tx, nullptr);
+    } else {
+        RemoveMempoolConflictsForLock(::SerializeHash(*islock), *islock);
     }
 }
 
@@ -1466,6 +1470,8 @@ void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const
         return;
     }
 
+    bool isLockedTxKnown = WITH_LOCK(cs, return pendingNoTxInstantSendLocks.find(islockHash) == pendingNoTxInstantSendLocks.end());
+
     bool activateBestChain = false;
     for (const auto& p : conflicts) {
         auto pindex = p.first;
@@ -1487,7 +1493,12 @@ void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const
             // This should not have happened and we are in a state were it's not safe to continue anymore
             assert(false);
         }
-        activateBestChain = true;
+        if (isLockedTxKnown) {
+            activateBestChain = true;
+        } else {
+            LogPrintf("CInstantSendManager::%s -- resetting block %s\n", __func__, pindex2->GetBlockHash().ToString());
+            ResetBlockFailureFlags(pindex2);
+        }
     }
 
     if (activateBestChain) {

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -830,7 +830,7 @@ void CInstantSendManager::ProcessMessageInstantSendLock(const CNode* pfrom, cons
     }
 
     LOCK(cs);
-    if (pendingInstantSendLocks.count(hash) || db.KnownInstantSendLock(hash)) {
+    if (pendingInstantSendLocks.count(hash) || pendingNoTxInstantSendLocks.count(hash) || db.KnownInstantSendLock(hash)) {
         return;
     }
 
@@ -1086,10 +1086,17 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
         }
     }
 
-    db.WriteNewInstantSendLock(hash, *islock);
-    if (pindexMined) {
-        db.WriteInstantSendLockMined(hash, pindexMined->nHeight);
+    if (tx == nullptr) {
+        // put it in a separate pending map and try again later
+        LOCK(cs);
+        pendingNoTxInstantSendLocks.emplace(hash, std::make_pair(from, islock));
+    } else {
+        db.WriteNewInstantSendLock(hash, *islock);
+        if (pindexMined) {
+            db.WriteInstantSendLockMined(hash, pindexMined->nHeight);
+        }
     }
+
     {
         LOCK(cs);
 
@@ -1114,7 +1121,8 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
     RemoveMempoolConflictsForLock(hash, *islock);
 
     if (tx != nullptr) {
-        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about an in-time lock for tx %s\n", __func__, tx->GetHash().ToString());
+        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about lock %s for tx %s\n", __func__,
+                hash.ToString(), tx->GetHash().ToString());
         GetMainSignals().NotifyTransactionLock(tx, islock);
         // bump mempool counter to make sure newly locked txes are picked up by getblocktemplate
         mempool.AddTransactionsUpdated(1);
@@ -1127,26 +1135,28 @@ void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
         return;
     }
 
-    CInstantSendLockPtr islock = db.GetInstantSendLockByTxid(tx->GetHash());
+    CInstantSendLockPtr islock{nullptr};
+    {
+        LOCK(cs);
+        auto it = pendingNoTxInstantSendLocks.begin();
+        while (it != pendingNoTxInstantSendLocks.end()) {
+            if (it->second.second->txid == tx->GetHash()) {
+                // we received an islock ealier
+                LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
+                         tx->GetHash().ToString(), it->first.ToString());
+                islock = it->second.second;
+                pendingInstantSendLocks.emplace(*it);
+                pendingNoTxInstantSendLocks.erase(it);
+                break;
+            }
+            ++it;
+        }
+    }
 
     if (islock == nullptr) {
         ProcessTx(*tx, false, Params().GetConsensus());
         // TX is not locked, so make sure it is tracked
         AddNonLockedTx(tx, nullptr);
-    } else {
-        {
-            // TX is locked, so make sure we don't track it anymore
-            LOCK(cs);
-            RemoveNonLockedTx(tx->GetHash(), true);
-        }
-        // In case the islock was received before the TX, filtered announcement might have missed this islock because
-        // we were unable to check for filter matches deep inside the TX. Now we have the TX, so we should retry.
-        CInv inv(islock->IsDeterministic() ? MSG_ISDLOCK : MSG_ISLOCK, ::SerializeHash(*islock));
-        g_connman->RelayInvFiltered(inv, *tx, islock->IsDeterministic() ? ISDLOCK_PROTO_VERSION : LLMQS_PROTO_VERSION);
-        // If the islock was received before the TX, we know we were not able to send
-        // the notification at that time, we need to do it now.
-        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about an earlier received lock for tx %s\n", __func__, tx->GetHash().ToString());
-        GetMainSignals().NotifyTransactionLock(tx, islock);
     }
 }
 
@@ -1219,6 +1229,19 @@ void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlock
             nonLockedTxs[in.prevout.hash].children.emplace(tx->GetHash());
             nonLockedTxsByOutpoints.emplace(in.prevout, tx->GetHash());
         }
+    }
+
+    auto it = pendingNoTxInstantSendLocks.begin();
+    while (it != pendingNoTxInstantSendLocks.end()) {
+        if (it->second.second->txid == tx->GetHash()) {
+            // we received an islock ealier, let's put it back into pending and verify/lock
+            LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
+                     tx->GetHash().ToString(), it->first.ToString());
+            pendingInstantSendLocks.emplace(*it);
+            pendingNoTxInstantSendLocks.erase(it);
+            break;
+        }
+        ++it;
     }
 
     LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, pindexMined=%s\n", __func__,
@@ -1585,7 +1608,7 @@ bool CInstantSendManager::AlreadyHave(const CInv& inv) const
     }
 
     LOCK(cs);
-    return pendingInstantSendLocks.count(inv.hash) != 0 || db.KnownInstantSendLock(inv.hash);
+    return pendingInstantSendLocks.count(inv.hash) != 0 || pendingNoTxInstantSendLocks.count(inv.hash) != 0 || db.KnownInstantSendLock(inv.hash);
 }
 
 bool CInstantSendManager::GetInstantSendLockByHash(const uint256& hash, llmq::CInstantSendLock& ret) const
@@ -1596,7 +1619,18 @@ bool CInstantSendManager::GetInstantSendLockByHash(const uint256& hash, llmq::CI
 
     auto islock = db.GetInstantSendLockByHash(hash);
     if (!islock) {
-        return false;
+        LOCK(cs);
+        auto it = pendingInstantSendLocks.find(hash);
+        if (it != pendingInstantSendLocks.end()) {
+            islock = it->second.second;
+        } else {
+            auto itNoTx = pendingNoTxInstantSendLocks.find(hash);
+            if (itNoTx != pendingNoTxInstantSendLocks.end()) {
+                islock = itNoTx->second.second;
+            } else {
+                return false;
+            }
+        }
     }
     ret = *islock;
     return true;
@@ -1633,6 +1667,25 @@ bool CInstantSendManager::IsLocked(const uint256& txHash) const
 bool CInstantSendManager::IsConflicted(const CTransaction& tx) const
 {
     return GetConflictingLock(tx) != nullptr;
+}
+
+bool CInstantSendManager::IsWaitingForTx(const uint256& txHash) const
+{
+    if (!IsInstantSendEnabled()) {
+        return false;
+    }
+
+    LOCK(cs);
+    auto it = pendingNoTxInstantSendLocks.begin();
+    while (it != pendingNoTxInstantSendLocks.end()) {
+        if (it->second.second->txid == txHash) {
+            LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
+                     txHash.ToString(), it->first.ToString());
+            return true;
+        }
+        ++it;
+    }
+    return false;
 }
 
 CInstantSendLockPtr CInstantSendManager::GetConflictingLock(const CTransaction& tx) const

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -1497,6 +1497,7 @@ void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const
             activateBestChain = true;
         } else {
             LogPrintf("CInstantSendManager::%s -- resetting block %s\n", __func__, pindex2->GetBlockHash().ToString());
+            LOCK(cs_main);
             ResetBlockFailureFlags(pindex2);
         }
     }

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -1089,7 +1089,7 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
     if (tx == nullptr) {
         // put it in a separate pending map and try again later
         LOCK(cs);
-        pendingNoTxInstantSendLocks.emplace(hash, std::make_pair(from, islock));
+        pendingNoTxInstantSendLocks.try_emplace(hash, std::make_pair(from, islock));
     } else {
         db.WriteNewInstantSendLock(hash, *islock);
         if (pindexMined) {
@@ -1147,7 +1147,7 @@ void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
                 LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
                          tx->GetHash().ToString(), it->first.ToString());
                 islock = it->second.second;
-                pendingInstantSendLocks.emplace(*it);
+                pendingInstantSendLocks.try_emplace(it->first, it->second);
                 pendingNoTxInstantSendLocks.erase(it);
                 break;
             }
@@ -1241,7 +1241,7 @@ void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlock
             // we received an islock ealier, let's put it back into pending and verify/lock
             LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
                      tx->GetHash().ToString(), it->first.ToString());
-            pendingInstantSendLocks.emplace(*it);
+            pendingInstantSendLocks.try_emplace(it->first, it->second);
             pendingNoTxInstantSendLocks.erase(it);
             break;
         }

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -196,6 +196,8 @@ private:
 
     // Incoming and not verified yet
     std::unordered_map<uint256, std::pair<NodeId, CInstantSendLockPtr>, StaticSaltedHasher> pendingInstantSendLocks GUARDED_BY(cs);
+    // Tried to veryfy but there is no tx yet
+    std::unordered_map<uint256, std::pair<NodeId, CInstantSendLockPtr>, StaticSaltedHasher> pendingNoTxInstantSendLocks GUARDED_BY(cs);
 
     // TXs which are neither IS locked nor ChainLocked. We use this to determine for which TXs we need to retry IS locking
     // of child TXs
@@ -251,6 +253,7 @@ private:
 
 public:
     bool IsLocked(const uint256& txHash) const;
+    bool IsWaitingForTx(const uint256& txHash) const;
     CInstantSendLockPtr GetConflictingLock(const CTransaction& tx) const;
 
     void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) override;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1395,7 +1395,9 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
             // masternode would not be able to exploit this to spam the network with specially
             // crafted invalid DSTX-es and potentially cause high load cheaply, because
             // corresponding checks in ProcessMessage won't let it to send DSTX-es too often.
-            bool fIgnoreRecentRejects = llmq::quorumInstantSendManager->IsLocked(inv.hash) || inv.type == MSG_DSTX;
+            bool fIgnoreRecentRejects = inv.type == MSG_DSTX ||
+                                        llmq::quorumInstantSendManager->IsWaitingForTx(inv.hash) ||
+                                        llmq::quorumInstantSendManager->IsLocked(inv.hash);
 
             return (!fIgnoreRecentRejects && recentRejects->contains(inv.hash)) ||
                    (inv.type == MSG_DSTX && static_cast<bool>(CCoinJoin::GetDSTX(inv.hash))) ||

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -587,14 +587,19 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                          REJECT_INVALID, "tx-txlock-conflict");
     }
 
-    // Check for conflicts with in-memory transactions
-    for (const CTxIn &txin : tx.vin)
-    {
-        const CTransaction* ptxConflicting = pool.GetConflictTx(txin.prevout);
-        if (ptxConflicting )
+    if (llmq::quorumInstantSendManager->IsWaitingForTx(hash)) {
+        pool.removeConflicts(tx);
+        pool.removeProTxConflicts(tx);
+    } else {
+        // Check for conflicts with in-memory transactions
+        for (const CTxIn &txin : tx.vin)
         {
-            // Transaction conflicts with mempool and RBF doesn't exist in Dash
-            return state.Invalid(false, REJECT_DUPLICATE, "txn-mempool-conflict");
+            const CTransaction* ptxConflicting = pool.GetConflictTx(txin.prevout);
+            if (ptxConflicting)
+            {
+                // Transaction conflicts with mempool and RBF doesn't exist in Dash
+                return state.Invalid(false, REJECT_DUPLICATE, "txn-mempool-conflict");
+            }
         }
     }
 


### PR DESCRIPTION
Store incomplete islocks separately (mem only), allow competing txes until the corresponding tx is known.

~Based on #4146 atm.~