### PR TITLE
build: Fix cmake prefix for bls-dash package

### DIFF
--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -32,7 +32,7 @@ endef
 
 define $(package)_set_vars
   $(package)_config_opts=-DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)/$(host_prefix)
-  $(package)_config_opts+= -DCMAKE_PREFIX_PATH=$($(package)_staging_dir)/$(host_prefix)
+  $(package)_config_opts+= -DCMAKE_PREFIX_PATH=$(host_prefix)
   $(package)_config_opts+= -DSTLIB=ON -DSHLIB=OFF -DSTBIN=ON
   $(package)_config_opts+= -DBUILD_BLS_PYTHON_BINDINGS=0 -DBUILD_BLS_TESTS=0 -DBUILD_BLS_BENCHMARKS=0
   $(package)_config_opts_linux=-DOPSYS=LINUX -DCMAKE_SYSTEM_NAME=Linux


### PR DESCRIPTION
Building `bls-dash` package with `libgmp3-dev` installed system-wide

`develop`:
`-- Configured GMP: /usr/lib/x86_64-linux-gnu/libgmp.so`

This PR:
`-- Configured GMP: /home/user/dash/depends/x86_64-pc-linux-gnu/lib/libgmp.a`