### PR TITLE
instantsend: Postpone mempool related cleanup fixes until dip0020 activation

### DIFF
--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1217,8 +1217,8 @@ void CInstantSendManager::NotifyChainLock(const CBlockIndex* pindexChainLock)
 void CInstantSendManager::UpdatedBlockTip(const CBlockIndex* pindexNew)
 {
     if (!fUpgradedDB) {
-        LOCK(cs_llmq_vbc);
-        if (VersionBitsState(pindexNew, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0020, llmq_versionbitscache) == ThresholdState::ACTIVE) {
+        LOCK(cs_main);
+        if (VersionBitsState(pindexNew, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0020, versionbitscache) == ThresholdState::ACTIVE) {
             db.Upgrade();
             fUpgradedDB = true;
         }

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1071,6 +1071,13 @@ void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
 
 void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& tx)
 {
+    {
+        LOCK(cs_main);
+        if (VersionBitsTipState(Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0020) != ThresholdState::ACTIVE) {
+            return;
+        }
+    }
+
     if (tx->vin.empty()) {
         return;
     }

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1071,14 +1071,11 @@ void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
 
 void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& tx)
 {
-    if (tx->vin.empty()) {
+    if (tx->vin.empty() || !fUpgradedDB) {
         return;
     }
 
     LOCK(cs);
-    if (!fUpgradedDB) {
-        return;
-    }
 
     CInstantSendLockPtr islock = db.GetInstantSendLockByTxid(tx->GetHash());
 
@@ -1220,14 +1217,11 @@ void CInstantSendManager::NotifyChainLock(const CBlockIndex* pindexChainLock)
 
 void CInstantSendManager::UpdatedBlockTip(const CBlockIndex* pindexNew)
 {
-    {
-        LOCK(cs);
-        if (!fUpgradedDB) {
-            LOCK(cs_llmq_vbc);
-            if (VersionBitsState(pindexNew, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0020, llmq_versionbitscache) == ThresholdState::ACTIVE) {
-                db.Upgrade();
-                fUpgradedDB = true;
-            }
+    if (!fUpgradedDB) {
+        LOCK(cs_llmq_vbc);
+        if (VersionBitsState(pindexNew, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0020, llmq_versionbitscache) == ThresholdState::ACTIVE) {
+            db.Upgrade();
+            fUpgradedDB = true;
         }
     }
 

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -1076,7 +1076,6 @@ void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& t
     }
 
     LOCK(cs);
-
     CInstantSendLockPtr islock = db.GetInstantSendLockByTxid(tx->GetHash());
 
     if (islock == nullptr) {

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -55,10 +55,10 @@ private:
     void WriteInstantSendLockMined(CDBBatch& batch, const uint256& hash, int nHeight);
     void RemoveInstantSendLockMined(CDBBatch& batch, const uint256& hash, int nHeight);
 
-    void Upgrade();
-
 public:
     explicit CInstantSendDb(CDBWrapper& _db);
+
+    void Upgrade();
 
     void WriteNewInstantSendLock(const uint256& hash, const CInstantSendLock& islock);
     void RemoveInstantSendLock(CDBBatch& batch, const uint256& hash, CInstantSendLockPtr islock, bool keep_cache = true);

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -87,6 +87,8 @@ private:
     mutable CCriticalSection cs;
     CInstantSendDb db;
 
+    bool fUpgradedDB GUARDED_BY(cs) {false};
+
     std::thread workThread;
     CThreadInterrupt workInterrupt;
 

--- a/src/llmq/quorums_instantsend.h
+++ b/src/llmq/quorums_instantsend.h
@@ -87,7 +87,7 @@ private:
     mutable CCriticalSection cs;
     CInstantSendDb db;
 
-    bool fUpgradedDB GUARDED_BY(cs) {false};
+    std::atomic<bool> fUpgradedDB{false};
 
     std::thread workThread;
     CThreadInterrupt workInterrupt;


### PR DESCRIPTION
Deploying nodes which have different logic of handling islocks (comparing to nodes already running on the network) can cause issues potentially. This PR reuses dip0020 hard-fork to ensure that old and new nodes behave the same while they still can talk to each other.