### PR TITLE
instantsend: Use `NotifyEntryRemoved` signal instead of calling `CInstantSendManager::TransactionRemovedFromMempool` from `CTxMemPool::removeUnchecked` directly

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -82,7 +82,7 @@ void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& 
     CCoinJoin::TransactionAddedToMempool(ptx);
 }
 
-void CDSNotificationInterface::TransactionRemovedFromMempool(const CTransactionRef& ptx)
+void CDSNotificationInterface::TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason)
 {
     llmq::quorumInstantSendManager->TransactionRemovedFromMempool(ptx);
 }

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -23,7 +23,7 @@ protected:
     void SynchronousUpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void TransactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime) override;
-    void TransactionRemovedFromMempool(const CTransactionRef& ptx) override;
+    void TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
     void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) override;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -623,9 +623,6 @@ bool CTxMemPool::removeSpentIndex(const uint256 txhash)
 void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 {
     NotifyEntryRemoved(it->GetSharedTx(), reason);
-    if (reason != MemPoolRemovalReason::BLOCK) {
-        llmq::quorumInstantSendManager->TransactionRemovedFromMempool(it->GetSharedTx());
-    }
     const uint256 hash = it->GetTx().GetHash();
     for (const CTxIn& txin : it->GetTx().vin)
         mapNextTx.erase(txin.prevout);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -112,7 +112,7 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx) {}
+    virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolRemovalReason reason) {}
     /**
      * Notifies listeners of a block being connected.
      * Provides a vector of transactions evicted from the mempool as a result.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1498,12 +1498,12 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
 
     for (const CTransactionRef& ptx : vtxConflicted) {
         SyncTransaction(ptx);
-        // UNKNONW because it's a manual removal, not using mempool logic
+        // UNKNOWN because it's a manual removal, not using mempool logic
         TransactionRemovedFromMempool(ptx, MemPoolRemovalReason::UNKNOWN);
     }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
         SyncTransaction(pblock->vtx[i], pindex, i);
-        // UNKNONW because it's a manual removal, not using mempool logic
+        // UNKNOWN because it's a manual removal, not using mempool logic
         TransactionRemovedFromMempool(pblock->vtx[i], MemPoolRemovalReason::UNKNOWN);
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1476,11 +1476,13 @@ void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx, int64_t nAcc
     }
 }
 
-void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx) {
-    LOCK(cs_wallet);
-    auto it = mapWallet.find(ptx->GetHash());
-    if (it != mapWallet.end()) {
-        it->second.fInMempool = false;
+void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolRemovalReason reason) {
+    if (reason != MemPoolRemovalReason::CONFLICT) {
+        LOCK(cs_wallet);
+        auto it = mapWallet.find(ptx->GetHash());
+        if (it != mapWallet.end()) {
+            it->second.fInMempool = false;
+        }
     }
 }
 
@@ -1496,11 +1498,13 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
 
     for (const CTransactionRef& ptx : vtxConflicted) {
         SyncTransaction(ptx);
-        TransactionRemovedFromMempool(ptx);
+        // UNKNONW because it's a manual removal, not using mempool logic
+        TransactionRemovedFromMempool(ptx, MemPoolRemovalReason::UNKNOWN);
     }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
         SyncTransaction(pblock->vtx[i], pindex, i);
-        TransactionRemovedFromMempool(pblock->vtx[i]);
+        // UNKNONW because it's a manual removal, not using mempool logic
+        TransactionRemovedFromMempool(pblock->vtx[i], MemPoolRemovalReason::UNKNOWN);
     }
 
     m_last_block_processed = pindex;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1033,7 +1033,7 @@ public:
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
     CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, CBlockIndex* pindexStop, const WalletRescanReserver& reserver, bool fUpdate = false);
-    void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
+    void TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolRemovalReason reason) override;
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!


### PR DESCRIPTION
Fixes potential `mempool.cs` vs `cs_main` (in `RemoveConflictingLock`) deadlock