### PR TITLE
Translations 202105 (add missing)

### DIFF
--- a/src/qt/locale/dash_ar.ts
+++ b/src/qt/locale/dash_ar.ts
@@ -247,10 +247,6 @@
         <translation>محفظة مشفرة</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 سوف يغلق الآن لإنهاء عملية التشفير. تذكر أن تشفير محفظتك لا يمكنه حماية أموالك بالكامل من التعرض للسرقة بسبب البرامج الضارة التي تصيب جهاز الكمبيوتر الخاص بك.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>مهم:يجب استبدال أي نسخ احتياطية سابقة قمت بها من ملف المحفظة ملف المحفظة المشفر حديثًا. تحتوي النسخ الاحتياطية السابقة ملف المحفظة غير المشفرة على نفس البذرة عالية الدقة ، ولا تزال تتمتع بالوصول الكامل إلى جميع أموالك مثل المحفظة الجديدة المشفرة.</translation>
     </message>
@@ -566,6 +562,10 @@
         <translation>ملف</translation>
     </message>
     <message>
+        <source>%1 &amp;information</source>
+        <translation>%1 معلومات</translation>
+    </message>
+    <message>
         <source>&amp;Settings</source>
         <translation>الإعدادات</translation>
     </message>
@@ -799,6 +799,10 @@
         <translation>تلقى مع عنوان</translation>
     </message>
     <message>
+        <source>Mixing Rounds</source>
+        <translation>جولات الخلط</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation>تاريخ</translation>
     </message>
@@ -889,6 +893,14 @@
     <message>
         <source>Some coins were unselected because they do not have enough mixing rounds.</source>
         <translation>لم يتم تحديد بعض العملات المعدنية لأنها لا تحتوي على دورات خلط كافية.</translation>
+    </message>
+    <message>
+        <source>Show all coins</source>
+        <translation>اظهار جميع العملات</translation>
+    </message>
+    <message>
+        <source>Show spendable coins only</source>
+        <translation>اظهار العملات التي يمكن صرفها فقط</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1315,6 +1327,50 @@
         <translation>إذا قمت بتعطيل الإنفاق من التغيير غير المؤكد ، فإن التغيير من معاملة&lt;br/&gt; لا يمكن استخدامه حتى يكون لهذه المعاملة تأكيد واحد على الأقل. &lt;br/&gt; يؤثر هذا أيضًا على كيفية حساب رصيدك.</translation>
     </message>
     <message>
+        <source>Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</source>
+        <translation>أظهر واجهة المزج على شاشة النظرة العامة واكشف عن شاشة إضافية تسمح بإنفاق عملات مختلطة بالكامل فقط. &lt;br/&gt; ستظهر أيضًا علامة تبويب جديدة بها المزيد من الإعدادات في مربع الحوار هذا ، يرجى التأكد من التحقق منها قبل خلط عملاتك المعدنية.</translation>
+    </message>
+    <message>
+        <source>Show additional information and buttons on overview screen.</source>
+        <translation>إظهار معلومات وأزرار إضافية على شاشة النظرة العامة.</translation>
+    </message>
+    <message>
+        <source>Enable advanced interface</source>
+        <translation>تفعيل الواجهة المتقدمة</translation>
+    </message>
+    <message>
+        <source>Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
+        <translation>عرض النوافذ المنبثقة للنظام لخلط المعاملات&lt;br/&gt; تمامًا مثل جميع أنواع المعاملات الأخرى.</translation>
+    </message>
+    <message>
+        <source>Show popups for mixing transactions</source>
+        <translation>عرض النوافذ المنبثقة لخلط المعاملات</translation>
+    </message>
+    <message>
+        <source>Show warning dialog when the wallet has very low number of keys left.</source>
+        <translation>إظهار مربع حوار التحذير عندما يكون هناك عدد قليل جدًا من المفاتيح المتبقية في المحفظة.</translation>
+    </message>
+    <message>
+        <source>Warn if the wallet is running out of keys</source>
+        <translation>تحذير إذا كانت المحفظة تنفد من المفاتيح</translation>
+    </message>
+    <message>
+        <source>Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
+        <translation>لتحديد ما إذا كنت تريد استخدام وضع الإرسال التجريبي مع جلسات خلط متعددة لكل مقطع.&lt;br/&gt;ملاحظة: يجب عليك استخدام هذه الميزة بعناية. &lt;br/&gt;تأكد من أن لديك دائمًا احتياطي محفظة (تلقائي) حديث في مكان آمن!</translation>
+    </message>
+    <message>
+        <source>Enable &amp;multi-session</source>
+        <translation>تمكين الإرسال متعدد الجلسات</translation>
+    </message>
+    <message>
+        <source>Mixing rounds</source>
+        <translation>جولات الخلط</translation>
+    </message>
+    <message>
+        <source>This amount acts as a threshold to turn off mixing once it's reached.</source>
+        <translation>يعمل هذا المقدار كعتبة لإيقاف تشغيل الخلط بمجرد الوصول إليه.</translation>
+    </message>
+    <message>
         <source>Target balance</source>
         <translation>الهدف رصيد</translation>
     </message>
@@ -1643,6 +1699,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>No inputs detected</source>
         <translation>لم يتم اكتشاف أي مدخلات</translation>
     </message>
+    <message>
+        <source>%1 Balance</source>
+        <translation>%1 الرصيد</translation>
+    </message>
     <message numerus="yes">
         <source>%n Rounds</source>
         <translation><numerusform>%n جولات</numerusform><numerusform>%n جولات</numerusform><numerusform>%n جولات</numerusform><numerusform>%n جولات</numerusform><numerusform>%n جولات</numerusform><numerusform>%n جولات</numerusform></translation>
@@ -1733,6 +1793,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>URI handling</source>
         <translation>التعامل مع العنوان</translation>
+    </message>
+    <message>
+        <source>'dash://' is not a valid URI. Use 'dash:' instead.</source>
+        <translation>'dash: //' ليس URI صالحًا. استخدم "شرطة:" بدلاً من ذلك.</translation>
     </message>
     <message>
         <source>Payment request fetch URL is invalid: %1</source>
@@ -2224,6 +2288,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>إعادة فحص ملفات بلوكشين2</translation>
     </message>
     <message>
+        <source>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</source>
+        <translation>-rescan = 1: إعادة فحص سلسلة الكتل بحثًا عن معاملات المحفظة المفقودة بدءًا من وقت إنشاء المحفظة.</translation>
+    </message>
+    <message>
+        <source>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</source>
+        <translation>-rescan = 2: إعادة فحص سلسلة الكتل بحثًا عن معاملات المحفظة المفقودة بدءًا من كتلة التكوين.</translation>
+    </message>
+    <message>
         <source>Wallet Path</source>
         <translation>محفظة path</translation>
     </message>
@@ -2262,6 +2334,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Reset</source>
         <translation>&amp;إعادة تعيين</translation>
+    </message>
+    <message>
+        <source>Node Type</source>
+        <translation>نوع العقدة</translation>
     </message>
     <message>
         <source>PoSe Score</source>
@@ -2460,8 +2536,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>لا</translation>
     </message>
     <message>
+        <source>Regular</source>
+        <translation>عادي</translation>
+    </message>
+    <message>
         <source>Masternode</source>
         <translation>ماسترنود</translation>
+    </message>
+    <message>
+        <source>Verified Masternode</source>
+        <translation>التحقق من Masternode</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2884,10 +2968,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>القيمة تتجاوز رصيدك</translation>
     </message>
     <message>
-        <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation>المجموع يتجاوز رصيدك عندما يتم اضافة %1 رسوم العملية</translation>
-    </message>
-    <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
         <translation>تم العثور على عنوان مكرر: يجب استخدام العناوين مرة واحدة فقط.</translation>
     </message>
@@ -3257,6 +3337,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>تأكيد %1</translation>
     </message>
     <message>
+        <source>locked via ChainLocks</source>
+        <translation>مغلق عبر ChainLocks</translation>
+    </message>
+    <message>
         <source>verified via InstantSend</source>
         <translation>محقق من فبل الإرسال الفوري</translation>
     </message>
@@ -3449,6 +3533,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>verified via InstantSend</source>
         <translation>محقق من فبل الإرسال الفوري</translation>
+    </message>
+    <message>
+        <source>locked via ChainLocks</source>
+        <translation>مغلق عبر ChainLocks</translation>
     </message>
     <message>
         <source>Received with</source>
@@ -4457,6 +4545,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>فشل في بدء صف مختلط جديد</translation>
     </message>
     <message>
+        <source>Incorrect -rescan mode, falling back to default value</source>
+        <translation>وضع المسح غير الصحيح ، والعودة إلى القيمة الافتراضية</translation>
+    </message>
+    <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
         <translation>فشل بالتحقق في اختبار التعقل. تم إيقاف %s.</translation>
     </message>
@@ -4509,6 +4601,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>فشل توقيع المعاملة</translation>
     </message>
     <message>
+        <source>Last queue was created too recently.</source>
+        <translation>تم إنشاء قائمة الانتظار الأخيرة مؤخرًا.</translation>
+    </message>
+    <message>
+        <source>Last successful action was too recent.</source>
+        <translation>آخر إجراء ناجح كان حديثًا جدًا.</translation>
+    </message>
+    <message>
         <source>Starting network threads...</source>
         <translation>بدء مؤشرات شبكة الاتصال...</translation>
     </message>
@@ -4551,6 +4651,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
         <translation>يتعذر الربط مع %s على هذا الكمبيوتر (الربط انتج خطأ %s)</translation>
+    </message>
+    <message>
+        <source>Unable to locate enough mixed funds for this transaction.</source>
+        <translation>تعذر تحديد موقع أموال مختلطة كافية لهذه المعاملة.</translation>
+    </message>
+    <message>
+        <source>Unable to locate enough non-denominated funds for this transaction.</source>
+        <translation>غير قادر على تحديد موقع أموال كافية غير مقومة لهذه المعاملة.</translation>
     </message>
     <message>
         <source>Unable to sign spork message, wrong key?</source>

--- a/src/qt/locale/dash_bg.ts
+++ b/src/qt/locale/dash_bg.ts
@@ -2,6 +2,10 @@
 <context>
     <name>AddressBookPage</name>
     <message>
+        <source>Enter address or label to search</source>
+        <translation>Търсене по адрес или наименование</translation>
+    </message>
+    <message>
         <source>Right-click to edit address or label</source>
         <translation>Десен бутон за да редактирате адрес или наименование</translation>
     </message>
@@ -130,6 +134,45 @@
     </message>
 </context>
 <context>
+    <name>AppearanceWidget</name>
+    <message>
+        <source>Lighter</source>
+        <translation>Изсветлен</translation>
+    </message>
+    <message>
+        <source>Bolder</source>
+        <translation>Потъмнен</translation>
+    </message>
+    <message>
+        <source>Font Weight Normal:</source>
+        <translation>Нормален шрифт:</translation>
+    </message>
+    <message>
+        <source>Smaller</source>
+        <translation>По-малък</translation>
+    </message>
+    <message>
+        <source>Bigger</source>
+        <translation>По-голям</translation>
+    </message>
+    <message>
+        <source>Font Scale:</source>
+        <translation>Мащаб на шрифта:</translation>
+    </message>
+    <message>
+        <source>Font Family:</source>
+        <translation>Вид на шрифта:</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation>Тема:</translation>
+    </message>
+    <message>
+        <source>Font Weight Bold:</source>
+        <translation>Потъмнен шрифт:</translation>
+    </message>
+</context>
+<context>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
@@ -146,6 +189,10 @@
     <message>
         <source>Repeat new passphrase</source>
         <translation>Въведете новата парола повторно</translation>
+    </message>
+    <message>
+        <source>Show password</source>
+        <translation>Покажи парола</translation>
     </message>
     <message>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
@@ -200,10 +247,6 @@
         <translation>Портфейлът е шифриран</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1  ще се затвори сега, за да завърши процеса на шифроване. Не забравяйте, че шифроването на портфейла Ви не може напълно да предпази средствата ви да бъдат откраднати от злонамерен софтуер, който е заразил компютъра Ви.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>ВАЖНО: Всички предишни архиви, които сте направили от файла на портфейла, трябва да бъдат заменени с новоиздадения, шифрован файл на портфейла. Предишните архиви на нешифрования файл с портфейли съдържат едно и също HD сиид и все още имат пълен достъп до всичките ви средства, точно като новия криптиран портфейл.</translation>
     </message>
@@ -253,6 +296,13 @@
     <message>
         <source>Banned Until</source>
         <translation>Забранен до</translation>
+    </message>
+</context>
+<context>
+    <name>BitcoinAmountField</name>
+    <message>
+        <source>Amount in %1</source>
+        <translation>Количество в %1</translation>
     </message>
 </context>
 <context>
@@ -340,6 +390,10 @@
     <message>
         <source>&amp;About %1</source>
         <translation>&amp;Относно %1</translation>
+    </message>
+    <message>
+        <source>Send %1 funds to a Dash address</source>
+        <translation>Изпрати %1 средства до Dash адрес</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
@@ -498,16 +552,26 @@
         <translation>%1 клиент</translation>
     </message>
     <message>
-        <source>&amp;PrivateSend information</source>
-        <translation>&amp;PrivateSend информация</translation>
+        <source>Wallet: %1
+</source>
+        <translation>Портфейл: %1
+</translation>
     </message>
     <message>
-        <source>Show the PrivateSend basic information</source>
-        <translation>Показване на базова информация на PrivateSend </translation>
+        <source>Wallet is &lt;b&gt;unencrypted&lt;/b&gt;</source>
+        <translation>Портфейлът е &lt;b&gt;нешифрован&lt;/b&gt;</translation>
     </message>
     <message>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
+    </message>
+    <message>
+        <source>%1 &amp;information</source>
+        <translation>%1 &amp;информация</translation>
+    </message>
+    <message>
+        <source>Show the %1 basic information</source>
+        <translation>Покажи %1 основната информация</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
@@ -664,10 +728,6 @@
         <translation>HD ключ генератора е &lt;b&gt;включен&lt;/b&gt;</translation>
     </message>
     <message>
-        <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation>HD ключ генератора е &lt;b&gt;изключен&lt;/b&gt;</translation>
-    </message>
-    <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Портфейлът е &lt;b&gt;криптиран&lt;/b&gt; и в момента &lt;b&gt;отключен&lt;/b&gt;</translation>
     </message>
@@ -747,8 +807,8 @@
         <translation>Получени с адрес</translation>
     </message>
     <message>
-        <source>PS Rounds</source>
-        <translation>PS цикли</translation>
+        <source>Mixing Rounds</source>
+        <translation>Цикли на смесване</translation>
     </message>
     <message>
         <source>Date</source>
@@ -815,10 +875,6 @@
         <translation>Моля преминете към "Режим Списък" за да използвате тази функция.</translation>
     </message>
     <message>
-        <source>Non-mixed input selected. &lt;b&gt;PrivateSend will be disabled.&lt;/b&gt;&lt;br&gt;&lt;br&gt;If you still want to use PrivateSend, please deselect all non-mixed inputs first and then check the PrivateSend checkbox again.</source>
-        <translation>Избран е не анонимизиран вход. &lt;b&gt;PrivateSend ще бъде изключен.&lt;/b&gt;&lt;br&gt;&lt;br&gt;Ако все още желаете да използвате PrivateSend, моля размаркирайте всички не анонимизирани входове и след това изберете PrivateSend опцията отново.</translation>
-    </message>
-    <message>
         <source>(%1 locked)</source>
         <translation>(%1 заключен)</translation>
     </message>
@@ -837,6 +893,30 @@
     <message>
         <source>Can vary +/- %1 duff(s) per input.</source>
         <translation>Може да варира +/- %1 duff(s) за вход.</translation>
+    </message>
+    <message>
+        <source>Some coins were unselected because they were spent.</source>
+        <translation>Някои монети не бяха избрани, защото бяха похарчени.</translation>
+    </message>
+    <message>
+        <source>Some coins were unselected because they do not have enough mixing rounds.</source>
+        <translation>Някои монети не бяха избрани, тъй като нямат достатъчно цикли за смесване.</translation>
+    </message>
+    <message>
+        <source>Show all coins</source>
+        <translation>Покажи всички монети</translation>
+    </message>
+    <message>
+        <source>Hide %1 coins</source>
+        <translation>Скрий %1 монети</translation>
+    </message>
+    <message>
+        <source>Show all %1 coins</source>
+        <translation>Покажи всички %1 монети</translation>
+    </message>
+    <message>
+        <source>Show spendable coins only</source>
+        <translation>Покажи само похарчените монети</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -876,10 +956,6 @@
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Адресът свързан с този запис от списък с адреси. Може да бъде променен само за адреси за изпращане.</translation>
-    </message>
-    <message>
-        <source>New receiving address</source>
-        <translation>Нов адрес за получаване</translation>
     </message>
     <message>
         <source>New sending address</source>
@@ -952,48 +1028,12 @@
         <translation>Опции за командния ред</translation>
     </message>
     <message>
-        <source>Usage:</source>
-        <translation>Използване:</translation>
+        <source>%1 information</source>
+        <translation>%1 информация</translation>
     </message>
     <message>
-        <source>command-line options</source>
-        <translation>опции на командния ред</translation>
-    </message>
-    <message>
-        <source>UI Options:</source>
-        <translation>UI опции:</translation>
-    </message>
-    <message>
-        <source>Choose data directory on startup (default: %u)</source>
-        <translation>Изберете директория за данни при стартиране (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Set language, for example "de_DE" (default: system locale)</source>
-        <translation>Задаване на език, например "de_DE" (по подразбиране: какъвто е от системата)</translation>
-    </message>
-    <message>
-        <source>Start minimized</source>
-        <translation>Стартирай минимизиран</translation>
-    </message>
-    <message>
-        <source>Set SSL root certificates for payment request (default: -system-)</source>
-        <translation>Задай SSL основен сертификат при искане за плащане (по подразбиране: -system-)</translation>
-    </message>
-    <message>
-        <source>Show splash screen on startup (default: %u)</source>
-        <translation>Покажи начален екран при стартиране (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Reset all settings changed in the GUI</source>
-        <translation>Нулиране на всички настройки направени чрез GUI</translation>
-    </message>
-    <message>
-        <source>PrivateSend information</source>
-        <translation>PrivateSend информация</translation>
-    </message>
-    <message>
-        <source>&lt;h3&gt;PrivateSend Basics&lt;/h3&gt; PrivateSend gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different "inputs" which you can think of as separate, discrete coins.&lt;br&gt; PrivateSend uses an innovative process to mix your inputs with the inputs of two other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The PrivateSend process works like this:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;PrivateSend begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called "masternodes." These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know "who" you are.&lt;/li&gt; &lt;li&gt;When two other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it's called a "round." Each round of PrivateSend makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these "change addresses." Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have PrivateSend disabled. &lt;hr&gt;For more information, see the &lt;a href="https://docs.dash.org/en/stable/wallets/dashcore/privatesend-instantsend.html"&gt;PrivateSend documentation&lt;/a&gt;.</source>
-        <translation>&lt;h3&gt;PrivateSend основни понятия&lt;/h3&gt; PrivateSend ви дава истинска финансова независимост чрез скриване произхода на средствата ви. Всички Dash монети в портфейла ви са съставени от различни "входове" които можете да приемете като отделни дискретни монети&lt;br&gt; PrivateSend използва иновативен процес като смесва вашите входове с входовете на други двама души без монетите да напускат изобщо портфейла ви. Имате пълен контрол върху парите си през цялото време. &lt;hr&gt; &lt;b&gt; PrivateSend процесът работи по следния начин:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;PrivateSend започва чрез разделяне на транзакцията ви до стандартни деноминации. Тези деноминации са 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH и 10 DASH --подобно на стандартните пари, които ползваме ежедневно.&lt;/li&gt; &lt;li&gt;Вашия портфейл изпраща запитване към специално конфигурираните софтуерни възли в мрежата, наречени "masternodes." Тези masternodes са информирани, че се интересувате от смесване на определена деноминация. Никаква идентификационна информация не се изпраща към   masternodes, така, че те никога не знаят "кой" сте.&lt;/li&gt; &lt;li&gt;Когато други двама души изпратят подобни съобщения, обозначаващи, че искат да смесят същата деноминация, смесващата сесия започва. Masternode смесват входовете и инструктират портфейлите на тримата потребители да платят ново трансформираните входове обратно към притежателите им. Вашият портфейл плаща деноминацията директно на себе си, но с различен адрес (наричан сменен адрес).  &lt;/li&gt; &lt;li&gt;С цел напълно скриване на доходите ви, вашият портфейл трябва да повтори този процес няколко пъти във всяка деноминация.  Всеки път завършеният процес се нарича "цикъл." Всеки цикъл на PrivateSend прави откриването на първоначалния източник на вашите средства напълно непроследим.&lt;/li&gt; &lt;li&gt;Този смесващ процес се случва като процес на заден фон без никаква намеса от ваша страна. Когато искате да направите транзакция, вашите средства са винаги анонимни. Не е необходимо допълнително изчакване. &lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;ВАЖНО:&lt;/b&gt; Вашият портфейл съдържа само 1000 от тези "сменяеми адреси". Всеки път когато се случва смесването до 9 от вашите адреси се ползват.  Това означава, че тези 1000 адреси се миксират в около 100 смесващи събития. Когато 900 се използват, вашия портфейл трябва да създаде повече адреси. Това може да стане само ако имате автоматично архивиране.&lt;br&gt; Следователно, потребителите, на които е изключено автоматичното архивиране, нямат и  PrivateSend включено. &lt;hr&gt;За повече информация вижте &lt;a href="https://docs.dash.org/en/stable/wallets/dashcore/privatesend-instantsend.html"&gt;документацията за PrivateSend&lt;/a&gt;.</translation>
+        <source>&lt;h3&gt;%1 Basics&lt;/h3&gt; %1 gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different "inputs" which you can think of as separate, discrete coins.&lt;br&gt; %1 uses an innovative process to mix your inputs with the inputs of two or more other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The %1 process works like this:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;%1 begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called "masternodes." These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know "who" you are.&lt;/li&gt; &lt;li&gt;When two or more other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it's called a "round." Each round of %1 makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these "change addresses." Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have %1 disabled. &lt;hr&gt;For more information, see the &lt;a style="%2" href="%3"&gt;%1 documentation&lt;/a&gt;.</source>
+        <translation>&lt;h3&gt;%1 основни понятия&lt;/h3&gt; %1 ви дава истинска финансова независимост чрез скриване произхода на средствата ви. Всички Dash монети в портфейла ви са съставени от различни "входове" които можете да приемете като отделни дискретни монети&lt;br&gt; %1 използва иновативен процес като смесва вашите входове с входовете на други двама души без монетите да напускат изобщо портфейла ви. Имате пълен контрол върху парите си през цялото време. &lt;hr&gt; &lt;b&gt; %1 процесът работи по следния начин:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;%1 започва чрез разделяне на транзакцията ви до стандартни деноминации. Тези деноминации са 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH и 10 DASH --подобно на стандартните пари, които ползваме ежедневно.&lt;/li&gt; &lt;li&gt;Вашия портфейл изпраща запитване към специално конфигурираните софтуерни възли в мрежата, наречени "masternodes." Тези masternodes са информирани, че се интересувате от смесване на определена деноминация. Никаква идентификационна информация не се изпраща към   masternodes, така, че те никога не знаят "кой" сте.&lt;/li&gt; &lt;li&gt;Когато други двама души изпратят подобни съобщения, обозначаващи, че искат да смесят същата деноминация, смесващата сесия започва. Masternode смесват входовете и инструктират портфейлите на тримата потребители да платят ново трансформираните входове обратно към притежателите им. Вашият портфейл плаща деноминацията директно на себе си, но с различен адрес (наричан сменен адрес).  &lt;/li&gt; &lt;li&gt;С цел напълно скриване на доходите ви, вашият портфейл трябва да повтори този процес няколко пъти във всяка деноминация.  Всеки път завършеният процес се нарича "цикъл." Всеки цикъл на %1 прави откриването на първоначалния източник на вашите средства напълно непроследим.&lt;/li&gt; &lt;li&gt;Този смесващ процес се случва като процес на заден фон без никаква намеса от ваша страна. Когато искате да направите транзакция, вашите средства са винаги анонимни. Не е необходимо допълнително изчакване. &lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;ВАЖНО:&lt;/b&gt; Вашият портфейл съдържа само 1000 от тези "сменяеми адреси". Всеки път когато се случва смесването до 9 от вашите адреси се ползват.  Това означава, че тези 1000 адреси се миксират в около 100 смесващи събития. Когато 900 се използват, вашия портфейл трябва да създаде повече адреси. Това може да стане само ако имате автоматично архивиране.&lt;br&gt; Следователно, потребителите, на които е изключено автоматичното архивиране, нямат и  %1 включено. &lt;hr&gt;За повече информация вижте &lt;a style="%2" href="%3"&gt;документацията за %1&lt;/a&gt;.</translation>
     </message>
 </context>
 <context>
@@ -1146,6 +1186,10 @@
         <translation>Копирай Collateral Outpoint</translation>
     </message>
     <message>
+        <source>Updating...</source>
+        <translation>Обновяване...</translation>
+    </message>
+    <message>
         <source>ENABLED</source>
         <translation>ВКЛЮЧЕН</translation>
     </message>
@@ -1172,6 +1216,14 @@
     <message>
         <source>NONE</source>
         <translation>НИЩО</translation>
+    </message>
+    <message>
+        <source>Filter by any property (e.g. address or protx hash)</source>
+        <translation>Филтрирайте по някакво свойство (напр. Адрес или хеш на protx)</translation>
+    </message>
+    <message>
+        <source>Please wait...</source>
+        <translation>Моля изчакайте...</translation>
     </message>
     <message>
         <source>Additional information for DIP3 Masternode %1</source>
@@ -1283,6 +1335,10 @@
         <translation>П&amp;ортфейл</translation>
     </message>
     <message>
+        <source>&amp;Appearance</source>
+        <translation>&amp;Външен вид</translation>
+    </message>
+    <message>
         <source>Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</source>
         <translation>Показване на допълнителен раздел показваш всичките Ви masternodes  в първият подраздел&lt;br/&gt;и всички masternodes в мрежата във вторият подраздел.</translation>
     </message>
@@ -1291,48 +1347,68 @@
         <translation>Показване на раздел Masternodes </translation>
     </message>
     <message>
-        <source>Show additional information and buttons for PrivateSend on overview screen.</source>
-        <translation>Показване на допълнителна информация и бутон PrivateSend на основния екран.</translation>
-    </message>
-    <message>
-        <source>Enable advanced PrivateSend interface</source>
-        <translation>Включване PrivateSend интерфейс за напреднали</translation>
-    </message>
-    <message>
-        <source>Show warning dialog when PrivateSend detects that wallet has very low number of keys left.</source>
-        <translation>Показване на предупреждение когато PrivateSend засече прекалено малък брой оставащи ключове.</translation>
-    </message>
-    <message>
-        <source>Warn if PrivateSend is running out of keys</source>
-        <translation>Предупреди ако PrivateSend е стартиран при недостатъчно ключове</translation>
-    </message>
-    <message>
-        <source>Whether to use experimental PrivateSend mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
-        <translation>Дали да се използва експериментален PrivateSend режим с мулти сесийно миксиране на блок.&lt;br/&gt;Бележка: Трябва да използвате тази функция внимателно.&lt;br/&gt;Убедете се, че винаги имате скоро направен (авто) архив копие на сигурно място!</translation>
-    </message>
-    <message>
-        <source>Enable PrivateSend &amp;multi-session</source>
-        <translation>Включи PrivateSend &amp;мулти сесия</translation>
-    </message>
-    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</source>
         <translation>Ако деактивирате харченето на непотвърдено ресто, рестото от транзакция&lt;br/&gt; няма да може да се използва преди да бъде получено поне едно потвърждение. &lt;br/&gt;Това се отразява и на начина на изчисление на баланса ви.</translation>
     </message>
     <message>
-        <source>PrivateSend rounds to use</source>
-        <translation>PrivateSend използвани цикъла</translation>
+        <source>Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</source>
+        <translation>Показване на интерфейса за смесване  в основния прозорец и показване на допълнителен процорез, който позволява да се харчат само напълно смесени монети.&lt;br/&gt; В този диалогов прозорец ще се появи и нов раздел с повече настройки, моля не забравяйте да ги проверите, преди да смесите монетите си. </translation>
     </message>
     <message>
-        <source>This amount acts as a threshold to turn off PrivateSend once it's reached.</source>
-        <translation>Тази сума действа като лимит, за да се изключи PrivateSend, когато веднъж бъде достигнат.</translation>
+        <source>Show additional information and buttons on overview screen.</source>
+        <translation>Показване на допълнителна информация и бутони на основния екран.</translation>
     </message>
     <message>
-        <source>Target PrivateSend balance</source>
-        <translation>Желан PrivateSend баланс</translation>
+        <source>Enable advanced interface</source>
+        <translation>Включване на интерфейс за напреднали</translation>
+    </message>
+    <message>
+        <source>Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
+        <translation>Показване на изскачащи прозорци за смесване на транзакции&lt;br/&gt;също както за всички други видове транзакции.</translation>
+    </message>
+    <message>
+        <source>Show popups for mixing transactions</source>
+        <translation>Показване на изскачащи прозорци за смесените транзакции</translation>
+    </message>
+    <message>
+        <source>Show warning dialog when the wallet has very low number of keys left.</source>
+        <translation>Показване на предупреждение когато портфейлът засече прекалено малък брой оставащи ключове.</translation>
+    </message>
+    <message>
+        <source>Warn if the wallet is running out of keys</source>
+        <translation>Предупреди ако портфейла е стартиран при недостатъчно ключове</translation>
+    </message>
+    <message>
+        <source>Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
+        <translation>Дали да се използва експериментален  режим с мулти сесийно смесване за блок.&lt;br/&gt;Бележка: Трябва да използвате тази функция внимателно.&lt;br/&gt;Убедете се, че винаги имате скоро направен (автоматичен) архив на сигурно място!</translation>
+    </message>
+    <message>
+        <source>Enable &amp;multi-session</source>
+        <translation>Включи  &amp;мулти-сесия</translation>
+    </message>
+    <message>
+        <source>Mixing rounds</source>
+        <translation>Цикли на смесване</translation>
+    </message>
+    <message>
+        <source>This amount acts as a threshold to turn off mixing once it's reached.</source>
+        <translation>Тази сума действа като лимит за да се изключи смесването, когато веднъж бъде достигната.</translation>
+    </message>
+    <message>
+        <source>Target balance</source>
+        <translation>Желан баланс</translation>
     </message>
     <message>
         <source>Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Автоматично отваря порта за Dash Core клиента в маршрутизатора. Това работи само когато вашият маршрутизатор поддържа UPnP и той е разрешен.</translation>
+    </message>
+    <message>
+        <source>Accept connections from outside.</source>
+        <translation>Приеми връзки отвън</translation>
+    </message>
+    <message>
+        <source>Allow incomin&amp;g connections</source>
+        <translation>Разреши входящи връзки</translation>
     </message>
     <message>
         <source>Connect to the Dash network through a SOCKS5 proxy.</source>
@@ -1347,6 +1423,18 @@
         <translation>Показва ако зададеното по подразбиране SOCKS5 proxy се използва за намиране на пиъри чрез тази мрежа.</translation>
     </message>
     <message>
+        <source>Use separate SOCKS&amp;5 proxy to reach peers via Tor hidden services:</source>
+        <translation>Използвай отделен SOCKS&amp;5 прокси за да достигнеш пиъри от Tor услуги:</translation>
+    </message>
+    <message>
+        <source>Hide the icon from the system tray.</source>
+        <translation>Скрий иконата от системният трей.</translation>
+    </message>
+    <message>
+        <source>&amp;Hide tray icon</source>
+        <translation>Скрий трей иконата</translation>
+    </message>
+    <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
         <translation>При затваряне на прозореца приложението остава минимизирано. Ако изберете тази опция, приложението може да се затвори само чрез Изход в менюто.</translation>
     </message>
@@ -1355,8 +1443,8 @@
         <translation>URL адреси на трети страни (например block Explorer), които се появяват в раздела с транзакции, като елементи от контекстното меню. %s в URL е заменен с хеша на транзакцията. Отделните URL адреси са разделени с вертикална линия |.</translation>
     </message>
     <message>
-        <source>Expert</source>
-        <translation>Експерт</translation>
+        <source>&amp;Third party transaction URLs</source>
+        <translation>&amp;URL транзакции на трети страни</translation>
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
@@ -1375,14 +1463,6 @@
         <translation>Активиране &amp;контролните функции на монетата</translation>
     </message>
     <message>
-        <source>Show system popups for PrivateSend mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
-        <translation>Показване на изскачащи системни прозорци при PrivateSend миксирани транзакции&lt;br/&gt;както за всички други видове транзакции.</translation>
-    </message>
-    <message>
-        <source>Show popups for PrivateSend transactions</source>
-        <translation>Показване на изскачащи прозорци за PrivateSend транзакции</translation>
-    </message>
-    <message>
         <source>&amp;Spend unconfirmed change</source>
         <translation>&amp;Изхарчете непотвърденото ресто</translation>
     </message>
@@ -1397,14 +1477,6 @@
     <message>
         <source>Map port using &amp;UPnP</source>
         <translation>Отваряне на входящия порт чрез &amp;UPnP</translation>
-    </message>
-    <message>
-        <source>Accept connections from outside</source>
-        <translation>Приемай връзки отвън</translation>
-    </message>
-    <message>
-        <source>Allow incoming connections</source>
-        <translation>Разреши входящи връзки</translation>
     </message>
     <message>
         <source>Proxy &amp;IP:</source>
@@ -1443,22 +1515,6 @@
         <translation>Свързване с мрежата на Dash чрез SOCKS5 прокси за Tor скрити услуги.</translation>
     </message>
     <message>
-        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services:</source>
-        <translation>Използва отделен SOCKS5 прокси, за достигне на пиъри чрез Tor скрити услуги:</translation>
-    </message>
-    <message>
-        <source>&amp;Window</source>
-        <translation>&amp;Прозорец</translation>
-    </message>
-    <message>
-        <source>&amp;Hide the icon from the system tray.</source>
-        <translation>&amp;Скрии иконата от системният трей.</translation>
-    </message>
-    <message>
-        <source>Hide tray icon</source>
-        <translation>Скрий try иконата</translation>
-    </message>
-    <message>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>След минимизиране ще е видима само иконата в системния трей.</translation>
     </message>
@@ -1489,10 +1545,6 @@ https://www.transifex.com/projects/p/dash/</source>
 https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
-        <source>User Interface Theme:</source>
-        <translation>Изглед на потребителския интерфейс:</translation>
-    </message>
-    <message>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Мерна единица за показваните суми:</translation>
     </message>
@@ -1503,10 +1555,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Decimal digits</source>
         <translation>Десетични цифри</translation>
-    </message>
-    <message>
-        <source>Third party transaction URLs</source>
-        <translation>URL транзакции на трети страни</translation>
     </message>
     <message>
         <source>Active command-line options that override above options:</source>
@@ -1529,12 +1577,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Отказ</translation>
     </message>
     <message>
-        <source>default</source>
-        <translation>по подразбиране</translation>
+        <source>Enable %1 features</source>
+        <translation>Включи%1 функции</translation>
     </message>
     <message>
-        <source>none</source>
-        <translation>няма</translation>
+        <source>default</source>
+        <translation>по подразбиране</translation>
     </message>
     <message>
         <source>Confirm options reset</source>
@@ -1628,10 +1676,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Изразходени:</translation>
     </message>
     <message>
-        <source>PrivateSend</source>
-        <translation>PrivateSend</translation>
-    </message>
-    <message>
         <source>Status:</source>
         <translation>Статус:</translation>
     </message>
@@ -1668,16 +1712,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Пусни/Спри Смесване</translation>
     </message>
     <message>
-        <source>PrivateSend Balance:</source>
-        <translation>PrivateSend баланс:</translation>
-    </message>
-    <message>
         <source>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</source>
         <translation>Деноминираните суми, които сте изпратили към Masternode. За смесване, другите потребители трябва да изпратят абсолютно същите деноминирани суми.</translation>
-    </message>
-    <message>
-        <source>(Last Message)</source>
-        <translation>(Последно съобщение)</translation>
     </message>
     <message>
         <source>out of sync</source>
@@ -1688,28 +1724,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Автоматичното архивиране е изключено, няма миксиране на разположение!</translation>
     </message>
     <message>
-        <source>Start Mixing</source>
-        <translation>Стартирай миксиране</translation>
-    </message>
-    <message>
-        <source>Stop Mixing</source>
-        <translation>Спри миксиране</translation>
-    </message>
-    <message>
         <source>No inputs detected</source>
         <translation>Не са открити монети</translation>
+    </message>
+    <message>
+        <source>%1 Balance</source>
+        <translation>%1 Баланс</translation>
     </message>
     <message numerus="yes">
         <source>%n Rounds</source>
         <translation><numerusform>%n Цикли</numerusform><numerusform>%n Цикли</numerusform></translation>
     </message>
     <message>
-        <source>Found enough compatible inputs to anonymize %1</source>
-        <translation>Намерени са достатъчно съвместими постъпления за анонимизиране %1</translation>
+        <source>Found enough compatible inputs to mix %1</source>
+        <translation>Намерени са достатъчно съвместими постъпления за да се смесят %1</translation>
     </message>
     <message>
-        <source>Not enough compatible inputs to anonymize &lt;span style='color:red;'&gt;%1&lt;/span&gt;,&lt;br&gt;will anonymize &lt;span style='color:red;'&gt;%2&lt;/span&gt; instead</source>
-        <translation>Няма достатъчно съвместими постъпления за анонимизиране &lt;span style='color:red;'&gt;%1&lt;/span&gt;,&lt;br/&gt;ще бъдат анонимизирани &lt;span style='color:red;'&gt;%2&lt;/span&gt; вместо</translation>
+        <source>Not enough compatible inputs to mix &lt;span style='%1'&gt;%2&lt;/span&gt;,&lt;br&gt;will mix &lt;span style='%1'&gt;%3&lt;/span&gt; instead</source>
+        <translation>Недостатъчно съвместими входове за смесване &lt;span style='%1'&gt;%2&lt;/span&gt;,&lt;br&gt;ще се смесят &lt;span style='%1'&gt;%3&lt;/span&gt; вместо</translation>
     </message>
     <message>
         <source>Overall progress</source>
@@ -1736,6 +1768,26 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>оставащи ключове: %1</translation>
     </message>
     <message>
+        <source>Start %1</source>
+        <translation>Старт %1</translation>
+    </message>
+    <message>
+        <source>If you don't want to see internal %1 fees/transactions select "Most Common" as Type on the "Transactions" tab.</source>
+        <translation>Ако не искате да видите вътрешните %1 такси/транзакции изберете "Най-често срещаните" като тип от таб "Транзакции" .</translation>
+    </message>
+    <message>
+        <source>%1 requires at least %2 to use.</source>
+        <translation>%1 изисква поне %2 за да започне.</translation>
+    </message>
+    <message>
+        <source>Wallet is locked and user declined to unlock. Disabling %1.</source>
+        <translation>Портфейлът е заключен и потребителя отказва отключване. Изключване %1.</translation>
+    </message>
+    <message>
+        <source>Stop %1</source>
+        <translation>Стоп %1</translation>
+    </message>
+    <message>
         <source>Disabled</source>
         <translation>Неактивно</translation>
     </message>
@@ -1744,8 +1796,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Много малък брой ключове останали от последният автоматичен архив!</translation>
     </message>
     <message>
-        <source>We are about to create a new automatic backup for you, however &lt;span style='color:red;'&gt; you should always make sure you have backups saved in some safe place&lt;/span&gt;!</source>
-        <translation>Ние ще направим нов автоматичен архив за вас, въпреки това &lt;span style='color:red;'&gt; винаги трябва да сте сигурни, че имате архив запазен на сигурно място&lt;/span&gt;!</translation>
+        <source>We are about to create a new automatic backup for you, however &lt;span style='%1'&gt; you should always make sure you have backups saved in some safe place&lt;/span&gt;!</source>
+        <translation>Ние ще направим нов автоматичен архив за вас, въпреки това &lt;span style='%1'&gt; винаги трябва да сте сигурни, че имате архив запазен на сигурно място&lt;/span&gt;!</translation>
     </message>
     <message>
         <source>Note: You can turn this message off in options.</source>
@@ -1775,24 +1827,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
         <translation>ВНИМАНИЕ! Неуспешно попълване на keypool, моля отключете портфейла си за да се извърши.</translation>
     </message>
-    <message>
-        <source>Last PrivateSend message:
-</source>
-        <translation>Последно PrivateSend съобщение:
-</translation>
-    </message>
-    <message>
-        <source>If you don't want to see internal PrivateSend fees/transactions select "Most Common" as Type on the "Transactions" tab.</source>
-        <translation>Ако не искате да видите вътрешните PrivateSend такси/транзакции изберете "Най-често срещаните" като тип от раздел "Транзакции" .</translation>
-    </message>
-    <message>
-        <source>PrivateSend requires at least %1 to use.</source>
-        <translation>PrivateSend се нуждае от поне %1 за да започне.</translation>
-    </message>
-    <message>
-        <source>Wallet is locked and user declined to unlock. Disabling PrivateSend.</source>
-        <translation>Портфейлът е заключен и потребителя отказва отключване. PrivateSend е деактивиран.</translation>
-    </message>
 </context>
 <context>
     <name>PaymentServer</name>
@@ -1807,6 +1841,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>URI handling</source>
         <translation>Обработка на URI</translation>
+    </message>
+    <message>
+        <source>'dash://' is not a valid URI. Use 'dash:' instead.</source>
+        <translation>'dash://' не е валиден URI. Използвайте 'dash:' вместо това.</translation>
     </message>
     <message>
         <source>Payment request fetch URL is invalid: %1</source>
@@ -1903,9 +1941,57 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>Ping</source>
         <translation>Пинг</translation>
     </message>
+    <message>
+        <source>Sent</source>
+        <translation>Изпратени</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation>Получени</translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
+    <message>
+        <source>Choose data directory on startup (default: %u)</source>
+        <translation>Изберете папка за данни при стартиране (по подразбиране: %u)</translation>
+    </message>
+    <message>
+        <source>Set the font family. Possible values: %1. (default: %2)</source>
+        <translation>Изберете вид на шрифта. Възможни стойности: %1. (по подразбиране: %2)</translation>
+    </message>
+    <message>
+        <source>Set a scale factor which gets applied to the base font size. Possible range %1 (smallest fonts) to %2 (largest fonts). (default: %3)</source>
+        <translation>Изберете мащабиране, което ще се приложи към основният размер на шрифта. Възможни граници %1 (най-малките шрифтове) до %2 (най-големите шрифтове). (по подразбиране: %3)</translation>
+    </message>
+    <message>
+        <source>Set the font weight for bold texts. Possible range %1 to %2 (default: %3)</source>
+        <translation>Задайте дебелина на шрифта за удебелени текстове. Възможни граници %1 до %2 (по подразбиране: %3)</translation>
+    </message>
+    <message>
+        <source>Set the font weight for normal texts. Possible range %1 to %2 (default: %3)</source>
+        <translation>Задайте дебелина за нормални текстове. Възможни граници %1 до %2 (по подразбиране: %3)</translation>
+    </message>
+    <message>
+        <source>Set language, for example "de_DE" (default: system locale)</source>
+        <translation>Задаване на език, например "de_DE" (по подразбиране: какъвто системния)</translation>
+    </message>
+    <message>
+        <source>Start minimized</source>
+        <translation>Стартирай минимизиран</translation>
+    </message>
+    <message>
+        <source>Reset all settings changed in the GUI</source>
+        <translation>Нулиране на всички настройки направени чрез GUI</translation>
+    </message>
+    <message>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>Задай SSL основен сертификат при искане за плащане (по подразбиране: -system-)</translation>
+    </message>
+    <message>
+        <source>Show splash screen on startup (default: %u)</source>
+        <translation>Покажи начален екран при стартиране (по подразбиране: %u)</translation>
+    </message>
     <message>
         <source>%1 didn't yet exit safely...</source>
         <translation>%1 все още не е излязъл безопастно...</translation>
@@ -1917,6 +2003,18 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Enter a Dash address (e.g. %1)</source>
         <translation>Въведете Dash адрес (напр.%1)</translation>
+    </message>
+    <message>
+        <source>Appearance Setup</source>
+        <translation>Конфигуриране на изгледа</translation>
+    </message>
+    <message>
+        <source>Please choose your preferred settings for the appearance of %1</source>
+        <translation>Моля изберете предпочитаните настройки за изгледа от %1</translation>
+    </message>
+    <message>
+        <source>This can also be adjusted later in the "Appearance" tab of the preferences.</source>
+        <translation>Това може да бъде настроено по-късно от "Изглед" таб в настройките.</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -1975,6 +2073,22 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1 и %2</translation>
     </message>
     <message>
+        <source>%1 B</source>
+        <translation>%1 Б</translation>
+    </message>
+    <message>
+        <source>%1 KB</source>
+        <translation>%1 КБ</translation>
+    </message>
+    <message>
+        <source>%1 MB</source>
+        <translation>%1 МБ</translation>
+    </message>
+    <message>
+        <source>%1 GB</source>
+        <translation>%1 ГБ</translation>
+    </message>
+    <message>
         <source>unknown</source>
         <translation>неизвестен</translation>
     </message>
@@ -1992,6 +2106,34 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Error: %1</source>
         <translation>Грешка: %1</translation>
+    </message>
+    <message>
+        <source>Error: Failed to load application fonts.</source>
+        <translation>Грешка: Неуспешно зареждане шрифтовете на приложението.</translation>
+    </message>
+    <message>
+        <source>Error: Specified font-family invalid. Valid values: %1.</source>
+        <translation>Грешка: Невалиден вид шрифт. Валидни стойности: %1.</translation>
+    </message>
+    <message>
+        <source>Error: Specified font-weight-normal invalid. Valid range %1 to %2.</source>
+        <translation>Грешка: Невалидна дебелина на нормален шрифт. Валидни граници %1 до %2.</translation>
+    </message>
+    <message>
+        <source>Error: Specified font-weight-bold invalid. Valid range %1 to %2.</source>
+        <translation>Грешка: Невалидна дебелина на удебелен шрифт. Валидни граници %1 до %2.</translation>
+    </message>
+    <message>
+        <source>Error: Specified font-scale invalid. Valid range %1 to %2.</source>
+        <translation>Грешка: Невалидно мащабиране на шрифта. Валидни граници %1 до %2.</translation>
+    </message>
+    <message>
+        <source>Error: Invalid -custom-css-dir path.</source>
+        <translation>Грешка: Невалиден -custom-css-dir път.</translation>
+    </message>
+    <message>
+        <source>Error: %1 CSS file(s) missing in -custom-css-dir path.</source>
+        <translation>Грешка: %1 CSS липсващи файлов(е) в -custom-css-dir път.</translation>
     </message>
 </context>
 <context>
@@ -2142,10 +2284,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&amp;Мрежов трафик</translation>
     </message>
     <message>
-        <source>Totals</source>
-        <translation>Общо:</translation>
-    </message>
-    <message>
         <source>Received</source>
         <translation>Получени</translation>
     </message>
@@ -2156,6 +2294,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Peers</source>
         <translation>&amp;Пиъри</translation>
+    </message>
+    <message>
+        <source>Wallet:</source>
+        <translation>Портфейл:</translation>
     </message>
     <message>
         <source>Banned peers</source>
@@ -2190,6 +2332,22 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Синхронизирани блокове</translation>
     </message>
     <message>
+        <source>Rescan blockchain files 1</source>
+        <translation>Повторно сканиране на блокчейн файловете 1</translation>
+    </message>
+    <message>
+        <source>Rescan blockchain files 2</source>
+        <translation>Повторно сканиране на блокчейн файловете 2</translation>
+    </message>
+    <message>
+        <source>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</source>
+        <translation>-rescan=1: Повторно сканиране на блокчейна за липсващи транзакции в портфейла, започвайки от времето на създаване на портфейла.</translation>
+    </message>
+    <message>
+        <source>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</source>
+        <translation>-rescan=2: Повторно сканиране на блокчейна за липсващи транзакции в портфейла, започвайки от първият блок в мрежата.</translation>
+    </message>
+    <message>
         <source>Wallet Path</source>
         <translation>Път на портфейла</translation>
     </message>
@@ -2202,12 +2360,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Datadir</translation>
     </message>
     <message>
+        <source>Last block hash</source>
+        <translation>Хеш на последният блок</translation>
+    </message>
+    <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Отваря %1 файла за откриване на грешки от текущата папка. Това може да отнеме няколко секунди при по-големи файлове.</translation>
     </message>
     <message>
         <source>InstantSend locks</source>
         <translation>InstantSend заключени</translation>
+    </message>
+    <message>
+        <source>(none)</source>
+        <translation>(липсва)</translation>
     </message>
     <message>
         <source>Decrease font size</source>
@@ -2220,6 +2386,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Reset</source>
         <translation>&amp;Изчистване</translation>
+    </message>
+    <message>
+        <source>Node Type</source>
+        <translation>Вид нод</translation>
+    </message>
+    <message>
+        <source>PoSe Score</source>
+        <translation>PoSe точки</translation>
     </message>
     <message>
         <source>Services</source>
@@ -2270,10 +2444,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Възстановен портфейл</translation>
     </message>
     <message>
-        <source>Rescan blockchain files</source>
-        <translation>Повторно сканиране на блокчейн файловете</translation>
-    </message>
-    <message>
         <source>Recover transactions 1</source>
         <translation>Възстановени транзакции 1</translation>
     </message>
@@ -2292,10 +2462,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>-salvagewallet: Attempt to recover private keys from a corrupt wallet.dat.</source>
         <translation>-salvagewallet: Опит да се възстановят частни ключове от повреден wallet.dat</translation>
-    </message>
-    <message>
-        <source>-rescan: Rescan the block chain for missing wallet transactions.</source>
-        <translation>-rescan: Повторно сканиране на регистъра от блокове за липсващи транзакции в портфейла.</translation>
     </message>
     <message>
         <source>-zapwallettxes=1: Recover transactions from blockchain (keep meta-data, e.g. account owner).</source>
@@ -2354,12 +2520,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Добре дошли в %1 RPC конзолата.</translation>
     </message>
     <message>
-        <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
-        <translation>Напишете &lt;b&gt;help&lt;/b&gt;, за да прегледате възможните команди.</translation>
-    </message>
-    <message>
         <source>Use up and down arrows to navigate history, and %1 to clear screen.</source>
         <translation>Използвайте стрелките нагоре и надолу  за разглеждане на историята, и %1 за изчистване на екрана.</translation>
+    </message>
+    <message>
+        <source>Type %1 for an overview of available commands.</source>
+        <translation>Въведи %1 за преглед на наличните команди.</translation>
+    </message>
+    <message>
+        <source>For more information on using this console type %1.</source>
+        <translation>За повече информация при използването на тази конзола въведете %1.</translation>
     </message>
     <message>
         <source>WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.</source>
@@ -2382,20 +2552,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Общо: %1 (Включено: %2)</translation>
     </message>
     <message>
-        <source>%1 B</source>
-        <translation>%1 Б</translation>
+        <source>Executing command without any wallet</source>
+        <translation>Изпълнение на команди без портфейл</translation>
     </message>
     <message>
-        <source>%1 KB</source>
-        <translation>%1 КБ</translation>
-    </message>
-    <message>
-        <source>%1 MB</source>
-        <translation>%1 МБ</translation>
-    </message>
-    <message>
-        <source>%1 GB</source>
-        <translation>%1 ГБ</translation>
+        <source>Executing command using "%1" wallet</source>
+        <translation>За изпълняване на команди използвайте "%1" портфейл</translation>
     </message>
     <message>
         <source>(node id: %1)</source>
@@ -2426,20 +2588,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Не</translation>
     </message>
     <message>
+        <source>Regular</source>
+        <translation>Редовно</translation>
+    </message>
+    <message>
+        <source>Masternode</source>
+        <translation>Masternode</translation>
+    </message>
+    <message>
+        <source>Verified Masternode</source>
+        <translation>Проверен Masternode</translation>
+    </message>
+    <message>
         <source>Unknown</source>
         <translation>Неизвестни</translation>
     </message>
 </context>
 <context>
     <name>ReceiveCoinsDialog</name>
-    <message>
-        <source>Reuse one of the previously used receiving addresses.&lt;br&gt;Reusing addresses has security and privacy issues.&lt;br&gt;Do not use this unless re-generating a payment request made before.</source>
-        <translation>Повторна употреба на един от адресите за получаване.&lt;br&gt;При повторно използване на адреси са възможни проблеми със сигурността и личната неприкосновеност.&lt;br&gt;Не използвайте адреса, освен ако не ре-генерирате предишна заявка за плащане.</translation>
-    </message>
-    <message>
-        <source>R&amp;euse an existing receiving address (not recommended)</source>
-        <translation>П&amp;овторно използване на съществуващ адрес за получаване (не се препоръчва)</translation>
-    </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Dash network.</source>
         <translation>Възможност  да се прикрепи съобщение към заявката за плащане, което да бъде показано при отваряне на заявката. Забележка: съобщението няма да бъде изпратено с плащането по мрежата на Dash.</translation>
@@ -2505,6 +2671,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Премахване</translation>
     </message>
     <message>
+        <source>Enter a label to associate with the new receiving address</source>
+        <translation>Въведете етикет, с който да свържете  новия адрес за получаване</translation>
+    </message>
+    <message>
+        <source>Enter a message to attach to the payment request</source>
+        <translation>Въведете съобщение, което да прикачите към искането за плащане</translation>
+    </message>
+    <message>
         <source>Copy URI</source>
         <translation>Копирай URI</translation>
     </message>
@@ -2566,6 +2740,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Message</source>
         <translation>Съобщение</translation>
+    </message>
+    <message>
+        <source>Wallet</source>
+        <translation>Портфейл</translation>
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
@@ -2682,10 +2860,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Целево време за потвърждение:</translation>
     </message>
     <message>
-        <source>PrivateSend</source>
-        <translation>PrivateSend</translation>
-    </message>
-    <message>
         <source>If the custom fee is set to 1000 duffs and the transaction is only 250 bytes, then "per kilobyte" only pays 250 duffs in fee,&lt;br /&gt;while "at least" pays 1000 duffs. For transactions bigger than a kilobyte both pay by kilobyte.</source>
         <translation>Ако променената такса е 1000 duffs и транзакцията е само 250 байта, тогава "за килобайт" само плаща такса 250 duffs,,&lt;br /&gt; тогава"за последно" заплаща 1000 duffs. За транзакции по-големи от килобайт едновременно се заплащат от килобайт.</translation>
     </message>
@@ -2786,6 +2960,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1 (%2 блока)</translation>
     </message>
     <message>
+        <source>from wallet %1</source>
+        <translation>от портфейл %1</translation>
+    </message>
+    <message>
         <source>using</source>
         <translation>използвайки</translation>
     </message>
@@ -2810,16 +2988,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&lt;b&gt;(%1 of %2 показани записи)&lt;/b&gt;</translation>
     </message>
     <message>
-        <source>PrivateSend funds only</source>
-        <translation>Само PrivateSend средства</translation>
+        <source>S&amp;end mixed funds</source>
+        <translation>Изпращайте смесени средства</translation>
+    </message>
+    <message>
+        <source>Confirm the %1 send action</source>
+        <translation>Потвърдете изпращането %1 </translation>
+    </message>
+    <message>
+        <source>%1 funds only</source>
+        <translation>%1 средства само</translation>
     </message>
     <message>
         <source>any available funds</source>
         <translation>всякакви налични средства</translation>
     </message>
     <message>
-        <source>(PrivateSend transactions have higher fees usually due to no change output being allowed)</source>
-        <translation>(PrivateSend транзакциите  имат по-високи такси, обикновено поради това, че не се допуска промяна на изхода)</translation>
+        <source>(%1 transactions have higher fees usually due to no change output being allowed)</source>
+        <translation>(%1 транзакциите  имат по-високи такси, обикновено поради това, че не се допуска промяна на изхода)</translation>
     </message>
     <message>
         <source>Transaction size: %1</source>
@@ -2834,8 +3020,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation><numerusform>Тази транзакция ще използва %n входа</numerusform><numerusform>Тази транзакция ще използва %n входа</numerusform></translation>
     </message>
     <message>
-        <source>Warning: Using PrivateSend with %1 or more inputs can harm your privacy and is not recommended</source>
-        <translation>Внимание: Използването на PrivateSend с %1 или повече входа може да попречи на вашата поверителност и не е препоръчително</translation>
+        <source>Warning: Using %1 with %2 or more inputs can harm your privacy and is not recommended</source>
+        <translation>Внимание: Използването %1 с %2 или повече входове могат да навредят на поверителността ви и не се препоръчва</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -2959,6 +3145,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>S&amp;ubtract fee from amount</source>
         <translation>Извадете таксата от сумата</translation>
+    </message>
+    <message>
+        <source>Use available balance</source>
+        <translation>Използвай наличния баланс</translation>
     </message>
     <message>
         <source>Message:</source>
@@ -3094,8 +3284,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Изчисти всички проверени съобщения в полето</translation>
     </message>
     <message>
+        <source>Enter a message to be signed</source>
+        <translation>Въведете съобщение за подписване</translation>
+    </message>
+    <message>
         <source>Click "Sign Message" to generate signature</source>
         <translation>Натиснете "Подписване на съобщение" за да създадете подпис</translation>
+    </message>
+    <message>
+        <source>Enter a message to be verified</source>
+        <translation>Въведете съобщението за проверка</translation>
+    </message>
+    <message>
+        <source>Enter a signature for the message to be verified</source>
+        <translation>Въведете подпис за проверка на съобщението</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
@@ -3152,16 +3354,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
-    <message>
-        <source>Version %1</source>
-        <translation>Версия %1</translation>
-    </message>
 </context>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
         <source>KB/s</source>
         <translation>КБ/с</translation>
+    </message>
+    <message>
+        <source>Total</source>
+        <translation>Общо</translation>
+    </message>
+    <message>
+        <source>Received</source>
+        <translation>Получени</translation>
+    </message>
+    <message>
+        <source>Sent</source>
+        <translation>Изпратени</translation>
     </message>
 </context>
 <context>
@@ -3177,10 +3387,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>conflicted</source>
         <translation>конфликтно</translation>
-    </message>
-    <message>
-        <source>%1/offline</source>
-        <translation>%1/офлайн</translation>
     </message>
     <message>
         <source>0/unconfirmed, %1</source>
@@ -3207,24 +3413,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>включена в %1 блока</translation>
     </message>
     <message>
-        <source>locked via LLMQ based ChainLocks</source>
-        <translation>заключена чрез LLMQ базирани ChainLocks</translation>
+        <source>locked via ChainLocks</source>
+        <translation>заключена чрез  ChainLocks</translation>
     </message>
     <message>
-        <source>verified via LLMQ based InstantSend</source>
-        <translation>потвърдена чрез LLMQ базиран InstantSend</translation>
+        <source>verified via InstantSend</source>
+        <translation>потвърдено чрез InstantSend</translation>
     </message>
     <message>
         <source>Status</source>
         <translation>Статус</translation>
-    </message>
-    <message>
-        <source>, has not been successfully broadcast yet</source>
-        <translation>, все още не е изпратено</translation>
-    </message>
-    <message numerus="yes">
-        <source>, broadcast through %n node(s)</source>
-        <translation><numerusform>, излъчено през %n нода</numerusform><numerusform>, излъчено през %n нода</numerusform></translation>
     </message>
     <message>
         <source>Date</source>
@@ -3381,10 +3579,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Подлежи на промяна до %1</translation>
     </message>
     <message>
-        <source>Offline</source>
-        <translation>Офлайн</translation>
-    </message>
-    <message>
         <source>Unconfirmed</source>
         <translation>Непотвърдено</translation>
     </message>
@@ -3409,12 +3603,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Неотлежал (%1 потвърждения, ще бъдат на разположение след %2)</translation>
     </message>
     <message>
-        <source>This block was not received by any other nodes and will probably not be accepted!</source>
-        <translation>Блокът не е получен от останалите участници и най-вероятно няма да бъде одобрен.</translation>
-    </message>
-    <message>
         <source>Generated but not accepted</source>
         <translation>Генерирана, но отхвърлена </translation>
+    </message>
+    <message>
+        <source>verified via InstantSend</source>
+        <translation>потвърдено чрез InstantSend</translation>
+    </message>
+    <message>
+        <source>locked via ChainLocks</source>
+        <translation>заключена чрез  ChainLocks</translation>
     </message>
     <message>
         <source>Received with</source>
@@ -3425,8 +3623,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Получен от</translation>
     </message>
     <message>
-        <source>Received via PrivateSend</source>
-        <translation>Получени чрез PrivateSend</translation>
+        <source>Received via %1</source>
+        <translation>Получени с %1</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3441,24 +3639,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Емитирани</translation>
     </message>
     <message>
-        <source>PrivateSend Denominate</source>
-        <translation>PrivateSend деноминиране</translation>
+        <source>%1 Mixing</source>
+        <translation>%1 Смесване</translation>
     </message>
     <message>
-        <source>PrivateSend Collateral Payment</source>
-        <translation>PrivateSend обезпечение на плащането</translation>
+        <source>%1 Collateral Payment</source>
+        <translation>%1 обезпечено плащането</translation>
     </message>
     <message>
-        <source>PrivateSend Make Collateral Inputs</source>
-        <translation>PrivateSend прави обезпечение на входовете</translation>
+        <source>%1 Make Collateral Inputs</source>
+        <translation>%1 прави обезпечение на постъпленията</translation>
     </message>
     <message>
-        <source>PrivateSend Create Denominations</source>
-        <translation>PrivateSend създава деноминации</translation>
+        <source>%1 Create Denominations</source>
+        <translation>%1  направени деноминации</translation>
     </message>
     <message>
-        <source>PrivateSend</source>
-        <translation>PrivateSend</translation>
+        <source>%1 Send</source>
+        <translation>%1 Изпрати</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -3489,10 +3687,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Дали има или не наблюдаван/watch-only адрес участващ в тази транзакция.</translation>
     </message>
     <message>
-        <source>Whether or not this transaction was locked by InstantSend.</source>
-        <translation>Дали тази транзакция е била заключена чрез InstantSend.</translation>
-    </message>
-    <message>
         <source>User-defined intent/purpose of the transaction.</source>
         <translation>Дефинирани от потребителя намерение/цели на сделката.</translation>
     </message>
@@ -3506,14 +3700,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>All</source>
         <translation>Всички</translation>
-    </message>
-    <message>
-        <source>Locked by InstantSend</source>
-        <translation>Заключена чрез InstantSend</translation>
-    </message>
-    <message>
-        <source>Not locked by InstantSend</source>
-        <translation>Не е заключена чрез InstantSend</translation>
     </message>
     <message>
         <source>Today</source>
@@ -3552,24 +3738,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Изпратени на</translation>
     </message>
     <message>
-        <source>PrivateSend</source>
-        <translation>PrivateSend</translation>
+        <source>%1 Send</source>
+        <translation>%1 Изпрати</translation>
     </message>
     <message>
-        <source>PrivateSend Make Collateral Inputs</source>
-        <translation>PrivateSend прави обезпечение на входовете</translation>
+        <source>%1 Make Collateral Inputs</source>
+        <translation>%1 Направи обезпечение на постъпленията</translation>
     </message>
     <message>
-        <source>PrivateSend Create Denominations</source>
-        <translation>PrivateSend създава деноминации</translation>
+        <source>%1 Create Denominations</source>
+        <translation>%1  Направи деноминации</translation>
     </message>
     <message>
-        <source>PrivateSend Denominate</source>
-        <translation>PrivateSend деноминиране</translation>
+        <source>%1 Mixing</source>
+        <translation>%1 Смесване</translation>
     </message>
     <message>
-        <source>PrivateSend Collateral Payment</source>
-        <translation>PrivateSend обезпечение на плащането</translation>
+        <source>%1 Collateral Payment</source>
+        <translation>%1 обезпечено плащането</translation>
     </message>
     <message>
         <source>To yourself</source>
@@ -3584,8 +3770,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Други</translation>
     </message>
     <message>
-        <source>Enter address or label to search</source>
-        <translation>Търсене по адрес или наименование</translation>
+        <source>Enter address, transaction id, or label to search</source>
+        <translation>Въведете адрес,номер на транзакция или етикет за търсене</translation>
     </message>
     <message>
         <source>Min amount</source>
@@ -3755,36 +3941,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Базата на портфейла беше запазена успешно в %1.</translation>
     </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Отказ</translation>
+    </message>
 </context>
 <context>
     <name>dash-core</name>
     <message>
-        <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>Свързва се с посочения адрес и винаги слуша за него. Използвайте [хост]:порт за изписване при IPv6</translation>
-    </message>
-    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation>Грешка: Очакването на входящи връзки е неуспешно (върната грешка %s)</translation>
-    </message>
-    <message>
-        <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation>Изпълни командата когато се получи съответното предупреждение или се появи друг проблем с мрежата (%s в cmd е подменено от съобщение)</translation>
-    </message>
-    <message>
-        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Изпълнете командата когато транзакцията в портфейла се променя  (%s в cmd е подменено с TxID)</translation>
-    </message>
-    <message>
-        <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Изпълнете командата когато има промяна в най-добрият блок (%s в cmd е подменена от  block hash)</translation>
-    </message>
-    <message>
-        <source>Name to construct url for KeePass entry that stores the wallet passphrase</source>
-        <translation>Име за създаване на URL за KeePass входа , който съхранява паролата за портфейла</translation>
-    </message>
-    <message>
-        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
-        <translation>Задаване броя на нишките потвърждаващи скрипта  (%u до %d, 0 = автоматично, &lt;0 = да се оставят толкова ядра свободни, по подразбиране: %d)</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
@@ -3799,52 +3965,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Внимание: Не е намерена пълна съвместимост с останалите в мрежата ! Може би се нуждаете от обновяване , или някой от другите нодове се нуждае от обновяване .</translation>
     </message>
     <message>
-        <source>Accept command line and JSON-RPC commands</source>
-        <translation>Приемай команден ред и JSON-RPC команди</translation>
-    </message>
-    <message>
-        <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
-        <translation>Разреши DNS справка за -addnode, -seednode и -connect</translation>
-    </message>
-    <message>
         <source>Already have that input.</source>
         <translation>Вече има такъв вход.</translation>
-    </message>
-    <message>
-        <source>Block creation options:</source>
-        <translation>Опции за създаване на блок:</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet</source>
         <translation>Връщане към по-стара версия на портфейла е невъзможно</translation>
     </message>
     <message>
-        <source>Cannot write default address</source>
-        <translation>Не може да напише адреса по подразбиране</translation>
-    </message>
-    <message>
         <source>Collateral not valid.</source>
         <translation>Обезпечението невалидно.</translation>
     </message>
     <message>
-        <source>Connect to a node to retrieve peer addresses, and disconnect</source>
-        <translation>Свържи се с възел за зараждане на адреси на пиъри, след това прекъсни връзката</translation>
-    </message>
-    <message>
-        <source>Connection options:</source>
-        <translation>Настройки на връзката:</translation>
-    </message>
-    <message>
         <source>Corrupted block database detected</source>
         <translation>Открита е повредена блок база данни</translation>
-    </message>
-    <message>
-        <source>Debugging/Testing options:</source>
-        <translation>Опции за Откриване на грешки/Тестване:</translation>
-    </message>
-    <message>
-        <source>Do not load the wallet and disable wallet RPC calls</source>
-        <translation>Не зареждай портфейла и деактивирай RPC повикванията на портфейла</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
@@ -3891,136 +4025,32 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Неуспешно "слушане" на всеки порт. Използвайте -listen=0 ако искате това.</translation>
     </message>
     <message>
-        <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
-        <translation>(1 =запазва tx meta data напр.акаунта на собственика и информация за искането за плащане,  2 = отпада tx meta data)</translation>
-    </message>
-    <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation>-maxtxfee  е с много голяма зададена стойност! Това е транзакционната такса, която ще платите ако направите единична транзакция.</translation>
     </message>
     <message>
-        <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>
-        <translation>Размера на такса (в %s/kB), която ще бъде използвана има достатъчно данни(по подразбиране: %s)</translation>
-    </message>
-    <message>
-        <source>Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)</source>
-        <translation>Приема препредадените транзакции получени от белия списък на пиърите,  дори когато не са препредадени транзакциите (по подразбиране: %d)</translation>
-    </message>
-    <message>
-        <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
-        <translation>Позволява JSON-RPC връзки от определен източник. Важи за &lt;IP&gt; са един единствен IP (например 1.2.3.4), мрежа / мрежова маска (напр. 1.2.3.4/255.255.255.0) или мрежа / CIDR (напр. 1.2.3.4/24). Тази опция може да бъде променяна многократно</translation>
-    </message>
-    <message>
-        <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
-        <translation>Свързва се с посочения адрес и добави в whitelist свързаните към него пиъри. Използвайте [хост]:порт за изписване при IPv6</translation>
-    </message>
-    <message>
-        <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
-        <translation>Създаване на нови файлове с достъп по подразбиране , вместо umask 077 (в сила само при изключена функционалност на портфейла)</translation>
-    </message>
-    <message>
-        <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
-        <translation>Изтриване на всички транзакции на портфейла и  възстановява само тези части на блок веригата чрез -rescan при стартиране</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transactions of attempted InstantSend double spend in &lt;address&gt;</source>
-        <translation>Включване публикуване на сурови транзакции при опит за двойно похарчване с InstantSend в &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish transaction hashes of attempted InstantSend double spend in &lt;address&gt;</source>
-        <translation>Включване публикуването хеша на транзакция при опит за двойно похарчване с InstantSend в &lt;address&gt;</translation>
+        <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
+        <translation>Не може да осигури конкретни връзки и да накара addrman да намира изходящи връзки едновременно.</translation>
     </message>
     <message>
         <source>Found unconfirmed denominated outputs, will wait till they confirm to continue.</source>
         <translation>Намерени са непотвърдени деноминирани средства, трябва да изчакате потвърждаването им за да продължите</translation>
     </message>
     <message>
-        <source>How thorough the block verification of -checkblocks is (0-4, default: %u)</source>
-        <translation>Как цялостната проверка на блок от -checkblocks е (0-4, по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</source>
-        <translation>Ако paytxfee не е зададен,включва достатъчно такса, така транзакциите започват потвърждение средно в рамките n блокове(по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)</source>
-        <translation>Ако този блок е във веригата приемете, че той и предишните са валидни и евентуално пропуснете този скрипт за проверка (0 за проверка на всичко, по подразбиране: %s, testnet: %s)</translation>
+        <source>Invalid -socketevents ('%s') specified. Only these modes are supported: %s</source>
+        <translation>Невалидни -socketevents ('%s') . Само тези режим се поддържат: %s</translation>
     </message>
     <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation>Невалидна сума за -maxtxfee=&lt;amount&gt;: '%s' (трябва да бъде най-малко от %s за да се избегне забиване на транзакциите)</translation>
     </message>
     <message>
-        <source>Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</source>
-        <translation>Поддържай пълен списък с транзакциите, използван от getrawtransaction rpc повикването (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
-        <translation>Максимален размер на данните в данни съдържащите транзакции , които можем да предадем или изкопаем  (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Number of seconds to keep misbehaving peers from reconnecting (default: %u)</source>
-        <translation>Брой секунди до възтановяване на връзката за зле държащите се пиъри (по подразбиране %u)</translation>
-    </message>
-    <message>
-        <source>Output debugging information (default: %u, supplying &lt;category&gt; is optional)</source>
-        <translation>Изходяща информация за грешки (по подразбиране: %u, задаването на &lt;category&gt; е опция)</translation>
-    </message>
-    <message>
-        <source>Overrides minimum spork signers to change spork value. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.</source>
-        <translation>Отменя се минималният брой ауторизатори на spork за промяна на стойността на spork. Полезно само за regtest и devnet. Използването на това в mainnet или testnet ще ви изхвърли от мрежата.</translation>
-    </message>
-    <message>
-        <source>PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.</source>
-        <translation>PrivateSend използва точно деноминираните суми за изпращане на средства, може да е необходимо да миксирате още няколко монети.</translation>
-    </message>
-    <message>
-        <source>Use N separate masternodes in parallel to mix funds (%u-%u, default: %u)</source>
-        <translation>Използвай N броя различни masternodes в паралел за миксиране на средства (%u-%u, по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
-        <translation>Използва отделен SOCKS5 прокси, за достигне на пиъри чрез Tor скрити услуги (по подразбиране: %s)</translation>
-    </message>
-    <message>
-        <source>User defined mnemonic for HD wallet (bip39). Only has effect during wallet creation/first start (default: randomly generated)</source>
-        <translation>Потребителски дефиниран мнемоничен за HD портфейла (bip39). Има ефект само по време на създаване на портфейла / първия старт (по подразбиране: произволно генериран)</translation>
-    </message>
-    <message>
-        <source>User defined seed for HD wallet (should be in hex). Only has effect during wallet creation/first start (default: randomly generated)</source>
-        <translation>Дефинирани от потребителя части за HD портфейл (трябва да са в шестнадесети). Има ефект само  по време на създаването на портфейла / първия старт (по подразбиране: произволно генериран)</translation>
-    </message>
-    <message>
-        <source>Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>
-        <translation>Whitelisted не могат да бъдат DoS забранени и техните транзакции ще бъдат винаги предадени, дори ако вече са в  mempool, полезно напр. за gateway</translation>
-    </message>
-    <message>
-        <source>(default: %s)</source>
-        <translation>(по подразбиране: %s)</translation>
-    </message>
-    <message>
-        <source>Accept public REST requests (default: %u)</source>
-        <translation>Приема публични REST заявки (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Always query for peer addresses via DNS lookup (default: %u)</source>
-        <translation>Винаги пускай заявка за адреси на пиъри през DNS справката (по подразбиране:  %u)</translation>
+        <source>Transaction index can't be disabled with governance validation enabled. Either start with -disablegovernance command line switch or enable transaction index.</source>
+        <translation>Индексът на транзакциите не може да бъде деактивиран в пълен режим. Или започнете с -disablegovernanc от командния ред или активирайте индексиране на транзакциите.</translation>
     </message>
     <message>
         <source>Can't mix: no compatible inputs found!</source>
         <translation>Не може да бъде миксирано: няма останали съвместими входящи средства.</translation>
-    </message>
-    <message>
-        <source>Chain selection options:</source>
-        <translation>Опции за избор на верига:</translation>
-    </message>
-    <message>
-        <source>Connect through SOCKS5 proxy</source>
-        <translation>Свързване през SOCKS5 прокси</translation>
-    </message>
-    <message>
-        <source>Connect to KeePassHttp on port &lt;port&gt; (default: %u)</source>
-        <translation>Свързване към KeePassHttp през порт &lt;port&gt; (по подразбиране: %u)</translation>
     </message>
     <message>
         <source>Entry exceeds maximum size.</source>
@@ -4047,16 +4077,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Открити са достатъчно потребители, подписва...</translation>
     </message>
     <message>
-        <source>How many blocks to check at startup (default: %u, 0 = all)</source>
-        <translation>Колко блока да проверява при стартиране (по подразбиране:  %u, 0 = всички)</translation>
-    </message>
-    <message>
         <source>Importing...</source>
         <translation>Внасяне...</translation>
-    </message>
-    <message>
-        <source>Include IP addresses in debug output (default: %u)</source>
-        <translation>Прикрепва IP адреси към debug записа (по подразбиране: %u)</translation>
     </message>
     <message>
         <source>Incompatible mode.</source>
@@ -4095,24 +4117,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Невалиден минимален брой ауторизатори на spork определен с -minsporkkeys</translation>
     </message>
     <message>
-        <source>Keep N DASH mixed (%u-%u, default: %u)</source>
-        <translation>Дръж N DASH миксирани (%u-%u, default: %u)</translation>
-    </message>
-    <message>
-        <source>Keep at most &lt;n&gt; unconnectable transactions in memory (default: %u)</source>
-        <translation>Пази най-много &lt;n&gt; несвързани транзакции в паметта (по подразбиране: %u)</translation>
-    </message>
-    <message>
         <source>Keypool ran out, please call keypoolrefill first</source>
         <translation>Keypool изтече, моля поискайте първо keypoolrefill</translation>
-    </message>
-    <message>
-        <source>Listen for JSON-RPC connections on &lt;port&gt; (default: %u or testnet: %u)</source>
-        <translation>Очаквай JSON-RPC входящи връзки на &lt;port&gt; (по подразбиране:%u или за тестовата мрежа: %u)</translation>
-    </message>
-    <message>
-        <source>Listen for connections on &lt;port&gt; (default: %u or testnet: %u)</source>
-        <translation>Слушане за входящи връзки на &lt;port&gt; (по подразбиране:%u или за тестовата мрежа: %u)</translation>
     </message>
     <message>
         <source>Loading banlist...</source>
@@ -4131,20 +4137,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Заключването е вече налично.</translation>
     </message>
     <message>
-        <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
-        <translation>Максимален размер на буфера при получаване, &lt;n&gt;*1000 байта (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
-        <translation>Максимален размер на буфера при изпращане, &lt;n&gt;*1000 байта (по подразбиране:  %u)</translation>
-    </message>
-    <message>
         <source>Mixing in progress...</source>
         <translation>В процес на смесване...</translation>
-    </message>
-    <message>
-        <source>Mnemonic passphrase is too long, must be at most 256 characters</source>
-        <translation>Мнемоничната парола е твърде дълга, трябва да бъде не по-дълга от 256 символа</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4167,80 +4161,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Не е в Мasternode списъка.</translation>
     </message>
     <message>
-        <source>Only connect to nodes in network &lt;net&gt; (ipv4, ipv6 or onion)</source>
-        <translation>Свързване само към точки от мрежата &lt;net&gt; (IPv4, IPv6 или onion)</translation>
-    </message>
-    <message>
-        <source>Prepend debug output with timestamp (default: %u)</source>
-        <translation>Прикрепва справката за грешки към времевия запис(по подразбиране:  %u)</translation>
-    </message>
-    <message>
-        <source>Rebuild chain state and block index from the blk*.dat files on disk</source>
-        <translation>Възстановяване състоянието на веригата и блок индекса от blk*.dat файловете на диска</translation>
-    </message>
-    <message>
-        <source>Rebuild chain state from the currently indexed blocks</source>
-        <translation>Възстановяване състоянието на веригата от сега индексирани блокове</translation>
-    </message>
-    <message>
-        <source>Send trace/debug info to debug.log file (default: %u)</source>
-        <translation>Изпрати информацията за грешки към  файла debug.log (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Set key pool size to &lt;n&gt; (default: %u)</source>
-        <translation>Задайте максимален брой на генерираните ключове до &lt;n&gt; (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Set the number of threads to service RPC calls (default: %d)</source>
-        <translation>Задай брой заявки обслужващи процеса RPC повикванията (по подразбиране:  %d)</translation>
-    </message>
-    <message>
-        <source>Specify configuration file (default: %s)</source>
-        <translation>Посочете конфигурационен файл (по подразбиране: %s)</translation>
-    </message>
-    <message>
-        <source>Specify connection timeout in milliseconds (minimum: 1, default: %d)</source>
-        <translation>Определете таймаут за свързване в милисекунди (минимум: 1, подразбиране: %d)</translation>
-    </message>
-    <message>
-        <source>Specify pid file (default: %s)</source>
-        <translation>Посочете pid-файла (по подразбиране:  %s)</translation>
-    </message>
-    <message>
-        <source>Spend unconfirmed change when sending transactions (default: %u)</source>
-        <translation>Изхарчете непотвърденото ресто при изпращане на транзакциите (по подразбиране: %u)</translation>
-    </message>
-    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Изпратено към Мастернода, чака в опашката %s</translation>
     </message>
     <message>
-        <source>Synchronization failed</source>
-        <translation>Синхронизацията е неуспешна</translation>
-    </message>
-    <message>
         <source>Synchronization finished</source>
         <translation>Синхронизацията е завършена</translation>
-    </message>
-    <message>
-        <source>Threshold for disconnecting misbehaving peers (default: %u)</source>
-        <translation>Праг на прекъсване на връзката при непорядъчно държащи се пиъри (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Too many %f denominations, removing.</source>
-        <translation>Твърде много %f деноминации, премахване.</translation>
-    </message>
-    <message>
-        <source>Too many %f denominations, skipping.</source>
-        <translation>Твърде много %f деноминации, прескочи.</translation>
-    </message>
-    <message>
-        <source>Tor control port password (default: empty)</source>
-        <translation>Tor контролира паролата на порта (по подразбиране: празно)</translation>
-    </message>
-    <message>
-        <source>Tor control port to use if onion listening enabled (default: %s)</source>
-        <translation>Tor контролира порта ако onion слушането е включено(по подразбиране: %s)</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4263,22 +4189,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Неподдържан аргумент -tor е намерен,използвайте -onion.</translation>
     </message>
     <message>
-        <source>Upgrade wallet to latest format on startup</source>
-        <translation>Обновяване на портфейла до последният формат при стартиране</translation>
-    </message>
-    <message>
-        <source>Use KeePass 2 integration using KeePassHttp plugin (default: %u)</source>
-        <translation>Използвай KeePass 2 интеграция чрез плъгина KeePassHttp (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Use UPnP to map the listening port (default: %u)</source>
-        <translation>Използвай UPnP за определяне на порта за слушане (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Use the test chain</source>
-        <translation>Използвайте тестовата мрежа</translation>
-    </message>
-    <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
         <translation>User Agent comment (%s) съдържа опасни символи.</translation>
     </message>
@@ -4295,6 +4205,18 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Не можете да намери случаен Masternode.</translation>
     </message>
     <message>
+        <source>%s can't be lower than %s</source>
+        <translation>%s не може да бъде по-малко от %s</translation>
+    </message>
+    <message>
+        <source>%s is idle.</source>
+        <translation>%s е в изчакване.</translation>
+    </message>
+    <message>
+        <source>%s request incomplete: %s</source>
+        <translation>%s незавършена заявка: %s</translation>
+    </message>
+    <message>
         <source>Can't mix while sync in progress.</source>
         <translation>Не може да се смесват, докато се синхронизира.</translation>
     </message>
@@ -4307,18 +4229,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Открит е невалиден скрипт.</translation>
     </message>
     <message>
-        <source>KeePassHttp id for the established association</source>
-        <translation>KeePassHttp id за осъществяване на връзка</translation>
-    </message>
-    <message>
-        <source>KeePassHttp key for AES encrypted communication with KeePass</source>
-        <translation>KeePassHttp ключ за  AES криптирана връзка с KeePass</translation>
-    </message>
-    <message>
-        <source>Disable all Dash specific functionality (Masternodes, PrivateSend, InstantSend, Governance) (0-1, default: %u)</source>
-        <translation>Изключване на всички специфични Dash функции (PrivateSend, InstantSend, Governance) (0-1, по подразбиране: %u)</translation>
-    </message>
-    <message>
         <source>%s file contains all private keys from this wallet. Do not share it with anyone!</source>
         <translation>Файл %s  съдържа всички частни ключове от този портфейл. Не го споделяйте с никого!</translation>
     </message>
@@ -4327,76 +4237,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-masternode опцията е оттеглена и игнорирана, уточняването на -masternodeblsprivkey е достатъчно да стартирате този нод като masternode.</translation>
     </message>
     <message>
-        <source>Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info)</source>
-        <translation>Добавете нод за да се свържете и опитайте да поддържате връзката отворена(виж 'addnode' RPC командата за повече информация)</translation>
-    </message>
-    <message>
-        <source>Bind to given address to listen for JSON-RPC connections. This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost, or if -rpcallowip has been specified, 0.0.0.0 and :: i.e., all addresses)</source>
-        <translation>Свържете с даден адрес за да слушате за JSON-RPC връзки. Тази опция се игнорира освен ако -rpcallowip също е преминал. Порта е опция и замества -rpcport. Използвай [host]:port нотация за IPv6. Тази опция може да бъде задавана многократно (по подразбиране: 127.0.0.1 и ::1 i.e., localhost, или ако -rpcallowip е посочен, 0.0.0.0 и:: т.е всички адреси)</translation>
-    </message>
-    <message>
-        <source>Connect only to the specified node(s); -connect=0 disables automatic connections (the rules for this peer are the same as for -addnode)</source>
-        <translation>Свързване само към определен нод(ове); -connect=0 изключва автоматичното свързване (правилата за този пиър са същите като за -addnode)</translation>
-    </message>
-    <message>
-        <source>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</source>
-        <translation>Открий собствения IP адрес (по подразбиране: 1, когато слуша и няма -externalip или -proxy)</translation>
-    </message>
-    <message>
-        <source>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</source>
-        <translation>Не дръжте в мемпула транзакции повече от &lt;n&gt; часа (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Enable multiple PrivateSend mixing sessions per block, experimental (0-1, default: %u)</source>
-        <translation>Активиране на няколко PrivateSend миксиращи сесии за нлок, експериментално (0-1, по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Execute command when a wallet InstantSend transaction is successfully locked (%s in cmd is replaced by TxID)</source>
-        <translation>Изпълнена команда когато транзакцията в  InstantSend портфейла е успешно заключена (%s в cmd е заместен от TxID)</translation>
-    </message>
-    <message>
-        <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
-        <translation>Допълнителни транзакции поддържани в паметта за реконструкции на компактни блокове (по подразбиране: %u)</translation>
-    </message>
-    <message>
         <source>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
         <translation>Не може да се създаде копие, файлът вече съществува! Това може да се случи, ако сте рестартирали портфейла си преди по-малко от 60 секунди. Може да продължите, ако сте разбрали това.</translation>
     </message>
     <message>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
-        <translation>Такси (в %s/kB) по-малки от тази се считат за нулева такса за прилагане, при копаене и създаване на транзакция (по подразбиране: %s)</translation>
-    </message>
-    <message>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</source>
-        <translation>Такси (в %s/kB) по-малки от това се считат за нулева такса при създаване на транзакция (по подразбиране: %s)</translation>
-    </message>
-    <message>
-        <source>If &lt;category&gt; is not supplied or if &lt;category&gt; = 1, output all debugging information.</source>
-        <translation>Ако &lt;category&gt; не е предоставена или ако &lt;category&gt; = 1, изведи цялата информация за отстраняване на грешки.</translation>
-    </message>
-    <message>
-        <source>Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)</source>
-        <translation>Поддържай пълен списък с транзакциите, използван за заявка за баланс, txids и неусвоени изходи за адресите (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain a full spent index, used to query the spending txid and input index for an outpoint (default: %u)</source>
-        <translation>Поддържай пълен списък с транзакциите, използва   похарчената txids и входящият списък за един изход (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain a timestamp index for block hashes, used to query blocks hashes by a range of timestamps (default: %u)</source>
-        <translation>Поддържайте времеви отпечатък на индекса  за блокираните на хешове, използван за заявки към блок-хешове от поредица времеви отпечатъци (по подразбиране:%u)</translation>
-    </message>
-    <message>
-        <source>Maintain at most &lt;n&gt; connections to peers (temporary service connections excluded) (default: %u)</source>
-        <translation>Поддържайте най-много &lt;n&gt; връзки към пиъри(без временните сервизни връзки)(по подразбиране: %u)</translation>
-    </message>
-    <message>
         <source>Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</source>
         <translation>Уверете се, че криптирате портфейла си и изтривате всички незашифровани резервни копия, след като сте се уверили, че портфейлът Ви работи!</translation>
-    </message>
-    <message>
-        <source>Maximum total size of all orphan transactions in megabytes (default: %u)</source>
-        <translation>Максимален общ размер на всички осиротели транзакции в мегабайти (по подразбиране: %u)</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
@@ -4407,28 +4253,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Изчистване: последното синхронизиране надхвърля почстените данни. Нужен е -reindex (изтегляне на цялата блко-верига в случай на "изчистен" възел)</translation>
     </message>
     <message>
-        <source>Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect used)</source>
-        <translation>Запитване за партньорски адреси чрез DNS lookup, са с малко адреси (по подразбиране: 1 освен ако не се използва -connect )</translation>
-    </message>
-    <message>
-        <source>Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)</source>
-        <translation>произволни удостоверения за всяка прокси връзка. Това дава възможност за изолация Tor потока (по подразбиране: %u)</translation>
-    </message>
-    <message>
         <source>Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.</source>
         <translation>Повторно сканиране не е възможно в изчистен режим. Вие ще трябва да използвате -reindex, което ще изтегли цялата блок-верига отново.</translation>
-    </message>
-    <message>
-        <source>Set the masternode BLS private key and enable the client to act as a masternode</source>
-        <translation>Задайте BLS  частен ключ на masternode и дайте възможност на клиента да действа като masternode</translation>
-    </message>
-    <message>
-        <source>Specify full path to directory for automatic wallet backups (must exist)</source>
-        <translation>Посочване на директория за автоматичен резервен архив на портфейла (трябва да съществува)</translation>
-    </message>
-    <message>
-        <source>Support filtering of blocks and transaction with bloom filters (default: %u)</source>
-        <translation>Поддържа филтриране на блоковете и транзакциите със свежи филтри (по подразбиране: %u)</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -4443,28 +4269,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Общата дължина на мрежовата версия на низ (%i) надвишава максималната дължина (%i). Намалете  броя или размера на коментарите.</translation>
     </message>
     <message>
-        <source>Transaction index can't be disabled in full mode. Either start with -litemode command line switch or enable transaction index.</source>
-        <translation>Индексът на транзакциите не може да бъде деактивиран в пълен режим. Или започнете с превключване  -litemode от командния ред или активирайте индексиране на транзакциите.</translation>
-    </message>
-    <message>
-        <source>Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)</source>
-        <translation>Опитва се да поддържа изходящият трафик по зададената цел (в MiB за 24h), 0 = без лимит (по подразбиране: %d)</translation>
-    </message>
-    <message>
-        <source>Unable to locate enough PrivateSend denominated funds for this transaction.</source>
-        <translation>Не са намерени достатъчно PrivateSend деноминирани средства за тази транзакция.</translation>
-    </message>
-    <message>
         <source>Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported.</source>
         <translation>Открит е неподдържан аргумент -socks .Настройката SOCKS версия вече не е възможна, само SOCKS5 прокси се поддържа.</translation>
     </message>
     <message>
         <source>Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay.</source>
         <translation>Неподдържан аргумент -whitelistalwaysrelay игнориран, използвайте -whitelistrelay и/или -whitelistforcerelay.</translation>
-    </message>
-    <message>
-        <source>Use UPnP to map the listening port (default: 1 when listening and no -proxy)</source>
-        <translation>Използвайте UPnP за определяне на порта за слушане (по подразбиране: 1 когато слуша без прокси)</translation>
     </message>
     <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
@@ -4487,68 +4297,52 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Необходимо е повторно изграждане на базата данни използвайки -reindex за да се върнете в неизчистен режим.Това ще изтегли отново съществуващата блок-верига</translation>
     </message>
     <message>
-        <source>(default: %u)</source>
-        <translation>(по подразбиране: %u)</translation>
+        <source>-litemode is deprecated.</source>
+        <translation>-litemode е отстарял.</translation>
     </message>
     <message>
         <source>-maxmempool must be at least %d MB</source>
         <translation>-maxmempoolтрябва да бъде поне %d MB</translation>
     </message>
     <message>
-        <source>&lt;category&gt; can be:</source>
-        <translation>&lt;category&gt; може да бъде:</translation>
-    </message>
-    <message>
-        <source>Append comment to the user agent string</source>
-        <translation>Добавяне на коментар към стринг на потребителският агент</translation>
-    </message>
-    <message>
         <source>Automatic backups disabled</source>
         <translation>Автоматичното архивиране е изключено</translation>
-    </message>
-    <message>
-        <source>Automatically create Tor hidden service (default: %d)</source>
-        <translation>Автоматично създаване на скрита Tor услуга (по подразбиране: %d)</translation>
     </message>
     <message>
         <source>ERROR! Failed to create automatic backup</source>
         <translation>ГРЕШКА! Неуспешно създаване на автоматичен архив</translation>
     </message>
     <message>
-        <source>Enable publish hash block in &lt;address&gt;</source>
-        <translation>Включва публикуване на блок хеш в &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash of governance objects (like proposals) in &lt;address&gt;</source>
-        <translation>Активиране публикуването на хеш от обектите за управление (като предложения) в &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash of governance votes in &lt;address&gt;</source>
-        <translation>Активиране публикуването на хеш от управляващите гласове в &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash transaction (locked via InstantSend) in &lt;address&gt;</source>
-        <translation>Включва публикуване хеша на транзакцията  (заключен чрез InstantSend) в &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash transaction in &lt;address&gt;</source>
-        <translation>Включва публикуване хеша на транзакцията в &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw block in &lt;address&gt;</source>
-        <translation>Включва публикуване необработеният блок в &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transaction (locked via InstantSend) in &lt;address&gt;</source>
-        <translation>Включва публикуване на необранотена транзакция (заключена чрез InstantSend) в &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transaction in &lt;address&gt;</source>
-        <translation>Включва публикуване на необранотена транзакция  в &lt;address&gt;</translation>
+        <source>Error upgrading evo database</source>
+        <translation>Грешка при надстройката на базата данни evo</translation>
     </message>
     <message>
         <source>Error: A fatal internal error occurred, see debug.log for details</source>
         <translation>Грешка: Възникна сериозна вътрешна грешка, виж debug.log за подробности</translation>
+    </message>
+    <message>
+        <source>Error: failed to add socket to epollfd (epoll_ctl returned error %s)</source>
+        <translation>Грешка: неуспешно добавяне на socket към epollfd (epoll_ctl дава грешка %s)</translation>
+    </message>
+    <message>
+        <source>Exceeded max tries.</source>
+        <translation>Надвишен брой опити.</translation>
+    </message>
+    <message>
+        <source>Failed to clear fulfilled requests cache at</source>
+        <translation>Неуспешно изчистване на кеша на изпълнени заявки при</translation>
+    </message>
+    <message>
+        <source>Failed to clear governance cache at</source>
+        <translation>Неуспешно изчистване на кеша за управление на</translation>
+    </message>
+    <message>
+        <source>Failed to clear masternode cache at</source>
+        <translation>Неуспешно изчистване на кеша на masternode при</translation>
+    </message>
+    <message>
+        <source>Failed to commit EvoDB</source>
+        <translation>Неуспешно фиксиране на EvoDB</translation>
     </message>
     <message>
         <source>Failed to create backup %s!</source>
@@ -4567,16 +4361,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Неуспешно зареждане на кеша за sporks от</translation>
     </message>
     <message>
-        <source>Fee (in %s/kB) to add to transactions you send (default: %s)</source>
-        <translation>Такса (в %s/kB) за добавяне към транзакцията,която изпращате (default: %s)</translation>
-    </message>
-    <message>
-        <source>Imports blocks from external blk000??.dat file on startup</source>
-        <translation>Внасяне на блокове от външен blk000??.dat  файл при стартиране</translation>
-    </message>
-    <message>
-        <source>InstantSend options:</source>
-        <translation>InstantSend опции:</translation>
+        <source>Failed to rescan the wallet during initialization</source>
+        <translation>Неуспешно сканиране на портфейла по време на инициализация</translation>
     </message>
     <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
@@ -4587,16 +4373,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Невалиден masternodeblsprivkey. Моля вижте документацията.</translation>
     </message>
     <message>
-        <source>Keep the transaction memory pool below &lt;n&gt; megabytes (default: %u)</source>
-        <translation>Дръж мемпула за транзакциите под &lt;n&gt; мегабайта (по подразбиране: %u)</translation>
+        <source>It has been replaced by -disablegovernance.</source>
+        <translation>Заменено е от -disablegovernance.</translation>
     </message>
     <message>
-        <source>Last PrivateSend was too recent.</source>
-        <translation>Последния PrivateSend беше твърде скоро.</translation>
-    </message>
-    <message>
-        <source>Last successful PrivateSend action was too recent.</source>
-        <translation>Последното успешно PrivateSend действие бе твърде скоро.</translation>
+        <source>Its replacement -disablegovernance has been forced instead.</source>
+        <translation>Подмяната му е причинена  от -disablegovernance .</translation>
     </message>
     <message>
         <source>Loading block index...</source>
@@ -4619,28 +4401,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Зареждане на портфейла...</translation>
     </message>
     <message>
-        <source>Location of the auth cookie (default: data dir)</source>
-        <translation>Местоположение на бисквитката за удостоверяване (по подразбиране: data dir)</translation>
-    </message>
-    <message>
-        <source>Make the wallet broadcast transactions</source>
-        <translation>Прави излъчващи транзакции от портфейла</translation>
-    </message>
-    <message>
-        <source>Masternode options:</source>
-        <translation>Masternode опции:</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Опашката с задачи на Masternode е пълна.</translation>
     </message>
     <message>
         <source>Masternode:</source>
         <translation>Masternode:</translation>
-    </message>
-    <message>
-        <source>Minimum bytes per sigop in transactions we relay and mine (default: %u)</source>
-        <translation>Минимум байта за sigop в транзакциите, които могат да се предадат и изкопаят (по подразбиране: %u)</translation>
     </message>
     <message>
         <source>Missing input transaction information.</source>
@@ -4655,14 +4421,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Няма съвпадащи деноминации за миксирането.</translation>
     </message>
     <message>
-        <source>Node relay options:</source>
-        <translation>Сменящи опции на node:</translation>
-    </message>
-    <message>
-        <source>Non-standard public key detected.</source>
-        <translation>Засечен е нестандартен публичен ключ.</translation>
-    </message>
-    <message>
         <source>Not compatible with existing transactions.</source>
         <translation>Несъвместим със съществуващите транзакции.</translation>
     </message>
@@ -4671,40 +4429,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Няма достатъчно налични файлови описания.</translation>
     </message>
     <message>
-        <source>Number of automatic wallet backups (default: %u)</source>
-        <translation>Брой на автоматичните резервни копия на порфейла (по подразбиране:  %u)</translation>
-    </message>
-    <message>
-        <source>Options:</source>
-        <translation>Опции:</translation>
-    </message>
-    <message>
-        <source>Password for JSON-RPC connections</source>
-        <translation>Парола за  JSON-RPC връзките</translation>
-    </message>
-    <message>
-        <source>Print version and exit</source>
-        <translation>Версия за печат и изход</translation>
-    </message>
-    <message>
-        <source>PrivateSend is idle.</source>
-        <translation>PrivateSend е без работа.</translation>
-    </message>
-    <message>
-        <source>PrivateSend options:</source>
-        <translation>PrivateSend опции:</translation>
-    </message>
-    <message>
-        <source>PrivateSend request complete:</source>
-        <translation>PrivateSend заявката е завършена:</translation>
-    </message>
-    <message>
-        <source>PrivateSend request incomplete:</source>
-        <translation>PrivateSend заявката е незавършена:</translation>
-    </message>
-    <message>
         <source>Prune cannot be configured with a negative value.</source>
         <translation>Изчистване не може да бъде конфигурирано с отрицателна стойност.</translation>
+    </message>
+    <message>
+        <source>Prune mode is incompatible with -disablegovernance=false.</source>
+        <translation>Олекотен режим е несъвместим с -disablegovernance=false.</translation>
     </message>
     <message>
         <source>Prune mode is incompatible with -txindex.</source>
@@ -4715,8 +4445,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Изчистване на блоковото пространство...</translation>
     </message>
     <message>
-        <source>Rescan the block chain for missing wallet transactions on startup</source>
-        <translation>Повторно сканиране на регистъра на блокове за липсващи в портфейла транзакции  при стартиране</translation>
+        <source>Specified -walletdir "%s" does not exist</source>
+        <translation>Посоченият -walletdir "%s" не съществува</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is a relative path</source>
+        <translation>Посоченият -walletdir "%s" е относителен път</translation>
+    </message>
+    <message>
+        <source>Specified -walletdir "%s" is not a directory</source>
+        <translation>Посоченият -walletdir "%s" не е папка</translation>
     </message>
     <message>
         <source>Synchronizing blockchain...</source>
@@ -4725,6 +4463,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
         <translation>Портфейлът няма да плаща по-малко от миналата такса за препредаване.</translation>
+    </message>
+    <message>
+        <source>This is expected because you are running a pruned node.</source>
+        <translation>Това се очаква, защото сте пуснали олекотен нод.</translation>
     </message>
     <message>
         <source>This is the minimum transaction fee you pay on every transaction.</source>
@@ -4759,16 +4501,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Невъзможно да се свърже към %s на този компютър. %s вероятно  вече работи.</translation>
     </message>
     <message>
+        <source>Unable to generate initial keys</source>
+        <translation>Не може да се генерират първоначални ключове</translation>
+    </message>
+    <message>
         <source>Upgrading UTXO database</source>
         <translation>Обновяване на UTXO база данни</translation>
     </message>
     <message>
-        <source>Use devnet chain with provided name</source>
-        <translation>Използвайте devnet веригата с предоставеното име</translation>
-    </message>
-    <message>
-        <source>Wallet debugging/testing options:</source>
-        <translation>Опции за Откриване на грешки/Тестване на портфейла:</translation>
+        <source>Wallet %s resides outside wallet directory %s</source>
+        <translation>Портфейл %s се намира извън директорията на портфейла %s</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4781,14 +4523,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Wasn't able to create wallet backup folder %s!</source>
         <translation>Не е в състояние да създаде архивираща папка за портфейла %s!</translation>
-    </message>
-    <message>
-        <source>Whether to operate in a blocks only mode (default: %u)</source>
-        <translation>Дали да работи само в блоков режим (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>You can not start a masternode in lite mode.</source>
-        <translation>Не може да стартирате masternode в олекотен режим.</translation>
     </message>
     <message>
         <source>You can not start a masternode with wallet enabled.</source>
@@ -4807,20 +4541,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Необходимо е повторно изграждане на базата данни използвайки -reindex, за да промените -txindex</translation>
     </message>
     <message>
-        <source>ZeroMQ notification options:</source>
-        <translation>ZeroMQ опции за уведомяване:</translation>
-    </message>
-    <message>
         <source>no mixing available.</source>
         <translation>няма налично миксиране.</translation>
     </message>
     <message>
         <source>see debug.log for details.</source>
         <translation>виж debug.log за подробности.</translation>
-    </message>
-    <message>
-        <source>RPC server options:</source>
-        <translation>Опции на RPC сървъра:</translation>
     </message>
     <message>
         <source>Dash Core</source>
@@ -4831,6 +4557,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%s разработчици</translation>
     </message>
     <message>
+        <source>%s uses exact denominated amounts to send funds, you might simply need to mix some more coins.</source>
+        <translation>%s използва точно деноминирани суми за изпращане на средства, може просто да се наложи да смесите още няколко монети.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation>Не може да се заключи дата директорията %s.%s вероятно вече работи.</translation>
     </message>
@@ -4839,44 +4569,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Разпространява се под MIT софтуерен лиценз,вижте придружаващият файл  %s или %s</translation>
     </message>
     <message>
-        <source>Enable use of PrivateSend for funds stored in this wallet (0-1, default: %u)</source>
-        <translation>Включи използването на PrivateSend за средства в този портфейл (0-1, по подразбиране: %u)</translation>
-    </message>
-    <message>
         <source>Error loading %s: You can't enable HD on an already existing non-HD wallet</source>
         <translation>Грешка при зареждане %s: Не можете да активирате HD във вече съществуващ не-HD портфейл</translation>
-    </message>
-    <message>
-        <source>Error loading wallet %s. -wallet parameter must only specify a filename (not a path).</source>
-        <translation>Грешка при зареждане на портфейла %s. -wallet параметър може да определя само име на файл (не път до файла).</translation>
     </message>
     <message>
         <source>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Грешка при четене на  %s! Всички ключове са прочетени коректно, но данните за транзакциите или записите в адресната книга може да липсват или са некоректни.</translation>
     </message>
     <message>
-        <source>Exclude debugging information for a category. Can be used in conjunction with -debug=1 to output debug logs for all categories except one or more specified categories.</source>
-        <translation>Изключете информацията за отстраняване на грешки за категория. Може да се използва заедно с -debug = 1 за извеждане на грешки за отстраняване на грешки за всички категории, с изключение на една или повече определени категории.</translation>
-    </message>
-    <message>
-        <source>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</source>
-        <translation>Приема препредадените транзакции получени от белия списък на пиърите,  дори когато не са препредадени транзакциите (по подразбиране: %d)</translation>
-    </message>
-    <message>
         <source>Incorrect or no devnet genesis block found. Wrong datadir for devnet specified?</source>
         <translation>Намерен е неправилен или не devnet блок. Грешно зададена data директория за devnet мрежата?</translation>
-    </message>
-    <message>
-        <source>Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)</source>
-        <translation>Максимално допустима корекция на средното време за връщане на пиъри. Локалната перспектива на времето може да бъде повлияна от пиери напред или назад от това количество. (по подразбиране:%u секунди)</translation>
-    </message>
-    <message>
-        <source>Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)</source>
-        <translation>Максимална крайна такса (в %s) използвана в единична или сурова транзакция, ако е зададена твърде малка, няма да бъдат възможни големи транзакции (по подразбиране: %s)</translation>
-    </message>
-    <message>
-        <source>Override spork address. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.</source>
-        <translation>Заменете spork адреса. Полезен само за regtest и devnet. Използването на това на mainnet или testnet ще прекъсне връзката ви с мрежата.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -4885,18 +4587,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
         <translation>Моля помогнете ако намерите %s полезен. Посетете %s за допълнителна информация за софтуера.</translation>
-    </message>
-    <message>
-        <source>Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex and -rescan. Warning: Reverting this setting requires re-downloading the entire blockchain. (default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, &gt;%u = automatically prune block files to stay under the specified target size in MiB)</source>
-        <translation>Редуциране на изискванията за пространство чрез изчистване (изтриване) стари блокове. Това позволява на RPC  да изтрие конкретни блокове и позволява автоматичното изчистване на стари блокове, ако е предвиден целеви размер в MiB. Този режим е несъвместим с -txindex и -rescan. внимание: Изключването на тази настройка изисква повторно изтегляне на цялата блок-верига. (по подразбиране: 0 = изключено изчистване на блокове, &gt;%u = желан размер в MiB за използване на блок файлове)</translation>
-    </message>
-    <message>
-        <source>Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)</source>
-        <translation>Задайте най-ниска такса (в %s / kB) за транзакции, които да бъдат включени в създаването на блок. (по подразбиране:%s)</translation>
-    </message>
-    <message>
-        <source>The fee rate (in %s/kB) that indicates your tolerance for discarding change by adding it to the fee (default: %s). Note: An output is discarded if it is dust at this rate, but we will always discard up to the dust relay fee and a discard fee above that is limited by the fee estimate for the longest target</source>
-        <translation>Стойността на таксата (в %s/kB), която показва вашата толерантност към отхвърляне на промяната, като я добавите към таксата (по подразбиране: %s). Забележка: Изходът се изхвърля, ако е с незначителна стойност на тази стойност, но винаги ще изхвърлим до таксата на тази незначителна стойност и такса, която е ограничена от оценката на таксата за най-дългата цел</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -4911,48 +4601,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Този продукт включва софтуер, разработен от проекта OpenSSL за използване в OpenSSL Toolkit %s и криптографски софтуер, написан от Eric Young и UPnP софтуер, написан от Thomas Bernard.</translation>
     </message>
     <message>
-        <source>Unable to locate enough PrivateSend non-denominated funds for this transaction.</source>
-        <translation>Невъзможно е да се намерят достатъчно средства, които не са деноминирани от PrivateSend, за тази транзакция.</translation>
-    </message>
-    <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation>Блокове не могат да се възпроизведат. Ще трябва да възстановите базата данни с помощта на -reindex-chainstate.</translation>
     </message>
     <message>
-        <source>Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)</source>
-        <translation>Използвайте N отделни Masternode за всеки деноминиран вход за миксиране на средства (%u-%u, по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Use hierarchical deterministic key generation (HD) after BIP39/BIP44. Only has effect during wallet creation/first start</source>
-        <translation>Използвайте йерархично детерминиращо генериране на ключ (HD) след bip39 / bip44. Има ефект само по време на създаване на портфейла / първия старт</translation>
-    </message>
-    <message>
-        <source>User defined mnemonic passphrase for HD wallet (BIP39). Only has effect during wallet creation/first start (default: empty string)</source>
-        <translation>Потребителски дефиниран мнемонична парола за HD портфейла (bip39). Има ефект само по време на създаване на портфейла / първия старт (по подразбиране:празен низ )</translation>
-    </message>
-    <message>
-        <source>Username and hashed password for JSON-RPC connections. The field &lt;userpw&gt; comes in the format: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. A canonical python script is included in share/rpcuser. The client then connects normally using the rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt; pair of arguments. This option can be specified multiple times</source>
-        <translation>Потребителско име и парола за JSON-RPC връзки. Полето &lt;userpw&gt; е във формата: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;.  Включен е каноничен скрипт на phyton в share/ rpcuser . След това клиентът се свързва нормално с помощта на rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt;двойка аргументи. Тази опция може да се зададе няколко пъти</translation>
-    </message>
-    <message>
-        <source>Wallet will not create transactions that violate mempool chain limits (default: %u)</source>
-        <translation>Портфейла няма да създава транзакции, които нарушават ограниченията на веригата на mempool (по подразбиране:%u)</translation>
-    </message>
-    <message>
         <source>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Внимание: Файла на портфейла  е повреден, данните са спасени! Оригиналния  %s е запазен като %s в %s; ако вашият баланс или транзакции са неверни трябва да възстановите от резервното копие/архив.</translation>
-    </message>
-    <message>
-        <source>Whether to save the mempool on shutdown and load on restart (default: %u)</source>
-        <translation>Дали да запазите мемпула при изключване и да се зареди при рестартиране (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.</source>
-        <translation>Whitelist пиъри свързани от даден  IP адрес(напр. 1.2.3.4) или дадената мрежова маска (напр. 1.2.3.0/24). Може да бъде определян многократно.</translation>
-    </message>
-    <message>
-        <source>You are starting in lite mode, most Dash-specific functionality is disabled.</source>
-        <translation>Стартирате в олекотен режим, повечето специфични за Dash функционалности са деактивирани.</translation>
     </message>
     <message>
         <source>%d of last 100 blocks have unexpected version</source>
@@ -4971,10 +4625,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%s е зададен твърде високо!</translation>
     </message>
     <message>
-        <source>(press q to shutdown and continue later)</source>
-        <translation>(натиснете q за изключване и продължете по-късно)</translation>
-    </message>
-    <message>
         <source>-devnet can only be specified once</source>
         <translation>-devnet може да се зададе само веднъж</translation>
     </message>
@@ -4987,20 +4637,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-rpcport трябва да се зададе когато -devnet и  -server са зададени</translation>
     </message>
     <message>
-        <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
-        <translation>Приемайте връзки отвън (по подразбиране: 1, ако няма -proxy или -connect)</translation>
-    </message>
-    <message>
-        <source>Allow RFC1918 addresses to be relayed and connected to (default: %u)</source>
-        <translation>Разрешава препредаването и свързването на RFC1918 адреси към  (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Attempt to recover private keys from a corrupt wallet on startup</source>
-        <translation>Опит да се възстановят частни ключове от повреден портфейл при стартиране</translation>
-    </message>
-    <message>
         <source>Cannot resolve -%s address: '%s'</source>
         <translation>Не може да установи -%s адрес: '%s'</translation>
+    </message>
+    <message>
+        <source>Cannot write to data directory '%s'; check permissions.</source>
+        <translation>Не може да се записва в data папката '%s'; проверете правата.</translation>
     </message>
     <message>
         <source>Change index out of range</source>
@@ -5009,10 +4651,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Copyright (C)</source>
         <translation>Авторски права (C)</translation>
-    </message>
-    <message>
-        <source>Create up to N inputs of each denominated amount (%u-%u, default: %u)</source>
-        <translation>Създайте до N входа за всяка деноминирана сума (%u-%u, по подразбиране: %u)</translation>
     </message>
     <message>
         <source>Error loading %s</source>
@@ -5031,20 +4669,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Грешка при зареждане %s: Не можете да деактивирате HD във вече съществуващ HD портфейл</translation>
     </message>
     <message>
-        <source>Error loading wallet %s. -wallet filename must be a regular file.</source>
-        <translation>Грешка при зареждането на портфейла %s. -wallet името на файл трябва да е обикновен файл.</translation>
-    </message>
-    <message>
         <source>Error loading wallet %s. Duplicate -wallet filename specified.</source>
         <translation>Грешка при зареждането на портфейла %s. Посочено е дублирано име на файлa.</translation>
     </message>
     <message>
-        <source>Error loading wallet %s. Invalid characters in -wallet filename.</source>
-        <translation>Грешка при зареждането на портфейла %s. Невалидни знаци в името на файла -wallet.</translation>
-    </message>
-    <message>
         <source>Error upgrading chainstate database</source>
         <translation>Грешка при надграждане на верижната база данни </translation>
+    </message>
+    <message>
+        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
+        <translation>Грешка:неуспешно добавяне на socket към kqueuefd (kevent дава грешка %s)</translation>
     </message>
     <message>
         <source>Failed to find mixing queue to join</source>
@@ -5053,6 +4687,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Failed to start a new mixing queue</source>
         <translation>Неуспешно стартиране на нова опашка за миксиране</translation>
+    </message>
+    <message>
+        <source>Incorrect -rescan mode, falling back to default value</source>
+        <translation>Некоректен -rescan режим, връщане към стойност по подразбиране</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
@@ -5083,20 +4721,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Зареждане на P2P адреси...</translation>
     </message>
     <message>
-        <source>Print this help message and exit</source>
-        <translation>Отпечатай това помощно съобщение и излез</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Намаляване -maxconnections от %d до %d, поради ограниченията на системата.</translation>
-    </message>
-    <message>
-        <source>Relay and mine data carrier transactions (default: %u)</source>
-        <translation>Смени и изкопай носещите данни транзакции (по подразбиране: %u)</translation>
-    </message>
-    <message>
-        <source>Relay non-P2SH multisig (default: %u)</source>
-        <translation>Смяна на не-P2SH многоподписани (по подразбиране: %u)</translation>
     </message>
     <message>
         <source>Replaying blocks...</source>
@@ -5107,14 +4733,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Повторно сканиране...</translation>
     </message>
     <message>
-        <source>Run in the background as a daemon and accept commands</source>
-        <translation>Стартира във фонов режим като демон и приема команди</translation>
-    </message>
-    <message>
-        <source>Send trace/debug info to console instead of debug.log file</source>
-        <translation>Изпрати информацията за грешки към конзолата, вместо файла debug.log</translation>
-    </message>
-    <message>
         <source>Session not complete!</source>
         <translation>Незавършена сесия!</translation>
     </message>
@@ -5123,48 +4741,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Сесията е изтекла.</translation>
     </message>
     <message>
-        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
-        <translation>Определи размера на кеша на базата от данни в мегабайти (%d до %d, по подразбиране: %d)</translation>
-    </message>
-    <message>
-        <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>Определи максималния размер на блока в байтове (по подразбиране: %d)</translation>
-    </message>
-    <message>
-        <source>Show all debugging options (usage: --help -help-debug)</source>
-        <translation>Покажи всички опции за откриване на грешки  (синтаксис: --help -help-debug)</translation>
-    </message>
-    <message>
-        <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
-        <translation>Свий debug.log файла при стартиране на клиента (по подразбиране: 1, когато няма -debug)</translation>
-    </message>
-    <message>
         <source>Signing transaction failed</source>
         <translation>Подписването на транзакцията се провали</translation>
     </message>
     <message>
-        <source>Specify data directory</source>
-        <translation>Определете директория за данните</translation>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation>Посочената директория за блоковете "%s" не съществува.</translation>
     </message>
     <message>
-        <source>Specify wallet file (within data directory)</source>
-        <translation>Посочете файла с портфейла (в папката с данни)</translation>
+        <source>Last queue was created too recently.</source>
+        <translation>Последната опашка беше твърде скоро.</translation>
     </message>
     <message>
-        <source>Specify your own public address</source>
-        <translation>Въведете Ваш публичен адрес</translation>
-    </message>
-    <message>
-        <source>Start PrivateSend automatically (0-1, default: %u)</source>
-        <translation>Стартирайте PrivateSend автоматично (0-1, по подразбиране: %u)</translation>
+        <source>Last successful action was too recent.</source>
+        <translation>Последното успешно действие беше твърде скоро.</translation>
     </message>
     <message>
         <source>Starting network threads...</source>
         <translation>Стартиране на мрежовите нишки...</translation>
-    </message>
-    <message>
-        <source>Synchronization pending...</source>
-        <translation>Изчаква синхронизация ...</translation>
     </message>
     <message>
         <source>Synchronizing governance objects...</source>
@@ -5191,10 +4785,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Транзакцията създадена успешно.</translation>
     </message>
     <message>
-        <source>Transaction fee and change calculation failed</source>
-        <translation>Таксата за транзакциите и изчислението за ресто не бяха успешни</translation>
-    </message>
-    <message>
         <source>Transaction fees are too high.</source>
         <translation>Таксите за транзакция са твърде високи.</translation>
     </message>
@@ -5209,6 +4799,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Unable to bind to %s on this computer (bind returned error %s)</source>
         <translation>Не може да се свърже с %s на този компютър (връща грешка %s)</translation>
+    </message>
+    <message>
+        <source>Unable to locate enough mixed funds for this transaction.</source>
+        <translation>Не са намерени достатъчно смесени средства за тази транзакция.</translation>
+    </message>
+    <message>
+        <source>Unable to locate enough non-denominated funds for this transaction.</source>
+        <translation>Не са намерени достатъчно  неденоминирани средства за тази транзакция.</translation>
     </message>
     <message>
         <source>Unable to sign spork message, wrong key?</source>
@@ -5227,10 +4825,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Неподдържана категория на журналиране %s=%s.</translation>
     </message>
     <message>
-        <source>Username for JSON-RPC connections</source>
-        <translation>Потребителско име за JSON-RPC връзките</translation>
-    </message>
-    <message>
         <source>Verifying blocks...</source>
         <translation>Проверка на блоковете...</translation>
     </message>
@@ -5239,24 +4833,32 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Много малък останали ключове: %d</translation>
     </message>
     <message>
-        <source>Wallet %s resides outside data directory %s</source>
-        <translation>Портфейла %s е разположен извън папката с данни %s</translation>
-    </message>
-    <message>
         <source>Wallet is locked.</source>
         <translation>Портфейлът е заключен.</translation>
     </message>
     <message>
-        <source>Wallet options:</source>
-        <translation>Настройки на портфейла:</translation>
-    </message>
-    <message>
-        <source>Wallet window title</source>
-        <translation>Заглавие на wallet прозореца</translation>
-    </message>
-    <message>
         <source>Warning</source>
         <translation>Предупреждение</translation>
+    </message>
+    <message>
+        <source>Warning: %s is deprecated, please use %s instead</source>
+        <translation>Внимение: %s е неизползваемо, моля използвайте %s instead</translation>
+    </message>
+    <message>
+        <source>Warning: can't use %s and %s together, will prefer %s</source>
+        <translation>Внимение: не може да се използва %s и %s заедно, за предпочитане %s</translation>
+    </message>
+    <message>
+        <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
+        <translation>Внимание: некоректен параметър %s, пътят трябва да съществува! Използвайте път по подразбиране.</translation>
+    </message>
+    <message>
+        <source>You are starting with governance validation disabled.</source>
+        <translation>Започвате с деактивирана проверка на управлението.</translation>
+    </message>
+    <message>
+        <source>You can not disable governance validation on a masternode.</source>
+        <translation>Не можете да деактивирате валидирането на управлението на masternode.</translation>
     </message>
     <message>
         <source>Your entries added successfully.</source>

--- a/src/qt/locale/dash_de.ts
+++ b/src/qt/locale/dash_de.ts
@@ -247,10 +247,6 @@
         <translation>Wallet verschlüsselt</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 wird jetzt beendet, um den Verschlüsselungsprozess abzuschließen. Bitte beachten Sie, dass die Wallet-Verschlüsselung nicht vollständig vor Diebstahl ihrer Dash durch Schadsoftware schützt, die ihren Computer befällt. </translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>WICHTIG: Alle vorherigen Wallet-Sicherungen sollten durch die neu erzeugte, verschlüsselte Wallet ersetzt werden. Vorherige Backups der unverschlüsselten Wallet beinhalten den gleichen HD-Seed, weswegen sie weiterhin auf das Guthaben der verschlüsselten Wallet zugreifen können. </translation>
     </message>
@@ -1388,7 +1384,7 @@
     </message>
     <message>
         <source>Enable &amp;multi-session</source>
-        <translation>&amp;multisession aktivieren</translation>
+        <translation>&amp;Multisession aktivieren</translation>
     </message>
     <message>
         <source>Mixing rounds</source>

--- a/src/qt/locale/dash_es.ts
+++ b/src/qt/locale/dash_es.ts
@@ -247,10 +247,6 @@
         <translation>Billetera cifrado</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 se cerrará al finalizar el proceso de encriptación. Recuerda que el cifrado de tu billetera no protege totalmente tus fondos de ser robados por infección de malware en tu computador.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>IMPORTANTE: Todas las copias de seguridad anteriores que haya realizado de su archivo de la billetera se deben reemplazar con el archivo de la billetera cifrado recién generado. Las copias de seguridad anteriores del archivo de la billetera sin cifrar contienen la misma semilla HD y aun contienen el acceso completo a todos tus fondos al igual que la nueva billetera cifrada.</translation>
     </message>
@@ -394,6 +390,10 @@
     <message>
         <source>&amp;About %1</source>
         <translation>&amp;Acerca de %1</translation>
+    </message>
+    <message>
+        <source>Send %1 funds to a Dash address</source>
+        <translation>Enviar %1 de los fondos a una dirección de Dash</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
@@ -807,6 +807,10 @@
         <translation>Recibido con la dirección</translation>
     </message>
     <message>
+        <source>Mixing Rounds</source>
+        <translation>Rondas de mezcla</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
@@ -897,6 +901,22 @@
     <message>
         <source>Some coins were unselected because they do not have enough mixing rounds.</source>
         <translation>Algunas monedas no se seleccionaron porque no tienen suficientes rondas de mezcla.</translation>
+    </message>
+    <message>
+        <source>Show all coins</source>
+        <translation>Mostrar todas las monedas</translation>
+    </message>
+    <message>
+        <source>Hide %1 coins</source>
+        <translation>Esconder %1 de las monedas</translation>
+    </message>
+    <message>
+        <source>Show all %1 coins</source>
+        <translation>Mostrar todas las monedas de %1</translation>
+    </message>
+    <message>
+        <source>Show spendable coins only</source>
+        <translation>Mostrar solo monedas gastables</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1331,6 +1351,10 @@
         <translation>Si desactiva el gasto del cambio sin confirmar, el cambio de una transacción&lt;br/&gt;no se podrá usar hasta que dicha transacción tenga al menos una confirmación.&lt;br/&gt; Esto también afecta al cómputo de su saldo.</translation>
     </message>
     <message>
+        <source>Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</source>
+        <translation>Mostrar la interfaz de mezcla en la pantalla de descripción general y revelar una pantalla adicional que permita gastar solo monedas completamente mezcladas.&lt;br/&gt;También aparecerá una nueva pestaña con más configuraciones en este cuadro de diálogo, asegúrate de verificarlas antes de mezclar tus monedas.</translation>
+    </message>
+    <message>
         <source>Show additional information and buttons on overview screen.</source>
         <translation>Mostrar información y botones adicionales en la pantalla de resumen.</translation>
     </message>
@@ -1343,12 +1367,32 @@
         <translation>Mostrar ventanas emergentes del sistema para transacciones de mezcla&lt;br/&gt;así como para cualquier otro tipo de transacciones.</translation>
     </message>
     <message>
+        <source>Show popups for mixing transactions</source>
+        <translation>Mostrar ventanas emergentes para mezclar transacciones</translation>
+    </message>
+    <message>
+        <source>Show warning dialog when the wallet has very low number of keys left.</source>
+        <translation>Mostrar un cuadro de diálogo de advertencia cuando a la billetera le queden pocas llaves disponibles.</translation>
+    </message>
+    <message>
+        <source>Warn if the wallet is running out of keys</source>
+        <translation>Advertir si la billetera se está quedando sin llaves</translation>
+    </message>
+    <message>
         <source>Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
         <translation>Ya sea para usar el modo experimental con múltiples sesiones de mezclado por bloque.&lt;br/&gt;Nota: debe usar esta función con cuidado.&lt;br/&gt;¡Asegúrese de tener siempre una copia de seguridad (automática) de la billetera en un lugar seguro!</translation>
     </message>
     <message>
         <source>Enable &amp;multi-session</source>
         <translation>Habilitar &amp;multisesión</translation>
+    </message>
+    <message>
+        <source>Mixing rounds</source>
+        <translation>Rondas de mezcla</translation>
+    </message>
+    <message>
+        <source>This amount acts as a threshold to turn off mixing once it's reached.</source>
+        <translation>Esta cantidad actúa como un límite mínimo para apagar la mezcla una vez que se alcance.</translation>
     </message>
     <message>
         <source>Target balance</source>
@@ -1740,6 +1784,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>El monedero está bloqueado y el usuario rechazó desbloquearlo. Desactivando %1.</translation>
     </message>
     <message>
+        <source>Stop %1</source>
+        <translation>Parada de %1</translation>
+    </message>
+    <message>
         <source>Disabled</source>
         <translation>Desactivado</translation>
     </message>
@@ -1793,6 +1841,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>URI handling</source>
         <translation>Gestión de URI</translation>
+    </message>
+    <message>
+        <source>'dash://' is not a valid URI. Use 'dash:' instead.</source>
+        <translation>'dash://' no es un URI válido. Usa 'dash:'.</translation>
     </message>
     <message>
         <source>Payment request fetch URL is invalid: %1</source>
@@ -2288,6 +2340,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Reexplorar la cadena de bloques 2</translation>
     </message>
     <message>
+        <source>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</source>
+        <translation>-rescan=1: Vuelve a escanear la cadena de bloques en busca de transacciones de billetera faltantes a partir del momento de creación de la billetera.</translation>
+    </message>
+    <message>
+        <source>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</source>
+        <translation>-rescan=2: Vuelve a escanear la cadena de bloques en busca de transacciones de billetera faltantes a partir del bloque génesis.</translation>
+    </message>
+    <message>
         <source>Wallet Path</source>
         <translation>Ruta de la billetera</translation>
     </message>
@@ -2326,6 +2386,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Reset</source>
         <translation>&amp;Reiniciar</translation>
+    </message>
+    <message>
+        <source>Node Type</source>
+        <translation>Tipo de nodo</translation>
     </message>
     <message>
         <source>PoSe Score</source>
@@ -2524,8 +2588,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>No</translation>
     </message>
     <message>
+        <source>Regular</source>
+        <translation>Regular</translation>
+    </message>
+    <message>
         <source>Masternode</source>
         <translation>Masternode</translation>
+    </message>
+    <message>
+        <source>Verified Masternode</source>
+        <translation>Masternodo verificado</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2914,6 +2986,14 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&lt;b&gt;(%1 of %2 entries displayed)&lt;/b&gt;</source>
         <translation>&lt;b&gt;(%1 de %2 registros mostrados)&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>S&amp;end mixed funds</source>
+        <translation>Enviar fondos mezclados</translation>
+    </message>
+    <message>
+        <source>Confirm the %1 send action</source>
+        <translation>Confirma la acción de envío %1</translation>
     </message>
     <message>
         <source>%1 funds only</source>
@@ -3333,6 +3413,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1 confirmaciones</translation>
     </message>
     <message>
+        <source>locked via ChainLocks</source>
+        <translation>bloqueado por cerraduras de cadena</translation>
+    </message>
+    <message>
         <source>verified via InstantSend</source>
         <translation>verificado a través de InstantSend</translation>
     </message>
@@ -3527,12 +3611,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>verificado a través de InstantSend</translation>
     </message>
     <message>
+        <source>locked via ChainLocks</source>
+        <translation>bloqueado por cerraduras de cadena</translation>
+    </message>
+    <message>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
         <source>Received from</source>
         <translation>Recibido desde</translation>
+    </message>
+    <message>
+        <source>Received via %1</source>
+        <translation>Recibido por %1</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3545,6 +3637,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Mined</source>
         <translation>Minado</translation>
+    </message>
+    <message>
+        <source>%1 Mixing</source>
+        <translation>Mezclar %1</translation>
     </message>
     <message>
         <source>%1 Collateral Payment</source>
@@ -4109,6 +4205,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>No se pudo encontrar un masternode aleatorio.</translation>
     </message>
     <message>
+        <source>%s can't be lower than %s</source>
+        <translation>%s no puede ser menor que %s</translation>
+    </message>
+    <message>
         <source>%s is idle.</source>
         <translation>%s está parado.</translation>
     </message>
@@ -4541,6 +4641,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>No se puede resolver -%s direccion: '%s'</translation>
     </message>
     <message>
+        <source>Cannot write to data directory '%s'; check permissions.</source>
+        <translation>No se puede escribir en el directorio de datos '%s'; comprobar los permisos.</translation>
+    </message>
+    <message>
         <source>Change index out of range</source>
         <translation>Cambio de indice fuera de rango</translation>
     </message>
@@ -4583,6 +4687,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Failed to start a new mixing queue</source>
         <translation>Error al iniciar una nueva cola de mezclado</translation>
+    </message>
+    <message>
+        <source>Incorrect -rescan mode, falling back to default value</source>
+        <translation>Modo de reescaneo incorrecto, retrocediendo al valor predeterminado</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
@@ -4637,6 +4745,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Falló la firma de la transacción</translation>
     </message>
     <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation>El directorio de bloques especificado "%s" no existe.</translation>
+    </message>
+    <message>
+        <source>Last queue was created too recently.</source>
+        <translation>La última cola se creó muy recientemente.</translation>
+    </message>
+    <message>
         <source>Last successful action was too recent.</source>
         <translation>La última acción exitosa era demasiado reciente.</translation>
     </message>
@@ -4685,6 +4801,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>No es posible enlazar con %s en este computador (enlazado ha dado el error %s)</translation>
     </message>
     <message>
+        <source>Unable to locate enough mixed funds for this transaction.</source>
+        <translation>No se pueden encontrar suficientes fondos mezclados para esta transacción.</translation>
+    </message>
+    <message>
         <source>Unable to locate enough non-denominated funds for this transaction.</source>
         <translation>No se pueden localizar fondos no denominados suficientes para esta transacción.</translation>
     </message>
@@ -4719,6 +4839,18 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning</source>
         <translation>Advertencia</translation>
+    </message>
+    <message>
+        <source>Warning: %s is deprecated, please use %s instead</source>
+        <translation>Advertencia: %s está obsoleto, utiliza %s en su lugar</translation>
+    </message>
+    <message>
+        <source>Warning: can't use %s and %s together, will prefer %s</source>
+        <translation>Advertencia: no se pueden usar %s y %s juntos, se prefiere %s</translation>
+    </message>
+    <message>
+        <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
+        <translation>Advertencia: parámetro %s incorrecto, ¡la ruta debe existir! Usando ruta predeterminada.</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_fr.ts
+++ b/src/qt/locale/dash_fr.ts
@@ -247,10 +247,6 @@
         <translation>Portefeuille chiffré</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 va maintenant être fermé afin de terminer le processus de chiffrage. Pour mémoire, le chiffrage de votre portefeuille ne peut protéger entièrement vos fonds d'être volés par un logiciel malveillant qui serait installé sur votre ordinateur.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>IMPORTANT : il convient que toutes les sauvegardes que vous avez faites précédemment de votre portefeuille soient remplacées par le fichier chiffré nouvellement créé. En effet, ces sauvegardes précédentes (non chiffrées) contiennent la même graine HD et ont un plein accès à tous vos fonds, tout comme le nouveau portefeuille chiffré.</translation>
     </message>

--- a/src/qt/locale/dash_it.ts
+++ b/src/qt/locale/dash_it.ts
@@ -247,10 +247,6 @@
         <translation>Portafoglio cifrato</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 si chiuderà ora per completare il processo di crittografia. Ricorda che il crittaggio del tuo portafoglio non può proteggere completamente i tuoi fondi dal furto tramite malware che infettano il tuo computer</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>IMPORTANTE: tutti i backup precedenti che hai fatto del tuo file del portafoglio devono essere sostituiti con il file del portafoglio appena generato. I backup precedenti del file del portafoglio non crittografato contengono lo stesso seed dell'HD e hanno ancora pieno accesso a tutti i tuoi fondi, proprio come il nuovo portafoglio crittografato.</translation>
     </message>

--- a/src/qt/locale/dash_ja.ts
+++ b/src/qt/locale/dash_ja.ts
@@ -203,10 +203,6 @@
         <translation>ウォレットは暗号化されました</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 は暗号化プロセスを終了するために閉じます。ウォレットの暗号化だけでは充分ではなく、使用しているコンピューターがマルウェアに感染して盗難される可能性があります。 </translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>重要： 過去のウォレットファイルのバックアップは、暗号化された新しいウォレットファイルに取り替える必要があります。暗号化されていないウォレットファイルの過去のバックアップは同じHDウォレットのシードを含むので、新しい暗号化ウォレットと同様にすべての資産にアクセスできます。</translation>
     </message>
@@ -502,14 +498,6 @@
     <message>
         <source>%1 client</source>
         <translation>%1 クライアント</translation>
-    </message>
-    <message>
-        <source>&amp;PrivateSend information</source>
-        <translation>プライベートセンドの情報(&amp;P)</translation>
-    </message>
-    <message>
-        <source>Show the PrivateSend basic information</source>
-        <translation>プライベートセンドの基本的な情報を表示</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -917,46 +905,6 @@
         <source>Command-line options</source>
         <translation>コマンドラインオプション</translation>
     </message>
-    <message>
-        <source>Usage:</source>
-        <translation>使用法：</translation>
-    </message>
-    <message>
-        <source>command-line options</source>
-        <translation>コマンドラインオプション</translation>
-    </message>
-    <message>
-        <source>UI Options:</source>
-        <translation>UIオプション:</translation>
-    </message>
-    <message>
-        <source>Choose data directory on startup (default: %u)</source>
-        <translation>起動時にデータディレクトリを選ぶ (初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Set language, for example "de_DE" (default: system locale)</source>
-        <translation>言語を設定 例： "de_DE" (デフォルト設定： システムの言語)</translation>
-    </message>
-    <message>
-        <source>Start minimized</source>
-        <translation>最小化された状態で起動</translation>
-    </message>
-    <message>
-        <source>Set SSL root certificates for payment request (default: -system-)</source>
-        <translation>送金リクエスト用にSSLルート証明書を設定（初期設定：-system-）</translation>
-    </message>
-    <message>
-        <source>Show splash screen on startup (default: %u)</source>
-        <translation>起動時にスプラッシュ画面を表示 (初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Reset all settings changed in the GUI</source>
-        <translation>GUI で行われた設定の変更を全てリセット</translation>
-    </message>
-    <message>
-        <source>PrivateSend information</source>
-        <translation>プライベートセンドの情報</translation>
-    </message>
     </context>
 <context>
     <name>Intro</name>
@@ -1234,40 +1182,8 @@
         <translation>マスターノードタブを表示する</translation>
     </message>
     <message>
-        <source>Show additional information and buttons for PrivateSend on overview screen.</source>
-        <translation>プライベートセンドの追加の情報とボタンを概要に表示</translation>
-    </message>
-    <message>
-        <source>Enable advanced PrivateSend interface</source>
-        <translation>高度なプライベートセンドのインターフェイスを有効にする</translation>
-    </message>
-    <message>
-        <source>Show warning dialog when PrivateSend detects that wallet has very low number of keys left.</source>
-        <translation>プライベートセンドがウォレットに非常に少ないキーしか残されてないことを検知したとき警告を表示</translation>
-    </message>
-    <message>
-        <source>Warn if PrivateSend is running out of keys</source>
-        <translation>プライベートセンドがキーを使い果たしているとき警告する</translation>
-    </message>
-    <message>
-        <source>Whether to use experimental PrivateSend mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
-        <translation>プライベートセンドモードを１ブロックあたり複数のミキシングセッションで実験的に使用する場合&lt;br/&gt;注意: この機能を十分に注意して使用してください。&lt;br/&gt;常に最新のウォレットバックアップを安全な場所に保管してください。</translation>
-    </message>
-    <message>
-        <source>Enable PrivateSend &amp;multi-session</source>
-        <translation>プライベートセンドとマルチセッションを有効にする(&amp;M)</translation>
-    </message>
-    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</source>
         <translation>もし未確認のチェンジを使用することを無効にする場合&lt;br/&gt;トランザクションから生じたチェンジはそのトランザクションが少なくとも一回コンファメーションがないと使用できません。&lt;br/&gt;これはまたあなたのウォレットの残高の計算にも影響を与えます。</translation>
-    </message>
-    <message>
-        <source>PrivateSend rounds to use</source>
-        <translation>プライベートセンドを利用する際のラウンド回数</translation>
-    </message>
-    <message>
-        <source>This amount acts as a threshold to turn off PrivateSend once it's reached.</source>
-        <translation>この設定は閾値として機能し、この量に達するとプライベートセンドが無効になります。</translation>
     </message>
     <message>
         <source>Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1308,14 +1224,6 @@
     <message>
         <source>Enable coin &amp;control features</source>
         <translation>コインコントロール機能を有効化 (&amp;C)</translation>
-    </message>
-    <message>
-        <source>Show system popups for PrivateSend mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
-        <translation>守秘送金［プライベートセンド］のミキシングトランザクション&lt;br/&gt;を他のすべてのトランザクションタイプと同じようにポップアップ表示します。</translation>
-    </message>
-    <message>
-        <source>Show popups for PrivateSend transactions</source>
-        <translation>守秘送金［プライベートセンド］トランザクションのポップアップを表示する</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
@@ -1523,10 +1431,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>使用可能：</translation>
     </message>
     <message>
-        <source>PrivateSend</source>
-        <translation>プライベートセンド</translation>
-    </message>
-    <message>
         <source>Status:</source>
         <translation>ステータス：</translation>
     </message>
@@ -1563,10 +1467,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ミキシング開始/停止 </translation>
     </message>
     <message>
-        <source>PrivateSend Balance:</source>
-        <translation>プライベートセンド残高:</translation>
-    </message>
-    <message>
         <source>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</source>
         <translation>マスターノードに送った通貨単位&lt;br&gt;ミキシングをするには他のユーザーが正確に同じ通貨単位を送る必要があります。</translation>
     </message>
@@ -1577,14 +1477,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Automatic backups are disabled, no mixing available!</source>
         <translation>自動バックアップが無効でミキシングは利用不可能です！</translation>
-    </message>
-    <message>
-        <source>Start Mixing</source>
-        <translation>ミキシング開始</translation>
-    </message>
-    <message>
-        <source>Stop Mixing</source>
-        <translation>ミキシング停止</translation>
     </message>
     <message>
         <source>No inputs detected</source>
@@ -1649,18 +1541,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
         <translation>警告! キープールの補充に失敗しました。ウォレットをアンロックしてキープールを補充してください</translation>
-    </message>
-    <message>
-        <source>If you don't want to see internal PrivateSend fees/transactions select "Most Common" as Type on the "Transactions" tab.</source>
-        <translation>プライベートセンドのトランザクションや手数料を非表示にしたい場合はトランザクションタブ上で”通常”をタイプとして選択してください。</translation>
-    </message>
-    <message>
-        <source>PrivateSend requires at least %1 to use.</source>
-        <translation>プライベートセンドは最低 %1 使用します。</translation>
-    </message>
-    <message>
-        <source>Wallet is locked and user declined to unlock. Disabling PrivateSend.</source>
-        <translation>ウォレットはロックされ、ユーザーはアンロックを拒否しました。プライベートセンドを無効にします。</translation>
     </message>
 </context>
 <context>
@@ -2135,10 +2015,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ウォレットの救出</translation>
     </message>
     <message>
-        <source>Rescan blockchain files</source>
-        <translation>ブロックチェーンファイルの再スキャン</translation>
-    </message>
-    <message>
         <source>Recover transactions 1</source>
         <translation>トランザクション1のリカバー</translation>
     </message>
@@ -2157,10 +2033,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>-salvagewallet: Attempt to recover private keys from a corrupt wallet.dat.</source>
         <translation>-salvagewallet: 問題のある wallet.dat からプライベートキーをリカバーします</translation>
-    </message>
-    <message>
-        <source>-rescan: Rescan the block chain for missing wallet transactions.</source>
-        <translation>-rescan: 不明なウォレットトランザクションがあるためブロックチェーンを再スキャンします</translation>
     </message>
     <message>
         <source>-zapwallettxes=1: Recover transactions from blockchain (keep meta-data, e.g. account owner).</source>
@@ -3202,10 +3074,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>送信元</translation>
     </message>
     <message>
-        <source>Received via PrivateSend</source>
-        <translation>プライベートセンド経由で受け取り</translation>
-    </message>
-    <message>
         <source>Sent to</source>
         <translation>送金先</translation>
     </message>
@@ -3216,22 +3084,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Mined</source>
         <translation>発掘済</translation>
-    </message>
-    <message>
-        <source>PrivateSend Denominate</source>
-        <translation>プライベートセンド：分割開始</translation>
-    </message>
-    <message>
-        <source>PrivateSend Collateral Payment</source>
-        <translation>プライベートセンド：コラテラル支払い</translation>
-    </message>
-    <message>
-        <source>PrivateSend Make Collateral Inputs</source>
-        <translation>プライベートセンド：コラテラル入力</translation>
-    </message>
-    <message>
-        <source>PrivateSend Create Denominations</source>
-        <translation>プライベートセンド：デノミネーション生成</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -3311,22 +3163,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Sent to</source>
         <translation>送金先</translation>
-    </message>
-    <message>
-        <source>PrivateSend Make Collateral Inputs</source>
-        <translation>プライベートセンド：コラテラル入力</translation>
-    </message>
-    <message>
-        <source>PrivateSend Create Denominations</source>
-        <translation>プライベートセンド：デノミネーション作成</translation>
-    </message>
-    <message>
-        <source>PrivateSend Denominate</source>
-        <translation>プライベートセンド：分割開始</translation>
-    </message>
-    <message>
-        <source>PrivateSend Collateral Payment</source>
-        <translation>プライベートセンド：コラテラル支払い</translation>
     </message>
     <message>
         <source>To yourself</source>
@@ -3508,36 +3344,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>ウォレットデータは正常に%1に保存されました</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>dash-core</name>
     <message>
-        <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>指定のアドレスへバインドし、その上で常にリッスンします。IPv6 は [host]:port 番号と表記します</translation>
-    </message>
-    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation>エラー： 受信中の接続をリッスンするのに失敗しました (エラー %s )</translation>
-    </message>
-    <message>
-        <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation>関連のアラートを受け取るか非常に長いのフォークを確認した場合コマンドを実行 (コマンド中の%sはメッセージに置換される)</translation>
-    </message>
-    <message>
-        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>ウォレットのトランザクションを変更する際にコマンドを実行 (cmd の %s は TxID に置換される)</translation>
-    </message>
-    <message>
-        <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>最良のブロックが変更する際にコマンドを実行 (cmd の %s はブロックハッシュに置換される)</translation>
-    </message>
-    <message>
-        <source>Name to construct url for KeePass entry that stores the wallet passphrase</source>
-        <translation>ウォレットのパスフレーズを保管するKeePass入力のurlを作成</translation>
-    </message>
-    <message>
-        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
-        <translation>スクリプト検証スレッドを設定 (%uから%dの間, 0 = 自動, &lt;0 = たくさんのコアを自由にしておく, 初期設定： %d)</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
@@ -3552,20 +3364,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>警告： ピアと完全に同意しないようです！あなたはアップグレードする必要があるかもしれません。または他のノードがアップグレードする必要があるかもしれません。</translation>
     </message>
     <message>
-        <source>Accept command line and JSON-RPC commands</source>
-        <translation>コマンドラインと JSON-RPC コマンドを許可</translation>
-    </message>
-    <message>
-        <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
-        <translation>-addnode, -seednode と -connect で DNS ルックアップを許可</translation>
-    </message>
-    <message>
         <source>Already have that input.</source>
         <translation>常時そのインプットを保持</translation>
-    </message>
-    <message>
-        <source>Block creation options:</source>
-        <translation>ブロック作成オプション：</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet</source>
@@ -3576,20 +3376,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>コラテラルが無効です</translation>
     </message>
     <message>
-        <source>Connection options:</source>
-        <translation>接続オプション：</translation>
-    </message>
-    <message>
         <source>Corrupted block database detected</source>
         <translation>破損したブロックデータベースが検知されました</translation>
-    </message>
-    <message>
-        <source>Debugging/Testing options:</source>
-        <translation>デバッグ／テスト用オプション：</translation>
-    </message>
-    <message>
-        <source>Do not load the wallet and disable wallet RPC calls</source>
-        <translation>ウォレットは読み込まず、ウォレットRPCコールを無効化する</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
@@ -3636,128 +3424,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ポートのリッスンに失敗しました。必要であれば -listen=0 を使用してください。</translation>
     </message>
     <message>
-        <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
-        <translation>(1 = トランザクションのメタデータ、例えばアカウントの所有者や支払いリクエストの内容を保持する, 2 = トランザクションのメタデータを破棄する)</translation>
-    </message>
-    <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation>-maxtxfee が非常に高く設定されています！ひとつのトランザクションでこの量の手数料が支払われてしまうことがあります。</translation>
-    </message>
-    <message>
-        <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>
-        <translation>十分なデータが蓄積されていない場合に手数料推定機能が利用する手数料レート (%s/kB) (初期設定: %s)</translation>
-    </message>
-    <message>
-        <source>Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)</source>
-        <translation>トランザクションの中継を行っていない場合でも、ホワイトリストのピアから受け取った中継トランザクションは受け取るようにする (初期設定: %d)</translation>
-    </message>
-    <message>
-        <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
-        <translation>指定したアクセス元からのJSON-RPC接続を許可する。有効な&lt;ip&gt;は、単一のIP (例　1.2.3.4)、ネットワーク/ネットマスク (例　1.2.3.4/255.255.255.0)、またはネットワーク/CIDR (例　1.2.3.4/24)です。このオプションは複数回指定できます。</translation>
-    </message>
-    <message>
-        <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
-        <translation>指定されたアドレスおよび、そこに接続を行ってきたホワイトリストのピアに対してバインドを行います。IPv6の場合には [host]:port 表記を使用してください</translation>
-    </message>
-    <message>
-        <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
-        <translation>umask 077 ではなく、システムのデフォルトパーミッションで新規ファイルを作成する (ウォレット機能が無効化されていた場合にのみ有効)</translation>
-    </message>
-    <message>
-        <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
-        <translation>ウォレットの全トランザクションを削除し、これらを-rescanオプションを用いることで起動時にブロックチェインのデータのみからリカバリします。</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transactions of attempted InstantSend double spend in &lt;address&gt;</source>
-        <translation>試行中のインスタントセンド二重支払い &lt;address&gt; の未確定トランザクションの生成を有効にする</translation>
-    </message>
-    <message>
-        <source>Enable publish transaction hashes of attempted InstantSend double spend in &lt;address&gt;</source>
-        <translation>&lt;address&gt;で試行されたインスタントセンド二重支払いのトランザクションハッシュの生成を有効にする</translation>
     </message>
     <message>
         <source>Found unconfirmed denominated outputs, will wait till they confirm to continue.</source>
         <translation>未確認の分割されたアウトプットを検出しました。継続を確認するまで待機します。</translation>
     </message>
     <message>
-        <source>How thorough the block verification of -checkblocks is (0-4, default: %u)</source>
-        <translation>-checkblocks のブロックの検証レベル (0-4, 初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</source>
-        <translation>paytxfee が設定されていなかった場合、平均して n ブロック以内にトランザクションが検証され始めるのに十分な手数料を含める (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)</source>
-        <translation>このブロックがブロックチェーン内に含まれていた場合には、このブロックおよびそれ以前のすべてのブロックを有効であるとみなし、スクリプトの検証を省略する (0ならすべてを検証、初期設定: %s、テストネット: %s)</translation>
-    </message>
-    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation>-maxtxfee=&lt;amount&gt; の数量の指定が無効です: '%s' (トランザクションが詰まってしまうのを防ぐため、少なくとも %s の最小中継手数料を指定しなければいけません)</translation>
     </message>
     <message>
-        <source>Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</source>
-        <translation>getrawtransaction rpc 呼び出し時に用いる、完全なトランザクションインデックスを保持する (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
-        <translation>中継およびマイニングを行う際の、データ運送トランザクションの中のデータの最大サイズ (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Number of seconds to keep misbehaving peers from reconnecting (default: %u)</source>
-        <translation>不正なピアを再接続するまでの秒数 (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Output debugging information (default: %u, supplying &lt;category&gt; is optional)</source>
-        <translation>デバッグ情報を出力する (初期設定： %u, &lt;category&gt; の指定は任意です)</translation>
-    </message>
-    <message>
-        <source>Overrides minimum spork signers to change spork value. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.</source>
-        <translation>スポーク値を変更するために最小のスポーク署名者を無視します。 regtestとdevnetでのみ使用可能です。これをmainnetやtestnetで使うとあなたは追放されます。</translation>
-    </message>
-    <message>
-        <source>Use N separate masternodes in parallel to mix funds (%u-%u, default: %u)</source>
-        <translation>資金を混合するためにN個の別々のマスターノードを並行して使用する (%u-%u, default: %u)</translation>
-    </message>
-    <message>
-        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
-        <translation>Tor 秘匿サービスを経由して別々の SOCKS5 プロキシを用いることでピアに到達する (初期設定： %s)</translation>
-    </message>
-    <message>
-        <source>User defined mnemonic for HD wallet (bip39). Only has effect during wallet creation/first start (default: randomly generated)</source>
-        <translation>HDウォレット用のユーザー定義ニーモニック。ウォレット生成時にしか有効でない（初期設定：ランダムに生成）</translation>
-    </message>
-    <message>
-        <source>User defined seed for HD wallet (should be in hex). Only has effect during wallet creation/first start (default: randomly generated)</source>
-        <translation>HDウォレット用のユーザー定義シード。ウォレット生成時にしか有効でない（初期設定：ランダムに生成）</translation>
-    </message>
-    <message>
-        <source>Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>
-        <translation>ホワイトリストのピアはDoSによるアクセス禁止処理が無効化され、トランザクションは例えmempool内に既に存在していたとしても常にリレーされます。これは例えばゲートウェイに対して有用です</translation>
-    </message>
-    <message>
-        <source>Accept public REST requests (default: %u)</source>
-        <translation>公開 REST リクエストを許可する (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Always query for peer addresses via DNS lookup (default: %u)</source>
-        <translation>DNS ルックアップを通してピアアドレスを常に問い合わせる (初期設定： %u)</translation>
-    </message>
-    <message>
         <source>Can't mix: no compatible inputs found!</source>
         <translation>ミキシング不可: 互換性のあるインプットが見つかりません</translation>
-    </message>
-    <message>
-        <source>Chain selection options:</source>
-        <translation>チェーン選択オプション:</translation>
-    </message>
-    <message>
-        <source>Connect through SOCKS5 proxy</source>
-        <translation>SOCKS5 プロキシ経由で接続</translation>
-    </message>
-    <message>
-        <source>Connect to KeePassHttp on port &lt;port&gt; (default: %u)</source>
-        <translation>Connect to KeePassHttp に接続：ポート &lt;port&gt; (初期設定: %u)</translation>
     </message>
     <message>
         <source>Entry exceeds maximum size.</source>
@@ -3784,16 +3464,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>充分なユーザーを発見しました、サインしています </translation>
     </message>
     <message>
-        <source>How many blocks to check at startup (default: %u, 0 = all)</source>
-        <translation>起動時に点検するブロック数 (初期設定： %u, 0=すべて)</translation>
-    </message>
-    <message>
         <source>Importing...</source>
         <translation>インポートしています…</translation>
-    </message>
-    <message>
-        <source>Include IP addresses in debug output (default: %u)</source>
-        <translation>デバッグ出力にIPアドレスを含める (初期設定： %u)</translation>
     </message>
     <message>
         <source>Incompatible mode.</source>
@@ -3836,14 +3508,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>キープールが枯渇しました。まずはじめに keypoolrefill を呼び出してください。</translation>
     </message>
     <message>
-        <source>Listen for JSON-RPC connections on &lt;port&gt; (default: %u or testnet: %u)</source>
-        <translation>&lt;port&gt; で JSON-RPC 接続をリッスン (初期設定： %u、テストネット： %u)</translation>
-    </message>
-    <message>
-        <source>Listen for connections on &lt;port&gt; (default: %u or testnet: %u)</source>
-        <translation>接続のリッスンを &lt;port&gt; で行う (初期設定： %u、テストネット: %u)</translation>
-    </message>
-    <message>
         <source>Loading banlist...</source>
         <translation>banリストを読み込んでいます...</translation>
     </message>
@@ -3860,20 +3524,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>すでにロックされています</translation>
     </message>
     <message>
-        <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
-        <translation>接続毎の最大受信バッファ &lt;n&gt;*1000 バイト (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
-        <translation>接続毎の最大送信バッファ &lt;n&gt;*1000 バイト (初期設定： %u)</translation>
-    </message>
-    <message>
         <source>Mixing in progress...</source>
         <translation>ミキシング中...</translation>
-    </message>
-    <message>
-        <source>Mnemonic passphrase is too long, must be at most 256 characters</source>
-        <translation>ニーモニックパスフレーズが長すぎます。最長で256文字です。</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -3892,56 +3544,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>マスターノードリストにありません</translation>
     </message>
     <message>
-        <source>Prepend debug output with timestamp (default: %u)</source>
-        <translation>デバッグ出力にタイムスタンプを付ける (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Rebuild chain state and block index from the blk*.dat files on disk</source>
-        <translation>チェーン状態およびブロックインデックスをディスク上の blk*.dat ファイルから再構築する</translation>
-    </message>
-    <message>
-        <source>Rebuild chain state from the currently indexed blocks</source>
-        <translation>既にインデックスされたブロックからチェイン状態を再構築する</translation>
-    </message>
-    <message>
-        <source>Send trace/debug info to debug.log file (default: %u)</source>
-        <translation>トレース/デバッグ情報を debug.logファイルに送信 (初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Set key pool size to &lt;n&gt; (default: %u)</source>
-        <translation>key pool のサイズを &lt;n&gt; (初期設定： %u) にセット</translation>
-    </message>
-    <message>
-        <source>Set the number of threads to service RPC calls (default: %d)</source>
-        <translation>RPC 呼び出しのスレッド数を設定 (初期設定： %d)</translation>
-    </message>
-    <message>
-        <source>Specify connection timeout in milliseconds (minimum: 1, default: %d)</source>
-        <translation>接続のタイムアウトをミリ秒単位で指定 (最小値： 1, 初期設定：: %d)</translation>
-    </message>
-    <message>
-        <source>Spend unconfirmed change when sending transactions (default: %u)</source>
-        <translation>トランザクション送信時に未検証のチェンジを使用する (初期設定： %u)</translation>
-    </message>
-    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>マスターノードにサブミット、待機中 %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>同期完了</translation>
-    </message>
-    <message>
-        <source>Threshold for disconnecting misbehaving peers (default: %u)</source>
-        <translation>不正なピアを切断するためのしきい値 (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Tor control port password (default: empty)</source>
-        <translation>Tor管理ポートのパスワード (初期値: 空文字)</translation>
-    </message>
-    <message>
-        <source>Tor control port to use if onion listening enabled (default: %s)</source>
-        <translation>Onion のリッスンが有効になっている場合に使用するTor管理ポート (初期値: %s)</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -3962,22 +3570,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Unsupported argument -tor found, use -onion.</source>
         <translation>サポートされていない引数 -tor が見つかりました。-onion を使用してください。</translation>
-    </message>
-    <message>
-        <source>Upgrade wallet to latest format on startup</source>
-        <translation>起動時にウォレットを最新のフォーマットにアップグレード</translation>
-    </message>
-    <message>
-        <source>Use KeePass 2 integration using KeePassHttp plugin (default: %u)</source>
-        <translation>KeePassHttp プラグインを使用してKeePass 2 インテグレーションを使用 (初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Use UPnP to map the listening port (default: %u)</source>
-        <translation>リッスンポートの割当に UPnP を使用 (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Use the test chain</source>
-        <translation>テストチェーンを使用</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -4008,68 +3600,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>無効なスクリプトが検出されました</translation>
     </message>
     <message>
-        <source>KeePassHttp id for the established association</source>
-        <translation>確立された接続用のKeePassHttp ID </translation>
-    </message>
-    <message>
-        <source>KeePassHttp key for AES encrypted communication with KeePass</source>
-        <translation>KeePassとの AES 暗号化接続用のKeePassHttp キー </translation>
-    </message>
-    <message>
         <source>%s file contains all private keys from this wallet. Do not share it with anyone!</source>
         <translation>%s ファイルはこのウォレットのプライベートキーをすべて保有しています。誰ともシェアしないでください。</translation>
     </message>
     <message>
-        <source>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</source>
-        <translation>自分のIPアドレスを解決する (初期値: リッスンをしており、-externalipまたは-proxyオプションが指定されていない場合は1)</translation>
-    </message>
-    <message>
-        <source>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</source>
-        <translation>mempool内でトランザクションを &lt;n&gt; 時間以上保持しない (初期値: %u)</translation>
-    </message>
-    <message>
-        <source>Enable multiple PrivateSend mixing sessions per block, experimental (0-1, default: %u)</source>
-        <translation>ブロック毎に複数のミキシングセッションを有効化する、実験的 (0-1, 初期値: %u)</translation>
-    </message>
-    <message>
-        <source>Execute command when a wallet InstantSend transaction is successfully locked (%s in cmd is replaced by TxID)</source>
-        <translation>インスタントセンドのトランザクションのロックに成功したとき、コマンドを実行 (コマンドの%sは TxIDに置換)</translation>
-    </message>
-    <message>
-        <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
-        <translation>コンパクトなブロック再構築のために追加のトランザクションをメモリーに保管 (初期設定: %u)</translation>
-    </message>
-    <message>
         <source>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
         <translation>バックアップ作成失敗、ファイルは既に存在します！これはウォレットを60秒以内にリスタートしたときに発生することがあります。これで問題なければ先に進むことができます。</translation>
-    </message>
-    <message>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
-        <translation>トランザクションの中継、採掘および作成の際には、この値未満の手数料 (%s/kB単位) はゼロであるとみなす (初期設定: %s)</translation>
-    </message>
-    <message>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</source>
-        <translation>トランザクション作成の際、この値未満の手数料 (%s/kB単位) はゼロであるとみなす (デフォルト: %s)</translation>
-    </message>
-    <message>
-        <source>If &lt;category&gt; is not supplied or if &lt;category&gt; = 1, output all debugging information.</source>
-        <translation>&lt;category&gt; が与えられなかった場合や &lt;category&gt; = 1 の場合には、すべてのデバッグ情報が出力されます。</translation>
-    </message>
-    <message>
-        <source>Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)</source>
-        <translation>残高、txids、未使用のアウトプットへの問い合わせに使用される、フルアドレスインデックスを保持 (初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain a full spent index, used to query the spending txid and input index for an outpoint (default: %u)</source>
-        <translation>txidとインプットインデックスの問い合わせに使用される、フルスペントインデックス (初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain a timestamp index for block hashes, used to query blocks hashes by a range of timestamps (default: %u)</source>
-        <translation>ブロックハッシュの問い合わせに使用される、ブロックハッシュ用のタイムスタンプインデックスを保持(初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain at most &lt;n&gt; connections to peers (temporary service connections excluded) (default: %u)</source>
-        <translation>最大 &lt;n&gt; 接続を保持 (一時的な接続を除外) (初期設定: %u)</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
@@ -4080,24 +3616,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>剪定: 最後のウォレット同期ポイントは、剪定されたデータよりも過去のものとなっています。-reindexをする必要があります (剪定されたノードの場合、ブロックチェイン全体をダウンロードしてください)</translation>
     </message>
     <message>
-        <source>Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect used)</source>
-        <translation>アドレスが少ない場合、DNSルックアップを介してピアアドレスを照会します（デフォルト：1 -connectを使用しない限り）</translation>
-    </message>
-    <message>
-        <source>Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)</source>
-        <translation>認証情報をプロキシー接続ごとにランダム化する。これによりTorストリーム分離をすることができます (初期設定: %u)</translation>
-    </message>
-    <message>
         <source>Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.</source>
         <translation>剪定モードでは再スキャンを行うことはできません。-reindexを使用し、ブロックチェーン全体を再ダウンロードする必要があります。</translation>
-    </message>
-    <message>
-        <source>Specify full path to directory for automatic wallet backups (must exist)</source>
-        <translation>自動ウォレットバックアップ用のディレクトリへのフルパスを指定してください</translation>
-    </message>
-    <message>
-        <source>Support filtering of blocks and transaction with bloom filters (default: %u)</source>
-        <translation>Bloomフィルタによる、ブロックおよびトランザクションのフィルタリングをサポート (初期値: %u)</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -4112,24 +3632,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ネットワークバージョン文字 (%i) の長さが最大の長さ (%i) を超えています。UAコメントの数や長さを削減してください。</translation>
     </message>
     <message>
-        <source>Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)</source>
-        <translation>送信転送量を与えられた目標値以下に維持するようにする (24時間あたり何MiBかで指定)。0 の場合は無制限 (初期値: %d)</translation>
-    </message>
-    <message>
-        <source>Unable to locate enough PrivateSend denominated funds for this transaction.</source>
-        <translation>このトランザクションのためのプライベートセンド用の分割された充分なファンドが見つかりません。</translation>
-    </message>
-    <message>
         <source>Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported.</source>
         <translation>サポートされていない引数 -socks が見つかりました。SOCKSバージョンの設定はできないようになりました。SOCKS5プロキシのみがサポートされています。</translation>
     </message>
     <message>
         <source>Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay.</source>
         <translation>サポートされていない引数 -whitelistalwaysrelay は無視されました。-whitelistrelay または -whitelistforcerelay を利用してください</translation>
-    </message>
-    <message>
-        <source>Use UPnP to map the listening port (default: 1 when listening and no -proxy)</source>
-        <translation>リッスン ポートの割当に UPnP を使用 (初期値: リッスン中および-proxy が指定されていない場合は1)</translation>
     </message>
     <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
@@ -4148,64 +3656,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>非剪定モードに戻るためには-reindexオプションを使用してデータベースを再構築する必要があります。これによりブロックチェーン全体の再ダウンロードが行われます。</translation>
     </message>
     <message>
-        <source>(default: %u)</source>
-        <translation>(初期値: %u)</translation>
-    </message>
-    <message>
         <source>-maxmempool must be at least %d MB</source>
         <translation>-maxmempoolは最低でも %d MB必要です</translation>
-    </message>
-    <message>
-        <source>&lt;category&gt; can be:</source>
-        <translation>&lt;category&gt;は以下の値を指定できます：</translation>
-    </message>
-    <message>
-        <source>Append comment to the user agent string</source>
-        <translation>ユーザエージェント文字列にコメントを追加</translation>
     </message>
     <message>
         <source>Automatic backups disabled</source>
         <translation>自動バックアップ無効</translation>
     </message>
     <message>
-        <source>Automatically create Tor hidden service (default: %d)</source>
-        <translation>Tor秘匿サービスを自動的に作成する (初期値: %d)</translation>
-    </message>
-    <message>
         <source>ERROR! Failed to create automatic backup</source>
         <translation>エラー! 自動バックアップ作成失敗</translation>
-    </message>
-    <message>
-        <source>Enable publish hash block in &lt;address&gt;</source>
-        <translation>&lt;address&gt;に対し、ハッシュブロックの公開を有効にする</translation>
-    </message>
-    <message>
-        <source>Enable publish hash of governance objects (like proposals) in &lt;address&gt;</source>
-        <translation> &lt;address&gt;に対し、ガバナンスオブジェクトのハッシュの公開を有効にする (プロポーザル等)</translation>
-    </message>
-    <message>
-        <source>Enable publish hash of governance votes in &lt;address&gt;</source>
-        <translation> &lt;address&gt;に対し、ガバナンスの投票のハッシュの公開を有効にする</translation>
-    </message>
-    <message>
-        <source>Enable publish hash transaction (locked via InstantSend) in &lt;address&gt;</source>
-        <translation>&lt;address&gt;に対し、ハッシュトランザクションの公開を有効にする (インスタントセンド経由でロック済)</translation>
-    </message>
-    <message>
-        <source>Enable publish hash transaction in &lt;address&gt;</source>
-        <translation>&lt;address&gt; に対し、ハッシュトランザクションの公開を有効にする</translation>
-    </message>
-    <message>
-        <source>Enable publish raw block in &lt;address&gt;</source>
-        <translation>&lt;address&gt; に対し、原ブロックの公開を有効にする</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transaction (locked via InstantSend) in &lt;address&gt;</source>
-        <translation>&lt;address&gt;に対し、原トランザクションの公開を有効にする (インスタントセンド経由でロック済)</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transaction in &lt;address&gt;</source>
-        <translation>&lt;address&gt; に対し、原トランザクションの公開を有効にする</translation>
     </message>
     <message>
         <source>Error: A fatal internal error occurred, see debug.log for details</source>
@@ -4228,36 +3688,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>スポークキャッシュの読み込み失敗：</translation>
     </message>
     <message>
-        <source>Fee (in %s/kB) to add to transactions you send (default: %s)</source>
-        <translation>送信するトランザクションに付加する手数料 (%s/kB単位) (初期値: %s)</translation>
-    </message>
-    <message>
-        <source>Imports blocks from external blk000??.dat file on startup</source>
-        <translation>起動時に外部の blk000??.dat ファイルからブロックをインポート</translation>
-    </message>
-    <message>
-        <source>InstantSend options:</source>
-        <translation>インスタントセンドオプション:</translation>
-    </message>
-    <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
         <translation>無効な額 -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid masternodeblsprivkey. Please see documentation.</source>
         <translation>マスターノードBLS秘密鍵が無効です。ドキュメントをお読み下さい。</translation>
-    </message>
-    <message>
-        <source>Keep the transaction memory pool below &lt;n&gt; megabytes (default: %u)</source>
-        <translation>トランザクションのメモリープールの総量を &lt;n&gt; メガバイト以下に維持する (初期値: %u)</translation>
-    </message>
-    <message>
-        <source>Last PrivateSend was too recent.</source>
-        <translation>最後のプライベートセンドを実行してから充分な時間が経っていません。</translation>
-    </message>
-    <message>
-        <source>Last successful PrivateSend action was too recent.</source>
-        <translation>最後の成功したプライベートセンドを実行してから充分な時間が経っていません。</translation>
     </message>
     <message>
         <source>Loading block index...</source>
@@ -4280,24 +3716,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ウォレットを読み込んでいます…</translation>
     </message>
     <message>
-        <source>Make the wallet broadcast transactions</source>
-        <translation>ウォレットにトランザクションをブロードキャストさせる</translation>
-    </message>
-    <message>
-        <source>Masternode options:</source>
-        <translation>マスターノードオプション:</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>マスターノードキューがいっぱいです</translation>
     </message>
     <message>
         <source>Masternode:</source>
         <translation>マスターノード:</translation>
-    </message>
-    <message>
-        <source>Minimum bytes per sigop in transactions we relay and mine (default: %u)</source>
-        <translation>中継またはマイニングするトランザクションのsigop毎の最小バイト (初期設定: %u)</translation>
     </message>
     <message>
         <source>Missing input transaction information.</source>
@@ -4312,44 +3736,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ミキシング用の分割がマッチしていません。</translation>
     </message>
     <message>
-        <source>Node relay options:</source>
-        <translation>ノード中継オプション：</translation>
-    </message>
-    <message>
         <source>Not compatible with existing transactions.</source>
         <translation>既存のトランザクションと互換性がありません。</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
         <translation>使用可能なファイルディスクリプタが不足しています。</translation>
-    </message>
-    <message>
-        <source>Number of automatic wallet backups (default: %u)</source>
-        <translation>自動ウォレットバックアップの数 (初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Options:</source>
-        <translation>オプション：</translation>
-    </message>
-    <message>
-        <source>Password for JSON-RPC connections</source>
-        <translation>JSON-RPC 接続のパスワード</translation>
-    </message>
-    <message>
-        <source>Print version and exit</source>
-        <translation>バージョンを表示し終了</translation>
-    </message>
-    <message>
-        <source>PrivateSend is idle.</source>
-        <translation>プライベートセンドはアイドル状態です。</translation>
-    </message>
-    <message>
-        <source>PrivateSend options:</source>
-        <translation>プライベートセンドオプション:</translation>
-    </message>
-    <message>
-        <source>PrivateSend request incomplete:</source>
-        <translation>プライベートセンドリクエスト未完了:</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -4362,10 +3754,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Pruning blockstore...</source>
         <translation>ブロックストアを剪定しています…</translation>
-    </message>
-    <message>
-        <source>Rescan the block chain for missing wallet transactions on startup</source>
-        <translation>起動時に失ったウォレットのトランザクションのブロックチェーンを再スキャン</translation>
     </message>
     <message>
         <source>Synchronizing blockchain...</source>
@@ -4412,14 +3800,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>UTXOデータベースを更新しています</translation>
     </message>
     <message>
-        <source>Use devnet chain with provided name</source>
-        <translation>devnet チェーンを与えられた名前とともに使用します。</translation>
-    </message>
-    <message>
-        <source>Wallet debugging/testing options:</source>
-        <translation>ウォレットのデバッグ／テスト用オプション:</translation>
-    </message>
-    <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation>ウォレットが書き直される必要がありました: 完了するために %s を再起動します</translation>
     </message>
@@ -4432,10 +3812,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>ウォレットバックアップフォルダー作成不可 %s!</translation>
     </message>
     <message>
-        <source>Whether to operate in a blocks only mode (default: %u)</source>
-        <translation>ブロック限定モードにおいて動作を行うかどうか (初期値: %u)</translation>
-    </message>
-    <message>
         <source>You can not start a masternode with wallet enabled.</source>
         <translation>ウォレットを有効にした状態でマスターノードを起動することはできません。</translation>
     </message>
@@ -4444,20 +3820,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-txindexを変更するために -reindexを使用してデータベースを再構築する必要があります。</translation>
     </message>
     <message>
-        <source>ZeroMQ notification options:</source>
-        <translation>ZeroMQ通知オプション:</translation>
-    </message>
-    <message>
         <source>no mixing available.</source>
         <translation>ミキシングは利用できません。</translation>
     </message>
     <message>
         <source>see debug.log for details.</source>
         <translation>詳細はdebug.logを参照してください。</translation>
-    </message>
-    <message>
-        <source>RPC server options:</source>
-        <translation>RPCサーバのオプション：</translation>
     </message>
     <message>
         <source>Dash Core</source>
@@ -4476,10 +3844,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>MITソフトウェアライセンスのもとで配布されています。付属のファイル %s または %s を参照してください</translation>
     </message>
     <message>
-        <source>Enable use of PrivateSend for funds stored in this wallet (0-1, default: %u)</source>
-        <translation>このウォレットに保管されている資金に対してプライベートセンドの使用を有効にします(0-1, 初期設定: %u)</translation>
-    </message>
-    <message>
         <source>Error loading %s: You can't enable HD on an already existing non-HD wallet</source>
         <translation>%s読み込みエラー: 既存の非HDウォレット上でHDを有効化できません</translation>
     </message>
@@ -4488,28 +3852,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%s の読み込みエラー! すべてのキーは正しく読み取れますが、トランザクションデータやアドレス帳のエントリが失われたか、正しくない可能性があります。</translation>
     </message>
     <message>
-        <source>Exclude debugging information for a category. Can be used in conjunction with -debug=1 to output debug logs for all categories except one or more specified categories.</source>
-        <translation>カテゴリのデバッグ情報を除外します。 -debug=1 と組み合わせて使用して、1つ以上の指定されたカテゴリを除くすべてのカテゴリのデバッグログを出力できます。</translation>
-    </message>
-    <message>
-        <source>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</source>
-        <translation>ホワイトリストのピアから受け取ったトランザクションに関しては、たとえローカルの中継ポリシーに違反しているとしても中継を行うようにする (初期設定: %d)</translation>
-    </message>
-    <message>
         <source>Incorrect or no devnet genesis block found. Wrong datadir for devnet specified?</source>
         <translation>無効なdevnetジェネシスブロックが発見されたか、またはdevnetジェネシスブロックが発見されません。 特定のdevnet用のデータディレクトリが間違ってませんか?</translation>
-    </message>
-    <message>
-        <source>Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)</source>
-        <translation>時間オフセット調整値のピア中央値に対する最大の許容値。ローカル時間の見込み値は、接続するピアにより前方ないし後方へ影響されます。(初期値: %u 秒)</translation>
-    </message>
-    <message>
-        <source>Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)</source>
-        <translation>ひとつのウォレットトランザクションまたは原トランザクションで使用する合計手数料の最大値 (%s 単位)。低すぎる値を指定すると巨大なトランザクションの作成ができなくなります (初期設定: %s)</translation>
-    </message>
-    <message>
-        <source>Override spork address. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.</source>
-        <translation>スポークアドレスを上書きします。regtest または devnetでのみ有効です。mainnet または testnet で使用した場合Banされます。</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -4518,14 +3862,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
         <translation>%s が有用だと感じられた方はぜひプロジェクトへの貢献をお願いします。ソフトウェアのより詳細な情報については %s をご覧ください。</translation>
-    </message>
-    <message>
-        <source>Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)</source>
-        <translation>ブロック生成時に取り込まれるトランザクションの最低手数料率 (%s/kB 単位)。(初期設定: %s)</translation>
-    </message>
-    <message>
-        <source>The fee rate (in %s/kB) that indicates your tolerance for discarding change by adding it to the fee (default: %s). Note: An output is discarded if it is dust at this rate, but we will always discard up to the dust relay fee and a discard fee above that is limited by the fee estimate for the longest target</source>
-        <translation>お釣りを手数料(default: %s)に追加することによりお釣りを破棄する許容範囲を示す手数料率 (in %s/kB) 。注意：アウトプットがこのレートでダストである場合、アウトプットは破棄されますが、常にダストリレー手数料まで破棄し、それを超える破棄料金は最長ターゲットの手数料見積もりによって制限されます</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -4540,40 +3876,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>この製品はOpenSSLプロジェクトにより開発されたソフトウェアをOpenSSLツールキット %s として利用しています &lt;https://www.openssl.org/&gt;。また、Eric Young氏により開発された暗号ソフトウェア、Thomas Bernard氏により書かれたUPnPソフトウェアを用いています。</translation>
     </message>
     <message>
-        <source>Unable to locate enough PrivateSend non-denominated funds for this transaction.</source>
-        <translation>このトランザクションに対してプライベートセンド用の分割されてない充分なファンドが検出できません。</translation>
-    </message>
-    <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation>ブロックを再生できません。 -reindex-chainstateを使用してデータベースを再構築する必要があります。</translation>
     </message>
     <message>
-        <source>Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)</source>
-        <translation>それぞれの分割されたインプットに対してN 個の別々のマスターノードを使用してファンドをミキシングします。(%u-%u, 初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Use hierarchical deterministic key generation (HD) after BIP39/BIP44. Only has effect during wallet creation/first start</source>
-        <translation>BIP39/BIP44のあとにHDキー生成を使用します。ウォレット作成時にのみ有効です。</translation>
-    </message>
-    <message>
-        <source>User defined mnemonic passphrase for HD wallet (BIP39). Only has effect during wallet creation/first start (default: empty string)</source>
-        <translation>ユーザー定義ニーモニックパスフレーズをHDウォレットに使用します (BIP39)。ウォレット作成時にのみ有効です。(初期設定: 空文字)</translation>
-    </message>
-    <message>
-        <source>Wallet will not create transactions that violate mempool chain limits (default: %u)</source>
-        <translation>ウォレットがmempoolチェーン制限数を超えてトランザクションを作らないようにする (初期値: %u)</translation>
-    </message>
-    <message>
         <source>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>警告: ウォレットファイルが破損していましたのでデータを復旧しました！元の %s は %s として %s に保存されました; 残高やトランザクションが正しくない場合にはバックアップから復元してください。</translation>
-    </message>
-    <message>
-        <source>Whether to save the mempool on shutdown and load on restart (default: %u)</source>
-        <translation>シャットダウン時にメモリプールを保存し、再起動時にロードするかどうか(初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.</source>
-        <translation>ホワイトリストとして登録するピア、接続元の IP アドレス (例: 1.2.3.4) または CIDR 表現のネットワーク (例: 1.2.3.0/24)。複数回指定することも可能。</translation>
     </message>
     <message>
         <source>%d of last 100 blocks have unexpected version</source>
@@ -4604,18 +3912,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-rpcport は、 -devnet と -server が指定されたとき指定しなければなりません。</translation>
     </message>
     <message>
-        <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
-        <translation>外部からの接続を許可（初期設定: 1 no -proxyまたは-connectの場合）</translation>
-    </message>
-    <message>
-        <source>Allow RFC1918 addresses to be relayed and connected to (default: %u)</source>
-        <translation>RFC1918 アドレスが中継され接続されるのを許可 (初期設定: %u)</translation>
-    </message>
-    <message>
-        <source>Attempt to recover private keys from a corrupt wallet on startup</source>
-        <translation>起動時に壊れたウォレットから秘密鍵を復旧することを試す</translation>
-    </message>
-    <message>
         <source>Cannot resolve -%s address: '%s'</source>
         <translation>-%s アドレス '%s' を解決できません</translation>
     </message>
@@ -4626,10 +3922,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Copyright (C)</source>
         <translation>Copyright (C)</translation>
-    </message>
-    <message>
-        <source>Create up to N inputs of each denominated amount (%u-%u, default: %u)</source>
-        <translation>各金種の額 (%u-%u, default: %u)のN個までのインプットを作成</translation>
     </message>
     <message>
         <source>Error loading %s</source>
@@ -4692,20 +3984,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>P2Pアドレスを読み込んでいます...</translation>
     </message>
     <message>
-        <source>Print this help message and exit</source>
-        <translation>このヘルプメッセージを表示し終了する</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>システム上の制約から、-maxconnections を %d から %d に削減します。</translation>
-    </message>
-    <message>
-        <source>Relay and mine data carrier transactions (default: %u)</source>
-        <translation>データ運送トランザクションのリレーおよび採掘を行う (初期設定： %u)</translation>
-    </message>
-    <message>
-        <source>Relay non-P2SH multisig (default: %u)</source>
-        <translation>P2SHでないマルチシグトランザクションをリレーする (初期設定： %u)</translation>
     </message>
     <message>
         <source>Replaying blocks...</source>
@@ -4716,10 +3996,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>再スキャン中…</translation>
     </message>
     <message>
-        <source>Run in the background as a daemon and accept commands</source>
-        <translation>デーモンとしてバックグランドで実行しコマンドを許可</translation>
-    </message>
-    <message>
         <source>Session not complete!</source>
         <translation>セッション未完了！</translation>
     </message>
@@ -4728,36 +4004,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>セッションタイムアウト</translation>
     </message>
     <message>
-        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
-        <translation>データベースのキャッシュサイズをメガバイトで設定 (%d から %d。初期設定： %d)</translation>
-    </message>
-    <message>
-        <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>最大ブロックサイズをバイトで設定 (初期設定： %d)</translation>
-    </message>
-    <message>
-        <source>Show all debugging options (usage: --help -help-debug)</source>
-        <translation>すべてのデバッグオプションを表示する (使い方： --help -help-debug)</translation>
-    </message>
-    <message>
-        <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
-        <translation>クライアント起動時に debug.log ファイルを縮小 (初期設定：1 -debug オプションを指定しない場合)</translation>
-    </message>
-    <message>
         <source>Signing transaction failed</source>
         <translation>トランザクションの署名に失敗</translation>
-    </message>
-    <message>
-        <source>Specify data directory</source>
-        <translation>データ ディレクトリの指定</translation>
-    </message>
-    <message>
-        <source>Specify your own public address</source>
-        <translation>あなた自身のパブリックなアドレスを指定</translation>
-    </message>
-    <message>
-        <source>Start PrivateSend automatically (0-1, default: %u)</source>
-        <translation>自動的にプライベートセンドを開始 (0-1, デフォルト: %u)</translation>
     </message>
     <message>
         <source>Starting network threads...</source>
@@ -4820,10 +4068,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>サポートされていないロギングカテゴリ %s=%s.</translation>
     </message>
     <message>
-        <source>Username for JSON-RPC connections</source>
-        <translation>JSON-RPC 接続のユーザー名</translation>
-    </message>
-    <message>
         <source>Verifying blocks...</source>
         <translation>ブロックの検証中…</translation>
     </message>
@@ -4834,10 +4078,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Wallet is locked.</source>
         <translation>ウォレットはロックされています。</translation>
-    </message>
-    <message>
-        <source>Wallet options:</source>
-        <translation>ウォレットオプション：</translation>
     </message>
     <message>
         <source>Warning</source>

--- a/src/qt/locale/dash_ko.ts
+++ b/src/qt/locale/dash_ko.ts
@@ -247,10 +247,6 @@
         <translation>지갑 암호화 완료</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>암호화 진행을 완료하기 위하여 %1 이/가 종료됩니다. 사용자 지갑 암호화를 진행한다고 하더라도 컴퓨터에 영향을 끼치는 맬웨어로부터 자금을 완전히 보호하지 못한다는 점을 기억하세요. </translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>중요: 당신의 지갑 파일에서 생성된 이전 백업은 새로 생성된 암호화 지갑 파일로 교체되어야 합니다.암호화되지 않은 이전 지갑 파일의 백업은 동일한 HD 시드를 가지며, 새로운 암호화 지갑과 마찬가지로 당신의 자금에 완전한 접근성을 제공합니다.</translation>
     </message>
@@ -394,6 +390,10 @@
     <message>
         <source>&amp;About %1</source>
         <translation>%1 정보(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Send %1 funds to a Dash address</source>
+        <translation>%1 금액을 대시 주소로 전송</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
@@ -564,6 +564,14 @@
     <message>
         <source>&amp;File</source>
         <translation>파일(&amp;F)</translation>
+    </message>
+    <message>
+        <source>%1 &amp;information</source>
+        <translation>%1 정보</translation>
+    </message>
+    <message>
+        <source>Show the %1 basic information</source>
+        <translation>%1 기본 정보를 보여줍니다</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
@@ -799,6 +807,10 @@
         <translation>함께 수신된 주소</translation>
     </message>
     <message>
+        <source>Mixing Rounds</source>
+        <translation>믹싱 라운드</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
@@ -889,6 +901,22 @@
     <message>
         <source>Some coins were unselected because they do not have enough mixing rounds.</source>
         <translation>일부 코인은 믹싱 라운드가 충분하지 않아 선택되지 않았습니다.</translation>
+    </message>
+    <message>
+        <source>Show all coins</source>
+        <translation>모든 코인을 보여줍니다</translation>
+    </message>
+    <message>
+        <source>Hide %1 coins</source>
+        <translation>%1 코인을 숨깁니다</translation>
+    </message>
+    <message>
+        <source>Show all %1 coins</source>
+        <translation>모든 %1 코인을 보여줍니다</translation>
+    </message>
+    <message>
+        <source>Show spendable coins only</source>
+        <translation>사용할 수 있는 코인만을 보여줍니다</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -999,7 +1027,15 @@
         <source>Command-line options</source>
         <translation>명령줄 옵션</translation>
     </message>
-    </context>
+    <message>
+        <source>%1 information</source>
+        <translation>%1 정보</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;%1 Basics&lt;/h3&gt; %1 gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different "inputs" which you can think of as separate, discrete coins.&lt;br&gt; %1 uses an innovative process to mix your inputs with the inputs of two or more other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The %1 process works like this:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;%1 begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called "masternodes." These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know "who" you are.&lt;/li&gt; &lt;li&gt;When two or more other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it's called a "round." Each round of %1 makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these "change addresses." Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have %1 disabled. &lt;hr&gt;For more information, see the &lt;a style="%2" href="%3"&gt;%1 documentation&lt;/a&gt;.</source>
+        <translation>&lt;h3&gt;%1 기본 정보&lt;/h3&gt; %1은 당신의 자금 출처를 가려 진정한 재정적 프라이버시를 보장합니다. 당신의 지갑에 보관된 모든 대시는 각기 다른 "입력값"으로 구성되어 있습니다. 쉽게 생각하면 별도의 분리된 동전으로 구성되어 있다고 볼 수 있습니다.&lt;br&gt;  %1은 당신의 코인이 지갑을 떠나지 않고도 그 입력값을 다른 두 사람의 입력값과 섞는 혁신적인 방식을 사용합니다. 이로써 당신의 자금은 언제나 당신의 통제 하에 있습니다.&lt;hr&gt;&lt;b&gt; %1은 다음과 같은 방식으로 작동합니다.&lt;/b&gt;&lt;ol type="1"&gt;&lt;li&gt; %1은 당신의 거래 입력값을 표준 단위로 쪼개는 것으로 시작합니다. 이렇게 분할하는 단위는 0.001대시, 0.01대시, 0.1대시, 1대시 혹은 10대시 입니다 - 귀하가 일상적으로 사용하는 지폐와 비슷하다고 생각하셔도 좋습니다. &lt;/li&gt;&lt;li&gt;이후 당신의 지갑은 "마스터노드"라고 불리는 네트워크의 특수 구성 소프트웨어 노드에 요청을 전송합니다. 이로써 이들 마스터노드는 당신이 특정 금액을 믹싱하고자 한다는 정보를 수신합니다. 마스터노드에는 당신의 개인 정보를 식별할 수 있는 어떤 내용도 전송되지 않습니다. 즉 당신이 "누구"인지 알 수 있는 방법은 없습니다.&lt;/li&gt;&lt;li&gt; 두 명의 다른 사람이 비슷한 메시지를 보내어 그들 역시 같은 단위의 금액을 믹싱하고 싶다는 정보를 나타내면 믹싱 세션이 시작됩니다. 마스터노드는 이들 입력값을 믹싱하여 세 사용자의 지갑에 변환된 입력을 지불하도록 지시합니다. 당신의 지갑은 해당 입력값을 곧바로 스스로에게 지불하지만, 지불되는 주소는 '변경 주소'라고 불리는 다른 주소로 보내집니다.&lt;/li&gt;&lt;li&gt; 당신의 자금을 완전히 가리기 위해서, 당신의 지갑은 이 과정을 각 대시 분할 단위만큼 여러번 반복합니다. 이러한 반복을 ‘라운드’라고 부릅니다. 프라이빗샌드의 각 라운드가 진행됨에 따라 당신이 송금하고자 하는 자금의 출처는 기하급수적으로 높은 수준으로 가려집니다.&lt;/li&gt;&lt;li&gt; 이 믹싱 과정은 당신이 개입할 필요 없이 백그라운드에서 진행됩니다. 당신이 거래를 원하는 경우, 당신의 자금은 이미 믹싱을 거친 것입니다. 추가적으로 대기할 필요 역시 없습니다. &lt;/li&gt;&lt;/ol&gt;&lt;hr&gt;&lt;b&gt;중요:&lt;/b&gt; 당신의 지갑은 1,000개의 ‘변경 주소’만을 가지고 있습니다. 믹싱을 실행할 때마다 최대 9개의 주소가 사용됩니다. 이는 곧 이들 1000개의 주소가 약 100개의 믹싱 작업을 위해 사용될 수 있다는 것을 의미합니다. 전체 1,000개의 주소 중 900개가 사용된 경우 당신의 지갑은 더 많은 주소를 만들어야 합니다. 그러나 이 작업은 당신이 자동 백업을 설정한 경우에만 수행됩니다. &lt;br&gt;따라서 백업이 비활성화된 사용자는 %1 역시 비활성화 됩니다. &lt;hr&gt;더 많은 정보를 위해서는 &lt;a style="%2" href="%3"&gt;%1 문서&lt;/a&gt;를 참조하세요.</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
     <message>
@@ -1315,6 +1351,54 @@
         <translation>확인되지 않은 잔액 사용을 중지하는 경우, 거래로부터 발생하는 잔액은 &lt;br/&gt;최소 한 번의 거래 확인이 발생할 때 까지 사용할 수 없습니다.&lt;br/&gt;이는 또한 당신의 잔고가 계산되는 방식에 영향을 미칠 수 있습니다.</translation>
     </message>
     <message>
+        <source>Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</source>
+        <translation>개요 화면의 믹싱 인터페이스를 보여주고, 완전히 믹싱된 코인만을 지불에 사용할 수 있도록 하는 추가적 스크린을 나타냅니다. &lt;br/&gt;더 많은 설정을 담은 새로운 탭이 이 대화창에 나타나게 되니, 코인을 믹싱하기 전 해당 내용을 확인하십시오.</translation>
+    </message>
+    <message>
+        <source>Show additional information and buttons on overview screen.</source>
+        <translation>개요 화면에 추가적 정보와 버튼을 보여줍니다.</translation>
+    </message>
+    <message>
+        <source>Enable advanced interface</source>
+        <translation>향상된 인터페이스를 활성화합니다</translation>
+    </message>
+    <message>
+        <source>Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
+        <translation>모든 다른 유형의 거래와 마찬가지로&lt;br/&gt;믹싱 거래를 위한 시스템 팝업을 보여줍니다</translation>
+    </message>
+    <message>
+        <source>Show popups for mixing transactions</source>
+        <translation>믹싱 거래를 위한 팝업을 보여줍니다</translation>
+    </message>
+    <message>
+        <source>Show warning dialog when the wallet has very low number of keys left.</source>
+        <translation>지갑에 적은 수의 키가 남아있는 경우 경고 대화창을 보여줍니다</translation>
+    </message>
+    <message>
+        <source>Warn if the wallet is running out of keys</source>
+        <translation>지갑에 키가 부족한 경우 경고합니다</translation>
+    </message>
+    <message>
+        <source>Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
+        <translation>블록당 다양한 믹싱 세션이 있는 실험 모드를 사용할 지 여부를 결정합니다. &lt;br/&gt;참고: 이 기능을 사용할 때는 주의해야 합니다.&lt;br/&gt;언제나 안전한 장소에 최신 지갑 (자동) 백업이 되어 있는 지 확인하세요!</translation>
+    </message>
+    <message>
+        <source>Enable &amp;multi-session</source>
+        <translation>멀티 세션 활성화(&amp;m)</translation>
+    </message>
+    <message>
+        <source>Mixing rounds</source>
+        <translation>믹싱 라운드</translation>
+    </message>
+    <message>
+        <source>This amount acts as a threshold to turn off mixing once it's reached.</source>
+        <translation>이 금액은 도달 시 믹싱을 종료하기 위한 한계점으로 작동합니다.</translation>
+    </message>
+    <message>
+        <source>Target balance</source>
+        <translation>타깃 잔고</translation>
+    </message>
+    <message>
         <source>Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>라우터에서 대시 코어 클라이언트를 자동으로 엽니다. 이 기능은 당신의 라우터가 UPnP를 지원하고 해당 기능이 작동하는 경우에만 가능합니다.</translation>
     </message>
@@ -1493,6 +1577,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>취소(&amp;C)</translation>
     </message>
     <message>
+        <source>Enable %1 features</source>
+        <translation>%1 기능 활성화</translation>
+    </message>
+    <message>
         <source>default</source>
         <translation>기본값</translation>
     </message>
@@ -1639,6 +1727,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>No inputs detected</source>
         <translation>입력이 감지되지 않습니다.</translation>
     </message>
+    <message>
+        <source>%1 Balance</source>
+        <translation>%1 잔고</translation>
+    </message>
     <message numerus="yes">
         <source>%n Rounds</source>
         <translation><numerusform>&amp;n 라운드</numerusform></translation>
@@ -1674,6 +1766,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>keys left: %1</source>
         <translation>남은 키의 수: %1</translation>
+    </message>
+    <message>
+        <source>Start %1</source>
+        <translation>%1 시작</translation>
+    </message>
+    <message>
+        <source>If you don't want to see internal %1 fees/transactions select "Most Common" as Type on the "Transactions" tab.</source>
+        <translation>내부 %1 수수료/거래를 보지 않으려면 "거래" 탭의 유형에서 "자주 사용된 항목"을 선택하세요. </translation>
+    </message>
+    <message>
+        <source>%1 requires at least %2 to use.</source>
+        <translation>%1 를 사용하기 위해서는 최소한 %2가 필요합니다.</translation>
+    </message>
+    <message>
+        <source>Wallet is locked and user declined to unlock. Disabling %1.</source>
+        <translation>지갑이 잠겨있으며 사용자가 잠금 해제를 거으며 사용자가 잠금 해제를 거절했습니다. %1를 비활성화 합니다.</translation>
+    </message>
+    <message>
+        <source>Stop %1</source>
+        <translation>%1 정지</translation>
     </message>
     <message>
         <source>Disabled</source>
@@ -1729,6 +1841,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>URI handling</source>
         <translation>URI 처리</translation>
+    </message>
+    <message>
+        <source>'dash://' is not a valid URI. Use 'dash:' instead.</source>
+        <translation>'dash://' 는 유효하지 않은 URI 입니다. 'dash:' 를 사용하세요.</translation>
     </message>
     <message>
         <source>Payment request fetch URL is invalid: %1</source>
@@ -1891,6 +2007,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Appearance Setup</source>
         <translation>외관 설정</translation>
+    </message>
+    <message>
+        <source>Please choose your preferred settings for the appearance of %1</source>
+        <translation>%1의 외관을 위해 원하는 설정을 선택하세요.</translation>
     </message>
     <message>
         <source>This can also be adjusted later in the "Appearance" tab of the preferences.</source>
@@ -2212,6 +2332,22 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>동기화 된 블록</translation>
     </message>
     <message>
+        <source>Rescan blockchain files 1</source>
+        <translation>블록체인 파일 1 재스캔</translation>
+    </message>
+    <message>
+        <source>Rescan blockchain files 2</source>
+        <translation>블록체인 파일 2 재스캔</translation>
+    </message>
+    <message>
+        <source>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</source>
+        <translation>-rescan=1: 지갑 생성시부터 누락된 지갑 거래를 위해 블록체인을 다시 스캔합니다.</translation>
+    </message>
+    <message>
+        <source>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</source>
+        <translation>-rescan=2: 제네시스 블록에서부터 누락된 지갑 거래를 위해 블록체인을 다시 스캔합니다.</translation>
+    </message>
+    <message>
         <source>Wallet Path</source>
         <translation>지갑 경로</translation>
     </message>
@@ -2250,6 +2386,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Reset</source>
         <translation>&amp;재설정(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Node Type</source>
+        <translation>노드 유형</translation>
     </message>
     <message>
         <source>PoSe Score</source>
@@ -2448,8 +2588,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>아니오</translation>
     </message>
     <message>
+        <source>Regular</source>
+        <translation>일반</translation>
+    </message>
+    <message>
         <source>Masternode</source>
         <translation>마스터노드</translation>
+    </message>
+    <message>
+        <source>Verified Masternode</source>
+        <translation>인증된 마스터노드</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2840,8 +2988,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&lt;b&gt;(%2 중 %1 입력값 표시됨)&lt;/b&gt;</translation>
     </message>
     <message>
+        <source>S&amp;end mixed funds</source>
+        <translation>믹싱된 자금 보내기(&amp;e)</translation>
+    </message>
+    <message>
+        <source>Confirm the %1 send action</source>
+        <translation>%1 전송 액션 확인</translation>
+    </message>
+    <message>
+        <source>%1 funds only</source>
+        <translation>%1 자금만</translation>
+    </message>
+    <message>
         <source>any available funds</source>
         <translation>이용이 가능한 모든 자금</translation>
+    </message>
+    <message>
+        <source>(%1 transactions have higher fees usually due to no change output being allowed)</source>
+        <translation>(%1 거래는 잔돈 아웃풋이 허용되지 않아 보다 높은 수수료가 책정됩니다)</translation>
     </message>
     <message>
         <source>Transaction size: %1</source>
@@ -2854,6 +3018,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message numerus="yes">
         <source>This transaction will consume %n input(s)</source>
         <translation><numerusform>이 거래는 %n 입력값을 소모합니다</numerusform></translation>
+    </message>
+    <message>
+        <source>Warning: Using %1 with %2 or more inputs can harm your privacy and is not recommended</source>
+        <translation>경고: %1를 %2 혹은 그 이상의 인풋으로 이용하게 되면 당신의 프라이버시가 침해될 수 있어 권장하지 않습니다.</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3245,6 +3413,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1 확인</translation>
     </message>
     <message>
+        <source>locked via ChainLocks</source>
+        <translation>체인락스로 잠김</translation>
+    </message>
+    <message>
         <source>verified via InstantSend</source>
         <translation>인스턴트샌드를 통해 검증됨</translation>
     </message>
@@ -3439,12 +3611,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>인스턴트샌드를 통해 검증됨</translation>
     </message>
     <message>
+        <source>locked via ChainLocks</source>
+        <translation>체인락스로 잠김</translation>
+    </message>
+    <message>
         <source>Received with</source>
         <translation>받은 주소</translation>
     </message>
     <message>
         <source>Received from</source>
         <translation>보낸 주소</translation>
+    </message>
+    <message>
+        <source>Received via %1</source>
+        <translation>%1을 통해 받음</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3457,6 +3637,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Mined</source>
         <translation>채굴</translation>
+    </message>
+    <message>
+        <source>%1 Mixing</source>
+        <translation>%1 믹싱</translation>
+    </message>
+    <message>
+        <source>%1 Collateral Payment</source>
+        <translation>%1 콜래트럴 지불</translation>
+    </message>
+    <message>
+        <source>%1 Make Collateral Inputs</source>
+        <translation>%1 콜래트럴 입력값 생성</translation>
+    </message>
+    <message>
+        <source>%1 Create Denominations</source>
+        <translation>%1 분할 단위 생성</translation>
+    </message>
+    <message>
+        <source>%1 Send</source>
+        <translation>%1 전송</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -3536,6 +3736,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Sent to</source>
         <translation>보낸 주소</translation>
+    </message>
+    <message>
+        <source>%1 Send</source>
+        <translation>%1 전송</translation>
+    </message>
+    <message>
+        <source>%1 Make Collateral Inputs</source>
+        <translation>%1 콜래트럴 입력값 생성</translation>
+    </message>
+    <message>
+        <source>%1 Create Denominations</source>
+        <translation>%1 분할 단위 생성</translation>
+    </message>
+    <message>
+        <source>%1 Mixing</source>
+        <translation>%1 믹싱</translation>
+    </message>
+    <message>
+        <source>%1 Collateral Payment</source>
+        <translation>%1 콜래트럴 지불</translation>
     </message>
     <message>
         <source>To yourself</source>
@@ -3985,6 +4205,18 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>임의의 마스터노드를 찾을 수 없습니다.</translation>
     </message>
     <message>
+        <source>%s can't be lower than %s</source>
+        <translation>%s는 %s보다 작을 수 없습니다</translation>
+    </message>
+    <message>
+        <source>%s is idle.</source>
+        <translation>%s를 사용되지 않고 있습니다.</translation>
+    </message>
+    <message>
+        <source>%s request incomplete: %s</source>
+        <translation>%s 요청이 완료되지 않았습니다: %s</translation>
+    </message>
+    <message>
         <source>Can't mix while sync in progress.</source>
         <translation>동기화가 진행되는 동안 믹싱할 수 없습니다.</translation>
     </message>
@@ -4325,6 +4557,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%s 개발자</translation>
     </message>
     <message>
+        <source>%s uses exact denominated amounts to send funds, you might simply need to mix some more coins.</source>
+        <translation>%s는 송금을 위하여 정확한 분할 단위 금액을 사용합니다. 단순히 더 많은 코인을 믹싱함으로써 문제를 해결할 수 있을 지도 모릅니다.</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation>%s 데이터 디렉토리에 잠금을 설정 할 수 없습니다. %s가 이미 실행 중인 것으로 보입니다.</translation>
     </message>
@@ -4405,6 +4641,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%s주소: '%s'를 확인할 수 없습니다.</translation>
     </message>
     <message>
+        <source>Cannot write to data directory '%s'; check permissions.</source>
+        <translation>'%s' 데이터 디렉토리를 생성할 수 없습니다: 허용 내역을 확인하십시오.</translation>
+    </message>
+    <message>
         <source>Change index out of range</source>
         <translation>범위 밖의 인덱스 변경</translation>
     </message>
@@ -4437,12 +4677,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>체인 상태 데이터베이스 업그레이드 중 오류가 발생했습니다.</translation>
     </message>
     <message>
+        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
+        <translation>오류: kqeuefd에 소켓을 추가하는 데 실패하였습니다 (kevent 반환 오류 %s)</translation>
+    </message>
+    <message>
         <source>Failed to find mixing queue to join</source>
         <translation>참여할 수 있는 믹싱 대기열을 찾는 데 실패하였습니다.</translation>
     </message>
     <message>
         <source>Failed to start a new mixing queue</source>
         <translation>새로운 믹싱 대기열을 시작하는 데 실패하였습니다.</translation>
+    </message>
+    <message>
+        <source>Incorrect -rescan mode, falling back to default value</source>
+        <translation>잘못된 -rescan 모드, 기본 값으로 돌아갑니다</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
@@ -4497,6 +4745,18 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>거래에 서명하는 데 실패하였습니다.</translation>
     </message>
     <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation>지정한 데이터 디렉토리 "%s"가 존재하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Last queue was created too recently.</source>
+        <translation>지난 큐가 너무 최근 생성되었습니다.</translation>
+    </message>
+    <message>
+        <source>Last successful action was too recent.</source>
+        <translation>지난 성공적 액션이 너무 최신입니다.</translation>
+    </message>
+    <message>
         <source>Starting network threads...</source>
         <translation>네트워크 스레드 시작중...</translation>
     </message>
@@ -4541,6 +4801,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>이 컴퓨터의 %s에 바인딩할 수 없습니다 (바인딩 과정에 %s 오류 발생)</translation>
     </message>
     <message>
+        <source>Unable to locate enough mixed funds for this transaction.</source>
+        <translation>이 거래에 필요한 믹싱 자금을 찾을 수 없습니다.</translation>
+    </message>
+    <message>
+        <source>Unable to locate enough non-denominated funds for this transaction.</source>
+        <translation>이 거래에 필요한 비 분할단위 자금을 찾을 수 없습니다.</translation>
+    </message>
+    <message>
         <source>Unable to sign spork message, wrong key?</source>
         <translation>스포크 메시지에 사인할 수 없습니다. 키가 잘못된 것일 수 있습니다.</translation>
     </message>
@@ -4571,6 +4839,18 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning</source>
         <translation>경고</translation>
+    </message>
+    <message>
+        <source>Warning: %s is deprecated, please use %s instead</source>
+        <translation>경고: %s는 더 이상 사용되지 않습니다. %s를 이용하십시오.</translation>
+    </message>
+    <message>
+        <source>Warning: can't use %s and %s together, will prefer %s</source>
+        <translation>경고: %s와 %s를 함께 사용할 수 ㅇ벗습니다. %s를 우선 사용합니다.</translation>
+    </message>
+    <message>
+        <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
+        <translation>경고: 잘못된 %s 파라미터입니다. 경로가 필요합니다! 디폴트 경로를 이용합니다.</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_nl.ts
+++ b/src/qt/locale/dash_nl.ts
@@ -247,10 +247,6 @@
         <translation>Portemonnee is versleuteld</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 wordt nu afgesloten om de versleuteling te voltooien. Denk eraan dat het versleutelen van uw portemonnee niet volledig kan beschermen tegen diefstal van uw geld door malware op uw computer.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>BELANGRIJK: Alle eerder gemaakte back-up van uw portemonneebestand dienen vervangen te worden door het nieuw gegenereerde, versleutelde portemonneebestand. Eerdere back-ups van de niet versleutelde portemonnee bevatten dezelfde HD seed en zullen nog steeds volledig toegang hebben tot uw geld net als de nieuwe, versleutelde portemonnee.</translation>
     </message>

--- a/src/qt/locale/dash_pl.ts
+++ b/src/qt/locale/dash_pl.ts
@@ -247,10 +247,6 @@
         <translation>Portfel zaszyfrowany</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 zostanie teraz zamknięty aby zakończyć proces szyfrowania. Pamiętaj, że zaszyfrowanie portfela nie gwarantuje pełnej ochrony przed kradzieżą twoich monet przez złośliwe oprogramowanie.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>WAŻNE: Wszystkie wykonane wcześniej kopie pliku portfela powinny być zamienione na nowe, zaszyfrowany plik portfela. Poprzednie kopie zapasowe niezaszyfrowanego porfela dalej mają dostęp do frazy HD oraz twoich funduszy tak samo jak nowy, zaszyfrowany portfel.</translation>
     </message>

--- a/src/qt/locale/dash_pt.ts
+++ b/src/qt/locale/dash_pt.ts
@@ -247,10 +247,6 @@
         <translation>Carteira criptografada</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>A %1 irá fechar agora para terminar o processo de encriptação. Lembre-se que encriptar sua carteira não fará com que seus Dash estejam totalmente a salvo de serem roubados por malwares que infectem seu computador.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>IMPORTANTE: Todos os backups anteriores feitos do seu arquivo de carteira devem ser substituídos pelo arquivo de carteira criptografado recém-gerado. Os backups anteriores do arquivo de carteira não criptografada contêm a mesma semente HD e ainda têm acesso total a todos os seus fundos, assim como a nova carteira criptografada.</translation>
     </message>

--- a/src/qt/locale/dash_ro.ts
+++ b/src/qt/locale/dash_ro.ts
@@ -203,10 +203,6 @@
         <translation>Portofel criptat</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 se va închide acum pentru a termina procesul de criptare. Amintește-ți că criptarea portofelului tău nu poate proteja complet fondurile tale  împotriva furtului de către un malware care infectează computerul tău.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>IMPORTANT: Toate backup-urile anterioare pe care le-ai realizat pentru fișierul portofelului tău ar trebui înlocuite cu fișierul portofelului criptat nou generat. Backup-urile anterioare ale fișierului portofelului necriptat conțin aceleași semințe HD și încă mai au acces deplin la toate fondurile tale la fel ca noul portofel criptat.</translation>
     </message>
@@ -502,14 +498,6 @@
     <message>
         <source>%1 client</source>
         <translation>Client %1</translation>
-    </message>
-    <message>
-        <source>&amp;PrivateSend information</source>
-        <translation>&amp;TrimitePrivat informații</translation>
-    </message>
-    <message>
-        <source>Show the PrivateSend basic information</source>
-        <translation>Afișează informațiile de bază pentru TrimitePrivat</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -941,51 +929,7 @@
         <source>Command-line options</source>
         <translation>Optiuni linie de comanda</translation>
     </message>
-    <message>
-        <source>Usage:</source>
-        <translation>Utilizare:</translation>
-    </message>
-    <message>
-        <source>command-line options</source>
-        <translation>Optiuni linie de comanda</translation>
-    </message>
-    <message>
-        <source>UI Options:</source>
-        <translation>Opțiuni UI:</translation>
-    </message>
-    <message>
-        <source>Choose data directory on startup (default: %u)</source>
-        <translation>Alege directorul de date la pornire (mod implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Set language, for example "de_DE" (default: system locale)</source>
-        <translation>Setează limba, de exemplu: "de_DE" (inițial: setare locală)</translation>
-    </message>
-    <message>
-        <source>Start minimized</source>
-        <translation>Pornește miniaturizat</translation>
-    </message>
-    <message>
-        <source>Set SSL root certificates for payment request (default: -system-)</source>
-        <translation>Setează certificatele rădăcină SSL pentru solicitarea de plată (mod implicit: -system-)</translation>
-    </message>
-    <message>
-        <source>Show splash screen on startup (default: %u)</source>
-        <translation>Arată ecranul splash la pornire (mod implicit: %u) </translation>
-    </message>
-    <message>
-        <source>Reset all settings changed in the GUI</source>
-        <translation>Resetează toate setările modificate în GUI</translation>
-    </message>
-    <message>
-        <source>PrivateSend information</source>
-        <translation>Informație TrimitePrivat</translation>
-    </message>
-    <message>
-        <source>&lt;h3&gt;PrivateSend Basics&lt;/h3&gt; PrivateSend gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different "inputs" which you can think of as separate, discrete coins.&lt;br&gt; PrivateSend uses an innovative process to mix your inputs with the inputs of two or more other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The PrivateSend process works like this:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;PrivateSend begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called "masternodes." These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know "who" you are.&lt;/li&gt; &lt;li&gt;When two or more other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it's called a "round." Each round of PrivateSend makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these "change addresses." Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have PrivateSend disabled. &lt;hr&gt;For more information, see the &lt;a style="%1" href="https://docs.dash.org/en/stable/wallets/dashcore/privatesend-instantsend.html"&gt;PrivateSend documentation&lt;/a&gt;.</source>
-        <translation>&lt;h3&gt;Informații de bază TrimitePrivat&lt;/h3&gt;TrimitePrivat oferă o intimitate financiară adevărată, ascunzând originea fondurilor. Toate monedele Dash din portofel sunt alcătuite din diferite "intrări" pe care le poți considera drept monede separate, discrete. &lt;br&gt; TrimitePrivat folosește un proces inovator pentru a amesteca intrările tale cu input-urile altor două persoane, fără ca monedele tale să părăsească vreodată portofelul tău. Menții controlul asupra banilor în orice moment.&lt;hr&gt; &lt;b&gt;Procesul TrimitePrivat funcționează astfel:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;TrimitePrivat începe prin ruperea intrărilor de tranzacții în denumiri standard. Aceste denumiri sunt 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH și 10 DASH - ceva asemănător cu banii de hârtie pe care îi folosim zilnic.&lt;/li&gt; &lt;li&gt;Portofelul tău trimite apoi cereri către nodurile software configurate special pe rețea, numite "masternodes". Aceste masternodes sunt informate atunci că eștii interesat să amesteci o anumită denominație. Nu sunt trimise nici un fel de informații identificabile la masternodes, astfel încât să nu știe niciodată "cine" ești.&lt;/li&gt; &lt;li&gt;Atunci când alte două persoane trimit mesaje similare, indicând faptul că doresc să amestece aceeași denominație, începe o sesiune de amestecare. Masternodul amestecă intrările și instruiește portofelele celor trei utilizatori să plătească intrarea transformată acum înapoi la ei înșiși. Portofelul tău plătește această denominație direct la sine, dar într-o altă adresă (numită o adresă de schimbare).&lt;/li&gt; &lt;li&gt;Pentru a închide complet fondurile tale, portofelul tău trebuie să repete acest proces de mai multe ori cu fiecare denominație. De fiecare dată când procesul este finalizat, se numește o "rundă". Fiecare rundă de TrimitePrivat o face exponențial mai dificil de determinat de unde au provenit fondurile.&lt;/li&gt; &lt;li&gt;Acest proces de amestecare se întâmplă în fundal, fără intervenție din partea ta când dorești să efectuezi o tranzacție, fondurile tale vor fi deja anonime. Nu este necesară o așteptare suplimentară.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt;Portofelul tău conține numai 1000 dintre aceste "adrese de schimbare". De fiecare dată când se întâmplă un eveniment de amestecare, până la 9 dintre adresele tale sunt epuizate. Aceasta înseamnă că cele 1000 de adrese durează aproximativ 100 de evenimente de amestecare. Atunci când sunt utilizate 900 dintre ele, portofelul tău trebuie să creeze mai multe adrese. Cu toate acestea, poți face acest lucru numai dacă ai activări de rezervă automate. &lt;br&gt;În consecință, utilizatorii care au backup-urile dezactivate vor avea și TrimitePrivat dezactivat . &lt;hr&gt;Pentru mai multe informații, consultă &lt;a style="%1" href="https://docs.dash.org/en/stable/wallets/dashcore/privatesend-instantsend.html"&gt;documentația PrivateSend&lt;/a&gt;.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>Intro</name>
     <message>
@@ -1281,44 +1225,8 @@
         <translation>Arată Pagina Masternode-urilor</translation>
     </message>
     <message>
-        <source>Show additional information and buttons for PrivateSend on overview screen.</source>
-        <translation>Afișează informații suplimentare și butoane pentru TrimitePrivat pe ecranul de ansamblu.</translation>
-    </message>
-    <message>
-        <source>Enable advanced PrivateSend interface</source>
-        <translation>Activează interfața avansată TrimitePrivat</translation>
-    </message>
-    <message>
-        <source>Show warning dialog when PrivateSend detects that wallet has very low number of keys left.</source>
-        <translation>Afișează dialogul de avertizare când TrimitePrivat detectează că portofelul are un număr foarte mic de chei rămase.</translation>
-    </message>
-    <message>
-        <source>Warn if PrivateSend is running out of keys</source>
-        <translation>Avertizează dacă TrimitePrivat nu mai are chei disponibile</translation>
-    </message>
-    <message>
-        <source>Whether to use experimental PrivateSend mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
-        <translation>Dacă utilizezi modul experimental TrimitePrivat cu mai multe sesiuni de amestecare pentru fiecare block.&lt;br/&gt;Notă: Utilizează cu atenție această caracteristică.&lt;br/&gt;Asigură-te că ai mereu un (auto)backup recent într-un loc sigur!</translation>
-    </message>
-    <message>
-        <source>Enable PrivateSend &amp;multi-session</source>
-        <translation>Activează TrimitePrivat &amp; multi-sesiune</translation>
-    </message>
-    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</source>
         <translation>Dacă dezactivezi cheltuirea restului neconfirmat, restul dintr-o tranzacție&lt;br/&gt;nu poate fi utilizat până când tranzacția nu are cel puțin o confirmare.&lt;br/&gt;Acest lucru afectează de asemenea modul în care se calculează soldul tău.</translation>
-    </message>
-    <message>
-        <source>PrivateSend rounds to use</source>
-        <translation>Runde TrimitePrivat de folosit</translation>
-    </message>
-    <message>
-        <source>This amount acts as a threshold to turn off PrivateSend once it's reached.</source>
-        <translation>Această sumă acționează ca un prag pentru a dezactiva TrimitePrivat după ce a fost atins.</translation>
-    </message>
-    <message>
-        <source>Target PrivateSend balance</source>
-        <translation>Obiectiv Sold TrimitePrivat:</translation>
     </message>
     <message>
         <source>Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1359,14 +1267,6 @@
     <message>
         <source>Enable coin &amp;control features</source>
         <translation>Activare caracteristici de control ale monedei</translation>
-    </message>
-    <message>
-        <source>Show system popups for PrivateSend mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
-        <translation>Afișează popup-uri de sistem pentru tranzacțiile de amestecare TrimitePrivat&lt;br/&gt;la fel ca pentru toate celelalte tipuri de tranzacții.</translation>
-    </message>
-    <message>
-        <source>Show popups for PrivateSend transactions</source>
-        <translation>Arată popup-urile pentru tranzacțiile TrimitePrivat</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
@@ -1578,10 +1478,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Cheltuibil:</translation>
     </message>
     <message>
-        <source>PrivateSend</source>
-        <translation>TrimitePrivat</translation>
-    </message>
-    <message>
         <source>Status:</source>
         <translation>Status:</translation>
     </message>
@@ -1618,10 +1514,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Start/Stop Amestecare</translation>
     </message>
     <message>
-        <source>PrivateSend Balance:</source>
-        <translation>Sold TrimitePrivat:</translation>
-    </message>
-    <message>
         <source>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</source>
         <translation>Denominațiile pe care le-ai trimis la Masternode.&lt;br&gt;Pentru a amesteca, ceilalți utilizatori trebuie să trimită exact aceleași denominații.</translation>
     </message>
@@ -1632,14 +1524,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Automatic backups are disabled, no mixing available!</source>
         <translation>Backupurile automate sunt dezactivate, amestecarea nu este disponibilă!</translation>
-    </message>
-    <message>
-        <source>Start Mixing</source>
-        <translation>Start Amestecare</translation>
-    </message>
-    <message>
-        <source>Stop Mixing</source>
-        <translation>Stop Amestecare</translation>
     </message>
     <message>
         <source>No inputs detected</source>
@@ -1712,18 +1596,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
         <translation>AVERTIZARE! Nu s-a reușit reîncărcarea keypool-ului, te rog deblochează portofelul pentru a face acest lucru.</translation>
-    </message>
-    <message>
-        <source>If you don't want to see internal PrivateSend fees/transactions select "Most Common" as Type on the "Transactions" tab.</source>
-        <translation>Dacă nu vrei să vezi taxele / tranzacțiile interne TrimitePrivat, selectează "Cele mai frecvente" ca Tip în pagina "Tranzacții".</translation>
-    </message>
-    <message>
-        <source>PrivateSend requires at least %1 to use.</source>
-        <translation>TrimitePrivat are nevoie de cel puțin %1 pentru a folosi.</translation>
-    </message>
-    <message>
-        <source>Wallet is locked and user declined to unlock. Disabling PrivateSend.</source>
-        <translation>Portofelul este blocat și utilizatorul a refuzat să deblocheze. Dezactivează TrimitePrivat.</translation>
     </message>
 </context>
 <context>
@@ -2198,10 +2070,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Salvează portofelul</translation>
     </message>
     <message>
-        <source>Rescan blockchain files</source>
-        <translation>Rescanează fișierele blockchain</translation>
-    </message>
-    <message>
         <source>Recover transactions 1</source>
         <translation>Recuperează tranzacții 1</translation>
     </message>
@@ -2220,10 +2088,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>-salvagewallet: Attempt to recover private keys from a corrupt wallet.dat.</source>
         <translation>-salvagewallet: Încearcă să recuperezi cheile private de la un wallet.dat. corupt</translation>
-    </message>
-    <message>
-        <source>-rescan: Rescan the block chain for missing wallet transactions.</source>
-        <translation>-rescan: Rescanează blockchain-ul pentru tranzacții care lipsesc din portofel.</translation>
     </message>
     <message>
         <source>-zapwallettxes=1: Recover transactions from blockchain (keep meta-data, e.g. account owner).</source>
@@ -2706,16 +2570,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&lt;b&gt;(%1 of %2 înregistrările afișate)&lt;/b&gt;</translation>
     </message>
     <message>
-        <source>PrivateSend funds only</source>
-        <translation>Fonduri TrimitePrivat doar</translation>
-    </message>
-    <message>
         <source>any available funds</source>
         <translation>orice fonduri disponibile</translation>
-    </message>
-    <message>
-        <source>(PrivateSend transactions have higher fees usually due to no change output being allowed)</source>
-        <translation>(Tranzactiile TrimitePrivat au taxe mai mari de obicei din cauza ca iesirile cu rest nu sunt permise)</translation>
     </message>
     <message>
         <source>Transaction size: %1</source>
@@ -2728,10 +2584,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message numerus="yes">
         <source>This transaction will consume %n input(s)</source>
         <translation><numerusform>Aceasta tranzactie va consuma %n din intrari</numerusform><numerusform>Aceasta tranzactie va consuma %n din intrari</numerusform><numerusform>Aceasta tranzactie va consuma %n din intrari</numerusform></translation>
-    </message>
-    <message>
-        <source>Warning: Using PrivateSend with %1 or more inputs can harm your privacy and is not recommended</source>
-        <translation>Avertisment: Folosirea TrimitePrivat cu %1 sau mai multe intrari poate provoca daune confidentialitatii tale si nu este recomandata</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3289,10 +3141,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Primit de la</translation>
     </message>
     <message>
-        <source>Received via PrivateSend</source>
-        <translation>Primit prin TrimitePrivat</translation>
-    </message>
-    <message>
         <source>Sent to</source>
         <translation>Trimis către</translation>
     </message>
@@ -3303,22 +3151,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Mined</source>
         <translation>Minat</translation>
-    </message>
-    <message>
-        <source>PrivateSend Denominate</source>
-        <translation>TrimitePrivat Denumire</translation>
-    </message>
-    <message>
-        <source>PrivateSend Collateral Payment</source>
-        <translation>TrimitePrivat Plată Colaterală</translation>
-    </message>
-    <message>
-        <source>PrivateSend Make Collateral Inputs</source>
-        <translation>TrimitePrivat Realizează Intrări Colaterale </translation>
-    </message>
-    <message>
-        <source>PrivateSend Create Denominations</source>
-        <translation>TrimitePrivat Creează Denumiri</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -3398,22 +3230,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Sent to</source>
         <translation>Trimis către</translation>
-    </message>
-    <message>
-        <source>PrivateSend Make Collateral Inputs</source>
-        <translation>TrimitePrivat Realizează Intrări Colaterale </translation>
-    </message>
-    <message>
-        <source>PrivateSend Create Denominations</source>
-        <translation>TrimitePrivat Creează Denumiri</translation>
-    </message>
-    <message>
-        <source>PrivateSend Denominate</source>
-        <translation>TrimitePrivat Denumire</translation>
-    </message>
-    <message>
-        <source>PrivateSend Collateral Payment</source>
-        <translation>TrimitePrivat Plată Colaterală</translation>
     </message>
     <message>
         <source>To yourself</source>
@@ -3595,36 +3411,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Datele portofelului s-au salvat cu succes la %1.</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>dash-core</name>
     <message>
-        <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>Leagă-te de adresa dată și ascultă întotdeauna. Utilizează [host]: Notation port pentru IPv6</translation>
-    </message>
-    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation>Eroare: Ascultarea conexiunilor de intrare nu a reuşit (ascultarea a reurnat eroarea %s)</translation>
-    </message>
-    <message>
-        <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation>Execută comanda când se primește o alertă relevantă sau vedem o furcă foarte lungă (%s în cmd se înlocuiește cu mesaj)</translation>
-    </message>
-    <message>
-        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Executati comanda cand o tranzactie a portofelului se schimba (%s in cmd este inlocuit de TxID)</translation>
-    </message>
-    <message>
-        <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Execută comanda când cel mai bun bloc se modifică (%s în cmd este înlocuit cu hash-ul blocului)</translation>
-    </message>
-    <message>
-        <source>Name to construct url for KeePass entry that stores the wallet passphrase</source>
-        <translation>Nume pentru a construi url pentru intrarea KeePass care stochează fraza de acces a portofelului</translation>
-    </message>
-    <message>
-        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
-        <translation>Setează numărul de fire de verificare a scriptului (%u la %d, 0 = auto, &lt;0 = lasă mai multe nuclee libere, implicit: %d)</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
@@ -3639,20 +3431,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Atenţie: Aparent, nu sîntem de acord cu toţi partenerii noştri! Va trebui să faceţi o actualizare, sau alte noduri necesită actualizare.</translation>
     </message>
     <message>
-        <source>Accept command line and JSON-RPC commands</source>
-        <translation>Se acceptă comenzi din linia de comandă și comenzi JSON-RPC</translation>
-    </message>
-    <message>
-        <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
-        <translation>Permite căutări DNS pentru -addnode, -seednode și -connect</translation>
-    </message>
-    <message>
         <source>Already have that input.</source>
         <translation>Această intrare deja există.</translation>
-    </message>
-    <message>
-        <source>Block creation options:</source>
-        <translation>Optiuni creare block</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet</source>
@@ -3663,20 +3443,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Colateralul nu este valabil.</translation>
     </message>
     <message>
-        <source>Connection options:</source>
-        <translation>Opțiuni de conectare:</translation>
-    </message>
-    <message>
         <source>Corrupted block database detected</source>
         <translation>Bloc defect din baza de date detectat</translation>
-    </message>
-    <message>
-        <source>Debugging/Testing options:</source>
-        <translation>Opțiuni pentru Debugging/Testare:</translation>
-    </message>
-    <message>
-        <source>Do not load the wallet and disable wallet RPC calls</source>
-        <translation>Nu încărca portofelul și dezactiva apelurile RPC din portofel</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
@@ -3723,136 +3491,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Am esuat ascultarea pe orice port. Folositi -listen=0 daca vreti asta.</translation>
     </message>
     <message>
-        <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
-        <translation>(1 = păstrează meta datele tx, de exemplu, proprietarul contului și informațiile despre solicitarea de plată, 2 = șterge meta datele tx)</translation>
-    </message>
-    <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation>-maxtxfee este setata foarte sus! Se pot plati taxe de aceasta marime pe o singura tranzactie.</translation>
-    </message>
-    <message>
-        <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>
-        <translation>O rată a comisionului (in %s/kB) care va fi utilizată atunci când estimarea taxelor are date insuficiente (implicit: %s)</translation>
-    </message>
-    <message>
-        <source>Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)</source>
-        <translation>Acceptă tranzacțiile transmise primite de la whitelisted peers, chiar și atunci când nu efectuezi transmiterea tranzacțiilor (implicit: %d)</translation>
-    </message>
-    <message>
-        <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
-        <translation>Permite conexiunile JSON-RPC din sursa specificată. Valabil pentru &lt;ip&gt; sunt un singur IP (ex. 1.2.3.4), o rețea / un netmask (ex. 1.2.3.4/255.255.255.0) sau o rețea/CIDR (ex. 1.2.3.4/24). Această opțiune poate fi specificată de mai multe ori</translation>
-    </message>
-    <message>
-        <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
-        <translation>Leagă-te de adresa dată și whitelist peers care se conectează la ea. Utilizează [host]: notation port pentru IPv6</translation>
-    </message>
-    <message>
-        <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
-        <translation>Creează fișiere noi cu permisiuni implicite de sistem, în loc de umask 077 (funcțional numai cu funcționalitatea portofelului dezactivată)</translation>
-    </message>
-    <message>
-        <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
-        <translation>Șterge toate tranzacțiile din portofel și recuperează numai acele părți ale blockchain-ului prin -rescan la pornire</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transactions of attempted InstantSend double spend in &lt;address&gt;</source>
-        <translation>Activează publicarea tranzacțiilor brute pentru încercarea de a cheltui dublu cu TrimiteInstant &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish transaction hashes of attempted InstantSend double spend in &lt;address&gt;</source>
-        <translation>Activează publicarea hash-urile de tranzacții pentru încercarea de a cheltui dublu cu TrimiteInstant &lt;address&gt;</translation>
     </message>
     <message>
         <source>Found unconfirmed denominated outputs, will wait till they confirm to continue.</source>
         <translation>S-au găsit rezultate denominate neconfirmate, vom aștepta până se confirmă continuarea.</translation>
     </message>
     <message>
-        <source>How thorough the block verification of -checkblocks is (0-4, default: %u)</source>
-        <translation>Cât de detaliată este verificarea block pentru -checkblocks (0-4, implicit: %u)</translation>
-    </message>
-    <message>
-        <source>If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</source>
-        <translation>Dacă paytxfee nu este setat, include o taxă suficientă pentru ca tranzacțiile să înceapă să fie confirmate în medie în n block-uri (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)</source>
-        <translation>Dacă acest block este în lanț, presupune că acesta și strămoșii săi sunt valabili și, eventual, ignoră verificarea scriptului (0 pentru a verifica tot, implicit: %s, testnet: %s)</translation>
-    </message>
-    <message>
         <source>Invalid amount for -maxtxfee=&lt;amount&gt;: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)</source>
         <translation>Sumă nevalidă pentru -maxtxfee=&lt;amount&gt;: '%s' (trebuie să fie cel puţin taxa minrelay de %s pentru a preveni blocarea tranzactiilor)</translation>
     </message>
     <message>
-        <source>Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</source>
-        <translation>Menține un index complet al tranzacțiilor, utilizat de către getrawtransaction rpc call (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
-        <translation>Dimensiunea maximă a datelor din tranzacțiile de transport de date pe care le transmitem și minerim (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Number of seconds to keep misbehaving peers from reconnecting (default: %u)</source>
-        <translation>Numărul de secunde pentru a păstra acei peers care au o conduită nepotrivită de la reconectare (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Output debugging information (default: %u, supplying &lt;category&gt; is optional)</source>
-        <translation>Informații despre debuggingul ieșirilor (implicit: %u, furnizarea &lt;category&gt; este opțională)</translation>
-    </message>
-    <message>
-        <source>Overrides minimum spork signers to change spork value. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.</source>
-        <translation>Depășește minimumul semnătorilor spork pentru a schimba valoarea spork. Doar util pentru regtest și devnet. Folosirea acestui lucru pe mainnet sau testnet te va bloca.</translation>
-    </message>
-    <message>
-        <source>PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.</source>
-        <translation>TrimitePrivat foloseste sume denominate exacte pentru a trimite fonduri, s-ar putea sa ai nevoie pur si simplu sa amesteci niste monede in plus.</translation>
-    </message>
-    <message>
-        <source>Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex, -rescan and -disablegovernance=false. Warning: Reverting this setting requires re-downloading the entire blockchain. (default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, &gt;=%u = automatically prune block files to stay under the specified target size in MiB)</source>
-        <translation>Redu cerințele de stocare activând tăierea (ștergerea) block-urilor vechi. Asta va permite apelarea la pruneblockchain RPC pentru a șterge block-uri specifice, și permite tăierea automată a block-urilor vechi dacă este furnizată o dimensiune țintă în MiB. Acest mod este incompatibil cu -txindex, -rescan și -disablegovernance=false. Avertisment: Inversarea acestei setări necesită re-descărcarea întregului blockchain. (implicit: 0 = dezactivați tăierea block-urilor, 1 = permiteți tăierea manuală prin RPC, &gt;=%u = taie automat fișierele block pentru a rămâne sub dimensiunea de țintă specificată în MiB)</translation>
-    </message>
-    <message>
-        <source>Use N separate masternodes in parallel to mix funds (%u-%u, default: %u)</source>
-        <translation>Foloseștee N masternode-uri separate în paralel pentru mixarea fondurilor (%u-%u, implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
-        <translation>Utilizează un proxy separat SOCKS5 pentru a ajunge la peers prin intermediul serviciilor ascunse Tor (implicit: %s)</translation>
-    </message>
-    <message>
-        <source>User defined mnemonic for HD wallet (bip39). Only has effect during wallet creation/first start (default: randomly generated)</source>
-        <translation>Mnemonic definit de utilizator pentru portofel HD (bip39). Are efect numai în timpul creării portofelului / primului start (implicit: generat aleator)</translation>
-    </message>
-    <message>
-        <source>User defined seed for HD wallet (should be in hex). Only has effect during wallet creation/first start (default: randomly generated)</source>
-        <translation>Seed definit de utilizator pentru portofel HD (ar trebui să fie in hex ). Are efect numai în timpul creării portofelului / primului start (implicit: generat aleator)</translation>
-    </message>
-    <message>
-        <source>Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>
-        <translation>Whitelisted peers nu pot fi interziși și tranzacțiile lor sunt întotdeauna transmise, chiar dacă acestea sunt deja în mempool, de ex. pentru un gateway</translation>
-    </message>
-    <message>
-        <source>Accept public REST requests (default: %u)</source>
-        <translation>Acceptă cererile publice REST (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Always query for peer addresses via DNS lookup (default: %u)</source>
-        <translation>Întotdeauna caută adrese pentru peers prin căutare DNS (implicit: %u)</translation>
-    </message>
-    <message>
         <source>Can't mix: no compatible inputs found!</source>
         <translation>Nu se poate amesteca: nu au fost găsite intrări compatibile!</translation>
-    </message>
-    <message>
-        <source>Chain selection options:</source>
-        <translation>Opțiunile de selectare a lanțului:</translation>
-    </message>
-    <message>
-        <source>Connect through SOCKS5 proxy</source>
-        <translation>Conectare prin proxy SOCKS5</translation>
-    </message>
-    <message>
-        <source>Connect to KeePassHttp on port &lt;port&gt; (default: %u)</source>
-        <translation>Conectează-te la KeePassHttp  din port&lt;port&gt; (implicit: %u)</translation>
     </message>
     <message>
         <source>Entry exceeds maximum size.</source>
@@ -3879,16 +3531,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>S-au găsit suficienți utilizatori, semnând ...</translation>
     </message>
     <message>
-        <source>How many blocks to check at startup (default: %u, 0 = all)</source>
-        <translation>Câte blocuri trebuiesc verificate la pornire (implicit: %u, 0 = tot)</translation>
-    </message>
-    <message>
         <source>Importing...</source>
         <translation>Import...</translation>
-    </message>
-    <message>
-        <source>Include IP addresses in debug output (default: %u)</source>
-        <translation>Include adrese IP în debug output (implicit: %u)</translation>
     </message>
     <message>
         <source>Incompatible mode.</source>
@@ -3931,14 +3575,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Keypool epuizat, folositi intai functia keypoolrefill</translation>
     </message>
     <message>
-        <source>Listen for JSON-RPC connections on &lt;port&gt; (default: %u or testnet: %u)</source>
-        <translation>Ascultă conexiunile JSON-RPC la&lt;port&gt; (implicit: %u sau testnet: %u)</translation>
-    </message>
-    <message>
-        <source>Listen for connections on &lt;port&gt; (default: %u or testnet: %u)</source>
-        <translation>Ascultă conexiunile la  &lt;port&gt; (implicit: %u sau testnet: %u)</translation>
-    </message>
-    <message>
         <source>Loading banlist...</source>
         <translation>Încărcare banlist...</translation>
     </message>
@@ -3955,20 +3591,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Blocarea este deja în vigoare.</translation>
     </message>
     <message>
-        <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
-        <translation>Buffer de primire maxim pe conexiune, &lt;n&gt;*1000 bytes (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
-        <translation>Buffer de trimitere maxim pe conexiune, &lt;n&gt;*1000 bytes (implicit: %u)</translation>
-    </message>
-    <message>
         <source>Mixing in progress...</source>
         <translation>Amestecare în curs ...</translation>
-    </message>
-    <message>
-        <source>Mnemonic passphrase is too long, must be at most 256 characters</source>
-        <translation>Fraza de access mnemonică este prea lungă, trebuie sa aibă cel mult 256 caractere</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -3991,56 +3615,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nu este în lista Masternode</translation>
     </message>
     <message>
-        <source>Prepend debug output with timestamp (default: %u)</source>
-        <translation>Prefixează debug output-ul cu marca de timp (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Rebuild chain state and block index from the blk*.dat files on disk</source>
-        <translation>Refă starea lanțului și blochează indexul din blk*.dat files de pe disc</translation>
-    </message>
-    <message>
-        <source>Rebuild chain state from the currently indexed blocks</source>
-        <translation>Refă starea lanțului din block-urile indexate până în prezent</translation>
-    </message>
-    <message>
-        <source>Send trace/debug info to debug.log file (default: %u)</source>
-        <translation>Trimite informații despre trace/debug în fișierul debug.log (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Set key pool size to &lt;n&gt; (default: %u)</source>
-        <translation>Setează dimensiunea polului cheilor la &lt;n&gt; (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Set the number of threads to service RPC calls (default: %d)</source>
-        <translation>Setează numărul de fire pentru a activa apelurile RPC (implicit: %d)</translation>
-    </message>
-    <message>
-        <source>Specify connection timeout in milliseconds (minimum: 1, default: %d)</source>
-        <translation>Specifică timpul de conectare în milisecunde (minimum: 1, implicit: %d)</translation>
-    </message>
-    <message>
-        <source>Spend unconfirmed change when sending transactions (default: %u)</source>
-        <translation>Cheltuie restul neconfirmat la trimiterea tranzacțiilor (implicit: %u)</translation>
-    </message>
-    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Trimis la masternode, așteaptă la coadă %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Sincronizarea s-a terminat</translation>
-    </message>
-    <message>
-        <source>Threshold for disconnecting misbehaving peers (default: %u)</source>
-        <translation> Prag pentru deconectarea acelor peers care au o conduita nepotrivită (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Tor control port password (default: empty)</source>
-        <translation>Parola pentru portul de control Tor (implicit: gol)</translation>
-    </message>
-    <message>
-        <source>Tor control port to use if onion listening enabled (default: %s)</source>
-        <translation>Portul de control Tor pentru utilizat dacă ascultarea onion a fost activată (implicit: %s)</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4061,22 +3641,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Unsupported argument -tor found, use -onion.</source>
         <translation>Argument nesuportat -tor găsit, folosiţi -onion.</translation>
-    </message>
-    <message>
-        <source>Upgrade wallet to latest format on startup</source>
-        <translation>Actualizează portofelul la cel mai recent format la pornire</translation>
-    </message>
-    <message>
-        <source>Use KeePass 2 integration using KeePassHttp plugin (default: %u)</source>
-        <translation>Utilizează integrarea KeePass 2 folosind plugin-ul KeePassHttp (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Use UPnP to map the listening port (default: %u)</source>
-        <translation>Utilizează UPnP pentru a mapa portul de ascultare (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Use the test chain</source>
-        <translation>Utilizează lanțul de testare</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -4107,14 +3671,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>S-a detectat un script nevalid.</translation>
     </message>
     <message>
-        <source>KeePassHttp id for the established association</source>
-        <translation>KeePassHttp id pentru asociația stabilită</translation>
-    </message>
-    <message>
-        <source>KeePassHttp key for AES encrypted communication with KeePass</source>
-        <translation>Cheie KeePassHttp pentru comunicarea criptată AES cu KeePass</translation>
-    </message>
-    <message>
         <source>%s file contains all private keys from this wallet. Do not share it with anyone!</source>
         <translation>%s fișierul conține toate cheile private din acest portofel. Nu le împărtăși nimănui!</translation>
     </message>
@@ -4123,64 +3679,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>- optiunea masternode este dezaprobata si ignorata - specificarea masternodeblsprivkey-ului este suficienta pentru a porni acest nod ca si un masternode.</translation>
     </message>
     <message>
-        <source>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</source>
-        <translation>Descoperă adresele IP proprii (implicit: 1 când asculți și nu -externalip sau -proxy)</translation>
-    </message>
-    <message>
-        <source>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</source>
-        <translation>Nu păstrai tranzacțiile în mempool mai mult decât &lt;n&gt; ore (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Enable multiple PrivateSend mixing sessions per block, experimental (0-1, default: %u)</source>
-        <translation>Activează mai multe sesiuni de amestecare TrimitePrivat per block, experimentale (0-1, implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Execute command when a wallet InstantSend transaction is successfully locked (%s in cmd is replaced by TxID)</source>
-        <translation>Execută comanda când o tranzacție InstantSend cu portofel este blocată cu succes (%s în cmd se înlocuiește cu TxID)</translation>
-    </message>
-    <message>
-        <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
-        <translation>Tranzacții suplimentare pe care trebuie să le păstrați în memorie pentru reconstrucții cu block compact (implicit: %u)</translation>
-    </message>
-    <message>
         <source>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
         <translation>Nu s-a reușit crearea unui backup, fișierul există deja! Acest lucru s-ar putea întâmpla dacă ai repornit portofelul în mai puțin de 60 de secunde. Poți continua dacă eşti de acord cu asta.</translation>
     </message>
     <message>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
-        <translation>Taxele (în %s/kB) mai mici decât atât sunt considerate taxe zero pentru relocare, minerit și crearea de tranzacții (implicit: %s)</translation>
-    </message>
-    <message>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</source>
-        <translation>Taxele (în %s/kB) mai mici decât atât sunt considerate comision zero pentru crearea tranzacțiilor (implicit: %s)</translation>
-    </message>
-    <message>
-        <source>If &lt;category&gt; is not supplied or if &lt;category&gt; = 1, output all debugging information.</source>
-        <translation>Dacă &lt;category&gt;nu este furnizat sau dacă &lt;category&gt; = 1, output toate informațiile de debugging.</translation>
-    </message>
-    <message>
-        <source>Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)</source>
-        <translation>Menține un index de adrese complet, folosit pentru a căuta balanța, txide și output-urile necheltuite pentru adrese (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain a full spent index, used to query the spending txid and input index for an outpoint (default: %u)</source>
-        <translation>Menține un index de cheltuieli integrale, folosit pentru a vedea cheltuielile txid și indexul de intrare pentru un punct de ieșire (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain a timestamp index for block hashes, used to query blocks hashes by a range of timestamps (default: %u)</source>
-        <translation>Menține unui index timestamp pentru hashe-urile block-urilor, utilizat pentru căutarea hashe-urile block-urilor cu ajutorul unui interval de timestamps (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain at most &lt;n&gt; connections to peers (temporary service connections excluded) (default: %u)</source>
-        <translation>Menține cel mult &lt;n&gt;conexiuni cu peers (excluderea conexiunilor temporare) (implicit : %u)</translation>
-    </message>
-    <message>
         <source>Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</source>
         <translation>Fii sigur sa criptezi portofelul tau si sa stergi toate backup-urile non-criptate dupa ce ai verificat ca portofelul functioneaza!</translation>
-    </message>
-    <message>
-        <source>Maximum total size of all orphan transactions in megabytes (default: %u)</source>
-        <translation>Marimea totala maxima a tuturor tranzactiilor orfane in megabytes (implicit: %u)</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
@@ -4191,28 +3695,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Reductie: ultima sincronizare merge dincolo de datele reductiei. Trebuie sa faceti -reindex (sa descarcati din nou intregul blockchain in cazul unui nod redus)</translation>
     </message>
     <message>
-        <source>Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect used)</source>
-        <translation>Interogare pentru adrese peer prin căutare DNS, dacă există puține adrese (implicit: 1 decât daca -conectarea este în folosință)</translation>
-    </message>
-    <message>
-        <source>Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)</source>
-        <translation>Randomizează acreditările pentru fiecare conexiune proxy. Asta permite izolarea stream-ului Tor (implicit: %u)</translation>
-    </message>
-    <message>
         <source>Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.</source>
         <translation>Rescanarile nu sunt posibile in modul redus. Va trebui sa folositi -reindex, ceea ce va descarca din nou intregul blockchain.</translation>
-    </message>
-    <message>
-        <source>Set the masternode BLS private key and enable the client to act as a masternode</source>
-        <translation>Seteza cheia BLS privata a masternodului si permite clientului sa se comporte ca un masternode</translation>
-    </message>
-    <message>
-        <source>Specify full path to directory for automatic wallet backups (must exist)</source>
-        <translation>Specifică calea completă la directorul pentru backupul automat al portofelului (trebuie să existe)</translation>
-    </message>
-    <message>
-        <source>Support filtering of blocks and transaction with bloom filters (default: %u)</source>
-        <translation>Suportă filtrarea block-urilor și tranzacția cu filtre bloom (implicit: %u)</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -4227,28 +3711,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Lungimea totala a sirului versiunii retelei (%i) depaseste lungimea maxima (%i). Reduceti numarul sa dimensiunea uacomments. </translation>
     </message>
     <message>
-        <source>Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)</source>
-        <translation>Încearcă să păstrezi traficul de ieșire sub ținta dată (în MiB per 24h), 0 = fără limită (implicit: %d)</translation>
-    </message>
-    <message>
-        <source>Unable to locate enough PrivateSend denominated funds for this transaction.</source>
-        <translation>Imposibil de localizat suficiente fonduri denominate TrimitePrivat pentru această tranzacție.</translation>
-    </message>
-    <message>
         <source>Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported.</source>
         <translation>S-a gasit un argument -socks nesuportat. Setarea versiunii SOCKS nu mai este posibila, sunt suportate doar proxiurile SOCKS5.</translation>
     </message>
     <message>
         <source>Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay.</source>
         <translation>Se ignora argumentul nesuportat -whitelistalwaysrelay, folositi -whitelistrelay si/sau -whitelistforcerelay.</translation>
-    </message>
-    <message>
-        <source>Use UPnP to map the listening port (default: 1 when listening and no -proxy)</source>
-        <translation>Utilizează UPnP pentru a mapa portul de ascultare (implicit: 1 când asculți și nu -proxy)</translation>
-    </message>
-    <message>
-        <source>Username and hashed password for JSON-RPC connections. The field &lt;userpw&gt; comes in the format: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. A canonical python script is included in share/rpcauth. The client then connects normally using the rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt; pair of arguments. This option can be specified multiple times</source>
-        <translation>Numele de utilizator și parola de salvare pentru conexiunile JSON-RPC. Câmpul &lt;userpw&gt; vine în formatul: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. Un script phyton canonic este inclus în share/rpcauth. Apoi, clientul se conectează în mod normal folosind rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt;pereche de argumente. Această opțiune poate fi specificată de mai multe ori </translation>
     </message>
     <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
@@ -4271,64 +3739,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Trebuie reconstruita intreaga baza de date folosind -reindex pentru a va intoarce la modul non-redus. Aceasta va determina descarcarea din nou a intregului blockchain</translation>
     </message>
     <message>
-        <source>(default: %u)</source>
-        <translation>(implicit: %u)</translation>
-    </message>
-    <message>
         <source>-maxmempool must be at least %d MB</source>
         <translation>-maxmempool trebuie sa fie macar %d MB</translation>
-    </message>
-    <message>
-        <source>&lt;category&gt; can be:</source>
-        <translation>&lt;category&gt; poate fi:</translation>
-    </message>
-    <message>
-        <source>Append comment to the user agent string</source>
-        <translation>Adaugă comentariu la user agent string</translation>
     </message>
     <message>
         <source>Automatic backups disabled</source>
         <translation>Backup-urile automate sunt dezactivate</translation>
     </message>
     <message>
-        <source>Automatically create Tor hidden service (default: %d)</source>
-        <translation>Creează automat serviciul ascuns Tor (implicit: %d)</translation>
-    </message>
-    <message>
         <source>ERROR! Failed to create automatic backup</source>
         <translation>EROARE! Backup-ul automat a eșuat</translation>
-    </message>
-    <message>
-        <source>Enable publish hash block in &lt;address&gt;</source>
-        <translation>Activează publicarea block-ului hash în &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash of governance objects (like proposals) in &lt;address&gt;</source>
-        <translation>Activează publicarea hash-urilor obiectelor de guvernanță (asemenea propunerilor) în &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash of governance votes in &lt;address&gt;</source>
-        <translation>Activează publicarea hash-urilor voturilor de guvernanță în &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash transaction (locked via InstantSend) in &lt;address&gt;</source>
-        <translation>Activează publicarea hash-ului tranzacției (blocat prin TrimiteInstant) în &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash transaction in &lt;address&gt;</source>
-        <translation>Activează publicarea hash-ului tranzacției în &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw block in &lt;address&gt;</source>
-        <translation>Activează publicarea block-ului raw în &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transaction (locked via InstantSend) in &lt;address&gt;</source>
-        <translation>Activează publicarea tranzacției raw (blocată prin TrimiteInstant) în &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transaction in &lt;address&gt;</source>
-        <translation>Activează publicarea tranzacției raw în &lt;address&gt;</translation>
     </message>
     <message>
         <source>Error: A fatal internal error occurred, see debug.log for details</source>
@@ -4351,36 +3771,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nu s-a putut încărca cache-ul sporks din</translation>
     </message>
     <message>
-        <source>Fee (in %s/kB) to add to transactions you send (default: %s)</source>
-        <translation>Taxa (în %s/kB) pentru a adăuga la tranzacțiile pe care le trimiți (implicit: %s)</translation>
-    </message>
-    <message>
-        <source>Imports blocks from external blk000??.dat file on startup</source>
-        <translation>Importă block-uri din fișierul blk000??.dat la pornire</translation>
-    </message>
-    <message>
-        <source>InstantSend options:</source>
-        <translation>Opțiuni TrimiteInstant:</translation>
-    </message>
-    <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
         <translation>Suma nevalidă pentru -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
     <message>
         <source>Invalid masternodeblsprivkey. Please see documentation.</source>
         <translation>masternodeblsprivkey nu este valabil. Consultă documentația.</translation>
-    </message>
-    <message>
-        <source>Keep the transaction memory pool below &lt;n&gt; megabytes (default: %u)</source>
-        <translation>Păstrează pol-ul de memorie pentru tranzacții sub &lt;n&gt; megabytes (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Last PrivateSend was too recent.</source>
-        <translation>Ultimul TrimitePrivat a fost prea recent. </translation>
-    </message>
-    <message>
-        <source>Last successful PrivateSend action was too recent.</source>
-        <translation>Ultima acțiune TrimitePrivat de succes a fost prea recentă.</translation>
     </message>
     <message>
         <source>Loading block index...</source>
@@ -4403,24 +3799,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Încarc portofel...</translation>
     </message>
     <message>
-        <source>Make the wallet broadcast transactions</source>
-        <translation>Fă ca portofelul sa trimită tranzacții</translation>
-    </message>
-    <message>
-        <source>Masternode options:</source>
-        <translation>Opțiuni Masternode:</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Queue-ul Masternode este plin.</translation>
     </message>
     <message>
         <source>Masternode:</source>
         <translation>Masternode:</translation>
-    </message>
-    <message>
-        <source>Minimum bytes per sigop in transactions we relay and mine (default: %u)</source>
-        <translation>Minimum de bytes per sigop în tranzacțiile pe care le transmitem și minerim (implicit: %u)</translation>
     </message>
     <message>
         <source>Missing input transaction information.</source>
@@ -4435,44 +3819,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nu au fost găsite denominări potrivite pentru amestecare.</translation>
     </message>
     <message>
-        <source>Node relay options:</source>
-        <translation>Opțiuni pentru node relay:</translation>
-    </message>
-    <message>
         <source>Not compatible with existing transactions.</source>
         <translation>Nu este compatibil cu tranzacțiile existente.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
         <translation>Nu sînt destule descriptoare disponibile.</translation>
-    </message>
-    <message>
-        <source>Number of automatic wallet backups (default: %u)</source>
-        <translation>Numărul de backup-uri automate ale portofelului (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Options:</source>
-        <translation>Setări:</translation>
-    </message>
-    <message>
-        <source>Password for JSON-RPC connections</source>
-        <translation>Parola pentru conexiunile JSON-RPC</translation>
-    </message>
-    <message>
-        <source>Print version and exit</source>
-        <translation>Printează versiunea și apoi exit</translation>
-    </message>
-    <message>
-        <source>PrivateSend is idle.</source>
-        <translation>TrimitePrivat este inactiv.</translation>
-    </message>
-    <message>
-        <source>PrivateSend options:</source>
-        <translation>opțiuni TrimitePrivat:</translation>
-    </message>
-    <message>
-        <source>PrivateSend request incomplete:</source>
-        <translation>solicitare TrimitePrivat incompletă:</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -4485,10 +3837,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Pruning blockstore...</source>
         <translation>Reductie blockstore...</translation>
-    </message>
-    <message>
-        <source>Rescan the block chain for missing wallet transactions on startup</source>
-        <translation>Schimbă din nou blockchain-ul pentru tranzacțiile lipsă din portofel la pornire</translation>
     </message>
     <message>
         <source>Synchronizing blockchain...</source>
@@ -4535,14 +3883,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Actualizarea bazei de date UTXO</translation>
     </message>
     <message>
-        <source>Use devnet chain with provided name</source>
-        <translation>Utilizează lanțul devnet cu numele furnizat</translation>
-    </message>
-    <message>
-        <source>Wallet debugging/testing options:</source>
-        <translation>Opțiuni de debugging/testare portofel:</translation>
-    </message>
-    <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
         <translation>Portofelul trebuie rescris: reporneşte %s pentru finalizare</translation>
     </message>
@@ -4553,10 +3893,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Wasn't able to create wallet backup folder %s!</source>
         <translation>Nu s-a putut creea un backup folder pentru portofel %s!</translation>
-    </message>
-    <message>
-        <source>Whether to operate in a blocks only mode (default: %u)</source>
-        <translation>Dacă funcționează doar într-un mod blocks only (implicit: %u)</translation>
     </message>
     <message>
         <source>You can not start a masternode with wallet enabled.</source>
@@ -4575,20 +3911,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Trebuie să reconstruiești baza de date utilizând -reindex pentru a schimba -txindex</translation>
     </message>
     <message>
-        <source>ZeroMQ notification options:</source>
-        <translation>Opțiuni de notificare ZeroMQ:</translation>
-    </message>
-    <message>
         <source>no mixing available.</source>
         <translation>mixing nu este valabil</translation>
     </message>
     <message>
         <source>see debug.log for details.</source>
         <translation>vezi debug.log pentru detalii.</translation>
-    </message>
-    <message>
-        <source>RPC server options:</source>
-        <translation>Opțiuni server RPC:</translation>
     </message>
     <message>
         <source>Dash Core</source>
@@ -4607,10 +3935,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Distribuit sub licenţa de programe MIT, vezi fişierul însoţitor %s sau %s</translation>
     </message>
     <message>
-        <source>Enable use of PrivateSend for funds stored in this wallet (0-1, default: %u)</source>
-        <translation>Activează TrimitePrivat pentru fondurile stocate în acest portofel (0-1, implicit: %u)</translation>
-    </message>
-    <message>
         <source>Error loading %s: You can't enable HD on an already existing non-HD wallet</source>
         <translation>Eroare la încărcare %s: Nu poți activa HD pe un portofel non-HD deja existent</translation>
     </message>
@@ -4619,28 +3943,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Eroare la citirea %s! Toate cheile sînt citite corect, dar datele tranzactiei sau anumite intrări din agenda sînt incorecte sau lipsesc.</translation>
     </message>
     <message>
-        <source>Exclude debugging information for a category. Can be used in conjunction with -debug=1 to output debug logs for all categories except one or more specified categories.</source>
-        <translation>Excludeți informațiile de debugging pentru o categorie. Poate fi utilizat împreună cu -debug=1 pentru a produce jurnalele de debug pentru toate categoriile, cu excepția uneia sau a mai multor categorii specificate.</translation>
-    </message>
-    <message>
-        <source>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</source>
-        <translation>Forțează transmiterea tranzacțiilor de la whitelisted peers, chiar dacă încalcă politica locală de transmitere (implicit: %d)</translation>
-    </message>
-    <message>
         <source>Incorrect or no devnet genesis block found. Wrong datadir for devnet specified?</source>
         <translation>Incorect sau nici un block de geneză devnet nu a fost găsit. Datadir greșit pentru specificarea devnet-ului?</translation>
-    </message>
-    <message>
-        <source>Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)</source>
-        <translation>Ajustarea compensării timpului maxim permis pentru peers. Perspectiva locală a timpului poate fi influențată de către peers înainte sau înapoi de către această cantitate. (implicit: %u secunde)</translation>
-    </message>
-    <message>
-        <source>Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)</source>
-        <translation>Taxe totale maxime (în %s) de utilizat într-o singură tranzacție din portofel sau tranzacție brută; setarea acestui nivel prea mic poate anula tranzacții mari (implicit: %s)</translation>
-    </message>
-    <message>
-        <source>Override spork address. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.</source>
-        <translation>Înlocuiește adresa spork. Este utilă doar pentru regtest și devnet. Utilizarea acesteia pe mainnet sau testnet va rezulta in blocare. </translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -4649,14 +3953,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
         <translation>Va rugam sa contribuiti daca apreciati ca %s va este util. Vizitati %s pentru mai multe informatii despre software.</translation>
-    </message>
-    <message>
-        <source>Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)</source>
-        <translation>Setează cea mai mică rată de taxă (în %s/kB) pentru tranzacțiile care vor fi incluse în crearea block-urilor. (implicit: %s)</translation>
-    </message>
-    <message>
-        <source>The fee rate (in %s/kB) that indicates your tolerance for discarding change by adding it to the fee (default: %s). Note: An output is discarded if it is dust at this rate, but we will always discard up to the dust relay fee and a discard fee above that is limited by the fee estimate for the longest target</source>
-        <translation>Rata taxei (in %s/kB) care indică toleranța ta pentru eliminarea schimbării prin adăugarea acesteia la taxă (implicit: %s). Notă: O producție este aruncată dacă este dust în acest ritm, dar vom elimina întotdeauna până la taxa de releu dust și o taxă de eliminare peste cea limitată de estimarea tarifului pentru cea mai lungă țintă</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -4671,40 +3967,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Acest produs include software dezvoltat de OpenSSL Project pentru a fi folosit in Toolkitul OpenSSL %s, software criptografic scris de Eric Young si software UPnP scris de Thomas Bernard. </translation>
     </message>
     <message>
-        <source>Unable to locate enough PrivateSend non-denominated funds for this transaction.</source>
-        <translation>Nu se pot localiza destule fonduri nedenominate TrimitePrivat pentru această tranzacție.</translation>
-    </message>
-    <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation>Imposibil de redat block-urile. Va trebui să reconstruiți baza de date folosind -reindex-chainstate.</translation>
     </message>
     <message>
-        <source>Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)</source>
-        <translation> Utilizați masternode-uri N separate pentru fiecare intrare nominală pentru a amesteca fonduri (%u-%u, implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Use hierarchical deterministic key generation (HD) after BIP39/BIP44. Only has effect during wallet creation/first start</source>
-        <translation>Utilizează generarea ierarhică de chei deterministe (HD) după BIP39 / BIP44. Are efect numai în timpul creării portofelului/primei porniri</translation>
-    </message>
-    <message>
-        <source>User defined mnemonic passphrase for HD wallet (BIP39). Only has effect during wallet creation/first start (default: empty string)</source>
-        <translation>Fraza de acces mnemonică definită de utilizator pentru portofelul HD (BIP39). Are efect numai în timpul creării portofelului/primula pornire (implicit: empty string)</translation>
-    </message>
-    <message>
-        <source>Wallet will not create transactions that violate mempool chain limits (default: %u)</source>
-        <translation>Portofelul nu va crea tranzacții care încalcă limitele lanțului mempool (implicit: %u)</translation>
-    </message>
-    <message>
         <source>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Atenţie: fişierul portofelului este corupt, date salvate! Fişierul %s a fost salvat ca %s in %s; dacă balanta sau tranzactiile sunt incorecte ar trebui să restauraţi dintr-o copie de siguranţă.</translation>
-    </message>
-    <message>
-        <source>Whether to save the mempool on shutdown and load on restart (default: %u)</source>
-        <translation>Dacă salvezi mempool-ul la oprire și-l încărci la repornire (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.</source>
-        <translation>Whitelist peers care se conectează de la adresa IP dată (ex. 1.2.3.4) sau rețeaua notată CIDR (ex. 1.2.3.0/24). Poate fi specificat de mai multe ori.</translation>
     </message>
     <message>
         <source>%d of last 100 blocks have unexpected version</source>
@@ -4735,18 +4003,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-rpcport trebuie specificat când -devnet și -server sunt specificate</translation>
     </message>
     <message>
-        <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
-        <translation>Acceptă conexiunile din exterior (implicit: 1 dacă nu -proxy sau -connect)</translation>
-    </message>
-    <message>
-        <source>Allow RFC1918 addresses to be relayed and connected to (default: %u)</source>
-        <translation>Permite adreselor RFC1918 să fie transmise și conectate la (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Attempt to recover private keys from a corrupt wallet on startup</source>
-        <translation>Încearcă să recuperezi cheile private de la un portofel corupt la pornire</translation>
-    </message>
-    <message>
         <source>Cannot resolve -%s address: '%s'</source>
         <translation>Nu se poate rezolva adresa -%s: '%s'</translation>
     </message>
@@ -4757,10 +4013,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Copyright (C)</source>
         <translation>Copyright (C)</translation>
-    </message>
-    <message>
-        <source>Create up to N inputs of each denominated amount (%u-%u, default: %u)</source>
-        <translation>Creează până la N intrări pentru fiecare sumă denominată (%u-%u, implicit: %u)</translation>
     </message>
     <message>
         <source>Error loading %s</source>
@@ -4780,7 +4032,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>Error loading wallet %s. Duplicate -wallet filename specified.</source>
-        <translation>Eroare la încărcarea portofelului %s. Numele de fișier duplicat -walet specificat.</translation>
+        <translation>Eroare la încărcarea portofelului %s. Numele de fișier duplicat -wallet specificat.</translation>
     </message>
     <message>
         <source>Error upgrading chainstate database</source>
@@ -4823,20 +4075,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Încărcare adrese P2P...</translation>
     </message>
     <message>
-        <source>Print this help message and exit</source>
-        <translation>Printează acest mesaj de ajutor și apoi exit</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Se micsoreaza -maxconnections de la %d la %d, datorita limitarilor de sistem.</translation>
-    </message>
-    <message>
-        <source>Relay and mine data carrier transactions (default: %u)</source>
-        <translation>Transmite si minereşte tranzacțiile cu operator de date (implicit: %u)</translation>
-    </message>
-    <message>
-        <source>Relay non-P2SH multisig (default: %u)</source>
-        <translation>Transmite multisig non-P2SH (implicit: %u)</translation>
     </message>
     <message>
         <source>Replaying blocks...</source>
@@ -4847,10 +4087,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Rescanare...</translation>
     </message>
     <message>
-        <source>Run in the background as a daemon and accept commands</source>
-        <translation>Rulează în fundal ca un demon și acceptă comenzi</translation>
-    </message>
-    <message>
         <source>Session not complete!</source>
         <translation>Sesiunea nu este completă!</translation>
     </message>
@@ -4859,36 +4095,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Sesiunea a expirat.</translation>
     </message>
     <message>
-        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
-        <translation>Setează dimensiunea memoriei cache a bazei de date în megabytes (%d to %d, implicit: %d)</translation>
-    </message>
-    <message>
-        <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>Setează dimensiunea maximă a bloclk-ului în bytes (implicit: %d)</translation>
-    </message>
-    <message>
-        <source>Show all debugging options (usage: --help -help-debug)</source>
-        <translation>Afișează toate opțiunile de debugging (utilizare: -help -help-debug)</translation>
-    </message>
-    <message>
-        <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
-        <translation>Micsorati fisierul debug.log la inceperea clientului (implicit: 1 cand nu -debug)</translation>
-    </message>
-    <message>
         <source>Signing transaction failed</source>
         <translation>Nu s-a reuşit semnarea tranzacţiei</translation>
-    </message>
-    <message>
-        <source>Specify data directory</source>
-        <translation>Specifică dosarul de date</translation>
-    </message>
-    <message>
-        <source>Specify your own public address</source>
-        <translation>Specifică adresa ta publică</translation>
-    </message>
-    <message>
-        <source>Start PrivateSend automatically (0-1, default: %u)</source>
-        <translation>Pornește TrimitePrivat automat (0-1, implicit: %u)</translation>
     </message>
     <message>
         <source>Starting network threads...</source>
@@ -4951,10 +4159,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Categorie de înregistrare neacceptată %s=%s.</translation>
     </message>
     <message>
-        <source>Username for JSON-RPC connections</source>
-        <translation>Utilizator pentru conexiunile JSON-RPC</translation>
-    </message>
-    <message>
         <source>Verifying blocks...</source>
         <translation>Se verifică blocurile...</translation>
     </message>
@@ -4965,10 +4169,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Wallet is locked.</source>
         <translation>Portofel blocat.</translation>
-    </message>
-    <message>
-        <source>Wallet options:</source>
-        <translation>Opțiuni pentru portofel:</translation>
     </message>
     <message>
         <source>Warning</source>

--- a/src/qt/locale/dash_sk.ts
+++ b/src/qt/locale/dash_sk.ts
@@ -247,10 +247,6 @@
         <translation>Peňaženka zašifrovaná</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 sa teraz ukončí, aby dokončil proces šifrovania. Nezabudnite, že zašifrovanie vašej peňaženky nemôže plne chrániť vaše finančné prostriedky pred krádežou škodlivým softvérom, ktorý napadol váš počítač.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>DÔLEŽITÉ: Všetky doterajšie záložné kópie peňaženky ktoré ste zhotovili by mali byť nahradené novým zašifrovaným súborom s peňaženkou. Predchádzajúce zálohy súboru nezašifrovanej peňaženky obsahujú rovnakú HD frázu a stále majú plný prístup k všetkým vašim finančným prostriedkom rovnako ako nová zašifrovaná peňaženka.</translation>
     </message>

--- a/src/qt/locale/dash_th.ts
+++ b/src/qt/locale/dash_th.ts
@@ -247,10 +247,6 @@
         <translation>กระเป๋าสตางค์ถูกเข้ารหัสเรียบร้อยแล้ว</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 จะปิดตอนนี้เพื่อสิ้นสุดขั้นตอนการเข้ารหัส โปรดทราบว่าการเข้ารหัสข้อมูลกระเป๋าสตางค์ของคุณไม่สามารถป้องกันเงินจากการถูกโจรกรรมจากคอมพิวเตอร์ของคุณได้อย่างเต็มที่</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>ข้อมูลสำคัญ: การสำรองข้อมูลใดๆก่อนหน้านี้ในไฟล์กระเป๋าสตางค์ควรจะถูกแทนที่โดยใช้ไฟล์กระเป๋าสตางค์ที่เข้ารหัสลับใหม่ที่สร้างขึ้น การสำรองข้อมูลก่อนหน้าของไฟล์กระเป๋าสตางค์ที่ไม่ได้เข้ารหัสด้วย HD Seed เดียวกันจะยังคงสามารถเข้าถึงกองทุนของคุณได้อย่างเต็มที่เช่นเดียวกับกระเป๋าสตางค์ใหม่ที่มีการเข้ารหัสลับใหม่</translation>
     </message>

--- a/src/qt/locale/dash_tr.ts
+++ b/src/qt/locale/dash_tr.ts
@@ -247,10 +247,6 @@
         <translation>Cüzdan şifrelendi</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 şimdi şifreleme işlemini bitirmek için kapanacak. Unutmayın, cüzdanınızı şifrelemek sizi bilgisayarınıza bulaşmış olan kötü amaçlı yazılımlar tarafından paranızın çalınmasına karşı tamamen korumaz.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>ÖNEMLİ: Cüzdanınızın eskiden yapılmış yedekleri yeni oluşturulmuş, şifreli cüzdan dosyası ile değiştirilmelidir. Şifresiz cüzdan dosyasının önceki yedekleri aynı HD kaynağını içerir ve yeni, şifreli cüzdanınız gibi tüm bakiyenize erişim sağlar.</translation>
     </message>

--- a/src/qt/locale/dash_vi.ts
+++ b/src/qt/locale/dash_vi.ts
@@ -243,10 +243,6 @@
         <translation>Ví đã được mã hoá.</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 sẽ được đóng bây giờ để hoàn thành tiến trình mã hoá. Hãy nhớ rằng mã hoá ví không thể hoàn toàn bảo vệ tiền của bạn khỏi bị ăn trộm bởi những mã độc đã thâm nhập máy tính của bạn.</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>QUAN TRỌNG: Bất cứ sao lưu nào bạn đã làm trước đó với ví của bạn thì nên thay thế bằng phiên bản sao lưu mới nhất đã được mã hoá. Những bản sao lưu trước mà không mã hoá mà chứa HD Seed thì vẫn có toàn quyền truy cập đến tiền trong ví của bạn giống y như phiên bản ví mới đã được mã hoá.</translation>
     </message>
@@ -390,10 +386,6 @@
     <message>
         <source>&amp;About %1</source>
         <translation>&amp;Khoảng %1</translation>
-    </message>
-    <message>
-        <source>PrivateSend coins to a Dash address</source>
-        <translation>Gửi PrivateSend đến một địa chỉ Dash</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
@@ -554,14 +546,6 @@
     <message>
         <source>Wallet is &lt;b&gt;unencrypted&lt;/b&gt;</source>
         <translation>Ví được &lt;b&gt;mở mã hoá&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>&amp;PrivateSend information</source>
-        <translation>Thông tin về &amp;PrivateSend</translation>
-    </message>
-    <message>
-        <source>Show the PrivateSend basic information</source>
-        <translation>Hiển thị những thông tin cơ bản về PrivateSend</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -901,14 +885,6 @@
         <translation>Hiển thị toàn bộ coin</translation>
     </message>
     <message>
-        <source>Hide PrivateSend coins</source>
-        <translation>Ẩn coin PrivateSend</translation>
-    </message>
-    <message>
-        <source>Show all PrivateSend coins</source>
-        <translation>Hiển thị tất cả coin PrivateSend</translation>
-    </message>
-    <message>
         <source>Show spendable coins only</source>
         <translation>Chỉ hiển thị những coin tiêu được</translation>
     </message>
@@ -950,10 +926,6 @@
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Địa chỉ tương ứng với địa chỉ này trong danh sách đầu vào. Chỉ có thể thay đổi địa chỉ gửi đi.</translation>
-    </message>
-    <message>
-        <source>New receiving address</source>
-        <translation>Tạo đị chỉ nhận mới</translation>
     </message>
     <message>
         <source>New sending address</source>
@@ -1025,67 +997,7 @@
         <source>Command-line options</source>
         <translation>Các tuỳ chọn dòng lệnh</translation>
     </message>
-    <message>
-        <source>Usage:</source>
-        <translation>Cách dùng:</translation>
-    </message>
-    <message>
-        <source>command-line options</source>
-        <translation>tuỳ chọn dòng lệnh</translation>
-    </message>
-    <message>
-        <source>UI Options:</source>
-        <translation>Các tuỳ chọn giao diện:</translation>
-    </message>
-    <message>
-        <source>Choose data directory on startup (default: %u)</source>
-        <translation>Chọn thư mục dữ liệu khi khởi động (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Set the font family. Possible values: %1. (default: %2)</source>
-        <translation>Thiết lập phông chữ. Giá trị có thể:%1. (ngầm định:%2)</translation>
-    </message>
-    <message>
-        <source>Set a scale factor which gets applied to the base font size. Possible range %1 (smallest fonts) to %2 (largest fonts). (default: %3)</source>
-        <translation>Thiết lập một mức tỷ lệ mà nó áp dụng cho kích thước font chữ cơ bản. Phạm vi có thể %1 (cỡ nhỏ nhất) cho đến %2 (cỡ to nhất), (ngầm định: %3)</translation>
-    </message>
-    <message>
-        <source>Set the font weight for bold texts. Possible range %1 to %2 (default: %3)</source>
-        <translation>Thiết lập độ đậm font cho văn bản dạng chữ đậm. Phạm vi có thể trong khoảng %1 đến %2 (ngầm định: %3)</translation>
-    </message>
-    <message>
-        <source>Set the font weight for normal texts. Possible range %1 to %2 (default: %3)</source>
-        <translation>Thiết lập độ đậm font cho văn bản dạng thường. Phạm vi có thể trong khoảng %1 đến %2 (ngầm định: %3)</translation>
-    </message>
-    <message>
-        <source>Set language, for example "de_DE" (default: system locale)</source>
-        <translation>Chọn ngôn ngữ, ví dụ "vn_VN" (ngầm định: theo hệ thống)</translation>
-    </message>
-    <message>
-        <source>Start minimized</source>
-        <translation>Bắt đầu thu nhỏ</translation>
-    </message>
-    <message>
-        <source>Set SSL root certificates for payment request (default: -system-)</source>
-        <translation>Đặt chứng thực gốc cho yêu cầu thanh toán (ngầm định: -hệ thống-)</translation>
-    </message>
-    <message>
-        <source>Show splash screen on startup (default: %u)</source>
-        <translation>Hiển thị màn hình thông tin khi khởi động (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Reset all settings changed in the GUI</source>
-        <translation>Tái thiết lập tất cả các thông số thay đổi trên giao diện đồ hoạ</translation>
-    </message>
-    <message>
-        <source>PrivateSend information</source>
-        <translation>Thông tin PrivateSend</translation>
-    </message>
-    <message>
-        <source>&lt;h3&gt;PrivateSend Basics&lt;/h3&gt; PrivateSend gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different "inputs" which you can think of as separate, discrete coins.&lt;br&gt; PrivateSend uses an innovative process to mix your inputs with the inputs of two or more other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The PrivateSend process works like this:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;PrivateSend begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called "masternodes." These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know "who" you are.&lt;/li&gt; &lt;li&gt;When two or more other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it's called a "round." Each round of PrivateSend makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these "change addresses." Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have PrivateSend disabled. &lt;hr&gt;For more information, see the &lt;a style="%1" href="https://docs.dash.org/en/stable/wallets/dashcore/privatesend-instantsend.html"&gt;PrivateSend documentation&lt;/a&gt;.</source>
-        <translation>&lt;h3&gt;Cơ bản về PrivateSend&lt;/h3&gt; PrivateSend cho bạn sự thực sự riêng tư về tài chính bằng việc che dấu những nguồn cung. Tất cả Dash trong ví của bạn bao gồm những "đầu vào" khác nhau mà bạn nghĩ đó là các coin riêng biệt và rời rạc.&lt;br&gt; PrivateSend sử dụng một tiến trình độc đáo để trộn các đầu vào của bạn với đầu vào của hai người khác, mà không làm cho các coin rời khỏi ví của bạn. Bạn vẫn giữ quyền kiểm soát tiền của bạn bất cứ lúc nào.&lt;hr&gt; &lt;b&gt;Quá trình PrivateSend làm việc như sau: &lt;/b&gt; &lt;ol type="1"&gt; &lt;li&gt;PrivateSend bắt đầu bằng việc chia các giao dịch đầu vào của bạn thành những mệnh giá chuẩn. Những mệnh giá đó là 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH, và 10 DASH -- cũng giống như các mệnh giá trên tiền giấy mà bạn sử dụng hàng ngày. &lt;/li&gt;&lt;li&gt;Ví của bạn sau đó gửi yêu cầu đến những nút phần mềm được cấu hình đặc biệt trên mạng gọi là các "masternode". Những masternode được báo rằng bạn quan tâm đến việc xáo trộn một mệnh giá nào đó. Không có thông tin định danh nào được gửi đến cho các masternode, và như vậy họ không bao giờ biết bạn "là ai". &lt;/li&gt; &lt;li&gt;Khi hai người kia gửi những thông điệp tương tự, có nghĩa là họ muốn xáo trộn cùng loại mệnh giá, một phiên xáo trộn bắt đầu. Masternode xáo trộn các đầu vào và hướng dẫn tất cả ví của cả ba người dùng để trả đầu vào đã được chuyển đổi trở lại cho chính họ. Ví của bạn sẽ trả mệnh giá đó trực tiếp cho nó, nhưng với một địa chỉ khác (được gọi là địa chỉ trả tiền lẻ). &lt;/li&gt; &lt;li&gt;Để thực sự che khuất nguồn tiền của bạn, ví của bạn phải lặp lại quy trình đó một số lần với mỗi mệnh giá nhất định. Mỗi lần tiến trình hoàn tất, nó được gọi là một "vòng". Mỗi vòng của PrivateSend làm nên độ khó bậc số mũ để xác định nguồn tiền của bạn đến từ đâu. &lt;/li&gt; &lt;li&gt;Quá trình xáo trộn này xảy ra trong chế độ nền mà không xen vào những việc khác của bạn. Khi bạn muốn thực hiện một giao dịch, nguồn tiền của bạn đã được ẩn danh rồi. Do đó bạn không cần phải đợi thêm gì nữa. &lt;/li&gt;&lt;/ol&gt; &lt;hr&gt; &lt;b&gt;QUAN TRỌNG:&lt;/b&gt; Ví của bạn chỉ có chứa 1000 "địa chỉ tiền trả lại". Mỗi lần một sự kiện xáo trộn xảy ra, có đến 9 địa chỉ sẽ được sử dụng. Điều đó có nghĩa với ví mới với 1000 địa chỉ thì dùng cho 100 lần trộn. Khi 900 địa chỉ đã được sử dụng, ví của bạn phải tạo thêm các địa chỉ mới. Nó chỉ có thể làm việc đó nếu bạn có chế độ tự động backup được bật&lt;br&gt; Kết quả là, những người dùng mà chế độ backup bị tắt sẽ có chế độ PrivateSend cũng bị tắt.&lt;hr&gt; Để biết thêm thông tin hãy xem &lt;a style="%1" href="https://docs.dash.org/en/stable/wallets/dashcore/privatesend-instantsend.html"&gt;Tài liệu về PrivateSend&lt;/a&gt;.</translation>
-    </message>
-</context>
+    </context>
 <context>
     <name>Intro</name>
     <message>
@@ -1397,44 +1309,8 @@
         <translation>Hiển thị trang Masternodes</translation>
     </message>
     <message>
-        <source>Show additional information and buttons for PrivateSend on overview screen.</source>
-        <translation>Hiển thị thêm thông tin và các nút cho PrivateSend trên màn hình tổng quát.</translation>
-    </message>
-    <message>
-        <source>Enable advanced PrivateSend interface</source>
-        <translation>Bật chế độ giao diện PrivateSend cao cấp</translation>
-    </message>
-    <message>
-        <source>Show warning dialog when PrivateSend detects that wallet has very low number of keys left.</source>
-        <translation>Hiển thị bảng hội thoại cảnh báo khi PrivateSend phát hiện ví chỉ còn rất ít khoá còn lại.</translation>
-    </message>
-    <message>
-        <source>Warn if PrivateSend is running out of keys</source>
-        <translation>Cảnh báo nếu PrivateSend đang thiếu khoá</translation>
-    </message>
-    <message>
-        <source>Whether to use experimental PrivateSend mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
-        <translation>Cho dù sử dụng thí nghiệm chế độ PrivateSend với việc trộn nhiều phiên trên một khối.&lt;br/&gt;Chú ý: Bạn cần sử dụng tính năng này một cách thận trọng.&lt;br/&gt;Hãy đảm bảo rằng bạn luôn lưu trữ sao lưu (tự động) ví gần nhất ở nơi an toàn.</translation>
-    </message>
-    <message>
-        <source>Enable PrivateSend &amp;multi-session</source>
-        <translation>Bật chế độ đa &amp;kênh PrivateSend</translation>
-    </message>
-    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction&lt;br/&gt;cannot be used until that transaction has at least one confirmation.&lt;br/&gt;This also affects how your balance is computed.</source>
         <translation>Nếu bạn vô hiệu hóa các chi tiêu của phần tiền lẻ chưa được xác nhận, phần tiền lẻ từ một giao dịch &lt;br/&gt;không thể được sử dụng đến khi giao dịch đó nhận được ít nhất một xác nhận. &lt;br/&gt;Điều này ảnh hưởng đến cách tính số dư của bạn.</translation>
-    </message>
-    <message>
-        <source>PrivateSend rounds to use</source>
-        <translation>Số vòng PrivateSend được dùng</translation>
-    </message>
-    <message>
-        <source>This amount acts as a threshold to turn off PrivateSend once it's reached.</source>
-        <translation>Số lượng này hoạt động như là một ngưỡng để tắt PrivateSend khi nó được chạm tới.</translation>
-    </message>
-    <message>
-        <source>Target PrivateSend balance</source>
-        <translation>Số dư đích cho PrivateSend</translation>
     </message>
     <message>
         <source>Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1499,14 +1375,6 @@
     <message>
         <source>Enable coin &amp;control features</source>
         <translation>Bật tính năng Kiểm soát &amp;Coin</translation>
-    </message>
-    <message>
-        <source>Show system popups for PrivateSend mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
-        <translation>Hiển thị bảng hội thoại cho giao dịch trộn PrivateSend &lt;br/&gt;giống như cho tất các các loại giao dịch khác.</translation>
-    </message>
-    <message>
-        <source>Show popups for PrivateSend transactions</source>
-        <translation>Hiển thị yêu cầu xác nhận cho các giao dịch PrivateSend</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
@@ -1718,10 +1586,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Có thể tiêu được:</translation>
     </message>
     <message>
-        <source>PrivateSend</source>
-        <translation>PrivateSend</translation>
-    </message>
-    <message>
         <source>Status:</source>
         <translation>Tình trạng:</translation>
     </message>
@@ -1758,10 +1622,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Bắt đầu/Tắt việc trộn</translation>
     </message>
     <message>
-        <source>PrivateSend Balance:</source>
-        <translation>Số dư PrivateSend:</translation>
-    </message>
-    <message>
         <source>The denominations you submitted to the Masternode.&lt;br&gt;To mix, other users must submit the exact same denominations.</source>
         <translation>Mệnh giá mà bạn gửi cho Masternode. &lt;br&gt;Để trộn, những người dùng khác cũng cần gửi chính xác dùng loại mệnh giá đó.</translation>
     </message>
@@ -1772,14 +1632,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Automatic backups are disabled, no mixing available!</source>
         <translation>Tính năng tự động backup đã được tắt,  không thể trộn được!</translation>
-    </message>
-    <message>
-        <source>Start Mixing</source>
-        <translation>Bắt đầu Trộn</translation>
-    </message>
-    <message>
-        <source>Stop Mixing</source>
-        <translation>Dừng Trộn</translation>
     </message>
     <message>
         <source>No inputs detected</source>
@@ -1860,18 +1712,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
         <translation>CẢNH BÁO! Không thể bổ sung keypool, hãy mở khoá ví của bạn để làm việc đó.</translation>
-    </message>
-    <message>
-        <source>If you don't want to see internal PrivateSend fees/transactions select "Most Common" as Type on the "Transactions" tab.</source>
-        <translation>Nếu bạn không muốn nhìn thấy thông tin nội bộ về phí/giao dich PrivateSend thì hãy chọn "Thông dụng nhất" là kiểu trên trang "Các giao dịch".</translation>
-    </message>
-    <message>
-        <source>PrivateSend requires at least %1 to use.</source>
-        <translation>PrivateSend yêu cầu ít nhất %1 để sử dụng.</translation>
-    </message>
-    <message>
-        <source>Wallet is locked and user declined to unlock. Disabling PrivateSend.</source>
-        <translation>Ví đã được khoá và người dùng từ chối mở khoá. Tắt chức năng PrivateSend.</translation>
     </message>
 </context>
 <context>
@@ -2414,10 +2254,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Cứu ví</translation>
     </message>
     <message>
-        <source>Rescan blockchain files</source>
-        <translation>Quét lại file blockchain</translation>
-    </message>
-    <message>
         <source>Recover transactions 1</source>
         <translation>Phục hồi các giao dịch 1</translation>
     </message>
@@ -2436,10 +2272,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>-salvagewallet: Attempt to recover private keys from a corrupt wallet.dat.</source>
         <translation>-salvagewallet: Thử phục hồi khoá riêng từ tệp wallet.dat bị lỗi.</translation>
-    </message>
-    <message>
-        <source>-rescan: Rescan the block chain for missing wallet transactions.</source>
-        <translation>-rescan: Quét lại blockchain để tìm những giao dịch bị thiếu.</translation>
     </message>
     <message>
         <source>-zapwallettxes=1: Recover transactions from blockchain (keep meta-data, e.g. account owner).</source>
@@ -2938,20 +2770,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&lt;b&gt;(%1 của %2 các thành phần được hiển thị)&lt;/b&gt;</translation>
     </message>
     <message>
-        <source>Confirm the PrivateSend action</source>
-        <translation>Xác nhận hành động PrivateSend</translation>
-    </message>
-    <message>
-        <source>PrivateSend funds only</source>
-        <translation>Ngân quỹ chỉ cho PrivateSend</translation>
-    </message>
-    <message>
         <source>any available funds</source>
         <translation>bất kỳ nguồn cung nào còn</translation>
-    </message>
-    <message>
-        <source>(PrivateSend transactions have higher fees usually due to no change output being allowed)</source>
-        <translation>(Các giao dịch PrivateSend có mức phí cao hơn thường do không được phép thay đổi đầu ra)</translation>
     </message>
     <message>
         <source>Transaction size: %1</source>
@@ -2964,10 +2784,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message numerus="yes">
         <source>This transaction will consume %n input(s)</source>
         <translation><numerusform>Giao dịch này sẽ dùng đến %n đầu vào</numerusform></translation>
-    </message>
-    <message>
-        <source>Warning: Using PrivateSend with %1 or more inputs can harm your privacy and is not recommended</source>
-        <translation>Cảnh báo: Sử dụng PrivateSend với %1 hoặc nhiều hơn các đầu vào có thể làm hại tính riêng tư cho bạn và nó không phải là điều được khuyến nghị</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3308,10 +3124,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>KB/s</translation>
     </message>
     <message>
-        <source>Totals</source>
-        <translation>Tổng số</translation>
-    </message>
-    <message>
         <source>Received</source>
         <translation>Đã nhận</translation>
     </message>
@@ -3569,10 +3381,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Nhận từ</translation>
     </message>
     <message>
-        <source>Received via PrivateSend</source>
-        <translation>Nhận được thông qua PrivateSend</translation>
-    </message>
-    <message>
         <source>Sent to</source>
         <translation>Gửi đến</translation>
     </message>
@@ -3583,22 +3391,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Mined</source>
         <translation>Được đào</translation>
-    </message>
-    <message>
-        <source>PrivateSend Denominate</source>
-        <translation>Mệnh giá PrivateSend</translation>
-    </message>
-    <message>
-        <source>PrivateSend Collateral Payment</source>
-        <translation>Thanh toán đảm bảo cho PrivateSend</translation>
-    </message>
-    <message>
-        <source>PrivateSend Make Collateral Inputs</source>
-        <translation>PrivateSend Tạo Đặt Cọc Đầu Vào</translation>
-    </message>
-    <message>
-        <source>PrivateSend Create Denominations</source>
-        <translation>PrivateSend Tạo Các Mệnh Giá</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -3678,22 +3470,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Sent to</source>
         <translation>Gửi đến</translation>
-    </message>
-    <message>
-        <source>PrivateSend Make Collateral Inputs</source>
-        <translation>PrivateSend Tạo Đặt Cọc Đầu Vào</translation>
-    </message>
-    <message>
-        <source>PrivateSend Create Denominations</source>
-        <translation>PrivateSend Tạo Các Mệnh Giá</translation>
-    </message>
-    <message>
-        <source>PrivateSend Denominate</source>
-        <translation>Mệnh giá PrivateSend</translation>
-    </message>
-    <message>
-        <source>PrivateSend Collateral Payment</source>
-        <translation>PrivateSend Collateral Payment</translation>
     </message>
     <message>
         <source>To yourself</source>
@@ -3879,36 +3655,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Dữ liệu ví đã được lưu thành công vào %1.</translation>
     </message>
-</context>
+    </context>
 <context>
     <name>dash-core</name>
     <message>
-        <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>Liên kết với địa chỉ nhất định và luôn luôn lắng nghe trên đó. Sử dụng ký hiệu [host]:port cho IPv6</translation>
-    </message>
-    <message>
         <source>Error: Listening for incoming connections failed (listen returned error %s)</source>
         <translation>Lỗi: Lắng nghe để nhận kết nối bị lỗi (lỗi trả về %s)</translation>
-    </message>
-    <message>
-        <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation>Thực hiện lệnh khi một cảnh báo liên quan được nhận hoặc chúng ta thấy sự phân nhánh thực sự dài (%s trong cmd được thay bởi message)</translation>
-    </message>
-    <message>
-        <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Thực hiện lệnh khi một giao dịch ví thay đổi (%s trong cmd được thay thế bởi TxID)</translation>
-    </message>
-    <message>
-        <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Thực hiện lệnh khi khối tốt nhất thay đổi (%s trong cmd được thay thế bởi giá trị băm của khối)</translation>
-    </message>
-    <message>
-        <source>Name to construct url for KeePass entry that stores the wallet passphrase</source>
-        <translation>Đặt tên để tạo dựng url cho các thành phần KeePass mà nó sẽ lưu giữ mật khẩu của ví</translation>
-    </message>
-    <message>
-        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
-        <translation>Thiết lập số luồng của kịch bản kiểm tra (%u to %d, 0 = tự động, &lt;0 = để nhiều lõi miễn phí, ngầm định: %d)</translation>
     </message>
     <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
@@ -3923,20 +3675,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Cảnh báo: Chúng ta có vẻ không được sự đồng ý một cách đầy đủ từ các đối tác ngang hàng! Bạn cần nâng cấp hoặc các nút khác cần nâng cấp.</translation>
     </message>
     <message>
-        <source>Accept command line and JSON-RPC commands</source>
-        <translation>Chấp nhận dòng lệnh và các lệnh JSON-RPC</translation>
-    </message>
-    <message>
-        <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
-        <translation>Cho phép DNS tìm kiếm -addnode, -seednode và -connect</translation>
-    </message>
-    <message>
         <source>Already have that input.</source>
         <translation>Đã có đầu vào đó.</translation>
-    </message>
-    <message>
-        <source>Block creation options:</source>
-        <translation>Tuỳ chọn tạo khối:</translation>
     </message>
     <message>
         <source>Cannot downgrade wallet</source>
@@ -3947,20 +3687,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Collateral không hợp lệ.</translation>
     </message>
     <message>
-        <source>Connection options:</source>
-        <translation>Tuỳ chọn kết nối:</translation>
-    </message>
-    <message>
         <source>Corrupted block database detected</source>
         <translation>Phát hiện ra dữ liệu khối bị hỏng</translation>
-    </message>
-    <message>
-        <source>Debugging/Testing options:</source>
-        <translation>Tuỳ chọn Gỡ rối/Kiểm tra:</translation>
-    </message>
-    <message>
-        <source>Do not load the wallet and disable wallet RPC calls</source>
-        <translation>Không tải ví và tắt các lời gọi ví RPC</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>
@@ -4007,80 +3735,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Không thành công khi lắng nghe trên các cổng. Sử dụng -listen=0 nếu bạn muốn nó.</translation>
     </message>
     <message>
-        <source>(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)</source>
-        <translation>(1 = giữ lại dữ liệu tx, ví dụ chủ tài khoản và thông tin yêu cầu thanh toán, 2 = bỏ dữ liệu tx)</translation>
-    </message>
-    <message>
         <source>-maxtxfee is set very high! Fees this large could be paid on a single transaction.</source>
         <translation>-maxtxfee được thiết lập rất cao! Mức phí cao này có thể được trả chỉ cho một giao dịch.</translation>
-    </message>
-    <message>
-        <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>
-        <translation>Một tỷ lệ phí (theo %s/kB) sẽ được sử dụng khi việc tính phí không có đủ dữ liệu (ngầm định: %s)</translation>
-    </message>
-    <message>
-        <source>Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)</source>
-        <translation>Chấp nhận các giao dịch chuyển tiếp nhận được từ các nút ngang hàng trong danh sách trắng thậm chí đó không phải giao dịch chuyển tiếp (ngầm định: %d)</translation>
-    </message>
-    <message>
-        <source>Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info). This option can be specified multiple times to add multiple nodes.</source>
-        <translation>Thêm một nút để kết nối và cố giữ kết nối mở (xem hướng dẫn câu lệnh RPC `addnode` để biết thêm thông tin). Tuỳ chọn này có thể được chỉ rõ nhiều lần để thêm nhiều nút.</translation>
-    </message>
-    <message>
-        <source>Allow JSON-RPC connections from specified source. Valid for &lt;ip&gt; are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times</source>
-        <translation>Cho phép các kết nối JSON-RPC từ các nguồn nhất định. Các địa chỉ &lt;ip&gt; hợp lệ là các địa chỉ IP đơn (ví dụ: 1.2.3.4), một mạng/netmask (ví dụ: 1.2.3.4/255.255.255.0) hoặc một mạng/CIDR (ví dụ: 1.2.3.4/24). Tuỳ chọn này có thể chỉ ra nhiều lần.</translation>
-    </message>
-    <message>
-        <source>Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6</source>
-        <translation>Liên kết với địa chỉ cụ thể và đưa nó vào danh sách chấp nhận của các đối tác kết nối vào nó. Sử dụng cách viết [địa chỉ máy]:cổng cho IPv6</translation>
-    </message>
-    <message>
-        <source>Bind to given address to listen for JSON-RPC connections. Do not expose the RPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost, or if -rpcallowip has been specified, 0.0.0.0 and :: i.e., all addresses)</source>
-        <translation>Liên kết với địa chỉ nhất định để nghe ngóng các kết nối JSON-RPC. Không nên để máy chủ RPC tiếp xúc với các mạng không đáng tin cậy như internet công cộng! Tùy chọn này bị bỏ qua trừ khi tham số -rpcallowip được xác định. Sử dụng cách ghi [máy chủ]:cổng cho IPv6. Tùy chọn này có thể được chỉ định nhiều lần (ngầm định: 127.0.0.1 và ::1, tức là localhost hoặc nếu -rpcallowip được chỉ định, 0.0.0.0 và :: tức là tất cả các địa chỉ)</translation>
     </message>
     <message>
         <source>Cannot provide specific connections and have addrman find outgoing connections at the same.</source>
         <translation>Không thể cung cấp những kết nối cụ thể và nhờ addrman tìm những kết nối tại cùng một thời điểm.</translation>
     </message>
     <message>
-        <source>Connect only to the specified node; -connect=0 disables automatic connections (the rules for this peer are the same as for -addnode). This option can be specified multiple times to connect to multiple nodes.</source>
-        <translation>Chỉ kết nối đến nút xác định; -connect=0 để tắt chế độ tự động kết nối (quy định này cho các nút ngang hàng cũng giống như với -addnode). Tuỳ chọn này có thể được thực hiện nhiều lần để kết nối tới nhiều nút.</translation>
-    </message>
-    <message>
-        <source>Connect to a node to retrieve peer addresses, and disconnect. This option can be specified multiple times to connect to multiple nodes.</source>
-        <translation>Kết nối với một nút để truy tìm các địa chỉ bạn, và ngắt kết nối. Tuỳ chọn này có thể chỉ rõ nhiều lần để kết nối đến nhiều nút.</translation>
-    </message>
-    <message>
-        <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
-        <translation>Tạo tệp mới với các quyền hệ thống ngầm định, thay vì umask 077 (chỉ có tác dụng với chức năng ví được tắt)</translation>
-    </message>
-    <message>
-        <source>Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup</source>
-        <translation>Xoá hết tất cả các giao dịch ví và chỉ phục hồi những phần đó của blockchain qua -rescan khi khởi động</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transactions of attempted InstantSend double spend in &lt;address&gt;</source>
-        <translation>Cho phép công bố các giao dịch thô đã dùng InstantSend trong việc tiêu lặp ở &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish transaction hashes of attempted InstantSend double spend in &lt;address&gt;</source>
-        <translation>Cho phép công bố các mã băm của giao dịch đã dùng InstantSend trong việc tiêu lặp ở &lt;address&gt;</translation>
-    </message>
-    <message>
         <source>Found unconfirmed denominated outputs, will wait till they confirm to continue.</source>
         <translation>Đã thấy các mệnh giá đầu ra chưa được xác nhận, sẽ đợi đến khi chúng xác nhận để tiếp tục.</translation>
-    </message>
-    <message>
-        <source>How thorough the block verification of -checkblocks is (0-4, default: %u)</source>
-        <translation>Cách kiểm tra khối triệt để -checkblocks là (0-4, ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)</source>
-        <translation>Nếu paytxfee không được thiết lập, bao gồm đầy đủ phí để giao dịch bắt đầu xác nhận bình quân trong n khối (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)</source>
-        <translation>Nếu khối này nằm trong chuỗi giả định rằng nó và các khối trước nó là hợp lệ và có khả năng bỏ qua kịch bản kiểm tra (0 để kiểm tra tất cả, ngầm định: %s, testnet: %s)</translation>
     </message>
     <message>
         <source>Invalid -socketevents ('%s') specified. Only these modes are supported: %s</source>
@@ -4091,112 +3755,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Số lượng không phù hợp cho -maxtxfee=&lt;số lượng&gt;: '%s' (phải bằng ít nhất mức phí chuyển tiếp tối thiểu %s để tránh tình trạng tắc các giao dịch)</translation>
     </message>
     <message>
-        <source>Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)</source>
-        <translation>Vị trí của cookie xác thực. Đường dẫn tương đối sẽ có được tiền tố trước bằng việc xác định một địa chỉ cụ thể trên mạng cụ thể. (ngầm định: data dir) </translation>
-    </message>
-    <message>
-        <source>Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)</source>
-        <translation>Duy trì một chỉ mục giao dịch đầy đủ, sử dụng bởi lệnh gọi rpc getrawtransaction (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Make outgoing connections only through network &lt;net&gt; (ipv4, ipv6 or onion). Incoming connections are not affected by this option. This option can be specified multiple times to allow multiple networks.</source>
-        <translation>Làm cho kết nối ra ngoài chỉ thông qua mạng lưới &lt;net&gt; (ipv4, ipv6 hoặc onion). Kết nối đến không bị ảnh hưởng bởi tuỳ chọn này. Tuỳ chọn này có thể được chỉ ra nhiều lần để cho phép nhiều mạng.</translation>
-    </message>
-    <message>
-        <source>Maximum size of data in data carrier transactions we relay and mine (default: %u)</source>
-        <translation>Kích thước tối đa của dữ liệu trong các giao dịch cung cấp dữ liệu, chúng tôi chuyển tiếp và đào (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Number of seconds to keep misbehaving peers from reconnecting (default: %u)</source>
-        <translation>Số giây hạn chế để không cho phép các đối tác ngang hàng cư xử không đúng tiếp tục kết nối lại (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Output debugging information (default: %u, supplying &lt;category&gt; is optional)</source>
-        <translation>Thông tin gỡ rối đầu ra (ngầm định: %u, cung cấp &lt;category&gt;  là một tuỳ chọn)</translation>
-    </message>
-    <message>
-        <source>Overrides minimum spork signers to change spork value. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.</source>
-        <translation>Ghi đè yêu cầu về số người ký spork tối thiểu để thay đổi giá trị spork. Chỉ hữu ích cho regtest và devnet. Không được sử dụng cái này trên mainnet hoặc test net.</translation>
-    </message>
-    <message>
-        <source>PrivateSend uses exact denominated amounts to send funds, you might simply need to mix some more coins.</source>
-        <translation>PrivateSend sử dụng chính xác số tiền đã được phân mệnh giá để gửi, bạn chỉ đơn giản cần trộn thêm nhiều coin nữa.</translation>
-    </message>
-    <message>
-        <source>Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex, -rescan and -disablegovernance=false. Warning: Reverting this setting requires re-downloading the entire blockchain. (default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, &gt;=%u = automatically prune block files to stay under the specified target size in MiB)</source>
-        <translation>Có thể giảm yêu cầu việc lưu trữ bằng việc bật tính năng xén bỏ (xoá) những khối cũ. Điều này cho phép RPC blockchain xén tỉa có thể được gọi để xoá bớt những khối cụ thể, và việc bật này cho phép tự động xén bỏ những khối cũ nếu kích thước mong muốn đạt một cỡ theo MB được chỉ rõ. Chế độ này không tương thích với -txindex, -rescan và -disablegovernance=false. Cảnh báo: Đảo ngược lại tuỳ chọn này cần tải lại toàn bộ blockchain. (ngầm định: 0 = tắt chế độ xén bỏ khối, 1 = cho phép xén bỏ thủ công theo RPC, &gt;=%u = tự động xén bỏ khối khỏi file để đảm bảo kích thước file nhỏ hơn ngưỡng đích theo MB).</translation>
-    </message>
-    <message>
-        <source>Send trace/debug info to console (default: 1 when no -daemon. To disable logging to file, set debuglogfile=0)</source>
-        <translation>Gửi thông tin trace/debug đến console (ngầm định: 1 khi không có -daemon. Để tắt việc ghi log vào file, đặt tham số debuglogfile=0)</translation>
-    </message>
-    <message>
-        <source>Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)</source>
-        <translation>Chỉ rõ file cấu hình. Đường dẫn tương đối với tiền tố xác định bởi vị trí datadir. (ngầm định: %s)</translation>
-    </message>
-    <message>
-        <source>Specify directory to hold wallets (default: &lt;datadir&gt;/wallets if it exists, otherwise &lt;datadir&gt;)</source>
-        <translation>Chỉ rõ thư mục chứa các ví (ngầm định: &lt;datadir&gt;/wallets nếu nó tồn tại, nếu không &lt;datadir&gt;)</translation>
-    </message>
-    <message>
-        <source>Specify location of debug log file. Relative paths will be prefixed by a net-specific datadir location. (0 to disable; default: %s)</source>
-        <translation>Chỉ rõ vị trí của file log debug. Đường dẫn tương đối xác định bởi tiền tố với vị trí xác định cụ thể bởi  datadir. (0 để tắt; ngầm định: %s)</translation>
-    </message>
-    <message>
-        <source>Specify pid file. Relative paths will be prefixed by a net-specific datadir location. (default: %s)</source>
-        <translation>Chỉ rõ file pid. Đường dẫn tương đối sẽ được xác định trước bởi một địa chỉ datadir cụ thể. (ngầm định: %s)</translation>
-    </message>
-    <message>
-        <source>Specify wallet database path. Can be specified multiple times to load multiple wallets. Path is interpreted relative to &lt;walletdir&gt; if it is not absolute, and will be created if it does not exist (as a directory containing a wallet.dat file and log files). For backwards compatibility this will also accept names of existing data files in &lt;walletdir&gt;.)</source>
-        <translation>Chỉ rõ đường dẫn đến cơ sở dữ liệu ví. Có thể chỉ định nhiều lần để nạp nhiều file ví. Đường dẫn được hiểu là đường dẫn tương đối với &lt;walletdir&gt; nếu không phải là đường dẫn tuyệt đối, và sẽ được tạo nếu nó chưa tồn tại (như là một thư mục có chứa file wallet.dat và file log). Để tương thích ngược nó cũng chấp nhận các tên của những file đã tồn tại trong &lt;walletdir&gt;.)</translation>
-    </message>
-    <message>
         <source>Transaction index can't be disabled with governance validation enabled. Either start with -disablegovernance command line switch or enable transaction index.</source>
         <translation>Chỉ mục giao dịch không thể tắt với tính năng xác thực quản trị đã được bật. Thay vào đó hãy khởi động với câu lệnh -disablegovernance hoặc bật chế độ chỉ mục giao dịch.</translation>
     </message>
     <message>
-        <source>Use N separate masternodes in parallel to mix funds (%u-%u, default: %u)</source>
-        <translation>Sử dụng N masternode riêng biệt một cách song song để trộn ngân quỹ (%u-%u, ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)</source>
-        <translation>Sửa dụng các SOCKS5 proxy riêng biệt cho mỗi đối tác ngang hàng thông qua dịch vụ ẩn Tor (ngầm định: %s)</translation>
-    </message>
-    <message>
-        <source>User defined mnemonic for HD wallet (bip39). Only has effect during wallet creation/first start (default: randomly generated)</source>
-        <translation>Sử dụng gợi nhớ cho ví (bip39). Chỉ có tác dụng trong khi tạo ví/khởi động lần đầu (ngầm định: sinh ngẫu nhiên)</translation>
-    </message>
-    <message>
-        <source>User defined seed for HD wallet (should be in hex). Only has effect during wallet creation/first start (default: randomly generated)</source>
-        <translation>Sử dụng mẫu định trước cho ví HD (nên ở dạng số thập lục hex). Chỉ có tác dụng trong việc khởi tạo/khởi động lần đầu (ngầm định: sinh ngẫu nhiên)</translation>
-    </message>
-    <message>
-        <source>Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>
-        <translation>Cái điểm ngang hàng trong danh sách trắng không thể bị cấm DoS và các giao dịch của nó luôn được chuyển tiếp, thậm chí cả khi nó đã có trong mempool, hữu ích ví dụ như cho một cửa ngõ</translation>
-    </message>
-    <message>
-        <source>Accept public REST requests (default: %u)</source>
-        <translation>Chấp nhận các yêu cầu REST công khai (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Always query for peer addresses via DNS lookup (default: %u)</source>
-        <translation>Luôn luôn tìm kiếm địa chỉ các đối tác ngang hàng thông qua tìm kiếm DNS (ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>Can't mix: no compatible inputs found!</source>
         <translation>Không thể trộn: không thấy đầu vào tương thích!</translation>
-    </message>
-    <message>
-        <source>Chain selection options:</source>
-        <translation>Các tuỳ chọn lựa chọn chuỗi:</translation>
-    </message>
-    <message>
-        <source>Connect through SOCKS5 proxy</source>
-        <translation>Kết nối thông qua SOCKS 5 proxy</translation>
-    </message>
-    <message>
-        <source>Connect to KeePassHttp on port &lt;port&gt; (default: %u)</source>
-        <translation>Kết nối tới KeePassHttp trên cổng &lt;port&gt; (ngầm định: %u)</translation>
     </message>
     <message>
         <source>Entry exceeds maximum size.</source>
@@ -4223,16 +3787,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Đã kiếm đủ người dùng, đang ký ...</translation>
     </message>
     <message>
-        <source>How many blocks to check at startup (default: %u, 0 = all)</source>
-        <translation>Bao nhiêu khối để kiểm tra khi khởi động (ngầm định: %u, 0 = tất cả)</translation>
-    </message>
-    <message>
         <source>Importing...</source>
         <translation>Đang nạp...</translation>
-    </message>
-    <message>
-        <source>Include IP addresses in debug output (default: %u)</source>
-        <translation>Kèm địa chỉ IP trong thông tin gỡ rối đầu ra (ngầm định: %u)</translation>
     </message>
     <message>
         <source>Incompatible mode.</source>
@@ -4275,14 +3831,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Keypool đã hết, hãy gọi keypoolrefill trước</translation>
     </message>
     <message>
-        <source>Listen for JSON-RPC connections on &lt;port&gt; (default: %u or testnet: %u)</source>
-        <translation>Lắng nghe kết nối JSON-RPC trên &lt;cổng&gt; (ngầm định: %u hoặc mạng thử: %u)</translation>
-    </message>
-    <message>
-        <source>Listen for connections on &lt;port&gt; (default: %u or testnet: %u)</source>
-        <translation>Lắng nghe kết nối từ &lt;cổng&gt; (ngầm định: %u hoặc mạng thử: %u)</translation>
-    </message>
-    <message>
         <source>Loading banlist...</source>
         <translation>Đang tải danh sách từ chối...</translation>
     </message>
@@ -4299,20 +3847,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Khoá đã sẵn sàng.</translation>
     </message>
     <message>
-        <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
-        <translation>Tối đa cho bộ đệm nhận của mỗi kết nối, &lt;n&gt;*1000 bytes (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: %u)</source>
-        <translation>Tối đa cho bộ đệm gửi của mỗi kết nối, &lt;n&gt;*1000 bytes (ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>Mixing in progress...</source>
         <translation>Đang trong quá trình trộn...</translation>
-    </message>
-    <message>
-        <source>Mnemonic passphrase is too long, must be at most 256 characters</source>
-        <translation>Câu gợi nhớ quá dài, nó chỉ được dài nhất là 256 ký tự</translation>
     </message>
     <message>
         <source>Need to specify a port with -whitebind: '%s'</source>
@@ -4335,56 +3871,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Không có trong danh sách Masternode.</translation>
     </message>
     <message>
-        <source>Prepend debug output with timestamp (default: %u)</source>
-        <translation>Thêm tiền tố đầu ra debug với dấu thời gian (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Rebuild chain state and block index from the blk*.dat files on disk</source>
-        <translation>Tái tạo chuỗi trạng thái và chỉ mục khối từ các file blk*.dat trên đĩa</translation>
-    </message>
-    <message>
-        <source>Rebuild chain state from the currently indexed blocks</source>
-        <translation>Tái tạo chuỗi trạng thái từ chỉ mục khối</translation>
-    </message>
-    <message>
-        <source>Send trace/debug info to debug.log file (default: %u)</source>
-        <translation>Gửi thông tin trace/debug vào file debug.log (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Set key pool size to &lt;n&gt; (default: %u)</source>
-        <translation>Thiết lập kích thước pool đến &lt;n&gt; (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Set the number of threads to service RPC calls (default: %d)</source>
-        <translation>Thiết lập số luồng phục vụ các lời gọi RPC (ngầm định: %d)</translation>
-    </message>
-    <message>
-        <source>Specify connection timeout in milliseconds (minimum: 1, default: %d)</source>
-        <translation>Hãy xác định thời gian hết hạn tính theo milli giây (tối thiểu: 1, ngầm định: %d)</translation>
-    </message>
-    <message>
-        <source>Spend unconfirmed change when sending transactions (default: %u)</source>
-        <translation>Tiên các khoản trả lại chưa được xác nhận khi gửi các giao dịch (ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>Submitted to masternode, waiting in queue %s</source>
         <translation>Đã được gửi cho masternode, đang đợi trong hàng đợi %s</translation>
     </message>
     <message>
         <source>Synchronization finished</source>
         <translation>Đồng bộ đã hoàn thành</translation>
-    </message>
-    <message>
-        <source>Threshold for disconnecting misbehaving peers (default: %u)</source>
-        <translation>Ngưỡng ngắt kết nối khi đối tác ngang hàng cư xử không đúng (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Tor control port password (default: empty)</source>
-        <translation>Mật khẩu kiểm soát cổng Tor (ngầm định: bỏ trống)</translation>
-    </message>
-    <message>
-        <source>Tor control port to use if onion listening enabled (default: %s)</source>
-        <translation>Bật cơ chế lắng nghe onion để có thể sử dụng cổng điều khiển Tor (ngầm định: %s)</translation>
     </message>
     <message>
         <source>Unable to start HTTP server. See debug log for details.</source>
@@ -4405,22 +3897,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Unsupported argument -tor found, use -onion.</source>
         <translation>Tuỳ chọn không được hỗ trợ -tor, hãy sử dụng -onion.</translation>
-    </message>
-    <message>
-        <source>Upgrade wallet to latest format on startup</source>
-        <translation>Nâng cấp ví lên định dạng mới nhất khi khởi động</translation>
-    </message>
-    <message>
-        <source>Use KeePass 2 integration using KeePassHttp plugin (default: %u)</source>
-        <translation>Sử dụng tích hợp KeePass 2 dùng KeePassHttp plugin (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Use UPnP to map the listening port (default: %u)</source>
-        <translation>Sử dụng UPnP để ánh xạ cổng lắng nghe (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Use the test chain</source>
-        <translation>Sử dụng chuỗi thử</translation>
     </message>
     <message>
         <source>User Agent comment (%s) contains unsafe characters.</source>
@@ -4451,14 +3927,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Kịch bản được phát hiện không hợp lệ.</translation>
     </message>
     <message>
-        <source>KeePassHttp id for the established association</source>
-        <translation>KeePassHttp id cho thiết lập sự kết hợp</translation>
-    </message>
-    <message>
-        <source>KeePassHttp key for AES encrypted communication with KeePass</source>
-        <translation>Khoá KeePassHttp cho liên lạc mã hoá AES với KeePass</translation>
-    </message>
-    <message>
         <source>%s file contains all private keys from this wallet. Do not share it with anyone!</source>
         <translation>File %s có chứa tất cả các khoá riêng từ ví này. Không nên chia sẻ nó với bất cứ ai.</translation>
     </message>
@@ -4467,64 +3935,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tuỳ chọn -masternode không được sử dụng nữa và bị bỏ qua, việc chỉ rõ tham số -masternodeblsprivkey là đủ để khởi động một nút như là một masternode.</translation>
     </message>
     <message>
-        <source>Discover own IP addresses (default: 1 when listening and no -externalip or -proxy)</source>
-        <translation>Tự phát hiện địa chỉ IP (ngầm định: 1 khi nghe và không dùng -externalip hoặc -proxy)</translation>
-    </message>
-    <message>
-        <source>Do not keep transactions in the mempool longer than &lt;n&gt; hours (default: %u)</source>
-        <translation>Không giữ các giao dịch trong mempool lâu hơn &lt;n&gt; giờ (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Enable multiple PrivateSend mixing sessions per block, experimental (0-1, default: %u)</source>
-        <translation>Cho phép nhiều phiên trộn PrivateSend cho mỗi khối, thí nghiệm (0-1, ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Execute command when a wallet InstantSend transaction is successfully locked (%s in cmd is replaced by TxID)</source>
-        <translation>Thực hiện lên khi một giao dịch InstantSend được khoá thành công (%s trong cmd được thay thế bằng TxID)</translation>
-    </message>
-    <message>
-        <source>Extra transactions to keep in memory for compact block reconstructions (default: %u)</source>
-        <translation>Những giao dịch khác được giữ ở trong bộ nhớ cho việc tái xây dựng các khối được gọn gàng (ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.</source>
         <translation>Không tạo được file dự phòng, file đã tồn tại rồi! Điều này có thể xảy ra nếu bạn khởi động lại ví trong ít hơn 60 giây. Bạn có thể tiếp tục nếu bạn đồng ý với việc đó.</translation>
     </message>
     <message>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)</source>
-        <translation>Phí (theo %s/kB) nhỏ hơn giá trị này được xem là không phí cho việc chuyển tiếp, đào và tạo giao dịch (ngầm định: %s)</translation>
-    </message>
-    <message>
-        <source>Fees (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)</source>
-        <translation>Phí (theo %s/kB) nhỏ hơn giá trị này được xem là không phí cho việc tạo giao dịch (ngầm định: %s)</translation>
-    </message>
-    <message>
-        <source>If &lt;category&gt; is not supplied or if &lt;category&gt; = 1, output all debugging information.</source>
-        <translation>Nếu &lt;category&gt; không được cung cấp hoặc nếu &lt;category&gt; = 1, xuất tất cả các thông tin gỡ lỗi.</translation>
-    </message>
-    <message>
-        <source>Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)</source>
-        <translation>Duy trì một chỉ mục địa chỉ đầy đủ, được dùng để tra cứu số dư, txids và những khoản tiền còn chưa tiêu của các địa chỉ (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain a full spent index, used to query the spending txid and input index for an outpoint (default: %u)</source>
-        <translation>Duy trì một chỉ mục địa chỉ đầy đủ, được dùng để tra cứu txids và những khoản tiền còn chưa tiêu của các địa chỉ (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain a timestamp index for block hashes, used to query blocks hashes by a range of timestamps (default: %u)</source>
-        <translation>Duy trì một chỉ mục đầy đủ các đánh dấu thời gian cho các giá trị băm của khối, được dùng để tra cứu số các giá trị băm trong một khoảng thời gian xác định (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Maintain at most &lt;n&gt; connections to peers (temporary service connections excluded) (default: %u)</source>
-        <translation>Duy trì nhiều nhất &lt;n&gt; kết nối đến các nút ngang hàng (các kết nối dịch vụ tạm thời không được tính) (ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!</source>
         <translation>Hãy chắc chắn rằng bạn sẽ mã hoá ví của bạn và xoá đi tất cả các bản sao lưu của ví mà không có mã hoá sau kiểm tra ví đã hoạt động tốt!</translation>
-    </message>
-    <message>
-        <source>Maximum total size of all orphan transactions in megabytes (default: %u)</source>
-        <translation>Kích thước tổng tối đa của tất cả các giao dịch mồ côi theo megabyte (ngầm định: %u)</translation>
     </message>
     <message>
         <source>Prune configured below the minimum of %d MiB.  Please use a higher number.</source>
@@ -4535,28 +3951,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Xén tỉa: việc đồng bộ ví mới đây đã đi quá dữ liệu được xén tỉa. Bạn cần -reindex (download toàn bộ blockchain lần nữa trong trường hợp các nút bị xén tỉa)</translation>
     </message>
     <message>
-        <source>Query for peer addresses via DNS lookup, if low on addresses (default: 1 unless -connect used)</source>
-        <translation>Truy vấn địa chỉ đối tác ngang hàng thông qua tra cứu DNS, nếu có ít địa chỉ (ngầm định: 1 trừ trường hợp -connect được sử dụng)</translation>
-    </message>
-    <message>
-        <source>Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)</source>
-        <translation>Ngẫu nhiên hoá các chứng thư cho mỗi kết nối qua proxy. Nó bật Tor stream isolation (ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.</source>
         <translation>Rescans là không thể trong chế độ xén tỉa. Bạn cần sử dụng -reindex mà nó sẽ tải xuống toàn bộ blockchain lại.</translation>
-    </message>
-    <message>
-        <source>Set the masternode BLS private key and enable the client to act as a masternode</source>
-        <translation>Thiết lập khoá riêng BLS cho masternode và bật phần mềm để nó hoạt động như là một masternode</translation>
-    </message>
-    <message>
-        <source>Specify full path to directory for automatic wallet backups (must exist)</source>
-        <translation>Hãy chỉ đường dẫn đầy đủ đến thư mục dành cho việc tự động backup ví (thư mục phải được tạo sẵn)</translation>
-    </message>
-    <message>
-        <source>Support filtering of blocks and transaction with bloom filters (default: %u)</source>
-        <translation>Hỗ trợ việc lọc các khối và giao dịch với bộ lọc bloom (ngầm định: %u)</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -4571,32 +3967,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Tổng độ dài của chuỗi phiên bản mạng (%i) vượt qua độ dài tối đa (%i). Hãy giảm số hoặc kích thước của uacomments.</translation>
     </message>
     <message>
-        <source>Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)</source>
-        <translation>Thử giữ cho thông lượng mạng truyền ra dưới ngưỡng (theo MiB mỗi 24 giờ), 0 = không giới hạn (ngầm định: %d)</translation>
-    </message>
-    <message>
-        <source>Try to create at least N inputs of each denominated amount (%u-%u, default: %u)</source>
-        <translation>Hãy cố tạo ít nhất N đầu vào cho mỗi một mức mệnh giá (%u-%u, ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Unable to locate enough PrivateSend denominated funds for this transaction.</source>
-        <translation>Không tìm đủ nguồn tiền PrivateSend denominated cho giao dịch này.</translation>
-    </message>
-    <message>
         <source>Unsupported argument -socks found. Setting SOCKS version isn't possible anymore, only SOCKS5 proxies are supported.</source>
         <translation>Tìm thấy tham số không được hỗ trợ -socks. Thiết lập phiên bản SOCKS không còn hiệu lực nữa, chỉ có proxy SOCKS5 mới được hỗ trợ.</translation>
     </message>
     <message>
         <source>Unsupported argument -whitelistalwaysrelay ignored, use -whitelistrelay and/or -whitelistforcerelay.</source>
         <translation>Tham số không được hỗ trợ -whitelistalwaysrelay đã bị bỏ qua, hãy sử dụng -whitelistrelay và/hoặc -whitelistforcerelay.</translation>
-    </message>
-    <message>
-        <source>Use UPnP to map the listening port (default: 1 when listening and no -proxy)</source>
-        <translation>Sử dụng UPnP để ánh xạ các cổng lắng nghe (ngầm định: 1 khi nghe và không -proxy)</translation>
-    </message>
-    <message>
-        <source>Username and hashed password for JSON-RPC connections. The field &lt;userpw&gt; comes in the format: &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. A canonical python script is included in share/rpcauth. The client then connects normally using the rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt; pair of arguments. This option can be specified multiple times</source>
-        <translation>Tên người dùng và mã băm mật khẩu cho kết nối JSON-RPC. Trường &lt;userpw&gt; đến trong định dạng &lt;USERNAME&gt;:&lt;SALT&gt;$&lt;HASH&gt;. Một file python chuẩn được gồm sẵn trong share/rpcauth. Phần mềm sau đó kết nối bình thường sử dụng bằng cặp tham số rpcuser=&lt;USERNAME&gt;/rpcpassword=&lt;PASSWORD&gt;. Tuỳ chọn này có thể được chỉ ra nhiều lần.</translation>
     </message>
     <message>
         <source>WARNING! Failed to replenish keypool, please unlock your wallet to do so.</source>
@@ -4619,10 +3995,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Bạn cần tái lập lại cơ sở dữ liệu sử dụng -reindex để quay trở lại chế độ không bị xén tỉa. Điều này sẽ làm tải lại toàn bộ blockchain</translation>
     </message>
     <message>
-        <source>(default: %u)</source>
-        <translation>(ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>-litemode is deprecated.</source>
         <translation>-litemode không được dùng nữa.</translation>
     </message>
@@ -4631,60 +4003,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-maxmempool phải ít nhất %d MB</translation>
     </message>
     <message>
-        <source>&lt;category&gt; can be:</source>
-        <translation>&lt;category&gt; có thể là:</translation>
-    </message>
-    <message>
-        <source>Append comment to the user agent string</source>
-        <translation>Thêm bình luận vào thông tin user agent</translation>
-    </message>
-    <message>
         <source>Automatic backups disabled</source>
         <translation>Tự động backup đã bị tắt</translation>
     </message>
     <message>
-        <source>Automatically create Tor hidden service (default: %d)</source>
-        <translation>Tự động tạo dịch vụ ẩn Tor (ngầm định: %d)</translation>
-    </message>
-    <message>
-        <source>Disable governance validation (0-1, default: %u)</source>
-        <translation>Tắt tính năng xác thực quản trị (0-1, ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>ERROR! Failed to create automatic backup</source>
         <translation>LỖI: Thất bại trong việc backup tự động</translation>
-    </message>
-    <message>
-        <source>Enable publish hash block in &lt;address&gt;</source>
-        <translation>Cho phép xuất bản khối băm trong &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash of governance objects (like proposals) in &lt;address&gt;</source>
-        <translation>Cho phép xuất bản hash cho đối tượng quản trị (như các đề xuất) trong &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash of governance votes in &lt;address&gt;</source>
-        <translation>Cho phép xuất bản hash của các biểu quyết quản trị trong &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash transaction (locked via InstantSend) in &lt;address&gt;</source>
-        <translation>Cho phép công bố hash transaction (khoá thông qua InstantSend) trong &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish hash transaction in &lt;address&gt;</source>
-        <translation>Cho phép công bố hash transaction trong &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw block in &lt;address&gt;</source>
-        <translation>Cho phép công bố các khối thô trong &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transaction (locked via InstantSend) in &lt;address&gt;</source>
-        <translation>Cho phép công bố các giao dịch thô (được khoá qua InstantSend) trong &lt;address&gt;</translation>
-    </message>
-    <message>
-        <source>Enable publish raw transaction in &lt;address&gt;</source>
-        <translation>Cho phép công bố giao dịch thô trong &lt;address&gt;</translation>
     </message>
     <message>
         <source>Error upgrading evo database</source>
@@ -4739,18 +4063,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Không thể quét lại ví trong quá trình khởi tạo</translation>
     </message>
     <message>
-        <source>Fee (in %s/kB) to add to transactions you send (default: %s)</source>
-        <translation>Phí (theo %s/kB) để thêm vào giao dịch mà bạn gửi (ngầm định: %s)</translation>
-    </message>
-    <message>
-        <source>Imports blocks from external blk000??.dat file on startup</source>
-        <translation>Nhập các khối từ các file ngoài blk000??.dat khi khởi động</translation>
-    </message>
-    <message>
-        <source>InstantSend options:</source>
-        <translation>Các tuỳ chọn InstantSend:</translation>
-    </message>
-    <message>
         <source>Invalid amount for -fallbackfee=&lt;amount&gt;: '%s'</source>
         <translation>Số lượng không hợp lệ cho -fallbackfee=&lt;amount&gt;: '%s'</translation>
     </message>
@@ -4765,18 +4077,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Its replacement -disablegovernance has been forced instead.</source>
         <translation>Sự thay thế -disablegovernance đã bị buộc phải thực hiện.</translation>
-    </message>
-    <message>
-        <source>Keep the transaction memory pool below &lt;n&gt; megabytes (default: %u)</source>
-        <translation>Giữ cho bể nhớ giao dịch dưới &lt;n&gt; megabytes (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Last PrivateSend was too recent.</source>
-        <translation>Lần gửi PrivateSend mới nhất quá gần.</translation>
-    </message>
-    <message>
-        <source>Last successful PrivateSend action was too recent.</source>
-        <translation>PrivateSend mới nhất được thực hiện quá gần đây.</translation>
     </message>
     <message>
         <source>Loading block index...</source>
@@ -4799,24 +4099,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Đang tải ví...</translation>
     </message>
     <message>
-        <source>Make the wallet broadcast transactions</source>
-        <translation>Làm cho ví truyền rộng các giao dịch</translation>
-    </message>
-    <message>
-        <source>Masternode options:</source>
-        <translation>Tuỳ chọn Masternode:</translation>
-    </message>
-    <message>
         <source>Masternode queue is full.</source>
         <translation>Danh sách hàng đợi Masternode đã đầy.</translation>
     </message>
     <message>
         <source>Masternode:</source>
         <translation>Masternode:</translation>
-    </message>
-    <message>
-        <source>Minimum bytes per sigop in transactions we relay and mine (default: %u)</source>
-        <translation>Số bytes tối thiểu mỗi sigop trong các giao dịch chúng ta chuyển tiếp và đào (ngầm định: %u)</translation>
     </message>
     <message>
         <source>Missing input transaction information.</source>
@@ -4831,44 +4119,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Không tìm thấy mệnh giá tương ứng để trộn.</translation>
     </message>
     <message>
-        <source>Node relay options:</source>
-        <translation>Tuỳ chọn trung chuyển nút:</translation>
-    </message>
-    <message>
         <source>Not compatible with existing transactions.</source>
         <translation>Không tương thích với các giao dịch hiện tại.</translation>
     </message>
     <message>
         <source>Not enough file descriptors available.</source>
         <translation>Chưa có đủ thông tin mô tả tệp.</translation>
-    </message>
-    <message>
-        <source>Number of automatic wallet backups (default: %u)</source>
-        <translation>Số lượng ví tự động backup (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Options:</source>
-        <translation>Tuỳ chọn:</translation>
-    </message>
-    <message>
-        <source>Password for JSON-RPC connections</source>
-        <translation>Mật khẩu cho kết nối JSON-RPC</translation>
-    </message>
-    <message>
-        <source>Print version and exit</source>
-        <translation>In ra phiên bản và thoát</translation>
-    </message>
-    <message>
-        <source>PrivateSend is idle.</source>
-        <translation>PrivateSend đang nghỉ</translation>
-    </message>
-    <message>
-        <source>PrivateSend options:</source>
-        <translation>Các tuỳ chọn PrivateSend:</translation>
-    </message>
-    <message>
-        <source>PrivateSend request incomplete:</source>
-        <translation>Yêu cầu gửi PrivateSend không hoàn thành:</translation>
     </message>
     <message>
         <source>Prune cannot be configured with a negative value.</source>
@@ -4887,18 +4143,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Đang xén tỉa các khối lưu trữ...</translation>
     </message>
     <message>
-        <source>Rescan the block chain for missing wallet transactions on startup</source>
-        <translation>Quét lại block chain để tìm ra những giao dịch mà ví còn thiếu khi khởi động</translation>
-    </message>
-    <message>
-        <source>Send reject messages per BIP61 (default: %u)</source>
-        <translation>Gửi thông điệp từ chối mỗi BIP61 (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Socket events mode, which must be one of: %s (default: %s)</source>
-        <translation>Chế độ sự kiện socket, nó phải là một trong số: %s (ngầm định: %s)</translation>
-    </message>
-    <message>
         <source>Specified -walletdir "%s" does not exist</source>
         <translation>Thư mục được chỉ ra -walletdir "%s" không tồn tại</translation>
     </message>
@@ -4911,16 +4155,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Thư mục được xác định bởi -walletdir "%s" không phải là một thư mục</translation>
     </message>
     <message>
-        <source>Sync mempool from other nodes on start (default: %u)</source>
-        <translation>Đồng bộ mempool từ các nút khác khi khởi động (ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>Synchronizing blockchain...</source>
         <translation>Đang đồng bộ blockchain...</translation>
-    </message>
-    <message>
-        <source>Target PrivateSend balance (%u-%u, default: %u)</source>
-        <translation>Số dư PrivateSend cần đạt (%u-%u, default: %u)</translation>
     </message>
     <message>
         <source>The wallet will avoid paying less than the minimum relay fee.</source>
@@ -4971,16 +4207,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Upgrading UTXO database</translation>
     </message>
     <message>
-        <source>Use devnet chain with provided name</source>
-        <translation>Sử dụng mạng phát triển có tên được cung cấp</translation>
-    </message>
-    <message>
         <source>Wallet %s resides outside wallet directory %s</source>
         <translation>Ví %s nằm ngoài thư mục ví %s</translation>
-    </message>
-    <message>
-        <source>Wallet debugging/testing options:</source>
-        <translation>Wallet debugging/testing options:</translation>
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart %s to complete</source>
@@ -4993,10 +4221,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Wasn't able to create wallet backup folder %s!</source>
         <translation>Không thể tạo được thư mục backup ví %s!</translation>
-    </message>
-    <message>
-        <source>Whether to operate in a blocks only mode (default: %u)</source>
-        <translation>Cho dù hoạt động trong chế độ chỉ có các khối (ngầm định: %u)</translation>
     </message>
     <message>
         <source>You can not start a masternode with wallet enabled.</source>
@@ -5015,20 +4239,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Bạn cần tái lập lại cơ sở dữ liệu sử dụng -reindex để thay đổi -txindex</translation>
     </message>
     <message>
-        <source>ZeroMQ notification options:</source>
-        <translation>Tuỳ chọn thông báo ZeroMQ:</translation>
-    </message>
-    <message>
         <source>no mixing available.</source>
         <translation>không có phiên trộn nào sẵn sàng.</translation>
     </message>
     <message>
         <source>see debug.log for details.</source>
         <translation>xem debug.log để biết thêm chi tiết.</translation>
-    </message>
-    <message>
-        <source>RPC server options:</source>
-        <translation>Tuỳ chọn cho RPC server</translation>
     </message>
     <message>
         <source>Dash Core</source>
@@ -5047,10 +4263,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Distributed under the MIT software license, see the accompanying file %s or %s</translation>
     </message>
     <message>
-        <source>Enable use of PrivateSend for funds stored in this wallet (0-1, default: %u)</source>
-        <translation>Cho phép việc sử dụng PrivateSend cho các khoản tiền được lưu trong ví này (0-1, ngầm định: %u)</translation>
-    </message>
-    <message>
         <source>Error loading %s: You can't enable HD on an already existing non-HD wallet</source>
         <translation>Lỗi khi tải %s: Bạn không thể bật HD trên một ví không HD</translation>
     </message>
@@ -5059,28 +4271,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Error reading %s! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</translation>
     </message>
     <message>
-        <source>Exclude debugging information for a category. Can be used in conjunction with -debug=1 to output debug logs for all categories except one or more specified categories.</source>
-        <translation>Loại bỏ thông tin gỡ rối cho một danh mục. Có thể sử dụng cùng với -debug=1 để xuất nhật ký gỡ rối cho tất cả các danh mục trừ một hoặc các danh mục được xác định.</translation>
-    </message>
-    <message>
-        <source>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</source>
-        <translation>Force relay of transactions from whitelisted peers even if they violate local relay policy (default: %d)</translation>
-    </message>
-    <message>
         <source>Incorrect or no devnet genesis block found. Wrong datadir for devnet specified?</source>
         <translation>Không chính xác hoặc không tìm thấy khối ban đầu của devnet. Thư mục dữ liệu devnet được cung cấp không chính xác?</translation>
-    </message>
-    <message>
-        <source>Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)</source>
-        <translation>Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount. (default: %u seconds)</translation>
-    </message>
-    <message>
-        <source>Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)</source>
-        <translation>Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)</translation>
-    </message>
-    <message>
-        <source>Override spork address. Only useful for regtest and devnet. Using this on mainnet or testnet will ban you.</source>
-        <translation>Ghi đè địa chỉ spork. Chỉ hữu ích với regtest và devnet. Sử dụng nó với mainnet và testnet sẽ cấm bạn.</translation>
     </message>
     <message>
         <source>Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly.</source>
@@ -5089,14 +4281,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Please contribute if you find %s useful. Visit %s for further information about the software.</source>
         <translation>Please contribute if you find %s useful. Visit %s for further information about the software.</translation>
-    </message>
-    <message>
-        <source>Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)</source>
-        <translation>Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)</translation>
-    </message>
-    <message>
-        <source>The fee rate (in %s/kB) that indicates your tolerance for discarding change by adding it to the fee (default: %s). Note: An output is discarded if it is dust at this rate, but we will always discard up to the dust relay fee and a discard fee above that is limited by the fee estimate for the longest target</source>
-        <translation>Mức phí (tính theo %s/kB) là thể hiện mức độ chịu đựng của bạn đối với việc loại bỏ khoản tiền lẻ trả lại bằng cách thêm nó vào phí (ngầm định: %s). Lưu ý: Một đầu ra bị loại bỏ nếu đó là bụi ở mức phí này, nhưng chúng tôi sẽ luôn loại bỏ phí chuyển tiếp bụi và phí loại bỏ ở trên mà bị giới hạn bởi ước tính phí cho mục tiêu dài nhất</translation>
     </message>
     <message>
         <source>This is the transaction fee you may discard if change is smaller than dust at this level</source>
@@ -5111,40 +4295,12 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit %s and cryptographic software written by Eric Young and UPnP software written by Thomas Bernard.</translation>
     </message>
     <message>
-        <source>Unable to locate enough PrivateSend non-denominated funds for this transaction.</source>
-        <translation>Không thể tìm đủ lượng ngân sách chưa phân mệnh giá Private Send cho giao dịch  này.</translation>
-    </message>
-    <message>
         <source>Unable to replay blocks. You will need to rebuild the database using -reindex-chainstate.</source>
         <translation>Không thể phát lại các khối. Bạn sẽ cần xây dựng lại cơ sở dữ liệu bằng cách sử dụng -reindex-chainstate.</translation>
     </message>
     <message>
-        <source>Use N separate masternodes for each denominated input to mix funds (%u-%u, default: %u)</source>
-        <translation>Sử dụng N masternode riêng biệt cho mỗi mệnh giá đầu vào để trộn ngân quỹ (%u-%u, ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Use hierarchical deterministic key generation (HD) after BIP39/BIP44. Only has effect during wallet creation/first start</source>
-        <translation>Sử dụng cơ chế sinh khoá theo xác định phân cấp (HD) sau BIP39/BIP44. Chỉ có tác dụng trong quá trình tạo ví/lần khởi động lần đầu tiên</translation>
-    </message>
-    <message>
-        <source>User defined mnemonic passphrase for HD wallet (BIP39). Only has effect during wallet creation/first start (default: empty string)</source>
-        <translation>Sử dụng mã gợi nhớ xác định trước cho ví HD (BIP39). Chỉ có tác dụng trong quá trình tạo ví/khởi động lần đầu (ngầm định: không có gì)</translation>
-    </message>
-    <message>
-        <source>Wallet will not create transactions that violate mempool chain limits (default: %u)</source>
-        <translation>Wallet will not create transactions that violate mempool chain limits (default: %u)</translation>
-    </message>
-    <message>
         <source>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Warning: Wallet file corrupt, data salvaged! Original %s saved as %s in %s; if your balance or transactions are incorrect you should restore from a backup.</translation>
-    </message>
-    <message>
-        <source>Whether to save the mempool on shutdown and load on restart (default: %u)</source>
-        <translation>Có nên lưu mempool khi tắt máy và tải lại khi khởi động lại (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.</source>
-        <translation>Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.</translation>
     </message>
     <message>
         <source>%d of last 100 blocks have unexpected version</source>
@@ -5175,18 +4331,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>-rpcport phải được chỉ rõ khi -devnet và -server được sử dụng</translation>
     </message>
     <message>
-        <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
-        <translation>Chấp nhận các kết nối từ ngoài (ngầm định: 1 nếu không -proxy hoặc -connect)</translation>
-    </message>
-    <message>
-        <source>Allow RFC1918 addresses to be relayed and connected to (default: %u)</source>
-        <translation>Cho phép địa chỉ RFC1918 để chuyển tiếp và kết nối đến (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Attempt to recover private keys from a corrupt wallet on startup</source>
-        <translation>Attempt to recover private keys from a corrupt wallet on startup</translation>
-    </message>
-    <message>
         <source>Cannot resolve -%s address: '%s'</source>
         <translation>Cannot resolve -%s address: '%s'</translation>
     </message>
@@ -5197,10 +4341,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Copyright (C)</source>
         <translation>Bản quyền (C)</translation>
-    </message>
-    <message>
-        <source>Create up to N inputs of each denominated amount (%u-%u, default: %u)</source>
-        <translation>Tạo tối đa N đầu vào của mỗi số tiền có mệnh giá (%u-%u, ngầm định: %u)</translation>
     </message>
     <message>
         <source>Error loading %s</source>
@@ -5263,20 +4403,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Loading P2P addresses...</translation>
     </message>
     <message>
-        <source>Print this help message and exit</source>
-        <translation>Print this help message and exit</translation>
-    </message>
-    <message>
         <source>Reducing -maxconnections from %d to %d, because of system limitations.</source>
         <translation>Giảm -maxconnections từ %d đến %d, bởi vì những giới hạn của hệ thống.</translation>
-    </message>
-    <message>
-        <source>Relay and mine data carrier transactions (default: %u)</source>
-        <translation>Chuyển tiếp và đào các giao dịch mang dữ liệu (ngầm định: %u)</translation>
-    </message>
-    <message>
-        <source>Relay non-P2SH multisig (default: %u)</source>
-        <translation>Chuyển tiếp các khoá đa chữ ký không phải P2SH (ngầm định: %u)</translation>
     </message>
     <message>
         <source>Replaying blocks...</source>
@@ -5287,10 +4415,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Đang quét lại...</translation>
     </message>
     <message>
-        <source>Run in the background as a daemon and accept commands</source>
-        <translation>Chạy trên chế độ nền như là một tiến trình ngầm và chấp nhận các lệnh</translation>
-    </message>
-    <message>
         <source>Session not complete!</source>
         <translation>Phiên làm việc chưa hoàn thành.</translation>
     </message>
@@ -5299,36 +4423,8 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Hết thời gian cho phiên làm việc.</translation>
     </message>
     <message>
-        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
-        <translation>Thiết lập kích thước bộ đệm cơ sở dữ liệu theo megabytes (%d đến %d, ngầm định: %d)</translation>
-    </message>
-    <message>
-        <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>Thiết lập kích thước khối tối đa theo bytes (ngầm định: %d)</translation>
-    </message>
-    <message>
-        <source>Show all debugging options (usage: --help -help-debug)</source>
-        <translation>Hiển thị tất cả các tuỳ chọn gỡ rối (cách sử dụng: --help -help-debug)</translation>
-    </message>
-    <message>
-        <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
-        <translation>Rút gọn tệp debug.log khi phần mềm khởi động (ngầm định: 1 khi không có -debug)</translation>
-    </message>
-    <message>
         <source>Signing transaction failed</source>
         <translation>Thất bại khi ký giao dịch</translation>
-    </message>
-    <message>
-        <source>Specify data directory</source>
-        <translation>Hãy chọn thư mục</translation>
-    </message>
-    <message>
-        <source>Specify your own public address</source>
-        <translation>Hãy xác định địa chỉ công khai của bạn</translation>
-    </message>
-    <message>
-        <source>Start PrivateSend automatically (0-1, default: %u)</source>
-        <translation>Khởi động PrivateSend một cách tự động (0-1, ngầm định: %u)</translation>
     </message>
     <message>
         <source>Starting network threads...</source>
@@ -5391,10 +4487,6 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>Danh mục ghi nhật ký không được hỗ trợ %s=%s.</translation>
     </message>
     <message>
-        <source>Username for JSON-RPC connections</source>
-        <translation>Username cho kết nối JSON-RPC</translation>
-    </message>
-    <message>
         <source>Verifying blocks...</source>
         <translation>Đang kiểm tra các khối...</translation>
     </message>
@@ -5405,10 +4497,6 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Wallet is locked.</source>
         <translation>Ví đã bị khoá.</translation>
-    </message>
-    <message>
-        <source>Wallet options:</source>
-        <translation>Tuỳ chọn ví:</translation>
     </message>
     <message>
         <source>Warning</source>

--- a/src/qt/locale/dash_zh_CN.ts
+++ b/src/qt/locale/dash_zh_CN.ts
@@ -247,10 +247,6 @@
         <translation>钱包已加密</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 将要关闭，以完成加密过程。请注意，加密钱包不能完全防止恶意软件入侵您的电脑盗取您的资金。</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>重要提示：请用新生成的加密钱包文件替换旧的钱包备份文件。先前未加密的旧钱包备份文件含有同样的HD种子，能够像新加密的钱包一样获取您的资金，而无需输入密码。</translation>
     </message>
@@ -394,6 +390,10 @@
     <message>
         <source>&amp;About %1</source>
         <translation>关于 %1</translation>
+    </message>
+    <message>
+        <source>Send %1 funds to a Dash address</source>
+        <translation>发送%1资金至一个Dash地址</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
@@ -552,12 +552,26 @@
         <translation>%1 客戶</translation>
     </message>
     <message>
+        <source>Wallet: %1
+</source>
+        <translation>钱包: %1
+</translation>
+    </message>
+    <message>
         <source>Wallet is &lt;b&gt;unencrypted&lt;/b&gt;</source>
         <translation>钱包 &lt;b&gt;未加密&lt;/b&gt;</translation>
     </message>
     <message>
         <source>&amp;File</source>
         <translation>文件(&amp;F)</translation>
+    </message>
+    <message>
+        <source>%1 &amp;information</source>
+        <translation>%1 &amp;信息</translation>
+    </message>
+    <message>
+        <source>Show the %1 basic information</source>
+        <translation>显示%1基础信息</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
@@ -893,6 +907,14 @@
         <translation>显示所有币</translation>
     </message>
     <message>
+        <source>Hide %1 coins</source>
+        <translation>隐藏 %1 的币</translation>
+    </message>
+    <message>
+        <source>Show all %1 coins</source>
+        <translation>显示所有%1的币</translation>
+    </message>
+    <message>
         <source>Show spendable coins only</source>
         <translation>只显示可使用的币</translation>
     </message>
@@ -1005,7 +1027,15 @@
         <source>Command-line options</source>
         <translation>命令行选项</translation>
     </message>
-    </context>
+    <message>
+        <source>%1 information</source>
+        <translation>%1信息</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;%1 Basics&lt;/h3&gt; %1 gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different "inputs" which you can think of as separate, discrete coins.&lt;br&gt; %1 uses an innovative process to mix your inputs with the inputs of two or more other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The %1 process works like this:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;%1 begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called "masternodes." These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know "who" you are.&lt;/li&gt; &lt;li&gt;When two or more other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it's called a "round." Each round of %1 makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these "change addresses." Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have %1 disabled. &lt;hr&gt;For more information, see the &lt;a style="%2" href="%3"&gt;%1 documentation&lt;/a&gt;.</source>
+        <translation>&lt;h3&gt;%1基础知识&lt;/h3&gt;%1通过隐藏您的资金来源为您提供真正的财务隐私。您的钱包中所有的Dash都由不同的“输入”组成，您可以将其视为分开的离散硬币。&lt;br&gt;%1使用创新的方法将您的输入与其他两个人的输入相结合，而过程中不会让您的Dash离开您的钱包。每时每刻，您仍然控制着您的钱。&lt;hr&gt;&lt;b&gt;%1的运作原理如下：&lt;/b&gt;&lt;ol type="1"&gt;&lt;li&gt;%1首先将您的交易分柝成多个标准面额的交易。这些标准面额分别为0.001 DASH，0.01 DASH，0.1 DASH，1 DASH和10 DASH --有点像您每天使用的纸币。&lt;/li&gt;&lt;li&gt;您的钱包然后发送请求到网络上有专门配置的软件节点，称为“主节点”。这些主节点会收到您希望混合一些资金的通知。没有可识别的信息发送到主节点，所以他们永远不会知道您是“谁”。&lt;li&gt;当另外两个人发送类似的消息时，表示希望混合相同的面额的话，混合会话就会开始。相关的主节点会混合这些输入，并指示所有三个用户的钱包将已经转换了输入的交易支付给自己。您的钱包直接支付给自己，但是付给不同的位址（称之为找零地址）。&lt;/li&gt;&lt;li&gt;为了完全掩盖您的资金来源，您的钱包必须以每个面额来重复此过程数次。每次这个过程完成后，都称之为一个“循环”。每个循环的%1都会令确定您的资金来源的工作倍加困难。&lt;/li&gt;&lt;li&gt;这种混合过程发生在后台，而不需要您进行任何操作。当您想进行交易时，您的资金将已被混币处理。不需再花额外的时间等待。&lt;/li&gt;&lt;/ol&gt;&lt;hr&gt;重要：&lt;b&gt;您的钱包只能拥有1000个“找零地址”。每次混合事件发生时，最多会使用9个找零地址。这意味着这1000个地址可以容许100次的混合事件。当其的中900个已经被使用后，您的钱包必须创建更多的地址。如果您启用了自动备份，则只能够这样做。&lt;br&gt;因此，禁用备份的用户也将禁用%1。&lt;hr&gt;如欲了解更多信息请参阅&lt;a style="%2" href="%3"&gt;%1文档&lt;/a&gt;。</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
     <message>
@@ -1321,8 +1351,52 @@
         <translation>如果您禁用还未确认的零钱，那么交易中找零的零钱&lt;br/&gt;至少需要1个确认才能使用。&lt;br/&gt;这也会影响余额的计算。</translation>
     </message>
     <message>
+        <source>Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</source>
+        <translation>在概览屏幕上显示混币界面，并显示一个仅允许使用完全混币资金的界面。&lt;br/&gt;该对话框中还将出现一个具有更多设置的标签，请确保在混币前检查这些设置。</translation>
+    </message>
+    <message>
+        <source>Show additional information and buttons on overview screen.</source>
+        <translation>在概况页面上显示额外信息和按钮。</translation>
+    </message>
+    <message>
+        <source>Enable advanced interface</source>
+        <translation>启用高级界面</translation>
+    </message>
+    <message>
+        <source>Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
+        <translation>显示混币交易的系统弹出窗口 &lt;br/&gt; 如同其他所有交易类型一样。</translation>
+    </message>
+    <message>
+        <source>Show popups for mixing transactions</source>
+        <translation>显示混币交易的弹出窗口</translation>
+    </message>
+    <message>
+        <source>Show warning dialog when the wallet has very low number of keys left.</source>
+        <translation>当钱包公钥所剩无几时，显示警告对话框。</translation>
+    </message>
+    <message>
+        <source>Warn if the wallet is running out of keys</source>
+        <translation>钱包公钥将用完时提示警告</translation>
+    </message>
+    <message>
+        <source>Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
+        <translation>是否使用实验性质的模式，当中每个内存块都会有多个混合会话。&lt;br/&gt;注意：您必须小心使用此功能。&lt;br/&gt;确保您总是有最近的钱包（自动）备份在一个安全的地方！</translation>
+    </message>
+    <message>
+        <source>Enable &amp;multi-session</source>
+        <translation>启动&amp;多轮</translation>
+    </message>
+    <message>
         <source>Mixing rounds</source>
         <translation>混币循环数</translation>
+    </message>
+    <message>
+        <source>This amount acts as a threshold to turn off mixing once it's reached.</source>
+        <translation>此金额作为关闭混币的阈值。</translation>
+    </message>
+    <message>
+        <source>Target balance</source>
+        <translation>目标余额</translation>
     </message>
     <message>
         <source>Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
@@ -1472,7 +1546,7 @@ https://www.transifex.com/projects/p/dash/</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
-        <translation>达世币金额单位(&amp;U)：</translation>
+        <translation>显示金额的单位:</translation>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
@@ -1501,6 +1575,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Cancel</source>
         <translation>取消(&amp;C)</translation>
+    </message>
+    <message>
+        <source>Enable %1 features</source>
+        <translation>启动 %1特性</translation>
     </message>
     <message>
         <source>default</source>
@@ -1649,6 +1727,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>No inputs detected</source>
         <translation>未检测到输入</translation>
     </message>
+    <message>
+        <source>%1 Balance</source>
+        <translation>%1 余额</translation>
+    </message>
     <message numerus="yes">
         <source>%n Rounds</source>
         <translation><numerusform>%n 次循环</numerusform></translation>
@@ -1684,6 +1766,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>keys left: %1</source>
         <translation>剩余密匙：%1</translation>
+    </message>
+    <message>
+        <source>Start %1</source>
+        <translation>开始%1</translation>
+    </message>
+    <message>
+        <source>If you don't want to see internal %1 fees/transactions select "Most Common" as Type on the "Transactions" tab.</source>
+        <translation>如果你不希望看到内部%1费用/交易，请在“交易”选项卡上选择“最常用”。</translation>
+    </message>
+    <message>
+        <source>%1 requires at least %2 to use.</source>
+        <translation>%1 要求至少 %2 以使用.</translation>
+    </message>
+    <message>
+        <source>Wallet is locked and user declined to unlock. Disabling %1.</source>
+        <translation>钱包已锁定需要用户解锁。 正在关闭%1。</translation>
+    </message>
+    <message>
+        <source>Stop %1</source>
+        <translation>停止 %1</translation>
     </message>
     <message>
         <source>Disabled</source>
@@ -1739,6 +1841,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>URI handling</source>
         <translation>URI 处理</translation>
+    </message>
+    <message>
+        <source>'dash://' is not a valid URI. Use 'dash:' instead.</source>
+        <translation>'dash://' 不是一个有效链接. 请使用'dash:'</translation>
     </message>
     <message>
         <source>Payment request fetch URL is invalid: %1</source>
@@ -2234,6 +2340,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>重新扫描区块链文件 2</translation>
     </message>
     <message>
+        <source>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</source>
+        <translation>-rescan=1: 从钱包创建时开始重新扫描区块链以查找遗漏的钱包交易。</translation>
+    </message>
+    <message>
+        <source>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</source>
+        <translation>-rescan=2: 从初始块开始重新扫描区块链以查找遗漏的钱包交易。</translation>
+    </message>
+    <message>
         <source>Wallet Path</source>
         <translation>钱包路径</translation>
     </message>
@@ -2272,6 +2386,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Reset</source>
         <translation>&amp;重置</translation>
+    </message>
+    <message>
+        <source>Node Type</source>
+        <translation>节点类型</translation>
     </message>
     <message>
         <source>PoSe Score</source>
@@ -2434,6 +2552,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>总计: %1 (已激活的: %2)</translation>
     </message>
     <message>
+        <source>Executing command without any wallet</source>
+        <translation>不通过任何钱包执行命令</translation>
+    </message>
+    <message>
+        <source>Executing command using "%1" wallet</source>
+        <translation>使用 "%1" 钱包执行命令</translation>
+    </message>
+    <message>
         <source>(node id: %1)</source>
         <translation>(节点ID：%1)</translation>
     </message>
@@ -2462,8 +2588,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>否</translation>
     </message>
     <message>
+        <source>Regular</source>
+        <translation>常规</translation>
+    </message>
+    <message>
         <source>Masternode</source>
         <translation>主节点</translation>
+    </message>
+    <message>
+        <source>Verified Masternode</source>
+        <translation>已验证的主节点</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2826,6 +2960,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%1 (%2 区块)</translation>
     </message>
     <message>
+        <source>from wallet %1</source>
+        <translation>来自%1钱包</translation>
+    </message>
+    <message>
         <source>using</source>
         <translation>使用</translation>
     </message>
@@ -2850,8 +2988,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&lt;b&gt;（在%2中%1个项目显示出来）&lt;/b&gt;</translation>
     </message>
     <message>
+        <source>S&amp;end mixed funds</source>
+        <translation>S&amp;end 混币资金</translation>
+    </message>
+    <message>
+        <source>Confirm the %1 send action</source>
+        <translation>确认%1发送行为</translation>
+    </message>
+    <message>
+        <source>%1 funds only</source>
+        <translation>仅支持%1资金</translation>
+    </message>
+    <message>
         <source>any available funds</source>
         <translation>全部有效金额</translation>
+    </message>
+    <message>
+        <source>(%1 transactions have higher fees usually due to no change output being allowed)</source>
+        <translation>(%1交易的手续费更高通常由于输出不允许更改)</translation>
     </message>
     <message>
         <source>Transaction size: %1</source>
@@ -2864,6 +3018,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message numerus="yes">
         <source>This transaction will consume %n input(s)</source>
         <translation><numerusform>此交易将消耗 %n 个输入</numerusform></translation>
+    </message>
+    <message>
+        <source>Warning: Using %1 with %2 or more inputs can harm your privacy and is not recommended</source>
+        <translation>提醒: 使用 %1与%2或更多输入不利于您的隐私保护，并不推荐</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3204,6 +3362,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>KB/s</translation>
     </message>
     <message>
+        <source>Total</source>
+        <translation>总额</translation>
+    </message>
+    <message>
         <source>Received</source>
         <translation>已接收</translation>
     </message>
@@ -3461,6 +3623,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>收款来自</translation>
     </message>
     <message>
+        <source>Received via %1</source>
+        <translation>已通过%1接收</translation>
+    </message>
+    <message>
         <source>Sent to</source>
         <translation>发送给</translation>
     </message>
@@ -3471,6 +3637,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Mined</source>
         <translation>挖矿所得</translation>
+    </message>
+    <message>
+        <source>%1 Mixing</source>
+        <translation>%1 混币</translation>
+    </message>
+    <message>
+        <source>%1 Collateral Payment</source>
+        <translation>%1抵押付款</translation>
+    </message>
+    <message>
+        <source>%1 Make Collateral Inputs</source>
+        <translation>%1进行抵押输入</translation>
+    </message>
+    <message>
+        <source>%1 Create Denominations</source>
+        <translation>%1 创建面额</translation>
+    </message>
+    <message>
+        <source>%1 Send</source>
+        <translation>%1 发送</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -3550,6 +3736,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Sent to</source>
         <translation>发送给</translation>
+    </message>
+    <message>
+        <source>%1 Send</source>
+        <translation>%1 发送</translation>
+    </message>
+    <message>
+        <source>%1 Make Collateral Inputs</source>
+        <translation>%1进行抵押输入</translation>
+    </message>
+    <message>
+        <source>%1 Create Denominations</source>
+        <translation>%1 创建面额</translation>
+    </message>
+    <message>
+        <source>%1 Mixing</source>
+        <translation>%1 混币</translation>
+    </message>
+    <message>
+        <source>%1 Collateral Payment</source>
+        <translation>%1抵押付款</translation>
     </message>
     <message>
         <source>To yourself</source>
@@ -3735,7 +3941,11 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>钱包数据成功保存至 %1 。</translation>
     </message>
-    </context>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+</context>
 <context>
     <name>dash-core</name>
     <message>
@@ -3993,6 +4203,18 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Can't find random Masternode.</source>
         <translation>无法找到随机主节点。</translation>
+    </message>
+    <message>
+        <source>%s can't be lower than %s</source>
+        <translation>%s不能低于%s</translation>
+    </message>
+    <message>
+        <source>%s is idle.</source>
+        <translation>%s处于空闲状态.</translation>
+    </message>
+    <message>
+        <source>%s request incomplete: %s</source>
+        <translation>%s 请求未完成: %s</translation>
     </message>
     <message>
         <source>Can't mix while sync in progress.</source>
@@ -4335,6 +4557,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%s 开发人员</translation>
     </message>
     <message>
+        <source>%s uses exact denominated amounts to send funds, you might simply need to mix some more coins.</source>
+        <translation>%s要求使用准确的已面额化资金来发送，您可能需要再混币处理一些资金。</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation>无法锁定数据目录 %s。%s 可能已经在运行。</translation>
     </message>
@@ -4415,6 +4641,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>无法解析 - %s 地址： '%s'</translation>
     </message>
     <message>
+        <source>Cannot write to data directory '%s'; check permissions.</source>
+        <translation>无法写入数据目录 '%s'; 请检查权限.</translation>
+    </message>
+    <message>
         <source>Change index out of range</source>
         <translation>修改索引超过范围</translation>
     </message>
@@ -4447,12 +4677,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>升级链状态数据库出错</translation>
     </message>
     <message>
+        <source>Error: failed to add socket to kqueuefd (kevent returned error %s)</source>
+        <translation>错误: 无法添加socket到kqueuefd (kevent 返回错误 %s)</translation>
+    </message>
+    <message>
         <source>Failed to find mixing queue to join</source>
         <translation>无法找到混币队列并加入</translation>
     </message>
     <message>
         <source>Failed to start a new mixing queue</source>
         <translation>无法开始一个新的混币队列</translation>
+    </message>
+    <message>
+        <source>Incorrect -rescan mode, falling back to default value</source>
+        <translation>错误的-rescan模式，恢复到默认值</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
@@ -4507,6 +4745,18 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>交易签名失败</translation>
     </message>
     <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation>指定的区块目录“%s”不存在。</translation>
+    </message>
+    <message>
+        <source>Last queue was created too recently.</source>
+        <translation>上一次队列才被创建.</translation>
+    </message>
+    <message>
+        <source>Last successful action was too recent.</source>
+        <translation>上一次成功操作才完成。</translation>
+    </message>
+    <message>
         <source>Starting network threads...</source>
         <translation>正在启动网络线程...</translation>
     </message>
@@ -4551,6 +4801,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>无法绑定此计算机上的%s (绑定返回错误 %s)</translation>
     </message>
     <message>
+        <source>Unable to locate enough mixed funds for this transaction.</source>
+        <translation>无法找到足够的混币资金来完成本次交易.</translation>
+    </message>
+    <message>
+        <source>Unable to locate enough non-denominated funds for this transaction.</source>
+        <translation>无法找到足够的未面额化资金来完成本次交易.</translation>
+    </message>
+    <message>
         <source>Unable to sign spork message, wrong key?</source>
         <translation>无法签署交叉信息，错误的密钥？</translation>
     </message>
@@ -4581,6 +4839,18 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning</source>
         <translation>警告</translation>
+    </message>
+    <message>
+        <source>Warning: %s is deprecated, please use %s instead</source>
+        <translation>警告: %s 已过时, 请使用 %s</translation>
+    </message>
+    <message>
+        <source>Warning: can't use %s and %s together, will prefer %s</source>
+        <translation>警告: 无法同时使用%s和%s, 将优先使用%s</translation>
+    </message>
+    <message>
+        <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
+        <translation>警告：不正确的参数 %s，路径必须存在！请使用预设路径。</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>

--- a/src/qt/locale/dash_zh_TW.ts
+++ b/src/qt/locale/dash_zh_TW.ts
@@ -247,10 +247,6 @@
         <translation>錢包已加密</translation>
     </message>
     <message>
-        <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your funds from being stolen by malware infecting your computer.</source>
-        <translation>%1 現在要關閉，好完成加密程序。請注意，加密錢包不能完全防止入侵你的電腦的惡意程式偷取達世幣。</translation>
-    </message>
-    <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. Previous backups of the unencrypted wallet file contain the same HD seed and still have full access to all your funds just like the new, encrypted wallet.</source>
         <translation>重要: 請改用新產生有加密的錢包檔，來取代舊錢包檔的備份。先前未加密錢包文件包含相同的HD種子，並且仍然可以像新的加密錢包一樣動用所有資金。</translation>
     </message>
@@ -394,6 +390,10 @@
     <message>
         <source>&amp;About %1</source>
         <translation>關於%1(&amp;A)</translation>
+    </message>
+    <message>
+        <source>Send %1 funds to a Dash address</source>
+        <translation>發送 %1 的款項到一個達世幣位址</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
@@ -564,6 +564,14 @@
     <message>
         <source>&amp;File</source>
         <translation>檔案(&amp;F)</translation>
+    </message>
+    <message>
+        <source>%1 &amp;information</source>
+        <translation>%1 (&amp;I)資訊</translation>
+    </message>
+    <message>
+        <source>Show the %1 basic information</source>
+        <translation>顯示 %1 的基本信息</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
@@ -799,6 +807,10 @@
         <translation>收款位址</translation>
     </message>
     <message>
+        <source>Mixing Rounds</source>
+        <translation>混合循環次數</translation>
+    </message>
+    <message>
         <source>Date</source>
         <translation>日期</translation>
     </message>
@@ -889,6 +901,22 @@
     <message>
         <source>Some coins were unselected because they do not have enough mixing rounds.</source>
         <translation>某些資金被取消選取，因為它們沒有足夠的混合次數。</translation>
+    </message>
+    <message>
+        <source>Show all coins</source>
+        <translation>顯示所有資金</translation>
+    </message>
+    <message>
+        <source>Hide %1 coins</source>
+        <translation>隱藏 %1 的資金</translation>
+    </message>
+    <message>
+        <source>Show all %1 coins</source>
+        <translation>顯示所有 %1 的資金</translation>
+    </message>
+    <message>
+        <source>Show spendable coins only</source>
+        <translation>只顯示可花費的資金</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -999,7 +1027,15 @@
         <source>Command-line options</source>
         <translation>命令列選項</translation>
     </message>
-    </context>
+    <message>
+        <source>%1 information</source>
+        <translation>%1 資訊</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;%1 Basics&lt;/h3&gt; %1 gives you true financial privacy by obscuring the origins of your funds. All the Dash in your wallet is comprised of different "inputs" which you can think of as separate, discrete coins.&lt;br&gt; %1 uses an innovative process to mix your inputs with the inputs of two or more other people, without having your coins ever leave your wallet. You retain control of your money at all times.&lt;hr&gt; &lt;b&gt;The %1 process works like this:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;%1 begins by breaking your transaction inputs down into standard denominations. These denominations are 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH and 10 DASH -- sort of like the paper money you use every day.&lt;/li&gt; &lt;li&gt;Your wallet then sends requests to specially configured software nodes on the network, called "masternodes." These masternodes are informed then that you are interested in mixing a certain denomination. No identifiable information is sent to the masternodes, so they never know "who" you are.&lt;/li&gt; &lt;li&gt;When two or more other people send similar messages, indicating that they wish to mix the same denomination, a mixing session begins. The masternode mixes up the inputs and instructs all three users' wallets to pay the now-transformed input back to themselves. Your wallet pays that denomination directly to itself, but in a different address (called a change address).&lt;/li&gt; &lt;li&gt;In order to fully obscure your funds, your wallet must repeat this process a number of times with each denomination. Each time the process is completed, it's called a "round." Each round of %1 makes it exponentially more difficult to determine where your funds originated.&lt;/li&gt; &lt;li&gt;This mixing process happens in the background without any intervention on your part. When you wish to make a transaction, your funds will already be mixed. No additional waiting is required.&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;&lt;b&gt;IMPORTANT:&lt;/b&gt; Your wallet only contains 1000 of these "change addresses." Every time a mixing event happens, up to 9 of your addresses are used up. This means those 1000 addresses last for about 100 mixing events. When 900 of them are used, your wallet must create more addresses. It can only do this, however, if you have automatic backups enabled.&lt;br&gt; Consequently, users who have backups disabled will also have %1 disabled. &lt;hr&gt;For more information, see the &lt;a style="%2" href="%3"&gt;%1 documentation&lt;/a&gt;.</source>
+        <translation>&lt;h3&gt;%1 基礎知識&lt;/h3&gt; %1 通過隱藏您的資金來源為您提供真正的財務隱私。您的錢包中所有的達世幣都由不同的“輸入”組成，您可以將其視為分開的離散硬幣。&lt;br&gt; %1 使用創新的方法將您的輸入與其他兩個人的輸入相結合，而過程中不會讓您的達世幣離開您的錢包。每時每刻，您仍然控制著您的錢。&lt;hr&gt; &lt;b&gt; %1 的運作原理如下:&lt;/b&gt;&lt;ol type="1"&gt; &lt;li&gt;%1 首先將您的交易分柝成多個標準面額的交易。這些標準面額分別為 0.001 DASH, 0.01 DASH, 0.1 DASH, 1 DASH 和 10 DASH -- 有點像您每天使用的紙幣。&lt;/li&gt; &lt;li&gt;您的錢包然後發送請求到網絡上有專門配置的軟件節點，稱為“主節點”。這些主節點會收到您希望混合一些資金的通知。沒有可識別的信息發送到主節點，所以他們永遠不會知道你是"誰"。&lt;/li&gt; &lt;li&gt;當另外兩個人發送類似的消息時，表示希望混合相同的面額的話，混合會話就會開始。相關的主節點會混合這些輸入，並指示所有三個用戶的錢包將已經轉換了輸入的交易支付給自己。你的錢包直接支付給自己，但是付給不同的位址 (稱之為找零位址)。&lt;/li&gt; &lt;li&gt;為了完全掩蓋您的資金來源，您的錢包必須以每個面額來重複此過程數次。每次這個過程完成後，都稱之為一個 "循環"。每個循環的 %1 都會令確定您的資金來源的工作倍加困難。&lt;/li&gt; &lt;li&gt;這種混合過程在後台進行，而不需要您進行任何操作。當您想進行交易時，您的資金將已被匿名處理。不需再花額外的時間等待。&lt;/li&gt; &lt;/ol&gt; &lt;hr&gt;重要:&lt;/b&gt; 您的錢包只能擁有1000個"找零位址。" 每次混合事件發生時，最多會使用9個找零位址。這意味著這1000個位址可以容許100次的混合事件。當其的中900個已經被使用後，您的錢包必須創建更多的位址。如果您啟用了自動備份，則只能夠這樣做。&lt;br&gt; 因此，禁用備份的用戶也將禁用 %1。&lt;hr&gt;如欲了解更多信息，請參閱 &lt;a style="%2" href="%3"&gt;%1 的文檔&lt;/a&gt;.</translation>
+    </message>
+</context>
 <context>
     <name>Intro</name>
     <message>
@@ -1315,6 +1351,54 @@
         <translation>如果你關掉「可以花還沒確認的零錢」，那麼交易中找零的零錢&lt;br/&gt;就必須要等交易至少有一次確認後，才能夠使用。&lt;br/&gt;這也會影響餘額的計算方式。</translation>
     </message>
     <message>
+        <source>Show mixing interface on Overview screen and reveal an additional screen which allows to spend fully mixed coins only.&lt;br/&gt;A new tab with more settings will also appear in this dialog, please make sure to check them before mixing your coins.</source>
+        <translation>在概覽屏幕上顯示混合界面，並顯示一個僅允許使用完全混合了的資金的屏幕。&lt;br/&gt;該對話框中還將出現一個具有更多設定的新標籤，請確保在混合資金之前檢查這些設定。</translation>
+    </message>
+    <message>
+        <source>Show additional information and buttons on overview screen.</source>
+        <translation>在概述屏幕上顯示其他信息和按鈕。</translation>
+    </message>
+    <message>
+        <source>Enable advanced interface</source>
+        <translation>啟用進階界面</translation>
+    </message>
+    <message>
+        <source>Show system popups for mixing transactions&lt;br/&gt;just like for all other transaction types.</source>
+        <translation>顯示混合交易的系統彈出窗口&lt;br/&gt;就像所有其他交易類型一樣。</translation>
+    </message>
+    <message>
+        <source>Show popups for mixing transactions</source>
+        <translation>顯示混合交易的彈出式窗口</translation>
+    </message>
+    <message>
+        <source>Show warning dialog when the wallet has very low number of keys left.</source>
+        <translation>當檢測到錢包尚餘非常少的公鑰時，就顯示警告對話框。</translation>
+    </message>
+    <message>
+        <source>Warn if the wallet is running out of keys</source>
+        <translation>如果錢包快要用完公鑰就發出警告</translation>
+    </message>
+    <message>
+        <source>Whether to use experimental mode with multiple mixing sessions per block.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</source>
+        <translation>是否使用實驗性質的模式，當中每個區塊都會有多個混合會話。注意 : 您必須小心使用此功能。&lt;br/&gt;確保你總是有最近的錢包 (自動) 備份在一個安全的地方！</translation>
+    </message>
+    <message>
+        <source>Enable &amp;multi-session</source>
+        <translation>啟用多重會話的發送</translation>
+    </message>
+    <message>
+        <source>Mixing rounds</source>
+        <translation>混合循環次數</translation>
+    </message>
+    <message>
+        <source>This amount acts as a threshold to turn off mixing once it's reached.</source>
+        <translation>此金額為關閉混合交易的門檻。</translation>
+    </message>
+    <message>
+        <source>Target balance</source>
+        <translation>目標結餘</translation>
+    </message>
+    <message>
         <source>Automatically open the Dash Core client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>自動在路由器上開放達世幣核心客戶端的通訊埠。只有在你的路由器支援且開啓「通用即插即用」協定(UPnP)時才有作用。</translation>
     </message>
@@ -1493,6 +1577,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>取消(&amp;C)</translation>
     </message>
     <message>
+        <source>Enable %1 features</source>
+        <translation>啟用 %1 功能</translation>
+    </message>
+    <message>
         <source>default</source>
         <translation>預設值</translation>
     </message>
@@ -1639,6 +1727,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <source>No inputs detected</source>
         <translation>沒有檢測到任何輸入</translation>
     </message>
+    <message>
+        <source>%1 Balance</source>
+        <translation>%1 結餘</translation>
+    </message>
     <message numerus="yes">
         <source>%n Rounds</source>
         <translation><numerusform>%n 次循環</numerusform></translation>
@@ -1674,6 +1766,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>keys left: %1</source>
         <translation>餘下鑰: %1</translation>
+    </message>
+    <message>
+        <source>Start %1</source>
+        <translation>啟動 %1</translation>
+    </message>
+    <message>
+        <source>If you don't want to see internal %1 fees/transactions select "Most Common" as Type on the "Transactions" tab.</source>
+        <translation>如果你不希望看到內部 %1 手續費/交易，請在"交易"種類標籤中選擇 "最常用的" 標籤。</translation>
+    </message>
+    <message>
+        <source>%1 requires at least %2 to use.</source>
+        <translation>%1 要求至少有 %2 才能使用。</translation>
+    </message>
+    <message>
+        <source>Wallet is locked and user declined to unlock. Disabling %1.</source>
+        <translation>錢包被鎖定，用戶拒絕解鎖。正在停用 %1。</translation>
+    </message>
+    <message>
+        <source>Stop %1</source>
+        <translation>停用 %1</translation>
     </message>
     <message>
         <source>Disabled</source>
@@ -1729,6 +1841,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>URI handling</source>
         <translation>URI 處理</translation>
+    </message>
+    <message>
+        <source>'dash://' is not a valid URI. Use 'dash:' instead.</source>
+        <translation>'dash://' 不是有效的URI。請用'dash:' 來代替。</translation>
     </message>
     <message>
         <source>Payment request fetch URL is invalid: %1</source>
@@ -2216,6 +2332,22 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>己同步的區塊</translation>
     </message>
     <message>
+        <source>Rescan blockchain files 1</source>
+        <translation>重新掃描區塊鏈文件 1</translation>
+    </message>
+    <message>
+        <source>Rescan blockchain files 2</source>
+        <translation>重新掃描區塊鏈文件 2</translation>
+    </message>
+    <message>
+        <source>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</source>
+        <translation>-rescan=1: 從錢包創建時間開始，重新掃描區塊鏈以尋找漏掉的錢包交易。</translation>
+    </message>
+    <message>
+        <source>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</source>
+        <translation>-rescan=2: 從創世區塊開始重新掃描區塊鏈以尋找漏掉的錢包交易。</translation>
+    </message>
+    <message>
         <source>Wallet Path</source>
         <translation>錢包路徑</translation>
     </message>
@@ -2254,6 +2386,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>&amp;Reset</source>
         <translation>重置(&amp;R)</translation>
+    </message>
+    <message>
+        <source>Node Type</source>
+        <translation>節點種類</translation>
     </message>
     <message>
         <source>PoSe Score</source>
@@ -2452,8 +2588,16 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>不是</translation>
     </message>
     <message>
+        <source>Regular</source>
+        <translation>正常</translation>
+    </message>
+    <message>
         <source>Masternode</source>
         <translation>主節點</translation>
+    </message>
+    <message>
+        <source>Verified Masternode</source>
+        <translation>已驗證的主節點</translation>
     </message>
     <message>
         <source>Unknown</source>
@@ -2844,8 +2988,24 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>&lt;b&gt;(在 %2 中 %1 個項目顯示出來)&lt;/b&gt;</translation>
     </message>
     <message>
+        <source>S&amp;end mixed funds</source>
+        <translation>(&amp;e) 發送已經混合的資金</translation>
+    </message>
+    <message>
+        <source>Confirm the %1 send action</source>
+        <translation>確認 %1 的發送動作</translation>
+    </message>
+    <message>
+        <source>%1 funds only</source>
+        <translation>只限 %1 的資金</translation>
+    </message>
+    <message>
         <source>any available funds</source>
         <translation>任何可用資金</translation>
+    </message>
+    <message>
+        <source>(%1 transactions have higher fees usually due to no change output being allowed)</source>
+        <translation>(由於不允許更改輸出的關係，%1 的交易手續費用會較高)</translation>
     </message>
     <message>
         <source>Transaction size: %1</source>
@@ -2858,6 +3018,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message numerus="yes">
         <source>This transaction will consume %n input(s)</source>
         <translation><numerusform>此交易將消耗 %n 個輸入</numerusform></translation>
+    </message>
+    <message>
+        <source>Warning: Using %1 with %2 or more inputs can harm your privacy and is not recommended</source>
+        <translation>警告: 在 %1 中使用 %2 或更多的輸入會損害您的隱私，因此不建議使用</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
@@ -3249,6 +3413,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>確認 %1 次</translation>
     </message>
     <message>
+        <source>locked via ChainLocks</source>
+        <translation>通過 ChainLocks 鎖定的</translation>
+    </message>
+    <message>
         <source>verified via InstantSend</source>
         <translation>經即時到帳系統核實</translation>
     </message>
@@ -3443,12 +3611,20 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>經即時到帳系統核實</translation>
     </message>
     <message>
+        <source>locked via ChainLocks</source>
+        <translation>通過 ChainLocks 鎖定的</translation>
+    </message>
+    <message>
         <source>Received with</source>
         <translation>收款</translation>
     </message>
     <message>
         <source>Received from</source>
         <translation>收款來自</translation>
+    </message>
+    <message>
+        <source>Received via %1</source>
+        <translation>經由 %1 收到的</translation>
     </message>
     <message>
         <source>Sent to</source>
@@ -3461,6 +3637,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Mined</source>
         <translation>開採所得</translation>
+    </message>
+    <message>
+        <source>%1 Mixing</source>
+        <translation>%1 混合中</translation>
+    </message>
+    <message>
+        <source>%1 Collateral Payment</source>
+        <translation>%1 抵押品付款</translation>
+    </message>
+    <message>
+        <source>%1 Make Collateral Inputs</source>
+        <translation>用作 %1 抵押品的輸入</translation>
+    </message>
+    <message>
+        <source>%1 Create Denominations</source>
+        <translation>%1 所產生的除名資金</translation>
+    </message>
+    <message>
+        <source>%1 Send</source>
+        <translation>%1 發送</translation>
     </message>
     <message>
         <source>watch-only</source>
@@ -3540,6 +3736,26 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Sent to</source>
         <translation>付款給</translation>
+    </message>
+    <message>
+        <source>%1 Send</source>
+        <translation>%1 發送</translation>
+    </message>
+    <message>
+        <source>%1 Make Collateral Inputs</source>
+        <translation>用作 %1 抵押品的輸入</translation>
+    </message>
+    <message>
+        <source>%1 Create Denominations</source>
+        <translation>%1 所產生的除名資金</translation>
+    </message>
+    <message>
+        <source>%1 Mixing</source>
+        <translation>%1 混合中</translation>
+    </message>
+    <message>
+        <source>%1 Collateral Payment</source>
+        <translation>%1 抵押品付款</translation>
     </message>
     <message>
         <source>To yourself</source>
@@ -3989,6 +4205,18 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>找不到隨機主節點。</translation>
     </message>
     <message>
+        <source>%s can't be lower than %s</source>
+        <translation>%s 付款額不能低於 %s</translation>
+    </message>
+    <message>
+        <source>%s is idle.</source>
+        <translation>%s 處於閒置狀態。</translation>
+    </message>
+    <message>
+        <source>%s request incomplete: %s</source>
+        <translation>%s 的相關請求未完成: %s</translation>
+    </message>
+    <message>
         <source>Can't mix while sync in progress.</source>
         <translation>在同步進行中時不能進行混合。</translation>
     </message>
@@ -4329,6 +4557,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>%s 開發人員</translation>
     </message>
     <message>
+        <source>%s uses exact denominated amounts to send funds, you might simply need to mix some more coins.</source>
+        <translation>%s 需要使用準確的已除名資金來發送，你可能需要再混合一資金來達到所需要求。</translation>
+    </message>
+    <message>
         <source>Cannot obtain a lock on data directory %s. %s is probably already running.</source>
         <translation>沒辦法鎖定資料目錄 %s。%s 可能已經在執行了。</translation>
     </message>
@@ -4409,6 +4641,10 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>沒辦法解析 -%s 參數指定的位址: '%s'</translation>
     </message>
     <message>
+        <source>Cannot write to data directory '%s'; check permissions.</source>
+        <translation>無法寫入數據到目錄 '%s'; 請檢查相關權限。</translation>
+    </message>
+    <message>
         <source>Change index out of range</source>
         <translation>找零的索引值超出範圍</translation>
     </message>
@@ -4451,6 +4687,10 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Failed to start a new mixing queue</source>
         <translation>無法開始一個新的混合隊列</translation>
+    </message>
+    <message>
+        <source>Incorrect -rescan mode, falling back to default value</source>
+        <translation>不正確的 -rescan 模式，恢復到預設值</translation>
     </message>
     <message>
         <source>Initialization sanity check failed. %s is shutting down.</source>
@@ -4505,6 +4745,18 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>簽署交易失敗</translation>
     </message>
     <message>
+        <source>Specified blocks directory "%s" does not exist.</source>
+        <translation>指定的區塊目錄 "%s" 不存在。</translation>
+    </message>
+    <message>
+        <source>Last queue was created too recently.</source>
+        <translation>距離上一個隊列的時間過短。</translation>
+    </message>
+    <message>
+        <source>Last successful action was too recent.</source>
+        <translation>距離上一次成功執行的時間過短。</translation>
+    </message>
+    <message>
         <source>Starting network threads...</source>
         <translation>正在啟動網路執行緒...</translation>
     </message>
@@ -4549,6 +4801,14 @@ https://www.transifex.com/projects/p/dash/</translation>
         <translation>無法和這台電腦上的 %s 繫結(回傳錯誤 %s)</translation>
     </message>
     <message>
+        <source>Unable to locate enough mixed funds for this transaction.</source>
+        <translation>無法為此交易找到足夠的已混合資金。</translation>
+    </message>
+    <message>
+        <source>Unable to locate enough non-denominated funds for this transaction.</source>
+        <translation>無法為此交易找到足夠的未除名資金。</translation>
+    </message>
+    <message>
         <source>Unable to sign spork message, wrong key?</source>
         <translation>無法簽署叉勺訊息訊息，錯誤的密鑰？</translation>
     </message>
@@ -4579,6 +4839,18 @@ https://www.transifex.com/projects/p/dash/</translation>
     <message>
         <source>Warning</source>
         <translation>警告</translation>
+    </message>
+    <message>
+        <source>Warning: %s is deprecated, please use %s instead</source>
+        <translation>警告: %s 已被淘汰，請改用 %s </translation>
+    </message>
+    <message>
+        <source>Warning: can't use %s and %s together, will prefer %s</source>
+        <translation>警告: 不能同時使用 %s 和 %s，將會把 %s 作為首選</translation>
+    </message>
+    <message>
+        <source>Warning: incorrect parameter %s, path must exist! Using default path.</source>
+        <translation>警告 : 不正確的參數 %s，路徑必須存在!  請使用預設路徑。</translation>
     </message>
     <message>
         <source>You are starting with governance validation disabled.</source>


### PR DESCRIPTION
Note: `ar` is a mess with lots of dropped mismatches like
```
dash_ar.ts: Mismatch between 'Received via %1' and 'تم الاستلام عبر٪ 1'
dash_ar.ts: Mismatch between '%1 Mixing' and '٪ 1 خلط'
dash_ar.ts: Mismatch between '%1 Collateral Payment' and '٪ 1 دفعة الضمان'
dash_ar.ts: Mismatch between '%1 Make Collateral Inputs' and '٪ 1 قم بعمل إدخالات جانبية'
dash_ar.ts: Mismatch between '%1 Create Denominations' and '٪ 1 قم بإنشاء فئة'
dash_ar.ts: Mismatch between '%1 Send' and '٪ 1 إرسال'
```