### PR TITLE
qt: Add `QFont::Normal` as a supported font weight when no other font weights were found

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1383,6 +1383,9 @@ bool loadFonts()
             }
             prevWeight = *weight;
         }
+        if (vecSupported.empty()) {
+            vecSupported.push_back(QFont::Normal);
+        }
         return vecSupported;
     };
 


### PR DESCRIPTION
~Should probably~ fix #4172 