### PR TITLE
depends: Undefine `BLSALLOC_SODIUM` in `bls-dash.mk`

### DIFF
--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -48,6 +48,8 @@ define $(package)_set_vars
     $(package)_config_opts_darwin+= -DCMAKE_AR="$(host_prefix)/native/bin/$($(package)_ar)"
     $(package)_config_opts_darwin+= -DCMAKE_RANLIB="$(host_prefix)/native/bin/$($(package)_ranlib)"
   endif
+
+  $(package)_cppflags+=-UBLSALLOC_SODIUM
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
This gets set if `libsodium` gets located by `cmake` in `bls-signatures`, see https://github.com/dashpay/bls-signatures/blob/main/CMakeLists.txt#L35 which leads to sodium being used here https://github.com/dashpay/bls-signatures/blob/main/src/bls.cpp#L47-L50 and that obviously leads to mixing shared/static libs like in #4168.

This is meant to be an replacement for #4174.