### PR TITLE
Merge #14416: Fix OSX dmg issue (10.12 to 10.14)

### DIFF
--- a/contrib/macdeploy/custom_dsstore.py
+++ b/contrib/macdeploy/custom_dsstore.py
@@ -13,7 +13,7 @@ package_name_ns = sys.argv[2]
 ds = DSStore.open(output_file, 'w+')
 ds['.']['bwsp'] = {
     'ShowStatusBar': False,
-    'WindowBounds': b'{{300, 280}, {500, 343}}',
+    'WindowBounds': '{{300, 280}, {500, 343}}',
     'ContainerShowSidebar': False,
     'SidebarWidth': 0,
     'ShowTabView': False,


### PR DESCRIPTION
Can't find this patch in btc v0.17 branch for some reason even though it says "was backported".

```
43719e0a3411e6a08e04908332cb44adfa00c6a2 [macOS] Remove DS_Store WindowBounds bytes object (Jonas Schnelli)

Pull request description:

  This seems to fix the macOS 10.12+ DMG issue in conjunction with Gitian on Bionic

Tree-SHA512: 3cdad7aaebed2eb320015e2053954444b28802a60505225d7f6affdd83c523de8738ecb53a48ba8c30266315716e3782c681208e6e547e94adcac39797139247
```

EDIT: Can confirm that it fixes the issue on my mac