### PR TITLE
wallet: Fix a warning for non-encrypted HD wallets

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -28,6 +28,7 @@
 #include <txmempool.h>
 #include <utilmoneystr.h>
 #include <wallet/fees.h>
+#include <warnings.h>
 
 #include <coinjoin/coinjoin-client.h>
 #include <coinjoin/coinjoin-client-options.h>
@@ -5120,9 +5121,9 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const WalletLocation& loc
         }
     }
 
-    // Warn user every time he starts non-encrypted HD wallet
-    if (gArgs.GetBoolArg("-usehd", DEFAULT_USE_HD_WALLET) && !walletInstance->IsLocked()) {
-        InitWarning(_("Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!"));
+    // Warn user every time a non-encrypted HD wallet is started
+    if (walletInstance->IsHDEnabled() && !walletInstance->IsLocked()) {
+        SetMiscWarning(_("Make sure to encrypt your wallet and delete all non-encrypted backups after you have verified that the wallet works!"));
     }
 
     if (gArgs.IsArgSet("-mintxfee")) {


### PR DESCRIPTION
Check `IsHDEnabled`, not `-usehd` option which is a much better/straightforward way in general and especially for wallets upgraded via `upgradetohd` rpc. Warn in label/rpc instead of msgbox/stderr: 1. it's not an error really, no need to annoy users with extra click at every start and 2. it's probably better to have it up there the whole time the wallet is running instead of 1 msg box at wallet start. Looks like that:

<img width="981" alt="Screenshot 2021-06-24 at 11 49 54" src="https://user-images.githubusercontent.com/1935069/123233273-986e6080-d4e2-11eb-9cf4-fcece6331067.png">
