### PR TITLE
wallet: Avoid generating an actual wallet key for the dummy one in CTransactionBuilder ctor

### DIFF
--- a/src/coinjoin/coinjoin-util.cpp
+++ b/src/coinjoin/coinjoin-util.cpp
@@ -132,7 +132,9 @@ CTransactionBuilder::CTransactionBuilder(std::shared_ptr<CWallet> pwalletIn, con
         LOCK(pwallet->cs_wallet);
         WalletBatch dummyBatch(pwallet->GetDBHandle(), "r+", false);
         dummyBatch.TxnBegin();
-        CPubKey dummyPubkey = pwallet->GenerateNewKey(dummyBatch, 0, false);
+        CKey secret;
+        secret.MakeNewKey(pwallet->CanSupportFeature(FEATURE_COMPRPUBKEY));
+        CPubKey dummyPubkey = secret.GetPubKey();
         dummyBatch.TxnAbort();
         dummyScript = ::GetScriptForDestination(dummyPubkey.GetID());
         // Create dummy signatures for all inputs


### PR DESCRIPTION
No need to expose wallet keys here, plus the old code was creating gaps in childkey indexes for HD wallets which complicates recovery.