### PR TITLE
Fix data races in bls_worker and use ctpl_stl queue.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -152,7 +152,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
-  ctpl.h \
+  ctpl_stl.h \
   cxxtimer.hpp \
   evo/cbtx.h \
   evo/deterministicmns.h \

--- a/src/bls/bls_worker.h
+++ b/src/bls/bls_worker.h
@@ -7,7 +7,7 @@
 
 #include <bls/bls.h>
 
-#include <ctpl.h>
+#include <ctpl_stl.h>
 
 #include <future>
 #include <mutex>

--- a/src/ctpl_stl.h
+++ b/src/ctpl_stl.h
@@ -1,25 +1,24 @@
-
 /*********************************************************
- *
- *  Copyright (C) 2014 by Vitaliy Vitsentiy
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *********************************************************/
+*
+*  Copyright (C) 2014 by Vitaliy Vitsentiy
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*********************************************************/
 
 
-#ifndef __ctpl_thread_pool_H__
-#define __ctpl_thread_pool_H__
+#ifndef __ctpl_stl_thread_pool_H__
+#define __ctpl_stl_thread_pool_H__
 
 #include <functional>
 #include <thread>
@@ -29,12 +28,8 @@
 #include <exception>
 #include <future>
 #include <mutex>
-#include <boost/lockfree/queue.hpp>
+#include <queue>
 
-
-#ifndef _ctplThreadPoolLength_
-#define _ctplThreadPoolLength_  100
-#endif
 
 
 // thread pool to run user's functors with signature
@@ -45,12 +40,40 @@
 
 namespace ctpl {
 
+    namespace detail {
+        template <typename T>
+        class Queue {
+        public:
+            bool push(T const & value) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->q.push(value);
+                return true;
+            }
+            // deletes the retrieved element, do not use for non integral types
+            bool pop(T & v) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                if (this->q.empty())
+                    return false;
+                v = this->q.front();
+                this->q.pop();
+                return true;
+            }
+            bool empty() {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                return this->q.empty();
+            }
+        private:
+            std::queue<T> q;
+            std::mutex mutex;
+        };
+    }
+
     class thread_pool {
 
     public:
 
-        thread_pool() : q(_ctplThreadPoolLength_) { this->init(); }
-        thread_pool(int nThreads, int queueSize = _ctplThreadPoolLength_) : q(queueSize) { this->init(); this->resize(nThreads); }
+        thread_pool() { this->init(); }
+        thread_pool(int nThreads) { this->init(); this->resize(nThreads); }
 
         // the destructor waits for all the functions in the queue to be finished
         ~thread_pool() {
@@ -99,24 +122,22 @@ namespace ctpl {
         void clear_queue() {
             std::function<void(int id)> * _f;
             while (this->q.pop(_f))
-                delete _f;  // empty the queue
+                delete _f; // empty the queue
         }
 
-        // pops a functional wraper to the original function
+        // pops a functional wrapper to the original function
         std::function<void(int)> pop() {
             std::function<void(int id)> * _f = nullptr;
             this->q.pop(_f);
-            std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
-
+            std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
             std::function<void(int)> f;
             if (_f)
                 f = *_f;
             return f;
         }
 
-
         // wait for all computing threads to finish and stop all threads
-        // may be called asyncronously to not pause the calling thread while waiting
+        // may be called asynchronously to not pause the calling thread while waiting
         // if isWait == true, all the functions in the queue are run, otherwise the queue is cleared without running the functions
         void stop(bool isWait = false) {
             if (!isWait) {
@@ -151,17 +172,14 @@ namespace ctpl {
         template<typename F, typename... Rest>
         auto push(F && f, Rest&&... rest) ->std::future<decltype(f(0, rest...))> {
             auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
-                std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
+                    std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
             );
-
             auto _f = new std::function<void(int id)>([pck](int id) {
                 (*pck)(id);
             });
             this->q.push(_f);
-
             std::unique_lock<std::mutex> lock(this->mutex);
             this->cv.notify_one();
-
             return pck->get_future();
         }
 
@@ -170,15 +188,12 @@ namespace ctpl {
         template<typename F>
         auto push(F && f) ->std::future<decltype(f(0))> {
             auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
-
             auto _f = new std::function<void(int id)>([pck](int id) {
                 (*pck)(id);
             });
             this->q.push(_f);
-
             std::unique_lock<std::mutex> lock(this->mutex);
             this->cv.notify_one();
-
             return pck->get_future();
         }
 
@@ -192,40 +207,37 @@ namespace ctpl {
         thread_pool & operator=(thread_pool &&);// = delete;
 
         void set_thread(int i) {
-            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]);  // a copy of the shared ptr to the flag
+            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]); // a copy of the shared ptr to the flag
             auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
                 std::atomic<bool> & _flag = *flag;
                 std::function<void(int id)> * _f;
                 bool isPop = this->q.pop(_f);
                 while (true) {
                     while (isPop) {  // if there is anything in the queue
-                        std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
+                        std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
                         (*_f)(i);
-
                         if (_flag)
                             return;  // the thread is wanted to stop, return even if the queue is not empty yet
                         else
                             isPop = this->q.pop(_f);
                     }
-
                     // the queue is empty here, wait for the next command
                     std::unique_lock<std::mutex> lock(this->mutex);
                     ++this->nWaiting;
                     this->cv.wait(lock, [this, &_f, &isPop, &_flag](){ isPop = this->q.pop(_f); return isPop || this->isDone || _flag; });
                     --this->nWaiting;
-
                     if (!isPop)
                         return;  // if the queue is empty and this->isDone == true or *flag then return
                 }
             };
-            this->threads[i].reset(new std::thread(f));  // compiler may not support std::make_unique()
+            this->threads[i].reset(new std::thread(f)); // compiler may not support std::make_unique()
         }
 
         void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
 
         std::vector<std::unique_ptr<std::thread>> threads;
         std::vector<std::shared_ptr<std::atomic<bool>>> flags;
-        mutable boost::lockfree::queue<std::function<void(int id)> *> q;
+        detail::Queue<std::function<void(int id)> *> q;
         std::atomic<bool> isDone;
         std::atomic<bool> isStop;
         std::atomic<int> nWaiting;  // how many threads are waiting
@@ -236,5 +248,4 @@ namespace ctpl {
 
 }
 
-#endif // __ctpl_thread_pool_H__
-
+#endif // __ctpl_stl_thread_pool_H__

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -6,7 +6,7 @@
 #define BITCOIN_LLMQ_QUORUMS_DKGSESSIONHANDLER_H
 
 
-#include <ctpl.h>
+#include <ctpl_stl.h>
 #include <net.h>
 
 class CBLSWorker;

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -8,7 +8,7 @@
 
 #include <support/allocators/secure.h>
 #include <chainparamsbase.h>
-#include <ctpl.h>
+#include <ctpl_stl.h>
 #include <random.h>
 #include <serialize.h>
 #include <stacktraces.h>

--- a/test/lint/lint-include-guards.sh
+++ b/test/lint/lint-include-guards.sh
@@ -10,7 +10,7 @@ export LC_ALL=C
 HEADER_ID_PREFIX="BITCOIN_"
 HEADER_ID_SUFFIX="_H"
 
-REGEXP_EXCLUDE_FILES_WITH_PREFIX="src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|bench/nanobench.h|univalue/|ctpl.h|bls/|crypto/sph)"
+REGEXP_EXCLUDE_FILES_WITH_PREFIX="src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|bench/nanobench.h|univalue/|ctpl_stl.h|bls/|crypto/sph)"
 
 EXIT_CODE=0
 for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_WITH_PREFIX}")

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -59,7 +59,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/filesystem/fstream.hpp
     boost/function.hpp
     boost/lexical_cast.hpp
-    boost/lockfree/queue.hpp
     boost/multi_index/hashed_index.hpp
     boost/multi_index/ordered_index.hpp
     boost/multi_index/sequenced_index.hpp


### PR DESCRIPTION
Thread sanitizer triggers data races on bls worker. Steps to reproduce:
```
./configure --enable-debug --prefix=`pwd`/depends/x86_64-pc-linux-gnu/ --with-sanitizers=thread
make clean
make -j4
python3 test/functional/feature_llmq_is_cl_conflicts.py
```

This pull request aims to fix all bls_worker related data races. The above testcase also trigger a data race on wallet/wallet.cpp function `KeepKey` which I am going to tackle in a different pull request as suggested by @PastaPastaPasta 

Fixes:
- Change ctpl implementation to use STL queue & mutex as suggested here https://github.com/dashpay/dash/pull/4126#issuecomment-829160064 
- Use ctpl synchronized queue instead of boost lockfree queue in bls worker aggregator.
- Use smart pointers for memory management of Aggregator and VectorAggregator. With `delete this;` the objects are prone to data race on the delete operator.
- Use smart pointers for memory management of ContributionVerifier. Same reason as for Aggregator and VectorAggregator.
- Pass shared_ptr by value to other threads via worker pool.

Benchmark for develop: https://pastebin.com/5qPBERhr
Benchmark for ctpl STL queue: https://pastebin.com/hx1UiqdZ
Benchmark for concurrent queue: https://pastebin.com/VXCXG5ak

There's no actual difference (very small) between them while used in the bls_worker, but I was curious to find out what causes the performance impact and I also did a profilling using `gprof` on the BLS bench. Here you can find the results: https://pastebin.com/AS14eSbr My opinion is that changing the queue is a micro-improvement when it comes to performance, but it is essential for the project to drop the `boost::lockfree::queue` as it has a data race where one can pop & access an already deleted element. My suggestion is to use the ctpl STL queue as it is correct, small (easy to maintain), easy to be understood and has tiny impact on performance (see benchmarks). I do not have a strong opinion on which queue we should use as long as it has little to no impact.