### PR TITLE
Merge bitcoin#13877: utils: Make fs::path::string() always return utf-8 string on Windows

### DIFF
--- a/src/fs.h
+++ b/src/fs.h
@@ -14,7 +14,6 @@
 #define BOOST_FILESYSTEM_NO_DEPRECATED
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 
 /** Filesystem operations and types */
 namespace fs = boost::filesystem;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -70,8 +70,6 @@
 #include <QMouseEvent>
 #include <QVBoxLayout>
 
-static fs::detail::utf8_codecvt_facet utf8;
-
 #if defined(Q_OS_MAC)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -1793,12 +1791,12 @@ void setClipboard(const QString& str)
 
 fs::path qstringToBoostPath(const QString &path)
 {
-    return fs::path(path.toStdString(), utf8);
+    return fs::path(path.toStdString());
 }
 
 QString boostPathToQString(const fs::path &path)
 {
-    return QString::fromStdString(path.string(utf8));
+    return QString::fromStdString(path.string());
 }
 
 QString formatDurationStr(int secs)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1279,7 +1279,11 @@ void SetupEnvironment()
     // A dummy locale is used to extract the internal default locale, used by
     // fs::path, which is then used to explicitly imbue the path.
     std::locale loc = fs::path::imbue(std::locale::classic());
+#ifndef WIN32
     fs::path::imbue(loc);
+#else
+    fs::path::imbue(std::locale(loc, new std::codecvt_utf8_utf16<wchar_t>()));
+#endif
 }
 
 bool SetupNetworking()

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -55,7 +55,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/chrono/chrono.hpp
     boost/date_time/posix_time/posix_time.hpp
     boost/filesystem.hpp
-    boost/filesystem/detail/utf8_codecvt_facet.hpp
     boost/filesystem/fstream.hpp
     boost/function.hpp
     boost/lexical_cast.hpp


### PR DESCRIPTION
…citly on Windows

bb6ca65f9890e8280ace32de5a37774e14705859 gui: get special folder in unicode (Chun Kuan Lee)
1c5d22585384c8bb05a27a04eab5c57b31d623fb Drop boost::scoped_array (Chun Kuan Lee)

Pull request description:

  Drop boost::scoped_array and simplify the code.

  `TCHAR` should be defined as `wchar_t` if `UNICODE` is defined. So we can use `.toStdWString().c_str()` to get wchar_t C-style string.

  Fix #13819

Tree-SHA512: 3fd4aa784129c9d1576b01e6ee27faa42d793e152d132f2dde504d917dad3a8e95e065fcbc54a3895d74fb6b2a9ed4f5ec67d893395552f585e225486a84a454

# Conflicts:
#	src/qt/guiutil.cpp