### PR TITLE
refactor: utilize GetLLMQParams, make it const, consistent naming

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -212,9 +212,9 @@ bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPre
                 continue;
             }
             auto qcHash = ::SerializeHash(qc.commitment);
-            const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)qc.commitment.llmqType);
-            auto& v = qcHashes[params.type];
-            if (v.size() == params.signingActiveQuorumCount) {
+            const auto& llmq_params = llmq::GetLLMQParams(qc.commitment.llmqType);
+            auto& v = qcHashes[llmq_params.type];
+            if (v.size() == llmq_params.signingActiveQuorumCount) {
                 // we pop the last entry, which is actually the oldest quorum as GetMinedAndActiveCommitmentsUntilBlock
                 // returned quorums in reversed order. This pop and later push can only work ONCE, but we rely on the
                 // fact that a block can only contain a single commitment for one LLMQ type
@@ -222,7 +222,7 @@ bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPre
             }
             v.emplace_back(qcHash);
             hashCount++;
-            if (v.size() > params.signingActiveQuorumCount) {
+            if (v.size() > llmq_params.signingActiveQuorumCount) {
                 return state.DoS(100, false, REJECT_INVALID, "excess-quorums-calc-cbtx-quorummerkleroot");
             }
         }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -874,8 +874,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
                 return _state.DoS(100, false, REJECT_INVALID, "bad-qc-payload");
             }
             if (!qc.commitment.IsNull()) {
-                const auto& params = Params().GetConsensus().llmqs.at(qc.commitment.llmqType);
-                uint32_t quorumHeight = qc.nHeight - (qc.nHeight % params.dkgInterval);
+                const auto& llmq_params = llmq::GetLLMQParams(qc.commitment.llmqType);
+                uint32_t quorumHeight = qc.nHeight - (qc.nHeight % llmq_params.dkgInterval);
                 auto quorumIndex = pindexPrev->GetAncestor(quorumHeight);
                 if (!quorumIndex || quorumIndex->GetBlockHash() != qc.commitment.quorumHash) {
                     // we should actually never get into this case as validation should have catched it...but lets be sure

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1583,8 +1583,8 @@ bool AppInitParameterInteraction()
     }
 
     if (chainparams.NetworkIDString() == CBaseChainParams::DEVNET) {
-        std::string strLLMQTypeChainLocks = gArgs.GetArg("-llmqchainlocks", Params().GetConsensus().llmqs.at(Params().GetConsensus().llmqTypeChainLocks).name);
-        std::string strLLMQTypeInstantSend = gArgs.GetArg("-llmqinstantsend", Params().GetConsensus().llmqs.at(Params().GetConsensus().llmqTypeInstantSend).name);
+        std::string strLLMQTypeChainLocks = gArgs.GetArg("-llmqchainlocks", llmq::GetLLMQParams(Params().GetConsensus().llmqTypeChainLocks).name);
+        std::string strLLMQTypeInstantSend = gArgs.GetArg("-llmqinstantsend", llmq::GetLLMQParams(Params().GetConsensus().llmqTypeInstantSend).name);
         Consensus::LLMQType llmqTypeChainLocks = Consensus::LLMQ_NONE;
         Consensus::LLMQType llmqTypeInstantSend = Consensus::LLMQ_NONE;
         for (const auto& p : Params().GetConsensus().llmqs) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -264,15 +264,15 @@ void CQuorumManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fInitial
 
 void CQuorumManager::EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexNew) const
 {
-    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    const auto& llmq_params = GetLLMQParams(llmqType);
 
     const auto& myProTxHash = activeMasternodeInfo.proTxHash;
-    auto lastQuorums = ScanQuorums(llmqType, pindexNew, (size_t)params.keepOldConnections);
+    auto lastQuorums = ScanQuorums(llmqType, pindexNew, (size_t)llmq_params.keepOldConnections);
 
     auto connmanQuorumsToDelete = g_connman->GetMasternodeQuorums(llmqType);
 
     // don't remove connections for the currently in-progress DKG round
-    int curDkgHeight = pindexNew->nHeight - (pindexNew->nHeight % params.dkgInterval);
+    int curDkgHeight = pindexNew->nHeight - (pindexNew->nHeight % llmq_params.dkgInterval);
     auto curDkgBlock = pindexNew->GetAncestor(curDkgHeight)->GetBlockHash();
     connmanQuorumsToDelete.erase(curDkgBlock);
 

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -36,17 +36,17 @@ bool CFinalCommitment::Verify(const CBlockIndex* pQuorumIndex, bool checkSigs) c
         LogPrintfFinalCommitment("invalid llmqType=%d\n", llmqType);
         return false;
     }
-    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    const auto& llmq_params = GetLLMQParams(llmqType);
 
-    if (!VerifySizes(params)) {
+    if (!VerifySizes(llmq_params)) {
         return false;
     }
 
-    if (CountValidMembers() < params.minSize) {
+    if (CountValidMembers() < llmq_params.minSize) {
         LogPrintfFinalCommitment("invalid validMembers count. validMembersCount=%d\n", CountValidMembers());
         return false;
     }
-    if (CountSigners() < params.minSize) {
+    if (CountSigners() < llmq_params.minSize) {
         LogPrintfFinalCommitment("invalid signers count. signersCount=%d\n", CountSigners());
         return false;
     }
@@ -68,7 +68,7 @@ bool CFinalCommitment::Verify(const CBlockIndex* pQuorumIndex, bool checkSigs) c
     }
 
     auto members = CLLMQUtils::GetAllQuorumMembers(llmqType, pQuorumIndex);
-    for (size_t i = members.size(); i < params.size; i++) {
+    for (size_t i = members.size(); i < llmq_params.size; i++) {
         if (validMembers[i]) {
             LogPrintfFinalCommitment("invalid validMembers bitset. bit %d should not be set\n", i);
             return false;
@@ -81,7 +81,7 @@ bool CFinalCommitment::Verify(const CBlockIndex* pQuorumIndex, bool checkSigs) c
 
     // sigs are only checked when the block is processed
     if (checkSigs) {
-        uint256 commitmentHash = CLLMQUtils::BuildCommitmentHash(params.type, quorumHash, validMembers, quorumPublicKey, quorumVvecHash);
+        uint256 commitmentHash = CLLMQUtils::BuildCommitmentHash(llmq_params.type, quorumHash, validMembers, quorumPublicKey, quorumVvecHash);
 
         std::vector<CBLSPublicKey> memberPubKeys;
         for (size_t i = 0; i < members.size(); i++) {
@@ -111,9 +111,8 @@ bool CFinalCommitment::VerifyNull() const
         LogPrintfFinalCommitment("invalid llmqType=%d\n", llmqType);
         return false;
     }
-    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
 
-    if (!IsNull() || !VerifySizes(params)) {
+    if (!IsNull() || !VerifySizes(GetLLMQParams(llmqType))) {
         return false;
     }
 

--- a/src/llmq/quorums_debug.cpp
+++ b/src/llmq/quorums_debug.cpp
@@ -124,8 +124,7 @@ UniValue CDKGDebugStatus::ToJson(int detailLevel) const
         if (!Params().GetConsensus().llmqs.count(p.first)) {
             continue;
         }
-        const auto& params = Params().GetConsensus().llmqs.at(p.first);
-        sessionsJson.pushKV(params.name, p.second.ToJson(detailLevel));
+        sessionsJson.pushKV(GetLLMQParams(p.first).name, p.second.ToJson(detailLevel));
     }
 
     ret.pushKV("session", sessionsJson);
@@ -161,7 +160,6 @@ void CDKGDebugManager::InitLocalSessionStatus(Consensus::LLMQType llmqType, cons
         it = localStatus.sessions.emplace(llmqType, CDKGDebugSessionStatus()).first;
     }
 
-    auto& params = Params().GetConsensus().llmqs.at(llmqType);
     auto& session = it->second;
     session.llmqType = llmqType;
     session.quorumHash = quorumHash;
@@ -169,7 +167,7 @@ void CDKGDebugManager::InitLocalSessionStatus(Consensus::LLMQType llmqType, cons
     session.phase = 0;
     session.statusBitset = 0;
     session.members.clear();
-    session.members.resize((size_t)params.size);
+    session.members.resize((size_t)GetLLMQParams(llmqType).size);
 }
 
 void CDKGDebugManager::UpdateLocalSessionStatus(Consensus::LLMQType llmqType, std::function<bool(CDKGDebugSessionStatus& status)>&& func)

--- a/src/llmq/quorums_instantsend.cpp
+++ b/src/llmq/quorums_instantsend.cpp
@@ -821,7 +821,7 @@ bool CInstantSendManager::ProcessPendingInstantSendLocks()
     }
 
     auto llmqType = Params().GetConsensus().llmqTypeInstantSend;
-    auto dkgInterval = Params().GetConsensus().llmqs.at(llmqType).dkgInterval;
+    auto dkgInterval = GetLLMQParams(llmqType).dkgInterval;
 
     // First check against the current active set and don't ban
     auto badISLocks = ProcessPendingInstantSendLocks(0, pend, false);

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -899,8 +899,7 @@ bool CSigningManager::GetVoteForId(Consensus::LLMQType llmqType, const uint256& 
 
 CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType, const uint256& selectionHash, int signHeight, int signOffset)
 {
-    auto& llmqParams = Params().GetConsensus().llmqs.at(llmqType);
-    size_t poolSize = (size_t)llmqParams.signingActiveQuorumCount;
+    size_t poolSize = GetLLMQParams(llmqType).signingActiveQuorumCount;
 
     CBlockIndex* pindexStart;
     {

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -42,10 +42,9 @@ std::vector<CDeterministicMNCPtr> CLLMQUtils::GetAllQuorumMembers(Consensus::LLM
         }
     }
 
-    auto& params = Params().GetConsensus().llmqs.at(llmqType);
     auto allMns = deterministicMNManager->GetListForBlock(pindexQuorum);
     auto modifier = ::SerializeHash(std::make_pair(llmqType, pindexQuorum->GetBlockHash()));
-    quorumMembers = allMns.CalculateQuorum(params.size, modifier);
+    quorumMembers = allMns.CalculateQuorum(GetLLMQParams(llmqType).size, modifier);
     LOCK(cs_members);
     mapQuorumMembers[llmqType].insert(pindexQuorum->GetBlockHash(), quorumMembers);
     return quorumMembers;
@@ -288,12 +287,10 @@ void CLLMQUtils::AddQuorumProbeConnections(Consensus::LLMQType llmqType, const C
 
 bool CLLMQUtils::IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quorumHash)
 {
-    auto& params = Params().GetConsensus().llmqs.at(llmqType);
-
     // sig shares and recovered sigs are only accepted from recent/active quorums
     // we allow one more active quorum as specified in consensus, as otherwise there is a small window where things could
     // fail while we are on the brink of a new quorum
-    auto quorums = quorumManager->ScanQuorums(llmqType, (int)params.signingActiveQuorumCount + 1);
+    auto quorums = quorumManager->ScanQuorums(llmqType, GetLLMQParams(llmqType).signingActiveQuorumCount + 1);
     for (const auto& q : quorums) {
         if (q->qc->quorumHash == quorumHash) {
             return true;


### PR DESCRIPTION
Removes all (besides one) usages of "Params().GetConsensus().llmqs.at" and instead uses the wrapper in quorum_utils.cpp

Rename all params to llmq_params for consistency and not conflict with non-llmq params

make some llmq_params const where possible

remove unneeded llmq_params variables where it's only used once

Signed-off-by: pasta <pasta@dashboost.org>