### PR TITLE
actions: creates an action to enable collatorators to rebase others pull requests easily

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,21 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: write
+jobs:
+  rebase:
+    name: Rebase
+    if: (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER') && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Rebase
+        uses: PastaPastaPasta/rebase@1.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
simply respond '/rebase' on a PR and (assuming PR creater allows repo collaborators to push), it will be rebased on the latest develop. I believe this will be useful in the case of some trivial rebases that are sometimes needed on a PR, otherwise, it should be used before merging PRs that will be merged via a merge commit in order to keep our history as close to linear as possible

Even though this does get content write permissions it's secure for a number of reasons. Actions cannot push to protected branches, so develop master etc are safe. Two, I've forked this action so that we know what it's running. And three, if you look at the actual script it's running in PastaPastaPasta/rebase, it's SUPER simple. Additionally, this can only be triggered by a message via collaborator or owner. 