### PR TITLE
Drop excessive cs_main locks in governance sync code

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -613,7 +613,7 @@ void CGovernanceManager::SyncSingleObjVotes(CNode* pnode, const uint256& nProp, 
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s -- syncing single object to peer=%d, nProp = %s\n", __func__, pnode->GetId(), nProp.ToString());
 
-    LOCK2(cs_main, cs);
+    LOCK(cs);
 
     // single valid object and its valid votes
     auto it = mapObjects.find(nProp);
@@ -671,7 +671,7 @@ void CGovernanceManager::SyncObjects(CNode* pnode, CConnman& connman) const
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s -- syncing all objects to peer=%d\n", __func__, pnode->GetId());
 
-    LOCK2(cs_main, cs);
+    LOCK(cs);
 
     // all valid objects, no votes
     for (const auto& objPair : mapObjects) {
@@ -974,7 +974,7 @@ int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& 
     }
 
     {
-        LOCK2(cs_main, cs);
+        LOCK(cs);
 
         if (mapObjects.empty()) return -2;
 


### PR DESCRIPTION
Not sure why we were holding them there in the first place. Also fixes a deadlock:
```
POTENTIAL DEADLOCK DETECTED
Previous lock order was:
 (1) cs masternode/masternode-sync.cpp:151 (in thread )
 (2) cs_main governance/governance.cpp:977 (in thread )
Current lock order is:
 (2) cs_main init.cpp:2071 (in thread )
 (2) cs_main validation.cpp:4510 (in thread )
 (1) cs ./masternode/masternode-sync.h:56 (in thread )
```