### PR TITLE
Merge #18743: depends: Add --sysroot option to mac os native compile flags

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -1,5 +1,5 @@
-build_darwin_CC:=$(shell xcrun -f clang)
-build_darwin_CXX:=$(shell xcrun -f clang++)
+build_darwin_CC:=$(shell xcrun -f clang) --sysroot $(shell xcrun --show-sdk-path)
+build_darwin_CXX:=$(shell xcrun -f clang++) --sysroot $(shell xcrun --show-sdk-path)
 build_darwin_AR:=$(shell xcrun -f ar)
 build_darwin_RANLIB:=$(shell xcrun -f ranlib)
 build_darwin_STRIP:=$(shell xcrun -f strip)


### PR DESCRIPTION
`14647: build: Remove illegal spacing in darwin.mk` from #4271 broke depends compilation on my machine. Backporting 18743 fixes the issue.

EDIT: 18743 is also a part of #4255 but it needs rebase anyway atm.