### PR TITLE
Change devnet uacomment from `devnet=<name>` to `devnet.<name>`

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1901,7 +1901,7 @@ bool AppInitMain()
 
     if (chainparams.NetworkIDString() == CBaseChainParams::DEVNET) {
         // Add devnet name to user agent. This allows to disconnect nodes immediately if they don't belong to our own devnet
-        uacomments.push_back(strprintf("devnet=%s", gArgs.GetDevNetName()));
+        uacomments.push_back(strprintf("devnet.%s", gArgs.GetDevNetName()));
     }
 
     for (const std::string& cmt : gArgs.GetArgs("-uacomment")) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2258,7 +2258,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             PushNodeVersion(pfrom, connman, GetAdjustedTime());
 
         if (Params().NetworkIDString() == CBaseChainParams::DEVNET) {
-            if (cleanSubVer.find(strprintf("devnet=%s", gArgs.GetDevNetName())) == std::string::npos) {
+            if (cleanSubVer.find(strprintf("devnet.%s", gArgs.GetDevNetName())) == std::string::npos) {
                 LOCK(cs_main);
                 LogPrintf("connected to wrong devnet. Reported version is %s, expected devnet name is %s\n", cleanSubVer, gArgs.GetDevNetName());
                 if (!pfrom->fInbound)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1038,7 +1038,7 @@ std::string ArgsManager::GetDevNetName() const
 {
     assert(IsArgSet("-devnet"));
     std::string devNetName = GetArg("-devnet", "");
-    return "devnet" + (devNetName.empty() ? "" : "-" + devNetName);
+    return "devnet" + (devNetName.empty() ? "" : "." + devNetName);
 }
 
 #ifndef WIN32

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -115,9 +115,9 @@ class P2PConnection(asyncio.Protocol):
 
         if self.network == "devnet" and self.devnet_name is not None:
             if self.uacomment is None:
-                self.strSubVer = MY_SUBVERSION % ("(devnet=devnet-%s)" % self.devnet_name).encode()
+                self.strSubVer = MY_SUBVERSION % ("(devnet.devnet-%s)" % self.devnet_name).encode()
             else:
-                self.strSubVer = MY_SUBVERSION % ("(devnet=devnet-%s,%s)" % (self.devnet_name, self.uacomment)).encode()
+                self.strSubVer = MY_SUBVERSION % ("(devnet.devnet-%s,%s)" % (self.devnet_name, self.uacomment)).encode()
         elif self.uacomment is not None:
             self.strSubVer = MY_SUBVERSION % ("(%s)" % self.uacomment).encode()
         else:


### PR DESCRIPTION
Backporting 15654 in #4213 broke devnet connections because of `SanitizeString` for `cleanSubVer`. The real issue actually is using unsafe character in devnet uacomments, so to fix this we should replace unsafe `=` with something safe e.g. `.`.

Note: if you need to connect to a pre-15654 devnet, you still need a pre-15654 node. This only fixes it for future devnets.