### PR TITLE
Add virtual destructors for CBLSWrapper and CBLSLazyWrapper

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -79,7 +79,9 @@ public:
         std::swap(fLegacy, ref.fLegacy);
         return *this;
     }
-
+    
+    virtual ~CBLSWrapper() {}
+    
     bool operator==(const C& r) const
     {
         return fValid == r.fValid && impl == r.impl;
@@ -319,6 +321,8 @@ public:
     {
         *this = r;
     }
+    
+    virtual ~CBLSLazyWrapper() {}
 
     CBLSLazyWrapper& operator=(const CBLSLazyWrapper& r)
     {

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -79,9 +79,9 @@ public:
         std::swap(fLegacy, ref.fLegacy);
         return *this;
     }
-    
+
     virtual ~CBLSWrapper() {}
-    
+
     bool operator==(const C& r) const
     {
         return fValid == r.fValid && impl == r.impl;
@@ -321,7 +321,6 @@ public:
     {
         *this = r;
     }
-    
     virtual ~CBLSLazyWrapper() {}
 
     CBLSLazyWrapper& operator=(const CBLSLazyWrapper& r)


### PR DESCRIPTION
Add virtual destructors for CBLSWrapper and CBLSLazyWrapper. This prevents from potential memory leaks when derived classes are deleted (using the base pointer) 