### PR TITLE
Few followups for recently merged PRs

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -227,7 +227,7 @@ private:
     int64_t nLastGood GUARDED_BY(cs);
 
     // discriminate entries based on port. Should be false on mainnet/testnet and can be true on devnet/regtest
-    bool discriminatePorts;
+    bool discriminatePorts GUARDED_BY(cs);
 
     //! Holds addrs inserted into tried table that collide with existing entries. Test-before-evict discipline used to resolve these collisions.
     std::set<int> m_tried_collisions;
@@ -291,7 +291,7 @@ protected:
     void SetServices_(const CService &addr, ServiceFlags nServices) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Get address info for address
-    CAddrInfo GetAddressInfo_(const CService& addr);
+    CAddrInfo GetAddressInfo_(const CService& addr) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
 public:
     //! Serialization versions.

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -91,6 +91,7 @@ void Check(const std::string& prv, const std::string& pub, int flags, const std:
             BOOST_CHECK_EQUAL(spks.size(), ref.size());
             for (size_t n = 0; n < spks.size(); ++n) {
                 BOOST_CHECK_EQUAL(ref[n], HexStr(spks[n]));
+                BOOST_CHECK_EQUAL(IsSolvable(Merge(key_provider, script_provider), spks[n]), (flags & UNSOLVABLE) == 0);
 
                 if (flags & SIGNABLE) {
                     CMutableTransaction spend;

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -58,11 +58,12 @@ public:
 
     CWalletTx& AddTxToChain(uint256 nTxHash)
     {
-        auto it = wallet->mapWallet.find(nTxHash);
-        assert(it != wallet->mapWallet.end());
+        std::map<uint256, CWalletTx>::iterator it;
         CMutableTransaction blocktx;
         {
             LOCK(wallet->cs_wallet);
+            it = wallet->mapWallet.find(nTxHash);
+            assert(it != wallet->mapWallet.end());
             blocktx = CMutableTransaction(*it->second.tx);
         }
         CreateAndProcessBlock({blocktx}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1043,6 +1043,8 @@ bool CWallet::AccountMove(std::string strFrom, std::string strTo, CAmount nAmoun
 
 bool CWallet::GetLabelDestination(CTxDestination &dest, const std::string& label, bool bForceNew)
 {
+    AssertLockHeld(cs_wallet);
+
     WalletBatch batch(*database);
 
     CAccount account;
@@ -2474,6 +2476,8 @@ CAmount CWalletTx::GetAnonymizedCredit(const CCoinControl* coinControl) const
     if (!pwallet)
         return 0;
 
+    AssertLockHeld(pwallet->cs_wallet);
+
     // Exclude coinbase and conflicted txes
     if (IsCoinBase() || GetDepthInMainChain() < 0)
         return 0;
@@ -2513,6 +2517,8 @@ CAmount CWalletTx::GetDenominatedCredit(bool unconfirmed, bool fUseCache) const
 {
     if (pwallet == nullptr)
         return 0;
+
+    AssertLockHeld(pwallet->cs_wallet);
 
     // Must wait until coinbase is safely deep enough in the chain before valuing it
     if (IsCoinBase() && GetBlocksToMaturity() > 0)
@@ -3725,6 +3731,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                 }
 
                 auto calculateFee = [&](CAmount& nFee) -> bool {
+                    AssertLockHeld(cs_wallet);
                     nBytes = CalculateMaximumSignedTxSize(txNew, this, coin_control.fAllowWatchOnly);
                     if (nBytes < 0) {
                         strFailReason = _("Signing transaction failed");

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -785,7 +785,7 @@ private:
     /* HD derive new child key (on internal or external chain) */
     void DeriveNewChildKey(WalletBatch &batch, const CKeyMetadata& metadata, CKey& secretRet, uint32_t nAccountIndex, bool fInternal /*= false*/) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    std::set<int64_t> setInternalKeyPool;
+    std::set<int64_t> setInternalKeyPool GUARDED_BY(cs_wallet);
     std::set<int64_t> setExternalKeyPool GUARDED_BY(cs_wallet);
     int64_t m_max_keypool_index GUARDED_BY(cs_wallet) = 0;
     std::map<CKeyID, int64_t> m_pool_key_to_index;


### PR DESCRIPTION
Not sure why but CI builds with `--enable-werror` did not catch these... local build did so here they are.

Note: missing `GUARDED_BY(cs)` annotations for `discriminatePorts` and `setInternalKeyPool` did not cause any error even with `--enable-werror`. Fixing them anyway simply to keep things more consistent.