### PR TITLE
Merge bitcoin#13988: Add checks for settxfee reasonableness

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2933,8 +2933,16 @@ static UniValue settxfee(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
 
     CAmount nAmount = AmountFromValue(request.params[0]);
+    CFeeRate tx_fee_rate(nAmount, 1000);
+    if (tx_fee_rate == 0) {
+        // automatic selection
+    } else if (tx_fee_rate < ::minRelayTxFee) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("txfee cannot be less than min relay tx fee (%s)", ::minRelayTxFee.ToString()));
+    } else if (tx_fee_rate < pwallet->m_min_fee) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("txfee cannot be less than wallet min fee (%s)", pwallet->m_min_fee.ToString()));
+    }
 
-    pwallet->m_pay_tx_fee = CFeeRate(nAmount, 1000);
+    pwallet->m_pay_tx_fee = tx_fee_rate;
     return true;
 }
 


### PR DESCRIPTION
Another backport with multiple parts... 

1. Successfully ported check settxfee reasonableness.
2. Not ported: Change to `walletcreatefundedpsbt` re. BIP125 adding replacable param.
3. Not ported (yet?) test for bad txfee rpc error from `test/functional/wallet_bumpfee.py`. Since Dash doesn't do RBF/bumpfee this test doesn't exist. Should it go somewhere else?