### PR TITLE
actions: Prevent accidental merging to master

### DIFF
--- a/.github/workflows/prevent-master-pr.yml
+++ b/.github/workflows/prevent-master-pr.yml
@@ -1,0 +1,13 @@
+name: Prevent Merging into Master
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  fail:
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+


### PR DESCRIPTION
This should fail anytime someone opens a PR to master. A PR to any other branch won't fail.

This likely not work until this is backported / merged into master, for that reason, it's a backport candidate.