### PR TITLE
bug: remove possible race condition crash; nullptr access

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1061,7 +1061,12 @@ bool CDeterministicMNManager::IsDIP3Enforced(int nHeight)
     LOCK(cs);
 
     if (nHeight == -1) {
-        nHeight = tipIndex->nHeight;
+        if (tipIndex == nullptr) {
+            // Since EnforcementHeight can be set to block 1, we shouldn't just return false here
+            nHeight = 1;
+        } else {
+            nHeight = tipIndex->nHeight;
+        }
     }
 
     return nHeight >= Params().GetConsensus().DIP0003EnforcementHeight;


### PR DESCRIPTION
This probably isn't a huge thing to fix, as I think this race condition would be VERY rare, but may as well fix it.

I'm not positive if this is the right approach or if we should just return false here