### PR TITLE
Backports v0.18 PR-13769 and 13767

### DIFF
--- a/src/interfaces/handler.cpp
+++ b/src/interfaces/handler.cpp
@@ -16,7 +16,7 @@ namespace {
 class HandlerImpl : public Handler
 {
 public:
-    HandlerImpl(boost::signals2::connection connection) : m_connection(std::move(connection)) {}
+    explicit HandlerImpl(boost::signals2::connection connection) : m_connection(std::move(connection)) {}
 
     void disconnect() override { m_connection.disconnect(); }
 

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -34,7 +34,7 @@ namespace {
 class PendingWalletTxImpl : public PendingWalletTx
 {
 public:
-    PendingWalletTxImpl(CWallet& wallet) : m_wallet(wallet), m_key(&wallet) {}
+    explicit PendingWalletTxImpl(CWallet& wallet) : m_wallet(wallet), m_key(&wallet) {}
 
     const CTransaction& get() override { return *m_tx; }
 
@@ -178,7 +178,7 @@ class WalletImpl : public Wallet
 public:
     CoinJoinImpl m_coinjoin;
 
-    WalletImpl(const std::shared_ptr<CWallet>& wallet) : m_shared_wallet(wallet), m_wallet(*wallet.get()), m_coinjoin(*wallet.get()) {}
+    explicit WalletImpl(const std::shared_ptr<CWallet>& wallet) : m_shared_wallet(wallet), m_wallet(*wallet.get()), m_coinjoin(*wallet.get()) {}
 
     void markDirty() override
     {

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -24,7 +24,7 @@ private:
     const CChainParams& m_params;
 
 public:
-    DestinationEncoder(const CChainParams& params) : m_params(params) {}
+    explicit DestinationEncoder(const CChainParams& params) : m_params(params) {}
 
     std::string operator()(const CKeyID& id) const
     {

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -73,7 +73,7 @@ public:
     QList<AddressTableEntry> cachedAddressTable;
     AddressTableModel *parent;
 
-    AddressTablePriv(AddressTableModel *_parent):
+    explicit AddressTablePriv(AddressTableModel *_parent):
         parent(_parent) {}
 
     void refreshAddressTable(interfaces::Wallet& wallet)

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -85,7 +85,7 @@ class RPCExecutor : public QObject
 {
     Q_OBJECT
 public:
-    RPCExecutor(interfaces::Node& node) : m_node(node) {}
+    explicit RPCExecutor(interfaces::Node& node) : m_node(node) {}
 
 public Q_SLOTS:
     void request(const QString &command, const WalletModel* wallet_model);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -59,7 +59,7 @@ struct TxLessThan
 class TransactionTablePriv
 {
 public:
-    TransactionTablePriv(TransactionTableModel *_parent) :
+    explicit TransactionTablePriv(TransactionTableModel *_parent) :
         parent(_parent)
     {
     }

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -64,7 +64,7 @@ void Check(const std::string& prv, const std::string& pub, int flags, const std:
     BOOST_CHECK_EQUAL(pub, pub2);
 
     // Check that both can be serialized with private key back to the private version, but not without private key.
-    std::string prv1, prv2;
+    std::string prv1;
     BOOST_CHECK(parse_priv->ToPrivateString(keys_priv, prv1));
     BOOST_CHECK_EQUAL(prv, prv1);
     BOOST_CHECK(!parse_priv->ToPrivateString(keys_pub, prv1));

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -895,17 +895,19 @@ BOOST_AUTO_TEST_CASE(script_build)
         }
     }
 
+#ifdef UPDATE_JSON_TESTS
     std::string strGen;
-
+#endif
     for (TestBuilder& test : tests) {
         test.Test();
         std::string str = JSONPrettyPrint(test.GetJSON());
-#ifndef UPDATE_JSON_TESTS
+#ifdef UPDATE_JSON_TESTS
+        strGen += str + ",\n";
+#else
         if (tests_set.count(str) == 0) {
             BOOST_CHECK_MESSAGE(false, "Missing auto script_valid test: " + test.GetComment());
         }
 #endif
-        strGen += str + ",\n";
     }
 
 #ifdef UPDATE_JSON_TESTS

--- a/src/test/test_dash.h
+++ b/src/test/test_dash.h
@@ -143,7 +143,7 @@ CBlock getBlock13b8a();
 // BOOST_CHECK_EXCEPTION predicates to check the specific validation error
 class HasReason {
 public:
-    HasReason(const std::string& reason) : m_reason(reason) {}
+    explicit HasReason(const std::string& reason) : m_reason(reason) {}
     bool operator() (const std::runtime_error& e) const {
         return std::string(e.what()).find(m_reason) != std::string::npos;
     };

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -23,7 +23,7 @@ BOOST_FIXTURE_TEST_SUITE(validation_block_tests, RegtestingSetup)
 struct TestSubscriber : public CValidationInterface {
     uint256 m_expected_tip;
 
-    TestSubscriber(uint256 tip) : m_expected_tip(tip) {}
+    explicit TestSubscriber(uint256 tip) : m_expected_tip(tip) {}
 
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
     {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1056,8 +1056,6 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         innerUsage += memusage::DynamicUsage(links.parents) + memusage::DynamicUsage(links.children);
         bool fDependsWait = false;
         setEntries setParentCheck;
-        int64_t parentSizes = 0;
-        unsigned int parentSigOpCount = 0;
         for (const CTxIn &txin : tx.vin) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
             indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
@@ -1065,10 +1063,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
                 const CTransaction& tx2 = it2->GetTx();
                 assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
                 fDependsWait = true;
-                if (setParentCheck.insert(it2).second) {
-                    parentSizes += it2->GetTxSize();
-                    parentSigOpCount += it2->GetSigOpCount();
-                }
+                setParentCheck.insert(it2);
             } else {
                 assert(pcoins->HaveCoin(txin.prevout));
             }


### PR DESCRIPTION
Merge #13769: Mark single-argument constructors "explicit"
Merge #13767: Remove redundant assignments (dead stores)