### PR TITLE
refactor: adjust cs_main usage in llmq code

### DIFF
--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -663,8 +663,8 @@ bool CSigningManager::ProcessPendingRecoveredSigs()
         const auto& v = p.second;
 
         if (batchVerifier.badSources.count(nodeId)) {
-            LOCK(cs_main);
             LogPrint(BCLog::LLMQ, "CSigningManager::%s -- invalid recSig from other node, banning peer=%d\n", __func__, nodeId);
+            LOCK(cs_main);
             Misbehaving(nodeId, 100);
             continue;
         }

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -609,24 +609,20 @@ void CSigSharesManager::CollectPendingSigSharesToVerify(
         }
     }
 
-    {
-        LOCK(cs_main);
+    // For the convenience of the caller, also build a map of quorumHash -> quorum
 
-        // For the convenience of the caller, also build a map of quorumHash -> quorum
+    for (auto& p : retSigShares) {
+        for (auto& sigShare : p.second) {
+            auto llmqType = sigShare.llmqType;
 
-        for (auto& p : retSigShares) {
-            for (auto& sigShare : p.second) {
-                auto llmqType = sigShare.llmqType;
-
-                auto k = std::make_pair(llmqType, sigShare.quorumHash);
-                if (retQuorums.count(k)) {
-                    continue;
-                }
-
-                CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, sigShare.quorumHash);
-                assert(quorum != nullptr);
-                retQuorums.emplace(k, quorum);
+            auto k = std::make_pair(llmqType, sigShare.quorumHash);
+            if (retQuorums.count(k)) {
+                continue;
             }
+
+            CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, sigShare.quorumHash);
+            assert(quorum != nullptr);
+            retQuorums.emplace(k, quorum);
         }
     }
 }


### PR DESCRIPTION
I don't see any reason for locking cs_main there. Also, might as well print first, before locking.