### PR TITLE
followup: 4303: 15297->16127: util/system.cpp: add thread safety annotations for dir_locks

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -184,7 +184,7 @@ bool LockDirectory(const fs::path& directory, const std::string lockfile_name, b
 
 void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name)
 {
-    std::lock_guard<std::mutex> lock(cs_dir_locks);
+    LOCK(cs_dir_locks);
     dir_locks.erase((directory / lockfile_name).string());
 }
 


### PR DESCRIPTION
Add a missing part of 16127 (which was backported before 15297/#4303)