### PR TITLE
lint: fix linter failure in lint-python-dead-code.sh

### DIFF
--- a/test/lint/lint-python-dead-code.sh
+++ b/test/lint/lint-python-dead-code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying


### PR DESCRIPTION
Signed-off-by: pasta <pasta@dashboost.org>