### PR TITLE
Add `-printcrashinfo` to hidden args

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -451,7 +451,7 @@ void SetupServerArgs()
     const auto regtestLLMQ = CreateChainParams(CBaseChainParams::REGTEST)->GetConsensus().llmqs.at(Consensus::LLMQ_TEST);
 
     // Hidden Options
-    std::vector<std::string> hidden_args = {"-h", "-help", "-dbcrashratio", "-forcecompactdb",
+    std::vector<std::string> hidden_args = {"-h", "-help", "-dbcrashratio", "-forcecompactdb", "-printcrashinfo",
         // GUI args. These will be overwritten by SetupUIArgs for the GUI
         "-allowselfsignedrootcertificates", "-choosedatadir", "-lang=<lang>", "-min", "-resetguisettings", "-rootcertificates=<file>", "-splash", "-uiplatform"};
 


### PR DESCRIPTION
Fixes `Error parsing command line arguments: Invalid parameter -printcrashinfo.` error.