### PR TITLE
Fix thread names for threads started via pools

### DIFF
--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -64,7 +64,7 @@ void CBLSWorker::Start()
     int workerCount = std::thread::hardware_concurrency() / 2;
     workerCount = std::max(std::min(1, workerCount), 4);
     workerPool.resize(workerCount);
-    RenameThreadPool(workerPool, "dash-bls-work");
+    RenameThreadPool(workerPool, "bls-work");
 }
 
 void CBLSWorker::Stop()

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -183,7 +183,7 @@ void CQuorumManager::Start()
     int workerCount = std::thread::hardware_concurrency() / 2;
     workerCount = std::max(std::min(1, workerCount), 4);
     workerPool.resize(workerCount);
-    RenameThreadPool(workerPool, "dash-q-mngr");
+    RenameThreadPool(workerPool, "q-mngr");
 }
 
 void CQuorumManager::Stop()


### PR DESCRIPTION
`RenameThreadPool` calls `ThreadRename` which adds `dash-` prefix internally