### PR TITLE
build: patch relic to satisfy gcc 11's stricter requirements

### DIFF
--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -6,6 +6,7 @@ $(package)_file_name=$(package)-$($(package)_download_file)
 $(package)_build_subdir=build
 $(package)_sha256_hash=276c8573104e5f18bb5b9fd3ffd49585dda5ba5f6de2de74759dda8ca5a9deac
 $(package)_dependencies=gmp cmake
+$(package)_patches=gcc_alignment_cast.patch
 
 $(package)_relic_version=3a23142be0a5510a3aa93cd6c76fc59d3fc732a5
 $(package)_relic_download_path=https://github.com/relic-toolkit/relic/archive
@@ -54,7 +55,12 @@ endef
 
 define $(package)_preprocess_cmds
   sed -i.old "s|GIT_REPOSITORY https://github.com/relic-toolkit/relic.git|URL \"../../relic-toolkit-$($(package)_relic_version).tar.gz\"|" src/CMakeLists.txt && \
-  sed -i.old "s|GIT_TAG        .*RELIC_GIT_TAG.*|URL_HASH SHA256=$($(package)_relic_sha256_hash)|" src/CMakeLists.txt
+  sed -i.old "s|GIT_TAG        .*RELIC_GIT_TAG.*||" src/CMakeLists.txt && \
+  tar xzf relic-toolkit-$($(package)_relic_version).tar.gz relic-$($(package)_relic_version)/src/md/blake2.h && \
+  patch -p1 relic-$($(package)_relic_version)/src/md/blake2.h < $($(package)_patch_dir)/gcc_alignment_cast.patch && \
+  gunzip relic-toolkit-$($(package)_relic_version).tar.gz && \
+  tar rf relic-toolkit-$($(package)_relic_version).tar relic-$($(package)_relic_version)/src/md/blake2.h && \
+  gzip relic-toolkit-$($(package)_relic_version).tar
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/bls-dash/gcc_alignment_cast.patch
+++ b/depends/patches/bls-dash/gcc_alignment_cast.patch
@@ -1,0 +1,21 @@
+From: Kittywhiskers Van Gogh <63189531+kittywhiskers@users.noreply.github.com>
+Date: Thu, 2 Sep 2021 00:18:25 +0530
+Subject: [PATCH] Resolve "not a multiple of its alignment" build error
+
+---
+ src/md/blake2.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/src/md/blake2.h
++++ b/src/md/blake2.h
+@@ -137,8 +137,8 @@ extern "C" {
+ 
+   /* Padded structs result in a compile-time error */
+   enum {
++    BLAKE2_DUMMY_1 = 1/(int)(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
++    BLAKE2_DUMMY_2 = 1/(int)(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
+-    BLAKE2_DUMMY_1 = 1/(sizeof(blake2s_param) == BLAKE2S_OUTBYTES),
+-    BLAKE2_DUMMY_2 = 1/(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
+   };
+ 
+   /* Streaming API */


### PR DESCRIPTION
## Description

Due to stricter requirements enforced in a recent GCC release, the package `bls-dash` doesn't compile on Fedora 34 and (therefore) fails to build depends. See https://github.com/openwall/john/issues/4604 and https://bugzilla.redhat.com/show_bug.cgi?id=1937076 for more information.

* `gcc_alignment_cast.patch` is generated from https://github.com/relic-toolkit/relic/commit/9206ae50b667de160fcc385ba3dc2c920143ab0a
