### PR TITLE
More of 13743: refactor: Replace boost::bind with std::bind

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -514,7 +514,7 @@ void WalletModel::subscribeToCoreSignals()
     m_handler_chainlock_received = m_wallet->handleChainLockReceived(std::bind(NotifyChainLockReceived, this, std::placeholders::_1));
     m_handler_show_progress = m_wallet->handleShowProgress(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
     m_handler_watch_only_changed = m_wallet->handleWatchOnlyChanged(std::bind(NotifyWatchonlyChanged, this, std::placeholders::_1));
-    m_handler_can_get_addrs_changed = m_wallet->handleCanGetAddressesChanged(boost::bind(NotifyCanGetAddressesChanged, this));
+    m_handler_can_get_addrs_changed = m_wallet->handleCanGetAddressesChanged(std::bind(NotifyCanGetAddressesChanged, this));
 }
 
 void WalletModel::unsubscribeFromCoreSignals()


### PR DESCRIPTION
Fixes
```
Use of boost::bind detected. Use std::bind instead.
src/qt/walletmodel.cpp:    m_handler_can_get_addrs_changed = m_wallet->handleCanGetAddressesChanged(boost::bind(NotifyCanGetAddressesChanged, this));
^---- failure generated from test/lint/lint-cpp.sh
```
https://gitlab.com/dashpay/dash/-/jobs/1554982691#L53

Sneaked in via 15225 https://github.com/dashpay/dash/commit/baa76aa3318a038f1d80f6e92f94667f90ad5c10#diff-3c5f55f5118243d479461d5445315d9d27772fde1f1d86d828f26d113d1ba8acR506 (#4359)