### PR TITLE
ci: Add github-action that automatically runs clang-format. Will not fail CI

### DIFF
--- a/.github/workflows/clang-diff-format.yml
+++ b/.github/workflows/clang-diff-format.yml
@@ -1,0 +1,17 @@
+name: Clang Diff Format Check
+
+on:
+  pull_request:
+    branches:
+      - develop
+jobs:
+  ClangFormat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Fetch git
+        run: git fetch
+      - name: Run Clang-Format-Diff.py
+        run: git diff -U0 origin/develop | ./contrib/devtools/clang-format-diff.py -p1
+


### PR DESCRIPTION
This will enable us to see if Clang-Format is mad at anything in a PR and will make it easy to tell a PR author what changes to likely do.

This doesn't fail CI, as clang-format is very picky, and we sometimes disagree with it, and I don't think it makes sense at this point to fail. It will only ever output the script output into CI. 

See https://github.com/PastaPastaPasta/dash/pull/24

(as a note: if in the future we want to cause this to fail, when format is unhappy, we should modify clang-format-diff.py and add a sys.exit(1) call when there is a problem, and detect that in the action.)