### PR TITLE
gitian: Some backports/fixes to revive gitian builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -750,10 +750,6 @@ AX_GCC_FUNC_ATTRIBUTE([dllimport])
 
 if test x$use_glibc_compat != xno; then
 
-  #glibc absorbed clock_gettime in 2.17. librt (its previous location) is safe to link
-  #in anyway for back-compat.
-  AC_CHECK_LIB([rt],[clock_gettime],, AC_MSG_ERROR(librt missing))
-
   #__fdelt_chk's params and return type have changed from long unsigned int to long int.
   # See which one is present here.
   AC_MSG_CHECKING(__fdelt_chk type)

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -128,7 +128,7 @@ script: |
   cat << EOF > ${WRAP_DIR}/${prog}
   #!/usr/bin/env bash
   # GCCVERSION=${GCCVERSION}
-  REAL="$(which -a ${prog}-8 | grep -v ${WRAP_DIR}/${prog} | head -1)"
+  REAL="$(which -a ${prog} | grep -v ${WRAP_DIR}/${prog} | head -1)"
   for var in "\$@"
   do
     if [ "\$var" = "-m32" ]; then

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -27,6 +27,7 @@ packages:
 - "python3-setuptools"
 - "fonts-tuffy"
 - "ccache"
+- "cmake"
 remotes:
 - "url": "https://github.com/dashpay/dash.git"
   "dir": "dash"

--- a/doc/build-cross.md
+++ b/doc/build-cross.md
@@ -11,7 +11,7 @@ MacOSX Cross-compilation
 Cross-compiling to MacOSX requires a few additional packages to be installed:
 
 ```bash
-$ sudo apt-get install python3-setuptools libcap-dev zlib1g-dev libbz2-dev
+$ sudo apt-get install python3-setuptools libcap-dev zlib1g-dev libbz2-dev cmake
 ```
 
 Additionally, the Mac OSX SDK must be downloaded and extracted manually:

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -336,17 +336,17 @@ BOOST_AUTO_TEST_CASE(netbase_getgroup)
 
 static const std::vector<CAddress> fixture_addresses({
     CAddress(
-        CService(CNetAddr(in6addr_loopback), 0 /* port */),
+        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0 /* port */),
         NODE_NONE,
         0x4966bc61U /* Fri Jan  9 02:54:25 UTC 2009 */
     ),
     CAddress(
-        CService(CNetAddr(in6addr_loopback), 0x00f1 /* port */),
+        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0x00f1 /* port */),
         NODE_NETWORK,
         0x83766279U /* Tue Nov 22 11:22:33 UTC 2039 */
     ),
     CAddress(
-        CService(CNetAddr(in6addr_loopback), 0xf1f2 /* port */),
+        CService(CNetAddr(in6_addr(IN6ADDR_LOOPBACK_INIT)), 0xf1f2 /* port */),
         static_cast<ServiceFlags>(NODE_NETWORK_LIMITED),
         0xffffffffU /* Sun Feb  7 06:28:15 UTC 2106 */
     )


### PR DESCRIPTION
Gitian started complaining recently as I mentioned earlier in https://github.com/dashpay/dash/pull/4356#pullrequestreview-743112943. Plus we broke `gitian-linux.yml` (17361 in #4378) and there is a macos cross-build specific issue because of `libtapi` (16392 in #4255). This PR fixes all these issues.