### PR TITLE
Merge #13578: [depends, zmq, doc] upgrade zeromq to 4.2.5 and avoid deprecated zeromq api functions

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.2.3
+$(package)_version=4.2.5
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0
+$(package)_sha256_hash=cc9090ba35713d59bb2f7d7965f877036c49c5558ea0c290b0dcc6f2a17e489f
 
 define $(package)_set_vars
   $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf --disable-Werror --disable-drafts

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -33,8 +33,10 @@ buffering or reassembly.
 
 ## Prerequisites
 
-The ZeroMQ feature in Dash Core requires ZeroMQ API version 4.x or
-newer. Typically, it is packaged by distributions as something like
+The ZeroMQ feature in Dash Core requires the ZeroMQ API >= 4.0.0
+[libzmq](https://github.com/zeromq/libzmq/releases).
+For version information, see [dependencies.md](dependencies.md).
+Typically, it is packaged by distributions as something like
 *libzmq3-dev*. The C++ wrapper for ZeroMQ is *not* needed.
 
 In order to run the example Python client scripts in the `contrib/zmq/`

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -84,10 +84,14 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
 // Called at startup to conditionally set up ZMQ socket(s)
 bool CZMQNotificationInterface::Initialize()
 {
+    int major = 0, minor = 0, patch = 0;
+    zmq_version(&major, &minor, &patch);
+    LogPrint(BCLog::ZMQ, "zmq: version %d.%d.%d\n", major, minor, patch);
+
     LogPrint(BCLog::ZMQ, "zmq: Initialize notification interface\n");
     assert(!pcontext);
 
-    pcontext = zmq_init(1);
+    pcontext = zmq_ctx_new();
 
     if (!pcontext)
     {
@@ -117,7 +121,7 @@ void CZMQNotificationInterface::Shutdown()
             LogPrint(BCLog::ZMQ, "zmq: Shutdown notifier %s at %s\n", notifier->GetType(), notifier->GetAddress());
             notifier->Shutdown();
         }
-        zmq_ctx_destroy(pcontext);
+        zmq_ctx_term(pcontext);
 
         pcontext = nullptr;
     }


### PR DESCRIPTION
f1bd03eb013b96ff040a8f835e4137fbd2a38cda [depends, zmq, doc] upgrade zeromq to 4.2.5 and avoid deprecated zeromq api functions (mruddy)

Pull request description:

  Upgrade the ZeroMQ dependency from version 4.2.3 to the latest stable version 4.2.5.

  This PR Follows the lead of https://github.com/bitcoin/bitcoin/pull/11986.

  I upgraded both patch files to correspond to the version `4.2.5` libzmq files.
  I assume doing so is still necessary and correct.

  Without updating the patch line numbers, things appear to work, but you get extra log messages while building `depends` because things don't exactly match, e.g.:
  ```
  /bitcoin/depends> make zeromq
  Extracting zeromq...
  /bitcoin/depends/sources/zeromq-4.2.5.tar.gz: OK
  Preprocessing zeromq...
  patching file src/windows.hpp
  Hunk #1 succeeded at 58 (offset 3 lines).
  patching file src/thread.cpp
  Hunk #1 succeeded at 307 with fuzz 2 (offset 87 lines).
  Hunk #2 succeeded at 323 with fuzz 2 (offset 90 lines).
  ```
  Updating the patches seemed cleaner, so I did it. Note that libzmq had some whitespace changes, so that's why the updated patches do too.

  More info: https://github.com/zeromq/libzmq/releases/tag/v4.2.5

  tags: libzmq, zmq, 0mq

Tree-SHA512: 78659dd276b5311e40634b1bbebb802ddd6b69662ba3c84995ef1e3795c49a78b1635112c7fd72a405ea36e2cc3bdeb84e6d00d4e491a349bba1dafff50e2fa5