### PR TITLE
Fix Dash build for Arch Linux with GCC 11.1

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1472,6 +1472,9 @@ uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn
     return ss.GetHash();
 }
 
+template uint256 SignatureHash<CMutableTransaction>(const CScript& scriptCode, const CMutableTransaction& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache);
+template uint256 SignatureHash<CTransaction>(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache);
+
 template <class T>
 bool GenericTransactionSignatureChecker<T>::VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const uint256& sighash) const
 {


### PR DESCRIPTION
The SignatureHash() template function is declared in a header but
defined in a .cpp file. That means only its instantiations are available
from outside.

For some reason, GCC 11.1 on Arch Linux doesn't see implicit
instantiations for CTransaction and CMutableTransaction.
Define these explicitly to make the compiler happy.

Signed-off-by: Dzutte <dzutte.tomsk@gmail.com>