### PR TITLE
Fix outdated config.(guess|sub) of libbacktrace

### DIFF
--- a/depends/packages/backtrace.mk
+++ b/depends/packages/backtrace.mk
@@ -9,6 +9,7 @@ $(package)_config_opts=--disable-shared --enable-host-shared --prefix=$(host_pre
 endef
 
 define $(package)_config_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub . && \
   $($(package)_autoconf)
 endef
 


### PR DESCRIPTION
The versions of config.guess and config.sub are too old and do not recognize linux musl architecture.