### PR TITLE
Merge bitcoin#17708: prevector: avoid misaligned member accesses

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -42,7 +42,7 @@ class CBLSWrapper
     friend class CBLSPublicKey;
     friend class CBLSSignature;
 
-    bool fLegacy;
+    bool fLegacy{true};
 
 protected:
     ImplType impl;

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -565,7 +565,9 @@ public:
             if (v.size() != s) {
                 v.resize(s);
             }
-            ::memmove(v.data(), &*b, s);
+            if (!v.empty()) {
+                ::memmove(v.data(), &*b, s);
+            }
         } else {
             v.assign(&*b, &*e);
         }

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -17,7 +17,6 @@
 
 #include <compat.h>
 
-#pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N
  *  elements directly (without heap allocation). The types Size and Diff are
  *  used to store element counts, and can be any unsigned + signed type.
@@ -149,14 +148,20 @@ public:
     };
 
 private:
-    size_type _size = 0;
+#pragma pack(push, 1)
     union direct_or_indirect {
         char direct[sizeof(T) * N];
         struct {
-            size_type capacity;
             char* indirect;
+            size_type capacity;
         };
-    } _union = {};
+    };
+#pragma pack(pop)
+    alignas(char*) direct_or_indirect _union = {};
+    size_type _size = 0;
+
+    static_assert(alignof(char*) % alignof(size_type) == 0 && sizeof(char*) % alignof(size_type) == 0, "size_type cannot have more restrictive alignment requirement than pointer");
+    static_assert(alignof(char*) % alignof(T) == 0, "value_type T cannot have more restrictive alignment requirement than pointer");
 
     T* direct_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.direct) + pos; }
     const T* direct_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.direct) + pos; }
@@ -566,7 +571,5 @@ public:
         }
     }
 };
-
-#pragma pack(pop)
 
 #endif // BITCOIN_PREVECTOR_H

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,5 +1,5 @@
-alignment:move.h
-alignment:prevector.h
+# -fsanitize=undefined suppressions
+# =================================
 bool:wallet/wallet.cpp
 float-divide-by-zero:policy/fees.cpp
 float-divide-by-zero:validation.cpp


### PR DESCRIPTION
Backport: Merge #17708: prevector: avoid misaligned member accesses
add ubsan supressions for below errors
runtime error: load of value 210, which is not a valid value for type 'bool'
runtime error: null pointer passed as argument 1, which is declared to never be null != 