### PR TITLE
cj: Fix deadlock in SignFinalTransaction

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -558,6 +558,7 @@ bool CCoinJoinClientSession::SignFinalTransaction(const CTransaction& finalTrans
     if (fMasternodeMode || pnode == nullptr) return false;
     if (!mixingMasternode) return false;
 
+    LOCK2(mempool.cs, mixingWallet.cs_wallet);
     LOCK(cs_coinjoin);
 
     finalMutableTransaction = CMutableTransaction{finalTransactionNew};


### PR DESCRIPTION
```
POTENTIAL DEADLOCK DETECTED
Previous lock order was:
 cs_deqsessions coinjoin/coinjoin-client.cpp:141 (in thread )
 ::mempool.cs coinjoin/coinjoin-client.cpp:561 (in thread )
 (1) cs_coinjoin coinjoin/coinjoin-client.cpp:561 (in thread )
 (2) cs_wallet wallet/wallet.cpp:315 (in thread )
Current lock order is:
 cs_deqsessions coinjoin/coinjoin-client.cpp:980 (in thread )
 cs_main coinjoin/coinjoin-client.cpp:788 (in thread )
 mempool.cs coinjoin/coinjoin-client.cpp:788 (in thread )
 (2) mixingWallet.cs_wallet coinjoin/coinjoin-client.cpp:789 (in thread )
 (1) cs_coinjoin ./coinjoin/coinjoin.h:369 (in thread )
```

Introduced in #4463