### PR TITLE
Compressed headers implementation.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1200,7 +1200,7 @@ namespace { // Variables internal to initialization process only
 int nMaxConnections;
 int nUserMaxConnections;
 int nFD;
-ServiceFlags nLocalServices = ServiceFlags(NODE_NETWORK | NODE_NETWORK_LIMITED);
+ServiceFlags nLocalServices = ServiceFlags(NODE_NETWORK | NODE_NETWORK_LIMITED | NODE_HEADERS_COMPRESSED);
 int64_t peer_connect_timeout;
 std::set<BlockFilterType> g_enabled_filter_types;
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -32,3 +32,102 @@ std::string CBlock::ToString() const
     }
     return s.str();
 }
+
+static void MarkVersionAsMostRecent(std::list<int32_t>& last_unique_versions, std::list<int32_t>::const_iterator version_it)
+{
+    if (version_it != last_unique_versions.cbegin()) {
+        // Move the found version to the front of the list
+        last_unique_versions.splice(last_unique_versions.begin(), last_unique_versions, version_it, std::next(version_it));
+    }
+}
+
+static void SaveVersionAsMostRecent(std::list<int32_t>& last_unique_versions, const int32_t version)
+{
+    last_unique_versions.push_front(version);
+
+    // Always keep the last 7 unique versions
+    constexpr std::size_t max_backwards_look_ups = 7;
+    if (last_unique_versions.size() > max_backwards_look_ups) {
+        // Evict the oldest version
+        last_unique_versions.pop_back();
+    }
+}
+
+void CompressibleBlockHeader::Compress(const std::vector<CompressibleBlockHeader>& previous_blocks, std::list<int32_t>& last_unique_versions)
+{
+    if (previous_blocks.empty()) {
+        // Previous block not available, we have to send the block completely uncompressed
+        SaveVersionAsMostRecent(last_unique_versions, nVersion);
+        return;
+    }
+
+    // Try to compress version
+    const auto version_it = std::find(last_unique_versions.cbegin(), last_unique_versions.cend(), nVersion);
+    if (version_it != last_unique_versions.cend()) {
+        // Version is found in the last 7 unique blocks.
+        bit_field.SetVersionOffset(static_cast<uint8_t>(std::distance(last_unique_versions.cbegin(), version_it) + 1));
+
+        // Mark the version as the most recent one
+        MarkVersionAsMostRecent(last_unique_versions, version_it);
+    } else {
+        // Save the version as the most recent one
+        SaveVersionAsMostRecent(last_unique_versions, nVersion);
+    }
+
+    // Previous block is available
+    const auto& last_block = previous_blocks.back();
+    bit_field.MarkAsCompressed(CompressedHeaderBitField::Flag::PREV_BLOCK_HASH);
+
+    // Compute compressed time diff
+    const int64_t time_diff = nTime - last_block.nTime;
+    if (time_diff <= std::numeric_limits<int16_t>::max() && time_diff >= std::numeric_limits<int16_t>::min()) {
+        time_offset = static_cast<int16_t>(time_diff);
+        bit_field.MarkAsCompressed(CompressedHeaderBitField::Flag::TIMESTAMP);
+    }
+
+    // If n_bits matches previous block, it can be compressed (not sent at all)
+    if (nBits == last_block.nBits) {
+        bit_field.MarkAsCompressed(CompressedHeaderBitField::Flag::NBITS);
+    }
+}
+
+void CompressibleBlockHeader::Uncompress(const std::vector<CBlockHeader>& previous_blocks, std::list<int32_t>& last_unique_versions)
+{
+    if (previous_blocks.empty()) {
+        // First block in chain is always uncompressed
+        SaveVersionAsMostRecent(last_unique_versions, nVersion);
+        return;
+    }
+
+    // We have the previous block
+    const auto& last_block = previous_blocks.back();
+
+    // Uncompress version
+    if (bit_field.IsVersionCompressed()) {
+        const auto version_offset = bit_field.GetVersionOffset();
+        if (version_offset <= last_unique_versions.size()) {
+            auto version_it = last_unique_versions.begin();
+            std::advance(version_it, version_offset - 1);
+            nVersion = *version_it;
+            MarkVersionAsMostRecent(last_unique_versions, version_it);
+        }
+    } else {
+        // Save the version as the most recent one
+        SaveVersionAsMostRecent(last_unique_versions, nVersion);
+    }
+
+    // Uncompress prev block hash
+    if (bit_field.IsCompressed(CompressedHeaderBitField::Flag::PREV_BLOCK_HASH)) {
+        hashPrevBlock = last_block.GetHash();
+    }
+
+    // Uncompress timestamp
+    if (bit_field.IsCompressed(CompressedHeaderBitField::Flag::TIMESTAMP)) {
+        nTime = last_block.nTime + time_offset;
+    }
+
+    // Uncompress n_bits
+    if (bit_field.IsCompressed(CompressedHeaderBitField::Flag::NBITS)) {
+        nBits = last_block.nBits;
+    }
+}

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -86,6 +86,9 @@ MAKE_MSG(CLSIG, "clsig");
 MAKE_MSG(ISLOCK, "islock");
 MAKE_MSG(ISDLOCK, "isdlock");
 MAKE_MSG(MNAUTH, "mnauth");
+MAKE_MSG(GETHEADERS2, "getheaders2");
+MAKE_MSG(SENDHEADERS2, "sendheaders2");
+MAKE_MSG(HEADERS2, "headers2");
 }; // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -164,7 +167,9 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::ISLOCK,
     NetMsgType::ISDLOCK,
     NetMsgType::MNAUTH,
-};
+    NetMsgType::GETHEADERS2,
+    NetMsgType::SENDHEADERS2,
+    NetMsgType::HEADERS2};
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
@@ -345,6 +350,7 @@ static std::string serviceFlagToStr(size_t bit)
     case NODE_BLOOM:           return "BLOOM";
     case NODE_COMPACT_FILTERS: return "COMPACT_FILTERS";
     case NODE_NETWORK_LIMITED: return "NETWORK_LIMITED";
+    case NODE_HEADERS_COMPRESSED: return "HEADERS_COMPRESSED";
     // Not using default, so we get warned when a case is missing
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -296,6 +296,9 @@ extern const char *CLSIG;
 extern const char *ISLOCK;
 extern const char *ISDLOCK;
 extern const char *MNAUTH;
+extern const char *GETHEADERS2;
+extern const char *SENDHEADERS2;
+extern const char *HEADERS2;
 };
 
 /* Get a vector of all valid message types (see above) */
@@ -324,6 +327,8 @@ enum ServiceFlags : uint64_t {
     // serving the last 288 blocks
     // See BIP159 for details on how this is implemented.
     NODE_NETWORK_LIMITED = (1 << 10),
+    // description will be provided
+    NODE_HEADERS_COMPRESSED = (1 << 11),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -8,7 +8,7 @@
 import random
 
 from test_framework.blocktools import create_block, create_coinbase
-from test_framework.messages import BlockTransactions, BlockTransactionsRequest, calculate_shortid, CBlock, CBlockHeader, CInv, COutPoint, CTransaction, CTxIn, CTxOut, FromHex, HeaderAndShortIDs, msg_block, msg_blocktxn, msg_cmpctblock, msg_getblocktxn, msg_getdata, msg_getheaders, msg_headers, msg_inv, msg_sendcmpct, msg_sendheaders, msg_tx, NODE_NETWORK, P2PHeaderAndShortIDs, PrefilledTransaction, ToHex
+from test_framework.messages import BlockTransactions, BlockTransactionsRequest, calculate_shortid, CBlock, CBlockHeader, CInv, COutPoint, CTransaction, CTxIn, CTxOut, FromHex, HeaderAndShortIDs, msg_block, msg_blocktxn, msg_cmpctblock, msg_getblocktxn, msg_getdata, msg_getheaders, msg_headers, msg_inv, msg_sendcmpct, msg_sendheaders, msg_tx, NODE_NETWORK, P2PHeaderAndShortIDs, PrefilledTransaction, ToHex, NODE_HEADERS_COMPRESSED
 from test_framework.mininode import mininode_lock, P2PInterface
 from test_framework.script import CScript, OP_TRUE, OP_DROP
 from test_framework.test_framework import BitcoinTestFramework
@@ -344,7 +344,8 @@ class CompactBlocksTest(BitcoinTestFramework):
 
             if announce == "inv":
                 test_node.send_message(msg_inv([CInv(2, block.sha256)]))
-                wait_until(lambda: "getheaders" in test_node.last_message, timeout=30, lock=mininode_lock)
+                getheaders_key = "getheaders2" if test_node.nServices & NODE_HEADERS_COMPRESSED else "getheaders"
+                wait_until(lambda: getheaders_key in test_node.last_message, timeout=30, lock=mininode_lock)
                 test_node.send_header_for_blocks([block])
             else:
                 test_node.send_header_for_blocks([block])
@@ -720,8 +721,8 @@ class CompactBlocksTest(BitcoinTestFramework):
     def run_test(self):
         # Setup the p2p connections
         self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
-        self.second_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
-        self.old_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
+        self.second_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_HEADERS_COMPRESSED)
+        self.old_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK | NODE_HEADERS_COMPRESSED)
 
         # We will need UTXOs to construct transactions in later tests.
         self.make_utxos()

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -8,7 +8,7 @@ Tests that a node configured with -prune=550 signals NODE_NETWORK_LIMITED correc
 and that it responds to getdata requests for blocks correctly:
     - send a block within 288 + 2 of the tip
     - disconnect peers who request blocks older than that."""
-from test_framework.messages import CInv, msg_getdata, NODE_BLOOM, NODE_NETWORK_LIMITED, msg_verack
+from test_framework.messages import CInv, msg_getdata, NODE_BLOOM, NODE_NETWORK_LIMITED, NODE_HEADERS_COMPRESSED, msg_verack
 from test_framework.mininode import P2PInterface, mininode_lock
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, disconnect_nodes, connect_nodes, sync_blocks, wait_until
@@ -49,7 +49,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
     def run_test(self):
         node = self.nodes[0].add_p2p_connection(P2PIgnoreInv())
 
-        expected_services = NODE_BLOOM | NODE_NETWORK_LIMITED
+        expected_services = NODE_BLOOM | NODE_NETWORK_LIMITED | NODE_HEADERS_COMPRESSED
 
         self.log.info("Check that node has signalled expected services.")
         assert_equal(node.nServices, expected_services)
@@ -77,7 +77,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
 
         node1.wait_for_addr()
         #must relay address with NODE_NETWORK_LIMITED
-        assert_equal(node1.firstAddrnServices, 1028) # Not 1036 like bitcoin, because NODE_WITNESS = 1 << 3 = 8
+        assert_equal(node1.firstAddrnServices, expected_services)
 
         self.nodes[0].disconnect_p2ps()
         node1.wait_for_disconnect()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -24,6 +24,7 @@ from test_framework.messages import (
     NODE_NETWORK,
     NODE_GETUTXO,NODE_BLOOM,
     NODE_NETWORK_LIMITED,
+    NODE_HEADERS_COMPRESSED
 )
 
 
@@ -42,6 +43,8 @@ def assert_net_servicesnames(servicesflag, servicenames):
         assert "BLOOM" in servicenames
     if servicesflag & NODE_NETWORK_LIMITED:
         assert "NETWORK_LIMITED" in servicenames
+    if servicesflag & NODE_HEADERS_COMPRESSED:
+        assert "HEADERS_COMPRESSED" in servicenames
 
 
 class NetTest(BitcoinTestFramework):
@@ -126,7 +129,7 @@ class NetTest(BitcoinTestFramework):
         # check the `servicesnames` field
         network_info = [node.getnetworkinfo() for node in self.nodes]
         for info in network_info:
-            assert_net_servicesnames(int(info["localservices"]), info["localservicesnames"])
+            assert_net_servicesnames(int(info["localservices"], 16), info["localservicesnames"])
 
     def _test_getaddednodeinfo(self):
         assert_equal(self.nodes[0].getaddednodeinfo(), [])
@@ -148,7 +151,7 @@ class NetTest(BitcoinTestFramework):
         assert_equal(peer_info[1][0]['addrbind'], peer_info[0][0]['addr'])
         # check the `servicesnames` field
         for info in peer_info:
-            assert_net_servicesnames(int(info[0]["services"]), info[0]["servicesnames"])
+            assert_net_servicesnames(int(info[0]["services"], 16), info[0]["servicesnames"])
 
     def test_service_flags(self):
         self.nodes[0].add_p2p_connection(P2PInterface(), services=(1 << 4) | (1 << 63))

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -24,7 +24,7 @@ from test_framework.messages import (
     NODE_NETWORK,
     NODE_GETUTXO,NODE_BLOOM,
     NODE_NETWORK_LIMITED,
-    NODE_HEADERS_COMPRESSED
+    NODE_HEADERS_COMPRESSED,
 )
 
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -109,6 +109,7 @@ BASE_SCRIPTS = [
     'feature_dip4_coinbasemerkleroots.py', # NOTE: needs dash_hash to pass
     # vv Tests less than 60s vv
     'p2p_sendheaders.py', # NOTE: needs dash_hash to pass
+    'p2p_sendheaders_compressed.py', # NOTE: needs dash_hash to pass
     'wallet_zapwallettxes.py',
     'wallet_importmulti.py',
     'mempool_limit.py',


### PR DESCRIPTION
This pull request aims to implement compressed headers support. Initial proposal can be found [here](https://github.com/willcl-ark/compressed-block-headers/blob/v1.0/compressed-block-headers.adoc), but the current implementation contains one different part: The first header in a `headers2` msg is always uncompressed (it contains the full `nBits`, `timestamp`, `version` and `prev_block_hash`). Otherwise, the following problem may arise:
	A peer (let’s name it P1) receiving headers from 2 different peers (P2 and P3) may not be able to correctly identify the previous block of the first header in a headers2 msg. The above scenario exemplifies such a case:

```
# Request block header from test_node
last_known_block = int(self.nodes[0].getbestblockhash(), 16)
block_a = self.mine_blocks(1)
inv_node.check_last_inv_announcement(inv=[block_a])
test_node.check_last_inv_announcement(inv=[block_a])
test_node.send_get_headers(locator=[last_known_block], hashstop=block_a)
test_node.wait_for_header(block_a)

# Request block header from inv_node
block_b = self.mine_blocks(1)
inv_node.check_last_inv_announcement(inv=[block_b])
test_node.check_last_inv_announcement(inv=[block_b])
inv_node.send_get_headers(locator=[block_a], hashstop=block_b)
inv_node.wait_for_header(block_b)

# At this point, both test_node and inv_node are not on "first connection" with our node as
# both of them sent headers to us
# According to requirements, after the "first connection" headers should be compressed
block_c = self.mine_blocks(1)
inv_node.check_last_inv_announcement(inv=[block_c])
test_node.check_last_inv_announcement(inv=[block_c])
test_node.send_get_headers(locator=[block_b], hashstop=block_c)
test_node.wait_for_header(block_c)  # supposing that the header we receive here is compressed, we should
                                    # decompress it against block_b (as that's the previous block), but the
                                    # last block received  from peer "test_node" is block_a
```

If we keep track of the last block header received from each peer, the above case is problematic as we will wrongly identify the previous block. After some discussions with @UdjinM6 we decided to send the first header uncompressed for now.

Thus, this pull request contains the following updates:
- First header is always compressed in a headers2 msg
- Version is uncompressed if it’s not matched within the last 7 headers block to be sent in the current msg
- Service flag to signal that the peer supports compressed header: `NODE_HEADERS_COMPRESSED`
- If compressed headers service is active, the peer will receive headers compressed
- If both `sendheaders` and `sendheaders2` are sent, the peer will respond with compressed headers
- Functional tests as for uncompressed headers (`p2p_sendheaders.py`)
- Updates regarding the existing functional tests to use the compressed headers if the `NODE_HEADERS_COMPRESSED` service flag is active
