### PR TITLE
ci: Enable tsan on linux64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -234,6 +234,15 @@ linux32-build:
   variables:
     BUILD_TARGET: linux32
 
+linux32_ubsan-build:
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
+  needs:
+    - i686-pc-linux-gnu
+  variables:
+    BUILD_TARGET: linux32_ubsan
+
 linux64-build:
   extends: .build-template
   needs:
@@ -247,6 +256,15 @@ linux64_cxx20-build:
     - x86_64-unknown-linux-gnu-debug
   variables:
     BUILD_TARGET: linux64_cxx20
+
+linux64_tsan-build:
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
+  needs:
+    - x86_64-unknown-linux-gnu-debug
+  variables:
+    BUILD_TARGET: linux64_tsan
 
 linux64_nowallet-build:
   extends:
@@ -286,9 +304,27 @@ linux32-test:
   variables:
     BUILD_TARGET: linux32
 
+linux32_ubsan-test:
+  extends:
+    - .test-template
+    - .skip-in-fast-mode-template
+  needs:
+    - linux32_ubsan-build
+  variables:
+    BUILD_TARGET: linux32_ubsan
+
 linux64-test:
   extends: .test-template
   needs:
     - linux64-build
   variables:
     BUILD_TARGET: linux64
+
+linux64_tsan-test:
+  extends:
+    - .test-template
+    - .skip-in-fast-mode-template
+  needs:
+    - linux64_tsan-build
+  variables:
+    BUILD_TARGET: linux64_tsan

--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -35,6 +35,9 @@ export MAKEJOBS
 export RUN_UNITTESTS=true
 export RUN_INTEGRATIONTESTS=true
 
+# Configure sanitizers options
+export TSAN_OPTIONS="suppressions=${SRC_DIR}/test/sanitizer_suppressions/tsan"
+
 if [ "$BUILD_TARGET" = "arm-linux" ]; then
   export HOST=arm-linux-gnueabihf
   export CHECK_DOC=1
@@ -53,16 +56,27 @@ elif [ "$BUILD_TARGET" = "linux32" ]; then
   export BITCOIN_CONFIG="--enable-zmq --disable-bip70 --enable-reduce-exports --enable-crash-hooks"
   export USE_SHELL="/bin/dash"
   export PYZMQ=true
+elif [ "$BUILD_TARGET" = "linux32_ubsan" ]; then
+  export HOST=i686-pc-linux-gnu
+  export BITCOIN_CONFIG="--enable-zmq --disable-bip70 --enable-reduce-exports --enable-crash-hooks --with-sanitizers=undefined"
+  export USE_SHELL="/bin/dash"
+  export PYZMQ=true
 elif [ "$BUILD_TARGET" = "linux64" ]; then
   export HOST=x86_64-unknown-linux-gnu
   export DEP_OPTS="NO_UPNP=1 DEBUG=1"
-  export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --with-sanitizers=undefined"
+  export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks"
+  export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG"
+  export PYZMQ=true
+elif [ "$BUILD_TARGET" = "linux64_tsan" ]; then
+  export HOST=x86_64-unknown-linux-gnu
+  export DEP_OPTS="NO_UPNP=1 DEBUG=1"
+  export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --with-sanitizers=thread"
   export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG"
   export PYZMQ=true
 elif [ "$BUILD_TARGET" = "linux64_cxx20" ]; then
   export HOST=x86_64-unknown-linux-gnu
   export DEP_OPTS="NO_UPNP=1 DEBUG=1"
-  export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --enable-c++20 --enable-suppress-external-warnings --enable-werror --with-sanitizers=undefined"
+  export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --enable-c++20 --enable-suppress-external-warnings --enable-werror"
   export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG"
   export PYZMQ=true
   export RUN_INTEGRATIONTESTS=false

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -235,10 +235,8 @@ void CCoinJoinClientSession::ProcessMessage(CNode* pfrom, const std::string& str
 }
 
 bool CCoinJoinClientManager::StartMixing() {
-    if (IsMixing()) {
-        return false;
-    }
-    return fMixing = true;
+    bool expected{false};
+    return fMixing.compare_exchange_strong(expected, true);
 }
 
 void CCoinJoinClientManager::StopMixing() {

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -9,6 +9,7 @@
 #include <coinjoin/coinjoin.h>
 
 #include <utility>
+#include <atomic>
 
 class CDeterministicMN;
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
@@ -178,7 +179,7 @@ private:
     // TODO: or map<denom, CCoinJoinClientSession> ??
     std::deque<CCoinJoinClientSession> deqSessions GUARDED_BY(cs_deqsessions);
 
-    bool fMixing{false};
+    std::atomic<bool> fMixing{false};
 
     int nCachedLastSuccessBlock{0};
     int nMinBlocksToWait{1}; // how many blocks to wait for after one successful mixing tx in non-multisession mode

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3218,13 +3218,14 @@ void CConnman::Stop()
         }
 
     // clean up some globals (to help leak detection)
-    for (CNode *pnode : vNodes) {
+    std::vector<CNode*> nodes;
+    WITH_LOCK(cs_vNodes, nodes.swap(vNodes));
+    for (CNode *pnode : nodes) {
         DeleteNode(pnode);
     }
     for (CNode *pnode : vNodesDisconnected) {
         DeleteNode(pnode);
     }
-    vNodes.clear();
     mapSocketToNode.clear();
     {
         LOCK(cs_vNodes);

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -1,8 +1,14 @@
 # ThreadSanitizer suppressions
 # ============================
 
+# Data races from zmq namespace
+race:zmq::*
+
 # WalletBatch (unidentified deadlock)
 deadlock:WalletBatch
+
+# deadlock false positive (see: https://github.com/dashpay/dash/pull/4563)
+deadlock:CChainState::ConnectTip
 
 # Intentional deadlock in tests
 deadlock:sync_tests::potential_deadlock_detected


### PR DESCRIPTION
This pull request enables thread sanitiser for linux64 build (including unit tests & functional tests) and fixes/suppresses the following:
- Switch ubsan to run on linux32 as tsan can't run there (linker does not support thread sanitizer)
- Fix data race in CCoinJoinClientManager (triggered by concurrent access on `fMixing`)
- Suppress data races triggered in zmq namespace (same suppression exists in bitcoin)
- Suppress deadlock false positive the sme way bitcoin does it (i.e. `deadlock:CChainState::ConnectTip`). False positive description:

```
One thread:
generateBlocks|mining.cpp:124
    CreateNewBlock
        LOCK2(cs_main, cs_mempool) | called from miner.cpp:128
            TestBlockValidity | called from miner.cpp:235
                    ConnectBlock | called from validation.cpp:4200
                        ProcessSpecialTxsInBlock | called from validation.cpp:2123
                            […]
                                NotifyMasternodeListChanged
                                    UpdateCachesAndClean
                                        LOCK(cs_main, cs_governance) | called from governance/governance.cpp:352
Lock order: cs_main, cs_mempool, cs_governance

The other thread:
AddGovernanceObject
    LOCK2(cs_main, cs_governance) | called from governance/governance.cpp:293
        IsValidLocally | called from governance/governance.cpp:298
            […]
                GetTransaction
                    mempool.get(hash) | called from validation.cpp:893
                        LOCK(cs_mempool) | called from txmempool.cpp:1219
Lock order: cs_main, cs_governance, cs_mempool
```

This kind of lock order inversion looks like a bug in tsan (similar known issue: https://github.com/google/sanitizers/issues/814) and can be easily reproduced with 3 locks by changing the order of the last 2 locks: thread1 locks A, B, C and thread2 locks A, C, B (assuming a reversed unlocking order). Godbolt example here: https://godbolt.org/z/81Y6frYKv (same example with std::scoped_lock https://godbolt.org/z/175x6Yv9h)

I will keep the PR in draft until everything is green and passing in gitlab ci.