### PR TITLE
Add missing implementations for chainlock and instantsend notifications in NotificationsHandlerImpl

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -228,6 +228,14 @@ public:
         auto locked_chain = m_chain.assumeLocked();
         m_notifications->ResendWalletTransactions(*locked_chain, best_block_time);
     }
+    void NotifyChainLock(const CBlockIndex* pindexChainLock, const std::shared_ptr<const llmq::CChainLockSig>& clsig) override
+    {
+        m_notifications->NotifyChainLock(pindexChainLock, clsig);
+    }
+    void NotifyTransactionLock(const CTransactionRef &tx, const std::shared_ptr<const llmq::CInstantSendLock>& islock) override
+    {
+        m_notifications->NotifyTransactionLock(tx, islock);
+    }
     Chain& m_chain;
     Chain::Notifications* m_notifications;
 };


### PR DESCRIPTION
A follow-up to 10973 backport dashpay/dash@438c93bd9a285fb07598ea58603abb0531f48429 merged via #4558