### PR TITLE
Simplify the interface for CRecoveredSig

### DIFF
--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -34,24 +34,34 @@ static constexpr int64_t DEFAULT_MAX_RECOVERED_SIGS_AGE{60 * 60 * 24 * 7};
 class CRecoveredSig
 {
 public:
-    Consensus::LLMQType llmqType;
-    uint256 quorumHash;
-    uint256 id;
-    uint256 msgHash;
-    CBLSLazySignature sig;
+    const Consensus::LLMQType llmqType{Consensus::LLMQType::LLMQ_NONE};
+    const uint256 quorumHash;
+    const uint256 id;
+    const uint256 msgHash;
+    const CBLSLazySignature sig;
 
+    CRecoveredSig() = default;
+
+    CRecoveredSig(Consensus::LLMQType _llmqType, const uint256& _quorumHash, const uint256& _id, const uint256& _msgHash, const CBLSLazySignature& _sig) :
+                  llmqType(_llmqType), quorumHash(_quorumHash), id(_id), msgHash(_msgHash), sig(_sig) {UpdateHash();};
+    CRecoveredSig(Consensus::LLMQType _llmqType, const uint256& _quorumHash, const uint256& _id, const uint256& _msgHash, const CBLSSignature& _sig) :
+                  llmqType(_llmqType), quorumHash(_quorumHash), id(_id), msgHash(_msgHash) {const_cast<CBLSLazySignature&>(sig).Set(_sig); UpdateHash();};
+
+private:
     // only in-memory
     uint256 hash;
-
-    SERIALIZE_METHODS(CRecoveredSig, obj)
-    {
-        READWRITE(obj.llmqType, obj.quorumHash, obj.id, obj.msgHash, obj.sig);
-        SER_READ(obj, obj.UpdateHash());
-    }
 
     void UpdateHash()
     {
         hash = ::SerializeHash(*this);
+    }
+
+public:
+    SERIALIZE_METHODS(CRecoveredSig, obj)
+    {
+        READWRITE(const_cast<Consensus::LLMQType&>(obj.llmqType), const_cast<uint256&>(obj.quorumHash), const_cast<uint256&>(obj.id),
+                  const_cast<uint256&>(obj.msgHash), const_cast<CBLSLazySignature&>(obj.sig));
+        SER_READ(obj, obj.UpdateHash());
     }
 
     const uint256& GetHash() const

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -803,13 +803,7 @@ void CSigSharesManager::TryRecoverSig(const CQuorumCPtr& quorum, const uint256& 
     LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- recovered signature. id=%s, msgHash=%s, time=%d\n", __func__,
               id.ToString(), msgHash.ToString(), t.count());
 
-    auto rs = std::make_shared<CRecoveredSig>();
-    rs->llmqType = quorum->params.type;
-    rs->quorumHash = quorum->qc->quorumHash;
-    rs->id = id;
-    rs->msgHash = msgHash;
-    rs->sig.Set(recoveredSig);
-    rs->UpdateHash();
+    auto rs = std::make_shared<CRecoveredSig>(quorum->params.type, quorum->qc->quorumHash, id, msgHash, recoveredSig);
 
     // There should actually be no need to verify the self-recovered signatures as it should always succeed. Let's
     // however still verify it from time to time, so that we have a chance to catch bugs. We do only this sporadic


### PR DESCRIPTION
I think this is valuable for a few reasons
1. It is obviously clear and enforced that UpdateHash is called whenever there is any data updated, this was not the case before
2. Using the interface is now clearer, and basically impossible to mess up, or to forget a field. Ofc the implementation is more messy, but I think that's a good tradeoff for a intuitive interface

We could also consider calculating the hash opportunistically such that we only calculate it if it's ever actually needed