### PR TITLE
Remove decomissioned mainnet seeder dnsseed.dashdot.io

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -256,7 +256,6 @@ public:
         // service bits we want, but we should get them updated to support all service bits wanted by any
         // release ASAP to avoid it where possible.
         vSeeds.emplace_back("dnsseed.dash.org");
-        vSeeds.emplace_back("dnsseed.dashdot.io");
 
         // Dash addresses start with 'X'
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,76);


### PR DESCRIPTION
I'll switch off dnsseed.dashdot.io on 2021/12/31 - testnet seeder testnet-seed.dashdot.io will stay online until further notice.