### PR TITLE
docker entrypoint: process environment variable masternode privkey

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,6 +16,14 @@ if [[ "$1" == "dashd" ]]; then
   else
     echo "Tor control credentials not provided"
   fi
+  
+  # If an masternode private key is provided (length of $CORE_MASTERNODE_OPERATOR_PRIVATE_KEY is nonzero) then dashd should be run as a masternode. Then we add masternodeblsprivkey to config.
+  if [[ -z $CORE_MASTERNODE_OPERATOR_PRIVATE_KEY ]]; then
+    echo "No CORE_MASTERNODE_OPERATOR_PRIVATE_KEY provided, this node is a regular wallet node."
+  else
+    echo "masternodeblsprivkey=$CORE_MASTERNODE_OPERATOR_PRIVATE_KEY" >> "$HOME/.dashcore/dash.conf"
+    echo "Added "masternodeblsprivkey=$CORE_MASTERNODE_OPERATOR_PRIVATE_KEY" to $HOME/.dashcore/dash.conf"
+  fi
 fi
 
 exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,7 +16,6 @@ if [[ "$1" == "dashd" ]]; then
   else
     echo "Tor control credentials not provided"
   fi
-  
   # If an masternode private key is provided (length of $CORE_MASTERNODE_OPERATOR_PRIVATE_KEY is nonzero) then dashd should be run as a masternode. Then we add masternodeblsprivkey to config.
   if [[ -z $CORE_MASTERNODE_OPERATOR_PRIVATE_KEY ]]; then
     echo "No CORE_MASTERNODE_OPERATOR_PRIVATE_KEY provided, this node is a regular wallet node."

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "$1" == "dashd" ]]; then
     echo "No CORE_MASTERNODE_OPERATOR_PRIVATE_KEY provided, this node is a regular wallet node."
   else
     echo "masternodeblsprivkey=$CORE_MASTERNODE_OPERATOR_PRIVATE_KEY" >> "$HOME/.dashcore/dash.conf"
-    echo "Added "masternodeblsprivkey=$CORE_MASTERNODE_OPERATOR_PRIVATE_KEY" to $HOME/.dashcore/dash.conf"
+    echo "Added masternodeblsprivkey to $HOME/.dashcore/dash.conf"
   fi
 fi
 


### PR DESCRIPTION
change the docker-entrypoint.sh script such that it processes the `CORE_MASTERNODE_OPERATOR_PRIVATE_KEY` environment variable. If present, this variable should be put in `dash.conf` under `masternodeblsprivkey`.

This is required for a fix to dashmate, to be able to access wallets on non-masternodes. See [this PR](https://github.com/dashevo/platform/pull/86) (and this [old PR](https://github.com/dashevo/dashmate/pull/466))

Note that this will require rebuilding the dashcore docker image (and pushing it to docker hub?). If this is not done before merging [https://github.com/dashevo/platform/pull/86](https://github.com/dashevo/platform/pull/86) then dashmate will break.

This change will not have effect on other dashcore code as far as I know/tested.