### PR TITLE
Optimize linters

### DIFF
--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install $APT_ARGS g++-arm-linux-gnueabihf && rm -r
 RUN apt-get update && apt-get install $APT_ARGS g++-mingw-w64-x86-64 && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install $APT_ARGS wine-stable wine32 wine64 bc nsis xorriso libncurses5 && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install $APT_ARGS python3-zmq && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS gawk jq && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install $APT_ARGS gawk jq parallel && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install $APT_ARGS imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools && rm -rf /var/lib/apt/lists/*
 
 ARG CPPCHECK_VERSION=2.4

--- a/contrib/devtools/circular-dependencies.py
+++ b/contrib/devtools/circular-dependencies.py
@@ -28,61 +28,83 @@ def module_name(path):
         return path[:-4]
     return None
 
-files = dict()
-deps = dict()
+if __name__=="__main__":
+    files = dict()
+    deps = dict()
 
-RE = re.compile("^#include <(.*)>")
+    RE = re.compile("^#include <(.*)>")
 
-# Iterate over files, and create list of modules
-for arg in sys.argv[1:]:
-    module = module_name(arg)
-    if module is None:
-        print("Ignoring file %s (does not constitute module)\n" % arg)
-    else:
-        files[arg] = module
-        deps[module] = set()
+    def handle_module(module):
+        module = module_name(arg)
+        if module is None:
+            print("Ignoring file %s (does not constitute module)\n" % arg)
+        else:
+            files[arg] = module
+            deps[module] = set()
 
-# Iterate again, and build list of direct dependencies for each module
-# TODO: implement support for multiple include directories
-for arg in sorted(files.keys()):
-    module = files[arg]
-    with open(arg, 'r', encoding="utf8") as f:
-        for line in f:
-            match = RE.match(line)
-            if match:
-                include = match.group(1)
-                included_module = module_name(include)
-                if included_module is not None and included_module in deps and included_module != module:
-                    deps[module].add(included_module)
 
-# Loop to find the shortest (remaining) circular dependency
-have_cycle = False
-while True:
-    shortest_cycle = None
-    for module in sorted(deps.keys()):
-        # Build the transitive closure of dependencies of module
-        closure = dict()
-        for dep in deps[module]:
-            closure[dep] = []
+    # Iterate over files, and create list of modules
+    for arg in sys.argv[1:]:
+        handle_module(arg)
+
+    def build_list_direct(arg):
+        module = files[arg]
+        with open(arg, 'r', encoding="utf8") as f:
+            for line in f:
+                match = RE.match(line)
+                if match:
+                    include = match.group(1)
+                    included_module = module_name(include)
+                    if included_module is not None and included_module in deps and included_module != module:
+                        deps[module].add(included_module)
+
+
+    # Iterate again, and build list of direct dependencies for each module
+    # TODO: implement support for multiple include directories
+    for arg in sorted(files.keys()):
+        build_list_direct(arg)
+    # Loop to find the shortest (remaining) circular dependency
+
+    def shortest_c_dep():
+        have_cycle = False
+
+        def handle_module(module, shortest_cycle):
+
+            # Build the transitive closure of dependencies of module
+            closure = dict()
+            for dep in deps[module]:
+                closure[dep] = []
+            while True:
+                old_size = len(closure)
+                old_closure_keys = sorted(closure.keys())
+                for src in old_closure_keys:
+                    for dep in deps[src]:
+                        if dep not in closure:
+                            closure[dep] = closure[src] + [src]
+                if len(closure) == old_size:
+                    break
+            # If module is in its own transitive closure, it's a circular dependency; check if it is the shortest
+            if module in closure and (shortest_cycle is None or len(closure[module]) + 1 < len(shortest_cycle)):
+                shortest_cycle = [module] + closure[module]
+
+            return shortest_cycle
+
         while True:
-            old_size = len(closure)
-            old_closure_keys = sorted(closure.keys())
-            for src in old_closure_keys:
-                for dep in deps[src]:
-                    if dep not in closure:
-                        closure[dep] = closure[src] + [src]
-            if len(closure) == old_size:
-                break
-        # If module is in its own transitive closure, it's a circular dependency; check if it is the shortest
-        if module in closure and (shortest_cycle is None or len(closure[module]) + 1 < len(shortest_cycle)):
-            shortest_cycle = [module] + closure[module]
-    if shortest_cycle is None:
-        break
-    # We have the shortest circular dependency; report it
-    module = shortest_cycle[0]
-    print("Circular dependency: %s" % (" -> ".join(shortest_cycle + [module])))
-    # And then break the dependency to avoid repeating in other cycles
-    deps[shortest_cycle[-1]] = deps[shortest_cycle[-1]] - set([module])
-    have_cycle = True
 
-sys.exit(1 if have_cycle else 0)
+            shortest_cycles = None
+            for module in sorted(deps.keys()):
+                shortest_cycles = handle_module(module, shortest_cycles)
+
+            if shortest_cycles is None:
+                break
+            # We have the shortest circular dependency; report it
+            module = shortest_cycles[0]
+            print("Circular dependency: %s" % (" -> ".join(shortest_cycles + [module])))
+            # And then break the dependency to avoid repeating in other cycles
+            deps[shortest_cycles[-1]] = deps[shortest_cycles[-1]] - set([module])
+            have_cycle = True
+
+        if have_cycle:
+            return True
+
+    sys.exit(1 if shortest_c_dep() else 0)

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -18,27 +18,28 @@ LINTALL=$(basename "${BASH_SOURCE[0]}")
 
 EXIT_CODE=0
 
-SCRIPTS=()
-
-for f in "${SCRIPTDIR}"/lint-*.sh; do
-  if [ "$(basename "$f")" != "$LINTALL" ]; then
-    SCRIPTS+=("$f")
-  fi
-done
-
-
-if ! parallel --help > /dev/null; then
-for f in "${SCRIPTDIR}"/lint-*.sh; do
-  if [ "$(basename "$f")" != "$LINTALL" ]; then
-    if ! "$f"; then
-      echo "^---- failure generated from $f"
-      EXIT_CODE=1
+if ! command -v parallel > /dev/null; then
+  for f in "${SCRIPTDIR}"/lint-*.sh; do
+    if [ "$(basename "$f")" != "$LINTALL" ]; then
+      if ! "$f"; then
+        echo "^---- failure generated from $f"
+        EXIT_CODE=1
+      fi
     fi
-  fi
-done
-elif ! parallel --jobs 100% bash ::: ${SCRIPTS[*]}; then
+  done
+else
+  SCRIPTS=()
+
+  for f in "${SCRIPTDIR}"/lint-*.sh; do
+    if [ "$(basename "$f")" != "$LINTALL" ]; then
+      SCRIPTS+=("$f")
+    fi
+  done
+
+  if ! parallel --jobs 100% bash ::: "${SCRIPTS[@]}"; then
     echo "^---- failure generated"
     EXIT_CODE=1
+  fi
 fi
 
 exit ${EXIT_CODE}

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -18,6 +18,16 @@ LINTALL=$(basename "${BASH_SOURCE[0]}")
 
 EXIT_CODE=0
 
+SCRIPTS=()
+
+for f in "${SCRIPTDIR}"/lint-*.sh; do
+  if [ "$(basename "$f")" != "$LINTALL" ]; then
+    SCRIPTS+=("$f")
+  fi
+done
+
+
+if ! parallel --help > /dev/null; then
 for f in "${SCRIPTDIR}"/lint-*.sh; do
   if [ "$(basename "$f")" != "$LINTALL" ]; then
     if ! "$f"; then
@@ -26,5 +36,9 @@ for f in "${SCRIPTDIR}"/lint-*.sh; do
     fi
   fi
 done
+elif ! parallel --jobs 100% bash ::: ${SCRIPTS[*]}; then
+    echo "^---- failure generated"
+    EXIT_CODE=1
+fi
 
 exit ${EXIT_CODE}

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -36,10 +36,11 @@ else
     fi
   done
 
-  if ! parallel --jobs 100% bash ::: "${SCRIPTS[@]}"; then
+  if ! parallel --jobs 100% --will-cite --joblog parallel_out.log bash ::: "${SCRIPTS[@]}"; then
     echo "^---- failure generated"
     EXIT_CODE=1
   fi
+  column -t parallel_out.log && rm parallel_out.log
 fi
 
 exit ${EXIT_CODE}


### PR DESCRIPTION
This branch achieves a simple 50% speedup for ./test/lint/lint-all.sh (on my 8 thread laptop), and 28% speedup in lint-circular-dependencies.sh, which doesn't make make sense since I haven't actually made any practical changes(just made into functions). Almost all of the time is spent in `handle_module`, so if anyone wants to optimize further, focus on that method. My original plan was to multi-thread it, but that appears non-trivial

The speedup 

This branch
```
lint-all.sh
real    0m44.096s
user    4m6.083s
sys     0m6.241s

lint-circular-dependencies.sh 
real    0m23.161s
user    0m22.997s
sys     0m0.087s
```
develop
```
lint-all.sh
real    1m22.912s
user    4m10.978s
sys     0m10.668s

lint-circular-dependencies.sh 
real    0m32.472s
user    0m32.352s
sys     0m0.076s
```

