### PR TITLE
optimize: adjust ci dockerfile for faster building

### DIFF
--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install $APT_ARGS build-essential git wget unzip g
                                                 cmake python3 python3-dev python3-pip python3-setuptools;
 
 # Python stuff
-RUN pip3 install pyzmq jinja2 flake8==3.8.3 codespell==1.17.1 vulture==2.3 yq # really needed?
+RUN pip3 install pyzmq jinja2 flake8==3.8.3 codespell==1.17.1 vulture==2.3 yq
 
 # dash_hash
 RUN git clone --depth 1 --no-tags https://github.com/dashpay/dash_hash

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -7,36 +7,37 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 # (zlib1g-dev and libssl-dev are needed for the Qt host binary builds, but should not be used by target binaries)
 ENV APT_ARGS="-y --no-install-recommends --no-upgrade"
 RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get install $APT_ARGS 
-    build-essential \
-    git \
-    wget \
-    unzip \
-    g++ \
+RUN apt-get update && apt-get install $APT_ARGS \
     autotools-dev \
-    libtool \
-    m4 \
     automake \
     autoconf \
-    pkg-config \
-    zlib1g-dev \
-    libssl-dev \
+    build-essential \
+    bsdmainutils \
     curl \
     ccache \
-    bsdmainutils \
     cmake \
+    git \
+    g++ \
+    wget \
+    unzip \
+    libtool \
+    libssl-dev \
+    m4 \
+    pkg-config \
     python3 \
     python3-dev \
     python3-pip \
-    python3-setuptools
+    python3-setuptools \
+    zlib1g-dev
 
 # Python stuff
 RUN pip3 install \
-    pyzmq \
-    jinja2 \
-    flake8==3.8.3 \
     codespell==1.17.1 \
-    vulture==2.3 yq
+    flake8==3.8.3 \
+    jinja2 \
+    pyzmq \
+    vulture==2.3 \
+    yq
 
 # dash_hash
 RUN git clone --depth 1 --no-tags https://github.com/dashpay/dash_hash
@@ -53,26 +54,26 @@ RUN useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /dash dash
 
 # Packages needed for all target builds
 RUN apt-get update && apt-get install $APT_ARGS \
+    bc \
+    gawk \
     g++-9-multilib \
     g++-arm-linux-gnueabihf \
     g++-mingw-w64-x86-64 \
-    wine-stable \
-    wine32 \
-    wine64 \
-    bc \
-    nsis \
-    xorriso \
-    libncurses5 \
-    python3-zmq \
-    gawk \
-    jq \
-    parallel \
     imagemagick \
+    jq \
     libcap-dev \
     librsvg2-bin \
     libz-dev \
     libbz2-dev \
     libtiff-tools \
+    libncurses5 \
+    nsis \
+    python3-zmq \
+    parallel \
+    wine-stable \
+    wine32 \
+    wine64 \
+    xorriso \
     && rm -rf /var/lib/apt/lists/*
 
 ARG CPPCHECK_VERSION=2.4

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -5,26 +5,17 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 
 # Build and base stuff
 # (zlib1g-dev and libssl-dev are needed for the Qt host binary builds, but should not be used by target binaries)
-# We split this up into multiple RUN lines as we might need to retry multiple times on Travis. This way we allow better
-# cache usage.
 ENV APT_ARGS="-y --no-install-recommends --no-upgrade"
-RUN apt-get update && apt-get install $APT_ARGS build-essential git wget unzip && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS g++ && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS autotools-dev libtool m4 automake autoconf pkg-config && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS zlib1g-dev libssl-dev curl ccache bsdmainutils cmake && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS python3 python3-dev && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS python3-pip python3-setuptools && rm -rf /var/lib/apt/lists/*
+RUN dpkg --add-architecture i386
+RUN apt-get update && apt-get install $APT_ARGS build-essential git wget unzip g++ autotools-dev libtool m4 automake \
+                                                autoconf pkg-config zlib1g-dev libssl-dev curl ccache bsdmainutils   \
+                                                cmake python3 python3-dev python3-pip python3-setuptools;
 
 # Python stuff
-RUN pip3 install pyzmq # really needed?
-RUN pip3 install jinja2
-RUN pip3 install flake8==3.8.3
-RUN pip3 install codespell==1.17.1
-RUN pip3 install vulture==2.3
-RUN pip3 install yq
+RUN pip3 install pyzmq jinja2 flake8==3.8.3 codespell==1.17.1 vulture==2.3 yq # really needed?
 
 # dash_hash
-RUN git clone https://github.com/dashpay/dash_hash
+RUN git clone --depth 1 --no-tags https://github.com/dashpay/dash_hash
 RUN cd dash_hash && python3 setup.py install
 
 ARG USER_ID=1000
@@ -37,14 +28,11 @@ RUN groupadd -g ${GROUP_ID} dash
 RUN useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /dash dash
 
 # Packages needed for all target builds
-RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get install $APT_ARGS g++-9-multilib && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS g++-arm-linux-gnueabihf && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS g++-mingw-w64-x86-64 && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS wine-stable wine32 wine64 bc nsis xorriso libncurses5 && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS python3-zmq && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS gawk jq parallel && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install $APT_ARGS imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install $APT_ARGS g++-9-multilib g++-arm-linux-gnueabihf g++-mingw-w64-x86-64       \
+                                                wine-stable wine32 wine64 bc nsis xorriso libncurses5 python3-zmq \
+                                                gawk jq parallel imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev   \
+                                                libtiff-tools                                                     \
+    && rm -rf /var/lib/apt/lists/*;
 
 ARG CPPCHECK_VERSION=2.4
 RUN curl -sL "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" | tar -xvzf - --directory /tmp/

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -9,7 +9,7 @@ ENV APT_ARGS="-y --no-install-recommends --no-upgrade"
 RUN dpkg --add-architecture i386
 RUN apt-get update && apt-get install $APT_ARGS build-essential git wget unzip g++ autotools-dev libtool m4 automake \
                                                 autoconf pkg-config zlib1g-dev libssl-dev curl ccache bsdmainutils   \
-                                                cmake python3 python3-dev python3-pip python3-setuptools;
+                                                cmake python3 python3-dev python3-pip python3-setuptools
 
 # Python stuff
 RUN pip3 install pyzmq jinja2 flake8==3.8.3 codespell==1.17.1 vulture==2.3 yq
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install $APT_ARGS g++-9-multilib g++-arm-linux-gnu
                                                 wine-stable wine32 wine64 bc nsis xorriso libncurses5 python3-zmq \
                                                 gawk jq parallel imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev   \
                                                 libtiff-tools                                                     \
-    && rm -rf /var/lib/apt/lists/*;
+    && rm -rf /var/lib/apt/lists/*
 
 ARG CPPCHECK_VERSION=2.4
 RUN curl -sL "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" | tar -xvzf - --directory /tmp/

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -7,12 +7,36 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 # (zlib1g-dev and libssl-dev are needed for the Qt host binary builds, but should not be used by target binaries)
 ENV APT_ARGS="-y --no-install-recommends --no-upgrade"
 RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get install $APT_ARGS build-essential git wget unzip g++ autotools-dev libtool m4 automake \
-                                                autoconf pkg-config zlib1g-dev libssl-dev curl ccache bsdmainutils   \
-                                                cmake python3 python3-dev python3-pip python3-setuptools
+RUN apt-get update && apt-get install $APT_ARGS 
+    build-essential \
+    git \
+    wget \
+    unzip \
+    g++ \
+    autotools-dev \
+    libtool \
+    m4 \
+    automake \
+    autoconf \
+    pkg-config \
+    zlib1g-dev \
+    libssl-dev \
+    curl \
+    ccache \
+    bsdmainutils \
+    cmake \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-setuptools
 
 # Python stuff
-RUN pip3 install pyzmq jinja2 flake8==3.8.3 codespell==1.17.1 vulture==2.3 yq
+RUN pip3 install \
+    pyzmq \
+    jinja2 \
+    flake8==3.8.3 \
+    codespell==1.17.1 \
+    vulture==2.3 yq
 
 # dash_hash
 RUN git clone --depth 1 --no-tags https://github.com/dashpay/dash_hash
@@ -28,10 +52,27 @@ RUN groupadd -g ${GROUP_ID} dash
 RUN useradd -u ${USER_ID} -g dash -s /bin/bash -m -d /dash dash
 
 # Packages needed for all target builds
-RUN apt-get update && apt-get install $APT_ARGS g++-9-multilib g++-arm-linux-gnueabihf g++-mingw-w64-x86-64       \
-                                                wine-stable wine32 wine64 bc nsis xorriso libncurses5 python3-zmq \
-                                                gawk jq parallel imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev   \
-                                                libtiff-tools                                                     \
+RUN apt-get update && apt-get install $APT_ARGS \
+    g++-9-multilib \
+    g++-arm-linux-gnueabihf \
+    g++-mingw-w64-x86-64 \
+    wine-stable \
+    wine32 \
+    wine64 \
+    bc \
+    nsis \
+    xorriso \
+    libncurses5 \
+    python3-zmq \
+    gawk \
+    jq \
+    parallel \
+    imagemagick \
+    libcap-dev \
+    librsvg2-bin \
+    libz-dev \
+    libbz2-dev \
+    libtiff-tools \
     && rm -rf /var/lib/apt/lists/*
 
 ARG CPPCHECK_VERSION=2.4


### PR DESCRIPTION
With this PR: 231.8 seconds
Without: 455.3 seconds

This PR
```
❯ docker-compose build --no-cache
Building container
[+] Building 231.8s (27/27) FINISHED                                                                           
 => [internal] load build definition from Dockerfile                                                      0.1s
 => => transferring dockerfile: 97B                                                                       0.0s
 => [internal] load .dockerignore                                                                         0.1s
 => => transferring context: 2B                                                                           0.0s
 => resolve image config for docker.io/edrevo/dockerfile-plus:latest                                      0.6s
 => [auth] edrevo/dockerfile-plus:pull token for registry-1.docker.io                                     0.0s
 => CACHED docker-image://docker.io/edrevo/dockerfile-plus@sha256:d234bd015db8acef1e628e012ea8815f6bf5ec  0.0s
 => local://dockerfile                                                                                    0.0s
 => => transferring dockerfile: 200B                                                                      0.0s
 => local://context                                                                                       0.0s
 => => transferring context: 4.00kB                                                                       0.0s
 => [internal] load metadata for docker.io/library/ubuntu:focal                                           0.0s
 => CACHED [stage-1  1/18] FROM docker.io/library/ubuntu:focal                                            0.0s
 => [stage-1  2/18] RUN dpkg --add-architecture i386                                                      0.4s
 => [stage-1  3/18] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade build  42.4s
 => [stage-1  4/18] RUN pip3 install pyzmq jinja2 flake8==3.8.3 codespell==1.17.1 vulture==2.3 yq # rea  13.6s 
 => [stage-1  5/18] RUN git clone --depth 1 --no-tags https://github.com/dashpay/dash_hash                6.3s 
 => [stage-1  6/18] RUN cd dash_hash && python3 setup.py install                                         11.9s 
 => [stage-1  7/18] RUN groupadd -g 1000 dash                                                             0.4s 
 => [stage-1  8/18] RUN useradd -u 1000 -g dash -s /bin/bash -m -d /dash dash                             0.4s 
 => [stage-1  9/18] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade g++-9  97.2s 
 => [stage-1 10/18] RUN curl -sL "https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shell  10.9s 
 => [stage-1 11/18] RUN ln -s x86_64-linux-gnu/asm /usr/include/asm                                       0.4s 
 => [stage-1 12/18] RUN   update-alternatives --set x86_64-w64-mingw32-gcc  /usr/bin/x86_64-w64-mingw32-  0.4s 
 => [stage-1 13/18] RUN mkdir /dash-src &&   mkdir -p /cache/ccache &&   mkdir /cache/depends &&   mkdir  0.4s 
 => [stage-1 14/18] WORKDIR /dash-src                                                                     0.1s 
 => [stage-1 15/18] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade sudo   16.5s 
 => [stage-1 16/18] RUN usermod -aG sudo dash                                                             0.4s 
 => [stage-1 17/18] RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers                               0.4s 
 => [stage-1 18/18] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade nano   19.3s 
 => exporting to image                                                                                    8.9s 
 => => exporting layers                                                                                   8.9s 
 => => writing image sha256:48175e1bc9485476985af56c27c603919f15b02d359012fab5bdfabf32398b62              0.0s 
 => => naming to docker.io/library/develop_container                                                      0.0s 
 ```
 
 develop
 ```
 ❯ docker-compose build --no-cache
Building container
[+] Building 455.3s (43/43) FINISHED                                                                           
 => [internal] load build definition from Dockerfile                                                      0.1s
 => => transferring dockerfile: 1.15kB                                                                    0.0s
 => [internal] load .dockerignore                                                                         0.1s
 => => transferring context: 2B                                                                           0.0s
 => resolve image config for docker.io/edrevo/dockerfile-plus:latest                                      0.5s
 => [auth] edrevo/dockerfile-plus:pull token for registry-1.docker.io                                     0.0s
 => CACHED docker-image://docker.io/edrevo/dockerfile-plus@sha256:d234bd015db8acef1e628e012ea8815f6bf5ec  0.0s
 => local://dockerfile                                                                                    0.0s
 => => transferring dockerfile: 2.12kB                                                                    0.0s
 => local://context                                                                                       0.0s
 => => transferring context: 11.27kB                                                                      0.0s
 => [internal] load metadata for docker.io/library/ubuntu:focal                                           0.0s
 => CACHED [stage-1  1/34] FROM docker.io/library/ubuntu:focal                                            0.0s
 => [stage-1  2/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade build  28.5s
 => [stage-1  3/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade g++ &  10.1s
 => [stage-1  4/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade autot  17.2s 
 => [stage-1  5/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade zlib1  20.1s 
 => [stage-1  6/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade pytho  20.8s 
 => [stage-1  7/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade pytho  18.8s 
 => [stage-1  8/34] RUN pip3 install pyzmq # really needed?                                              12.2s 
 => [stage-1  9/34] RUN pip3 install jinja2                                                              11.8s 
 => [stage-1 10/34] RUN pip3 install flake8==3.8.3                                                       11.9s 
 => [stage-1 11/34] RUN pip3 install codespell==1.17.1                                                   11.7s 
 => [stage-1 12/34] RUN pip3 install vulture==2.3                                                        11.6s 
 => [stage-1 13/34] RUN pip3 install yq                                                                  12.0s 
 => [stage-1 14/34] RUN git clone https://github.com/dashpay/dash_hash                                    5.9s 
 => [stage-1 15/34] RUN cd dash_hash && python3 setup.py install                                         11.6s 
 => [stage-1 16/34] RUN groupadd -g 1000 dash                                                             0.4s 
 => [stage-1 17/34] RUN useradd -u 1000 -g dash -s /bin/bash -m -d /dash dash                             0.4s 
 => [stage-1 18/34] RUN dpkg --add-architecture i386                                                      0.4s 
 => [stage-1 19/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade g++-9  20.9s 
 => [stage-1 20/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade g++-a  22.1s 
 => [stage-1 21/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade g++-m  26.0s 
 => [stage-1 22/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade wine-  68.9s 
 => [stage-1 23/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade pytho  17.6s 
 => [stage-1 24/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade cppch  18.2s 
 => [stage-1 25/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade image  18.8s 
 => [stage-1 26/34] RUN curl -sL "https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shell  11.3s 
 => [stage-1 27/34] RUN ln -s x86_64-linux-gnu/asm /usr/include/asm                                       0.4s 
 => [stage-1 28/34] RUN   update-alternatives --set x86_64-w64-mingw32-gcc  /usr/bin/x86_64-w64-mingw32-  0.4s 
 => [stage-1 29/34] RUN mkdir /dash-src &&   mkdir -p /cache/ccache &&   mkdir /cache/depends &&   mkdir  0.4s 
 => [stage-1 30/34] WORKDIR /dash-src                                                                     0.1s 
 => [stage-1 31/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade sudo   16.7s 
 => [stage-1 32/34] RUN usermod -aG sudo dash                                                             0.4s
 => [stage-1 33/34] RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers                               0.4s 
 => [stage-1 34/34] RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade nano   19.3s 
 => exporting to image                                                                                    7.0s 
 => => exporting layers                                                                                   6.9s 
 => => writing image sha256:2097cea8217f926ac60799159efc3122e37f9b231ac1f87a555d65aae5a5ee0b              0.0s 
 => => naming to docker.io/library/develop_container                                                      0.0s 
 ```