### PR TITLE
actions: implement predict-conflicts actions

### DIFF
--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -9,7 +9,6 @@ permissions:
   checks: none
   deployments: none
   issues: none
-  #metadata: read
   packages: none
   repository-projects: none
   security-events: none

--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -1,0 +1,25 @@
+name: "Check Potential Conflicts"
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+  # Enforce other not needed permissions are off
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  #metadata: read
+  packages: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check potential conflicts
+        uses: outsideris/potential-conflicts-checker-action@0.1.0
+        with:
+          ghToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This action will comment on a PR, if there is another PR that changes the same file that it changes.

See https://github.com/PastaPastaPasta/dash/pull/25 and https://github.com/PastaPastaPasta/dash/pull/26 (opened at basically the same time). As these conflict, they both get comments linking to the other PR. 

Then https://github.com/PastaPastaPasta/dash/pull/27 was opened a minute or two later. This PR triggers another comment on 25 and 26 as there is now an additional PR they may conflict with, and a comment gets placed on itself.

Then https://github.com/PastaPastaPasta/dash/pull/28 was opened, but since it didn't potentially conflict with any other PRs, no comments were generated

This will be quite useful to prioritize merging between different PRs and avoiding very annoying git conflict resolutions.  