### PR TITLE
Fix two small backport issues

### DIFF
--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -908,6 +908,10 @@ RPCConsole QTableView {
     color: #c7c7c7;
 }
 
+RPCConsole QWidget#detailWidget {
+    background-color: #323233;
+}
+
 #rpcAutoCompleter {
     background-color: #39393b;
     border-color: #4a4a4b;

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -892,6 +892,10 @@ RPCConsole QTableView {
     color: #555;
 }
 
+RPCConsole QWidget#detailWidget {
+    background-color: #f2f2f4;
+}
+
 #rpcAutoCompleter {
     background-color: #eaeaec;
     border-color: #dcdcdc;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2648,7 +2648,7 @@ void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainPar
         if (nUpgraded > 0)
             AppendWarning(warningMessages, strprintf(_("%d of last 100 blocks have unexpected version"), nUpgraded));
     }
-    std::string strMessage = strprintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo) evodb_cache=%.1fMiB%s\n", __func__,
+    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo) evodb_cache=%.1fMiB%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,
       log(pindexNew->nChainWork.getdouble())/log(2.0), (unsigned long)pindexNew->nChainTx,
       FormatISO8601DateTime(pindexNew->GetBlockTime()),


### PR DESCRIPTION
1. [16854](https://github.com/dashpay/dash/pull/4606/commits/c29d0c5cf6fb1c980d7137f2650330d8cffc9966) backported via #4606 broke log output.
2. Not sure which commit exactly, probably [15136](https://github.com/dashpay/dash/pull/4482/commits/33a38b84defae8844231471ce506eab7a1cd74d1) backported via #4482, broke peer's details widget for Dark macOS theme and `Light` Dash Core theme combination and vice versa. Kudos to @kittywhiskers for reporting the issue 👍 

GUI issue example
<img width="689" alt="Screenshot 2021-12-30 at 21 20 53" src="https://user-images.githubusercontent.com/1935069/147779556-29c213be-5ae1-4c35-bbf8-25f9ab4c8a8a.png">

