### PR TITLE
Merge #15308 #15754 #15483 #16332

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -245,7 +245,7 @@ after_success:
         FILE_ENV="./ci/test/00_setup_env_amd64_qt5.sh"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [trusty]  [depends for now]'
+      name: 'x86_64 Linux  [GOAL: install]  [trusty]  [no functional tests, no depends, only system libs]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_amd64_trusty.sh"
 
@@ -269,6 +269,6 @@ after_success:
         FILE_ENV="./ci/test/00_setup_env_amd64_nowallet.sh"
 
     - stage: test
-      name: 'macOS 10.12  [GOAL: deploy]'
+      name: 'macOS 10.12  [GOAL: deploy] [no functional tests]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_mac.sh"

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -376,7 +376,7 @@ public:
         LOCK(m_wallet->cs_wallet);
         auto mi = m_wallet->mapWallet.find(txid);
         if (mi != m_wallet->mapWallet.end()) {
-            num_blocks = locked_chain->getHeight().value_or(-1);
+            num_blocks = locked_chain->getHeight().get_value_or(-1);
             in_mempool = mi->second.InMempool();
             order_form = mi->second.vOrderForm;
             tx_status = MakeWalletTxStatus(*locked_chain, mi->second);
@@ -411,7 +411,7 @@ public:
             return false;
         }
         balances = getBalances();
-        num_blocks = locked_chain->getHeight().value_or(-1);
+        num_blocks = locked_chain->getHeight().get_value_or(-1);
         return true;
     }
     CAmount getBalance() override

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -256,6 +256,10 @@ static UniValue getrpcinfo(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
     result.pushKV("active_commands", active_commands);
 
+    const std::string path = LogInstance().m_file_path.string();
+    UniValue log_path(UniValue::VSTR, path);
+    result.pushKV("logpath", log_path);
+
     return result;
 }
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -234,7 +234,8 @@ static UniValue getrpcinfo(const JSONRPCRequest& request)
             "    \"method\"       (string)  The name of the RPC command \n"
             "    \"duration\"     (numeric)  The running time in microseconds\n"
             "   },...\n"
-            "  ]\n"
+            "  ],\n"
+            " \"logpath\": \"xxx\" (string) The complete file path to the debug log\n"
             "}\n"
                 },
                 RPCExamples{

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -226,8 +226,20 @@ static UniValue getrpcinfo(const JSONRPCRequest& request)
             RPCHelpMan{"getrpcinfo",
                        "\nReturns details of the RPC server.\n",
                        {},
-                       RPCResults{},
-                       RPCExamples{""},
+                RPCResult{
+            "{\n"
+            " \"active_commands\" (array) All active commands\n"
+            "  [\n"
+            "   {               (object) Information about an active command\n"
+            "    \"method\"       (string)  The name of the RPC command \n"
+            "    \"duration\"     (numeric)  The running time in microseconds\n"
+            "   },...\n"
+            "  ]\n"
+            "}\n"
+                },
+                RPCExamples{
+                    HelpExampleCli("getrpcinfo", "")
+                + HelpExampleRpc("getrpcinfo", "")},
             }.ToString()
         );
     }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -10,6 +10,7 @@
 #include <txmempool.h>
 
 #include <future>
+#include <utility>
 
 #include <boost/signals2/signal.hpp>
 
@@ -91,7 +92,10 @@ size_t CMainSignals::CallbacksPending() {
 }
 
 void CMainSignals::RegisterWithMempoolSignals(CTxMemPool& pool) {
-    g_connNotifyEntryRemoved.emplace(&pool, pool.NotifyEntryRemoved.connect(std::bind(&CMainSignals::MempoolEntryRemoved, this, std::placeholders::_1, std::placeholders::_2)));
+    g_connNotifyEntryRemoved.emplace(std::piecewise_construct,
+        std::forward_as_tuple(&pool),
+        std::forward_as_tuple(pool.NotifyEntryRemoved.connect(std::bind(&CMainSignals::MempoolEntryRemoved, this, std::placeholders::_1, std::placeholders::_2)))
+    );
 }
 
 void CMainSignals::UnregisterWithMempoolSignals(CTxMemPool& pool) {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -999,7 +999,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     file << strprintf("# Wallet dump created by Dash Core %s\n", CLIENT_BUILD);
     file << strprintf("# * Created on %s\n", FormatISO8601DateTime(GetTime()));
     const Optional<int> tip_height = locked_chain->getHeight();
-    file << strprintf("# * Best block at time of backup was %i (%s),\n", tip_height.value_or(-1), tip_height ? locked_chain->getBlockHash(*tip_height).ToString() : "(missing block hash)");
+    file << strprintf("# * Best block at time of backup was %i (%s),\n", tip_height.get_value_or(-1), tip_height ? locked_chain->getBlockHash(*tip_height).ToString() : "(missing block hash)");
     file << strprintf("#   mined on %s\n", tip_height ? FormatISO8601DateTime(locked_chain->getBlockTime(*tip_height)) : "(missing block time)");
     file << "\n";
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3402,7 +3402,7 @@ static uint32_t GetLocktimeForNewTransaction(interfaces::Chain& chain, interface
     // now we ensure code won't be written that makes assumptions about
     // nLockTime that preclude a fix later.
     if (IsCurrentForAntiFeeSniping(chain, locked_chain)) {
-        locktime = locked_chain.getHeight().value_or(-1);
+        locktime = locked_chain.getHeight().get_value_or(-1);
 
         // Secondly occasionally randomly pick a nLockTime even further back, so
         // that transactions that are delayed after signing for whatever reason,

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Tests some generic aspects of the RPC interface."""
 
+import os
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_greater_than_or_equal
@@ -31,6 +32,7 @@ class RPCInterfaceTest(BitcoinTestFramework):
         command = info['active_commands'][0]
         assert_equal(command['method'], 'getrpcinfo')
         assert_greater_than_or_equal(command['duration'], 0)
+        assert_equal(info['logpath'], os.path.join(self.nodes[0].datadir, 'regtest', 'debug.log'))
 
     def test_batch_request(self):
         self.log.info("Testing basic JSON-RPC batch request...")


### PR DESCRIPTION
cb3511b9d Add release notes for importing key origin info change (Andrew Chow)
4c75a69f3 Test importing descriptors with key origin information (Andrew Chow)
02d6586d7 Import KeyOriginData when importing descriptors (Andrew Chow)
3d235dff5 Implement a function to add KeyOriginInfo to a wallet (Andrew Chow)
eab63bc26 Store key origin info in key metadata (Andrew Chow)
345bff601 Remove hdmasterkeyid (Andrew Chow)
bac8c676a Add a method to CWallet to write just CKeyMetadata (Andrew Chow)
e7652d3f6 Add WriteHDKeypath function and move *HDKeypath to util/bip32.{h,cpp} (Andrew Chow)
c45415f73 Refactor keymetadata writing to a separate method (Andrew Chow)

Pull request description:

  This PR allows for key origin data as defined by the descriptors document to be imported to the wallet when importing a descriptor using `importmulti`. This allows the `walletprocesspsbt` to include the BIP 32 derivation paths for keys that it is watching that are from a different HD wallet.

  In order to make this easier to use, a new field `hdmasterkeyfingerprint` has been added to `getaddressinfo`. Additionally I have removed `hdmasterkeyid` as was planned. I think that this API change is fine since it was going to be removed in 0.18 anyways. `CKeyMetadata` has also been extended to store key origin info to facilitate this.

Tree-SHA512: 9c7794f3c793da57e23c5abbdc3d58779ee9dea3d53168bb86c0643a4ad5a11a446264961e2f772f35eea645048cb60954ed58050002caee4e43cd9f51215097