### PR TITLE
actions: introduce handle_potential_conflicts.py to only warn on true conflicts. Fail CI when there is a conflict

### DIFF
--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -5,7 +5,7 @@ import requests
 import hjson
 
 '''Looks like'''
-input = '''{ pull_number: 26, 
+'''{ pull_number: 26, 
     conflictPrs: 
         [ { number: 25, 
             files: [ '.github/workflows/testfile' ], 

--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -39,7 +39,7 @@ def main():
             good.append(this_pr_num)
         elif "Can’t automatically merge" in r.text:
             bad.append(this_pr_num)
-        else: 
+        else:
             raise Exception("not mergeable or unmergable!")
 
     print("Not conflicting PRs: ", good)

--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -1,0 +1,58 @@
+import sys
+import requests
+
+# need to install via pip
+import hjson
+
+'''Looks like'''
+input = '''{ pull_number: 26, 
+    conflictPrs: 
+        [ { number: 25, 
+            files: [ '.github/workflows/testfile' ], 
+            conflicts: [ '.github/workflows/testfile' ] }
+        { number: 24, 
+            files: [ '.github/workflows/testfile' ], 
+            conflicts: [ '.github/workflows/testfile' ] } ] }'''
+
+def main():
+    input = sys.argv[1]
+    print(input)
+    j_input = hjson.loads(input)
+    print(j_input)
+
+
+    our_pr_num = j_input['pull_number']
+    our_pr_label = get_label(our_pr_num)
+    conflictPrs = j_input['conflictPrs']
+
+    good = []
+    bad = []
+
+    for conflict in conflictPrs:
+        this_pr_num = conflict['number']
+        print(this_pr_num)
+
+        r = requests.get(f'https://api.github.com/repos/PastaPastaPasta/dash/pulls/{conflict["number"]}')
+        print(r.json()['head']['label'])
+        r = requests.get(f'https://github.com/PastaPastaPasta/dash/branches/pre_mergeable/{our_pr_label}...{get_label(this_pr_num)}')
+        if "These branches can be automatically merged." in r.text:
+            good.append(this_pr_num)
+        elif "Can’t automatically merge" in r.text:
+            bad.append(this_pr_num)
+        else: 
+            raise Exception("not mergeable or unmergable!")
+
+    print("Not conflicting PRs: ", good)
+
+    print("Conflicting PRs: ", bad)
+    if len(bad) > 0:
+        sys.exit(1)
+
+
+
+def get_label(pr_num):
+    return requests.get(f'https://api.github.com/repos/PastaPastaPasta/dash/pulls/{pr_num}').json()['head']['label']
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -32,9 +32,9 @@ def main():
         this_pr_num = conflict['number']
         print(this_pr_num)
 
-        r = requests.get(f'https://api.github.com/repos/PastaPastaPasta/dash/pulls/{conflict["number"]}')
+        r = requests.get(f'https://api.github.com/repos/dashpay/dash/pulls/{conflict["number"]}')
         print(r.json()['head']['label'])
-        r = requests.get(f'https://github.com/PastaPastaPasta/dash/branches/pre_mergeable/{our_pr_label}...{get_label(this_pr_num)}')
+        r = requests.get(f'https://github.com/dashpay/dash/branches/pre_mergeable/{our_pr_label}...{get_label(this_pr_num)}')
         if "These branches can be automatically merged." in r.text:
             good.append(this_pr_num)
         elif "Can’t automatically merge" in r.text:
@@ -51,7 +51,7 @@ def main():
 
 
 def get_label(pr_num):
-    return requests.get(f'https://api.github.com/repos/PastaPastaPasta/dash/pulls/{pr_num}').json()['head']['label']
+    return requests.get(f'https://api.github.com/repos/dashpay/dash/pulls/{pr_num}').json()['head']['label']
 
 
 if __name__ == "__main__":

--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -5,13 +5,13 @@ import requests
 import hjson
 
 '''Looks like'''
-'''{ pull_number: 26, 
-    conflictPrs: 
-        [ { number: 25, 
-            files: [ '.github/workflows/testfile' ], 
+'''{ pull_number: 26,
+    conflictPrs:
+        [ { number: 25,
+            files: [ '.github/workflows/testfile' ],
             conflicts: [ '.github/workflows/testfile' ] }
-        { number: 24, 
-            files: [ '.github/workflows/testfile' ], 
+        { number: 24,
+            files: [ '.github/workflows/testfile' ],
             conflicts: [ '.github/workflows/testfile' ] } ] }'''
 
 def main():

--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -1,5 +1,7 @@
 name: "Check Potential Conflicts"
-on: pull_request_target
+on:
+  - pull_request_target
+  - pull_request_review
 
 permissions:
   contents: read
@@ -18,7 +20,9 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: check potential conflicts
-        uses: PastaPastaPasta/potential-conflicts-checker-action@0.1.1
+      - name: check for potential conflicts
+        uses: PastaPastaPasta/potential-conflicts-checker-action@0.1.9
         with:
           ghToken: "${{ secrets.GITHUB_TOKEN }}"
+      - name: validate potential conflicts
+        run: wget https://raw.githubusercontent.com/dashpay/dash/develop/.github/workflows/handle_potential_conflicts.py && pip3 install hjson && python3 handle_potential_conflicts.py "$conflicts"


### PR DESCRIPTION
The CI action will now run on any any change to the PR, or a review on the PR, such that the conflict information is hopefully as up to date as possible.