### PR TITLE
refactor: use a vector instead of map for llmqs

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -110,15 +110,36 @@ static CBlock FindDevNetGenesisBlock(const CBlock &prevBlock, const CAmount& rew
 
 void CChainParams::AddLLMQ(Consensus::LLMQType llmqType)
 {
-    assert(consensus.llmqs.count(llmqType) == 0);
+    assert(!HasLLMQ(llmqType));
     for (const auto& llmq_param : Consensus::available_llmqs) {
         if (llmq_param.type == llmqType) {
-            consensus.llmqs[llmqType] = llmq_param;
+            consensus.llmqs.push_back(llmq_param);
             return;
         }
     }
     error("CChainParams::%s: unknown LLMQ type %d", __func__, static_cast<uint8_t>(llmqType));
     assert(false);
+}
+
+const Consensus::LLMQParams& CChainParams::GetLLMQ(Consensus::LLMQType llmqType) const
+{
+    for (const auto& llmq_param : consensus.llmqs) {
+        if (llmq_param.type == llmqType) {
+            return llmq_param;
+        }
+    }
+    error("CChainParams::%s: unknown LLMQ type %d", __func__, static_cast<uint8_t>(llmqType));
+    assert(false);
+}
+
+bool CChainParams::HasLLMQ(Consensus::LLMQType llmqType) const
+{
+    for (const auto& llmq_param : consensus.llmqs) {
+        if (llmq_param.type == llmqType) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**
@@ -682,11 +703,11 @@ public:
         nExtCoinType = 1;
 
         // long living quorum params
-        AddLLMQ(Consensus::LLMQType::LLMQ_DEVNET);
         AddLLMQ(Consensus::LLMQType::LLMQ_50_60);
         AddLLMQ(Consensus::LLMQType::LLMQ_400_60);
         AddLLMQ(Consensus::LLMQType::LLMQ_400_85);
         AddLLMQ(Consensus::LLMQType::LLMQ_100_67);
+        AddLLMQ(Consensus::LLMQType::LLMQ_DEVNET);
         consensus.llmqTypeChainLocks = Consensus::LLMQType::LLMQ_50_60;
         consensus.llmqTypeInstantSend = Consensus::LLMQType::LLMQ_50_60;
         consensus.llmqTypePlatform = Consensus::LLMQType::LLMQ_100_67;
@@ -761,11 +782,12 @@ public:
      */
     void UpdateLLMQDevnetParameters(int size, int threshold)
     {
-        auto& params = consensus.llmqs.at(Consensus::LLMQType::LLMQ_DEVNET);
-        params.size = size;
-        params.minSize = threshold;
-        params.threshold = threshold;
-        params.dkgBadVotesThreshold = threshold;
+        auto params = ranges::find_if(consensus.llmqs, [](const auto& llmq){ return llmq.type == Consensus::LLMQType::LLMQ_DEVNET;});
+        assert(params != consensus.llmqs.end());
+        params->size = size;
+        params->minSize = threshold;
+        params->threshold = threshold;
+        params->dkgBadVotesThreshold = threshold;
     }
     void UpdateLLMQDevnetParametersFromArgs(const ArgsManager& args);
 };
@@ -991,11 +1013,12 @@ public:
      */
     void UpdateLLMQTestParameters(int size, int threshold)
     {
-        auto& params = consensus.llmqs.at(Consensus::LLMQType::LLMQ_TEST);
-        params.size = size;
-        params.minSize = threshold;
-        params.threshold = threshold;
-        params.dkgBadVotesThreshold = threshold;
+        auto params = ranges::find_if(consensus.llmqs, [](const auto& llmq){ return llmq.type == Consensus::LLMQType::LLMQ_TEST;});
+        assert(params != consensus.llmqs.end());
+        params->size = size;
+        params->minSize = threshold;
+        params->threshold = threshold;
+        params->dkgBadVotesThreshold = threshold;
     }
     void UpdateLLMQTestParametersFromArgs(const ArgsManager& args);
 };
@@ -1151,11 +1174,11 @@ void CDevNetParams::UpdateDevnetLLMQChainLocksFromArgs(const ArgsManager& args)
 {
     if (!args.IsArgSet("-llmqchainlocks")) return;
 
-    std::string strLLMQType = gArgs.GetArg("-llmqchainlocks", std::string(consensus.llmqs.at(consensus.llmqTypeChainLocks).name));
+    std::string strLLMQType = gArgs.GetArg("-llmqchainlocks", std::string(Params().GetLLMQ(consensus.llmqTypeChainLocks).name));
     Consensus::LLMQType llmqType = Consensus::LLMQType::LLMQ_NONE;
-    for (const auto& p : consensus.llmqs) {
-        if (p.second.name == strLLMQType) {
-            llmqType = p.first;
+    for (const auto& params : consensus.llmqs) {
+        if (params.name == strLLMQType) {
+            llmqType = params.type;
         }
     }
     if (llmqType == Consensus::LLMQType::LLMQ_NONE) {
@@ -1169,11 +1192,11 @@ void CDevNetParams::UpdateDevnetLLMQInstantSendFromArgs(const ArgsManager& args)
 {
     if (!args.IsArgSet("-llmqinstantsend")) return;
 
-    std::string strLLMQType = gArgs.GetArg("-llmqinstantsend", std::string(consensus.llmqs.at(consensus.llmqTypeInstantSend).name));
+    std::string strLLMQType = gArgs.GetArg("-llmqinstantsend", std::string(Params().GetLLMQ(consensus.llmqTypeInstantSend).name));
     Consensus::LLMQType llmqType = Consensus::LLMQType::LLMQ_NONE;
-    for (const auto& p : consensus.llmqs) {
-        if (p.second.name == strLLMQType) {
-            llmqType = p.first;
+    for (const auto& params : consensus.llmqs) {
+        if (params.name == strLLMQType) {
+            llmqType = params.type;
         }
     }
     if (llmqType == Consensus::LLMQType::LLMQ_NONE) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -10,6 +10,7 @@
 #include <consensus/merkle.h>
 #include <llmq/params.h>
 #include <tinyformat.h>
+#include <util/ranges.h>
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <versionbitsinfo.h>

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -106,6 +106,9 @@ public:
     const std::vector<std::string>& SporkAddresses() const { return vSporkAddresses; }
     int MinSporkKeys() const { return nMinSporkKeys; }
     bool BIP9CheckMasternodesUpgraded() const { return fBIP9CheckMasternodesUpgraded; }
+    const Consensus::LLMQParams& GetLLMQ(Consensus::LLMQType llmqType) const;
+    bool HasLLMQ(Consensus::LLMQType llmqType) const;
+
 protected:
     CChainParams() {}
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -115,7 +115,7 @@ struct Params {
     int nHighSubsidyBlocks{0};
     int nHighSubsidyFactor{1};
 
-    std::map<LLMQType, LLMQParams> llmqs;
+    std::vector<LLMQParams> llmqs;
     LLMQType llmqTypeChainLocks;
     LLMQType llmqTypeInstantSend{LLMQType::LLMQ_NONE};
     LLMQType llmqTypePlatform{LLMQType::LLMQ_NONE};

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1010,8 +1010,8 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const CBlockIndex*
             mnListsCache.emplace(snapshot.GetBlockHash(), snapshot);
         } else {
             // keep snapshots for yet alive quorums
-            if (ranges::any_of(Params().GetConsensus().llmqs, [&snapshot, this](const auto& p_llmq){
-                const auto& [_, params] = p_llmq; LOCK(cs);
+            if (ranges::any_of(Params().GetConsensus().llmqs, [&snapshot, this](const auto& params){
+                LOCK(cs);
                 return (snapshot.GetHeight() % params.dkgInterval == 0) &&
                 (snapshot.GetHeight() + params.dkgInterval * (params.keepOldConnections + 1) >= tipIndex->nHeight);
             })) {
@@ -1081,8 +1081,7 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
             toDeleteLists.emplace_back(p.first);
             continue;
         }
-        bool fQuorumCache = ranges::any_of(Params().GetConsensus().llmqs, [&nHeight, &p](const auto& p_llmq){
-            const auto& [_, params] = p_llmq;
+        bool fQuorumCache = ranges::any_of(Params().GetConsensus().llmqs, [&nHeight, &p](const auto& params){
             return (p.second.GetHeight() % params.dkgInterval == 0) &&
                    (p.second.GetHeight() + params.dkgInterval * (params.keepOldConnections + 1) >= nHeight);
         });
@@ -1094,7 +1093,7 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
         if (tipIndex && tipIndex->pprev && (p.first == tipIndex->pprev->GetBlockHash())) {
             toDeleteLists.emplace_back(p.first);
         } else if (ranges::any_of(Params().GetConsensus().llmqs,
-                                  [&p](const auto& p_llmq){ return p.second.GetHeight() % p_llmq.second.dkgInterval == 0; })) {
+                                  [&p](const auto& llmqParams){ return p.second.GetHeight() % llmqParams.dkgInterval == 0; })) {
             toDeleteLists.emplace_back(p.first);
         }
     }

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -51,7 +51,7 @@ bool CheckMNHFTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidat
         return state.DoS(100, false, REJECT_INVALID, "bad-mnhf-quorum-hash");
     }
 
-    if (!Params().GetConsensus().llmqs.count(Params().GetConsensus().llmqTypeMnhf)) {
+    if (!Params().HasLLMQ(Params().GetConsensus().llmqTypeMnhf)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-mnhf-type");
     }
 

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -57,7 +57,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& strC
             return;
         }
 
-        if (!Params().GetConsensus().llmqs.count(qc.llmqType)) {
+        if (!Params().HasLLMQ(qc.llmqType)) {
             LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- invalid commitment type %d from peer=%d\n", __func__,
                      static_cast<uint8_t>(qc.llmqType), pfrom->GetId());
             LOCK(cs_main);
@@ -483,10 +483,10 @@ std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> CQuorumBlockProce
 {
     std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> ret;
 
-    for (const auto& p : Params().GetConsensus().llmqs) {
-        auto& v = ret[p.second.type];
-        v.reserve(p.second.signingActiveQuorumCount);
-        auto commitments = GetMinedCommitmentsUntilBlock(p.second.type, pindex, p.second.signingActiveQuorumCount);
+    for (const auto& params : Params().GetConsensus().llmqs) {
+        auto& v = ret[params.type];
+        v.reserve(params.signingActiveQuorumCount);
+        auto commitments = GetMinedCommitmentsUntilBlock(params.type, pindex, params.signingActiveQuorumCount);
         std::copy(commitments.begin(), commitments.end(), std::back_inserter(v));
     }
 

--- a/src/llmq/commitment.cpp
+++ b/src/llmq/commitment.cpp
@@ -33,7 +33,7 @@ bool CFinalCommitment::Verify(const CBlockIndex* pQuorumBaseBlockIndex, bool che
         return false;
     }
 
-    if (!Params().GetConsensus().llmqs.count(llmqType)) {
+    if (!Params().HasLLMQ(llmqType)) {
         LogPrintfFinalCommitment("invalid llmqType=%d\n", static_cast<uint8_t>(llmqType));
         return false;
     }
@@ -108,7 +108,7 @@ bool CFinalCommitment::Verify(const CBlockIndex* pQuorumBaseBlockIndex, bool che
 
 bool CFinalCommitment::VerifyNull() const
 {
-    if (!Params().GetConsensus().llmqs.count(llmqType)) {
+    if (!Params().HasLLMQ(llmqType)) {
         LogPrintfFinalCommitment("invalid llmqType=%d\n", static_cast<uint8_t>(llmqType));
         return false;
     }
@@ -159,7 +159,7 @@ bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, 
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
     }
 
-    if (!Params().GetConsensus().llmqs.count(qcTx.commitment.llmqType)) {
+    if (!Params().HasLLMQ(qcTx.commitment.llmqType)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-type");
     }
 

--- a/src/llmq/debug.cpp
+++ b/src/llmq/debug.cpp
@@ -19,7 +19,7 @@ UniValue CDKGDebugSessionStatus::ToJson(int detailLevel) const
 {
     UniValue ret(UniValue::VOBJ);
 
-    if (!Params().GetConsensus().llmqs.count(llmqType) || quorumHash.IsNull()) {
+    if (!Params().HasLLMQ(llmqType) || quorumHash.IsNull()) {
         return ret;
     }
 
@@ -117,7 +117,7 @@ UniValue CDKGDebugStatus::ToJson(int detailLevel) const
 
     UniValue sessionsJson(UniValue::VOBJ);
     for (const auto& p : sessions) {
-        if (!Params().GetConsensus().llmqs.count(p.first)) {
+        if (!Params().HasLLMQ(p.first)) {
             continue;
         }
         sessionsJson.pushKV(std::string(GetLLMQParams(p.first).name), p.second.ToJson(detailLevel));

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -27,10 +27,10 @@ CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, bool unitTests, b
 {
     MigrateDKG();
 
-    for (const auto& qt : Params().GetConsensus().llmqs) {
+    for (const auto& params : Params().GetConsensus().llmqs) {
         dkgSessionHandlers.emplace(std::piecewise_construct,
-                std::forward_as_tuple(qt.first),
-                std::forward_as_tuple(qt.second, blsWorker, *this));
+                std::forward_as_tuple(params.type),
+                std::forward_as_tuple(params, blsWorker, *this));
     }
 }
 

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -617,7 +617,7 @@ bool CSigningManager::PreVerifyRecoveredSig(const CRecoveredSig& recoveredSig, b
     retBan = false;
 
     auto llmqType = recoveredSig.llmqType;
-    if (!Params().GetConsensus().llmqs.count(llmqType)) {
+    if (!Params().HasLLMQ(llmqType)) {
         retBan = true;
         return false;
     }

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -305,7 +305,7 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
 bool CSigSharesManager::ProcessMessageSigSesAnn(const CNode* pfrom, const CSigSesAnn& ann)
 {
     auto llmqType = ann.llmqType;
-    if (!Params().GetConsensus().llmqs.count(llmqType)) {
+    if (!Params().HasLLMQ(llmqType)) {
         return false;
     }
     if (ann.sessionId == UNINITIALIZED_SESSION_ID || ann.quorumHash.IsNull() || ann.id.IsNull() || ann.msgHash.IsNull()) {

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -371,7 +371,7 @@ std::map<Consensus::LLMQType, QvvecSyncMode> CLLMQUtils::GetEnabledQuorumVvecSyn
         }
 
         if (auto optLLMQParams = ranges::find_if_opt(Params().GetConsensus().llmqs,
-                                                     [&strLLMQType](const auto& p){return p.second.name == strLLMQType;})) {
+                                                     [&strLLMQType](const auto& params){return params.name == strLLMQType;})) {
             llmqType = optLLMQParams->type;
         } else {
             throw std::invalid_argument(strprintf("Invalid llmqType in -llmq-qvvec-sync: %s", strEntry));

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -337,11 +337,10 @@ std::vector<std::reference_wrapper<const Consensus::LLMQParams>> CLLMQUtils::Get
 {
     std::vector<std::reference_wrapper<const Consensus::LLMQParams>> ret;
     ret.reserve(Params().GetConsensus().llmqs.size());
-    for (const auto& params : Params().GetConsensus().llmqs) {
-        if (IsQuorumTypeEnabled(params.type, pindex)) {
-            ret.emplace_back(params);
-        }
-    }
+
+    std::copy_if(Params().GetConsensus().llmqs.begin(), Params().GetConsensus().llmqs.end(), std::back_inserter(ret),
+                 [&pindex](const auto& params){return IsQuorumTypeEnabled(params.type, pindex);});
+
     return ret;
 }
 

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -325,9 +325,9 @@ std::vector<Consensus::LLMQType> CLLMQUtils::GetEnabledQuorumTypes(const CBlockI
 {
     std::vector<Consensus::LLMQType> ret;
     ret.reserve(Params().GetConsensus().llmqs.size());
-    for (const auto& [type, _] : Params().GetConsensus().llmqs) {
-        if (IsQuorumTypeEnabled(type, pindex)) {
-            ret.push_back(type);
+    for (const auto& params : Params().GetConsensus().llmqs) {
+        if (IsQuorumTypeEnabled(params.type, pindex)) {
+            ret.push_back(params.type);
         }
     }
     return ret;
@@ -337,8 +337,8 @@ std::vector<std::reference_wrapper<const Consensus::LLMQParams>> CLLMQUtils::Get
 {
     std::vector<std::reference_wrapper<const Consensus::LLMQParams>> ret;
     ret.reserve(Params().GetConsensus().llmqs.size());
-    for (const auto& [type, params] : Params().GetConsensus().llmqs) {
-        if (IsQuorumTypeEnabled(type, pindex)) {
+    for (const auto& params : Params().GetConsensus().llmqs) {
+        if (IsQuorumTypeEnabled(params.type, pindex)) {
             ret.emplace_back(params);
         }
     }
@@ -373,7 +373,7 @@ std::map<Consensus::LLMQType, QvvecSyncMode> CLLMQUtils::GetEnabledQuorumVvecSyn
 
         if (auto optLLMQParams = ranges::find_if_opt(Params().GetConsensus().llmqs,
                                                      [&strLLMQType](const auto& p){return p.second.name == strLLMQType;})) {
-            llmqType = optLLMQParams->first;
+            llmqType = optLLMQParams->type;
         } else {
             throw std::invalid_argument(strprintf("Invalid llmqType in -llmq-qvvec-sync: %s", strEntry));
         }
@@ -407,8 +407,8 @@ template <typename CacheType>
 void CLLMQUtils::InitQuorumsCache(CacheType& cache)
 {
     for (auto& llmq : Params().GetConsensus().llmqs) {
-        cache.emplace(std::piecewise_construct, std::forward_as_tuple(llmq.first),
-                      std::forward_as_tuple(llmq.second.signingActiveQuorumCount + 1));
+        cache.emplace(std::piecewise_construct, std::forward_as_tuple(llmq.type),
+                      std::forward_as_tuple(llmq.signingActiveQuorumCount + 1));
     }
 }
 template void CLLMQUtils::InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>>& cache);
@@ -417,7 +417,7 @@ template void CLLMQUtils::InitQuorumsCache<std::map<Consensus::LLMQType, unorder
 
 const Consensus::LLMQParams& GetLLMQParams(Consensus::LLMQType llmqType)
 {
-    return Params().GetConsensus().llmqs.at(llmqType);
+    return Params().GetLLMQ(llmqType);
 }
 
 } // namespace llmq

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -137,7 +137,7 @@ static UniValue quorum_info(const JSONRPCRequest& request)
         quorum_info_help();
 
     Consensus::LLMQType llmqType = (Consensus::LLMQType)ParseInt32V(request.params[1], "llmqType");
-    if (!Params().GetConsensus().llmqs.count(llmqType)) {
+    if (!Params().HasLLMQ(llmqType)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid LLMQ type");
     }
 
@@ -413,7 +413,7 @@ static UniValue quorum_sigs_cmd(const JSONRPCRequest& request)
     }
 
     Consensus::LLMQType llmqType = (Consensus::LLMQType)ParseInt32V(request.params[1], "llmqType");
-    if (!Params().GetConsensus().llmqs.count(llmqType)) {
+    if (!Params().HasLLMQ(llmqType)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid LLMQ type");
     }
 
@@ -528,7 +528,7 @@ static UniValue quorum_selectquorum(const JSONRPCRequest& request)
     }
 
     Consensus::LLMQType llmqType = (Consensus::LLMQType)ParseInt32V(request.params[1], "llmqType");
-    if (!Params().GetConsensus().llmqs.count(llmqType)) {
+    if (!Params().HasLLMQ(llmqType)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid LLMQ type");
     }
 


### PR DESCRIPTION
this is a valuable refactor for a number of reasons.

it forces the removal of more verbose `Params().GetConsensus().llmqs.count` and instead call to `Params().HasLLMQ()`

`llmqs` is now stored in contiguous memory (which hopefully means better lookup time / iteration time)

std::vector is much more constexpr friendly (std::vector can be used in a constexpr context starting in c++20), and normally is better optimized


Signed-off-by: Pasta <pasta@dashboost.org>