### PR TITLE
remove redundant call to c_str

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -89,7 +89,7 @@ static CBlock FindDevNetGenesisBlock(const CBlock &prevBlock, const CAmount& rew
     std::string devNetName = gArgs.GetDevNetName();
     assert(!devNetName.empty());
 
-    CBlock block = CreateDevNetGenesisBlock(prevBlock.GetHash(), devNetName.c_str(), prevBlock.nTime + 1, 0, prevBlock.nBits, reward);
+    CBlock block = CreateDevNetGenesisBlock(prevBlock.GetHash(), devNetName, prevBlock.nTime + 1, 0, prevBlock.nBits, reward);
 
     arith_uint256 bnTarget;
     bnTarget.SetCompact(block.nBits);


### PR DESCRIPTION
CreateDevNetGenesisBlock takes a std::string, not a const char*

Signed-off-by: Pasta <pasta@dashboost.org>