### PR TITLE
instantsend: make sure islocks we read from db are the ones we expected

### DIFF
--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -326,10 +326,10 @@ CInstantSendLockPtr CInstantSendDb::GetInstantSendLockByHash(const uint256& hash
 
     ret = std::make_shared<CInstantSendLock>(CInstantSendLock::isdlock_version);
     bool exists = db->Read(std::make_tuple(DB_ISLOCK_BY_HASH, hash), *ret);
-    if (!exists) {
+    if (!exists || (::SerializeHash(*ret) != hash)) {
         ret = std::make_shared<CInstantSendLock>();
         exists = db->Read(std::make_tuple(DB_ISLOCK_BY_HASH, hash), *ret);
-        if (!exists) {
+        if (!exists || (::SerializeHash(*ret) != hash)) {
             ret = nullptr;
         }
     }


### PR DESCRIPTION
Fallback to the legacy version and then to nullptr.

It turned out that some v0 islocks can be deserialized as v1+ islocks (where `version` would equal to inputs size and everything else is a mess). This fix ensures we handle such situations properly.