### PR TITLE
Reduce MIN_STANDARD_TX_SIZE to 83 bytes

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -22,8 +22,8 @@ static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2000000;
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
-/** The minimum size for transactions we're willing to relay/mine (1 empty scriptSig input + 1 P2PKH output = 85 bytes) */
-static const unsigned int MIN_STANDARD_TX_SIZE = 85;
+/** The minimum size for transactions we're willing to relay/mine (1 empty scriptSig input + 1 P2SH output = 83 bytes) */
+static const unsigned int MIN_STANDARD_TX_SIZE = 83;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -551,7 +551,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         return state.DoS(0, false, REJECT_NONSTANDARD, reason);
 
     // Do not work on transactions that are too small.
-    // A transaction with 1 empty scriptSig input and 1 P2PKH output has size of 85 bytes.
+    // A transaction with 1 empty scriptSig input and 1 P2SH output has size of 83 bytes.
     // Transactions smaller than this are not relayed to reduce unnecessary malloc overhead.
     if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) < MIN_STANDARD_TX_SIZE)
         return state.DoS(0, false, REJECT_NONSTANDARD, "tx-size-small");


### PR DESCRIPTION
The limit was introduced in https://github.com/dashpay/dash/pull/4192/commits/906be7e144410e7f44384456999a72edb0ce37f3 and bumped to 85 bytes in https://github.com/dashpay/dash/pull/4192/commits/11aa04e7eca6aa44f1b6673fbd19606532a570cd. Switching from P2WKH to P2PKH is how we dashify things usually, so everything looked ok. But the reason P2PWKH was picked in the original PR was that it was the _smallest_ possible one. With this in mind we should really be switching from P2WKH to P2SH here since it's 2 bytes smaller than P2PKH.

This bug is the reason why `p2p_invalid_tx.py` fails in #4612 atm.