### PR TITLE
ci: adjust handle_potential_conflicts.py such that if mergable_state is dirty (conflicting with base branch), don't check against it.

### DIFF
--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -32,8 +32,14 @@ def main():
         this_pr_num = conflict['number']
         print(this_pr_num)
 
-        r = requests.get(f'https://api.github.com/repos/dashpay/dash/pulls/{conflict["number"]}')
+        r = requests.get(f'https://api.github.com/repos/dashpay/dash/pulls/{this_pr_num}')
         print(r.json()['head']['label'])
+
+        mergable_state = r.json()['mergeable_state']
+        if mergable_state == "dirty":
+            print(f'{this_pr_num} needs rebase. Skipping conflict check')
+            continue
+
         r = requests.get(f'https://github.com/dashpay/dash/branches/pre_mergeable/{our_pr_label}...{get_label(this_pr_num)}')
         if "These branches can be automatically merged." in r.text:
             good.append(this_pr_num)


### PR DESCRIPTION
Should make the indicator much more valuable