### PR TITLE
Partially revert 4652

### DIFF
--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -357,6 +357,22 @@ bool CCoinJoin::IsCollateralValid(const CTransaction& txCollateral)
     return true;
 }
 
+std::string CCoinJoin::DenominationToString(int nDenom)
+{
+    CAmount nDenomAmount = DenominationToAmount(nDenom);
+
+    switch (nDenomAmount) {
+        case  0: return "N/A";
+        case -1: return "out-of-bounds";
+        case -2: return "non-denom";
+        case -3: return "to-amount-error";
+        default: return ValueFromAmount(nDenomAmount).getValStr();
+    }
+
+    // shouldn't happen
+    return "to-string-error";
+}
+
 std::string CCoinJoin::GetMessageByID(PoolMessage nMessageID)
 {
     switch (nMessageID) {

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -438,21 +438,7 @@ public:
     /*
     Same as DenominationToAmount but returns a string representation
     */
-    static constexpr std::string_view DenominationToString(int nDenom)
-    {
-        CAmount nDenomAmount = DenominationToAmount(nDenom);
-
-        switch (nDenomAmount) {
-            case  0: return "N/A";
-            case -1: return "out-of-bounds";
-            case -2: return "non-denom";
-            case -3: return "to-amount-error";
-            default: return ValueFromAmount(nDenomAmount).getValStr();
-        }
-
-        // shouldn't happen
-        return "to-string-error";
-    }
+    static std::string DenominationToString(int nDenom);
 
     static std::string GetMessageByID(PoolMessage nMessageID);
 


### PR DESCRIPTION
Using `string_view` results in things like `nSessionDenom: 2 (\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00)` etc. for some reason.

#4652