### PR TITLE
build: allow building without openssl, enables native m1 development builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -654,10 +654,10 @@ case $host in
          dnl It's safe to add these paths even if the functionality is disabled by
          dnl the user (--without-wallet or --without-gui for example).
 
+         bdb_prefix=`$BREW --prefix berkeley-db4 2>/dev/null`
+         qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
          if test x$enable_bip70 != xno; then
            openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
-           bdb_prefix=`$BREW --prefix berkeley-db4 2>/dev/null`
-           qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
            if test x$openssl_prefix != x; then
              PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
              export PKG_CONFIG_PATH

--- a/configure.ac
+++ b/configure.ac
@@ -654,12 +654,14 @@ case $host in
          dnl It's safe to add these paths even if the functionality is disabled by
          dnl the user (--without-wallet or --without-gui for example).
 
-         openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
-         bdb_prefix=`$BREW --prefix berkeley-db4 2>/dev/null`
-         qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
-         if test x$openssl_prefix != x; then
-           PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
-           export PKG_CONFIG_PATH
+         if test x$enable_bip70 != xno; then
+           openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
+           bdb_prefix=`$BREW --prefix berkeley-db4 2>/dev/null`
+           qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
+           if test x$openssl_prefix != x; then
+             PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
+             export PKG_CONFIG_PATH
+           fi
          fi
          if test x$bdb_prefix != x; then
            CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
@@ -1358,8 +1360,10 @@ if test x$use_pkgconfig = xyes; then
   m4_ifdef(
     [PKG_CHECK_MODULES],
     [
-      PKG_CHECK_MODULES([SSL], [libssl],, [AC_MSG_ERROR(openssl not found.)])
-      PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto not found.)])
+      if test x$enable_bip70 != xno; then
+        PKG_CHECK_MODULES([SSL], [libssl],, [AC_MSG_ERROR(openssl not found.)])
+        PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto not found.)])
+      fi
       if test x$enable_bip70 != xno; then
         BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes], [have_protobuf=no])])
       fi

--- a/configure.ac
+++ b/configure.ac
@@ -234,6 +234,13 @@ AC_ARG_WITH([system-univalue],
   [system_univalue=$withval],
   [system_univalue=no]
 )
+
+AC_ARG_WITH([openssl],
+  [AS_HELP_STRING([--with-openssl],
+  [enable openssl (default is yes if OpenSSL is found)])],
+  [use_openssl=$withval],
+  [use_openssl=yes])
+
 AC_ARG_ENABLE([zmq],
   [AS_HELP_STRING([--disable-zmq],
   [disable ZMQ notifications])],
@@ -656,7 +663,7 @@ case $host in
 
          bdb_prefix=`$BREW --prefix berkeley-db4 2>/dev/null`
          qt5_prefix=`$BREW --prefix qt5 2>/dev/null`
-         if test x$enable_bip70 != xno; then
+         if test x$use_openssl != xno; then
            openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
            if test x$openssl_prefix != x; then
              PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
@@ -1173,6 +1180,7 @@ if test "x$enable_fuzz" = "xyes"; then
   bitcoin_enable_qt_dbus=no
   enable_wallet=no
   use_bench=no
+  use_openssl=no
   use_upnp=no
   use_zmq=no
 else
@@ -1360,9 +1368,9 @@ if test x$use_pkgconfig = xyes; then
   m4_ifdef(
     [PKG_CHECK_MODULES],
     [
-      if test x$enable_bip70 != xno; then
-        PKG_CHECK_MODULES([SSL], [libssl],, [AC_MSG_ERROR(openssl not found.)])
-        PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto not found.)])
+      if test x$use_openssl != xno; then
+        PKG_CHECK_MODULES([SSL], [libssl],, [use_openssl=no])
+        PKG_CHECK_MODULES([CRYPTO], [libcrypto],, [use_openssl=no])
       fi
       if test x$enable_bip70 != xno; then
         BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes], [have_protobuf=no])])
@@ -1389,11 +1397,13 @@ if test x$use_pkgconfig = xyes; then
     ]
   )
 else
-  AC_CHECK_HEADER([openssl/crypto.h],,AC_MSG_ERROR(libcrypto headers missing))
-  AC_CHECK_LIB([crypto],      [main],CRYPTO_LIBS=-lcrypto, AC_MSG_ERROR(libcrypto missing))
+  if test x$use_openssl != xno; then
+    AC_CHECK_HEADER([openssl/crypto.h],,[use_openssl=no])
+    AC_CHECK_LIB([crypto],      [main],CRYPTO_LIBS=-lcrypto, [use_openssl=no])
 
-  AC_CHECK_HEADER([openssl/ssl.h],, AC_MSG_ERROR(libssl headers missing),)
-  AC_CHECK_LIB([ssl],         [main],SSL_LIBS=-lssl, AC_MSG_ERROR(libssl missing))
+    AC_CHECK_HEADER([openssl/ssl.h],, [use_openssl=no])
+    AC_CHECK_LIB([ssl],         [main],SSL_LIBS=-lssl, [use_openssl=no])
+  fi
 
   if test x$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests != xnononono; then
     AC_CHECK_HEADER([event2/event.h],, AC_MSG_ERROR(libevent headers missing),)
@@ -1631,6 +1641,12 @@ if test x$bitcoin_enable_qt != xno; then
     fi
     enable_bip70=no
     AC_MSG_RESULT(no)
+  elif test x$use_openssl = xno; then
+    if test x$enable_bip70 = xyes; then
+      AC_MSG_ERROR(OpenSSL missing)
+    fi
+    enable_bip70=no
+    AC_MSG_RESULT(no)
   else
     if test x$enable_bip70 != xno; then
       AC_DEFINE([ENABLE_BIP70],[1],[Define if BIP70 support should be compiled in])
@@ -1640,6 +1656,10 @@ if test x$bitcoin_enable_qt != xno; then
       AC_MSG_RESULT([no])
     fi
   fi
+fi
+
+if test x$use_openssl = xyes; then
+  AC_DEFINE([USE_OPENSSL],[1],[Define to 1 to use OpenSSL])
 fi
 
 AM_CONDITIONAL([ENABLE_ZMQ], [test "x$use_zmq" = "xyes"])
@@ -1823,6 +1843,7 @@ if test x$bitcoin_enable_qt != xno; then
     echo "    with bip70        = $enable_bip70"
     echo "    with qr           = $use_qr"
 fi
+echo "  with openssl        = $use_openssl"
 echo "  with zmq            = $use_zmq"
 echo "  with test           = $use_tests"
 echo "  with bench          = $use_bench"

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -34,6 +34,7 @@ BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 NO_PROTOBUF ?=
+NO_OPENSSL ?=
 NO_WALLET ?=
 NO_ZMQ ?=
 NO_UPNP ?=
@@ -136,6 +137,7 @@ upnp_packages_$(NO_UPNP) = $(upnp_packages)
 zmq_packages_$(NO_ZMQ) = $(zmq_packages)
 
 protobuf_packages_$(NO_PROTOBUF) = $(protobuf_packages)
+openssl_packages_$(NO_OPENSSL) = $(openssl_packages)
 
 packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
@@ -143,6 +145,10 @@ native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_nativ
 ifneq ($(protobuf_packages_),)
 native_packages += $(protobuf_native_packages)
 packages += $(protobuf_packages)
+endif
+
+ifneq ($(openssl_packages_),)
+packages += $(openssl_packages)
 endif
 
 ifneq ($(zmq_packages_),)

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,7 +1,9 @@
-packages:=boost openssl libevent gmp bls-dash backtrace cmake immer
+packages:=boost libevent gmp bls-dash backtrace cmake immer
 
 protobuf_native_packages = native_protobuf
 protobuf_packages = protobuf
+
+openssl_packages = openssl
 
 qt_packages = qrencode zlib
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -4,7 +4,10 @@ $(package)_download_path=https://download.qt.io/archive/qt/5.9/$($(package)_vers
 $(package)_suffix=opensource-src-$($(package)_version).tar.xz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=9b9dec1f67df1f94bce2955c5604de992d529dde72050239154c56352da0907d
-$(package)_dependencies=openssl zlib
+$(package)_dependencies=zlib
+ifeq ($(NO_OPENSSL),)
+$(package)_dependencies+= openssl
+endif
 $(package)_linux_dependencies=freetype fontconfig libxcb
 $(package)_qt_libs=corelib network widgets gui plugins testlib
 $(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_riscv64_arch.patch
@@ -62,7 +65,9 @@ $(package)_config_opts += -no-xinput2
 $(package)_config_opts += -nomake examples
 $(package)_config_opts += -nomake tests
 $(package)_config_opts += -opensource
+ifeq ($(NO_OPENSSL),)
 $(package)_config_opts += -openssl-linked
+endif
 $(package)_config_opts += -optimized-tools
 $(package)_config_opts += -pch
 $(package)_config_opts += -pkg-config

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -24,7 +24,9 @@
 #include <cstdlib>
 #include <memory>
 
+#ifdef ENABLE_BIP70
 #include <openssl/x509_vfy.h>
+#endif
 
 #include <QApplication>
 #include <QByteArray>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -24,7 +24,7 @@
 #include <cstdlib>
 #include <memory>
 
-#ifdef ENABLE_BIP70
+#if USE_OPENSSL
 #include <openssl/x509_vfy.h>
 #endif
 

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -16,8 +16,10 @@
 #include <test/setup_common.h>
 #include <util/strencodings.h>
 
+#if USE_OPENSSL
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
+#endif
 
 #include <QFileOpenEvent>
 #include <QTemporaryFile>

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -28,7 +28,9 @@
 #include <QObject>
 #include <QTest>
 
+#ifdef ENABLE_BIP70
 #include <openssl/ssl.h>
+#endif
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
@@ -75,7 +77,9 @@ int main(int argc, char *argv[])
     BitcoinApplication app(*node);
     app.setApplicationName("Dash-Qt-test");
 
+#ifdef ENABLE_BIP70
     SSL_library_init();
+#endif
 
     AppTests app_tests(app);
     if (QTest::qExec(&app_tests) != 0) {

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -28,7 +28,7 @@
 #include <QObject>
 #include <QTest>
 
-#ifdef ENABLE_BIP70
+#if USE_OPENSSL
 #include <openssl/ssl.h>
 #endif
 
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     BitcoinApplication app(*node);
     app.setApplicationName("Dash-Qt-test");
 
-#ifdef ENABLE_BIP70
+#if USE_OPENSSL
     SSL_library_init();
 #endif
 


### PR DESCRIPTION
When building on M1, inside of depends, you should use `make NO_PROTOBUF=1 NO_OPENSSL=1 -j8`