### PR TITLE
test: skip test properly if zmq missing

### DIFF
--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -11,10 +11,6 @@ import json
 import random
 import struct
 import time
-try:
-    import zmq
-finally:
-    pass
 
 from test_framework.test_framework import DashTestFramework
 from test_framework.mininode import P2PInterface
@@ -104,6 +100,7 @@ class DashZMQTest (DashTestFramework):
         # Check that dashd has been built with ZMQ enabled.
         config = configparser.ConfigParser()
         config.read_file(open(self.options.configfile))
+        import zmq
 
         try:
             # Setup the ZMQ subscriber socket
@@ -232,6 +229,7 @@ class DashZMQTest (DashTestFramework):
         self.unsubscribe(chain_lock_publishers)
 
     def test_instantsend_publishers(self):
+        import zmq
         instantsend_publishers = [
             ZMQPublisher.hash_tx_lock,
             ZMQPublisher.raw_tx_lock,


### PR DESCRIPTION
Not sure if this is a proper way to fix it. I discovered that `interface_zmq_dash.py` failed with an error if pyzmq wasn't installed unlike `interface_zmq.py` which simply gets skipped in that scenario as shown here:

interface_zmq.py                      | ○ Skipped | 1 s
interface_zmq_dash.py                 | ✖ Failed  | 0 s

This change moves the imports below where the check for the module occurs so the test skips instead of throwing an error. It appeared to work properly for me. Note that the bitcoin-based zmq test also has a double import of zmq although it's structured a little differently.