### PR TITLE
feat: introduce devnetVersion for devnet breaking changes; always use DGW on devnets

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -593,8 +593,8 @@ public:
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
-        consensus.nPowKGWHeight = 4001; // nPowKGWHeight >= nPowDGWHeight means "no KGW"
-        consensus.nPowDGWHeight = 4001;
+        consensus.nPowKGWHeight = 0; // nPowKGWHeight >= nPowDGWHeight means "no KGW"
+        consensus.nPowDGWHeight = 0;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -43,7 +43,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     return genesis;
 }
 
-static CBlock CreateDevNetGenesisBlock(const uint256 &prevBlockHash, const std::string& devNetName, uint32_t nTime, uint32_t nNonce, uint32_t nBits, const CAmount& genesisReward)
+static CBlock CreateDevNetGenesisBlock(const uint256 &prevBlockHash, const std::string& devNetName, int devnet_version, uint32_t nTime, uint32_t nNonce, uint32_t nBits, const CAmount& genesisReward)
 {
     assert(!devNetName.empty());
 
@@ -52,7 +52,7 @@ static CBlock CreateDevNetGenesisBlock(const uint256 &prevBlockHash, const std::
     txNew.vin.resize(1);
     txNew.vout.resize(1);
     // put height (BIP34) and devnet name into coinbase
-    txNew.vin[0].scriptSig = CScript() << 1 << std::vector<unsigned char>(devNetName.begin(), devNetName.end());
+    txNew.vin[0].scriptSig = CScript() << 1 << std::vector<unsigned char>(devNetName.begin(), devNetName.end()) << devnet_version;
     txNew.vout[0].nValue = genesisReward;
     txNew.vout[0].scriptPubKey = CScript() << OP_RETURN;
 
@@ -85,12 +85,12 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
     return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
 }
 
-static CBlock FindDevNetGenesisBlock(const CBlock &prevBlock, const CAmount& reward)
+static CBlock FindDevNetGenesisBlock(const CBlock &prevBlock, const CAmount& reward, int devnet_version)
 {
     std::string devNetName = gArgs.GetDevNetName();
     assert(!devNetName.empty());
 
-    CBlock block = CreateDevNetGenesisBlock(prevBlock.GetHash(), devNetName, prevBlock.nTime + 1, 0, prevBlock.nBits, reward);
+    CBlock block = CreateDevNetGenesisBlock(prevBlock.GetHash(), devNetName, devnet_version, prevBlock.nTime + 1, 0, prevBlock.nBits, reward);
 
     arith_uint256 bnTarget;
     bnTarget.SetCompact(block.nBits);
@@ -682,7 +682,8 @@ public:
         assert(consensus.hashGenesisBlock == uint256S("0x000008ca1832a4baf228eb1553c03d3a2c8e02399550dd6ea8d65cec3ef23d2e"));
         assert(genesis.hashMerkleRoot == uint256S("0xe0028eb9648db56b1ac77cf090b99048a8007e2bb64b68f092c03c7f56a662c7"));
 
-        devnetGenesis = FindDevNetGenesisBlock(genesis, 50 * COIN);
+        devnetVersion = 1; // This should be bumped every time there is some breaking change to devnets
+        devnetGenesis = FindDevNetGenesisBlock(genesis, /*reward=*/50 * COIN, /*devnet_version=*/devnetVersion);
         consensus.hashDevnetGenesisBlock = devnetGenesis.GetHash();
 
         vFixedSeeds.clear();

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -64,6 +64,7 @@ public:
 
     const CBlock& GenesisBlock() const { return genesis; }
     const CBlock& DevNetGenesisBlock() const { return devnetGenesis; }
+    int DevNetVersion() const { return devnetVersion; }
     /** Default value for -checkmempool and -checkblockindex argument */
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
@@ -124,6 +125,7 @@ protected:
     std::string strNetworkID;
     CBlock genesis;
     CBlock devnetGenesis;
+    int devnetVersion;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1775,7 +1775,7 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     if (chainparams.NetworkIDString() == CBaseChainParams::DEVNET) {
         // Add devnet name to user agent. This allows to disconnect nodes immediately if they don't belong to our own devnet
-        uacomments.push_back(strprintf("devnet.%s", gArgs.GetDevNetName()));
+        uacomments.push_back(strprintf("devnet.%d.%s", chainparams.DevNetVersion(), gArgs.GetDevNetName()));
     }
 
     for (const std::string& cmt : gArgs.GetArgs("-uacomment")) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2513,9 +2513,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             PushNodeVersion(pfrom, connman, GetAdjustedTime());
 
         if (Params().NetworkIDString() == CBaseChainParams::DEVNET) {
-            if (cleanSubVer.find(strprintf("devnet.%s", gArgs.GetDevNetName())) == std::string::npos) {
+            auto expected_version = strprintf("devnet.%d.%s", Params().DevNetVersion(), gArgs.GetDevNetName());
+            if (cleanSubVer.find(expected_version) == std::string::npos) {
                 LOCK(cs_main);
-                LogPrintf("connected to wrong devnet. Reported version is %s, expected devnet name is %s\n", cleanSubVer, gArgs.GetDevNetName());
+                LogPrintf("connected to wrong devnet. Reported version is %s, expected devnet name is %s\n", cleanSubVer, expected_version);
                 if (!pfrom->fInbound)
                     Misbehaving(pfrom->GetId(), 100); // don't try to connect again
                 else

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -157,10 +157,11 @@ class P2PConnection(asyncio.Protocol):
 
         if net == "devnet":
             devnet_name = "devnet1"  # see initialize_datadir()
+            devnet_version = 1
             if self.uacomment is None:
-                self.strSubVer = MY_SUBVERSION % ("(devnet.devnet-%s)" % devnet_name).encode()
+                self.strSubVer = MY_SUBVERSION % ("(devnet.%d.devnet-%s)" % (devnet_version, devnet_name)).encode()
             else:
-                self.strSubVer = MY_SUBVERSION % ("(devnet.devnet-%s,%s)" % (devnet_name, self.uacomment)).encode()
+                self.strSubVer = MY_SUBVERSION % ("(devnet.%d.devnet-%s,%s)" % (devnet_version, devnet_name, self.uacomment)).encode()
         elif self.uacomment is not None:
             self.strSubVer = MY_SUBVERSION % ("(%s)" % self.uacomment).encode()
         else:


### PR DESCRIPTION
This adds a devnetVersion to both the devnet coinbase, and to the uacomment. This allows us to introduce breaking changes to devnets that are not silent to end users. Previously we introduced a breaking change that then caused issues later because we forgot about it. Now that I want to do another breaking change, it probably makes sense to introduce this logic now.

The second bit, is a breaking change that removes the bitcoin difficulty algorithm from devnets, this is a breaking change for devnets, additionally, since this PR changes the uacomment, it may be a breaking change from the perspective of mobile clients.

fixes https://github.com/dashpay/dash/issues/4292