### PR TITLE
wallet: Fix CanGenerateKeys

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1992,8 +1992,7 @@ bool CWallet::CanGenerateKeys()
     if (IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) || IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
         return false;
     }
-    // A wallet can generate keys if it has a non-null HD chain (IsHDEnabled) or it is a non-HD wallet (pre FEATURE_HD)
-    return IsHDEnabled() || nWalletVersion < FEATURE_HD;
+    return true;
 }
 
 bool CWallet::CanGetAddresses(bool internal)


### PR DESCRIPTION
Using wallet flags should be enough here, no need for any additional conditions.

NOTE: Wallets created prior to #4627 have wallet version set to FEATURE_HD even when no HD chain was initialized, that's why they have issues without this fix.

Fixes #4699