### PR TITLE
Add function to validate DSTX message

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2362,6 +2362,56 @@ std::string RejectCodeToString(const unsigned char code)
     return "";
 }
 
+bool static ValidateDSTX(CCoinJoinBroadcastTx dstx, uint256 hashTx, bool &bReturn)
+{
+    bReturn = true;
+    if (!dstx.IsValidStructure()) {
+        LogPrint(BCLog::COINJOIN, "DSTX -- Invalid DSTX structure: %s\n", hashTx.ToString());
+        return false;
+    }
+    if(CCoinJoin::GetDSTX(hashTx)) {
+        LogPrint(BCLog::COINJOIN, "DSTX -- Already have %s, skipping...\n", hashTx.ToString());
+        return true; // not an error
+    }
+
+    const CBlockIndex* pindex{nullptr};
+    CDeterministicMNCPtr dmn{nullptr};
+    {
+        LOCK(cs_main);
+        pindex = chainActive.Tip();
+    }
+    // It could be that a MN is no longer in the list but its DSTX is not yet mined.
+    // Try to find a MN up to 24 blocks deep to make sure such dstx-es are relayed and processed correctly.
+    for (int i = 0; i < 24 && pindex; ++i) {
+        dmn = deterministicMNManager->GetListForBlock(pindex).GetMNByCollateral(dstx.masternodeOutpoint);
+        if (dmn) break;
+        pindex = pindex->pprev;
+    }
+    if(!dmn) {
+        LogPrint(BCLog::COINJOIN, "DSTX -- Can't find masternode %s to verify %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
+        return false;
+    }
+
+    if (!mmetaman.GetMetaInfo(dmn->proTxHash)->IsValidForMixingTxes()) {
+        LogPrint(BCLog::COINJOIN, "DSTX -- Masternode %s is sending too many transactions %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
+        return true;
+        // TODO: Not an error? Could it be that someone is relaying old DSTXes
+        // we have no idea about (e.g we were offline)? How to handle them?
+    }
+
+    if (!dstx.CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
+        LogPrint(BCLog::COINJOIN, "DSTX -- CheckSignature() failed for %s\n", hashTx.ToString());
+        return false;
+    }
+
+    LogPrint(BCLog::COINJOIN, "DSTX -- Got Masternode transaction %s\n", hashTx.ToString());
+    mempool.PrioritiseTransaction(hashTx, 0.1*COIN);
+    mmetaman.DisallowMixing(dmn->proTxHash);
+
+    bReturn = false;
+    return true;
+}
+
 bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, bool enable_bip61)
 {
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->GetId());
@@ -3149,49 +3199,15 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         // Process custom logic, no matter if tx will be accepted to mempool later or not
         if (nInvType == MSG_DSTX) {
-            uint256 hashTx = tx.GetHash();
-            if (!dstx.IsValidStructure()) {
-                LogPrint(BCLog::COINJOIN, "DSTX -- Invalid DSTX structure: %s\n", hashTx.ToString());
-                return false;
-            }
-            if(CCoinJoin::GetDSTX(hashTx)) {
-                LogPrint(BCLog::COINJOIN, "DSTX -- Already have %s, skipping...\n", hashTx.ToString());
-                return true; // not an error
-            }
 
-            const CBlockIndex* pindex{nullptr};
-            CDeterministicMNCPtr dmn{nullptr};
-            {
-                LOCK(cs_main);
-                pindex = ::ChainActive().Tip();
-            }
-            // It could be that a MN is no longer in the list but its DSTX is not yet mined.
-            // Try to find a MN up to 24 blocks deep to make sure such dstx-es are relayed and processed correctly.
-            for (int i = 0; i < 24 && pindex; ++i) {
-                dmn = deterministicMNManager->GetListForBlock(pindex).GetMNByCollateral(dstx.masternodeOutpoint);
-                if (dmn) break;
-                pindex = pindex->pprev;
-            }
-            if(!dmn) {
-                LogPrint(BCLog::COINJOIN, "DSTX -- Can't find masternode %s to verify %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
-                return false;
-            }
-
-            if (!mmetaman.GetMetaInfo(dmn->proTxHash)->IsValidForMixingTxes()) {
-                LogPrint(BCLog::COINJOIN, "DSTX -- Masternode %s is sending too many transactions %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
-                return true;
-                // TODO: Not an error? Could it be that someone is relaying old DSTXes
-                // we have no idea about (e.g we were offline)? How to handle them?
-            }
-
-            if (!dstx.CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
-                LogPrint(BCLog::COINJOIN, "DSTX -- CheckSignature() failed for %s\n", hashTx.ToString());
-                return false;
-            }
-
-            LogPrint(BCLog::COINJOIN, "DSTX -- Got Masternode transaction %s\n", hashTx.ToString());
-            mempool.PrioritiseTransaction(hashTx, 0.1*COIN);
-            mmetaman.DisallowMixing(dmn->proTxHash);
+           // Validate DSTX and return bRet if we need to return from here            
+           bool bDoReturn = false;
+           uint256 hashTx = tx.GetHash();
+           bool bRet = ValidateDSTX(dstx, hashTx, bDoReturn);
+           if (bDoReturn)
+           {
+               return bRet;
+           }
         }
 
         LOCK2(cs_main, g_cs_orphans);
@@ -4908,5 +4924,9 @@ public:
         mapOrphanTransactionsByPrev.clear();
         nMapOrphanTransactionsSize = 0;
     }
+<<<<<<< HEAD
 };
 static CNetProcessingCleanup instance_of_cnetprocessingcleanup;
+=======
+} instance_of_cnetprocessingcleanup;
+>>>>>>> Add function to validate DSTX message

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4924,9 +4924,5 @@ public:
         mapOrphanTransactionsByPrev.clear();
         nMapOrphanTransactionsSize = 0;
     }
-<<<<<<< HEAD
 };
 static CNetProcessingCleanup instance_of_cnetprocessingcleanup;
-=======
-} instance_of_cnetprocessingcleanup;
->>>>>>> Add function to validate DSTX message

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2378,7 +2378,7 @@ bool static ValidateDSTX(CCoinJoinBroadcastTx dstx, uint256 hashTx, bool &bRetur
     CDeterministicMNCPtr dmn{nullptr};
     {
         LOCK(cs_main);
-        pindex = chainActive.Tip();
+        pindex = ::ChainActive().Tip();
     }
     // It could be that a MN is no longer in the list but its DSTX is not yet mined.
     // Try to find a MN up to 24 blocks deep to make sure such dstx-es are relayed and processed correctly.
@@ -3204,8 +3204,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
            bool bDoReturn = false;
            uint256 hashTx = tx.GetHash();
            bool bRet = ValidateDSTX(dstx, hashTx, bDoReturn);
-           if (bDoReturn)
-           {
+           if (bDoReturn) {
                return bRet;
            }
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3200,7 +3200,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         // Process custom logic, no matter if tx will be accepted to mempool later or not
         if (nInvType == MSG_DSTX) {
 
-           // Validate DSTX and return bRet if we need to return from here            
+           // Validate DSTX and return bRet if we need to return from here
            bool bDoReturn = false;
            uint256 hashTx = tx.GetHash();
            bool bRet = ValidateDSTX(dstx, hashTx, bDoReturn);


### PR DESCRIPTION
This PR is part of addressing issue 4078 - Test DSTX validation during propogation #4078 (https://github.com/dashpay/dash/issues/4078) 

A function ValidateDSTX() has been added that essentially captures the existing code to validate a DSTX message. A unit test can be created to call this method in order for testing DSTX validation