### PR TITLE
qt: Fix Repair tab

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -858,9 +858,9 @@ void RPCConsole::buildParameterlist(QString arg)
     // Get command-line arguments and remove the application name
     QStringList args;
 
-    for (const auto& key_pair : gArgs.GetCommandLineArgs()) {
-        for (const auto& value : key_pair.second) {
-            args << QString::fromStdString(key_pair.first + "=" + value);
+    for (const auto& [key, values] : gArgs.GetCommandLineArgs()) {
+        for (const auto& value : values) {
+            args << QString::fromStdString(key + "=" + value);
         }
     }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -860,7 +860,11 @@ void RPCConsole::buildParameterlist(QString arg)
 
     for (const auto& [key, values] : gArgs.GetCommandLineArgs()) {
         for (const auto& value : values) {
-            args << QString::fromStdString(key + "=" + value);
+            if (value.empty()) {
+                args << QString::fromStdString(key);
+            } else {
+                args << QString::fromStdString(key + "=" + value);
+            }
         }
     }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -856,8 +856,13 @@ void RPCConsole::walletReindex()
 void RPCConsole::buildParameterlist(QString arg)
 {
     // Get command-line arguments and remove the application name
-    QStringList args = QApplication::arguments();
-    args.removeFirst();
+    QStringList args;
+
+    for (const auto& key_pair : gArgs.GetCommandLineArgs()) {
+        for (const auto& value : key_pair.second) {
+            args << QString::fromStdString(key_pair.first + "=" + value);
+        }
+    }
 
     // Remove existing repair-options
     args.removeAll(SALVAGEWALLET);

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -401,6 +401,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
 {
     LOCK(cs_args);
     m_override_args.clear();
+    m_command_line_args.clear();
 
     for (int i = 1; i < argc; i++) {
         std::string key(argv[i]);
@@ -438,6 +439,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
             if (!InterpretOption(key, val, flags, m_override_args, error)) {
                 return false;
             }
+            m_command_line_args[key].push_back(val);
         } else {
             error = strprintf("Invalid parameter %s", key.c_str());
             return false;
@@ -455,6 +457,12 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
         }
     }
     return true;
+}
+
+const std::map<std::string, std::vector<std::string>> ArgsManager::GetCommandLineArgs() const
+{
+    LOCK(cs_args);
+    return m_command_line_args;
 }
 
 unsigned int ArgsManager::FlagsOfKnownArg(const std::string& key) const

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -193,6 +193,7 @@ protected:
 
     mutable CCriticalSection cs_args;
     std::map<std::string, std::vector<std::string>> m_override_args GUARDED_BY(cs_args);
+    std::map<std::string, std::vector<std::string>> m_command_line_args GUARDED_BY(cs_args);
     std::map<std::string, std::vector<std::string>> m_config_args GUARDED_BY(cs_args);
     std::string m_network GUARDED_BY(cs_args);
     std::set<std::string> m_network_only_args GUARDED_BY(cs_args);
@@ -224,6 +225,11 @@ public:
      * Log warnings for unrecognized section names in the config file.
      */
     const std::list<SectionInfo> GetUnrecognizedSections() const;
+
+    /**
+     * Return the map of all the args passed via cmd line
+     */
+    const std::map<std::string, std::vector<std::string>> GetCommandLineArgs() const;
 
     /**
      * Return a vector of strings of the given argument


### PR DESCRIPTION
It was broken by https://github.com/dashpay/dash/pull/4586/commits/7b8ddda8ea784f764e8790a27d7133251aec3ac5. To reproduce the issue: open testnet wallet (via `--testnet` in cmd line), open Repair tab, click "Upgrade wallet" (the less harmful one) - wallet restarts with `-upgradewallet` but no `--testnet` so it's a mainnet wallet now.