### PR TITLE
refactor: remove some CCriticalSection for Mutex or atomic

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -611,11 +611,8 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
     CService addrLocalUnlocked = GetAddrLocal();
     stats.addrLocal = addrLocalUnlocked.IsValid() ? addrLocalUnlocked.ToString() : "";
 
-    {
-        LOCK(cs_mnauth);
-        X(verifiedProRegTxHash);
-        X(verifiedPubKeyHash);
-    }
+    X(verifiedProRegTxHash);
+    X(verifiedPubKeyHash);
     X(m_masternode_connection);
 }
 #undef X

--- a/src/net.h
+++ b/src/net.h
@@ -1105,11 +1105,10 @@ private:
     mutable CCriticalSection cs_addrLocal;
 
     // Challenge sent in VERSION to be answered with MNAUTH (only happens between MNs)
-    mutable CCriticalSection cs_mnauth;
-    uint256 sentMNAuthChallenge GUARDED_BY(cs_mnauth);
-    uint256 receivedMNAuthChallenge GUARDED_BY(cs_mnauth);
-    uint256 verifiedProRegTxHash GUARDED_BY(cs_mnauth);
-    uint256 verifiedPubKeyHash GUARDED_BY(cs_mnauth);
+    std::atomic<uint256> sentMNAuthChallenge;
+    std::atomic<uint256> receivedMNAuthChallenge;
+    std::atomic<uint256> verifiedProRegTxHash;
+    std::atomic<uint256> verifiedPubKeyHash;
 
 public:
 
@@ -1246,42 +1245,34 @@ public:
     bool CanRelay() const { return !m_masternode_connection || m_masternode_iqr_connection; }
 
     uint256 GetSentMNAuthChallenge() const {
-        LOCK(cs_mnauth);
         return sentMNAuthChallenge;
     }
 
     uint256 GetReceivedMNAuthChallenge() const {
-        LOCK(cs_mnauth);
         return receivedMNAuthChallenge;
     }
 
     uint256 GetVerifiedProRegTxHash() const {
-        LOCK(cs_mnauth);
         return verifiedProRegTxHash;
     }
 
     uint256 GetVerifiedPubKeyHash() const {
-        LOCK(cs_mnauth);
         return verifiedPubKeyHash;
     }
 
     void SetSentMNAuthChallenge(const uint256& newSentMNAuthChallenge) {
-        LOCK(cs_mnauth);
         sentMNAuthChallenge = newSentMNAuthChallenge;
     }
 
     void SetReceivedMNAuthChallenge(const uint256& newReceivedMNAuthChallenge) {
-        LOCK(cs_mnauth);
         receivedMNAuthChallenge = newReceivedMNAuthChallenge;
     }
 
     void SetVerifiedProRegTxHash(const uint256& newVerifiedProRegTxHash) {
-        LOCK(cs_mnauth);
         verifiedProRegTxHash = newVerifiedProRegTxHash;
     }
 
     void SetVerifiedPubKeyHash(const uint256& newVerifiedPubKeyHash) {
-        LOCK(cs_mnauth);
         verifiedPubKeyHash = newVerifiedPubKeyHash;
     }
 };


### PR DESCRIPTION
When possible we should use Mutex instead of CCriticalSection (it is faster / more efficient to acquire)