### PR TITLE
fuzz: repair broken tests, correct mistakes, add ci build to detect these earlier

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -257,6 +257,13 @@ linux64_cxx20-build:
   variables:
     BUILD_TARGET: linux64_cxx20
 
+linux64_fuzz-build:
+  extends: .build-template
+  needs:
+    - x86_64-unknown-linux-gnu-debug
+  variables:
+    BUILD_TARGET: linux64_fuzz
+
 linux64_tsan-build:
   extends:
     - .build-template

--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -37,6 +37,7 @@ export RUN_INTEGRATIONTESTS=true
 
 # Configure sanitizers options
 export TSAN_OPTIONS="suppressions=${SRC_DIR}/test/sanitizer_suppressions/tsan"
+export UBSAN_OPTIONS="suppressions=${SRC_DIR}/test/sanitizer_suppressions/ubsan"
 
 if [ "$BUILD_TARGET" = "arm-linux" ]; then
   export HOST=arm-linux-gnueabihf

--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -75,6 +75,14 @@ elif [ "$BUILD_TARGET" = "linux64_tsan" ]; then
   export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --with-sanitizers=thread"
   export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG"
   export PYZMQ=true
+elif [ "$BUILD_TARGET" = "linux64_fuzz" ]; then
+  export HOST=x86_64-unknown-linux-gnu
+  export DEP_OPTS="NO_UPNP=1 DEBUG=1"
+  export BITCOIN_CONFIG="--enable-zmq --disable-ccache --enable-fuzz --with-sanitizers=fuzzer,address,undefined CC=clang CXX=clang++"
+  export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG"
+  export PYZMQ=true
+  export RUN_UNITTESTS=false
+  export RUN_INTEGRATIONTESTS=false
 elif [ "$BUILD_TARGET" = "linux64_cxx20" ]; then
   export HOST=x86_64-unknown-linux-gnu
   export DEP_OPTS="NO_UPNP=1 DEBUG=1"

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install $APT_ARGS \
     bsdmainutils \
     curl \
     ccache \
+    clang \
     cmake \
     git \
     g++ \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -109,7 +109,7 @@ FUZZ_SUITE_LD_COMMON = \
  $(CRYPTO_LIBS) \
  $(EVENT_PTHREADS_LIBS) \
  $(BLS_LIBS) \
- $(GMP_LIBS \
+ $(GMP_LIBS) \
  $(BACKTRACE_LIB)
 
 # test_dash binary #

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -36,13 +36,13 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         return;
     }
     const Consensus::Params& consensus_params = Params().GetConsensus();
-    BlockValidationState validation_state_pow_and_merkle;
+    CValidationState validation_state_pow_and_merkle;
     const bool valid_incl_pow_and_merkle = CheckBlock(block, validation_state_pow_and_merkle, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ true);
-    BlockValidationState validation_state_pow;
+    CValidationState validation_state_pow;
     const bool valid_incl_pow = CheckBlock(block, validation_state_pow, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ false);
-    BlockValidationState validation_state_merkle;
+    CValidationState validation_state_merkle;
     const bool valid_incl_merkle = CheckBlock(block, validation_state_merkle, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ true);
-    BlockValidationState validation_state_none;
+    CValidationState validation_state_none;
     const bool valid_incl_none = CheckBlock(block, validation_state_none, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ false);
     if (valid_incl_pow_and_merkle) {
         assert(valid_incl_pow && valid_incl_merkle && valid_incl_none);
@@ -52,12 +52,5 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     (void)block.GetHash();
     (void)block.ToString();
     (void)BlockMerkleRoot(block);
-    if (!block.vtx.empty()) {
-        // TODO: Avoid array index out of bounds error in BlockWitnessMerkleRoot
-        //       when block.vtx.empty().
-        (void)BlockWitnessMerkleRoot(block);
-    }
-    (void)GetBlockWeight(block);
-    (void)GetWitnessCommitmentIndex(block);
     (void)RecursiveDynamicUsage(block);
 }

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -19,6 +19,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     FlatSigningProvider signing_provider;
     std::string error;
     for (const bool require_checksum : {true, false}) {
-        Parse(descriptor, signing_provider);
+        Parse(descriptor, signing_provider, error);
     }
 }

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -13,6 +13,7 @@
 #include <key.h>
 #include <merkleblock.h>
 #include <net.h>
+#include <netbase.h>
 #include <primitives/block.h>
 #include <protocol.h>
 #include <psbt.h>
@@ -42,9 +43,9 @@ struct invalid_fuzzing_input_exception : public std::exception {
 };
 
 template <typename T>
-CDataStream Serialize(const T& obj)
+CDataStream Serialize(const T& obj, const int version = INIT_PROTO_VERSION)
 {
-    CDataStream ds(SER_NETWORK, INIT_PROTO_VERSION);
+    CDataStream ds(SER_NETWORK, version);
     ds << obj;
     return ds;
 }
@@ -77,9 +78,9 @@ void DeserializeFromFuzzingInput(const std::vector<uint8_t>& buffer, T& obj)
 }
 
 template <typename T>
-void AssertEqualAfterSerializeDeserialize(const T& obj)
+void AssertEqualAfterSerializeDeserialize(const T& obj, const int version = INIT_PROTO_VERSION)
 {
-    assert(Deserialize<T>(Serialize(obj)) == obj);
+    assert(Deserialize<T>(Serialize(obj, version)) == obj);
 }
 
 } // namespace
@@ -181,7 +182,10 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 #elif NETADDR_DESERIALIZE
         CNetAddr na;
         DeserializeFromFuzzingInput(buffer, na);
-        AssertEqualAfterSerializeDeserialize(na);
+        if (na.IsAddrV1Compatible()) {
+            AssertEqualAfterSerializeDeserialize(na);
+        }
+        AssertEqualAfterSerializeDeserialize(na, INIT_PROTO_VERSION | ADDRV2_FORMAT);
 #elif SERVICE_DESERIALIZE
         CService s;
         DeserializeFromFuzzingInput(buffer, s);

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -30,7 +30,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         }
     }();
     const CScript script(script_bytes.begin(), script_bytes.end());
-    for (const auto sig_version : {SigVersion::BASE, SigVersion::WITNESS_V0}) {
+    for (const auto sig_version : {SigVersion::BASE}) {
         std::vector<std::vector<unsigned char>> stack;
         (void)EvalScript(stack, script, flags, BaseSignatureChecker(), sig_version, nullptr);
     }

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -31,6 +31,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 
     try {
         const CTransaction tx(deserialize, ds);
+        const PrecomputedTransactionData txdata(tx);
 
         unsigned int verify_flags;
         ds >> verify_flags;
@@ -40,7 +41,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         unsigned int fuzzed_flags;
         ds >> fuzzed_flags;
 
-        std::vector<CTxOut> spent_outputs;
         for (unsigned i = 0; i < tx.vin.size(); ++i) {
             CTxOut prevout;
             ds >> prevout;
@@ -48,13 +48,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                 // prevouts should be consensus-valid
                 prevout.nValue = 1;
             }
-            spent_outputs.push_back(prevout);
-        }
-        PrecomputedTransactionData txdata;
-        txdata.Init(tx, std::move(spent_outputs));
 
-        for (unsigned i = 0; i < tx.vin.size(); ++i) {
-            const CTxOut& prevout = txdata.m_spent_outputs.at(i);
             const TransactionSignatureChecker checker{&tx, i, prevout.nValue, txdata};
 
             ScriptError serror;

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <coins.h>
+#include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <core_io.h>

--- a/src/test/fuzz/tx_in.cpp
+++ b/src/test/fuzz/tx_in.cpp
@@ -25,8 +25,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         return;
     }
 
-    (void)GetTransactionInputWeight(tx_in);
-    (void)GetVirtualTransactionInputSize(tx_in);
     (void)RecursiveDynamicUsage(tx_in);
 
     (void)tx_in.ToString();

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -32,3 +32,4 @@ unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
 vptr:fs.cpp
+vptr:bls/bls.h


### PR DESCRIPTION
### Additional Notes

The fuzzing system has been more-or-less been a relatively unmaintained and untested portion of Dash Core, this PR aims to resolve that. As fuzzing targets haven't been tested with CI, malformed build files and code make their way into the codebase.

The following is implemented in this PR:

* Fixes for broken fuzzing harnesses and malformed backports
* Introduction of a fuzzing CI build to ensure that code is validated before merge
* Introduction of `clang` into the Dash CI Docker image (needed for fuzzing) 
* Definition of formerly missing `UBSAN_OPTIONS` environment variable, addition of header to exemption list to mitigate build error. See below.

```
bls/bls.h:103:11: runtime error: downcast of address 0xff99c0c8 which does not point to an object of type 'CBLSSecretKey'
0xff99c0c8: note: object is of type 'CBLSWrapper<bls::PrivateKey, 32u, CBLSSecretKey>'
 74 f5 21 f7  b8 54 1f 60 01 b0 1f f7  08 ec ce f6 00 f5 21 f7  00 00 00 00 00 00 00 00  00 00 00 00
              ^~~~~~~~~~~
              vptr for 'CBLSWrapper<bls::PrivateKey, 32u, CBLSSecretKey>'
    #0 0x5a6ceee7 in CBLSWrapper<bls::PrivateKey, 32u, CBLSSecretKey>::Reset() bls/bls.h:103
    #1 0x5a6ceee7 in CBLSWrapper<bls::PrivateKey, 32u, CBLSSecretKey>::SetByteVector(std::vector<unsigned char, std::allocator<unsigned char> > const&) bls/bls.h:114
    #2 0x5a6ceee7 in CBLSWrapper<bls::PrivateKey, 32u, CBLSSecretKey>::CBLSWrapper(std::vector<unsigned char, std::allocator<unsigned char> > const&, bool) bls/bls.h:64
    #3 0x5a6ceee7 in CBLSSecretKey::CBLSWrapper(std::vector<unsigned char, std::allocator<unsigned char> > const&, bool) bls/bls.h:235
    #4 0x5a6ceee7 in evo_simplifiedmns_tests::simplifiedmns_merkleroots::test_method() test/evo_simplifiedmns_tests.cpp:29
    #5 0x5a6d1ed9 in simplifiedmns_merkleroots_invoker test/evo_simplifiedmns_tests.cpp:15
    #6 0x5f8120a5 in boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x92a50a5)
    #7 0x5f81054b in boost::execution_monitor::catch_signals(boost::function<int ()> const&) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x92a354b)
    #8 0x5f8105f0 in boost::execution_monitor::execute(boost::function<int ()> const&) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x92a35f0)
    #9 0x5f8106de in boost::execution_monitor::vexecute(boost::function<void ()> const&) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x92a36de)
    #10 0x5f7d57c8 in boost::unit_test::unit_test_monitor_t::execute_and_translate(boost::function<void ()> const&, unsigned long) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x92687c8)
    #11 0x5f7b639e in boost::unit_test::framework::state::execute_test_tree(unsigned long, unsigned long, boost::unit_test::framework::state::random_generator_helper const*) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x924939e)
    #12 0x5f7b6861 in boost::unit_test::framework::state::execute_test_tree(unsigned long, unsigned long, boost::unit_test::framework::state::random_generator_helper const*) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x9249861)
    #13 0x5f7b6861 in boost::unit_test::framework::state::execute_test_tree(unsigned long, unsigned long, boost::unit_test::framework::state::random_generator_helper const*) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x9249861)
    #14 0x5f7accad in boost::unit_test::framework::run(unsigned long, bool) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x923fcad)
    #15 0x5f7d369c in boost::unit_test::unit_test_main(boost::unit_test::test_suite* (*)(int, char**), int, char**) (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x926669c)
    #16 0x59bdef44 in main (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x3671f44)
    #17 0xf6fa2ee4 in __libc_start_main (/lib/i386-linux-gnu/libc.so.6+0x1aee4)
    #18 0x59be03b4 in _start (/builds/dashpay/dash/build-ci/dashcore-linux32_ubsan/src/test/test_dash+0x36733b4)
```