### PR TITLE
Merge #18533: scripted-diff: Replace strCommand with msg_type

### DIFF
--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -123,7 +123,7 @@ public:
     {
     }
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
 
     void UnlockCoins();
 
@@ -151,7 +151,7 @@ public:
 class CCoinJoinClientQueueManager : public CCoinJoinBaseManager
 {
 public:
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
 
     void DoMaintenance();
 };
@@ -195,7 +195,7 @@ public:
     explicit CCoinJoinClientManager(CWallet& wallet) :
         mixingWallet(wallet) {}
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
 
     bool StartMixing();
     void StopMixing();

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -26,26 +26,26 @@
 CCoinJoinServer coinJoinServer;
 constexpr static CAmount DEFAULT_MAX_RAW_TX_FEE{COIN / 10};
 
-void CCoinJoinServer::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
     if (!fMasternodeMode) return;
     if (!masternodeSync.IsBlockchainSynced()) return;
 
-    if (strCommand == NetMsgType::DSACCEPT) {
-        ProcessDSACCEPT(pfrom, strCommand, vRecv, connman, enable_bip61);
+    if (msg_type == NetMsgType::DSACCEPT) {
+        ProcessDSACCEPT(pfrom, msg_type, vRecv, connman, enable_bip61);
         return;
-    } else if (strCommand == NetMsgType::DSQUEUE) {
-        ProcessDSQUEUE(pfrom, strCommand, vRecv, connman, enable_bip61);
+    } else if (msg_type == NetMsgType::DSQUEUE) {
+        ProcessDSQUEUE(pfrom, msg_type, vRecv, connman, enable_bip61);
         return;
-    } else if (strCommand == NetMsgType::DSVIN) {
-        ProcessDSVIN(pfrom, strCommand, vRecv, connman, enable_bip61);
+    } else if (msg_type == NetMsgType::DSVIN) {
+        ProcessDSVIN(pfrom, msg_type, vRecv, connman, enable_bip61);
         return;
-    } else if (strCommand == NetMsgType::DSSIGNFINALTX) {
-        ProcessDSSIGNFINALTX(pfrom, strCommand, vRecv, connman, enable_bip61);
+    } else if (msg_type == NetMsgType::DSSIGNFINALTX) {
+        ProcessDSSIGNFINALTX(pfrom, msg_type, vRecv, connman, enable_bip61);
     }
 }
 
-void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
     if (IsSessionReady()) {
         // too many users in this session already, reject new ones
@@ -110,7 +110,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& strComman
     }
 }
 
-void CCoinJoinServer::ProcessDSQUEUE(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessDSQUEUE(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
     CCoinJoinQueue dsq;
     vRecv >> dsq;
@@ -166,7 +166,7 @@ void CCoinJoinServer::ProcessDSQUEUE(CNode* pfrom, const std::string& strCommand
     }
 }
 
-void CCoinJoinServer::ProcessDSVIN(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessDSVIN(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
     //do we have enough users in the current session?
     if (!IsSessionReady()) {
@@ -192,7 +192,7 @@ void CCoinJoinServer::ProcessDSVIN(CNode* pfrom, const std::string& strCommand, 
     }
 }
 
-void CCoinJoinServer::ProcessDSSIGNFINALTX(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessDSSIGNFINALTX(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
     std::vector<CTxIn> vecTxIn;
     vRecv >> vecTxIn;

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -64,10 +64,10 @@ private:
     void RelayStatus(PoolStatusUpdate nStatusUpdate, CConnman& connman, PoolMessage nMessageID = MSG_NOERR);
     void RelayCompletedTransaction(PoolMessage nMessageID, CConnman& connman);
 
-    void ProcessDSACCEPT(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
-    void ProcessDSQUEUE(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
-    void ProcessDSVIN(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
-    void ProcessDSSIGNFINALTX(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessDSACCEPT(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessDSQUEUE(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessDSVIN(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessDSSIGNFINALTX(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
 
     void SetNull();
 
@@ -76,7 +76,7 @@ public:
         vecSessionCollaterals(),
         fUnitTest(false) {}
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
 
     bool HasTimedOut() const;
     void CheckTimeout(CConnman& connman);

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -53,9 +53,9 @@ void CMNAuth::PushMNAUTH(CNode* pnode, CConnman& connman)
     connman.PushMessage(pnode, CNetMsgMaker(pnode->GetSendVersion()).Make(NetMsgType::MNAUTH, mnauth));
 }
 
-void CMNAuth::ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman& connman)
+void CMNAuth::ProcessMessage(CNode* pnode, const std::string& msg_type, CDataStream& vRecv, CConnman& connman)
 {
-    if (strCommand != NetMsgType::MNAUTH || !masternodeSync.IsBlockchainSynced()) {
+    if (msg_type != NetMsgType::MNAUTH || !masternodeSync.IsBlockchainSynced()) {
         // we can't verify MNAUTH messages when we don't have the latest MN list
         return;
     }

--- a/src/evo/mnauth.h
+++ b/src/evo/mnauth.h
@@ -45,7 +45,7 @@ public:
     }
 
     static void PushMNAUTH(CNode* pnode, CConnman& connman);
-    static void ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
+    static void ProcessMessage(CNode* pnode, const std::string& msg_type, CDataStream& vRecv, CConnman& connman);
     static void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff);
 };
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -86,13 +86,13 @@ bool CGovernanceManager::SerializeVoteForHash(const uint256& nHash, CDataStream&
     return cmapVoteToObject.Get(nHash, pGovobj) && pGovobj->GetVoteFile().SerializeVoteToStream(nHash, ss);
 }
 
-void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
     if (fDisableGovernance) return;
     if (!masternodeSync.IsBlockchainSynced()) return;
 
     // ANOTHER USER IS ASKING US TO HELP THEM SYNC GOVERNANCE OBJECT DATA
-    if (strCommand == NetMsgType::MNGOVERNANCESYNC) {
+    if (msg_type == NetMsgType::MNGOVERNANCESYNC) {
         // Ignore such requests until we are fully synced.
         // We could start processing this after masternode list is synced
         // but this is a heavy one so it's better to finish sync first.
@@ -115,7 +115,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
     }
 
     // A NEW GOVERNANCE OBJECT HAS ARRIVED
-    else if (strCommand == NetMsgType::MNGOVERNANCEOBJECT) {
+    else if (msg_type == NetMsgType::MNGOVERNANCEOBJECT) {
         // MAKE SURE WE HAVE A VALID REFERENCE TO THE TIP BEFORE CONTINUING
 
         CGovernanceObject govobj;
@@ -184,7 +184,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
     }
 
     // A NEW GOVERNANCE OBJECT VOTE HAS ARRIVED
-    else if (strCommand == NetMsgType::MNGOVERNANCEOBJECTVOTE) {
+    else if (msg_type == NetMsgType::MNGOVERNANCEOBJECTVOTE) {
         CGovernanceVote vote;
         vRecv >> vote;
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -232,7 +232,7 @@ public:
     void SyncSingleObjVotes(CNode* pnode, const uint256& nProp, const CBloomFilter& filter, CConnman& connman);
     void SyncObjects(CNode* pnode, CConnman& connman) const;
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
 
     void DoMaintenance(CConnman& connman);
 

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -39,9 +39,9 @@ CQuorumBlockProcessor::CQuorumBlockProcessor(CEvoDB &_evoDb) :
     CLLMQUtils::InitQuorumsCache(mapHasMinedCommitmentCache);
 }
 
-void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
+void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
-    if (strCommand == NetMsgType::QFCOMMITMENT) {
+    if (msg_type == NetMsgType::QFCOMMITMENT) {
         CFinalCommitment qc;
         vRecv >> qc;
 

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -46,7 +46,7 @@ public:
 
     bool UpgradeDB();
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv);
 
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -77,13 +77,13 @@ CChainLockSig CChainLocksHandler::GetBestChainLock() const
     return bestChainLock;
 }
 
-void CChainLocksHandler::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
+void CChainLocksHandler::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
     if (!AreChainLocksEnabled()) {
         return;
     }
 
-    if (strCommand == NetMsgType::CLSIG) {
+    if (msg_type == NetMsgType::CLSIG) {
         CChainLockSig clsig;
         vRecv >> clsig;
 

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -76,7 +76,7 @@ public:
     bool GetChainLockByHash(const uint256& hash, CChainLockSig& ret) const;
     CChainLockSig GetBestChainLock() const;
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv);
     void ProcessNewChainLock(NodeId from, const CChainLockSig& clsig, const uint256& hash);
     void AcceptedBlockHeader(const CBlockIndex* pindexNew);
     void UpdatedBlockTip();

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -106,16 +106,16 @@ void CDKGSessionHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
              params.name, quorumIndex, currentHeight, pQuorumBaseBlockIndex->nHeight, int(oldPhase), int(phase));
 }
 
-void CDKGSessionHandler::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
+void CDKGSessionHandler::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
     // We don't handle messages in the calling thread as deserialization/processing of these would block everything
-    if (strCommand == NetMsgType::QCONTRIB) {
+    if (msg_type == NetMsgType::QCONTRIB) {
         pendingContributions.PushPendingMessage(pfrom->GetId(), vRecv);
-    } else if (strCommand == NetMsgType::QCOMPLAINT) {
+    } else if (msg_type == NetMsgType::QCOMPLAINT) {
         pendingComplaints.PushPendingMessage(pfrom->GetId(), vRecv);
-    } else if (strCommand == NetMsgType::QJUSTIFICATION) {
+    } else if (msg_type == NetMsgType::QJUSTIFICATION) {
         pendingJustifications.PushPendingMessage(pfrom->GetId(), vRecv);
-    } else if (strCommand == NetMsgType::QPCOMMITMENT) {
+    } else if (msg_type == NetMsgType::QPCOMMITMENT) {
         pendingPrematureCommitments.PushPendingMessage(pfrom->GetId(), vRecv);
     }
 }

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -145,7 +145,7 @@ public:
     ~CDKGSessionHandler() = default;
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew);
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv);
 
     void StartThread();
     void StopThread();

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -158,7 +158,7 @@ void CDKGSessionManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fIni
     }
 }
 
-void CDKGSessionManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
+void CDKGSessionManager::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
     static Mutex cs_indexedQuorumsCache;
     static std::map<Consensus::LLMQType, unordered_lru_cache<uint256, int, StaticSaltedHasher>> indexedQuorumsCache GUARDED_BY(cs_indexedQuorumsCache);
@@ -166,15 +166,15 @@ void CDKGSessionManager::ProcessMessage(CNode* pfrom, const std::string& strComm
     if (!IsQuorumDKGEnabled())
         return;
 
-    if (strCommand != NetMsgType::QCONTRIB
-        && strCommand != NetMsgType::QCOMPLAINT
-        && strCommand != NetMsgType::QJUSTIFICATION
-        && strCommand != NetMsgType::QPCOMMITMENT
-        && strCommand != NetMsgType::QWATCH) {
+    if (msg_type != NetMsgType::QCONTRIB
+        && msg_type != NetMsgType::QCOMPLAINT
+        && msg_type != NetMsgType::QJUSTIFICATION
+        && msg_type != NetMsgType::QPCOMMITMENT
+        && msg_type != NetMsgType::QWATCH) {
         return;
     }
 
-    if (strCommand == NetMsgType::QWATCH) {
+    if (msg_type == NetMsgType::QWATCH) {
         pfrom->qwatch = true;
         return;
     }
@@ -250,7 +250,7 @@ void CDKGSessionManager::ProcessMessage(CNode* pfrom, const std::string& strComm
 
     assert(quorumIndex != -1);
     WITH_LOCK(cs_indexedQuorumsCache, indexedQuorumsCache[llmqType].insert(quorumHash, quorumIndex));
-    dkgSessionHandlers.at(std::make_pair(llmqType, quorumIndex)).ProcessMessage(pfrom, strCommand, vRecv);
+    dkgSessionHandlers.at(std::make_pair(llmqType, quorumIndex)).ProcessMessage(pfrom, msg_type, vRecv);
 }
 
 bool CDKGSessionManager::AlreadyHave(const CInv& inv) const

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -55,7 +55,7 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload);
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv);
     bool AlreadyHave(const CInv& inv) const;
     bool GetContribution(const uint256& hash, CDKGContribution& ret) const;
     bool GetComplaint(const uint256& hash, CDKGComplaint& ret) const;

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -769,14 +769,14 @@ void CInstantSendManager::HandleNewInstantSendLockRecoveredSig(const llmq::CReco
     pendingInstantSendLocks.emplace(hash, std::make_pair(-1, islock));
 }
 
-void CInstantSendManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
+void CInstantSendManager::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
     if (!IsInstantSendEnabled()) {
         return;
     }
 
-    if (strCommand == NetMsgType::ISLOCK || strCommand == NetMsgType::ISDLOCK) {
-        const auto islock_version = strCommand == NetMsgType::ISLOCK ? CInstantSendLock::islock_version : CInstantSendLock::isdlock_version;
+    if (msg_type == NetMsgType::ISLOCK || msg_type == NetMsgType::ISDLOCK) {
+        const auto islock_version = msg_type == NetMsgType::ISLOCK ? CInstantSendLock::islock_version : CInstantSendLock::isdlock_version;
         const auto islock = std::make_shared<CInstantSendLock>(islock_version);
         vRecv >> *islock;
         ProcessMessageInstantSendLock(pfrom, islock);

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -262,7 +262,7 @@ public:
 
     void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) override;
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv);
 
     void TransactionAddedToMempool(const CTransactionRef& tx);
     void TransactionRemovedFromMempool(const CTransactionRef& tx);

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -528,18 +528,18 @@ size_t CQuorumManager::GetQuorumRecoveryStartOffset(const CQuorumCPtr pQuorum, c
     return nIndex % pQuorum->qc->validMembers.size();
 }
 
-void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand, CDataStream& vRecv)
+void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& msg_type, CDataStream& vRecv)
 {
     auto strFunc = __func__;
     auto errorHandler = [&](const std::string& strError, int nScore = 10) {
-        LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- %s: %s, from peer=%d\n", strFunc, strCommand, strError, pFrom->GetId());
+        LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- %s: %s, from peer=%d\n", strFunc, msg_type, strError, pFrom->GetId());
         if (nScore > 0) {
             LOCK(cs_main);
             Misbehaving(pFrom->GetId(), nScore);
         }
     };
 
-    if (strCommand == NetMsgType::QGETDATA) {
+    if (msg_type == NetMsgType::QGETDATA) {
 
         if (!fMasternodeMode || pFrom == nullptr || (pFrom->GetVerifiedProRegTxHash().IsNull() && !pFrom->qwatch)) {
             errorHandler("Not a verified masternode or a qwatch connection");
@@ -620,7 +620,7 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& strCommand,
         return;
     }
 
-    if (strCommand == NetMsgType::QDATA) {
+    if (msg_type == NetMsgType::QDATA) {
         if ((!fMasternodeMode && !CLLMQUtils::IsWatchQuorumsEnabled()) || pFrom == nullptr || (pFrom->GetVerifiedProRegTxHash().IsNull() && !pFrom->qwatch)) {
             errorHandler("Not a verified masternode or a qwatch connection");
             return;

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -209,7 +209,7 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload) const;
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv);
 
     static bool HasQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash);
 

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -568,9 +568,9 @@ bool CSigningManager::GetRecoveredSigForGetData(const uint256& hash, CRecoveredS
     return true;
 }
 
-void CSigningManager::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
+void CSigningManager::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
-    if (strCommand == NetMsgType::QSIGREC) {
+    if (msg_type == NetMsgType::QSIGREC) {
         auto recoveredSig = std::make_shared<CRecoveredSig>();
         vRecv >> *recoveredSig;
         ProcessMessageRecoveredSig(pfrom, recoveredSig);

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -154,7 +154,7 @@ public:
     bool AlreadyHave(const CInv& inv) const;
     bool GetRecoveredSigForGetData(const uint256& hash, CRecoveredSig& ret) const;
 
-    void ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv);
+    void ProcessMessage(CNode* pnode, const std::string& msg_type, CDataStream& vRecv);
 
     // This is called when a recovered signature was was reconstructed from another P2P message and is known to be valid
     // This is the case for example when a signature appears as part of InstantSend or ChainLocks

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -221,14 +221,14 @@ void CSigSharesManager::InterruptWorkerThread()
     workInterrupt();
 }
 
-void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
+void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
     // non-masternodes are not interested in sigshares
     if (!fMasternodeMode || WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) {
         return;
     }
 
-    if (sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && strCommand == NetMsgType::QSIGSHARE) {
+    if (sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && msg_type == NetMsgType::QSIGSHARE) {
         std::vector<CSigShare> receivedSigShares;
         vRecv >> receivedSigShares;
 
@@ -243,7 +243,7 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
         }
     }
 
-    if (strCommand == NetMsgType::QSIGSESANN) {
+    if (msg_type == NetMsgType::QSIGSESANN) {
         std::vector<CSigSesAnn> msgs;
         vRecv >> msgs;
         if (msgs.size() > MAX_MSGS_CNT_QSIGSESANN) {
@@ -256,7 +256,7 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
             BanNode(pfrom->GetId());
             return;
         }
-    } else if (strCommand == NetMsgType::QSIGSHARESINV) {
+    } else if (msg_type == NetMsgType::QSIGSHARESINV) {
         std::vector<CSigSharesInv> msgs;
         vRecv >> msgs;
         if (msgs.size() > MAX_MSGS_CNT_QSIGSHARESINV) {
@@ -269,7 +269,7 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
             BanNode(pfrom->GetId());
             return;
         }
-    } else if (strCommand == NetMsgType::QGETSIGSHARES) {
+    } else if (msg_type == NetMsgType::QGETSIGSHARES) {
         std::vector<CSigSharesInv> msgs;
         vRecv >> msgs;
         if (msgs.size() > MAX_MSGS_CNT_QGETSIGSHARES) {
@@ -282,7 +282,7 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
             BanNode(pfrom->GetId());
             return;
         }
-    } else if (strCommand == NetMsgType::QBSIGSHARES) {
+    } else if (msg_type == NetMsgType::QBSIGSHARES) {
         std::vector<CBatchedSigShares> msgs;
         vRecv >> msgs;
         size_t totalSigsCount = 0;

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -390,7 +390,7 @@ public:
     void UnregisterAsRecoveredSigsListener();
     void InterruptWorkerThread();
 
-    void ProcessMessage(const CNode* pnode, const std::string& strCommand, CDataStream& vRecv);
+    void ProcessMessage(const CNode* pnode, const std::string& msg_type, CDataStream& vRecv);
 
     void AsyncSign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
     CSigShare CreateSigShare(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash) const;

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -95,9 +95,9 @@ std::string CMasternodeSync::GetSyncStatus() const
     }
 }
 
-void CMasternodeSync::ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv) const
+void CMasternodeSync::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv) const
 {
-    if (strCommand == NetMsgType::SYNCSTATUSCOUNT) { //Sync status count
+    if (msg_type == NetMsgType::SYNCSTATUSCOUNT) { //Sync status count
 
         //do not care about stats if sync process finished
         if (IsSynced()) return;

--- a/src/masternode/sync.h
+++ b/src/masternode/sync.h
@@ -65,7 +65,7 @@ public:
     void Reset(bool fForce = false, bool fNotifyReset = true);
     void SwitchToNextAsset(CConnman& connman);
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv) const;
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv) const;
     void ProcessTick(CConnman& connman);
 
     void AcceptedBlockHeader(const CBlockIndex *pindexNew);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1873,12 +1873,12 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
         //   nUnconnectingHeaders gets reset back to 0.
         if (!LookupBlockIndex(headers[0].hashPrevBlock) && nCount < MAX_BLOCKS_TO_ANNOUNCE) {
             nodestate->nUnconnectingHeaders++;
-            std::string strCommand = (pfrom->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
-            connman->PushMessage(pfrom, msgMaker.Make(strCommand, ::ChainActive().GetLocator(pindexBestHeader), uint256()));
+            std::string msg_type = (pfrom->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
+            connman->PushMessage(pfrom, msgMaker.Make(msg_type, ::ChainActive().GetLocator(pindexBestHeader), uint256()));
             LogPrint(BCLog::NET, "received header %s: missing prev block %s, sending %s (%d) to end (peer=%d, nUnconnectingHeaders=%d)\n",
                     headers[0].GetHash().ToString(),
                     headers[0].hashPrevBlock.ToString(),
-                    strCommand,
+                    msg_type,
                     pindexBestHeader->nHeight,
                     pfrom->GetId(), nodestate->nUnconnectingHeaders);
             // Set hashLastUnknownBlock for this peer, so that if we
@@ -1980,9 +1980,9 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of ::ChainActive().Tip or pindexBestHeader, continue
             // from there instead.
-            std::string strCommand = (pfrom->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
-            LogPrint(BCLog::NET, "more %s (%d) to end to peer=%d (startheight:%d)\n", strCommand, pindexLast->nHeight, pfrom->GetId(), pfrom->nStartingHeight);
-            connman->PushMessage(pfrom, msgMaker.Make(strCommand, ::ChainActive().GetLocator(pindexLast), uint256()));
+            std::string msg_type = (pfrom->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
+            LogPrint(BCLog::NET, "more %s (%d) to end to peer=%d (startheight:%d)\n", msg_type, pindexLast->nHeight, pfrom->GetId(), pfrom->nStartingHeight);
+            connman->PushMessage(pfrom, msgMaker.Make(msg_type, ::ChainActive().GetLocator(pindexLast), uint256()));
         }
 
         bool fCanDirectFetch = CanDirectFetch(chainparams.GetConsensus());
@@ -2411,10 +2411,10 @@ std::pair<bool /*ret*/, bool /*do_return*/> static ValidateDSTX(CCoinJoinBroadca
     return {true, false};
 }
 
-bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, bool enable_bip61)
+bool static ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, bool enable_bip61)
 {
-    LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->GetId());
-    statsClient.inc("message.received." + SanitizeString(strCommand), 1.0f);
+    LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(msg_type), vRecv.size(), pfrom->GetId());
+    statsClient.inc("message.received." + SanitizeString(msg_type), 1.0f);
 
     if (gArgs.IsArgSet("-dropmessagestest") && GetRand(gArgs.GetArg("-dropmessagestest", 0)) == 0)
     {
@@ -2423,15 +2423,15 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     }
 
     if (!(pfrom->GetLocalServices() & NODE_BLOOM) &&
-              (strCommand == NetMsgType::FILTERLOAD ||
-               strCommand == NetMsgType::FILTERADD))
+              (msg_type == NetMsgType::FILTERLOAD ||
+               msg_type == NetMsgType::FILTERADD))
     {
         LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 100);
         return false;
     }
 
-    if (strCommand == NetMsgType::REJECT)
+    if (msg_type == NetMsgType::REJECT)
     {
         std::string strMsg; unsigned char ccode; std::string strReason;
         uint256 hash;
@@ -2466,12 +2466,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::VERSION) {
+    if (msg_type == NetMsgType::VERSION) {
         // Each connection can only send one version message
         if (pfrom->nVersion != 0)
         {
             if (enable_bip61) {
-                connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_DUPLICATE, std::string("Duplicate version message")));
+                connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, msg_type, REJECT_DUPLICATE, std::string("Duplicate version message")));
             }
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 1);
@@ -2501,7 +2501,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         {
             LogPrint(BCLog::NET, "peer=%d does not offer the expected services (%08x offered, %08x expected); disconnecting\n", pfrom->GetId(), nServices, GetDesirableServiceFlags(nServices));
             if (enable_bip61) {
-                connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_NONSTANDARD,
+                connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, msg_type, REJECT_NONSTANDARD,
                                    strprintf("Expected to offer services %08x", GetDesirableServiceFlags(nServices))));
             }
             pfrom->fDisconnect = true;
@@ -2512,7 +2512,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // disconnect from peers older than this proto version
             LogPrint(BCLog::NET, "peer=%d using obsolete version %i; disconnecting\n", pfrom->GetId(), nVersion);
             if (enable_bip61) {
-                connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE,
+                connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, msg_type, REJECT_OBSOLETE,
                                    strprintf("Version must be %d or greater", MIN_PEER_PROTO_VERSION)));
             }
             pfrom->fDisconnect = true;
@@ -2671,7 +2671,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     // At this point, the outgoing message serialization version can't change.
     const CNetMsgMaker msgMaker(pfrom->GetSendVersion());
 
-    if (strCommand == NetMsgType::VERACK)
+    if (msg_type == NetMsgType::VERACK)
     {
         pfrom->SetRecvVersion(std::min(pfrom->nVersion.load(), PROTOCOL_VERSION));
 
@@ -2730,7 +2730,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     if (pfrom->nTimeFirstMessageReceived == 0) {
         // First message after VERSION/VERACK
         pfrom->nTimeFirstMessageReceived = GetTimeMicros();
-        pfrom->fFirstMessageIsMNAUTH = strCommand == NetMsgType::MNAUTH;
+        pfrom->fFirstMessageIsMNAUTH = msg_type == NetMsgType::MNAUTH;
         // Note: do not break the flow here
 
         if (pfrom->m_masternode_probe_connection && !pfrom->fFirstMessageIsMNAUTH) {
@@ -2740,9 +2740,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
     }
 
-    if (strCommand == NetMsgType::ADDR || strCommand == NetMsgType::ADDRV2) {
+    if (msg_type == NetMsgType::ADDR || msg_type == NetMsgType::ADDRV2) {
         int stream_version = vRecv.GetVersion();
-        if (strCommand == NetMsgType::ADDRV2) {
+        if (msg_type == NetMsgType::ADDRV2) {
             // Add ADDRV2_FORMAT to the version so that the CNetAddr and CAddress
             // unserialize methods know that an address in v2 format is coming.
             stream_version |= ADDRV2_FORMAT;
@@ -2760,7 +2760,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         if (vAddr.size() > 1000)
         {
             LOCK(cs_main);
-            Misbehaving(pfrom->GetId(), 20, strprintf("%s message size = %u", strCommand, vAddr.size()));
+            Misbehaving(pfrom->GetId(), 20, strprintf("%s message size = %u", msg_type, vAddr.size()));
             return false;
         }
 
@@ -2801,24 +2801,24 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::SENDADDRV2) {
+    if (msg_type == NetMsgType::SENDADDRV2) {
         pfrom->m_wants_addrv2 = true;
         return true;
     }
 
-    if (strCommand == NetMsgType::SENDHEADERS) {
+    if (msg_type == NetMsgType::SENDHEADERS) {
         LOCK(cs_main);
         State(pfrom->GetId())->fPreferHeaders = true;
         return true;
     }
 
-    if (strCommand == NetMsgType::SENDHEADERS2) {
+    if (msg_type == NetMsgType::SENDHEADERS2) {
         LOCK(cs_main);
         State(pfrom->GetId())->fPreferHeadersCompressed = true;
         return true;
     }
 
-    if (strCommand == NetMsgType::SENDCMPCT) {
+    if (msg_type == NetMsgType::SENDCMPCT) {
         bool fAnnounceUsingCMPCTBLOCK = false;
         uint64_t nCMPCTBLOCKVersion = 1;
         vRecv >> fAnnounceUsingCMPCTBLOCK >> nCMPCTBLOCKVersion;
@@ -2832,7 +2832,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     }
 
 
-    if (strCommand == NetMsgType::SENDDSQUEUE)
+    if (msg_type == NetMsgType::SENDDSQUEUE)
     {
         bool b;
         vRecv >> b;
@@ -2841,14 +2841,14 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     }
 
 
-    if (strCommand == NetMsgType::QSENDRECSIGS) {
+    if (msg_type == NetMsgType::QSENDRECSIGS) {
         bool b;
         vRecv >> b;
         pfrom->fSendRecSigs = b;
         return true;
     }
 
-    if (strCommand == NetMsgType::INV) {
+    if (msg_type == NetMsgType::INV) {
         std::vector<CInv> vInv;
         vRecv >> vInv;
         if (vInv.size() > MAX_INV_SZ)
@@ -2907,9 +2907,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     // fell back to inv we probably have a reorg which we should get the headers for first,
                     // we now only provide a getheaders response here. When we receive the headers, we will
                     // then ask for the blocks we need.
-                    std::string strCommand = (pfrom->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
-                    connman->PushMessage(pfrom, msgMaker.Make(strCommand, ::ChainActive().GetLocator(pindexBestHeader), inv.hash));
-                    LogPrint(BCLog::NET, "%s (%d) %s to peer=%d\n", strCommand, pindexBestHeader->nHeight, inv.hash.ToString(), pfrom->GetId());
+                    std::string msg_type = (pfrom->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
+                    connman->PushMessage(pfrom, msgMaker.Make(msg_type, ::ChainActive().GetLocator(pindexBestHeader), inv.hash));
+                    LogPrint(BCLog::NET, "%s (%d) %s to peer=%d\n", msg_type, pindexBestHeader->nHeight, inv.hash.ToString(), pfrom->GetId());
                 }
             }
             else
@@ -2933,7 +2933,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::GETDATA) {
+    if (msg_type == NetMsgType::GETDATA) {
         std::vector<CInv> vInv;
         vRecv >> vInv;
         if (vInv.size() > MAX_INV_SZ)
@@ -2954,7 +2954,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::GETBLOCKS) {
+    if (msg_type == NetMsgType::GETBLOCKS) {
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;
@@ -3024,7 +3024,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::GETBLOCKTXN) {
+    if (msg_type == NetMsgType::GETBLOCKTXN) {
         BlockTransactionsRequest req;
         vRecv >> req;
 
@@ -3073,20 +3073,20 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::GETHEADERS || strCommand == NetMsgType::GETHEADERS2) {
+    if (msg_type == NetMsgType::GETHEADERS || msg_type == NetMsgType::GETHEADERS2) {
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;
 
         if (locator.vHave.size() > MAX_LOCATOR_SZ) {
-            LogPrint(BCLog::NET, "%s locator size %lld > %d, disconnect peer=%d\n", strCommand, locator.vHave.size(), MAX_LOCATOR_SZ, pfrom->GetId());
+            LogPrint(BCLog::NET, "%s locator size %lld > %d, disconnect peer=%d\n", msg_type, locator.vHave.size(), MAX_LOCATOR_SZ, pfrom->GetId());
             pfrom->fDisconnect = true;
             return true;
         }
 
         LOCK(cs_main);
         if (::ChainstateActive().IsInitialBlockDownload() && !pfrom->HasPermission(PF_NOBAN)) {
-            LogPrint(BCLog::NET, "Ignoring %s from peer=%d because node is in initial block download\n", strCommand, pfrom->GetId());
+            LogPrint(BCLog::NET, "Ignoring %s from peer=%d because node is in initial block download\n", msg_type, pfrom->GetId());
             return true;
         }
 
@@ -3137,12 +3137,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             connman->PushMessage(pfrom, msgMaker.Make(msg_type, v_headers));
         };
 
-        LogPrint(BCLog::NET, "%s %d to %s from peer=%d\n", strCommand, (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), pfrom->GetId());
-        if (strCommand == NetMsgType::GETHEADERS) {
+        LogPrint(BCLog::NET, "%s %d to %s from peer=%d\n", msg_type, (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), pfrom->GetId());
+        if (msg_type == NetMsgType::GETHEADERS) {
             // we must use CBlocks, as CBlockHeaders won't include the 0x00 nTx count at the end
             std::vector<CBlock> v_headers;
             send_headers(NetMsgType::HEADERS, v_headers, [](const auto block_pindex) { return block_pindex->GetBlockHeader(); });
-        } else if (strCommand == NetMsgType::GETHEADERS2) {
+        } else if (msg_type == NetMsgType::GETHEADERS2) {
             // Keeps track of the last 7 unique version blocks
             std::list<int32_t> last_unique_versions;
             std::vector<CompressibleBlockHeader> v_headers;
@@ -3156,7 +3156,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::TX || strCommand == NetMsgType::DSTX || strCommand == NetMsgType::LEGACYTXLOCKREQUEST) {
+    if (msg_type == NetMsgType::TX || msg_type == NetMsgType::DSTX || msg_type == NetMsgType::LEGACYTXLOCKREQUEST) {
         // Stop processing the transaction early if
         // We are in blocks only mode and peer is either not whitelisted or whitelistrelay is off
         if (!g_relay_txes && !pfrom->HasPermission(PF_RELAY))
@@ -3170,12 +3170,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         int nInvType = MSG_TX;
 
         // Read data and assign inv type
-        if(strCommand == NetMsgType::TX) {
+        if(msg_type == NetMsgType::TX) {
             vRecv >> ptx;
-        } else if(strCommand == NetMsgType::LEGACYTXLOCKREQUEST) {
+        } else if(msg_type == NetMsgType::LEGACYTXLOCKREQUEST) {
             // we keep processing the legacy IX message here but revert to handling it as a regular TX
             vRecv >> ptx;
-        } else if (strCommand == NetMsgType::DSTX) {
+        } else if (msg_type == NetMsgType::DSTX) {
             vRecv >> dstx;
             ptx = dstx.tx;
             nInvType = MSG_DSTX;
@@ -3325,7 +3325,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 pfrom->GetId(),
                 FormatStateMessage(state));
             if (enable_bip61 && state.GetRejectCode() > 0 && state.GetRejectCode() < REJECT_INTERNAL) { // Never send AcceptToMemoryPool's internal codes over P2P
-                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::REJECT, strCommand, (unsigned char)state.GetRejectCode(),
+                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::REJECT, msg_type, (unsigned char)state.GetRejectCode(),
                                    state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash));
             }
             if (nDoS > 0) {
@@ -3335,7 +3335,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::CMPCTBLOCK)
+    if (msg_type == NetMsgType::CMPCTBLOCK)
     {
         // Ignore cmpctblock received while importing
         if (fImporting || fReindex) {
@@ -3556,7 +3556,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::BLOCKTXN)
+    if (msg_type == NetMsgType::BLOCKTXN)
     {
         // Ignore blocktxn received while importing
         if (fImporting || fReindex) {
@@ -3637,7 +3637,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::HEADERS || strCommand == NetMsgType::HEADERS2) {
+    if (msg_type == NetMsgType::HEADERS || msg_type == NetMsgType::HEADERS2) {
         // Ignore headers received while importing
         if (fImporting || fReindex) {
             LogPrint(BCLog::NET, "Unexpected headers message received from peer %d\n", pfrom->GetId());
@@ -3654,13 +3654,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             return false;
         }
 
-        if (strCommand == NetMsgType::HEADERS) {
+        if (msg_type == NetMsgType::HEADERS) {
             headers.resize(nCount);
             for (unsigned int n = 0; n < nCount; n++) {
                 vRecv >> headers[n];
                 ReadCompactSize(vRecv); // ignore tx count; assume it is 0.
             }
-        } else if (strCommand == NetMsgType::HEADERS2) {
+        } else if (msg_type == NetMsgType::HEADERS2) {
             std::list<int32_t> last_unique_versions;
             for (unsigned int n = 0; n < nCount; n++) {
                 CompressibleBlockHeader block_header_compressed;
@@ -3678,7 +3678,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return ProcessHeadersMessage(pfrom, connman, headers, chainparams, should_punish);
     }
 
-    if (strCommand == NetMsgType::BLOCK)
+    if (msg_type == NetMsgType::BLOCK)
     {
         // Ignore block received while importing
         if (fImporting || fReindex) {
@@ -3713,7 +3713,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::GETADDR) {
+    if (msg_type == NetMsgType::GETADDR) {
         // This asymmetric behavior for inbound and outbound connections was introduced
         // to prevent a fingerprinting attack: an attacker can send specific fake addresses
         // to users' AddrMan and later request them by sending getaddr messages.
@@ -3743,7 +3743,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::MEMPOOL) {
+    if (msg_type == NetMsgType::MEMPOOL) {
         if (!(pfrom->GetLocalServices() & NODE_BLOOM) && !pfrom->HasPermission(PF_MEMPOOL))
         {
             if (!pfrom->HasPermission(PF_NOBAN))
@@ -3769,7 +3769,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::PING) {
+    if (msg_type == NetMsgType::PING) {
         uint64_t nonce = 0;
         vRecv >> nonce;
         // Echo the message back with the nonce. This allows for two useful features:
@@ -3787,7 +3787,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::PONG) {
+    if (msg_type == NetMsgType::PONG) {
         int64_t pingUsecEnd = nTimeReceived;
         uint64_t nonce = 0;
         size_t nAvail = vRecv.in_avail();
@@ -3843,7 +3843,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::FILTERLOAD) {
+    if (msg_type == NetMsgType::FILTERLOAD) {
         CBloomFilter filter;
         vRecv >> filter;
 
@@ -3863,7 +3863,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::FILTERADD) {
+    if (msg_type == NetMsgType::FILTERADD) {
         std::vector<unsigned char> vData;
         vRecv >> vData;
 
@@ -3887,7 +3887,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::FILTERCLEAR) {
+    if (msg_type == NetMsgType::FILTERCLEAR) {
         LOCK(pfrom->cs_filter);
         if (pfrom->GetLocalServices() & NODE_BLOOM) {
             pfrom->pfilter = nullptr;
@@ -3897,7 +3897,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     }
 
 
-    if (strCommand == NetMsgType::GETMNLISTDIFF) {
+    if (msg_type == NetMsgType::GETMNLISTDIFF) {
         CGetSimplifiedMNListDiff cmd;
         vRecv >> cmd;
 
@@ -3914,30 +3914,30 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::GETCFILTERS) {
+    if (msg_type == NetMsgType::GETCFILTERS) {
         ProcessGetCFilters(*pfrom, vRecv, chainparams, *connman);
         return true;
     }
 
-    if (strCommand == NetMsgType::GETCFHEADERS) {
+    if (msg_type == NetMsgType::GETCFHEADERS) {
         ProcessGetCFHeaders(*pfrom, vRecv, chainparams, *connman);
         return true;
     }
 
-    if (strCommand == NetMsgType::GETCFCHECKPT) {
+    if (msg_type == NetMsgType::GETCFCHECKPT) {
         ProcessGetCFCheckPt(*pfrom, vRecv, chainparams, *connman);
         return true;
     }
 
 
-    if (strCommand == NetMsgType::MNLISTDIFF) {
+    if (msg_type == NetMsgType::MNLISTDIFF) {
         // we have never requested this
         LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 100, strprintf("received not-requested mnlistdiff. peer=%d", pfrom->GetId()));
         return true;
     }
 
-    if (strCommand == NetMsgType::GETQUORUMROTATIONINFO) {
+    if (msg_type == NetMsgType::GETQUORUMROTATIONINFO) {
         llmq::CGetQuorumRotationInfo cmd;
         vRecv >> cmd;
 
@@ -3954,14 +3954,14 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         return true;
     }
 
-    if (strCommand == NetMsgType::QUORUMROTATIONINFO) {
+    if (msg_type == NetMsgType::QUORUMROTATIONINFO) {
         // we have never requested this
         LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 100, strprintf("received not-requested quorumrotationinfo. peer=%d", pfrom->GetId()));
         return true;
     }
 
-    if (strCommand == NetMsgType::NOTFOUND) {
+    if (msg_type == NetMsgType::NOTFOUND) {
         // Remove the NOTFOUND transactions from the peer
         LOCK(cs_main);
         CNodeState *state = State(pfrom->GetId());
@@ -3989,7 +3989,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     bool found = false;
     const std::vector<std::string> &allMessages = getAllNetMessageTypes();
     for (const std::string& msg : allMessages) {
-        if(msg == strCommand) {
+        if(msg == msg_type) {
             found = true;
             break;
         }
@@ -3999,28 +3999,28 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     {
         //probably one the extensions
 #ifdef ENABLE_WALLET
-        coinJoinClientQueueManager.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
+        coinJoinClientQueueManager.ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
         for (auto& pair : coinJoinClientManagers) {
-            pair.second->ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
+            pair.second->ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
         }
 #endif // ENABLE_WALLET
-        coinJoinServer.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
-        sporkManager.ProcessSporkMessages(pfrom, strCommand, vRecv, *connman);
-        masternodeSync.ProcessMessage(pfrom, strCommand, vRecv);
-        governance.ProcessMessage(pfrom, strCommand, vRecv, *connman, enable_bip61);
-        CMNAuth::ProcessMessage(pfrom, strCommand, vRecv, *connman);
-        llmq::quorumBlockProcessor->ProcessMessage(pfrom, strCommand, vRecv);
-        llmq::quorumDKGSessionManager->ProcessMessage(pfrom, strCommand, vRecv);
-        llmq::quorumManager->ProcessMessage(pfrom, strCommand, vRecv);
-        llmq::quorumSigSharesManager->ProcessMessage(pfrom, strCommand, vRecv);
-        llmq::quorumSigningManager->ProcessMessage(pfrom, strCommand, vRecv);
-        llmq::chainLocksHandler->ProcessMessage(pfrom, strCommand, vRecv);
-        llmq::quorumInstantSendManager->ProcessMessage(pfrom, strCommand, vRecv);
+        coinJoinServer.ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
+        sporkManager.ProcessSporkMessages(pfrom, msg_type, vRecv, *connman);
+        masternodeSync.ProcessMessage(pfrom, msg_type, vRecv);
+        governance.ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
+        CMNAuth::ProcessMessage(pfrom, msg_type, vRecv, *connman);
+        llmq::quorumBlockProcessor->ProcessMessage(pfrom, msg_type, vRecv);
+        llmq::quorumDKGSessionManager->ProcessMessage(pfrom, msg_type, vRecv);
+        llmq::quorumManager->ProcessMessage(pfrom, msg_type, vRecv);
+        llmq::quorumSigSharesManager->ProcessMessage(pfrom, msg_type, vRecv);
+        llmq::quorumSigningManager->ProcessMessage(pfrom, msg_type, vRecv);
+        llmq::chainLocksHandler->ProcessMessage(pfrom, msg_type, vRecv);
+        llmq::quorumInstantSendManager->ProcessMessage(pfrom, msg_type, vRecv);
         return true;
     }
 
     // Ignore unknown commands for extensibility
-    LogPrint(BCLog::NET, "Unknown command \"%s\" from peer=%d\n", SanitizeString(strCommand), pfrom->GetId());
+    LogPrint(BCLog::NET, "Unknown command \"%s\" from peer=%d\n", SanitizeString(msg_type), pfrom->GetId());
 
     return true;
 }
@@ -4119,7 +4119,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
         LogPrint(BCLog::NET, "PROCESSMESSAGE: ERRORS IN HEADER %s peer=%d\n", SanitizeString(msg.m_command), pfrom->GetId());
         return fMoreWork;
     }
-    const std::string& strCommand = msg.m_command;
+    const std::string& msg_type = msg.m_command;
 
     // Message size
     unsigned int nMessageSize = msg.m_message_size;
@@ -4129,7 +4129,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     if (!msg.m_valid_checksum)
     {
         LogPrint(BCLog::NET, "%s(%s, %u bytes): CHECKSUM ERROR peer=%d\n", __func__,
-           SanitizeString(strCommand), nMessageSize, pfrom->GetId());
+           SanitizeString(msg_type), nMessageSize, pfrom->GetId());
         return fMoreWork;
     }
 
@@ -4137,7 +4137,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     bool fRet = false;
     try
     {
-        fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.m_time, chainparams, connman, interruptMsgProc, m_enable_bip61);
+        fRet = ProcessMessage(pfrom, msg_type, vRecv, msg.m_time, chainparams, connman, interruptMsgProc, m_enable_bip61);
         if (interruptMsgProc)
             return false;
         if (!pfrom->vRecvGetData.empty())
@@ -4146,23 +4146,23 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     catch (const std::ios_base::failure& e)
     {
         if (m_enable_bip61) {
-            connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_MALFORMED, std::string("error parsing message")));
+            connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, msg_type, REJECT_MALFORMED, std::string("error parsing message")));
         }
         if (strstr(e.what(), "end of data")) {
             // Allow exceptions from under-length message on vRecv
-            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught, normally caused by a message being shorter than its stated length\n", __func__, SanitizeString(strCommand), nMessageSize, e.what());
+            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught, normally caused by a message being shorter than its stated length\n", __func__, SanitizeString(msg_type), nMessageSize, e.what());
         } else if (strstr(e.what(), "size too large")) {
             // Allow exceptions from over-long size
-            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught\n", __func__, SanitizeString(strCommand), nMessageSize, e.what());
+            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught\n", __func__, SanitizeString(msg_type), nMessageSize, e.what());
         } else if (strstr(e.what(), "non-canonical ReadCompactSize()")) {
             // Allow exceptions from non-canonical encoding
-            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught\n", __func__, SanitizeString(strCommand), nMessageSize, e.what());
+            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught\n", __func__, SanitizeString(msg_type), nMessageSize, e.what());
         } else if (strstr(e.what(), "Superfluous witness record")) {
             // Allow exceptions from illegal witness encoding
-            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught\n", __func__, SanitizeString(strCommand), nMessageSize, e.what());
+            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught\n", __func__, SanitizeString(msg_type), nMessageSize, e.what());
         } else if (strstr(e.what(), "Unknown transaction optional data")) {
             // Allow exceptions from unknown witness encoding
-            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught\n", __func__, SanitizeString(strCommand), nMessageSize, e.what());
+            LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' caught\n", __func__, SanitizeString(msg_type), nMessageSize, e.what());
         } else {
             PrintExceptionContinue(std::current_exception(), "ProcessMessages()");
         }
@@ -4171,7 +4171,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     }
 
     if (!fRet) {
-        LogPrint(BCLog::NET, "%s(%s, %u bytes) FAILED peer=%d\n", __func__, SanitizeString(strCommand), nMessageSize, pfrom->GetId());
+        LogPrint(BCLog::NET, "%s(%s, %u bytes) FAILED peer=%d\n", __func__, SanitizeString(msg_type), nMessageSize, pfrom->GetId());
     }
 
     LOCK(cs_main);
@@ -4218,13 +4218,13 @@ void PeerLogicValidation::ConsiderEviction(CNode *pto, int64_t time_in_seconds)
                 pto->fDisconnect = true;
             } else {
                 assert(state.m_chain_sync.m_work_header);
-                std::string strCommand = (pto->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
+                std::string msg_type = (pto->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
                 LogPrint(BCLog::NET, "sending %s to outbound peer=%d to verify chain work (current best known block:%s, benchmark blockhash: %s)\n",
-                        strCommand,
+                        msg_type,
                         pto->GetId(),
                         state.pindexBestKnownBlock != nullptr ? state.pindexBestKnownBlock->GetBlockHash().ToString() : "<none>",
                         state.m_chain_sync.m_work_header->GetBlockHash().ToString());
-                connman->PushMessage(pto, msgMaker.Make(strCommand, ::ChainActive().GetLocator(state.m_chain_sync.m_work_header->pprev), uint256()));
+                connman->PushMessage(pto, msgMaker.Make(msg_type, ::ChainActive().GetLocator(state.m_chain_sync.m_work_header->pprev), uint256()));
                 state.m_chain_sync.m_sent_getheaders = true;
                 constexpr int64_t HEADERS_RESPONSE_TIME = 120; // 2 minutes
                 // Bump the timeout to allow a response, which could clear the timeout
@@ -4397,13 +4397,13 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
             std::vector<CAddress> vAddr;
             vAddr.reserve(pto->vAddrToSend.size());
 
-            const char* strCommand;
+            const char* msg_type;
             int make_flags;
             if (pto->m_wants_addrv2) {
-                strCommand = NetMsgType::ADDRV2;
+                msg_type = NetMsgType::ADDRV2;
                 make_flags = ADDRV2_FORMAT;
             } else {
-                strCommand = NetMsgType::ADDR;
+                msg_type = NetMsgType::ADDR;
                 make_flags = 0;
             }
 
@@ -4416,14 +4416,14 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                     // receiver rejects addr messages larger than 1000
                     if (vAddr.size() >= 1000)
                     {
-                        connman->PushMessage(pto, msgMaker.Make(make_flags, strCommand, vAddr));
+                        connman->PushMessage(pto, msgMaker.Make(make_flags, msg_type, vAddr));
                         vAddr.clear();
                     }
                 }
             }
             pto->vAddrToSend.clear();
             if (!vAddr.empty())
-                connman->PushMessage(pto, msgMaker.Make(make_flags, strCommand, vAddr));
+                connman->PushMessage(pto, msgMaker.Make(make_flags, msg_type, vAddr));
             // we only send the big addr message once
             if (pto->vAddrToSend.capacity() > 40)
                 pto->vAddrToSend.shrink_to_fit();
@@ -4449,9 +4449,9 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                    got back an empty response.  */
                 if (pindexStart->pprev)
                     pindexStart = pindexStart->pprev;
-                std::string strCommand = (pto->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
-                LogPrint(BCLog::NET, "initial %s (%d) to peer=%d (startheight:%d)\n", strCommand, pindexStart->nHeight, pto->GetId(), pto->nStartingHeight);
-                connman->PushMessage(pto, msgMaker.Make(strCommand, ::ChainActive().GetLocator(pindexStart), uint256()));
+                std::string msg_type = (pto->nServices & NODE_HEADERS_COMPRESSED) ? NetMsgType::GETHEADERS2 : NetMsgType::GETHEADERS;
+                LogPrint(BCLog::NET, "initial %s (%d) to peer=%d (startheight:%d)\n", msg_type, pindexStart->nHeight, pto->GetId(), pto->nStartingHeight);
+                connman->PushMessage(pto, msgMaker.Make(msg_type, ::ChainActive().GetLocator(pindexStart), uint256()));
             }
         }
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -102,15 +102,15 @@ void CSporkManager::CheckAndRemove()
     }
 }
 
-void CSporkManager::ProcessSporkMessages(CNode* pfrom, std::string_view strCommand, CDataStream& vRecv, CConnman& connman)
+void CSporkManager::ProcessSporkMessages(CNode* pfrom, std::string_view msg_type, CDataStream& vRecv, CConnman& connman)
 {
-    ProcessSpork(pfrom, strCommand, vRecv, connman);
-    ProcessGetSporks(pfrom, strCommand, connman);
+    ProcessSpork(pfrom, msg_type, vRecv, connman);
+    ProcessGetSporks(pfrom, msg_type, connman);
 }
 
-void CSporkManager::ProcessSpork(const CNode* pfrom, std::string_view strCommand, CDataStream& vRecv, CConnman& connman)
+void CSporkManager::ProcessSpork(const CNode* pfrom, std::string_view msg_type, CDataStream& vRecv, CConnman& connman)
 {
-    if (strCommand != NetMsgType::SPORK) return;
+    if (msg_type != NetMsgType::SPORK) return;
 
     CSporkMessage spork;
     vRecv >> spork;
@@ -171,9 +171,9 @@ void CSporkManager::ProcessSpork(const CNode* pfrom, std::string_view strCommand
     spork.Relay(connman);
 }
 
-void CSporkManager::ProcessGetSporks(CNode* pfrom, std::string_view strCommand, CConnman& connman)
+void CSporkManager::ProcessGetSporks(CNode* pfrom, std::string_view msg_type, CConnman& connman)
 {
-    if (strCommand != NetMsgType::GETSPORKS) return;
+    if (msg_type != NetMsgType::GETSPORKS) return;
 
     LOCK(cs); // make sure to not lock this together with cs_main
     for (const auto& pair : mapSporksActive) {

--- a/src/spork.h
+++ b/src/spork.h
@@ -231,7 +231,7 @@ public:
     /**
      * ProcessSporkMessages is used to call ProcessSpork and ProcessGetSporks. See below
      */
-    void ProcessSporkMessages(CNode* pfrom, std::string_view strCommand, CDataStream& vRecv, CConnman& connman);
+    void ProcessSporkMessages(CNode* pfrom, std::string_view msg_type, CDataStream& vRecv, CConnman& connman);
 
     /**
      * ProcessSpork is used to handle the 'spork' p2p message.
@@ -239,7 +239,7 @@ public:
      * For 'spork', it validates the spork and adds it to the internal spork storage and
      * performs any necessary processing.
      */
-    void ProcessSpork(const CNode* pfrom, std::string_view strCommand, CDataStream& vRecv, CConnman& connman) LOCKS_EXCLUDED(cs);
+    void ProcessSpork(const CNode* pfrom, std::string_view msg_type, CDataStream& vRecv, CConnman& connman) LOCKS_EXCLUDED(cs);
 
 
     /**
@@ -247,7 +247,7 @@ public:
      *
      * For 'getsporks', it sends active sporks to the requesting peer.
      */
-    void ProcessGetSporks(CNode* pfrom, std::string_view strCommand, CConnman& connman) LOCKS_EXCLUDED(cs);
+    void ProcessGetSporks(CNode* pfrom, std::string_view msg_type, CConnman& connman) LOCKS_EXCLUDED(cs);
 
     /**
      * UpdateSpork is used by the spork RPC command to set a new spork value, sign


### PR DESCRIPTION
scripted-diff: Merge #18533 Replace strCommand with msg_type

-BEGIN VERIFY SCRIPT-
sed -i 's/\<strCommand\>/msg_type/g' src/coinjoin/client.cpp 
sed -i 's/\<strCommand\>/msg_type/g' src/coinjoin/client.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/coinjoin/server.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/coinjoin/server.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/evo/mnauth.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/evo/mnauth.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/governance/governance.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/governance/governance.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/blockprocessor.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/blockprocessor.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/chainlocks.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/chainlocks.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/dkgsessionhandler.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/dkgsessionhandler.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/dkgsessionmgr.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/dkgsessionmgr.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/instantsend.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/instantsend.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/quorums.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/quorums.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/signing.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/signing.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/signing_shares.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/llmq/signing_shares.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/masternode/sync.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/masternode/sync.h 
sed -i 's/\<strCommand\>/msg_type/g'  src/net_processing.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/spork.cpp 
sed -i 's/\<strCommand\>/msg_type/g'  src/spork.h
-END VERIFY SCRIPT-