### PR TITLE
chore: bump MIN_PEER_PROTO_VERSION to 70215

### DIFF
--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -74,7 +74,7 @@ bool CCoinJoinQueue::Relay(CConnman& connman)
 {
     connman.ForEachNode([&connman, this](CNode* pnode) {
         CNetMsgMaker msgMaker(pnode->GetSendVersion());
-        if (pnode->nVersion >= MIN_COINJOIN_PEER_PROTO_VERSION && pnode->fSendDSQueue) {
+        if (pnode->fSendDSQueue) {
             connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSQUEUE, (*this)));
         }
     });

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -47,17 +47,6 @@ void CCoinJoinServer::ProcessMessage(CNode* pfrom, const std::string& strCommand
 
 void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
-    if (pfrom->nVersion < MIN_COINJOIN_PEER_PROTO_VERSION) {
-        LogPrint(BCLog::COINJOIN, "DSACCEPT -- peer=%d using obsolete version %i\n", pfrom->GetId(), pfrom->nVersion);
-        if (enable_bip61) {
-            connman.PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::REJECT, strCommand,
-                                                                                  REJECT_OBSOLETE, strprintf(
-                                "Version must be %d or greater", MIN_COINJOIN_PEER_PROTO_VERSION)));
-        }
-        PushStatus(pfrom, STATUS_REJECTED, ERR_VERSION, connman);
-        return;
-    }
-
     if (IsSessionReady()) {
         // too many users in this session already, reject new ones
         LogPrint(BCLog::COINJOIN, "DSACCEPT -- queue is already full!\n");
@@ -123,16 +112,6 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& strComman
 
 void CCoinJoinServer::ProcessDSQUEUE(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
-    if (pfrom->nVersion < MIN_COINJOIN_PEER_PROTO_VERSION) {
-        LogPrint(BCLog::COINJOIN, "DSQUEUE -- peer=%d using obsolete version %i\n", pfrom->GetId(), pfrom->nVersion);
-        if (enable_bip61) {
-            connman.PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::REJECT, strCommand,
-                                                                                  REJECT_OBSOLETE, strprintf(
-                                "Version must be %d or greater", MIN_COINJOIN_PEER_PROTO_VERSION)));
-        }
-        return;
-    }
-
     CCoinJoinQueue dsq;
     vRecv >> dsq;
 
@@ -189,17 +168,6 @@ void CCoinJoinServer::ProcessDSQUEUE(CNode* pfrom, const std::string& strCommand
 
 void CCoinJoinServer::ProcessDSVIN(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
-    if (pfrom->nVersion < MIN_COINJOIN_PEER_PROTO_VERSION) {
-        LogPrint(BCLog::COINJOIN, "DSVIN -- peer=%d using obsolete version %i\n", pfrom->GetId(), pfrom->nVersion);
-        if (enable_bip61) {
-            connman.PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::REJECT, strCommand,
-                                                                                  REJECT_OBSOLETE, strprintf(
-                                "Version must be %d or greater", MIN_COINJOIN_PEER_PROTO_VERSION)));
-        }
-        PushStatus(pfrom, STATUS_REJECTED, ERR_VERSION, connman);
-        return;
-    }
-
     //do we have enough users in the current session?
     if (!IsSessionReady()) {
         LogPrint(BCLog::COINJOIN, "DSVIN -- session not complete!\n");
@@ -226,16 +194,6 @@ void CCoinJoinServer::ProcessDSVIN(CNode* pfrom, const std::string& strCommand, 
 
 void CCoinJoinServer::ProcessDSSIGNFINALTX(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
-    if (pfrom->nVersion < MIN_COINJOIN_PEER_PROTO_VERSION) {
-        LogPrint(BCLog::COINJOIN, "DSSIGNFINALTX -- peer=%d using obsolete version %i\n", pfrom->GetId(), pfrom->nVersion);
-        if (enable_bip61) {
-            connman.PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::REJECT, strCommand,
-                                                                                  REJECT_OBSOLETE, strprintf(
-                                "Version must be %d or greater", MIN_COINJOIN_PEER_PROTO_VERSION)));
-        }
-        return;
-    }
-
     std::vector<CTxIn> vecTxIn;
     vRecv >> vecTxIn;
 

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -102,17 +102,13 @@ public:
     std::vector<uint256> deletedMNs;
     std::vector<CSimplifiedMNListEntry> mnList;
 
-    // starting with proto version LLMQS_PROTO_VERSION, we also transfer changes in active quorums
     std::vector<std::pair<uint8_t, uint256>> deletedQuorums; // p<LLMQType, quorumHash>
     std::vector<llmq::CFinalCommitment> newQuorums;
 
     SERIALIZE_METHODS(CSimplifiedMNListDiff, obj)
     {
         READWRITE(obj.baseBlockHash, obj.blockHash, obj.cbTxMerkleTree, obj.cbTx, obj.deletedMNs, obj.mnList);
-
-        if (s.GetVersion() >= LLMQS_PROTO_VERSION) {
-            READWRITE(obj.deletedQuorums, obj.newQuorums);
-        }
+        READWRITE(obj.deletedQuorums, obj.newQuorums);
     }
 
     CSimplifiedMNListDiff();

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -677,7 +677,7 @@ void CGovernanceObject::Relay(CConnman& connman) const
         return;
     }
 
-    int minProtoVersion = MIN_GOVERNANCE_PEER_PROTO_VERSION;
+    int minProtoVersion = MIN_PEER_PROTO_VERSION;
     if (nObjectType == GOVERNANCE_OBJECT_PROPOSAL) {
         // We know this proposal is valid locally, otherwise we would not get to the point we should relay it.
         // But we don't want to relay it to pre-GOVSCRIPT_PROTO_VERSION peers if payment_address is p2sh

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -129,15 +129,8 @@ void CGovernanceVote::Relay(CConnman& connman) const
         return;
     }
 
-    // When this vote is from non-valid (PoSe banned) MN, we should only announce it to v0.14.0.1 nodes as older nodes
-    // will ban us otherwise.
-    int minVersion = MIN_GOVERNANCE_PEER_PROTO_VERSION;
-    if (!CDeterministicMNList::IsMNValid(*dmn)) {
-        minVersion = GOVERNANCE_POSE_BANNED_VOTES_VERSION;
-    }
-
     CInv inv(MSG_GOVERNANCE_OBJECT_VOTE, GetHash());
-    connman.RelayInv(inv, minVersion);
+    connman.RelayInv(inv);
 }
 
 void CGovernanceVote::UpdateHash() const

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -150,7 +150,7 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CCha
 
     // Note: do not hold cs while calling RelayInv
     AssertLockNotHeld(cs);
-    g_connman->RelayInv(clsigInv, LLMQS_PROTO_VERSION);
+    g_connman->RelayInv(clsigInv);
 
     if (pindex == nullptr) {
         // we don't know the block/header for this CLSIG yet, so bail out for now

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -1082,11 +1082,11 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
     const auto is_det = islock->IsDeterministic();
     CInv inv(is_det ? MSG_ISDLOCK : MSG_ISLOCK, hash);
     if (tx != nullptr) {
-        g_connman->RelayInvFiltered(inv, *tx, is_det ? ISDLOCK_PROTO_VERSION : LLMQS_PROTO_VERSION);
+        g_connman->RelayInvFiltered(inv, *tx, is_det ? ISDLOCK_PROTO_VERSION : MIN_PEER_PROTO_VERSION);
     } else {
         // we don't have the TX yet, so we only filter based on txid. Later when that TX arrives, we will re-announce
         // with the TX taken into account.
-        g_connman->RelayInvFiltered(inv, islock->txid, is_det ? ISDLOCK_PROTO_VERSION : LLMQS_PROTO_VERSION);
+        g_connman->RelayInvFiltered(inv, islock->txid, is_det ? ISDLOCK_PROTO_VERSION : MIN_PEER_PROTO_VERSION);
     }
 
     ResolveBlockConflicts(hash, *islock);

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -828,7 +828,7 @@ void CSigningManager::ProcessRecoveredSig(const std::shared_ptr<const CRecovered
     if (fMasternodeMode) {
         CInv inv(MSG_QUORUM_RECOVERED_SIG, recoveredSig->GetHash());
         g_connman->ForEachNode([&](CNode* pnode) {
-            if (pnode->nVersion >= LLMQS_PROTO_VERSION && pnode->fSendRecSigs) {
+            if (pnode->fSendRecSigs) {
                 pnode->PushInventory(inv);
             }
         });

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -255,7 +255,6 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 }
                 netfulfilledman.AddFulfilledRequest(pnode->addr, "governance-sync");
 
-                if (pnode->nVersion < MIN_GOVERNANCE_PEER_PROTO_VERSION) continue;
                 nTriedPeerCount++;
 
                 SendGovernanceSyncRequest(pnode, connman);

--- a/src/version.h
+++ b/src/version.h
@@ -26,9 +26,6 @@ static const int MIN_MASTERNODE_PROTO_VERSION = 70219;
 //! if possible, avoid requesting addresses nodes older than this
 static const int CADDR_TIME_VERSION = 31402;
 
-//! minimum peer version accepted by mixing pool
-static const int MIN_COINJOIN_PEER_PROTO_VERSION = 70215;
-
 //! protocol version is included in MNAUTH starting with this version
 static const int MNAUTH_NODE_VER_VERSION = 70218;
 

--- a/src/version.h
+++ b/src/version.h
@@ -17,30 +17,17 @@ static const int PROTOCOL_VERSION = 70221;
 static const int INIT_PROTO_VERSION = 209;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 70213;
+static const int MIN_PEER_PROTO_VERSION = 70215;
 
 //! minimum proto version of masternode to accept in DKGs
 static const int MIN_MASTERNODE_PROTO_VERSION = 70219;
-
-//! minimum proto version for governance sync and messages
-static const int MIN_GOVERNANCE_PEER_PROTO_VERSION = 70213;
-
-//! minimum proto version to broadcast governance messages from banned masternodes
-static const int GOVERNANCE_POSE_BANNED_VOTES_VERSION = 70215;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this
 static const int CADDR_TIME_VERSION = 31402;
 
-//! introduction of LLMQs
-static const int LLMQS_PROTO_VERSION = 70214;
-
-//! introduction of SENDDSQUEUE
-//! TODO we can remove this in 0.15.0.0
-static const int SENDDSQUEUE_PROTO_VERSION = 70214;
-
 //! minimum peer version accepted by mixing pool
-static const int MIN_COINJOIN_PEER_PROTO_VERSION = 70213;
+static const int MIN_COINJOIN_PEER_PROTO_VERSION = 70215;
 
 //! protocol version is included in MNAUTH starting with this version
 static const int MNAUTH_NODE_VER_VERSION = 70218;


### PR DESCRIPTION
simplifies logic, removes branches

This protocol version is from v14 in May of 2019, should be more than safe to bump this in v18