### PR TITLE
Fix: Use github workspace for building image

### DIFF
--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -43,7 +43,7 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v2
       with:
-        context: ./docker
+        context: ${{ github.workspace }}
         file: ./contrib/containers/deploy/Dockerfile.GitHubActions.Release
         push: true
         tags: ${{ steps.docker_meta.outputs.tags }}

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -34,7 +34,7 @@ USER dash
 
 VOLUME ["/dash"]
 
-COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY dash/contrib/containers/deploy/docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 9998 9999 19998 19999


### PR DESCRIPTION
The Github CI release process was previously failing due to the context directory (./docker) being moved in the develop branch. This PR ensures we use the Github Workspace directory (which always exists) for building and deploying images to Dockerhub.