### PR TITLE
fix(rpc): display proper governance fee in `getgovernanceinfo`

### DIFF
--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -1174,13 +1174,15 @@ static UniValue getgovernanceinfo(const JSONRPCRequest& request)
     }
 
     int nLastSuperblock = 0, nNextSuperblock = 0;
-    int nBlockHeight = WITH_LOCK(cs_main, return ::ChainActive().Height());
+    const auto* pindex = WITH_LOCK(cs_main, return ::ChainActive().Tip());
+    int nBlockHeight = pindex->nHeight;
 
     CSuperblock::GetNearestSuperblocksHeights(nBlockHeight, nLastSuperblock, nNextSuperblock);
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("governanceminquorum", Params().GetConsensus().nGovernanceMinQuorum);
-    obj.pushKV("proposalfee", ValueFromAmount(GOVERNANCE_PROPOSAL_FEE_TX));
+    bool fork_active = VersionBitsState(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0024, versionbitscache) == ThresholdState::ACTIVE;
+    obj.pushKV("proposalfee", ValueFromAmount(fork_active ? GOVERNANCE_PROPOSAL_FEE_TX : GOVERNANCE_PROPOSAL_FEE_TX_OLD));
     obj.pushKV("superblockcycle", Params().GetConsensus().nSuperblockCycle);
     obj.pushKV("lastsuperblock", nLastSuperblock);
     obj.pushKV("nextsuperblock", nNextSuperblock);


### PR DESCRIPTION
fix rpc `getgovernanceinfo` proposal fee output

See this patch for a test (but it causes the main test in the file not to run for some reason

```
Index: test/functional/feature_governance_objects.py
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/test/functional/feature_governance_objects.py b/test/functional/feature_governance_objects.py
--- a/test/functional/feature_governance_objects.py	(revision 786d0b39f6b4bf6f05acf437baac4d184a7b06cc)
+++ b/test/functional/feature_governance_objects.py	(date 1650299271683)
@@ -51,6 +51,8 @@
 
     def run_test(self):
 
+        self.log.info("main")
+
         time_start = time.time()
         object_type = 1  # GOVERNANCE PROPOSAL
 
@@ -99,5 +101,22 @@
         assert_raises_rpc_error(-8, "Negative count", self.nodes[0].gobject, "list-prepared", -1000)
 
 
+class DashGovFeeTest (DashTestFramework):
+    def set_test_params(self):
+        self.set_dash_test_params(1, 0)
+
+    def run_test(self):
+
+        self.log.info("Check that initial proposalfee is 5 Dash")
+        assert self.nodes[0].getblockchaininfo()['bip9_softforks']['dip0024']['status'] != 'active'
+        assert self.nodes[0].getgovernanceinfo()['proposalfee'] == 5
+
+        self.log.info("Activating DIP24")
+        self.activate_dip0024(slow_mode=True)
+        self.log.info('Check that proposalfee is now 1 Dash')
+        assert self.nodes[0].getgovernanceinfo()['proposalfee'] == 1
+
+
 if __name__ == '__main__':
+    DashGovFeeTest().main()
     DashGovernanceTest().main()
     
```
