### PR TITLE
fix: include optional

### DIFF
--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -13,6 +13,7 @@
 #include <saltedhasher.h>
 #include <streams.h>
 #include <sync.h>
+#include <optional>
 
 #include <unordered_map>
 

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -11,6 +11,7 @@
 #include <random.h>
 #include <set>
 #include <sync.h>
+#include <optional>
 #include <vector>
 #include <versionbits.h>
 


### PR DESCRIPTION
I don't know if this is a machine specific thing (Ubuntu 21.10), but I couldn't compile anything after 728699d without this. Also, have no idea if this is correct, but it did work for me :slightly_smiling_face: 