### PR TITLE
fix(instantsend): avoid an iterator invalidation in pendingInstantSendLocks handling

### DIFF
--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -883,18 +883,28 @@ bool CInstantSendManager::ProcessPendingInstantSendLocks(bool deterministic)
         // only process a max 32 locks at a time to avoid duplicate verification of recovered signatures which have been
         // verified by CSigningManager in parallel
         const size_t maxCount = 32;
-        if (pendingInstantSendLocks.size() <= maxCount) {
-            pend = std::move(pendingInstantSendLocks);
-        } else {
-            for (auto it = pendingInstantSendLocks.begin(); it != pendingInstantSendLocks.end() && pend.size() < maxCount;) {
-                if (it->second.second->IsDeterministic() == deterministic) {
-                    pend.emplace(it->first, std::move(it->second));
-                    pendingInstantSendLocks.erase(it);
-                } else {
-                    ++it;
-                }
+        // The keys of the removed values are temporaily stored here to avoid invalidating an iterator
+        std::vector<uint256> removed;
+        removed.reserve(maxCount);
+
+        for (auto& [uint256_key, nodeid_islptr_pair] : pendingInstantSendLocks) {
+            const auto& [nodeId, islock_ptr] = nodeid_islptr_pair;
+            // Check if we've reached max count
+            if (pend.size() >= maxCount) {
+                fMoreWork = true;
+                break;
             }
-            fMoreWork = true;
+            // Check if we care about this islock on this run, if so, move it to pend, otherwise just continue
+            if (islock_ptr->IsDeterministic() == deterministic) {
+                pend.emplace(uint256_key, std::move(nodeid_islptr_pair));
+                removed.emplace_back(uint256_key);
+            } else {
+                continue;
+            }
+        }
+
+        for (auto& rem : removed) {
+            pendingInstantSendLocks.erase(rem);
         }
     }
 

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -887,24 +887,23 @@ bool CInstantSendManager::ProcessPendingInstantSendLocks(bool deterministic)
         std::vector<uint256> removed;
         removed.reserve(maxCount);
 
-        for (auto& [uint256_key, nodeid_islptr_pair] : pendingInstantSendLocks) {
-            const auto& [nodeId, islock_ptr] = nodeid_islptr_pair;
+        for (const auto& [islockHash, nodeid_islptr_pair] : pendingInstantSendLocks) {
+            const auto& [_, islock_ptr] = nodeid_islptr_pair;
             // Check if we've reached max count
             if (pend.size() >= maxCount) {
                 fMoreWork = true;
                 break;
             }
-            // Check if we care about this islock on this run, if so, move it to pend, otherwise just continue
-            if (islock_ptr->IsDeterministic() == deterministic) {
-                pend.emplace(uint256_key, std::move(nodeid_islptr_pair));
-                removed.emplace_back(uint256_key);
-            } else {
+            // Check if we care about this islock on this run
+            if (islock_ptr->IsDeterministic() != deterministic) {
                 continue;
             }
+            pend.emplace(islockHash, std::move(nodeid_islptr_pair));
+            removed.emplace_back(islockHash);
         }
 
-        for (auto& rem : removed) {
-            pendingInstantSendLocks.erase(rem);
+        for (const auto& islockHash : removed) {
+            pendingInstantSendLocks.erase(islockHash);
         }
     }
 


### PR DESCRIPTION
…dLocks handling

this also removes the following, as it doesn't take into account deterministic / not deterministic
```
if (pendingInstantSendLocks.size() <= maxCount) {
    pend = std::move(pendingInstantSendLocks);
}
```

Also uses structured bindings