### PR TITLE
fix(qt): fix crash when first enabling governance tab due to null-ptr deref

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -153,14 +153,20 @@ void WalletView::setClientModel(ClientModel *_clientModel)
 {
     this->clientModel = _clientModel;
 
-    overviewPage->setClientModel(_clientModel);
-    sendCoinsPage->setClientModel(_clientModel);
-    coinJoinCoinsPage->setClientModel(_clientModel);
+    if (overviewPage != nullptr) {
+        overviewPage->setClientModel(_clientModel);
+    }
+    if (sendCoinsPage != nullptr) {
+        sendCoinsPage->setClientModel(_clientModel);
+    }
+    if (coinJoinCoinsPage != nullptr) {
+        coinJoinCoinsPage->setClientModel(_clientModel);
+    }
     QSettings settings;
-    if (settings.value("fShowMasternodesTab").toBool()) {
+    if (settings.value("fShowMasternodesTab").toBool() && masternodeListPage != nullptr) {
         masternodeListPage->setClientModel(_clientModel);
     }
-    if (settings.value("fShowGovernanceTab").toBool()) {
+    if (settings.value("fShowGovernanceTab").toBool() && governanceListPage != nullptr) {
         governanceListPage->setClientModel(_clientModel);
     }
 }


### PR DESCRIPTION
Decided to also apply the same logic to the other items so that we don't do nullptr dereferences. You can replicate this crash with the master node tab too.

Thanks to XKCD for initial report

fixes https://github.com/dashpay/dash/issues/4794

replication
```
./src/qt/dash-qt --regtest --resetguisettings
Enable governance
shutdown
```