### PR TITLE
Edge case fix for Rotation

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -369,7 +369,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> CLLMQUtils::GetQuorumQuarterMembe
         sortedCombinedMns.push_back(std::move(m));
     }
 
-    if (sortedCombinedMns.empty()) return quarterQuorumMembers;
+    if (sortedCombinedMns.empty()) return {};
 
     //Mode 0: No skipping
     if (snapshot.mnSkipListMode == SnapshotSkipMode::MODE_NO_SKIPPING) {

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -385,7 +385,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> CLLMQUtils::GetQuorumQuarterMembe
                     }
                 }
             }
-            break;
+            return quarterQuorumMembers;
         }
         case SnapshotSkipMode::MODE_SKIPPING_ENTRIES: // List holds entries to be skipped
         {
@@ -415,14 +415,13 @@ std::vector<std::vector<CDeterministicMNCPtr>> CLLMQUtils::GetQuorumQuarterMembe
                     }
                 }
             }
-            break;
+            return quarterQuorumMembers;
         }
         case SnapshotSkipMode::MODE_NO_SKIPPING_ENTRIES: // List holds entries to be kept
-            [[fallthrough]]; //TODO Mode 2 will be written. Not used now
         case SnapshotSkipMode::MODE_ALL_SKIPPED: // Every node was skipped. Returning empty quarterQuorumMembers
-            {}
+        default:
+            return {};
     }
-    return quarterQuorumMembers;
 }
 
 std::pair<CDeterministicMNList, CDeterministicMNList> CLLMQUtils::GetMNUsageBySnapshot(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex, const llmq::CQuorumSnapshot& snapshot, int nHeight)

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -369,6 +369,8 @@ std::vector<std::vector<CDeterministicMNCPtr>> CLLMQUtils::GetQuorumQuarterMembe
         sortedCombinedMns.push_back(std::move(m));
     }
 
+    if (sortedCombinedMns.empty()) return quarterQuorumMembers;
+
     //Mode 0: No skipping
     if (snapshot.mnSkipListMode == SnapshotSkipMode::MODE_NO_SKIPPING) {
         auto itm = sortedCombinedMns.begin();


### PR DESCRIPTION
@PastaPastaPasta @UdjinM6 Need to take care of this particular case where a quorum spashot is written in evoDB with a corresponding empty MNs list. 
We just need to return empty list while loading previous shares from quorum snapshot. Otherwise a seg fault can happen.
This scenario happened in the last devnet and by luck it wasn't reproduced on previous deployments.