### PR TITLE
fix: bump dkgBadVotesThreshold to 80%

### DIFF
--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -262,7 +262,7 @@ static constexpr std::array<LLMQParams, 10> available_llmqs = {
         .dkgPhaseBlocks = 2,
         .dkgMiningWindowStart = 10, // dkgPhaseBlocks * 5 = after finalization
         .dkgMiningWindowEnd = 18,
-        .dkgBadVotesThreshold = 40,
+        .dkgBadVotesThreshold = 48,
 
         .signingActiveQuorumCount = 32,
         .keepOldConnections = 33,


### PR DESCRIPTION
this was a copy/paste mistake in rotation PR. this should be merged in for rc2 (and this is fine since rc2 is already a breaking change