### PR TITLE
rpc: fix and simplify `quorum rotationinfo`

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1463,7 +1463,7 @@ class DashTestFramework(BitcoinTestFramework):
 
         best_block_hash = self.nodes[0].getbestblockhash()
         block_height = self.nodes[0].getblockcount()
-        quorum_rotation_info = self.nodes[0].quorum("rotationinfo", best_block_hash, 0, False)
+        quorum_rotation_info = self.nodes[0].quorum("rotationinfo", best_block_hash)
         self.log.info("h("+str(block_height)+"):"+str(quorum_rotation_info))
 
         return (quorum_info_0, quorum_info_1)


### PR DESCRIPTION
Issues with current implementation: params list is not mentioning `baseBlockHashes`, `baseBlockHashesNb` looks excessive, no default values, handling of baseBlockHash-es is off by 1 (`3 + i` should be `4 + i`).

before:
```
> help quorum rotationinfo

quorum rotationinfo "blockRequestHash" baseBlockHashesNb extraShare
Get quorum rotation information

Arguments:
1. blockRequestHash     (string, required) The blockHash of the request.
2. baseBlockHashesNb    (numeric, required) Number of baseBlockHashes
3. extraShare           (boolean, required) Extra share
```

after:
```
> help quorum rotationinfo

quorum rotationinfo "blockRequestHash" ( extraShare "baseBlockHash..." )
Get quorum rotation information

Arguments:
1. blockRequestHash    (string, required) The blockHash of the request.
2. extraShare          (boolean, optional, default=false) Extra share
3. baseBlockHash...    (string, optional, default=) baseBlockHashes
```

Noticed this while reviewing #4734 (note to @Munkybooty: this patch is doing even more than the one I proposed there initially, you'll have to adjust 4734 accordingly on rebase)