### PR TITLE
Correct returned variable

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -421,7 +421,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> CLLMQUtils::GetQuorumQuarterMembe
         case SnapshotSkipMode::MODE_NO_SKIPPING_ENTRIES: // List holds entries to be kept
         case SnapshotSkipMode::MODE_ALL_SKIPPED: // Every node was skipped. Returning empty quarterQuorumMembers
         default:
-            return {};
+            return quarterQuorumMembers;
     }
 }
 

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -365,13 +365,13 @@ std::vector<std::vector<CDeterministicMNCPtr>> CLLMQUtils::GetQuorumQuarterMembe
         std::move(sortedMnsUsedAtH.begin(), sortedMnsUsedAtH.end(), std::back_inserter(sortedCombinedMns));
     }
 
-    if (sortedCombinedMns.empty()) return {};
-
     auto numQuorums = size_t(llmqParams.signingActiveQuorumCount);
     auto quorumSize = size_t(llmqParams.size);
     auto quarterSize = quorumSize / 4;
 
     std::vector<std::vector<CDeterministicMNCPtr>> quarterQuorumMembers(numQuorums);
+
+    if (sortedCombinedMns.empty()) return quarterQuorumMembers;
 
     switch (snapshot.mnSkipListMode) {
         case SnapshotSkipMode::MODE_NO_SKIPPING:


### PR DESCRIPTION
@PastaPastaPasta Basically we must return N empty vectors (where N = number of quorumIndexes) instead of {}
(Sorry I missed that yesterday)