### PR TITLE
tests: make inv replies in `interface_zmq_dash.py` stricter, fix a bug

### DIFF
--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -81,11 +81,11 @@ class TestP2PConn(P2PInterface):
         inv = msg_inv([CInv(31 if deterministic else 30, hash)])
         self.send_message(inv)
 
-    def send_tx(self, tx, deterministic):
+    def send_tx(self, tx):
         hash = uint256_from_str(hash256(tx.serialize()))
         self.txes[hash] = tx
 
-        inv = msg_inv([CInv(31 if deterministic else 30, hash)])
+        inv = msg_inv([CInv(MSG_TX, hash)])
         self.send_message(inv)
 
     def on_getdata(self, message):
@@ -327,7 +327,7 @@ class DashZMQTest (DashTestFramework):
             # this is expected
             pass
         # Now send the tx itself
-        self.test_node.send_tx(FromHex(msg_tx(), rpc_raw_tx_3['hex']), deterministic)
+        self.test_node.send_tx(FromHex(msg_tx(), rpc_raw_tx_3['hex']))
         self.wait_for_instantlock(rpc_raw_tx_3['txid'], self.nodes[0])
         # Validate hashtxlock
         zmq_tx_lock_hash = self.subscribers[ZMQPublisher.hash_tx_lock].receive().read(32).hex()

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -13,7 +13,7 @@ import struct
 import time
 
 from test_framework.test_framework import DashTestFramework
-from test_framework.mininode import P2PInterface
+from test_framework.mininode import P2PInterface, MSG_TX, MSG_TYPE_MASK
 from test_framework.util import assert_equal, assert_raises_rpc_error
 from test_framework.messages import (
     CBlock,
@@ -90,9 +90,9 @@ class TestP2PConn(P2PInterface):
 
     def on_getdata(self, message):
         for inv in message.inv:
-            if inv.hash in self.islocks:
+            if ((inv.type & MSG_TYPE_MASK) == 30 or (inv.type & MSG_TYPE_MASK) == 31) and inv.hash in self.islocks:
                 self.send_message(self.islocks[inv.hash])
-            if inv.hash in self.txes:
+            if (inv.type & MSG_TYPE_MASK) == MSG_TX and inv.hash in self.txes:
                 self.send_message(self.txes[inv.hash])
 
 


### PR DESCRIPTION
I did not pay enough attention to this part in https://github.com/dashpay/dash/pull/4797/commits/aa38b74fbc7533ab7250585da801ad3511d5463c, just refactored it mechanically...

Fixes a bug introduced in #3852.