### PR TITLE
feat(rpc/wallet): allow skipping/forcing blockchain rescan on upgradetohd

### DIFF
--- a/doc/release-notes-4822.md
+++ b/doc/release-notes-4822.md
@@ -1,0 +1,3 @@
+Miscellaneous RPC Changes
+-------------------------
+- In rpc `upgradetohd` new parameter `rescan` was added which allows users to skip or force blockchain rescan. This params defaults to `false` when `mnemonic` parameter is empty and `true` otherwise.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -196,6 +196,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "rescanblockchain", 1, "stop_height"},
     { "createwallet", 1, "disable_private_keys"},
     { "createwallet", 2, "blank"},
+    { "upgradetohd", 3, "rescan"},
     { "getnodeaddresses", 0, "count"},
     { "stop", 0, "wait" },
 };

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2567,6 +2567,7 @@ static UniValue upgradetohd(const JSONRPCRequest& request)
             {"mnemonic", RPCArg::Type::STR, /* default */ "", "Mnemonic as defined in BIP39 to use for the new HD wallet. Use an empty string \"\" to generate a new random mnemonic."},
             {"mnemonicpassphrase", RPCArg::Type::STR, /* default */ "", "Optional mnemonic passphrase as defined in BIP39"},
             {"walletpassphrase", RPCArg::Type::STR, /* default */ "", "If your wallet is encrypted you must have your wallet passphrase here. If your wallet is not encrypted specifying wallet passphrase will trigger wallet encryption."},
+            {"rescan", RPCArg::Type::BOOL, /* default */ "false if mnemonic is empty", "Whether to rescan the blockchain for missing transactions or not"},
         },
         RPCResult{
             RPCResult::Type::BOOL, "", "true if successful"
@@ -2650,7 +2651,8 @@ static UniValue upgradetohd(const JSONRPCRequest& request)
     }
 
     // If you are generating new mnemonic it is assumed that the addresses have never gotten a transaction before, so you don't need to rescan for transactions
-    if (!generate_mnemonic) {
+    bool rescan = request.params[3].isNull() ? !generate_mnemonic : request.params[3].get_bool();
+    if (rescan) {
         WalletRescanReserver reserver(pwallet);
         if (!reserver.reserve()) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait.");
@@ -3926,7 +3928,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "signmessage",                      &signmessage,                   {"address","message"} },
     { "wallet",             "signrawtransactionwithwallet",     &signrawtransactionwithwallet,  {"hexstring","prevtxs","sighashtype"} },
     { "wallet",             "unloadwallet",                     &unloadwallet,                  {"wallet_name"} },
-    { "wallet",             "upgradetohd",                      &upgradetohd,                   {"mnemonic", "mnemonicpassphrase", "walletpassphrase"} },
+    { "wallet",             "upgradetohd",                      &upgradetohd,                   {"mnemonic", "mnemonicpassphrase", "walletpassphrase", "rescan"} },
     { "wallet",             "walletlock",                       &walletlock,                    {} },
     { "wallet",             "walletpassphrasechange",           &walletpassphrasechange,        {"oldpassphrase","newpassphrase"} },
     { "wallet",             "walletpassphrase",                 &walletpassphrase,              {"passphrase","timeout","mixingonly"} },


### PR DESCRIPTION
Use cases:
1. "I-know-what-I'm-doing mode": I want a wallet with a specific mnemonic and I know it was never used before (or I don't care about old txes for some reason), I don't need any rescans
2. "paranoid mode": make sure the new mnemonic that was just generated (when there was no mnemonic provided via params) was never used before