### PR TITLE
trivial: bump immer to 9cb6a5a, fix irange to work on c++20

### DIFF
--- a/depends/packages/immer.mk
+++ b/depends/packages/immer.mk
@@ -1,9 +1,9 @@
 package=immer
-$(package)_version=v0.6.2
+$(package)_version=v0.7.0
 $(package)_download_path=https://github.com/arximboldi/immer/archive
 $(package)_download_file=$($(package)_version).tar.gz
 $(package)_file_name=$(package)-$($(package)_download_file)
-$(package)_sha256_hash=c3bb8847034437dee64adacb04e1e0163ae640b596c582eb4c0aa1d7c6447cd7
+$(package)_sha256_hash=cf67ab428aa3610eb0f72d0ea936c15cce3f91df26ee143ab783acd053507fe4
 $(package)_build_subdir=build_tmp
 $(package)_dependencies=cmake boost
 

--- a/src/util/irange.h
+++ b/src/util/irange.h
@@ -41,10 +41,10 @@ public:
         iterator operator++() { value_ += step_; return *this; }
         reference operator*() { return value_; }
         const pointer operator->() { return &value_; }
-        bool operator==(const iterator& rhs) { return positive_step_ ? (value_ >= rhs.value_ && value_ > boundary_)
-                                                                     : (value_ <= rhs.value_ && value_ < boundary_); }
-        bool operator!=(const iterator& rhs) { return positive_step_ ? (value_ < rhs.value_ && value_ >= boundary_)
-                                                                     : (value_ > rhs.value_ && value_ <= boundary_); }
+        bool operator==(const iterator& rhs) const { return positive_step_ ? (value_ >= rhs.value_ && value_ > boundary_)
+                                                                           : (value_ <= rhs.value_ && value_ < boundary_); }
+        bool operator!=(const iterator& rhs) const { return positive_step_ ? (value_ < rhs.value_ && value_ >= boundary_)
+                                                                           : (value_ > rhs.value_ && value_ <= boundary_); }
 
     private:
         value_type value_;


### PR DESCRIPTION
C++20 introduces [default comparisons](https://en.cppreference.com/w/cpp/language/default_comparisons) which has the delightful feature of introducing reversed order comparisons, which reduces the amount of code you have to write but also means that now your operator functions must have the same input and output type (at least in our case).

Immer took care of this in https://github.com/arximboldi/immer/pull/194 and so we've bumped the package to the minimum version that contains the pull request.

**Errors encountered before this pull request (building with `--enable-debug --enable-c++20` )**

```
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:37:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/tuple:39:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/array:39:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/stdexcept:39:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/string:52:
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/stl_algo.h:3193:22: error: use of overloaded operator '!=' is ambiguous (with operand types 'immer::detail::hamts::champ_iterator<std::pair<uint256, std::shared_ptr<const CDeterministicMN> >, immer::map<uint256, std::shared_ptr<const CDeterministicMN>, CDeterministicMNList::ImmerHasher, std::equal_to<uint256>, immer::memory_policy<immer::free_list_heap_policy<immer::cpp_heap, 1024>, immer::refcount_policy, immer::no_transience_policy, false, true>, 5>::hash_key, immer::map<uint256, std::shared_ptr<const CDeterministicMN>, CDeterministicMNList::ImmerHasher, std::equal_to<uint256>, immer::memory_policy<immer::free_list_heap_policy<immer::cpp_heap, 1024>, immer::refcount_policy, immer::no_transience_policy, false, true>, 5>::equal_key, immer::memory_policy<immer::free_list_heap_policy<immer::cpp_heap, 1024>, immer::refcount_policy, immer::no_transience_policy, false, true>, 5>' and 'immer::detail::hamts::champ_iterator<std::pair<uint256, std::shared_ptr<const CDeterministicMN> >, immer::map<uint256, std::shared_ptr<const CDeterministicMN>, CDeterministicMNList::ImmerHasher, std::equal_to<uint256>, immer::memory_policy<immer::free_list_heap_policy<immer::cpp_heap, 1024>, immer::refcount_policy, immer::no_transience_policy, false, true>, 5>::hash_key, immer::map<uint256, std::shared_ptr<const CDeterministicMN>, CDeterministicMNList::ImmerHasher, std::equal_to<uint256>, immer::memory_policy<immer::free_list_heap_policy<immer::cpp_heap, 1024>, immer::refcount_policy, immer::no_transience_policy, false, true>, 5>::equal_key, immer::memory_policy<immer::free_list_heap_policy<immer::cpp_heap, 1024>, immer::refcount_policy, immer::no_transience_policy, false, true>, 5>')
      for (; __first != __last; ++__first)
             ~~~~~~~ ^  ~~~~~~
[...]
./llmq/utils.h:137:27: error: use of overloaded operator '!=' is ambiguous (with operand types 'irange::detail::Range<unsigned long>::iterator' and 'irange::detail::Range<unsigned long>::iterator')
        for (const auto i : irange::range(vBits.size())) {
                          ^
```