### PR TITLE
fix(wallet): Fix wallet autobackup on start

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5030,7 +5030,9 @@ bool CWallet::Verify(interfaces::Chain& chain, const WalletLocation& location, b
     std::unique_ptr<WalletDatabase> database = CreateWalletDatabase(wallet_path);
 
     try {
-        return database->Verify(error_string);
+        if (!database->Verify(error_string)) {
+            return false;
+        }
     } catch (const fs::filesystem_error& e) {
         error_string = Untranslated(strprintf("Error loading wallet %s. %s", location.GetName(), fsbridge::get_filesystem_error_message(e)));
         return false;
@@ -5041,6 +5043,8 @@ bool CWallet::Verify(interfaces::Chain& chain, const WalletLocation& location, b
     if (!tempWallet->AutoBackupWallet(wallet_path, error_string, warnings) && !error_string.original.empty()) {
         return false;
     }
+
+    return true;
 }
 
 std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain, const WalletLocation& location, bilingual_str& error, std::vector<bilingual_str>& warnings, uint64_t wallet_creation_flags)


### PR DESCRIPTION
19324 follow-up (merged via 4714 https://github.com/dashpay/dash/pull/4714/commits/a40b94755a14eaf3ad3c883085d01d695ea4f6bc) - `AutoBackupWallet()` call was unreachable.

NOTE: It's safe to call it after `Verify()` because 18918 backport (https://github.com/dashpay/dash/pull/4714/commits/07a4d482494d29f7cf687ee94a0590a5a6c736d8) moved salvage logic out of `Verify*()`.