### PR TITLE
fix(qt): include `upgradetohd` into "no history" list

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -69,6 +69,7 @@ const QStringList historyFilter = QStringList()
     << "importmulti"
     << "signmessagewithprivkey"
     << "signrawtransactionwithkey"
+    << "upgradetohd"
     << "walletpassphrase"
     << "walletpassphrasechange"
     << "encryptwallet";


### PR DESCRIPTION
Almost all params (besides `rescan`) provided to `upgradetohd` rpc are password-like and should not be stored in rpc console history.