### PR TITLE
feat(qt): UI fixes for window "Wallet Repair"

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1390,15 +1390,12 @@
       </layout>
      </widget>
      <widget class="QWidget" name="pageRepair">
-      <widget class="QPushButton" name="btn_rescan1">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>100</y>
-         <width>301</width>
-         <height>23</height>
-        </rect>
+      <layout class="QGridLayout" name="repairLayout" columnstretch="0,1">
+       <property name="horizontalSpacing">
+        <number>12</number>
        </property>
+       <item row="3" column="0">
+      <widget class="QPushButton" name="btn_rescan1">
        <property name="minimumSize">
         <size>
          <width>180</width>
@@ -1409,15 +1406,9 @@
         <string>Rescan blockchain files 1</string>
        </property>
       </widget>
+       </item>
+       <item row="4" column="0">
       <widget class="QPushButton" name="btn_rescan2">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>150</y>
-         <width>301</width>
-         <height>23</height>
-        </rect>
-       </property>
        <property name="minimumSize">
         <size>
          <width>180</width>
@@ -1428,15 +1419,9 @@
         <string>Rescan blockchain files 2</string>
        </property>
       </widget>
+       </item>
+       <item row="5" column="0">
       <widget class="QPushButton" name="btn_upgradewallet">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>200</y>
-         <width>301</width>
-         <height>23</height>
-        </rect>
-       </property>
        <property name="minimumSize">
         <size>
          <width>180</width>
@@ -1447,15 +1432,9 @@
         <string>Upgrade wallet format</string>
        </property>
       </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
       <widget class="QLabel" name="label_repair_helptext">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>30</y>
-         <width>711</width>
-         <height>41</height>
-        </rect>
-       </property>
        <property name="text">
         <string>The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockchain files or missing/obsolete transactions.</string>
        </property>
@@ -1463,15 +1442,9 @@
         <bool>true</bool>
        </property>
       </widget>
+       </item>
+       <item row="3" column="1">
       <widget class="QLabel" name="label_repair_rescan1">
-       <property name="geometry">
-        <rect>
-         <x>330</x>
-         <y>90</y>
-         <width>411</width>
-         <height>41</height>
-        </rect>
-       </property>
        <property name="text">
         <string>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</string>
        </property>
@@ -1479,15 +1452,9 @@
         <bool>true</bool>
        </property>
       </widget>
+       </item>
+       <item row="4" column="1">
       <widget class="QLabel" name="label_repair_rescan2">
-       <property name="geometry">
-        <rect>
-         <x>330</x>
-         <y>140</y>
-         <width>411</width>
-         <height>41</height>
-        </rect>
-       </property>
        <property name="text">
         <string>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</string>
        </property>
@@ -1495,15 +1462,9 @@
         <bool>true</bool>
        </property>
       </widget>
+       </item>
+       <item row="5" column="1">
       <widget class="QLabel" name="label_repair_upgrade">
-       <property name="geometry">
-        <rect>
-         <x>330</x>
-         <y>190</y>
-         <width>411</width>
-         <height>41</height>
-        </rect>
-       </property>
        <property name="text">
         <string>-upgradewallet: Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself!)</string>
        </property>
@@ -1511,15 +1472,9 @@
         <bool>true</bool>
        </property>
       </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
       <widget class="QLabel" name="label_repair_header">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>10</y>
-         <width>711</width>
-         <height>16</height>
-        </rect>
-       </property>
        <property name="text">
         <string>Wallet repair options.</string>
        </property>
@@ -1527,28 +1482,16 @@
         <bool>true</bool>
        </property>
       </widget>
+       </item>
+       <item row="6" column="0">
       <widget class="QPushButton" name="btn_reindex">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>250</y>
-         <width>301</width>
-         <height>23</height>
-        </rect>
-       </property>
        <property name="text">
         <string>Rebuild index</string>
        </property>
       </widget>
+       </item>
+       <item row="6" column="1">
       <widget class="QLabel" name="label_repair_reindex">
-       <property name="geometry">
-        <rect>
-         <x>330</x>
-         <y>240</y>
-         <width>411</width>
-         <height>41</height>
-        </rect>
-       </property>
        <property name="text">
         <string>-reindex: Rebuild block chain index from current blk000??.dat files.</string>
        </property>
@@ -1556,19 +1499,22 @@
         <bool>true</bool>
        </property>
       </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
       <widget class="QLabel" name="wallet_path">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>70</y>
-         <width>731</width>
-         <height>21</height>
-        </rect>
-       </property>
        <property name="text">
         <string>Wallet Path</string>
        </property>
       </widget>
+       </item>
+       <item row="7" column="1">
+        <spacer name="verticalSpacerRepair">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1394,118 +1394,118 @@
        <property name="horizontalSpacing">
         <number>12</number>
        </property>
-       <item row="3" column="0">
-      <widget class="QPushButton" name="btn_rescan1">
-       <property name="minimumSize">
-        <size>
-         <width>180</width>
-         <height>23</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Rescan blockchain files 1</string>
-       </property>
-      </widget>
-       </item>
-       <item row="4" column="0">
-      <widget class="QPushButton" name="btn_rescan2">
-       <property name="minimumSize">
-        <size>
-         <width>180</width>
-         <height>23</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Rescan blockchain files 2</string>
-       </property>
-      </widget>
-       </item>
-       <item row="5" column="0">
-      <widget class="QPushButton" name="btn_upgradewallet">
-       <property name="minimumSize">
-        <size>
-         <width>180</width>
-         <height>23</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Upgrade wallet format</string>
-       </property>
-      </widget>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="label_repair_header">
+         <property name="text">
+          <string>Wallet repair options.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item row="1" column="0" colspan="2">
-      <widget class="QLabel" name="label_repair_helptext">
-       <property name="text">
-        <string>The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockchain files or missing/obsolete transactions.</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-       </item>
-       <item row="3" column="1">
-      <widget class="QLabel" name="label_repair_rescan1">
-       <property name="text">
-        <string>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-       </item>
-       <item row="4" column="1">
-      <widget class="QLabel" name="label_repair_rescan2">
-       <property name="text">
-        <string>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-       </item>
-       <item row="5" column="1">
-      <widget class="QLabel" name="label_repair_upgrade">
-       <property name="text">
-        <string>-upgradewallet: Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself!)</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-       </item>
-       <item row="0" column="0" colspan="2">
-      <widget class="QLabel" name="label_repair_header">
-       <property name="text">
-        <string>Wallet repair options.</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-       </item>
-       <item row="6" column="0">
-      <widget class="QPushButton" name="btn_reindex">
-       <property name="text">
-        <string>Rebuild index</string>
-       </property>
-      </widget>
-       </item>
-       <item row="6" column="1">
-      <widget class="QLabel" name="label_repair_reindex">
-       <property name="text">
-        <string>-reindex: Rebuild block chain index from current blk000??.dat files.</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
+        <widget class="QLabel" name="label_repair_helptext">
+         <property name="text">
+          <string>The buttons below will restart the wallet with command-line options to repair the wallet, fix issues with corrupt blockchain files or missing/obsolete transactions.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item row="2" column="0" colspan="2">
-      <widget class="QLabel" name="wallet_path">
-       <property name="text">
-        <string>Wallet Path</string>
-       </property>
-      </widget>
+        <widget class="QLabel" name="wallet_path">
+         <property name="text">
+          <string>Wallet Path</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QPushButton" name="btn_rescan1">
+         <property name="minimumSize">
+          <size>
+           <width>180</width>
+           <height>23</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Rescan blockchain files 1</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="label_repair_rescan1">
+         <property name="text">
+          <string>-rescan=1: Rescan the block chain for missing wallet transactions starting from wallet creation time.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QPushButton" name="btn_rescan2">
+         <property name="minimumSize">
+          <size>
+           <width>180</width>
+           <height>23</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Rescan blockchain files 2</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="label_repair_rescan2">
+         <property name="text">
+          <string>-rescan=2: Rescan the block chain for missing wallet transactions starting from genesis block.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QPushButton" name="btn_upgradewallet">
+         <property name="minimumSize">
+          <size>
+           <width>180</width>
+           <height>23</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Upgrade wallet format</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="label_repair_upgrade">
+         <property name="text">
+          <string>-upgradewallet: Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself!)</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QPushButton" name="btn_reindex">
+         <property name="text">
+          <string>Rebuild index</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QLabel" name="label_repair_reindex">
+         <property name="text">
+          <string>-reindex: Rebuild block chain index from current blk000??.dat files.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item row="7" column="1">
         <spacer name="verticalSpacerRepair">


### PR DESCRIPTION
It changes hard-coded position of each element on wallet-repair window to flexible layout.

Previous solution works good only with one font size and it didn't look nice with non-standard font size (see screenshots)

![image](https://user-images.githubusercontent.com/545784/169815592-df1ae0e8-12f9-482b-840d-d589d8e56715.png)

![image](https://user-images.githubusercontent.com/545784/169814615-1acf127b-b00d-4991-89ec-976ee3349cac.png)
