### PR TITLE
fix!: Return FinalCommitment in qrinfo (instead of simply quorumHash)

### DIFF
--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -90,12 +90,14 @@ void CQuorumRotationInfo::ToJson(UniValue& obj) const
         mnListDiffAtHMinus4C.value().ToJson(objdiff4c);
         obj.pushKV("mnListDiffAtHMinus4C", objdiff4c);
     }
-
-    UniValue hlists(UniValue::VARR);
-    for (const auto& h : lastQuorumHashPerIndex) {
-        hlists.push_back(h.ToString());
+    
+    UniValue hqclists(UniValue::VARR);
+    for (const auto& qc : lastCommitmentPerIndex) {
+        UniValue objqc;
+        qc.ToJson(objqc);
+        hqclists.push_back(objqc);
     }
-    obj.pushKV("lastQuorumHashPerIndex", hlists);
+    obj.pushKV("lastCommitmentPerIndex", hqclists);
 
     UniValue snapshotlist(UniValue::VARR);
     for (const auto& snap : quorumSnapshotList) {
@@ -298,7 +300,12 @@ bool BuildQuorumRotationInfo(const CGetQuorumRotationInfo& request, CQuorumRotat
     std::vector<std::pair<int, const CBlockIndex*>> qdata = quorumBlockProcessor->GetLastMinedCommitmentsPerQuorumIndexUntilBlock(llmqType, blockIndex, 0);
 
     for (const auto& obj : qdata) {
-        response.lastQuorumHashPerIndex.push_back(obj.second->GetBlockHash());
+        uint256 minedBlockHash;
+        llmq::CFinalCommitmentPtr qc = llmq::quorumBlockProcessor->GetMinedCommitment(llmqType, obj.second->GetBlockHash(), minedBlockHash);
+        if (qc == nullptr) {
+            return false;
+        }
+        response.lastCommitmentPerIndex.push_back(*qc);
 
         int quorumCycleStartHeight = obj.second->nHeight - (obj.second->nHeight % llmqParams.dkgInterval);
         snapshotHeightsNeeded.insert(quorumCycleStartHeight - cycleLength);

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -90,7 +90,6 @@ void CQuorumRotationInfo::ToJson(UniValue& obj) const
         mnListDiffAtHMinus4C.value().ToJson(objdiff4c);
         obj.pushKV("mnListDiffAtHMinus4C", objdiff4c);
     }
-    
     UniValue hqclists(UniValue::VARR);
     for (const auto& qc : lastCommitmentPerIndex) {
         UniValue objqc;

--- a/src/llmq/snapshot.h
+++ b/src/llmq/snapshot.h
@@ -7,6 +7,7 @@
 
 #include <evo/evodb.h>
 #include <evo/simplifiedmns.h>
+#include <llmq/commitment.h>
 #include <llmq/params.h>
 #include <saltedhasher.h>
 #include <serialize.h>
@@ -115,7 +116,7 @@ public:
     std::optional<CQuorumSnapshot> quorumSnapshotAtHMinus4C;
     std::optional<CSimplifiedMNListDiff> mnListDiffAtHMinus4C;
 
-    std::vector<uint256> lastQuorumHashPerIndex;
+    std::vector<llmq::CFinalCommitment> lastCommitmentPerIndex;
     std::vector<CQuorumSnapshot> quorumSnapshotList;
     std::vector<CSimplifiedMNListDiff> mnListDiffList;
 
@@ -146,8 +147,8 @@ public:
             ::Serialize(s, mnListDiffAtHMinus4C.value());
         }
 
-        WriteCompactSize(s, lastQuorumHashPerIndex.size());
-        for (const auto& obj : lastQuorumHashPerIndex) {
+        WriteCompactSize(s, lastCommitmentPerIndex.size());
+        for (const auto& obj : lastCommitmentPerIndex) {
             ::Serialize(s, obj);
         }
 
@@ -178,8 +179,9 @@ public:
         size_t cnt = ReadCompactSize(s);
         for ([[maybe_unused]] const auto _ : irange::range(cnt)) {
             uint256 hash;
-            ::Unserialize(s, hash);
-            lastQuorumHashPerIndex.push_back(std::move(hash));
+            CFinalCommitment qc;
+            ::Unserialize(s, qc);
+            lastCommitmentPerIndex.push_back(std::move(qc));
         }
 
         cnt = ReadCompactSize(s);


### PR DESCRIPTION
`qrinfo` message must return last `FinalCommitment` instead of simply `quorumHash`.
Clients need additional information (quorumPublicKey for instance) in order to verify locks.