### PR TITLE
fix!: Adjusted keepOldConnections value for llmq_devnet

### DIFF
--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -217,7 +217,7 @@ static constexpr std::array<LLMQParams, 10> available_llmqs = {
 
         .signingActiveQuorumCount = 4, // just a few ones to allow easier testing
 
-        .keepOldConnections = 4,
+        .keepOldConnections = 5,
         .recoveryMembers = 6,
     },
 


### PR DESCRIPTION
As mentioned in llmq/params.h:

```
// Used for intra-quorum communication. This is the number of quorums for which we should keep old connections. This
// should be at least one more then the active quorums set.
int keepOldConnections;
```

With rotation we increased `signingActiveQuorumCount` to 4 for `llmq_devnet` but we never adjusted `keepOldConnections`

