### PR TITLE
feat(qt): Add an option to keep custom change address

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -319,6 +319,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="keepChangeAddress">
+            <property name="toolTip">
+             <string>Whether to keep the specified custom change address or not.</string>
+            </property>
+            <property name="text">
+             <string>Keep custom change &amp;address</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="showMasternodesTab">
             <property name="toolTip">
              <string>Show additional tab listing all your masternodes in first sub-tab&lt;br/&gt;and all masternodes on the network in second sub-tab.</string>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -313,6 +313,7 @@ void OptionsDialog::setMapper()
 
     /* Wallet */
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
+    mapper->addMapping(ui->keepChangeAddress, OptionsModel::KeepChangeAddress);
     mapper->addMapping(ui->showMasternodesTab, OptionsModel::ShowMasternodesTab);
     mapper->addMapping(ui->showGovernanceTab, OptionsModel::ShowGovernanceTab);
     mapper->addMapping(ui->showAdvancedCJUI, OptionsModel::ShowAdvancedCJUI);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -146,6 +146,10 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("fCoinControlFeatures", false);
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
 
+    if (!settings.contains("fKeepChangeAddress"))
+        settings.setValue("fKeepChangeAddress", false);
+    fKeepChangeAddress = settings.value("fKeepChangeAddress", false).toBool();
+
     if (!settings.contains("digits"))
         settings.setValue("digits", "2");
 
@@ -472,6 +476,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
 #ifdef ENABLE_WALLET
         case CoinControlFeatures:
             return fCoinControlFeatures;
+        case KeepChangeAddress:
+            return fKeepChangeAddress;
 #endif // ENABLE_WALLET
         case Prune:
             return settings.value("bPrune");
@@ -693,6 +699,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             fCoinControlFeatures = value.toBool();
             settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
             Q_EMIT coinControlFeaturesChanged(fCoinControlFeatures);
+            break;
+        case KeepChangeAddress:
+            fKeepChangeAddress = value.toBool();
+            settings.setValue("fKeepChangeAddress", fKeepChangeAddress);
+            Q_EMIT keepChangeAddressChanged(fKeepChangeAddress);
             break;
         case Prune:
             if (settings.value("bPrune") != value) {

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -52,6 +52,7 @@ public:
         FontWeightBold,       // int
         Language,             // QString
         CoinControlFeatures,  // bool
+        KeepChangeAddress,    // bool
         ThreadsScriptVerif,   // int
         Prune,                // bool
         PruneSize,            // int
@@ -86,6 +87,7 @@ public:
     int getDisplayUnit() const { return nDisplayUnit; }
     QString getThirdPartyTxUrls() const { return strThirdPartyTxUrls; }
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
+    bool getKeepChangeAddress() const { return fKeepChangeAddress; }
     bool getShowAdvancedCJUI() { return fShowAdvancedCJUI; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
     void emitCoinJoinEnabledChanged();
@@ -107,6 +109,7 @@ private:
     int nDisplayUnit;
     QString strThirdPartyTxUrls;
     bool fCoinControlFeatures;
+    bool fKeepChangeAddress;
     bool fShowAdvancedCJUI;
     /* settings that were overridden by command-line */
     QString strOverriddenByCommandLine;
@@ -123,6 +126,7 @@ Q_SIGNALS:
     void coinJoinAmountChanged();
     void AdvancedCJUIChanged(bool);
     void coinControlFeaturesChanged(bool);
+    void keepChangeAddressChanged(bool);
     void hideTrayIconChanged(bool);
 };
 

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -67,6 +67,7 @@ private:
     bool fNewRecipientAllowed;
     void send(QList<SendCoinsRecipient> recipients);
     bool fFeeMinimized;
+    bool fKeepChangeAddress;
 
     // Process WalletModel::SendCoinsReturn and generate a pair consisting
     // of a message and message flags for use in Q_EMIT message().
@@ -98,6 +99,7 @@ private Q_SLOTS:
     void coinControlClipboardChange();
     void updateFeeSectionControls();
     void updateSmartFeeLabel();
+    void keepChangeAddressChanged(bool);
 
 Q_SIGNALS:
     // Fired when a message should be reported to the user


### PR DESCRIPTION
Allow users to keep custom change address they specified earlier from one tx to another and between restarts. This can be useful for wallets handling donation/charity/etc. addresses, would allow them to provide max transparency with less efforts. Address reuse is not a very good practice in general though so default is "off".

(_requested by TheDesertLynx on Discord recently but we are in feature-freeze mode so targeting 18.1_)