### PR TITLE
backport: bitcoin 20564, 20661 (addrv2 follow-ups)

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -1165,17 +1165,22 @@ public:
         addrKnown.insert(_addr.GetKey());
     }
 
+    /**
+     * Whether the peer supports the address. For example, a peer that does not
+     * implement BIP155 cannot receive Tor v3 addresses because it requires
+     * ADDRv2 (BIP155) encoding.
+     */
+    bool IsAddrCompatible(const CAddress& addr) const
+    {
+        return m_wants_addrv2 || addr.IsAddrV1Compatible();
+    }
+
     void PushAddress(const CAddress& _addr, FastRandomContext &insecure_rand)
     {
-        // Whether the peer supports the address in `_addr`. For example,
-        // nodes that do not implement BIP155 cannot receive Tor v3 addresses
-        // because they require ADDRv2 (BIP155) encoding.
-        const bool addr_format_supported = m_wants_addrv2 || _addr.IsAddrV1Compatible();
-
         // Known checking here is only to save space from duplicates.
         // SendMessages will filter it again for knowns that were added
         // after addresses were pushed.
-        if (_addr.IsValid() && !addrKnown.contains(_addr.GetKey()) && addr_format_supported) {
+        if (_addr.IsValid() && !addrKnown.contains(_addr.GetKey()) && IsAddrCompatible(_addr)) {
             if (vAddrToSend.size() >= MAX_ADDR_TO_SEND) {
                 vAddrToSend[insecure_rand.randrange(vAddrToSend.size())] = _addr;
             } else {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2609,11 +2609,10 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
 
         const CNetMsgMaker msg_maker(INIT_PROTO_VERSION);
         // Signal ADDRv2 support (BIP155).
-        if (nSendVersion >= 70016) {
+        if (nSendVersion >= ADDRV2_PROTO_VERSION) {
             // BIP155 defines addrv2 and sendaddrv2 for all protocol versions, but some
             // implementations reject messages they don't know. As a courtesy, don't send
-            // it to nodes with a version before 70016, as no software is known to support
-            // BIP155 that doesn't announce at least that protocol version number.
+            // it to nodes with a version before ADDRV2_PROTO_VERSION.
             connman->PushMessage(pfrom, msg_maker.Make(NetMsgType::SENDADDRV2));
         }
 
@@ -2752,6 +2751,10 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
     }
 
     if (msg_type == NetMsgType::SENDADDRV2) {
+        if (pfrom->GetSendVersion() < ADDRV2_PROTO_VERSION) {
+            // Ignore previous implementations
+            return true;
+        }
         if (pfrom->fSuccessfullyConnected) {
             // Disconnect peers that send SENDADDRV2 message after VERACK; this
             // must be negotiated between VERSION and VERACK.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1487,8 +1487,8 @@ static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connma
     std::array<std::pair<uint64_t, CNode*>,2> best{{{0, nullptr}, {0, nullptr}}};
     assert(nRelayNodes <= best.size());
 
-    auto sortfunc = [&best, &hasher, nRelayNodes](CNode* pnode) {
-        if (pnode->nVersion >= CADDR_TIME_VERSION) {
+    auto sortfunc = [&best, &hasher, nRelayNodes, addr](CNode* pnode) {
+        if (pnode->nVersion >= CADDR_TIME_VERSION && pnode->IsAddrCompatible(addr)) {
             uint64_t hashKey = CSipHasher(hasher).Write(pnode->GetId()).Finalize();
             for (unsigned int i = 0; i < nRelayNodes; i++) {
                 if (hashKey > best[i].first) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2608,6 +2608,15 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
         }
 
         const CNetMsgMaker msg_maker(INIT_PROTO_VERSION);
+        // Signal ADDRv2 support (BIP155).
+        if (nSendVersion >= 70016) {
+            // BIP155 defines addrv2 and sendaddrv2 for all protocol versions, but some
+            // implementations reject messages they don't know. As a courtesy, don't send
+            // it to nodes with a version before 70016, as no software is known to support
+            // BIP155 that doesn't announce at least that protocol version number.
+            connman->PushMessage(pfrom, msg_maker.Make(NetMsgType::SENDADDRV2));
+        }
+
         connman->PushMessage(pfrom, msg_maker.Make(NetMsgType::VERACK));
 
         pfrom->nServices = nServices;
@@ -2714,10 +2723,6 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             CMNAuth::PushMNAUTH(pfrom, *connman);
         }
 
-        // Signal ADDRv2 support (BIP155).
-        // NOTE: Should NOT send this prior to MNMAUTH.
-        connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::SENDADDRV2));
-
         // Tell our peer we prefer to receive headers rather than inv's
         // We send this to non-NODE NETWORK peers as well, because even
         // non-NODE NETWORK peers can announce blocks (such as pruning
@@ -2743,6 +2748,17 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
         }
 
         pfrom->fSuccessfullyConnected = true;
+        return true;
+    }
+
+    if (msg_type == NetMsgType::SENDADDRV2) {
+        if (pfrom->fSuccessfullyConnected) {
+            // Disconnect peers that send SENDADDRV2 message after VERACK; this
+            // must be negotiated between VERSION and VERACK.
+            pfrom->fDisconnect = true;
+            return false;
+        }
+        pfrom->m_wants_addrv2 = true;
         return true;
     }
 
@@ -2824,11 +2840,6 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
         if (pfrom->fOneShot)
             pfrom->fDisconnect = true;
         statsClient.gauge("peers.knownAddresses", connman->GetAddressCount(), 1.0f);
-        return true;
-    }
-
-    if (msg_type == NetMsgType::SENDADDRV2) {
-        pfrom->m_wants_addrv2 = true;
         return true;
     }
 

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70222;
+static const int PROTOCOL_VERSION = 70223;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -37,6 +37,9 @@ static const int ISDLOCK_PROTO_VERSION = 70220;
 
 //! GOVSCRIPT was activated in this version
 static const int GOVSCRIPT_PROTO_VERSION = 70221;
+
+//! ADDRV2 was introduced in this version
+static const int ADDRV2_PROTO_VERSION = 70223;
 
 // Make sure that none of the values above collide with `ADDRV2_FORMAT`.
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -32,7 +32,7 @@ from test_framework.util import hex_str_to_bytes
 import dash_hash
 
 MIN_VERSION_SUPPORTED = 60001
-MY_VERSION = 70220  # ISDLOCK_PROTO_VERSION
+MY_VERSION = 70223  # ADDRV2_PROTO_VERSION
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3%s/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -433,9 +433,9 @@ class P2PInterface(P2PConnection):
 
     def on_version(self, message):
         assert message.nVersion >= MIN_VERSION_SUPPORTED, "Version {} received. Test framework only supports versions greater than {}".format(message.nVersion, MIN_VERSION_SUPPORTED)
-        self.send_message(msg_verack())
         if self.support_addrv2:
             self.send_message(msg_sendaddrv2())
+        self.send_message(msg_verack())
         self.nServices = message.nServices
 
     # Connection helper methods


### PR DESCRIPTION
NOTE: fbacffe035ab51cdce82fa0c1a814ca1e28ba25d would make it incompatible with previous v0.18.x/v18.0.x versions (would disconnect peers), so I added a bit of backwards compatibility in 8c25b4c16c.