### PR TITLE
fix: Faster feature_llmq_rotation.py + introduction of llmq_devnet_dip0024

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -720,6 +720,7 @@ public:
         AddLLMQ(Consensus::LLMQType::LLMQ_400_85);
         AddLLMQ(Consensus::LLMQType::LLMQ_100_67);
         AddLLMQ(Consensus::LLMQType::LLMQ_DEVNET);
+        AddLLMQ(Consensus::LLMQType::LLMQ_DEVNET_V2);
         consensus.llmqTypeChainLocks = Consensus::LLMQType::LLMQ_50_60;
         consensus.llmqTypeInstantSend = Consensus::LLMQType::LLMQ_50_60;
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_60_75;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -720,7 +720,7 @@ public:
         AddLLMQ(Consensus::LLMQType::LLMQ_400_85);
         AddLLMQ(Consensus::LLMQType::LLMQ_100_67);
         AddLLMQ(Consensus::LLMQType::LLMQ_DEVNET);
-        AddLLMQ(Consensus::LLMQType::LLMQ_DEVNET_V2);
+        AddLLMQ(Consensus::LLMQType::LLMQ_DEVNET_DIP0024);
         consensus.llmqTypeChainLocks = Consensus::LLMQType::LLMQ_50_60;
         consensus.llmqTypeInstantSend = Consensus::LLMQType::LLMQ_50_60;
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_60_75;

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -196,7 +196,7 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
         .minSize = 3,
         .threshold = 2,
 
-        .dkgInterval = 24, // one DKG per hour
+        .dkgInterval = 24, // DKG cycle
         .dkgPhaseBlocks = 2,
         .dkgMiningWindowStart = 13, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
         .dkgMiningWindowEnd = 20,
@@ -246,7 +246,7 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
         .minSize = 6,
         .threshold = 4,
 
-        .dkgInterval = 48, // one DKG per hour
+        .dkgInterval = 48, // DKG cycle
         .dkgPhaseBlocks = 2,
         .dkgMiningWindowStart = 13, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
         .dkgMiningWindowEnd = 20,
@@ -297,7 +297,7 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
         .minSize = 50,
         .threshold = 45,
 
-        .dkgInterval = 24 * 12, // one DKG every 12 hours
+        .dkgInterval = 24 * 12, // DKG cycle every 12 hours
         .dkgPhaseBlocks = 2,
         .dkgMiningWindowStart = 43, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
         .dkgMiningWindowEnd = 50,

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -24,14 +24,17 @@ enum class LLMQType : uint8_t {
     LLMQ_TEST = 100, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
 
     // for devnets only
-    LLMQ_DEVNET = 101, // 10 members, 6 (60%) threshold, one per hour. Params might differ when -llmqdevnetparams is used
+    LLMQ_DEVNET = 101, // 12 members, 6 (50%) threshold, one per hour. Params might differ when -llmqdevnetparams is used
 
     // for testing activation of new quorums only
     LLMQ_TEST_V17 = 102, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
 
+    // for testing only
     LLMQ_TEST_DIP0024 = 103, // 4 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
-
     LLMQ_TEST_INSTANTSEND = 104, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestinstantsendparams is used
+
+    // for devnets only. rotated version (v2) for devnets
+    LLMQ_DEVNET_V2 = 105 // 12 members, 6 (50%) threshold, one per hour. Params might differ when -llmqdevnetparams is used
 };
 
 // Configures a LLMQ and its DKG
@@ -103,7 +106,7 @@ struct LLMQParams {
 };
 
 
-static constexpr std::array<LLMQParams, 10> available_llmqs = {
+static constexpr std::array<LLMQParams, 11> available_llmqs = {
 
     /**
      * llmq_test
@@ -227,6 +230,30 @@ static constexpr std::array<LLMQParams, 10> available_llmqs = {
         .signingActiveQuorumCount = 4, // just a few ones to allow easier testing
 
         .keepOldConnections = 5,
+        .recoveryMembers = 6,
+    },
+
+    /**
+     * llmq_devnet_2
+     * This quorum is only used for testing on devnets
+     *
+     */
+    LLMQParams{
+        .type = LLMQType::LLMQ_DEVNET_V2,
+        .name = "llmq_devnet_v2",
+        .size = 12,
+        .minSize = 7,
+        .threshold = 6,
+
+        .dkgInterval = 24, // one DKG per hour
+        .dkgPhaseBlocks = 2,
+        .dkgMiningWindowStart = 10, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 18,
+        .dkgBadVotesThreshold = 7,
+
+        .signingActiveQuorumCount = 4, // just a few ones to allow easier testing
+
+        .keepOldConnections = 8,
         .recoveryMembers = 6,
     },
 

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -198,7 +198,7 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
 
         .dkgInterval = 24, // DKG cycle
         .dkgPhaseBlocks = 2,
-        .dkgMiningWindowStart = 13, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
+        .dkgMiningWindowStart = 12, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization
         .dkgMiningWindowEnd = 20,
         .dkgBadVotesThreshold = 2,
 
@@ -248,7 +248,7 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
 
         .dkgInterval = 48, // DKG cycle
         .dkgPhaseBlocks = 2,
-        .dkgMiningWindowStart = 13, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
+        .dkgMiningWindowStart = 12, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization
         .dkgMiningWindowEnd = 20,
         .dkgBadVotesThreshold = 7,
 
@@ -299,7 +299,7 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
 
         .dkgInterval = 24 * 12, // DKG cycle every 12 hours
         .dkgPhaseBlocks = 2,
-        .dkgMiningWindowStart = 43, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
+        .dkgMiningWindowStart = 42, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization
         .dkgMiningWindowEnd = 50,
         .dkgBadVotesThreshold = 48,
 

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -198,7 +198,7 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
 
         .dkgInterval = 24, // one DKG per hour
         .dkgPhaseBlocks = 2,
-        .dkgMiningWindowStart = 12, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowStart = 13, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
         .dkgMiningWindowEnd = 20,
         .dkgBadVotesThreshold = 2,
 
@@ -241,14 +241,15 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
     LLMQParams{
         .type = LLMQType::LLMQ_DEVNET_DIP0024,
         .name = "llmq_devnet_dip0024",
+        .useRotation = true,
         .size = 8,
         .minSize = 6,
         .threshold = 4,
 
         .dkgInterval = 48, // one DKG per hour
         .dkgPhaseBlocks = 2,
-        .dkgMiningWindowStart = 10, // dkgPhaseBlocks * 5 = after finalization
-        .dkgMiningWindowEnd = 18,
+        .dkgMiningWindowStart = 13, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
+        .dkgMiningWindowEnd = 20,
         .dkgBadVotesThreshold = 7,
 
         .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
@@ -298,7 +299,7 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
 
         .dkgInterval = 24 * 12, // one DKG every 12 hours
         .dkgPhaseBlocks = 2,
-        .dkgMiningWindowStart = 42, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowStart = 43, // signingActiveQuorumCount + dkgPhaseBlocks * 5 = after finalization + 1
         .dkgMiningWindowEnd = 50,
         .dkgBadVotesThreshold = 48,
 

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -34,7 +34,7 @@ enum class LLMQType : uint8_t {
     LLMQ_TEST_INSTANTSEND = 104, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestinstantsendparams is used
 
     // for devnets only. rotated version (v2) for devnets
-    LLMQ_DEVNET_V2 = 105 // 12 members, 6 (50%) threshold, one per hour. Params might differ when -llmqdevnetparams is used
+    LLMQ_DEVNET_DIP0024 = 105 // 8 members, 4 (50%) threshold, one per hour. Params might differ when -llmqdevnetparams is used
 };
 
 // Configures a LLMQ and its DKG
@@ -234,27 +234,27 @@ static constexpr std::array<LLMQParams, 11> available_llmqs = {
     },
 
     /**
-     * llmq_devnet_2
+     * llmq_devnet_dip0024
      * This quorum is only used for testing on devnets
      *
      */
     LLMQParams{
-        .type = LLMQType::LLMQ_DEVNET_V2,
-        .name = "llmq_devnet_v2",
-        .size = 12,
-        .minSize = 7,
-        .threshold = 6,
+        .type = LLMQType::LLMQ_DEVNET_DIP0024,
+        .name = "llmq_devnet_dip0024",
+        .size = 8,
+        .minSize = 6,
+        .threshold = 4,
 
-        .dkgInterval = 24, // one DKG per hour
+        .dkgInterval = 48, // one DKG per hour
         .dkgPhaseBlocks = 2,
         .dkgMiningWindowStart = 10, // dkgPhaseBlocks * 5 = after finalization
         .dkgMiningWindowEnd = 18,
         .dkgBadVotesThreshold = 7,
 
-        .signingActiveQuorumCount = 4, // just a few ones to allow easier testing
+        .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
 
-        .keepOldConnections = 8,
-        .recoveryMembers = 6,
+        .keepOldConnections = 4,
+        .recoveryMembers = 4,
     },
 
     /**

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -854,7 +854,7 @@ bool CLLMQUtils::IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const
             }
             break;
         case Consensus::LLMQType::LLMQ_60_75:
-        case Consensus::LLMQType::LLMQ_DEVNET_V2:
+        case Consensus::LLMQType::LLMQ_DEVNET_DIP0024:
         case Consensus::LLMQType::LLMQ_TEST_DIP0024: {
             bool fDIP0024IsActive = optDIP0024IsActive.has_value() ? *optDIP0024IsActive : CLLMQUtils::IsDIP0024Active(pindex);
             if (!fDIP0024IsActive) {

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -827,6 +827,7 @@ bool CLLMQUtils::IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const
     switch (llmqType)
     {
         case Consensus::LLMQType::LLMQ_TEST_INSTANTSEND:
+        case Consensus::LLMQType::LLMQ_DEVNET:
         case Consensus::LLMQType::LLMQ_50_60: {
             if (IsInstantSendLLMQTypeShared()) {
                 break;
@@ -853,6 +854,7 @@ bool CLLMQUtils::IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const
             }
             break;
         case Consensus::LLMQType::LLMQ_60_75:
+        case Consensus::LLMQType::LLMQ_DEVNET_V2:
         case Consensus::LLMQType::LLMQ_TEST_DIP0024: {
             bool fDIP0024IsActive = optDIP0024IsActive.has_value() ? *optDIP0024IsActive : CLLMQUtils::IsDIP0024Active(pindex);
             if (!fDIP0024IsActive) {
@@ -860,8 +862,6 @@ bool CLLMQUtils::IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const
             }
             break;
         }
-        case Consensus::LLMQType::LLMQ_DEVNET:
-            break;
         default:
             throw std::runtime_error(strprintf("%s: Unknown LLMQ type %d", __func__, static_cast<uint8_t>(llmqType)));
     }

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -53,7 +53,7 @@ class TestP2PConn(P2PInterface):
 
 class LLMQQuorumRotationTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(16, 15, fast_dip3_enforcement=True)
+        self.set_dash_test_params(9, 8, fast_dip3_enforcement=True)
         self.set_dash_llmq_test_params(4, 4)
 
     def run_test(self):
@@ -124,23 +124,6 @@ class LLMQQuorumRotationTest(DashTestFramework):
         expectedNew = [q_100_1, q_102_1, q_103_1_0, q_103_1_1]
         quorumList = self.test_getmnlistdiff_quorums(b_1, b_2, quorumList, expectedDeleted, expectedNew)
 
-        (quorum_info_2_0, quorum_info_2_1) = self.mine_cycle_quorum(llmq_type_name=llmq_type_name, llmq_type=llmq_type)
-        quorum_members_2_0 = extract_quorum_members(quorum_info_2_0)
-        quorum_members_2_1 = extract_quorum_members(quorum_info_2_1)
-        assert_equal(len(intersection(quorum_members_2_0, quorum_members_2_1)), 0)
-        self.log.info("Quorum #2_0 members: " + str(quorum_members_2_0))
-        self.log.info("Quorum #2_1 members: " + str(quorum_members_2_1))
-
-        q_100_2 = QuorumId(100, int(quorum_info_2_0["quorumHash"], 16))
-        q_102_2 = QuorumId(102, int(quorum_info_2_0["quorumHash"], 16))
-        q_103_2_0 = QuorumId(103, int(quorum_info_2_0["quorumHash"], 16))
-        q_103_2_1 = QuorumId(103, int(quorum_info_2_1["quorumHash"], 16))
-
-        b_3 = self.nodes[0].getbestblockhash()
-        expectedDeleted = [q_100_0, q_102_0, q_103_1_0, q_103_1_1]
-        expectedNew = [q_100_2, q_102_2, q_103_2_0, q_103_2_1]
-        quorumList = self.test_getmnlistdiff_quorums(b_2, b_3, quorumList, expectedDeleted, expectedNew)
-
         mninfos_online = self.mninfo.copy()
         nodes = [self.nodes[0]] + [mn.node for mn in mninfos_online]
         sync_blocks(nodes)
@@ -151,12 +134,6 @@ class LLMQQuorumRotationTest(DashTestFramework):
 
         assert_greater_than_or_equal(len(intersection(quorum_members_0_0, quorum_members_1_0)), 3)
         assert_greater_than_or_equal(len(intersection(quorum_members_0_1, quorum_members_1_1)), 3)
-
-        assert_greater_than_or_equal(len(intersection(quorum_members_0_0, quorum_members_2_0)), 2)
-        assert_greater_than_or_equal(len(intersection(quorum_members_0_1, quorum_members_2_1)), 2)
-
-        assert_greater_than_or_equal(len(intersection(quorum_members_1_0, quorum_members_2_0)), 3)
-        assert_greater_than_or_equal(len(intersection(quorum_members_1_1, quorum_members_2_1)), 3)
 
         self.log.info("Mine a quorum to invalidate")
         (quorum_info_3_0, quorum_info_3_1) = self.mine_cycle_quorum(llmq_type_name=llmq_type_name, llmq_type=llmq_type)


### PR DESCRIPTION
This PR includes:

- Introduction of new llmq_type: `llmq_devnet_dip0024` similar to `llmq_devnet`. The reason is because  deployments on small devnets are done with `llmqinstantsenddip0024=llmq_devnet` thus the value of `keepOldConnections` is not aligned with rotation logic (`2 x signingActiveQuorumCount`)
- Faster `feature_llmq_rotation.py` test by reducing the number of masternodes and by removing one cycle (~40% faster on my machine)