### PR TITLE
fix(gov): do not allow empty proposal names

### DIFF
--- a/src/governance/validators.cpp
+++ b/src/governance/validators.cpp
@@ -98,6 +98,11 @@ bool CProposalValidator::ValidateName()
         return false;
     }
 
+    if (strName.size() == 0) {
+        strErrorMessages += "name cannot be empty;";
+        return false;
+    }
+
     static constexpr std::string_view strAllowedChars{"-_abcdefghijklmnopqrstuvwxyz0123456789"};
 
     strName = ToLower(strName);

--- a/src/governance/validators.cpp
+++ b/src/governance/validators.cpp
@@ -98,7 +98,7 @@ bool CProposalValidator::ValidateName()
         return false;
     }
 
-    if (strName.size() == 0) {
+    if (strName.empty()) {
         strErrorMessages += "name cannot be empty;";
         return false;
     }

--- a/src/test/data/proposals_invalid.json
+++ b/src/test/data/proposals_invalid.json
@@ -16,5 +16,6 @@
 {"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": "25.75", "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
 {"end_epoch": "1491368400", "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
 {"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": "1474261086", "type": 1, "url": "http://dashcentral.org/dean-miller-5493"},
-{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 2, "url": "http://dashcentral.org/dean-miller-5493"}
+{"end_epoch": 1491368400, "name": "dean-miller-5493", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 2, "url": "http://dashcentral.org/dean-miller-5493"},
+{"end_epoch": 1491368400, "name": "", "payment_address": "XpG61qAVhdyN7AqVZQsHfJL7AEk4dPVinc", "payment_amount": 25.75, "start_epoch": 1474261086, "type": 1, "url": "http://dashcentral.org/dean-miller-5493"}
 ]


### PR DESCRIPTION
This is the only check in Sentinel that does not also exist in Core. Additionally, if someone _does_ submit a nameless proposal, then currently Sentinel will vote it down and they will lose the 5 Dash.

We might want to put a minimum name size like in URL, I'm open to discussion here.