### PR TITLE
Merge #18530: Add test for -blocksonly and -whitelistforcerelay param interaction

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3267,8 +3267,8 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
 
     if (msg_type == NetMsgType::TX || msg_type == NetMsgType::DSTX || msg_type == NetMsgType::LEGACYTXLOCKREQUEST) {
         // Stop processing the transaction early if
-        // We are in blocks only mode and peer is either not whitelisted or whitelistrelay is off
-        // or if this peer is supposed to be a block-relay-only peer
+        // 1) We are in blocks only mode and peer has no relay permission
+        // 2) This peer is a block-relay-only peer
         if ((!g_relay_txes && !pfrom->HasPermission(PF_RELAY)) || (pfrom->m_tx_relay == nullptr))
         {
             LogPrint(BCLog::NET, "transaction sent in violation of protocol peer=%d\n", pfrom->GetId());

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -58,6 +58,29 @@ class P2PBlocksOnly(BitcoinTestFramework):
             self.nodes[0].p2p.wait_for_tx(txid)
             assert_equal(self.nodes[0].getmempoolinfo()['size'], 1)
 
+        self.log.info('Check that txs from whitelisted peers are not rejected and relayed to others')
+        self.log.info("Restarting node 0 with whitelist permission and blocksonly")
+        self.restart_node(0, ["-persistmempool=0", "-whitelist=127.0.0.1", "-whitelistforcerelay", "-blocksonly"])
+        assert_equal(self.nodes[0].getrawmempool(),[])
+        first_peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        second_peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        peer_1_info = self.nodes[0].getpeerinfo()[0]
+        assert_equal(peer_1_info['whitelisted'], True)
+        assert_equal(peer_1_info['permissions'], ['noban', 'forcerelay', 'relay', 'mempool'])
+        peer_2_info = self.nodes[0].getpeerinfo()[1]
+        assert_equal(peer_2_info['whitelisted'], True)
+        assert_equal(peer_2_info['permissions'], ['noban', 'forcerelay', 'relay', 'mempool'])
+        assert_equal(self.nodes[0].testmempoolaccept([sigtx])[0]['allowed'], True)
+        txid = self.nodes[0].testmempoolaccept([sigtx])[0]['txid']
+
+        self.log.info('Check that the tx from whitelisted first_peer is relayed to others (ie.second_peer)')
+        with self.nodes[0].assert_debug_log(["received getdata"]):
+            first_peer.send_message(msg_tx(FromHex(CTransaction(), sigtx)))
+            self.log.info('Check that the whitelisted peer is still connected after sending the transaction')
+            assert_equal(first_peer.is_connected, True)
+            second_peer.wait_for_tx(txid)
+            assert_equal(self.nodes[0].getmempoolinfo()['size'], 1)
+        self.log.info("Whitelisted peer's transaction is accepted and relayed")
 
 if __name__ == '__main__':
     P2PBlocksOnly().main()


### PR DESCRIPTION
0ea5d70b4756f376342417e0019490233cb4a918 Updated comment for the condition where a transaction relay is denied (glowang)
be01449cc8eb7bb97531a967f5d1dcc7b8865d1e Add test for param interaction b/w -blocksonly and -whitelistforcerelay (glowang)

Pull request description:

  Related to: #18428

  When -blocksonly is turned on, a node would still relay transactions from whitelisted peers. This funcitonality has not been tested.

ACKs for top commit:
  MarcoFalke:
    ACK 0ea5d70b4756f376342417e0019490233cb4a918

Tree-SHA512: 4e99c88281cb518cc67f5f3be7171a7b413933047b5d24a04bb3ff2210a82e914d69079f64cd5bac9206ec435e21a622c8e69cedbc2ccb39d2328ac5c01668e5