### PR TITLE
fix!: Relaxing Pos DKG check on last successful connection

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -131,6 +131,8 @@ void CMNAuth::ProcessMessage(CNode* pnode, const std::string& msg_type, CDataStr
         }
     }
 
+    mmetaman.GetMetaInfo(mnauth.proRegTxHash)->SetLastInboundOutboundSuccess(GetAdjustedTime());
+
     connman.ForEachNode([&](CNode* pnode2) {
         if (pnode->fDisconnect) {
             // we've already disconnected the new peer

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -473,10 +473,10 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions() const
             logger.Batch("%s does not have min proto version %d (has %d)", m->dmn->proTxHash.ToString(), MIN_MASTERNODE_PROTO_VERSION, it->second);
         }
 
-        auto lastOutbound = mmetaman.GetMetaInfo(m->dmn->proTxHash)->GetLastOutboundSuccess();
-        if (GetAdjustedTime() - lastOutbound > 60 * 60) {
+        auto lastMNConnection = mmetaman.GetMetaInfo(m->dmn->proTxHash)->GetLastInboundOutboundSuccess();
+        if (GetAdjustedTime() - lastMNConnection > 60 * 60) {
             m->badConnection = true;
-            logger.Batch("%s no outbound connection since %d seconds", m->dmn->proTxHash.ToString(), GetAdjustedTime() - lastOutbound);
+            logger.Batch("%s no inbound/outbound connection since %d seconds", m->dmn->proTxHash.ToString(), GetAdjustedTime() - lastMNConnection);
         }
     }
 }

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -10,7 +10,7 @@
 
 CMasternodeMetaMan mmetaman;
 
-const std::string CMasternodeMetaMan::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-2";
+const std::string CMasternodeMetaMan::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-3";
 
 UniValue CMasternodeMetaInfo::ToJson() const
 {
@@ -24,6 +24,9 @@ UniValue CMasternodeMetaInfo::ToJson() const
     ret.pushKV("lastOutboundAttemptElapsed", now - lastOutboundAttempt);
     ret.pushKV("lastOutboundSuccess", lastOutboundSuccess);
     ret.pushKV("lastOutboundSuccessElapsed", now - lastOutboundSuccess);
+    ret.pushKV("lastInbountOutboundSuccess", lastInbountOutboundSuccess);
+    ret.pushKV("lastInbountOutboundSuccessElapsed", now - lastInbountOutboundSuccess);
+
 
     return ret;
 }

--- a/src/masternode/meta.h
+++ b/src/masternode/meta.h
@@ -37,6 +37,7 @@ private:
 
     std::atomic<int64_t> lastOutboundAttempt{0};
     std::atomic<int64_t> lastOutboundSuccess{0};
+    std::atomic<int64_t> lastInbountOutboundSuccess{0};
 
 public:
     CMasternodeMetaInfo() = default;
@@ -47,7 +48,8 @@ public:
         nMixingTxCount(ref.nMixingTxCount.load()),
         mapGovernanceObjectsVotedOn(ref.mapGovernanceObjectsVotedOn),
         lastOutboundAttempt(ref.lastOutboundAttempt.load()),
-        lastOutboundSuccess(ref.lastOutboundSuccess.load())
+        lastOutboundSuccess(ref.lastOutboundSuccess.load()),
+        lastInbountOutboundSuccess(ref.lastInbountOutboundSuccess.load())
     {
     }
 
@@ -60,7 +62,8 @@ public:
                 obj.nMixingTxCount,
                 obj.mapGovernanceObjectsVotedOn,
                 obj.lastOutboundAttempt,
-                obj.lastOutboundSuccess
+                obj.lastOutboundSuccess,
+                obj.lastInbountOutboundSuccess
                 );
     }
 
@@ -82,6 +85,8 @@ public:
     int64_t GetLastOutboundAttempt() const { return lastOutboundAttempt; }
     void SetLastOutboundSuccess(int64_t t) { lastOutboundSuccess = t; }
     int64_t GetLastOutboundSuccess() const { return lastOutboundSuccess; }
+    void SetLastInboundOutboundSuccess(int64_t t) { lastInbountOutboundSuccess = t; }
+    int64_t GetLastInboundOutboundSuccess() const { return lastInbountOutboundSuccess; }
 };
 using CMasternodeMetaInfoPtr = std::shared_ptr<CMasternodeMetaInfo>;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2469,14 +2469,18 @@ void CConnman::ThreadOpenMasternodeConnections()
                         it = masternodePendingProbes.erase(it);
                         continue;
                     }
-                    bool connectedAndOutbound = connectedProRegTxHashes.count(dmn->proTxHash) && !connectedProRegTxHashes[dmn->proTxHash];
-                    if (connectedAndOutbound) {
-                        // we already have an outbound connection to this MN so there is no theed to probe it again
+                    if (connectedProRegTxHashes.count(dmn->proTxHash)) {
                         mmetaman.GetMetaInfo(dmn->proTxHash)->SetLastInboundOutboundSuccess(nANow);
-                        mmetaman.GetMetaInfo(dmn->proTxHash)->SetLastOutboundSuccess(nANow);
-                        it = masternodePendingProbes.erase(it);
-                        continue;
+
+                        bool connectedAndOutbound = !connectedProRegTxHashes[dmn->proTxHash];
+                        if (connectedAndOutbound) {
+                            // we already have an outbound connection to this MN so there is no theed to probe it again
+                            mmetaman.GetMetaInfo(dmn->proTxHash)->SetLastOutboundSuccess(nANow);
+                            it = masternodePendingProbes.erase(it);
+                            continue;
+                        }
                     }
+
                     ++it;
 
                     int64_t lastAttempt = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastOutboundAttempt();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2472,11 +2472,11 @@ void CConnman::ThreadOpenMasternodeConnections()
                     bool connectedAndOutbound = connectedProRegTxHashes.count(dmn->proTxHash) && !connectedProRegTxHashes[dmn->proTxHash];
                     if (connectedAndOutbound) {
                         // we already have an outbound connection to this MN so there is no theed to probe it again
+                        mmetaman.GetMetaInfo(dmn->proTxHash)->SetLastInboundOutboundSuccess(nANow);
                         mmetaman.GetMetaInfo(dmn->proTxHash)->SetLastOutboundSuccess(nANow);
                         it = masternodePendingProbes.erase(it);
                         continue;
                     }
-
                     ++it;
 
                     int64_t lastAttempt = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastOutboundAttempt();
@@ -2517,6 +2517,7 @@ void CConnman::ThreadOpenMasternodeConnections()
             LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- connection failed for masternode  %s, service=%s\n", __func__, connectToDmn->proTxHash.ToString(), connectToDmn->pdmnState->addr.ToString(false));
             // reset last outbound success
             mmetaman.GetMetaInfo(connectToDmn->proTxHash)->SetLastOutboundSuccess(0);
+            mmetaman.GetMetaInfo(connectToDmn->proTxHash)->SetLastInboundOutboundSuccess(0);
         }
     }
 }


### PR DESCRIPTION
On testnet we saw that when `SPORK_23_QUORUM_POSE` is active, newly joining masternodes are getting PoS punished/banned.

When a masternode comes online it initiates connections, but the code on other mns in DKGs would give a PoSe ban if they hadn’t “accepted” a connection from it. This is because new nodes are the ones initiating.

This PR transforms the check from checking if the last outcound success is no older than 60 x 60 seconds to any bound success.