### PR TITLE
fix(llmq): avoid probing mns too often instead of using a tiny window to probe them

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -780,11 +780,11 @@ void CLLMQUtils::AddQuorumProbeConnections(const Consensus::LLMQParams& llmqPara
             continue;
         }
         auto lastOutbound = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastOutboundSuccess();
-        // re-probe after 50 minutes so that the "good connection" check in the DKG doesn't fail just because we're on
-        // the brink of timeout
-        if (curTime - lastOutbound > 50 * 60) {
-            probeConnections.emplace(dmn->proTxHash);
+        if (curTime - lastOutbound < 10 * 60) {
+            // avoid re-probing nodes too often
+            continue;
         }
+        probeConnections.emplace(dmn->proTxHash);
     }
 
     if (!probeConnections.empty()) {


### PR DESCRIPTION
We only call `AddQuorumProbeConnections` when a new quorum is intialized. It's possible to miss the 10 minute probe window if `Contribute` phase takes too long (when 2 blocks were mined in 10+ minutes). 50 minutes should be enough and probing once in 10 minutes should be safe.