### PR TITLE
feat(rpc): getnetworkinfo RPC enrichment response

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3392,13 +3392,16 @@ void CConnman::AddPendingProbeConnections(const std::set<uint256> &proTxHashes)
     masternodePendingProbes.insert(proTxHashes.begin(), proTxHashes.end());
 }
 
-size_t CConnman::GetNodeCount(NumConnections flags)
+size_t CConnman::GetNodeCount(NumConnections flags, bool fOnlyVerifiedMN)
 {
     LOCK(cs_vNodes);
 
     int nNum = 0;
     for (const auto& pnode : vNodes) {
         if (pnode->fDisconnect) {
+            continue;
+        }
+        if (fOnlyVerifiedMN && pnode->GetVerifiedProRegTxHash().IsNull()) {
             continue;
         }
         if (flags & (pnode->fInbound ? CONNECTIONS_IN : CONNECTIONS_OUT)) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3392,7 +3392,7 @@ void CConnman::AddPendingProbeConnections(const std::set<uint256> &proTxHashes)
     masternodePendingProbes.insert(proTxHashes.begin(), proTxHashes.end());
 }
 
-size_t CConnman::GetNodeCount(NumConnections flags, bool fOnlyVerifiedMN)
+size_t CConnman::GetNodeCount(NumConnections flags)
 {
     LOCK(cs_vNodes);
 
@@ -3401,7 +3401,7 @@ size_t CConnman::GetNodeCount(NumConnections flags, bool fOnlyVerifiedMN)
         if (pnode->fDisconnect) {
             continue;
         }
-        if (fOnlyVerifiedMN && pnode->GetVerifiedProRegTxHash().IsNull()) {
+        if ((flags & CONNECTIONS_VERIFIED) && pnode->GetVerifiedProRegTxHash().IsNull()) {
             continue;
         }
         if (flags & (pnode->fInbound ? CONNECTIONS_IN : CONNECTIONS_OUT)) {

--- a/src/net.h
+++ b/src/net.h
@@ -146,6 +146,9 @@ public:
         CONNECTIONS_IN = (1U << 0),
         CONNECTIONS_OUT = (1U << 1),
         CONNECTIONS_ALL = (CONNECTIONS_IN | CONNECTIONS_OUT),
+        CONNECTIONS_VERIFIED = (1U << 2),
+        CONNECTIONS_VERIFIED_IN = (CONNECTIONS_VERIFIED | CONNECTIONS_IN),
+        CONNECTIONS_VERIFIED_OUT = (CONNECTIONS_VERIFIED | CONNECTIONS_OUT),
     };
 
     enum SocketEventsMode {
@@ -433,7 +436,7 @@ public:
     bool IsMasternodeQuorumRelayMember(const uint256& protxHash);
     void AddPendingProbeConnections(const std::set<uint256>& proTxHashes);
 
-    size_t GetNodeCount(NumConnections num, bool fOnlyVerifiedMN = false);
+    size_t GetNodeCount(NumConnections num);
     size_t GetMaxOutboundNodeCount();
     void GetNodeStats(std::vector<CNodeStats>& vstats);
     bool DisconnectNode(const std::string& node);

--- a/src/net.h
+++ b/src/net.h
@@ -433,7 +433,7 @@ public:
     bool IsMasternodeQuorumRelayMember(const uint256& protxHash);
     void AddPendingProbeConnections(const std::set<uint256>& proTxHashes);
 
-    size_t GetNodeCount(NumConnections num);
+    size_t GetNodeCount(NumConnections num, bool fOnlyVerifiedMN = false);
     size_t GetMaxOutboundNodeCount();
     void GetNodeStats(std::vector<CNodeStats>& vstats);
     bool DisconnectNode(const std::string& node);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -541,6 +541,11 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
     if (node.connman) {
         obj.pushKV("networkactive", node.connman->GetNetworkActive());
         obj.pushKV("connections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
+        obj.pushKV("inboundconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_IN));
+        obj.pushKV("outboundconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_OUT));
+        obj.pushKV("mnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL, true));
+        obj.pushKV("inboundmnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_IN, true));
+        obj.pushKV("outboundmnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_OUT, true));
         std::string strSocketEvents;
         switch (node.connman->GetSocketEventsMode()) {
             case CConnman::SOCKETEVENTS_SELECT:

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -490,7 +490,12 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
                         }},
                         {RPCResult::Type::BOOL, "localrelay", "true if transaction relay is requested from peers"},
                         {RPCResult::Type::NUM, "timeoffset", "the time offset"},
-                        {RPCResult::Type::NUM, "connections", "the number of connections"},
+                        {RPCResult::Type::NUM, "connections", "the number of inbound and outbound connections"},
+                        {RPCResult::Type::NUM, "inboundconnections", "the number of inbound connections"},
+                        {RPCResult::Type::NUM, "outboundconnections", "the number of outbound connections"},
+                        {RPCResult::Type::NUM, "mnconnections", "the number of verified mn connections"},
+                        {RPCResult::Type::NUM, "inboundmnconnections", "the number of inbound verified mn connections"},
+                        {RPCResult::Type::NUM, "outboundmnconnections", "the number of outbound verified mn connections"},
                         {RPCResult::Type::BOOL, "networkactive", "whether p2p networking is enabled"},
                         {RPCResult::Type::STR, "socketevents", "the socket events mode, either kqueue, epoll, poll or select"},
                         {RPCResult::Type::ARR, "networks", "information per network",
@@ -543,9 +548,9 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
         obj.pushKV("connections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
         obj.pushKV("inboundconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_IN));
         obj.pushKV("outboundconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_OUT));
-        obj.pushKV("mnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL, true));
-        obj.pushKV("inboundmnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_IN, true));
-        obj.pushKV("outboundmnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_OUT, true));
+        obj.pushKV("mnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_VERIFIED));
+        obj.pushKV("inboundmnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_VERIFIED_IN));
+        obj.pushKV("outboundmnconnections",   (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_VERIFIED_OUT));
         std::string strSocketEvents;
         switch (node.connman->GetSocketEventsMode()) {
             case CConnman::SOCKETEVENTS_SELECT:


### PR DESCRIPTION
Adding the following extra information when calling RPC `getnetworkinfo`:
- `inboundconnections`: Total inbound connections
- `outboundconnections`: Total outbound connections
- `connections`: Total inbound and outbound
- `inboundmnconnections`: Total verified MN inbound connections
- `outboundmnconnections`: Total verified MN outbound connections
- `mnconnections`: Total verified MN connections

