### PR TITLE
fix!: GetNumCommitmentsRequired Rotation

### DIFF
--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -440,12 +440,13 @@ size_t CQuorumBlockProcessor::GetNumCommitmentsRequired(const Consensus::LLMQPar
 
     bool rotation_enabled = CLLMQUtils::IsQuorumRotationEnabled(llmqParams.type, pindex);
     size_t quorums_num = rotation_enabled ? llmqParams.signingActiveQuorumCount : 1;
+
+    if (rotation_enabled) return quorums_num;
+
     size_t ret{0};
 
-    for (const auto quorumIndex : irange::range(quorums_num)) {
-        uint256 quorumHash = GetQuorumBlockHash(llmqParams, nHeight, quorumIndex);
-        if (!quorumHash.IsNull() && !HasMinedCommitment(llmqParams.type, quorumHash)) ++ret;
-    }
+    uint256 quorumHash = GetQuorumBlockHash(llmqParams, nHeight, 0);
+    if (!quorumHash.IsNull() && !HasMinedCommitment(llmqParams.type, quorumHash)) ++ret;
 
     return ret;
 }

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -440,13 +440,12 @@ size_t CQuorumBlockProcessor::GetNumCommitmentsRequired(const Consensus::LLMQPar
 
     bool rotation_enabled = CLLMQUtils::IsQuorumRotationEnabled(llmqParams.type, pindex);
     size_t quorums_num = rotation_enabled ? llmqParams.signingActiveQuorumCount : 1;
-
-    if (rotation_enabled) return quorums_num;
-
     size_t ret{0};
 
-    uint256 quorumHash = GetQuorumBlockHash(llmqParams, nHeight, 0);
-    if (!quorumHash.IsNull() && !HasMinedCommitment(llmqParams.type, quorumHash)) ++ret;
+    for (const auto quorumIndex : irange::range(quorums_num)) {
+        uint256 quorumHash = GetQuorumBlockHash(llmqParams, nHeight, quorumIndex);
+        if (!quorumHash.IsNull() && !HasMinedCommitment(llmqParams.type, quorumHash)) ++ret;
+    }
 
     return ret;
 }
@@ -731,6 +730,8 @@ std::optional<std::vector<CFinalCommitment>> CQuorumBlockProcessor::GetMineableC
         if (quorumHash.IsNull()) {
             break;
         }
+
+        if (HasMinedCommitment(llmqParams.type, quorumHash)) continue;
 
         LOCK(minableCommitmentsCs);
 


### PR DESCRIPTION
When calculating number of required commitments with rotation, they always need to be equal to `signingActiveQuorumCount` since the miner always produce `signingActiveQuorumCount` qcommits (either null or non-null).

On devnet-jack-daniels, on a rotation cycle, DKG of the `quorumIndex` 0 succeed but the one on `quorumIndex` 1 failed (for any reason).
So the miner tries to produce a block with a non-null qcommit and a null qcommit.
But as the code is at the moment, `GetNumCommitmentsRequired` returns 1 which leads to `bad-qc-not-allowed`.
