### PR TITLE
chore: Pass KeyOriginInfo instead of CKeyMetadata to DeriveChildExtKey

### DIFF
--- a/src/hdchain.cpp
+++ b/src/hdchain.cpp
@@ -8,9 +8,6 @@
 #include <tinyformat.h>
 #include <util/system.h>
 #include <util/strencodings.h>
-#ifdef ENABLE_WALLET
-#include <wallet/walletdb.h>
-#endif
 
 bool CHDChain::SetNull()
 {
@@ -159,7 +156,7 @@ uint256 CHDChain::GetSeedHash()
     return Hash(vchSeed.begin(), vchSeed.end());
 }
 
-void CHDChain::DeriveChildExtKey(uint32_t nAccountIndex, bool fInternal, uint32_t nChildIndex, CExtKey& extKeyRet, CKeyMetadata& metadata)
+void CHDChain::DeriveChildExtKey(uint32_t nAccountIndex, bool fInternal, uint32_t nChildIndex, CExtKey& extKeyRet, KeyOriginInfo& key_origin)
 {
     LOCK(cs);
     // Use BIP44 keypath scheme i.e. m / purpose' / coin_type' / account' / change / address_index
@@ -188,17 +185,15 @@ void CHDChain::DeriveChildExtKey(uint32_t nAccountIndex, bool fInternal, uint32_
 
 #ifdef ENABLE_WALLET
     // We should never ever update an already existing key_origin here
-    assert(!metadata.has_key_origin);
-    assert(metadata.key_origin.path.empty());
-    metadata.key_origin.path.push_back(44 | 0x80000000);
-    metadata.key_origin.path.push_back(Params().ExtCoinType() | 0x80000000);
-    metadata.key_origin.path.push_back(nAccountIndex | 0x80000000);
-    metadata.key_origin.path.push_back(fInternal ? 1 : 0);
-    metadata.key_origin.path.push_back(nChildIndex);
+    assert(key_origin.path.empty());
+    key_origin.path.push_back(44 | 0x80000000);
+    key_origin.path.push_back(Params().ExtCoinType() | 0x80000000);
+    key_origin.path.push_back(nAccountIndex | 0x80000000);
+    key_origin.path.push_back(fInternal ? 1 : 0);
+    key_origin.path.push_back(nChildIndex);
 
     CKeyID master_id = masterKey.key.GetPubKey().GetID();
-    std::copy(master_id.begin(), master_id.begin() + 4, metadata.key_origin.fingerprint);
-    metadata.has_key_origin = true;
+    std::copy(master_id.begin(), master_id.begin() + 4, key_origin.fingerprint);
 #endif
 }
 

--- a/src/hdchain.h
+++ b/src/hdchain.h
@@ -4,9 +4,8 @@
 #define BITCOIN_HDCHAIN_H
 
 #include <key.h>
+#include <script/keyorigin.h>
 #include <sync.h>
-
-class CKeyMetadata;
 
 /* hd account data model */
 class CHDAccount
@@ -110,7 +109,7 @@ public:
     uint256 GetID() const { LOCK(cs); return id; }
 
     uint256 GetSeedHash();
-    void DeriveChildExtKey(uint32_t nAccountIndex, bool fInternal, uint32_t nChildIndex, CExtKey& extKeyRet, CKeyMetadata& metadata);
+    void DeriveChildExtKey(uint32_t nAccountIndex, bool fInternal, uint32_t nChildIndex, CExtKey& extKeyRet, KeyOriginInfo& key_origin);
 
     void AddAccount();
     bool GetAccount(uint32_t nAccountIndex, CHDAccount& hdAccountRet);

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -40,8 +40,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "governance/governance -> masternode/sync -> governance/governance"
     "governance/governance -> net_processing -> governance/governance"
     "governance/object -> governance/validators -> governance/object"
-    "hdchain -> wallet/walletdb -> hdchain"
-    "hdchain -> wallet/walletdb -> script/sign -> script/signingprovider -> hdchain"
     "llmq/quorums -> llmq/utils -> llmq/quorums"
     "llmq/blockprocessor -> net_processing -> llmq/blockprocessor"
     "llmq/chainlocks -> llmq/instantsend -> llmq/chainlocks"


### PR DESCRIPTION
Resolves "hdchain -> wallet/walletdb -> ... -> hdchain" circular dependencies