### PR TITLE
refactor: begin llmq deglobalisation

### DIFF
--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -65,7 +65,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     }
 #endif // ENABLE_WALLET
 
-    instantSendManager.UpdatedBlockTip(pindexNew);
+    llmq::quorumInstantSendManager->UpdatedBlockTip(pindexNew);
     llmq::chainLocksHandler->UpdatedBlockTip();
 
     llmq::quorumManager->UpdatedBlockTip(pindexNew, fInitialDownload);
@@ -76,14 +76,14 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx, int64_t nAcceptTime)
 {
-    instantSendManager.TransactionAddedToMempool(ptx);
+    llmq::quorumInstantSendManager->TransactionAddedToMempool(ptx);
     llmq::chainLocksHandler->TransactionAddedToMempool(ptx, nAcceptTime);
     CCoinJoin::TransactionAddedToMempool(ptx);
 }
 
 void CDSNotificationInterface::TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason)
 {
-    instantSendManager.TransactionRemovedFromMempool(ptx);
+    llmq::quorumInstantSendManager->TransactionRemovedFromMempool(ptx);
 }
 
 void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted)
@@ -96,14 +96,14 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
     // to abandon a transaction and then have it inadvertently cleared by
     // the notification that the conflicted transaction was evicted.
 
-    instantSendManager.BlockConnected(pblock, pindex, vtxConflicted);
+    llmq::quorumInstantSendManager->BlockConnected(pblock, pindex, vtxConflicted);
     llmq::chainLocksHandler->BlockConnected(pblock, pindex, vtxConflicted);
     CCoinJoin::BlockConnected(pblock, pindex, vtxConflicted);
 }
 
 void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
 {
-    instantSendManager.BlockDisconnected(pblock, pindexDisconnected);
+    llmq::quorumInstantSendManager->BlockDisconnected(pblock, pindexDisconnected);
     llmq::chainLocksHandler->BlockDisconnected(pblock, pindexDisconnected);
     CCoinJoin::BlockDisconnected(pblock, pindexDisconnected);
 }
@@ -116,6 +116,6 @@ void CDSNotificationInterface::NotifyMasternodeListChanged(bool undo, const CDet
 
 void CDSNotificationInterface::NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const llmq::CChainLockSig>& clsig)
 {
-    instantSendManager.NotifyChainLock(pindex);
+    llmq::quorumInstantSendManager->NotifyChainLock(pindex);
     CCoinJoin::NotifyChainLock(pindex);
 }

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -65,7 +65,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     }
 #endif // ENABLE_WALLET
 
-    llmq::quorumInstantSendManager->UpdatedBlockTip(pindexNew);
+    instantSendManager.UpdatedBlockTip(pindexNew);
     llmq::chainLocksHandler->UpdatedBlockTip();
 
     llmq::quorumManager->UpdatedBlockTip(pindexNew, fInitialDownload);
@@ -76,14 +76,14 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx, int64_t nAcceptTime)
 {
-    llmq::quorumInstantSendManager->TransactionAddedToMempool(ptx);
+    instantSendManager.TransactionAddedToMempool(ptx);
     llmq::chainLocksHandler->TransactionAddedToMempool(ptx, nAcceptTime);
     CCoinJoin::TransactionAddedToMempool(ptx);
 }
 
 void CDSNotificationInterface::TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason)
 {
-    llmq::quorumInstantSendManager->TransactionRemovedFromMempool(ptx);
+    instantSendManager.TransactionRemovedFromMempool(ptx);
 }
 
 void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted)
@@ -96,14 +96,14 @@ void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock
     // to abandon a transaction and then have it inadvertently cleared by
     // the notification that the conflicted transaction was evicted.
 
-    llmq::quorumInstantSendManager->BlockConnected(pblock, pindex, vtxConflicted);
+    instantSendManager.BlockConnected(pblock, pindex, vtxConflicted);
     llmq::chainLocksHandler->BlockConnected(pblock, pindex, vtxConflicted);
     CCoinJoin::BlockConnected(pblock, pindex, vtxConflicted);
 }
 
 void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
 {
-    llmq::quorumInstantSendManager->BlockDisconnected(pblock, pindexDisconnected);
+    instantSendManager.BlockDisconnected(pblock, pindexDisconnected);
     llmq::chainLocksHandler->BlockDisconnected(pblock, pindexDisconnected);
     CCoinJoin::BlockDisconnected(pblock, pindexDisconnected);
 }
@@ -116,6 +116,6 @@ void CDSNotificationInterface::NotifyMasternodeListChanged(bool undo, const CDet
 
 void CDSNotificationInterface::NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const llmq::CChainLockSig>& clsig)
 {
-    llmq::quorumInstantSendManager->NotifyChainLock(pindex);
+    instantSendManager.NotifyChainLock(pindex);
     CCoinJoin::NotifyChainLock(pindex);
 }

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -6,11 +6,14 @@
 #define BITCOIN_DSNOTIFICATIONINTERFACE_H
 
 #include <validationinterface.h>
+namespace llmq {
+    class CInstantSendManager;
+}
 
 class CDSNotificationInterface : public CValidationInterface
 {
 public:
-    explicit CDSNotificationInterface(CConnman& connmanIn): connman(connmanIn) {}
+    explicit CDSNotificationInterface(CConnman& connmanIn, llmq::CInstantSendManager& isMan): connman(connmanIn), instantSendManager(isMan) {}
     virtual ~CDSNotificationInterface() = default;
 
     // a small helper to initialize current block height in sub-modules on startup
@@ -31,6 +34,7 @@ protected:
 
 private:
     CConnman& connman;
+    llmq::CInstantSendManager& instantSendManager;
 };
 
 #endif // BITCOIN_DSNOTIFICATIONINTERFACE_H

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -6,14 +6,11 @@
 #define BITCOIN_DSNOTIFICATIONINTERFACE_H
 
 #include <validationinterface.h>
-namespace llmq {
-    class CInstantSendManager;
-}
 
 class CDSNotificationInterface : public CValidationInterface
 {
 public:
-    explicit CDSNotificationInterface(CConnman& connmanIn, llmq::CInstantSendManager& isMan): connman(connmanIn), instantSendManager(isMan) {}
+    explicit CDSNotificationInterface(CConnman& connmanIn): connman(connmanIn) {}
     virtual ~CDSNotificationInterface() = default;
 
     // a small helper to initialize current block height in sub-modules on startup
@@ -34,7 +31,6 @@ protected:
 
 private:
     CConnman& connman;
-    llmq::CInstantSendManager& instantSendManager;
 };
 
 #endif // BITCOIN_DSNOTIFICATIONINTERFACE_H

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -26,8 +26,8 @@ bool MNHFTx::Verify(const CBlockIndex* pQuorumIndex) const
     int signOffset{llmq::GetLLMQParams(llmqType).dkgInterval};
 
     const uint256 requestId = ::SerializeHash(std::make_pair(CBLSIG_REQUESTID_PREFIX, pQuorumIndex->nHeight));
-    return llmq::CSigningManager::VerifyRecoveredSig(llmqType, pQuorumIndex->nHeight, requestId, pQuorumIndex->GetBlockHash(), sig, 0) ||
-           llmq::CSigningManager::VerifyRecoveredSig(llmqType, pQuorumIndex->nHeight, requestId, pQuorumIndex->GetBlockHash(), sig, signOffset);
+    return llmq::quorumSigningManager->VerifyRecoveredSig(llmqType, pQuorumIndex->nHeight, requestId, pQuorumIndex->GetBlockHash(), sig, 0) ||
+           llmq::quorumSigningManager->VerifyRecoveredSig(llmqType, pQuorumIndex->nHeight, requestId, pQuorumIndex->GetBlockHash(), sig, signOffset);
 }
 
 bool CheckMNHFTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2003,7 +2003,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
                 llmq::quorumSnapshotManager.reset();
                 llmq::quorumSnapshotManager.reset(new llmq::CQuorumSnapshotManager(*evoDb));
 
-                llmq::InitLLMQSystem(node, *evoDb, *node.mempool, *node.connman, false, fReset || fReindexChainState);
+                llmq::InitLLMQSystem(node, *evoDb, false, fReset || fReindexChainState);
 
                 if (fReset) {
                     pblocktree->WriteReindexing(true);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -88,7 +88,6 @@
 #include <llmq/signing.h>
 #include <llmq/snapshot.h>
 #include <llmq/utils.h>
-#include <llmq/instantsend.h>
 
 #include <statsd_client.h>
 
@@ -1912,7 +1911,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     }
 #endif
 
-    pdsNotificationInterface = new CDSNotificationInterface(*node.connman, *llmq::quorumInstantSendManager);
+    pdsNotificationInterface = new CDSNotificationInterface(*node.connman);
     RegisterValidationInterface(pdsNotificationInterface);
 
     uint64_t nMaxOutboundLimit = 0; //unlimited unless -maxuploadtarget is set

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -88,6 +88,7 @@
 #include <llmq/signing.h>
 #include <llmq/snapshot.h>
 #include <llmq/utils.h>
+#include <llmq/instantsend.h>
 
 #include <statsd_client.h>
 
@@ -1911,7 +1912,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     }
 #endif
 
-    pdsNotificationInterface = new CDSNotificationInterface(*node.connman);
+    pdsNotificationInterface = new CDSNotificationInterface(*node.connman, *llmq::quorumInstantSendManager);
     RegisterValidationInterface(pdsNotificationInterface);
 
     uint64_t nMaxOutboundLimit = 0; //unlimited unless -maxuploadtarget is set
@@ -2003,7 +2004,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
                 llmq::quorumSnapshotManager.reset();
                 llmq::quorumSnapshotManager.reset(new llmq::CQuorumSnapshotManager(*evoDb));
 
-                llmq::InitLLMQSystem(*evoDb, *node.mempool, *node.connman, false, fReset || fReindexChainState);
+                llmq::InitLLMQSystem(node, *evoDb, *node.mempool, *node.connman, false, fReset || fReindexChainState);
 
                 if (fReset) {
                     pblocktree->WriteReindexing(true);

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -23,9 +23,9 @@ namespace llmq
 {
 CChainLocksHandler* chainLocksHandler;
 
-CChainLocksHandler::CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman) :
+CChainLocksHandler::CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman, CSigningManager& sigMan) :
     scheduler(std::make_unique<CScheduler>()),
-    mempool(_mempool), connman(_connman)
+    mempool(_mempool), connman(_connman), signingManager(sigMan)
 {
     CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, scheduler.get());
     scheduler_thread = std::make_unique<std::thread>(std::bind(&TraceThread<CScheduler::Function>, "cl-schdlr", serviceLoop));
@@ -39,7 +39,7 @@ CChainLocksHandler::~CChainLocksHandler()
 
 void CChainLocksHandler::Start()
 {
-    quorumSigningManager->RegisterRecoveredSigsListener(this);
+    signingManager.RegisterRecoveredSigsListener(this);
     scheduler->scheduleEvery([&]() {
         CheckActiveState();
         EnforceBestChainLock();
@@ -51,7 +51,7 @@ void CChainLocksHandler::Start()
 void CChainLocksHandler::Stop()
 {
     scheduler->stop();
-    quorumSigningManager->UnregisterRecoveredSigsListener(this);
+    signingManager.UnregisterRecoveredSigsListener(this);
 }
 
 bool CChainLocksHandler::AlreadyHave(const CInv& inv) const
@@ -117,7 +117,7 @@ void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CCha
     }
 
     const uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, clsig.getHeight()));
-    if (!llmq::CSigningManager::VerifyRecoveredSig(Params().GetConsensus().llmqTypeChainLocks, clsig.getHeight(), requestId, clsig.getBlockHash(), clsig.getSig())) {
+    if (!signingManager.VerifyRecoveredSig(Params().GetConsensus().llmqTypeChainLocks, clsig.getHeight(), requestId, clsig.getBlockHash(), clsig.getSig())) {
         LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- invalid CLSIG (%s), peer=%d\n", __func__, clsig.ToString(), from);
         if (from != -1) {
             LOCK(cs_main);
@@ -335,7 +335,7 @@ void CChainLocksHandler::TrySignChainTip()
         lastSignedMsgHash = msgHash;
     }
 
-    quorumSigningManager->AsyncSignIfMember(Params().GetConsensus().llmqTypeChainLocks, requestId, msgHash);
+    signingManager.AsyncSignIfMember(Params().GetConsensus().llmqTypeChainLocks, requestId, msgHash);
 }
 
 void CChainLocksHandler::TransactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime)

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -27,6 +27,8 @@ class CTxMemPool;
 namespace llmq
 {
 
+class CSigningManager;
+
 class CChainLocksHandler : public CRecoveredSigsListener
 {
     static constexpr int64_t CLEANUP_INTERVAL = 1000 * 30;
@@ -37,6 +39,7 @@ class CChainLocksHandler : public CRecoveredSigsListener
 
 private:
     CConnman& connman;
+    CSigningManager& signingManager;
     CTxMemPool& mempool;
     std::unique_ptr<CScheduler> scheduler;
     std::unique_ptr<std::thread> scheduler_thread;
@@ -70,7 +73,7 @@ private:
     int64_t lastCleanupTime GUARDED_BY(cs) {0};
 
 public:
-    explicit CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman);
+    explicit CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman, CSigningManager& sigMan);
     ~CChainLocksHandler();
 
     void Start();

--- a/src/llmq/debug.cpp
+++ b/src/llmq/debug.cpp
@@ -14,7 +14,6 @@
 
 namespace llmq
 {
-CDKGDebugManager* quorumDKGDebugManager;
 
 UniValue CDKGDebugSessionStatus::ToJson(int quorumIndex, int detailLevel) const
 {

--- a/src/llmq/debug.h
+++ b/src/llmq/debug.h
@@ -105,8 +105,6 @@ public:
     void UpdateLocalMemberStatus(Consensus::LLMQType llmqType, int quorumIndex, size_t memberIdx, std::function<bool(CDKGDebugMemberStatus& status)>&& func);
 };
 
-extern CDKGDebugManager* quorumDKGDebugManager;
-
 } // namespace llmq
 
 #endif // BITCOIN_LLMQ_DEBUG_H

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -116,7 +116,7 @@ bool CDKGSession::Init(const CBlockIndex* _pQuorumBaseBlockIndex, const std::vec
     }
 
     if (!myProTxHash.IsNull()) {
-        quorumDKGDebugManager->InitLocalSessionStatus(params, quorumIndex, m_quorum_base_block_index->GetBlockHash(), m_quorum_base_block_index->nHeight);
+        dkgDebugManager.InitLocalSessionStatus(params, quorumIndex, m_quorum_base_block_index->GetBlockHash(), m_quorum_base_block_index->nHeight);
         relayMembers = CLLMQUtils::GetQuorumRelayMembers(params, m_quorum_base_block_index, myProTxHash, true);
         std::stringstream ss;
         for (const auto& r : relayMembers) {
@@ -198,7 +198,7 @@ void CDKGSession::SendContributions(CDKGPendingMessages& pendingMessages)
 
     logger.Flush();
 
-    quorumDKGDebugManager->UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
+    dkgDebugManager.UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
         status.sentContributions = true;
         return true;
     });
@@ -281,7 +281,7 @@ void CDKGSession::ReceiveMessage(const CDKGContribution& qc, bool& retBan)
     CInv inv(MSG_QUORUM_CONTRIB, hash);
     RelayInvToParticipants(inv);
 
-    quorumDKGDebugManager->UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
+    dkgDebugManager.UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
         status.receivedContribution = true;
         return true;
     });
@@ -321,7 +321,7 @@ void CDKGSession::ReceiveMessage(const CDKGContribution& qc, bool& retBan)
 
     if (complain) {
         member->weComplain = true;
-        quorumDKGDebugManager->UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
+        dkgDebugManager.UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
             status.weComplain = true;
             return true;
         });
@@ -389,7 +389,7 @@ void CDKGSession::VerifyPendingContributions()
             const auto& m = members[memberIndexes[i]];
             logger.Batch("invalid contribution from %s. will complain later", m->dmn->proTxHash.ToString());
             m->weComplain = true;
-            quorumDKGDebugManager->UpdateLocalMemberStatus(params.type, quorumIndex, m->idx, [&](CDKGDebugMemberStatus& status) {
+            dkgDebugManager.UpdateLocalMemberStatus(params.type, quorumIndex, m->idx, [&](CDKGDebugMemberStatus& status) {
                 status.weComplain = true;
                 return true;
             });
@@ -515,7 +515,7 @@ void CDKGSession::SendComplaint(CDKGPendingMessages& pendingMessages)
 
     logger.Flush();
 
-    quorumDKGDebugManager->UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
+    dkgDebugManager.UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
         status.sentComplaint = true;
         return true;
     });
@@ -588,7 +588,7 @@ void CDKGSession::ReceiveMessage(const CDKGComplaint& qc, bool& retBan)
     CInv inv(MSG_QUORUM_COMPLAINT, hash);
     RelayInvToParticipants(inv);
 
-    quorumDKGDebugManager->UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
+    dkgDebugManager.UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
         status.receivedComplaint = true;
         return true;
     });
@@ -614,7 +614,7 @@ void CDKGSession::ReceiveMessage(const CDKGComplaint& qc, bool& retBan)
         if (qc.complainForMembers[i]) {
             m->complaintsFromOthers.emplace(qc.proTxHash);
             m->someoneComplain = true;
-            quorumDKGDebugManager->UpdateLocalMemberStatus(params.type, quorumIndex, m->idx, [&](CDKGDebugMemberStatus& status) {
+            dkgDebugManager.UpdateLocalMemberStatus(params.type, quorumIndex, m->idx, [&](CDKGDebugMemberStatus& status) {
                 return status.complaintsFromMembers.emplace(member->idx).second;
             });
             if (AreWeMember() && i == myIdx) {
@@ -709,7 +709,7 @@ void CDKGSession::SendJustification(CDKGPendingMessages& pendingMessages, const 
 
     logger.Flush();
 
-    quorumDKGDebugManager->UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
+    dkgDebugManager.UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
         status.sentJustification = true;
         return true;
     });
@@ -799,7 +799,7 @@ void CDKGSession::ReceiveMessage(const CDKGJustification& qj, bool& retBan)
     CInv inv(MSG_QUORUM_JUSTIFICATION, hash);
     RelayInvToParticipants(inv);
 
-    quorumDKGDebugManager->UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
+    dkgDebugManager.UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
         status.receivedJustification = true;
         return true;
     });
@@ -1021,7 +1021,7 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
 
     logger.Flush();
 
-    quorumDKGDebugManager->UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
+    dkgDebugManager.UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
         status.sentPrematureCommitment = true;
         return true;
     });
@@ -1158,7 +1158,7 @@ void CDKGSession::ReceiveMessage(const CDKGPrematureCommitment& qc, bool& retBan
     CInv inv(MSG_QUORUM_PREMATURE_COMMITMENT, hash);
     RelayInvToParticipants(inv);
 
-    quorumDKGDebugManager->UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
+    dkgDebugManager.UpdateLocalMemberStatus(params.type, quorumIndex, member->idx, [&](CDKGDebugMemberStatus& status) {
         status.receivedPrematureCommitment = true;
         return true;
     });
@@ -1296,7 +1296,7 @@ void CDKGSession::MarkBadMember(size_t idx)
     if (member->bad) {
         return;
     }
-    quorumDKGDebugManager->UpdateLocalMemberStatus(params.type, quorumIndex, idx, [&](CDKGDebugMemberStatus& status) {
+    dkgDebugManager.UpdateLocalMemberStatus(params.type, quorumIndex, idx, [&](CDKGDebugMemberStatus& status) {
         status.bad = true;
         return true;
     });

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -210,6 +210,8 @@ public:
     bool someoneComplain{false};
 };
 
+class CDKGDebugManager;
+
 /**
  * The DKG session is a single instance of the DKG process. It is owned and called by CDKGSessionHandler, which passes
  * received DKG messages to the session. The session is not persistent and will loose it's state (the whole object is
@@ -236,6 +238,7 @@ private:
     CBLSWorker& blsWorker;
     CBLSWorkerCache cache;
     CDKGSessionManager& dkgManager;
+    CDKGDebugManager& dkgDebugManager;
 
     const CBlockIndex* m_quorum_base_block_index{nullptr};
     int quorumIndex{0};
@@ -276,8 +279,8 @@ private:
     std::set<uint256> validCommitments GUARDED_BY(invCs);
 
 public:
-    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager, CConnman& _connman) :
-        params(_params), blsWorker(_blsWorker), cache(_blsWorker), dkgManager(_dkgManager), connman(_connman) {}
+    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager, CDKGDebugManager& dkgDebugMan, CConnman& _connman) :
+        params(_params), blsWorker(_blsWorker), cache(_blsWorker), dkgManager(_dkgManager), dkgDebugManager(dkgDebugMan), connman(_connman) {}
 
     bool Init(const CBlockIndex* pQuorumBaseBlockIndex, const std::vector<CDeterministicMNCPtr>& mns, const uint256& _myProTxHash, int _quorumIndex);
 

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -141,7 +141,7 @@ void CDKGSessionHandler::StopThread()
 
 bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
 {
-    curSession = std::make_unique<CDKGSession>(params, blsWorker, dkgManager, connman);
+    curSession = std::make_unique<CDKGSession>(params, blsWorker, dkgManager, dkgDebugManager, connman);
 
     if (!deterministicMNManager->IsDIP3Enforced(pQuorumBaseBlockIndex->nHeight)) {
         return false;
@@ -199,9 +199,9 @@ void CDKGSessionHandler::WaitForNextPhase(std::optional<QuorumPhase> curPhase,
     LogPrint(BCLog::LLMQ_DKG, "CDKGSessionManager::%s -- %s qi[%d] - done, curPhase=%d, nextPhase=%d\n", __func__, params.name, quorumIndex, curPhase.has_value() ? int(*curPhase) : -1, int(nextPhase));
 
     if (nextPhase == QuorumPhase::Initialized) {
-        quorumDKGDebugManager->ResetLocalSessionStatus(params.type, quorumIndex);
+        dkgDebugManager.ResetLocalSessionStatus(params.type, quorumIndex);
     } else {
-        quorumDKGDebugManager->UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
+        dkgDebugManager.UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
             bool changed = status.phase != (uint8_t) nextPhase;
             status.phase = (uint8_t) nextPhase;
             return changed;
@@ -485,7 +485,7 @@ void CDKGSessionHandler::HandleDKGRound()
         throw AbortPhaseException();
     }
 
-    quorumDKGDebugManager->UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
+    dkgDebugManager.UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
         bool changed = status.phase != (uint8_t) QuorumPhase::Initialized;
         status.phase = (uint8_t) QuorumPhase::Initialized;
         return changed;
@@ -547,7 +547,7 @@ void CDKGSessionHandler::PhaseHandlerThread()
             LogPrint(BCLog::LLMQ_DKG, "CDKGSessionHandler::%s -- %s qi[%d] - starting HandleDKGRound\n", __func__, params.name, quorumIndex);
             HandleDKGRound();
         } catch (AbortPhaseException& e) {
-            quorumDKGDebugManager->UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
+            dkgDebugManager.UpdateLocalSessionStatus(params.type, quorumIndex, [&](CDKGDebugSessionStatus& status) {
                 status.aborted = true;
                 return true;
             });

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -93,6 +93,8 @@ public:
     }
 };
 
+class CDKGDebugManager;
+
 /**
  * Handles multiple sequential sessions of one specific LLMQ type. There is one instance of this class per LLMQ type.
  *
@@ -113,6 +115,7 @@ private:
     const int quorumIndex;
     CBLSWorker& blsWorker;
     CDKGSessionManager& dkgManager;
+    CDKGDebugManager& dkgDebugManager;
 
     QuorumPhase phase GUARDED_BY(cs) {QuorumPhase::Idle};
     int currentHeight GUARDED_BY(cs) {-1};
@@ -128,13 +131,14 @@ private:
     CDKGPendingMessages pendingPrematureCommitments;
 
 public:
-    CDKGSessionHandler(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager, CConnman& _connman, int _quorumIndex) :
+    CDKGSessionHandler(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager, CConnman& _connman, CDKGDebugManager& dkgDebugMan, int _quorumIndex) :
             params(_params),
             blsWorker(_blsWorker),
             dkgManager(_dkgManager),
             connman(_connman),
+            dkgDebugManager(dkgDebugMan),
             quorumIndex(_quorumIndex),
-            curSession(std::make_unique<CDKGSession>(_params, _blsWorker, _dkgManager, _connman)),
+            curSession(std::make_unique<CDKGSession>(_params, _blsWorker, _dkgManager, dkgDebugMan, _connman)),
             pendingContributions((size_t)_params.size * 2, MSG_QUORUM_CONTRIB), // we allow size*2 messages as we need to make sure we see bad behavior (double messages)
             pendingComplaints((size_t)_params.size * 2, MSG_QUORUM_COMPLAINT),
             pendingJustifications((size_t)_params.size * 2, MSG_QUORUM_JUSTIFICATION),

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -24,9 +24,9 @@ static const std::string DB_VVEC = "qdkg_V";
 static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
-CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CDKGDebugManager& dkgDebugMan, bool unitTests, bool fWipe) :
+CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CDKGDebugManager& _dkgDebugManager, bool unitTests, bool fWipe) :
         db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
-        blsWorker(_blsWorker), connman(_connman), dkgDebugManager(dkgDebugMan)
+        blsWorker(_blsWorker), connman(_connman), dkgDebugManager(_dkgDebugManager)
 {
     MigrateDKG();
 
@@ -36,7 +36,7 @@ CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorke
         for (const auto i : irange::range(session_count)) {
             dkgSessionHandlers.emplace(std::piecewise_construct,
                                        std::forward_as_tuple(params.type, i),
-                                       std::forward_as_tuple(params, blsWorker, *this, connman, dkgDebugMan, i));
+                                       std::forward_as_tuple(params, blsWorker, *this, connman, dkgDebugManager, i));
         }
     }
 }

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -24,9 +24,9 @@ static const std::string DB_VVEC = "qdkg_V";
 static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
-CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, bool unitTests, bool fWipe) :
+CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CDKGDebugManager& dkgDebugMan, bool unitTests, bool fWipe) :
         db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
-        blsWorker(_blsWorker), connman(_connman)
+        blsWorker(_blsWorker), connman(_connman), dkgDebugManager(dkgDebugMan)
 {
     MigrateDKG();
 
@@ -36,7 +36,7 @@ CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorke
         for (const auto i : irange::range(session_count)) {
             dkgSessionHandlers.emplace(std::piecewise_construct,
                                        std::forward_as_tuple(params.type, i),
-                                       std::forward_as_tuple(params, blsWorker, *this, connman, i));
+                                       std::forward_as_tuple(params, blsWorker, *this, connman, dkgDebugMan, i));
         }
     }
 }

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -24,6 +24,7 @@ private:
     std::unique_ptr<CDBWrapper> db{nullptr};
     CBLSWorker& blsWorker;
     CConnman& connman;
+    CDKGDebugManager& dkgDebugManager;
 
     //TODO name struct instead of std::pair
     std::map<std::pair<Consensus::LLMQType, int>, CDKGSessionHandler> dkgSessionHandlers;
@@ -48,7 +49,7 @@ private:
     mutable std::map<ContributionsCacheKey, ContributionsCacheEntry> contributionsCache GUARDED_BY(contributionsCacheCs);
 
 public:
-    CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, bool unitTests, bool fWipe);
+    CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CDKGDebugManager& dkgDebugMan, bool unitTests, bool fWipe);
     ~CDKGSessionManager() = default;
 
     void StartThreads();

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -49,7 +49,7 @@ private:
     mutable std::map<ContributionsCacheKey, ContributionsCacheEntry> contributionsCache GUARDED_BY(contributionsCacheCs);
 
 public:
-    CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CDKGDebugManager& dkgDebugMan, bool unitTests, bool fWipe);
+    CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CDKGDebugManager& _dkgDebugManager, bool unitTests, bool fWipe);
     ~CDKGSessionManager() = default;
 
     void StartThreads();

--- a/src/llmq/init.cpp
+++ b/src/llmq/init.cpp
@@ -25,18 +25,18 @@ namespace llmq
 
 CBLSWorker* blsWorker;
 
-void InitLLMQSystem(NodeContext& node, CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, bool unitTests, bool fWipe)
+void InitLLMQSystem(NodeContext& node, CEvoDB& evoDb, bool unitTests, bool fWipe)
 {
     blsWorker = new CBLSWorker();
 
     node.quorumDKGDebugManager = std::make_unique<CDKGDebugManager>();
-    quorumBlockProcessor = new CQuorumBlockProcessor(evoDb, connman);
-    quorumDKGSessionManager = new CDKGSessionManager(connman, *blsWorker, *node.quorumDKGDebugManager, unitTests, fWipe);
-    quorumManager = new CQuorumManager(evoDb, connman, *blsWorker, *quorumDKGSessionManager);
-    quorumSigSharesManager = new CSigSharesManager(connman, *quorumManager);
-    quorumSigningManager = new CSigningManager(connman, *quorumManager, *quorumSigSharesManager, unitTests, fWipe);
-    chainLocksHandler = new CChainLocksHandler(mempool, connman, *quorumSigningManager);
-    quorumInstantSendManager = new CInstantSendManager(mempool, connman, *chainLocksHandler, *quorumSigningManager, unitTests, fWipe);
+    quorumBlockProcessor = new CQuorumBlockProcessor(evoDb, *node.connman);
+    quorumDKGSessionManager = new CDKGSessionManager(*node.connman, *blsWorker, *node.quorumDKGDebugManager, unitTests, fWipe);
+    quorumManager = new CQuorumManager(evoDb, *node.connman, *blsWorker, *quorumDKGSessionManager);
+    quorumSigSharesManager = new CSigSharesManager(*node.connman, *quorumManager);
+    quorumSigningManager = new CSigningManager(*node.connman, *quorumManager, *quorumSigSharesManager, unitTests, fWipe);
+    chainLocksHandler = new CChainLocksHandler(*node.mempool, *node.connman, *quorumSigningManager);
+    quorumInstantSendManager = new CInstantSendManager(*node.mempool, *node.connman, *chainLocksHandler, *quorumSigningManager, unitTests, fWipe);
 
     // NOTE: we use this only to wipe the old db, do NOT use it for anything else
     // TODO: remove it in some future version

--- a/src/llmq/init.h
+++ b/src/llmq/init.h
@@ -15,7 +15,7 @@ namespace llmq
 {
 
 // Init/destroy LLMQ globals
-void InitLLMQSystem(NodeContext& node, CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, bool unitTests, bool fWipe = false);
+void InitLLMQSystem(NodeContext& node, CEvoDB& evoDb, bool unitTests, bool fWipe = false);
 void DestroyLLMQSystem();
 
 // Manage scheduled tasks, threads, listeners etc.

--- a/src/llmq/init.h
+++ b/src/llmq/init.h
@@ -9,12 +9,13 @@ class CConnman;
 class CDBWrapper;
 class CEvoDB;
 class CTxMemPool;
+class NodeContext;
 
 namespace llmq
 {
 
 // Init/destroy LLMQ globals
-void InitLLMQSystem(CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, bool unitTests, bool fWipe = false);
+void InitLLMQSystem(NodeContext& node, CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, bool unitTests, bool fWipe = false);
 void DestroyLLMQSystem();
 
 // Manage scheduled tasks, threads, listeners etc.

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -27,8 +27,8 @@
 namespace llmq
 {
 
-static const std::string INPUTLOCK_REQUESTID_PREFIX = "inlock";
-static const std::string ISLOCK_REQUESTID_PREFIX = "islock";
+static constexpr std::string_view INPUTLOCK_REQUESTID_PREFIX = "inlock";
+static constexpr std::string_view ISLOCK_REQUESTID_PREFIX = "islock";
 
 static const std::string DB_ISLOCK_BY_HASH = "is_i";
 static const std::string DB_HASH_BY_TXID = "is_tx";
@@ -37,7 +37,7 @@ static const std::string DB_MINED_BY_HEIGHT_AND_HASH = "is_m";
 static const std::string DB_ARCHIVED_BY_HEIGHT_AND_HASH = "is_a1";
 static const std::string DB_ARCHIVED_BY_HASH = "is_a2";
 
-static const std::string DB_VERSION = "is_v";
+static constexpr std::string_view DB_VERSION = "is_v";
 
 const int CInstantSendDb::CURRENT_VERSION;
 const uint8_t CInstantSendLock::islock_version;
@@ -461,12 +461,12 @@ void CInstantSendManager::Start()
 
     workThread = std::thread(&TraceThread<std::function<void()> >, "isman", std::function<void()>(std::bind(&CInstantSendManager::WorkThreadMain, this)));
 
-    quorumSigningManager->RegisterRecoveredSigsListener(this);
+    signingManager.RegisterRecoveredSigsListener(this);
 }
 
 void CInstantSendManager::Stop()
 {
-    quorumSigningManager->UnregisterRecoveredSigsListener(this);
+    signingManager.UnregisterRecoveredSigsListener(this);
 
     // make sure to call InterruptWorkerThread() first
     if (!workInterrupt) {
@@ -530,8 +530,8 @@ bool CInstantSendManager::TrySignInputLocks(const CTransaction& tx, bool fRetroa
 
         uint256 otherTxHash;
         // TODO check that we didn't vote for the other IS type also
-        if (quorumSigningManager->GetVoteForId(params.llmqTypeDIP0024InstantSend, id, otherTxHash) ||
-            quorumSigningManager->GetVoteForId(params.llmqTypeInstantSend, id, otherTxHash)) {
+        if (signingManager.GetVoteForId(params.llmqTypeDIP0024InstantSend, id, otherTxHash) ||
+            signingManager.GetVoteForId(params.llmqTypeInstantSend, id, otherTxHash)) {
             if (otherTxHash != tx.GetHash()) {
                 LogPrintf("CInstantSendManager::%s -- txid=%s: input %s is conflicting with previous vote for tx %s\n", __func__,
                           tx.GetHash().ToString(), in.prevout.ToStringShort(), otherTxHash.ToString());
@@ -542,10 +542,10 @@ bool CInstantSendManager::TrySignInputLocks(const CTransaction& tx, bool fRetroa
 
         // don't even try the actual signing if any input is conflicting
         if (auto llmqs = {params.llmqTypeDIP0024InstantSend, params.llmqTypeInstantSend};
-            ranges::any_of(llmqs, [&id, &tx](const auto& llmqType){
-                return quorumSigningManager->IsConflicting(llmqType, id, tx.GetHash());})
+            ranges::any_of(llmqs, [this, &id, &tx](const auto& llmqType){
+                return signingManager.IsConflicting(llmqType, id, tx.GetHash());})
                 ) {
-            LogPrintf("CInstantSendManager::%s -- txid=%s: quorumSigningManager->IsConflicting returned true. id=%s\n", __func__,
+            LogPrintf("CInstantSendManager::%s -- txid=%s: signingManager.IsConflicting returned true. id=%s\n", __func__,
                       tx.GetHash().ToString(), id.ToString());
             return false;
         }
@@ -565,7 +565,7 @@ bool CInstantSendManager::TrySignInputLocks(const CTransaction& tx, bool fRetroa
         WITH_LOCK(cs_inputReqests, inputRequestIds.emplace(id));
         LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s: trying to vote on input %s with id %s. fRetroactive=%d\n", __func__,
                  tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString(), fRetroactive);
-        if (quorumSigningManager->AsyncSignIfMember(llmqType, id, tx.GetHash(), {}, fRetroactive)) {
+        if (signingManager.AsyncSignIfMember(llmqType, id, tx.GetHash(), {}, fRetroactive)) {
             LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s: voted on input %s with id %s\n", __func__,
                      tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString());
         }
@@ -622,7 +622,7 @@ bool CInstantSendManager::CheckCanLock(const COutPoint& outpoint, bool printDebu
         nTxAge = ::ChainActive().Height() - pindexMined->nHeight + 1;
     }
 
-    if (nTxAge < nInstantSendConfirmationsRequired && !llmq::chainLocksHandler->HasChainLock(pindexMined->nHeight, pindexMined->GetBlockHash())) {
+    if (nTxAge < nInstantSendConfirmationsRequired && !chainLocksHandler.HasChainLock(pindexMined->nHeight, pindexMined->GetBlockHash())) {
         if (printDebug) {
             LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s: outpoint %s too new and not ChainLocked. nTxAge=%d, nInstantSendConfirmationsRequired=%d\n", __func__,
                      txHash.ToString(), outpoint.ToStringShort(), nTxAge, nInstantSendConfirmationsRequired);
@@ -687,7 +687,7 @@ void CInstantSendManager::TrySignInstantSendLock(const CTransaction& tx)
 
     for (auto& in : tx.vin) {
         auto id = ::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, in.prevout));
-        if (!quorumSigningManager->HasRecoveredSig(llmqType, id, tx.GetHash())) {
+        if (!signingManager.HasRecoveredSig(llmqType, id, tx.GetHash())) {
             return;
         }
     }
@@ -713,7 +713,7 @@ void CInstantSendManager::TrySignInstantSendLock(const CTransaction& tx)
 
     auto id = islock.GetRequestId();
 
-    if (quorumSigningManager->HasRecoveredSigForId(llmqType, id)) {
+    if (signingManager.HasRecoveredSigForId(llmqType, id)) {
         return;
     }
 
@@ -726,7 +726,7 @@ void CInstantSendManager::TrySignInstantSendLock(const CTransaction& tx)
         txToCreatingInstantSendLocks.emplace(tx.GetHash(), &e.first->second);
     }
 
-    quorumSigningManager->AsyncSignIfMember(llmqType, id, tx.GetHash());
+    signingManager.AsyncSignIfMember(llmqType, id, tx.GetHash());
 }
 
 void CInstantSendManager::HandleNewInstantSendLockRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
@@ -950,7 +950,7 @@ std::unordered_set<uint256, StaticSaltedHasher> CInstantSendManager::ProcessPend
         auto id = islock->GetRequestId();
 
         // no need to verify an ISLOCK if we already have verified the recovered sig that belongs to it
-        if (quorumSigningManager->HasRecoveredSig(llmqType, id, islock->txid)) {
+        if (signingManager.HasRecoveredSig(llmqType, id, islock->txid)) {
             alreadyVerified++;
             continue;
         }
@@ -971,7 +971,7 @@ std::unordered_set<uint256, StaticSaltedHasher> CInstantSendManager::ProcessPend
             }
         }
 
-        auto quorum = llmq::CSigningManager::SelectQuorumForSigning(llmqType, id, nSignHeight, signOffset);
+        auto quorum = signingManager.SelectQuorumForSigning(llmqType, id, nSignHeight, signOffset);
         if (!quorum) {
             // should not happen, but if one fails to select, all others will also fail to select
             return {};
@@ -983,7 +983,7 @@ std::unordered_set<uint256, StaticSaltedHasher> CInstantSendManager::ProcessPend
         // We can reconstruct the CRecoveredSig objects from the islock and pass it to the signing manager, which
         // avoids unnecessary double-verification of the signature. We however only do this when verification here
         // turns out to be good (which is checked further down)
-        if (!quorumSigningManager->HasRecoveredSigForId(llmqType, id)) {
+        if (!signingManager.HasRecoveredSigForId(llmqType, id)) {
             recSigs.try_emplace(hash, CRecoveredSig(llmqType, quorum->qc->quorumHash, id, islock->txid, islock->sig));
         }
     }
@@ -1024,10 +1024,10 @@ std::unordered_set<uint256, StaticSaltedHasher> CInstantSendManager::ProcessPend
         auto it = recSigs.find(hash);
         if (it != recSigs.end()) {
             auto recSig = std::make_shared<CRecoveredSig>(std::move(it->second));
-            if (!quorumSigningManager->HasRecoveredSigForId(llmqType, recSig->getId())) {
+            if (!signingManager.HasRecoveredSigForId(llmqType, recSig->getId())) {
                 LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s: passing reconstructed recSig to signing mgr, peer=%d\n", __func__,
                          islock->txid.ToString(), hash.ToString(), nodeId);
-                quorumSigningManager->PushReconstructedRecoveredSig(recSig);
+                signingManager.PushReconstructedRecoveredSig(recSig);
             }
         }
     }
@@ -1057,7 +1057,7 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
 
         // Let's see if the TX that was locked by this islock is already mined in a ChainLocked block. If yes,
         // we can simply ignore the islock, as the ChainLock implies locking of all TXs in that chain
-        if (pindexMined != nullptr && llmq::chainLocksHandler->HasChainLock(pindexMined->nHeight, pindexMined->GetBlockHash())) {
+        if (pindexMined != nullptr && chainLocksHandler.HasChainLock(pindexMined->nHeight, pindexMined->GetBlockHash())) {
             LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txlock=%s, islock=%s: dropping islock as it already got a ChainLock in block %s, peer=%d\n", __func__,
                      islock->txid.ToString(), hash.ToString(), hashBlock.ToString(), from);
             return;
@@ -1197,7 +1197,7 @@ void CInstantSendManager::BlockConnected(const std::shared_ptr<const CBlock>& pb
                 continue;
             }
 
-            if (!IsLocked(tx->GetHash()) && !chainLocksHandler->HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
+            if (!IsLocked(tx->GetHash()) && !chainLocksHandler.HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
                 ProcessTx(*tx, true, Params().GetConsensus());
                 // TX is not locked, so make sure it is tracked
                 AddNonLockedTx(tx, pindex);
@@ -1306,7 +1306,7 @@ void CInstantSendManager::TruncateRecoveredSigsForInputs(const llmq::CInstantSen
     for (auto& in : islock.inputs) {
         auto inputRequestId = ::SerializeHash(std::make_pair(INPUTLOCK_REQUESTID_PREFIX, in));
         WITH_LOCK(cs_inputReqests, inputRequestIds.erase(inputRequestId));
-        quorumSigningManager->TruncateRecoveredSig(CLLMQUtils::GetInstantSendLLMQType(islock.IsDeterministic()), inputRequestId);
+        signingManager.TruncateRecoveredSig(CLLMQUtils::GetInstantSendLLMQType(islock.IsDeterministic()), inputRequestId);
     }
 }
 
@@ -1359,7 +1359,7 @@ void CInstantSendManager::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
 
         // And we don't need the recovered sig for the ISLOCK anymore, as the block in which it got mined is considered
         // fully confirmed now
-        quorumSigningManager->TruncateRecoveredSig(CLLMQUtils::GetInstantSendLLMQType(islock->IsDeterministic()), islock->GetRequestId());
+        signingManager.TruncateRecoveredSig(CLLMQUtils::GetInstantSendLLMQType(islock->IsDeterministic()), islock->GetRequestId());
     }
 
     db.RemoveArchivedInstantSendLocks(pindex->nHeight - 100);
@@ -1448,7 +1448,7 @@ void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const
     bool hasChainLockedConflict = false;
     for (const auto& p : conflicts) {
         auto pindex = p.first;
-        if (chainLocksHandler->HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
+        if (chainLocksHandler.HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
             hasChainLockedConflict = true;
             break;
         }
@@ -1497,7 +1497,7 @@ void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const
     if (activateBestChain) {
         CValidationState state;
         if (!ActivateBestChain(state, Params())) {
-            LogPrintf("CChainLocksHandler::%s -- ActivateBestChain failed: %s\n", __func__, FormatStateMessage(state));
+            LogPrintf("CInstantSendManager::%s -- ActivateBestChain failed: %s\n", __func__, FormatStateMessage(state));
             // This should not have happened and we are in a state were it's not safe to continue anymore
             assert(false);
         }

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -20,6 +20,8 @@
 
 namespace llmq
 {
+class CChainLocksHandler;
+class CSigningManager;
 
 struct CInstantSendLock
 {
@@ -194,6 +196,8 @@ class CInstantSendManager : public CRecoveredSigsListener
 {
 private:
     CInstantSendDb db;
+    CChainLocksHandler& chainLocksHandler;
+    CSigningManager& signingManager;
     CConnman& connman;
     CTxMemPool& mempool;
 
@@ -243,7 +247,7 @@ private:
     std::unordered_set<uint256, StaticSaltedHasher> pendingRetryTxs GUARDED_BY(cs_pendingRetry);
 
 public:
-    explicit CInstantSendManager(CTxMemPool& _mempool, CConnman& _connman, bool unitTests, bool fWipe) : db(unitTests, fWipe), mempool(_mempool), connman(_connman) { workInterrupt.reset(); }
+    explicit CInstantSendManager(CTxMemPool& _mempool, CConnman& _connman, CChainLocksHandler& clHandler, CSigningManager& signingMan, bool unitTests, bool fWipe) : db(unitTests, fWipe), mempool(_mempool), connman(_connman), chainLocksHandler(clHandler), signingManager(signingMan) { workInterrupt.reset(); }
     ~CInstantSendManager() = default;
 
     void Start();

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -832,7 +832,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                     return;
                 }
 
-                if (quorumManager->RequestQuorumData(pNode, pQuorum->qc->llmqType, pQuorum->m_quorum_base_block_index, nDataMask, proTxHash)) {
+                if (this->RequestQuorumData(pNode, pQuorum->qc->llmqType, pQuorum->m_quorum_base_block_index, nDataMask, proTxHash)) {
                     nTimeLastSuccess = GetAdjustedTime();
                     printLog("Requested");
                 } else {

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -528,8 +528,8 @@ void CRecoveredSigsDb::CleanupOldVotes(int64_t maxAge)
 
 //////////////////
 
-CSigningManager::CSigningManager(CConnman& _connman, bool fMemory, bool fWipe) :
-    db(fMemory, fWipe), connman(_connman)
+CSigningManager::CSigningManager(CConnman& _connman, CQuorumManager& quorumMan, CSigSharesManager& sigSharesMan, bool fMemory, bool fWipe) :
+    db(fMemory, fWipe), connman(_connman), quorumManager(quorumMan), sigSharesManager(sigSharesMan)
 {
 }
 
@@ -614,7 +614,7 @@ bool CSigningManager::PreVerifyRecoveredSig(const CRecoveredSig& recoveredSig, b
         return false;
     }
 
-    CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, recoveredSig.getQuorumHash());
+    CQuorumCPtr quorum = quorumManager.GetQuorum(llmqType, recoveredSig.getQuorumHash());
 
     if (!quorum) {
         LogPrint(BCLog::LLMQ, "CSigningManager::%s -- quorum %s not found\n", __func__,
@@ -672,7 +672,7 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
             auto llmqType = recSig->getLlmqType();
             auto quorumKey = std::make_pair(recSig->getLlmqType(), recSig->getQuorumHash());
             if (!retQuorums.count(quorumKey)) {
-                CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, recSig->getQuorumHash());
+                CQuorumCPtr quorum = quorumManager.GetQuorum(llmqType, recSig->getQuorumHash());
                 if (!quorum) {
                     LogPrint(BCLog::LLMQ, "CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
                               recSig->getQuorumHash().ToString(), nodeId);
@@ -887,7 +887,7 @@ bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, const uint
         // TODO fix this by re-signing when the next block arrives, but only when that block results in a change of the quorum list and no recovered signature has been created in the mean time
         quorum = SelectQuorumForSigning(llmqType, id);
     } else {
-        quorum = quorumManager->GetQuorum(llmqType, quorumHash);
+        quorum = quorumManager.GetQuorum(llmqType, quorumHash);
     }
 
     if (!quorum) {
@@ -931,9 +931,9 @@ bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, const uint
 
     if (allowReSign) {
         // make us re-announce all known shares (other nodes might have run into a timeout)
-        quorumSigSharesManager->ForceReAnnouncement(quorum, llmqType, id, msgHash);
+        sigSharesManager.ForceReAnnouncement(quorum, llmqType, id, msgHash);
     }
-    quorumSigSharesManager->AsyncSign(quorum, id, msgHash);
+    sigSharesManager.AsyncSign(quorum, id, msgHash);
 
     return true;
 }
@@ -1000,7 +1000,7 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
     }
 
     if (CLLMQUtils::IsQuorumRotationEnabled(llmqType, pindexStart)) {
-        auto quorums = quorumManager->ScanQuorums(llmqType, pindexStart, poolSize);
+        auto quorums = quorumManager.ScanQuorums(llmqType, pindexStart, poolSize);
         if (quorums.empty()) {
             return nullptr;
         }
@@ -1024,7 +1024,7 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
         }
         return *itQuorum;
     } else {
-        auto quorums = quorumManager->ScanQuorums(llmqType, pindexStart, poolSize);
+        auto quorums = quorumManager.ScanQuorums(llmqType, pindexStart, poolSize);
         if (quorums.empty()) {
             return nullptr;
         }

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -528,8 +528,8 @@ void CRecoveredSigsDb::CleanupOldVotes(int64_t maxAge)
 
 //////////////////
 
-CSigningManager::CSigningManager(CConnman& _connman, CQuorumManager& quorumMan, CSigSharesManager& sigSharesMan, bool fMemory, bool fWipe) :
-    db(fMemory, fWipe), connman(_connman), quorumManager(quorumMan), sigSharesManager(sigSharesMan)
+CSigningManager::CSigningManager(CConnman& _connman, CQuorumManager& _quorumManager, CSigSharesManager& _sigSharesManager, bool fMemory, bool fWipe) :
+    db(fMemory, fWipe), connman(_connman), quorumManager(_quorumManager), sigSharesManager(_sigSharesManager)
 {
 }
 

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -183,7 +183,7 @@ private:
     std::vector<CRecoveredSigsListener*> recoveredSigsListeners GUARDED_BY(cs);
 
 public:
-    CSigningManager(CConnman& _connman, CQuorumManager& quorumMan, CSigSharesManager& sigSharesMan, bool fMemory, bool fWipe);
+    CSigningManager(CConnman& _connman, CQuorumManager& _quorumManager, CSigSharesManager& _sigSharesManager, bool fMemory, bool fWipe);
 
     bool AlreadyHave(const CInv& inv) const;
     bool GetRecoveredSigForGetData(const uint256& hash, CRecoveredSig& ret) const;

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -152,6 +152,9 @@ public:
     virtual void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) = 0;
 };
 
+class CQuorumManager;
+class CSigSharesManager;
+
 class CSigningManager
 {
     friend class CSigSharesManager;
@@ -165,6 +168,8 @@ private:
     mutable CCriticalSection cs;
 
     CConnman& connman;
+    CQuorumManager& quorumManager;
+    CSigSharesManager& sigSharesManager;
     CRecoveredSigsDb db;
 
     // Incoming and not verified yet
@@ -178,7 +183,7 @@ private:
     std::vector<CRecoveredSigsListener*> recoveredSigsListeners GUARDED_BY(cs);
 
 public:
-    CSigningManager(CConnman& _connman, bool fMemory, bool fWipe);
+    CSigningManager(CConnman& _connman, CQuorumManager& quorumMan, CSigSharesManager& sigSharesMan, bool fMemory, bool fWipe);
 
     bool AlreadyHave(const CInv& inv) const;
     bool GetRecoveredSigForGetData(const uint256& hash, CRecoveredSig& ret) const;
@@ -197,7 +202,7 @@ public:
 
 private:
     void ProcessMessageRecoveredSig(CNode* pfrom, const std::shared_ptr<const CRecoveredSig>& recoveredSig);
-    static bool PreVerifyRecoveredSig(const CRecoveredSig& recoveredSig, bool& retBan);
+    bool PreVerifyRecoveredSig(const CRecoveredSig& recoveredSig, bool& retBan);
 
     void CollectPendingRecoveredSigsToVerify(size_t maxUniqueSessions,
             std::unordered_map<NodeId, std::list<std::shared_ptr<const CRecoveredSig>>>& retSigShares,
@@ -222,10 +227,10 @@ public:
     bool GetVoteForId(Consensus::LLMQType llmqType, const uint256& id, uint256& msgHashRet) const;
 
     static std::vector<CQuorumCPtr> GetActiveQuorumSet(Consensus::LLMQType llmqType, int signHeight);
-    static CQuorumCPtr SelectQuorumForSigning(Consensus::LLMQType llmqType, const uint256& selectionHash, int signHeight = -1 /*chain tip*/, int signOffset = SIGN_HEIGHT_OFFSET);
+    CQuorumCPtr SelectQuorumForSigning(Consensus::LLMQType llmqType, const uint256& selectionHash, int signHeight = -1 /*chain tip*/, int signOffset = SIGN_HEIGHT_OFFSET);
 
     // Verifies a recovered sig that was signed while the chain tip was at signedAtTip
-    static bool VerifyRecoveredSig(Consensus::LLMQType llmqType, int signedAtHeight, const uint256& id, const uint256& msgHash, const CBLSSignature& sig, int signOffset = SIGN_HEIGHT_OFFSET);
+    bool VerifyRecoveredSig(Consensus::LLMQType llmqType, int signedAtHeight, const uint256& id, const uint256& msgHash, const CBLSSignature& sig, int signOffset = SIGN_HEIGHT_OFFSET);
 };
 
 extern CSigningManager* quorumSigningManager;

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -200,16 +200,6 @@ void CSigSharesManager::StopWorkerThread()
     }
 }
 
-void CSigSharesManager::RegisterAsRecoveredSigsListener()
-{
-    quorumSigningManager->RegisterRecoveredSigsListener(this);
-}
-
-void CSigSharesManager::UnregisterAsRecoveredSigsListener()
-{
-    quorumSigningManager->UnregisterRecoveredSigsListener(this);
-}
-
 void CSigSharesManager::InterruptWorkerThread()
 {
     workInterrupt();
@@ -308,7 +298,7 @@ bool CSigSharesManager::ProcessMessageSigSesAnn(const CNode* pfrom, const CSigSe
 
     LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- ann={%s}, node=%d\n", __func__, ann.ToString(), pfrom->GetId());
 
-    auto quorum = quorumManager->GetQuorum(llmqType, ann.getQuorumHash());
+    auto quorum = quorumManager.GetQuorum(llmqType, ann.getQuorumHash());
     if (!quorum) {
         // TODO should we ban here?
         LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- quorum %s not found, node=%d\n", __func__,
@@ -456,7 +446,7 @@ bool CSigSharesManager::ProcessMessageBatchedSigShares(const CNode* pfrom, const
 
 void CSigSharesManager::ProcessMessageSigShare(NodeId fromId, const CSigShare& sigShare)
 {
-    auto quorum = quorumManager->GetQuorum(sigShare.getLlmqType(), sigShare.getQuorumHash());
+    auto quorum = quorumManager.GetQuorum(sigShare.getLlmqType(), sigShare.getQuorumHash());
     if (!quorum) {
         return;
     }
@@ -597,7 +587,7 @@ void CSigSharesManager::CollectPendingSigSharesToVerify(
                 continue;
             }
 
-            CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, sigShare.getQuorumHash());
+            CQuorumCPtr quorum = quorumManager.GetQuorum(llmqType, sigShare.getQuorumHash());
             assert(quorum != nullptr);
             retQuorums.try_emplace(k, quorum);
         }
@@ -1258,7 +1248,7 @@ void CSigSharesManager::Cleanup()
     // Find quorums which became inactive
     for (auto it = quorums.begin(); it != quorums.end(); ) {
         if (CLLMQUtils::IsQuorumActive(it->first.first, it->first.second)) {
-            it->second = quorumManager->GetQuorum(it->first.first, it->first.second);
+            it->second = quorumManager.GetQuorum(it->first.first, it->first.second);
             ++it;
         } else {
             it = quorums.erase(it);

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -394,11 +394,12 @@ private:
     FastRandomContext rnd GUARDED_BY(cs);
 
     CConnman& connman;
+    CQuorumManager& quorumManager;
     int64_t lastCleanupTime{0};
     std::atomic<uint32_t> recoveredSigsCounter{0};
 
 public:
-    explicit CSigSharesManager(CConnman& _connman) : connman(_connman)
+    explicit CSigSharesManager(CConnman& _connman, CQuorumManager& quorumMan) : connman(_connman), quorumManager(quorumMan)
     {
         workInterrupt.reset();
     };

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -10,5 +10,7 @@
 #include <net_processing.h>
 #include <scheduler.h>
 
+#include <llmq/debug.h>
+
 NodeContext::NodeContext() {}
 NodeContext::~NodeContext() {}

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -23,6 +23,10 @@ class ChainClient;
 class WalletClient;
 } // namespace interfaces
 
+namespace llmq {
+class CDKGDebugManager;
+}
+
 //! NodeContext struct containing references to chain state and connection
 //! state.
 //!
@@ -48,6 +52,10 @@ struct NodeContext {
     interfaces::WalletClient* wallet_client{nullptr};
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};
+
+    // Dash
+    std::unique_ptr<llmq::CDKGDebugManager> quorumDKGDebugManager;
+    // End Dash
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -182,8 +182,10 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request)
         }
     }
 
+    NodeContext& node = EnsureNodeContext(request.context);
+
     llmq::CDKGDebugStatus status;
-    llmq::quorumDKGDebugManager->GetLocalDebugStatus(status);
+    node.quorumDKGDebugManager->GetLocalDebugStatus(status);
 
     auto ret = status.ToJson(detailLevel);
 
@@ -218,7 +220,6 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request)
                                                                                       pQuorumBaseBlockIndex, proTxHash,
                                                                                       true);
                     std::map<uint256, CAddress> foundConnections;
-                    NodeContext& node = EnsureNodeContext(request.context);
                     node.connman->ForEachNode([&](const CNode* pnode) {
                         auto verifiedProRegTxHash = pnode->GetVerifiedProRegTxHash();
                         if (!verifiedProRegTxHash.IsNull() && allConnections.count(verifiedProRegTxHash)) {
@@ -771,7 +772,7 @@ static UniValue verifychainlock(const JSONRPCRequest& request)
 
     const auto llmqType = Params().GetConsensus().llmqTypeChainLocks;
     const uint256 nRequestId = ::SerializeHash(std::make_pair(llmq::CLSIG_REQUESTID_PREFIX, nBlockHeight));
-    return llmq::CSigningManager::VerifyRecoveredSig(llmqType, nBlockHeight, nRequestId, nBlockHash, chainLockSig);
+    return llmq::quorumSigningManager->VerifyRecoveredSig(llmqType, nBlockHeight, nRequestId, nBlockHash, chainLockSig);
 }
 
 static void verifyislock_help(const JSONRPCRequest& request)

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -190,7 +190,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     }
 
     deterministicMNManager.reset(new CDeterministicMNManager(*evoDb, *m_node.connman));
-    llmq::InitLLMQSystem(m_node, *evoDb, *m_node.mempool, *m_node.connman, true);
+    llmq::InitLLMQSystem(m_node, *evoDb, true);
 }
 
 TestingSetup::~TestingSetup()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -190,7 +190,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     }
 
     deterministicMNManager.reset(new CDeterministicMNManager(*evoDb, *m_node.connman));
-    llmq::InitLLMQSystem(*evoDb, *m_node.mempool, *m_node.connman, true);
+    llmq::InitLLMQSystem(m_node, *evoDb, *m_node.mempool, *m_node.connman, true);
 }
 
 TestingSetup::~TestingSetup()


### PR DESCRIPTION
This does some of the easy deblogalisation in LLMQ code. There is much more work to do in this regard, but this PR is a good first step. The biggest accomplishment I guess of this PR is fully removing the `quorumDKGDebugManager` global. However, we also changed a lot of global member accesses into class member accesses.