### PR TITLE
refactor: migrate globals to managed pointers in preparation for deglobalization 

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -36,7 +36,7 @@ void CCoinJoinClientQueueManager::ProcessMessage(CNode* pfrom, const std::string
 {
     if (fMasternodeMode) return;
     if (!CCoinJoinClientOptions::IsEnabled()) return;
-    if (!masternodeSync.IsBlockchainSynced()) return;
+    if (!masternodeSync->IsBlockchainSynced()) return;
 
     if (!CheckDiskSpace(GetDataDir())) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinClientQueueManager::ProcessMessage -- Not enough disk space, disabling CoinJoin.\n");
@@ -117,7 +117,7 @@ void CCoinJoinClientManager::ProcessMessage(CNode* pfrom, const std::string& msg
 {
     if (fMasternodeMode) return;
     if (!CCoinJoinClientOptions::IsEnabled()) return;
-    if (!masternodeSync.IsBlockchainSynced()) return;
+    if (!masternodeSync->IsBlockchainSynced()) return;
 
     if (!CheckDiskSpace(GetDataDir())) {
         ResetPool();
@@ -141,7 +141,7 @@ void CCoinJoinClientSession::ProcessMessage(CNode* pfrom, const std::string& msg
 {
     if (fMasternodeMode) return;
     if (!CCoinJoinClientOptions::IsEnabled()) return;
-    if (!masternodeSync.IsBlockchainSynced()) return;
+    if (!masternodeSync->IsBlockchainSynced()) return;
 
     if (msg_type == NetMsgType::DSSTATUSUPDATE) {
         if (!mixingMasternode) return;
@@ -272,7 +272,7 @@ bilingual_str CCoinJoinClientSession::GetStatus(bool fWaitForBlock) const
     nStatusMessageProgress += 10;
     std::string strSuffix;
 
-    if (fWaitForBlock || !masternodeSync.IsBlockchainSynced()) {
+    if (fWaitForBlock || !masternodeSync->IsBlockchainSynced()) {
         return strAutoDenomResult;
     }
 
@@ -658,7 +658,7 @@ void CCoinJoinClientManager::UpdatedSuccessBlock()
 
 bool CCoinJoinClientManager::WaitForAnotherBlock() const
 {
-    if (!masternodeSync.IsBlockchainSynced()) return true;
+    if (!masternodeSync->IsBlockchainSynced()) return true;
 
     if (CCoinJoinClientOptions::IsMultiSessionEnabled()) return false;
 
@@ -740,7 +740,7 @@ bool CCoinJoinClientSession::DoAutomaticDenominating(CConnman& connman, bool fDr
     if (fMasternodeMode) return false; // no client-side mixing on masternodes
     if (nState != POOL_STATE_IDLE) return false;
 
-    if (!masternodeSync.IsBlockchainSynced()) {
+    if (!masternodeSync->IsBlockchainSynced()) {
         strAutoDenomResult = _("Can't mix while sync in progress.");
         return false;
     }
@@ -920,7 +920,7 @@ bool CCoinJoinClientManager::DoAutomaticDenominating(CConnman& connman, bool fDr
     if (fMasternodeMode) return false; // no client-side mixing on masternodes
     if (!CCoinJoinClientOptions::IsEnabled() || !IsMixing()) return false;
 
-    if (!masternodeSync.IsBlockchainSynced()) {
+    if (!masternodeSync->IsBlockchainSynced()) {
         strAutoDenomResult = _("Can't mix while sync in progress.");
         return false;
     }
@@ -1786,9 +1786,10 @@ void CCoinJoinClientManager::UpdatedBlockTip(const CBlockIndex* pindex)
 void CCoinJoinClientQueueManager::DoMaintenance()
 {
     if (!CCoinJoinClientOptions::IsEnabled()) return;
+    if (masternodeSync == nullptr) return;
     if (fMasternodeMode) return; // no client-side mixing on masternodes
 
-    if (!masternodeSync.IsBlockchainSynced() || ShutdownRequested()) return;
+    if (!masternodeSync->IsBlockchainSynced() || ShutdownRequested()) return;
 
     CheckQueue();
 }
@@ -1796,9 +1797,10 @@ void CCoinJoinClientQueueManager::DoMaintenance()
 void CCoinJoinClientManager::DoMaintenance(CConnman& connman)
 {
     if (!CCoinJoinClientOptions::IsEnabled()) return;
+    if (masternodeSync == nullptr) return;
     if (fMasternodeMode) return; // no client-side mixing on masternodes
 
-    if (!masternodeSync.IsBlockchainSynced() || ShutdownRequested()) return;
+    if (!masternodeSync->IsBlockchainSynced() || ShutdownRequested()) return;
 
     static int nTick = 0;
     static int nDoAutoNextRun = nTick + COINJOIN_AUTO_TIMEOUT_MIN;

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -29,10 +29,10 @@
 #include <univalue.h>
 
 std::map<const std::string, std::shared_ptr<CCoinJoinClientManager>> coinJoinClientManagers;
-CCoinJoinClientQueueManager coinJoinClientQueueManager;
+std::unique_ptr<CCoinJoinClientQueueManager> coinJoinClientQueueManager;
 
 
-void CCoinJoinClientQueueManager::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinClientQueueManager::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61)
 {
     if (fMasternodeMode) return;
     if (!CCoinJoinClientOptions::IsEnabled()) return;
@@ -44,11 +44,11 @@ void CCoinJoinClientQueueManager::ProcessMessage(CNode* pfrom, const std::string
     }
 
     if (msg_type == NetMsgType::DSQUEUE) {
-        CCoinJoinClientQueueManager::ProcessDSQueue(pfrom, msg_type, vRecv, connman, enable_bip61);
+        CCoinJoinClientQueueManager::ProcessDSQueue(pfrom, msg_type, vRecv, enable_bip61);
     }
 }
 
-void CCoinJoinClientQueueManager::ProcessDSQueue(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinClientQueueManager::ProcessDSQueue(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, bool enable_bip61)
 {
     CCoinJoinQueue dsq;
     vRecv >> dsq;
@@ -86,7 +86,7 @@ void CCoinJoinClientQueueManager::ProcessDSQueue(CNode* pfrom, const std::string
 
     // if the queue is ready, submit if we can
     if (dsq.fReady && ranges::any_of(coinJoinClientManagers,
-                                     [&dmn, &connman](const auto& pair){ return pair.second->TrySubmitDenominate(dmn->pdmnState->addr, connman); })) {
+                                     [this, &dmn](const auto& pair){ return pair.second->TrySubmitDenominate(dmn->pdmnState->addr, this->connman); })) {
         LogPrint(BCLog::COINJOIN, "DSQUEUE -- CoinJoin queue (%s) is ready on masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
         return;
     } else {
@@ -1009,6 +1009,7 @@ CDeterministicMNCPtr CCoinJoinClientManager::GetRandomNotUsedMasternode()
 bool CCoinJoinClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman)
 {
     if (!CCoinJoinClientOptions::IsEnabled()) return false;
+    if (coinJoinClientQueueManager == nullptr) return false;
 
     auto mnList = deterministicMNManager->GetListAtChainTip();
 
@@ -1020,7 +1021,7 @@ bool CCoinJoinClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, 
 
     // Look through the queues and see if anything matches
     CCoinJoinQueue dsq;
-    while (coinJoinClientQueueManager.GetQueueItemAndTry(dsq)) {
+    while (coinJoinClientQueueManager->GetQueueItemAndTry(dsq)) {
         auto dmn = mnList.GetValidMNByCollateral(dsq.masternodeOutpoint);
 
         if (!dmn) {
@@ -1845,7 +1846,10 @@ void CCoinJoinClientManager::GetJsonInfo(UniValue& obj) const
 
 void DoCoinJoinMaintenance(CConnman& connman)
 {
-    coinJoinClientQueueManager.DoMaintenance();
+    if (coinJoinClientQueueManager != nullptr) {
+        coinJoinClientQueueManager->DoMaintenance();
+    }
+
     for (const auto& pair : coinJoinClientManagers) {
         pair.second->DoMaintenance(connman);
     }

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -28,7 +28,7 @@ class UniValue;
 extern std::map<const std::string, std::shared_ptr<CCoinJoinClientManager>> coinJoinClientManagers;
 
 // The object to track mixing queues
-extern CCoinJoinClientQueueManager coinJoinClientQueueManager;
+extern std::unique_ptr<CCoinJoinClientQueueManager> coinJoinClientQueueManager;
 
 class CPendingDsaRequest
 {
@@ -150,11 +150,15 @@ public:
  */
 class CCoinJoinClientQueueManager : public CCoinJoinBaseManager
 {
+private:
+    CConnman& connman;
+
 public:
-    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61) LOCKS_EXCLUDED(cs_vecqueue);
+    explicit CCoinJoinClientQueueManager(CConnman& _connman) :
+        connman(_connman) {};
 
-    void ProcessDSQueue(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61);
-
+    void ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61) LOCKS_EXCLUDED(cs_vecqueue);
+    void ProcessDSQueue(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61);
     void DoMaintenance();
 };
 

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -457,14 +457,14 @@ void CCoinJoin::CheckDSTXes(const CBlockIndex* pindex)
 
 void CCoinJoin::UpdatedBlockTip(const CBlockIndex* pindex)
 {
-    if (pindex && masternodeSync.IsBlockchainSynced()) {
+    if (pindex && masternodeSync->IsBlockchainSynced()) {
         CheckDSTXes(pindex);
     }
 }
 
 void CCoinJoin::NotifyChainLock(const CBlockIndex* pindex)
 {
-    if (pindex && masternodeSync.IsBlockchainSynced()) {
+    if (pindex && masternodeSync->IsBlockchainSynced()) {
         CheckDSTXes(pindex);
     }
 }

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -29,7 +29,7 @@ constexpr static CAmount DEFAULT_MAX_RAW_TX_FEE{COIN / 10};
 void CCoinJoinServer::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61)
 {
     if (!fMasternodeMode) return;
-    if (!masternodeSync.IsBlockchainSynced()) return;
+    if (!masternodeSync->IsBlockchainSynced()) return;
 
     if (msg_type == NetMsgType::DSACCEPT) {
         ProcessDSACCEPT(pfrom, msg_type, vRecv, enable_bip61);
@@ -866,8 +866,8 @@ void CCoinJoinServer::SetState(PoolState nStateNew)
 void CCoinJoinServer::DoMaintenance() const
 {
     if (!fMasternodeMode) return; // only run on masternodes
-
-    if (!masternodeSync.IsBlockchainSynced() || ShutdownRequested()) return;
+    if (masternodeSync == nullptr || !masternodeSync->IsBlockchainSynced()) return;
+    if (ShutdownRequested()) return;
 
     if (!coinJoinServer) return;
 

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -23,34 +23,34 @@
 
 #include <univalue.h>
 
-CCoinJoinServer coinJoinServer;
+std::unique_ptr<CCoinJoinServer> coinJoinServer;
 constexpr static CAmount DEFAULT_MAX_RAW_TX_FEE{COIN / 10};
 
-void CCoinJoinServer::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61)
 {
     if (!fMasternodeMode) return;
     if (!masternodeSync.IsBlockchainSynced()) return;
 
     if (msg_type == NetMsgType::DSACCEPT) {
-        ProcessDSACCEPT(pfrom, msg_type, vRecv, connman, enable_bip61);
+        ProcessDSACCEPT(pfrom, msg_type, vRecv, enable_bip61);
         return;
     } else if (msg_type == NetMsgType::DSQUEUE) {
-        ProcessDSQUEUE(pfrom, msg_type, vRecv, connman, enable_bip61);
+        ProcessDSQUEUE(pfrom, msg_type, vRecv, enable_bip61);
         return;
     } else if (msg_type == NetMsgType::DSVIN) {
-        ProcessDSVIN(pfrom, msg_type, vRecv, connman, enable_bip61);
+        ProcessDSVIN(pfrom, msg_type, vRecv, enable_bip61);
         return;
     } else if (msg_type == NetMsgType::DSSIGNFINALTX) {
-        ProcessDSSIGNFINALTX(pfrom, msg_type, vRecv, connman, enable_bip61);
+        ProcessDSSIGNFINALTX(pfrom, msg_type, vRecv, enable_bip61);
     }
 }
 
-void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61)
 {
     if (IsSessionReady()) {
         // too many users in this session already, reject new ones
         LogPrint(BCLog::COINJOIN, "DSACCEPT -- queue is already full!\n");
-        PushStatus(pfrom, STATUS_REJECTED, ERR_QUEUE_FULL, connman);
+        PushStatus(pfrom, STATUS_REJECTED, ERR_QUEUE_FULL);
         return;
     }
 
@@ -62,7 +62,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& msg_type,
     auto mnList = deterministicMNManager->GetListAtChainTip();
     auto dmn = WITH_LOCK(activeMasternodeInfoCs, return mnList.GetValidMNByCollateral(activeMasternodeInfo.outpoint));
     if (!dmn) {
-        PushStatus(pfrom, STATUS_REJECTED, ERR_MN_LIST, connman);
+        PushStatus(pfrom, STATUS_REJECTED, ERR_MN_LIST);
         return;
     }
 
@@ -77,7 +77,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& msg_type,
                                [&mnOutpoint](const auto& q){return q.masternodeOutpoint == mnOutpoint;})) {
                 // refuse to create another queue this often
                 LogPrint(BCLog::COINJOIN, "DSACCEPT -- last dsq is still in queue, refuse to mix\n");
-                PushStatus(pfrom, STATUS_REJECTED, ERR_RECENT, connman);
+                PushStatus(pfrom, STATUS_REJECTED, ERR_RECENT);
                 return;
             }
         }
@@ -90,27 +90,27 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode* pfrom, const std::string& msg_type,
             } else {
                 LogPrint(BCLog::COINJOIN, "DSACCEPT -- last dsq too recent, must wait: peer=%d\n", pfrom->GetId());
             }
-            PushStatus(pfrom, STATUS_REJECTED, ERR_RECENT, connman);
+            PushStatus(pfrom, STATUS_REJECTED, ERR_RECENT);
             return;
         }
     }
 
     PoolMessage nMessageID = MSG_NOERR;
 
-    bool fResult = nSessionID == 0 ? CreateNewSession(dsa, nMessageID, connman)
+    bool fResult = nSessionID == 0 ? CreateNewSession(dsa, nMessageID)
             : AddUserToExistingSession(dsa, nMessageID);
     if (fResult) {
         LogPrint(BCLog::COINJOIN, "DSACCEPT -- is compatible, please submit!\n");
-        PushStatus(pfrom, STATUS_ACCEPTED, nMessageID, connman);
+        PushStatus(pfrom, STATUS_ACCEPTED, nMessageID);
         return;
     } else {
         LogPrint(BCLog::COINJOIN, "DSACCEPT -- not compatible with existing transactions!\n");
-        PushStatus(pfrom, STATUS_REJECTED, nMessageID, connman);
+        PushStatus(pfrom, STATUS_REJECTED, nMessageID);
         return;
     }
 }
 
-void CCoinJoinServer::ProcessDSQUEUE(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessDSQUEUE(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61)
 {
     CCoinJoinQueue dsq;
     vRecv >> dsq;
@@ -166,12 +166,12 @@ void CCoinJoinServer::ProcessDSQUEUE(CNode* pfrom, const std::string& msg_type, 
     }
 }
 
-void CCoinJoinServer::ProcessDSVIN(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessDSVIN(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61)
 {
     //do we have enough users in the current session?
     if (!IsSessionReady()) {
         LogPrint(BCLog::COINJOIN, "DSVIN -- session not complete!\n");
-        PushStatus(pfrom, STATUS_REJECTED, ERR_SESSION, connman);
+        PushStatus(pfrom, STATUS_REJECTED, ERR_SESSION);
         return;
     }
 
@@ -183,17 +183,17 @@ void CCoinJoinServer::ProcessDSVIN(CNode* pfrom, const std::string& msg_type, CD
     PoolMessage nMessageID = MSG_NOERR;
 
     entry.addr = pfrom->addr;
-    if (AddEntry(connman, entry, nMessageID)) {
-        PushStatus(pfrom, STATUS_ACCEPTED, nMessageID, connman);
-        CheckPool(connman);
+    if (AddEntry(entry, nMessageID)) {
+        PushStatus(pfrom, STATUS_ACCEPTED, nMessageID);
+        CheckPool();
         LOCK(cs_coinjoin);
-        RelayStatus(STATUS_ACCEPTED, connman);
+        RelayStatus(STATUS_ACCEPTED);
     } else {
-        PushStatus(pfrom, STATUS_REJECTED, nMessageID, connman);
+        PushStatus(pfrom, STATUS_REJECTED, nMessageID);
     }
 }
 
-void CCoinJoinServer::ProcessDSSIGNFINALTX(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
+void CCoinJoinServer::ProcessDSSIGNFINALTX(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, bool enable_bip61)
 {
     std::vector<CTxIn> vecTxIn;
     vRecv >> vecTxIn;
@@ -208,13 +208,13 @@ void CCoinJoinServer::ProcessDSSIGNFINALTX(CNode* pfrom, const std::string& msg_
         if (!AddScriptSig(txin)) {
             LogPrint(BCLog::COINJOIN, "DSSIGNFINALTX -- AddScriptSig() failed at %d/%d, session: %d\n", nTxInIndex, nTxInsCount, nSessionID);
             LOCK(cs_coinjoin);
-            RelayStatus(STATUS_REJECTED, connman);
+            RelayStatus(STATUS_REJECTED);
             return;
         }
         LogPrint(BCLog::COINJOIN, "DSSIGNFINALTX -- AddScriptSig() %d/%d success\n", nTxInIndex, nTxInsCount);
     }
     // all is good
-    CheckPool(connman);
+    CheckPool();
 }
 
 void CCoinJoinServer::SetNull()
@@ -230,7 +230,7 @@ void CCoinJoinServer::SetNull()
 //
 // Check the mixing progress and send client updates if a Masternode
 //
-void CCoinJoinServer::CheckPool(CConnman& connman)
+void CCoinJoinServer::CheckPool()
 {
     if (!fMasternodeMode) return;
 
@@ -239,7 +239,7 @@ void CCoinJoinServer::CheckPool(CConnman& connman)
     // If we have an entry for each collateral, then create final tx
     if (nState == POOL_STATE_ACCEPTING_ENTRIES && size_t(GetEntriesCount()) == vecSessionCollaterals.size()) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- FINALIZE TRANSACTIONS\n");
-        CreateFinalTransaction(connman);
+        CreateFinalTransaction();
         return;
     }
 
@@ -248,21 +248,21 @@ void CCoinJoinServer::CheckPool(CConnman& connman)
     if (nState == POOL_STATE_ACCEPTING_ENTRIES && CCoinJoinServer::HasTimedOut()
             && GetEntriesCount() >= CCoinJoin::GetMinPoolParticipants()) {
         // Punish misbehaving participants
-        ChargeFees(connman);
+        ChargeFees();
         // Try to complete this session ignoring the misbehaving ones
-        CreateFinalTransaction(connman);
+        CreateFinalTransaction();
         return;
     }
 
     // If we have all the signatures, try to compile the transaction
     if (nState == POOL_STATE_SIGNING && IsSignaturesComplete()) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckPool -- SIGNING\n");
-        CommitFinalTransaction(connman);
+        CommitFinalTransaction();
         return;
     }
 }
 
-void CCoinJoinServer::CreateFinalTransaction(CConnman& connman)
+void CCoinJoinServer::CreateFinalTransaction()
 {
     AssertLockNotHeld(cs_coinjoin);
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateFinalTransaction -- FINALIZE TRANSACTIONS\n");
@@ -289,10 +289,10 @@ void CCoinJoinServer::CreateFinalTransaction(CConnman& connman)
 
     // request signatures from clients
     SetState(POOL_STATE_SIGNING);
-    RelayFinalTransaction(CTransaction(finalMutableTransaction), connman);
+    RelayFinalTransaction(CTransaction(finalMutableTransaction));
 }
 
-void CCoinJoinServer::CommitFinalTransaction(CConnman& connman)
+void CCoinJoinServer::CommitFinalTransaction()
 {
     AssertLockNotHeld(cs_coinjoin);
     if (!fMasternodeMode) return; // check and relay final tx only on masternode
@@ -311,7 +311,7 @@ void CCoinJoinServer::CommitFinalTransaction(CConnman& connman)
             LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- AcceptToMemoryPool() error: Transaction not valid\n");
             WITH_LOCK(cs_coinjoin, SetNull());
             // not much we can do in this case, just notify clients
-            RelayCompletedTransaction(ERR_INVALID_TX, connman);
+            RelayCompletedTransaction(ERR_INVALID_TX);
             return;
         }
     }
@@ -331,10 +331,10 @@ void CCoinJoinServer::CommitFinalTransaction(CConnman& connman)
     connman.RelayInv(inv);
 
     // Tell the clients it was successful
-    RelayCompletedTransaction(MSG_SUCCESS, connman);
+    RelayCompletedTransaction(MSG_SUCCESS);
 
     // Randomly charge clients
-    ChargeRandomFees(connman);
+    ChargeRandomFees();
 
     // Reset
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- COMPLETED -- RESETTING\n");
@@ -353,7 +353,7 @@ void CCoinJoinServer::CommitFinalTransaction(CConnman& connman)
 // transaction for the client to be able to enter the pool. This transaction is kept by the Masternode
 // until the transaction is either complete or fails.
 //
-void CCoinJoinServer::ChargeFees(CConnman& connman) const
+void CCoinJoinServer::ChargeFees() const
 {
     AssertLockNotHeld(cs_coinjoin);
     if (!fMasternodeMode) return;
@@ -406,7 +406,7 @@ void CCoinJoinServer::ChargeFees(CConnman& connman) const
     if (nState == POOL_STATE_ACCEPTING_ENTRIES || nState == POOL_STATE_SIGNING) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::ChargeFees -- found uncooperative node (didn't %s transaction), charging fees: %s", /* Continued */
             (nState == POOL_STATE_SIGNING) ? "sign" : "send", vecOffendersCollaterals[0]->ToString());
-        ConsumeCollateral(connman, vecOffendersCollaterals[0]);
+        ConsumeCollateral(vecOffendersCollaterals[0]);
     }
 }
 
@@ -422,18 +422,18 @@ void CCoinJoinServer::ChargeFees(CConnman& connman) const
     stop these kinds of attacks 1 in 10 successful transactions are charged. This
     adds up to a cost of 0.001DRK per transaction on average.
 */
-void CCoinJoinServer::ChargeRandomFees(CConnman& connman) const
+void CCoinJoinServer::ChargeRandomFees() const
 {
     if (!fMasternodeMode) return;
 
     for (const auto& txCollateral : vecSessionCollaterals) {
         if (GetRandInt(100) > 10) return;
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::ChargeRandomFees -- charging random fees, txCollateral=%s", txCollateral->ToString()); /* Continued */
-        ConsumeCollateral(connman, txCollateral);
+        ConsumeCollateral(txCollateral);
     }
 }
 
-void CCoinJoinServer::ConsumeCollateral(CConnman& connman, const CTransactionRef& txref) const
+void CCoinJoinServer::ConsumeCollateral(const CTransactionRef& txref) const
 {
     LOCK(cs_main);
     CValidationState validationState;
@@ -459,7 +459,7 @@ bool CCoinJoinServer::HasTimedOut() const
 //
 // Check for extraneous timeout
 //
-void CCoinJoinServer::CheckTimeout(CConnman& connman)
+void CCoinJoinServer::CheckTimeout()
 {
     if (!fMasternodeMode) return;
 
@@ -470,7 +470,7 @@ void CCoinJoinServer::CheckTimeout(CConnman& connman)
 
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckTimeout -- %s timed out -- resetting\n",
         (nState == POOL_STATE_SIGNING) ? "Signing" : "Session");
-    ChargeFees(connman);
+    ChargeFees();
     WITH_LOCK(cs_coinjoin, SetNull());
 }
 
@@ -479,7 +479,7 @@ void CCoinJoinServer::CheckTimeout(CConnman& connman)
     After receiving multiple dsa messages, the queue will switch to "accepting entries"
     which is the active state right before merging the transaction
 */
-void CCoinJoinServer::CheckForCompleteQueue(CConnman& connman)
+void CCoinJoinServer::CheckForCompleteQueue()
 {
     if (!fMasternodeMode) return;
 
@@ -542,7 +542,7 @@ bool CCoinJoinServer::IsInputScriptSigValid(const CTxIn& txin) const
 //
 // Add a client's transaction inputs/outputs to the pool
 //
-bool CCoinJoinServer::AddEntry(CConnman& connman, const CCoinJoinEntry& entry, PoolMessage& nMessageIDRet)
+bool CCoinJoinServer::AddEntry(const CCoinJoinEntry& entry, PoolMessage& nMessageIDRet)
 {
     AssertLockNotHeld(cs_coinjoin);
     if (!fMasternodeMode) return false;
@@ -562,7 +562,7 @@ bool CCoinJoinServer::AddEntry(CConnman& connman, const CCoinJoinEntry& entry, P
     if (entry.vecTxDSIn.size() > COINJOIN_ENTRY_MAX_SIZE) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR: too many inputs! %d/%d\n", __func__, entry.vecTxDSIn.size(), COINJOIN_ENTRY_MAX_SIZE);
         nMessageIDRet = ERR_MAXIMUM;
-        ConsumeCollateral(connman, entry.txCollateral);
+        ConsumeCollateral(entry.txCollateral);
         return false;
     }
 
@@ -590,7 +590,7 @@ bool CCoinJoinServer::AddEntry(CConnman& connman, const CCoinJoinEntry& entry, P
     if (!IsValidInOuts(vin, entry.vecTxOut, nMessageIDRet, &fConsumeCollateral)) {
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- ERROR! IsValidInOuts() failed: %s\n", __func__, CCoinJoin::GetMessageByID(nMessageIDRet).translated);
         if (fConsumeCollateral) {
-            ConsumeCollateral(connman, entry.txCollateral);
+            ConsumeCollateral(entry.txCollateral);
         }
         return false;
     }
@@ -673,7 +673,7 @@ bool CCoinJoinServer::IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& n
     return true;
 }
 
-bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet, CConnman& connman)
+bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet)
 {
     if (!fMasternodeMode || nSessionID != 0) return false;
 
@@ -762,7 +762,7 @@ bool CCoinJoinServer::IsSessionReady() const
     return false;
 }
 
-void CCoinJoinServer::RelayFinalTransaction(const CTransaction& txFinal, CConnman& connman)
+void CCoinJoinServer::RelayFinalTransaction(const CTransaction& txFinal)
 {
     AssertLockHeld(cs_coinjoin);
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- nSessionID: %d  nSessionDenom: %d (%s)\n",
@@ -770,35 +770,35 @@ void CCoinJoinServer::RelayFinalTransaction(const CTransaction& txFinal, CConnma
 
     // final mixing tx with empty signatures should be relayed to mixing participants only
     for (const auto& entry : vecEntries) {
-        bool fOk = connman.ForNode(entry.addr, [&txFinal, &connman, this](CNode* pnode) {
+        bool fOk = connman.ForNode(entry.addr, [&txFinal, this](CNode* pnode) {
             CNetMsgMaker msgMaker(pnode->GetSendVersion());
             connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSFINALTX, nSessionID.load(), txFinal));
             return true;
         });
         if (!fOk) {
             // no such node? maybe this client disconnected or our own connection went down
-            RelayStatus(STATUS_REJECTED, connman);
+            RelayStatus(STATUS_REJECTED);
             break;
         }
     }
 }
 
-void CCoinJoinServer::PushStatus(CNode* pnode, PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID, CConnman& connman) const
+void CCoinJoinServer::PushStatus(CNode* pnode, PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID) const
 {
     if (!pnode) return;
     CCoinJoinStatusUpdate psssup(nSessionID, nState, 0, nStatusUpdate, nMessageID);
     connman.PushMessage(pnode, CNetMsgMaker(pnode->GetSendVersion()).Make(NetMsgType::DSSTATUSUPDATE, psssup));
 }
 
-void CCoinJoinServer::RelayStatus(PoolStatusUpdate nStatusUpdate, CConnman& connman, PoolMessage nMessageID)
+void CCoinJoinServer::RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID)
 {
     AssertLockHeld(cs_coinjoin);
     unsigned int nDisconnected{};
     // status updates should be relayed to mixing participants only
     for (const auto& entry : vecEntries) {
         // make sure everyone is still connected
-        bool fOk = connman.ForNode(entry.addr, [&nStatusUpdate, &nMessageID, &connman, this](CNode* pnode) {
-            PushStatus(pnode, nStatusUpdate, nMessageID, connman);
+        bool fOk = connman.ForNode(entry.addr, [&nStatusUpdate, &nMessageID, this](CNode* pnode) {
+            PushStatus(pnode, nStatusUpdate, nMessageID);
             return true;
         });
         if (!fOk) {
@@ -814,8 +814,8 @@ void CCoinJoinServer::RelayStatus(PoolStatusUpdate nStatusUpdate, CConnman& conn
 
     // notify everyone else that this session should be terminated
     for (const auto& entry : vecEntries) {
-        connman.ForNode(entry.addr, [&connman, this](CNode* pnode) {
-            PushStatus(pnode, STATUS_REJECTED, MSG_NOERR, connman);
+        connman.ForNode(entry.addr, [this](CNode* pnode) {
+            PushStatus(pnode, STATUS_REJECTED, MSG_NOERR);
             return true;
         });
     }
@@ -827,7 +827,7 @@ void CCoinJoinServer::RelayStatus(PoolStatusUpdate nStatusUpdate, CConnman& conn
     }
 }
 
-void CCoinJoinServer::RelayCompletedTransaction(PoolMessage nMessageID, CConnman& connman)
+void CCoinJoinServer::RelayCompletedTransaction(PoolMessage nMessageID)
 {
     AssertLockNotHeld(cs_coinjoin);
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- nSessionID: %d  nSessionDenom: %d (%s)\n",
@@ -836,14 +836,14 @@ void CCoinJoinServer::RelayCompletedTransaction(PoolMessage nMessageID, CConnman
     // final mixing tx with empty signatures should be relayed to mixing participants only
     LOCK(cs_coinjoin);
     for (const auto& entry : vecEntries) {
-        bool fOk = connman.ForNode(entry.addr, [&nMessageID, &connman, this](CNode* pnode) {
+        bool fOk = connman.ForNode(entry.addr, [&nMessageID, this](CNode* pnode) {
             CNetMsgMaker msgMaker(pnode->GetSendVersion());
             connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSCOMPLETE, nSessionID.load(), nMessageID));
             return true;
         });
         if (!fOk) {
             // no such node? maybe client disconnected or our own connection went down
-            RelayStatus(STATUS_REJECTED, connman);
+            RelayStatus(STATUS_REJECTED);
             break;
         }
     }
@@ -863,15 +863,17 @@ void CCoinJoinServer::SetState(PoolState nStateNew)
     nState = nStateNew;
 }
 
-void CCoinJoinServer::DoMaintenance(CConnman& connman) const
+void CCoinJoinServer::DoMaintenance() const
 {
     if (!fMasternodeMode) return; // only run on masternodes
 
     if (!masternodeSync.IsBlockchainSynced() || ShutdownRequested()) return;
 
-    coinJoinServer.CheckForCompleteQueue(connman);
-    coinJoinServer.CheckPool(connman);
-    coinJoinServer.CheckTimeout(connman);
+    if (!coinJoinServer) return;
+
+    coinJoinServer->CheckForCompleteQueue();
+    coinJoinServer->CheckPool();
+    coinJoinServer->CheckTimeout();
 }
 
 void CCoinJoinServer::GetJsonInfo(UniValue& obj) const

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -71,7 +71,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     llmq::quorumManager->UpdatedBlockTip(pindexNew, fInitialDownload);
     llmq::quorumDKGSessionManager->UpdatedBlockTip(pindexNew, fInitialDownload);
 
-    if (!fDisableGovernance) governance.UpdatedBlockTip(pindexNew, connman);
+    if (!fDisableGovernance) governance->UpdatedBlockTip(pindexNew, connman);
 }
 
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx, int64_t nAcceptTime)
@@ -111,7 +111,7 @@ void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBl
 void CDSNotificationInterface::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff, CConnman& connman)
 {
     CMNAuth::NotifyMasternodeListChanged(undo, oldMNList, diff, connman);
-    governance.UpdateCachesAndClean();
+    governance->UpdateCachesAndClean();
 }
 
 void CDSNotificationInterface::NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const llmq::CChainLockSig>& clsig)

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -29,12 +29,14 @@ void CDSNotificationInterface::InitializeCurrentBlockTip()
 void CDSNotificationInterface::AcceptedBlockHeader(const CBlockIndex *pindexNew)
 {
     llmq::chainLocksHandler->AcceptedBlockHeader(pindexNew);
-    masternodeSync.AcceptedBlockHeader(pindexNew);
+    if (masternodeSync != nullptr) {
+        masternodeSync->AcceptedBlockHeader(pindexNew);
+    }
 }
 
 void CDSNotificationInterface::NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload)
 {
-    masternodeSync.NotifyHeaderTip(pindexNew, fInitialDownload, connman);
+    masternodeSync->NotifyHeaderTip(pindexNew, fInitialDownload);
 }
 
 void CDSNotificationInterface::SynchronousUpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
@@ -50,7 +52,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     if (pindexNew == pindexFork) // blocks were disconnected without any new ones
         return;
 
-    masternodeSync.UpdatedBlockTip(pindexNew, fInitialDownload, connman);
+    masternodeSync->UpdatedBlockTip(pindexNew, fInitialDownload);
 
     // Update global DIP0001 activation status
     fDIP0001ActiveAtTip = pindexNew->nHeight >= Params().GetConsensus().DIP0001Height;

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -55,7 +55,7 @@ void CMNAuth::PushMNAUTH(CNode* pnode, CConnman& connman)
 
 void CMNAuth::ProcessMessage(CNode* pnode, const std::string& msg_type, CDataStream& vRecv, CConnman& connman)
 {
-    if (msg_type != NetMsgType::MNAUTH || !masternodeSync.IsBlockchainSynced()) {
+    if (msg_type != NetMsgType::MNAUTH || !masternodeSync->IsBlockchainSynced()) {
         // we can't verify MNAUTH messages when we don't have the latest MN list
         return;
     }

--- a/src/governance/classes.h
+++ b/src/governance/classes.h
@@ -14,6 +14,7 @@ class CTxOut;
 class CTransaction;
 
 class CSuperblock;
+class CGovernanceManager;
 class CGovernanceTriggerManager;
 class CSuperblockManager;
 
@@ -55,15 +56,15 @@ public:
 class CSuperblockManager
 {
 private:
-    static bool GetBestSuperblock(CSuperblock_sptr& pSuperblockRet, int nBlockHeight);
+    static bool GetBestSuperblock(CGovernanceManager& governanceManager, CSuperblock_sptr& pSuperblockRet, int nBlockHeight);
 
 public:
-    static bool IsSuperblockTriggered(int nBlockHeight);
+    static bool IsSuperblockTriggered(CGovernanceManager& governanceManager, int nBlockHeight);
 
-    static bool GetSuperblockPayments(int nBlockHeight, std::vector<CTxOut>& voutSuperblockRet);
-    static void ExecuteBestSuperblock(int nBlockHeight);
+    static bool GetSuperblockPayments(CGovernanceManager& governanceManager, int nBlockHeight, std::vector<CTxOut>& voutSuperblockRet);
+    static void ExecuteBestSuperblock(CGovernanceManager& governanceManager, int nBlockHeight);
 
-    static bool IsValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
+    static bool IsValid(CGovernanceManager& governanceManager, const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
 };
 
 /**
@@ -135,7 +136,7 @@ public:
     // TELL THE ENGINE WE EXECUTED THIS EVENT
     void SetExecuted() { nStatus = SEEN_OBJECT_EXECUTED; }
 
-    CGovernanceObject* GetGovernanceObject();
+    CGovernanceObject* GetGovernanceObject(CGovernanceManager& governanceManager);
 
     int GetBlockHeight() const
     {
@@ -147,7 +148,7 @@ public:
     CAmount GetPaymentsTotalAmount();
 
     bool IsValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
-    bool IsExpired() const;
+    bool IsExpired(const CGovernanceManager& governanceManager) const;
 };
 
 #endif // BITCOIN_GOVERNANCE_CLASSES_H

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -21,7 +21,7 @@
 #include <spork.h>
 #include <validation.h>
 
-CGovernanceManager governance;
+std::unique_ptr<CGovernanceManager> governance;
 
 int nSubmittedFinalBudget;
 
@@ -1189,7 +1189,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex* pindex, CConnman& co
 
     CheckPostponedObjects(connman);
 
-    CSuperblockManager::ExecuteBestSuperblock(pindex->nHeight);
+    CSuperblockManager::ExecuteBestSuperblock(*this, pindex->nHeight);
 }
 
 void CGovernanceManager::RequestOrphanObjects(CConnman& connman)

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -477,11 +477,9 @@ std::vector<CGovernanceVote> CGovernanceManager::GetCurrentVotes(const uint256& 
     return vecResult;
 }
 
-std::vector<CGovernanceObject> CGovernanceManager::GetAllNewerThan(int64_t nMoreThanTime) const
+void CGovernanceManager::GetAllNewerThan(std::vector<CGovernanceObject>& objs, int64_t nMoreThanTime) const
 {
     LOCK(cs);
-
-    std::vector<CGovernanceObject> vGovObjs;
 
     for (const auto& objPair : mapObjects) {
         // IF THIS OBJECT IS OLDER THAN TIME, CONTINUE
@@ -490,10 +488,8 @@ std::vector<CGovernanceObject> CGovernanceManager::GetAllNewerThan(int64_t nMore
         }
 
         // ADD GOVERNANCE OBJECT TO LIST
-        vGovObjs.push_back(objPair.second);
+        objs.push_back(objPair.second);
     }
-
-    return vGovObjs;
 }
 
 //

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1283,7 +1283,7 @@ void CGovernanceManager::RemoveInvalidVotes()
     lastMNListForVotingKeys = std::make_shared<CDeterministicMNList>(curMNList);
 }
 
-bool AreSuperblocksEnabled()
+bool AreSuperblocksEnabled(const CSporkManager& sporkManager)
 {
     return sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED);
 }

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -90,14 +90,14 @@ bool CGovernanceManager::SerializeVoteForHash(const uint256& nHash, CDataStream&
 void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, CConnman& connman, bool enable_bip61)
 {
     if (fDisableGovernance) return;
-    if (!masternodeSync.IsBlockchainSynced()) return;
+    if (masternodeSync == nullptr || !masternodeSync->IsBlockchainSynced()) return;
 
     // ANOTHER USER IS ASKING US TO HELP THEM SYNC GOVERNANCE OBJECT DATA
     if (msg_type == NetMsgType::MNGOVERNANCESYNC) {
         // Ignore such requests until we are fully synced.
         // We could start processing this after masternode list is synced
         // but this is a heavy one so it's better to finish sync first.
-        if (!masternodeSync.IsSynced()) return;
+        if (!masternodeSync->IsSynced()) return;
 
         uint256 nProp;
         CBloomFilter filter;
@@ -129,7 +129,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& msg_typ
             EraseObjectRequest(pfrom->GetId(), CInv(MSG_GOVERNANCE_OBJECT, nHash));
         }
 
-        if (!masternodeSync.IsBlockchainSynced()) {
+        if (!masternodeSync->IsBlockchainSynced()) {
             LogPrint(BCLog::GOBJECT, "MNGOVERNANCEOBJECT -- masternode list not synced\n");
             return;
         }
@@ -198,7 +198,7 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& msg_typ
         }
 
         // Ignore such messages until masternode list is synced
-        if (!masternodeSync.IsBlockchainSynced()) {
+        if (!masternodeSync->IsBlockchainSynced()) {
             LogPrint(BCLog::GOBJECT, "MNGOVERNANCEOBJECTVOTE -- masternode list not synced\n");
             return;
         }
@@ -216,11 +216,11 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& msg_typ
         CGovernanceException exception;
         if (ProcessVote(pfrom, vote, exception, connman)) {
             LogPrint(BCLog::GOBJECT, "MNGOVERNANCEOBJECTVOTE -- %s new\n", strHash);
-            masternodeSync.BumpAssetLastTime("MNGOVERNANCEOBJECTVOTE");
+            masternodeSync->BumpAssetLastTime("MNGOVERNANCEOBJECTVOTE");
             vote.Relay(connman);
         } else {
             LogPrint(BCLog::GOBJECT, "MNGOVERNANCEOBJECTVOTE -- Rejected vote, error = %s\n", exception.what());
-            if ((exception.GetNodePenalty() != 0) && masternodeSync.IsSynced()) {
+            if ((exception.GetNodePenalty() != 0) && masternodeSync->IsSynced()) {
                 LOCK(cs_main);
                 Misbehaving(pfrom->GetId(), exception.GetNodePenalty());
             }
@@ -302,7 +302,7 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
     // Update the rate buffer
     MasternodeRateUpdate(govobj);
 
-    masternodeSync.BumpAssetLastTime("CGovernanceManager::AddGovernanceObject");
+    masternodeSync->BumpAssetLastTime("CGovernanceManager::AddGovernanceObject");
 
     // WE MIGHT HAVE PENDING/ORPHAN VOTES FOR THIS OBJECT
 
@@ -315,9 +315,7 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
 void CGovernanceManager::UpdateCachesAndClean()
 {
     // Return on initial sync, spammed the debug.log and provided no use
-    if (!masternodeSync.IsBlockchainSynced()) {
-        return;
-    }
+    if (masternodeSync == nullptr || !masternodeSync->IsBlockchainSynced()) return;
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::UpdateCachesAndClean\n");
 
@@ -511,23 +509,22 @@ struct sortProposalsByVotes {
 
 void CGovernanceManager::DoMaintenance(CConnman& connman)
 {
-    if (fDisableGovernance || !masternodeSync.IsSynced() || ShutdownRequested()) return;
+    if (fDisableGovernance) return;
+    if (masternodeSync == nullptr || !masternodeSync->IsSynced()) return;
+    if (ShutdownRequested()) return;
 
     // CHECK OBJECTS WE'VE ASKED FOR, REMOVE OLD ENTRIES
-
     CleanOrphanObjects();
-
     RequestOrphanObjects(connman);
 
     // CHECK AND REMOVE - REPROCESS GOVERNANCE OBJECTS
-
     UpdateCachesAndClean();
 }
 
 bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
 {
     // do not request objects until it's time to sync
-    if (!masternodeSync.IsBlockchainSynced()) return false;
+    if (!masternodeSync->IsBlockchainSynced()) return false;
 
     LOCK(cs);
 
@@ -580,7 +577,7 @@ bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)
 void CGovernanceManager::SyncSingleObjVotes(CNode* pnode, const uint256& nProp, const CBloomFilter& filter, CConnman& connman)
 {
     // do not provide any data until our node is synced
-    if (!masternodeSync.IsSynced()) return;
+    if (!masternodeSync->IsSynced()) return;
 
     int nVoteCount = 0;
 
@@ -629,7 +626,7 @@ void CGovernanceManager::SyncSingleObjVotes(CNode* pnode, const uint256& nProp, 
 void CGovernanceManager::SyncObjects(CNode* pnode, CConnman& connman) const
 {
     // do not provide any data until our node is synced
-    if (!masternodeSync.IsSynced()) return;
+    if (!masternodeSync->IsSynced()) return;
 
     if (netfulfilledman.HasFulfilledRequest(pnode->addr, NetMsgType::MNGOVERNANCESYNC)) {
         // Asking for the whole list multiple times in a short period of time is no good
@@ -722,7 +719,7 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
 
     fRateCheckBypassed = false;
 
-    if (!masternodeSync.IsSynced() || !fRateChecksEnabled) {
+    if (!masternodeSync->IsSynced() || !fRateChecksEnabled) {
         return true;
     }
 
@@ -836,7 +833,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
 
 void CGovernanceManager::CheckPostponedObjects(CConnman& connman)
 {
-    if (!masternodeSync.IsSynced()) return;
+    if (!masternodeSync->IsSynced()) return;
 
     LOCK2(cs_main, ::mempool.cs); // Lock mempool because of GetTransaction deep inside
     LOCK(cs);
@@ -1241,7 +1238,7 @@ void CGovernanceManager::CleanOrphanObjects()
 
 void CGovernanceManager::RemoveInvalidVotes()
 {
-    if (!masternodeSync.IsSynced()) {
+    if (!masternodeSync->IsSynced()) {
         return;
     }
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -241,7 +241,7 @@ public:
 
     // These commands are only used in RPC
     std::vector<CGovernanceVote> GetCurrentVotes(const uint256& nParentHash, const COutPoint& mnCollateralOutpointFilter) const;
-    std::vector<CGovernanceObject> GetAllNewerThan(int64_t nMoreThanTime) const;
+    void GetAllNewerThan(std::vector<CGovernanceObject>& objs, int64_t nMoreThanTime) const;
 
     void AddGovernanceObject(CGovernanceObject& govobj, CConnman& connman, const CNode* pfrom = nullptr);
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -19,7 +19,7 @@ class CGovernanceObject;
 class CGovernanceVote;
 class CSporkManager;
 
-extern CGovernanceManager governance;
+extern std::unique_ptr<CGovernanceManager> governance;
 
 static constexpr int RATE_BUFFER_SIZE = 5;
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -17,6 +17,7 @@ class CGovernanceManager;
 class CGovernanceTriggerManager;
 class CGovernanceObject;
 class CGovernanceVote;
+class CSporkManager;
 
 extern CGovernanceManager governance;
 
@@ -380,6 +381,6 @@ private:
 
 };
 
-bool AreSuperblocksEnabled();
+bool AreSuperblocksEnabled(const CSporkManager& sporkManager);
 
 #endif // BITCOIN_GOVERNANCE_GOVERNANCE_H

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -168,7 +168,7 @@ bool CGovernanceObject::ProcessVote(const CGovernanceVote& vote, CGovernanceExce
 
     int64_t nNow = GetAdjustedTime();
     int64_t nVoteTimeUpdate = voteInstanceRef.nTime;
-    if (governance.AreRateChecksEnabled()) {
+    if (governance->AreRateChecksEnabled()) {
         int64_t nTimeDelta = nNow - voteInstanceRef.nTime;
         if (nTimeDelta < GOVERNANCE_UPDATE_MIN) {
             std::ostringstream ostr;
@@ -194,7 +194,7 @@ bool CGovernanceObject::ProcessVote(const CGovernanceVote& vote, CGovernanceExce
              << ", vote hash = " << vote.GetHash().ToString();
         LogPrintf("%s\n", ostr.str());
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
-        governance.AddInvalidVote(vote);
+        governance->AddInvalidVote(vote);
         return false;
     }
 

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -672,7 +672,7 @@ bool CGovernanceObject::GetCurrentMNVotes(const COutPoint& mnCollateralOutpoint,
 void CGovernanceObject::Relay(CConnman& connman) const
 {
     // Do not relay until fully synced
-    if (!masternodeSync.IsSynced()) {
+    if (!masternodeSync->IsSynced()) {
         LogPrint(BCLog::GOBJECT, "CGovernanceObject::Relay -- won't relay until fully synced\n");
         return;
     }

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -118,7 +118,7 @@ std::string CGovernanceVote::ToString() const
 void CGovernanceVote::Relay(CConnman& connman) const
 {
     // Do not relay until fully synced
-    if (!masternodeSync.IsSynced()) {
+    if (!masternodeSync->IsSynced()) {
         LogPrint(BCLog::GOBJECT, "CGovernanceVote::Relay -- won't relay until fully synced\n");
         return;
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1698,30 +1698,6 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
         StartScriptCheckWorkerThreads(script_threads);
     }
 
-    std::vector<std::string> vSporkAddresses;
-    if (args.IsArgSet("-sporkaddr")) {
-        vSporkAddresses = args.GetArgs("-sporkaddr");
-    } else {
-        vSporkAddresses = Params().SporkAddresses();
-    }
-    for (const auto& address: vSporkAddresses) {
-        if (!sporkManager.SetSporkAddress(address)) {
-            return InitError(_("Invalid spork address specified with -sporkaddr"));
-        }
-    }
-
-    int minsporkkeys = args.GetArg("-minsporkkeys", Params().MinSporkKeys());
-    if (!sporkManager.SetMinSporkKeys(minsporkkeys)) {
-        return InitError(_("Invalid minimum number of spork signers specified with -minsporkkeys"));
-    }
-
-
-    if (args.IsArgSet("-sporkkey")) { // spork priv key
-        if (!sporkManager.SetPrivKey(args.GetArg("-sporkkey", ""))) {
-            return InitError(_("Unable to sign spork message, wrong key?"));
-        }
-    }
-
     assert(activeMasternodeInfo.blsKeyOperator == nullptr);
     assert(activeMasternodeInfo.blsPubKeyOperator == nullptr);
     fMasternodeMode = false;
@@ -1812,6 +1788,30 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
 
     node.peer_logic.reset(new PeerLogicValidation(node.connman.get(), node.banman.get(), *node.scheduler, chainman, *node.mempool, args.GetBoolArg("-enablebip61", DEFAULT_ENABLE_BIP61)));
     RegisterValidationInterface(node.peer_logic.get());
+
+    std::vector<std::string> vSporkAddresses;
+    if (args.IsArgSet("-sporkaddr")) {
+        vSporkAddresses = args.GetArgs("-sporkaddr");
+    } else {
+        vSporkAddresses = Params().SporkAddresses();
+    }
+    for (const auto& address: vSporkAddresses) {
+        if (!sporkManager.SetSporkAddress(address)) {
+            return InitError(_("Invalid spork address specified with -sporkaddr"));
+        }
+    }
+
+    int minsporkkeys = args.GetArg("-minsporkkeys", Params().MinSporkKeys());
+    if (!sporkManager.SetMinSporkKeys(minsporkkeys)) {
+        return InitError(_("Invalid minimum number of spork signers specified with -minsporkkeys"));
+    }
+
+
+    if (args.IsArgSet("-sporkkey")) { // spork priv key
+        if (!sporkManager.SetPrivKey(args.GetArg("-sporkkey", ""))) {
+            return InitError(_("Unable to sign spork message, wrong key?"));
+        }
+    }
 
     // sanitize comments per BIP-0014, format user agent and check total size
     std::vector<std::string> uacomments;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -280,6 +280,7 @@ void PrepareShutdown(NodeContext& node)
 
     // After related databases and caches have been flushed, destroy pointers
     // and reset all to nullptr.
+    ::masternodeSync.reset();
     ::governance.reset();
     ::sporkManager.reset();
 
@@ -2327,6 +2328,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
 
     // ********************************************************* Step 10a: Setup CoinJoin
 
+    ::masternodeSync = std::make_unique<CMasternodeSync>(*node.connman);
     ::coinJoinServer = std::make_unique<CCoinJoinServer>(*node.connman);
 #ifdef ENABLE_WALLET
     ::coinJoinClientQueueManager = std::make_unique<CCoinJoinClientQueueManager>(*node.connman);
@@ -2388,7 +2390,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     // ********************************************************* Step 10b: schedule Dash-specific tasks
 
     node.scheduler->scheduleEvery(std::bind(&CNetFulfilledRequestManager::DoMaintenance, std::ref(netfulfilledman)), 60 * 1000);
-    node.scheduler->scheduleEvery(std::bind(&CMasternodeSync::DoMaintenance, std::ref(masternodeSync), std::ref(*node.connman)), 1 * 1000);
+    node.scheduler->scheduleEvery(std::bind(&CMasternodeSync::DoMaintenance, std::ref(*::masternodeSync)), 1 * 1000);
     node.scheduler->scheduleEvery(std::bind(&CMasternodeUtils::DoMaintenance, std::ref(*node.connman)), 60 * 1000);
     node.scheduler->scheduleEvery(std::bind(&CDeterministicMNManager::DoMaintenance, std::ref(*deterministicMNManager)), 10 * 1000);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -232,6 +232,9 @@ void PrepareShutdown(NodeContext& node)
     llmq::StopLLMQSystem();
 
     ::coinJoinServer.reset();
+#ifdef ENABLE_WALLET
+    ::coinJoinClientQueueManager.reset();
+#endif // ENABLE_WALLET
 
     // fRPCInWarmup should be `false` if we completed the loading sequence
     // before a shutdown request was received
@@ -2315,6 +2318,10 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     // ********************************************************* Step 10a: Setup CoinJoin
 
     ::coinJoinServer = std::make_unique<CCoinJoinServer>(*node.connman);
+#ifdef ENABLE_WALLET
+    ::coinJoinClientQueueManager = std::make_unique<CCoinJoinClientQueueManager>(*node.connman);
+#endif // ENABLE_WALLET
+
     g_wallet_init_interface.InitCoinJoinSettings();
 
     // ********************************************************* Step 10b: Load cache data

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -274,12 +274,13 @@ void PrepareShutdown(NodeContext& node)
         flatdb6.Dump(*::sporkManager);
         if (!fDisableGovernance) {
             CFlatDB<CGovernanceManager> flatdb3("governance.dat", "magicGovernanceCache");
-            flatdb3.Dump(governance);
+            flatdb3.Dump(*::governance);
         }
     }
 
     // After related databases and caches have been flushed, destroy pointers
     // and reset all to nullptr.
+    ::governance.reset();
     ::sporkManager.reset();
 
     // After the threads that potentially access these pointers have been stopped,
@@ -1793,6 +1794,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     node.peer_logic.reset(new PeerLogicValidation(node.connman.get(), node.banman.get(), *node.scheduler, chainman, *node.mempool, args.GetBoolArg("-enablebip61", DEFAULT_ENABLE_BIP61)));
     RegisterValidationInterface(node.peer_logic.get());
 
+    ::governance = std::make_unique<CGovernanceManager>();
     assert(!::sporkManager);
     ::sporkManager = std::make_unique<CSporkManager>();
 
@@ -2357,10 +2359,10 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     uiInterface.InitMessage(_("Loading governance cache...").translated);
     CFlatDB<CGovernanceManager> flatdb3(strDBName, "magicGovernanceCache");
     if (fLoadCacheFiles && !fDisableGovernance) {
-        if(!flatdb3.Load(governance)) {
+        if(!flatdb3.Load(*::governance)) {
             return InitError(strprintf(_("Failed to load governance cache from %s"), (pathDB / strDBName).string()));
         }
-        governance.InitOnLoad();
+        ::governance->InitOnLoad();
     } else {
         CGovernanceManager governanceTmp;
         if(!flatdb3.Dump(governanceTmp)) {
@@ -2390,7 +2392,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     node.scheduler->scheduleEvery(std::bind(&CDeterministicMNManager::DoMaintenance, std::ref(*deterministicMNManager)), 10 * 1000);
 
     if (!fDisableGovernance) {
-        node.scheduler->scheduleEvery(std::bind(&CGovernanceManager::DoMaintenance, std::ref(governance), std::ref(*node.connman)), 60 * 5 * 1000);
+        node.scheduler->scheduleEvery(std::bind(&CGovernanceManager::DoMaintenance, std::ref(*::governance), std::ref(*node.connman)), 60 * 5 * 1000);
     }
 
     if (fMasternodeMode) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -231,6 +231,8 @@ void PrepareShutdown(NodeContext& node)
     StopHTTPServer();
     llmq::StopLLMQSystem();
 
+    ::coinJoinServer.reset();
+
     // fRPCInWarmup should be `false` if we completed the loading sequence
     // before a shutdown request was received
     std::string statusmessage;
@@ -2312,6 +2314,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
 
     // ********************************************************* Step 10a: Setup CoinJoin
 
+    ::coinJoinServer = std::make_unique<CCoinJoinServer>(*node.connman);
     g_wallet_init_interface.InitCoinJoinSettings();
 
     // ********************************************************* Step 10b: Load cache data
@@ -2377,7 +2380,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     }
 
     if (fMasternodeMode) {
-        node.scheduler->scheduleEvery(std::bind(&CCoinJoinServer::DoMaintenance, std::ref(coinJoinServer), std::ref(*node.connman)), 1 * 1000);
+        node.scheduler->scheduleEvery(std::bind(&CCoinJoinServer::DoMaintenance, std::ref(*::coinJoinServer)), 1 * 1000);
         node.scheduler->scheduleEvery(std::bind(&llmq::CDKGSessionManager::CleanupOldContributions, std::ref(*llmq::quorumDKGSessionManager)), 60 * 60 * 1000);
 #ifdef ENABLE_WALLET
     } else if(CCoinJoinClientOptions::IsEnabled()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -365,7 +365,8 @@ void PrepareShutdown(NodeContext& node)
         pdsNotificationInterface = nullptr;
     }
     if (fMasternodeMode) {
-        UnregisterValidationInterface(activeMasternodeManager);
+        UnregisterValidationInterface(activeMasternodeManager.get());
+        activeMasternodeManager.reset();
     }
 
     {
@@ -1952,8 +1953,8 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
 
     if (fMasternodeMode) {
         // Create and register activeMasternodeManager, will init later in ThreadImport
-        activeMasternodeManager = new CActiveMasternodeManager(*node.connman);
-        RegisterValidationInterface(activeMasternodeManager);
+        activeMasternodeManager = std::make_unique<CActiveMasternodeManager>(*node.connman);
+        RegisterValidationInterface(activeMasternodeManager.get());
     }
 
     uint64_t nMaxOutboundLimit = 0; //unlimited unless -maxuploadtarget is set

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -88,15 +88,15 @@ class MasternodeSyncImpl : public Masternode::Sync
 public:
     bool isSynced() override
     {
-        return masternodeSync.IsSynced();
+        return masternodeSync == nullptr ? false : masternodeSync->IsSynced();
     }
     bool isBlockchainSynced() override
     {
-        return masternodeSync.IsBlockchainSynced();
+        return masternodeSync == nullptr ? false : masternodeSync->IsBlockchainSynced();
     }
     std::string getSyncStatus() override
     {
-        return masternodeSync.GetSyncStatus();
+        return masternodeSync == nullptr ? "" : masternodeSync->GetSyncStatus();
     }
 };
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -64,13 +64,10 @@ public:
 class GOVImpl : public GOV
 {
 public:
-    bool getAllNewerThan(std::vector<CGovernanceObject> &obj, int64_t nMoreThanTime) override
+    void getAllNewerThan(std::vector<CGovernanceObject> &objs, int64_t nMoreThanTime) override
     {
-        if (governance != nullptr) {
-            obj = governance->GetAllNewerThan(nMoreThanTime);
-            return true;
-        }
-        return false;
+        if (governance == nullptr) return;
+        governance->GetAllNewerThan(objs, nMoreThanTime);
     }
 };
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -79,10 +79,7 @@ class LLMQImpl : public LLMQ
 public:
     size_t getInstantSentLockCount() override
     {
-        if (!llmq::quorumInstantSendManager) {
-            return 0;
-        }
-        return llmq::quorumInstantSendManager->GetInstantSendLockCount();
+        return llmq::quorumInstantSendManager == nullptr ? 0 : llmq::quorumInstantSendManager->GetInstantSendLockCount();
     }
 };
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -57,7 +57,7 @@ class EVOImpl : public EVO
 public:
     CDeterministicMNList getListAtChainTip() override
     {
-        return deterministicMNManager->GetListAtChainTip();
+        return deterministicMNManager == nullptr ? CDeterministicMNList() : deterministicMNManager->GetListAtChainTip();
     }
 };
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -64,9 +64,13 @@ public:
 class GOVImpl : public GOV
 {
 public:
-    std::vector<CGovernanceObject> getAllNewerThan(int64_t nMoreThanTime) override
+    bool getAllNewerThan(std::vector<CGovernanceObject> &obj, int64_t nMoreThanTime) override
     {
-        return governance.GetAllNewerThan(nMoreThanTime);
+        if (governance != nullptr) {
+            obj = governance->GetAllNewerThan(nMoreThanTime);
+            return true;
+        }
+        return false;
     }
 };
 

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -53,7 +53,7 @@ class GOV
 {
 public:
     virtual ~GOV() {}
-    virtual bool getAllNewerThan(std::vector<CGovernanceObject> &obj, int64_t nMoreThanTime) = 0;
+    virtual void getAllNewerThan(std::vector<CGovernanceObject> &objs, int64_t nMoreThanTime) = 0;
 };
 
 //! Interface for the src/llmq part of a dash node (dashd process).

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -53,7 +53,7 @@ class GOV
 {
 public:
     virtual ~GOV() {}
-    virtual std::vector<CGovernanceObject> getAllNewerThan(int64_t nMoreThanTime) = 0;
+    virtual bool getAllNewerThan(std::vector<CGovernanceObject> &obj, int64_t nMoreThanTime) = 0;
 };
 
 //! Interface for the src/llmq part of a dash node (dashd process).

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -27,7 +27,7 @@
 namespace llmq
 {
 
-CQuorumBlockProcessor* quorumBlockProcessor;
+std::unique_ptr<CQuorumBlockProcessor> quorumBlockProcessor;
 
 static const std::string DB_MINED_COMMITMENT = "q_mc";
 static const std::string DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT = "q_mcih";

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -73,7 +73,7 @@ private:
     static uint256 GetQuorumBlockHash(const Consensus::LLMQParams& llmqParams, int nHeight, int quorumIndex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
-extern CQuorumBlockProcessor* quorumBlockProcessor;
+extern std::unique_ptr<CQuorumBlockProcessor> quorumBlockProcessor;
 
 } // namespace llmq
 

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -279,7 +279,7 @@ void CChainLocksHandler::TrySignChainTip()
     // considered safe when it is islocked or at least known since 10 minutes (from mempool or block). These checks are
     // performed for the tip (which we try to sign) and the previous 5 blocks. If a ChainLocked block is found on the
     // way down, we consider all TXs to be safe.
-    if (IsInstantSendEnabled(spork_manager) && RejectConflictingBlocks(spork_manager)) {
+    if (quorumInstantSendManager->IsInstantSendEnabled() && quorumInstantSendManager->RejectConflictingBlocks()) {
         const auto* pindexWalk = pindex;
         while (pindexWalk != nullptr) {
             if (pindex->nHeight - pindexWalk->nHeight > 5) {
@@ -438,14 +438,14 @@ CChainLocksHandler::BlockTxs::mapped_type CChainLocksHandler::GetBlockTxs(const 
 
 bool CChainLocksHandler::IsTxSafeForMining(const uint256& txid) const
 {
-    if (!RejectConflictingBlocks(spork_manager)) {
+    if (!quorumInstantSendManager->RejectConflictingBlocks()) {
         return true;
     }
     if (!isEnabled || !isEnforced) {
         return true;
     }
 
-    if (!IsInstantSendEnabled(spork_manager)) {
+    if (!quorumInstantSendManager->IsInstantSendEnabled()) {
         return true;
     }
     if (quorumInstantSendManager->IsLocked(txid)) {

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -234,7 +234,7 @@ void CChainLocksHandler::TrySignChainTip()
         return;
     }
 
-    if (!masternodeSync.IsBlockchainSynced()) {
+    if (!masternodeSync->IsBlockchainSynced()) {
         return;
     }
 
@@ -350,7 +350,7 @@ void CChainLocksHandler::TransactionAddedToMempool(const CTransactionRef& tx, in
 
 void CChainLocksHandler::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted)
 {
-    if (!masternodeSync.IsBlockchainSynced()) {
+    if (!masternodeSync->IsBlockchainSynced()) {
         return;
     }
 
@@ -610,7 +610,7 @@ bool CChainLocksHandler::InternalHasConflictingChainLock(int nHeight, const uint
 
 void CChainLocksHandler::Cleanup()
 {
-    if (!masternodeSync.IsBlockchainSynced()) {
+    if (!masternodeSync->IsBlockchainSynced()) {
         return;
     }
 

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -21,7 +21,7 @@
 
 namespace llmq
 {
-CChainLocksHandler* chainLocksHandler;
+std::unique_ptr<CChainLocksHandler> chainLocksHandler;
 
 CChainLocksHandler::CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman, CSporkManager& sporkManager) :
     scheduler(std::make_unique<CScheduler>()),

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -23,9 +23,10 @@ namespace llmq
 {
 CChainLocksHandler* chainLocksHandler;
 
-CChainLocksHandler::CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman) :
+CChainLocksHandler::CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman, CSporkManager& sporkManager) :
     scheduler(std::make_unique<CScheduler>()),
     mempool(_mempool), connman(_connman),
+    spork_manager(sporkManager),
     scheduler_thread(std::make_unique<std::thread>([&] { TraceThread("cl-schdlr", [&] { scheduler->serviceQueue(); }); }))
 {
 }
@@ -80,7 +81,7 @@ CChainLockSig CChainLocksHandler::GetBestChainLock() const
 
 void CChainLocksHandler::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
-    if (!AreChainLocksEnabled()) {
+    if (!AreChainLocksEnabled(spork_manager)) {
         return;
     }
 
@@ -211,7 +212,7 @@ void CChainLocksHandler::CheckActiveState()
     const bool fDIP0008Active = WITH_LOCK(cs_main, return (::ChainActive().Tip() != nullptr) && (::ChainActive().Tip()->pprev != nullptr) && ::ChainActive().Tip()->pprev->nHeight >= Params().GetConsensus().DIP0008Height);
 
     bool oldIsEnforced = isEnforced;
-    isEnabled = AreChainLocksEnabled();
+    isEnabled = AreChainLocksEnabled(spork_manager);
     isEnforced = (fDIP0008Active && isEnabled);
 
     if (!oldIsEnforced && isEnforced) {
@@ -278,7 +279,7 @@ void CChainLocksHandler::TrySignChainTip()
     // considered safe when it is islocked or at least known since 10 minutes (from mempool or block). These checks are
     // performed for the tip (which we try to sign) and the previous 5 blocks. If a ChainLocked block is found on the
     // way down, we consider all TXs to be safe.
-    if (IsInstantSendEnabled() && RejectConflictingBlocks()) {
+    if (IsInstantSendEnabled(spork_manager) && RejectConflictingBlocks(spork_manager)) {
         const auto* pindexWalk = pindex;
         while (pindexWalk != nullptr) {
             if (pindex->nHeight - pindexWalk->nHeight > 5) {
@@ -437,14 +438,14 @@ CChainLocksHandler::BlockTxs::mapped_type CChainLocksHandler::GetBlockTxs(const 
 
 bool CChainLocksHandler::IsTxSafeForMining(const uint256& txid) const
 {
-    if (!RejectConflictingBlocks()) {
+    if (!RejectConflictingBlocks(spork_manager)) {
         return true;
     }
     if (!isEnabled || !isEnforced) {
         return true;
     }
 
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return true;
     }
     if (quorumInstantSendManager->IsLocked(txid)) {
@@ -667,7 +668,7 @@ void CChainLocksHandler::Cleanup()
     lastCleanupTime = GetTimeMillis();
 }
 
-bool AreChainLocksEnabled()
+bool AreChainLocksEnabled(const CSporkManager& sporkManager)
 {
     return sporkManager.IsSporkActive(SPORK_19_CHAINLOCKS_ENABLED);
 }

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -109,7 +109,7 @@ private:
     void Cleanup();
 };
 
-extern CChainLocksHandler* chainLocksHandler;
+extern std::unique_ptr<CChainLocksHandler> chainLocksHandler;
 
 bool AreChainLocksEnabled(const CSporkManager& sporkManager);
 

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -23,6 +23,7 @@ class CConnman;
 class CBlockIndex;
 class CScheduler;
 class CTxMemPool;
+class CSporkManager;
 
 namespace llmq
 {
@@ -38,6 +39,7 @@ class CChainLocksHandler : public CRecoveredSigsListener
 private:
     CConnman& connman;
     CTxMemPool& mempool;
+    CSporkManager& spork_manager;
     std::unique_ptr<CScheduler> scheduler;
     std::unique_ptr<std::thread> scheduler_thread;
     mutable CCriticalSection cs;
@@ -70,7 +72,7 @@ private:
     int64_t lastCleanupTime GUARDED_BY(cs) {0};
 
 public:
-    explicit CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman);
+    explicit CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman, CSporkManager& sporkManager);
     ~CChainLocksHandler();
 
     void Start();
@@ -109,7 +111,7 @@ private:
 
 extern CChainLocksHandler* chainLocksHandler;
 
-bool AreChainLocksEnabled();
+bool AreChainLocksEnabled(const CSporkManager& sporkManager);
 
 } // namespace llmq
 

--- a/src/llmq/debug.cpp
+++ b/src/llmq/debug.cpp
@@ -14,7 +14,7 @@
 
 namespace llmq
 {
-CDKGDebugManager* quorumDKGDebugManager;
+std::unique_ptr<CDKGDebugManager> quorumDKGDebugManager;
 
 UniValue CDKGDebugSessionStatus::ToJson(int quorumIndex, int detailLevel) const
 {

--- a/src/llmq/debug.h
+++ b/src/llmq/debug.h
@@ -105,7 +105,7 @@ public:
     void UpdateLocalMemberStatus(Consensus::LLMQType llmqType, int quorumIndex, size_t memberIdx, std::function<bool(CDKGDebugMemberStatus& status)>&& func);
 };
 
-extern CDKGDebugManager* quorumDKGDebugManager;
+extern std::unique_ptr<CDKGDebugManager> quorumDKGDebugManager;
 
 } // namespace llmq
 

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -18,7 +18,7 @@
 namespace llmq
 {
 
-CDKGSessionManager* quorumDKGSessionManager;
+std::unique_ptr<CDKGSessionManager> quorumDKGSessionManager;
 
 static const std::string DB_VVEC = "qdkg_V";
 static const std::string DB_SKCONTRIB = "qdkg_S";

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -24,9 +24,9 @@ static const std::string DB_VVEC = "qdkg_V";
 static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
-CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, bool unitTests, bool fWipe) :
+CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CSporkManager& sporkManager, bool unitTests, bool fWipe) :
         db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
-        blsWorker(_blsWorker), connman(_connman)
+        blsWorker(_blsWorker), connman(_connman), spork_manager(sporkManager)
 {
     if (!fMasternodeMode && !utils::IsWatchQuorumsEnabled()) {
         // Regular nodes do not care about any DKG internals, bail out
@@ -157,7 +157,7 @@ void CDKGSessionManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fIni
         return;
     if (!deterministicMNManager->IsDIP3Enforced(pindexNew->nHeight))
         return;
-    if (!IsQuorumDKGEnabled())
+    if (!IsQuorumDKGEnabled(spork_manager))
         return;
 
     for (auto& qt : dkgSessionHandlers) {
@@ -170,7 +170,7 @@ void CDKGSessionManager::ProcessMessage(CNode* pfrom, const std::string& msg_typ
     static Mutex cs_indexedQuorumsCache;
     static std::map<Consensus::LLMQType, unordered_lru_cache<uint256, int, StaticSaltedHasher>> indexedQuorumsCache GUARDED_BY(cs_indexedQuorumsCache);
 
-    if (!IsQuorumDKGEnabled())
+    if (!IsQuorumDKGEnabled(spork_manager))
         return;
 
     if (msg_type != NetMsgType::QCONTRIB
@@ -262,7 +262,7 @@ void CDKGSessionManager::ProcessMessage(CNode* pfrom, const std::string& msg_typ
 
 bool CDKGSessionManager::AlreadyHave(const CInv& inv) const
 {
-    if (!IsQuorumDKGEnabled())
+    if (!IsQuorumDKGEnabled(spork_manager))
         return false;
 
     for (const auto& p : dkgSessionHandlers) {
@@ -279,7 +279,7 @@ bool CDKGSessionManager::AlreadyHave(const CInv& inv) const
 
 bool CDKGSessionManager::GetContribution(const uint256& hash, CDKGContribution& ret) const
 {
-    if (!IsQuorumDKGEnabled())
+    if (!IsQuorumDKGEnabled(spork_manager))
         return false;
 
     for (const auto& p : dkgSessionHandlers) {
@@ -300,7 +300,7 @@ bool CDKGSessionManager::GetContribution(const uint256& hash, CDKGContribution& 
 
 bool CDKGSessionManager::GetComplaint(const uint256& hash, CDKGComplaint& ret) const
 {
-    if (!IsQuorumDKGEnabled())
+    if (!IsQuorumDKGEnabled(spork_manager))
         return false;
 
     for (const auto& p : dkgSessionHandlers) {
@@ -321,7 +321,7 @@ bool CDKGSessionManager::GetComplaint(const uint256& hash, CDKGComplaint& ret) c
 
 bool CDKGSessionManager::GetJustification(const uint256& hash, CDKGJustification& ret) const
 {
-    if (!IsQuorumDKGEnabled())
+    if (!IsQuorumDKGEnabled(spork_manager))
         return false;
 
     for (const auto& p : dkgSessionHandlers) {
@@ -342,7 +342,7 @@ bool CDKGSessionManager::GetJustification(const uint256& hash, CDKGJustification
 
 bool CDKGSessionManager::GetPrematureCommitment(const uint256& hash, CDKGPrematureCommitment& ret) const
 {
-    if (!IsQuorumDKGEnabled())
+    if (!IsQuorumDKGEnabled(spork_manager))
         return false;
 
     for (const auto& p : dkgSessionHandlers) {
@@ -501,7 +501,7 @@ void CDKGSessionManager::CleanupOldContributions() const
     }
 }
 
-bool IsQuorumDKGEnabled()
+bool IsQuorumDKGEnabled(const CSporkManager& sporkManager)
 {
     return sporkManager.IsSporkActive(SPORK_17_QUORUM_DKG_ENABLED);
 }

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -12,6 +12,7 @@
 
 class UniValue;
 class CBlockIndex;
+class CSporkManager;
 
 namespace llmq
 {
@@ -24,6 +25,7 @@ private:
     std::unique_ptr<CDBWrapper> db{nullptr};
     CBLSWorker& blsWorker;
     CConnman& connman;
+    CSporkManager& spork_manager;
 
     //TODO name struct instead of std::pair
     std::map<std::pair<Consensus::LLMQType, int>, CDKGSessionHandler> dkgSessionHandlers;
@@ -48,7 +50,7 @@ private:
     mutable std::map<ContributionsCacheKey, ContributionsCacheEntry> contributionsCache GUARDED_BY(contributionsCacheCs);
 
 public:
-    CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, bool unitTests, bool fWipe);
+    CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CSporkManager& sporkManager, bool unitTests, bool fWipe);
     ~CDKGSessionManager() = default;
 
     void StartThreads();
@@ -79,7 +81,7 @@ private:
     void CleanupCache() const;
 };
 
-bool IsQuorumDKGEnabled();
+bool IsQuorumDKGEnabled(const CSporkManager& sporkManager);
 
 extern CDKGSessionManager* quorumDKGSessionManager;
 

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -83,7 +83,7 @@ private:
 
 bool IsQuorumDKGEnabled(const CSporkManager& sporkManager);
 
-extern CDKGSessionManager* quorumDKGSessionManager;
+extern std::unique_ptr<CDKGSessionManager> quorumDKGSessionManager;
 
 } // namespace llmq
 

--- a/src/llmq/init.cpp
+++ b/src/llmq/init.cpp
@@ -21,20 +21,20 @@
 namespace llmq
 {
 
-CBLSWorker* blsWorker;
+std::shared_ptr<CBLSWorker> blsWorker;
 
 void InitLLMQSystem(CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, CSporkManager& sporkManager, bool unitTests, bool fWipe)
 {
-    blsWorker = new CBLSWorker();
+    blsWorker = std::make_shared<CBLSWorker>();
 
-    quorumDKGDebugManager = new CDKGDebugManager();
-    quorumBlockProcessor = new CQuorumBlockProcessor(evoDb, connman);
-    quorumDKGSessionManager = new CDKGSessionManager(connman, *blsWorker, sporkManager, unitTests, fWipe);
-    quorumManager = new CQuorumManager(evoDb, connman, *blsWorker, *quorumDKGSessionManager);
-    quorumSigSharesManager = new CSigSharesManager(connman);
-    quorumSigningManager = new CSigningManager(connman, unitTests, fWipe);
-    chainLocksHandler = new CChainLocksHandler(mempool, connman, sporkManager);
-    quorumInstantSendManager = new CInstantSendManager(mempool, connman, sporkManager, unitTests, fWipe);
+    quorumDKGDebugManager = std::make_unique<CDKGDebugManager>();
+    quorumBlockProcessor = std::make_unique<CQuorumBlockProcessor>(evoDb, connman);
+    quorumDKGSessionManager = std::make_unique<CDKGSessionManager>(connman, *blsWorker, sporkManager, unitTests, fWipe);
+    quorumManager = std::make_unique<CQuorumManager>(evoDb, connman, *blsWorker, *quorumDKGSessionManager);
+    quorumSigSharesManager = std::make_unique<CSigSharesManager>(connman);
+    quorumSigningManager = std::make_unique<CSigningManager>(connman, unitTests, fWipe);
+    chainLocksHandler = std::make_unique<CChainLocksHandler>(mempool, connman, sporkManager);
+    quorumInstantSendManager = std::make_unique<CInstantSendManager>(mempool, connman, sporkManager, unitTests, fWipe);
 
     // NOTE: we use this only to wipe the old db, do NOT use it for anything else
     // TODO: remove it in some future version
@@ -43,24 +43,15 @@ void InitLLMQSystem(CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, CSpor
 
 void DestroyLLMQSystem()
 {
-    delete quorumInstantSendManager;
-    quorumInstantSendManager = nullptr;
-    delete chainLocksHandler;
-    chainLocksHandler = nullptr;
-    delete quorumSigningManager;
-    quorumSigningManager = nullptr;
-    delete quorumSigSharesManager;
-    quorumSigSharesManager = nullptr;
-    delete quorumManager;
-    quorumManager = nullptr;
-    delete quorumDKGSessionManager;
-    quorumDKGSessionManager = nullptr;
-    delete quorumBlockProcessor;
-    quorumBlockProcessor = nullptr;
-    delete quorumDKGDebugManager;
-    quorumDKGDebugManager = nullptr;
-    delete blsWorker;
-    blsWorker = nullptr;
+    quorumInstantSendManager.reset();
+    chainLocksHandler.reset();
+    quorumSigningManager.reset();
+    quorumSigSharesManager.reset();
+    quorumManager.reset();
+    quorumDKGSessionManager.reset();
+    quorumBlockProcessor.reset();
+    quorumDKGDebugManager.reset();
+    blsWorker.reset();
     LOCK(cs_llmq_vbc);
     llmq_versionbitscache.Clear();
 }

--- a/src/llmq/init.cpp
+++ b/src/llmq/init.cpp
@@ -23,18 +23,18 @@ namespace llmq
 
 CBLSWorker* blsWorker;
 
-void InitLLMQSystem(CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, bool unitTests, bool fWipe)
+void InitLLMQSystem(CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, CSporkManager& sporkManager, bool unitTests, bool fWipe)
 {
     blsWorker = new CBLSWorker();
 
     quorumDKGDebugManager = new CDKGDebugManager();
     quorumBlockProcessor = new CQuorumBlockProcessor(evoDb, connman);
-    quorumDKGSessionManager = new CDKGSessionManager(connman, *blsWorker, unitTests, fWipe);
+    quorumDKGSessionManager = new CDKGSessionManager(connman, *blsWorker, sporkManager, unitTests, fWipe);
     quorumManager = new CQuorumManager(evoDb, connman, *blsWorker, *quorumDKGSessionManager);
     quorumSigSharesManager = new CSigSharesManager(connman);
     quorumSigningManager = new CSigningManager(connman, unitTests, fWipe);
-    chainLocksHandler = new CChainLocksHandler(mempool, connman);
-    quorumInstantSendManager = new CInstantSendManager(mempool, connman, unitTests, fWipe);
+    chainLocksHandler = new CChainLocksHandler(mempool, connman, sporkManager);
+    quorumInstantSendManager = new CInstantSendManager(mempool, connman, sporkManager, unitTests, fWipe);
 
     // NOTE: we use this only to wipe the old db, do NOT use it for anything else
     // TODO: remove it in some future version

--- a/src/llmq/init.h
+++ b/src/llmq/init.h
@@ -9,12 +9,13 @@ class CConnman;
 class CDBWrapper;
 class CEvoDB;
 class CTxMemPool;
+class CSporkManager;
 
 namespace llmq
 {
 
 // Init/destroy LLMQ globals
-void InitLLMQSystem(CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, bool unitTests, bool fWipe = false);
+void InitLLMQSystem(CEvoDB& evoDb, CTxMemPool& mempool, CConnman& connman, CSporkManager& sporkManager, bool unitTests, bool fWipe = false);
 void DestroyLLMQSystem();
 
 // Manage scheduled tasks, threads, listeners etc.

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -480,7 +480,7 @@ void CInstantSendManager::Stop()
 
 void CInstantSendManager::ProcessTx(const CTransaction& tx, bool fRetroactive, const Consensus::Params& params)
 {
-    if (!fMasternodeMode || !IsInstantSendEnabled() || !masternodeSync.IsBlockchainSynced()) {
+    if (!fMasternodeMode || !IsInstantSendEnabled(spork_manager) || !masternodeSync.IsBlockchainSynced()) {
         return;
     }
 
@@ -507,7 +507,7 @@ void CInstantSendManager::ProcessTx(const CTransaction& tx, bool fRetroactive, c
     // However, if we are processing a tx because it was included in a block we should
     // sign even if mempool IS signing is disabled. This allows a ChainLock to happen on this
     // block after we retroactively locked all transactions.
-    if (!IsInstantSendMempoolSigningEnabled() && !fRetroactive) return;
+    if (!IsInstantSendMempoolSigningEnabled(spork_manager) && !fRetroactive) return;
 
     if (!TrySignInputLocks(tx, fRetroactive, utils::GetInstantSendLLMQType(WITH_LOCK(cs_main, return ::ChainActive().Tip())), params)) {
         return;
@@ -635,7 +635,7 @@ bool CInstantSendManager::CheckCanLock(const COutPoint& outpoint, bool printDebu
 
 void CInstantSendManager::HandleNewRecoveredSig(const CRecoveredSig& recoveredSig)
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return;
     }
 
@@ -763,7 +763,7 @@ void CInstantSendManager::HandleNewInstantSendLockRecoveredSig(const llmq::CReco
 
 void CInstantSendManager::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return;
     }
 
@@ -865,7 +865,7 @@ bool CInstantSendManager::ProcessPendingInstantSendLocks(bool deterministic)
     decltype(pendingInstantSendLocks) pend;
     bool fMoreWork{false};
 
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return false;
     }
 
@@ -1131,7 +1131,7 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
 
 void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
 {
-    if (!IsInstantSendEnabled() || !masternodeSync.IsBlockchainSynced() || tx->vin.empty()) {
+    if (!IsInstantSendEnabled(spork_manager) || !masternodeSync.IsBlockchainSynced() || tx->vin.empty()) {
         return;
     }
 
@@ -1180,7 +1180,7 @@ void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& t
 
 void CInstantSendManager::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted)
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return;
     }
 
@@ -1326,7 +1326,7 @@ void CInstantSendManager::UpdatedBlockTip(const CBlockIndex* pindexNew)
 
     bool fDIP0008Active = pindexNew->pprev && pindexNew->pprev->nHeight >= Params().GetConsensus().DIP0008Height;
 
-    if (AreChainLocksEnabled() && fDIP0008Active) {
+    if (AreChainLocksEnabled(spork_manager) && fDIP0008Active) {
         // Nothing to do here. We should keep all islocks and let chainlocks handle them.
         return;
     }
@@ -1341,7 +1341,7 @@ void CInstantSendManager::UpdatedBlockTip(const CBlockIndex* pindexNew)
 
 void CInstantSendManager::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return;
     }
 
@@ -1564,7 +1564,7 @@ void CInstantSendManager::ProcessPendingRetryLockTxs()
         return;
     }
 
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return;
     }
 
@@ -1619,7 +1619,7 @@ void CInstantSendManager::ProcessPendingRetryLockTxs()
 
 bool CInstantSendManager::AlreadyHave(const CInv& inv) const
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return true;
     }
 
@@ -1629,7 +1629,7 @@ bool CInstantSendManager::AlreadyHave(const CInv& inv) const
 
 bool CInstantSendManager::GetInstantSendLockByHash(const uint256& hash, llmq::CInstantSendLock& ret) const
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return false;
     }
 
@@ -1654,7 +1654,7 @@ bool CInstantSendManager::GetInstantSendLockByHash(const uint256& hash, llmq::CI
 
 CInstantSendLockPtr CInstantSendManager::GetInstantSendLockByTxid(const uint256& txid) const
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return nullptr;
     }
 
@@ -1663,7 +1663,7 @@ CInstantSendLockPtr CInstantSendManager::GetInstantSendLockByTxid(const uint256&
 
 bool CInstantSendManager::IsLocked(const uint256& txHash) const
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return false;
     }
 
@@ -1672,7 +1672,7 @@ bool CInstantSendManager::IsLocked(const uint256& txHash) const
 
 bool CInstantSendManager::IsWaitingForTx(const uint256& txHash) const
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return false;
     }
 
@@ -1691,7 +1691,7 @@ bool CInstantSendManager::IsWaitingForTx(const uint256& txHash) const
 
 CInstantSendLockPtr CInstantSendManager::GetConflictingLock(const CTransaction& tx) const
 {
-    if (!IsInstantSendEnabled()) {
+    if (!IsInstantSendEnabled(spork_manager)) {
         return nullptr;
     }
 
@@ -1725,17 +1725,17 @@ void CInstantSendManager::WorkThreadMain()
     }
 }
 
-bool IsInstantSendEnabled()
+bool IsInstantSendEnabled(const CSporkManager& sporkManager)
 {
     return !fReindex && !fImporting && sporkManager.IsSporkActive(SPORK_2_INSTANTSEND_ENABLED);
 }
 
-bool IsInstantSendMempoolSigningEnabled()
+bool IsInstantSendMempoolSigningEnabled(const CSporkManager& sporkManager)
 {
     return !fReindex && !fImporting && sporkManager.GetSporkValue(SPORK_2_INSTANTSEND_ENABLED) == 0;
 }
 
-bool RejectConflictingBlocks()
+bool RejectConflictingBlocks(const CSporkManager& sporkManager)
 {
     if (!masternodeSync.IsBlockchainSynced()) {
         return false;

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -43,7 +43,7 @@ const int CInstantSendDb::CURRENT_VERSION;
 const uint8_t CInstantSendLock::islock_version;
 const uint8_t CInstantSendLock::isdlock_version;
 
-CInstantSendManager* quorumInstantSendManager;
+std::unique_ptr<CInstantSendManager> quorumInstantSendManager;
 
 uint256 CInstantSendLock::GetRequestId() const
 {

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -480,7 +480,7 @@ void CInstantSendManager::Stop()
 
 void CInstantSendManager::ProcessTx(const CTransaction& tx, bool fRetroactive, const Consensus::Params& params)
 {
-    if (!fMasternodeMode || !IsInstantSendEnabled(spork_manager) || !masternodeSync.IsBlockchainSynced()) {
+    if (!fMasternodeMode || !IsInstantSendEnabled(spork_manager) || !masternodeSync->IsBlockchainSynced()) {
         return;
     }
 
@@ -1131,7 +1131,7 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
 
 void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
 {
-    if (!IsInstantSendEnabled(spork_manager) || !masternodeSync.IsBlockchainSynced() || tx->vin.empty()) {
+    if (!IsInstantSendEnabled(spork_manager) || !masternodeSync->IsBlockchainSynced() || tx->vin.empty()) {
         return;
     }
 
@@ -1190,7 +1190,7 @@ void CInstantSendManager::BlockConnected(const std::shared_ptr<const CBlock>& pb
         }
     }
 
-    if (masternodeSync.IsBlockchainSynced()) {
+    if (masternodeSync->IsBlockchainSynced()) {
         for (const auto& tx : pblock->vtx) {
             if (tx->IsCoinBase() || tx->vin.empty()) {
                 // coinbase and TXs with no inputs can't be locked
@@ -1737,7 +1737,7 @@ bool IsInstantSendMempoolSigningEnabled(const CSporkManager& sporkManager)
 
 bool RejectConflictingBlocks(const CSporkManager& sporkManager)
 {
-    if (!masternodeSync.IsBlockchainSynced()) {
+    if (!masternodeSync->IsBlockchainSynced()) {
         return false;
     }
     if (!sporkManager.IsSporkActive(SPORK_3_INSTANTSEND_BLOCK_FILTERING)) {

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -318,7 +318,7 @@ public:
     size_t GetInstantSendLockCount() const;
 };
 
-extern CInstantSendManager* quorumInstantSendManager;
+extern std::unique_ptr<CInstantSendManager> quorumInstantSendManager;
 
 bool IsInstantSendEnabled(const CSporkManager& sporkManager);
 /**

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -316,18 +316,18 @@ public:
     void RemoveConflictingLock(const uint256& islockHash, const CInstantSendLock& islock);
 
     size_t GetInstantSendLockCount() const;
+
+    bool IsInstantSendEnabled() const;
+    /**
+     * If true, MN should sign all transactions, if false, MN should not sign
+     * transactions in mempool, but should sign txes included in a block. This
+     * allows ChainLocks to continue even while this spork is disabled.
+     */
+    bool IsInstantSendMempoolSigningEnabled() const;
+    bool RejectConflictingBlocks() const;
 };
 
 extern std::unique_ptr<CInstantSendManager> quorumInstantSendManager;
-
-bool IsInstantSendEnabled(const CSporkManager& sporkManager);
-/**
- * If true, MN should sign all transactions, if false, MN should not sign
- * transactions in mempool, but should sign txes included in a block. This
- * allows ChainLocks to continue even while this spork is disabled.
- */
-bool IsInstantSendMempoolSigningEnabled(const CSporkManager& sporkManager);
-bool RejectConflictingBlocks(const CSporkManager& sporkManager);
 
 } // namespace llmq
 

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -18,6 +18,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
+class CSporkManager;
+
 namespace llmq
 {
 
@@ -196,6 +198,7 @@ private:
     CInstantSendDb db;
     CConnman& connman;
     CTxMemPool& mempool;
+    CSporkManager& spork_manager;
 
     std::atomic<bool> fUpgradedDB{false};
 
@@ -243,7 +246,7 @@ private:
     std::unordered_set<uint256, StaticSaltedHasher> pendingRetryTxs GUARDED_BY(cs_pendingRetry);
 
 public:
-    explicit CInstantSendManager(CTxMemPool& _mempool, CConnman& _connman, bool unitTests, bool fWipe) : db(unitTests, fWipe), mempool(_mempool), connman(_connman) { workInterrupt.reset(); }
+    explicit CInstantSendManager(CTxMemPool& _mempool, CConnman& _connman, CSporkManager& sporkManager, bool unitTests, bool fWipe) : db(unitTests, fWipe), mempool(_mempool), connman(_connman), spork_manager(sporkManager) { workInterrupt.reset(); }
     ~CInstantSendManager() = default;
 
     void Start();
@@ -317,14 +320,14 @@ public:
 
 extern CInstantSendManager* quorumInstantSendManager;
 
-bool IsInstantSendEnabled();
+bool IsInstantSendEnabled(const CSporkManager& sporkManager);
 /**
  * If true, MN should sign all transactions, if false, MN should not sign
  * transactions in mempool, but should sign txes included in a block. This
  * allows ChainLocks to continue even while this spork is disabled.
  */
-bool IsInstantSendMempoolSigningEnabled();
-bool RejectConflictingBlocks();
+bool IsInstantSendMempoolSigningEnabled(const CSporkManager& sporkManager);
+bool RejectConflictingBlocks(const CSporkManager& sporkManager);
 
 } // namespace llmq
 

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -266,7 +266,7 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
 
 void CQuorumManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fInitialDownload) const
 {
-    if (!masternodeSync.IsBlockchainSynced()) {
+    if (!masternodeSync->IsBlockchainSynced()) {
         return;
     }
 
@@ -842,7 +842,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
         };
         printLog("Start");
 
-        while (!masternodeSync.IsBlockchainSynced() && !quorumThreadInterrupt) {
+        while (!masternodeSync->IsBlockchainSynced() && !quorumThreadInterrupt) {
             quorumThreadInterrupt.sleep_for(std::chrono::seconds(nRequestTimeout));
         }
 

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -30,7 +30,7 @@ namespace llmq
 static const std::string DB_QUORUM_SK_SHARE = "q_Qsk";
 static const std::string DB_QUORUM_QUORUM_VVEC = "q_Qqvvec";
 
-CQuorumManager* quorumManager;
+std::unique_ptr<CQuorumManager> quorumManager;
 
 CCriticalSection cs_data_requests;
 static std::unordered_map<CQuorumDataRequestKey, CQuorumDataRequest, StaticSaltedHasher> mapQuorumDataRequests GUARDED_BY(cs_data_requests);

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -259,7 +259,7 @@ private:
     void StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, const CBlockIndex* pIndex, uint16_t nDataMask) const;
 };
 
-extern CQuorumManager* quorumManager;
+extern std::unique_ptr<CQuorumManager> quorumManager;
 
 } // namespace llmq
 

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -25,7 +25,7 @@
 namespace llmq
 {
 
-CSigningManager* quorumSigningManager;
+std::unique_ptr<CSigningManager> quorumSigningManager;
 
 UniValue CRecoveredSig::ToJson() const
 {

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -228,7 +228,7 @@ public:
     static bool VerifyRecoveredSig(Consensus::LLMQType llmqType, int signedAtHeight, const uint256& id, const uint256& msgHash, const CBLSSignature& sig, int signOffset = SIGN_HEIGHT_OFFSET);
 };
 
-extern CSigningManager* quorumSigningManager;
+extern std::unique_ptr<CSigningManager> quorumSigningManager;
 
 } // namespace llmq
 

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -215,7 +215,7 @@ void CSigSharesManager::InterruptWorkerThread()
     workInterrupt();
 }
 
-void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
+void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& msg_type, CDataStream& vRecv, const CSporkManager& sporkManager)
 {
     // non-masternodes are not interested in sigshares
     if (!fMasternodeMode || WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) {

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -23,7 +23,7 @@
 namespace llmq
 {
 
-CSigSharesManager* quorumSigSharesManager = nullptr;
+std::unique_ptr<CSigSharesManager> quorumSigSharesManager;
 
 void CSigShare::UpdateKey()
 {

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -463,7 +463,7 @@ private:
     void WorkThreadMain();
 };
 
-extern CSigSharesManager* quorumSigSharesManager;
+extern std::unique_ptr<CSigSharesManager> quorumSigSharesManager;
 
 } // namespace llmq
 

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -21,6 +21,7 @@
 
 class CEvoDB;
 class CScheduler;
+class CSporkManager;
 
 class CDeterministicMN;
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
@@ -411,7 +412,7 @@ public:
     void UnregisterAsRecoveredSigsListener();
     void InterruptWorkerThread();
 
-    void ProcessMessage(const CNode* pnode, const std::string& msg_type, CDataStream& vRecv);
+    void ProcessMessage(const CNode* pnode, const std::string& msg_type, CDataStream& vRecv, const CSporkManager& sporkManager);
 
     void AsyncSign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
     std::optional<CSigShare> CreateSigShare(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash) const;

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -552,12 +552,12 @@ static bool EvalSpork(Consensus::LLMQType llmqType, int64_t spork_value)
 
 bool IsAllMembersConnectedEnabled(Consensus::LLMQType llmqType)
 {
-    return EvalSpork(llmqType, sporkManager.GetSporkValue(SPORK_21_QUORUM_ALL_CONNECTED));
+    return EvalSpork(llmqType, sporkManager->GetSporkValue(SPORK_21_QUORUM_ALL_CONNECTED));
 }
 
 bool IsQuorumPoseEnabled(Consensus::LLMQType llmqType)
 {
-    return EvalSpork(llmqType, sporkManager.GetSporkValue(SPORK_23_QUORUM_POSE));
+    return EvalSpork(llmqType, sporkManager->GetSporkValue(SPORK_23_QUORUM_POSE));
 }
 
 bool IsQuorumRotationEnabled(Consensus::LLMQType llmqType, const CBlockIndex* pindex)

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -16,7 +16,7 @@
 // Keep track of the active Masternode
 CCriticalSection activeMasternodeInfoCs;
 CActiveMasternodeInfo activeMasternodeInfo GUARDED_BY(activeMasternodeInfoCs);
-CActiveMasternodeManager* activeMasternodeManager;
+std::unique_ptr<CActiveMasternodeManager> activeMasternodeManager;
 
 std::string CActiveMasternodeManager::GetStateString() const
 {

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -17,7 +17,7 @@ class CActiveMasternodeManager;
 
 extern CActiveMasternodeInfo activeMasternodeInfo;
 extern CCriticalSection activeMasternodeInfoCs;
-extern CActiveMasternodeManager* activeMasternodeManager;
+extern std::unique_ptr<CActiveMasternodeManager> activeMasternodeManager;
 
 struct CActiveMasternodeInfo {
     // Keys for the active Masternode

--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -45,7 +45,7 @@ bool IsOldBudgetBlockValueValid(const CBlock& block, int nBlockHeight, CAmount b
     if(nBlockHeight >= consensusParams.nBudgetPaymentsStartBlock &&
        nOffset < consensusParams.nBudgetPaymentsWindowBlocks) {
         // NOTE: old budget system is disabled since 12.1
-        if(masternodeSync.IsSynced()) {
+        if(masternodeSync->IsSynced()) {
             // no old budget blocks should be accepted here on mainnet,
             // testnet/devnet/regtest should produce regular blocks only
             LogPrint(BCLog::GOBJECT, "%s -- WARNING: Client synced but old budget system is disabled, checking block value against block reward\n", __func__);
@@ -120,7 +120,7 @@ bool IsBlockValueValid(const CSporkManager& sporkManager, CGovernanceManager& go
         return false;
     }
 
-    if(!masternodeSync.IsSynced() || fDisableGovernance) {
+    if(!masternodeSync->IsSynced() || fDisableGovernance) {
         LogPrint(BCLog::MNPAYMENTS, "%s -- WARNING: Not enough data, checked superblock max bounds only\n", __func__);
         // not enough data for full checks but at least we know that the superblock limits were honored.
         // We rely on the network to have followed the correct chain in this case

--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -77,7 +77,8 @@ bool IsOldBudgetBlockValueValid(const CBlock& block, int nBlockHeight, CAmount b
 *   - When non-superblocks are detected, the normal schedule should be maintained
 */
 
-bool IsBlockValueValid(const CSporkManager& sporkManager, const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet)
+bool IsBlockValueValid(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                       const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet)
 {
     const Consensus::Params& consensusParams = Params().GetConsensus();
     bool isBlockRewardValueMet = (block.vtx[0]->GetValueOut() <= blockReward);
@@ -139,7 +140,7 @@ bool IsBlockValueValid(const CSporkManager& sporkManager, const CBlock& block, i
         return isBlockRewardValueMet;
     }
 
-    if (!CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
+    if (!CSuperblockManager::IsSuperblockTriggered(governanceManager, nBlockHeight)) {
         // we are on a valid superblock height but a superblock was not triggered
         // revert to block reward limits in this case
         if(!isBlockRewardValueMet) {
@@ -150,7 +151,7 @@ bool IsBlockValueValid(const CSporkManager& sporkManager, const CBlock& block, i
     }
 
     // this actually also checks for correct payees and not only amount
-    if (!CSuperblockManager::IsValid(*block.vtx[0], nBlockHeight, blockReward)) {
+    if (!CSuperblockManager::IsValid(governanceManager, *block.vtx[0], nBlockHeight, blockReward)) {
         // triggered but invalid? that's weird
         LogPrintf("%s -- ERROR: Invalid superblock detected at height %d: %s", __func__, nBlockHeight, block.vtx[0]->ToString()); /* Continued */
         // should NOT allow invalid superblocks, when superblocks are enabled
@@ -162,7 +163,8 @@ bool IsBlockValueValid(const CSporkManager& sporkManager, const CBlock& block, i
     return true;
 }
 
-bool IsBlockPayeeValid(const CSporkManager& sporkManager, const CTransaction& txNew, int nBlockHeight, CAmount blockReward)
+bool IsBlockPayeeValid(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                       const CTransaction& txNew, int nBlockHeight, CAmount blockReward)
 {
     if(fDisableGovernance) {
         //there is no budget data to use to check anything, let's just accept the longest chain
@@ -187,8 +189,8 @@ bool IsBlockPayeeValid(const CSporkManager& sporkManager, const CTransaction& tx
     // SEE IF THIS IS A VALID SUPERBLOCK
 
     if(AreSuperblocksEnabled(sporkManager)) {
-        if(CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
-            if(CSuperblockManager::IsValid(txNew, nBlockHeight, blockReward)) {
+        if(CSuperblockManager::IsSuperblockTriggered(governanceManager, nBlockHeight)) {
+            if(CSuperblockManager::IsValid(governanceManager, txNew, nBlockHeight, blockReward)) {
                 LogPrint(BCLog::GOBJECT, "%s -- Valid superblock at height %d: %s", __func__, nBlockHeight, txNew.ToString()); /* Continued */
                 // continue validation, should also pay MN
             } else {
@@ -214,13 +216,14 @@ bool IsBlockPayeeValid(const CSporkManager& sporkManager, const CTransaction& tx
     return false;
 }
 
-void FillBlockPayments(const CSporkManager& sporkManager, CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet)
+void FillBlockPayments(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                       CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet)
 {
     // only create superblocks if spork is enabled AND if superblock is actually triggered
     // (height should be validated inside)
-    if(AreSuperblocksEnabled(sporkManager) && CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
+    if(AreSuperblocksEnabled(sporkManager) && CSuperblockManager::IsSuperblockTriggered(governanceManager, nBlockHeight)) {
         LogPrint(BCLog::GOBJECT, "%s -- triggered superblock creation at height %d\n", __func__, nBlockHeight);
-        CSuperblockManager::GetSuperblockPayments(nBlockHeight, voutSuperblockPaymentsRet);
+        CSuperblockManager::GetSuperblockPayments(governanceManager, nBlockHeight, voutSuperblockPaymentsRet);
     }
 
     if (!CMasternodePayments::GetMasternodeTxOuts(nBlockHeight, blockReward, voutMasternodePaymentsRet)) {

--- a/src/masternode/payments.h
+++ b/src/masternode/payments.h
@@ -14,12 +14,13 @@ class CMasternodePayments;
 class CBlock;
 class CTransaction;
 struct CMutableTransaction;
+class CSporkManager;
 class CTxOut;
 
 /// TODO: all 4 functions do not belong here really, they should be refactored/moved somewhere (main.cpp ?)
-bool IsBlockValueValid(const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet);
-bool IsBlockPayeeValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
-void FillBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet);
+bool IsBlockValueValid(const CSporkManager& sporkManager, const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet);
+bool IsBlockPayeeValid(const CSporkManager& sporkManager, const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
+void FillBlockPayments(const CSporkManager& sporkManager, CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet);
 
 extern CMasternodePayments mnpayments;
 

--- a/src/masternode/payments.h
+++ b/src/masternode/payments.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+class CGovernanceManager;
 class CMasternodePayments;
 class CBlock;
 class CTransaction;
@@ -18,9 +19,12 @@ class CSporkManager;
 class CTxOut;
 
 /// TODO: all 4 functions do not belong here really, they should be refactored/moved somewhere (main.cpp ?)
-bool IsBlockValueValid(const CSporkManager& sporkManager, const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet);
-bool IsBlockPayeeValid(const CSporkManager& sporkManager, const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
-void FillBlockPayments(const CSporkManager& sporkManager, CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet);
+bool IsBlockValueValid(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                       const CBlock& block, int nBlockHeight, CAmount blockReward, std::string& strErrorRet);
+bool IsBlockPayeeValid(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                       const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
+void FillBlockPayments(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                       CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet);
 
 extern CMasternodePayments mnpayments;
 

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -14,11 +14,12 @@
 #include <util/translation.h>
 
 class CMasternodeSync;
-CMasternodeSync masternodeSync;
+std::unique_ptr<CMasternodeSync> masternodeSync;
 
-CMasternodeSync::CMasternodeSync() :
+CMasternodeSync::CMasternodeSync(CConnman& _connman) :
     nTimeAssetSyncStarted(GetTime()),
-    nTimeLastBumped(GetTime())
+    nTimeLastBumped(GetTime()),
+    connman(_connman)
 {
 }
 
@@ -59,7 +60,7 @@ std::string CMasternodeSync::GetAssetName() const
     }
 }
 
-void CMasternodeSync::SwitchToNextAsset(CConnman& connman)
+void CMasternodeSync::SwitchToNextAsset()
 {
     switch(nCurrentAsset)
     {
@@ -110,7 +111,7 @@ void CMasternodeSync::ProcessMessage(CNode* pfrom, const std::string& msg_type, 
     }
 }
 
-void CMasternodeSync::ProcessTick(CConnman& connman)
+void CMasternodeSync::ProcessTick()
 {
     static int nTick = 0;
     nTick++;
@@ -193,7 +194,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                     //    for at least MASTERNODE_SYNC_TICK_SECONDS/MASTERNODE_SYNC_TIMEOUT_SECONDS (depending on
                     //    the number of connected peers).
                     // We must be at the tip already, let's move to the next asset.
-                    SwitchToNextAsset(connman);
+                    SwitchToNextAsset();
                     uiInterface.NotifyAdditionalDataSyncProgressChanged(nSyncProgress);
 
                     if (gArgs.GetBoolArg("-syncmempool", DEFAULT_SYNC_MEMPOOL)) {
@@ -214,7 +215,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
 
             if(nCurrentAsset == MASTERNODE_SYNC_GOVERNANCE) {
                 if (fDisableGovernance) {
-                    SwitchToNextAsset(connman);
+                    SwitchToNextAsset();
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;
                 }
@@ -227,7 +228,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                         LogPrintf("CMasternodeSync::ProcessTick -- WARNING: failed to sync %s\n", GetAssetName());
                         // it's kind of ok to skip this for now, hopefully we'll catch up later?
                     }
-                    SwitchToNextAsset(connman);
+                    SwitchToNextAsset();
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;
                 }
@@ -242,7 +243,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
 
                 nTriedPeerCount++;
 
-                SendGovernanceSyncRequest(pnode, connman);
+                SendGovernanceSyncRequest(pnode);
 
                 break; //this will cause each peer to get one request each six seconds for the various assets we need
             }
@@ -283,7 +284,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 LogPrintf("CMasternodeSync::ProcessTick -- nTick %d nCurrentAsset %d -- asked for all objects, nothing to do\n", nTick, MASTERNODE_SYNC_GOVERNANCE);
                 // reset nTimeNoObjectsLeft to be able to use the same condition on resync
                 nTimeNoObjectsLeft = 0;
-                SwitchToNextAsset(connman);
+                SwitchToNextAsset();
                 connman.ReleaseNodeVector(vNodesCopy);
                 return;
             }
@@ -296,7 +297,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
     connman.ReleaseNodeVector(vNodesCopy);
 }
 
-void CMasternodeSync::SendGovernanceSyncRequest(CNode* pnode, CConnman& connman)
+void CMasternodeSync::SendGovernanceSyncRequest(CNode* pnode)
 {
     CNetMsgMaker msgMaker(pnode->GetSendVersion());
 
@@ -316,7 +317,7 @@ void CMasternodeSync::AcceptedBlockHeader(const CBlockIndex *pindexNew)
     }
 }
 
-void CMasternodeSync::NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload, CConnman& connman)
+void CMasternodeSync::NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitialDownload)
 {
     if (pindexNew == nullptr) {
         return;
@@ -331,7 +332,7 @@ void CMasternodeSync::NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitia
     }
 }
 
-void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload, CConnman& connman)
+void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload)
 {
     LogPrint(BCLog::MNSYNC, "CMasternodeSync::UpdatedBlockTip -- pindexNew->nHeight: %d fInitialDownload=%d\n", pindexNew->nHeight, fInitialDownload);
     nTimeLastUpdateBlockTip = GetAdjustedTime();
@@ -371,9 +372,9 @@ void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitia
                 pindexNew->nHeight, pindexTip->nHeight, fInitialDownload, fReachedBestHeader);
 }
 
-void CMasternodeSync::DoMaintenance(CConnman &connman)
+void CMasternodeSync::DoMaintenance()
 {
     if (ShutdownRequested()) return;
 
-    ProcessTick(connman);
+    ProcessTick();
 }

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -137,7 +137,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
 
     // gradually request the rest of the votes after sync finished
     if(IsSynced()) {
-        governance.RequestGovernanceObjectVotes(vNodesCopy, connman);
+        governance->RequestGovernanceObjectVotes(vNodesCopy, connman);
         connman.ReleaseNodeVector(vNodesCopy);
         return;
     }
@@ -261,7 +261,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
         if(!netfulfilledman.HasFulfilledRequest(pnode->addr, "governance-sync")) {
             continue; // to early for this node
         }
-        int nObjsLeftToAsk = governance.RequestGovernanceObjectVotes(pnode, connman);
+        int nObjsLeftToAsk = governance->RequestGovernanceObjectVotes(pnode, connman);
         // check for data
         if(nObjsLeftToAsk == 0) {
             static int64_t nTimeNoObjectsLeft = 0;
@@ -274,7 +274,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
             // make sure the condition below is checked only once per tick
             if(nLastTick == nTick) continue;
             if(GetTime() - nTimeNoObjectsLeft > MASTERNODE_SYNC_TIMEOUT_SECONDS &&
-                governance.GetVoteCount() - nLastVotes < std::max(int(0.0001 * nLastVotes), MASTERNODE_SYNC_TICK_SECONDS)
+                governance->GetVoteCount() - nLastVotes < std::max(int(0.0001 * nLastVotes), MASTERNODE_SYNC_TICK_SECONDS)
             ) {
                 // We already asked for all objects, waited for MASTERNODE_SYNC_TIMEOUT_SECONDS
                 // after that and less then 0.01% or MASTERNODE_SYNC_TICK_SECONDS
@@ -288,7 +288,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman)
                 return;
             }
             nLastTick = nTick;
-            nLastVotes = governance.GetVoteCount();
+            nLastVotes = governance->GetVoteCount();
         }
     }
 

--- a/src/masternode/utils.cpp
+++ b/src/masternode/utils.cpp
@@ -17,8 +17,8 @@
 
 void CMasternodeUtils::DoMaintenance(CConnman& connman)
 {
-    if(!masternodeSync.IsBlockchainSynced() || ShutdownRequested())
-        return;
+    if (masternodeSync == nullptr || !masternodeSync->IsBlockchainSynced()) return;
+    if (ShutdownRequested()) return;
 
     std::vector<CDeterministicMNCPtr> vecDmns; // will be empty when no wallet
 #ifdef ENABLE_WALLET

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -25,6 +25,7 @@
 #include <evo/specialtx.h>
 #include <evo/cbtx.h>
 #include <evo/simplifiedmns.h>
+#include <governance/governance.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/chainlocks.h>
 #include <llmq/utils.h>
@@ -54,8 +55,10 @@ BlockAssembler::Options::Options() {
     nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
 }
 
-BlockAssembler::BlockAssembler(const CSporkManager& sporkManager, const CTxMemPool& mempool, const CChainParams& params, const Options& options)
+BlockAssembler::BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                               const CTxMemPool& mempool, const CChainParams& params, const Options& options)
     : spork_manager(sporkManager),
+      governance_manager(governanceManager),
       chainparams(params),
       m_mempool(mempool)
 {
@@ -81,8 +84,9 @@ static BlockAssembler::Options DefaultOptions()
     return options;
 }
 
-BlockAssembler::BlockAssembler(const CSporkManager& sporkManager, const CTxMemPool& mempool, const CChainParams& params)
-    : BlockAssembler(sporkManager, mempool, params, DefaultOptions()) {}
+BlockAssembler::BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                               const CTxMemPool& mempool, const CChainParams& params)
+    : BlockAssembler(sporkManager, governanceManager, mempool, params, DefaultOptions()) {}
 
 void BlockAssembler::resetBlock()
 {
@@ -212,7 +216,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Update coinbase transaction with additional info about masternode and governance payments,
     // get some info back to pass to getblocktemplate
-    FillBlockPayments(spork_manager, coinbaseTx, nHeight, blockReward, pblocktemplate->voutMasternodePayments, pblocktemplate->voutSuperblockPayments);
+    FillBlockPayments(spork_manager, governance_manager, coinbaseTx, nHeight, blockReward, pblocktemplate->voutMasternodePayments, pblocktemplate->voutSuperblockPayments);
 
     pblock->vtx[0] = MakeTransactionRef(std::move(coinbaseTx));
     pblocktemplate->vTxFees[0] = -nFees;

--- a/src/miner.h
+++ b/src/miner.h
@@ -20,6 +20,7 @@
 class CBlockIndex;
 class CChainParams;
 class CConnman;
+class CGovernanceManager;
 class CScript;
 class CSporkManager;
 
@@ -150,6 +151,7 @@ private:
     const CChainParams& chainparams;
     const CTxMemPool& m_mempool;
     const CSporkManager& spork_manager;
+    CGovernanceManager& governance_manager;
 
 public:
     struct Options {
@@ -158,8 +160,10 @@ public:
         CFeeRate blockMinFeeRate;
     };
 
-    explicit BlockAssembler(const CSporkManager& sporkManager, const CTxMemPool& mempool, const CChainParams& params);
-    explicit BlockAssembler(const CSporkManager& sporkManager, const CTxMemPool& mempool, const CChainParams& params, const Options& options);
+    explicit BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                            const CTxMemPool& mempool, const CChainParams& params);
+    explicit BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
+                            const CTxMemPool& mempool, const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
     std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn);

--- a/src/miner.h
+++ b/src/miner.h
@@ -21,6 +21,7 @@ class CBlockIndex;
 class CChainParams;
 class CConnman;
 class CScript;
+class CSporkManager;
 
 namespace Consensus { struct Params; };
 
@@ -148,6 +149,7 @@ private:
     int64_t nLockTimeCutoff;
     const CChainParams& chainparams;
     const CTxMemPool& m_mempool;
+    const CSporkManager& spork_manager;
 
 public:
     struct Options {
@@ -156,8 +158,8 @@ public:
         CFeeRate blockMinFeeRate;
     };
 
-    explicit BlockAssembler(const CTxMemPool& mempool, const CChainParams& params);
-    explicit BlockAssembler(const CTxMemPool& mempool, const CChainParams& params, const Options& options);
+    explicit BlockAssembler(const CSporkManager& sporkManager, const CTxMemPool& mempool, const CChainParams& params);
+    explicit BlockAssembler(const CSporkManager& sporkManager, const CTxMemPool& mempool, const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
     std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1130,7 +1130,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     }
 
     // don't accept incoming connections until blockchain is synced
-    if(fMasternodeMode && !masternodeSync.IsBlockchainSynced()) {
+    if(fMasternodeMode && !masternodeSync->IsBlockchainSynced()) {
         LogPrint(BCLog::NET, "AcceptConnection -- blockchain is not synced yet, skipping inbound connection attempt\n");
         CloseSocket(hSocket);
         return;
@@ -1287,7 +1287,7 @@ void CConnman::NotifyNumConnectionsChanged()
     // If we had zero connections before and new connections now or if we just dropped
     // to zero connections reset the sync process if its outdated.
     if ((vNodesSize > 0 && nPrevNodeCount == 0) || (vNodesSize == 0 && nPrevNodeCount > 0)) {
-        masternodeSync.Reset();
+        masternodeSync->Reset();
     }
 
     if(vNodesSize != nPrevNodeCount) {
@@ -2399,7 +2399,7 @@ void CConnman::ThreadOpenMasternodeConnections()
 
         didConnect = false;
 
-        if (!fNetworkActive || !masternodeSync.IsBlockchainSynced())
+        if (!fNetworkActive || !masternodeSync->IsBlockchainSynced())
             continue;
 
         std::set<CService> connectedNodes;
@@ -2837,7 +2837,7 @@ void CConnman::SetNetworkActive(bool active)
 
     // Always call the Reset() if the network gets enabled/disabled to make sure the sync process
     // gets a reset if its outdated..
-    masternodeSync.Reset();
+    masternodeSync->Reset();
 
     uiInterface.NotifyNetworkActiveChanged(fNetworkActive);
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1535,7 +1535,7 @@ bool static AlreadyHave(const CInv& inv, const CTxMemPool& mempool) EXCLUSIVE_LO
 
     case MSG_GOVERNANCE_OBJECT:
     case MSG_GOVERNANCE_OBJECT_VOTE:
-        return ! governance.ConfirmInventoryRequest(inv);
+        return ! governance->ConfirmInventoryRequest(inv);
 
     case MSG_QUORUM_FINAL_COMMITMENT:
         return llmq::quorumBlockProcessor->HasMineableCommitment(inv.hash);
@@ -1828,9 +1828,9 @@ void static ProcessGetData(CNode* pfrom, const CChainParams& chainparams, CConnm
             if (!push && inv.type == MSG_GOVERNANCE_OBJECT) {
                 CDataStream ss(SER_NETWORK, pfrom->GetSendVersion());
                 bool topush = false;
-                if (governance.HaveObjectForHash(inv.hash)) {
+                if (governance->HaveObjectForHash(inv.hash)) {
                     ss.reserve(1000);
-                    if (governance.SerializeObjectForHash(inv.hash, ss)) {
+                    if (governance->SerializeObjectForHash(inv.hash, ss)) {
                         topush = true;
                     }
                 }
@@ -1843,9 +1843,9 @@ void static ProcessGetData(CNode* pfrom, const CChainParams& chainparams, CConnm
             if (!push && inv.type == MSG_GOVERNANCE_OBJECT_VOTE) {
                 CDataStream ss(SER_NETWORK, pfrom->GetSendVersion());
                 bool topush = false;
-                if (governance.HaveVoteForHash(inv.hash)) {
+                if (governance->HaveVoteForHash(inv.hash)) {
                     ss.reserve(1000);
-                    if (governance.SerializeVoteForHash(inv.hash, ss)) {
+                    if (governance->SerializeVoteForHash(inv.hash, ss)) {
                         topush = true;
                     }
                 }
@@ -4116,7 +4116,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
         coinJoinServer->ProcessMessage(pfrom, msg_type, vRecv, enable_bip61);
         sporkManager->ProcessSporkMessages(pfrom, msg_type, vRecv, *connman);
         masternodeSync.ProcessMessage(pfrom, msg_type, vRecv);
-        governance.ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
+        governance->ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
         CMNAuth::ProcessMessage(pfrom, msg_type, vRecv, *connman);
         llmq::quorumBlockProcessor->ProcessMessage(pfrom, msg_type, vRecv);
         llmq::quorumDKGSessionManager->ProcessMessage(pfrom, msg_type, vRecv);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1530,7 +1530,7 @@ bool static AlreadyHave(const CInv& inv, const CTxMemPool& mempool) EXCLUSIVE_LO
     case MSG_SPORK:
         {
             CSporkMessage spork;
-            return sporkManager.GetSporkByHash(inv.hash, spork);
+            return sporkManager->GetSporkByHash(inv.hash, spork);
         }
 
     case MSG_GOVERNANCE_OBJECT:
@@ -1819,7 +1819,7 @@ void static ProcessGetData(CNode* pfrom, const CChainParams& chainparams, CConnm
 
             if (!push && inv.type == MSG_SPORK) {
                 CSporkMessage spork;
-                if (sporkManager.GetSporkByHash(inv.hash, spork)) {
+                if (sporkManager->GetSporkByHash(inv.hash, spork)) {
                     connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::SPORK, spork));
                     push = true;
                 }
@@ -4114,14 +4114,14 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
         }
 #endif // ENABLE_WALLET
         coinJoinServer->ProcessMessage(pfrom, msg_type, vRecv, enable_bip61);
-        sporkManager.ProcessSporkMessages(pfrom, msg_type, vRecv, *connman);
+        sporkManager->ProcessSporkMessages(pfrom, msg_type, vRecv, *connman);
         masternodeSync.ProcessMessage(pfrom, msg_type, vRecv);
         governance.ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
         CMNAuth::ProcessMessage(pfrom, msg_type, vRecv, *connman);
         llmq::quorumBlockProcessor->ProcessMessage(pfrom, msg_type, vRecv);
         llmq::quorumDKGSessionManager->ProcessMessage(pfrom, msg_type, vRecv);
         llmq::quorumManager->ProcessMessage(pfrom, msg_type, vRecv);
-        llmq::quorumSigSharesManager->ProcessMessage(pfrom, msg_type, vRecv);
+        llmq::quorumSigSharesManager->ProcessMessage(pfrom, msg_type, vRecv, *sporkManager);
         llmq::quorumSigningManager->ProcessMessage(pfrom, msg_type, vRecv);
         llmq::chainLocksHandler->ProcessMessage(pfrom, msg_type, vRecv);
         llmq::quorumInstantSendManager->ProcessMessage(pfrom, msg_type, vRecv);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4113,7 +4113,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             pair.second->ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
         }
 #endif // ENABLE_WALLET
-        coinJoinServer.ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
+        coinJoinServer->ProcessMessage(pfrom, msg_type, vRecv, enable_bip61);
         sporkManager.ProcessSporkMessages(pfrom, msg_type, vRecv, *connman);
         masternodeSync.ProcessMessage(pfrom, msg_type, vRecv);
         governance.ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4108,7 +4108,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
     {
         //probably one the extensions
 #ifdef ENABLE_WALLET
-        coinJoinClientQueueManager.ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
+        coinJoinClientQueueManager->ProcessMessage(pfrom, msg_type, vRecv, enable_bip61);
         for (auto& pair : coinJoinClientManagers) {
             pair.second->ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4115,7 +4115,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
 #endif // ENABLE_WALLET
         coinJoinServer->ProcessMessage(pfrom, msg_type, vRecv, enable_bip61);
         sporkManager->ProcessSporkMessages(pfrom, msg_type, vRecv, *connman);
-        masternodeSync.ProcessMessage(pfrom, msg_type, vRecv);
+        masternodeSync->ProcessMessage(pfrom, msg_type, vRecv);
         governance->ProcessMessage(pfrom, msg_type, vRecv, *connman, enable_bip61);
         CMNAuth::ProcessMessage(pfrom, msg_type, vRecv, *connman);
         llmq::quorumBlockProcessor->ProcessMessage(pfrom, msg_type, vRecv);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1452,7 +1452,7 @@ void BitcoinGUI::setAdditionalDataSyncProgress(double nSyncProgress)
     if(!clientModel)
         return;
 
-    // If masternodeSync.Reset() has been called make sure status bar shows the correct information.
+    // If masternodeSync->Reset() has been called make sure status bar shows the correct information.
     if (nSyncProgress == -1) {
         setNumBlocks(m_node.getNumBlocks(), QDateTime::fromTime_t(m_node.getLastBlockTime()), QString::fromStdString(m_node.getLastBlockHash()), m_node.getVerificationProgress(), false);
         if (clientModel->getNumConnections()) {

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -132,9 +132,9 @@ int64_t ClientModel::getHeaderTipTime() const
     return cachedBestHeaderTime;
 }
 
-std::vector<CGovernanceObject> ClientModel::getAllGovernanceObjects()
+bool ClientModel::getAllGovernanceObjects(std::vector<CGovernanceObject> &obj)
 {
-    return m_node.gov().getAllNewerThan(0);
+    return m_node.gov().getAllNewerThan(obj, 0);
 }
 
 void ClientModel::updateNumConnections(int numConnections)

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -132,9 +132,9 @@ int64_t ClientModel::getHeaderTipTime() const
     return cachedBestHeaderTime;
 }
 
-bool ClientModel::getAllGovernanceObjects(std::vector<CGovernanceObject> &obj)
+void ClientModel::getAllGovernanceObjects(std::vector<CGovernanceObject> &obj)
 {
-    return m_node.gov().getAllNewerThan(obj, 0);
+    m_node.gov().getAllNewerThan(obj, 0);
 }
 
 void ClientModel::updateNumConnections(int numConnections)

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -68,7 +68,7 @@ public:
     CDeterministicMNList getMasternodeList() const;
     void refreshMasternodeList();
 
-    std::vector<CGovernanceObject> getAllGovernanceObjects();
+    bool getAllGovernanceObjects(std::vector<CGovernanceObject> &obj);
 
     //! Returns enum BlockSource of the current importing/syncing state
     enum BlockSource getBlockSource() const;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -68,7 +68,7 @@ public:
     CDeterministicMNList getMasternodeList() const;
     void refreshMasternodeList();
 
-    bool getAllGovernanceObjects(std::vector<CGovernanceObject> &obj);
+    void getAllGovernanceObjects(std::vector<CGovernanceObject> &obj);
 
     //! Returns enum BlockSource of the current importing/syncing state
     enum BlockSource getBlockSource() const;

--- a/src/qt/governancelist.cpp
+++ b/src/qt/governancelist.cpp
@@ -348,17 +348,16 @@ void GovernanceList::updateProposalList()
         proposalModel->setVotingParams(nAbsVoteReq);
 
         std::vector<CGovernanceObject> govObjList;
-        if (clientModel->getAllGovernanceObjects(govObjList)) {
-            std::vector<const Proposal*> newProposals;
-            for (const auto& govObj : govObjList) {
-                if (govObj.GetObjectType() != GOVERNANCE_OBJECT_PROPOSAL) {
-                    continue; // Skip triggers.
-                }
-
-                newProposals.emplace_back(new Proposal(govObj, proposalModel));
+        clientModel->getAllGovernanceObjects(govObjList);
+        std::vector<const Proposal*> newProposals;
+        for (const auto& govObj : govObjList) {
+            if (govObj.GetObjectType() != GOVERNANCE_OBJECT_PROPOSAL) {
+                continue; // Skip triggers.
             }
-            proposalModel->reconcile(newProposals);
+
+            newProposals.emplace_back(new Proposal(govObj, proposalModel));
         }
+        proposalModel->reconcile(newProposals);
     }
 
     // Schedule next update.

--- a/src/qt/governancelist.cpp
+++ b/src/qt/governancelist.cpp
@@ -347,16 +347,18 @@ void GovernanceList::updateProposalList()
         const int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nMnCount / 10);
         proposalModel->setVotingParams(nAbsVoteReq);
 
-        const std::vector<CGovernanceObject> govObjList = clientModel->getAllGovernanceObjects();
-        std::vector<const Proposal*> newProposals;
-        for (const auto& govObj : govObjList) {
-            if (govObj.GetObjectType() != GOVERNANCE_OBJECT_PROPOSAL) {
-                continue; // Skip triggers.
-            }
+        std::vector<CGovernanceObject> govObjList;
+        if (clientModel->getAllGovernanceObjects(govObjList)) {
+            std::vector<const Proposal*> newProposals;
+            for (const auto& govObj : govObjList) {
+                if (govObj.GetObjectType() != GOVERNANCE_OBJECT_PROPOSAL) {
+                    continue; // Skip triggers.
+                }
 
-            newProposals.emplace_back(new Proposal(govObj, proposalModel));
+                newProposals.emplace_back(new Proposal(govObj, proposalModel));
+            }
+            proposalModel->reconcile(newProposals);
         }
-        proposalModel->reconcile(newProposals);
     }
 
     // Schedule next update.

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -153,7 +153,7 @@ static UniValue getcoinjoininfo(const JSONRPCRequest& request)
 
     CCoinJoinClientOptions::GetJsonInfo(obj);
 
-    obj.pushKV("queue_size", coinJoinClientQueueManager.GetQueueSize());
+    obj.pushKV("queue_size", coinJoinClientQueueManager->GetQueueSize());
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -144,7 +144,7 @@ static UniValue getcoinjoininfo(const JSONRPCRequest& request)
     UniValue obj(UniValue::VOBJ);
 
     if (fMasternodeMode) {
-        coinJoinServer.GetJsonInfo(obj);
+        coinJoinServer->GetJsonInfo(obj);
         return obj;
     }
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -723,7 +723,9 @@ static UniValue ListObjects(const std::string& strCachedSignal, const std::strin
 
     LOCK2(cs_main, governance->cs);
 
-    std::vector<CGovernanceObject> objs = governance->GetAllNewerThan(nStartTime);
+    std::vector<CGovernanceObject> objs;
+    governance->GetAllNewerThan(objs, nStartTime);
+
     governance->UpdateLastDiffTime(GetTime());
     // CREATE RESULTS FOR USER
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -317,7 +317,7 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 {
     gobject_submit_help(request);
 
-    if(!masternodeSync.IsBlockchainSynced()) {
+    if(!masternodeSync->IsBlockchainSynced()) {
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Must wait for client to sync with masternode network. Try again in a minute or so.");
     }
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -50,7 +50,7 @@ static UniValue gobject_count(const JSONRPCRequest& request)
     if (strMode != "json" && strMode != "all")
         gobject_count_help(request);
 
-    return strMode == "json" ? governance.ToJson() : governance.ToString();
+    return strMode == "json" ? governance->ToJson() : governance->ToString();
 }
 
 static void gobject_deserialize_help(const JSONRPCRequest& request)
@@ -395,7 +395,7 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 
     // RELAY THIS OBJECT
     // Reject if rate check fails but don't update buffer
-    if (!governance.MasternodeRateCheck(govobj)) {
+    if (!governance->MasternodeRateCheck(govobj)) {
         LogPrintf("gobject(submit) -- Object submission rejected because of rate check failure - hash = %s\n", strHash);
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Object creation rate limit exceeded");
     }
@@ -404,10 +404,10 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 
     const NodeContext& node = EnsureNodeContext(request.context);
     if (fMissingConfirmations) {
-        governance.AddPostponedObject(govobj);
+        governance->AddPostponedObject(govobj);
         govobj.Relay(*node.connman);
     } else {
-        governance.AddGovernanceObject(govobj, *node.connman);
+        governance->AddGovernanceObject(govobj, *node.connman);
     }
 
     return govobj.GetHash().ToString();
@@ -451,8 +451,8 @@ static UniValue gobject_vote_conf(const JSONRPCRequest& request)
 
     int govObjType;
     {
-        LOCK(governance.cs);
-        CGovernanceObject *pGovObj = governance.FindGovernanceObject(hash);
+        LOCK(governance->cs);
+        CGovernanceObject *pGovObj = governance->FindGovernanceObject(hash);
         if (!pGovObj) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Governance object not found");
         }
@@ -505,7 +505,7 @@ static UniValue gobject_vote_conf(const JSONRPCRequest& request)
 
     CGovernanceException exception;
     const NodeContext& node = EnsureNodeContext(request.context);
-    if (governance.ProcessVoteAndRelay(vote, exception, *node.connman)) {
+    if (governance->ProcessVoteAndRelay(vote, exception, *node.connman)) {
         nSuccessful++;
         statusObj.pushKV("result", "success");
     } else {
@@ -528,8 +528,8 @@ static UniValue VoteWithMasternodes(const JSONRPCRequest& request, const std::ma
 {
     const NodeContext& node = EnsureNodeContext(request.context);
     {
-        LOCK(governance.cs);
-        CGovernanceObject *pGovObj = governance.FindGovernanceObject(hash);
+        LOCK(governance->cs);
+        CGovernanceObject *pGovObj = governance->FindGovernanceObject(hash);
         if (!pGovObj) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Governance object not found");
         }
@@ -567,7 +567,7 @@ static UniValue VoteWithMasternodes(const JSONRPCRequest& request, const std::ma
         }
 
         CGovernanceException exception;
-        if (governance.ProcessVoteAndRelay(vote, exception, *node.connman)) {
+        if (governance->ProcessVoteAndRelay(vote, exception, *node.connman)) {
             nSuccessful++;
             statusObj.pushKV("result", "success");
         } else {
@@ -721,10 +721,10 @@ static UniValue ListObjects(const std::string& strCachedSignal, const std::strin
         g_txindex->BlockUntilSyncedToCurrentChain();
     }
 
-    LOCK2(cs_main, governance.cs);
+    LOCK2(cs_main, governance->cs);
 
-    std::vector<CGovernanceObject> objs = governance.GetAllNewerThan(nStartTime);
-    governance.UpdateLastDiffTime(GetTime());
+    std::vector<CGovernanceObject> objs = governance->GetAllNewerThan(nStartTime);
+    governance->UpdateLastDiffTime(GetTime());
     // CREATE RESULTS FOR USER
 
     for (const auto& govObj : objs) {
@@ -834,7 +834,7 @@ static UniValue gobject_diff(const JSONRPCRequest& request)
     if (strType != "proposals" && strType != "triggers" && strType != "all")
         return "Invalid type, should be 'proposals', 'triggers' or 'all'";
 
-    return ListObjects(strCachedSignal, strType, governance.GetLastDiffTime());
+    return ListObjects(strCachedSignal, strType, governance->GetLastDiffTime());
 }
 
 static void gobject_get_help(const JSONRPCRequest& request)
@@ -861,8 +861,8 @@ static UniValue gobject_get(const JSONRPCRequest& request)
     }
 
     // FIND THE GOVERNANCE OBJECT THE USER IS LOOKING FOR
-    LOCK2(cs_main, governance.cs);
-    CGovernanceObject* pGovObj = governance.FindGovernanceObject(hash);
+    LOCK2(cs_main, governance->cs);
+    CGovernanceObject* pGovObj = governance->FindGovernanceObject(hash);
 
     if (pGovObj == nullptr) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown governance object");
@@ -958,9 +958,9 @@ static UniValue gobject_getcurrentvotes(const JSONRPCRequest& request)
 
     // FIND OBJECT USER IS LOOKING FOR
 
-    LOCK(governance.cs);
+    LOCK(governance->cs);
 
-    CGovernanceObject* pGovObj = governance.FindGovernanceObject(hash);
+    CGovernanceObject* pGovObj = governance->FindGovernanceObject(hash);
 
     if (pGovObj == nullptr) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown governance-hash");
@@ -972,7 +972,7 @@ static UniValue gobject_getcurrentvotes(const JSONRPCRequest& request)
 
     // GET MATCHING VOTES BY HASH, THEN SHOW USERS VOTE INFORMATION
 
-    std::vector<CGovernanceVote> vecVotes = governance.GetCurrentVotes(hash, mnCollateralOutpoint);
+    std::vector<CGovernanceVote> vecVotes = governance->GetCurrentVotes(hash, mnCollateralOutpoint);
     for (const auto& vote : vecVotes) {
         bResult.pushKV(vote.GetHash().ToString(),  vote.ToString());
     }
@@ -1102,8 +1102,8 @@ static UniValue voteraw(const JSONRPCRequest& request)
 
     int govObjType;
     {
-        LOCK(governance.cs);
-        CGovernanceObject *pGovObj = governance.FindGovernanceObject(hashGovObj);
+        LOCK(governance->cs);
+        CGovernanceObject *pGovObj = governance->FindGovernanceObject(hashGovObj);
         if (!pGovObj) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Governance object not found");
         }
@@ -1137,7 +1137,7 @@ static UniValue voteraw(const JSONRPCRequest& request)
 
     CGovernanceException exception;
     const NodeContext& node = EnsureNodeContext(request.context);
-    if (governance.ProcessVoteAndRelay(vote, exception, *node.connman)) {
+    if (governance->ProcessVoteAndRelay(vote, exception, *node.connman)) {
         return "Voted successfully";
     } else {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Error voting : " + exception.GetMessage());

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -7,6 +7,7 @@
 #include <governance/classes.h>
 #include <index/txindex.h>
 #include <node/context.h>
+#include <governance/governance.h>
 #include <masternode/node.h>
 #include <masternode/payments.h>
 #include <net.h>
@@ -269,9 +270,9 @@ static std::string GetRequiredPaymentsString(int nBlockHeight, const CDeterminis
             strPayments += ", " + EncodeDestination(dest);
         }
     }
-    if (CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
+    if (CSuperblockManager::IsSuperblockTriggered(*governance, nBlockHeight)) {
         std::vector<CTxOut> voutSuperblock;
-        if (!CSuperblockManager::GetSuperblockPayments(nBlockHeight, voutSuperblock)) {
+        if (!CSuperblockManager::GetSuperblockPayments(*governance, nBlockHeight, voutSuperblock)) {
             return strPayments + ", error";
         }
         std::string strSBPayees = "Unknown";
@@ -434,7 +435,7 @@ static UniValue masternode_payments(const JSONRPCRequest& request)
         std::vector<CTxOut> voutMasternodePayments, voutDummy;
         CMutableTransaction dummyTx;
         CAmount blockReward = nBlockFees + GetBlockSubsidy(pindex->pprev->nBits, pindex->pprev->nHeight, Params().GetConsensus());
-        FillBlockPayments(*sporkManager, dummyTx, pindex->nHeight, blockReward, voutMasternodePayments, voutDummy);
+        FillBlockPayments(*sporkManager, *governance, dummyTx, pindex->nHeight, blockReward, voutMasternodePayments, voutDummy);
 
         UniValue blockObj(UniValue::VOBJ);
         CAmount payedPerBlock{0};

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -15,6 +15,7 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <univalue.h>
+#include <spork.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/rpcwallet.h>
@@ -433,7 +434,7 @@ static UniValue masternode_payments(const JSONRPCRequest& request)
         std::vector<CTxOut> voutMasternodePayments, voutDummy;
         CMutableTransaction dummyTx;
         CAmount blockReward = nBlockFees + GetBlockSubsidy(pindex->pprev->nBits, pindex->pprev->nHeight, Params().GetConsensus());
-        FillBlockPayments(dummyTx, pindex->nHeight, blockReward, voutMasternodePayments, voutDummy);
+        FillBlockPayments(*sporkManager, dummyTx, pindex->nHeight, blockReward, voutMasternodePayments, voutDummy);
 
         UniValue blockObj(UniValue::VOBJ);
         CAmount payedPerBlock{0};

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -698,7 +698,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
 
     // next bock is a superblock and we need governance info to correctly construct it
     if (AreSuperblocksEnabled(*sporkManager)
-        && !masternodeSync.IsSynced()
+        && !masternodeSync->IsSynced()
         && CSuperblock::IsValidBlockHeight(::ChainActive().Height() + 1))
             throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, PACKAGE_NAME " is syncing with network...");
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -24,6 +24,7 @@
 #include <script/descriptor.h>
 #include <script/sign.h>
 #include <shutdown.h>
+#include <spork.h>
 #include <txmempool.h>
 #include <util/fees.h>
 #include <util/strencodings.h>
@@ -151,7 +152,7 @@ UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& mempool, 
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd && !ShutdownRequested())
     {
-        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(mempool, Params()).CreateNewBlock(coinbaseScript->reserveScript));
+        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(*sporkManager, mempool, Params()).CreateNewBlock(coinbaseScript->reserveScript));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
@@ -361,7 +362,7 @@ static UniValue generateblock(const JSONRPCRequest& request)
         LOCK(cs_main);
 
         CTxMemPool empty_mempool;
-        std::unique_ptr<CBlockTemplate> blocktemplate(BlockAssembler(empty_mempool, chainparams).CreateNewBlock(coinbase_script));
+        std::unique_ptr<CBlockTemplate> blocktemplate(BlockAssembler(*sporkManager, empty_mempool, chainparams).CreateNewBlock(coinbase_script));
         if (!blocktemplate) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         }
@@ -696,7 +697,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, PACKAGE_NAME " is in initial sync and waiting for blocks...");
 
     // next bock is a superblock and we need governance info to correctly construct it
-    if (AreSuperblocksEnabled()
+    if (AreSuperblocksEnabled(*sporkManager)
         && !masternodeSync.IsSynced()
         && CSuperblock::IsValidBlockHeight(::ChainActive().Height() + 1))
             throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, PACKAGE_NAME " is syncing with network...");
@@ -768,7 +769,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
 
         // Create new block
         CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = BlockAssembler(mempool, Params()).CreateNewBlock(scriptDummy);
+        pblocktemplate = BlockAssembler(*sporkManager, mempool, Params()).CreateNewBlock(scriptDummy);
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 
@@ -930,7 +931,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     }
     result.pushKV("superblock", superblockObjArray);
     result.pushKV("superblocks_started", pindexPrev->nHeight + 1 > consensusParams.nSuperblockStartBlock);
-    result.pushKV("superblocks_enabled", AreSuperblocksEnabled());
+    result.pushKV("superblocks_enabled", AreSuperblocksEnabled(*sporkManager));
 
     result.pushKV("coinbase_payload", HexStr(pblock->vtx[0]->vExtraPayload));
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -152,7 +152,7 @@ UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& mempool, 
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd && !ShutdownRequested())
     {
-        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(*sporkManager, mempool, Params()).CreateNewBlock(coinbaseScript->reserveScript));
+        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(*sporkManager, *governance, mempool, Params()).CreateNewBlock(coinbaseScript->reserveScript));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
@@ -362,7 +362,7 @@ static UniValue generateblock(const JSONRPCRequest& request)
         LOCK(cs_main);
 
         CTxMemPool empty_mempool;
-        std::unique_ptr<CBlockTemplate> blocktemplate(BlockAssembler(*sporkManager, empty_mempool, chainparams).CreateNewBlock(coinbase_script));
+        std::unique_ptr<CBlockTemplate> blocktemplate(BlockAssembler(*sporkManager, *governance, empty_mempool, chainparams).CreateNewBlock(coinbase_script));
         if (!blocktemplate) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         }
@@ -769,7 +769,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
 
         // Create new block
         CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = BlockAssembler(*sporkManager, mempool, Params()).CreateNewBlock(scriptDummy);
+        pblocktemplate = BlockAssembler(*sporkManager, *governance, mempool, Params()).CreateNewBlock(scriptDummy);
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -149,13 +149,13 @@ static UniValue spork(const JSONRPCRequest& request)
     if (strCommand == "show") {
         UniValue ret(UniValue::VOBJ);
         for (const auto& sporkDef : sporkDefs) {
-            ret.pushKV(std::string(sporkDef.name), sporkManager.GetSporkValue(sporkDef.sporkId));
+            ret.pushKV(std::string(sporkDef.name), sporkManager->GetSporkValue(sporkDef.sporkId));
         }
         return ret;
     } else if(strCommand == "active"){
         UniValue ret(UniValue::VOBJ);
         for (const auto& sporkDef : sporkDefs) {
-            ret.pushKV(std::string(sporkDef.name), sporkManager.IsSporkActive(sporkDef.sporkId));
+            ret.pushKV(std::string(sporkDef.name), sporkManager->IsSporkActive(sporkDef.sporkId));
         }
         return ret;
     }
@@ -195,7 +195,7 @@ static UniValue sporkupdate(const JSONRPCRequest& request)
     int64_t nValue = request.params[1].get_int64();
 
     // broadcast new spork
-    if (sporkManager.UpdateSpork(nSporkID, nValue, *node.connman)) {
+    if (sporkManager->UpdateSpork(nSporkID, nValue, *node.connman)) {
         return "success";
     }
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -91,25 +91,24 @@ static UniValue mnsync(const JSONRPCRequest& request)
 
     if(strMode == "status") {
         UniValue objStatus(UniValue::VOBJ);
-        objStatus.pushKV("AssetID", masternodeSync.GetAssetID());
-        objStatus.pushKV("AssetName", masternodeSync.GetAssetName());
-        objStatus.pushKV("AssetStartTime", masternodeSync.GetAssetStartTime());
-        objStatus.pushKV("Attempt", masternodeSync.GetAttempt());
-        objStatus.pushKV("IsBlockchainSynced", masternodeSync.IsBlockchainSynced());
-        objStatus.pushKV("IsSynced", masternodeSync.IsSynced());
+        objStatus.pushKV("AssetID", masternodeSync->GetAssetID());
+        objStatus.pushKV("AssetName", masternodeSync->GetAssetName());
+        objStatus.pushKV("AssetStartTime", masternodeSync->GetAssetStartTime());
+        objStatus.pushKV("Attempt", masternodeSync->GetAttempt());
+        objStatus.pushKV("IsBlockchainSynced", masternodeSync->IsBlockchainSynced());
+        objStatus.pushKV("IsSynced", masternodeSync->IsSynced());
         return objStatus;
     }
 
     if(strMode == "next")
     {
-        NodeContext& node = EnsureNodeContext(request.context);
-        masternodeSync.SwitchToNextAsset(*node.connman);
-        return "sync updated to " + masternodeSync.GetAssetName();
+        masternodeSync->SwitchToNextAsset();
+        return "sync updated to " + masternodeSync->GetAssetName();
     }
 
     if(strMode == "reset")
     {
-        masternodeSync.Reset(true);
+        masternodeSync->Reset(true);
         return "success";
     }
     return "failure";

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -22,7 +22,7 @@
 
 #include <string>
 
-CSporkManager sporkManager;
+std::unique_ptr<CSporkManager> sporkManager;
 
 bool CSporkManager::SporkValueIsActive(SporkId nSporkID, int64_t& nActiveValueRet) const
 {

--- a/src/spork.h
+++ b/src/spork.h
@@ -71,7 +71,7 @@ struct CSporkDef
     MAKE_SPORK_DEF(SPORK_23_QUORUM_POSE,                   4070908800ULL), // OFF
 };
 #undef MAKE_SPORK_DEF
-extern CSporkManager sporkManager;
+extern std::unique_ptr<CSporkManager> sporkManager;
 
 /**
  * Sporks are network parameters used primarily to prevent forking and turn

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -19,6 +19,7 @@
 #include <evo/specialtx.h>
 #include <evo/providertx.h>
 #include <evo/deterministicmns.h>
+#include <governance/governance.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -213,7 +214,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_CHECK_EQUAL(VersionBitsTipState(consensus_params, deployment_id), ThresholdState::STARTED);
         BOOST_CHECK_EQUAL(VersionBitsTipStatistics(consensus_params, deployment_id).threshold, threshold(0));
         // Next block should be signaling by default
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         const uint32_t bitmask = ((uint32_t)1) << consensus_params.vDeployments[deployment_id].bit;
         BOOST_CHECK_EQUAL(::ChainActive().Tip()->nVersion & bitmask, 0);
         BOOST_CHECK_EQUAL(pblocktemplate->block.nVersion & bitmask, bitmask);
@@ -280,7 +281,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
         BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
     }
 
@@ -291,7 +292,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
     {
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 13748571607);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 6874285801); // 0.4999999998
@@ -306,7 +307,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
             }
             LOCK(cs_main);
             auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-            const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         }
     }
@@ -315,7 +316,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         // Reward split should reach ~60/40 after reallocation is done
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 10221599170);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 6132959502); // 0.6
@@ -329,7 +330,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         }
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
     }
 
@@ -337,7 +338,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         // Reward split should reach ~60/40 after reallocation is done
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 9491484944);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 5694890966); // 0.6

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -13,6 +13,7 @@
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
+#include <spork.h>
 #include <validation.h>
 
 #include <evo/specialtx.h>
@@ -212,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_CHECK_EQUAL(VersionBitsTipState(consensus_params, deployment_id), ThresholdState::STARTED);
         BOOST_CHECK_EQUAL(VersionBitsTipStatistics(consensus_params, deployment_id).threshold, threshold(0));
         // Next block should be signaling by default
-        const auto pblocktemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         const uint32_t bitmask = ((uint32_t)1) << consensus_params.vDeployments[deployment_id].bit;
         BOOST_CHECK_EQUAL(::ChainActive().Tip()->nVersion & bitmask, 0);
         BOOST_CHECK_EQUAL(pblocktemplate->block.nVersion & bitmask, bitmask);
@@ -279,7 +280,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
         BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
     }
 
@@ -290,7 +291,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
     {
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 13748571607);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 6874285801); // 0.4999999998
@@ -305,7 +306,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
             }
             LOCK(cs_main);
             auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-            const auto pblocktemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         }
     }
@@ -314,7 +315,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         // Reward split should reach ~60/40 after reallocation is done
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 10221599170);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 6132959502); // 0.6
@@ -328,7 +329,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         }
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
     }
 
@@ -336,7 +337,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         // Reward split should reach ~60/40 after reallocation is done
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 9491484944);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 5694890966); // 0.6

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -9,6 +9,7 @@
 #include <miner.h>
 #include <pow.h>
 #include <script/standard.h>
+#include <spork.h>
 #include <test/util/blockfilter.h>
 #include <test/util/setup_common.h>
 #include <util/time.h>
@@ -62,7 +63,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -5,6 +5,7 @@
 #include <blockfilter.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <governance/governance.h>
 #include <index/blockfilterindex.h>
 #include <miner.h>
 #include <pow.h>
@@ -63,7 +64,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;

--- a/src/test/dynamic_activation_thresholds_tests.cpp
+++ b/src/test/dynamic_activation_thresholds_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <governance/governance.h>
 #include <miner.h>
 #include <script/interpreter.h>
 #include <spork.h>
@@ -73,7 +74,7 @@ struct TestChainDATSetup : public TestChainSetup
             BOOST_CHECK_EQUAL(VersionBitsTipState(consensus_params, deployment_id), ThresholdState::STARTED);
             BOOST_CHECK_EQUAL(VersionBitsTipStatistics(consensus_params, deployment_id).threshold, threshold(0));
             // Next block should be signaling by default
-            const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             const uint32_t bitmask = ((uint32_t)1) << consensus_params.vDeployments[deployment_id].bit;
             BOOST_CHECK_EQUAL(::ChainActive().Tip()->nVersion & bitmask, 0);
             BOOST_CHECK_EQUAL(pblocktemplate->block.nVersion & bitmask, bitmask);

--- a/src/test/dynamic_activation_thresholds_tests.cpp
+++ b/src/test/dynamic_activation_thresholds_tests.cpp
@@ -8,6 +8,7 @@
 #include <consensus/validation.h>
 #include <miner.h>
 #include <script/interpreter.h>
+#include <spork.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -72,7 +73,7 @@ struct TestChainDATSetup : public TestChainSetup
             BOOST_CHECK_EQUAL(VersionBitsTipState(consensus_params, deployment_id), ThresholdState::STARTED);
             BOOST_CHECK_EQUAL(VersionBitsTipStatistics(consensus_params, deployment_id).threshold, threshold(0));
             // Next block should be signaling by default
-            const auto pblocktemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             const uint32_t bitmask = ((uint32_t)1) << consensus_params.vDeployments[deployment_id].bit;
             BOOST_CHECK_EQUAL(::ChainActive().Tip()->nVersion & bitmask, 0);
             BOOST_CHECK_EQUAL(pblocktemplate->block.nVersion & bitmask, bitmask);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -266,8 +266,8 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChainDIP3Setup)
 {
     CKey sporkKey;
     sporkKey.MakeNewKey(false);
-    sporkManager.SetSporkAddress(EncodeDestination(sporkKey.GetPubKey().GetID()));
-    sporkManager.SetPrivKey(EncodeSecret(sporkKey));
+    sporkManager->SetSporkAddress(EncodeDestination(sporkKey.GetPubKey().GetID()));
+    sporkManager->SetPrivKey(EncodeSecret(sporkKey));
 
     auto utxos = BuildSimpleUtxoMap(m_coinbase_txns);
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
+#include <governance/governance.h>
 #include <miner.h>
 #include <policy/policy.h>
 #include <pow.h>
@@ -45,7 +46,7 @@ BlockAssembler MinerTestingSetup::AssemblerForTest(const CChainParams& params)
 
     options.nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
     options.blockMinFeeRate = blockMinFeeRate;
-    return BlockAssembler(*sporkManager, *m_node.mempool, params, options);
+    return BlockAssembler(*sporkManager, *governance, *m_node.mempool, params, options);
 }
 
 constexpr static struct {

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -11,6 +11,7 @@
 #include <policy/policy.h>
 #include <pow.h>
 #include <script/standard.h>
+#include <spork.h>
 #include <uint256.h>
 #include <util/strencodings.h>
 #include <util/system.h>
@@ -44,7 +45,7 @@ BlockAssembler MinerTestingSetup::AssemblerForTest(const CChainParams& params)
 
     options.nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
     options.blockMinFeeRate = blockMinFeeRate;
-    return BlockAssembler(*m_node.mempool, params, options);
+    return BlockAssembler(*sporkManager, *m_node.mempool, params, options);
 }
 
 constexpr static struct {

--- a/src/test/util.cpp
+++ b/src/test/util.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <consensus/merkle.h>
+#include <governance/governance.h>
 #include <key_io.h>
 #include <miner.h>
 #include <node/context.h>
@@ -80,7 +81,7 @@ std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coi
 {
     assert(node.mempool);
     auto block = std::make_shared<CBlock>(
-        BlockAssembler{*sporkManager, *node.mempool, Params()}
+        BlockAssembler{*sporkManager, *governance, *node.mempool, Params()}
             .CreateNewBlock(coinbase_scriptPubKey)
             ->block);
 

--- a/src/test/util.cpp
+++ b/src/test/util.cpp
@@ -11,6 +11,7 @@
 #include <node/context.h>
 #include <pow.h>
 #include <script/standard.h>
+#include <spork.h>
 #include <validation.h>
 #include <util/check.h>
 #ifdef ENABLE_WALLET
@@ -79,7 +80,7 @@ std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coi
 {
     assert(node.mempool);
     auto block = std::make_shared<CBlock>(
-        BlockAssembler{*node.mempool, Params()}
+        BlockAssembler{*sporkManager, *node.mempool, Params()}
             .CreateNewBlock(coinbase_scriptPubKey)
             ->block);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -37,6 +37,7 @@
 
 #include <bls/bls.h>
 #include <coinjoin/coinjoin.h>
+#include <coinjoin/server.h>
 #include <evo/cbtx.h>
 #include <evo/deterministicmns.h>
 #include <evo/evodb.h>
@@ -189,6 +190,8 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
         m_node.connman->Init(options);
     }
 
+    ::coinJoinServer = std::make_unique<CCoinJoinServer>(*m_node.connman);
+
     deterministicMNManager.reset(new CDeterministicMNManager(*evoDb, *m_node.connman));
     llmq::InitLLMQSystem(*evoDb, *m_node.mempool, *m_node.connman, true);
 }
@@ -204,6 +207,7 @@ TestingSetup::~TestingSetup()
     StopScriptCheckWorkerThreads();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
+    ::coinJoinServer.reset();
     m_node.connman.reset();
     m_node.banman.reset();
     UnloadBlockIndex(m_node.mempool);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -36,6 +36,9 @@
 #include <util/validation.h>
 
 #include <bls/bls.h>
+#ifdef ENABLE_WALLET
+#include <coinjoin/client.h>
+#endif // ENABLE_WALLET
 #include <coinjoin/coinjoin.h>
 #include <coinjoin/server.h>
 #include <evo/cbtx.h>
@@ -191,6 +194,9 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     }
 
     ::coinJoinServer = std::make_unique<CCoinJoinServer>(*m_node.connman);
+#ifdef ENABLE_WALLET
+    ::coinJoinClientQueueManager = std::make_unique<CCoinJoinClientQueueManager>(*m_node.connman);
+#endif // ENABLE_WALLET
 
     deterministicMNManager.reset(new CDeterministicMNManager(*evoDb, *m_node.connman));
     llmq::InitLLMQSystem(*evoDb, *m_node.mempool, *m_node.connman, true);
@@ -207,6 +213,9 @@ TestingSetup::~TestingSetup()
     StopScriptCheckWorkerThreads();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
+#ifdef ENABLE_WALLET
+    ::coinJoinClientQueueManager.reset();
+#endif // ENABLE_WALLET
     ::coinJoinServer.reset();
     m_node.connman.reset();
     m_node.banman.reset();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -23,6 +23,7 @@
 #include <rpc/server.h>
 #include <script/sigcache.h>
 #include <streams.h>
+#include <spork.h>
 #include <txdb.h>
 #include <util/memory.h>
 #include <util/strencodings.h>
@@ -193,13 +194,14 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
         m_node.connman->Init(options);
     }
 
+    ::sporkManager = std::make_unique<CSporkManager>();
     ::coinJoinServer = std::make_unique<CCoinJoinServer>(*m_node.connman);
 #ifdef ENABLE_WALLET
     ::coinJoinClientQueueManager = std::make_unique<CCoinJoinClientQueueManager>(*m_node.connman);
 #endif // ENABLE_WALLET
 
     deterministicMNManager.reset(new CDeterministicMNManager(*evoDb, *m_node.connman));
-    llmq::InitLLMQSystem(*evoDb, *m_node.mempool, *m_node.connman, true);
+    llmq::InitLLMQSystem(*evoDb, *m_node.mempool, *m_node.connman, *sporkManager, true);
 }
 
 TestingSetup::~TestingSetup()
@@ -217,6 +219,7 @@ TestingSetup::~TestingSetup()
     ::coinJoinClientQueueManager.reset();
 #endif // ENABLE_WALLET
     ::coinJoinServer.reset();
+    ::sporkManager.reset();
     m_node.connman.reset();
     m_node.banman.reset();
     UnloadBlockIndex(m_node.mempool);
@@ -281,7 +284,7 @@ CBlock TestChainSetup::CreateAndProcessBlock(const std::vector<CMutableTransacti
 CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
 
     std::vector<CTransactionRef> llmqCommitments;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -10,6 +10,7 @@
 #include <consensus/params.h>
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
+#include <governance/governance.h>
 #include <index/txindex.h>
 #include <init.h>
 #include <interfaces/chain.h>
@@ -195,6 +196,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     }
 
     ::sporkManager = std::make_unique<CSporkManager>();
+    ::governance = std::make_unique<CGovernanceManager>();
     ::coinJoinServer = std::make_unique<CCoinJoinServer>(*m_node.connman);
 #ifdef ENABLE_WALLET
     ::coinJoinClientQueueManager = std::make_unique<CCoinJoinClientQueueManager>(*m_node.connman);
@@ -219,6 +221,7 @@ TestingSetup::~TestingSetup()
     ::coinJoinClientQueueManager.reset();
 #endif // ENABLE_WALLET
     ::coinJoinServer.reset();
+    ::governance.reset();
     ::sporkManager.reset();
     m_node.connman.reset();
     m_node.banman.reset();
@@ -284,7 +287,7 @@ CBlock TestChainSetup::CreateAndProcessBlock(const std::vector<CMutableTransacti
 CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
 
     std::vector<CTransactionRef> llmqCommitments;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -14,6 +14,7 @@
 #include <index/txindex.h>
 #include <init.h>
 #include <interfaces/chain.h>
+#include <masternode/sync.h>
 #include <miner.h>
 #include <net.h>
 #include <net_processing.h>
@@ -197,6 +198,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
 
     ::sporkManager = std::make_unique<CSporkManager>();
     ::governance = std::make_unique<CGovernanceManager>();
+    ::masternodeSync = std::make_unique<CMasternodeSync>(*m_node.connman);
     ::coinJoinServer = std::make_unique<CCoinJoinServer>(*m_node.connman);
 #ifdef ENABLE_WALLET
     ::coinJoinClientQueueManager = std::make_unique<CCoinJoinClientQueueManager>(*m_node.connman);
@@ -221,6 +223,7 @@ TestingSetup::~TestingSetup()
     ::coinJoinClientQueueManager.reset();
 #endif // ENABLE_WALLET
     ::coinJoinServer.reset();
+    ::masternodeSync.reset();
     ::governance.reset();
     ::sporkManager.reset();
     m_node.connman.reset();

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -8,6 +8,7 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
+#include <governance/governance.h>
 #include <miner.h>
 #include <pow.h>
 #include <random.h>
@@ -69,7 +70,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     CScript pubKey;
     pubKey << i++ << OP_TRUE;
 
-    auto ptemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(pubKey);
+    auto ptemplate = BlockAssembler(*sporkManager, *governance, *m_node.mempool, Params()).CreateNewBlock(pubKey);
     auto pblock = std::make_shared<CBlock>(ptemplate->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -12,6 +12,7 @@
 #include <pow.h>
 #include <random.h>
 #include <script/standard.h>
+#include <spork.h>
 #include <test/util/setup_common.h>
 #include <util/time.h>
 #include <validation.h>
@@ -68,7 +69,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     CScript pubKey;
     pubKey << i++ << OP_TRUE;
 
-    auto ptemplate = BlockAssembler(*m_node.mempool, Params()).CreateNewBlock(pubKey);
+    auto ptemplate = BlockAssembler(*sporkManager, *m_node.mempool, Params()).CreateNewBlock(pubKey);
     auto pblock = std::make_shared<CBlock>(ptemplate->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2307,7 +2307,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     // DASH : CHECK TRANSACTIONS FOR INSTANTSEND
 
-    if (llmq::RejectConflictingBlocks(*sporkManager)) {
+    if (llmq::quorumInstantSendManager->RejectConflictingBlocks()) {
         // Require other nodes to comply, send them some data in case they are missing it.
         for (const auto& tx : block.vtx) {
             // skip txes that have no inputs

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -55,6 +55,7 @@
 #include <evo/evodb.h>
 #include <evo/specialtx.h>
 #include <evo/specialtxman.h>
+#include <governance/governance.h>
 
 #include <llmq/instantsend.h>
 #include <llmq/chainlocks.h>
@@ -2337,7 +2338,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     int64_t nTime5_2 = GetTimeMicros(); nTimeSubsidy += nTime5_2 - nTime5_1;
     LogPrint(BCLog::BENCHMARK, "      - GetBlockSubsidy: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_2 - nTime5_1), nTimeSubsidy * MICRO, nTimeSubsidy * MILLI / nBlocksTotal);
 
-    if (!IsBlockValueValid(*sporkManager, block, pindex->nHeight, blockReward, strError)) {
+    if (!IsBlockValueValid(*sporkManager, *governance, block, pindex->nHeight, blockReward, strError)) {
         // NOTE: Do not punish, the node might be missing governance data
         return state.Invalid(ValidationInvalidReason::NONE, error("ConnectBlock(DASH): %s", strError), REJECT_INVALID, "bad-cb-amount");
     }
@@ -2345,7 +2346,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     int64_t nTime5_3 = GetTimeMicros(); nTimeValueValid += nTime5_3 - nTime5_2;
     LogPrint(BCLog::BENCHMARK, "      - IsBlockValueValid: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_3 - nTime5_2), nTimeValueValid * MICRO, nTimeValueValid * MILLI / nBlocksTotal);
 
-    if (!IsBlockPayeeValid(*sporkManager, *block.vtx[0], pindex->nHeight, blockReward)) {
+    if (!IsBlockPayeeValid(*sporkManager, *governance, *block.vtx[0], pindex->nHeight, blockReward)) {
         // NOTE: Do not punish, the node might be missing governance data
         return state.Invalid(ValidationInvalidReason::NONE, error("ConnectBlock(DASH): couldn't find masternode or superblock payments"), REJECT_INVALID, "bad-cb-payee");
     }

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -90,6 +90,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "llmq/dkgsessionmgr -> llmq/quorums -> llmq/dkgsessionmgr"
     "llmq/snapshot -> llmq/utils -> llmq/snapshot"
     "spork -> validation -> spork"
+    "governance/governance -> validation -> governance/governance"
 )
 
 EXIT_CODE=0

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -89,6 +89,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "llmq/dkgsession -> llmq/dkgsessionmgr -> llmq/quorums -> llmq/dkgsession"
     "llmq/dkgsessionmgr -> llmq/quorums -> llmq/dkgsessionmgr"
     "llmq/snapshot -> llmq/utils -> llmq/snapshot"
+    "spork -> validation -> spork"
 )
 
 EXIT_CODE=0


### PR DESCRIPTION
## Additional Notes

In preparation of moving some Dash-specific globals to `NodeContext` (which cannot contain anything that isn't a pointer), many globals have been transformed into `unique_ptr`s (with the sole exception of `CBLSWorker`, which is a `shared_ptr`). 

To reduce the amount of redundant reference passing, some classes were modified to make a `CConnman` object a member of the class, dereferenced from `NodeContext` during initialisation. 

This could not be done for `CSporkManager` and `CGovernanceManager` as they both rely on Dash's flat database implementation which does not take objects that accept initialisation parameters kindly due to an implicit copy being triggered when dumping database components, so they need their database and management components split out before they can take any arguments.