### PR TITLE
fix(llmq): use keepOldConnections

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -224,8 +224,7 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
     LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Process block %s\n", __func__, pIndex->GetBlockHash().ToString());
 
     for (auto& params : Params().GetConsensus().llmqs) {
-        // Process signingActiveQuorumCount + 1 quorums for all available llmqTypes
-        const auto vecQuorums = ScanQuorums(params.type, pIndex, params.signingActiveQuorumCount + 1);
+        const auto vecQuorums = ScanQuorums(params.type, pIndex, params.keepOldConnections);
 
         // First check if we are member of any quorum of this type
         auto proTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -821,7 +821,7 @@ bool CLLMQUtils::IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quo
     // sig shares and recovered sigs are only accepted from recent/active quorums
     // we allow one more active quorum as specified in consensus, as otherwise there is a small window where things could
     // fail while we are on the brink of a new quorum
-    auto quorums = quorumManager->ScanQuorums(llmqType, GetLLMQParams(llmqType).signingActiveQuorumCount + 1);
+    auto quorums = quorumManager->ScanQuorums(llmqType, GetLLMQParams(llmqType).keepOldConnections);
     return ranges::any_of(quorums, [&quorumHash](const auto& q){ return q->qc->quorumHash == quorumHash; });
 }
 
@@ -966,7 +966,7 @@ void CLLMQUtils::InitQuorumsCache(CacheType& cache)
 {
     for (const auto& llmq : Params().GetConsensus().llmqs) {
         cache.emplace(std::piecewise_construct, std::forward_as_tuple(llmq.type),
-                      std::forward_as_tuple(llmq.signingActiveQuorumCount + 1));
+                      std::forward_as_tuple(llmq.keepOldConnections));
     }
 }
 template void CLLMQUtils::InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>>& cache);


### PR DESCRIPTION
We must scan/cache keepOldConnections quorums or we won't be able to process sig shares signed in the 8 blocks window (signig offset) once new quorum(s) are mined.

(reviving https://github.com/dashpay/dash/commit/7b53306bc13672185afaf84bac72df86bcd54cb9 from #4890, I was probably right there initially https://github.com/dashpay/dash/pull/4890#discussion_r905398678)