### PR TITLE
fix: Handle quorum watch connections correctly

### DIFF
--- a/src/masternode/utils.cpp
+++ b/src/masternode/utils.cpp
@@ -64,6 +64,9 @@ void CMasternodeUtils::DoMaintenance(CConnman& connman)
         } else if (GetSystemTimeInSeconds() - pnode->nTimeConnected < 5) {
             // non-verified, give it some time to verify itself
             return;
+        } else if (pnode->qwatch) {
+            // keep watching nodes
+            return;
         }
         // we're not disconnecting masternode probes for at least a few seconds
         if (pnode->m_masternode_probe_connection && GetSystemTimeInSeconds() - pnode->nTimeConnected < 5) return;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2810,7 +2810,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             // Tell our peer that he should send us CoinJoin queue messages
             connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::SENDDSQUEUE, true));
             // Tell our peer that he should send us intra-quorum messages
-            if (llmq::CLLMQUtils::IsWatchQuorumsEnabled() && !pfrom->m_masternode_connection) {
+            if (llmq::CLLMQUtils::IsWatchQuorumsEnabled() && connman->IsMasternodeQuorumNode(pfrom)) {
                 connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::QWATCH));
             }
         }


### PR DESCRIPTION
We add them via EnsureQuorumConnections+ThreadOpenMasternodeConnections so they are clearly masternode connections and they are dropped regularly which is annoying. But also, we don't want every masternode connection to be a qwatch one, we want only the ones we added via that algo.