### PR TITLE
fix(dkg/net): Drop outdated connections to nodes that became masternodes recently

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2843,7 +2843,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
 
     if (pfrom->nTimeFirstMessageReceived == 0) {
         // First message after VERSION/VERACK
-        pfrom->nTimeFirstMessageReceived = GetTimeMicros();
+        pfrom->nTimeFirstMessageReceived = GetSystemTimeInSeconds();
         pfrom->fFirstMessageIsMNAUTH = msg_type == NetMsgType::MNAUTH;
         // Note: do not break the flow here
 


### PR DESCRIPTION
Such nodes won't be seen as masternodes by RelayInvToParticipants otherwise so no contributions will be sent to them when they are picked as relay members which in its turn may result in other nodes PoSe-punishing us.