### PR TITLE
fix(llmq): Store QuorumDataRequests per {ProTx, quorumHash, llmqType}

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -33,7 +33,10 @@ static const std::string DB_QUORUM_QUORUM_VVEC = "q_Qqvvec";
 CQuorumManager* quorumManager;
 
 CCriticalSection cs_data_requests;
-static std::unordered_map<std::pair<uint256, bool>, CQuorumDataRequest, StaticSaltedHasher> mapQuorumDataRequests GUARDED_BY(cs_data_requests);
+//key = <ProTx, bool, quorumHash, llmqType>
+//TODO: Document purpose of bool
+using key_t = std::tuple<uint256, bool, uint256, uint8_t>;
+static std::unordered_map<key_t, CQuorumDataRequest, StaticSaltedHasher> mapQuorumDataRequests GUARDED_BY(cs_data_requests);
 
 static uint256 MakeQuorumKey(const CQuorum& q)
 {
@@ -463,7 +466,8 @@ bool CQuorumManager::RequestQuorumData(CNode* pFrom, Consensus::LLMQType llmqTyp
     }
 
     LOCK(cs_data_requests);
-    auto key = std::make_pair(pFrom->GetVerifiedProRegTxHash(), true);
+    auto quorumHash = pQuorumBaseBlockIndex->GetBlockHash();
+    auto key = std::make_tuple(pFrom->GetVerifiedProRegTxHash(), true, quorumHash, (uint8_t)llmqType);
     auto it = mapQuorumDataRequests.emplace(key, CQuorumDataRequest(llmqType, pQuorumBaseBlockIndex->GetBlockHash(), nDataMask, proTxHash));
     if (!it.second && !it.first->second.IsExpired()) {
         LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Already requested\n", __func__);
@@ -614,11 +618,13 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& msg_type, C
 
         {
             LOCK2(cs_main, cs_data_requests);
-            auto key = std::make_pair(pFrom->GetVerifiedProRegTxHash(), false);
+            auto quorumHash = request.GetQuorumHash();
+            auto llmqType = (uint8_t) request.GetLLMQType();
+            auto key = std::make_tuple(pFrom->GetVerifiedProRegTxHash(), false, quorumHash, llmqType);
             auto it = mapQuorumDataRequests.find(key);
             if (it == mapQuorumDataRequests.end()) {
                 it = mapQuorumDataRequests.emplace(key, request).first;
-            } else if(it->second.IsExpired()) {
+            } else if (it->second.IsExpired()) {
                 it->second = request;
             } else {
                 errorHandler("Request limit exceeded", 25);
@@ -687,7 +693,10 @@ void CQuorumManager::ProcessMessage(CNode* pFrom, const std::string& msg_type, C
 
         {
             LOCK2(cs_main, cs_data_requests);
-            auto it = mapQuorumDataRequests.find(std::make_pair(pFrom->GetVerifiedProRegTxHash(), true));
+            auto quorumHash = request.GetQuorumHash();
+            auto llmqType = (uint8_t) request.GetLLMQType();
+            auto key = std::make_tuple(pFrom->GetVerifiedProRegTxHash(), true, quorumHash, llmqType);
+            auto it = mapQuorumDataRequests.find(key);
             if (it == mapQuorumDataRequests.end()) {
                 errorHandler("Not requested");
                 return;
@@ -862,7 +871,10 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                 pCurrentMemberHash = &vecMemberHashes[(nMyStartOffset + nTries++) % vecMemberHashes.size()];
                 {
                     LOCK(cs_data_requests);
-                    auto it = mapQuorumDataRequests.find(std::make_pair(*pCurrentMemberHash, true));
+                    auto quorumHash = pQuorum->qc->quorumHash;
+                    auto llmqType = (uint8_t)pQuorum->qc->quorumIndex;
+                    auto key = std::make_tuple(*pCurrentMemberHash, true, quorumHash, (uint8_t)llmqType);
+                    auto it = mapQuorumDataRequests.find(key);
                     if (it != mapQuorumDataRequests.end() && !it->second.IsExpired()) {
                         printLog("Already asked");
                         continue;
@@ -887,7 +899,10 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                     printLog("Requested");
                 } else {
                     LOCK(cs_data_requests);
-                    auto it = mapQuorumDataRequests.find(std::make_pair(verifiedProRegTxHash, true));
+                    auto quorumHash = pQuorum->qc->quorumHash;
+                    auto llmqType = (uint8_t)pQuorum->qc->quorumIndex;
+                    auto key = std::make_tuple(*pCurrentMemberHash, true, quorumHash, (uint8_t)llmqType);
+                    auto it = mapQuorumDataRequests.find(key);
                     if (it == mapQuorumDataRequests.end()) {
                         printLog("Failed");
                         pNode->fDisconnect = true;

--- a/src/saltedhasher.h
+++ b/src/saltedhasher.h
@@ -13,6 +13,20 @@
 
 template<typename T> struct SaltedHasherImpl;
 
+template<typename N, typename M, typename K, typename Q>
+struct SaltedHasherImpl<std::tuple<N, M, K, Q>>
+{
+    static std::size_t CalcHash(const std::tuple<N, M, K, Q>& v, uint64_t k0, uint64_t k1)
+    {
+        CSipHasher c(k0, k1);
+        c.Write((unsigned char*)&std::get<0>(v), sizeof(M));
+        c.Write((unsigned char*)&std::get<1>(v), sizeof(N));
+        c.Write((unsigned char*)&std::get<2>(v), sizeof(K));
+        c.Write((unsigned char*)&std::get<3>(v), sizeof(Q));
+        return c.Finalize();
+    }
+};
+
 template<typename N>
 struct SaltedHasherImpl<std::pair<uint256, N>>
 {


### PR DESCRIPTION
Quorum data requests must be stored per masternode, quorumHash and llmqType because currently masternodes participating in multiple quorums are p2p banning each other for keep requesting QData.