### PR TITLE
fix: resolve some memory leaks

### DIFF
--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -269,7 +269,13 @@ struct Aggregator : public std::enable_shared_from_this<Aggregator<T>> {
 
     void PushAggQueue(const T& v)
     {
-        aggQueue.push(new T(v));
+        auto copyT = new T(v);
+        try {
+            aggQueue.push(copyT);
+        } catch (...) {
+            delete copyT;
+            throw;
+        }
 
         if (++aggQueueSize >= batchSize) {
             // we've collected enough intermediate results to form a new batch.

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -730,12 +730,13 @@ UniValue importelectrumwallet(const JSONRPCRequest& request)
         }
     } else {
         // json
-        char* buffer = new char [nFilesize];
-        file.read(buffer, nFilesize);
         UniValue data(UniValue::VOBJ);
-        if(!data.read(buffer))
-            throw JSONRPCError(RPC_TYPE_ERROR, "Cannot parse Electrum wallet export file");
-        delete[] buffer;
+        {
+            auto buffer = std::make_unique<char[]>(nFilesize);
+            file.read(buffer.get(), nFilesize);
+            if(!data.read(buffer.get()))
+                throw JSONRPCError(RPC_TYPE_ERROR, "Cannot parse Electrum wallet export file");
+        }
 
         std::vector<std::string> vKeys = data.getKeys();
 


### PR DESCRIPTION
 - In wallet/rpcdump memory the leak would happen, if wallet is not correct JSON
 - In BLS the leak would happen, if object hasn't been pushed in queue by some reason. Need to remove temporary object also