### PR TITLE
Merge bitcoin#23315: [22.x] build: explicitly disable libsecp256k1...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1822,7 +1822,7 @@ PKGCONFIG_LIBDIR_TEMP="$PKG_CONFIG_LIBDIR"
 unset PKG_CONFIG_LIBDIR
 PKG_CONFIG_LIBDIR="$PKGCONFIG_LIBDIR_TEMP"
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --disable-openssl-tests"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT


### PR DESCRIPTION
Merge bitcoin/bitcoin#23315: [22.x] build: explicitly disable libsecp256k1 openssl based tests

e959b46aa933856e7636557f4ec6fce0efbc76aa build: explicitly disable libsecp256k1 openssl based tests (fanquake)

Pull request description:

  Backport of #23314

  These tests are failing when run against OpenSSL 3, and have been
  removed upstream, bitcoin-core/secp256k1#983, so
  disabled them for now to avoid `make check` failures.

  Note that this will also remove warning output from our build, due to
  the use of deprecated OpenSSL API functions. See #23048.

Top commit has no ACKs.

Tree-SHA512: ab3213dc82e7a64a005ce237710009bb447dee2702c4c02245e70df62063a00add73c4e80e9c619ce57345d4a2808fd4dc08e2e02a319b0f3d9285b8b0056599