### PR TITLE
fix(rpc): Fix off-by-1 in `protx diff`

### DIFF
--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1152,8 +1152,8 @@ static UniValue protx_diff(const JSONRPCRequest& request)
     uint256 baseBlockHash = ParseBlock(request.params[0], "baseBlock");
     uint256 blockHash = ParseBlock(request.params[1], "block");
     bool extended = false;
-    if (!request.params[3].isNull()) {
-        extended = ParseBoolV(request.params[3], "extended");
+    if (!request.params[2].isNull()) {
+        extended = ParseBoolV(request.params[2], "extended");
     }
 
     CSimplifiedMNListDiff mnListDiff;


### PR DESCRIPTION
Introduced in https://github.com/dashpay/dash/pull/4740/commits/4ba59400540c9510b00fa0ff03470b661d6b587f (#4740) which wasn't tweaked accordingly after the rebase of https://github.com/dashpay/dash/commit/055bad15d4cef1dfd2f51ea4ac8477704d463f00 on top of huge RPC changes. 

NOTE: #4740 wasn't backborted to `v18.x` https://github.com/dashpay/dash/pull/4740#issuecomment-1165832628, `protx diff` should work fine in RC12 (with 2 params).

cc @thephez 