### PR TITLE
fix: Restore caching in `CalcCbTxMerkleRootMNList`

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -129,7 +129,7 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
         static uint256 merkleRootCached;
         static bool mutatedCached{false};
 
-        if (sml.mnList == smlCached.mnList) {
+        if (sml == smlCached) {
             merkleRootRet = merkleRootCached;
             if (mutatedCached) {
                 return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "mutated-cached-calc-cb-mnmerkleroot");

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -115,6 +115,17 @@ uint256 CSimplifiedMNList::CalcMerkleRoot(bool* pmutated) const
     return ComputeMerkleRoot(leaves, pmutated);
 }
 
+bool CSimplifiedMNList::operator==(const CSimplifiedMNList& rhs) const
+{
+    return mnList.size() == rhs.mnList.size() &&
+            std::equal(mnList.begin(), mnList.end(), rhs.mnList.begin(),
+                [](const std::unique_ptr<CSimplifiedMNListEntry>& left, const std::unique_ptr<CSimplifiedMNListEntry>& right)
+                {
+                    return *left == *right;
+                }
+            );
+}
+
 CSimplifiedMNListDiff::CSimplifiedMNListDiff() = default;
 
 CSimplifiedMNListDiff::~CSimplifiedMNListDiff() = default;

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -78,6 +78,7 @@ public:
     explicit CSimplifiedMNList(const CDeterministicMNList& dmnList);
 
     uint256 CalcMerkleRoot(bool* pmutated = nullptr) const;
+    bool operator==(const CSimplifiedMNList& rhs) const;
 };
 
 /// P2P messages


### PR DESCRIPTION
#3014 improved sorting but broke caching in `CalcCbTxMerkleRootMNList` it seems - comparing two vectors of different pointers always fails so the cache is never really used.