### PR TITLE
chore: bump ChainTxData for mainnet and testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -360,10 +360,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            1617874573, // * UNIX timestamp of last known number of transactions (Block 1450962)
-            34709765,   // * total number of transactions between genesis and that timestamp
+            1660074878, // * UNIX timestamp of last known number of transactions (Block 1718597)
+            43702293,   // * total number of transactions between genesis and that timestamp
                         //   (the tx=... number in the ChainStateFlushed debug.log lines)
-            0.3         // * estimated number of transactions per second after that timestamp
+            0.175       // * estimated number of transactions per second after that timestamp
         };
     }
 };
@@ -558,10 +558,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            1617874832, // * UNIX timestamp of last known number of transactions (Block 477483)
-            4926985,    // * total number of transactions between genesis and that timestamp
+            1659215338, // * UNIX timestamp of last known number of transactions (Block 771537)
+            5579961,    // * total number of transactions between genesis and that timestamp
                         //   (the tx=... number in the ChainStateFlushed debug.log lines)
-            0.01        // * estimated number of transactions per second after that timestamp
+            0.018       // * estimated number of transactions per second after that timestamp
         };
     }
 };


### PR DESCRIPTION
mainnet
```
getchaintxstats
{
  "time": 1660074878,
  "txcount": 43702293,
  "window_final_block_hash": "0000000000000002ee5a0d2caa3f78cd630ece1a12ce74f7a8146eb6689b1b66",
  "window_final_block_height": 1718597,
  "window_block_count": 17280,
  "window_tx_count": 476084,
  "window_interval": 2724994,
  "txrate": 0.174710109453452
}
```

testnet
```
> $ ./src/dash-cli --testnet getchaintxstats                                                               [±chore/bump-min-work-assume-valid ●]
{
  "time": 1659319535,
  "txcount": 5577222,
  "window_final_block_hash": "00000c9d1544ca21b5a2070c61cab65b2d7ef7aa1afac94a949e65cecb0b7d0f",
  "window_final_block_height": 771537,
  "window_block_count": 17280,
  "window_tx_count": 40775,
  "window_interval": 2533438,
  "txrate": 0.01609472977037528
}
```