### PR TITLE
fix(llmq): Drop quorum members cache on undo

### DIFF
--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -284,6 +284,8 @@ bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, const CBlockIndex* pi
 {
     AssertLockHeld(cs_main);
 
+    llmq::utils::PreComputeQuorumMembers(pindex, true);
+
     std::multimap<Consensus::LLMQType, CFinalCommitment> qcs;
     CValidationState dummy;
     if (!GetCommitmentsFromBlock(block, pindex, qcs, dummy)) {

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -53,9 +53,9 @@ namespace utils
 {
 
 // includes members which failed DKG
-std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex);
+std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex, bool reset_cache = false);
 
-void PreComputeQuorumMembers(const CBlockIndex* pQuorumBaseBlockIndex);
+void PreComputeQuorumMembers(const CBlockIndex* pQuorumBaseBlockIndex, bool reset_cache = false);
 static std::vector<CDeterministicMNCPtr> ComputeQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex);
 static std::vector<std::vector<CDeterministicMNCPtr>> ComputeQuorumMembersByQuarterRotation(Consensus::LLMQType llmqType, const CBlockIndex* pCycleQuorumBaseBlockIndex);
 


### PR DESCRIPTION
Syncing on testnet using 0.17.0.3 works up to the fork block - the block that mined quorum commitment for llmq type 5 (on testnet: 769866, `00000050ec7aa1b187c3a9df0d80a2ed2821d5836b596b962bcbc4c261b4bcd5`). Switching to v18.0.0-rc12 to sync further doesn't help https://github.com/dashpay/dash/issues/4947#issuecomment-1204934497:
```
ERROR: ConnectBlock(DASH): ProcessSpecialTxsInBlock for block 0000003c43b3ae7fffe61278ca5537a0e256ebf4d709d45f0ab040271074d51e failed with bad-qc-invalid (code 16)
InvalidChainFound: invalid block=0000003c43b3ae7fffe61278ca5537a0e256ebf4d709d45f0ab040271074d51e  height=770730  log2_work=57.31213602  date=2022-07-29T13:22:06Z
InvalidChainFound:  current best=0000001f04c47d2a72e87199b35ad5d21780c224b483bba2451e3eb9691d21a9  height=770729  log2_work=57.31213602  date=2022-07-29T13:20:06Z
```

This PR should help with v18 migration for nodes that failed to update in time. Still have to invalidate/reconsider the pre-fork quorum cycle start block (on testnet: 769824, `000000fc830a6a67ddc41f10d197654fdecfb8a739ea77ca9fdf3fcc46775790`) to recalculate quorum members but it's better than having to reindex the whole chain https://github.com/dashpay/dash/issues/4947#issuecomment-1205784813.