### PR TITLE
fix(rpc): `masternode outputs` should work correctly with multiple outputs created via a single tx

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -179,7 +179,11 @@ static void masternode_outputs_help(const JSONRPCRequest& request)
     RPCHelpMan{"masternode outputs",
         "Print masternode compatible outputs\n",
         {},
-        RPCResults{},
+        RPCResult {
+            RPCResult::Type::ARR, "", "A list of outpoints that can be/are used as masternode collaterals",
+            {
+                {RPCResult::Type::STR, "", "A (potential) masternode collateral"},
+            }},
         RPCExamples{""}
     }.Check(request);
 }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -200,12 +200,12 @@ static UniValue masternode_outputs(const JSONRPCRequest& request)
         LOCK(pwallet->cs_wallet);
         pwallet->AvailableCoins(vPossibleCoins, true, &coin_control);
     }
-    UniValue obj(UniValue::VOBJ);
+    UniValue outputsArr(UniValue::VARR);
     for (const auto& out : vPossibleCoins) {
-        obj.pushKV(out.tx->GetHash().ToString(), strprintf("%d", out.i));
+        outputsArr.push_back(out.GetInputCoin().outpoint.ToStringShort());
     }
 
-    return obj;
+    return outputsArr;
 }
 
 #endif // ENABLE_WALLET

--- a/test/functional/rpc_masternode.py
+++ b/test/functional/rpc_masternode.py
@@ -66,6 +66,13 @@ class RPCMasternodeTest(DashTestFramework):
             assert_equal(gbt_masternode[i]["script"], payments_masternode["payees"][i]["script"])
             assert_equal(gbt_masternode[i]["amount"], payments_masternode["payees"][i]["amount"])
 
+        self.log.info("test that `masternode outputs` show correct list")
+        addr1 = self.nodes[0].getnewaddress()
+        addr2 = self.nodes[0].getnewaddress()
+        self.nodes[0].sendmany('', {addr1: 1000, addr2: 1000})
+        self.nodes[0].generate(1)
+        # we have 3 masternodes that are running already and 2 new outputs we just created
+        assert_equal(len(self.nodes[0].masternode("outputs")), 5)
 
 if __name__ == '__main__':
     RPCMasternodeTest().main()


### PR DESCRIPTION
Currently it only shows the last one since it's an object with the same key (txid) for every outpoint.

kudos to @kxcd for discovering this 👍