### PR TITLE
fix: Guard mnauth by local masternode service

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -19,8 +19,20 @@
 void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CActiveMasternodeManager& mn_activeman)
 {
     CMNAuth mnauth;
-    if (mn_activeman.GetProTxHash().IsNull()) {
+    const uint256 pro_tx_hash{mn_activeman.GetProTxHash()};
+    if (pro_tx_hash.IsNull()) {
         return;
+    }
+    if (peer.IsInboundConn()) {
+        const CService expected_service{mn_activeman.GetService()};
+        const CService connected_service{static_cast<const CService&>(peer.addrBind)};
+        if (expected_service != connected_service) {
+            LogPrint(BCLog::NET_NETCONN, /* Continued */
+                     "CMNAuth::%s -- Not sending MNAUTH on unexpected local service, expected=%s, connected=%s, "
+                     "peer=%d\n",
+                     __func__, expected_service.ToStringAddrPort(), connected_service.ToStringAddrPort(), peer.GetId());
+            return;
+        }
     }
 
     const auto receivedMNAuthChallenge = peer.GetReceivedMNAuthChallenge();
@@ -39,7 +51,7 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CActiveMasternode
     }
     const uint256 signHash{::SerializeHash(std::make_tuple(mn_activeman.GetPubKey(), receivedMNAuthChallenge, peer.IsInboundConn(), nOurNodeVersion))};
 
-    mnauth.proRegTxHash = mn_activeman.GetProTxHash();
+    mnauth.proRegTxHash = pro_tx_hash;
 
     // all clients uses basic BLS
     mnauth.sig = mn_activeman.Sign(signHash, false);

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -26,7 +26,8 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CActiveMasternode
     if (peer.IsInboundConn()) {
         const CService expected_service{mn_activeman.GetService()};
         const CService connected_service{static_cast<const CService&>(peer.addrBind)};
-        if (expected_service != connected_service) {
+        if (expected_service.GetPort() != connected_service.GetPort() ||
+            expected_service.GetNetwork() != peer.ConnectedThroughNetwork()) {
             LogPrint(BCLog::NET_NETCONN, /* Continued */
                      "CMNAuth::%s -- Not sending MNAUTH on unexpected local service, expected=%s, connected=%s, "
                      "peer=%d\n",

--- a/test/functional/p2p_mnauth.py
+++ b/test/functional/p2p_mnauth.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test MNAUTH emission on the registered masternode service only.
+"""
+
+from test_framework.test_framework import (
+    DashTestFramework,
+    MasternodeInfo,
+)
+from test_framework.util import (
+    assert_equal,
+    p2p_port,
+)
+
+
+class P2PMNAUTHTest(DashTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.alt_port = p2p_port(10)
+        self.mn_port = p2p_port(2)
+        self.set_dash_test_params(3, 1, extra_args=[
+            [],
+            [],
+            [f"-bind=127.0.0.1:{self.alt_port}", f"-externalip=127.0.0.1:{self.mn_port}"],
+        ])
+
+    def run_test(self):
+        masternode: MasternodeInfo = self.mninfo[0]
+        masternode_node = masternode.get_node(self)
+        connector = self.nodes[1]
+        use_v2transport = self.options.v2transport
+
+        expected_addr = f"127.0.0.1:{masternode.nodePort}"
+        alternate_addr = f"127.0.0.1:{self.alt_port}"
+
+        self.wait_until(lambda: masternode_node.masternode("status")["state"] == "READY")
+        assert_equal(masternode_node.masternode("status")["service"], expected_addr)
+
+        self.log.info(f"Connect to the registered masternode service over {'v2' if use_v2transport else 'v1'} and expect MNAUTH")
+        with connector.assert_debug_log([f"Masternode probe successful for {masternode.proTxHash}"]):
+            assert_equal(connector.masternode("connect", expected_addr, use_v2transport), "successfully connected")
+
+        self.log.info(f"Connect to the alternate bind over {'v2' if use_v2transport else 'v1'} and expect no MNAUTH")
+        with masternode_node.assert_debug_log(["Not sending MNAUTH on unexpected local service"]):
+            with connector.assert_debug_log(["connection is a masternode probe but first received message is not MNAUTH"]):
+                assert_equal(connector.masternode("connect", alternate_addr, use_v2transport), "successfully connected")
+
+
+if __name__ == '__main__':
+    P2PMNAUTHTest().main()

--- a/test/functional/p2p_mnauth.py
+++ b/test/functional/p2p_mnauth.py
@@ -7,6 +7,8 @@
 Test MNAUTH emission on the registered masternode service only.
 """
 
+import platform
+
 from test_framework.test_framework import (
     DashTestFramework,
     MasternodeInfo,
@@ -22,13 +24,24 @@ class P2PMNAUTHTest(DashTestFramework):
         self.add_wallet_options(parser)
 
     def set_test_params(self):
+        # Disable the framework's implicit `bind=127.0.0.1` so all binds for the
+        # masternode are visible in this file rather than coming from the conf.
+        self.bind_to_localhost_only = False
         self.alt_port = p2p_port(10)
         self.mn_port = p2p_port(2)
-        self.set_dash_test_params(3, 1, extra_args=[
-            [],
-            [],
-            [f"-bind=127.0.0.1:{self.alt_port}", f"-externalip=127.0.0.1:{self.mn_port}"],
-        ])
+        # NAT-style variant requires a non-127.0.0.1 loopback bind; only Linux
+        # routes 127.0.0.0/8 to lo by default.
+        self.nat_capable = platform.system() == "Linux"
+
+        mn_args = [
+            f"-bind=127.0.0.1:{self.mn_port}",
+            f"-bind=127.0.0.1:{self.alt_port}",
+            f"-externalip=127.0.0.1:{self.mn_port}",
+        ]
+        if self.nat_capable:
+            mn_args.append(f"-bind=127.0.0.2:{self.mn_port}")
+
+        self.set_dash_test_params(3, 1, extra_args=[[], [], mn_args])
 
     def run_test(self):
         masternode: MasternodeInfo = self.mninfo[0]
@@ -50,6 +63,12 @@ class P2PMNAUTHTest(DashTestFramework):
         with masternode_node.assert_debug_log(["Not sending MNAUTH on unexpected local service"]):
             with connector.assert_debug_log(["connection is a masternode probe but first received message is not MNAUTH"]):
                 assert_equal(connector.masternode("connect", alternate_addr, use_v2transport), "successfully connected")
+
+        if self.nat_capable:
+            nat_addr = f"127.0.0.2:{self.mn_port}"
+            self.log.info(f"Connect to a different loopback IP on the registered port over {'v2' if use_v2transport else 'v1'} (NAT-style: addrBind address differs from advertised externalip, ports match) and expect MNAUTH")
+            with connector.assert_debug_log([f"Masternode probe successful for {masternode.proTxHash}"]):
+                assert_equal(connector.masternode("connect", nat_addr, use_v2transport), "successfully connected")
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_mnauth_onion.py
+++ b/test/functional/p2p_mnauth_onion.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test that MNAUTH is suppressed when an inbound arrives over a different network class
+than the masternode's registered service. Specifically: an IPv4-registered masternode
+must not emit MNAUTH on a Tor-tagged inbound, even when the local port matches — that
+would deanonymize the masternode by linking its onion endpoint to its IPv4 identity.
+
+Set up: bind the masternode's listener at its registered port with `=onion`, so that any
+inbound arriving there is treated by dashd as a Tor connection (m_inbound_onion=true).
+Port match is then guaranteed and only the network differs, isolating the network check.
+"""
+
+from test_framework.test_framework import (
+    DashTestFramework,
+    MasternodeInfo,
+)
+from test_framework.util import (
+    assert_equal,
+    p2p_port,
+)
+
+
+class P2PMNAUTHOnionTest(DashTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.bind_to_localhost_only = False
+        self.mn_port = p2p_port(2)
+        self.set_dash_test_params(3, 1, extra_args=[
+            [],
+            [],
+            [
+                f"-bind=127.0.0.1:{self.mn_port}=onion",
+                f"-externalip=127.0.0.1:{self.mn_port}",
+            ],
+        ])
+
+    def run_test(self):
+        masternode: MasternodeInfo = self.mninfo[0]
+        masternode_node = masternode.get_node(self)
+        connector = self.nodes[1]
+        use_v2transport = self.options.v2transport
+
+        expected_addr = f"127.0.0.1:{masternode.nodePort}"
+
+        self.wait_until(lambda: masternode_node.masternode("status")["state"] == "READY")
+        assert_equal(masternode_node.masternode("status")["service"], expected_addr)
+
+        self.log.info(f"Probe the MN over {'v2' if use_v2transport else 'v1'} via its onion-tagged listener; ports match, network differs, expect no MNAUTH")
+        with masternode_node.assert_debug_log(["Not sending MNAUTH on unexpected local service"]):
+            with connector.assert_debug_log(["connection is a masternode probe but first received message is not MNAUTH"]):
+                assert_equal(connector.masternode("connect", expected_addr, use_v2transport), "successfully connected")
+
+
+if __name__ == '__main__':
+    P2PMNAUTHOnionTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -353,6 +353,8 @@ BASE_SCRIPTS = [
     'p2p_ibd_txrelay.py',
     'rpc_coinjoin.py',
     'rpc_masternode.py',
+    'p2p_mnauth.py --v1transport',
+    'p2p_mnauth.py --v2transport',
     'rpc_mnauth.py',
     'rpc_verifychainlock.py',
     'wallet_create_tx.py --legacy-wallet',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -355,6 +355,8 @@ BASE_SCRIPTS = [
     'rpc_masternode.py',
     'p2p_mnauth.py --v1transport',
     'p2p_mnauth.py --v2transport',
+    'p2p_mnauth_onion.py --v1transport',
+    'p2p_mnauth_onion.py --v2transport',
     'rpc_mnauth.py',
     'rpc_verifychainlock.py',
     'wallet_create_tx.py --legacy-wallet',


### PR DESCRIPTION
A node can be bound to multiple addresses. Send `mnauth` to nodes connected to the right address only to avoid confusion.

Thanks @kxcd 👍 