### PR TITLE
Revert "fix spaces/monospace fonts in qt console"

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -437,7 +437,6 @@ bool isDust(interfaces::Node& node, const QString& address, const CAmount& amoun
 QString HtmlEscape(const QString& str, bool fMultiLine)
 {
     QString escaped = str.toHtmlEscaped();
-    escaped = escaped.replace(" ", "&nbsp;");
     if(fMultiLine)
     {
         escaped = escaped.replace("\n", "<br>\n");


### PR DESCRIPTION
This reverts commit 54a78ed036ba30df71636a136ad7c34e0e6445b7.

This was an old hack. It conflicts with https://github.com/dashpay/dash/pull/4570/commits/d7281c82efb179ee9a6e3b78906c622cebd2567e (labels show `&nbsp;` instead of spaces e.g. `label with spaces` is shown as `label&nbsp;with&nbsp;spaces`) and I believe we do not the hack anymore, so let's just revert it.

Thanks @splawik21 for discovering the issue 👍 