### PR TITLE
Bitcoin backport related to CWallet refactoring: bitcoin#17304, partial #10235

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -673,6 +673,17 @@ bool LegacyScriptPubKeyMan::HavePrivateKeys() const
     return !mapKeys.empty() || !mapCryptedKeys.empty();
 }
 
+void LegacyScriptPubKeyMan::RewriteDB()
+{
+    AssertLockHeld(cs_wallet);
+    setInternalKeyPool.clear();
+    setExternalKeyPool.clear();
+    m_pool_key_to_index.clear();
+    // Note: can't top-up keypool here, because wallet is locked.
+    // User will be prompted to unlock wallet the next operation
+    // that requires a new key.
+}
+
 static int64_t GetOldestKeyInPool(const std::set<int64_t>& setKeyPool, WalletBatch& batch) {
     if (setKeyPool.empty()) {
         return GetTime();

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1602,7 +1602,7 @@ bool LegacyScriptPubKeyMan::ImportPubKeys(const std::vector<CKeyID>& ordered_pub
     return true;
 }
 
-bool LegacyScriptPubKeyMan::ImportScriptPubKeys(const std::string& label, const std::set<CScript>& script_pub_keys, const bool have_solving_data, const bool apply_label, const int64_t timestamp)
+bool LegacyScriptPubKeyMan::ImportScriptPubKeys(const std::set<CScript>& script_pub_keys, const bool have_solving_data, const int64_t timestamp)
 {
     WalletBatch batch(m_storage.GetDatabase());
     for (const CScript& script : script_pub_keys) {
@@ -1610,11 +1610,6 @@ bool LegacyScriptPubKeyMan::ImportScriptPubKeys(const std::string& label, const 
             if (!AddWatchOnlyWithDB(batch, script, timestamp)) {
                 return false;
             }
-        }
-        CTxDestination dest;
-        ExtractDestination(script, dest);
-        if (apply_label && IsValidDestination(dest)) {
-            m_wallet.SetAddressBookWithDB(batch, dest, label, "receive");
         }
     }
     return true;

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -472,7 +472,7 @@ bool LegacyScriptPubKeyMan::SetHDChain(WalletBatch &batch, const CHDChain& chain
             throw std::runtime_error(std::string(__func__) + ": WriteHDChain failed");
         }
 
-        m_wallet.UnsetWalletFlagWithDB(batch, WALLET_FLAG_BLANK_WALLET);
+        m_storage.UnsetBlankWalletFlag(batch);
     }
 
     return true;
@@ -493,7 +493,7 @@ bool LegacyScriptPubKeyMan::SetCryptedHDChain(WalletBatch &batch, const CHDChain
             if (!batch.WriteCryptedHDChain(chain))
                 throw std::runtime_error(std::string(__func__) + ": WriteCryptedHDChain failed");
         }
-        m_wallet.UnsetWalletFlagWithDB(batch, WALLET_FLAG_BLANK_WALLET);
+        m_storage.UnsetBlankWalletFlag(batch);
     }
 
     return true;
@@ -1114,7 +1114,7 @@ bool LegacyScriptPubKeyMan::AddHDPubKey(WalletBatch &batch, const CExtPubKey &ex
     if (!batch.WriteHDPubKey(hdPubKey, mapKeyMetadata[extPubKey.pubkey.GetID()])) {
         return false;
     }
-    m_wallet.UnsetWalletFlagWithDB(batch, WALLET_FLAG_BLANK_WALLET);
+    m_storage.UnsetBlankWalletFlag(batch);
     return true;
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -336,8 +336,6 @@ void LegacyScriptPubKeyMan::UpgradeKeyMetadata()
             }
         }
     }
-    batch.reset(); //write before setting the flag
-    m_storage.SetWalletFlag(WALLET_FLAG_KEY_ORIGIN_METADATA);
 }
 
 void LegacyScriptPubKeyMan::GenerateNewHDChain(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase)

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -666,7 +666,18 @@ bool LegacyScriptPubKeyMan::CanGetAddresses(bool internal)
     return keypool_has_keys;
 }
 
+
+bool LegacyScriptPubKeyMan::HavePrivateKeys() const
+{
+    LOCK(cs_KeyStore);
+    return !mapKeys.empty() || !mapCryptedKeys.empty();
+}
+
 static int64_t GetOldestKeyInPool(const std::set<int64_t>& setKeyPool, WalletBatch& batch) {
+    if (setKeyPool.empty()) {
+        return GetTime();
+    }
+
     CKeyPool keypool;
     int64_t nIndex = *(setKeyPool.begin());
     if (!batch.ReadPool(nIndex, keypool)) {

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -12,9 +12,8 @@
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/wallet.h>
 
-bool LegacyScriptPubKeyMan::GetNewDestination(const std::string label, CTxDestination& dest, std::string& error)
+bool LegacyScriptPubKeyMan::GetNewDestination(CTxDestination& dest, std::string& error)
 {
-    LOCK(cs_wallet);
     error.clear();
     TopUpKeyPool();
 
@@ -26,8 +25,6 @@ bool LegacyScriptPubKeyMan::GetNewDestination(const std::string label, CTxDestin
     }
     //LearnRelatedScripts(new_key);
     dest = new_key.GetID();
-
-    m_wallet.SetAddressBook(dest, label, "receive");
     return true;
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1331,12 +1331,14 @@ bool LegacyScriptPubKeyMan::TopUpKeyPool(unsigned int kpSize)
     return true;
 }
 
+/*
 void LegacyScriptPubKeyMan::AddKeypoolPubkey(const CPubKey& pubkey, const bool internal)
 {
     WalletBatch batch(m_storage.GetDatabase());
     AddKeypoolPubkeyWithDB(pubkey, internal, batch);
     NotifyCanGetAddressesChanged();
 }
+*/
 
 void LegacyScriptPubKeyMan::AddKeypoolPubkeyWithDB(const CPubKey& pubkey, const bool internal, WalletBatch& batch)
 {

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -678,6 +678,21 @@ size_t LegacyScriptPubKeyMan::KeypoolCountInternalKeys()
     return setInternalKeyPool.size();
 }
 
+const CKeyMetadata* LegacyScriptPubKeyMan::GetMetadata(uint160 id) const
+{
+    AssertLockHeld(cs_wallet);
+    auto it = mapKeyMetadata.find(CKeyID(id));
+    if (it != mapKeyMetadata.end()) {
+        return &it->second;
+    } else {
+        auto it2 = m_script_metadata.find(CScriptID(id));
+        if (it2 != m_script_metadata.end()) {
+            return &it2->second;
+        }
+    }
+    return nullptr;
+}
+
 /**
  * Update wallet first key creation time. This should be called whenever keys
  * are added to the wallet, with the oldest key creation time.

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -731,6 +731,12 @@ size_t LegacyScriptPubKeyMan::KeypoolCountInternalKeys()
     return setInternalKeyPool.size();
 }
 
+unsigned int LegacyScriptPubKeyMan::GetKeyPoolSize() const
+{
+    AssertLockHeld(cs_wallet);
+    return setInternalKeyPool.size() + setExternalKeyPool.size();
+}
+
 const CKeyMetadata* LegacyScriptPubKeyMan::GetMetadata(uint160 id) const
 {
     AssertLockHeld(cs_wallet);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -266,6 +266,31 @@ bool LegacyScriptPubKeyMan::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
     return true;
 }
 
+bool LegacyScriptPubKeyMan::GetReservedDestination(bool internal, int64_t& index, CKeyPool& keypool)
+{
+    {
+        if (!ReserveKeyFromKeyPool(index, keypool, internal)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void LegacyScriptPubKeyMan::KeepDestination(int64_t index)
+{
+    KeepKey(index);
+}
+
+void LegacyScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, const CPubKey& pubkey)
+{
+    ReturnKey(index, internal, pubkey);
+}
+
+bool LegacyScriptPubKeyMan::TopUp(unsigned int size)
+{
+    return TopUpKeyPool(size);
+}
+
 void LegacyScriptPubKeyMan::UpgradeKeyMetadata()
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -441,7 +441,7 @@ bool LegacyScriptPubKeyMan::SetHDChain(WalletBatch &batch, const CHDChain& chain
             throw std::runtime_error(std::string(__func__) + ": WriteHDChain failed");
         }
 
-        m_wallet.UnsetWalletFlag(batch, WALLET_FLAG_BLANK_WALLET);
+        m_wallet.UnsetWalletFlagWithDB(batch, WALLET_FLAG_BLANK_WALLET);
     }
 
     return true;
@@ -462,7 +462,7 @@ bool LegacyScriptPubKeyMan::SetCryptedHDChain(WalletBatch &batch, const CHDChain
             if (!batch.WriteCryptedHDChain(chain))
                 throw std::runtime_error(std::string(__func__) + ": WriteCryptedHDChain failed");
         }
-        m_wallet.UnsetWalletFlag(batch, WALLET_FLAG_BLANK_WALLET);
+        m_wallet.UnsetWalletFlagWithDB(batch, WALLET_FLAG_BLANK_WALLET);
     }
 
     return true;
@@ -742,7 +742,7 @@ bool LegacyScriptPubKeyMan::AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& s
                                  secret.GetPrivKey(),
                                  mapKeyMetadata[pubkey.GetID()]);
     }
-    m_wallet.UnsetWalletFlag(batch, WALLET_FLAG_BLANK_WALLET);
+    m_storage.UnsetBlankWalletFlag(batch);
     return true;
 }
 
@@ -952,7 +952,7 @@ bool LegacyScriptPubKeyMan::AddWatchOnlyWithDB(WalletBatch &batch, const CScript
     UpdateTimeFirstKey(meta.nCreateTime);
     NotifyWatchonlyChanged(true);
     if (batch.WriteWatchOnly(dest, meta)) {
-        m_wallet.UnsetWalletFlag(batch, WALLET_FLAG_BLANK_WALLET);
+        m_storage.UnsetBlankWalletFlag(batch);
         return true;
     }
     return false;
@@ -1035,7 +1035,7 @@ bool LegacyScriptPubKeyMan::AddHDPubKey(WalletBatch &batch, const CExtPubKey &ex
     if (!batch.WriteHDPubKey(hdPubKey, mapKeyMetadata[extPubKey.pubkey.GetID()])) {
         return false;
     }
-    m_wallet.UnsetWalletFlag(batch, WALLET_FLAG_BLANK_WALLET);
+    m_wallet.UnsetWalletFlagWithDB(batch, WALLET_FLAG_BLANK_WALLET);
     return true;
 }
 
@@ -1518,7 +1518,7 @@ bool LegacyScriptPubKeyMan::AddCScriptWithDB(WalletBatch& batch, const CScript& 
     if (!FillableSigningProvider::AddCScript(redeemScript))
         return false;
     if (batch.WriteCScript(Hash160(redeemScript), redeemScript)) {
-        m_wallet.UnsetWalletFlag(batch, WALLET_FLAG_BLANK_WALLET);
+        m_storage.UnsetBlankWalletFlag(batch);
         return true;
     }
     return false;

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -700,6 +700,11 @@ int64_t LegacyScriptPubKeyMan::GetTimeFirstKey() const
     return nTimeFirstKey;
 }
 
+bool LegacyScriptPubKeyMan::LoadKey(const CKey& key, const CPubKey &pubkey)
+{
+    return AddKeyPubKeyInner(key, pubkey);
+}
+
 bool LegacyScriptPubKeyMan::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
 {
     WalletBatch batch(m_storage.GetDatabase());

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -737,6 +737,12 @@ unsigned int LegacyScriptPubKeyMan::GetKeyPoolSize() const
     return setInternalKeyPool.size() + setExternalKeyPool.size();
 }
 
+int64_t LegacyScriptPubKeyMan::GetTimeFirstKey() const
+{
+    AssertLockHeld(cs_wallet);
+    return nTimeFirstKey;
+}
+
 const CKeyMetadata* LegacyScriptPubKeyMan::GetMetadata(uint160 id) const
 {
     AssertLockHeld(cs_wallet);
@@ -766,12 +772,6 @@ void LegacyScriptPubKeyMan::UpdateTimeFirstKey(int64_t nCreateTime)
     } else if (!nTimeFirstKey || nCreateTime < nTimeFirstKey) {
         nTimeFirstKey = nCreateTime;
     }
-}
-
-int64_t LegacyScriptPubKeyMan::GetTimeFirstKey() const
-{
-    AssertLockHeld(cs_wallet);
-    return nTimeFirstKey;
 }
 
 bool LegacyScriptPubKeyMan::LoadKey(const CKey& key, const CPubKey &pubkey)

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -35,6 +35,8 @@ public:
 //! Default for -keypool
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 
+std::vector<CKeyID> GetAffectedKeys(const CScript& spk, const SigningProvider& provider);
+
 /** A key from a CWallet's keypool
  *
  * The wallet holds several keypools. These are sets of keys that have not
@@ -144,6 +146,9 @@ public:
 
     virtual bool TopUp(unsigned int size = 0) { return false; }
 
+    //! Mark unused addresses as being used
+    virtual void MarkUnusedAddresses(WalletBatch &batch, const CScript& script, const uint256& hashBlock) {}
+
     /* Returns true if HD is enabled */
     virtual bool IsHDEnabled() const { return false; }
 
@@ -246,6 +251,8 @@ public:
     void ReturnDestination(int64_t index, bool internal, const CPubKey& pubkey) override;
 
     bool TopUp(unsigned int size = 0) override;
+
+    void MarkUnusedAddresses(WalletBatch &batch, const CScript& script, const uint256& hashBlock) override;
 
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
     void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -164,6 +164,7 @@ public:
 
     virtual size_t KeypoolCountExternalKeys() { return 0; }
     virtual size_t KeypoolCountInternalKeys() { return 0; }
+    virtual unsigned int GetKeyPoolSize() const { return 0; }
 
     virtual const CKeyMetadata* GetMetadata(uint160 id) const { return nullptr; }
 };
@@ -275,6 +276,7 @@ public:
 
     //! Fetches a key from the keypool
     bool GetKeyFromPool(CPubKey &key, bool fInternal /*= false*/);
+    unsigned int GetKeyPoolSize() const override;
 
     const CKeyMetadata* GetMetadata(uint160 id) const override;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -26,7 +26,7 @@ public:
     virtual const std::string GetDisplayName() const = 0;
     virtual WalletDatabase& GetDatabase() = 0;
     virtual bool IsWalletFlagSet(uint64_t) const = 0;
-    virtual void SetWalletFlag(uint64_t) = 0;
+    virtual void UnsetBlankWalletFlag(WalletBatch&) = 0;
     virtual bool CanSupportFeature(enum WalletFeature) const = 0;
     virtual void SetMinVersion(enum WalletFeature, WalletBatch* = nullptr, bool = false) = 0;
     virtual bool IsLocked(bool fForMixing = false) const = 0;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -206,9 +206,9 @@ private:
      * nTimeFirstKey more intelligently for more efficient rescans.
      */
     bool AddWatchOnly(const CScript& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool AddWatchOnlyWithDB(WalletBatch &batch, const CScript& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool AddWatchOnlyInMem(const CScript &dest);
 
-    bool AddWatchOnlyWithDB(WalletBatch &batch, const CScript& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     void AddKeypoolPubkeyWithDB(const CPubKey& pubkey, const bool internal, WalletBatch& batch);
 
@@ -227,6 +227,8 @@ private:
     int64_t m_max_keypool_index GUARDED_BY(cs_wallet) = 0;
     std::map<CKeyID, int64_t> m_pool_key_to_index;
 
+    //! Fetches a key from the keypool
+    bool GetKeyFromPool(CPubKey &key, bool fInternal /*= false*/);
     /**
      * Reserves a key from the keypool and sets nIndex to its index
      *
@@ -276,8 +278,6 @@ public:
     size_t KeypoolCountExternalKeys() override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     size_t KeypoolCountInternalKeys() override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    //! Fetches a key from the keypool
-    bool GetKeyFromPool(CPubKey &key, bool fInternal /*= false*/);
     unsigned int GetKeyPoolSize() const override;
 
     int64_t GetTimeFirstKey() const override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -154,6 +154,8 @@ public:
 
     virtual size_t KeypoolCountExternalKeys() { return 0; }
     virtual size_t KeypoolCountInternalKeys() { return 0; }
+
+    virtual const CKeyMetadata* GetMetadata(uint160 id) const { return nullptr; }
 };
 
 class LegacyScriptPubKeyMan : public ScriptPubKeyMan, public FillableSigningProvider
@@ -257,6 +259,8 @@ public:
 
     //! Fetches a key from the keypool
     bool GetKeyFromPool(CPubKey &key, bool fInternal /*= false*/);
+
+    const CKeyMetadata* GetMetadata(uint160 id) const override;
 
     bool CanGetAddresses(bool internal = false) override;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -166,6 +166,8 @@ public:
     virtual size_t KeypoolCountInternalKeys() { return 0; }
     virtual unsigned int GetKeyPoolSize() const { return 0; }
 
+    virtual int64_t GetTimeFirstKey() const { return 0; }
+
     virtual const CKeyMetadata* GetMetadata(uint160 id) const { return nullptr; }
 };
 
@@ -278,6 +280,8 @@ public:
     bool GetKeyFromPool(CPubKey &key, bool fInternal /*= false*/);
     unsigned int GetKeyPoolSize() const override;
 
+    int64_t GetTimeFirstKey() const override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     const CKeyMetadata* GetMetadata(uint160 id) const override;
 
     bool CanGetAddresses(bool internal = false) override;
@@ -365,8 +369,6 @@ public:
 
     /* Returns true if the wallet can generate new keys */
     bool CanGenerateKeys();
-
-    int64_t GetTimeFirstKey() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Adds a HDPubKey into the wallet(database)
     bool AddHDPubKey(WalletBatch &batch, const CExtPubKey &extPubKey, bool fInternal);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -137,8 +137,11 @@ public:
     virtual isminetype IsMine(const CScript& script) const { return ISMINE_NO; }
     virtual isminetype IsMine(const CTxDestination& dest) const { return ISMINE_NO; }
 
-    //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
-    virtual void UpgradeKeyMetadata() {}
+    virtual bool GetReservedDestination(bool internal, int64_t& index, CKeyPool& keypool) { return false; }
+    virtual void KeepDestination(int64_t index) {}
+    virtual void ReturnDestination(int64_t index, bool internal, const CPubKey& pubkey) {}
+
+    virtual bool TopUp(unsigned int size = 0) { return false; }
 
     /* Returns true if HD is enabled */
     virtual bool IsHDEnabled() const { return false; }
@@ -235,8 +238,15 @@ public:
 
     //! will encrypt previously unencrypted keys
     bool EncryptKeys(CKeyingMaterial& vMasterKeyIn);
+
+    bool GetReservedDestination(bool internal, int64_t& index, CKeyPool& keypool) override;
+    void KeepDestination(int64_t index) override;
+    void ReturnDestination(int64_t index, bool internal, const CPubKey& pubkey) override;
+
+    bool TopUp(unsigned int size = 0) override;
+
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
-    void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) override;
+    void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const override;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -339,7 +339,7 @@ public:
 
     bool ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const bool internal, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool ImportScriptPubKeys(const std::string& label, const std::set<CScript>& script_pub_keys, const bool have_solving_data, const bool apply_label, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool ImportScriptPubKeys(const std::set<CScript>& script_pub_keys, const bool have_solving_data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /* Returns true if the wallet can generate new keys */
     bool CanGenerateKeys();

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -155,6 +155,8 @@ public:
     /* Returns true if the wallet can give out new addresses. This means it has keys in the keypool or can generate new keys */
     virtual bool CanGetAddresses(bool internal = false) { return false; }
 
+    virtual bool HavePrivateKeys() const { return false; }
+
     virtual int64_t GetOldestKeyPoolTime() { return GetTime(); }
 
     virtual size_t KeypoolCountExternalKeys() { return 0; }
@@ -259,6 +261,8 @@ public:
 
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const override;
+
+    bool HavePrivateKeys() const override;
 
     int64_t GetOldestKeyPoolTime() override;
     size_t KeypoolCountExternalKeys() override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -157,6 +157,9 @@ public:
 
     virtual bool HavePrivateKeys() const { return false; }
 
+    //! The action to do when the DB needs rewrite
+    virtual void RewriteDB() {}
+
     virtual int64_t GetOldestKeyPoolTime() { return GetTime(); }
 
     virtual size_t KeypoolCountExternalKeys() { return 0; }
@@ -263,6 +266,8 @@ public:
     bool IsHDEnabled() const override;
 
     bool HavePrivateKeys() const override;
+
+    void RewriteDB() override;
 
     int64_t GetOldestKeyPoolTime() override;
     size_t KeypoolCountExternalKeys() override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -134,6 +134,7 @@ public:
     ScriptPubKeyMan(WalletStorage& storage) : m_storage(storage) {}
 
     virtual ~ScriptPubKeyMan() {};
+    virtual bool GetNewDestination(CTxDestination& dest, std::string& error) { return false; }
     virtual isminetype IsMine(const CScript& script) const { return ISMINE_NO; }
     virtual isminetype IsMine(const CTxDestination& dest) const { return ISMINE_NO; }
 
@@ -231,8 +232,7 @@ private:
     void ReturnKey(int64_t nIndex, bool fInternal, const CPubKey& pubkey);
 
 public:
-    bool GetNewDestination(const std::string label, CTxDestination& dest, std::string& error);
-
+    bool GetNewDestination(CTxDestination& dest, std::string& error) override;
     isminetype IsMine(const CScript& script) const override;
     isminetype IsMine(const CTxDestination& dest) const override;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -275,7 +275,7 @@ public:
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
-    bool LoadKey(const CKey& key, const CPubKey &pubkey) { return AddKeyPubKeyInner(key, pubkey); }
+    bool LoadKey(const CKey& key, const CPubKey &pubkey);
     //! Adds an encrypted key to the store, and saves it to disk.
     bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4533,7 +4533,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         if (gArgs.GetArg("-rescan", 0) != 2) {
             Optional<int64_t> time_first_key;
             if (auto spk_man = walletInstance->m_spk_man.get()) {
-                LOCK(walletInstance->cs_wallet);
+                LOCK(spk_man->cs_wallet);
                 int64_t time = spk_man->GetTimeFirstKey();
                 if (!time_first_key || time < *time_first_key) time_first_key = time;
             }
@@ -4568,9 +4568,9 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         walletInstance->WalletLogPrintf("setInternalKeyPool.size() = %u\n",   walletInstance->KeypoolCountInternalKeys());
         walletInstance->WalletLogPrintf("mapWallet.size() = %u\n",            walletInstance->mapWallet.size());
         walletInstance->WalletLogPrintf("mapAddressBook.size() = %u\n",       walletInstance->mapAddressBook.size());
-        {
-            LOCK(walletInstance->cs_wallet);
-            walletInstance->WalletLogPrintf("nTimeFirstKey = %u\n",               walletInstance->m_spk_man->GetTimeFirstKey());
+        if (auto spk_man = walletInstance->m_spk_man.get()) {
+            LOCK(spk_man->cs_wallet);
+            walletInstance->WalletLogPrintf("nTimeFirstKey = %u\n", spk_man->GetTimeFirstKey());
         }
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1586,15 +1586,20 @@ void CWallet::UnsetWalletFlag(uint64_t flag)
 {
     LOCK(cs_wallet);
     WalletBatch batch(*database);
-    UnsetWalletFlag(batch, flag);
+    UnsetWalletFlagWithDB(batch, flag);
 }
 
-void CWallet::UnsetWalletFlag(WalletBatch& batch, uint64_t flag)
+void CWallet::UnsetWalletFlagWithDB(WalletBatch& batch, uint64_t flag)
 {
     LOCK(cs_wallet);
     m_wallet_flags &= ~flag;
     if (!batch.WriteWalletFlags(m_wallet_flags))
         throw std::runtime_error(std::string(__func__) + ": writing wallet flags failed");
+}
+
+void CWallet::UnsetBlankWalletFlag(WalletBatch& batch)
+{
+    UnsetWalletFlagWithDB(batch, WALLET_FLAG_BLANK_WALLET);
 }
 
 bool CWallet::IsWalletFlagSet(uint64_t flag) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4533,6 +4533,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         if (gArgs.GetArg("-rescan", 0) != 2) {
             Optional<int64_t> time_first_key;
             if (auto spk_man = walletInstance->m_spk_man.get()) {
+                LOCK(walletInstance->cs_wallet);
                 int64_t time = spk_man->GetTimeFirstKey();
                 if (!time_first_key || time < *time_first_key) time_first_key = time;
             }
@@ -4567,7 +4568,10 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         walletInstance->WalletLogPrintf("setInternalKeyPool.size() = %u\n",   walletInstance->KeypoolCountInternalKeys());
         walletInstance->WalletLogPrintf("mapWallet.size() = %u\n",            walletInstance->mapWallet.size());
         walletInstance->WalletLogPrintf("mapAddressBook.size() = %u\n",       walletInstance->mapAddressBook.size());
-        walletInstance->WalletLogPrintf("nTimeFirstKey = %u\n",               walletInstance->m_spk_man->GetTimeFirstKey());
+        {
+            LOCK(walletInstance->cs_wallet);
+            walletInstance->WalletLogPrintf("nTimeFirstKey = %u\n",               walletInstance->m_spk_man->GetTimeFirstKey());
+        }
     }
 
     return walletInstance;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3567,13 +3567,10 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
     {
         if (database->Rewrite("\x04pool"))
         {
-            setInternalKeyPool.clear();
-            setExternalKeyPool.clear();
+            if (auto spk_man = m_spk_man.get()) {
+                spk_man->RewriteDB();
+            }
             nKeysLeftSinceAutoBackup = 0;
-            m_spk_man->m_pool_key_to_index.clear();
-            // Note: can't top-up keypool here, because wallet is locked.
-            // User will be prompted to unlock wallet the next operation
-            // that requires a new key.
         }
     }
 
@@ -3638,12 +3635,9 @@ DBErrors CWallet::ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256
     {
         if (database->Rewrite("\x04pool"))
         {
-            setInternalKeyPool.clear();
-            setExternalKeyPool.clear();
-            m_spk_man->m_pool_key_to_index.clear();
-            // Note: can't top-up keypool here, because wallet is locked.
-            // User will be prompted to unlock wallet the next operation
-            // that requires a new key.
+            if (auto spk_man = m_spk_man.get()) {
+                spk_man->RewriteDB();
+            }
         }
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -337,8 +337,6 @@ std::string COutput::ToString() const
     return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->tx->vout[i].nValue));
 }
 
-std::vector<CKeyID> GetAffectedKeys(const CScript& spk, const SigningProvider& provider);
-
 const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
 {
     LOCK(cs_wallet);
@@ -980,33 +978,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, CWalletTx::Co
             WalletBatch batch(*database);
             // loop though all outputs
             for (const CTxOut& txout: tx.vout) {
-                // extract addresses, check if they match with an unused keypool key, update metadata if needed
-                if (m_spk_man == nullptr) continue;
-                AssertLockHeld(m_spk_man->cs_wallet);
-                for (const auto& keyid : GetAffectedKeys(txout.scriptPubKey, *m_spk_man)) {
-                    std::map<CKeyID, int64_t>::const_iterator mi = m_spk_man->m_pool_key_to_index.find(keyid);
-                    if (mi != m_spk_man->m_pool_key_to_index.end()) {
-                        WalletLogPrintf("%s: Detected a used keypool key, mark all keypool key up to this key as used\n", __func__);
-                        MarkReserveKeysAsUsed(mi->second);
-
-                        if (!m_spk_man->TopUp()) {
-                            WalletLogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
-                        }
-                    }
-                    if (!confirm.hashBlock.IsNull()) {
-                        int64_t block_time;
-                        bool found_block = chain().findBlock(confirm.hashBlock, nullptr /* block */, &block_time);
-                        assert(found_block);
-                        if (mapKeyMetadata[keyid].nCreateTime > block_time) {
-                            WalletLogPrintf("%s: Found a key which appears to be used earlier than we expected, updating metadata\n", __func__);
-                            CPubKey vchPubKey;
-                            bool res = m_spk_man->GetPubKey(keyid, vchPubKey);
-                            assert(res); // this should never fail
-                            mapKeyMetadata[keyid].nCreateTime = block_time;
-                            batch.WriteKeyMetadata(mapKeyMetadata[keyid], vchPubKey, true);
-                            m_spk_man->UpdateTimeFirstKey(block_time);
-                        }
-                    }
+                if (auto spk_man = m_spk_man.get()) {
+                    spk_man->MarkUnusedAddresses(batch, txout.scriptPubKey, confirm.hashBlock);
                 }
             }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3719,6 +3719,17 @@ size_t CWallet::KeypoolCountInternalKeys()
     return count;
 }
 
+unsigned int CWallet::GetKeyPoolSize() const
+{
+    AssertLockHeld(cs_wallet);
+
+    unsigned int count = 0;
+    if (auto spk_man = m_spk_man.get()) {
+        count += spk_man->GetKeyPoolSize();
+    }
+    return count;
+}
+
 bool CWallet::TopUpKeyPool(unsigned int kpSize)
 {
     bool res = true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3743,12 +3743,17 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
 
 bool CWallet::GetNewDestination(const std::string label, CTxDestination& dest, std::string& error)
 {
+    LOCK(cs_wallet);
     error.clear();
     bool result = false;
     auto spk_man = m_spk_man.get();
     if (spk_man) {
-        result = spk_man->GetNewDestination(label, dest, error);
+        result = spk_man->GetNewDestination(dest, error);
     }
+    if (result) {
+        SetAddressBook(dest, label, "receive");
+    }
+
     return result;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4358,9 +4358,10 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         error = strprintf(_("Error loading %s: Private keys can only be disabled during creation"), walletFile);
         return NULL;
     } else if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-        LOCK(walletInstance->cs_KeyStore);
-        if (!walletInstance->mapKeys.empty() || !walletInstance->mapCryptedKeys.empty()) {
-            warnings.push_back(strprintf(_("Warning: Private keys detected in wallet {%s} with disabled private keys"), walletFile));
+        if (walletInstance->m_spk_man) {
+            if (walletInstance->m_spk_man->HavePrivateKeys()) {
+                warnings.push_back(strprintf(_("Warning: Private keys detected in wallet {%s} with disabled private keys"), walletFile));
+            }
         }
     }
     else if (gArgs.IsArgSet("-usehd")) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -350,10 +350,15 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
 
 void CWallet::UpgradeKeyMetadata()
 {
+    if (IsLocked() || IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA)) {
+        return;
+    }
+
     if (m_spk_man) {
         AssertLockHeld(m_spk_man->cs_wallet);
         m_spk_man->UpgradeKeyMetadata();
     }
+    SetWalletFlag(WALLET_FLAG_KEY_ORIGIN_METADATA);
 }
 
 bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1698,8 +1698,18 @@ bool CWallet::ImportScriptPubKeys(const std::string& label, const std::set<CScri
         return false;
     }
     AssertLockHeld(spk_man->cs_wallet);
-    if (!spk_man->ImportScriptPubKeys(label, script_pub_keys, have_solving_data, apply_label, timestamp)) {
+    if (!spk_man->ImportScriptPubKeys(script_pub_keys, have_solving_data, timestamp)) {
         return false;
+    }
+    if (apply_label) {
+        WalletBatch batch(*database);
+        for (const CScript& script : script_pub_keys) {
+            CTxDestination dest;
+            ExtractDestination(script, dest);
+            if (IsValidDestination(dest)) {
+                SetAddressBookWithDB(batch, dest, label, "receive");
+            }
+        }
     }
     return true;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1108,11 +1108,7 @@ public:
 
     bool DelAddressBook(const CTxDestination& address);
 
-    unsigned int GetKeyPoolSize() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
-    {
-        AssertLockHeld(cs_wallet);
-        return setInternalKeyPool.size() + setExternalKeyPool.size();
-    }
+    unsigned int GetKeyPoolSize() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! signify that a particular wallet feature is now used. this may change nWalletVersion and nWalletMaxVersion if those are lower
     void SetMinVersion(enum WalletFeature, WalletBatch* batch_in = nullptr, bool fExplicit = false) override;
@@ -1290,8 +1286,6 @@ public:
     LegacyScriptPubKeyMan::WatchKeyMap& mapWatchKeys GUARDED_BY(cs_KeyStore) = m_spk_man->mapWatchKeys;
     LegacyScriptPubKeyMan::HDPubKeyMap& mapHdPubKeys GUARDED_BY(cs_KeyStore) = m_spk_man->mapHdPubKeys;
     WalletBatch*& encrypted_batch GUARDED_BY(cs_wallet) = m_spk_man->encrypted_batch;
-    std::set<int64_t>& setInternalKeyPool GUARDED_BY(cs_wallet) = m_spk_man->setInternalKeyPool;
-    std::set<int64_t>& setExternalKeyPool GUARDED_BY(cs_wallet) = m_spk_man->setExternalKeyPool;
     int64_t& nTimeFirstKey GUARDED_BY(cs_wallet) = m_spk_man->nTimeFirstKey;
     std::map<CKeyID, CKeyMetadata>& mapKeyMetadata GUARDED_BY(cs_wallet) = m_spk_man->mapKeyMetadata;
     std::map<CScriptID, CKeyMetadata>& m_script_metadata GUARDED_BY(cs_wallet) = m_spk_man->m_script_metadata;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1229,7 +1229,7 @@ public:
     void BlockUntilSyncedToCurrentChain() LOCKS_EXCLUDED(cs_main, cs_wallet);
 
     /** set a single wallet flag */
-    void SetWalletFlag(uint64_t flags) override;
+    void SetWalletFlag(uint64_t flags);
 
     /** Unsets a single wallet flag */
     void UnsetWalletFlag(uint64_t flag);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -730,6 +730,14 @@ private:
 
     std::atomic<uint64_t> m_wallet_flags{0};
 
+    bool SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& address, const std::string& strName, const std::string& strPurpose);
+
+    //! Unsets a wallet flag and saves it to disk
+    void UnsetWalletFlagWithDB(WalletBatch& batch, uint64_t flag);
+
+    //! Unset the blank wallet flag and saves it to disk
+    void UnsetBlankWalletFlag(WalletBatch& batch) override;
+
     /** Interface for accessing chain state. */
     interfaces::Chain* m_chain;
 
@@ -1096,7 +1104,6 @@ public:
     void AutoLockMasternodeCollaterals();
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    bool SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& address, const std::string& strName, const std::string& strPurpose);
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
 
     bool DelAddressBook(const CTxDestination& address);
@@ -1233,7 +1240,6 @@ public:
 
     /** Unsets a single wallet flag */
     void UnsetWalletFlag(uint64_t flag);
-    void UnsetWalletFlag(WalletBatch& batch, uint64_t flag);
 
     /** check if a certain wallet flag is set */
     bool IsWalletFlagSet(uint64_t flag) const override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1286,9 +1286,6 @@ public:
     LegacyScriptPubKeyMan::WatchKeyMap& mapWatchKeys GUARDED_BY(cs_KeyStore) = m_spk_man->mapWatchKeys;
     LegacyScriptPubKeyMan::HDPubKeyMap& mapHdPubKeys GUARDED_BY(cs_KeyStore) = m_spk_man->mapHdPubKeys;
     WalletBatch*& encrypted_batch GUARDED_BY(cs_wallet) = m_spk_man->encrypted_batch;
-    int64_t& nTimeFirstKey GUARDED_BY(cs_wallet) = m_spk_man->nTimeFirstKey;
-    std::map<CKeyID, CKeyMetadata>& mapKeyMetadata GUARDED_BY(cs_wallet) = m_spk_man->mapKeyMetadata;
-    std::map<CScriptID, CKeyMetadata>& m_script_metadata GUARDED_BY(cs_wallet) = m_spk_man->m_script_metadata;
     using CryptedKeyMap = LegacyScriptPubKeyMan::CryptedKeyMap;
 };
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1295,7 +1295,6 @@ public:
     int64_t& nTimeFirstKey GUARDED_BY(cs_wallet) = m_spk_man->nTimeFirstKey;
     std::map<CKeyID, CKeyMetadata>& mapKeyMetadata GUARDED_BY(cs_wallet) = m_spk_man->mapKeyMetadata;
     std::map<CScriptID, CKeyMetadata>& m_script_metadata GUARDED_BY(cs_wallet) = m_spk_man->m_script_metadata;
-    void MarkReserveKeysAsUsed(int64_t keypool_id) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(m_spk_man->cs_wallet); m_spk_man->MarkReserveKeysAsUsed(keypool_id); }
     using CryptedKeyMap = LegacyScriptPubKeyMan::CryptedKeyMap;
 };
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
That is a next backport related to CWallet refactoring. It split to many commits (same as original pull request) for easier conflict resolving and code review, but should be squashed before merging. 

✔️ Merge bitcoin#16227: Refactor CWallet's inheritance chain
✔️ Merge bitcoin#17260: Split some CWallet functions into new LegacyScriptPubKeyMan
✔️  Merge bitcoin#17300: LegacyScriptPubKeyMan code cleanups
✔️  Merge bitcoin#16237: Have the wallet give out destinations instead of keys
✔️  Merge bitcoin#16301: Use CWallet::Import* functions in all import* RPCs
✔️  Merge bitcoin#16383: rpcwallet: default include_watchonly to true for watchonly wallets
✔️  Merge bitcoin#16798: Refactor rawtransaction_util's SignTransaction to separate prevtx parsing
✔️  Merge bitcoin#16900: doc: Fix doxygen comment for SignTransaction in rpc/rawtransaction_util
↻  Merge bitcoin#17304: refactor: Move many functions into LegacyScriptPubKeyMan and further separate it from CWallet
☐ Merge bitcoin#17381: LegacyScriptPubKeyMan code cleanups
☐ Merge bitcoin#17371: Refactor: Require scriptPubKey to get wallet SigningProvider
☐ Merge bitcoin#17237: wallet: LearnRelatedScripts only if KeepDestination
☐ Merge bitcoin#17373: wallet: Various fixes and cleanup to keypool handling in LegacyScriptPubKeyMan and CWallet
☐ Merge bitcoin#17369: Refactor: Move encryption code between KeyMan and Wallet
☐ Merge bitcoin#17537: wallet: Cleanup and move opportunistic and superfluous TopUp()
☐ Merge bitcoin#17677: Activate watchonly wallet behavior for LegacySPKM only
☐ Merge bitcoin#17924: Bug: IsUsedDestination shouldn't use key id as script id for ScriptHash
☐ Merge bitcoin#17261: Make ScriptPubKeyMan an actual interface and the wallet to have multiple
☐ Merge bitcoin#18026: psbt_wallet_tests: use unique_ptr for GetSigningProvider
☐ Merge bitcoin#18067: wallet: Improve LegacyScriptPubKeyMan::CanProvide script recognition
☐ Merge bitcoin#18193: scripted-diff: Wallet: Rename incorrectly named *UsedDestination

Therefore 2 commits are skipped because code is not relevant:
 - 8b0d82bb428de9e7f1da7c61574e7a8376a62d43 Refactor: Move Upgrade code out of CWallet::CreateWalletFromFile
 - 0eac7088ab878372a72f85f9c5f7662a14199083 Refactor: Move SetupGeneration code out of CWallet

-------------------
commit bbc9e4133cc5e2c970a557f7c2368e04911aec43
Merge: fba574c90 152b0a00d
Author: Wladimir J. van der Laan <laanwj@protonmail.com>
Date:   Mon Nov 4 16:01:30 2019 +0100

    Merge #17304: refactor: Move many functions into LegacyScriptPubKeyMan and further separate it from CWallet
    
    152b0a00d8e681dd098f6b548447b82ab54ebe3c Refactor: Move nTimeFirstKey accesses out of CWallet (Andrew Chow)
    7ef47b88e67718766c92d23973742d08436176e0 Refactor: Move GetKeypoolSize code out of CWallet (Andrew Chow)
    089e17d45c8147bd0303bcbf02dc0f7d6b387f2a Refactor: Move RewriteDB code out of CWallet (Andrew Chow)
    0eac7088ab878372a72f85f9c5f7662a14199083 Refactor: Move SetupGeneration code out of CWallet (Andrew Chow)
    f45d12b36cee05aa3c2685b951d27bd8a58539ae Refactor: Move HavePrivateKeys code out of CWallet::CreateWalletFromFile (Andrew Chow)
    8b0d82bb428de9e7f1da7c61574e7a8376a62d43 Refactor: Move Upgrade code out of CWallet::CreateWalletFromFile (Andrew Chow)
    46865ec958b6b9bde04a827de598975f14bdb5e7 Refactor: Move MarkUnusedAddresses code out of CWallet::AddToWalletIfInvolvingMe (Andrew Chow)
    a18edd7b383d667b15b6d4b87aa3a055a9fa5051 Refactor: Move GetMetadata code out of getaddressinfo (Andrew Chow)
    9716bbe0f8081814cbf052e8211d1c6a838e5262 Refactor: Move LoadKey LegacyScriptPubKeyMan method definition (Andrew Chow)
    67be6b9e213da1fd7b2e8438c445c5a64092e831 Refactor: Move SetAddressBookWithDB call out of LegacyScriptPubKeyMan::ImportScriptPubKeys (Andrew Chow)
    fc2867fdf50f47e5ad5f43445e500e3a477a8074 refactor: Replace UnsetWalletFlagWithDB with UnsetBlankWalletFlag in ScriptPubKeyMan (Andrew Chow)
    78e7cbc7ba5938ab2ae6347141ca793a8fc09853 Refactor: Remove UnsetWalletFlag call from LegacyScriptPubKeyMan::SetHDSeed (Andrew Chow)
    0391aba52dcc33613295fd6099c804ac7134b063 Remove SetWalletFlag from WalletStorage (Andrew Chow)
    4c5491f99c6b8ca779c48be63eb2ba18d98ee52a Refactor: Move SetWalletFlag out of LegacyScriptPubKeyMan::UpgradeKeyMetadata (Andrew Chow)
    769acef85730a6c0e2f5603fbd673b176c2d34d0 Refactor: Move SetAddressBook call out of LegacyScriptPubKeyMan::GetNewDestination (Andrew Chow)
    acedc5b8230ed9ad07f96f51f0ef862ab3a41d5e Refactor: Add new ScriptPubKeyMan virtual methods (Andrew Chow)
    533d8b364f4e589aa1acb28cdea5e6e6e80d34dc Refactor: Declare LegacyScriptPubKeyMan methods as virtual (Andrew Chow)
    b4cb18bce3c9a6adab2fa32f3dad4ad966b33be0 MOVEONLY: Reorder LegacyScriptPubKeyMan methods (Andrew Chow)
    
    Pull request description:
    
      Moves several more key management and metadata functions into LegacyScriptPubKeyMan from CWallet to further separate the two.
    
      Note to reviewers: All of the `if (auto spk_man = walletInstance->m_spk_man.get()) {` blocks will be replaced with for loops in the next PR so you may see some things in those blocks that don't necessarily make sense with an `if` but will with a `for`.


## How Has This Been Tested?
By running unit/functional tests.

Please, pay extra attention during code review to these 4 snippet:
 
- should this method has  `EXCLUSIVE_LOCKS_REQUIRED` or not? bitcoin does not have
(even some other methods do)
```
int64_t GetTimeFirstKey() const override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
```

 - Please, help to check method  
```
LegacyScriptPubKeyMan::MarkUnusedAddresses
```
Code seems correct, but I am not sure that is it right place to do it (code with bitcoin slightly different here)

- Why method 'CWallet::ZapSelectTx` doesn't have this line?
```
    nKeysLeftSinceAutoBackup = 0;
```
Seems as it was missing in past but I am not 100% sure. Can anyone confirm it?



## Breaking Changes
Seems compatible, should be none as underlying backport is a "refactor"


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
