### PR TITLE
Fix #4994

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -204,7 +204,7 @@ public:
 
     size_t GetValidMNsCount() const
     {
-        return ranges::count_if(mnMap, [](const auto& p){ return IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [&](const auto& p){ return IsMNValid(*p.second); });
     }
 
     /**


### PR DESCRIPTION
Fix #4994 , error: `this' was not captured for this lambda function

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
