### PR TITLE
fix(build): Fix incorrect type conversion

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -133,10 +133,10 @@ private:
 
     static constexpr std::byte to_byte(const Flag flag)
     {
-        return std::byte{flag};
+        return static_cast<std::byte>(flag);
     }
 
-    static constexpr std::byte VERSION_BIT_MASK = std::byte{Flag::VERSION_BIT_0} | std::byte{Flag::VERSION_BIT_1} | std::byte{Flag::VERSION_BIT_2};
+    static constexpr std::byte VERSION_BIT_MASK = static_cast<std::byte>(Flag::VERSION_BIT_0) | static_cast<std::byte>(Flag::VERSION_BIT_1) | static_cast<std::byte>(Flag::VERSION_BIT_2);
 };
 
 struct CompressibleBlockHeader : CBlockHeader {


### PR DESCRIPTION
It's incorrect to convert between different `enum` classes using initialisation.
However, it's OK to convert between different `enum` classes using the same underlying type using `static_cast`.

## Issue being fixed or feature implemented
Compilation failure with GCC 12.

## What was done?
Fixed incorrect type conversion.


## How Has This Been Tested?
Successfully built packages for Fedora 36 using GCC 12.
https://obs.infoserver.lv/project/monitor/cryptocurrency

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
