### PR TITLE
fix(gui): Fix crashes when trying to run `dash-qt` with `--disablewallet`

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1343,8 +1343,10 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QStri
     // Disabling macOS App Nap on initial sync, disk, reindex operations and mixing.
     bool disableAppNap = !m_node.masternodeSync().isSynced();
 #ifdef ENABLE_WALLET
-    for (const auto& wallet : m_node.walletClient().getWallets()) {
-        disableAppNap |= wallet->coinJoin().isMixing();
+    if (walletFrame != nullptr) {
+        for (const auto& wallet : m_node.walletClient().getWallets()) {
+            disableAppNap |= wallet->coinJoin().isMixing();
+        }
     }
 #endif // ENABLE_WALLET
     if (disableAppNap) {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1343,7 +1343,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QStri
     // Disabling macOS App Nap on initial sync, disk, reindex operations and mixing.
     bool disableAppNap = !m_node.masternodeSync().isSynced();
 #ifdef ENABLE_WALLET
-    if (walletFrame != nullptr) {
+    if (enableWallet) {
         for (const auto& wallet : m_node.walletClient().getWallets()) {
             disableAppNap |= wallet->coinJoin().isMixing();
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fix crashes when trying to run `dash-qt` with `--disablewallet`

## What was done?

## How Has This Been Tested?
run `dash-qt --disablewallet`

## Breaking Changes
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
