### PR TITLE
backport: partial bitcoin#23819 ConnectBlock: don't serialize block hash twice

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1978,7 +1978,10 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     AssertLockHeld(cs_main);
     assert(pindex);
-    assert(*pindex->phashBlock == block.GetHash());
+
+    uint256 block_hash{block.GetHash()};
+    assert(*pindex->phashBlock == block_hash);
+
     assert(m_clhandler);
     assert(m_isman);
     assert(m_quorum_block_processor);
@@ -2026,7 +2029,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     // Special case for the genesis block, skipping connection of its transactions
     // (its coinbase is unspendable)
-    if (block.GetHash() == chainparams.GetConsensus().hashGenesisBlock) {
+    if (block_hash == chainparams.GetConsensus().hashGenesisBlock) {
         if (!fJustCheck)
             view.SetBestBlock(pindex->GetBlockHash());
         return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2105,7 +2105,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     // make sure old budget is the real one
     if (pindex->nHeight == chainparams.GetConsensus().nSuperblockStartBlock &&
         chainparams.GetConsensus().nSuperblockStartHash != uint256() &&
-        block.GetHash() != chainparams.GetConsensus().nSuperblockStartHash) {
+        block_hash != chainparams.GetConsensus().nSuperblockStartHash) {
             return state.Invalid(ValidationInvalidReason::CONSENSUS, error("ConnectBlock(): invalid superblock start"), REJECT_INVALID, "bad-sb-start");
     }
     /// END DASH


### PR DESCRIPTION
Backports (bitcoin#23819) a simple block hash re-use to save a bunch of CPU cycles in ConnectBlock(), especially useful given X11's computational cost, re-use was applied to Dash-specific ontop of the original [commit by jb55](https://github.com/bitcoin/bitcoin/pull/23819/commits/80e1c55687aae61767f1ade0826746cda00d6a24).