### PR TITLE
refactor/fix: use the shared_ptr<CWallet> where possible instead of getting the underlying pointer

### DIFF
--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -34,7 +34,6 @@ static UniValue coinjoin(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
 
     if (fMasternodeMode)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Client-side mixing is not supported on masternodes");
@@ -50,12 +49,12 @@ static UniValue coinjoin(const JSONRPCRequest& request)
         }
     }
 
-    auto it = coinJoinClientManagers.find(pwallet->GetName());
+    auto it = coinJoinClientManagers.find(wallet->GetName());
 
     if (request.params[0].get_str() == "start") {
         {
-            LOCK(pwallet->cs_wallet);
-            if (pwallet->IsLocked(true))
+            LOCK(wallet->cs_wallet);
+            if (wallet->IsLocked(true))
                 throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please unlock wallet for mixing with walletpassphrase first.");
         }
 
@@ -156,15 +155,14 @@ static UniValue getcoinjoininfo(const JSONRPCRequest& request)
     obj.pushKV("queue_size", coinJoinClientQueueManager->GetQueueSize());
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    CWallet* const pwallet = wallet.get();
-    if (!pwallet) {
+    if (!wallet) {
         return obj;
     }
 
-    coinJoinClientManagers.at(pwallet->GetName())->GetJsonInfo(obj);
+    coinJoinClientManagers.at(wallet->GetName())->GetJsonInfo(obj);
 
-    obj.pushKV("keys_left",     pwallet->nKeysLeftSinceAutoBackup);
-    obj.pushKV("warnings",      pwallet->nKeysLeftSinceAutoBackup < COINJOIN_KEYS_THRESHOLD_WARNING
+    obj.pushKV("keys_left",     wallet->nKeysLeftSinceAutoBackup);
+    obj.pushKV("warnings",      wallet->nKeysLeftSinceAutoBackup < COINJOIN_KEYS_THRESHOLD_WARNING
                                         ? "WARNING: keypool is almost depleted!" : "");
 #endif // ENABLE_WALLET
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -196,15 +196,14 @@ static UniValue masternode_outputs(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
 
     // Find possible candidates
     std::vector<COutput> vPossibleCoins;
     CCoinControl coin_control;
     coin_control.nCoinType = CoinType::ONLY_MASTERNODE_COLLATERAL;
     {
-        LOCK(pwallet->cs_wallet);
-        pwallet->AvailableCoins(vPossibleCoins, true, &coin_control);
+        LOCK(wallet->cs_wallet);
+        wallet->AvailableCoins(vPossibleCoins, true, &coin_control);
     }
     UniValue outputsArr(UniValue::VARR);
     for (const auto& out : vPossibleCoins) {

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -194,7 +194,7 @@ static void FundSpecialTx(CWallet* pwallet, CMutableTransaction& tx, const Speci
     ds << payload;
     tx.vExtraPayload.assign(ds.begin(), ds.end());
 
-    static CTxOut dummyTxOut(0, CScript() << OP_RETURN);
+    static const CTxOut dummyTxOut(0, CScript() << OP_RETURN);
     std::vector<CRecipient> vecSend;
     bool dummyTxOutAdded = false;
 
@@ -446,10 +446,9 @@ static UniValue protx_register(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
 
     if (isExternalRegister || isFundRegister) {
-        EnsureWalletIsUnlocked(pwallet);
+        EnsureWalletIsUnlocked(wallet.get());
     }
 
     size_t paramIdx = 0;
@@ -485,8 +484,8 @@ static UniValue protx_register(const JSONRPCRequest& request)
         paramIdx += 2;
 
         // TODO unlock on failure
-        LOCK(pwallet->cs_wallet);
-        pwallet->LockCoin(ptx.collateralOutpoint);
+        LOCK(wallet->cs_wallet);
+        wallet->LockCoin(ptx.collateralOutpoint);
     }
 
     if (request.params[paramIdx].get_str() != "") {
@@ -533,7 +532,7 @@ static UniValue protx_register(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Dash address: ") + request.params[paramIdx + 6].get_str());
     }
 
-    FundSpecialTx(pwallet, tx, ptx, fundDest);
+    FundSpecialTx(wallet.get(), tx, ptx, fundDest);
     UpdateSpecialTxInputsHash(tx, ptx);
 
     bool fSubmit{true};
@@ -580,7 +579,7 @@ static UniValue protx_register(const JSONRPCRequest& request)
             return ret;
         } else {
             // lets prove we own the collateral
-            LegacyScriptPubKeyMan* spk_man = pwallet->GetLegacyScriptPubKeyMan();
+            LegacyScriptPubKeyMan* spk_man = wallet->GetLegacyScriptPubKeyMan();
             if (!spk_man) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "This type of wallet does not support this command");
             }
@@ -602,9 +601,8 @@ static UniValue protx_register_submit(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
 
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(wallet.get());
 
     CMutableTransaction tx;
     if (!DecodeHexTx(tx, request.params[0].get_str())) {
@@ -656,9 +654,8 @@ static UniValue protx_update_service(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
 
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(wallet.get());
 
     CProUpServTx ptx;
     ptx.nVersion = CProUpServTx::CURRENT_VERSION;
@@ -715,7 +712,7 @@ static UniValue protx_update_service(const JSONRPCRequest& request)
         }
     }
 
-    FundSpecialTx(pwallet, tx, ptx, feeSource);
+    FundSpecialTx(wallet.get(), tx, ptx, feeSource);
 
     SignSpecialTxPayloadByHash(tx, ptx, keyOperator);
     SetTxPayload(tx, ptx);
@@ -752,9 +749,8 @@ static UniValue protx_update_registrar(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
 
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(wallet.get());
 
     CProUpRegTx ptx;
     ptx.nVersion = CProUpRegTx::CURRENT_VERSION;
@@ -785,7 +781,7 @@ static UniValue protx_update_registrar(const JSONRPCRequest& request)
         ptx.scriptPayout = GetScriptForDestination(payoutDest);
     }
 
-    LegacyScriptPubKeyMan* spk_man = pwallet->GetLegacyScriptPubKeyMan();
+    LegacyScriptPubKeyMan* spk_man = wallet->GetLegacyScriptPubKeyMan();
     if (!spk_man) {
         throw JSONRPCError(RPC_WALLET_ERROR, "This type of wallet does not support this command");
     }
@@ -809,7 +805,7 @@ static UniValue protx_update_registrar(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Dash address: ") + request.params[4].get_str());
     }
 
-    FundSpecialTx(pwallet, tx, ptx, feeSourceDest);
+    FundSpecialTx(wallet.get(), tx, ptx, feeSourceDest);
     SignSpecialTxPayloadByHash(tx, ptx, keyOwner);
     SetTxPayload(tx, ptx);
 
@@ -845,9 +841,8 @@ static UniValue protx_revoke(const JSONRPCRequest& request)
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
 
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(wallet.get());
 
     CProUpRevTx ptx;
     ptx.nVersion = CProUpRevTx::CURRENT_VERSION;
@@ -880,17 +875,17 @@ static UniValue protx_revoke(const JSONRPCRequest& request)
         CTxDestination feeSourceDest = DecodeDestination(request.params[3].get_str());
         if (!IsValidDestination(feeSourceDest))
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Dash address: ") + request.params[3].get_str());
-        FundSpecialTx(pwallet, tx, ptx, feeSourceDest);
+        FundSpecialTx(wallet.get(), tx, ptx, feeSourceDest);
     } else if (dmn->pdmnState->scriptOperatorPayout != CScript()) {
         // Using funds from previousely specified operator payout address
         CTxDestination txDest;
         ExtractDestination(dmn->pdmnState->scriptOperatorPayout, txDest);
-        FundSpecialTx(pwallet, tx, ptx, txDest);
+        FundSpecialTx(wallet.get(), tx, ptx, txDest);
     } else if (dmn->pdmnState->scriptPayout != CScript()) {
         // Using funds from previousely specified masternode payout address
         CTxDestination txDest;
         ExtractDestination(dmn->pdmnState->scriptPayout, txDest);
-        FundSpecialTx(pwallet, tx, ptx, txDest);
+        FundSpecialTx(wallet.get(), tx, ptx, txDest);
     } else {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No payout or fee source addresses found, can't revoke");
     }
@@ -1002,16 +997,13 @@ static UniValue protx_list(const JSONRPCRequest& request)
 {
     protx_list_help(request);
 
-    CWallet* pwallet;
+    std::shared_ptr<CWallet> wallet{nullptr};
 #ifdef ENABLE_WALLET
     try {
-        std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-        pwallet = wallet.get();
+        wallet = GetWalletForJSONRPCRequest(request);
     } catch (...) {
-        pwallet = nullptr;
+        wallet = nullptr;
     }
-#else
-    pwallet = nullptr;
 #endif
 
     std::string type = "registered";
@@ -1026,11 +1018,11 @@ static UniValue protx_list(const JSONRPCRequest& request)
     }
 
     if (type == "wallet") {
-        if (!pwallet) {
+        if (!wallet) {
             throw std::runtime_error("\"protx list wallet\" not supported when wallet is disabled");
         }
 #ifdef ENABLE_WALLET
-        LOCK2(pwallet->cs_wallet, cs_main);
+        LOCK2(wallet->cs_wallet, cs_main);
 
         if (request.params.size() > 4) {
             protx_list_help(request);
@@ -1044,7 +1036,7 @@ static UniValue protx_list(const JSONRPCRequest& request)
         }
 
         std::vector<COutPoint> vOutpts;
-        pwallet->ListProTxCoins(vOutpts);
+        wallet->ListProTxCoins(vOutpts);
         std::set<COutPoint> setOutpts;
         for (const auto& outpt : vOutpts) {
             setOutpts.emplace(outpt);
@@ -1053,11 +1045,11 @@ static UniValue protx_list(const JSONRPCRequest& request)
         CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(::ChainActive()[height]);
         mnList.ForEachMN(false, [&](const auto& dmn) {
             if (setOutpts.count(dmn.collateralOutpoint) ||
-                CheckWalletOwnsKey(pwallet, dmn.pdmnState->keyIDOwner) ||
-                CheckWalletOwnsKey(pwallet, dmn.pdmnState->keyIDVoting) ||
-                CheckWalletOwnsScript(pwallet, dmn.pdmnState->scriptPayout) ||
-                CheckWalletOwnsScript(pwallet, dmn.pdmnState->scriptOperatorPayout)) {
-                ret.push_back(BuildDMNListEntry(pwallet, dmn, detailed));
+                CheckWalletOwnsKey(wallet.get(), dmn.pdmnState->keyIDOwner) ||
+                CheckWalletOwnsKey(wallet.get(), dmn.pdmnState->keyIDVoting) ||
+                CheckWalletOwnsScript(wallet.get(), dmn.pdmnState->scriptPayout) ||
+                CheckWalletOwnsScript(wallet.get(), dmn.pdmnState->scriptOperatorPayout)) {
+                ret.push_back(BuildDMNListEntry(wallet.get(), dmn, detailed));
             }
         });
 #endif
@@ -1078,7 +1070,7 @@ static UniValue protx_list(const JSONRPCRequest& request)
         CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(::ChainActive()[height]);
         bool onlyValid = type == "valid";
         mnList.ForEachMN(onlyValid, [&](const auto& dmn) {
-            ret.push_back(BuildDMNListEntry(pwallet, dmn, detailed));
+            ret.push_back(BuildDMNListEntry(wallet.get(), dmn, detailed));
         });
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid type specified");
@@ -1110,16 +1102,13 @@ static UniValue protx_info(const JSONRPCRequest& request)
 {
     protx_info_help(request);
 
-    CWallet* pwallet;
+    std::shared_ptr<CWallet> wallet{nullptr};
 #ifdef ENABLE_WALLET
     try {
-        std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-        pwallet = wallet.get();
+        wallet = GetWalletForJSONRPCRequest(request);
     } catch (...) {
-        pwallet = nullptr;
+        wallet = nullptr;
     }
-#else
-    pwallet = nullptr;
 #endif
 
     if (g_txindex) {
@@ -1132,7 +1121,7 @@ static UniValue protx_info(const JSONRPCRequest& request)
     if (!dmn) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s not found", proTxHash.ToString()));
     }
-    return BuildDMNListEntry(pwallet, *dmn, true);
+    return BuildDMNListEntry(wallet.get(), *dmn, true);
 }
 
 static void protx_diff_help(const JSONRPCRequest& request)

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1002,7 +1002,6 @@ static UniValue protx_list(const JSONRPCRequest& request)
     try {
         wallet = GetWalletForJSONRPCRequest(request);
     } catch (...) {
-        wallet = nullptr;
     }
 #endif
 
@@ -1107,7 +1106,6 @@ static UniValue protx_info(const JSONRPCRequest& request)
     try {
         wallet = GetWalletForJSONRPCRequest(request);
     } catch (...) {
-        wallet = nullptr;
     }
 #endif
 


### PR DESCRIPTION
This is also a fix in regards to the rpcevo.cpp file where the old code could result in a dangling pointer that could result in a crash as the shared_ptr we get back is discarded while the underlying ptr is still being used

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
No point to create a new variable for the raw ptr when we have the shared_ptr here. 

Also there is a potential crash due to an invalidated raw pointer along the same line

## What was done?
<!--- Describe your changes in detail -->
use the shared_ptr instead of raw, and resolve the lifetime issues

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
compiling / make check

## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->
no

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
