### PR TITLE
fix: make masternodeSync available as early as possible

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1791,6 +1791,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     ::governance = std::make_unique<CGovernanceManager>();
     assert(!::sporkManager);
     ::sporkManager = std::make_unique<CSporkManager>();
+    ::masternodeSync = std::make_unique<CMasternodeSync>(*node.connman);
 
     std::vector<std::string> vSporkAddresses;
     if (args.IsArgSet("-sporkaddr")) {
@@ -2316,7 +2317,6 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     // ********************************************************* Step 10a: Setup CoinJoin
 
-    ::masternodeSync = std::make_unique<CMasternodeSync>(*node.connman);
     ::coinJoinServer = std::make_unique<CCoinJoinServer>(*node.connman);
 #ifdef ENABLE_WALLET
     ::coinJoinClientQueueManager = std::make_unique<CCoinJoinClientQueueManager>(*node.connman);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes some random crash loops, in my case it started to crash on each run with
```
   0#: (0x5569A2415AF1) stl_vector.h:601    - std::vector<unsigned long, std::allocator<unsigned long> >::operator=(std::vector<unsigned long, std::allocator<unsigned long> >&&)
   1#: (0x5569A2415AF1) stacktraces.cpp:780 - HandlePosixSignal
   2#: (0x7F6159B01980) <unknown-file>      - ???
   3#: (0x5569A22237EF) atomic_base.h:396   - std::__atomic_base<int>::load(std::memory_order) const
   4#: (0x5569A22237EF) atomic_base.h:259   - std::__atomic_base<int>::operator int() const
   5#: (0x5569A22237EF) sync.h:59           - CMasternodeSync::IsSynced() const
   6#: (0x5569A22237EF) payments.cpp:123    - IsBlockValueValid(CSporkManager const&, CGovernanceManager&, CBlock const&, int, long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)
   7#: (0x5569A20C089E) validation.cpp:2360 - CChainState::ConnectBlock(CBlock const&, CValidationState&, CBlockIndex*, CCoinsViewCache&, CChainParams const&, bool)
   8#: (0x5569A20D2846) validation.cpp:4740 - CVerifyDB::VerifyDB(CChainParams const&, CCoinsView*, int, int)
   9#: (0x5569A1D5432F) basic_string.h:211  - std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_is_local() const
  10#: (0x5569A1D5432F) basic_string.h:220  - std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()
  11#: (0x5569A1D5432F) basic_string.h:657  - std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string()
  12#: (0x5569A1D5432F) init.cpp:2197       - AppInitMain(std::variant<std::nullopt_t, std::reference_wrapper<NodeContext>, std::reference_wrapper<WalletContext>, std::reference_wrapper<CTxMemPool>, std::reference_wrapper<ChainstateManager> > const&, NodeContext&, interfaces::BlockAndHeaderTipInfo*)
  13#: (0x5569A1D30A0D) bitcoind.cpp:153    - AppInit
  14#: (0x5569A1D21E2D) bitcoind.cpp:183    - main
  15#: (0x7F6158F61C87) <unknown-file>      - ???
  16#: (0x5569A1D2FE0A) <unknown-file>      - ???
```
## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
dashd started to crash on each run. This patch fixed it.

## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
