### PR TITLE
fix: params cleanup in `pow_tests/get_next_work`

### DIFF
--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -121,6 +121,7 @@ BOOST_AUTO_TEST_CASE(get_next_work)
     // test special rules for slow blocks on devnet/testnet
     gArgs.SoftSetBoolArg("-devnet", true);
     const auto chainParamsDev = CreateChainParams(CBaseChainParams::DEVNET);
+    gArgs.ForceRemoveArg("devnet");
 
     // make sure normal rules apply
     blockHeader.nTime = 1408732505; // Block #123457


### PR DESCRIPTION
## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid leaking `devnet` param into other tests.

https://gitlab.com/UdjinM6/dash/-/jobs/3221459032#L3035: note lots of `Error: -port must be specified when -devnet and -listen are specified`

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
0aa5dc0251 https://gitlab.com/UdjinM6/dash/-/jobs/3247713299

## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
