### PR TITLE
fix(rpc): Fix non-fatal check in `generateblock`

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -372,7 +372,8 @@ static UniValue generateblock(const JSONRPCRequest& request)
         block = blocktemplate->block;
     }
 
-    CHECK_NONFATAL(block.vtx.size() == 1);
+    // 1 coinbase + could have a few quorum commitments
+    CHECK_NONFATAL(block.vtx.size() >= 1);
 
     // Add transactions
     block.vtx.insert(block.vtx.end(), txs.begin(), txs.end());


### PR DESCRIPTION
## Issue being fixed or feature implemented
`generateblock` was not aware of Dash-specific txes
```
rpc/mining.cpp:375 (generateblock)
Internal bug detected: 'block.vtx.size() == 1'
```

👍 to @strophy for finding it

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
