### PR TITLE
fix: built of dashbls for glibc v2.35

### DIFF
--- a/src/dashbls/src/test.cpp
+++ b/src/dashbls/src/test.cpp
@@ -17,6 +17,9 @@
 #include <thread>
 
 #include "bls.hpp"
+
+// the define `MINSIGSTKSZ` is not a const since glibc v2.35
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #include <catch2/catch.hpp>
 
 extern "C" {


### PR DESCRIPTION
## Issue being fixed or feature implemented
That's a fix for build subproject dashbls for glibc v2.35.
Alternate solution to update `catch2` library to version 2.13.5 or newer: https://github.com/catchorg/Catch2/blob/devel/docs/release-notes.md#2135


## What was done?
Added new define to use static value instead.

## How Has This Been Tested?
Built + run unit tests in problem environment.

## Breaking Changes
no breaking changes.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
