### PR TITLE
fix: read item out of array `blockinfo` in miner tests

### DIFF
--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -88,6 +88,7 @@ constexpr static struct {
     {0, 0x40045af7}, {0, 0x6000df7a}, {0, 0xe00131a1}, {0, 0x40021386},
     {0, 0xa00891b5}, {0, 0x60007854}, {0, 0x60021730}
 };
+constexpr static size_t blockinfo_size = sizeof(blockinfo) / sizeof(blockinfo[0]);
 
 static CBlockIndex CreateBlockIndex(int nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
@@ -230,7 +231,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     std::vector<CTransactionRef> txFirst;
 
     auto createAndProcessEmptyBlock = [&]() {
-        int i = ::ChainActive().Height();
+        int i = ::ChainActive().Height() % blockinfo_size;
         CBlock *pblock = &pemptyblocktemplate->block; // pointer for convenience
         {
             LOCK(cs_main);


### PR DESCRIPTION
This array contains 119 items and all of them are used. But during test created one extra block that also need `blockinfo`. 

## Issue being fixed or feature implemented
It is UB and it triggers an address sanitizer.


## What was done?
Elements of `blockinfo` are re-used for extra blocks.

## How Has This Been Tested?
Run unit tests with sanitizers.

## Breaking Changes
no breaking changes

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
