### PR TITLE
fix(consensus)!: Rotation member computation fix

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -258,6 +258,9 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
 
     for (auto i = 0; i < nQuorums; ++i) {
         for (const auto& mn : previousQuarters.quarterHMinusC[i]) {
+            if (!allMns.HasMN(mn->proTxHash)) {
+                continue;
+            }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {
                 continue;
             }
@@ -271,6 +274,9 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
             }
         }
         for (const auto& mn : previousQuarters.quarterHMinus2C[i]) {
+            if (!allMns.HasMN(mn->proTxHash)) {
+                continue;
+            }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {
                 continue;
             }
@@ -284,6 +290,9 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
             }
         }
         for (const auto& mn : previousQuarters.quarterHMinus3C[i]) {
+            if (!allMns.HasMN(mn->proTxHash)) {
+                continue;
+            }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {
                 continue;
             }
@@ -323,7 +332,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
             ss << m->proTxHash.ToString().substr(0, 4) << "|";
         }
         ss << "]";
-        LogPrint(BCLog::LLMQ, "BuildNewQuorumQuarterMembers h[%d] sortedCombinedMnsList[%s]\n",
+        LogPrint(BCLog::LLMQ, "BuildNewQuorumQuarterMembers h[%d] sortedCombinedMns[%s]\n",
                  pQuorumBaseBlockIndex->nHeight, ss.str());
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When one or more masternodes spend their collaterals between two rotation cycle, then they need to be removed when filling the sorted combined list (See https://github.com/dashpay/dips/blob/master/dip-0024.md#changes-to-the-initialization-phase).

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
