### PR TITLE
fix(consensus)!: avoid using the same mn twice in one indexed quorum

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -332,10 +332,21 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
     auto idx = 0;
     for (auto i = 0; i < nQuorums; ++i) {
         auto usedMNsCount = MnsUsedAtHIndexed[i].GetAllMNsCount();
+        auto updated{false};
+        auto initial_loop_idx = idx;
         while (quarterQuorumMembers[i].size() < quarterSize && (usedMNsCount + quarterQuorumMembers[i].size() < sortedCombinedMnsList.size())) {
+            bool skip{true};
             if (!MnsUsedAtHIndexed[i].HasMN(sortedCombinedMnsList[idx]->proTxHash)) {
-                quarterQuorumMembers[i].push_back(sortedCombinedMnsList[idx]);
-            } else {
+                try {
+                    // NOTE: AddMN is the one that can throw exceptions, must be exicuted first
+                    MnsUsedAtHIndexed[i].AddMN(sortedCombinedMnsList[idx]);
+                    quarterQuorumMembers[i].push_back(sortedCombinedMnsList[idx]);
+                    updated = true;
+                    skip = false;
+                } catch (const std::runtime_error& e) {
+                }
+            }
+            if (skip) {
                 if (firstSkippedIndex == 0) {
                     firstSkippedIndex = idx;
                     skipList.push_back(idx);
@@ -345,6 +356,15 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
             }
             if (++idx == sortedCombinedMnsList.size()) {
                 idx = 0;
+            }
+            if (idx == initial_loop_idx) {
+                // we made full "while" loop
+                if (!updated) {
+                    // there are not enough MNs, there is nothing we can do here
+                    return std::vector<std::vector<CDeterministicMNCPtr>>(nQuorums);
+                }
+                // reset and try again
+                updated = false;
             }
         }
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
On small networks we might loop multiple times over the list of available masternodes and add the same masternode to the same indexed quorum twice. This results in a PoSe punishment/banning because such masternode will become a "schrodinger" one 😄  - both valid and invalid member (with different indexes in the `members` list).

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
I reindexed both testnet and mainnet with this patch.

## Breaking Changes
Testnet forks at 813663, 000000575c6605c5b889b3d3afe6d74c2de0955a64eb4b38d2fc8b1141256f8a. The last correct block is 813662, 0000015fd00c8ab72954727adeed0a2a163de6154d75da30d74104b4fe0d866e.

Mainnet is fine because masternode list is large enough to never hit this edge case.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
