### PR TITLE
fix(tests): adjust nonce in blockinfo to make tests faster

### DIFF
--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -86,7 +86,7 @@ constexpr static struct {
     {0, 0x4000b6b6}, {0, 0x6000ea25}, {0, 0x400989d9}, {0, 0xc000877f},
     {0, 0x6000d17c}, {0, 0xc0009228}, {0, 0x4002827f}, {0, 0x80056a85},
     {0, 0x40045af7}, {0, 0x6000df7a}, {0, 0xe00131a1}, {0, 0x40021386},
-    {0, 0xa00891b5}, {0, 0x60007854}, {0, 0x60021730}
+    {0, 0xa00891b5}, {0, 0x60007854}, {0, 0x602cee70}
 };
 
 static CBlockIndex CreateBlockIndex(int nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Makes `miner_tests` ~60 seconds faster on my machine

## What was done?
Set correct nonce to "find" the corresponding block in one go

## How Has This Been Tested?
`time ./src/test/test_dash -t miner_tests`
100-ish vs 40-ish seconds

## Breaking Changes
none


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
