### PR TITLE
feat: adjust delays and pull intervals to speed up functional tests

### DIFF
--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -45,8 +45,9 @@ class QuorumDataRecoveryTest(DashTestFramework):
         if qdata_recovery_enabled:
             # trigger recovery threads and wait for them to start
             self.nodes[0].generate(1)
+
             self.bump_mocktime(self.quorum_data_thread_request_timeout_seconds + 1)
-            time.sleep(self.quorum_data_thread_request_timeout_seconds + 1)
+            time.sleep(1)
         self.sync_blocks()
 
     def restart_mns(self, mns=None, exclude=[], reindex=False, qvvec_sync=[], qdata_recovery_enabled=True):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1325,7 +1325,7 @@ class DashTestFramework(BitcoinTestFramework):
 
         wait_until(check_probes, timeout=timeout, sleep=1)
 
-    def wait_for_quorum_phase(self, quorum_hash, phase, expected_member_count, check_received_messages, check_received_messages_count, mninfos, llmq_type_name="llmq_test", timeout=30, sleep=1):
+    def wait_for_quorum_phase(self, quorum_hash, phase, expected_member_count, check_received_messages, check_received_messages_count, mninfos, llmq_type_name="llmq_test", timeout=30, sleep=0.5):
         def check_dkg_session():
             member_count = 0
             for mn in mninfos:


### PR DESCRIPTION
## Issue being fixed or feature implemented
This should speed up test `feature_llmq_data_recovery.py` for 30% from 500+ seconds to ~350 seconds (running locally) and all other tests that uses any quorum, such as `feature_llmq_simplepose.py`

Time of CI running is also decreased noticeable 168min -> 131min
21 jobs for [pr-5091/knst/dash/functional-tests-delays](https://gitlab.com/dashpay/dash/-/commits/pr-5091/knst/dash/functional-tests-delays)
in 131 minutes and 20 seconds (queued for 4 seconds)
vs some other pull request:
23 jobs for [pr-5100/UdjinM6/dash/fix_GetStateFor_perf](https://gitlab.com/dashpay/dash/-/commits/pr-5100/UdjinM6/dash/fix_GetStateFor_perf)
in 195 minutes and 33 seconds (queued for 28 minutes and 13 seconds)

## What was done?
decreased delays in functional tests

## How Has This Been Tested?
I run several times locally and run CI/CD to see that it doesn't fail

## Breaking Changes
no breaking changes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
