### PR TITLE
fix: disable tests for dash-bls.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1833,7 +1833,9 @@ PKGCONFIG_LIBDIR_TEMP="$PKG_CONFIG_LIBDIR"
 unset PKG_CONFIG_LIBDIR
 PKG_CONFIG_LIBDIR="$PKGCONFIG_LIBDIR_TEMP"
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-module-recovery --disable-openssl-tests"
+# these extra args should be used only for these subdirectories: `dashbls` and `secp256k1`
+# dnl set extra options for `dashbls` and `secp256k1` sub projects
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --enable-tests=no --enable-module-recovery --disable-openssl-tests"
 AC_CONFIG_SUBDIRS([src/dashbls src/secp256k1])
 
 AC_OUTPUT


### PR DESCRIPTION
Test of dash-bls should be built/run in dedicated repo bls-signatures

## Issue being fixed or feature implemented
It is alternate solution for https://github.com/dashpay/dash/pull/5082
Beside, tests for bls should be run in bls repo, not in dash core.


## What was done?
Disabled tests by configure

## How Has This Been Tested?
Built dash core. Tests for bls indeed is not built anymore.

## Breaking Changes
No breaking changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone