### PR TITLE
refactor: move CInstantSendManager::PreVerifyInstantSendLock into CIn stantSendLock::TriviallyValid

### DIFF
--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -787,7 +787,7 @@ void CInstantSendManager::ProcessMessageInstantSendLock(const CNode* pfrom, cons
         fDIP0024IsActive = utils::IsDIP0024Active(::ChainActive().Tip());
     }
 
-    if (!PreVerifyInstantSendLock(*islock)) {
+    if (!islock->TriviallyValid()) {
         LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 100);
         return;
@@ -830,18 +830,17 @@ void CInstantSendManager::ProcessMessageInstantSendLock(const CNode* pfrom, cons
 
 /**
  * Handles trivial ISLock verification
- * @param islock The islock message being undergoing verification
  * @return returns false if verification failed, otherwise true
  */
-bool CInstantSendManager::PreVerifyInstantSendLock(const llmq::CInstantSendLock& islock)
+bool CInstantSendLock::TriviallyValid() const
 {
-    if (islock.txid.IsNull() || islock.inputs.empty()) {
+    if (txid.IsNull() || inputs.empty()) {
         return false;
     }
 
     // Check that each input is unique
     std::set<COutPoint> dups;
-    for (const auto& o : islock.inputs) {
+    for (const auto& o : inputs) {
         if (!dups.emplace(o).second) {
             return false;
         }

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -58,6 +58,7 @@ struct CInstantSendLock
 
     uint256 GetRequestId() const;
     bool IsDeterministic() const { return nVersion != islock_version; }
+    bool TriviallyValid() const;
 };
 
 using CInstantSendLockPtr = std::shared_ptr<CInstantSendLock>;
@@ -280,7 +281,6 @@ private:
     void TrySignInstantSendLock(const CTransaction& tx) LOCKS_EXCLUDED(cs_creating);
 
     void ProcessMessageInstantSendLock(const CNode* pfrom, const CInstantSendLockPtr& islock);
-    static bool PreVerifyInstantSendLock(const CInstantSendLock& islock);
     bool ProcessPendingInstantSendLocks();
     bool ProcessPendingInstantSendLocks(bool deterministic) LOCKS_EXCLUDED(cs_pendingLocks);
 


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
