### PR TITLE
feat(rpc): Updated quorum listextended RPC

### DIFF
--- a/doc/release-notes-5076.md
+++ b/doc/release-notes-5076.md
@@ -1,7 +1,7 @@
 New RPCs
 --------
 
-- `quorum listextended` is the cousin of `quorum list` with more enriched reply. Like `quorum list` "count" parameter can be used. Will list active quorums if "count" is not specified.
+- `quorum listextended` is the cousin of `quorum list` with more enriched reply. By using `height` parameter RPC will list active quorums at specified height (or at tip if `height` is not specified.)
 This RPC returns the following data per quorum grouped per llmqTypes:
   - For each `quorumHash`:
     - `creationHeight`: Block height where its DKG started

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -127,7 +127,7 @@ static UniValue quorum_list_extended(const JSONRPCRequest& request)
     UniValue ret(UniValue::VOBJ);
 
     LLMQContext& llmq_ctx = EnsureLLMQContext(request.context);
-    CBlockIndex* pblockindex = nHeight != -1 ? ::ChainActive()[nHeight] : WITH_LOCK(cs_main, return ::ChainActive().Tip());
+    CBlockIndex* pblockindex = nHeight != -1 ? WITH_LOCK(cs_main, return ::ChainActive()[nHeight]) : WITH_LOCK(cs_main, return ::ChainActive().Tip());
 
     for (const auto& type : llmq::utils::GetEnabledQuorumTypes(pblockindex)) {
         const auto& llmq_params = llmq::GetLLMQParams(type);

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -94,14 +94,15 @@ static void quorum_list_extended_help(const JSONRPCRequest& request)
             {
                 {RPCResult::Type::ARR, "quorumName", "List of quorum details per quorum type",
                 {
-                        {RPCResult::Type::OBJ, "","",
-                        {
+                    {RPCResult::Type::OBJ, "", "",
+                    {
                         {RPCResult::Type::OBJ, "xxxx", "Quorum hash. Note: most recent quorums come first.",
                         {
-                                 {RPCResult::Type::NUM, "creationHeight", "Block height where the DKG started."},
-                                 {RPCResult::Type::NUM, "quorumIndex", "Quorum index (applicable only to rotated quorums)."},
-                                 {RPCResult::Type::STR_HEX, "minedBlockHash", "Blockhash where the commitment was mined."}
-                         }}}},
+                            {RPCResult::Type::NUM, "creationHeight", "Block height where the DKG started."},
+                            {RPCResult::Type::NUM, "quorumIndex", "Quorum index (applicable only to rotated quorums)."},
+                            {RPCResult::Type::STR_HEX, "minedBlockHash", "Blockhash where the commitment was mined."}
+                        }}
+                    }}
                 }}
             }},
             RPCExamples{

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -87,7 +87,7 @@ static void quorum_list_extended_help(const JSONRPCRequest& request)
     RPCHelpMan{"quorum listextended",
         "Extended list of on-chain quorums\n",
         {
-            {"count", RPCArg::Type::NUM, /* default */ "", "Number of quorums to list. Will list active quorums if \"count\" is not specified."},
+            {"height", RPCArg::Type::NUM, /* default */ "", "The height index. Will list active quorums at tip if \"height\" is not specified."},
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
@@ -104,8 +104,8 @@ static void quorum_list_extended_help(const JSONRPCRequest& request)
             }},
             RPCExamples{
                 HelpExampleCli("quorum", "listextended")
-                + HelpExampleCli("quorum", "listextended 10")
-                + HelpExampleRpc("quorum", "listextended, 10")
+                + HelpExampleCli("quorum", "listextended 1980")
+                + HelpExampleRpc("quorum", "listextended, 1980")
             },
     }.Check(request);
 }
@@ -114,24 +114,24 @@ static UniValue quorum_list_extended(const JSONRPCRequest& request)
 {
     quorum_list_extended_help(request);
 
-    int count = -1;
+    int nHeight = -1;
     if (!request.params[0].isNull()) {
-        count = ParseInt32V(request.params[0], "count");
-        if (count < 0) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "count can't be negative");
+        nHeight = ParseInt32V(request.params[0], "height");
+        if (nHeight < 0 || nHeight > WITH_LOCK(cs_main, return ::ChainActive().Height())) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
         }
     }
 
     UniValue ret(UniValue::VOBJ);
 
     LLMQContext& llmq_ctx = EnsureLLMQContext(request.context);
-    CBlockIndex* pindexTip = WITH_LOCK(cs_main, return ::ChainActive().Tip());
+    CBlockIndex* pblockindex = nHeight != -1 ? ::ChainActive()[nHeight] : WITH_LOCK(cs_main, return ::ChainActive().Tip());
 
-    for (const auto& type : llmq::utils::GetEnabledQuorumTypes(pindexTip)) {
+    for (const auto& type : llmq::utils::GetEnabledQuorumTypes(pblockindex)) {
         const auto& llmq_params = llmq::GetLLMQParams(type);
         UniValue v(UniValue::VARR);
 
-        auto quorums = llmq_ctx.qman->ScanQuorums(type, pindexTip, count > -1 ? count : llmq_params.signingActiveQuorumCount);
+        auto quorums = llmq_ctx.qman->ScanQuorums(type, pblockindex, llmq_params.signingActiveQuorumCount);
         for (const auto& q : quorums) {
             UniValue obj(UniValue::VOBJ);
             {

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -96,8 +96,8 @@ static void quorum_list_extended_help(const JSONRPCRequest& request)
                 {
                         {RPCResult::Type::OBJ, "","",
                         {
-				{RPCResult::Type::OBJ, "xxxx", "Quorum hash. Note: most recent quorums come first.",
-                         	{
+                        {RPCResult::Type::OBJ, "xxxx", "Quorum hash. Note: most recent quorums come first.",
+                        {
                                  {RPCResult::Type::NUM, "creationHeight", "Block height where the DKG started."},
                                  {RPCResult::Type::NUM, "quorumIndex", "Quorum index (applicable only to rotated quorums)."},
                                  {RPCResult::Type::STR_HEX, "minedBlockHash", "Blockhash where the commitment was mined."}

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -92,20 +92,22 @@ static void quorum_list_extended_help(const JSONRPCRequest& request)
         RPCResult{
             RPCResult::Type::OBJ, "", "",
             {
-                {RPCResult::Type::OBJ_DYN, "quorumName", "List of quorum details per some quorum type",
+                {RPCResult::Type::ARR, "quorumName", "List of quorum details per quorum type",
                 {
-                        {RPCResult::Type::OBJ, "xxxx", "Quorum hash. Note: most recent quorums come first.",
-                         {
+                        {RPCResult::Type::OBJ, "","",
+                        {
+				{RPCResult::Type::OBJ, "xxxx", "Quorum hash. Note: most recent quorums come first.",
+                         	{
                                  {RPCResult::Type::NUM, "creationHeight", "Block height where the DKG started."},
                                  {RPCResult::Type::NUM, "quorumIndex", "Quorum index (applicable only to rotated quorums)."},
                                  {RPCResult::Type::STR_HEX, "minedBlockHash", "Blockhash where the commitment was mined."}
-                         }},
+                         }}}},
                 }}
             }},
             RPCExamples{
                 HelpExampleCli("quorum", "listextended")
-                + HelpExampleCli("quorum", "listextended 1980")
-                + HelpExampleRpc("quorum", "listextended, 1980")
+                + HelpExampleCli("quorum", "listextended 2500")
+                + HelpExampleRpc("quorum", "listextended, 2500")
             },
     }.Check(request);
 }


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- At the request of Platform team, this RPC should accept `height` instead of `count`. RPC replies with the signing quorums active at requested `height`. If `height` isn't specified, then tip is used for the construction of the reply.
- Corrections were made on the description of reply model.

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
