### PR TITLE
fix: support new format of electrum backup files in importelectrumwallet

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -686,6 +686,9 @@ UniValue importelectrumwallet(const JSONRPCRequest& request)
 
     pwallet->ShowProgress(_("Importing...").translated, 0); // show progress dialog in GUI
 
+    // Electrum backups were modified to include a prefix before the private key
+    // The new format of the private_key field is: "prefix:private key"
+    // Where prefix is, for example, "p2pkh" or "p2sh"
     if(strFileExt == "csv") {
         while (file.good()) {
             pwallet->ShowProgress("", std::max(1, std::min(99, (int)(((double)file.tellg() / (double)nFilesize) * 100))));
@@ -697,10 +700,6 @@ UniValue importelectrumwallet(const JSONRPCRequest& request)
             boost::split(vstr, line, boost::is_any_of(","));
             if (vstr.size() < 2)
                 continue;
-
-            // Electrum backups were modified to include a prefix before the private key
-            // The new format of the private_key field is: "prefix:private key"
-            // Where prefix is, for example, "p2pkh" or "p2sh"
             std::vector<std::string> vstr2;
             boost::split(vstr2, vstr[1], boost::is_any_of(":"));
             CKey key;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -747,7 +747,20 @@ UniValue importelectrumwallet(const JSONRPCRequest& request)
             pwallet->ShowProgress("", std::max(1, std::min(99, int(i*100/data.size()))));
             if(!data[vKeys[i]].isStr())
                 continue;
-            CKey key = DecodeSecret(data[vKeys[i]].get_str());
+            std::vector<std::string> vstr2;
+            boost::split(vstr2, data[vKeys[i]].get_str(), boost::is_any_of(":"));
+            CKey key;
+            if (vstr2.size() < 1 || vstr2.size() > 2) {
+                continue;
+            }
+            else if (vstr2.size() == 1) {
+                // Legacy format with only private key in the private_key field
+                key = DecodeSecret(data[vKeys[i]].get_str());
+            }
+            else {
+                // New format with "prefix:private key" in the private_key field
+                key = DecodeSecret(vstr2[1]);
+            }
             if (!key.IsValid()) {
                 continue;
             }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fix for the `importelectrumwallet` issue report in #5106 

## What was done?
<!--- Describe your changes in detail -->
Check the `private_key` field for prefixes set off by ":" when processing electrum CSV/JSON backup files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by importing a backup modified to include both styles of private key formatting

## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->
None :crossed_fingers: 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
