### PR TITLE
refactor: convert maybe_error into generic `Result` template class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -328,6 +328,7 @@ BITCOIN_CORE_H = \
   util/overflow.h \
   util/ranges.h \
   util/readwritefile.h \
+  util/result.h \
   util/underlying.h \
   util/serfloat.h \
   util/settings.h \


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removed non-generic maybe_error and replaced with a generic `Result` class paired with `Ok` and `Err` structs

## What was done?
<!--- Describe your changes in detail -->
This is a simple implementation of the Result type in C++. The Result type is a type that can either be an Ok value, which represents a successful operation and contains a value, or an Err value, which represents a failed operation and contains an error value.

The Result class is a template class that takes two types: T, which is the type of the value that an Ok result will contain, and E, which is the type of the value that an Err result will contain.

The Ok and Err structs are also templates, and are used to construct Ok and Err values. The Ok struct has a single member val_ of type T, and the Err struct has a single member val_ of type E.

The Result class has a constructor that takes either an Ok value or an Err value, and stores the value internally. It also has several member functions that can be used to access the value of the Result and check whether it is an Ok or Err value.

The is_ok() and is_err() member functions can be used to check whether the Result is an Ok or Err value, respectively. The operator bool() function allows the Result to be used in a boolean context, such as an if statement. The unwrap() and unwrap_err() member functions can be used to get the value contained in the Result, but will assert if the Result is not of the expected type.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
building, unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->
Should be none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
