### PR TITLE
fix: resolve potential deadlock

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -581,7 +581,9 @@ void CGovernanceManager::SyncSingleObjVotes(CNode& peer, const uint256& nProp, c
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s -- syncing single object to peer=%d, nProp = %s\n", __func__, peer.GetId(), nProp.ToString());
 
-    LOCK(cs);
+    // TODO: drop cs_main here when v19 activation is buried
+    // and CGovernanceVote::CheckSignature no longer needs to use ::ChainActive()
+    LOCK2(cs_main, cs);
 
     // single valid object and its valid votes
     auto it = mapObjects.find(nProp);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -775,6 +775,9 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
 
 bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, CGovernanceException& exception, CConnman& connman)
 {
+    // TODO: drop cs_main here when v19 activation is buried
+    // and CGovernanceVote::CheckSignature no longer needs to use ::ChainActive()
+    LOCK(cs_main);
     ENTER_CRITICAL_SECTION(cs)
     uint256 nHashVote = vote.GetHash();
     uint256 nHashGovobj = vote.GetParentHash();

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1243,7 +1243,9 @@ void CGovernanceManager::RemoveInvalidVotes()
         return;
     }
 
-    LOCK(cs);
+    // TODO: drop cs_main here when v19 activation is buried
+    // and CGovernanceVote::CheckSignature no longer needs to use ::ChainActive()
+    LOCK2(cs_main, cs);
 
     auto curMNList = deterministicMNManager->GetListAtChainTip();
     auto diff = lastMNListForVotingKeys->BuildDiff(curMNList);


### PR DESCRIPTION
## Issue being fixed or feature implemented
```
POTENTIAL DEADLOCK DETECTED
Previous lock order was:
 (2) 'cs_main' in governance/governance.cpp:1096 (in thread 'init')
 (1) 'cs' in governance/governance.cpp:1096 (in thread 'init')
Current lock order is:
 (1) 'cs' in governance/governance.cpp:778 (in thread 'msghand')
 'cs' in governance/object.cpp:104 (in thread 'msghand')
 (2) '::cs_main' in validation.cpp:117 (in thread 'msghand')
```

#5021 follow-up
## What was done?
Lock `cs_main` earlier

## How Has This Been Tested?
run dashd on testnet

## Breaking Changes
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
