### PR TITLE
fix: preserve the original order of fields in CDeterministicMNStateDiff

### DIFF
--- a/src/evo/dmnstate.h
+++ b/src/evo/dmnstate.h
@@ -149,7 +149,7 @@ public:
         Field_scriptOperatorPayout              = 0x2000,
     };
 
-#define DMN_STATE_DIFF_ALL_FIELDS_BUT_PUBKEY \
+#define DMN_STATE_DIFF_ALL_FIELDS \
     DMN_STATE_DIFF_LINE(nRegisteredHeight) \
     DMN_STATE_DIFF_LINE(nLastPaidHeight) \
     DMN_STATE_DIFF_LINE(nPoSePenalty) \
@@ -159,14 +159,11 @@ public:
     DMN_STATE_DIFF_LINE(confirmedHash) \
     DMN_STATE_DIFF_LINE(confirmedHashWithProRegTxHash) \
     DMN_STATE_DIFF_LINE(keyIDOwner) \
+    DMN_STATE_DIFF_LINE(pubKeyOperator) \
     DMN_STATE_DIFF_LINE(keyIDVoting) \
     DMN_STATE_DIFF_LINE(addr) \
     DMN_STATE_DIFF_LINE(scriptPayout) \
     DMN_STATE_DIFF_LINE(scriptOperatorPayout)
-
-#define DMN_STATE_DIFF_ALL_FIELDS \
-    DMN_STATE_DIFF_ALL_FIELDS_BUT_PUBKEY \
-    DMN_STATE_DIFF_LINE(pubKeyOperator) \
 
 public:
     uint32_t fields{0};
@@ -185,13 +182,14 @@ public:
     SERIALIZE_METHODS(CDeterministicMNStateDiff, obj)
     {
         READWRITE(VARINT(obj.fields));
-#define DMN_STATE_DIFF_LINE(f) if (obj.fields & Field_##f) READWRITE(obj.state.f);
-        DMN_STATE_DIFF_ALL_FIELDS_BUT_PUBKEY
+#define DMN_STATE_DIFF_LINE(f) \
+        if (obj.fields & Field_pubKeyOperator) {\
+            /* TODO: implement migration to Basic BLS after the fork */ \
+            READWRITE(CBLSLazyPublicKeyVersionWrapper(const_cast<CBLSLazyPublicKey&>(obj.state.pubKeyOperator), true)); \
+        } else if (obj.fields & Field_##f) READWRITE(obj.state.f);
+
+        DMN_STATE_DIFF_ALL_FIELDS
 #undef DMN_STATE_DIFF_LINE
-        if (obj.fields & Field_pubKeyOperator) {
-            // TODO: implement migration to Basic BLS after the fork
-            READWRITE(CBLSLazyPublicKeyVersionWrapper(const_cast<CBLSLazyPublicKey&>(obj.state.pubKeyOperator), true));
-        }
     }
 
     void ApplyToState(CDeterministicMNState& target) const


### PR DESCRIPTION
## Issue being fixed or feature implemented
We shouldn't have changed it in the first place if we want to avoid additional migration/reindexing. I did not think about it when I proposed this patch in #5021, sorry 🙈 Thanks @ogabrielides for noticing 👍 

#5021 follow-up

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
