### PR TITLE
fix!: Rotation members calc v19

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -256,9 +256,11 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
     auto MnsNotUsedAtH = CDeterministicMNList();
     std::vector<CDeterministicMNList> MnsUsedAtHIndexed(nQuorums);
 
+    bool skipRemovedMNs = IsV19Active(pQuorumBaseBlockIndex) || (Params().NetworkIDString() == CBaseChainParams::TESTNET);
+
     for (auto i = 0; i < nQuorums; ++i) {
         for (const auto& mn : previousQuarters.quarterHMinusC[i]) {
-            if (IsV19Active(pQuorumBaseBlockIndex) && !allMns.HasMN(mn->proTxHash)) {
+            if (skipRemovedMNs && !allMns.HasMN(mn->proTxHash)) {
                 continue;
             }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {
@@ -274,7 +276,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
             }
         }
         for (const auto& mn : previousQuarters.quarterHMinus2C[i]) {
-            if (IsV19Active(pQuorumBaseBlockIndex) && !allMns.HasMN(mn->proTxHash)) {
+            if (skipRemovedMNs && !allMns.HasMN(mn->proTxHash)) {
                 continue;
             }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {
@@ -290,7 +292,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
             }
         }
         for (const auto& mn : previousQuarters.quarterHMinus3C[i]) {
-            if (IsV19Active(pQuorumBaseBlockIndex) && !allMns.HasMN(mn->proTxHash)) {
+            if (skipRemovedMNs && !allMns.HasMN(mn->proTxHash)) {
                 continue;
             }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -258,7 +258,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
 
     for (auto i = 0; i < nQuorums; ++i) {
         for (const auto& mn : previousQuarters.quarterHMinusC[i]) {
-            if (!allMns.HasMN(mn->proTxHash)) {
+            if (IsV19Active(pQuorumBaseBlockIndex) && !allMns.HasMN(mn->proTxHash)) {
                 continue;
             }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {
@@ -274,7 +274,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
             }
         }
         for (const auto& mn : previousQuarters.quarterHMinus2C[i]) {
-            if (!allMns.HasMN(mn->proTxHash)) {
+            if (IsV19Active(pQuorumBaseBlockIndex) && !allMns.HasMN(mn->proTxHash)) {
                 continue;
             }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {
@@ -290,7 +290,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
             }
         }
         for (const auto& mn : previousQuarters.quarterHMinus3C[i]) {
-            if (!allMns.HasMN(mn->proTxHash)) {
+            if (IsV19Active(pQuorumBaseBlockIndex) && !allMns.HasMN(mn->proTxHash)) {
                 continue;
             }
             if (allMns.IsMNPoSeBanned(mn->proTxHash)) {


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->
With 18.2, block `0000000000000044356e582f9748f9baf084e5b7946e6386b32620d540830fda` is marked invalid with `bad-qc-invalid`.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While the 19 isn’t active -> Calculate rotation members based on 18.1 code
Once 19 active -> Calculate rotation members based on 18.2 code

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
