### PR TITLE
fix: avoid re-propogating old qfcommit messages

### DIFF
--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -91,6 +91,13 @@ void CQuorumBlockProcessor::ProcessMessage(const CNode& peer, std::string_view m
             Misbehaving(peer.GetId(), 100);
             return;
         }
+        if (pQuorumBaseBlockIndex->nHeight < (::ChainActive().Height() - GetLLMQParams(type).dkgInterval)) {
+            LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- block %s is too old, peer=%d\n", __func__,
+                     qc.quorumHash.ToString(), peer.GetId());
+            // TODO: enable punishment in some future version when all/most nodes are running with this fix
+            // Misbehaving(peer.GetId(), 100);
+            return;
+        }
     }
 
     {

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -98,6 +98,12 @@ void CQuorumBlockProcessor::ProcessMessage(const CNode& peer, std::string_view m
             // Misbehaving(peer.GetId(), 100);
             return;
         }
+        if (HasMinedCommitment(type, qc.quorumHash)) {
+            LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- commitment for quorum hash[%s], type[%d], quorumIndex[%d] is already mined, peer=%d\n",
+                     __func__, qc.quorumHash.ToString(), uint8_t(type), qc.quorumIndex, qc.nVersion, peer.GetId());
+            // NOTE: do not punish here
+            return;
+        }
     }
 
     {

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -100,7 +100,7 @@ void CQuorumBlockProcessor::ProcessMessage(const CNode& peer, std::string_view m
         }
         if (HasMinedCommitment(type, qc.quorumHash)) {
             LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- commitment for quorum hash[%s], type[%d], quorumIndex[%d] is already mined, peer=%d\n",
-                     __func__, qc.quorumHash.ToString(), uint8_t(type), qc.quorumIndex, qc.nVersion, peer.GetId());
+                     __func__, qc.quorumHash.ToString(), uint8_t(type), qc.quorumIndex, peer.GetId());
             // NOTE: do not punish here
             return;
         }


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes an issue where qfcommit messages can be replayed from the past, then are validated and propagated to other nodes. This patch changes it so that old qfcommits are not relayed.

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed to a node, and ensured that the log messages are shown. 

## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
