### PR TITLE
refactor: improved initialization of members of LLMQContext and related changes

### DIFF
--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -20,53 +20,44 @@
 #include <masternode/sync.h>
 
 LLMQContext::LLMQContext(CEvoDB& evo_db, CTxMemPool& mempool, CConnman& connman, CSporkManager& sporkman,
-                         const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe) {
-    Create(evo_db, mempool, connman, sporkman, peerman, unit_tests, wipe);
-
-    /* Context aliases to globals used by the LLMQ system */
-    quorum_block_processor = llmq::quorumBlockProcessor.get();
-    qman = llmq::quorumManager.get();
-    clhandler = llmq::chainLocksHandler.get();
-    isman = llmq::quorumInstantSendManager.get();
-}
-
-LLMQContext::~LLMQContext() {
-    isman = nullptr;
-    clhandler = nullptr;
-    qman = nullptr;
-    quorum_block_processor = nullptr;
-
-    Destroy();
-}
-
-void LLMQContext::Create(CEvoDB& evo_db, CTxMemPool& mempool, CConnman& connman, CSporkManager& sporkman,
-                         const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe) {
-    bls_worker = std::make_shared<CBLSWorker>();
-
-    dkg_debugman = std::make_unique<llmq::CDKGDebugManager>();
-    llmq::quorumBlockProcessor = std::make_unique<llmq::CQuorumBlockProcessor>(evo_db, connman, peerman);
-    qdkgsman = std::make_unique<llmq::CDKGSessionManager>(connman, *bls_worker, *dkg_debugman, *llmq::quorumBlockProcessor, sporkman, peerman, unit_tests, wipe);
-    llmq::quorumManager = std::make_unique<llmq::CQuorumManager>(evo_db, connman, *bls_worker, *llmq::quorumBlockProcessor, *qdkgsman, ::masternodeSync, peerman);
-    sigman = std::make_unique<llmq::CSigningManager>(connman, *llmq::quorumManager, peerman, unit_tests, wipe);
-    shareman = std::make_unique<llmq::CSigSharesManager>(connman, *llmq::quorumManager, *sigman, peerman);
-    llmq::chainLocksHandler = std::make_unique<llmq::CChainLocksHandler>(mempool, connman, sporkman, *sigman, *shareman, *llmq::quorumManager, *::masternodeSync, peerman);
-    llmq::quorumInstantSendManager = std::make_unique<llmq::CInstantSendManager>(mempool, connman, sporkman, *llmq::quorumManager, *sigman, *shareman, *llmq::chainLocksHandler, *::masternodeSync, peerman, unit_tests, wipe);
-
+                         const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe) :
+    bls_worker{std::make_shared<CBLSWorker>()},
+    dkg_debugman{std::make_unique<llmq::CDKGDebugManager>()},
+    quorum_block_processor{[&]() -> llmq::CQuorumBlockProcessor* const {
+        assert(llmq::quorumBlockProcessor == nullptr);
+        llmq::quorumBlockProcessor = std::make_unique<llmq::CQuorumBlockProcessor>(evo_db, connman, peerman);
+        return llmq::quorumBlockProcessor.get();
+    }()},
+    qdkgsman{std::make_unique<llmq::CDKGSessionManager>(connman, *bls_worker, *dkg_debugman, *quorum_block_processor, sporkman, peerman, unit_tests, wipe)},
+    qman{[&]() -> llmq::CQuorumManager* const {
+        assert(llmq::quorumManager == nullptr);
+        llmq::quorumManager = std::make_unique<llmq::CQuorumManager>(evo_db, connman, *bls_worker, *quorum_block_processor, *qdkgsman, ::masternodeSync, peerman);
+        return llmq::quorumManager.get();
+    }()},
+    sigman{std::make_unique<llmq::CSigningManager>(connman, *llmq::quorumManager, peerman, unit_tests, wipe)},
+    shareman{std::make_unique<llmq::CSigSharesManager>(connman, *llmq::quorumManager, *sigman, peerman)},
+    clhandler{[&]() -> llmq::CChainLocksHandler* const {
+        assert(llmq::chainLocksHandler == nullptr);
+        llmq::chainLocksHandler = std::make_unique<llmq::CChainLocksHandler>(mempool, connman, sporkman, *sigman, *shareman, *llmq::quorumManager, *::masternodeSync, peerman);
+        return llmq::chainLocksHandler.get();
+    }()},
+    isman{[&]() -> llmq::CInstantSendManager* const {
+        assert(llmq::quorumInstantSendManager == nullptr);
+        llmq::quorumInstantSendManager = std::make_unique<llmq::CInstantSendManager>(mempool, connman, sporkman, *llmq::quorumManager, *sigman, *shareman, *llmq::chainLocksHandler, *::masternodeSync, peerman, unit_tests, wipe);
+        return llmq::quorumInstantSendManager.get();
+    }()}
+{
     // NOTE: we use this only to wipe the old db, do NOT use it for anything else
     // TODO: remove it in some future version
     auto llmqDbTmp = std::make_unique<CDBWrapper>(unit_tests ? "" : (GetDataDir() / "llmq"), 1 << 20, unit_tests, true);
 }
 
-void LLMQContext::Destroy() {
+LLMQContext::~LLMQContext() {
+    // LLMQContext doesn't own these objects, but still need to care of them for consistancy:
     llmq::quorumInstantSendManager.reset();
     llmq::chainLocksHandler.reset();
-    shareman.reset();
-    sigman.reset();
     llmq::quorumManager.reset();
-    qdkgsman.reset();
     llmq::quorumBlockProcessor.reset();
-    dkg_debugman.reset();
-    bls_worker.reset();
     {
         LOCK(llmq::cs_llmq_vbc);
         llmq::llmq_versionbitscache.Clear();
@@ -74,54 +65,40 @@ void LLMQContext::Destroy() {
 }
 
 void LLMQContext::Interrupt() {
-    if (shareman != nullptr) {
-        shareman->InterruptWorkerThread();
-    }
-    if (llmq::quorumInstantSendManager != nullptr) {
-        llmq::quorumInstantSendManager->InterruptWorkerThread();
-    }
+    shareman->InterruptWorkerThread();
+
+    assert(isman == llmq::quorumInstantSendManager.get());
+    llmq::quorumInstantSendManager->InterruptWorkerThread();
 }
 
 void LLMQContext::Start() {
-    if (bls_worker != nullptr) {
-        bls_worker->Start();
-    }
-    if (qdkgsman != nullptr) {
-        qdkgsman->StartThreads();
-    }
-    if (llmq::quorumManager != nullptr) {
-        llmq::quorumManager->Start();
-    }
-    if (shareman != nullptr) {
-        shareman->RegisterAsRecoveredSigsListener();
-        shareman->StartWorkerThread();
-    }
-    if (llmq::chainLocksHandler != nullptr) {
-        llmq::chainLocksHandler->Start();
-    }
-    if (llmq::quorumInstantSendManager != nullptr) {
-        llmq::quorumInstantSendManager->Start();
-    }
+    assert(quorum_block_processor == llmq::quorumBlockProcessor.get());
+    assert(qman == llmq::quorumManager.get());
+    assert(clhandler == llmq::chainLocksHandler.get());
+    assert(isman == llmq::quorumInstantSendManager.get());
+
+    bls_worker->Start();
+    qdkgsman->StartThreads();
+    qman->Start();
+    shareman->RegisterAsRecoveredSigsListener();
+    shareman->StartWorkerThread();
+
+    llmq::chainLocksHandler->Start();
+    llmq::quorumInstantSendManager->Start();
 }
 
 void LLMQContext::Stop() {
-    if (llmq::quorumInstantSendManager != nullptr) {
-        llmq::quorumInstantSendManager->Stop();
-    }
-    if (llmq::chainLocksHandler != nullptr) {
-        llmq::chainLocksHandler->Stop();
-    }
-    if (shareman != nullptr) {
-        shareman->StopWorkerThread();
-        shareman->UnregisterAsRecoveredSigsListener();
-    }
-    if (llmq::quorumManager != nullptr) {
-        llmq::quorumManager->Stop();
-    }
-    if (qdkgsman != nullptr) {
-        qdkgsman->StopThreads();
-    }
-    if (bls_worker != nullptr) {
-        bls_worker->Stop();
-    }
+    assert(quorum_block_processor == llmq::quorumBlockProcessor.get());
+    assert(qman == llmq::quorumManager.get());
+    assert(clhandler == llmq::chainLocksHandler.get());
+    assert(isman == llmq::quorumInstantSendManager.get());
+
+    llmq::quorumInstantSendManager->Stop();
+    llmq::chainLocksHandler->Stop();
+
+    shareman->StopWorkerThread();
+    shareman->UnregisterAsRecoveredSigsListener();
+    qman->Stop();
+    qdkgsman->StopThreads();
+    bls_worker->Stop();
 }

--- a/src/llmq/context.h
+++ b/src/llmq/context.h
@@ -27,27 +27,35 @@ class CInstantSendManager;
 }
 
 struct LLMQContext {
+    LLMQContext() = delete;
+    LLMQContext(const LLMQContext&) = delete;
     LLMQContext(CEvoDB& evo_db, CTxMemPool& mempool, CConnman& connman, CSporkManager& sporkman,
                 const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe);
     ~LLMQContext();
 
-    void Create(CEvoDB& evo_db, CTxMemPool& mempool, CConnman& connman, CSporkManager& sporkman,
-                const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe);
-    void Destroy();
     void Interrupt();
     void Start();
     void Stop();
 
-    std::shared_ptr<CBLSWorker> bls_worker;
-    std::unique_ptr<llmq::CDKGDebugManager> dkg_debugman;
-    std::unique_ptr<llmq::CDKGSessionManager> qdkgsman;
-    std::unique_ptr<llmq::CSigSharesManager> shareman;
-    std::unique_ptr<llmq::CSigningManager> sigman;
-
-    llmq::CQuorumBlockProcessor* quorum_block_processor{nullptr};
-    llmq::CQuorumManager* qman{nullptr};
-    llmq::CChainLocksHandler* clhandler{nullptr};
-    llmq::CInstantSendManager* isman{nullptr};
+    /** Guaranteed if LLMQContext is initialized then all members are valid too
+     *
+     *  Please note, that members here should not be re-ordered, because initialization
+     *  some of them requires other member initialized.
+     *  For example, constructor `quorumManager` requires `bls_worker`.
+     *
+     *  Some objects are still global variables and their de-globalization is not trivial
+     *  at this point. LLMQContext keeps just a pointer to them and doesn't own these objects,
+     *  but it still guarantees that objects are created and valid
+     */
+    const std::shared_ptr<CBLSWorker> bls_worker;
+    const std::unique_ptr<llmq::CDKGDebugManager> dkg_debugman;
+    llmq::CQuorumBlockProcessor* const quorum_block_processor;
+    const std::unique_ptr<llmq::CDKGSessionManager> qdkgsman;
+    llmq::CQuorumManager* const qman;
+    const std::unique_ptr<llmq::CSigningManager> sigman;
+    const std::unique_ptr<llmq::CSigSharesManager> shareman;
+    llmq::CChainLocksHandler* const clhandler;
+    llmq::CInstantSendManager* const isman;
 };
 
 #endif // BITCOIN_LLMQ_CONTEXT_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -28,6 +28,7 @@
 #include <governance/governance.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/chainlocks.h>
+#include <llmq/context.h>
 #include <llmq/instantsend.h>
 #include <llmq/utils.h>
 #include <masternode/payments.h>
@@ -57,16 +58,15 @@ BlockAssembler::Options::Options() {
 }
 
 BlockAssembler::BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
-                               const llmq::CQuorumBlockProcessor& quorumBlockProcessor, llmq::CChainLocksHandler& clhandler,
-                               llmq::CInstantSendManager& isman, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params, const Options& options) :
+                               LLMQContext& llmq_ctx, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params, const Options& options) :
       chainparams(params),
       m_mempool(mempool),
       m_chainstate(chainstate),
       spork_manager(sporkManager),
       governance_manager(governanceManager),
-      quorum_block_processor(quorumBlockProcessor),
-      m_clhandler(clhandler),
-      m_isman(isman),
+      quorum_block_processor(*llmq_ctx.quorum_block_processor),
+      m_clhandler(*llmq_ctx.clhandler),
+      m_isman(*llmq_ctx.isman),
       m_evoDb(evoDb)
 {
     blockMinFeeRate = options.blockMinFeeRate;
@@ -92,9 +92,8 @@ static BlockAssembler::Options DefaultOptions()
 }
 
 BlockAssembler::BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
-                               const llmq::CQuorumBlockProcessor& quorumBlockProcessor, llmq::CChainLocksHandler& clhandler,
-                               llmq::CInstantSendManager& isman, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params)
-    : BlockAssembler(sporkManager, governanceManager, quorumBlockProcessor, clhandler, isman, evoDb, chainstate, mempool, params, DefaultOptions()) {}
+                               LLMQContext& llmq_ctx, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params)
+    : BlockAssembler(sporkManager, governanceManager, llmq_ctx, evoDb, chainstate, mempool, params, DefaultOptions()) {}
 
 void BlockAssembler::resetBlock()
 {

--- a/src/miner.h
+++ b/src/miner.h
@@ -24,6 +24,7 @@ class CCreditPoolDiff;
 class CGovernanceManager;
 class CScript;
 class CSporkManager;
+struct LLMQContext;
 
 namespace Consensus { struct Params; };
 namespace llmq {
@@ -172,11 +173,9 @@ public:
     };
 
     explicit BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
-                            const llmq::CQuorumBlockProcessor& quorumBlockProcessor, llmq::CChainLocksHandler& clhandler,
-                            llmq::CInstantSendManager& isman, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params);
+                            LLMQContext& llmq_ctx, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params);
     explicit BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
-                            const llmq::CQuorumBlockProcessor& quorumBlockProcessor, llmq::CChainLocksHandler& clhandler,
-                            llmq::CInstantSendManager& isman, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params, const Options& options);
+                            LLMQContext& llmq_ctx, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
     std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn);

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1471,7 +1471,7 @@ static UniValue protx_diff(const JSONRPCRequest& request, const ChainstateManage
 
     CSimplifiedMNListDiff mnListDiff;
     std::string strError;
-    LLMQContext& llmq_ctx = EnsureAnyLLMQContext(request.context);
+    const LLMQContext& llmq_ctx = EnsureAnyLLMQContext(request.context);
 
     if (!BuildSimplifiedMNListDiff(baseBlockHash, blockHash, mnListDiff, *llmq_ctx.quorum_block_processor, strError, extended)) {
         throw std::runtime_error(strError);

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -175,7 +175,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
         BOOST_CHECK(::ChainActive().Height() < Params().GetConsensus().BRRHeight);
         // Creating blocks by different ways
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler,  *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
     }
     for ([[maybe_unused]] auto _ : irange::range(1999)) {
         CreateAndProcessBlock({}, coinbaseKey);
@@ -202,7 +202,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
         BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler,  *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
     }
 
@@ -213,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
     {
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler,  *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 13748571607);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 6874285801); // 0.4999999998
@@ -228,7 +228,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
             }
             LOCK(cs_main);
             auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-            const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler,  *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         }
     }
@@ -237,7 +237,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         // Reward split should reach ~60/40 after reallocation is done
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler,  *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 10221599170);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 6132959502); // 0.6
@@ -251,7 +251,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         }
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler,  *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
     }
 
@@ -259,7 +259,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         // Reward split should reach ~60/40 after reallocation is done
         LOCK(cs_main);
         auto masternode_payment = GetMasternodePayment(::ChainActive().Height(), GetBlockSubsidy(::ChainActive().Tip()->nBits, ::ChainActive().Height(), consensus_params), 2500);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler,  *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 9491484944);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 5694890966); // 0.6

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -69,7 +69,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler, *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;

--- a/src/test/dynamic_activation_thresholds_tests.cpp
+++ b/src/test/dynamic_activation_thresholds_tests.cpp
@@ -79,7 +79,7 @@ struct TestChainDATSetup : public TestChainSetup
             BOOST_CHECK_EQUAL(VersionBitsState(::ChainActive().Tip(), consensus_params, deployment_id, versionbitscache), ThresholdState::STARTED);
             BOOST_CHECK_EQUAL(VersionBitsStatistics(::ChainActive().Tip(), consensus_params, deployment_id, versionbitscache).threshold, threshold(0));
             // Next block should be signaling by default
-            const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler, *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             const uint32_t bitmask = ((uint32_t)1) << consensus_params.vDeployments[deployment_id].bit;
             BOOST_CHECK_EQUAL(::ChainActive().Tip()->nVersion & bitmask, 0);
             BOOST_CHECK_EQUAL(pblocktemplate->block.nVersion & bitmask, bitmask);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -51,7 +51,7 @@ BlockAssembler MinerTestingSetup::AssemblerForTest(const CChainParams& params)
 
     options.nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
     options.blockMinFeeRate = blockMinFeeRate;
-    return BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler, *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, params, options);
+    return BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, params, options);
 }
 
 constexpr static struct {

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coi
 {
     assert(node.mempool);
     auto block = std::make_shared<CBlock>(
-        BlockAssembler{*sporkManager, *governance, *node.llmq_ctx->quorum_block_processor, *node.llmq_ctx->clhandler, *node.llmq_ctx->isman, *node.evodb, ::ChainstateActive(), *node.mempool, Params()}
+        BlockAssembler{*sporkManager, *governance, *node.llmq_ctx, *node.evodb, ::ChainstateActive(), *node.mempool, Params()}
             .CreateNewBlock(coinbase_scriptPubKey)
             ->block);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -346,8 +346,7 @@ CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns,
     const CChainParams& chainparams = Params();
     CTxMemPool empty_pool;
     CBlock block = BlockAssembler(
-            *sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor,
-            *m_node.llmq_ctx->clhandler, *m_node.llmq_ctx->isman, *m_node.evodb,
+            *sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb,
             ::ChainstateActive(), empty_pool, chainparams
         ).CreateNewBlock(scriptPubKey)->block;
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     CScript pubKey;
     pubKey << i++ << OP_TRUE;
 
-    auto ptemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx->quorum_block_processor, *m_node.llmq_ctx->clhandler,  *m_node.llmq_ctx->isman, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(pubKey);
+    auto ptemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(pubKey);
     auto pblock = std::make_shared<CBlock>(ptemplate->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;


### PR DESCRIPTION
LLMQContext uses RAII to initialize all members. Ensured that all members always initialized correctly in proper order if LLMQContext exists.

BlockAssembler, CChainState use too many agruments and they are making wrong assumption that members of LLMQContext can be constructed and used independently, but that's not true. Instead, let's pass LLMQContext whenever possible.

## Issue being fixed or feature implemented
https://github.com/dashpay/dash-issues/issues/52

## How Has This Been Tested?
Run unit/functional test and introduce no breaking changes.


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone