### PR TITLE
feat(rpc): Added previousConsecutiveDKGFailures for rotation in quorum rpc

### DIFF
--- a/doc/release-notes-5158.md
+++ b/doc/release-notes-5158.md
@@ -1,4 +1,4 @@
 Updated RPCs
 --------
 
-- `quorum info`: New field `previouslyFailedConsecutiveDKGs` will be returned for rotated LLMQs. This field will hold the number of previously consecutive failed DGKs before the currently active one. Note: If no previously commitments were found then 0 will be returned for `previouslyFailedConsecutiveDKGs`.
+- `quorum info`: New field `previouslyFailedConsecutiveDKGs` will be returned for rotated LLMQs. This field will hold the number of previously consecutive failed DGKs for the corresponding quorumIndex before the currently active one. Note: If no previously commitments were found then 0 will be returned for `previouslyFailedConsecutiveDKGs`.

--- a/doc/release-notes-5158.md
+++ b/doc/release-notes-5158.md
@@ -1,4 +1,4 @@
 Updated RPCs
 --------
 
-- `quorum info`: The new `previouslyFailedConsecutiveDKGs` field will be returned for rotated LLMQs. This field will hold the number of previous consecutive DKG failures for the corresponding quorumIndex before the currently active one. Note: If no previous commitments were found then 0 will be returned for `previouslyFailedConsecutiveDKGs`.
+- `quorum info`: The new `previousConsecutiveDKGFailures` field will be returned for rotated LLMQs. This field will hold the number of previous consecutive DKG failures for the corresponding quorumIndex before the currently active one. Note: If no previous commitments were found then 0 will be returned for `previousConsecutiveDKGFailures`.

--- a/doc/release-notes-5158.md
+++ b/doc/release-notes-5158.md
@@ -1,4 +1,4 @@
 Updated RPCs
 --------
 
-- `quorum info`: New field `previouslyFailedConsecutiveDKGs` will be returned for rotated LLMQs. This field will hold the number of previously consecutive failed DGKs for the corresponding quorumIndex before the currently active one. Note: If no previously commitments were found then 0 will be returned for `previouslyFailedConsecutiveDKGs`.
+- `quorum info`: The new `previouslyFailedConsecutiveDKGs` field will be returned for rotated LLMQs. This field will hold the number of previous consecutive DKG failures for the corresponding quorumIndex before the currently active one. Note: If no previous commitments were found then 0 will be returned for `previouslyFailedConsecutiveDKGs`.

--- a/doc/release-notes-5158.md
+++ b/doc/release-notes-5158.md
@@ -1,0 +1,4 @@
+Updated RPCs
+--------
+
+- `quorum info`: New field `previouslyFailedConsecutiveDKGs` will be returned for rotated LLMQs. This field will hold the number of previously consecutive failed DGKs before the currently active one. Note: If no previously commitments were found then 0 will be returned for `previouslyFailedConsecutiveDKGs`.

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -192,8 +192,8 @@ static UniValue BuildQuorumInfo(const llmq::CQuorumCPtr& quorum, bool includeMem
     if (quorum->params.useRotation) {
         auto previousActiveCommitment = llmq::quorumBlockProcessor->GetLastMinedCommitmentsByQuorumIndexUntilBlock(quorum->params.type, quorum->m_quorum_base_block_index, quorum->qc->quorumIndex, 0);
         if (previousActiveCommitment.has_value()) {
-            int previouslyConsecutiveFailedDKGs = (quorum->m_quorum_base_block_index->nHeight - previousActiveCommitment.value()->nHeight) /  quorum->params.dkgInterval - 1;
-            ret.pushKV("previousConsecutiveDKGFailures", previouslyConsecutiveFailedDKGs);
+            int previousConsecutiveDKGFailures = (quorum->m_quorum_base_block_index->nHeight - previousActiveCommitment.value()->nHeight) /  quorum->params.dkgInterval - 1;
+            ret.pushKV("previousConsecutiveDKGFailures", previousConsecutiveDKGFailures);
         }
         else {
             ret.pushKV("previousConsecutiveDKGFailures", 0);

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -189,6 +189,17 @@ static UniValue BuildQuorumInfo(const llmq::CQuorumCPtr& quorum, bool includeMem
     ret.pushKV("quorumIndex", quorum->qc->quorumIndex);
     ret.pushKV("minedBlock", quorum->minedBlockHash.ToString());
 
+    if (quorum->params.useRotation) {
+        auto previousActiveCommitment = llmq::quorumBlockProcessor->GetLastMinedCommitmentsByQuorumIndexUntilBlock(quorum->params.type, quorum->m_quorum_base_block_index, quorum->qc->quorumIndex, 0);
+        if (previousActiveCommitment.has_value()) {
+            int previouslyFailedConsecutiveDKGs = (quorum->m_quorum_base_block_index->nHeight - previousActiveCommitment.value()->nHeight) /  quorum->params.dkgInterval - 1;
+            ret.pushKV("previouslyFailedConsecutiveDKGs", previouslyFailedConsecutiveDKGs);
+        }
+        else {
+            ret.pushKV("previouslyFailedConsecutiveDKGs", 0);
+        }
+    }
+
     if (includeMembers) {
         UniValue membersArr(UniValue::VARR);
         for (size_t i = 0; i < quorum->members.size(); i++) {

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -192,11 +192,11 @@ static UniValue BuildQuorumInfo(const llmq::CQuorumCPtr& quorum, bool includeMem
     if (quorum->params.useRotation) {
         auto previousActiveCommitment = llmq::quorumBlockProcessor->GetLastMinedCommitmentsByQuorumIndexUntilBlock(quorum->params.type, quorum->m_quorum_base_block_index, quorum->qc->quorumIndex, 0);
         if (previousActiveCommitment.has_value()) {
-            int previouslyFailedConsecutiveDKGs = (quorum->m_quorum_base_block_index->nHeight - previousActiveCommitment.value()->nHeight) /  quorum->params.dkgInterval - 1;
-            ret.pushKV("previouslyFailedConsecutiveDKGs", previouslyFailedConsecutiveDKGs);
+            int previouslyConsecutiveFailedDKGs = (quorum->m_quorum_base_block_index->nHeight - previousActiveCommitment.value()->nHeight) /  quorum->params.dkgInterval - 1;
+            ret.pushKV("previousConsecutiveDKGFailures", previouslyConsecutiveFailedDKGs);
         }
         else {
-            ret.pushKV("previouslyFailedConsecutiveDKGs", 0);
+            ret.pushKV("previousConsecutiveDKGFailures", 0);
         }
     }
 


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Platform and research team have requested this change.

## What was done?
<!--- Describe your changes in detail -->
`quorum info` was updated with the introduction of new field `previousConsecutiveDKGFailures` that be returned only for rotated LLMQs. 
This field will hold the number of previously consecutive failed DGKs for the corresponding quorumIndex before the currently active one. 
Note: If no previously commitments were found then 0 will be returned for `previousConsecutiveDKGFailures`.

Example:

- DKG `A` was successful
- DKG `B` failed
- DKG `C` failed
- DKG `D` was successful
- DKG `E` was successful

- `previousConsecutiveDKGFailures` = 0 when requesting for quorum `A` (because `A` is the first ever created quorum for that quorumIndex)
- `previousConsecutiveDKGFailures` = 2 when requesting for quorum `D`
- `previousConsecutiveDKGFailures` = 0 when requesting for quorum `E`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
