### PR TITLE
fix: resolve crash on close bug in macos

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -581,7 +581,7 @@ void BitcoinGUI::createMenuBar()
     connect(minimize_action, &QAction::triggered, [] {
         QApplication::activeWindow()->showMinimized();
     });
-    connect(qApp, &QApplication::focusWindowChanged, [minimize_action] (QWindow* window) {
+    connect(qApp, &QApplication::focusWindowChanged, this, [minimize_action] (QWindow* window) {
         minimize_action->setEnabled(window != nullptr && (window->flags() & Qt::Dialog) != Qt::Dialog && window->windowState() != Qt::WindowMinimized);
     });
 
@@ -596,7 +596,7 @@ void BitcoinGUI::createMenuBar()
         }
     });
 
-    connect(qApp, &QApplication::focusWindowChanged, [zoom_action] (QWindow* window) {
+    connect(qApp, &QApplication::focusWindowChanged, this, [zoom_action] (QWindow* window) {
         zoom_action->setEnabled(window != nullptr);
     });
 #endif


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes two crash on close bugs on macOS. I thought there were some GitHub issues that describe them, but I can't find them now.

This should be merged via merge commit to preserve the fact this is a backport

## What was done?
zoom_action and minimize_action are both actions inside of window_menu and window_menu is inside of appMenuBar. appMenuBar is deleted on quit, which also deletes all the stuff inside of it, and invalidates the pointers we are holding onto inside of these lambdas. I had a different fix that was from capturing `this` inside of the lambda, and checking if appMenuBar was deleted yet, however bitcoin actually dealt with this fix in bitcoin-core/gui#680

This should get back ported if we create another 18.2 / 18.1 version

## How Has This Been Tested?
starting and stopping many times

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
