### PR TITLE
chore: Merge master 18.2.1 back into develop

### DIFF
--- a/doc/release-notes/dash/release-notes-18.2.0.md
+++ b/doc/release-notes/dash/release-notes-18.2.0.md
@@ -1,19 +1,16 @@
-Dash Core version v18.2.1
+Dash Core version v18.2.0
 =========================
 
 Release is now available from:
 
   <https://www.dash.org/downloads/#wallets>
 
-This is a new hotfix version release, bringing various bugfixes.
+This is a new minor version release, bringing new features, various bugfixes
+and other improvements.
 
-Please note that v18.2.0 was revoked due to a bug; this version fixes that bug.
+This release is optional for all nodes.
 
-This release is optional for all nodes; however, v18.2.1 is required to be
-able to use both mainnet and testnet. Currently, v18.2.0 is not working on mainnet,
-and v18.1.1 is not working on testnet; v18.2.1 will work on both networks.
-
-Please report bugs using the issue tracker at GitHub:
+Please report bugs using the issue tracker at github:
 
   <https://github.com/dashpay/dash/issues>
 
@@ -41,20 +38,15 @@ downgrade to an older version is only possible with a reindex
 Downgrade warning
 -----------------
 
-### Downgrade to a version < v18.2.1
+### Downgrade to a version < v18.2.0
 
-Downgrading to a version older than v18.2.1 is supported.
+Downgrading to a version older than v18.2.0 is supported.
 
 ### Downgrade to a version < v18.0.1
 
 Downgrading to a version older than v18.0.1 is not supported due to changes in
 the indexes database folder. If you need to use an older version, you must
 either reindex or re-sync the whole chain.
-
-### Downgrade of masternodes to < 18.2.1
-
-It is highly recommended not to downgrade masternodes below 18.2.1, as 18.2.1 (and 18.1.1)
-fix important bugs which may result in your masternode being PoSe banned.
 
 ### Downgrade of masternodes to < v18.0.1
 
@@ -72,26 +64,48 @@ releases are minimized, however we do not guarantee there are no breaking change
 Bitcoin backports often introduce breaking changes, and are a likely source of
 breaking changes in minor releases. Patch releases should never contain breaking changes.
 
+This release **does** include breaking changes. Please read below to see if they will affect you.
+
 Notable changes
 ===============
-See #5145 and #5142; these 2 PR fix important bugs in previous versions. Specifically,
-#5145 fixes an issue where qfcommit messages can be replayed from the past, then are
-validated and propagated to other nodes. This patch prevents old qfcommits
-from being relayed. #5142 is a fix which enables this version to function both on testnet
-and mainnet.
 
 
 Remote Procedure Call (RPC) Changes
 -----------------------------------
 
 ### The new RPCs are:
-None
+
+- `analyzepsbt` examines a PSBT and provides information about what
+  the PSBT contains and the next steps that need to be taken in order
+  to complete the transaction. For each input of a PSBT, `analyzepsbt`
+  provides information about what information is missing for that
+  input, including whether a UTXO needs to be provided, what pubkeys
+  still need to be provided, which scripts need to be provided, and
+  what signatures are still needed. Every input will also list which
+  role is needed to complete that input, and `analyzepsbt` will also
+  list the next role in general needed to complete the PSBT.
+  `analyzepsbt` will also provide the estimated fee rate and estimated
+  virtual size of the completed transaction if it has enough
+  information to do so.
+- `quorum listextended` is the cousin of `quorum list` with a more enriched reply. By using the `height` parameter, the RPC will list active quorums at a specified height (or at the tip if `height` is not specified).
+  This RPC returns the following data per quorum grouped per llmqTypes:
+    - For each `quorumHash`:
+        - `creationHeight`: Block height where its DKG started
+        - `quorumIndex`: Returned only for rotated llmqTypes
+        - `minedBlockHash`: Hash of the block containing the mined final commitment
+        - `numValidMembers`: The total of valid members.
+        - `healthRatio`: The ratio of healthy members to quorum size. Range [0.0 - 1.0].
+- `getbalances` returns an object with all balances (`mine`,
+  `untrusted_pending` and `immature`). Please refer to the RPC help of
+  `getbalances` for details. The new RPC is intended to replace
+  `getunconfirmedbalance` and the balance fields in `getwalletinfo`, as well as
+  `getbalance`. The old calls may be removed in a future version.
 
 ### The removed RPCs are:
 None
 
 ### Changes in existing RPCs introduced through bitcoin backports:
-None
+- `walletprocesspsbt` and `walletcreatefundedpsbt` now include BIP 32 derivation paths by default for public keys if we know them. This can be disabled by setting `bip32derivs` to `false`.
 
 ### Dash-specific changes in existing RPCs:
 None
@@ -100,19 +114,20 @@ Please check `help <command>` for more detailed information on specific RPCs.
 
 Command-line options
 --------------------
-None
+
 
 Please check `Help -> Command-line options` in Qt wallet or `dashd --help` for
 more information.
 
 Backports from Bitcoin Core
 ---------------------------
-None
 
-v18.2.1 Change log
+This release introduces many hundreds updates from Bitcoin v0.18/v0.19/v0.20/v0.21/v22. Bitcoin changes that do not align with Dash’s product needs, such as SegWit and RBF, are excluded from our backporting. For additional detail on what’s included in Bitcoin, please refer to their release notes.
+
+v18.2.0 Change log
 ==================
 
-See detailed [set of changes](https://github.com/dashpay/dash/compare/v18.2.0...dashpay:v18.2.1).
+See detailed [set of changes](https://github.com/dashpay/dash/compare/v18.1.0...dashpay:v18.2.0).
 
 Credits
 =======
@@ -123,6 +138,8 @@ Thanks to everyone who directly contributed to this release:
 - Konstantin Akimov
 - Odysseas Gabrielides
 - PastaPastaPasta
+- strophy
+- thephez
 - UdjinM6
 
 As well as everyone that submitted issues, reviewed pull requests, helped debug the release candidates, and write DIPs that were implemented in this release.
@@ -150,8 +167,6 @@ Dash Core tree 0.12.1.x was a fork of Bitcoin Core tree 0.12.
 
 These release are considered obsolete. Old release notes can be found here:
 
-- [v18.2.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-18.2.0.md) released Jan/01/2023
-- [v18.1.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-18.1.1.md) released January/08/2023
 - [v18.1.0](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-18.1.0.md) released October/09/2022
 - [v18.0.2](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-18.0.2.md) released October/09/2022
 - [v18.0.1](https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-18.0.1.md) released August/17/2022


### PR DESCRIPTION
NOTE: ignoring changes from 54ea80e00d4fce1e1609da0d79f69f102ba443cd and 2b23c8ef6eec0a59bb71a1bed375f35d72051164