### PR TITLE
feat: reduce autoresending of wallet transactions to an average of 2 hours

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2300,7 +2300,7 @@ void CWallet::ResendWalletTransactions()
     if (GetTime() < nNextResend || !fBroadcastTransactions) return;
     bool fFirst = (nNextResend == 0);
     // resend 1-3 hours from now, ~2 hours on average.
-    nNextResend = GetTime() + (1 * 60 * 60) + GetRand(3 * 60 * 60);
+    nNextResend = GetTime() + (1 * 60 * 60) + GetRand(2 * 60 * 60);
     if (fFirst) return;
 
     // Only do it if there's been a new block since last time

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2299,8 +2299,8 @@ void CWallet::ResendWalletTransactions()
     // that these are our transactions.
     if (GetTime() < nNextResend || !fBroadcastTransactions) return;
     bool fFirst = (nNextResend == 0);
-    // resend 12-36 hours from now, ~1 day on average.
-    nNextResend = GetTime() + (12 * 60 * 60) + GetRand(24 * 60 * 60);
+    // resend 1-3 hours from now, ~2 hours on average.
+    nNextResend = GetTime() + (1 * 60 * 60) + GetRand(3 * 60 * 60);
     if (fFirst) return;
 
     // Only do it if there's been a new block since last time

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -58,9 +58,9 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         assert_equal(node.p2ps[1].tx_invs_received[txid], 0)
 
         self.log.info("Bump time & check that transaction is rebroadcast")
-        # Transaction should be rebroadcast approximately 24 hours in the future,
-        # but can range from 12-36. So bump 36 hours to be sure.
-        rebroadcast_time = self.mocktime + 36 * 60 * 60
+        # Transaction should be rebroadcast approximately 2 hours in the future,
+        # but can range from 1-3. So bump 3 hours to be sure.
+        rebroadcast_time = self.mocktime + 3 * 60 * 60
         node.setmocktime(rebroadcast_time)
         self.mocktime = rebroadcast_time
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
autoresending was really slow

## What was done?
reduced the time range to from 1-3 hours from now

## How Has This Been Tested?
hasn't

## Breaking Changes
Shouldn't be

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
