### PR TITLE
refactor(stats): modernize `statsd::StatsdClient`, make global `unique_ptr`

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -289,6 +289,7 @@ void PrepareShutdown(NodeContext& node)
     node.banman.reset();
     node.addrman.reset();
     node.netgroupman.reset();
+    ::statsClient.reset();
 
     if (node.mempool && node.mempool->IsLoaded() && node.args->GetBoolArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         DumpMempool(*node.mempool);
@@ -839,12 +840,12 @@ static void PeriodicStats(ArgsManager& args, ChainstateManager& chainman, const 
     CCoinsStats stats{CoinStatsHashType::NONE};
     chainman.ActiveChainstate().ForceFlushStateToDisk();
     if (WITH_LOCK(cs_main, return GetUTXOStats(&chainman.ActiveChainstate().CoinsDB(), std::ref(chainman.m_blockman), stats, RpcInterruptionPoint, chainman.ActiveChain().Tip()))) {
-        statsClient.gauge("utxoset.tx", stats.nTransactions, 1.0f);
-        statsClient.gauge("utxoset.txOutputs", stats.nTransactionOutputs, 1.0f);
-        statsClient.gauge("utxoset.dbSizeBytes", stats.nDiskSize, 1.0f);
-        statsClient.gauge("utxoset.blockHeight", stats.nHeight, 1.0f);
+        ::statsClient->gauge("utxoset.tx", stats.nTransactions, 1.0f);
+        ::statsClient->gauge("utxoset.txOutputs", stats.nTransactionOutputs, 1.0f);
+        ::statsClient->gauge("utxoset.dbSizeBytes", stats.nDiskSize, 1.0f);
+        ::statsClient->gauge("utxoset.blockHeight", stats.nHeight, 1.0f);
         if (stats.total_amount.has_value()) {
-            statsClient.gauge("utxoset.totalAmount", (double)stats.total_amount.value() / (double)COIN, 1.0f);
+            ::statsClient->gauge("utxoset.totalAmount", (double)stats.total_amount.value() / (double)COIN, 1.0f);
         }
     } else {
         // something went wrong
@@ -866,22 +867,22 @@ static void PeriodicStats(ArgsManager& args, ChainstateManager& chainman, const 
     int64_t timeDiff = maxTime - minTime;
     double nNetworkHashPS = workDiff.getdouble() / timeDiff;
 
-    statsClient.gaugeDouble("network.hashesPerSecond", nNetworkHashPS);
-    statsClient.gaugeDouble("network.terahashesPerSecond", nNetworkHashPS / 1e12);
-    statsClient.gaugeDouble("network.petahashesPerSecond", nNetworkHashPS / 1e15);
-    statsClient.gaugeDouble("network.exahashesPerSecond", nNetworkHashPS / 1e18);
+    ::statsClient->gaugeDouble("network.hashesPerSecond", nNetworkHashPS);
+    ::statsClient->gaugeDouble("network.terahashesPerSecond", nNetworkHashPS / 1e12);
+    ::statsClient->gaugeDouble("network.petahashesPerSecond", nNetworkHashPS / 1e15);
+    ::statsClient->gaugeDouble("network.exahashesPerSecond", nNetworkHashPS / 1e18);
     // No need for cs_main, we never use null tip here
-    statsClient.gaugeDouble("network.difficulty", (double)GetDifficulty(tip));
+    ::statsClient->gaugeDouble("network.difficulty", (double)GetDifficulty(tip));
 
-    statsClient.gauge("transactions.txCacheSize", WITH_LOCK(cs_main, return chainman.ActiveChainstate().CoinsTip().GetCacheSize()), 1.0f);
-    statsClient.gauge("transactions.totalTransactions", tip->nChainTx, 1.0f);
+    ::statsClient->gauge("transactions.txCacheSize", WITH_LOCK(cs_main, return chainman.ActiveChainstate().CoinsTip().GetCacheSize()), 1.0f);
+    ::statsClient->gauge("transactions.totalTransactions", tip->nChainTx, 1.0f);
 
     {
         LOCK(mempool.cs);
-        statsClient.gauge("transactions.mempool.totalTransactions", mempool.size(), 1.0f);
-        statsClient.gauge("transactions.mempool.totalTxBytes", (int64_t) mempool.GetTotalTxSize(), 1.0f);
-        statsClient.gauge("transactions.mempool.memoryUsageBytes", (int64_t) mempool.DynamicMemoryUsage(), 1.0f);
-        statsClient.gauge("transactions.mempool.minFeePerKb", mempool.GetMinFee(args.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK(), 1.0f);
+        ::statsClient->gauge("transactions.mempool.totalTransactions", mempool.size(), 1.0f);
+        ::statsClient->gauge("transactions.mempool.totalTxBytes", (int64_t) mempool.GetTotalTxSize(), 1.0f);
+        ::statsClient->gauge("transactions.mempool.memoryUsageBytes", (int64_t) mempool.DynamicMemoryUsage(), 1.0f);
+        ::statsClient->gauge("transactions.mempool.minFeePerKb", mempool.GetMinFee(args.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK(), 1.0f);
     }
 }
 
@@ -1523,6 +1524,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     fListen = args.GetBoolArg("-listen", DEFAULT_LISTEN);
     fDiscover = args.GetBoolArg("-discover", true);
     const bool ignores_incoming_txs{args.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)};
+
+    // We need to initialize statsClient early as currently, statsClient is called
+    // regardless of whether transmitting stats are desirable or not and if
+    // statsClient isn't present when that attempt is made, the client will crash.
+    ::statsClient = std::make_unique<statsd::StatsdClient>();
 
     {
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1528,7 +1528,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     // We need to initialize g_stats_client early as currently, g_stats_client is called
     // regardless of whether transmitting stats are desirable or not and if
     // g_stats_client isn't present when that attempt is made, the client will crash.
-    ::g_stats_client = std::make_unique<statsd::StatsdClient>();
+    ::g_stats_client = std::make_unique<statsd::StatsdClient>(args.GetArg("-statshost", DEFAULT_STATSD_HOST),
+                                                              args.GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
+                                                              args.GetArg("-statsport", DEFAULT_STATSD_PORT),
+                                                              args.GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),
+                                                              args.GetBoolArg("-statsenabled", DEFAULT_STATSD_ENABLE));
 
     {
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -623,7 +623,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
                              /*inbound_onion=*/false,
                              std::move(i2p_transient_session));
     pnode->AddRef();
-    ::statsClient->inc("peers.connect", 1.0f);
+    ::g_stats_client->inc("peers.connect", 1.0f);
 
     // We're making a new connection, harvest entropy from the time (and our peer count)
     RandAddEvent((uint32_t)id);
@@ -666,7 +666,7 @@ void CNode::CloseSocketDisconnect(CConnman* connman)
     m_sock.reset();
     m_i2p_sam_session.reset();
 
-    ::statsClient->inc("peers.disconnect", 1.0f);
+    ::g_stats_client->inc("peers.disconnect", 1.0f);
 }
 
 void CConnman::AddWhitelistPermissionFlags(NetPermissionFlags& flags, const CNetAddr &addr) const {
@@ -817,7 +817,7 @@ bool CNode::ReceiveMsgBytes(Span<const uint8_t> msg_bytes, bool& complete)
             }
             assert(i != mapRecvBytesPerMsgType.end());
             i->second += msg.m_raw_message_size;
-            ::statsClient->count("bandwidth.message." + std::string(msg.m_type) + ".bytesReceived", msg.m_raw_message_size, 1.0f);
+            ::g_stats_client->count("bandwidth.message." + std::string(msg.m_type) + ".bytesReceived", msg.m_raw_message_size, 1.0f);
 
             // push the message to the process queue,
             vRecvMsg.push_back(std::move(msg));
@@ -1741,20 +1741,20 @@ void CConnman::CalculateNumConnectionsChangedStats()
             torNodes++;
         const auto last_ping_time = count_microseconds(pnode->m_last_ping_time);
         if (last_ping_time > 0)
-            ::statsClient->timing("peers.ping_us", last_ping_time, 1.0f);
+            ::g_stats_client->timing("peers.ping_us", last_ping_time, 1.0f);
     }
     for (const std::string &msg : getAllNetMessageTypes()) {
-        ::statsClient->gauge("bandwidth.message." + msg + ".totalBytesReceived", mapRecvBytesMsgStats[msg], 1.0f);
-        ::statsClient->gauge("bandwidth.message." + msg + ".totalBytesSent", mapSentBytesMsgStats[msg], 1.0f);
+        ::g_stats_client->gauge("bandwidth.message." + msg + ".totalBytesReceived", mapRecvBytesMsgStats[msg], 1.0f);
+        ::g_stats_client->gauge("bandwidth.message." + msg + ".totalBytesSent", mapSentBytesMsgStats[msg], 1.0f);
     }
-    ::statsClient->gauge("peers.totalConnections", nPrevNodeCount, 1.0f);
-    ::statsClient->gauge("peers.spvNodeConnections", spvNodes, 1.0f);
-    ::statsClient->gauge("peers.fullNodeConnections", fullNodes, 1.0f);
-    ::statsClient->gauge("peers.inboundConnections", inboundNodes, 1.0f);
-    ::statsClient->gauge("peers.outboundConnections", outboundNodes, 1.0f);
-    ::statsClient->gauge("peers.ipv4Connections", ipv4Nodes, 1.0f);
-    ::statsClient->gauge("peers.ipv6Connections", ipv6Nodes, 1.0f);
-    ::statsClient->gauge("peers.torConnections", torNodes, 1.0f);
+    ::g_stats_client->gauge("peers.totalConnections", nPrevNodeCount, 1.0f);
+    ::g_stats_client->gauge("peers.spvNodeConnections", spvNodes, 1.0f);
+    ::g_stats_client->gauge("peers.fullNodeConnections", fullNodes, 1.0f);
+    ::g_stats_client->gauge("peers.inboundConnections", inboundNodes, 1.0f);
+    ::g_stats_client->gauge("peers.outboundConnections", outboundNodes, 1.0f);
+    ::g_stats_client->gauge("peers.ipv4Connections", ipv4Nodes, 1.0f);
+    ::g_stats_client->gauge("peers.ipv6Connections", ipv6Nodes, 1.0f);
+    ::g_stats_client->gauge("peers.torConnections", torNodes, 1.0f);
 }
 
 bool CConnman::ShouldRunInactivityChecks(const CNode& node, std::chrono::seconds now) const
@@ -4124,8 +4124,8 @@ bool CConnman::DisconnectNode(NodeId id)
 void CConnman::RecordBytesRecv(uint64_t bytes)
 {
     nTotalBytesRecv += bytes;
-    ::statsClient->count("bandwidth.bytesReceived", bytes, 0.1f);
-    ::statsClient->gauge("bandwidth.totalBytesReceived", nTotalBytesRecv, 0.01f);
+    ::g_stats_client->count("bandwidth.bytesReceived", bytes, 0.1f);
+    ::g_stats_client->gauge("bandwidth.totalBytesReceived", nTotalBytesRecv, 0.01f);
 }
 
 void CConnman::RecordBytesSent(uint64_t bytes)
@@ -4134,8 +4134,8 @@ void CConnman::RecordBytesSent(uint64_t bytes)
     LOCK(m_total_bytes_sent_mutex);
 
     nTotalBytesSent += bytes;
-    ::statsClient->count("bandwidth.bytesSent", bytes, 0.01f);
-    ::statsClient->gauge("bandwidth.totalBytesSent", nTotalBytesSent, 0.01f);
+    ::g_stats_client->count("bandwidth.bytesSent", bytes, 0.01f);
+    ::g_stats_client->gauge("bandwidth.totalBytesSent", nTotalBytesSent, 0.01f);
 
     const auto now = GetTime<std::chrono::seconds>();
     if (nMaxOutboundCycleStartTime + MAX_UPLOAD_TIMEFRAME < now)
@@ -4291,8 +4291,8 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
         msg.data.data()
     );
 
-    ::statsClient->count(strprintf("bandwidth.message.%s.bytesSent", msg.m_type), nMessageSize, 1.0f);
-    ::statsClient->inc(strprintf("message.sent.%s", msg.m_type), 1.0f);
+    ::g_stats_client->count(strprintf("bandwidth.message.%s.bytesSent", msg.m_type), nMessageSize, 1.0f);
+    ::g_stats_client->inc(strprintf("message.sent.%s", msg.m_type), 1.0f);
 
     {
         LOCK(pnode->cs_vSend);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1688,9 +1688,9 @@ void PeerManagerImpl::Misbehaving(const NodeId pnode, const int howmuch, const s
     if (score_now >= DISCOURAGEMENT_THRESHOLD && score_before < DISCOURAGEMENT_THRESHOLD) {
         warning = " DISCOURAGE THRESHOLD EXCEEDED";
         peer->m_should_discourage = true;
-        statsClient.inc("misbehavior.banned", 1.0f);
+        ::statsClient->inc("misbehavior.banned", 1.0f);
     } else {
-        statsClient.count("misbehavior.amount", howmuch, 1.0);
+        ::statsClient->count("misbehavior.amount", howmuch, 1.0);
     }
 
     LogPrint(BCLog::NET, "Misbehaving: peer=%d (%d -> %d)%s%s\n",
@@ -3260,7 +3260,7 @@ void PeerManagerImpl::ProcessMessage(
     AssertLockHeld(g_msgproc_mutex);
 
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(msg_type), vRecv.size(), pfrom.GetId());
-    statsClient.inc("message.received." + SanitizeString(msg_type), 1.0f);
+    ::statsClient->inc("message.received." + SanitizeString(msg_type), 1.0f);
 
     const bool is_masternode = m_mn_activeman != nullptr;
 
@@ -3759,7 +3759,7 @@ void PeerManagerImpl::ProcessMessage(
             if (inv.IsMsgBlk()) {
                 const bool fAlreadyHave = AlreadyHaveBlock(inv.hash);
                 LogPrint(BCLog::NET, "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
-                statsClient.inc(strprintf("message.received.inv_%s", inv.GetCommand()), 1.0f);
+                ::statsClient->inc(strprintf("message.received.inv_%s", inv.GetCommand()), 1.0f);
 
                 UpdateBlockAvailability(pfrom.GetId(), inv.hash);
                 if (!fAlreadyHave && !fImporting && !fReindex && !mapBlocksInFlight.count(inv.hash)) {
@@ -3774,7 +3774,7 @@ void PeerManagerImpl::ProcessMessage(
             } else {
                 const bool fAlreadyHave = AlreadyHave(inv);
                 LogPrint(BCLog::NET, "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
-                statsClient.inc(strprintf("message.received.inv_%s", inv.GetCommand()), 1.0f);
+                ::statsClient->inc(strprintf("message.received.inv_%s", inv.GetCommand()), 1.0f);
 
                 static std::set<int> allowWhileInIBDObjs = {
                         MSG_SPORK

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1688,9 +1688,9 @@ void PeerManagerImpl::Misbehaving(const NodeId pnode, const int howmuch, const s
     if (score_now >= DISCOURAGEMENT_THRESHOLD && score_before < DISCOURAGEMENT_THRESHOLD) {
         warning = " DISCOURAGE THRESHOLD EXCEEDED";
         peer->m_should_discourage = true;
-        ::statsClient->inc("misbehavior.banned", 1.0f);
+        ::g_stats_client->inc("misbehavior.banned", 1.0f);
     } else {
-        ::statsClient->count("misbehavior.amount", howmuch, 1.0);
+        ::g_stats_client->count("misbehavior.amount", howmuch, 1.0);
     }
 
     LogPrint(BCLog::NET, "Misbehaving: peer=%d (%d -> %d)%s%s\n",
@@ -3260,7 +3260,7 @@ void PeerManagerImpl::ProcessMessage(
     AssertLockHeld(g_msgproc_mutex);
 
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(msg_type), vRecv.size(), pfrom.GetId());
-    ::statsClient->inc("message.received." + SanitizeString(msg_type), 1.0f);
+    ::g_stats_client->inc("message.received." + SanitizeString(msg_type), 1.0f);
 
     const bool is_masternode = m_mn_activeman != nullptr;
 
@@ -3759,7 +3759,7 @@ void PeerManagerImpl::ProcessMessage(
             if (inv.IsMsgBlk()) {
                 const bool fAlreadyHave = AlreadyHaveBlock(inv.hash);
                 LogPrint(BCLog::NET, "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
-                ::statsClient->inc(strprintf("message.received.inv_%s", inv.GetCommand()), 1.0f);
+                ::g_stats_client->inc(strprintf("message.received.inv_%s", inv.GetCommand()), 1.0f);
 
                 UpdateBlockAvailability(pfrom.GetId(), inv.hash);
                 if (!fAlreadyHave && !fImporting && !fReindex && !mapBlocksInFlight.count(inv.hash)) {
@@ -3774,7 +3774,7 @@ void PeerManagerImpl::ProcessMessage(
             } else {
                 const bool fAlreadyHave = AlreadyHave(inv);
                 LogPrint(BCLog::NET, "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom.GetId());
-                ::statsClient->inc(strprintf("message.received.inv_%s", inv.GetCommand()), 1.0f);
+                ::g_stats_client->inc(strprintf("message.received.inv_%s", inv.GetCommand()), 1.0f);
 
                 static std::set<int> allowWhileInIBDObjs = {
                         MSG_SPORK

--- a/src/random.h
+++ b/src/random.h
@@ -207,10 +207,6 @@ public:
         return rand32() % nMax;
     }
 
-    uint32_t operator()(uint32_t nMax) {
-        return rand32(nMax);
-    }
-
     /** Generate random bytes. */
     template <typename B = unsigned char>
     std::vector<B> randbytes(size_t len);

--- a/src/statsd_client.cpp
+++ b/src/statsd_client.cpp
@@ -61,9 +61,12 @@ bool StatsdClient::ShouldSend(float sample_rate)
     return sample_rate > std::uniform_real_distribution<float>(0.f, 1.f)(insecure_rand);
 }
 
-StatsdClient::StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
-                           const std::string& ns, bool enabled)
-    : m_port{port}, m_host{host}, m_nodename{nodename}, m_ns{ns}
+StatsdClient::StatsdClient(const std::string& host, const std::string& nodename, uint16_t port, const std::string& ns,
+                           bool enabled) :
+    m_port{port},
+    m_host{host},
+    m_nodename{nodename},
+    m_ns{ns}
 {
     if (!enabled) {
         LogPrintf("Transmitting stats are disabled, will not init StatsdClient\n");
@@ -99,22 +102,15 @@ StatsdClient::StatsdClient(const std::string& host, const std::string& nodename,
 void StatsdClient::cleanup(std::string& key)
 {
     auto pos = key.find_first_of(":|@");
-    while (pos != std::string::npos)
-    {
+    while (pos != std::string::npos) {
         key[pos] = '_';
         pos = key.find_first_of(":|@");
     }
 }
 
-bool StatsdClient::dec(const std::string& key, float sample_rate)
-{
-    return count(key, -1, sample_rate);
-}
+bool StatsdClient::dec(const std::string& key, float sample_rate) { return count(key, -1, sample_rate); }
 
-bool StatsdClient::inc(const std::string& key, float sample_rate)
-{
-    return count(key, 1, sample_rate);
-}
+bool StatsdClient::inc(const std::string& key, float sample_rate) { return count(key, 1, sample_rate); }
 
 bool StatsdClient::count(const std::string& key, int64_t value, float sample_rate)
 {
@@ -148,8 +144,7 @@ bool StatsdClient::send(std::string key, int64_t value, const std::string& type,
     }
 
     // partition stats by node name if set
-    if (!m_nodename.empty())
-        key = key + "." + m_nodename;
+    if (!m_nodename.empty()) key = key + "." + m_nodename;
 
     cleanup(key);
 
@@ -173,8 +168,7 @@ bool StatsdClient::sendDouble(std::string key, double value, const std::string& 
     }
 
     // partition stats by node name if set
-    if (!m_nodename.empty())
-        key = key + "." + m_nodename;
+    if (!m_nodename.empty()) key = key + "." + m_nodename;
 
     cleanup(key);
 

--- a/src/statsd_client.cpp
+++ b/src/statsd_client.cpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <cstdio>
 
-std::unique_ptr<statsd::StatsdClient> statsClient;
+std::unique_ptr<statsd::StatsdClient> g_stats_client;
 
 namespace statsd {
 

--- a/src/statsd_client.cpp
+++ b/src/statsd_client.cpp
@@ -61,8 +61,8 @@ bool StatsdClient::ShouldSend(float sample_rate)
     return sample_rate > std::uniform_real_distribution<float>(0.f, 1.f)(insecure_rand);
 }
 
-StatsdClient::StatsdClient(const std::string& host, const std::string& nodename, uint16_t port, const std::string& ns,
-                           bool enabled)
+StatsdClient::StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
+                           const std::string& ns, bool enabled)
     : m_port{port}, m_host{host}, m_nodename{nodename}, m_ns{ns}
 {
     if (!enabled) {

--- a/src/statsd_client.cpp
+++ b/src/statsd_client.cpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <cstdio>
 
-statsd::StatsdClient statsClient;
+std::unique_ptr<statsd::StatsdClient> statsClient;
 
 namespace statsd {
 

--- a/src/statsd_client.cpp
+++ b/src/statsd_client.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2014-2017 Statoshi Developers
+// Copyright (c) 2020-2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 /**
 Copyright (c) 2014, Rex
 All rights reserved.

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2014-2017 Statoshi Developers
 // Copyright (c) 2020-2023 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -12,7 +12,7 @@
 #include <memory>
 
 static const bool DEFAULT_STATSD_ENABLE = false;
-static const int DEFAULT_STATSD_PORT = 8125;
+static const uint16_t DEFAULT_STATSD_PORT = 8125;
 static const std::string DEFAULT_STATSD_HOST = "127.0.0.1";
 static const std::string DEFAULT_STATSD_HOSTNAME = "";
 static const std::string DEFAULT_STATSD_NAMESPACE = "";
@@ -25,20 +25,17 @@ static const int MAX_STATSD_PERIOD = 60 * 60;
 namespace statsd {
 class StatsdClient {
     public:
-        explicit StatsdClient(const std::string& host, const std::string& nodename, short port, const std::string& ns,
+        explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port, const std::string& ns,
                               bool enabled);
         ~StatsdClient();
 
     public:
-        const char* errmsg();
-
-    public:
         int inc(const std::string& key, float sample_rate = 1.0);
         int dec(const std::string& key, float sample_rate = 1.0);
-        int count(const std::string& key, size_t value, float sample_rate = 1.0);
-        int gauge(const std::string& key, size_t value, float sample_rate = 1.0);
+        int count(const std::string& key, int64_t value, float sample_rate = 1.0);
+        int gauge(const std::string& key, int64_t value, float sample_rate = 1.0);
         int gaugeDouble(const std::string& key, double value, float sample_rate = 1.0);
-        int timing(const std::string& key, size_t ms, float sample_rate = 1.0);
+        int timing(const std::string& key, int64_t ms, float sample_rate = 1.0);
 
     public:
         /**
@@ -50,7 +47,7 @@ class StatsdClient {
         /* (Low Level Api) manually send a message
          * type = "c", "g" or "ms"
          */
-        int send(std::string key, size_t value,
+        int send(std::string key, int64_t value,
                 const std::string& type, float sample_rate);
         int sendDouble(std::string key, double value,
                 const std::string& type, float sample_rate);
@@ -61,12 +58,11 @@ class StatsdClient {
 
     private:
         bool m_init{false};
-        char m_errmsg[1024];
         SOCKET m_sock{INVALID_SOCKET};
         struct sockaddr_in m_server;
 
         const bool m_enabled{false};
-        const short m_port;
+        const uint16_t m_port;
         const std::string m_host;
         const std::string m_nodename;
         const std::string m_ns;

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -22,7 +22,7 @@ static const std::string DEFAULT_STATSD_NAMESPACE{""};
 // schedule periodic measurements, in seconds: default - 1 minute, min - 5 sec, max - 1h.
 static constexpr int DEFAULT_STATSD_PERIOD{60};
 static constexpr int MIN_STATSD_PERIOD{5};
-static constexpr int MAX_STATSD_PERIOD{60*60};
+static constexpr int MAX_STATSD_PERIOD{60 * 60};
 
 namespace statsd {
 class StatsdClient {

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -63,7 +63,6 @@ class StatsdClient {
         mutable Mutex cs;
         mutable FastRandomContext insecure_rand GUARDED_BY(cs);
 
-        bool m_init{false};
         std::unique_ptr<Sock> m_sock{nullptr};
         std::pair<struct sockaddr_storage, socklen_t> m_server{{}, sizeof(struct sockaddr_storage)};
 

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_STATSD_CLIENT_H
 #define BITCOIN_STATSD_CLIENT_H
 
+#include <util/sock.h>
+
 #include <string>
 #include <memory>
 
@@ -20,18 +22,13 @@ static const int MIN_STATSD_PERIOD = 5;
 static const int MAX_STATSD_PERIOD = 60 * 60;
 
 namespace statsd {
-
-struct _StatsdClientData;
-
 class StatsdClient {
     public:
-        explicit StatsdClient(const std::string& host, const std::string& nodename, int port, const std::string& ns,
+        explicit StatsdClient(const std::string& host, const std::string& nodename, short port, const std::string& ns,
                               bool enabled);
         ~StatsdClient();
 
     public:
-        // you can config at anytime; client will use new address (useful for Singleton)
-        void config(const std::string& host, const std::string& nodename, int port, const std::string& ns);
         const char* errmsg();
 
     public:
@@ -61,13 +58,18 @@ class StatsdClient {
         int init();
         static void cleanup(std::string& key);
 
-    protected:
-        const std::unique_ptr<struct _StatsdClientData> d;
-
     private:
-        const bool m_enabled{false};
-};
+        bool m_init{false};
+        char m_errmsg[1024];
+        SOCKET m_sock{INVALID_SOCKET};
+        struct sockaddr_in m_server;
 
+        const bool m_enabled{false};
+        const short m_port;
+        const std::string m_host;
+        const std::string m_nodename;
+        const std::string m_ns;
+};
 } // namespace statsd
 
 extern std::unique_ptr<statsd::StatsdClient> g_stats_client;

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -55,7 +55,6 @@ class StatsdClient {
                 const std::string& type, float sample_rate);
 
     protected:
-        int init();
         static void cleanup(std::string& key);
 
     private:
@@ -69,7 +68,6 @@ class StatsdClient {
         SOCKET m_sock{INVALID_SOCKET};
         struct sockaddr_in m_server;
 
-        const bool m_enabled{false};
         const uint16_t m_port;
         const std::string m_host;
         const std::string m_nodename;

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -13,22 +13,22 @@
 #include <string>
 #include <memory>
 
-static const bool DEFAULT_STATSD_ENABLE = false;
-static const uint16_t DEFAULT_STATSD_PORT = 8125;
-static const std::string DEFAULT_STATSD_HOST = "127.0.0.1";
-static const std::string DEFAULT_STATSD_HOSTNAME = "";
-static const std::string DEFAULT_STATSD_NAMESPACE = "";
+static constexpr bool DEFAULT_STATSD_ENABLE{false};
+static constexpr uint16_t DEFAULT_STATSD_PORT{8125};
+static const std::string DEFAULT_STATSD_HOST{"127.0.0.1"};
+static const std::string DEFAULT_STATSD_HOSTNAME{""};
+static const std::string DEFAULT_STATSD_NAMESPACE{""};
 
 // schedule periodic measurements, in seconds: default - 1 minute, min - 5 sec, max - 1h.
-static const int DEFAULT_STATSD_PERIOD = 60;
-static const int MIN_STATSD_PERIOD = 5;
-static const int MAX_STATSD_PERIOD = 60 * 60;
+static constexpr int DEFAULT_STATSD_PERIOD{60};
+static constexpr int MIN_STATSD_PERIOD{5};
+static constexpr int MAX_STATSD_PERIOD{60*60};
 
 namespace statsd {
 class StatsdClient {
     public:
-        explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port, const std::string& ns,
-                              bool enabled);
+        explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port,
+                              const std::string& ns, bool enabled);
 
     public:
         bool inc(const std::string& key, float sample_rate = 1.f);

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -29,7 +29,6 @@ class StatsdClient {
     public:
         explicit StatsdClient(const std::string& host, const std::string& nodename, uint16_t port, const std::string& ns,
                               bool enabled);
-        ~StatsdClient();
 
     public:
         int inc(const std::string& key, float sample_rate = 1.f);
@@ -65,8 +64,8 @@ class StatsdClient {
         mutable FastRandomContext insecure_rand GUARDED_BY(cs);
 
         bool m_init{false};
-        SOCKET m_sock{INVALID_SOCKET};
-        struct sockaddr_in m_server;
+        std::unique_ptr<Sock> m_sock{nullptr};
+        std::pair<struct sockaddr_storage, socklen_t> m_server{{}, sizeof(struct sockaddr_storage)};
 
         const uint16_t m_port;
         const std::string m_host;

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -25,12 +25,13 @@ struct _StatsdClientData;
 
 class StatsdClient {
     public:
-        explicit StatsdClient(const std::string& host = DEFAULT_STATSD_HOST, int port = DEFAULT_STATSD_PORT, const std::string& ns = DEFAULT_STATSD_NAMESPACE);
+        explicit StatsdClient(const std::string& host, const std::string& nodename, int port, const std::string& ns,
+                              bool enabled);
         ~StatsdClient();
 
     public:
         // you can config at anytime; client will use new address (useful for Singleton)
-        void config(const std::string& host, int port, const std::string& ns = DEFAULT_STATSD_NAMESPACE);
+        void config(const std::string& host, const std::string& nodename, int port, const std::string& ns);
         const char* errmsg();
 
     public:
@@ -62,6 +63,9 @@ class StatsdClient {
 
     protected:
         const std::unique_ptr<struct _StatsdClientData> d;
+
+    private:
+        const bool m_enabled{false};
 };
 
 } // namespace statsd

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -66,6 +66,6 @@ class StatsdClient {
 
 } // namespace statsd
 
-extern statsd::StatsdClient statsClient;
+extern std::unique_ptr<statsd::StatsdClient> statsClient;
 
 #endif // BITCOIN_STATSD_CLIENT_H

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -6,6 +6,8 @@
 #ifndef BITCOIN_STATSD_CLIENT_H
 #define BITCOIN_STATSD_CLIENT_H
 
+#include <random.h>
+#include <threadsafety.h>
 #include <util/sock.h>
 
 #include <string>
@@ -30,12 +32,12 @@ class StatsdClient {
         ~StatsdClient();
 
     public:
-        int inc(const std::string& key, float sample_rate = 1.0);
-        int dec(const std::string& key, float sample_rate = 1.0);
-        int count(const std::string& key, int64_t value, float sample_rate = 1.0);
-        int gauge(const std::string& key, int64_t value, float sample_rate = 1.0);
-        int gaugeDouble(const std::string& key, double value, float sample_rate = 1.0);
-        int timing(const std::string& key, int64_t ms, float sample_rate = 1.0);
+        int inc(const std::string& key, float sample_rate = 1.f);
+        int dec(const std::string& key, float sample_rate = 1.f);
+        int count(const std::string& key, int64_t value, float sample_rate = 1.f);
+        int gauge(const std::string& key, int64_t value, float sample_rate = 1.f);
+        int gaugeDouble(const std::string& key, double value, float sample_rate = 1.f);
+        int timing(const std::string& key, int64_t ms, float sample_rate = 1.f);
 
     public:
         /**
@@ -57,6 +59,12 @@ class StatsdClient {
         static void cleanup(std::string& key);
 
     private:
+        bool ShouldSend(float sample_rate);
+
+    private:
+        mutable Mutex cs;
+        mutable FastRandomContext insecure_rand GUARDED_BY(cs);
+
         bool m_init{false};
         SOCKET m_sock{INVALID_SOCKET};
         struct sockaddr_in m_server;

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -66,6 +66,6 @@ class StatsdClient {
 
 } // namespace statsd
 
-extern std::unique_ptr<statsd::StatsdClient> statsClient;
+extern std::unique_ptr<statsd::StatsdClient> g_stats_client;
 
 #endif // BITCOIN_STATSD_CLIENT_H

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -31,32 +31,27 @@ class StatsdClient {
                               bool enabled);
 
     public:
-        int inc(const std::string& key, float sample_rate = 1.f);
-        int dec(const std::string& key, float sample_rate = 1.f);
-        int count(const std::string& key, int64_t value, float sample_rate = 1.f);
-        int gauge(const std::string& key, int64_t value, float sample_rate = 1.f);
-        int gaugeDouble(const std::string& key, double value, float sample_rate = 1.f);
-        int timing(const std::string& key, int64_t ms, float sample_rate = 1.f);
-
-    public:
-        /**
-         * (Low Level Api) manually send a message
-         * which might be composed of several lines.
-         */
-        int send(const std::string& message);
+        bool inc(const std::string& key, float sample_rate = 1.f);
+        bool dec(const std::string& key, float sample_rate = 1.f);
+        bool count(const std::string& key, int64_t value, float sample_rate = 1.f);
+        bool gauge(const std::string& key, int64_t value, float sample_rate = 1.f);
+        bool gaugeDouble(const std::string& key, double value, float sample_rate = 1.f);
+        bool timing(const std::string& key, int64_t ms, float sample_rate = 1.f);
 
         /* (Low Level Api) manually send a message
          * type = "c", "g" or "ms"
          */
-        int send(std::string key, int64_t value,
-                const std::string& type, float sample_rate);
-        int sendDouble(std::string key, double value,
-                const std::string& type, float sample_rate);
-
-    protected:
-        static void cleanup(std::string& key);
+        bool send(std::string key, int64_t value, const std::string& type, float sample_rate);
+        bool sendDouble(std::string key, double value, const std::string& type, float sample_rate);
 
     private:
+        /**
+         * (Low Level Api) manually send a message
+         * which might be composed of several lines.
+         */
+        bool send(const std::string& message);
+
+        void cleanup(std::string& key);
         bool ShouldSend(float sample_rate);
 
     private:

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -39,6 +39,7 @@
 #include <scheduler.h>
 #include <script/sigcache.h>
 #include <spork.h>
+#include <statsd_client.h>
 #include <streams.h>
 #include <test/util/index.h>
 #include <txdb.h>
@@ -182,6 +183,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     SetupNetworking();
     InitSignatureCache();
     InitScriptExecutionCache();
+    ::statsClient = std::make_unique<statsd::StatsdClient>();
     m_node.chain = interfaces::MakeChain(m_node);
 
     m_node.netgroupman = std::make_unique<NetGroupManager>(/*asmap=*/std::vector<bool>());
@@ -217,6 +219,7 @@ BasicTestingSetup::~BasicTestingSetup()
     m_node.connman.reset();
     m_node.addrman.reset();
     m_node.netgroupman.reset();
+    ::statsClient.reset();
 
     LogInstance().DisconnectTestLogger();
     fs::remove_all(m_path_root);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -183,7 +183,13 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     SetupNetworking();
     InitSignatureCache();
     InitScriptExecutionCache();
-    ::g_stats_client = std::make_unique<statsd::StatsdClient>();
+    ::g_stats_client = std::make_unique<statsd::StatsdClient>(
+        m_node.args->GetArg("-statshost", DEFAULT_STATSD_HOST),
+        m_node.args->GetArg("-statshostname", DEFAULT_STATSD_HOSTNAME),
+        m_node.args->GetArg("-statsport", DEFAULT_STATSD_PORT),
+        m_node.args->GetArg("-statsns", DEFAULT_STATSD_NAMESPACE),
+        m_node.args->GetBoolArg("-statsenabled", DEFAULT_STATSD_ENABLE)
+    );
     m_node.chain = interfaces::MakeChain(m_node);
 
     m_node.netgroupman = std::make_unique<NetGroupManager>(/*asmap=*/std::vector<bool>());

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -183,7 +183,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     SetupNetworking();
     InitSignatureCache();
     InitScriptExecutionCache();
-    ::statsClient = std::make_unique<statsd::StatsdClient>();
+    ::g_stats_client = std::make_unique<statsd::StatsdClient>();
     m_node.chain = interfaces::MakeChain(m_node);
 
     m_node.netgroupman = std::make_unique<NetGroupManager>(/*asmap=*/std::vector<bool>());
@@ -219,7 +219,7 @@ BasicTestingSetup::~BasicTestingSetup()
     m_node.connman.reset();
     m_node.addrman.reset();
     m_node.netgroupman.reset();
-    ::statsClient.reset();
+    ::g_stats_client.reset();
 
     LogInstance().DisconnectTestLogger();
     fs::remove_all(m_path_root);

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -51,8 +51,8 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
 
     LogPrint(BCLog::MEMPOOL, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
              m_orphans.size(), m_outpoint_to_orphan_it.size());
-    statsClient.inc("transactions.orphans.add", 1.0f);
-    statsClient.gauge("transactions.orphans", m_orphans.size());
+    ::statsClient->inc("transactions.orphans.add", 1.0f);
+    ::statsClient->gauge("transactions.orphans", m_orphans.size());
 
     return true;
 }
@@ -87,8 +87,8 @@ int TxOrphanage::EraseTx(const uint256& txid)
     assert(m_orphan_tx_size >= it->second.nTxSize);
     m_orphan_tx_size -= it->second.nTxSize;
     m_orphans.erase(it);
-    statsClient.inc("transactions.orphans.remove", 1.0f);
-    statsClient.gauge("transactions.orphans", m_orphans.size());
+    ::statsClient->inc("transactions.orphans.remove", 1.0f);
+    ::statsClient->gauge("transactions.orphans", m_orphans.size());
     return 1;
 }
 

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -51,8 +51,8 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
 
     LogPrint(BCLog::MEMPOOL, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
              m_orphans.size(), m_outpoint_to_orphan_it.size());
-    ::statsClient->inc("transactions.orphans.add", 1.0f);
-    ::statsClient->gauge("transactions.orphans", m_orphans.size());
+    ::g_stats_client->inc("transactions.orphans.add", 1.0f);
+    ::g_stats_client->gauge("transactions.orphans", m_orphans.size());
 
     return true;
 }
@@ -87,8 +87,8 @@ int TxOrphanage::EraseTx(const uint256& txid)
     assert(m_orphan_tx_size >= it->second.nTxSize);
     m_orphan_tx_size -= it->second.nTxSize;
     m_orphans.erase(it);
-    ::statsClient->inc("transactions.orphans.remove", 1.0f);
-    ::statsClient->gauge("transactions.orphans", m_orphans.size());
+    ::g_stats_client->inc("transactions.orphans.remove", 1.0f);
+    ::g_stats_client->gauge("transactions.orphans", m_orphans.size());
     return 1;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -612,7 +612,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // is it already in the memory pool?
     if (m_pool.exists(hash)) {
-        ::statsClient->inc("transactions.duplicate", 1.0f);
+        ::g_stats_client->inc("transactions.duplicate", 1.0f);
         return state.Invalid(TxValidationResult::TX_CONFLICT, "txn-already-in-mempool");
     }
 
@@ -838,11 +838,11 @@ bool MemPoolAccept::Finalize(const ATMPArgs& args, Workspace& ws)
     CAmount nValueOut = tx.GetValueOut();
     unsigned int nSigOps = GetTransactionSigOpCount(tx, m_view, STANDARD_SCRIPT_VERIFY_FLAGS);
 
-    ::statsClient->count("transactions.sizeBytes", entry->GetTxSize(), 1.0f);
-    ::statsClient->count("transactions.fees", nModifiedFees, 1.0f);
-    ::statsClient->count("transactions.inputValue", nValueOut - nModifiedFees, 1.0f);
-    ::statsClient->count("transactions.outputValue", nValueOut, 1.0f);
-    ::statsClient->count("transactions.sigOps", nSigOps, 1.0f);
+    ::g_stats_client->count("transactions.sizeBytes", entry->GetTxSize(), 1.0f);
+    ::g_stats_client->count("transactions.fees", nModifiedFees, 1.0f);
+    ::g_stats_client->count("transactions.inputValue", nValueOut - nModifiedFees, 1.0f);
+    ::g_stats_client->count("transactions.outputValue", nValueOut, 1.0f);
+    ::g_stats_client->count("transactions.sigOps", nSigOps, 1.0f);
 
     // Add memory address index
     if (fAddressIndex) {
@@ -895,10 +895,10 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
     const CTransaction& tx = *ptx;
     auto finish = Now<SteadyMilliseconds>();
     auto diff = finish - start;
-    ::statsClient->timing("AcceptToMemoryPool_ms", count_milliseconds(diff), 1.0f);
-    ::statsClient->inc("transactions.accepted", 1.0f);
-    ::statsClient->count("transactions.inputs", tx.vin.size(), 1.0f);
-    ::statsClient->count("transactions.outputs", tx.vout.size(), 1.0f);
+    ::g_stats_client->timing("AcceptToMemoryPool_ms", count_milliseconds(diff), 1.0f);
+    ::g_stats_client->inc("transactions.accepted", 1.0f);
+    ::g_stats_client->count("transactions.inputs", tx.vin.size(), 1.0f);
+    ::g_stats_client->count("transactions.outputs", tx.vout.size(), 1.0f);
 
     return MempoolAcceptResult::Success(ws.m_base_fees);
 }
@@ -1319,7 +1319,7 @@ void CChainState::InvalidChainFound(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
 
-    ::statsClient->inc("warnings.InvalidChainFound", 1.0f);
+    ::g_stats_client->inc("warnings.InvalidChainFound", 1.0f);
 
     if (!m_chainman.m_best_invalid || pindexNew->nChainWork > m_chainman.m_best_invalid->nChainWork) {
         m_chainman.m_best_invalid = pindexNew;
@@ -1343,7 +1343,7 @@ void CChainState::ConflictingChainFound(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
 
-    ::statsClient->inc("warnings.ConflictingChainFound", 1.0f);
+    ::g_stats_client->inc("warnings.ConflictingChainFound", 1.0f);
 
     LogPrintf("%s: conflicting block=%s  height=%d  log2_work=%f  date=%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
@@ -1362,7 +1362,7 @@ void CChainState::InvalidBlockFound(CBlockIndex *pindex, const BlockValidationSt
 {
     AssertLockHeld(cs_main);
 
-    ::statsClient->inc("warnings.InvalidBlockFound", 1.0f);
+    ::g_stats_client->inc("warnings.InvalidBlockFound", 1.0f);
     if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
         pindex->nStatus |= BLOCK_FAILED_VALID;
         m_chainman.m_failed_blocks.insert(pindex);
@@ -1526,7 +1526,7 @@ bool CheckInputScripts(const CTransaction& tx, TxValidationState &state, const C
 
     auto finish = Now<SteadyMilliseconds>();
     auto diff = finish - start;
-    ::statsClient->timing("CheckInputScripts_ms", count_milliseconds(diff), 1.0f);
+    ::g_stats_client->timing("CheckInputScripts_ms", count_milliseconds(diff), 1.0f);
     return true;
 }
 
@@ -1729,7 +1729,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
 
     auto finish = Now<SteadyMilliseconds>();
     auto diff = finish - start;
-    ::statsClient->timing("DisconnectBlock_ms", count_milliseconds(diff), 1.0f);
+    ::g_stats_client->timing("DisconnectBlock_ms", count_milliseconds(diff), 1.0f);
 
     return fClean ? DISCONNECT_OK : DISCONNECT_UNCLEAN;
 }
@@ -2296,12 +2296,12 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     int64_t nTime8 = GetTimeMicros(); nTimeCallbacks += nTime8 - nTime5;
     LogPrint(BCLog::BENCHMARK, "    - Callbacks: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime8 - nTime5), nTimeCallbacks * MICRO, nTimeCallbacks * MILLI / nBlocksTotal);
 
-    ::statsClient->timing("ConnectBlock_ms", (nTime8 - nTimeStart) / 1000, 1.0f);
-    ::statsClient->gauge("blocks.tip.SizeBytes", ::GetSerializeSize(block, PROTOCOL_VERSION), 1.0f);
-    ::statsClient->gauge("blocks.tip.Height", m_chain.Height(), 1.0f);
-    ::statsClient->gauge("blocks.tip.Version", block.nVersion, 1.0f);
-    ::statsClient->gauge("blocks.tip.NumTransactions", block.vtx.size(), 1.0f);
-    ::statsClient->gauge("blocks.tip.SigOps", nSigOps, 1.0f);
+    ::g_stats_client->timing("ConnectBlock_ms", (nTime8 - nTimeStart) / 1000, 1.0f);
+    ::g_stats_client->gauge("blocks.tip.SizeBytes", ::GetSerializeSize(block, PROTOCOL_VERSION), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.Height", m_chain.Height(), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.Version", block.nVersion, 1.0f);
+    ::g_stats_client->gauge("blocks.tip.NumTransactions", block.vtx.size(), 1.0f);
+    ::g_stats_client->gauge("blocks.tip.SigOps", nSigOps, 1.0f);
 
     TRACE6(validation, block_connected,
         block.GetHash().data(),
@@ -2772,7 +2772,7 @@ bool CChainState::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew
     LogPrint(BCLog::BENCHMARK, "  - Connect postprocess: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime6 - nTime5) * MILLI, nTimePostConnect * MICRO, nTimePostConnect * MILLI / nBlocksTotal);
     LogPrint(BCLog::BENCHMARK, "- Connect block: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime6 - nTime1) * MILLI, nTimeTotal * MICRO, nTimeTotal * MILLI / nBlocksTotal);
 
-    ::statsClient->timing("ConnectTip_ms", (nTime6 - nTime1) / 1000, 1.0f);
+    ::g_stats_client->timing("ConnectTip_ms", (nTime6 - nTime1) / 1000, 1.0f);
 
     connectTrace.BlockConnected(pindexNew, std::move(pthisBlock));
     return true;
@@ -3084,7 +3084,7 @@ bool CChainState::ActivateBestChain(BlockValidationState& state, std::shared_ptr
 
     auto finish = Now<SteadyMilliseconds>();
     auto diff = finish - start;
-    ::statsClient->timing("ActivateBestChain_ms", count_milliseconds(diff), 1.0f);
+    ::g_stats_client->timing("ActivateBestChain_ms", count_milliseconds(diff), 1.0f);
 
     // Write changes periodically to disk, after relay.
     if (!FlushStateToDisk(state, FlushStateMode::PERIODIC)) {
@@ -3572,7 +3572,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
 
     auto finish = Now<SteadyMicroseconds>();
     auto diff = finish - start;
-    ::statsClient->timing("CheckBlock_us", count_microseconds(diff), 1.0f);
+    ::g_stats_client->timing("CheckBlock_us", count_microseconds(diff), 1.0f);
 
     return true;
 }
@@ -3943,7 +3943,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
 
     auto finish = Now<SteadyMicroseconds>();
     auto diff = finish - start;
-    ::statsClient->timing("AcceptBlock_us", count_microseconds(diff), 1.0f);
+    ::g_stats_client->timing("AcceptBlock_us", count_microseconds(diff), 1.0f);
 
     return true;
 }

--- a/test/lint/run-lint-format-strings.py
+++ b/test/lint/run-lint-format-strings.py
@@ -24,8 +24,6 @@ FALSE_POSITIVES = [
     ("src/qt/networkstyle.cpp", "strprintf(titleAddText, gArgs.GetDevNetName())"),
     ("src/rpc/evo.cpp", "strprintf(it->second, nParamNum)"),
     ("src/stacktraces.cpp", "strprintf(fmtStr, i, si.pc, lstr, fstr)"),
-    ("src/statsd_client.cpp", "snprintf(d->errmsg, sizeof(d->errmsg), \"could not create socket, err=%m\")"),
-    ("src/statsd_client.cpp", "snprintf(d->errmsg, sizeof(d->errmsg), \"sendto server fail, host=%s:%d, err=%m\", d->host.c_str(), d->port)"),
     ("src/util/system.cpp", "strprintf(_(COPYRIGHT_HOLDERS).translated, COPYRIGHT_HOLDERS_SUBSTITUTION)"),
     ("src/validationinterface.cpp", "LogPrint(BCLog::VALIDATION, fmt \"\\n\", __VA_ARGS__)"),
     ("src/wallet/wallet.h",  "WalletLogPrintf(std::string fmt, Params... parameters)"),


### PR DESCRIPTION
## Additional Information

Support for transmitting stats to a Statsd server has been courtesy of Statoshi ([repo](https://github.com/jlopp/statoshi)), implemented Dec, 2020 by [dash#2515](https://github.com/dashpay/dash/pull/2515) but since then, it hasn't gotten much attention aside from benefiting from codebase-wide changes and the occasional compiler appeasement. This pull request aims to give our statistics code some TLC.

Changes include:

* Limiting initialization to solely during construction and moving the responsibility of fetching arguments outside of `statsd::StatsdClient`.
* Using the RAII `Socks` wrapper as early as possible (we still need to construct a raw socket ourselves but this is done in the initializer and control is moved to the wrapper and everywhere else, the wrapper is used) 
* Utilizing existing networking code to generate the socket address
  * This lets us trivially allow IPv6 connections as the responsibility to construct it safely is moved to `CService`.
* Using `std::string` and our string manipulation capabilities (replacing `snprintf` with `strprintf`), replacing platform-specific types (replacing `short` with `uint16_t`).

## Breaking Changes

None observed.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone
