### PR TITLE
fix: keeping reference to local variable in Coin Join unit tests

### DIFF
--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -129,7 +129,6 @@ public:
     CTransactionBuilderTestSetup()
     {
         CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-        NodeContext node;
         chain = interfaces::MakeChain(node);
         wallet = std::make_unique<CWallet>(chain.get(), "", CreateMockWalletDatabase());
         bool firstRun;
@@ -151,6 +150,7 @@ public:
         RemoveWallet(wallet, std::nullopt);
     }
 
+    NodeContext node;
     std::shared_ptr<interfaces::Chain> chain;
     std::shared_ptr<CWallet> wallet;
 


### PR DESCRIPTION
It become a visible UB (crash) after backport bitcoin#19848

## What was done?
Increased life-term for object under reference

## How Has This Been Tested?
Run unit/functional tests with and without bitcoin#19848

## Breaking Changes
No breaking changes

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
