### PR TITLE
refactor: remove dependency of dummyWallet in RecoverDatabaseFile on NodeContext

### DIFF
--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -4,7 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <fs.h>
-#include <node/context.h>
 #include <streams.h>
 #include <util/translation.h>
 #include <wallet/salvage.h>
@@ -130,10 +129,8 @@ bool RecoverDatabaseFile(const fs::path& file_path, bilingual_str& error, std::v
         return false;
     }
 
-    NodeContext node;
-    auto chain = interfaces::MakeChain(node);
     DbTxn* ptxn = env->TxnBegin();
-    CWallet dummyWallet(chain.get(), "", CreateDummyWalletDatabase());
+    CWallet dummyWallet(nullptr, "", CreateDummyWalletDatabase());
     for (KeyValPair& row : salvagedData)
     {
         /* Filter for only private key type KV pairs to be added to the salvaged wallet */


### PR DESCRIPTION
## Issue being fixed or feature implemented
Bitcoin#15639 removes libbitcoin-server library from list of wallet linkage list.
It is not possible to remove this dependency in dash now because coinjoin hardly used libbitcoin-server in client side.
Despite that, this dependency can be removed.

## What was done?
Removed NodeContext from dummyWallet by providing nullptr as a chain pointer.


## How Has This Been Tested?
Validated, that linkage error "NodeContext is unknown symbol" disappeared in case if remove libbitcoin-server dependency.

## Breaking Changes
No breaking changes

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
