### PR TITLE
fix(qt): Ignore change output in reassignAmounts

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -233,7 +233,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
     newTx = m_wallet->createTransaction(vecSend, coinControl, !privateKeysDisabled() /* sign */, nChangePosRet, nFeeRequired, error);
     transaction.setTransactionFee(nFeeRequired);
     if (fSubtractFeeFromAmount && newTx)
-        transaction.reassignAmounts();
+        transaction.reassignAmounts(nChangePosRet);
 
     if(!newTx)
     {

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -41,14 +41,16 @@ void WalletModelTransaction::setTransactionFee(const CAmount& newFee)
     fee = newFee;
 }
 
-void WalletModelTransaction::reassignAmounts()
+void WalletModelTransaction::reassignAmounts(int nChangePos)
 {
     // For each recipient look for a matching CTxOut in walletTransaction and reassign amounts
     for (QList<SendCoinsRecipient>::iterator it = recipients.begin(); it != recipients.end(); ++it)
     {
         SendCoinsRecipient& rcp = (*it);
         {
+            int nPos = 0;
             for (const auto& txout : wtx.get()->vout) {
+                if (nPos++ == nChangePos) continue; // ignore change output
                 CScript scriptPubKey = GetScriptForDestination(DecodeDestination(rcp.address.toStdString()));
                 if (txout.scriptPubKey == scriptPubKey) {
                     rcp.amount = txout.nValue;

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -41,7 +41,7 @@ void WalletModelTransaction::setTransactionFee(const CAmount& newFee)
     fee = newFee;
 }
 
-void WalletModelTransaction::reassignAmounts(int nChangePos)
+void WalletModelTransaction::reassignAmounts(const int nChangePos)
 {
     // For each recipient look for a matching CTxOut in walletTransaction and reassign amounts
     for (QList<SendCoinsRecipient>::iterator it = recipients.begin(); it != recipients.end(); ++it)

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -33,7 +33,7 @@ public:
 
     CAmount getTotalTransactionAmount() const;
 
-    void reassignAmounts(); // needed for the subtract-fee-from-amount feature
+    void reassignAmounts(int nChangePos); // needed for the subtract-fee-from-amount feature
 
 private:
     QList<SendCoinsRecipient> recipients;

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -33,7 +33,7 @@ public:
 
     CAmount getTotalTransactionAmount() const;
 
-    void reassignAmounts(int nChangePos); // needed for the subtract-fee-from-amount feature
+    void reassignAmounts(const int nChangePos); // needed for the subtract-fee-from-amount feature
 
 private:
     QList<SendCoinsRecipient> recipients;


### PR DESCRIPTION
## Issue being fixed or feature implemented
#5180 

## What was done?
`reassignAmounts` was behaving incorrectly when change and recipient address were the same. Ignore change output should fix it.

## How Has This Been Tested?
To reproduce #5180: create a tx which sends to some address but has a custom change address set to the very same address too (enable "custom change address" checkbox and paste an address there), make sure the "subtract fee from amount" checkbox is enabled. The problem should go away when the patch is applied.

## Breaking Changes
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
