### PR TITLE
refactor: remove protx_update_service_legacy

### DIFF
--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -670,7 +670,8 @@ static void protx_update_service_help(const JSONRPCRequest& request)
         },
     }.Check(request);
 }
-static UniValue protx_update_service_wrapper(const JSONRPCRequest& request, const bool specific_legacy_bls_scheme)
+
+static UniValue protx_update_service(const JSONRPCRequest& request)
 {
     protx_update_service_help(request);
 
@@ -680,11 +681,7 @@ static UniValue protx_update_service_wrapper(const JSONRPCRequest& request, cons
     EnsureWalletIsUnlocked(wallet.get());
 
     CProUpServTx ptx;
-    if (specific_legacy_bls_scheme) {
-        ptx.nVersion = CProUpServTx::LEGACY_BLS_VERSION;
-    } else {
-        ptx.nVersion = CProUpServTx::GetVersion(llmq::utils::IsV19Active(::ChainActive().Tip()));
-    }
+    ptx.nVersion = CProUpServTx::GetVersion(llmq::utils::IsV19Active(::ChainActive().Tip()));
     ptx.proTxHash = ParseHashV(request.params[0], "proTxHash");
 
     if (!Lookup(request.params[1].get_str().c_str(), ptx.addr, Params().GetDefaultPort(), false)) {
@@ -744,15 +741,6 @@ static UniValue protx_update_service_wrapper(const JSONRPCRequest& request, cons
     SetTxPayload(tx, ptx);
 
     return SignAndSendSpecialTx(request, tx);
-}
-static UniValue protx_update_service(const JSONRPCRequest& request)
-{
-    return protx_update_service_wrapper(request, false);
-}
-
-static UniValue protx_update_service_legacy(const JSONRPCRequest& request)
-{
-    return protx_update_service_wrapper(request, true);
 }
 
 static void protx_update_registrar_help(const JSONRPCRequest& request)
@@ -1283,8 +1271,6 @@ static UniValue protx(const JSONRPCRequest& request)
         return protx_register_submit(new_request);
     } else if (command == "protxupdate_service") {
         return protx_update_service(new_request);
-    } else if (command == "protxupdate_service_legacy") {
-        return protx_update_service_legacy(new_request);
     } else if (command == "protxupdate_registrar") {
         return protx_update_registrar(new_request);
     } else if (command == "protxupdate_registrar_legacy") {


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removed RPC `protx update_service_legacy` since this RPC parses BLS private key (instead of BLS public key).
BLS scheme do not affect private keys, contrary to public keys.

## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
