### PR TITLE
fix: get rid of [most] clang warnings during build on linux

### DIFF
--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -122,7 +122,7 @@ private:
 
 public:
     explicit CCoinJoinClientSession(CWallet& pwallet, const std::unique_ptr<CMasternodeSync>& mn_sync) :
-        mixingWallet(pwallet), m_mn_sync(mn_sync)
+        m_mn_sync(mn_sync), mixingWallet(pwallet)
     {
     }
 
@@ -205,7 +205,7 @@ public:
     CCoinJoinClientManager& operator=(CCoinJoinClientManager const&) = delete;
 
     explicit CCoinJoinClientManager(CWallet& wallet, const std::unique_ptr<CMasternodeSync>& mn_sync) :
-        mixingWallet(wallet), m_mn_sync(mn_sync) {}
+        m_mn_sync(mn_sync), mixingWallet(wallet) {}
 
     void ProcessMessage(CNode& peer, CConnman& connman, std::string_view msg_type, CDataStream& vRecv) LOCKS_EXCLUDED(cs_deqsessions);
 

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -76,10 +76,11 @@ private:
 
 public:
     explicit CCoinJoinServer(CConnman& _connman, const std::unique_ptr<CMasternodeSync>& mn_sync) :
-        vecSessionCollaterals(),
-        fUnitTest(false),
         connman(_connman),
-        m_mn_sync(mn_sync) {};
+        m_mn_sync(mn_sync),
+        vecSessionCollaterals(),
+        fUnitTest(false)
+    {}
 
     void ProcessMessage(CNode& pfrom, std::string_view msg_type, CDataStream& vRecv);
 

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -545,7 +545,7 @@ std::vector<const CBlockIndex*> CQuorumBlockProcessor::GetMinedCommitmentsUntilB
         }
 
         uint32_t nMinedHeight = std::numeric_limits<uint32_t>::max() - be32toh(std::get<2>(curKey));
-        if (nMinedHeight > uint32_t(pindex->nHeight)) {
+        if (nMinedHeight > static_cast<uint32_t>(pindex->nHeight)) {
             break;
         }
 
@@ -588,7 +588,7 @@ std::optional<const CBlockIndex*> CQuorumBlockProcessor::GetLastMinedCommitments
         }
 
         uint32_t nMinedHeight = std::numeric_limits<uint32_t>::max() - be32toh(std::get<3>(curKey));
-        if (nMinedHeight > pindex->nHeight) {
+        if (nMinedHeight > static_cast<uint32_t>(pindex->nHeight)) {
             return std::nullopt;
         }
 

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -25,9 +25,14 @@ namespace llmq
 std::unique_ptr<CChainLocksHandler> chainLocksHandler;
 
 CChainLocksHandler::CChainLocksHandler(CTxMemPool& _mempool, CConnman& _connman, CSporkManager& sporkManager, CSigningManager& _sigman, CSigSharesManager& _shareman, const std::unique_ptr<CMasternodeSync>& mn_sync) :
-    scheduler(std::make_unique<CScheduler>()), mempool(_mempool), connman(_connman), spork_manager(sporkManager), sigman(_sigman), shareman(_shareman),
-    scheduler_thread(std::make_unique<std::thread>([&] { TraceThread("cl-schdlr", [&] { scheduler->serviceQueue(); }); })),
-    m_mn_sync(mn_sync)
+    connman(_connman),
+    mempool(_mempool),
+    spork_manager(sporkManager),
+    sigman(_sigman),
+    shareman(_shareman),
+    m_mn_sync(mn_sync),
+    scheduler(std::make_unique<CScheduler>()),
+    scheduler_thread(std::make_unique<std::thread>([&] { TraceThread("cl-schdlr", [&] { scheduler->serviceQueue(); }); }))
 {
 }
 

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -134,12 +134,12 @@ public:
     CDKGSessionHandler(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager,
                        CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, CConnman& _connman, int _quorumIndex) :
             params(_params),
+            connman(_connman),
+            quorumIndex(_quorumIndex),
             blsWorker(_blsWorker),
             dkgManager(_dkgManager),
             dkgDebugManager(_dkgDebugManager),
             quorumBlockProcessor(_quorumBlockProcessor),
-            connman(_connman),
-            quorumIndex(_quorumIndex),
             curSession(std::make_unique<CDKGSession>(_params, _blsWorker, _dkgManager, _dkgDebugManager, _connman)),
             pendingContributions((size_t)_params.size * 2, MSG_QUORUM_CONTRIB), // we allow size*2 messages as we need to make sure we see bad behavior (double messages)
             pendingComplaints((size_t)_params.size * 2, MSG_QUORUM_COMPLAINT),

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -462,7 +462,7 @@ void CDKGSessionManager::CleanupOldContributions() const
 
     for (const auto& params : Params().GetConsensus().llmqs) {
         // For how many blocks recent DKG info should be kept
-        const size_t MAX_STORE_DEPTH = 2 * params.signingActiveQuorumCount * params.dkgInterval;
+        const int MAX_STORE_DEPTH = 2 * params.signingActiveQuorumCount * params.dkgInterval;
 
         LogPrint(BCLog::LLMQ, "CDKGSessionManager::%s -- looking for old entries for llmq type %d\n", __func__, uint8_t(params.type));
 

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -23,7 +23,7 @@ static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
 CDKGSessionManager::CDKGSessionManager(CConnman& _connman, CBLSWorker& _blsWorker, CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, CSporkManager& sporkManager, bool unitTests, bool fWipe) :
         db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
-        blsWorker(_blsWorker), connman(_connman), dkgDebugManager(_dkgDebugManager), quorumBlockProcessor(_quorumBlockProcessor),spork_manager(sporkManager)
+        blsWorker(_blsWorker), connman(_connman), spork_manager(sporkManager), dkgDebugManager(_dkgDebugManager), quorumBlockProcessor(_quorumBlockProcessor)
 {
     if (!fMasternodeMode && !utils::IsWatchQuorumsEnabled()) {
         // Regular nodes do not care about any DKG internals, bail out

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -853,8 +853,10 @@ bool CInstantSendManager::ProcessPendingInstantSendLocks()
 {
     const CBlockIndex* pBlockIndexTip = WITH_LOCK(cs_main, return ::ChainActive().Tip());
     if (pBlockIndexTip && utils::GetInstantSendLLMQType(qman, pBlockIndexTip) == Params().GetConsensus().llmqTypeDIP0024InstantSend) {
-        // Don't short circuit. Try to process deterministic and not deterministic islocks
-        return ProcessPendingInstantSendLocks(true) & ProcessPendingInstantSendLocks(false);
+        // Don't short circuit. Try to process both deterministic and not deterministic islocks independable
+        bool deterministicRes = ProcessPendingInstantSendLocks(true);
+        bool nondeterministicRes = ProcessPendingInstantSendLocks(false);
+        return deterministicRes && nondeterministicRes;
     } else {
         return ProcessPendingInstantSendLocks(false);
     }

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -260,7 +260,7 @@ public:
     explicit CInstantSendManager(CTxMemPool& _mempool, CConnman& _connman, CSporkManager& sporkManager,
                                  CQuorumManager& _qman, CSigningManager& _sigman, CSigSharesManager& _shareman,
                                  CChainLocksHandler& _clhandler, const std::unique_ptr<CMasternodeSync>& mn_sync, bool unitTests, bool fWipe) :
-        db(unitTests, fWipe), mempool(_mempool), connman(_connman), spork_manager(sporkManager), qman(_qman), sigman(_sigman), shareman(_shareman),
+        db(unitTests, fWipe), connman(_connman), mempool(_mempool), spork_manager(sporkManager), qman(_qman), sigman(_sigman), shareman(_shareman),
         clhandler(_clhandler), m_mn_sync(mn_sync)
     {
         workInterrupt.reset();

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -188,11 +188,11 @@ bool CQuorum::ReadContributions(CEvoDB& evoDb)
 
 CQuorumManager::CQuorumManager(CEvoDB& _evoDb, CConnman& _connman, CBLSWorker& _blsWorker, CQuorumBlockProcessor& _quorumBlockProcessor,
                                CDKGSessionManager& _dkgManager, const std::unique_ptr<CMasternodeSync>& mn_sync) :
-    connman(_connman),
     m_evoDb(_evoDb),
+    connman(_connman),
     blsWorker(_blsWorker),
-    quorumBlockProcessor(_quorumBlockProcessor),
     dkgManager(_dkgManager),
+    quorumBlockProcessor(_quorumBlockProcessor),
     m_mn_sync(mn_sync)
 {
     utils::InitQuorumsCache(mapQuorumsCache);

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -1006,7 +1006,7 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
         //Extract last 64 bits of selectionHash
         uint64_t b = selectionHash.GetUint64(3);
         //Take last n bits of b
-        int signer = int((((1 << n) - 1) & (b >> (64 - n - 1))));
+        uint64_t signer = (((1 << n) - 1) & (b >> (64 - n - 1)));
 
         if (signer > quorums.size()) {
             return nullptr;
@@ -1014,7 +1014,7 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
         auto itQuorum = std::find_if(quorums.begin(),
                                      quorums.end(),
                                      [signer](const CQuorumCPtr& obj) {
-                                         return int(obj->qc->quorumIndex) == signer;
+                                         return uint64_t(obj->qc->quorumIndex) == signer;
                                      });
         if (itQuorum == quorums.end()) {
             return nullptr;

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -164,8 +164,8 @@ class CSigningManager
 private:
     mutable CCriticalSection cs;
 
-    CConnman& connman;
     CRecoveredSigsDb db;
+    CConnman& connman;
     const CQuorumManager& qman;
 
     // Incoming and not verified yet

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -113,7 +113,7 @@ std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqTy
 
         auto q = ComputeQuorumMembersByQuarterRotation(llmqType, pCycleQuorumBaseBlockIndex);
         LOCK(cs_indexed_members);
-        for (int i = 0; i < static_cast<int>(q.size()); ++i) {
+        for (const size_t i : irange::range(q.size())) {
             mapIndexedQuorumMembers[llmqType].insert(std::make_pair(pCycleQuorumBaseBlockIndex->GetBlockHash(), i), q[i]);
         }
 
@@ -151,15 +151,15 @@ std::vector<std::vector<CDeterministicMNCPtr>> ComputeQuorumMembersByQuarterRota
 
     PreviousQuorumQuarters previousQuarters = GetPreviousQuorumQuarterMembers(llmqParams, pBlockHMinusCIndex, pBlockHMinus2CIndex, pBlockHMinus3CIndex, pCycleQuorumBaseBlockIndex->nHeight);
 
-    auto nQuorums = size_t(llmqParams.signingActiveQuorumCount);
-    std::vector<std::vector<CDeterministicMNCPtr>> quorumMembers(nQuorums);
+    size_t nQuorums = static_cast<size_t>(llmqParams.signingActiveQuorumCount);
+    std::vector<std::vector<CDeterministicMNCPtr>> quorumMembers{nQuorums};
 
     auto newQuarterMembers = BuildNewQuorumQuarterMembers(llmqParams, pCycleQuorumBaseBlockIndex, previousQuarters);
     //TODO Check if it is triggered from outside (P2P, block validation). Throwing an exception is probably a wiser choice
     //assert (!newQuarterMembers.empty());
 
     if (LogAcceptCategory(BCLog::LLMQ)) {
-        for (auto i = 0; i < nQuorums; ++i) {
+        for (const size_t i : irange::range(nQuorums)) {
             std::stringstream ss;
 
             ss << " 3Cmns[";
@@ -184,7 +184,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> ComputeQuorumMembersByQuarterRota
         }
     }
 
-    for (auto i = 0; i < nQuorums; ++i) {
+    for (const size_t i : irange::range(nQuorums)) {
         for (const auto &m: previousQuarters.quarterHMinus3C[i]) {
             quorumMembers[i].push_back(std::move(m));
         }
@@ -219,8 +219,8 @@ PreviousQuorumQuarters GetPreviousQuorumQuarterMembers(const Consensus::LLMQPara
                                                                    const CBlockIndex* pBlockHMinus3CIndex,
                                                                    int nHeight)
 {
-    auto nQuorums = size_t(llmqParams.signingActiveQuorumCount);
-    PreviousQuorumQuarters quarters(nQuorums);
+    size_t nQuorums = static_cast<size_t>(llmqParams.signingActiveQuorumCount);
+    PreviousQuorumQuarters quarters{nQuorums};
 
     std::optional<llmq::CQuorumSnapshot> quSnapshotHMinusC = quorumSnapshotManager->GetSnapshotForBlock(llmqParams.type, pBlockHMinusCIndex);
     if (quSnapshotHMinusC.has_value()) {
@@ -250,11 +250,11 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
                                                                                         const CBlockIndex* pQuorumBaseBlockIndex,
                                                                                         const PreviousQuorumQuarters& previousQuarters)
 {
-    auto nQuorums = size_t(llmqParams.signingActiveQuorumCount);
-    std::vector<std::vector<CDeterministicMNCPtr>> quarterQuorumMembers(nQuorums);
+    size_t nQuorums = static_cast<size_t>(llmqParams.signingActiveQuorumCount);
+    std::vector<std::vector<CDeterministicMNCPtr>> quarterQuorumMembers{nQuorums};
 
-    auto quorumSize = size_t(llmqParams.size);
-    auto quarterSize = quorumSize / 4;
+    size_t quorumSize = static_cast<size_t>(llmqParams.size);
+    auto quarterSize{quorumSize / 4};
     const CBlockIndex* pWorkBlockIndex = pQuorumBaseBlockIndex->GetAncestor(pQuorumBaseBlockIndex->nHeight - 8);
     auto modifier = ::SerializeHash(std::make_pair(llmqParams.type, pWorkBlockIndex->GetBlockHash()));
 
@@ -267,11 +267,11 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
 
     auto MnsUsedAtH = CDeterministicMNList();
     auto MnsNotUsedAtH = CDeterministicMNList();
-    std::vector<CDeterministicMNList> MnsUsedAtHIndexed(nQuorums);
+    std::vector<CDeterministicMNList> MnsUsedAtHIndexed{nQuorums};
 
     bool skipRemovedMNs = IsV19Active(pQuorumBaseBlockIndex) || (Params().NetworkIDString() == CBaseChainParams::TESTNET);
 
-    for (auto i = 0; i < nQuorums; ++i) {
+    for (const size_t i : irange::range(nQuorums)) {
         for (const auto& mn : previousQuarters.quarterHMinusC[i]) {
             if (skipRemovedMNs && !allMns.HasMN(mn->proTxHash)) {
                 continue;
@@ -352,12 +352,12 @@ std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(cons
     }
 
     std::vector<int> skipList;
-    int firstSkippedIndex = 0;
-    auto idx = 0;
-    for (auto i = 0; i < nQuorums; ++i) {
+    size_t firstSkippedIndex = 0;
+    size_t idx{0};
+    for (const size_t i : irange::range(nQuorums)) {
         auto usedMNsCount = MnsUsedAtHIndexed[i].GetAllMNsCount();
-        auto updated{false};
-        auto initial_loop_idx = idx;
+        bool updated{false};
+        size_t initial_loop_idx = idx;
         while (quarterQuorumMembers[i].size() < quarterSize && (usedMNsCount + quarterQuorumMembers[i].size() < sortedCombinedMnsList.size())) {
             bool skip{true};
             if (!MnsUsedAtHIndexed[i].HasMN(sortedCombinedMnsList[idx]->proTxHash)) {
@@ -462,9 +462,9 @@ std::vector<std::vector<CDeterministicMNCPtr>> GetQuorumQuarterMembersBySnapshot
                  pQuorumBaseBlockIndex->nHeight, nHeight, ss.str());
     }
 
-    auto numQuorums = size_t(llmqParams.signingActiveQuorumCount);
-    auto quorumSize = size_t(llmqParams.size);
-    auto quarterSize = quorumSize / 4;
+    size_t numQuorums = static_cast<size_t>(llmqParams.signingActiveQuorumCount);
+    size_t quorumSize = static_cast<size_t>(llmqParams.size);
+    auto quarterSize{quorumSize / 4};
 
     std::vector<std::vector<CDeterministicMNCPtr>> quarterQuorumMembers(numQuorums);
 
@@ -476,7 +476,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> GetQuorumQuarterMembersBySnapshot
         case SnapshotSkipMode::MODE_NO_SKIPPING:
         {
             auto itm = sortedCombinedMns.begin();
-            for (auto i = 0; i < llmqParams.signingActiveQuorumCount; ++i) {
+            for (const size_t i : irange::range(numQuorums)) {
                 while (quarterQuorumMembers[i].size() < quarterSize) {
                     quarterQuorumMembers[i].push_back(*itm);
                     itm++;
@@ -500,9 +500,9 @@ std::vector<std::vector<CDeterministicMNCPtr>> GetQuorumQuarterMembersBySnapshot
                 }
             }
 
-            auto idx = 0;
+            int idx = 0;
             auto itsk = processesdSkipList.begin();
-            for (auto i = 0; i < llmqParams.signingActiveQuorumCount; ++i) {
+            for (const size_t i : irange::range(numQuorums)) {
                 while (quarterQuorumMembers[i].size() < quarterSize) {
                     if (itsk != processesdSkipList.end() && idx == *itsk) {
                         itsk++;
@@ -510,7 +510,7 @@ std::vector<std::vector<CDeterministicMNCPtr>> GetQuorumQuarterMembersBySnapshot
                         quarterQuorumMembers[i].push_back(sortedCombinedMns[idx]);
                     }
                     idx++;
-                    if (idx == sortedCombinedMns.size()) {
+                    if (idx == static_cast<int>(sortedCombinedMns.size())) {
                         idx = 0;
                     }
                 }

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -32,6 +32,19 @@ VersionBitsCache llmq_versionbitscache;
 namespace utils
 
 {
+// Forward declarations
+static std::vector<CDeterministicMNCPtr> ComputeQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex);
+static std::vector<std::vector<CDeterministicMNCPtr>> ComputeQuorumMembersByQuarterRotation(Consensus::LLMQType llmqType, const CBlockIndex* pCycleQuorumBaseBlockIndex);
+
+static std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(const Consensus::LLMQParams& llmqParams, const CBlockIndex* pQuorumBaseBlockIndex, const PreviousQuorumQuarters& quarters);
+
+static PreviousQuorumQuarters GetPreviousQuorumQuarterMembers(const Consensus::LLMQParams& llmqParams, const CBlockIndex* pBlockHMinusCIndex, const CBlockIndex* pBlockHMinus2CIndex, const CBlockIndex* pBlockHMinus3CIndex, int nHeight);
+static std::vector<std::vector<CDeterministicMNCPtr>> GetQuorumQuarterMembersBySnapshot(const Consensus::LLMQParams& llmqParams, const CBlockIndex* pQuorumBaseBlockIndex, const llmq::CQuorumSnapshot& snapshot, int nHeights);
+static std::pair<CDeterministicMNList, CDeterministicMNList> GetMNUsageBySnapshot(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex, const llmq::CQuorumSnapshot& snapshot, int nHeight);
+
+static void BuildQuorumSnapshot(const Consensus::LLMQParams& llmqParams, const CDeterministicMNList& allMns, const CDeterministicMNList& mnUsedAtH, std::vector<CDeterministicMNCPtr>& sortedCombinedMns, CQuorumSnapshot& quorumSnapshot, int nHeight, std::vector<int>& skipList, const CBlockIndex* pQuorumBaseBlockIndex);
+
+static bool IsInstantSendLLMQTypeShared();
 
 void PreComputeQuorumMembers(const CBlockIndex* pQuorumBaseBlockIndex, bool reset_cache)
 {

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -58,16 +58,6 @@ namespace utils
 std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex, bool reset_cache = false);
 
 void PreComputeQuorumMembers(const CBlockIndex* pQuorumBaseBlockIndex, bool reset_cache = false);
-static std::vector<CDeterministicMNCPtr> ComputeQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex);
-static std::vector<std::vector<CDeterministicMNCPtr>> ComputeQuorumMembersByQuarterRotation(Consensus::LLMQType llmqType, const CBlockIndex* pCycleQuorumBaseBlockIndex);
-
-static std::vector<std::vector<CDeterministicMNCPtr>> BuildNewQuorumQuarterMembers(const Consensus::LLMQParams& llmqParams, const CBlockIndex* pQuorumBaseBlockIndex, const PreviousQuorumQuarters& quarters);
-
-static PreviousQuorumQuarters GetPreviousQuorumQuarterMembers(const Consensus::LLMQParams& llmqParams, const CBlockIndex* pBlockHMinusCIndex, const CBlockIndex* pBlockHMinus2CIndex, const CBlockIndex* pBlockHMinus3CIndex, int nHeight);
-static std::vector<std::vector<CDeterministicMNCPtr>> GetQuorumQuarterMembersBySnapshot(const Consensus::LLMQParams& llmqParams, const CBlockIndex* pQuorumBaseBlockIndex, const llmq::CQuorumSnapshot& snapshot, int nHeights);
-static std::pair<CDeterministicMNList, CDeterministicMNList> GetMNUsageBySnapshot(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex, const llmq::CQuorumSnapshot& snapshot, int nHeight);
-
-static void BuildQuorumSnapshot(const Consensus::LLMQParams& llmqParams, const CDeterministicMNList& allMns, const CDeterministicMNList& mnUsedAtH, std::vector<CDeterministicMNCPtr>& sortedCombinedMns, CQuorumSnapshot& quorumSnapshot, int nHeight, std::vector<int>& skipList, const CBlockIndex* pQuorumBaseBlockIndex);
 
 uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash);
 uint256 BuildSignHash(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& id, const uint256& msgHash);
@@ -95,7 +85,6 @@ Consensus::LLMQType GetInstantSendLLMQType(bool deterministic);
 bool IsDIP0024Active(const CBlockIndex* pindex);
 bool IsV19Active(const CBlockIndex* pindex);
 const CBlockIndex* V19ActivationIndex(const CBlockIndex* pindex);
-static bool IsInstantSendLLMQTypeShared();
 
 /// Returns the state of `-llmq-data-recovery`
 bool QuorumDataRecoveryEnabled();
@@ -107,7 +96,7 @@ bool IsWatchQuorumsEnabled();
 std::map<Consensus::LLMQType, QvvecSyncMode> GetEnabledQuorumVvecSyncEntries();
 
 template<typename NodesContainer, typename Continue, typename Callback>
-static void IterateNodesRandom(NodesContainer& nodeStates, Continue&& cont, Callback&& callback, FastRandomContext& rnd)
+void IterateNodesRandom(NodesContainer& nodeStates, Continue&& cont, Callback&& callback, FastRandomContext& rnd)
 {
     std::vector<typename NodesContainer::iterator> rndNodes;
     rndNodes.reserve(nodeStates.size());

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -31,7 +31,7 @@ struct CActiveMasternodeInfo {
 };
 
 
-class CActiveMasternodeManager : public CValidationInterface
+class CActiveMasternodeManager final : public CValidationInterface
 {
 public:
     enum masternode_state_t {

--- a/src/masternode/utils.cpp
+++ b/src/masternode/utils.cpp
@@ -30,11 +30,11 @@ void CMasternodeUtils::DoMaintenance(CConnman& connman, const CMasternodeSync& m
     // Don't disconnect masternode connections when we have less then the desired amount of outbound nodes
     int nonMasternodeCount = 0;
     connman.ForEachNode(CConnman::AllNodes, [&](CNode* pnode) {
-        if (!pnode->fInbound &&
+        if ((!pnode->fInbound &&
             !pnode->fFeeler &&
             !pnode->m_manual_connection &&
             !pnode->m_masternode_connection &&
-            !pnode->m_masternode_probe_connection
+            !pnode->m_masternode_probe_connection)
             ||
             // treat unverified MNs as non-MNs here
             pnode->GetVerifiedProRegTxHash().IsNull()) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -58,12 +58,12 @@ BlockAssembler::Options::Options() {
 
 BlockAssembler::BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
                                const llmq::CQuorumBlockProcessor& quorumBlockProcessor, llmq::CChainLocksHandler& clhandler,
-                               llmq::CInstantSendManager& isman, CEvoDB& evoDb, const CTxMemPool& mempool, const CChainParams& params, const Options& options)
-    : spork_manager(sporkManager),
-      governance_manager(governanceManager),
-      quorum_block_processor(quorumBlockProcessor),
+                               llmq::CInstantSendManager& isman, CEvoDB& evoDb, const CTxMemPool& mempool, const CChainParams& params, const Options& options) :
       chainparams(params),
       m_mempool(mempool),
+      spork_manager(sporkManager),
+      governance_manager(governanceManager),
+      quorum_block_processor(quorumBlockProcessor),
       m_clhandler(clhandler),
       m_isman(isman),
       m_evoDb(evoDb)

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -295,9 +295,9 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request)
     for (const auto& type : llmq::utils::GetEnabledQuorumTypes(pindexTip)) {
         const auto& llmq_params = llmq::GetLLMQParams(type);
         bool rotation_enabled = llmq::utils::IsQuorumRotationEnabled(type, pindexTip);
-        size_t quorums_num = rotation_enabled ? llmq_params.signingActiveQuorumCount : 1;
+        int quorums_num = rotation_enabled ? llmq_params.signingActiveQuorumCount : 1;
 
-        for (int quorumIndex = 0; quorumIndex < quorums_num; ++quorumIndex) {
+        for (const int quorumIndex : irange::range(quorums_num)) {
             UniValue obj(UniValue::VOBJ);
             obj.pushKV("llmqType", std::string(llmq_params.name));
             obj.pushKV("quorumIndex", quorumIndex);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -82,7 +82,7 @@ bool static IsCompressedOrUncompressedPubKey(const valtype &vchPubKey) {
     return true;
 }
 
-bool static IsCompressedPubKey(const valtype &vchPubKey) {
+[[maybe_unused]] bool static IsCompressedPubKey(const valtype &vchPubKey) {
     if (vchPubKey.size() != CPubKey::COMPRESSED_SIZE) {
         //  Non-canonical public key: invalid length for compressed key
         return false;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1213,8 +1213,8 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                         valtype vchOut1, vchOut2;
                         vchOut1.insert(vchOut1.end(), vch.begin(), vch.begin() + nPosition);
                         vchOut2.insert(vchOut2.end(), vch.begin() + nPosition, vch.end());
-                        stack.emplace_back(move(vchOut1));
-                        stack.emplace_back(move(vchOut2));
+                        stack.emplace_back(std::move(vchOut1));
+                        stack.emplace_back(std::move(vchOut2));
                     }
                 }
                 break;

--- a/src/test/evo_trivialvalidation.cpp
+++ b/src/test/evo_trivialvalidation.cpp
@@ -27,19 +27,19 @@ BOOST_AUTO_TEST_CASE(trivialvalidation_valid)
 
     for (uint8_t idx = 1; idx < vectors.size(); idx++) {
         UniValue test = vectors[idx];
-        uint32_t txHeight;
         uint256 txHash;
         std::string txType;
         CMutableTransaction tx;
         try {
             // Additional data
-            txHeight = test[0].get_int();
+            int32_t txHeight = test[0].get_int();
             txHash = uint256S(test[1].get_str());
             txType = test[2].get_str();
             // Raw transaction
             CDataStream stream(ParseHex(test[3].get_str()), SER_NETWORK, PROTOCOL_VERSION);
             stream >> tx;
             // Sanity check
+            BOOST_CHECK(txHeight > 1);
             BOOST_CHECK_EQUAL(tx.nVersion, 3);
             BOOST_CHECK_EQUAL(tx.GetHash(), txHash);
             // Deserialization based on transaction nType


### PR DESCRIPTION
## Issue being fixed or feature implemented
Build on linux with clang produce a lot of warnings.
Some of them are fixed in this PR.

## What was done?
Fixed several types of warnings:
 - order of member initialization in constructors
 - mixing signed/unsigned wariables
 - moved static functions from header to cpp file
 - other fixes

## How Has This Been Tested?
Set up clang build on Linux + run build + unit/functional tests.

## Breaking Changes
Should not be breaking changes


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
