### PR TITLE
fix: using BLSDKG_GenerateContributions in benchmark

### DIFF
--- a/src/bench/bls_dkg.cpp
+++ b/src/bench/bls_dkg.cpp
@@ -166,8 +166,8 @@ static void BLSDKG_InitDKG(benchmark::Bench& bench, uint32_t epoch_iters, int qu
     } \
     BENCHMARK(BLSDKG_VerifyContributionShares_##name##_##quorumSize)
 
-BENCH_GenerateContributions(simple, 10, 50);
-BENCH_GenerateContributions(simple, 50, 5);
+BENCH_GenerateContributions(simple, 50, 50);
+BENCH_GenerateContributions(simple, 100, 5);
 
 BENCH_InitDKG(simple, 10, 100)
 BENCH_InitDKG(simple, 50, 10)

--- a/src/bench/bls_dkg.cpp
+++ b/src/bench/bls_dkg.cpp
@@ -130,7 +130,7 @@ static void BLSDKG_GenerateContributions(benchmark::Bench& bench, uint32_t epoch
 #define BENCH_GenerateContributions(name, quorumSize, epoch_iters) \
     static void BLSDKG_GenerateContributions_##name##_##quorumSize(benchmark::Bench& bench) \
     {                                                \
-        BLSDKG_InitDKG(bench, epoch_iters, quorumSize); \
+        BLSDKG_GenerateContributions(bench, epoch_iters, quorumSize); \
     } \
     BENCHMARK(BLSDKG_GenerateContributions_##name##_##quorumSize)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
BLSDKG_InitDKG used twice. Instead, once should be used BLSDKG_GenerateContributions



## What was done?
Replaced BLSDKG_InitDKG to BLSDKG_GenerateContributions


## How Has This Been Tested?
With patch (completely other numbers for `BLSDKG_GenerateContributions`):
```
|       12,400,083.80 |               80.64 |   22.4% |      0.14 | :wavy_dash: `BLSDKG_GenerateContributions_simple_10` (Unstable with ~54.3 iters. Increase `minEpochIterations` to e.g. 543)
|       72,281,069.33 |               13.83 |    1.5% |      0.81 | `BLSDKG_GenerateContributions_simple_50`
|       36,100,161.96 |               27.70 |    2.5% |      0.40 | `BLSDKG_InitDKG_simple_10`
|      124,084,124.30 |                8.06 |    1.9% |      1.35 | `BLSDKG_InitDKG_simple_50`
```
Without patch (same number for InitDKG and GenerateContributions):
```
|       36,636,218.34 |               27.30 |    0.9% |      0.41 | `BLSDKG_GenerateContributions_simple_10`
|      124,856,040.60 |                8.01 |    2.8% |      1.37 | `BLSDKG_GenerateContributions_simple_50`
|       36,886,990.17 |               27.11 |    1.2% |      0.40 | `BLSDKG_InitDKG_simple_10`
|      120,018,476.30 |                8.33 |    2.5% |      1.30 | `BLSDKG_InitDKG_simple_50`
```

## Breaking Changes
no breaking changes


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
