### PR TITLE
fix: using checkMalleable in serialization of CBLSSignatureVersionWrapper

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -306,8 +306,8 @@ public:
 
 class ConstCBLSPublicKeyVersionWrapper {
 private:
-    bool legacy;
     const CBLSPublicKey& obj;
+    bool legacy;
 public:
     ConstCBLSPublicKeyVersionWrapper(const CBLSPublicKey& obj, bool legacy)
             : obj(obj)
@@ -321,9 +321,9 @@ public:
 
 class CBLSPublicKeyVersionWrapper {
 private:
+    CBLSPublicKey& obj;
     bool legacy;
     bool checkMalleable;
-    CBLSPublicKey& obj;
 public:
     CBLSPublicKeyVersionWrapper(CBLSPublicKey& obj, bool legacy, bool checkMalleable = true)
             : obj(obj)
@@ -369,9 +369,9 @@ public:
 
 class CBLSSignatureVersionWrapper {
 private:
+    CBLSSignature& obj;
     bool legacy;
     bool checkMalleable;
-    CBLSSignature& obj;
 public:
     CBLSSignatureVersionWrapper(CBLSSignature& obj, bool legacy, bool checkMalleable = true)
             : obj(obj)
@@ -561,8 +561,8 @@ using CBLSLazyPublicKey = CBLSLazyWrapper<CBLSPublicKey>;
 
 class CBLSLazyPublicKeyVersionWrapper {
 private:
-    bool legacy;
     CBLSLazyPublicKey& obj;
+    bool legacy;
 public:
     CBLSLazyPublicKeyVersionWrapper(CBLSLazyPublicKey& obj, bool legacy)
             : obj(obj)

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -307,13 +307,11 @@ public:
 class ConstCBLSPublicKeyVersionWrapper {
 private:
     bool legacy;
-    bool checkMalleable;
     const CBLSPublicKey& obj;
 public:
-    ConstCBLSPublicKeyVersionWrapper(const CBLSPublicKey& obj, bool legacy, bool checkMalleable = true)
+    ConstCBLSPublicKeyVersionWrapper(const CBLSPublicKey& obj, bool legacy)
             : obj(obj)
             , legacy(legacy)
-            , checkMalleable(checkMalleable)
     {}
     template <typename Stream>
     inline void Serialize(Stream& s) const {

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -383,7 +383,7 @@ public:
         obj.Serialize(s, legacy);
     }
     template <typename Stream>
-    inline void Unserialize(Stream& s, bool checkMalleable = true) {
+    inline void Unserialize(Stream& s) {
         obj.Unserialize(s, legacy, checkMalleable);
     }
 };


### PR DESCRIPTION
## Issue being fixed or feature implemented
This changes are required, because constructor `CBLSSignatureVersionWrapper` doesn't work as expected.
You may pass `checkMalleable = false` in constructor, but it will be used `true` as default argument anyway


## What was done?
- fixed using flag `checkMalleable` in `CBLSSignatureVersionWrapper`
- removed unused `checkMalleable` in `ConstCBLSPublicKeyVersionWrapper`
- fixed order initialization in constructor (eliminate clang warning)
- re-ordered class members to reduce memory usage



## How Has This Been Tested?
Run functional/unit tests

## Breaking Changes
It changes API behavior but does it break anything?


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
