### PR TITLE
style: adjust template of new PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,53 +1,52 @@
-<!--
-*** Please remove the following help text before submitting: ***
+***Please remove the italicized help prompts before submitting or merging***
 
-Provide a general summary of your changes in the Title above
+_Provide a general summary of your changes in the Title above_
 
-Pull requests without a rationale and clear improvement may be closed
-immediately.
+_Pull requests without a rationale and clear improvement may be closed
+immediately._
 
-Please provide clear motivation for your patch and explain how it improves
+_Please provide clear motivation for your patch and explain how it improves
 Dash Core user experience or Dash Core developer experience
-significantly:
+significantly:_
 
-* Any test improvements or new tests that improve coverage are always welcome.
-* All other changes should have accompanying unit tests (see `src/test/`) or
+* _Any test improvements or new tests that improve coverage are always welcome._
+* _All other changes should have accompanying unit tests (see `src/test/`) or
   functional tests (see `test/`). Contributors should note which tests cover
   modified code. If no tests exist for a region of modified code, new tests
-  should accompany the change.
-* Bug fixes are most welcome when they come with steps to reproduce or an
+  should accompany the change._
+* _Bug fixes are most welcome when they come with steps to reproduce or an
   explanation of the potential issue as well as reasoning for the way the bug
-  was fixed.
-* Features are welcome, but might be rejected due to design or scope issues.
+  was fixed._
+* _Features are welcome, but might be rejected due to design or scope issues.
   If a feature is based on a lot of dependencies, contributors should first
-  consider building the system outside of Dash Core, if possible.
--->
+  consider building the system outside of Dash Core, if possible._
+
 
 ## Issue being fixed or feature implemented
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to the issue here. -->
+ - _Why is this change required? What problem does it solve?_
+ - _If it fixes an open issue, please link to the issue here._
 
 
 ## What was done?
-<!--- Describe your changes in detail -->
+  _Describe your changes in detail_
 
 
 ## How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+  _Please describe in detail how you tested your changes._
+
+  _Include details of your testing environment, and the tests you ran
+to see how your change affects other areas of the code, etc._
 
 
 ## Breaking Changes
-<!--- Please describe any breaking changes your code introduces -->
+  _Please describe any breaking changes your code introduces_
 
 
 ## Checklist:
-<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+  _Go over all the following points, and put an `x` in all the boxes that apply._
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have added or updated relevant unit/integration/functional/e2e tests
 - [ ] I have made corresponding changes to the documentation
+- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
 
-**For repository code-owners and collaborators only**
-- [ ] I have assigned this pull request to a milestone


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently template for "New pull request" have a lot of instruction that are formatted as comments by html/markdown tag.
It makes this instruction to append in the final commit message when pull request is merged because they are invisible for reviewer (marked as comment).

With new template the messages would be more likely to be cleaned up before merging.


## What was done?
Replaced commented text in template to cursive test (italic)


## How Has This Been Tested?
By clicking "Preview" on GitHub


## Breaking Changes
No breaking changes, it's trivial change


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
