### PR TITLE
contrib: Enable building in Guix containers

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -46,7 +46,7 @@ script: |
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"
   HOST_CXXFLAGS="-O2 -g"
-  HOST_LDFLAGS_BASE="-static-libstdc++"
+  HOST_LDFLAGS_BASE="-static-libstdc++ -Wl,-O2"
 
   export TZ="UTC"
   export BUILD_DIR="$PWD"

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -1,0 +1,229 @@
+# Bootstrappable Bitcoin Core Builds
+
+This directory contains the files necessary to perform bootstrappable Bitcoin
+Core builds.
+
+[Bootstrappability][b17e] furthers our binary security guarantees by allowing us
+to _audit and reproduce_ our toolchain instead of blindly _trusting_ binary
+downloads.
+
+We achieve bootstrappability by using Guix as a functional package manager.
+
+## Requirements
+
+Conservatively, a x86_64 machine with:
+
+- 2 or more logical cores
+- 4GB of free disk space on the partition that /gnu/store will reside in
+- 24GB of free disk space on the partition that the Bitcoin Core git repository
+  resides in
+
+> Note: these requirements are slightly less onerous than those of Gitian builds
+
+## Setup
+
+### Installing Guix
+
+If you're just testing this out, you can use the
+[Dockerfile][fanquake/guix-docker] for convenience. It automatically speeds up
+your builds by [using substitutes](#speeding-up-builds-with-substitute-servers).
+If you don't want this behaviour, refer to the [next
+section](#choosing-your-security-model).
+
+Otherwise, follow the [Guix installation guide][guix/bin-install].
+
+> Note: For those who like to keep their filesystems clean, Guix is designed to
+> be very standalone and _will not_ conflict with your system's package
+> manager/existing setup. It _only_ touches `/var/guix`, `/gnu`, and
+> `~/.config/guix`.
+
+### Choosing your security model
+
+Guix allows us to achieve better binary security by using our CPU time to build
+everything from scratch. However, it doesn't sacrifice user choice in pursuit of
+this: users can decide whether or not to bootstrap and to use substitutes.
+
+After installation, you may want to consider [adding substitute
+servers](#speeding-up-builds-with-substitute-servers) to speed up your build if
+that fits your security model (say, if you're just testing that this works).
+This is skippable if you're using the [Dockerfile][fanquake/guix-docker].
+
+If you prefer not to use any substitutes, make sure to set
+`ADDITIONAL_GUIX_ENVIRONMENT_FLAGS` like the following snippet. The first build
+will take a while, but the resulting packages will be cached for future builds.
+
+```sh
+export ADDITIONAL_GUIX_ENVIRONMENT_FLAGS='--no-substitutes'
+```
+
+Likewise, to perform a bootstrapped build (takes even longer):
+
+```sh
+export ADDITIONAL_GUIX_ENVIRONMENT_FLAGS='--bootstrap --no-substitutes'
+```
+
+### Using the right Guix
+
+Once Guix is installed, deploy our patched version into your current Guix
+profile. The changes there are slowly being upstreamed.
+
+```sh
+guix pull --url=https://github.com/dongcarl/guix.git \
+          --commit=82c77e52b8b46e0a3aad2cb12307c2e30547deec \
+          --max-jobs=4 # change accordingly
+```
+
+Make sure that you are using your current profile. (You are prompted to do this
+at the end of the `guix pull`)
+
+```bash
+export PATH="${HOME}/.config/guix/current/bin${PATH:+:}$PATH"
+```
+
+> Note: There is ongoing work to eliminate this entire section using Guix
+> [inferiors][guix/inferiors] and [channels][guix/channels].
+
+## Usage
+
+### As a Development Environment
+
+For a Bitcoin Core depends development environment, simply invoke
+
+```sh
+guix environment --manifest=contrib/guix/manifest.scm
+```
+
+And you'll land back in your shell with all the build dependencies required for
+a `depends` build injected into your environment.
+
+### As a Tool for Deterministic Builds
+
+From the top of a clean Bitcoin Core repository:
+
+```sh
+./contrib/guix/guix-build.sh
+```
+
+After the build finishes successfully (check the status code please), compare
+hashes:
+
+```sh
+find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
+```
+
+#### Recognized environment variables
+
+* _**HOSTS**_
+
+  Override the space-separated list of platform triples for which to perform a
+  bootstrappable build. _(defaults to "i686-linux-gnu x86\_64-linux-gnu
+  arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu")_
+
+  > Windows and OS X platform triplet support are WIP.
+
+* _**SOURCES_PATH**_
+
+  Set the depends tree download cache for sources. This is passed through to the
+  depends tree. Setting this to the same directory across multiple builds of the
+  depends tree can eliminate unnecessary redownloading of package sources.
+
+* _**MAX_JOBS**_
+
+  Override the maximum number of jobs to run simultaneously, you might want to
+  do so on a memory-limited machine. This may be passed to `make` as in `make
+  --jobs="$MAX_JOBS"` or `xargs` as in `xargs -P"$MAX_JOBS"`. _(defaults to the
+  value of `nproc` outside the container)_
+
+* _**SOURCE_DATE_EPOCH**_
+
+  Override the reference UNIX timestamp used for bit-for-bit reproducibility,
+  the variable name conforms to [standard][r12e/source-date-epoch]. _(defaults
+  to the output of `$(git log --format=%at -1)`)_
+
+* _**V**_
+
+  If non-empty, will pass `V=1` to all `make` invocations, making `make` output
+  verbose.
+
+* _**ADDITIONAL_GUIX_ENVIRONMENT_FLAGS**_
+
+  Additional flags to be passed to `guix environment`. For a fully-bootstrapped
+  build, set this to `--bootstrap --no-substitutes` (refer to the [security
+  model section](#choosing-your-security-model) for more details). Note that a
+  fully-bootstrapped build will take quite a long time on the first run.
+
+## Tips and Tricks
+
+### Speeding up builds with substitute servers
+
+_This whole section is automatically done in the convenience
+[Dockerfiles][fanquake/guix-docker]_
+
+For those who are used to life in the fast _(and trustful)_ lane, you can use
+[substitute servers][guix/substitutes] to enable binary downloads of packages.
+
+> For those who only want to use substitutes from the official Guix build farm
+> and have authorized the build farm's signing key during Guix's installation,
+> you don't need to do anything.
+
+#### Authorize the signing keys
+
+For the official Guix build farm at https://ci.guix.gnu.org, run as root:
+
+```
+guix archive --authorize < ~root/.config/guix/current/share/guix/ci.guix.gnu.org.pub
+```
+
+For dongcarl's substitute server at https://guix.carldong.io, run as root:
+
+```sh
+wget -qO- 'https://guix.carldong.io/signing-key.pub' | guix archive --authorize
+```
+
+#### Use the substitute servers
+
+The official Guix build farm at https://ci.guix.gnu.org is automatically used
+unless the `--no-substitutes` flag is supplied.
+
+This can be overridden for all `guix` invocations by passing the
+`--substitute-urls` option to your invocation of `guix-daemon`. This can also be
+overridden on a call-by-call basis by passing the same `--substitute-urls`
+option to client tools such at `guix environment`.
+
+To use dongcarl's substitute server for Bitcoin Core builds after having
+[authorized his signing key](#authorize-the-signing-keys):
+
+```
+export ADDITIONAL_GUIX_ENVIRONMENT_FLAGS='--substitute-urls="https://guix.carldong.io https://ci.guix.gnu.org"'
+```
+
+## FAQ
+
+### How can I trust the binary installation?
+
+As mentioned at the bottom of [this manual page][guix/bin-install]:
+
+> The binary installation tarballs can be (re)produced and verified simply by
+> running the following command in the Guix source tree:
+>
+>     make guix-binary.x86_64-linux.tar.xz
+
+### When will Guix be packaged in debian?
+
+Vagrant Cascadian has been making good progress on this
+[here][debian/guix-package]. We have all the pieces needed to put up an APT
+repository and will likely put one up soon.
+
+[b17e]: http://bootstrappable.org/
+[r12e/source-date-epoch]: https://reproducible-builds.org/docs/source-date-epoch/
+
+[guix/install.sh]: https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh
+[guix/bin-install]: https://www.gnu.org/software/guix/manual/en/html_node/Binary-Installation.html
+[guix/env-setup]: https://www.gnu.org/software/guix/manual/en/html_node/Build-Environment-Setup.html
+[guix/substitutes]: https://www.gnu.org/software/guix/manual/en/html_node/Substitutes.html
+[guix/substitute-server-auth]: https://www.gnu.org/software/guix/manual/en/html_node/Substitute-Server-Authorization.html
+[guix/inferiors]: https://www.gnu.org/software/guix/manual/en/html_node/Inferiors.html
+[guix/channels]: https://www.gnu.org/software/guix/manual/en/html_node/Channels.html
+
+[debian/guix-package]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850644
+[fanquake/guix-docker]: https://github.com/fanquake/core-review/tree/master/guix

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -62,15 +62,16 @@ Likewise, to perform a bootstrapped build (takes even longer):
 export ADDITIONAL_GUIX_ENVIRONMENT_FLAGS='--bootstrap --no-substitutes'
 ```
 
-### Using the right Guix
+### Using a version of Guix with `guix time-machine` capabilities
 
-Once Guix is installed, deploy our patched version into your current Guix
-profile. The changes there are slowly being upstreamed.
+> Note: This entire section can be skipped if you are already using a version of
+> Guix that has [the `guix time-machine` command][guix/time-machine].
+
+Once Guix is installed, if it doesn't have the `guix time-machine` command, pull
+the latest `guix`.
 
 ```sh
-guix pull --url=https://github.com/dongcarl/guix.git \
-          --commit=82c77e52b8b46e0a3aad2cb12307c2e30547deec \
-          --max-jobs=4 # change accordingly
+guix pull --max-jobs=4 # change number of jobs accordingly
 ```
 
 Make sure that you are using your current profile. (You are prompted to do this
@@ -79,9 +80,6 @@ at the end of the `guix pull`)
 ```bash
 export PATH="${HOME}/.config/guix/current/bin${PATH:+:}$PATH"
 ```
-
-> Note: There is ongoing work to eliminate this entire section using Guix
-> [inferiors][guix/inferiors] and [channels][guix/channels].
 
 ## Usage
 
@@ -224,6 +222,7 @@ repository and will likely put one up soon.
 [guix/substitute-server-auth]: https://www.gnu.org/software/guix/manual/en/html_node/Substitute-Server-Authorization.html
 [guix/inferiors]: https://www.gnu.org/software/guix/manual/en/html_node/Inferiors.html
 [guix/channels]: https://www.gnu.org/software/guix/manual/en/html_node/Channels.html
+[guix/time-machine]: https://guix.gnu.org/manual/en/html_node/Invoking-guix-time_002dmachine.html
 
 [debian/guix-package]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850644
 [fanquake/guix-docker]: https://github.com/fanquake/core-review/tree/master/guix

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -114,7 +114,7 @@ find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
 * _**HOSTS**_
 
   Override the space-separated list of platform triples for which to perform a
-  bootstrappable build. _(defaults to "i686-linux-gnu x86\_64-linux-gnu
+  bootstrappable build. _(defaults to "x86\_64-linux-gnu
   arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu")_
 
   > Windows and OS X platform triplet support are WIP.

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -220,8 +220,6 @@ repository and will likely put one up soon.
 [guix/env-setup]: https://www.gnu.org/software/guix/manual/en/html_node/Build-Environment-Setup.html
 [guix/substitutes]: https://www.gnu.org/software/guix/manual/en/html_node/Substitutes.html
 [guix/substitute-server-auth]: https://www.gnu.org/software/guix/manual/en/html_node/Substitute-Server-Authorization.html
-[guix/inferiors]: https://www.gnu.org/software/guix/manual/en/html_node/Inferiors.html
-[guix/channels]: https://www.gnu.org/software/guix/manual/en/html_node/Channels.html
 [guix/time-machine]: https://guix.gnu.org/manual/en/html_node/Invoking-guix-time_002dmachine.html
 
 [debian/guix-package]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850644

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -13,7 +13,6 @@ We achieve bootstrappability by using Guix as a functional package manager.
 
 Conservatively, a x86_64 machine with:
 
-- 2 or more logical cores
 - 4GB of free disk space on the partition that /gnu/store will reside in
 - 24GB of free disk space on the partition that the Bitcoin Core git repository
   resides in

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+set -e -o pipefail
+
+# Determine the maximum number of jobs to run simultaneously (overridable by
+# environment)
+MAX_JOBS="${MAX_JOBS:-$(nproc)}"
+
+# Download the depends sources now as we won't have internet access in the build
+# container
+make -C "${PWD}/depends" -j"$MAX_JOBS" download ${V:+V=1} ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"}
+
+# Determine the reference time used for determinism (overridable by environment)
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
+
+# Deterministically build Bitcoin Core for HOSTs (overriable by environment)
+for host in ${HOSTS=i686-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
+
+    # Display proper warning when the user interrupts the build
+    trap 'echo "** INT received while building ${host}, you may want to clean up the relevant output and distsrc-* directories before rebuilding"' INT
+
+    # Run the build script 'contrib/guix/libexec/build.sh' in the build
+    # container specified by 'contrib/guix/manifest.scm'
+    # shellcheck disable=SC2086
+    guix environment --manifest="${PWD}/contrib/guix/manifest.scm" \
+                     --container \
+                     --pure \
+                     --no-cwd \
+                     --share="$PWD"=/bitcoin \
+                     ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
+                     ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
+                     -- env HOST="$host" \
+                            MAX_JOBS="$MAX_JOBS" \
+                            SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
+                            ${V:+V=1} \
+                            ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
+                          bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
+
+done

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -20,7 +20,7 @@ time-machine() {
 }
 
 # Deterministically build Bitcoin Core for HOSTs (overriable by environment)
-for host in ${HOSTS=i686-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
+for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
 
     # Display proper warning when the user interrupts the build
     trap 'echo "** INT received while building ${host}, you may want to clean up the relevant output and distsrc-* directories before rebuilding"' INT

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -13,6 +13,12 @@ make -C "${PWD}/depends" -j"$MAX_JOBS" download ${V:+V=1} ${SOURCES_PATH:+SOURCE
 # Determine the reference time used for determinism (overridable by environment)
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 
+time-machine() {
+    guix time-machine --url=https://github.com/dongcarl/guix.git \
+                      --commit=b3a7c72c8b2425f8ddb0fc6e3b1caeed40f86dee \
+                      -- "$@"
+}
+
 # Deterministically build Bitcoin Core for HOSTs (overriable by environment)
 for host in ${HOSTS=i686-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
 
@@ -22,18 +28,18 @@ for host in ${HOSTS=i686-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-
     # Run the build script 'contrib/guix/libexec/build.sh' in the build
     # container specified by 'contrib/guix/manifest.scm'
     # shellcheck disable=SC2086
-    guix environment --manifest="${PWD}/contrib/guix/manifest.scm" \
-                     --container \
-                     --pure \
-                     --no-cwd \
-                     --share="$PWD"=/bitcoin \
-                     ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
-                     ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
-                     -- env HOST="$host" \
-                            MAX_JOBS="$MAX_JOBS" \
-                            SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
-                            ${V:+V=1} \
-                            ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
-                          bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
+    time-machine environment --manifest="${PWD}/contrib/guix/manifest.scm" \
+                             --container \
+                             --pure \
+                             --no-cwd \
+                             --share="$PWD"=/bitcoin \
+                             ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
+                             ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
+                             -- env HOST="$host" \
+                                    MAX_JOBS="$MAX_JOBS" \
+                                    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
+                                    ${V:+V=1} \
+                                    ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
+                                  bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
 
 done

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -105,6 +105,7 @@ for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv
                                  --pure \
                                  --no-cwd \
                                  --share="$PWD"=/bitcoin \
+                                 --expose="$(git rev-parse --git-common-dir)" \
                                  ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
                                  ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
                                  -- env HOST="$host" \

--- a/contrib/guix/guix-build.sh
+++ b/contrib/guix/guix-build.sh
@@ -13,33 +13,106 @@ make -C "${PWD}/depends" -j"$MAX_JOBS" download ${V:+V=1} ${SOURCES_PATH:+SOURCE
 # Determine the reference time used for determinism (overridable by environment)
 SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log --format=%at -1)}"
 
+# Execute "$@" in a pinned, possibly older version of Guix, for reproducibility
+# across time.
 time-machine() {
     guix time-machine --url=https://github.com/dongcarl/guix.git \
-                      --commit=b3a7c72c8b2425f8ddb0fc6e3b1caeed40f86dee \
+                      --commit=b066c25026f21fb57677aa34692a5034338e7ee3 \
                       -- "$@"
 }
 
-# Deterministically build Bitcoin Core for HOSTs (overriable by environment)
-for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu}; do
+# Function to be called when building for host ${1} and the user interrupts the
+# build
+int_trap() {
+cat << EOF
+** INT received while building ${1}, you may want to clean up the relevant
+   output, deploy, and distsrc-* directories before rebuilding
+
+Hint: To blow everything away, you may want to use:
+
+  $ git clean -xdff --exclude='/depends/SDKs/*'
+
+Specifically, this will remove all files without an entry in the index,
+excluding the SDK directory. Practically speaking, this means that all ignored
+and untracked files and directories will be wiped, allowing you to start anew.
+EOF
+}
+
+# Deterministically build Bitcoin Core for HOSTs (overridable by environment)
+# shellcheck disable=SC2153
+for host in ${HOSTS=x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu x86_64-w64-mingw32}; do
 
     # Display proper warning when the user interrupts the build
-    trap 'echo "** INT received while building ${host}, you may want to clean up the relevant output and distsrc-* directories before rebuilding"' INT
+    trap 'int_trap ${host}' INT
 
-    # Run the build script 'contrib/guix/libexec/build.sh' in the build
-    # container specified by 'contrib/guix/manifest.scm'
-    # shellcheck disable=SC2086
-    time-machine environment --manifest="${PWD}/contrib/guix/manifest.scm" \
-                             --container \
-                             --pure \
-                             --no-cwd \
-                             --share="$PWD"=/bitcoin \
-                             ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
-                             ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
-                             -- env HOST="$host" \
-                                    MAX_JOBS="$MAX_JOBS" \
-                                    SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
-                                    ${V:+V=1} \
-                                    ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
-                                  bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
+    (
+        # Required for 'contrib/guix/manifest.scm' to output the right manifest
+        # for the particular $HOST we're building for
+        export HOST="$host"
+
+        # Run the build script 'contrib/guix/libexec/build.sh' in the build
+        # container specified by 'contrib/guix/manifest.scm'.
+        #
+        # Explanation of `guix environment` flags:
+        #
+        #   --container        run command within an isolated container
+        #
+        #     Running in an isolated container minimizes build-time differences
+        #     between machines and improves reproducibility
+        #
+        #   --pure             unset existing environment variables
+        #
+        #     Same rationale as --container
+        #
+        #   --no-cwd           do not share current working directory with an
+        #                      isolated container
+        #
+        #     When --container is specified, the default behavior is to share
+        #     the current working directory with the isolated container at the
+        #     same exact path (e.g. mapping '/home/satoshi/bitcoin/' to
+        #     '/home/satoshi/bitcoin/'). This means that the $PWD inside the
+        #     container becomes a source of irreproducibility. --no-cwd disables
+        #     this behaviour.
+        #
+        #   --share=SPEC       for containers, share writable host file system
+        #                      according to SPEC
+        #
+        #   --share="$PWD"=/bitcoin
+        #
+        #                     maps our current working directory to /bitcoin
+        #                     inside the isolated container, which we later cd
+        #                     into.
+        #
+        #     While we don't want to map our current working directory to the
+        #     same exact path (as this introduces irreproducibility), we do want
+        #     it to be at a _fixed_ path _somewhere_ inside the isolated
+        #     container so that we have something to build. '/bitcoin' was
+        #     chosen arbitrarily.
+        #
+        #   ${SOURCES_PATH:+--share="$SOURCES_PATH"}
+        #
+        #                     make the downloaded depends sources path available
+        #                     inside the isolated container
+        #
+        #     The isolated container has no network access as it's in a
+        #     different network namespace from the main machine, so we have to
+        #     make the downloaded depends sources available to it. The sources
+        #     should have been downloaded prior to this invocation.
+        #
+        # shellcheck disable=SC2086
+        time-machine environment --manifest="${PWD}/contrib/guix/manifest.scm" \
+                                 --container \
+                                 --pure \
+                                 --no-cwd \
+                                 --share="$PWD"=/bitcoin \
+                                 ${SOURCES_PATH:+--share="$SOURCES_PATH"} \
+                                 ${ADDITIONAL_GUIX_ENVIRONMENT_FLAGS} \
+                                 -- env HOST="$host" \
+                                        MAX_JOBS="$MAX_JOBS" \
+                                        SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:?unable to determine value}" \
+                                        ${V:+V=1} \
+                                        ${SOURCES_PATH:+SOURCES_PATH="$SOURCES_PATH"} \
+                                      bash -c "cd /bitcoin && bash contrib/guix/libexec/build.sh"
+    )
 
 done

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -30,23 +30,38 @@ fi
 # Given a package name and an output name, return the path of that output in our
 # current guix environment
 store_path() {
-    grep --extended-regexp "/[^-]{32}-${1}-cross-${HOST}-[^-]+${2:+-${2}}" "${GUIX_ENVIRONMENT}/manifest" \
+    grep --extended-regexp "/[^-]{32}-${1}-[^-]+${2:+-${2}}" "${GUIX_ENVIRONMENT}/manifest" \
         | head --lines=1 \
         | sed --expression='s|^[[:space:]]*"||' \
               --expression='s|"[[:space:]]*$||'
 }
 
 # Determine output paths to use in CROSS_* environment variables
-CROSS_GLIBC="$(store_path glibc)"
-CROSS_GLIBC_STATIC="$(store_path glibc static)"
-CROSS_KERNEL="$(store_path linux-libre-headers)"
-CROSS_GCC="$(store_path gcc)"
+CROSS_GLIBC="$(store_path glibc-cross-${HOST})"
+CROSS_GLIBC_STATIC="$(store_path glibc-cross-${HOST} static)"
+CROSS_KERNEL="$(store_path linux-libre-headers-cross-${HOST})"
+CROSS_GCC="$(store_path gcc-cross-${HOST})"
+CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
 
 # Set environment variables to point Guix's cross-toolchain to the right
 # includes/libs for $HOST
-export CROSS_C_INCLUDE_PATH="${CROSS_GCC}/include:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
-export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
-export CROSS_LIBRARY_PATH="${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib:${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_KERNEL}/lib"
+#
+# NOTE: CROSS_C_INCLUDE_PATH is missing ${CROSS_GCC_LIB}/include-fixed, because
+# the limits.h in it is missing a '#include_next <limits.h>'
+#
+export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
+export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
+export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+
+# Sanity check CROSS_*_PATH directories
+IFS=':' read -ra PATHS <<< "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
+for p in "${PATHS[@]}"; do
+    if [ ! -d "$p" ]; then
+        echo "'$p' doesn't exist or isn't a directory... Aborting..."
+        exit 1
+    fi
+done
 
 # Disable Guix ld auto-rpath behavior
 export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
@@ -121,17 +136,10 @@ DISTNAME="$(basename "$SOURCEDIST" '.tar.gz')"
 # Binary Tarball Building #
 ###########################
 
-# Create a spec file to normalize ssp linking behaviour
-spec_file="$(mktemp)"
-cat << EOF > "$spec_file"
-*link_ssp:
-%{fstack-protector|fstack-protector-all|fstack-protector-strong|fstack-protector-explicit:}
-EOF
-
 # Similar flags to Gitian
 CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
-HOST_CFLAGS="-O2 -g -specs=${spec_file} -ffile-prefix-map=${PWD}=."
-HOST_CXXFLAGS="-O2 -g -specs=${spec_file} -ffile-prefix-map=${PWD}=."
+HOST_CFLAGS="-O2 -g -ffile-prefix-map=${PWD}=."
+HOST_CXXFLAGS="-O2 -g -ffile-prefix-map=${PWD}=."
 HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++"
 
 # Make $HOST-specific native binaries from depends available in $PATH

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -177,7 +177,7 @@ HOST_CXXFLAGS="$HOST_CFLAGS"
 
 # LDFLAGS
 case "$HOST" in
-    *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++" ;;
+    *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++ -Wl,-O2" ;;
     *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
 esac
 

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -141,19 +141,17 @@ make -C depends --jobs="$MAX_JOBS" HOST="$HOST" \
 # Source Tarball Building #
 ###########################
 
-# Create the source tarball and move it to "${OUTDIR}/src" if not already there
-if [ -z "$(find "${OUTDIR}/src" -name 'bitcoin-*.tar.gz')" ]; then
-    ./autogen.sh
-    env CONFIG_SITE="${BASEPREFIX}/${HOST}/share/config.site" ./configure --prefix=/
-    make dist GZIP_ENV='-9n' ${V:+V=1}
-    mkdir -p "${OUTDIR}/src"
-    mv "$(find "${PWD}" -name 'bitcoin-*.tar.gz')" "${OUTDIR}/src/"
-fi
+# Define DISTNAME variable.
+# shellcheck source=contrib/gitian-descriptors/assign_DISTNAME
+source contrib/gitian-descriptors/assign_DISTNAME
 
-# Determine the full path to our source tarball
-SOURCEDIST="$(find "${OUTDIR}/src" -name 'bitcoin-*.tar.gz')"
-# Determine our distribution name (e.g. bitcoin-0.18.0)
-DISTNAME="$(basename "$SOURCEDIST" '.tar.gz')"
+GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
+
+# Create the source tarball if not already there
+if [ ! -e "$GIT_ARCHIVE" ]; then
+    mkdir -p "$(dirname "$GIT_ARCHIVE")"
+    git archive --output="$GIT_ARCHIVE" HEAD
+fi
 
 ###########################
 # Binary Tarball Building #
@@ -187,7 +185,9 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
     cd "$DISTSRC"
 
     # Extract the source tarball
-    tar --strip-components=1 -xf "${SOURCEDIST}"
+    tar -xf "${GIT_ARCHIVE}"
+
+    ./autogen.sh
 
     # Configure this DISTSRC for $HOST
     # shellcheck disable=SC2086
@@ -221,7 +221,7 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
     # Make the os-specific installers
     case "$HOST" in
         *mingw*)
-            make deploy ${V:+V=1}
+            make deploy ${V:+V=1} BITCOIN_WIN_INSTALLER="${OUTDIR}/${DISTNAME}-win64-setup-unsigned.exe"
             ;;
     esac
 
@@ -233,11 +233,6 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
     # Install built Bitcoin Core to $INSTALLPATH
     make install DESTDIR="${INSTALLPATH}" ${V:+V=1}
 
-    case "$HOST" in
-        *mingw*)
-            cp -f --target-directory="$OUTDIR" ./*-setup-unsigned.exe
-            ;;
-    esac
     (
         cd installed
 
@@ -265,7 +260,7 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
                 cp "${DISTSRC}/doc/README_windows.txt" "${DISTNAME}/readme.txt"
                 ;;
             *linux*)
-                cp "${DISTSRC}/doc/README.md" "${DISTNAME}/"
+                cp "${DISTSRC}/README.md" "${DISTNAME}/"
                 ;;
         esac
 
@@ -308,7 +303,7 @@ case "$HOST" in
         (
             cd ./windeploy
             mkdir unsigned
-            cp --target-directory=unsigned/ "$OUTDIR"/bitcoin-*-setup-unsigned.exe
+            cp --target-directory=unsigned/ "${OUTDIR}/${DISTNAME}-win64-setup-unsigned.exe"
             find . -print0 \
                 | sort --zero-terminated \
                 | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+set -e -o pipefail
+
+# Check that environment variables assumed to be set by the environment are set
+echo "Building for platform triple ${HOST:?not set} with reference timestamp ${SOURCE_DATE_EPOCH:?not set}..."
+echo "At most ${MAX_JOBS:?not set} jobs will run at once..."
+
+#####################
+# Environment Setup #
+#####################
+
+# The depends folder also serves as a base-prefix for depends packages for
+# $HOSTs after successfully building.
+BASEPREFIX="${PWD}/depends"
+
+# Setup an output directory for our build
+OUTDIR="${OUTDIR:-${PWD}/output}"
+[ -e "$OUTDIR" ] || mkdir -p "$OUTDIR"
+
+# Setup the directory where our Bitcoin Core build for HOST will occur
+DISTSRC="${DISTSRC:-${PWD}/distsrc-${HOST}}"
+if [ -e "$DISTSRC" ]; then
+    echo "DISTSRC directory '${DISTSRC}' exists, probably because of previous builds... Aborting..."
+    exit 1
+else
+    mkdir -p "$DISTSRC"
+fi
+
+# Given a package name and an output name, return the path of that output in our
+# current guix environment
+store_path() {
+    grep --extended-regexp "/[^-]{32}-${1}-cross-${HOST}-[^-]+${2:+-${2}}" "${GUIX_ENVIRONMENT}/manifest" \
+        | head --lines=1 \
+        | sed --expression='s|^[[:space:]]*"||' \
+              --expression='s|"[[:space:]]*$||'
+}
+
+# Determine output paths to use in CROSS_* environment variables
+CROSS_GLIBC="$(store_path glibc)"
+CROSS_GLIBC_STATIC="$(store_path glibc static)"
+CROSS_KERNEL="$(store_path linux-libre-headers)"
+CROSS_GCC="$(store_path gcc)"
+
+# Set environment variables to point Guix's cross-toolchain to the right
+# includes/libs for $HOST
+export CROSS_C_INCLUDE_PATH="${CROSS_GCC}/include:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
+export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
+export CROSS_LIBRARY_PATH="${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib:${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_KERNEL}/lib"
+
+# Disable Guix ld auto-rpath behavior
+export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
+
+# Make /usr/bin if it doesn't exist
+[ -e /usr/bin ] || mkdir -p /usr/bin
+
+# Symlink file and env to a conventional path
+[ -e /usr/bin/file ] || ln -s --no-dereference "$(command -v file)" /usr/bin/file
+[ -e /usr/bin/env ]  || ln -s --no-dereference "$(command -v env)"  /usr/bin/env
+
+# Determine the correct value for -Wl,--dynamic-linker for the current $HOST
+glibc_dynamic_linker=$(
+    case "$HOST" in
+        i686-linux-gnu)      echo /lib/ld-linux.so.2 ;;
+        x86_64-linux-gnu)    echo /lib64/ld-linux-x86-64.so.2 ;;
+        arm-linux-gnueabihf) echo /lib/ld-linux-armhf.so.3 ;;
+        aarch64-linux-gnu)   echo /lib/ld-linux-aarch64.so.1 ;;
+        riscv64-linux-gnu)   echo /lib/ld-linux-riscv64-lp64d.so.1 ;;
+        *)                   exit 1 ;;
+    esac
+)
+
+# Environment variables for determinism
+export QT_RCC_TEST=1
+export QT_RCC_SOURCE_DATE_OVERRIDE=1
+export TAR_OPTIONS="--owner=0 --group=0 --numeric-owner --mtime='@${SOURCE_DATE_EPOCH}' --sort=name"
+export TZ="UTC"
+
+####################
+# Depends Building #
+####################
+
+# Build the depends tree, overriding variables that assume multilib gcc
+make -C depends --jobs="$MAX_JOBS" HOST="$HOST" \
+                                   ${V:+V=1} \
+                                   ${SOURCES_PATH+SOURCES_PATH="$SOURCES_PATH"} \
+                                   i686_linux_CC=i686-linux-gnu-gcc \
+                                   i686_linux_CXX=i686-linux-gnu-g++ \
+                                   i686_linux_AR=i686-linux-gnu-ar \
+                                   i686_linux_RANLIB=i686-linux-gnu-ranlib \
+                                   i686_linux_NM=i686-linux-gnu-nm \
+                                   i686_linux_STRIP=i686-linux-gnu-strip \
+                                   x86_64_linux_CC=x86_64-linux-gnu-gcc \
+                                   x86_64_linux_CXX=x86_64-linux-gnu-g++ \
+                                   x86_64_linux_AR=x86_64-linux-gnu-ar \
+                                   x86_64_linux_RANLIB=x86_64-linux-gnu-ranlib \
+                                   x86_64_linux_NM=x86_64-linux-gnu-nm \
+                                   x86_64_linux_STRIP=x86_64-linux-gnu-strip \
+                                   qt_config_opts_i686_linux='-platform linux-g++ -xplatform bitcoin-linux-g++'
+
+
+###########################
+# Source Tarball Building #
+###########################
+
+# Create the source tarball and move it to "${OUTDIR}/src" if not already there
+if [ -z "$(find "${OUTDIR}/src" -name 'bitcoin-*.tar.gz')" ]; then
+    ./autogen.sh
+    env CONFIG_SITE="${BASEPREFIX}/${HOST}/share/config.site" ./configure --prefix=/
+    make dist GZIP_ENV='-9n' ${V:+V=1}
+    mkdir -p "${OUTDIR}/src"
+    mv "$(find "${PWD}" -name 'bitcoin-*.tar.gz')" "${OUTDIR}/src/"
+fi
+
+# Determine the full path to our source tarball
+SOURCEDIST="$(find "${OUTDIR}/src" -name 'bitcoin-*.tar.gz')"
+# Determine our distribution name (e.g. bitcoin-0.18.0)
+DISTNAME="$(basename "$SOURCEDIST" '.tar.gz')"
+
+###########################
+# Binary Tarball Building #
+###########################
+
+# Create a spec file to normalize ssp linking behaviour
+spec_file="$(mktemp)"
+cat << EOF > "$spec_file"
+*link_ssp:
+%{fstack-protector|fstack-protector-all|fstack-protector-strong|fstack-protector-explicit:}
+EOF
+
+# Similar flags to Gitian
+CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
+HOST_CFLAGS="-O2 -g -specs=${spec_file} -ffile-prefix-map=${PWD}=."
+HOST_CXXFLAGS="-O2 -g -specs=${spec_file} -ffile-prefix-map=${PWD}=."
+HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++"
+
+# Make $HOST-specific native binaries from depends available in $PATH
+export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
+(
+    cd "$DISTSRC"
+
+    # Extract the source tarball
+    tar --strip-components=1 -xf "${SOURCEDIST}"
+
+    # Configure this DISTSRC for $HOST
+    # shellcheck disable=SC2086
+    env CONFIG_SITE="${BASEPREFIX}/${HOST}/share/config.site" \
+        ./configure --prefix=/ \
+                    --disable-ccache \
+                    --disable-maintainer-mode \
+                    --disable-dependency-tracking \
+                    ${CONFIGFLAGS} \
+                    CFLAGS="${HOST_CFLAGS}" \
+                    CXXFLAGS="${HOST_CXXFLAGS}" \
+                    LDFLAGS="${HOST_LDFLAGS}"
+
+    sed -i.old 's/-lstdc++ //g' {./,src/dashbls/,src/secp256k1/}{config.status,libtool}
+
+
+    # Build Bitcoin Core
+    make --jobs="$MAX_JOBS" ${V:+V=1}
+
+    # Perform basic ELF security checks on a series of executables.
+    make -C src --jobs=1 check-security ${V:+V=1}
+    # Check that executables only contain allowed gcc, glibc and libstdc++
+    # version symbols for Linux distro back-compatibility.
+    make -C src --jobs=1 check-symbols  ${V:+V=1}
+
+    # Setup the directory where our Bitcoin Core build for HOST will be
+    # installed. This directory will also later serve as the input for our
+    # binary tarballs.
+    INSTALLPATH="${PWD}/installed/${DISTNAME}"
+    mkdir -p "${INSTALLPATH}"
+    # Install built Bitcoin Core to $INSTALLPATH
+    make install DESTDIR="${INSTALLPATH}" ${V:+V=1}
+    (
+        cd installed
+
+        # Prune libtool and object archives
+        find . -name "lib*.la" -delete
+        find . -name "lib*.a" -delete
+
+        # Prune pkg-config files
+        rm -r "${DISTNAME}/lib/pkgconfig"
+
+        # Split binaries and libraries from their debug symbols
+        {
+            find "${DISTNAME}/bin" -type f -executable -print0
+            find "${DISTNAME}/lib" -type f -print0
+        } | xargs -0 -n1 -P"$MAX_JOBS" -I{} "${DISTSRC}/contrib/devtools/split-debug.sh" {} {} {}.dbg
+
+        cp "${DISTSRC}/doc/README.md" "${DISTNAME}/"
+
+        # Finally, deterministically produce {non-,}debug binary tarballs ready
+        # for release
+        find "${DISTNAME}" -not -name "*.dbg" -print0 \
+            | sort --zero-terminated \
+            | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+            | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" \
+            || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" && exit 1 )
+        find "${DISTNAME}" -name "*.dbg" -print0 \
+            | sort --zero-terminated \
+            | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+            | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" \
+            || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" && exit 1 )
+    )
+)

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 export LC_ALL=C
 set -e -o pipefail
+export TZ=UTC
 
 # Check that environment variables assumed to be set by the environment are set
 echo "Building for platform triple ${HOST:?not set} with reference timestamp ${SOURCE_DATE_EPOCH:?not set}..."
@@ -36,23 +37,41 @@ store_path() {
               --expression='s|"[[:space:]]*$||'
 }
 
-# Determine output paths to use in CROSS_* environment variables
-CROSS_GLIBC="$(store_path glibc-cross-${HOST})"
-CROSS_GLIBC_STATIC="$(store_path glibc-cross-${HOST} static)"
-CROSS_KERNEL="$(store_path linux-libre-headers-cross-${HOST})"
-CROSS_GCC="$(store_path gcc-cross-${HOST})"
-CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
-CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
-
 # Set environment variables to point Guix's cross-toolchain to the right
 # includes/libs for $HOST
-#
-# NOTE: CROSS_C_INCLUDE_PATH is missing ${CROSS_GCC_LIB}/include-fixed, because
-# the limits.h in it is missing a '#include_next <limits.h>'
-#
-export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
-export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
-export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+case "$HOST" in
+    *mingw*)
+        # Determine output paths to use in CROSS_* environment variables
+        CROSS_GLIBC="$(store_path "mingw-w64-x86_64-winpthreads")"
+        CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
+        CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+        CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
+
+        NATIVE_GCC="$(store_path gcc-glibc-2.27-toolchain)"
+        export LIBRARY_PATH="${NATIVE_GCC}/lib:${NATIVE_GCC}/lib64"
+        export CPATH="${NATIVE_GCC}/include"
+
+        export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GCC_LIB}/include-fixed:${CROSS_GLIBC}/include"
+        export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
+        export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib"
+        ;;
+    *linux*)
+        CROSS_GLIBC="$(store_path "glibc-cross-${HOST}")"
+        CROSS_GLIBC_STATIC="$(store_path "glibc-cross-${HOST}" static)"
+        CROSS_KERNEL="$(store_path "linux-libre-headers-cross-${HOST}")"
+        CROSS_GCC="$(store_path "gcc-cross-${HOST}")"
+        CROSS_GCC_LIBS=( "${CROSS_GCC}/lib/gcc/${HOST}"/* ) # This expands to an array of directories...
+        CROSS_GCC_LIB="${CROSS_GCC_LIBS[0]}" # ...we just want the first one (there should only be one)
+
+        # NOTE: CROSS_C_INCLUDE_PATH is missing ${CROSS_GCC_LIB}/include-fixed, because
+        # the limits.h in it is missing a '#include_next <limits.h>'
+        export CROSS_C_INCLUDE_PATH="${CROSS_GCC_LIB}/include:${CROSS_GLIBC}/include:${CROSS_KERNEL}/include"
+        export CROSS_CPLUS_INCLUDE_PATH="${CROSS_GCC}/include/c++:${CROSS_GCC}/include/c++/${HOST}:${CROSS_GCC}/include/c++/backward:${CROSS_C_INCLUDE_PATH}"
+        export CROSS_LIBRARY_PATH="${CROSS_GCC}/lib:${CROSS_GCC}/${HOST}/lib:${CROSS_GCC_LIB}:${CROSS_GLIBC}/lib:${CROSS_GLIBC_STATIC}/lib"
+        ;;
+    *)
+        exit 1 ;;
+esac
 
 # Sanity check CROSS_*_PATH directories
 IFS=':' read -ra PATHS <<< "${CROSS_C_INCLUDE_PATH}:${CROSS_CPLUS_INCLUDE_PATH}:${CROSS_LIBRARY_PATH}"
@@ -74,16 +93,20 @@ export GUIX_LD_WRAPPER_DISABLE_RPATH=yes
 [ -e /usr/bin/env ]  || ln -s --no-dereference "$(command -v env)"  /usr/bin/env
 
 # Determine the correct value for -Wl,--dynamic-linker for the current $HOST
-glibc_dynamic_linker=$(
-    case "$HOST" in
-        i686-linux-gnu)      echo /lib/ld-linux.so.2 ;;
-        x86_64-linux-gnu)    echo /lib64/ld-linux-x86-64.so.2 ;;
-        arm-linux-gnueabihf) echo /lib/ld-linux-armhf.so.3 ;;
-        aarch64-linux-gnu)   echo /lib/ld-linux-aarch64.so.1 ;;
-        riscv64-linux-gnu)   echo /lib/ld-linux-riscv64-lp64d.so.1 ;;
-        *)                   exit 1 ;;
-    esac
-)
+case "$HOST" in
+    *linux*)
+        glibc_dynamic_linker=$(
+            case "$HOST" in
+                i686-linux-gnu)      echo /lib/ld-linux.so.2 ;;
+                x86_64-linux-gnu)    echo /lib64/ld-linux-x86-64.so.2 ;;
+                arm-linux-gnueabihf) echo /lib/ld-linux-armhf.so.3 ;;
+                aarch64-linux-gnu)   echo /lib/ld-linux-aarch64.so.1 ;;
+                riscv64-linux-gnu)   echo /lib/ld-linux-riscv64-lp64d.so.1 ;;
+                *)                   exit 1 ;;
+            esac
+        )
+        ;;
+esac
 
 # Environment variables for determinism
 export QT_RCC_TEST=1
@@ -136,11 +159,27 @@ DISTNAME="$(basename "$SOURCEDIST" '.tar.gz')"
 # Binary Tarball Building #
 ###########################
 
-# Similar flags to Gitian
-CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
-HOST_CFLAGS="-O2 -g -ffile-prefix-map=${PWD}=."
-HOST_CXXFLAGS="-O2 -g -ffile-prefix-map=${PWD}=."
-HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++"
+# CONFIGFLAGS
+CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
+case "$HOST" in
+    *linux*) CONFIGFLAGS+=" --enable-glibc-back-compat" ;;
+esac
+
+# CFLAGS
+HOST_CFLAGS="-O2 -g"
+case "$HOST" in
+    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${PWD}=." ;;
+    *mingw*)  HOST_CFLAGS+=" -fno-ident" ;;
+esac
+
+# CXXFLAGS
+HOST_CXXFLAGS="$HOST_CFLAGS"
+
+# LDFLAGS
+case "$HOST" in
+    *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++" ;;
+    *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
+esac
 
 # Make $HOST-specific native binaries from depends available in $PATH
 export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
@@ -160,7 +199,7 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
                     ${CONFIGFLAGS} \
                     CFLAGS="${HOST_CFLAGS}" \
                     CXXFLAGS="${HOST_CXXFLAGS}" \
-                    LDFLAGS="${HOST_LDFLAGS}"
+                    ${HOST_LDFLAGS:+LDFLAGS="${HOST_LDFLAGS}"}
 
     sed -i.old 's/-lstdc++ //g' {./,src/dashbls/,src/secp256k1/}{config.status,libtool}
 
@@ -170,9 +209,21 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 
     # Perform basic ELF security checks on a series of executables.
     make -C src --jobs=1 check-security ${V:+V=1}
-    # Check that executables only contain allowed gcc, glibc and libstdc++
-    # version symbols for Linux distro back-compatibility.
-    make -C src --jobs=1 check-symbols  ${V:+V=1}
+
+    case "$HOST" in
+        *linux*|*mingw*)
+            # Check that executables only contain allowed gcc, glibc and libstdc++
+            # version symbols for Linux distro back-compatibility.
+            make -C src --jobs=1 check-symbols  ${V:+V=1}
+            ;;
+    esac
+
+    # Make the os-specific installers
+    case "$HOST" in
+        *mingw*)
+            make deploy ${V:+V=1}
+            ;;
+    esac
 
     # Setup the directory where our Bitcoin Core build for HOST will be
     # installed. This directory will also later serve as the input for our
@@ -181,8 +232,20 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
     mkdir -p "${INSTALLPATH}"
     # Install built Bitcoin Core to $INSTALLPATH
     make install DESTDIR="${INSTALLPATH}" ${V:+V=1}
+
+    case "$HOST" in
+        *mingw*)
+            cp -f --target-directory="$OUTDIR" ./*-setup-unsigned.exe
+            ;;
+    esac
     (
         cd installed
+
+        case "$HOST" in
+            *mingw*)
+                mv --target-directory="$DISTNAME"/lib/ "$DISTNAME"/bin/*.dll
+                ;;
+        esac
 
         # Prune libtool and object archives
         find . -name "lib*.la" -delete
@@ -197,19 +260,60 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
             find "${DISTNAME}/lib" -type f -print0
         } | xargs -0 -n1 -P"$MAX_JOBS" -I{} "${DISTSRC}/contrib/devtools/split-debug.sh" {} {} {}.dbg
 
-        cp "${DISTSRC}/doc/README.md" "${DISTNAME}/"
+        case "$HOST" in
+            *mingw*)
+                cp "${DISTSRC}/doc/README_windows.txt" "${DISTNAME}/readme.txt"
+                ;;
+            *linux*)
+                cp "${DISTSRC}/doc/README.md" "${DISTNAME}/"
+                ;;
+        esac
 
         # Finally, deterministically produce {non-,}debug binary tarballs ready
         # for release
-        find "${DISTNAME}" -not -name "*.dbg" -print0 \
-            | sort --zero-terminated \
-            | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
-            | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" \
-            || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" && exit 1 )
-        find "${DISTNAME}" -name "*.dbg" -print0 \
-            | sort --zero-terminated \
-            | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
-            | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" \
-            || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" && exit 1 )
+        case "$HOST" in
+            *mingw*)
+                find "${DISTNAME}" -not -name "*.dbg" -print0 \
+                    | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
+                find "${DISTNAME}" -not -name "*.dbg" \
+                    | sort \
+                    | zip -X@ "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}.zip" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}.zip" && exit 1 )
+                find "${DISTNAME}" -name "*.dbg" -print0 \
+                    | xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
+                find "${DISTNAME}" -name "*.dbg" \
+                    | sort \
+                    | zip -X@ "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}-debug.zip" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST//x86_64-w64-mingw32/win64}-debug.zip" && exit 1 )
+                ;;
+            *linux*)
+                find "${DISTNAME}" -not -name "*.dbg" -print0 \
+                    | sort --zero-terminated \
+                    | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+                    | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}.tar.gz" && exit 1 )
+                find "${DISTNAME}" -name "*.dbg" -print0 \
+                    | sort --zero-terminated \
+                    | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+                    | gzip -9n > "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" \
+                    || ( rm -f "${OUTDIR}/${DISTNAME}-${HOST}-debug.tar.gz" && exit 1 )
+                ;;
+        esac
     )
 )
+
+case "$HOST" in
+    *mingw*)
+        cp -rf --target-directory=. contrib/windeploy
+        (
+            cd ./windeploy
+            mkdir unsigned
+            cp --target-directory=unsigned/ "$OUTDIR"/bitcoin-*-setup-unsigned.exe
+            find . -print0 \
+                | sort --zero-terminated \
+                | tar --create --no-recursion --mode='u+rw,go+r-w,a+X' --null --files-from=- \
+                | gzip -9n > "${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz" \
+                || ( rm -f "${OUTDIR}/${DISTNAME}-win-unsigned.tar.gz" && exit 1 )
+        )
+        ;;
+esac

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -1,0 +1,160 @@
+(use-modules (gnu)
+             (gnu packages)
+             (gnu packages autotools)
+             (gnu packages base)
+             (gnu packages bash)
+             (gnu packages check)
+             (gnu packages commencement)
+             (gnu packages compression)
+             (gnu packages cross-base)
+             (gnu packages file)
+             (gnu packages gawk)
+             (gnu packages gcc)
+             (gnu packages linux)
+             (gnu packages perl)
+             (gnu packages pkg-config)
+             (gnu packages python)
+             (gnu packages shells)
+             (gnu packages bison)
+             (guix build-system trivial)
+             (guix gexp)
+             (guix packages)
+             (guix profiles)
+             (guix utils))
+
+(define (make-ssp-fixed-gcc xgcc)
+  "Given a XGCC package, return a modified package that uses the SSP function
+from glibc instead of from libssp.so. Taken from:
+http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
+  (package
+   (inherit xgcc)
+   (arguments
+    (substitute-keyword-arguments (package-arguments xgcc)
+      ((#:make-flags flags)
+       `(cons "gcc_cv_libc_provides_ssp=yes" ,flags))))))
+
+(define (make-gcc-rpath-link xgcc)
+  "Given a XGCC package, return a modified package that replace each instance of
+-rpath in the default system spec that's inserted by Guix with -rpath-link"
+  (package
+   (inherit xgcc)
+   (arguments
+    (substitute-keyword-arguments (package-arguments xgcc)
+      ((#:phases phases)
+       `(modify-phases ,phases
+          (add-after 'pre-configure 'replace-rpath-with-rpath-link
+            (lambda _
+              (substitute* (cons "gcc/config/rs6000/sysv4.h"
+                                 (find-files "gcc/config"
+                                             "^gnu-user.*\\.h$"))
+                (("-rpath=") "-rpath-link="))
+              #t))))))))
+
+(define (make-cross-toolchain target
+                              base-gcc-for-libc
+                              base-kernel-headers
+                              base-libc
+                              base-gcc)
+  "Create a cross-compilation toolchain package for TARGET"
+  (let* ((xbinutils (cross-binutils target))
+         ;; 1. Build a cross-compiling gcc without targeting any libc, derived
+         ;; from BASE-GCC-FOR-LIBC
+         (xgcc-sans-libc (cross-gcc target
+                                    #:xgcc base-gcc-for-libc
+                                    #:xbinutils xbinutils))
+         ;; 2. Build cross-compiled kernel headers with XGCC-SANS-LIBC, derived
+         ;; from BASE-KERNEL-HEADERS
+         (xkernel (cross-kernel-headers target
+                                        base-kernel-headers
+                                        xgcc-sans-libc
+                                        xbinutils))
+         ;; 3. Build a cross-compiled libc with XGCC-SANS-LIBC and XKERNEL,
+         ;; derived from BASE-LIBC
+         (xlibc (cross-libc target
+                            base-libc
+                            xgcc-sans-libc
+                            xbinutils
+                            xkernel))
+         ;; 4. Build a cross-compiling gcc targeting XLIBC, derived from
+         ;; BASE-GCC
+         (xgcc (cross-gcc target
+                          #:xgcc base-gcc
+                          #:xbinutils xbinutils
+                          #:libc xlibc)))
+    ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and
+    ;; XGCC
+    (package
+      (name (string-append target "-toolchain"))
+      (version (package-version xgcc))
+      (source #f)
+      (build-system trivial-build-system)
+      (arguments '(#:builder (begin (mkdir %output) #t)))
+      (propagated-inputs
+       `(("binutils" ,xbinutils)
+         ("libc" ,xlibc)
+         ("libc:static" ,xlibc "static")
+         ("gcc" ,xgcc)))
+      (synopsis (string-append "Complete GCC tool chain for " target))
+      (description (string-append "This package provides a complete GCC tool
+chain for " target " development."))
+      (home-page (package-home-page xgcc))
+      (license (package-license xgcc)))))
+
+(define* (make-bitcoin-cross-toolchain target
+                                  #:key
+                                  (base-gcc-for-libc gcc-5)
+                                  (base-kernel-headers linux-libre-headers-4.19)
+                                  (base-libc glibc-2.27)
+                                  (base-gcc (make-gcc-rpath-link
+                                             (make-ssp-fixed-gcc gcc-9))))
+  "Convienience wrapper around MAKE-CROSS-TOOLCHAIN with default values
+desirable for building Bitcoin Core release binaries."
+  (make-cross-toolchain target
+                   base-gcc-for-libc
+                   base-kernel-headers
+                   base-libc
+                   base-gcc))
+
+(packages->manifest
+ (list ;; The Basics
+       bash-minimal
+       which
+       coreutils
+       util-linux
+       ;; File(system) inspection
+       file
+       grep
+       diffutils
+       findutils
+       ;; File transformation
+       patch
+       gawk
+       sed
+       ;; Compression and archiving
+       tar
+       bzip2
+       gzip
+       xz
+       zlib
+       ;; Build tools
+       gnu-make
+       libtool
+       autoconf
+       automake
+       pkg-config
+       bison
+       ;; Scripting
+       perl
+       python-3.7
+       ;; Native gcc 9 toolchain targeting glibc 2.27
+       (make-gcc-toolchain gcc-9 glibc-2.27)
+       ;; Cross gcc 9 toolchains targeting glibc 2.27
+       (make-bitcoin-cross-toolchain "i686-linux-gnu")
+       (make-bitcoin-cross-toolchain "x86_64-linux-gnu")
+       (make-bitcoin-cross-toolchain "aarch64-linux-gnu")
+       (make-bitcoin-cross-toolchain "arm-linux-gnueabihf")
+       ;; The glibc 2.27 for riscv64 needs gcc 7 to successfully build (see:
+       ;; https://www.gnu.org/software/gcc/gcc-7/changes.html#riscv). The final
+       ;; toolchain is still a gcc 9 toolchain targeting glibc 2.27.
+       (make-bitcoin-cross-toolchain "riscv64-linux-gnu"
+                                     #:base-gcc-for-libc gcc-7)))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -10,17 +10,34 @@
              (gnu packages file)
              (gnu packages gawk)
              (gnu packages gcc)
+             (gnu packages installers)
              (gnu packages linux)
+             (gnu packages mingw)
              (gnu packages perl)
              (gnu packages pkg-config)
              (gnu packages python)
              (gnu packages shells)
              (gnu packages bison)
+             (guix build-system gnu)
              (guix build-system trivial)
              (guix gexp)
              (guix packages)
              (guix profiles)
              (guix utils))
+
+(define (make-ssp-fixed-gcc xgcc)
+  "Given a XGCC package, return a modified package that uses the SSP function
+from glibc instead of from libssp.so. Our `symbol-check' script will complain if
+we link against libssp.so, and thus will ensure that this works properly.
+
+Taken from:
+http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
+  (package
+   (inherit xgcc)
+   (arguments
+    (substitute-keyword-arguments (package-arguments xgcc)
+      ((#:make-flags flags)
+       `(cons "gcc_cv_libc_provides_ssp=yes" ,flags))))))
 
 (define (make-gcc-rpath-link xgcc)
   "Given a XGCC package, return a modified package that replace each instance of
@@ -103,46 +120,78 @@ desirable for building Bitcoin Core release binaries."
                    base-libc
                    base-gcc))
 
+(define (make-gcc-with-pthreads gcc)
+  (package-with-extra-configure-variable gcc "--enable-threads" "posix"))
+
+(define (make-mingw-pthreads-cross-toolchain target)
+  "Create a cross-compilation toolchain package for TARGET"
+  (let* ((xbinutils (cross-binutils target))
+         (pthreads-xlibc mingw-w64-x86_64-winpthreads)
+         (pthreads-xgcc (make-gcc-with-pthreads
+                         (cross-gcc target
+                                    #:xgcc (make-ssp-fixed-gcc gcc-9)
+                                    #:xbinutils xbinutils
+                                    #:libc pthreads-xlibc))))
+    ;; Define a meta-package that propagates the resulting XBINUTILS, XLIBC, and
+    ;; XGCC
+    (package
+      (name (string-append target "-posix-toolchain"))
+      (version (package-version pthreads-xgcc))
+      (source #f)
+      (build-system trivial-build-system)
+      (arguments '(#:builder (begin (mkdir %output) #t)))
+      (propagated-inputs
+       `(("binutils" ,xbinutils)
+         ("libc" ,pthreads-xlibc)
+         ("gcc" ,pthreads-xgcc)))
+      (synopsis (string-append "Complete GCC tool chain for " target))
+      (description (string-append "This package provides a complete GCC tool
+chain for " target " development."))
+      (home-page (package-home-page pthreads-xgcc))
+      (license (package-license pthreads-xgcc)))))
+
+
 (packages->manifest
- (list ;; The Basics
-       bash-minimal
-       which
-       coreutils
-       util-linux
-       ;; File(system) inspection
-       file
-       grep
-       diffutils
-       findutils
-       ;; File transformation
-       patch
-       gawk
-       sed
-       ;; Compression and archiving
-       tar
-       bzip2
-       gzip
-       xz
-       zlib
-       ;; Build tools
-       gnu-make
-       libtool
-       autoconf
-       automake
-       pkg-config
-       bison
-       ;; Scripting
-       perl
-       python-3.7
-       ;; Native gcc 9 toolchain targeting glibc 2.27
-       (make-gcc-toolchain gcc-9 glibc-2.27)
-       ;; Cross gcc 9 toolchains targeting glibc 2.27
-       (make-bitcoin-cross-toolchain "i686-linux-gnu")
-       (make-bitcoin-cross-toolchain "x86_64-linux-gnu")
-       (make-bitcoin-cross-toolchain "aarch64-linux-gnu")
-       (make-bitcoin-cross-toolchain "arm-linux-gnueabihf")
-       ;; The glibc 2.27 for riscv64 needs gcc 7 to successfully build (see:
-       ;; https://www.gnu.org/software/gcc/gcc-7/changes.html#riscv). The final
-       ;; toolchain is still a gcc 9 toolchain targeting glibc 2.27.
-       (make-bitcoin-cross-toolchain "riscv64-linux-gnu"
-                                     #:base-gcc-for-libc gcc-7)))
+ (append
+  (list ;; The Basics
+        bash-minimal
+        which
+        coreutils
+        util-linux
+        ;; File(system) inspection
+        file
+        grep
+        diffutils
+        findutils
+        ;; File transformation
+        patch
+        gawk
+        sed
+        ;; Compression and archiving
+        tar
+        bzip2
+        gzip
+        xz
+        zlib
+        ;; Build tools
+        gnu-make
+        libtool
+        autoconf
+        automake
+        pkg-config
+        bison
+        ;; Scripting
+        perl
+        python-3.7
+        ;; Native gcc 9 toolchain targeting glibc 2.27
+        (make-gcc-toolchain gcc-9 glibc-2.27))
+  (let ((target (getenv "HOST")))
+    (cond ((string-suffix? "-mingw32" target)
+           ;; Windows
+           (list zip (make-mingw-pthreads-cross-toolchain "x86_64-w64-mingw32") nsis-x86_64))
+          ((string-contains target "riscv64-linux-")
+           (list (make-bitcoin-cross-toolchain "riscv64-linux-gnu"
+                                               #:base-gcc-for-libc gcc-7)))
+          ((string-contains target "-linux-")
+           (list (make-bitcoin-cross-toolchain target)))
+          (else '())))))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -22,17 +22,6 @@
              (guix profiles)
              (guix utils))
 
-(define (make-ssp-fixed-gcc xgcc)
-  "Given a XGCC package, return a modified package that uses the SSP function
-from glibc instead of from libssp.so. Taken from:
-http://www.linuxfromscratch.org/hlfs/view/development/chapter05/gcc-pass1.html"
-  (package
-   (inherit xgcc)
-   (arguments
-    (substitute-keyword-arguments (package-arguments xgcc)
-      ((#:make-flags flags)
-       `(cons "gcc_cv_libc_provides_ssp=yes" ,flags))))))
-
 (define (make-gcc-rpath-link xgcc)
   "Given a XGCC package, return a modified package that replace each instance of
 -rpath in the default system spec that's inserted by Guix with -rpath-link"
@@ -105,8 +94,7 @@ chain for " target " development."))
                                   (base-gcc-for-libc gcc-5)
                                   (base-kernel-headers linux-libre-headers-4.19)
                                   (base-libc glibc-2.27)
-                                  (base-gcc (make-gcc-rpath-link
-                                             (make-ssp-fixed-gcc gcc-9))))
+                                  (base-gcc (make-gcc-rpath-link gcc-9)))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
   (make-cross-toolchain target

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -18,6 +18,7 @@
              (gnu packages python)
              (gnu packages shells)
              (gnu packages bison)
+             (gnu packages version-control)
              (guix build-system gnu)
              (guix build-system trivial)
              (guix gexp)
@@ -183,6 +184,8 @@ chain for " target " development."))
         ;; Scripting
         perl
         python-3.7
+        ;; Git
+        git
         ;; Native gcc 9 toolchain targeting glibc 2.27
         (make-gcc-toolchain gcc-9 glibc-2.27))
   (let ((target (getenv "HOST")))

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -107,7 +107,7 @@ chain for " target " development."))
                                   (base-libc glibc-2.27)
                                   (base-gcc (make-gcc-rpath-link
                                              (make-ssp-fixed-gcc gcc-9))))
-  "Convienience wrapper around MAKE-CROSS-TOOLCHAIN with default values
+  "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
 desirable for building Bitcoin Core release binaries."
   (make-cross-toolchain target
                    base-gcc-for-libc

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -249,7 +249,8 @@ define $(package)_preprocess_cmds
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   sed -i.old "s|QMAKE_CC                = \$$$$\$$$${CROSS_COMPILE}clang|QMAKE_CC                = $($(package)_cc)|" qtbase/mkspecs/common/clang.conf && \
   sed -i.old "s|QMAKE_CXX               = \$$$$\$$$${CROSS_COMPILE}clang++|QMAKE_CXX               = $($(package)_cxx)|" qtbase/mkspecs/common/clang.conf && \
-  sed -i.old "s/error(\"failed to parse default search paths from compiler output\")/\!darwin: error(\"failed to parse default search paths from compiler output\")/g" qtbase/mkspecs/features/toolchain.prf
+  sed -i.old "s/error(\"failed to parse default search paths from compiler output\")/\!darwin: error(\"failed to parse default search paths from compiler output\")/g" qtbase/mkspecs/features/toolchain.prf && \
+  sed -i.old "s/LIBRARY_PATH/(CROSS_)?\0/g" qtbase/mkspecs/features/toolchain.prf
 endef
 
 define $(package)_config_cmds

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -2,6 +2,11 @@ Name "@PACKAGE_NAME@ (64-bit)"
 
 RequestExecutionLevel highest
 SetCompressor /SOLID lzma
+SetDateSave off
+
+# Uncomment these lines when investigating reproducibility errors
+#SetCompress off
+#SetDatablockOptimize off
 
 # General Symbol Definitions
 !define REGKEY "SOFTWARE\$(^Name)"

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -558,7 +558,16 @@ static int CommandLineRPC(int argc, char *argv[])
     return nRet;
 }
 
+#ifdef WIN32
+// Export main() and ensure working ASLR on Windows.
+// Exporting a symbol will prevent the linker from stripping
+// the .reloc section from the binary, which is a requirement
+// for ASLR. This is a temporary workaround until a fixed
+// version of binutils is used for releases.
+__declspec(dllexport) int main(int argc, char* argv[])
+#else
 int main(int argc, char* argv[])
+#endif
 {
     RegisterPrettyTerminateHander();
     RegisterPrettySignalHandlers();


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR enables building dash in Guix containers. [Guix](https://www.gnu.org/software/guix/manual/en/html_node/Features.html) is a transactional package manager much like Nix, but unlike Nix, it has more of a focus on [bootstrappability](https://www.gnu.org/software/guix/manual/en/html_node/Bootstrapping.html) and [reproducibility](https://www.gnu.org/software/guix/blog/tags/reproducible-builds/) which are attractive for security-sensitive projects like dash, bitcoin.

Furthermore seems as Guix will replace gitian for binary builds.

## What was done?
For this first PR backported minimum amount of PR to make guix run successful in my environment.
Currently it can build these targets:
 - aarch64-linux-gnu
 - arm-linux-gnueabihf
 - riscv64-linux-gnu
 - x86_64-linux-gnu
 - x86_64-w64-mingw32

There is NO DASHification yet
Please, help me to test `guix` on your local host, review this pull request and give me your feedback.
I'd like to do DASHification later, bitcoin has ~50 other backports that are easier to merge without dashification at this early stage.

## How Has This Been Tested?
Were built all 5 targets on my kubuntu 22.xx and tried to run some binaries

## Breaking Changes
No breaking changes

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
