### PR TITLE
fix/tests: fix `legacy` param usage in `bls generate` and `bls fromsecret`, add tests

### DIFF
--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1319,9 +1319,8 @@ static UniValue bls_generate(const JSONRPCRequest& request)
     CBLSSecretKey sk;
     sk.MakeNewKey();
     bool bls_legacy_scheme = !llmq::utils::IsV19Active(::ChainActive().Tip());
-    if (!request.params[1].isNull()) {
-        RPCTypeCheckArgument(request.params[1], UniValue::VBOOL);
-        bls_legacy_scheme = request.params[1].get_bool();
+    if (!request.params[0].isNull()) {
+        bls_legacy_scheme = ParseBoolV(request.params[0], "bls_legacy_scheme");
     }
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("secret", sk.ToString());
@@ -1359,8 +1358,7 @@ static UniValue bls_fromsecret(const JSONRPCRequest& request)
     CBLSSecretKey sk = ParseBLSSecretKey(request.params[0].get_str(), "secretKey");
     bool bls_legacy_scheme = !llmq::utils::IsV19Active(::ChainActive().Tip());
     if (!request.params[1].isNull()) {
-        RPCTypeCheckArgument(request.params[1], UniValue::VBOOL);
-        bls_legacy_scheme = request.params[1].get_bool();
+        bls_legacy_scheme = ParseBoolV(request.params[1], "bls_legacy_scheme");
     }
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("secret", sk.ToString());

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -416,4 +416,50 @@ BOOST_AUTO_TEST_CASE(rpc_getblockstats_calculate_percentiles_by_size)
     }
 }
 
+BOOST_AUTO_TEST_CASE(rpc_bls)
+{
+    UniValue r;
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls generate")));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls generate 1")));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
+    std::string secret_legacy = find_value(r.get_obj(), "secret").get_str();
+    std::string public_legacy = find_value(r.get_obj(), "public").get_str();
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls generate 0")));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "basic");
+    std::string secret_basic = find_value(r.get_obj(), "secret").get_str();
+    std::string public_basic = find_value(r.get_obj(), "public").get_str();
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_legacy));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), public_legacy);
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_legacy + std::string(" 1")));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), public_legacy);
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_legacy + std::string(" 0")));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "basic");
+    BOOST_CHECK(find_value(r.get_obj(), "public").get_str() != public_legacy);
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_basic + std::string(" 0")));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "basic");
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), public_basic);
+
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret_basic + std::string(" 1")));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
+    BOOST_CHECK(find_value(r.get_obj(), "public").get_str() != public_basic);
+
+    std::string secret = "0b072b1b8b28335b0460aa695ee8ce1f60dc01e6eb12655ece2a877379dfdb51";
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "legacy");
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), "9379c28e0f50546906fe733f1222c8f7e39574d513790034f1fec1476286eb652a350c8c0e630cd2cc60d10c26d6f6ee");
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("bls fromsecret ") + secret + " 0"));
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "scheme").get_str(), "basic");
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "public").get_str(), "b379c28e0f50546906fe733f1222c8f7e39574d513790034f1fec1476286eb652a350c8c0e630cd2cc60d10c26d6f6ee");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Issue being fixed or feature implemented
`legacy` param is either ignored (wrong param index) or rejected (can't use `RPCTypeCheckArgument`/`get_bool()` for params not listed in `vRPCConvertParams` and we can't add them there either because they have no exact indexes)

## What was done?
switched to `ParseBoolV`, added unit tests

## How Has This Been Tested?
`./src/test/test_dash -t rpc_tests/rpc_bls`

## Breaking Changes
n/a


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
