### PR TITLE
refactor: introduce enum class for MnType and clean up implementation accordingly

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -192,7 +192,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
             if (dmn->pdmnState->nLastPaidHeight == nHeight) {
                 // We found the last MN Payee.
                 // If the last payee is a HPMN, we need to check its consecutive payments and pay him again if needed
-                if (dmn->nType == MnType::HighPerformance && dmn->pdmnState->nConsecutivePayments < CMnType::HighPerformance().voting_weight) {
+                if (dmn->nType == MnType::HighPerformance && dmn->pdmnState->nConsecutivePayments < dmn_types::HighPerformance.voting_weight) {
                     best = dmn;
                 }
             }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -192,7 +192,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
             if (dmn->pdmnState->nLastPaidHeight == nHeight) {
                 // We found the last MN Payee.
                 // If the last payee is a HPMN, we need to check its consecutive payments and pay him again if needed
-                if (dmn->nType == MnType::HighPerformance.index && dmn->pdmnState->nConsecutivePayments < MnType::HighPerformance.voting_weight) {
+                if (dmn->nType == MnType::HighPerformance && dmn->pdmnState->nConsecutivePayments < CMnType::HighPerformance().voting_weight) {
                     best = dmn;
                 }
             }
@@ -268,7 +268,7 @@ std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CDeterministicMNList
             return;
         }
         if (onlyHighPerformanceMasternodes) {
-            if (dmn->nType != MnType::HighPerformance.index)
+            if (dmn->nType != MnType::HighPerformance)
                 return;
         }
         // calculate sha256(sha256(proTxHash, confirmedHash), modifier) per MN
@@ -471,7 +471,7 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTota
                 dmn->proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.Get().ToString())));
     }
 
-    if (dmn->nType == MnType::HighPerformance.index) {
+    if (dmn->nType == MnType::HighPerformance) {
         if (!AddUniqueProperty(*dmn, dmn->pdmnState->platformNodeID)) {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
             throw(std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate platformNodeID=%s", __func__,
@@ -512,7 +512,7 @@ void CDeterministicMNList::UpdateMN(const CDeterministicMN& oldDmn, const std::s
         throw(std::runtime_error(strprintf("%s: Can't update a masternode %s with a duplicate pubKeyOperator=%s", __func__,
                 oldDmn.proTxHash.ToString(), pdmnState->pubKeyOperator.Get().ToString())));
     }
-    if (dmn->nType == MnType::HighPerformance.index) {
+    if (dmn->nType == MnType::HighPerformance) {
         if (!UpdateUniqueProperty(*dmn, oldState->platformNodeID, dmn->pdmnState->platformNodeID)) {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
             throw(std::runtime_error(strprintf("%s: Can't update a masternode %s with a duplicate platformNodeID=%s", __func__,
@@ -572,7 +572,7 @@ void CDeterministicMNList::RemoveMN(const uint256& proTxHash)
                 proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.Get().ToString())));
     }
 
-    if (dmn->nType == MnType::HighPerformance.index) {
+    if (dmn->nType == MnType::HighPerformance) {
         if (!DeleteUniqueProperty(*dmn, dmn->pdmnState->platformNodeID)) {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
             throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with a duplicate platformNodeID=%s", __func__,
@@ -745,11 +745,11 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-payload");
             }
 
-            if (proTx.nType == MnType::HighPerformance.index && !llmq::utils::IsV19Active(pindexPrev)) {
+            if (proTx.nType == MnType::HighPerformance && !llmq::utils::IsV19Active(pindexPrev)) {
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-payload");
             }
 
-            auto dmn = std::make_shared<CDeterministicMN>(newList.GetTotalRegisteredCount(), proTx.nType == MnType::HighPerformance.index);
+            auto dmn = std::make_shared<CDeterministicMN>(newList.GetTotalRegisteredCount(), proTx.nType);
             dmn->proTxHash = tx.GetHash();
 
             // collateralOutpoint is either pointing to an external collateral or to the ProRegTx itself
@@ -808,7 +808,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-payload");
             }
 
-            if (proTx.nType == MnType::HighPerformance.index && !llmq::utils::IsV19Active(pindexPrev)) {
+            if (proTx.nType == MnType::HighPerformance && !llmq::utils::IsV19Active(pindexPrev)) {
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-payload");
             }
 
@@ -820,17 +820,17 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
             if (!dmn) {
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-hash");
             }
-            if (proTx.nType == MnType::HighPerformance.index && dmn->nType != MnType::HighPerformance.index) {
-                return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-type");
+            if (proTx.nType != dmn->nType) {
+                return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-type-mismatch");
             }
-            if (proTx.nType == MnType::Regular.index && dmn->nType != MnType::Regular.index) {
+            if (proTx.nType != MnType::Regular && proTx.nType != MnType::HighPerformance) {
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-type");
             }
 
             auto newState = std::make_shared<CDeterministicMNState>(*dmn->pdmnState);
             newState->addr = proTx.addr;
             newState->scriptOperatorPayout = proTx.scriptOperatorPayout;
-            if (proTx.nType == MnType::HighPerformance.index) {
+            if (proTx.nType == MnType::HighPerformance) {
                 newState->platformNodeID = proTx.platformNodeID;
                 newState->platformP2PPort = proTx.platformP2PPort;
                 newState->platformHTTPPort = proTx.platformHTTPPort;
@@ -946,7 +946,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
         // No need to check if v19 is active, since HPMN ProRegTx are allowed only after v19 activation
         // TODO: Skip this code once v20 is active
         // Note: If the payee wasn't found in the current block that's fine
-        if (dmn->nType == MnType::HighPerformance.index) {
+        if (dmn->nType == MnType::HighPerformance) {
             ++newState->nConsecutivePayments;
             if (debugLogs) {
                 LogPrintf("CDeterministicMNManager::%s -- MN %s is a HPMN, bumping nConsecutivePayments to %d\n",
@@ -965,7 +965,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
     auto newList2 = newList;
     newList2.ForEachMN(false, [&](auto& dmn) {
         if (payee != nullptr && dmn.proTxHash == payee->proTxHash) return;
-        if (dmn.nType != MnType::HighPerformance.index) return;
+        if (dmn.nType != MnType::HighPerformance) return;
         if (dmn.pdmnState->nConsecutivePayments == 0) return;
         if (debugLogs) {
             LogPrintf("CDeterministicMNManager::%s -- MN %s, reset nConsecutivePayments %d->0\n",
@@ -1399,7 +1399,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
         return false;
     }
 
-    if (ptx.nType == MnType::HighPerformance.index) {
+    if (ptx.nType == MnType::HighPerformance) {
         if (!CheckPlatformFields(ptx, state)) {
             return false;
         }
@@ -1510,7 +1510,7 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
         return false;
     }
 
-    if (ptx.nType == MnType::HighPerformance.index) {
+    if (ptx.nType == MnType::HighPerformance) {
         if (!CheckPlatformFields(ptx, state)) {
             return false;
         }

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -45,9 +45,9 @@ public:
     static constexpr uint16_t MN_TYPE_FORMAT = 1;
 
     CDeterministicMN() = delete; // no default constructor, must specify internalId
-    explicit CDeterministicMN(uint64_t _internalId, bool highPerformanceMasternode = false) :
+    explicit CDeterministicMN(uint64_t _internalId, MnType mnType = MnType::Regular) :
         internalId(_internalId),
-        nType(highPerformanceMasternode ? MnType::HighPerformance.index : MnType::Regular.index)
+        nType(mnType)
     {
         // only non-initial values
         assert(_internalId != std::numeric_limits<uint64_t>::max());
@@ -62,7 +62,7 @@ public:
     uint256 proTxHash;
     COutPoint collateralOutpoint;
     uint16_t nOperatorReward{0};
-    uint16_t nType{MnType::Regular.index};
+    MnType nType{MnType::Regular};
     std::shared_ptr<const CDeterministicMNState> pdmnState;
 
     template <typename Stream, typename Operation>
@@ -89,7 +89,7 @@ public:
         if (format_version >= MN_TYPE_FORMAT && (s.GetVersion() == CLIENT_VERSION || s.GetVersion() >= DMN_TYPE_PROTO_VERSION)) {
             READWRITE(nType);
         } else {
-            nType = MnType::Regular.index;
+            nType = MnType::Regular;
         }
     }
 
@@ -227,7 +227,7 @@ public:
 
     [[nodiscard]] size_t GetAllHPMNsCount() const
     {
-        return ranges::count_if(mnMap, [](const auto& p) { return p.second->nType == MnType::HighPerformance.index; });
+        return ranges::count_if(mnMap, [](const auto& p) { return p.second->nType == MnType::HighPerformance; });
     }
 
     /**

--- a/src/evo/dmn_types.h
+++ b/src/evo/dmn_types.h
@@ -18,37 +18,39 @@ enum class MnType : uint16_t {
 
 template<> struct is_serializable_enum<MnType> : std::true_type {};
 
-struct CMnType
+namespace dmn_types {
+
+struct mntype_struct
 {
     const int32_t voting_weight;
     const CAmount collat_amount;
     const std::string_view description;
-
-    [[nodiscard]] static constexpr CMnType Regular() {
-        return CMnType{
-            .voting_weight = 1,
-            .collat_amount = 1000 * COIN,
-            .description = "Regular",
-        };
-    }
-    [[nodiscard]] static constexpr CMnType HighPerformance() {
-        return CMnType{
-            .voting_weight = 4,
-            .collat_amount = 4000 * COIN,
-            .description = "HighPerformance",
-        };
-    }
-    [[nodiscard]] static constexpr bool IsCollateralAmount(CAmount amount) {
-        return amount == Regular().collat_amount ||
-            amount == HighPerformance().collat_amount;
-    }
 };
 
-[[nodiscard]] constexpr const CMnType GetMnType(MnType type)
+constexpr auto Regular = mntype_struct{
+    .voting_weight = 1,
+    .collat_amount = 1000 * COIN,
+    .description = "Regular",
+};
+constexpr auto HighPerformance = mntype_struct{
+    .voting_weight = 4,
+    .collat_amount = 4000 * COIN,
+    .description = "HighPerformance",
+};
+
+[[nodiscard]] static constexpr bool IsCollateralAmount(CAmount amount)
+{
+    return amount == Regular.collat_amount ||
+        amount == HighPerformance.collat_amount;
+}
+
+} // namespace dmn_types
+
+[[nodiscard]] constexpr const dmn_types::mntype_struct GetMnType(MnType type)
 {
     switch (type) {
-        case MnType::Regular: return CMnType::Regular();
-        case MnType::HighPerformance: return CMnType::HighPerformance();
+        case MnType::Regular: return dmn_types::Regular;
+        case MnType::HighPerformance: return dmn_types::HighPerformance;
         default: assert(false);
     }
 }

--- a/src/evo/dmn_types.h
+++ b/src/evo/dmn_types.h
@@ -24,27 +24,27 @@ struct CMnType
     const CAmount collat_amount;
     const std::string_view description;
 
-    static constexpr CMnType Regular() {
+    [[nodiscard]] static constexpr CMnType Regular() {
         return CMnType{
             .voting_weight = 1,
             .collat_amount = 1000 * COIN,
             .description = "Regular",
         };
     }
-    static constexpr CMnType HighPerformance() {
+    [[nodiscard]] static constexpr CMnType HighPerformance() {
         return CMnType{
             .voting_weight = 4,
             .collat_amount = 4000 * COIN,
             .description = "HighPerformance",
         };
     }
-    static constexpr bool IsCollateralAmount(CAmount amount) {
+    [[nodiscard]] static constexpr bool IsCollateralAmount(CAmount amount) {
         return amount == Regular().collat_amount ||
             amount == HighPerformance().collat_amount;
     }
 };
 
-constexpr const CMnType GetMnType(MnType type)
+[[nodiscard]] constexpr const CMnType GetMnType(MnType type)
 {
     switch (type) {
         case MnType::Regular: return CMnType::Regular();

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -15,7 +15,7 @@ maybe_error CProRegTx::IsTriviallyValid(bool is_bls_legacy_scheme) const
     if (nVersion == 0 || nVersion > GetVersion(is_bls_legacy_scheme)) {
         return {ValidationInvalidReason::CONSENSUS, "bad-protx-version"};
     }
-    if (nType != MnType::Regular.index && nType != MnType::HighPerformance.index) {
+    if (nType != MnType::Regular && nType != MnType::HighPerformance) {
         return {ValidationInvalidReason::CONSENSUS, "bad-protx-type"};
     }
     if (nMode != 0) {
@@ -80,7 +80,7 @@ std::string CProRegTx::ToString() const
     }
 
     return strprintf("CProRegTx(nVersion=%d, nType=%d, collateralOutpoint=%s, addr=%s, nOperatorReward=%f, ownerAddress=%s, pubKeyOperator=%s, votingAddress=%s, scriptPayout=%s, platformNodeID=%s, platformP2PPort=%d, platformHTTPPort=%d)",
-                     nVersion, nType, collateralOutpoint.ToStringShort(), addr.ToString(), (double)nOperatorReward / 100, EncodeDestination(PKHash(keyIDOwner)), pubKeyOperator.ToString(nVersion == LEGACY_BLS_VERSION), EncodeDestination(PKHash(keyIDVoting)), payee, platformNodeID.ToString(), platformP2PPort, platformHTTPPort);
+                     nVersion, static_cast<int>(nType), collateralOutpoint.ToStringShort(), addr.ToString(), (double)nOperatorReward / 100, EncodeDestination(PKHash(keyIDOwner)), pubKeyOperator.ToString(nVersion == LEGACY_BLS_VERSION), EncodeDestination(PKHash(keyIDVoting)), payee, platformNodeID.ToString(), platformP2PPort, platformHTTPPort);
 }
 
 maybe_error CProUpServTx::IsTriviallyValid(bool is_bls_legacy_scheme) const
@@ -101,7 +101,7 @@ std::string CProUpServTx::ToString() const
     }
 
     return strprintf("CProUpServTx(nVersion=%d, nType=%d, proTxHash=%s, addr=%s, operatorPayoutAddress=%s, platformNodeID=%s, platformP2PPort=%d, platformHTTPPort=%d)",
-                     nVersion, nType, proTxHash.ToString(), addr.ToString(), payee, platformNodeID.ToString(), platformP2PPort, platformHTTPPort);
+                     nVersion, static_cast<int>(nType), proTxHash.ToString(), addr.ToString(), payee, platformNodeID.ToString(), platformP2PPort, platformHTTPPort);
 }
 
 maybe_error CProUpRegTx::IsTriviallyValid(bool is_bls_legacy_scheme) const

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -34,7 +34,7 @@ public:
     }
 
     uint16_t nVersion{LEGACY_BLS_VERSION};                 // message version
-    uint16_t nType{MnType::Regular.index};
+    MnType nType{MnType::Regular};
     uint16_t nMode{0};                                     // only 0 supported for now
     COutPoint collateralOutpoint{uint256(), (uint32_t)-1}; // if hash is null, we refer to a ProRegTx output
     CService addr;
@@ -70,7 +70,7 @@ public:
                 obj.scriptPayout,
                 obj.inputsHash
         );
-        if (obj.nVersion == BASIC_BLS_VERSION && obj.nType == MnType::HighPerformance.index) {
+        if (obj.nVersion == BASIC_BLS_VERSION && obj.nType == MnType::HighPerformance) {
             READWRITE(
                 obj.platformNodeID,
                 obj.platformP2PPort,
@@ -92,7 +92,7 @@ public:
         obj.clear();
         obj.setObject();
         obj.pushKV("version", nVersion);
-        obj.pushKV("type", nType);
+        obj.pushKV("type", static_cast<uint16_t>(nType));
         obj.pushKV("collateralHash", collateralOutpoint.hash.ToString());
         obj.pushKV("collateralIndex", (int)collateralOutpoint.n);
         obj.pushKV("service", addr.ToString(false));
@@ -105,7 +105,7 @@ public:
         }
         obj.pushKV("pubKeyOperator", pubKeyOperator.ToString(nVersion == LEGACY_BLS_VERSION));
         obj.pushKV("operatorReward", (double)nOperatorReward / 100);
-        if (nType == MnType::HighPerformance.index) {
+        if (nType == MnType::HighPerformance) {
             obj.pushKV("platformNodeID", platformNodeID.ToString());
             obj.pushKV("platformP2PPort", platformP2PPort);
             obj.pushKV("platformHTTPPort", platformHTTPPort);
@@ -129,7 +129,7 @@ public:
     }
 
     uint16_t nVersion{LEGACY_BLS_VERSION}; // message version
-    uint16_t nType{MnType::Regular.index};
+    MnType nType{MnType::Regular};
     uint256 proTxHash;
     CService addr;
     uint160 platformNodeID{};
@@ -158,7 +158,7 @@ public:
                 obj.scriptOperatorPayout,
                 obj.inputsHash
         );
-        if (obj.nVersion == BASIC_BLS_VERSION && obj.nType == MnType::HighPerformance.index) {
+        if (obj.nVersion == BASIC_BLS_VERSION && obj.nType == MnType::HighPerformance) {
             READWRITE(
                 obj.platformNodeID,
                 obj.platformP2PPort,
@@ -178,14 +178,14 @@ public:
         obj.clear();
         obj.setObject();
         obj.pushKV("version", nVersion);
-        obj.pushKV("type", nType);
+        obj.pushKV("type", static_cast<uint16_t>(nType));
         obj.pushKV("proTxHash", proTxHash.ToString());
         obj.pushKV("service", addr.ToString(false));
         CTxDestination dest;
         if (ExtractDestination(scriptOperatorPayout, dest)) {
             obj.pushKV("operatorPayoutAddress", EncodeDestination(dest));
         }
-        if (nType == MnType::HighPerformance.index) {
+        if (nType == MnType::HighPerformance) {
             obj.pushKV("platformNodeID", platformNodeID.ToString());
             obj.pushKV("platformP2PPort", platformP2PPort);
             obj.pushKV("platformHTTPPort", platformHTTPPort);

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -57,7 +57,7 @@ std::string CSimplifiedMNListEntry::ToString() const
     }
 
     return strprintf("CSimplifiedMNListEntry(nType=%d, proRegTxHash=%s, confirmedHash=%s, service=%s, pubKeyOperator=%s, votingAddress=%s, isValid=%d, payoutAddress=%s, operatorPayoutAddress=%s, platformHTTPPort=%d, platformNodeID=%s)",
-                     nType, proRegTxHash.ToString(), confirmedHash.ToString(), service.ToString(false), pubKeyOperator.Get().ToString(), EncodeDestination(PKHash(keyIDVoting)), isValid, payoutAddress, operatorPayoutAddress, platformHTTPPort, platformNodeID.ToString());
+                     static_cast<int>(nType), proRegTxHash.ToString(), confirmedHash.ToString(), service.ToString(false), pubKeyOperator.Get().ToString(), EncodeDestination(PKHash(keyIDVoting)), isValid, payoutAddress, operatorPayoutAddress, platformHTTPPort, platformNodeID.ToString());
 }
 
 void CSimplifiedMNListEntry::ToJson(UniValue& obj, bool extended) const
@@ -71,8 +71,8 @@ void CSimplifiedMNListEntry::ToJson(UniValue& obj, bool extended) const
     obj.pushKV("votingAddress", EncodeDestination(PKHash(keyIDVoting)));
     obj.pushKV("isValid", isValid);
     obj.pushKV("nVersion", nVersion);
-    obj.pushKV("nType", nType);
-    if (nType == MnType::HighPerformance.index) {
+    obj.pushKV("nType", static_cast<uint16_t>(nType));
+    if (nType == MnType::HighPerformance) {
         obj.pushKV("platformHTTPPort", platformHTTPPort);
         obj.pushKV("platformNodeID", platformNodeID.ToString());
     }

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -34,7 +34,7 @@ public:
     CBLSLazyPublicKey pubKeyOperator;
     CKeyID keyIDVoting;
     bool isValid{false};
-    uint16_t nType{MnType::Regular.index};
+    MnType nType{MnType::Regular};
     uint16_t platformHTTPPort{0};
     uint160 platformNodeID{};
     CScript scriptPayout; // mem-only
@@ -75,7 +75,7 @@ public:
                 );
         if (obj.nVersion == BASIC_BLS_VERSION) {
             READWRITE(obj.nType);
-            if (obj.nType == MnType::HighPerformance.index) {
+            if (obj.nType == MnType::HighPerformance) {
                 READWRITE(obj.platformHTTPPort);
                 READWRITE(obj.platformNodeID);
             }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -668,7 +668,7 @@ static UniValue masternodelist(const JSONRPCRequest& request)
             objMN.pushKV("payee", payeeStr);
             objMN.pushKV("status", dmnToStatus(dmn));
             objMN.pushKV("type", std::string(GetMnType(dmn.nType).description));
-            if (dmn.nType == MnType::HighPerformance.index) {
+            if (dmn.nType == MnType::HighPerformance) {
                 objMN.pushKV("platformNodeID", dmn.pdmnState->platformNodeID.ToString());
                 objMN.pushKV("platformP2PPort", dmn.pdmnState->platformP2PPort);
                 objMN.pushKV("platformHTTPPort", dmn.pdmnState->platformHTTPPort);

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -132,7 +132,7 @@ static CMutableTransaction CreateProRegTx(const CTxMemPool& mempool, SimpleUTXOM
     CMutableTransaction tx;
     tx.nVersion = 3;
     tx.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx, utxos, scriptPayout, CMnType::Regular().collat_amount);
+    FundTransaction(tx, utxos, scriptPayout, dmn_types::Regular.collat_amount);
     proTx.inputsHash = CalcTxInputsHash(CTransaction(tx));
     SetTxPayload(tx, proTx);
     SignTransaction(mempool, tx, coinbaseKey);

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -132,7 +132,7 @@ static CMutableTransaction CreateProRegTx(const CTxMemPool& mempool, SimpleUTXOM
     CMutableTransaction tx;
     tx.nVersion = 3;
     tx.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx, utxos, scriptPayout, MnType::Regular.collat_amount);
+    FundTransaction(tx, utxos, scriptPayout, CMnType::Regular().collat_amount);
     proTx.inputsHash = CalcTxInputsHash(CTransaction(tx));
     SetTxPayload(tx, proTx);
     SignTransaction(mempool, tx, coinbaseKey);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -110,7 +110,7 @@ static CMutableTransaction CreateProRegTx(const CTxMemPool& mempool, SimpleUTXOM
     CMutableTransaction tx;
     tx.nVersion = 3;
     tx.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx, utxos, scriptPayout, CMnType::Regular().collat_amount, coinbaseKey);
+    FundTransaction(tx, utxos, scriptPayout, dmn_types::Regular.collat_amount, coinbaseKey);
     proTx.inputsHash = CalcTxInputsHash(CTransaction(tx));
     SetTxPayload(tx, proTx);
     SignTransaction(mempool, tx, coinbaseKey);
@@ -468,7 +468,7 @@ void FuncTestMempoolReorg(TestChainSetup& setup)
 
     // Create a MN with an external collateral
     CMutableTransaction tx_collateral;
-    FundTransaction(tx_collateral, utxos, scriptCollateral, CMnType::Regular().collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_collateral, utxos, scriptCollateral, dmn_types::Regular.collat_amount, setup.coinbaseKey);
     SignTransaction(*(setup.m_node.mempool), tx_collateral, setup.coinbaseKey);
 
     auto block = std::make_shared<CBlock>(setup.CreateBlock({tx_collateral}, setup.coinbaseKey));
@@ -486,7 +486,7 @@ void FuncTestMempoolReorg(TestChainSetup& setup)
     payload.scriptPayout = scriptPayout;
 
     for (size_t i = 0; i < tx_collateral.vout.size(); ++i) {
-        if (tx_collateral.vout[i].nValue == CMnType::Regular().collat_amount) {
+        if (tx_collateral.vout[i].nValue == dmn_types::Regular.collat_amount) {
             payload.collateralOutpoint = COutPoint(tx_collateral.GetHash(), i);
             break;
         }
@@ -495,7 +495,7 @@ void FuncTestMempoolReorg(TestChainSetup& setup)
     CMutableTransaction tx_reg;
     tx_reg.nVersion = 3;
     tx_reg.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx_reg, utxos, scriptPayout, CMnType::Regular().collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_reg, utxos, scriptPayout, dmn_types::Regular.collat_amount, setup.coinbaseKey);
     payload.inputsHash = CalcTxInputsHash(CTransaction(tx_reg));
     CMessageSigner::SignMessage(payload.MakeSignString(), payload.vchSig, collateralKey);
     SetTxPayload(tx_reg, payload);
@@ -555,7 +555,7 @@ void FuncTestMempoolDualProregtx(TestChainSetup& setup)
     payload.scriptPayout = scriptPayout;
 
     for (size_t i = 0; i < tx_reg1.vout.size(); ++i) {
-        if (tx_reg1.vout[i].nValue == CMnType::Regular().collat_amount) {
+        if (tx_reg1.vout[i].nValue == dmn_types::Regular.collat_amount) {
             payload.collateralOutpoint = COutPoint(tx_reg1.GetHash(), i);
             break;
         }
@@ -564,7 +564,7 @@ void FuncTestMempoolDualProregtx(TestChainSetup& setup)
     CMutableTransaction tx_reg2;
     tx_reg2.nVersion = 3;
     tx_reg2.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx_reg2, utxos, scriptPayout, CMnType::Regular().collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_reg2, utxos, scriptPayout, dmn_types::Regular.collat_amount, setup.coinbaseKey);
     payload.inputsHash = CalcTxInputsHash(CTransaction(tx_reg2));
     CMessageSigner::SignMessage(payload.MakeSignString(), payload.vchSig, collateralKey);
     SetTxPayload(tx_reg2, payload);
@@ -599,7 +599,7 @@ void FuncVerifyDB(TestChainSetup& setup)
 
     // Create a MN with an external collateral
     CMutableTransaction tx_collateral;
-    FundTransaction(tx_collateral, utxos, scriptCollateral, CMnType::Regular().collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_collateral, utxos, scriptCollateral, dmn_types::Regular.collat_amount, setup.coinbaseKey);
     SignTransaction(*(setup.m_node.mempool), tx_collateral, setup.coinbaseKey);
 
     auto block = std::make_shared<CBlock>(setup.CreateBlock({tx_collateral}, setup.coinbaseKey));
@@ -617,7 +617,7 @@ void FuncVerifyDB(TestChainSetup& setup)
     payload.scriptPayout = scriptPayout;
 
     for (size_t i = 0; i < tx_collateral.vout.size(); ++i) {
-        if (tx_collateral.vout[i].nValue == CMnType::Regular().collat_amount) {
+        if (tx_collateral.vout[i].nValue == dmn_types::Regular.collat_amount) {
             payload.collateralOutpoint = COutPoint(tx_collateral.GetHash(), i);
             break;
         }
@@ -626,7 +626,7 @@ void FuncVerifyDB(TestChainSetup& setup)
     CMutableTransaction tx_reg;
     tx_reg.nVersion = 3;
     tx_reg.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx_reg, utxos, scriptPayout, CMnType::Regular().collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_reg, utxos, scriptPayout, dmn_types::Regular.collat_amount, setup.coinbaseKey);
     payload.inputsHash = CalcTxInputsHash(CTransaction(tx_reg));
     CMessageSigner::SignMessage(payload.MakeSignString(), payload.vchSig, collateralKey);
     SetTxPayload(tx_reg, payload);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -110,7 +110,7 @@ static CMutableTransaction CreateProRegTx(const CTxMemPool& mempool, SimpleUTXOM
     CMutableTransaction tx;
     tx.nVersion = 3;
     tx.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx, utxos, scriptPayout, MnType::Regular.collat_amount, coinbaseKey);
+    FundTransaction(tx, utxos, scriptPayout, CMnType::Regular().collat_amount, coinbaseKey);
     proTx.inputsHash = CalcTxInputsHash(CTransaction(tx));
     SetTxPayload(tx, proTx);
     SignTransaction(mempool, tx, coinbaseKey);
@@ -468,7 +468,7 @@ void FuncTestMempoolReorg(TestChainSetup& setup)
 
     // Create a MN with an external collateral
     CMutableTransaction tx_collateral;
-    FundTransaction(tx_collateral, utxos, scriptCollateral, MnType::Regular.collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_collateral, utxos, scriptCollateral, CMnType::Regular().collat_amount, setup.coinbaseKey);
     SignTransaction(*(setup.m_node.mempool), tx_collateral, setup.coinbaseKey);
 
     auto block = std::make_shared<CBlock>(setup.CreateBlock({tx_collateral}, setup.coinbaseKey));
@@ -486,7 +486,7 @@ void FuncTestMempoolReorg(TestChainSetup& setup)
     payload.scriptPayout = scriptPayout;
 
     for (size_t i = 0; i < tx_collateral.vout.size(); ++i) {
-        if (tx_collateral.vout[i].nValue == MnType::Regular.collat_amount) {
+        if (tx_collateral.vout[i].nValue == CMnType::Regular().collat_amount) {
             payload.collateralOutpoint = COutPoint(tx_collateral.GetHash(), i);
             break;
         }
@@ -495,7 +495,7 @@ void FuncTestMempoolReorg(TestChainSetup& setup)
     CMutableTransaction tx_reg;
     tx_reg.nVersion = 3;
     tx_reg.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx_reg, utxos, scriptPayout, MnType::Regular.collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_reg, utxos, scriptPayout, CMnType::Regular().collat_amount, setup.coinbaseKey);
     payload.inputsHash = CalcTxInputsHash(CTransaction(tx_reg));
     CMessageSigner::SignMessage(payload.MakeSignString(), payload.vchSig, collateralKey);
     SetTxPayload(tx_reg, payload);
@@ -555,7 +555,7 @@ void FuncTestMempoolDualProregtx(TestChainSetup& setup)
     payload.scriptPayout = scriptPayout;
 
     for (size_t i = 0; i < tx_reg1.vout.size(); ++i) {
-        if (tx_reg1.vout[i].nValue == MnType::Regular.collat_amount) {
+        if (tx_reg1.vout[i].nValue == CMnType::Regular().collat_amount) {
             payload.collateralOutpoint = COutPoint(tx_reg1.GetHash(), i);
             break;
         }
@@ -564,7 +564,7 @@ void FuncTestMempoolDualProregtx(TestChainSetup& setup)
     CMutableTransaction tx_reg2;
     tx_reg2.nVersion = 3;
     tx_reg2.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx_reg2, utxos, scriptPayout, MnType::Regular.collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_reg2, utxos, scriptPayout, CMnType::Regular().collat_amount, setup.coinbaseKey);
     payload.inputsHash = CalcTxInputsHash(CTransaction(tx_reg2));
     CMessageSigner::SignMessage(payload.MakeSignString(), payload.vchSig, collateralKey);
     SetTxPayload(tx_reg2, payload);
@@ -599,7 +599,7 @@ void FuncVerifyDB(TestChainSetup& setup)
 
     // Create a MN with an external collateral
     CMutableTransaction tx_collateral;
-    FundTransaction(tx_collateral, utxos, scriptCollateral, MnType::Regular.collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_collateral, utxos, scriptCollateral, CMnType::Regular().collat_amount, setup.coinbaseKey);
     SignTransaction(*(setup.m_node.mempool), tx_collateral, setup.coinbaseKey);
 
     auto block = std::make_shared<CBlock>(setup.CreateBlock({tx_collateral}, setup.coinbaseKey));
@@ -617,7 +617,7 @@ void FuncVerifyDB(TestChainSetup& setup)
     payload.scriptPayout = scriptPayout;
 
     for (size_t i = 0; i < tx_collateral.vout.size(); ++i) {
-        if (tx_collateral.vout[i].nValue == MnType::Regular.collat_amount) {
+        if (tx_collateral.vout[i].nValue == CMnType::Regular().collat_amount) {
             payload.collateralOutpoint = COutPoint(tx_collateral.GetHash(), i);
             break;
         }
@@ -626,7 +626,7 @@ void FuncVerifyDB(TestChainSetup& setup)
     CMutableTransaction tx_reg;
     tx_reg.nVersion = 3;
     tx_reg.nType = TRANSACTION_PROVIDER_REGISTER;
-    FundTransaction(tx_reg, utxos, scriptPayout, MnType::Regular.collat_amount, setup.coinbaseKey);
+    FundTransaction(tx_reg, utxos, scriptPayout, CMnType::Regular().collat_amount, setup.coinbaseKey);
     payload.inputsHash = CalcTxInputsHash(CTransaction(tx_reg));
     CMessageSigner::SignMessage(payload.MakeSignString(), payload.vchSig, collateralKey);
     SetTxPayload(tx_reg, payload);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2535,7 +2535,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
                 if (CCoinJoin::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts
                 found = !CCoinJoin::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
             } else if(nCoinType == CoinType::ONLY_MASTERNODE_COLLATERAL) {
-                found = CMnType::IsCollateralAmount(pcoin->tx->vout[i].nValue);
+                found = dmn_types::IsCollateralAmount(pcoin->tx->vout[i].nValue);
             } else if(nCoinType == CoinType::ONLY_COINJOIN_COLLATERAL) {
                 found = CCoinJoin::IsCollateralAmount(pcoin->tx->vout[i].nValue);
             } else {
@@ -3046,7 +3046,7 @@ std::vector<CompactTallyItem> CWallet::SelectCoinsGroupedByAddresses(bool fSkipD
             if(fAnonymizable) {
                 // ignore collaterals
                 if(CCoinJoin::IsCollateralAmount(wtx.tx->vout[i].nValue)) continue;
-                if (fMasternodeMode && CMnType::IsCollateralAmount(wtx.tx->vout[i].nValue)) continue;
+                if (fMasternodeMode && dmn_types::IsCollateralAmount(wtx.tx->vout[i].nValue)) continue;
                 // ignore outputs that are 10 times smaller then the smallest denomination
                 // otherwise they will just lead to higher fee / lower priority
                 if(wtx.tx->vout[i].nValue <= nSmallestDenom/10) continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2535,7 +2535,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
                 if (CCoinJoin::IsCollateralAmount(pcoin->tx->vout[i].nValue)) continue; // do not use collateral amounts
                 found = !CCoinJoin::IsDenominatedAmount(pcoin->tx->vout[i].nValue);
             } else if(nCoinType == CoinType::ONLY_MASTERNODE_COLLATERAL) {
-                found = pcoin->tx->vout[i].nValue == MnType::Regular.collat_amount || pcoin->tx->vout[i].nValue == MnType::HighPerformance.collat_amount;
+                found = CMnType::IsCollateralAmount(pcoin->tx->vout[i].nValue);
             } else if(nCoinType == CoinType::ONLY_COINJOIN_COLLATERAL) {
                 found = CCoinJoin::IsCollateralAmount(pcoin->tx->vout[i].nValue);
             } else {
@@ -3046,7 +3046,7 @@ std::vector<CompactTallyItem> CWallet::SelectCoinsGroupedByAddresses(bool fSkipD
             if(fAnonymizable) {
                 // ignore collaterals
                 if(CCoinJoin::IsCollateralAmount(wtx.tx->vout[i].nValue)) continue;
-                if (fMasternodeMode && (wtx.tx->vout[i].nValue == MnType::Regular.collat_amount || wtx.tx->vout[i].nValue == MnType::HighPerformance.collat_amount)) continue;
+                if (fMasternodeMode && CMnType::IsCollateralAmount(wtx.tx->vout[i].nValue)) continue;
                 // ignore outputs that are 10 times smaller then the smallest denomination
                 // otherwise they will just lead to higher fee / lower priority
                 if(wtx.tx->vout[i].nValue <= nSmallestDenom/10) continue;


### PR DESCRIPTION
## Issue being fixed or feature implemented
expressions like `nType == MnType::HighPerformance.index` look pretty confusing in current implementation of 4k HPMN.

Changing `uint8_t` index to `enum class MnType : uint8_t` give pros:
 - switch inside GetMnType() and any similar code will show a compiler warning if any type is missing.
 - instead "MnType::HighPerformance.index" you can write MnType::HighPerformance
 - you can remove confusing `.index` from MnType

But also Cons:
 - instead  `log("%d", nType)` you need to write `log("%d", static_cast<int>(nType))`;

## What was done?
Introduced new enum class MnType and rewritten generating Regular/HighPerformance objects with params (description, collateral amount, etc).

Also were added attributes [[no_discard]] for related code.

## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
No breaking changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
