### PR TITLE
feat(llmq): llmq_test_platform threshold adjustment

### DIFF
--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -218,8 +218,8 @@ static constexpr std::array<LLMQParams, 12> available_llmqs = {
         .type = LLMQType::LLMQ_TEST_PLATFORM,
         .name = "llmq_test_platform",
         .useRotation = false,
-        .size = 4,
-        .minSize = 3,
+        .size = 3,
+        .minSize = 2,
         .threshold = 2,
 
         .dkgInterval = 24, // DKG cycle

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -32,7 +32,7 @@ enum class LLMQType : uint8_t {
     // for testing only
     LLMQ_TEST_DIP0024 = 103,     // 4 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
     LLMQ_TEST_INSTANTSEND = 104, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestinstantsendparams is used
-    LLMQ_TEST_PLATFORM = 106,    // 4 members, 2 (66%) threshold, one per hour.
+    LLMQ_TEST_PLATFORM = 106,    // 3 members, 2 (66%) threshold, one per hour.
 
     // for devnets only. rotated version (v2) for devnets
     LLMQ_DEVNET_DIP0024 = 105 // 8 members, 4 (50%) threshold, one per hour. Params might differ when -llmqdevnetparams is used

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -68,7 +68,7 @@ class LLMQHPMNTest(DashTestFramework):
 
         self.log.info("Test llmq_platform are formed only with HPMNs")
         for i in range(3):
-            quorum_i_hash = self.mine_quorum(llmq_type_name='llmq_test_platform', llmq_type=106)
+            quorum_i_hash = self.mine_quorum(llmq_type_name='llmq_test_platform', llmq_type=106, expected_connections=2, expected_members=3, expected_contributions=3, expected_complaints=0, expected_justifications=0, expected_commitments=3 )
             self.test_quorum_members_are_high_performance(quorum_i_hash, llmq_type=106)
 
         self.log.info("Test that HPMNs are present in MN list")


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->
As discussed with Platform team, threshold for `llmq_test_platform` needed to be 67%. Therefore, the size went from 4 members to 3 (while keeping threshold to 2)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
