### PR TITLE
refactor/fix: return `Invalid` mn type instead of crashing on `assert` in `GetMnType`

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -823,7 +823,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
             if (proTx.nType != dmn->nType) {
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-type-mismatch");
             }
-            if (proTx.nType != MnType::Regular && proTx.nType != MnType::HighPerformance) {
+            if (!IsValidMnType(proTx.nType)) {
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-protx-type");
             }
 

--- a/src/evo/dmn_types.h
+++ b/src/evo/dmn_types.h
@@ -14,6 +14,7 @@
 enum class MnType : uint16_t {
     Regular = 0,
     HighPerformance = 1,
+    Invalid = std::numeric_limits<uint16_t>::max(),
 };
 
 template<> struct is_serializable_enum<MnType> : std::true_type {};
@@ -25,6 +26,17 @@ struct mntype_struct
     const int32_t voting_weight;
     const CAmount collat_amount;
     const std::string_view description;
+
+    bool operator==(const mntype_struct& r) const
+    {
+        return  voting_weight == r.voting_weight &&
+                collat_amount == r.collat_amount &&
+                description == r.description;
+    }
+    bool operator!=(const mntype_struct& r) const
+    {
+        return !(*this == r);
+    }
 };
 
 constexpr auto Regular = mntype_struct{
@@ -36,6 +48,11 @@ constexpr auto HighPerformance = mntype_struct{
     .voting_weight = 4,
     .collat_amount = 4000 * COIN,
     .description = "HighPerformance",
+};
+constexpr auto Invalid = mntype_struct{
+    .voting_weight = 0,
+    .collat_amount = MAX_MONEY,
+    .description = "Invalid",
 };
 
 [[nodiscard]] static constexpr bool IsCollateralAmount(CAmount amount)
@@ -51,8 +68,13 @@ constexpr auto HighPerformance = mntype_struct{
     switch (type) {
         case MnType::Regular: return dmn_types::Regular;
         case MnType::HighPerformance: return dmn_types::HighPerformance;
-        default: assert(false);
+        default: return dmn_types::Invalid;
     }
+}
+
+[[nodiscard]] constexpr const bool IsValidMnType(MnType type)
+{
+    return GetMnType(type) != dmn_types::Invalid;
 }
 
 #endif // BITCOIN_EVO_DMN_TYPES_H

--- a/src/evo/dmn_types.h
+++ b/src/evo/dmn_types.h
@@ -14,6 +14,7 @@
 enum class MnType : uint16_t {
     Regular = 0,
     HighPerformance = 1,
+    COUNT,
     Invalid = std::numeric_limits<uint16_t>::max(),
 };
 
@@ -26,17 +27,6 @@ struct mntype_struct
     const int32_t voting_weight;
     const CAmount collat_amount;
     const std::string_view description;
-
-    bool operator==(const mntype_struct& r) const
-    {
-        return  voting_weight == r.voting_weight &&
-                collat_amount == r.collat_amount &&
-                description == r.description;
-    }
-    bool operator!=(const mntype_struct& r) const
-    {
-        return !(*this == r);
-    }
 };
 
 constexpr auto Regular = mntype_struct{
@@ -74,7 +64,7 @@ constexpr auto Invalid = mntype_struct{
 
 [[nodiscard]] constexpr const bool IsValidMnType(MnType type)
 {
-    return GetMnType(type) != dmn_types::Invalid;
+    return type < MnType::COUNT;
 }
 
 #endif // BITCOIN_EVO_DMN_TYPES_H

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -15,7 +15,7 @@ maybe_error CProRegTx::IsTriviallyValid(bool is_bls_legacy_scheme) const
     if (nVersion == 0 || nVersion > GetVersion(is_bls_legacy_scheme)) {
         return {ValidationInvalidReason::CONSENSUS, "bad-protx-version"};
     }
-    if (nType != MnType::Regular && nType != MnType::HighPerformance) {
+    if (!IsValidMnType(nType)) {
         return {ValidationInvalidReason::CONSENSUS, "bad-protx-type"};
     }
     if (nMode != 0) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
We use `GetMnType` in some critical parts of code where we process data from blocks and such. Having `assert` called there makes me nervous 😅

## What was done?
We should simply consider all unknown types invalid instead of crashing here. Introduced new dummy mn type for which no real mn can ever satisfy conditions.

## How Has This Been Tested?
run tests

## Breaking Changes
n/a


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
