### PR TITLE
chrore: bump version in gitian to 19

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "dash-linux-18"
+name: "dash-linux-19"
 enable_cache: true
 distro: "ubuntu"
 suites:

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "dash-osx-18"
+name: "dash-osx-19"
 enable_cache: true
 distro: "ubuntu"
 suites:

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "dash-win-18"
+name: "dash-win-19"
 enable_cache: true
 distro: "ubuntu"
 suites:


### PR DESCRIPTION
Name of some files in gitian's build contains "18" instead 19.

## Issue being fixed or feature implemented


## What was done?
Version bumped in gitian's related configs

## How Has This Been Tested?
Will be tested with next RC of v19

## Breaking Changes
No breaking changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation @PastaPastaPasta may you update release TODO checklist, please?
- [x] I have assigned this pull request to a milestone
