### PR TITLE
fix(qt): Overview page should always be accessible

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -939,7 +939,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
 {
 #ifdef ENABLE_WALLET
     if (walletFrame != nullptr) {
-        overviewButton->setEnabled(enabled);
+        // NOTE: overviewButton is always enabled
         sendCoinsButton->setEnabled(enabled);
         coinJoinCoinsButton->setEnabled(enabled && clientModel->coinJoinOptions().isEnabled());
         receiveCoinsButton->setEnabled(enabled);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -14,7 +14,6 @@
 
 #include <cassert>
 
-#include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
@@ -32,7 +31,7 @@ WalletFrame::WalletFrame(BitcoinGUI* _gui) :
     walletFrameLayout->addWidget(walletStack);
 
     // hbox for no wallet
-    QGroupBox* no_wallet_group = new QGroupBox(walletStack);
+    no_wallet_group = new QGroupBox(walletStack);
     QVBoxLayout* no_wallet_layout = new QVBoxLayout(no_wallet_group);
 
     QLabel *noWallet = new QLabel(tr("No wallet has been loaded.\nGo to File > Open Wallet to load a wallet.\n- OR -"));
@@ -172,6 +171,12 @@ void WalletFrame::gotoGovernancePage()
 void WalletFrame::gotoOverviewPage()
 {
     QMap<WalletModel*, WalletView*>::const_iterator i;
+
+    if (mapWalletViews.empty()) {
+        walletStack->setCurrentWidget(no_wallet_group);
+        return;
+    }
+
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoOverviewPage();
 }

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_WALLETFRAME_H
 
 #include <QFrame>
+#include <QGroupBox>
 #include <QMap>
 
 class BitcoinGUI;
@@ -55,6 +56,7 @@ private:
     BitcoinGUI *gui;
     ClientModel *clientModel;
     QMap<WalletModel*, WalletView*> mapWalletViews;
+    QGroupBox* no_wallet_group;
     MasternodeList* masternodeListPage;
     GovernanceList* governanceListPage;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Overview page shows either wallet info or "Create wallet" button. Unlike in bitcoin we can switch to other pages even when no wallets are enabled (because we have Masternodes and Governance tabs) but then there is no way to return back to Overview page.

## What was done?
Keep Overview tab always enabled. Make a no-wallet groupbox a member of `WalletFrame` and add logic to switch to it when needed.

## How Has This Been Tested?
`./src/qt/dash-qt --regtest --nowallet`

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

PS. kudos to @thephez for reporting :)