### PR TITLE
fix: making builds of guix to produce same output whatever git config

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -31,7 +31,7 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$
     fi
 
     # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
-    GIT_COMMIT=$(git rev-parse --short HEAD)
+    GIT_COMMIT=$(git rev-parse --short=12 HEAD)
     git diff-index --quiet HEAD -- || GIT_COMMIT="$GIT_COMMIT-dirty"
 fi
 


### PR DESCRIPTION
Builds are different, because git command output are different:




## Issue being fixed or feature implemented
in pr #5194 different OS produced different hashes of binary.
That's due to different behaviour of this command:
```sh
$ git rev-parse --short HEAD
b3f242da14 - on my localhost Kubuntu 22.10
b3f242da1 - inside pastapastapasta's docker
```

## What was done?
This fix forces to git print always 12 character


## How Has This Been Tested?
Run in different environment

## Breaking Changes
No breaking changes


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
