### PR TITLE
chore(rpc): removed protx_revoke_legacy

### DIFF
--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1099,7 +1099,7 @@ static void protx_revoke_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static UniValue protx_revoke_wrapper(const JSONRPCRequest& request, const bool specific_legacy_bls_scheme)
+static UniValue protx_revoke(const JSONRPCRequest& request)
 {
     protx_revoke_help(request);
 
@@ -1109,11 +1109,7 @@ static UniValue protx_revoke_wrapper(const JSONRPCRequest& request, const bool s
     EnsureWalletIsUnlocked(wallet.get());
 
     CProUpRevTx ptx;
-    if (specific_legacy_bls_scheme) {
-        ptx.nVersion = CProUpRevTx::LEGACY_BLS_VERSION;
-    } else {
-        ptx.nVersion = CProUpRevTx::GetVersion(llmq::utils::IsV19Active(::ChainActive().Tip()));
-    }
+    ptx.nVersion = CProUpRevTx::GetVersion(llmq::utils::IsV19Active(::ChainActive().Tip()));
     ptx.proTxHash = ParseHashV(request.params[0], "proTxHash");
 
     CBLSSecretKey keyOperator = ParseBLSSecretKey(request.params[1].get_str(), "operatorKey");
@@ -1164,15 +1160,6 @@ static UniValue protx_revoke_wrapper(const JSONRPCRequest& request, const bool s
     return SignAndSendSpecialTx(request, tx);
 }
 
-static UniValue protx_revoke(const JSONRPCRequest& request)
-{
-    return protx_revoke_wrapper(request, false);
-}
-
-static UniValue protx_revoke_legacy(const JSONRPCRequest& request)
-{
-    return protx_revoke_wrapper(request, true);
-}
 #endif//ENABLE_WALLET
 
 static void protx_list_help(const JSONRPCRequest& request)
@@ -1514,8 +1501,6 @@ static UniValue protx(const JSONRPCRequest& request)
         return protx_update_registrar_legacy(new_request);
     } else if (command == "protxrevoke") {
         return protx_revoke(new_request);
-    } else if (command == "protxrevoke_legacy") {
-        return protx_revoke_legacy(new_request);
     } else
 #endif
     if (command == "protxlist") {


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->
Removed protx_revoke_legacy since it required a BLS secret key and not a BLS public key.
(BLS scheme is not applicable to secret keys)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
