### PR TITLE
feat: show/store pubKeyOperator using the same scheme it was set originally via protx-es

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -121,8 +121,7 @@ bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev
         int64_t nTime2 = GetTimeMicros(); nTimeDMN += nTime2 - nTime1;
         LogPrint(BCLog::BENCHMARK, "            - BuildNewListFromBlock: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeDMN * 0.000001);
 
-        bool v19active = llmq::utils::IsV19Active(pindexPrev);
-        CSimplifiedMNList sml(tmpMNList, v19active);
+        CSimplifiedMNList sml(tmpMNList);
 
         int64_t nTime3 = GetTimeMicros(); nTimeSMNL += nTime3 - nTime2;
         LogPrint(BCLog::BENCHMARK, "            - CSimplifiedMNList: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeSMNL * 0.000001);

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -510,7 +510,7 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTota
     if (dmn->pdmnState->pubKeyOperator.Get().IsValid() && !AddUniqueProperty(*dmn, dmn->pdmnState->pubKeyOperator)) {
         mnUniquePropertyMap = mnUniquePropertyMapSaved;
         throw(std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate pubKeyOperator=%s", __func__,
-                dmn->proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.Get().ToString())));
+                dmn->proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.Get().ToString(dmn->pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION))));
     }
 
     if (dmn->nType == MnType::HighPerformance) {
@@ -552,7 +552,7 @@ void CDeterministicMNList::UpdateMN(const CDeterministicMN& oldDmn, const std::s
     if (!UpdateUniqueProperty(*dmn, oldState->pubKeyOperator, pdmnState->pubKeyOperator)) {
         mnUniquePropertyMap = mnUniquePropertyMapSaved;
         throw(std::runtime_error(strprintf("%s: Can't update a masternode %s with a duplicate pubKeyOperator=%s", __func__,
-                oldDmn.proTxHash.ToString(), pdmnState->pubKeyOperator.Get().ToString())));
+                oldDmn.proTxHash.ToString(), pdmnState->pubKeyOperator.Get().ToString(pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION))));
     }
     if (dmn->nType == MnType::HighPerformance) {
         if (!UpdateUniqueProperty(*dmn, oldState->platformNodeID, dmn->pdmnState->platformNodeID)) {
@@ -611,7 +611,7 @@ void CDeterministicMNList::RemoveMN(const uint256& proTxHash)
     if (dmn->pdmnState->pubKeyOperator.Get().IsValid() && !DeleteUniqueProperty(*dmn, dmn->pdmnState->pubKeyOperator)) {
         mnUniquePropertyMap = mnUniquePropertyMapSaved;
         throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with a pubKeyOperator=%s", __func__,
-                proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.Get().ToString())));
+                proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.Get().ToString(dmn->pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION))));
     }
 
     if (dmn->nType == MnType::HighPerformance) {

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -377,23 +377,18 @@ CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNL
 
 CSimplifiedMNListDiff CDeterministicMNList::BuildSimplifiedDiff(const CDeterministicMNList& to, bool extended) const
 {
-    bool v19active = llmq::utils::IsV19Active(::ChainActive().Tip());
     CSimplifiedMNListDiff diffRet;
     diffRet.baseBlockHash = blockHash;
     diffRet.blockHash = to.blockHash;
-    diffRet.nVersion = v19active ? CSimplifiedMNListDiff::BASIC_BLS_VERSION : CSimplifiedMNListDiff::LEGACY_BLS_VERSION;
 
     to.ForEachMN(false, [&](const auto& toPtr) {
         auto fromPtr = GetMN(toPtr.proTxHash);
         if (fromPtr == nullptr) {
             CSimplifiedMNListEntry sme(toPtr);
-            sme.nVersion = diffRet.nVersion;
             diffRet.mnList.push_back(std::move(sme));
         } else {
             CSimplifiedMNListEntry sme1(toPtr);
             CSimplifiedMNListEntry sme2(*fromPtr);
-            sme1.nVersion = diffRet.nVersion;
-            sme2.nVersion = diffRet.nVersion;
             if ((sme1 != sme2) ||
                 (extended && (sme1.scriptPayout != sme2.scriptPayout || sme1.scriptOperatorPayout != sme2.scriptOperatorPayout))) {
                     diffRet.mnList.push_back(std::move(sme1));

--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -29,7 +29,7 @@ std::string CDeterministicMNState::ToString() const
     return strprintf("CDeterministicMNState(nRegisteredHeight=%d, nLastPaidHeight=%d, nPoSePenalty=%d, nPoSeRevivedHeight=%d, nPoSeBanHeight=%d, nRevocationReason=%d, "
                      "ownerAddress=%s, pubKeyOperator=%s, votingAddress=%s, addr=%s, payoutAddress=%s, operatorPayoutAddress=%s)",
                      nRegisteredHeight, nLastPaidHeight, nPoSePenalty, nPoSeRevivedHeight, nPoSeBanHeight, nRevocationReason,
-                     EncodeDestination(PKHash(keyIDOwner)), pubKeyOperator.Get().ToString(), EncodeDestination(PKHash(keyIDVoting)), addr.ToStringIPPort(false), payoutAddress, operatorPayoutAddress);
+                     EncodeDestination(PKHash(keyIDOwner)), pubKeyOperator.Get().ToString(nVersion == CProRegTx::LEGACY_BLS_VERSION), EncodeDestination(PKHash(keyIDVoting)), addr.ToStringIPPort(false), payoutAddress, operatorPayoutAddress);
 }
 
 void CDeterministicMNState::ToJson(UniValue& obj, MnType nType) const
@@ -56,7 +56,7 @@ void CDeterministicMNState::ToJson(UniValue& obj, MnType nType) const
     if (ExtractDestination(scriptPayout, dest)) {
         obj.pushKV("payoutAddress", EncodeDestination(dest));
     }
-    obj.pushKV("pubKeyOperator", pubKeyOperator.Get().ToString());
+    obj.pushKV("pubKeyOperator", pubKeyOperator.Get().ToString(nVersion == CProRegTx::LEGACY_BLS_VERSION));
     if (ExtractDestination(scriptOperatorPayout, dest)) {
         obj.pushKV("operatorPayoutAddress", EncodeDestination(dest));
     }

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -32,6 +32,7 @@ CSimplifiedMNListEntry::CSimplifiedMNListEntry(const CDeterministicMN& dmn) :
     isValid(!dmn.pdmnState->IsBanned()),
     scriptPayout(dmn.pdmnState->scriptPayout),
     scriptOperatorPayout(dmn.pdmnState->scriptOperatorPayout),
+    nVersion(dmn.pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION ? LEGACY_BLS_VERSION : BASIC_BLS_VERSION),
     nType(dmn.nType),
     platformHTTPPort(dmn.pdmnState->platformHTTPPort),
     platformNodeID(dmn.pdmnState->platformNodeID)
@@ -58,7 +59,7 @@ std::string CSimplifiedMNListEntry::ToString() const
     }
 
     return strprintf("CSimplifiedMNListEntry(nType=%d, proRegTxHash=%s, confirmedHash=%s, service=%s, pubKeyOperator=%s, votingAddress=%s, isValid=%d, payoutAddress=%s, operatorPayoutAddress=%s, platformHTTPPort=%d, platformNodeID=%s)",
-                     ToUnderlying(nType), proRegTxHash.ToString(), confirmedHash.ToString(), service.ToString(false), pubKeyOperator.Get().ToString(), EncodeDestination(PKHash(keyIDVoting)), isValid, payoutAddress, operatorPayoutAddress, platformHTTPPort, platformNodeID.ToString());
+                     ToUnderlying(nType), proRegTxHash.ToString(), confirmedHash.ToString(), service.ToString(false), pubKeyOperator.Get().ToString(nVersion == LEGACY_BLS_VERSION), EncodeDestination(PKHash(keyIDVoting)), isValid, payoutAddress, operatorPayoutAddress, platformHTTPPort, platformNodeID.ToString());
 }
 
 void CSimplifiedMNListEntry::ToJson(UniValue& obj, bool extended) const
@@ -68,7 +69,7 @@ void CSimplifiedMNListEntry::ToJson(UniValue& obj, bool extended) const
     obj.pushKV("proRegTxHash", proRegTxHash.ToString());
     obj.pushKV("confirmedHash", confirmedHash.ToString());
     obj.pushKV("service", service.ToString(false));
-    obj.pushKV("pubKeyOperator", pubKeyOperator.Get().ToString());
+    obj.pushKV("pubKeyOperator", pubKeyOperator.Get().ToString(nVersion == LEGACY_BLS_VERSION));
     obj.pushKV("votingAddress", EncodeDestination(PKHash(keyIDVoting)));
     obj.pushKV("isValid", isValid);
     obj.pushKV("nVersion", nVersion);
@@ -102,14 +103,14 @@ CSimplifiedMNList::CSimplifiedMNList(const std::vector<CSimplifiedMNListEntry>& 
     });
 }
 
-CSimplifiedMNList::CSimplifiedMNList(const CDeterministicMNList& dmnList, bool isV19Active)
+CSimplifiedMNList::CSimplifiedMNList(const CDeterministicMNList& dmnList)
 {
     mnList.resize(dmnList.GetAllMNsCount());
 
     size_t i = 0;
-    dmnList.ForEachMN(false, [this, &i, isV19Active](auto& dmn) {
+    dmnList.ForEachMN(false, [this, &i](auto& dmn) {
         auto sme = std::make_unique<CSimplifiedMNListEntry>(dmn);
-        sme->nVersion = isV19Active ? CSimplifiedMNListEntry::BASIC_BLS_VERSION : CSimplifiedMNListEntry::LEGACY_BLS_VERSION;
+        sme->nVersion = (dmn.pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION) ? CSimplifiedMNListEntry::LEGACY_BLS_VERSION : CSimplifiedMNListEntry::BASIC_BLS_VERSION;
         mnList[i++] = std::move(sme);
     });
 

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -39,7 +39,7 @@ public:
     uint160 platformNodeID{};
     CScript scriptPayout; // mem-only
     CScript scriptOperatorPayout; // mem-only
-    uint16_t nVersion{LEGACY_BLS_VERSION}; // mem-only
+    uint16_t nVersion{LEGACY_BLS_VERSION};
 
     CSimplifiedMNListEntry() = default;
     explicit CSimplifiedMNListEntry(const CDeterministicMN& dmn);
@@ -65,6 +65,9 @@ public:
 
     SERIALIZE_METHODS(CSimplifiedMNListEntry, obj)
     {
+        if ((s.GetType() & SER_NETWORK) && s.GetVersion() >= BLS_SCHEME_PROTO_VERSION) {
+            READWRITE(obj.nVersion);
+        }
         READWRITE(
                 obj.proRegTxHash,
                 obj.confirmedHash,
@@ -95,7 +98,7 @@ public:
 
     CSimplifiedMNList() = default;
     explicit CSimplifiedMNList(const std::vector<CSimplifiedMNListEntry>& smlEntries);
-    explicit CSimplifiedMNList(const CDeterministicMNList& dmnList, bool isV19Active);
+    explicit CSimplifiedMNList(const CDeterministicMNList& dmnList);
 
     uint256 CalcMerkleRoot(bool* pmutated = nullptr) const;
     bool operator==(const CSimplifiedMNList& rhs) const;
@@ -118,8 +121,7 @@ public:
 class CSimplifiedMNListDiff
 {
 public:
-    static constexpr uint16_t LEGACY_BLS_VERSION = 1;
-    static constexpr uint16_t BASIC_BLS_VERSION = 2;
+    static constexpr uint16_t CURRENT_VERSION = 1;
 
     uint256 baseBlockHash;
     uint256 blockHash;
@@ -127,7 +129,7 @@ public:
     CTransactionRef cbTx;
     std::vector<uint256> deletedMNs;
     std::vector<CSimplifiedMNListEntry> mnList;
-    uint16_t nVersion{LEGACY_BLS_VERSION};
+    uint16_t nVersion{CURRENT_VERSION};
 
     std::vector<std::pair<uint8_t, uint256>> deletedQuorums; // p<LLMQType, quorumHash>
     std::vector<llmq::CFinalCommitment> newQuorums;

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -501,7 +501,7 @@ bool CGovernanceObject::IsValidLocally(std::string& strError, bool& fMissingConf
 
         // Check that we have a valid MN signature
         if (!CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
-            strError = "Invalid masternode signature for: " + strOutpoint + ", pubkey = " + dmn->pdmnState->pubKeyOperator.Get().ToString();
+            strError = "Invalid masternode signature for: " + strOutpoint + ", pubkey = " + dmn->pdmnState->pubKeyOperator.Get().ToString(dmn->pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION);
             return false;
         }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1692,7 +1692,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
             activeMasternodeInfo.blsKeyOperator = std::make_unique<CBLSSecretKey>(keyOperator);
             activeMasternodeInfo.blsPubKeyOperator = std::make_unique<CBLSPublicKey>(keyOperator.GetPublicKey());
         }
-        LogPrintf("MASTERNODE:\n  blsPubKeyOperator: %s\n", activeMasternodeInfo.blsPubKeyOperator->ToString());
+        LogPrintf("MASTERNODE:\n  blsPubKeyOperator: %s\n", activeMasternodeInfo.blsPubKeyOperator->ToString(activeMasternodeInfo.legacy));
     } else {
         LOCK(activeMasternodeInfoCs);
         activeMasternodeInfo.blsKeyOperator = std::make_unique<CBLSSecretKey>();

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -131,6 +131,7 @@ void CActiveMasternodeManager::Init(const CBlockIndex* pindex)
 
     activeMasternodeInfo.proTxHash = dmn->proTxHash;
     activeMasternodeInfo.outpoint = dmn->collateralOutpoint;
+    activeMasternodeInfo.legacy = dmn->pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION;
     state = MASTERNODE_READY;
 }
 

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -28,6 +28,7 @@ struct CActiveMasternodeInfo {
     uint256 proTxHash;
     COutPoint outpoint;
     CService service;
+    bool legacy{true}; // TODO: or nVersion?
 };
 
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -320,7 +320,7 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
     bool fMnFound = WITH_LOCK(activeMasternodeInfoCs, return mnList.HasValidMNByCollateral(activeMasternodeInfo.outpoint));
 
     LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
-            (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsPubKeyOperator ? activeMasternodeInfo.blsPubKeyOperator->ToString() : "N/A")),
+            (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsPubKeyOperator ? activeMasternodeInfo.blsPubKeyOperator->ToString(activeMasternodeInfo.legacy) : "N/A")),
             WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.outpoint.ToStringShort()), request.params.size(), fMnFound);
 
     // ASSEMBLE NEW GOVERNANCE OBJECT FROM USER PARAMETERS

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -676,7 +676,7 @@ static UniValue masternodelist(const JSONRPCRequest& request)
                            EncodeDestination(PKHash(dmn.pdmnState->keyIDOwner)) << " " <<
                            EncodeDestination(PKHash(dmn.pdmnState->keyIDVoting)) << " " <<
                            collateralAddressStr << " " <<
-                           dmn.pdmnState->pubKeyOperator.Get().ToString();
+                           dmn.pdmnState->pubKeyOperator.Get().ToString(dmn.pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION);
             std::string strInfo = streamInfo.str();
             if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
@@ -698,7 +698,7 @@ static UniValue masternodelist(const JSONRPCRequest& request)
             objMN.pushKV("owneraddress", EncodeDestination(PKHash(dmn.pdmnState->keyIDOwner)));
             objMN.pushKV("votingaddress", EncodeDestination(PKHash(dmn.pdmnState->keyIDVoting)));
             objMN.pushKV("collateraladdress", collateralAddressStr);
-            objMN.pushKV("pubkeyoperator", dmn.pdmnState->pubKeyOperator.Get().ToString());
+            objMN.pushKV("pubkeyoperator", dmn.pdmnState->pubKeyOperator.Get().ToString(dmn.pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION));
             obj.pushKV(strOutpoint, objMN);
         } else if (strMode == "lastpaidblock") {
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
@@ -715,7 +715,7 @@ static UniValue masternodelist(const JSONRPCRequest& request)
             obj.pushKV(strOutpoint, EncodeDestination(PKHash(dmn.pdmnState->keyIDOwner)));
         } else if (strMode == "pubkeyoperator") {
             if (strFilter !="" && strOutpoint.find(strFilter) == std::string::npos) return;
-            obj.pushKV(strOutpoint, dmn.pdmnState->pubKeyOperator.Get().ToString());
+            obj.pushKV(strOutpoint, dmn.pdmnState->pubKeyOperator.Get().ToString(dmn.pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION));
         } else if (strMode == "status") {
             std::string strStatus = dmnToStatus(dmn);
             if (strFilter !="" && strStatus.find(strFilter) == std::string::npos &&

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -210,7 +210,7 @@ static UniValue BuildQuorumInfo(const llmq::CQuorumCPtr& quorum, bool includeMem
             UniValue mo(UniValue::VOBJ);
             mo.pushKV("proTxHash", dmn->proTxHash.ToString());
             mo.pushKV("service", dmn->pdmnState->addr.ToString());
-            mo.pushKV("pubKeyOperator", dmn->pdmnState->pubKeyOperator.Get().ToString());
+            mo.pushKV("pubKeyOperator", dmn->pdmnState->pubKeyOperator.Get().ToString(dmn->pdmnState->nVersion == CProRegTx::LEGACY_BLS_VERSION));
             mo.pushKV("valid", quorum->qc->validMembers[i]);
             if (quorum->qc->validMembers[i]) {
                 CBLSPublicKey pubKey = quorum->GetPubKeyShare(i);

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -66,8 +66,17 @@ class DIP3V19Test(DashTestFramework):
         b_0 = self.nodes[0].getbestblockhash()
         self.test_getmnlistdiff(null_hash, b_0, {}, [], expected_updated)
 
+        mn_list_before = self.nodes[0].masternodelist()
+        pubkeyoperator_list_before = set([mn_list_before[e]["pubkeyoperator"] for e in mn_list_before])
+
         self.activate_v19(expected_activation_height=900)
         self.log.info("Activated v19 at height:" + str(self.nodes[0].getblockcount()))
+
+        mn_list_after = self.nodes[0].masternodelist()
+        pubkeyoperator_list_after = set([mn_list_after[e]["pubkeyoperator"] for e in mn_list_after])
+
+        self.log.info("pubkeyoperator should still be shown using legacy scheme")
+        assert_equal(pubkeyoperator_list_before, pubkeyoperator_list_after)
 
         self.move_to_next_cycle()
         self.log.info("Cycle H height:" + str(self.nodes[0].getblockcount()))

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -139,7 +139,7 @@ class DIP3V19Test(DashTestFramework):
         # Verify that the merkle root matches what we locally calculate
         hashes = []
         for mn in sorted(new_mn_list.values(), key=lambda mn: ser_uint256(mn.proRegTxHash)):
-            hashes.append(hash256(mn.serialize()))
+            hashes.append(hash256(mn.serialize(with_version = False)))
         merkle_root = CBlock.get_merkle_root(hashes)
         assert_equal(merkle_root, cbtx.merkleRootMNList)
 

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -181,7 +181,7 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         # Verify that the merkle root matches what we locally calculate
         hashes = []
         for mn in sorted(newMNList.values(), key=lambda mn: ser_uint256(mn.proRegTxHash)):
-            hashes.append(hash256(mn.serialize()))
+            hashes.append(hash256(mn.serialize(with_version = False)))
         merkleRoot = CBlock.get_merkle_root(hashes)
         assert_equal(merkleRoot, cbtx.merkleRootMNList)
 

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -253,7 +253,7 @@ class LLMQHPMNTest(DashTestFramework):
         # Verify that the merkle root matches what we locally calculate
         hashes = []
         for mn in sorted(newMNList.values(), key=lambda mn: ser_uint256(mn.proRegTxHash)):
-            hashes.append(hash256(mn.serialize()))
+            hashes.append(hash256(mn.serialize(with_version = False)))
         merkleRoot = CBlock.get_merkle_root(hashes)
         assert_equal(merkleRoot, cbtx.merkleRootMNList)
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1080,7 +1080,7 @@ class CCbTx:
 
 
 class CSimplifiedMNListEntry:
-    __slots__ = ("proRegTxHash", "confirmedHash", "service", "pubKeyOperator", "keyIDVoting", "isValid", "version", "type", "platformHTTPPort", "platformNodeID")
+    __slots__ = ("proRegTxHash", "confirmedHash", "service", "pubKeyOperator", "keyIDVoting", "isValid", "nVersion", "type", "platformHTTPPort", "platformNodeID")
 
     def __init__(self):
         self.set_null()
@@ -1092,34 +1092,36 @@ class CSimplifiedMNListEntry:
         self.pubKeyOperator = b'\x00' * 48
         self.keyIDVoting = 0
         self.isValid = False
-        self.version = 0
+        self.nVersion = 0
         self.type = 0
         self.platformHTTPPort = 0
         self.platformNodeID = b'\x00' * 20
 
-    def deserialize(self, f, version):
-        self.version = version # memory only
+    def deserialize(self, f):
+        self.nVersion = struct.unpack("<H", f.read(2))[0]
         self.proRegTxHash = deser_uint256(f)
         self.confirmedHash = deser_uint256(f)
         self.service.deserialize(f)
         self.pubKeyOperator = f.read(48)
         self.keyIDVoting = f.read(20)
         self.isValid = struct.unpack("<?", f.read(1))[0]
-        if self.version == 2:
+        if self.nVersion == 2:
             self.type = struct.unpack("<H", f.read(2))[0]
             if self.type == 1:
                 self.platformHTTPPort = struct.unpack("<H", f.read(2))[0]
                 self.platformNodeID = f.read(20)
 
-    def serialize(self):
+    def serialize(self, with_version = True):
         r = b""
+        if with_version:
+            r += struct.pack("<H", self.nVersion)
         r += ser_uint256(self.proRegTxHash)
         r += ser_uint256(self.confirmedHash)
         r += self.service.serialize()
         r += self.pubKeyOperator
         r += self.keyIDVoting
         r += struct.pack("<?", self.isValid)
-        if self.version == 2:
+        if self.nVersion == 2:
             r += struct.pack("<H", self.type)
             if self.type == 1:
                 r += struct.pack("<H", self.platformHTTPPort)
@@ -1957,7 +1959,7 @@ class msg_getmnlistd:
 QuorumId = namedtuple('QuorumId', ['llmqType', 'quorumHash'])
 
 class msg_mnlistdiff:
-    __slots__ = ("baseBlockHash", "blockHash", "merkleProof", "cbTx", "version", "deletedMNs", "mnList", "deletedQuorums", "newQuorums",)
+    __slots__ = ("baseBlockHash", "blockHash", "merkleProof", "cbTx", "nVersion", "deletedMNs", "mnList", "deletedQuorums", "newQuorums",)
     command = b"mnlistdiff"
 
     def __init__(self):
@@ -1965,7 +1967,7 @@ class msg_mnlistdiff:
         self.blockHash = 0
         self.merkleProof = CPartialMerkleTree()
         self.cbTx = None
-        self.version = 0
+        self.nVersion = 0
         self.deletedMNs = []
         self.mnList = []
         self.deletedQuorums = []
@@ -1978,12 +1980,12 @@ class msg_mnlistdiff:
         self.cbTx = CTransaction()
         self.cbTx.deserialize(f)
         self.cbTx.rehash()
-        self.version = struct.unpack("<H", f.read(2))[0]
+        self.nVersion = struct.unpack("<H", f.read(2))[0]
         self.deletedMNs = deser_uint256_vector(f)
         self.mnList = []
         for i in range(deser_compact_size(f)):
             e = CSimplifiedMNListEntry()
-            e.deserialize(f, self.version)
+            e.deserialize(f)
             self.mnList.append(e)
 
         self.deletedQuorums = []


### PR DESCRIPTION
## Issue being fixed or feature implemented
It's pretty confusing that we display `pubKeyOperator` using new theme after v19 hf for masternodes that were never registered with proregtx v2. This patch aims to fix this.

## What was done?
Store `nVersion` (legacy/bls) in `CDeterministicMNState` and `CDeterministicMNStateDiff`. As a side-effect this patch also changes the way `nVersion` behaves in `CSimplifiedMNListEntry` and `CSimplifiedMNList` (and imo in the right way). And as a yet another side-effect this also changes the way `pubKeyOperator` is stored in `CDeterministicMNState` and `CDeterministicMNStateDiff` (no need for post-v19-hf db migration anymore). Tweaked all the debug and rpc output to use these changes and display `pubKeyOperator` using the right scheme.

## How Has This Been Tested?
n/a

## Breaking Changes
Changes in `CDeterministicMNState`, `CDeterministicMNStateDiff` and `CalcCbTxMerkleRootMNList` will split testnet at v19 hf point if we merge this. Changes in `CSimplifiedMNListEntry` and `CSimplifiedMNList` might require attention of mobile teams.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
