### PR TITLE
refactor: tweak GetLLMQ to fail gracefully and let caller handle results accordingly

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -107,7 +107,7 @@ static CBlock FindDevNetGenesisBlock(const CBlock &prevBlock, const CAmount& rew
 
 void CChainParams::AddLLMQ(Consensus::LLMQType llmqType)
 {
-    assert(!HasLLMQ(llmqType));
+    assert(!GetLLMQ(llmqType).has_value());
     for (const auto& llmq_param : Consensus::available_llmqs) {
         if (llmq_param.type == llmqType) {
             consensus.llmqs.push_back(llmq_param);
@@ -118,25 +118,14 @@ void CChainParams::AddLLMQ(Consensus::LLMQType llmqType)
     assert(false);
 }
 
-const Consensus::LLMQParams& CChainParams::GetLLMQ(Consensus::LLMQType llmqType) const
+std::optional<Consensus::LLMQParams> CChainParams::GetLLMQ(Consensus::LLMQType llmqType) const
 {
     for (const auto& llmq_param : consensus.llmqs) {
         if (llmq_param.type == llmqType) {
-            return llmq_param;
+            return std::make_optional(llmq_param);
         }
     }
-    error("CChainParams::%s: unknown LLMQ type %d", __func__, static_cast<uint8_t>(llmqType));
-    assert(false);
-}
-
-bool CChainParams::HasLLMQ(Consensus::LLMQType llmqType) const
-{
-    for (const auto& llmq_param : consensus.llmqs) {
-        if (llmq_param.type == llmqType) {
-            return true;
-        }
-    }
-    return false;
+    return std::nullopt;
 }
 
 /**
@@ -1279,7 +1268,10 @@ void CDevNetParams::UpdateDevnetLLMQChainLocksFromArgs(const ArgsManager& args)
 {
     if (!args.IsArgSet("-llmqchainlocks")) return;
 
-    std::string strLLMQType = gArgs.GetArg("-llmqchainlocks", std::string(GetLLMQ(consensus.llmqTypeChainLocks).name));
+    const auto& llmq_params_opt = GetLLMQ(consensus.llmqTypeChainLocks);
+    assert(llmq_params_opt.has_value());
+
+    std::string strLLMQType = gArgs.GetArg("-llmqchainlocks", std::string(llmq_params_opt->name));
 
     Consensus::LLMQType llmqType = Consensus::LLMQType::LLMQ_NONE;
     for (const auto& params : consensus.llmqs) {
@@ -1301,7 +1293,10 @@ void CDevNetParams::UpdateDevnetLLMQInstantSendFromArgs(const ArgsManager& args)
 {
     if (!args.IsArgSet("-llmqinstantsend")) return;
 
-    std::string strLLMQType = gArgs.GetArg("-llmqinstantsend", std::string(GetLLMQ(consensus.llmqTypeInstantSend).name));
+    const auto& llmq_params_opt = GetLLMQ(consensus.llmqTypeInstantSend);
+    assert(llmq_params_opt.has_value());
+
+    std::string strLLMQType = gArgs.GetArg("-llmqinstantsend", std::string(llmq_params_opt->name));
 
     Consensus::LLMQType llmqType = Consensus::LLMQType::LLMQ_NONE;
     for (const auto& params : consensus.llmqs) {
@@ -1323,7 +1318,10 @@ void CDevNetParams::UpdateDevnetLLMQInstantSendDIP0024FromArgs(const ArgsManager
 {
     if (!args.IsArgSet("-llmqinstantsenddip0024")) return;
 
-    std::string strLLMQType = gArgs.GetArg("-llmqinstantsenddip0024", std::string(GetLLMQ(consensus.llmqTypeDIP0024InstantSend).name));
+    const auto& llmq_params_opt = GetLLMQ(consensus.llmqTypeDIP0024InstantSend);
+    assert(llmq_params_opt.has_value());
+
+    std::string strLLMQType = gArgs.GetArg("-llmqinstantsenddip0024", std::string(llmq_params_opt->name));
 
     Consensus::LLMQType llmqType = Consensus::LLMQType::LLMQ_NONE;
     for (const auto& params : consensus.llmqs) {
@@ -1345,7 +1343,10 @@ void CDevNetParams::UpdateDevnetLLMQPlatformFromArgs(const ArgsManager& args)
 {
     if (!args.IsArgSet("-llmqplatform")) return;
 
-    std::string strLLMQType = gArgs.GetArg("-llmqplatform", std::string(GetLLMQ(consensus.llmqTypePlatform).name));
+    const auto& llmq_params_opt = GetLLMQ(consensus.llmqTypePlatform);
+    assert(llmq_params_opt.has_value());
+
+    std::string strLLMQType = gArgs.GetArg("-llmqplatform", std::string(llmq_params_opt->name));
 
     Consensus::LLMQType llmqType = Consensus::LLMQType::LLMQ_NONE;
     for (const auto& params : consensus.llmqs) {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -112,8 +112,7 @@ public:
     const std::vector<std::string>& SporkAddresses() const { return vSporkAddresses; }
     int MinSporkKeys() const { return nMinSporkKeys; }
     bool BIP9CheckMasternodesUpgraded() const { return fBIP9CheckMasternodesUpgraded; }
-    const Consensus::LLMQParams& GetLLMQ(Consensus::LLMQType llmqType) const;
-    bool HasLLMQ(Consensus::LLMQType llmqType) const;
+    std::optional<Consensus::LLMQParams> GetLLMQ(Consensus::LLMQType llmqType) const;
 
 protected:
     CChainParams() {}

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -954,9 +954,12 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
                 return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-qc-payload");
             }
             if (!qc.commitment.IsNull()) {
-                const auto& llmq_params = llmq::GetLLMQParams(qc.commitment.llmqType);
+                const auto& llmq_params_opt = llmq::GetLLMQParams(qc.commitment.llmqType);
+                if (!llmq_params_opt.has_value()) {
+                    return _state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-qc-commitment-type");
+                }
                 int qcnHeight = int(qc.nHeight);
-                int quorumHeight = qcnHeight - (qcnHeight % llmq_params.dkgInterval) + int(qc.commitment.quorumIndex);
+                int quorumHeight = qcnHeight - (qcnHeight % llmq_params_opt->dkgInterval) + int(qc.commitment.quorumIndex);
                 auto pQuorumBaseBlockIndex = pindexPrev->GetAncestor(quorumHeight);
                 if (!pQuorumBaseBlockIndex || pQuorumBaseBlockIndex->GetBlockHash() != qc.commitment.quorumHash) {
                     // we should actually never get into this case as validation should have caught it...but let's be sure

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -59,7 +59,8 @@ void CQuorumBlockProcessor::ProcessMessage(const CNode& peer, std::string_view m
         return;
     }
 
-    if (!Params().HasLLMQ(qc.llmqType)) {
+    const auto& llmq_params_opt = GetLLMQParams(qc.llmqType);
+    if (!llmq_params_opt.has_value()) {
         LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- invalid commitment type %d from peer=%d\n", __func__,
                  ToUnderlying(qc.llmqType), peer.GetId());
         Misbehaving(peer.GetId(), 100);
@@ -85,14 +86,14 @@ void CQuorumBlockProcessor::ProcessMessage(const CNode& peer, std::string_view m
             // same, can't punish
             return;
         }
-        int quorumHeight = pQuorumBaseBlockIndex->nHeight - (pQuorumBaseBlockIndex->nHeight % GetLLMQParams(type).dkgInterval) + int(qc.quorumIndex);
+        int quorumHeight = pQuorumBaseBlockIndex->nHeight - (pQuorumBaseBlockIndex->nHeight % llmq_params_opt->dkgInterval) + int(qc.quorumIndex);
         if (quorumHeight != pQuorumBaseBlockIndex->nHeight) {
             LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- block %s is not the first block in the DKG interval, peer=%d\n", __func__,
                      qc.quorumHash.ToString(), peer.GetId());
             Misbehaving(peer.GetId(), 100);
             return;
         }
-        if (pQuorumBaseBlockIndex->nHeight < (::ChainActive().Height() - GetLLMQParams(type).dkgInterval)) {
+        if (pQuorumBaseBlockIndex->nHeight < (::ChainActive().Height() - llmq_params_opt->dkgInterval)) {
             LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- block %s is too old, peer=%d\n", __func__,
                      qc.quorumHash.ToString(), peer.GetId());
             // TODO: enable punishment in some future version when all/most nodes are running with this fix
@@ -177,7 +178,7 @@ bool CQuorumBlockProcessor::ProcessBlock(const CBlock& block, const CBlockIndex*
         if (numCommitmentsRequired > numCommitmentsInNewBlock) {
             return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-qc-missing");
         }
-        if (llmq::utils::IsQuorumRotationEnabled(params.type, pindex)) {
+        if (llmq::utils::IsQuorumRotationEnabled(params, pindex)) {
             LogPrintf("[ProcessBlock] h[%d] numCommitmentsRequired[%d] numCommitmentsInNewBlock[%d]\n", pindex->nHeight, numCommitmentsRequired, numCommitmentsInNewBlock);
         }
     }
@@ -213,7 +214,12 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
 {
     AssertLockHeld(cs_main);
 
-    const auto& llmq_params = GetLLMQParams(qc.llmqType);
+    const auto& llmq_params_opt = GetLLMQParams(qc.llmqType);
+    if (!llmq_params_opt.has_value()) {
+        LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- invalid commitment type %d\n", __func__, ToUnderlying(qc.llmqType));
+        return false;
+    }
+    const auto& llmq_params = llmq_params_opt.value();
 
     uint256 quorumHash = GetQuorumBlockHash(llmq_params, nHeight, qc.quorumIndex);
 
@@ -267,7 +273,7 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
         return true;
     }
 
-    bool rotation_enabled = utils::IsQuorumRotationEnabled(llmq_params.type, pQuorumBaseBlockIndex);
+    bool rotation_enabled = utils::IsQuorumRotationEnabled(llmq_params, pQuorumBaseBlockIndex);
 
     if (rotation_enabled) {
         LogPrint(BCLog::LLMQ, "[ProcessCommitment] height[%d] pQuorumBaseBlockIndex[%d] quorumIndex[%d] qversion[%d] Built\n",
@@ -320,7 +326,10 @@ bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, const CBlockIndex* pi
 
         m_evoDb.Erase(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(qc.llmqType, qc.quorumHash)));
 
-        if (llmq::utils::IsQuorumRotationEnabled(qc.llmqType, pindex)) {
+        const auto& llmq_params_opt = GetLLMQParams(qc.llmqType);
+        assert(llmq_params_opt.has_value());
+
+        if (llmq::utils::IsQuorumRotationEnabled(llmq_params_opt.value(), pindex)) {
             m_evoDb.Erase(BuildInversedHeightKeyIndexed(qc.llmqType, pindex->nHeight, int(qc.quorumIndex)));
         } else {
             m_evoDb.Erase(BuildInversedHeightKey(qc.llmqType, pindex->nHeight));
@@ -379,7 +388,9 @@ bool CQuorumBlockProcessor::UpgradeDB()
                 }
                 const auto* pQuorumBaseBlockIndex = LookupBlockIndex(qc.quorumHash);
                 m_evoDb.GetRawDB().Write(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(qc.llmqType, qc.quorumHash)), std::make_pair(qc, pindex->GetBlockHash()));
-                if (llmq::utils::IsQuorumRotationEnabled(qc.llmqType, pQuorumBaseBlockIndex)) {
+                const auto& llmq_params_opt = GetLLMQParams(qc.llmqType);
+                assert(llmq_params_opt.has_value());
+                if (llmq::utils::IsQuorumRotationEnabled(llmq_params_opt.value(), pQuorumBaseBlockIndex)) {
                     m_evoDb.GetRawDB().Write(BuildInversedHeightKeyIndexed(qc.llmqType, pindex->nHeight, int(qc.quorumIndex)), pQuorumBaseBlockIndex->nHeight);
                 } else {
                     m_evoDb.GetRawDB().Write(BuildInversedHeightKey(qc.llmqType, pindex->nHeight), pQuorumBaseBlockIndex->nHeight);
@@ -413,8 +424,14 @@ bool CQuorumBlockProcessor::GetCommitmentsFromBlock(const CBlock& block, const C
                 return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-qc-payload");
             }
 
+            const auto& llmq_params_opt = GetLLMQParams(qc.commitment.llmqType);
+            if (!llmq_params_opt.has_value()) {
+                // should not happen as it was verified before processing the block
+                return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-qc-commitment-type");
+            }
+
             // only allow one commitment per type and per block (This was changed with rotation)
-            if (!utils::IsQuorumRotationEnabled(qc.commitment.llmqType, pindex)) {
+            if (!utils::IsQuorumRotationEnabled(llmq_params_opt.value(), pindex)) {
                 if (ret.count(qc.commitment.llmqType) != 0) {
                     return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-qc-dup");
                 }
@@ -461,7 +478,7 @@ size_t CQuorumBlockProcessor::GetNumCommitmentsRequired(const Consensus::LLMQPar
     assert(nHeight <= ::ChainActive().Height() + 1);
     const auto *const pindex = ::ChainActive().Height() < nHeight ? ::ChainActive().Tip() : ::ChainActive().Tip()->GetAncestor(nHeight);
 
-    bool rotation_enabled = utils::IsQuorumRotationEnabled(llmqParams.type, pindex);
+    bool rotation_enabled = utils::IsQuorumRotationEnabled(llmqParams, pindex);
     size_t quorums_num = rotation_enabled ? llmqParams.signingActiveQuorumCount : 1;
     size_t ret{0};
 
@@ -614,10 +631,11 @@ std::optional<const CBlockIndex*> CQuorumBlockProcessor::GetLastMinedCommitments
 
 std::vector<std::pair<int, const CBlockIndex*>> CQuorumBlockProcessor::GetLastMinedCommitmentsPerQuorumIndexUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t cycle) const
 {
-    const Consensus::LLMQParams& llmqParams = GetLLMQParams(llmqType);
+    const auto& llmq_params_opt = GetLLMQParams(llmqType);
+    assert(llmq_params_opt.has_value());
     std::vector<std::pair<int, const CBlockIndex*>> ret;
 
-    for (const auto quorumIndex : irange::range(llmqParams.signingActiveQuorumCount)) {
+    for (const auto quorumIndex : irange::range(llmq_params_opt->signingActiveQuorumCount)) {
         std::optional<const CBlockIndex*> q = GetLastMinedCommitmentsByQuorumIndexUntilBlock(llmqType, pindex, quorumIndex, cycle);
         if (q.has_value()) {
             ret.emplace_back(quorumIndex, q.value());
@@ -665,7 +683,7 @@ std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> CQuorumBlockProce
     for (const auto& params : Params().GetConsensus().llmqs) {
         auto& v = ret[params.type];
         v.reserve(params.signingActiveQuorumCount);
-        if (utils::IsQuorumRotationEnabled(params.type, pindex)) {
+        if (utils::IsQuorumRotationEnabled(params, pindex)) {
             std::vector<std::pair<int, const CBlockIndex*>> commitments = GetLastMinedCommitmentsPerQuorumIndexUntilBlock(params.type, pindex, 0);
             std::transform(commitments.begin(), commitments.end(), std::back_inserter(v),
                            [](const std::pair<int, const CBlockIndex*>& p) { return p.second; });
@@ -744,7 +762,7 @@ std::optional<std::vector<CFinalCommitment>> CQuorumBlockProcessor::GetMineableC
     assert(nHeight <= ::ChainActive().Height() + 1);
     const auto *const pindex = ::ChainActive().Height() < nHeight ? ::ChainActive().Tip() : ::ChainActive().Tip()->GetAncestor(nHeight);
 
-    bool rotation_enabled = utils::IsQuorumRotationEnabled(llmqParams.type, pindex);
+    bool rotation_enabled = utils::IsQuorumRotationEnabled(llmqParams, pindex);
     bool basic_bls_enabled = utils::IsV19Active(pindex);
     size_t quorums_num = rotation_enabled ? llmqParams.signingActiveQuorumCount : 1;
 

--- a/src/llmq/debug.cpp
+++ b/src/llmq/debug.cpp
@@ -19,7 +19,7 @@ UniValue CDKGDebugSessionStatus::ToJson(int quorumIndex, int detailLevel) const
 {
     UniValue ret(UniValue::VOBJ);
 
-    if (!Params().HasLLMQ(llmqType) || quorumHash.IsNull()) {
+    if (!GetLLMQParams(llmqType).has_value() || quorumHash.IsNull()) {
         return ret;
     }
 
@@ -118,11 +118,12 @@ UniValue CDKGDebugStatus::ToJson(int detailLevel) const
     // TODO Support array of sessions
     UniValue sessionsArrJson(UniValue::VARR);
     for (const auto& p : sessions) {
-        if (!Params().HasLLMQ(p.first.first)) {
+        const auto& llmq_params_opt = GetLLMQParams(p.first.first);
+        if (!llmq_params_opt.has_value()) {
             continue;
         }
         UniValue s(UniValue::VOBJ);
-        s.pushKV("llmqType", std::string(GetLLMQParams(p.first.first).name));
+        s.pushKV("llmqType", std::string(llmq_params_opt->name));
         s.pushKV("quorumIndex", p.first.second);
         s.pushKV("status", p.second.ToJson(p.first.second, detailLevel));
 

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -86,7 +86,7 @@ bool CDKGSession::Init(const CBlockIndex* _pQuorumBaseBlockIndex, const std::vec
 
     CDKGLogger logger(*this, __func__);
 
-    if (LogAcceptCategory(BCLog::LLMQ) && utils::IsQuorumRotationEnabled(params.type, m_quorum_base_block_index)) {
+    if (LogAcceptCategory(BCLog::LLMQ) && utils::IsQuorumRotationEnabled(params, m_quorum_base_block_index)) {
         int cycleQuorumBaseHeight = m_quorum_base_block_index->nHeight - quorumIndex;
         const CBlockIndex* pCycleQuorumBaseBlockIndex = m_quorum_base_block_index->GetAncestor(cycleQuorumBaseHeight);
         std::stringstream ss;
@@ -1207,7 +1207,7 @@ std::vector<CFinalCommitment> CDKGSession::FinalizeCommitments()
         fqc.quorumPublicKey = first.quorumPublicKey;
         fqc.quorumVvecHash = first.quorumVvecHash;
 
-        if (utils::IsQuorumRotationEnabled(fqc.llmqType, m_quorum_base_block_index)) {
+        if (utils::IsQuorumRotationEnabled(params, m_quorum_base_block_index)) {
             fqc.nVersion = utils::IsV19Active(m_quorum_base_block_index) ? CFinalCommitment::BASIC_BLS_INDEXED_QUORUM_VERSION : CFinalCommitment::LEGACY_BLS_INDEXED_QUORUM_VERSION;
             fqc.quorumIndex = quorumIndex;
         } else {

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -257,7 +257,7 @@ class CDKGSession
     friend class CDKGLogger;
 
 private:
-    const Consensus::LLMQParams& params;
+    const Consensus::LLMQParams params;
 
     CBLSWorker& blsWorker;
     CBLSWorkerCache cache;

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -105,7 +105,7 @@ void CDKGSessionHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
 {
     //AssertLockNotHeld(cs_main);
     //Indexed quorums (greater than 0) are enabled with Quorum Rotation
-    if (quorumIndex > 0 && !utils::IsQuorumRotationEnabled(params.type, pindexNew)) {
+    if (quorumIndex > 0 && !utils::IsQuorumRotationEnabled(params, pindexNew)) {
         return;
     }
     LOCK(cs);

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -109,7 +109,7 @@ private:
     mutable CCriticalSection cs;
     std::atomic<bool> stopRequested{false};
 
-    const Consensus::LLMQParams& params;
+    const Consensus::LLMQParams params;
     CConnman& connman;
     const int quorumIndex;
     CBLSWorker& blsWorker;

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -196,11 +196,13 @@ void CDKGSessionManager::ProcessMessage(CNode& pfrom, const CQuorumManager& quor
     vRecv.Rewind(sizeof(uint256));
     vRecv.Rewind(sizeof(uint8_t));
 
-    if (!Params().HasLLMQ(llmqType)) {
+    const auto& llmq_params_opt = GetLLMQParams(llmqType);
+    if (!llmq_params_opt.has_value()) {
         LogPrintf("CDKGSessionManager -- invalid llmqType [%d]\n", ToUnderlying(llmqType));
         Misbehaving(pfrom.GetId(), 100);
         return;
     }
+    const auto& llmq_params = llmq_params_opt.value();
 
     int quorumIndex{-1};
 
@@ -229,10 +231,9 @@ void CDKGSessionManager::ProcessMessage(CNode& pfrom, const CQuorumManager& quor
             return;
         }
 
-        const Consensus::LLMQParams& llmqParams = GetLLMQParams(llmqType);
-        quorumIndex = pQuorumBaseBlockIndex->nHeight % llmqParams.dkgInterval;
-        int quorumIndexMax = utils::IsQuorumRotationEnabled(llmqType, pQuorumBaseBlockIndex) ?
-                llmqParams.signingActiveQuorumCount - 1 : 0;
+        quorumIndex = pQuorumBaseBlockIndex->nHeight % llmq_params.dkgInterval;
+        int quorumIndexMax = utils::IsQuorumRotationEnabled(llmq_params, pQuorumBaseBlockIndex) ?
+                llmq_params.signingActiveQuorumCount - 1 : 0;
 
         if (quorumIndex > quorumIndexMax) {
             LogPrintf("CDKGSessionManager -- invalid quorumHash %s\n", quorumHash.ToString());

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -287,7 +287,7 @@ private:
     bool ProcessPendingInstantSendLocks();
     bool ProcessPendingInstantSendLocks(bool deterministic) LOCKS_EXCLUDED(cs_pendingLocks);
 
-    std::unordered_set<uint256, StaticSaltedHasher> ProcessPendingInstantSendLocks(const Consensus::LLMQType llmqType,
+    std::unordered_set<uint256, StaticSaltedHasher> ProcessPendingInstantSendLocks(const Consensus::LLMQParams& llmq_params,
                                                                                    int signOffset,
                                                                                    const std::unordered_map<uint256,
                                                                                    std::pair<NodeId, CInstantSendLockPtr>,

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -108,6 +108,11 @@ struct LLMQParams {
     int recoveryMembers;
 };
 
+//static_assert(std::is_trivial_v<Consensus::LLMQParams>, "LLMQParams is not a trivial type");
+static_assert(std::is_trivially_copyable_v<Consensus::LLMQParams>, "LLMQParams is not trivially copyable");
+//static_assert(std::is_trivially_default_constructible_v<Consensus::LLMQParams>, "LLMQParams is not trivially default constructible");
+static_assert(std::is_trivially_assignable_v<Consensus::LLMQParams, Consensus::LLMQParams>, "LLMQParams is not trivially assignable");
+
 
 static constexpr std::array<LLMQParams, 14> available_llmqs = {
 

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -158,7 +158,7 @@ class CQuorum
 {
     friend class CQuorumManager;
 public:
-    const Consensus::LLMQParams& params;
+    const Consensus::LLMQParams params;
     CFinalCommitmentPtr qc;
     const CBlockIndex* m_quorum_base_block_index{nullptr};
     uint256 minedBlockHash;

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -223,7 +223,7 @@ public:
     bool GetVoteForId(Consensus::LLMQType llmqType, const uint256& id, uint256& msgHashRet) const;
 
     static std::vector<CQuorumCPtr> GetActiveQuorumSet(Consensus::LLMQType llmqType, int signHeight);
-    static CQuorumCPtr SelectQuorumForSigning(Consensus::LLMQType llmqType, const CQuorumManager& quorum_manager, const uint256& selectionHash, int signHeight = -1 /*chain tip*/, int signOffset = SIGN_HEIGHT_OFFSET);
+    static CQuorumCPtr SelectQuorumForSigning(const Consensus::LLMQParams& llmq_params, const CQuorumManager& quorum_manager, const uint256& selectionHash, int signHeight = -1 /*chain tip*/, int signOffset = SIGN_HEIGHT_OFFSET);
 
     // Verifies a recovered sig that was signed while the chain tip was at signedAtTip
     static bool VerifyRecoveredSig(Consensus::LLMQType llmqType, const CQuorumManager& quorum_manager, int signedAtHeight, const uint256& id, const uint256& msgHash, const CBLSSignature& sig, int signOffset = SIGN_HEIGHT_OFFSET);

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -168,8 +168,10 @@ bool BuildQuorumRotationInfo(const CGetQuorumRotationInfo& request, CQuorumRotat
     Consensus::LLMQType llmqType = utils::GetInstantSendLLMQType(qman, blockIndex);
 
     // Since the returned quorums are in reversed order, the most recent one is at index 0
-    const Consensus::LLMQParams& llmqParams = GetLLMQParams(llmqType);
-    const int cycleLength = llmqParams.dkgInterval;
+    const auto& llmq_params_opt = GetLLMQParams(llmqType);
+    assert(llmq_params_opt.has_value());
+
+    const int cycleLength = llmq_params_opt->dkgInterval;
     constexpr int workDiff = 8;
 
     const CBlockIndex* hBlockIndex = blockIndex->GetAncestor(blockIndex->nHeight - (blockIndex->nHeight % cycleLength));
@@ -307,7 +309,7 @@ bool BuildQuorumRotationInfo(const CGetQuorumRotationInfo& request, CQuorumRotat
         }
         response.lastCommitmentPerIndex.push_back(*qc);
 
-        int quorumCycleStartHeight = obj.second->nHeight - (obj.second->nHeight % llmqParams.dkgInterval);
+        int quorumCycleStartHeight = obj.second->nHeight - (obj.second->nHeight % llmq_params_opt->dkgInterval);
         snapshotHeightsNeeded.insert(quorumCycleStartHeight - cycleLength);
         snapshotHeightsNeeded.insert(quorumCycleStartHeight - 2 * cycleLength);
         snapshotHeightsNeeded.insert(quorumCycleStartHeight - 3 * cycleLength);

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -79,7 +79,7 @@ bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const CQuorumMana
 std::vector<Consensus::LLMQType> GetEnabledQuorumTypes(const CBlockIndex* pindex);
 std::vector<std::reference_wrapper<const Consensus::LLMQParams>> GetEnabledQuorumParams(const CBlockIndex* pindex);
 
-bool IsQuorumRotationEnabled(Consensus::LLMQType llmqType, const CBlockIndex* pindex);
+bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, const CBlockIndex* pindex);
 Consensus::LLMQType GetInstantSendLLMQType(const CQuorumManager& qman, const CBlockIndex* pindex);
 Consensus::LLMQType GetInstantSendLLMQType(bool deterministic);
 bool IsDIP0024Active(const CBlockIndex* pindex);
@@ -130,7 +130,7 @@ void InitQuorumsCache(CacheType& cache);
 
 } // namespace utils
 
-const Consensus::LLMQParams& GetLLMQParams(Consensus::LLMQType llmqType);
+[[ nodiscard ]] const std::optional<Consensus::LLMQParams> GetLLMQParams(Consensus::LLMQType llmqType);
 
 } // namespace llmq
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
This allows us to have a bit more granular control over GetLLMQ results, removes code duplication and also optimises things a tiny bit by replacing "HasLLMQ + GetLLMQParams" calls with simply "GetLLMQParams".

## What was done?
Use `optional` in `GetLLMQ`, drop `HasLLMQ`.

## How Has This Been Tested?
run tests, reindex on testnet/mainnet

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
