### PR TITLE
chore: Move logs about `nConsecutivePayments` under `MNPAYMENTS` debug category

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1002,14 +1002,14 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
         if (dmn->nType == MnType::HighPerformance) {
             ++newState->nConsecutivePayments;
             if (debugLogs) {
-                LogPrintf("CDeterministicMNManager::%s -- MN %s is a HPMN, bumping nConsecutivePayments to %d\n",
+                LogPrint(BCLog::MNPAYMENTS, "CDeterministicMNManager::%s -- MN %s is a HPMN, bumping nConsecutivePayments to %d\n",
                           __func__, dmn->proTxHash.ToString(), newState->nConsecutivePayments);
             }
         }
         newList.UpdateMN(payee->proTxHash, newState);
         if (debugLogs) {
             dmn = newList.GetMN(payee->proTxHash);
-            LogPrintf("CDeterministicMNManager::%s -- MN %s, nConsecutivePayments=%d\n",
+            LogPrint(BCLog::MNPAYMENTS, "CDeterministicMNManager::%s -- MN %s, nConsecutivePayments=%d\n",
                       __func__, dmn->proTxHash.ToString(), dmn->pdmnState->nConsecutivePayments);
         }
     }
@@ -1021,7 +1021,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
         if (dmn.nType != MnType::HighPerformance) return;
         if (dmn.pdmnState->nConsecutivePayments == 0) return;
         if (debugLogs) {
-            LogPrintf("CDeterministicMNManager::%s -- MN %s, reset nConsecutivePayments %d->0\n",
+            LogPrint(BCLog::MNPAYMENTS, "CDeterministicMNManager::%s -- MN %s, reset nConsecutivePayments %d->0\n",
                       __func__, dmn.proTxHash.ToString(), dmn.pdmnState->nConsecutivePayments);
         }
         auto newState = std::make_shared<CDeterministicMNState>(*dmn.pdmnState);


### PR DESCRIPTION
## Issue being fixed or feature implemented
These messages are pretty annoying on reindex and shouldn't really be shown in logs unless you actually need to debug mn payments.

## What was done?
move messages under `MNPAYMENTS` debug category

## How Has This Been Tested?
reindex

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
