### PR TITLE
fix: check HPMNs duplicate on tx broadcast

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1499,6 +1499,13 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
             return state.Invalid(ValidationInvalidReason::TX_BAD_SPECIAL, false, REJECT_DUPLICATE, "bad-protx-dup-key");
         }
 
+        // never allow duplicate platformNodeIds for HPMNs
+        if (ptx.nType == MnType::HighPerformance) {
+            if (mnList.HasUniqueProperty(ptx.platformNodeID)) {
+                return state.Invalid(ValidationInvalidReason::TX_BAD_SPECIAL, false, REJECT_DUPLICATE, "bad-protx-dup-platformnodeid");
+            }
+        }
+
         if (!deterministicMNManager->IsDIP3Enforced(pindexPrev->nHeight)) {
             if (ptx.keyIDOwner != ptx.keyIDVoting) {
                 return state.Invalid(ValidationInvalidReason::TX_BAD_SPECIAL, false, REJECT_INVALID, "bad-protx-key-not-same");
@@ -1562,6 +1569,13 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
         // don't allow updating to addresses already used by other MNs
         if (mnList.HasUniqueProperty(ptx.addr) && mnList.GetUniquePropertyMN(ptx.addr)->proTxHash != ptx.proTxHash) {
             return state.Invalid(ValidationInvalidReason::TX_BAD_SPECIAL, false, REJECT_DUPLICATE, "bad-protx-dup-addr");
+        }
+
+        // don't allow updating to platformNodeIds already used by other HPMNs
+        if (ptx.nType == MnType::HighPerformance) {
+            if (mnList.HasUniqueProperty(ptx.platformNodeID)  && mnList.GetUniquePropertyMN(ptx.platformNodeID)->proTxHash != ptx.proTxHash) {
+                return state.Invalid(ValidationInvalidReason::TX_BAD_SPECIAL, false, REJECT_DUPLICATE, "bad-protx-dup-platformnodeid");
+            }
         }
 
         if (ptx.scriptOperatorPayout != CScript()) {

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -43,7 +43,7 @@ class TestP2PConn(P2PInterface):
 
 class DIP3V19Test(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True)
+        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True, hpmn_count=2)
 
     def run_test(self):
         # Connect all nodes to node1 so that we always have the whole network connected
@@ -77,6 +77,23 @@ class DIP3V19Test(DashTestFramework):
         self.log.info("Cycle H+2C height:" + str(self.nodes[0].getblockcount()))
 
         self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
+
+        hpmn_info_0 = self.dynamically_add_masternode(hpmn=True, rnd=7)
+        assert hpmn_info_0 is not None
+        self.nodes[0].generate(8)
+        self.sync_blocks(self.nodes)
+
+        self.log.info("Checking that protxs with duplicate HPMN fields are rejected")
+        hpmn_info_1 = self.dynamically_add_masternode(hpmn=True, rnd=7, should_be_rejected=True)
+        assert hpmn_info_1 is None
+        self.dynamically_hpmn_update_service(hpmn_info_0, 8)
+        hpmn_info_2 = self.dynamically_add_masternode(hpmn=True, rnd=8, should_be_rejected=True)
+        assert hpmn_info_2 is None
+        hpmn_info_3 = self.dynamically_add_masternode(hpmn=True, rnd=9)
+        assert hpmn_info_3 is not None
+        self.nodes[0].generate(8)
+        self.sync_blocks(self.nodes)
+        self.dynamically_hpmn_update_service(hpmn_info_0, 9, should_be_rejected=True)
 
         revoke_protx = self.mninfo[-1].proTxHash
         revoke_keyoperator = self.mninfo[-1].keyOperator

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -10,11 +10,9 @@ Checks HPMNs
 
 '''
 from _decimal import Decimal
-import random
 from io import BytesIO
 
 from test_framework.mininode import P2PInterface
-from test_framework.script import hash160
 from test_framework.messages import CBlock, CBlockHeader, CCbTx, CMerkleBlock, FromHex, hash256, msg_getmnlistd, \
     QuorumId, ser_uint256
 from test_framework.test_framework import DashTestFramework

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -103,7 +103,7 @@ class LLMQHPMNTest(DashTestFramework):
             self.test_getmnlistdiff(null_hash, b_i, {}, [], expectedUpdated)
 
             self.test_masternode_count(expected_mns_count=4, expected_hpmns_count=i+1)
-            self.test_hpmn_update_service(hpmn_info)
+            self.dynamically_hpmn_update_service(hpmn_info)
 
         self.log.info("Test llmq_platform are formed only with HPMNs")
         for i in range(3):
@@ -234,25 +234,6 @@ class LLMQHPMNTest(DashTestFramework):
         detailed_count = mn_count['detailed']
         assert_equal(detailed_count['regular']['total'], expected_mns_count)
         assert_equal(detailed_count['hpmn']['total'], expected_hpmns_count)
-
-    def test_hpmn_update_service(self, hpmn_info):
-        funds_address = self.nodes[0].getnewaddress()
-        operator_reward_address = self.nodes[0].getnewaddress()
-
-        # For the sake of the test, generate random nodeid, p2p and http platform values
-        rnd = random.randint(1000, 65000)
-        platform_node_id = hash160(b'%d' % rnd).hex()
-        platform_p2p_port = '%d' % (rnd + 1)
-        platform_http_port = '%d' % (rnd + 2)
-
-        self.nodes[0].sendtoaddress(funds_address, 1)
-        self.nodes[0].generate(1)
-        self.sync_all(self.nodes)
-
-        self.nodes[0].protx('update_service_hpmn', hpmn_info.proTxHash, hpmn_info.addr, hpmn_info.keyOperator, platform_node_id, platform_p2p_port, platform_http_port, operator_reward_address, funds_address)
-        self.nodes[0].generate(1)
-        self.sync_all(self.nodes)
-        self.log.info("Updated HPMN %s: platformNodeID=%s, platformP2PPort=%s, platformHTTPPort=%s" % (hpmn_info.proTxHash, platform_node_id, platform_p2p_port, platform_http_port))
 
     def test_getmnlistdiff(self, baseBlockHash, blockHash, baseMNList, expectedDeleted, expectedUpdated):
         d = self.test_getmnlistdiff_base(baseBlockHash, blockHash)


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this fix, uniqueness of HPMN `platformNodeID` was checked only while processing a block containing a `ProRegTx` or a `ProUpServTx`.
This is not enough as a `ProRegTx` or `ProUpServTx` containing duplicate HPMN `platformNodeID` must be rejected at tx broadcast level.

## What was done?
<!--- Describe your changes in detail -->
Checking uniqueness when calling respective RPC and when receiving such txs. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
