### PR TITLE
fix(governance): Do not keep triggers longer than nSuperblockCycle

### DIFF
--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -677,17 +677,18 @@ bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, CAmount b
 bool CSuperblock::IsExpired(const CGovernanceManager& governanceManager) const
 {
     int nExpirationBlocks;
-    // Executed triggers are kept for another superblock cycle (approximately 1 month),
-    // other valid triggers are kept for ~1 day only, everything else is pruned after ~1h.
+    // Executed triggers are kept for another superblock cycle (approximately 1 month for mainnet).
+    // Other valid triggers are kept for ~1 day only (for mainnet, but no longer than a superblock cycle for other networks).
+    // Everything else is pruned after ~1h (for mainnet, but no longer than a superblock cycle for other networks).
     switch (nStatus) {
     case SEEN_OBJECT_EXECUTED:
         nExpirationBlocks = Params().GetConsensus().nSuperblockCycle;
         break;
     case SEEN_OBJECT_IS_VALID:
-        nExpirationBlocks = 576;
+        nExpirationBlocks = std::min(576, Params().GetConsensus().nSuperblockCycle);
         break;
     default:
-        nExpirationBlocks = 24;
+        nExpirationBlocks = std::min(24, Params().GetConsensus().nSuperblockCycle);
         break;
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Keeping too many triggers on testnet and syncing them can result in p2p bans because some of these triggers might be invalid already. Limiting their lifetime should help.

## What was done?


## How Has This Been Tested?

## Breaking Changes


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
