### PR TITLE
fix(wallet): autobackup fixes

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4869,6 +4869,11 @@ bool CWallet::AutoBackupWallet(const fs::path& wallet_path, bilingual_str& error
         return false;
     }
 
+    if (IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
+        WalletLogPrintf("Wallet is blank, won't create new backup for it!\n");
+        return false;
+    }
+
     if (nWalletBackups <= 0) {
         WalletLogPrintf("Automatic wallet backups are disabled!\n");
         return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -336,6 +336,12 @@ std::shared_ptr<CWallet> CreateWallet(interfaces::Chain& chain, const std::strin
             }
             // end TODO
 
+            // backup the wallet we just encrypted
+            if (!wallet->AutoBackupWallet("", error, warnings) && !error.original.empty()) {
+                status = DatabaseStatus::FAILED_ENCRYPT;
+                return nullptr;
+            }
+
             // Relock the wallet
             wallet->Lock();
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4864,7 +4864,7 @@ bool CWallet::AutoBackupWallet(const fs::path& wallet_path, bilingual_str& error
         strWalletName = "wallet.dat";
     }
 
-    if (!IsBDBFile(BDBDataFile(wallet_path))) {
+    if (!wallet_path.empty() && !IsBDBFile(BDBDataFile(wallet_path))) {
         WalletLogPrintf("Automatic wallet backups are currently only supported with Berkeley DB!\n");
         return false;
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
pls see individual commits

fixes an issue (reported by @strophy recently) where mixing wouldn't start in a fresh new wallet

not 100% sure but [99867eb](https://github.com/dashpay/dash/pull/5269/commits/99867eb769ef01ba30463f9d1db5cd72e7d4a599) might also fix #5350 reported by @splawik21 so this could also be a v19 backport candidate

## What was done?


## How Has This Been Tested?
mixing on testnet

## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
