### PR TITLE
feat(rpc): Added RPC cleardiscouraged

### DIFF
--- a/doc/release-notes-5273.md
+++ b/doc/release-notes-5273.md
@@ -1,0 +1,5 @@
+Added RPCs
+--------
+
+- `cleardiscouraged` clears all the already discouraged peers.
+

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -68,6 +68,16 @@ void BanMan::ClearBanned()
     if (m_client_interface) m_client_interface->BannedListChanged();
 }
 
+void BanMan::ClearDiscouraged()
+{
+    {
+        LOCK(m_cs_banned);
+        m_discouraged.reset();
+        m_is_dirty = true;
+    }
+    if (m_client_interface) m_client_interface->BannedListChanged();
+}
+
 bool BanMan::IsDiscouraged(const CNetAddr& net_addr)
 {
     LOCK(m_cs_banned);

--- a/src/banman.h
+++ b/src/banman.h
@@ -63,6 +63,7 @@ public:
     void Ban(const CSubNet& sub_net, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
     void Discourage(const CNetAddr& net_addr);
     void ClearBanned();
+    void ClearDiscouraged();
 
     //! Return whether net_addr is banned
     bool IsBanned(const CNetAddr& net_addr);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -736,6 +736,27 @@ static UniValue clearbanned(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+static UniValue cleardiscouraged(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"cleardiscouraged",
+               "\nClear all discouraged nodes.\n",
+               {},
+               RPCResult{RPCResult::Type::NONE, "", ""},
+               RPCExamples{
+                       HelpExampleCli("cleardiscouraged", "")
+                       + HelpExampleRpc("cleardiscouraged", "")
+               },
+    }.Check(request);
+    NodeContext& node = EnsureNodeContext(request.context);
+    if (!node.banman) {
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
+    }
+
+    node.banman->ClearDiscouraged();
+
+    return NullUniValue;
+}
+
 static UniValue setnetworkactive(const JSONRPCRequest& request)
 {
     RPCHelpMan{"setnetworkactive",
@@ -825,6 +846,7 @@ static const CRPCCommand commands[] =
     { "network",            "setban",                 &setban,                 {"subnet", "command", "bantime", "absolute"} },
     { "network",            "listbanned",             &listbanned,             {} },
     { "network",            "clearbanned",            &clearbanned,            {} },
+    { "network",            "cleardiscouraged",       &cleardiscouraged,        {} },
     { "network",            "setnetworkactive",       &setnetworkactive,       {"state"} },
     { "network",            "getnodeaddresses",       &getnodeaddresses,       {"count"} },
 };


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->
Added RPC `cleardiscouraged` which clears internally the list of discouraged peers.

Note: Implementation of a `listdiscouraged` RPC is not possible because the internal data structure used for discouraged peers is a Bloom filter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
