### PR TITLE
fix: hpmn adjustements to getprojectedmnpayees

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -250,7 +250,7 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int
         return CompareByLastPaid(a.get(), b.get());
     });
 
-    result.resize(nCount - (GetMnType(MnType::HighPerformance).voting_weight - remaining_hpmn_payments));
+    result.resize(nCount);
 
     return result;
 }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -239,10 +239,7 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int
     });
 
     ForEachMNShared(true, [&](const CDeterministicMNCPtr& dmn) {
-        result.emplace_back(dmn);
-        if (dmn->nType == MnType::HighPerformance) {
-            result.emplace_back(dmn);
-            result.emplace_back(dmn);
+        for ([[maybe_unused]] auto _ : irange::range(GetMnType(dmn->nType).voting_weight)) {
             result.emplace_back(dmn);
         }
     });

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -19,6 +19,7 @@
 
 #include <immer/map.hpp>
 
+#include <numeric>
 #include <unordered_map>
 #include <utility>
 
@@ -239,6 +240,14 @@ public:
     [[nodiscard]] size_t GetValidHPMNsCount() const
     {
         return ranges::count_if(mnMap, [](const auto& p) { return p.second->nType == MnType::HighPerformance && IsMNValid(*p.second); });
+    }
+
+    [[nodiscard]] size_t GetValidWeightedMNsCount() const
+    {
+        return std::accumulate(mnMap.begin(), mnMap.end(), 0, [](auto res, const auto& p) {
+                                                                if (!IsMNValid(*p.second)) return res;
+                                                                return res + GetMnType(p.second->nType).voting_weight;
+                                                            });
     }
 
     /**


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`GetProjectedMNPayees` wasn't projecting MN payees correctly.

## What was done?
<!--- Describe your changes in detail -->
HPMNs are now added 4 times before sorting the return list.
In addition, the case of last payee being HPMN and having still pending payments is handled.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Masternodes / Next Payment tab on Qt client on Testnet.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
