### PR TITLE
fix: add a missing name for key `hdaccounts` for RPC help for `getwalletinfo`

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2474,7 +2474,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
                             {RPCResult::Type::STR_AMOUNT, "paytxfee", "the transaction fee configuration, set in " + CURRENCY_UNIT + "/kB"},
                             {RPCResult::Type::STR_HEX, "hdchainid", "the ID of the HD chain"},
                             {RPCResult::Type::STR, "hdaccountcount", "how many accounts of the HD chain are in this wallet"},
-                            {RPCResult::Type::ARR, "", "",
+                            {RPCResult::Type::ARR, "hdaccounts", "",
                                 {
                                 {RPCResult::Type::OBJ, "", "",
                                     {


### PR DESCRIPTION
## Issue being fixed or feature implemented
RPC help has a wrongly generated RPC help output in CLI and online help: https://dashcore.readme.io/docs/core-api-ref-remote-procedure-calls-wallet#getwalletinfo

New version:
```
...
"hdaccounts" : [                        (json array)
  {                                     (json object)
    "hdaccountindex" : n,               (numeric) the index of the account
    "hdexternalkeyindex" : n,           (numeric) current external childkey index
    "hdinternalkeyindex" : n            (numeric) current internal childkey index
  },
  ...
],
...
```

against old version:
```
...
"" : [                                  (json array)
  {                                     (json object)
    "hdaccountindex" : n,               (numeric) the index of the account
    "hdexternalkeyindex" : n,           (numeric) current external childkey index
    "hdinternalkeyindex" : n            (numeric) current internal childkey index
  },
  ...
],
...
```



## What was done?
Add a missing name `hdaccounts` for that key for `getwalletinfo` RPC


## How Has This Been Tested?
Run a command `help getwalletinfo` for old and for new versions.


## Breaking Changes
No breaking changes. It doesn't change rpc, only change text description (help).


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have assigned this pull request to a milestone
