### PR TITLE
fix(qt): should use weighted mn count when calculating payments in Masternodes tab

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -19,6 +19,7 @@
 
 #include <immer/map.hpp>
 
+#include <limits>
 #include <numeric>
 #include <unordered_map>
 #include <utility>
@@ -333,10 +334,10 @@ public:
     /**
      * Calculates the projected MN payees for the next *count* blocks. The result is not guaranteed to be correct
      * as PoSe banning might occur later
-     * @param count
+     * @param nCount the number of payees to return. "nCount = max()"" means "all", use it to avoid calling GetValidWeightedMNsCount twice.
      * @return
      */
-    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(int nCount) const;
+    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(int nCount = std::numeric_limits<int>::max()) const;
 
     /**
      * Calculate a quorum based on the modifier. The resulting list is deterministically sorted by score

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -15,8 +15,6 @@
 
 #include <univalue.h>
 
-#include <limits>
-
 #include <QMessageBox>
 #include <QTableWidgetItem>
 #include <QtGui/QClipboard>
@@ -204,8 +202,7 @@ void MasternodeList::updateDIP3List()
 
     nTimeUpdatedDIP3 = GetTime();
 
-    // using max() here to avoid calling GetValidWeightedMNsCount twice
-    auto projectedPayees = mnList.GetProjectedMNPayees(std::numeric_limits<int>::max());
+    auto projectedPayees = mnList.GetProjectedMNPayees();
     std::map<uint256, int> nextPayments;
     for (size_t i = 0; i < projectedPayees.size(); i++) {
         const auto& dmn = projectedPayees[i];

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -15,6 +15,8 @@
 
 #include <univalue.h>
 
+#include <limits>
+
 #include <QMessageBox>
 #include <QTableWidgetItem>
 #include <QtGui/QClipboard>
@@ -202,7 +204,8 @@ void MasternodeList::updateDIP3List()
 
     nTimeUpdatedDIP3 = GetTime();
 
-    auto projectedPayees = mnList.GetProjectedMNPayees(mnList.GetValidMNsCount());
+    // using max() here to avoid calling GetValidWeightedMNsCount twice
+    auto projectedPayees = mnList.GetProjectedMNPayees(std::numeric_limits<int>::max());
     std::map<uint256, int> nextPayments;
     for (size_t i = 0; i < projectedPayees.size(); i++) {
         const auto& dmn = projectedPayees[i];


### PR DESCRIPTION
## Issue being fixed or feature implemented
Masternodes tab was showing UNKNOWN next payment for some enabled MNs

reported by @kxcd aka xkcd

## What was done?
ask for the maximum data available, let GetProjectedMNPayees crop it

## How Has This Been Tested?
run dash-qt, check the list on Masternodes tab

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
