### PR TITLE
trivial(doc): fix typos in getrawtransaction and decoderawtransaction help texts

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -143,7 +143,7 @@ static UniValue getrawtransaction(const JSONRPCRequest& request)
                             {RPCResult::Type::STR_HEX, "txid", "The transaction id (same as provided)"},
                             {RPCResult::Type::NUM, "size", "The serialized transaction size"},
                             {RPCResult::Type::NUM, "version", "The version"},
-                            {RPCResult::Type::NUM, "version", "The type"},
+                            {RPCResult::Type::NUM, "type", "The type"},
                             {RPCResult::Type::NUM_TIME, "locktime", "The lock time"},
                             {RPCResult::Type::ARR, "vin", "",
                             {
@@ -494,7 +494,7 @@ static UniValue decoderawtransaction(const JSONRPCRequest& request)
                         {RPCResult::Type::STR_HEX, "txid", "The transaction id"},
                         {RPCResult::Type::NUM, "size", "The transaction size"},
                         {RPCResult::Type::NUM, "version", "The version"},
-                        {RPCResult::Type::NUM, "version", "The type"},
+                        {RPCResult::Type::NUM, "type", "The type"},
                         {RPCResult::Type::NUM_TIME, "locktime", "The lock time"},
                         {RPCResult::Type::ARR, "vin", "",
                         {


### PR DESCRIPTION
## Issue being fixed or feature implemented
fix typos in getrawtransaction and decoderawtransaction help texts

## What was done?
tweak field name to match https://github.com/dashpay/dash/blob/develop/src/core_write.cpp#L192

## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
