### PR TITLE
fix: Fix missing includes

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <algorithm>
+#include <stdexcept>
 #ifdef ARENA_DEBUG
 #include <iomanip>
 #include <iostream>

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_BIP32_H
 
 #include <attributes.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
The `<stdexcept>` include is needed for `std::runtime_error` definition.
The `<cstdint>` include is needed for `uint8_t` and `uint32_t` definition.

## Issue being fixed or feature implemented
Compilation failure with GCC 13.
GCC 13 is more strict about missing includes that were included indirectly by previous versions of GCC.


## What was done?
Added missing includes.

## How Has This Been Tested?
Successful compilation on Fedora 38 with GCC 13. All tests passed successfully.


## Breaking Changes
None.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
