### PR TITLE
fix: add passed HPMN payments to the list in GetProjectedMNPayees

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -246,6 +246,14 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int
             result.emplace_back(dmn);
         }
     });
+
+    if (hpmn_to_be_skipped != nullptr) {
+        // if hpmn is in the middle of payments, add entries for already paid ones to the end of the list
+        for ([[maybe_unused]] auto _ : irange::range(hpmn_to_be_skipped->pdmnState->nConsecutivePayments)) {
+            result.emplace_back(hpmn_to_be_skipped);
+        }
+    }
+
     std::sort(result.begin() + remaining_hpmn_payments, result.end(), [&](const CDeterministicMNCPtr& a, const CDeterministicMNCPtr& b) {
         return CompareByLastPaid(a.get(), b.get());
     });


### PR DESCRIPTION
## Issue being fixed or feature implemented
Not having them in the list is 1. wrong 2. creates empty entries in results (nullptr-s)
Should fix crashes like https://github.com/dashpay/dash/pull/5287#issuecomment-1498518599

## What was done?
Add missing entries

## How Has This Been Tested?
Run dash-qt on testnet, wait when a HPMN is the payee. develop - crash, this PR - no crash.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
