### PR TITLE
fix(governance): use weighted mn count

### DIFF
--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -711,13 +711,13 @@ void CGovernanceObject::UpdateSentinelVariables()
 {
     // CALCULATE MINIMUM SUPPORT LEVELS REQUIRED
 
-    int nMnCount = (int)deterministicMNManager->GetListAtChainTip().GetValidMNsCount();
-    if (nMnCount == 0) return;
+    int nWeightedMnCount = (int)deterministicMNManager->GetListAtChainTip().GetValidWeightedMNsCount();
+    if (nWeightedMnCount == 0) return;
 
     // CALCULATE THE MINIMUM VOTE COUNT REQUIRED FOR FULL SIGNAL
 
-    int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nMnCount / 10);
-    int nAbsDeleteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, (2 * nMnCount) / 3);
+    int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nWeightedMnCount / 10);
+    int nAbsDeleteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, (2 * nWeightedMnCount) / 3);
 
     // SET SENTINEL FLAGS TO FALSE
 

--- a/src/qt/governancelist.cpp
+++ b/src/qt/governancelist.cpp
@@ -344,11 +344,11 @@ void GovernanceList::setClientModel(ClientModel* model)
 void GovernanceList::updateProposalList()
 {
     if (this->clientModel) {
-        // A proposal is considered passing if (YES votes - NO votes) >= (Total Number of Masternodes / 10),
+        // A proposal is considered passing if (YES votes - NO votes) >= (Total Weight of Masternodes / 10),
         // count total valid (ENABLED) masternodes to determine passing threshold.
         // Need to query number of masternodes here with access to clientModel.
-        const int nMnCount = clientModel->getMasternodeList().GetValidMNsCount();
-        const int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nMnCount / 10);
+        const int nWeightedMnCount = clientModel->getMasternodeList().GetValidWeightedMNsCount();
+        const int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nWeightedMnCount / 10);
         proposalModel->setVotingParams(nAbsVoteReq);
 
         std::vector<CGovernanceObject> govObjList;


### PR DESCRIPTION
## Issue being fixed or feature implemented
vote thresholds were counted incorrectly

## What was done?
switch from `GetValidMNsCount()` to `GetValidWeightedMNsCount()`


## How Has This Been Tested?
...

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
