### PR TITLE
feat: min protocol version check for SML serialisation

### DIFF
--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -74,6 +74,9 @@ public:
                 obj.isValid
                 );
         if (obj.nVersion == BASIC_BLS_VERSION) {
+            if ((s.GetType() & SER_NETWORK) && s.GetVersion() < DMN_TYPE_PROTO_VERSION) {
+                return;
+            }
             READWRITE(obj.nType);
             if (obj.nType == MnType::HighPerformance) {
                 READWRITE(obj.platformHTTPPort);

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -73,10 +73,10 @@ public:
                 obj.keyIDVoting,
                 obj.isValid
                 );
+        if ((s.GetType() & SER_NETWORK) && s.GetVersion() < DMN_TYPE_PROTO_VERSION) {
+            return;
+        }
         if (obj.nVersion == BASIC_BLS_VERSION) {
-            if ((s.GetType() & SER_NETWORK) && s.GetVersion() < DMN_TYPE_PROTO_VERSION) {
-                return;
-            }
             READWRITE(obj.nType);
             if (obj.nType == MnType::HighPerformance) {
                 READWRITE(obj.platformHTTPPort);

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -32,7 +32,7 @@ from test_framework.util import hex_str_to_bytes, assert_equal
 import dash_hash
 
 MIN_VERSION_SUPPORTED = 60001
-MY_VERSION = 70225  # BLS_SCHEME_PROTO_VERSION
+MY_VERSION = 70227  # DMN_TYPE_PROTO_VERSION
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3%s/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Provide a general summary of your changes in the Title above

Pull requests without a rationale and clear improvement may be closed
immediately.

Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible.
-->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was reported/requested by @HashEngineering:
> Older versions of our App won't sync due to  if (obj.nVersion == BASIC_BLS_VERSION) .  Older versions don't know what version a SML Entry is.  As such, they will never read the type field.  On the android client this causes an offset problem when reading the mnlistdiff and it will throw an exception that bans the peer that supplied it.  Soon enough, no peers will be left to connect to because they will all give the android client bad data. 

## What was done?
<!--- Describe your changes in detail -->
With this PR, SML will serialise the new v19 fields (`nType`, `platformHTTPPort`, `platformNodeID`) if the client's version is at least equal to `70227`.
Note: Serialisation for hashing skips the above rule.

Also, functional test mininode protocol version is set to `70227`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
