### PR TITLE
fix(ci): skip more jobs in "FAST_MODE"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -245,21 +245,27 @@ linux64-build:
     BUILD_TARGET: linux64
 
 linux64_cxx20-build:
-  extends: .build-template
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
   needs:
     - x86_64-pc-linux-gnu-debug
   variables:
     BUILD_TARGET: linux64_cxx20
 
 linux64_sqlite-build:
-  extends: .build-template
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
   needs:
     - x86_64-pc-linux-gnu-debug
   variables:
     BUILD_TARGET: linux64_sqlite
 
 linux64_fuzz-build:
-  extends: .build-template
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
   needs:
     - x86_64-pc-linux-gnu-debug
   variables:
@@ -320,7 +326,9 @@ linux64-test:
     BUILD_TARGET: linux64
 
 linux64_sqlite-test:
-  extends: .test-template
+  extends:
+    - .test-template
+    - .skip-in-fast-mode-template
   needs:
     - linux64_sqlite-build
   variables:


### PR DESCRIPTION
## Issue being fixed or feature implemented
CI should not be running that many jobs in "FAST_MODE"
https://github.com/dashpay/dash/blob/develop/.gitlab-ci.yml#L5

## What was done?
assign `.skip-in-fast-mode-template` template to more jobs

## How Has This Been Tested?
ran CI in my repo
before: https://gitlab.com/UdjinM6/dash/-/pipelines/832175740
after: https://gitlab.com/UdjinM6/dash/-/pipelines/832176325

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
