### PR TITLE
fix: improved reliability of functional tests that activates dip24

### DIFF
--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -349,13 +349,7 @@ class LLMQ_IS_CL_Conflicts(DashTestFramework):
         request_id = hash256(request_id_buf)[::-1].hex()
         message_hash = block.hash
 
-        quorum_member = None
-        for mn in self.mninfo:
-            res = mn.node.quorum('sign', 100, request_id, message_hash)
-            if res and quorum_member is None:
-                quorum_member = mn
-
-        recSig = self.get_recovered_sig(request_id, message_hash, node=quorum_member.node)
+        recSig = self.get_recovered_sig(request_id, message_hash)
         clsig = msg_clsig(height, block.sha256, hex_str_to_bytes(recSig['sig']))
         return clsig
 

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -190,7 +190,8 @@ class DashZMQTest (DashTestFramework):
 
         def validate_recovered_sig(request_id, msg_hash):
             # Make sure the recovered sig exists by RPC
-            rpc_recovered_sig = self.get_recovered_sig(request_id, msg_hash)
+            self.wait_for_recovered_sig(request_id, msg_hash)
+            rpc_recovered_sig = self.mninfo[0].node.quorum('getrecsig', 100, request_id, msg_hash)
             # Validate hashrecoveredsig
             zmq_recovered_sig_hash = self.subscribers[ZMQPublisher.hash_recovered_sig].receive().read(32).hex()
             assert_equal(zmq_recovered_sig_hash, msg_hash)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1896,31 +1896,26 @@ class DashTestFramework(BitcoinTestFramework):
         time.sleep(1)
         self.log.info('Moved from block %d to %d' % (cur_block, self.nodes[0].getblockcount()))
 
-    def check_sigs(self, rec_sig_id, rec_sig_msg_hash, llmq_type):
-        for mn in self.mninfo:
-            if not mn.node.quorum("hasrecsig", llmq_type, rec_sig_id, rec_sig_msg_hash):
-                return False
-        return True
-
-    def wait_for_sigs(self, rec_sig_id, rec_sig_msg_hash, llmq_type, timeout):
-        wait_until(lambda: self.check_sigs(rec_sig_id, rec_sig_msg_hash, llmq_type), timeout = timeout)
+    def wait_for_recovered_sig(self, rec_sig_id, rec_sig_msg_hash, llmq_type=100, timeout=10):
+        def check_recovered_sig():
+            self.bump_mocktime(1)
+            for mn in self.mninfo:
+                if not mn.node.quorum("hasrecsig", llmq_type, rec_sig_id, rec_sig_msg_hash):
+                    return False
+            return True
+        wait_until(check_recovered_sig, timeout=timeout, sleep=1)
 
     def get_recovered_sig(self, rec_sig_id, rec_sig_msg_hash, llmq_type=100):
         # Note: recsigs aren't relayed to regular nodes by default,
         # make sure to pick a mn as a node to query for recsigs.
         try:
-            self.bump_mocktime(1)
-
             quorumHash = self.mninfo[0].node.quorum("selectquorum", llmq_type, rec_sig_id)["quorumHash"]
             for mn in self.mninfo:
                 mn.node.quorum("sign", llmq_type, rec_sig_id, rec_sig_msg_hash, quorumHash)
-
-            self.wait_for_sigs(rec_sig_id, rec_sig_msg_hash, llmq_type, 10 * self.options.timeout_scale)
-
+            self.wait_for_recovered_sig(rec_sig_id, rec_sig_msg_hash, llmq_type, 10)
             return self.mninfo[0].node.quorum("getrecsig", llmq_type, rec_sig_id, rec_sig_msg_hash)
         except JSONRPCException as e:
             self.log.info(f"getrecsig failed with '{e}'")
-
         assert False
 
     def get_quorum_masternodes(self, q, llmq_type=100):


### PR DESCRIPTION
## Issue being fixed or feature implemented
Functional tests in CI and locally often fails without a good reason (pretty randomly)

## What was done?
It was re-implemented `get_recovered_sig` and updated `create_raw_tx` for better selection/change output.

## How Has This Been Tested?
Run functional times with bug amount of parrallel jobs:
```
test/functional/test_runner.py -j 20 feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py  feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py feature_llmq_is_cl_conflicts.py
```
Without these changes usually 2-3 instance fails.
With these changes all failures happened only for `p2p_addrv2_relay.py` and `mempool_unbroadcast.py`. Beside feature_llmq_is_conflicts.py improved stability of `interface_zmq_dash.py` also.

## Breaking Changes
No breaking changes

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
