### PR TITLE
ci: add ci for merging into master

### DIFF
--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -1,0 +1,29 @@
+name: Check Merge Fast-Forward Only
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check_merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "noreply@example.com"
+
+      - name: Check merge --ff-only
+        run: |
+          git fetch origin master:master
+          git checkout master
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            git merge --ff-only ${{ github.event.pull_request.head.sha }}
+          else
+            git merge --ff-only ${{ github.sha }}
+          fi


### PR DESCRIPTION
## Issue being fixed or feature implemented
This adds a check that ensures branches merge cleanly into master via a ff-only

## What was done?
Added a GitHub action created via gpt-4 :)

## How Has This Been Tested?
https://github.com/PastaPastaPasta/dash/actions/runs/4703432752/jobs/8341923994 and https://github.com/PastaPastaPasta/dash/actions/runs/4703457936/jobs/8341980146 for expected pass and expected fail 

## Breaking Changes
None, should be back ported to v19.x branch when we get the chance.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
