### PR TITLE
fix: ./autogen fails due to newline

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -211,7 +211,6 @@ test_fuzz_fuzz_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_fuzz_LDFLAGS = $(FUZZ_SUITE_LDFLAGS_COMMON) $(RUNTIME_LDFLAGS)
 test_fuzz_fuzz_SOURCES = \
   test/fuzz/addition_overflow.cpp \
-
   test/fuzz/addrman.cpp \
   test/fuzz/asmap.cpp \
   test/fuzz/asmap_direct.cpp \


### PR DESCRIPTION
## Issue being fixed or feature implemented
Develop doesn't build: ./autogen.sh fails

## What was done?
remove newline

## How Has This Been Tested?
./autogen.sh

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

