### PR TITLE
build: add `--hardened-runtime` for macos detached signature creation to enable notarization

### DIFF
--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -22,7 +22,7 @@ fi
 rm -rf ${TEMPDIR}
 mkdir -p ${TEMPDIR}
 
-${SIGNAPPLE} sign -f --detach "${TEMPDIR}/${OUTROOT}"  "$@" "${BUNDLE}"
+${SIGNAPPLE} sign --hardened-runtime -f --detach "${TEMPDIR}/${OUTROOT}"  "$@" "${BUNDLE}"
 
 tar -C "${TEMPDIR}" -czf "${OUT}" .
 rm -rf "${TEMPDIR}"


### PR DESCRIPTION
## Issue being fixed or feature implemented
Slightly changes the detached signature creation code 

## What was done?
Investigated what exactly needed to be done for notarization (docs to come), tried it again, then when it failed as expected trying to figure it out, then figuring it out :) simple change in the end.

## How Has This Been Tested?
created macOS detached sigs and notarized 19.0.0-rc.10 binaries and ensured that all worked as expected. See binary attached here (sha256 3829e863831b05c3d76785540183bee556c4bab03dac98f5872df06668b9cb20) 
[dashcore-19.0.0-rc.10-osx.dmg.zip](https://github.com/dashpay/dash/files/11246273/dashcore-19.0.0-rc.10-osx.dmg.zip). You can also do a signed gitian-build for rc.10 and should replicate these hashes. 


## Breaking Changes
Should be none; I would like to backport this to 19 as a 19.0.1

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

