### PR TITLE
refactor: conver std::vector const references to Span

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -84,21 +84,21 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch, int max_ret_
     return true;
 }
 
-std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
+std::string EncodeBase58(Span<const unsigned char> input)
 {
     // Skip & count leading zeroes.
     int zeroes = 0;
     int length = 0;
-    while (pbegin != pend && *pbegin == 0) {
-        pbegin++;
+    while (input.size() > 0 && input[0] == 0) {
+        input = input.subspan(1);
         zeroes++;
     }
     // Allocate enough space in big-endian base58 representation.
-    int size = (pend - pbegin) * 138 / 100 + 1; // log(256) / log(58), rounded up.
+    int size = input.size() * 138 / 100 + 1; // log(256) / log(58), rounded up.
     std::vector<unsigned char> b58(size);
     // Process the bytes.
-    while (pbegin != pend) {
-        int carry = *pbegin;
+    while (input.size() > 0) {
+        int carry = input[0];
         int i = 0;
         // Apply "b58 = b58 * 256 + ch".
         for (std::vector<unsigned char>::reverse_iterator it = b58.rbegin(); (carry != 0 || i < length) && (it != b58.rend()); it++, i++) {
@@ -109,7 +109,7 @@ std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
 
         assert(carry == 0);
         length = i;
-        pbegin++;
+        input = input.subspan(1);
     }
     // Skip leading zeroes in base58 result.
     std::vector<unsigned char>::iterator it = b58.begin() + (size - length);
@@ -124,11 +124,6 @@ std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
     return str;
 }
 
-std::string EncodeBase58(const std::vector<unsigned char>& vch)
-{
-    return EncodeBase58(vch.data(), vch.data() + vch.size());
-}
-
 bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len)
 {
     if (!ValidAsCString(str)) {
@@ -137,10 +132,10 @@ bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, in
     return DecodeBase58(str.c_str(), vchRet, max_ret_len);
 }
 
-std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn)
+std::string EncodeBase58Check(Span<const unsigned char> input)
 {
     // add 4-byte hash check to the end
-    std::vector<unsigned char> vch(vchIn);
+    std::vector<unsigned char> vch(input.begin(), input.end());
     uint256 hash = Hash(vch.begin(), vch.end());
     vch.insert(vch.end(), (unsigned char*)&hash, (unsigned char*)&hash + 4);
     return EncodeBase58(vch);

--- a/src/base58.h
+++ b/src/base58.h
@@ -15,20 +15,15 @@
 #define BITCOIN_BASE58_H
 
 #include <attributes.h>
+#include <span.h>
 
 #include <string>
 #include <vector>
 
 /**
- * Encode a byte sequence as a base58-encoded string.
- * pbegin and pend cannot be nullptr, unless both are.
+ * Encode a byte span as a base58-encoded string
  */
-std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend);
-
-/**
- * Encode a byte vector as a base58-encoded string
- */
-std::string EncodeBase58(const std::vector<unsigned char>& vch);
+std::string EncodeBase58(Span<const unsigned char> input);
 
 /**
  * Decode a base58-encoded string (psz) into a byte vector (vchRet).
@@ -44,9 +39,9 @@ std::string EncodeBase58(const std::vector<unsigned char>& vch);
 [[nodiscard]] bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len);
 
 /**
- * Encode a byte vector into a base58-encoded string, including checksum
+ * Encode a byte span into a base58-encoded string, including checksum
  */
-std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn);
+std::string EncodeBase58Check(Span<const unsigned char> input);
 
 /**
  * Decode a base58-encoded string (psz) that includes a checksum into a byte

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -20,7 +20,7 @@ static void Base58Encode(benchmark::Bench& bench)
         }
     };
     bench.batch(buff.size()).unit("byte").run([&] {
-        EncodeBase58(buff.data(), buff.data() + buff.size());
+        EncodeBase58(buff);
     });
 }
 
@@ -34,10 +34,8 @@ static void Base58CheckEncode(benchmark::Bench& bench)
             200, 24
         }
     };
-    std::vector<unsigned char> vch;
-    vch.assign(buff.begin(), buff.end());
     bench.batch(buff.size()).unit("byte").run([&] {
-        EncodeBase58Check(vch);
+        EncodeBase58Check(buff);
     });
 }
 

--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -39,7 +39,7 @@ void CBLSSecretKey::AggregateInsecure(const CBLSSecretKey& o)
     cachedHash.SetNull();
 }
 
-CBLSSecretKey CBLSSecretKey::AggregateInsecure(const std::vector<CBLSSecretKey>& sks)
+CBLSSecretKey CBLSSecretKey::AggregateInsecure(Span<CBLSSecretKey> sks)
 {
     if (sks.empty()) {
         return {};
@@ -75,7 +75,7 @@ void CBLSSecretKey::MakeNewKey()
 }
 #endif
 
-bool CBLSSecretKey::SecretKeyShare(const std::vector<CBLSSecretKey>& msk, const CBLSId& _id)
+bool CBLSSecretKey::SecretKeyShare(Span<CBLSSecretKey> msk, const CBLSId& _id)
 {
     fValid = false;
     cachedHash.SetNull();
@@ -147,7 +147,7 @@ void CBLSPublicKey::AggregateInsecure(const CBLSPublicKey& o)
     cachedHash.SetNull();
 }
 
-CBLSPublicKey CBLSPublicKey::AggregateInsecure(const std::vector<CBLSPublicKey>& pks)
+CBLSPublicKey CBLSPublicKey::AggregateInsecure(Span<CBLSPublicKey> pks)
 {
     if (pks.empty()) {
         return {};
@@ -171,7 +171,7 @@ CBLSPublicKey CBLSPublicKey::AggregateInsecure(const std::vector<CBLSPublicKey>&
     return ret;
 }
 
-bool CBLSPublicKey::PublicKeyShare(const std::vector<CBLSPublicKey>& mpk, const CBLSId& _id)
+bool CBLSPublicKey::PublicKeyShare(Span<CBLSPublicKey> mpk, const CBLSId& _id)
 {
     fValid = false;
     cachedHash.SetNull();
@@ -225,7 +225,7 @@ void CBLSSignature::AggregateInsecure(const CBLSSignature& o)
     cachedHash.SetNull();
 }
 
-CBLSSignature CBLSSignature::AggregateInsecure(const std::vector<CBLSSignature>& sigs)
+CBLSSignature CBLSSignature::AggregateInsecure(Span<CBLSSignature> sigs)
 {
     if (sigs.empty()) {
         return {};
@@ -249,8 +249,8 @@ CBLSSignature CBLSSignature::AggregateInsecure(const std::vector<CBLSSignature>&
     return ret;
 }
 
-CBLSSignature CBLSSignature::AggregateSecure(const std::vector<CBLSSignature>& sigs,
-                                             const std::vector<CBLSPublicKey>& pks,
+CBLSSignature CBLSSignature::AggregateSecure(Span<CBLSSignature> sigs,
+                                             Span<CBLSPublicKey> pks,
                                              const uint256& hash)
 {
     if (sigs.size() != pks.size() || sigs.empty()) {
@@ -306,7 +306,7 @@ bool CBLSSignature::VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& h
     return VerifyInsecure(pubKey, hash, bls::bls_legacy_scheme.load());
 }
 
-bool CBLSSignature::VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& pubKeys, const std::vector<uint256>& hashes) const
+bool CBLSSignature::VerifyInsecureAggregated(Span<CBLSPublicKey> pubKeys, Span<uint256> hashes) const
 {
     if (!IsValid()) {
         return false;
@@ -333,7 +333,7 @@ bool CBLSSignature::VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& p
     }
 }
 
-bool CBLSSignature::VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash) const
+bool CBLSSignature::VerifySecureAggregated(Span<CBLSPublicKey> pks, const uint256& hash) const
 {
     if (pks.empty()) {
         return false;
@@ -352,7 +352,7 @@ bool CBLSSignature::VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks
     }
 }
 
-bool CBLSSignature::Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids)
+bool CBLSSignature::Recover(Span<CBLSSignature> sigs, Span<CBLSId> ids)
 {
     fValid = false;
     cachedHash.SetNull();

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -210,7 +210,7 @@ public:
         Unserialize(s, bls::bls_legacy_scheme.load(), checkMalleable);
     }
 
-    inline bool CheckMalleable(const std::vector<uint8_t>& vecBytes, const bool specificLegacyScheme) const
+    inline bool CheckMalleable(Span<uint8_t> vecBytes, const bool specificLegacyScheme) const
     {
         if (memcmp(vecBytes.data(), ToByteVector(specificLegacyScheme).data(), SerSize)) {
             // TODO not sure if this is actually possible with the BLS libs. I'm assuming here that somewhere deep inside
@@ -221,7 +221,7 @@ public:
         return true;
     }
 
-    inline bool CheckMalleable(const std::vector<uint8_t>& vecBytes) const
+    inline bool CheckMalleable(Span<uint8_t> vecBytes) const
     {
         return CheckMalleable(vecBytes, bls::bls_legacy_scheme.load());
     }
@@ -282,12 +282,12 @@ public:
     CBLSSecretKey& operator=(const CBLSSecretKey&) = default;
 
     void AggregateInsecure(const CBLSSecretKey& o);
-    static CBLSSecretKey AggregateInsecure(const std::vector<CBLSSecretKey>& sks);
+    static CBLSSecretKey AggregateInsecure(Span<CBLSSecretKey> sks);
 
 #ifndef BUILD_BITCOIN_INTERNAL
     void MakeNewKey();
 #endif
-    bool SecretKeyShare(const std::vector<CBLSSecretKey>& msk, const CBLSId& id);
+    bool SecretKeyShare(Span<CBLSSecretKey> msk, const CBLSId& id);
 
     [[nodiscard]] CBLSPublicKey GetPublicKey() const;
     [[nodiscard]] CBLSSignature Sign(const uint256& hash) const;
@@ -307,9 +307,9 @@ public:
     CBLSPublicKey() = default;
 
     void AggregateInsecure(const CBLSPublicKey& o);
-    static CBLSPublicKey AggregateInsecure(const std::vector<CBLSPublicKey>& pks);
+    static CBLSPublicKey AggregateInsecure(Span<CBLSPublicKey> pks);
 
-    bool PublicKeyShare(const std::vector<CBLSPublicKey>& mpk, const CBLSId& id);
+    bool PublicKeyShare(Span<CBLSPublicKey> mpk, const CBLSId& id);
     bool DHKeyExchange(const CBLSSecretKey& sk, const CBLSPublicKey& pk);
 
 };
@@ -364,17 +364,17 @@ public:
     CBLSSignature& operator=(const CBLSSignature&) = default;
 
     void AggregateInsecure(const CBLSSignature& o);
-    static CBLSSignature AggregateInsecure(const std::vector<CBLSSignature>& sigs);
-    static CBLSSignature AggregateSecure(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSPublicKey>& pks, const uint256& hash);
+    static CBLSSignature AggregateInsecure(Span<CBLSSignature> sigs);
+    static CBLSSignature AggregateSecure(Span<CBLSSignature> sigs, Span<CBLSPublicKey> pks, const uint256& hash);
 
     void SubInsecure(const CBLSSignature& o);
     [[nodiscard]] bool VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& hash, const bool specificLegacyScheme) const;
     [[nodiscard]] bool VerifyInsecure(const CBLSPublicKey& pubKey, const uint256& hash) const;
-    [[nodiscard]] bool VerifyInsecureAggregated(const std::vector<CBLSPublicKey>& pubKeys, const std::vector<uint256>& hashes) const;
+    [[nodiscard]] bool VerifyInsecureAggregated(Span<CBLSPublicKey> pubKeys, Span<uint256> hashes) const;
 
-    [[nodiscard]] bool VerifySecureAggregated(const std::vector<CBLSPublicKey>& pks, const uint256& hash) const;
+    [[nodiscard]] bool VerifySecureAggregated(Span<CBLSPublicKey> pks, const uint256& hash) const;
 
-    bool Recover(const std::vector<CBLSSignature>& sigs, const std::vector<CBLSId>& ids);
+    bool Recover(Span<CBLSSignature> sigs, Span<CBLSId> ids);
 };
 
 class CBLSSignatureVersionWrapper {

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -925,12 +925,11 @@ void CGovernanceManager::RequestGovernanceObject(CNode* pfrom, const uint256& nH
 
 int CGovernanceManager::RequestGovernanceObjectVotes(CNode& peer, CConnman& connman)
 {
-    std::vector<CNode*> vNodesCopy;
-    vNodesCopy.push_back(&peer);
-    return RequestGovernanceObjectVotes(vNodesCopy, connman);
+    std::array<CNode*, 1> nodeCopy{&peer};
+    return RequestGovernanceObjectVotes(nodeCopy, connman);
 }
 
-int CGovernanceManager::RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy, CConnman& connman)
+int CGovernanceManager::RequestGovernanceObjectVotes(Span<CNode*> vNodesCopy, CConnman& connman)
 {
     static std::map<uint256, std::map<CService, int64_t> > mapAskedRecently;
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -347,7 +347,7 @@ public:
     void InitOnLoad();
 
     int RequestGovernanceObjectVotes(CNode& peer, CConnman& connman);
-    int RequestGovernanceObjectVotes(const std::vector<CNode*>& vNodesCopy, CConnman& connman);
+    int RequestGovernanceObjectVotes(Span<CNode*> vNodesCopy, CConnman& connman);
 
 private:
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash, CConnman& connman, bool fUseFilter = false);

--- a/src/qt/governancelist.cpp
+++ b/src/qt/governancelist.cpp
@@ -231,7 +231,7 @@ void ProposalModel::remove(int row)
     endRemoveRows();
 }
 
-void ProposalModel::reconcile(const std::vector<const Proposal*>& proposals)
+void ProposalModel::reconcile(Span<const Proposal*> proposals)
 {
     // Vector of m_data.count() false values. Going through new proposals,
     // set keep_index true for each old proposal found in the new proposals.

--- a/src/qt/governancelist.h
+++ b/src/qt/governancelist.h
@@ -113,7 +113,7 @@ public:
     static int columnWidth(int section);
     void append(const Proposal* proposal);
     void remove(int row);
-    void reconcile(const std::vector<const Proposal*>& proposals);
+    void reconcile(Span<const Proposal*> proposals);
     void setVotingParams(int nAbsVoteReq);
 
     const Proposal* getProposalAt(const QModelIndex& index) const;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -262,7 +262,7 @@ static std::string DummyAddress(const CChainParams &params)
     std::vector<unsigned char> sourcedata = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
     sourcedata.insert(sourcedata.end(), dummydata, dummydata + sizeof(dummydata));
     for(int i=0; i<256; ++i) { // Try every trailing byte
-        std::string s = EncodeBase58(sourcedata.data(), sourcedata.data() + sourcedata.size());
+        std::string s = EncodeBase58(sourcedata);
         if (!IsValidDestinationString(s)) {
             return s;
         }

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
         std::vector<unsigned char> sourcedata = ParseHex(test[0].get_str());
         std::string base58string = test[1].get_str();
         BOOST_CHECK_MESSAGE(
-                    EncodeBase58(sourcedata.data(), sourcedata.data() + sourcedata.size()) == base58string,
+                    EncodeBase58(sourcedata) == base58string,
                     strTest);
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
refactoring to convert std::vector const ref parameters into Spans

## What was done?


## How Has This Been Tested?
make -j8 check

## Breaking Changes
Should be none

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

