### PR TITLE
refactor: drop flag m_block_relay_peer and use m_addr_relay object instead

### DIFF
--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -1526,7 +1526,7 @@ void CInstantSendManager::AskNodesForLockedTx(const uint256& txid, const CConnma
         if (nodesToAskFor.size() >= 4) {
             return;
         }
-        if (!pnode->m_block_relay_only_peer) {
+        if (pnode->IsAddrRelayPeer()) {
             LOCK(pnode->m_tx_relay->cs_tx_inventory);
             if (pnode->m_tx_relay->filterInventoryKnown.contains(txid)) {
                 pnode->AddRef();

--- a/src/net.h
+++ b/src/net.h
@@ -1051,8 +1051,6 @@ public:
     int64_t nNextAddrSend GUARDED_BY(cs_sendProcessing){0};
     int64_t nNextLocalAddrSend GUARDED_BY(cs_sendProcessing){0};
 
-    const bool m_block_relay_only_peer;
-
     // Don't relay addr messages to peers that we connect to as block-relay-only
     // peers (to prevent adversaries from inferring these links from addr
     // traffic).
@@ -1063,7 +1061,7 @@ public:
         // Stop processing non-block data early if
         // 1) We are in blocks only mode and peer has no relay permission
         // 2) This peer is a block-relay-only peer
-        return (!g_relay_txes && !HasPermission(PF_RELAY)) || m_block_relay_only_peer;
+        return (!g_relay_txes && !HasPermission(PF_RELAY)) || !IsAddrRelayPeer();
     }
 
     // List of block ids we still have announce.
@@ -1110,8 +1108,8 @@ public:
     };
 
     // in bitcoin: m_tx_relay == nullptr if we're not relaying transactions with this peer
-    // in dash: m_tx_relay should never be nullptr, use m_block_relay_only_peer == true instead
-    std::unique_ptr<TxRelay> m_tx_relay;
+    // in dash: m_tx_relay should never be nullptr, use `IsAddrRelayPeer() == false` instead
+    std::unique_ptr<TxRelay> m_tx_relay{std::make_unique<TxRelay>()};
 
     // Used for headers announcements - unfiltered blocks to relay
     std::vector<uint256> vBlockHashesToAnnounce GUARDED_BY(cs_inventory);


### PR DESCRIPTION
## Issue being fixed or feature implemented
This refactoring is a follow-up changes to backport bitcoin#17164 (PR #5314)

These changes are reduce difference in implementation for our code and bitcoin's


## What was done?
Removed a flag m_block_relay_peer. Instead I call IsAddrRelayPeer() that has same information now.
It changes logic introduced in #4888 due to dash-specific code.


## How Has This Been Tested?
Run unit/functional tests.

## Breaking Changes
No breaking changes

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone 

