### PR TITLE
refactor: move CDeterministicMN class members above functions

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -46,6 +46,12 @@ public:
     static constexpr uint16_t CURRENT_MN_FORMAT = 0;
     static constexpr uint16_t MN_TYPE_FORMAT = 1;
 
+    uint256 proTxHash;
+    COutPoint collateralOutpoint;
+    uint16_t nOperatorReward{0};
+    MnType nType{MnType::Regular};
+    std::shared_ptr<const CDeterministicMNState> pdmnState;
+
     CDeterministicMN() = delete; // no default constructor, must specify internalId
     explicit CDeterministicMN(uint64_t _internalId, MnType mnType = MnType::Regular) :
         internalId(_internalId),
@@ -60,12 +66,6 @@ public:
     {
         SerializationOp(s, CSerActionUnserialize(), format_version);
     }
-
-    uint256 proTxHash;
-    COutPoint collateralOutpoint;
-    uint16_t nOperatorReward{0};
-    MnType nType{MnType::Regular};
-    std::shared_ptr<const CDeterministicMNState> pdmnState;
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, const uint8_t format_version)


### PR DESCRIPTION
## Issue being fixed or feature implemented
I was trying to look at the members inside of CDeterministicMN and overlooked most of them initially since they're not at the top

## What was done?
Moved the members up

## How Has This Been Tested?
Compiling

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

