### PR TITLE
chore: Delay v20 activation (regtest only)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -988,8 +988,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nTimeout = 999999999999ULL;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize = 480;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdStart = 240; // 80% of 300
-        consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdMin = 180;   // 60% of 300
+        consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdStart = 384; // 80% of 480
+        consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdMin = 288;   // 60% of 480
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;     // this corresponds to 10 periods
 
         // The best chain should have at least this much work.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -987,7 +987,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nTimeout = 999999999999ULL;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize = 320;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize = 480;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdStart = 240; // 80% of 300
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdMin = 180;   // 60% of 300
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;     // this corresponds to 10 periods


### PR DESCRIPTION
## Issue being fixed or feature implemented

## What was done?
Increased v20 deployment window size in order to delay v20 activation. Only for regtest

## How Has This Been Tested?

## Breaking Changes

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

