### PR TITLE
fix(qt): provide correct data into intro dlg

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -206,7 +206,7 @@ bool Intro::pickDataDirectory(interfaces::Node& node)
         }
 
         /* Let the user choose one */
-        Intro intro(0, node.getAssumedChainStateSize(), node.getAssumedChainStateSize());
+        Intro intro(0, node.getAssumedBlockchainSize(), node.getAssumedChainStateSize());
         GUIUtil::disableMacFocusRect(&intro);
         GUIUtil::loadStyleSheet(true);
         intro.setDataDirectory(dataDirDefaultCurrent);


### PR DESCRIPTION
## Issue being fixed or feature implemented
we failed to backport 13216 correctly in #4359

noticed this while reviewing/testing #5255 

## What was done?
fix it

## How Has This Been Tested?
run qt with `-resetguisetting` and check info with and without the patch on testnet for example (or tweak regtest params and test there)

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

