### PR TITLE
docs: wrong threshold for LLMQ_25_67

### DIFF
--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -19,7 +19,7 @@ enum class LLMQType : uint8_t {
     LLMQ_400_85 = 3, // 400 members, 340 (85%) threshold, one every 24 hours
     LLMQ_100_67 = 4, // 100 members, 67 (67%) threshold, one per hour
     LLMQ_60_75 = 5,  // 60 members, 45 (75%) threshold, one every 12 hours
-    LLMQ_25_67 = 6, // 25 members, 67 (67%) threshold, one per hour
+    LLMQ_25_67 = 6, // 25 members, 17 (67%) threshold, one per hour
 
     // for testing only
     LLMQ_TEST = 100, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used


### PR DESCRIPTION
Invalid number of minimum members in comments for LLMQ_25_67


## Issue being fixed or feature implemented

Invalid number of minimum members in comments for LLMQ_25_67


## What was done?
- Replaced `67` with `17`


## How Has This Been Tested?
None


## Breaking Changes
None


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

