### PR TITLE
feat: mnlistdiff v19 activation height

### DIFF
--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -9,6 +9,7 @@
 #include <evo/deterministicmns.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/commitment.h>
+#include <llmq/utils.h>
 #include <evo/specialtx.h>
 
 #include <pubkey.h>
@@ -233,6 +234,7 @@ void CSimplifiedMNListDiff::ToJson(UniValue& obj, bool extended) const
             obj.pushKV("merkleRootQuorums", cbTxPayload.merkleRootQuorums.ToString());
         }
     }
+    obj.pushKV("v19activationHeight", v19activationHeight);
 }
 
 bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& blockHash, CSimplifiedMNListDiff& mnListDiffRet,
@@ -295,6 +297,10 @@ bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& bloc
     }
     vMatch[0] = true; // only coinbase matches
     mnListDiffRet.cbTxMerkleTree = CPartialMerkleTree(vHashes, vMatch);
+
+    const CBlockIndex* tipBlockIndex = ::ChainActive().Tip();
+    const CBlockIndex* v19ActivationBlockIndex = llmq::utils::V19ActivationIndex(tipBlockIndex);
+    mnListDiffRet.v19activationHeight = v19ActivationBlockIndex != nullptr ? v19ActivationBlockIndex->nHeight : -1;
 
     return true;
 }

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -131,6 +131,7 @@ public:
     std::vector<uint256> deletedMNs;
     std::vector<CSimplifiedMNListEntry> mnList;
     uint16_t nVersion{LEGACY_BLS_VERSION};
+    int v19activationHeight;
 
     std::vector<std::pair<uint8_t, uint256>> deletedQuorums; // p<LLMQType, quorumHash>
     std::vector<llmq::CFinalCommitment> newQuorums;
@@ -143,6 +144,9 @@ public:
         }
         READWRITE(obj.deletedMNs, obj.mnList);
         READWRITE(obj.deletedQuorums, obj.newQuorums);
+        if ((s.GetType() & SER_NETWORK) && s.GetVersion() >= V19_ACTIVATION_HEIGHT_MNLISTDIFF_PROTO_VERSION) {
+            READWRITE(obj.v19activationHeight);
+        }
     }
 
     CSimplifiedMNListDiff();

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -131,7 +131,7 @@ public:
     std::vector<uint256> deletedMNs;
     std::vector<CSimplifiedMNListEntry> mnList;
     uint16_t nVersion{LEGACY_BLS_VERSION};
-    int v19activationHeight;
+    int v19activationHeight{-1};
 
     std::vector<std::pair<uint8_t, uint256>> deletedQuorums; // p<LLMQType, quorumHash>
     std::vector<llmq::CFinalCommitment> newQuorums;

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70227;
+static const int PROTOCOL_VERSION = 70228;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -48,6 +48,9 @@ static const int COINJOIN_PROTX_HASH_PROTO_VERSION = 70226;
 
 //! Masternode type was introduced in this version
 static const int DMN_TYPE_PROTO_VERSION = 70227;
+
+//! V19ActivationHeight in MNLISTDIFF
+static const int V19_ACTIVATION_HEIGHT_MNLISTDIFF_PROTO_VERSION = 70228;
 
 // Make sure that none of the values above collide with `ADDRV2_FORMAT`.
 

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -283,6 +283,10 @@ class LLMQHPMNTest(DashTestFramework):
         assert_equal(set([QuorumId(e["llmqType"], int(e["quorumHash"], 16)) for e in d2["deletedQuorums"]]), set(d.deletedQuorums))
         assert_equal(set([QuorumId(e["llmqType"], int(e["quorumHash"], 16)) for e in d2["newQuorums"]]), set([QuorumId(e.llmqType, e.quorumHash) for e in d.newQuorums]))
 
+        blockchain_info = self.nodes[0].getblockchaininfo()
+        if blockchain_info["softforks"]["v19"]["active"]:
+            assert_equal(blockchain_info["softforks"]["v19"]["height"], d.v19activationHeight)
+        
         return d
 
 if __name__ == '__main__':

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -286,7 +286,7 @@ class LLMQHPMNTest(DashTestFramework):
         blockchain_info = self.nodes[0].getblockchaininfo()
         if blockchain_info["softforks"]["v19"]["active"]:
             assert_equal(blockchain_info["softforks"]["v19"]["height"], d.v19activationHeight)
-        
+
         return d
 
 if __name__ == '__main__':

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -32,7 +32,7 @@ from test_framework.util import hex_str_to_bytes, assert_equal
 import dash_hash
 
 MIN_VERSION_SUPPORTED = 60001
-MY_VERSION = 70227  # DMN_TYPE_PROTO_VERSION
+MY_VERSION = 70228  # V19_ACTIVATION_HEIGHT_MNLISTDIFF_PROTO_VERSION
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3%s/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
@@ -1972,7 +1972,7 @@ class msg_getmnlistd:
 QuorumId = namedtuple('QuorumId', ['llmqType', 'quorumHash'])
 
 class msg_mnlistdiff:
-    __slots__ = ("baseBlockHash", "blockHash", "merkleProof", "cbTx", "version", "deletedMNs", "mnList", "deletedQuorums", "newQuorums",)
+    __slots__ = ("baseBlockHash", "blockHash", "merkleProof", "cbTx", "version", "deletedMNs", "mnList", "deletedQuorums", "newQuorums", "v19activationHeight")
     command = b"mnlistdiff"
 
     def __init__(self):
@@ -1985,6 +1985,7 @@ class msg_mnlistdiff:
         self.mnList = []
         self.deletedQuorums = []
         self.newQuorums = []
+        self.v19activationHeight = 0
 
     def deserialize(self, f):
         self.baseBlockHash = deser_uint256(f)
@@ -2011,6 +2012,7 @@ class msg_mnlistdiff:
             qc = CFinalCommitment()
             qc.deserialize(f)
             self.newQuorums.append(qc)
+        self.v19activationHeight = struct.unpack("<i", f.read(4))[0]
 
     def __repr__(self):
         return "msg_mnlistdiff(baseBlockHash=%064x, blockHash=%064x)" % (self.baseBlockHash, self.blockHash)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Feature requested by @HashEngineering. Mobile clients when requesting `mnlistdiff` for an interval of block containing the actual v19 fork activation are unable to process and calculate correctly the `merkleMNRoot` (because of the new scheme).
Mobile clients need to know the exact v19 activation height and re-request `mnlistdiff` splitted in 2 calls:
- One until the last block before the fork: get all the BLS data in legacy scheme
- One starting from the first v19 block until the actual request block: get all the BLS data in basic scheme

## What was done?
`CSimplifiedMNListDiff` now holds the new field `v19activationHeight`. This field is serialised only for clients with protocol version greater or equal to `70228`.
Note: This field is set to -1 until the fork activates.

Increased the protocol version also in functional test mininode.

## How Has This Been Tested?
Checking that `v19activationHeight` matches the height in `getblockchaininfo` RPC for v19 BIP9.

## Breaking Changes

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

