### PR TITLE
fix: dash is no more pretending being a 'libdashbls'

### DIFF
--- a/src/dashbls/configure.ac
+++ b/src/dashbls/configure.ac
@@ -783,3 +783,4 @@ AC_OUTPUT
 
 dnl Peplace conflict-prone PACKAGE-prefixed macros with DASHBLS
 sed -i.old 's/PACKAGE/DASHBLS/g' depends/relic/include/relic_conf.h
+sed -i.old 's/PACKAGE/DASHBLS/g' config.status


### PR DESCRIPTION
## Issue being fixed or feature implemented

It resolves: https://github.com/dashpay/dash/issues/5270

## What was done?
It is still workaround, but it should works more reliable that previous solution.



## How Has This Been Tested?
Using project awhile - not changed to dashbls yet.


## Breaking Changes
No breaking changes

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone