### PR TITLE
ci: implement guix build by label request in CI 

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -41,13 +41,13 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
-      - name: Cache Guix store
-        uses: actions/cache@v2
-        with:
-          path: /tmp/guix-store
-          key: guix-${{ hashFiles('**/guix.scm') }}
-          restore-keys: |
-            guix-
+#      - name: Cache Guix store
+#        uses: actions/cache@v2
+#        with:
+#          path: /tmp/guix-store
+#          key: guix-${{ hashFiles('**/guix.scm') }}
+#          restore-keys: |
+#            guix-
 
       - name: Run Guix build
         run: |
@@ -55,7 +55,7 @@ jobs:
           mkdir -p depends/SDKs && \
           mkdir -p /tmp/guix-store && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
-          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -v /tmp/guix-store:/gnu/store -w /dash alpine-guix:latest && \
+          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
           docker exec guix-daemon bash -c "\
           chmod 777 /dash/depends && \
           git config --global --add safe.directory /dash && \

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Cache Guix store
         uses: actions/cache@v2
         with:
-          path: /gnu/store
+          path: /tmp/guix-store
           key: guix-${{ hashFiles('**/guix.scm') }}
           restore-keys: |
             guix-
@@ -53,8 +53,9 @@ jobs:
         run: |
           export ADDITIONAL_GUIX_COMMON_FLAGS='--max-jobs=32' && \
           mkdir -p depends/SDKs && \
+          mkdir -p /tmp/guix-store && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
-          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
+          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -v /tmp/guix-store:/gnu/store -w /dash alpine-guix:latest && \
           docker exec guix-daemon bash -c "\
           chmod 777 /dash/depends && \
           git config --global --add safe.directory /dash && \

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir -p depends/SDKs && \
           ls depends/SDKs && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
-          docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && contrib/guix/guix-build"
+          docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && HOSTS="x86_64-linux-gnu" contrib/guix/guix-build"
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -1,15 +1,37 @@
-on: [push, pull_request]
+name: Guix Build
+
+on:
+  push:
+  pull_request:
 
 jobs:
-  guix_build:
+  build:
     runs-on: ubuntu-latest
-#    container:
-#      image: alpine-guix
     steps:
-      - name: Checkout repository
+      - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          repository: dashpay/dash
 
-      - name: Run Guix build
-        run: contrib/guix/guix-build
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git make bash curl bzip2 ca-certificates shadow
+          sudo locale-gen en_US.UTF-8
+          sudo update-ca-certificates
+        shell: bash
+
+      - name: Install Guix
+        run: |
+          sudo mkdir -p /usr/local/guix
+          sudo chown -R $(whoami) /usr/local/guix
+          curl -L https://git.io/JYOYR | tar xzf - --strip-components=1 -C /usr/local/guix
+          echo 'export GUIX_LOCPATH=$HOME/.guix-profile/lib/locale' >> ~/.bashrc
+          echo 'export PATH="$HOME/.guix-profile/bin:$PATH"' >> ~/.bashrc
+          . $HOME/.bashrc
+          guix pull
+        shell: bash
+
+      - name: Run Guix Build
+        run: |
+          cd dash/contrib/guix
+          ./guix-build
+        shell: bash

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Run Guix build
         run: |
+          ls /dash/depends/SDKs &&
           docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && contrib/guix/guix-build"
 
       - name: Ensure build passes

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -3,8 +3,8 @@ on: [push, pull_request]
 jobs:
   guix_build:
     runs-on: ubuntu-latest
-    container:
-      image: alpine-guix
+#    container:
+#      image: alpine-guix
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -10,8 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
-        host: [ x86_64-linux-gnu, x86_64-apple-darwin18 ]
+        host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -1,16 +1,13 @@
 name: Guix Build
 
 on:
-  push:
   pull_request:
+    types: [ labeled ]
 
 jobs:
   build:
     runs-on: self-hosted
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
+    if: contains(github.event.pull_request.labels.*.name, 'guix-build')
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -41,14 +38,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
-#      - name: Cache Guix store
-#        uses: actions/cache@v2
-#        with:
-#          path: /tmp/guix-store
-#          key: guix-${{ hashFiles('**/guix.scm') }}
-#          restore-keys: |
-#            guix-
-
       - name: Run Guix build
         run: |
           export ADDITIONAL_GUIX_COMMON_FLAGS='--max-jobs=32' && \
@@ -72,9 +61,7 @@ jobs:
         run: |
           sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
           sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/qt/dash-qt{,.exe}
-#          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
       - name: Compute SHA256 checksum
         run: |
           sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
           sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/qt/dash-qt{,.exe}
-#          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -1,0 +1,15 @@
+on: [push, pull_request]
+
+jobs:
+  guix_build:
+    runs-on: ubuntu-latest
+    container:
+      image: <your_docker_image_name_here>
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          repository: dashpay/dash
+
+      - name: Run Guix build
+        run: contrib/guix/guix-build

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -8,20 +8,36 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git make bash curl bzip2 ca-certificates guix
-          sudo locale-gen en_US.UTF-8
-        shell: bash
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Run Guix Build
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./contrib/guix/Dockerfile
+          load: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Run Guix build
         run: |
-          ls /
-          ls
-          cd contrib/guix
-          ./guix-build
-        shell: bash
+          docker run --rm -v $(pwd):/dash -w /dash dashpay/dash contrib/guix/guix-build
+
+      - name: Ensure build passes
+        run: |
+          if [[ $? != 0 ]]; then
+            echo "Guix build failed!"
+            exit 1
+          fi

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -18,11 +18,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Hash Dockerfile
+        id: dockerfile
+        run: |
+          echo "::set-output name=hash::$(sha256sum ./contrib/guix/Dockerfile | cut -d ' ' -f1)"
+
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ steps.dockerfile.outputs.hash }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
@@ -35,6 +40,14 @@ jobs:
           tags: alpine-guix:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Cache Guix store
+        uses: actions/cache@v2
+        with:
+          path: /gnu/store
+          key: guix-${{ hashFiles('**/guix.scm') }}
+          restore-keys: |
+            guix-
 
       - name: Run Guix build
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -14,19 +14,8 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y git make bash curl bzip2 ca-certificates
+          sudo apt-get install -y git make bash curl bzip2 ca-certificates guix
           sudo locale-gen en_US.UTF-8
-        shell: bash
-
-      - name: Install Guix
-        run: |
-          sudo mkdir -p /usr/local/guix
-          sudo chown -R $(whoami) /usr/local/guix
-          curl -L https://git.io/JYOYR | tar xzf - --strip-components=1 -C /usr/local/guix
-          echo 'export GUIX_LOCPATH=$HOME/.guix-profile/lib/locale' >> ~/.bashrc
-          echo 'export PATH="$HOME/.guix-profile/bin:$PATH"' >> ~/.bashrc
-          . $HOME/.bashrc
-          guix pull
         shell: bash
 
       - name: Run Guix Build

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -28,12 +28,13 @@ jobs:
           context: .
           file: ./contrib/guix/Dockerfile
           load: true
+          tags: alpine-guix:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Run Guix build
         run: |
-          docker run --rm -v $(pwd):/dash -w /dash dashpay/dash contrib/guix/guix-build
+          docker run --rm -v $(pwd):/dash -w /dash alpine-guix:latest contrib/guix/guix-build
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Run Guix build
         run: |
           ls /dash/depends/SDKs && \
-          mkdir -p depends/SDKs && \
-          curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
+          mkdir -p /dash/depends/SDKs && \
+          curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C /dash/depends/SDKs && \
           docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && contrib/guix/guix-build"
 
       - name: Ensure build passes

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -4,7 +4,7 @@ jobs:
   guix_build:
     runs-on: ubuntu-latest
     container:
-      image: <your_docker_image_name_here>
+      image: alpine-guix
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Guix build
         run: |
-          docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest contrib/guix/guix-build
+          docker run --rm -v ${{ github.workspace }}:/dash -v ${{ github.workspace }}/.git:/dash/.git -w /dash alpine-guix:latest contrib/guix/guix-build
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Guix build
         run: |
-          docker run --rm -v $(pwd):/dash -w /dash alpine-guix:latest contrib/guix/guix-build
+          docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest contrib/guix/guix-build
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           mkdir -p depends/SDKs && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
-          docker run -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
+          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
           docker exec guix-daemon bash -c "\
           git config --global --add safe.directory /dash && \
           cd /dash && \

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
     steps:

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Guix build
         run: |
-          docker run --rm -v ${{ github.workspace }}:/dash -v ${{ github.workspace }}/.git:/dash/.git -w /dash alpine-guix:latest contrib/guix/guix-build
+          docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && contrib/guix/guix-build"
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -49,38 +49,18 @@ jobs:
 #          restore-keys: |
 #            guix-
 
-      - name: Cache Guix store
-        id: cache-guix
-        uses: actions/cache@v2
-        with:
-          path: /gnu/store
-          key: guix-store-${{ hashFiles('contrib/guix/manifest.scm') }}
-          restore-keys: |
-            guix-store-
-
-      - name: Run Guix Daemon
-        run: |
-          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest
-
-      - name: Copy /gnu/store into Docker container
-        run: |
-          docker cp /gnu/store guix-daemon:/gnu
-
       - name: Run Guix build
         run: |
           export ADDITIONAL_GUIX_COMMON_FLAGS='--max-jobs=32' && \
           mkdir -p depends/SDKs && \
           mkdir -p /tmp/guix-store && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
+          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
           docker exec guix-daemon bash -c "\
           chmod 777 /dash/depends && \
           git config --global --add safe.directory /dash && \
           cd /dash && \
           contrib/guix/guix-build"
-
-      - name: Copy /gnu/store from Docker container to host
-        run: |
-          docker cp guix-daemon:/gnu/store /gnu
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   build:
     runs-on: self-hosted
-    strategy:
-      fail-fast: false
-      matrix:
-        host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
           chmod 777 /dash/depends && \
           git config --global --add safe.directory /dash && \
           cd /dash && \
-          HOSTS=${{ matrix.host }} contrib/guix/guix-build"
+          HOSTS="x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu x86_64-w64-mingw32 x86_64-apple-darwin18" contrib/guix/guix-build"
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
+#        host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
+        host: [ x86_64-linux-gnu, x86_64-apple-darwin18 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -49,18 +49,38 @@ jobs:
 #          restore-keys: |
 #            guix-
 
+      - name: Cache Guix store
+        id: cache-guix
+        uses: actions/cache@v2
+        with:
+          path: /gnu/store
+          key: guix-store-${{ hashFiles('contrib/guix/manifest.scm') }}
+          restore-keys: |
+            guix-store-
+
+      - name: Run Guix Daemon
+        run: |
+          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest
+
+      - name: Copy /gnu/store into Docker container
+        run: |
+          docker cp /gnu/store guix-daemon:/gnu
+
       - name: Run Guix build
         run: |
           export ADDITIONAL_GUIX_COMMON_FLAGS='--max-jobs=32' && \
           mkdir -p depends/SDKs && \
           mkdir -p /tmp/guix-store && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
-          docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
           docker exec guix-daemon bash -c "\
           chmod 777 /dash/depends && \
           git config --global --add safe.directory /dash && \
           cd /dash && \
           contrib/guix/guix-build"
+
+      - name: Copy /gnu/store from Docker container to host
+        run: |
+          docker cp guix-daemon:/gnu/store /gnu
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Run Guix Build
         run: |
+          ls /
+          ls
           cd dash/contrib/guix
           ./guix-build
         shell: bash

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -14,9 +14,8 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y git make bash curl bzip2 ca-certificates shadow
+          sudo apt-get install -y git make bash curl bzip2 ca-certificates
           sudo locale-gen en_US.UTF-8
-          sudo update-ca-certificates
         shell: bash
 
       - name: Install Guix

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -46,7 +46,7 @@ jobs:
           chmod 777 /dash/depends && \
           git config --global --add safe.directory /dash && \
           cd /dash && \
-          HOSTS="x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu riscv64-linux-gnu x86_64-w64-mingw32 x86_64-apple-darwin18" contrib/guix/guix-build"
+          contrib/guix/guix-build"
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Guix build
         run: |
-          export ADDITIONAL_GUIX_COMMON_FLAGS='--max-jobs=32' &&
+          export ADDITIONAL_GUIX_COMMON_FLAGS='--max-jobs=32' && \
           mkdir -p depends/SDKs && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
           docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Run Guix build
         run: |
+          export ADDITIONAL_GUIX_COMMON_FLAGS='--max-jobs=32' &&
           mkdir -p depends/SDKs && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
           docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -22,6 +22,6 @@ jobs:
         run: |
           ls /
           ls
-          cd dash/contrib/guix
+          cd contrib/guix
           ./guix-build
         shell: bash

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -70,9 +70,11 @@ jobs:
           fi
       - name: Compute SHA1 checksum
         run: |
-          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/{,qt}/dash{d,-qt}
+          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
+          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/qt/dash-qt{,.exe}
 #          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
       - name: Compute SHA256 checksum
         run: |
-          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/{,qt}/dash{d,-qt}
+          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
+          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/qt/dash-qt{,.exe}
 #          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -34,9 +34,9 @@ jobs:
 
       - name: Run Guix build
         run: |
-          mkdir -p /dash/depends/SDKs && \
-          ls /dash/depends/SDKs && \
-          curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C /dash/depends/SDKs && \
+          mkdir -p depends/SDKs && \
+          ls depends/SDKs && \
+          curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
           docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && contrib/guix/guix-build"
 
       - name: Ensure build passes

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -44,7 +44,7 @@ jobs:
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
           docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
           docker exec guix-daemon bash -c "\
-          chmod -R 777 /dash && \
+          chmod 777 /dash/depends && \
           git config --global --add safe.directory /dash && \
           cd /dash && \
           HOSTS=${{ matrix.host }} contrib/guix/guix-build"

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -69,7 +69,9 @@ jobs:
           fi
       - name: Compute SHA1 checksum
         run: |
-          sha1sum ./distsrc-*/src/dash*
+          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/{,qt}/dash{d,-qt}
+#          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
       - name: Compute SHA256 checksum
         run: |
-          sha256sum ./distsrc-*/src/dash*
+          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/{,qt}/dash{d,-qt}
+#          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        host: [ x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin18 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,7 +43,7 @@ jobs:
           docker exec guix-daemon bash -c "\
           git config --global --add safe.directory /dash && \
           cd /dash && \
-          HOSTS="x86_64-linux-gnu" contrib/guix/guix-build"
+          HOSTS=${{ matrix.host }} contrib/guix/guix-build"
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -34,8 +34,8 @@ jobs:
 
       - name: Run Guix build
         run: |
-          ls /dash/depends/SDKs && \
           mkdir -p /dash/depends/SDKs && \
+          ls /dash/depends/SDKs && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C /dash/depends/SDKs && \
           docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && contrib/guix/guix-build"
 

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -44,6 +44,7 @@ jobs:
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
           docker run --privileged -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
           docker exec guix-daemon bash -c "\
+          chmod -R 777 /dash && \
           git config --global --add safe.directory /dash && \
           cd /dash && \
           HOSTS=${{ matrix.host }} contrib/guix/guix-build"

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -40,7 +40,7 @@ jobs:
           docker exec guix-daemon bash -c "\
           git config --global --add safe.directory /dash && \
           cd /dash && \
-          contrib/guix/guix-build"
+          HOSTS="x86_64-linux-gnu" contrib/guix/guix-build"
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -54,3 +54,9 @@ jobs:
             echo "Guix build failed!"
             exit 1
           fi
+      - name: Compute SHA1 checksum
+        run: |
+          sha1sum ./distsrc-*/src/dash*
+      - name: Compute SHA256 checksum
+        run: |
+          sha256sum ./distsrc-*/src/dash*

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -35,9 +35,12 @@ jobs:
       - name: Run Guix build
         run: |
           mkdir -p depends/SDKs && \
-          ls depends/SDKs && \
           curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
-          docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && HOSTS="x86_64-linux-gnu" contrib/guix/guix-build"
+          docker run -d --name guix-daemon --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest && \
+          docker exec guix-daemon bash -c "\
+          git config --global --add safe.directory /dash && \
+          cd /dash && \
+          contrib/guix/guix-build"
 
       - name: Ensure build passes
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: Run Guix build
         run: |
-          ls /dash/depends/SDKs &&
+          ls /dash/depends/SDKs && \
+          mkdir -p depends/SDKs && \
+          curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs && \
           docker run --rm -v ${{ github.workspace }}:/dash -w /dash alpine-guix:latest bash -c "git config --global --add safe.directory /dash && contrib/guix/guix-build"
 
       - name: Ensure build passes

--- a/contrib/guix/Dockerfile
+++ b/contrib/guix/Dockerfile
@@ -57,3 +57,7 @@ RUN git clone https://github.com/dashpay/dash.git /dash
 RUN mkdir base_cache sources SDKs
 
 WORKDIR /dash
+
+RUN mkdir -p depends/SDKs && \
+    curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs
+

--- a/contrib/guix/Dockerfile
+++ b/contrib/guix/Dockerfile
@@ -50,7 +50,7 @@ RUN for i in $(seq -w 1 ${builder_count}); do    \
               "guixbuilder${i}" ;                \
     done
 
-CMD ["/root/.config/guix/current/bin/guix-daemon","--build-users-group=guixbuild"]
+ENTRYPOINT ["/root/.config/guix/current/bin/guix-daemon","--build-users-group=guixbuild"]
 
 RUN git clone https://github.com/dashpay/dash.git /dash
 

--- a/contrib/guix/Dockerfile
+++ b/contrib/guix/Dockerfile
@@ -59,5 +59,5 @@ RUN mkdir base_cache sources SDKs
 WORKDIR /dash
 
 RUN mkdir -p depends/SDKs && \
-    curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs
+    curl -L https://bitcoincore.org/depends-sources/sdks/Xcode-12.1-12A7403-extracted-SDK-with-libcxx-headers.tar.gz | tar -xz -C depends/SDKs
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Automated guix builds in CI when specifically requested 

## What was done?
Any PR with the `build-guix` label added will automatically have the Guix build ran and the hashes placed in the CI output to compare against


## How Has This Been Tested?
This PR

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

