### PR TITLE
ci: clone dash_hash at a specific tag

### DIFF
--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -43,7 +43,8 @@ RUN pip3 install \
     multiprocess
 
 # dash_hash
-RUN git clone --depth 1 --no-tags https://github.com/dashpay/dash_hash
+ARG DASH_HASH_VERSION=1.4.0
+RUN git clone --depth 1 --no-tags --branch=${DASH_HASH_VERSION} https://github.com/dashpay/dash_hash
 RUN cd dash_hash && python3 setup.py install
 
 ARG USER_ID=1000


### PR DESCRIPTION
## Issue being fixed or feature implemented
should fix ci failures like https://gitlab.com/dashpay/dash/-/jobs/4261565118 in #5291 

## What was done?
Use the exact dash_hash version/tag instead of simply using `master`. Bumping `DASH_HASH_VERSION` invalidates docker cache.

## How Has This Been Tested?
Ran it in my gitlab ci

## Breaking Changes
n/a


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

