### PR TITLE
fix: do not hold cs_map_quorums for too long

### DIFF
--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -259,7 +259,7 @@ private:
     // all private methods here are cs_main-free
     void CheckQuorumConnections(const Consensus::LLMQParams& llmqParams, const CBlockIndex *pindexNew) const;
 
-    CQuorumPtr BuildQuorumFromCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex) const EXCLUSIVE_LOCKS_REQUIRED(cs_map_quorums);
+    CQuorumPtr BuildQuorumFromCommitment(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex) const;
     bool BuildQuorumContributions(const CFinalCommitmentPtr& fqc, const std::shared_ptr<CQuorum>& quorum) const;
 
     CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const CBlockIndex* pindex) const;


### PR DESCRIPTION
## Issue being fixed or feature implemented
`cs_map_quorums` was introduced to protect `mapQuorumsCache` only. We shouldn't hold it for too long or require it to be held in `BuildQuorumFromCommitment`.

## What was done?
limit the scope of `cs_map_quorums`

## How Has This Been Tested?
build and run tests locally and in gitlab ci

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

