### PR TITLE
ci: build TSan with clang 15 and add -Werror=thread-safety, fix-up stacktraces

### DIFF
--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -12,5 +12,6 @@ export DEP_OPTS="NO_UPNP=1 DEBUG=1"
 export TEST_RUNNER_EXTRA="--extended --exclude feature_pruning,feature_dbcrash,wallet_multiwallet.py" # Temporarily suppress ASan heap-use-after-free (see issue #14163)
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --with-sanitizers=thread"
+export BITCOIN_CONFIG="${BITCOIN_CONFIG} CC=clang-15 CXX=clang++-15 CXXFLAGS=-Werror=thread-safety"
 export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG"
 export PYZMQ=true

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -11,7 +11,7 @@ export PACKAGES="clang-8 llvm-8 python3-zmq qtbase5-dev qttools5-dev-tools libev
 export DEP_OPTS="NO_UPNP=1 DEBUG=1"
 export TEST_RUNNER_EXTRA="--extended --exclude feature_pruning,feature_dbcrash,wallet_multiwallet.py" # Temporarily suppress ASan heap-use-after-free (see issue #14163)
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --with-sanitizers=thread"
+export BITCOIN_CONFIG="--enable-zmq --enable-reduce-exports --enable-crash-hooks --enable-suppress-external-warnings --with-sanitizers=thread"
 export BITCOIN_CONFIG="${BITCOIN_CONFIG} CC=clang-15 CXX=clang++-15 CXXFLAGS=-Werror=thread-safety"
 export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG"
 export PYZMQ=true

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -77,8 +77,7 @@ RUN apt-get update && apt-get install $APT_ARGS \
     wine-stable \
     wine32 \
     wine64 \
-    xorriso \
-    && rm -rf /var/lib/apt/lists/*
+    xorriso
 
 ARG CPPCHECK_VERSION=2.10
 RUN curl -sL "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" | tar -xvzf - --directory /tmp/
@@ -101,6 +100,20 @@ RUN \
   update-alternatives --set x86_64-w64-mingw32-gcc  /usr/bin/x86_64-w64-mingw32-gcc-posix; \
   update-alternatives --set x86_64-w64-mingw32-g++  /usr/bin/x86_64-w64-mingw32-g++-posix; \
   exit 0
+
+ARG LLVM_VERSION=15
+# Setup Clang+LLVM support
+RUN apt-get update && apt-get install $APT_ARGS \
+    lsb-release \
+    software-properties-common \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd /tmp && \
+    wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    /tmp/llvm.sh ${LLVM_VERSION} && \
+    rm -rf /tmp/llvm.sh
 
 RUN \
   mkdir -p /src/dash && \

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -536,12 +536,9 @@ static std::map<void*, std::shared_ptr<std::vector<uint64_t>>> g_stacktraces;
 
 #if CRASH_HOOKS_WRAPPED_CXX_ABI
 // These come in through -Wl,-wrap
-// It only works on GCC
 extern "C" void* __real___cxa_allocate_exception(size_t thrown_size);
 extern "C" void __real___cxa_free_exception(void * thrown_exception);
-#if __clang__
-#error not supported on WIN32 (no dlsym support)
-#elif WIN32
+#if WIN32
 extern "C" void __real__assert(const char *assertion, const char *file, unsigned int line);
 extern "C" void __real__wassert(const wchar_t *assertion, const wchar_t *file, unsigned int line);
 #else

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -557,7 +557,7 @@ extern "C" void __real___cxa_free_exception(void * thrown_exception)
     static auto f = (void(*)(void*))dlsym(RTLD_NEXT, "__cxa_free_exception");
     return f(thrown_exception);
 }
-#if defined(__clang__)
+#if defined(__clang__) && defined(__APPLE__)
 extern "C" void __attribute__((noreturn)) __real___assert_rtn(const char *function, const char *file, int line, const char *assertion)
 {
     static auto f = (void(__attribute__((noreturn)) *) (const char*, const char*, int, const char*))dlsym(RTLD_NEXT, "__assert_rtn");
@@ -622,7 +622,7 @@ static __attribute__((noinline)) crash_info GetCrashInfoFromAssertion(const char
     return ci;
 }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(__APPLE__)
 extern "C" void __attribute__((noinline)) WRAPPED_NAME(__assert_rtn)(const char *function, const char *file, int line, const char *assertion)
 {
     auto ci = GetCrashInfoFromAssertion(assertion, file, line, function);

--- a/src/stacktraces.cpp
+++ b/src/stacktraces.cpp
@@ -18,7 +18,7 @@
 #include <memory>
 #include <atomic>
 
-#if WIN32
+#if defined(WIN32)
 #include <windows.h>
 #include <dbghelp.h>
 #include <thread>
@@ -30,14 +30,14 @@
 #include <csignal>
 #endif
 
-#if !WIN32
+#if !defined(WIN32)
 #include <dlfcn.h>
-#if !__APPLE__
+#if !defined(__APPLE__)
 #include <link.h>
 #endif
 #endif
 
-#if __APPLE__
+#if defined(__APPLE__)
 #include <mach-o/dyld.h>
 #include <mach/mach_init.h>
 #include <sys/sysctl.h>
@@ -52,7 +52,7 @@
 
 std::string DemangleSymbol(const std::string& name)
 {
-#if __GNUC__ || __clang__
+#if defined(__GNUC__) || defined(__clang__)
     int status = -4; // some arbitrary value to eliminate the compiler warning
     char* str = abi::__cxa_demangle(name.c_str(), nullptr, nullptr, &status);
     if (status != 0) {
@@ -74,7 +74,7 @@ static std::atomic<bool> skipAbortSignal(false);
 
 static ssize_t GetExeFileNameImpl(char* buf, size_t bufSize)
 {
-#if WIN32
+#if defined(WIN32)
     std::vector<TCHAR> tmp(bufSize);
     DWORD len = GetModuleFileName(nullptr, tmp.data(), bufSize);
     if (len >= bufSize) {
@@ -84,7 +84,7 @@ static ssize_t GetExeFileNameImpl(char* buf, size_t bufSize)
         buf[i] = (char)tmp[i];
     }
     return len;
-#elif __APPLE__
+#elif defined(__APPLE__)
     uint32_t bufSize2 = (uint32_t)bufSize;
     if (_NSGetExecutablePath(buf, &bufSize2) != 0) {
         // it's not entirely clear if the value returned by _NSGetExecutablePath includes the null character
@@ -127,7 +127,7 @@ static void my_backtrace_error_callback (void *data, const char *msg,
 
 static backtrace_state* GetLibBacktraceState()
 {
-#if WIN32
+#if defined(WIN32)
     // libbacktrace is not able to handle the DWARF debuglink in the .exe
     // but luckily we can just specify the .dbg file here as it's a valid PE/XCOFF file
     static std::string debugFileName = g_exeFileName + ".dbg";
@@ -140,7 +140,7 @@ static backtrace_state* GetLibBacktraceState()
 }
 #endif // ENABLE_STACKTRACES
 
-#if WIN32
+#if defined(WIN32)
 static uint64_t GetBaseAddress()
 {
     return 0;
@@ -188,7 +188,7 @@ static __attribute__((noinline)) std::vector<uint64_t> GetStackFrames(size_t ski
     STACKFRAME64 stackframe;
     ZeroMemory(&stackframe, sizeof(STACKFRAME64));
 
-#ifdef __i386__
+#if defined(__i386__)
     image = IMAGE_FILE_MACHINE_I386;
     stackframe.AddrPC.Offset = context.Eip;
     stackframe.AddrPC.Mode = AddrModeFlat;
@@ -196,7 +196,7 @@ static __attribute__((noinline)) std::vector<uint64_t> GetStackFrames(size_t ski
     stackframe.AddrFrame.Mode = AddrModeFlat;
     stackframe.AddrStack.Offset = context.Esp;
     stackframe.AddrStack.Mode = AddrModeFlat;
-#elif __x86_64__
+#elif defined(__x86_64__)
     image = IMAGE_FILE_MACHINE_AMD64;
     stackframe.AddrPC.Offset = context.Rip;
     stackframe.AddrPC.Mode = AddrModeFlat;
@@ -240,7 +240,7 @@ static __attribute__((noinline)) std::vector<uint64_t> GetStackFrames(size_t ski
 }
 #else
 
-#if __APPLE__
+#if defined(__APPLE__)
 static uint64_t GetBaseAddress()
 {
     mach_port_name_t target_task;
@@ -534,11 +534,11 @@ static void PrintCrashInfo(const crash_info& ci)
 static StdMutex g_stacktraces_mutex;
 static std::map<void*, std::shared_ptr<std::vector<uint64_t>>> g_stacktraces;
 
-#if CRASH_HOOKS_WRAPPED_CXX_ABI
+#ifdef CRASH_HOOKS_WRAPPED_CXX_ABI
 // These come in through -Wl,-wrap
 extern "C" void* __real___cxa_allocate_exception(size_t thrown_size);
 extern "C" void __real___cxa_free_exception(void * thrown_exception);
-#if WIN32
+#if defined(WIN32)
 extern "C" void __real__assert(const char *assertion, const char *file, unsigned int line);
 extern "C" void __real__wassert(const wchar_t *assertion, const wchar_t *file, unsigned int line);
 #else
@@ -557,13 +557,13 @@ extern "C" void __real___cxa_free_exception(void * thrown_exception)
     static auto f = (void(*)(void*))dlsym(RTLD_NEXT, "__cxa_free_exception");
     return f(thrown_exception);
 }
-#if __clang__
+#if defined(__clang__)
 extern "C" void __attribute__((noreturn)) __real___assert_rtn(const char *function, const char *file, int line, const char *assertion)
 {
     static auto f = (void(__attribute__((noreturn)) *) (const char*, const char*, int, const char*))dlsym(RTLD_NEXT, "__assert_rtn");
     f(function, file, line, assertion);
 }
-#elif WIN32
+#elif defined(WIN32)
 #error not supported on WIN32 (no dlsym support)
 #else
 extern "C" void __real___assert_fail(const char *assertion, const char *file, unsigned int line, const char *function)
@@ -574,7 +574,7 @@ extern "C" void __real___assert_fail(const char *assertion, const char *file, un
 #endif
 #endif
 
-#if CRASH_HOOKS_WRAPPED_CXX_ABI
+#ifdef CRASH_HOOKS_WRAPPED_CXX_ABI
 #define WRAPPED_NAME(x) __wrap_##x
 #else
 #define WRAPPED_NAME(x) x
@@ -622,7 +622,7 @@ static __attribute__((noinline)) crash_info GetCrashInfoFromAssertion(const char
     return ci;
 }
 
-#if __clang__
+#if defined(__clang__)
 extern "C" void __attribute__((noinline)) WRAPPED_NAME(__assert_rtn)(const char *function, const char *file, int line, const char *assertion)
 {
     auto ci = GetCrashInfoFromAssertion(assertion, file, line, function);
@@ -630,7 +630,7 @@ extern "C" void __attribute__((noinline)) WRAPPED_NAME(__assert_rtn)(const char 
     skipAbortSignal = true;
     __real___assert_rtn(function, file, line, assertion);
 }
-#elif WIN32
+#elif defined(WIN32)
 extern "C" void __attribute__((noinline)) WRAPPED_NAME(_assert)(const char *assertion, const char *file, unsigned int line)
 {
     auto ci = GetCrashInfoFromAssertion(assertion, file, line, nullptr);
@@ -760,7 +760,7 @@ void RegisterPrettyTerminateHander()
     std::set_terminate(terminate_handler);
 }
 
-#if !WIN32
+#if !defined(WIN32)
 static void HandlePosixSignal(int s)
 {
     if (s == SIGABRT && skipAbortSignal) {
@@ -837,7 +837,7 @@ LONG WINAPI HandleWindowsException(EXCEPTION_POINTERS * ExceptionInfo)
 
 void RegisterPrettySignalHandlers()
 {
-#if WIN32
+#if defined(WIN32)
     SetUnhandledExceptionFilter(HandleWindowsException);
 #else
     const std::vector<int> posix_signals = {
@@ -853,7 +853,7 @@ void RegisterPrettySignalHandlers()
             SIGTRAP,    // Trace/breakpoint trap
             SIGXCPU,    // CPU time limit exceeded (4.2BSD)
             SIGXFSZ,    // File size limit exceeded (4.2BSD)
-#if __APPLE__
+#if defined(__APPLE__)
             SIGEMT,     // emulation instruction executed
 #endif
     };


### PR DESCRIPTION
 ## Description

Pull request was inspired by the need to debug lock problems when working on https://github.com/dashpay/dash/pull/5352.

As far as I'm aware, only macOS has `-Werror=thread-safety` as part of its default `CXXFLAGS` despite the capability being present on Linux as well. This PR introduces thread safety checks for that into our thread sanitizer build.

Additionally, since we're using Clang, something that on first glimpse, appears to be something that `stacktraces.cpp` isn't happy with, due to `-Wl,-wrap` being available only on GCC, that no longer seems to be the case, since the version of Clang with comes with `focal`, its `lld` _does_ have support for `-wrap` (see [man page for `lld` on `focal`](https://manpages.ubuntu.com/manpages/focal/en/man1/lld.1.html)).

The current `stable` version of Clang/LLVM is 15, at the time of this pull request (see https://apt.llvm.org/) but `focal` ships with an older version, requiring us to use the official LLVM APT repository. I feel we should be testing with recent compilers alongside the ones shipped by LTS distributions. 

Certain bugs are only made apparent when testing on rolling release distros or distros that have faster update cycles, like Fedora (see https://github.com/dashpay/dash/pull/5295 for an illustration of that), which ship with more recent compilers. Until we overhaul our CI systems to test using those distros directly (our current infrastructure is centered around using a "development image" with an LTS distro as the base), this is the best we can do.

A similar pull request testing against the latest GCC stable will be welcome as that is currently outside the scope of this PR as the changes made were to make sure that builds were operating as expected on Clang/LLVM 15.