### PR TITLE
test: Fix tsan build failure

### DIFF
--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -40,13 +40,8 @@ const int window{500}, th_start{400}, th_end{300};
 
 struct TestChainBRRBeforeActivationSetup : public TestChainSetup
 {
-    TestChainBRRBeforeActivationSetup() : TestChainSetup(497)
-    {
-        // Force fast DIP3 activation
-        gArgs.ForceSetArg("-dip3params", "30:50");
-        SelectParams(CBaseChainParams::REGTEST);
-        gArgs.ForceRemoveArg("dip3params");
-    }
+    // Force fast DIP3 activation
+    TestChainBRRBeforeActivationSetup() : TestChainSetup(497, {"-dip3params=30:50"}) {}
 };
 
 static SimpleUTXOMap BuildSimpleUtxoMap(const std::vector<CTransactionRef>& txs)

--- a/src/test/dynamic_activation_thresholds_tests.cpp
+++ b/src/test/dynamic_activation_thresholds_tests.cpp
@@ -34,10 +34,7 @@ static constexpr int threshold(int attempt)
 
 struct TestChainDATSetup : public TestChainSetup
 {
-    TestChainDATSetup() : TestChainSetup(window - 2) {
-        gArgs.ForceSetArg("-vbparams","testdummy:0:999999999999:100:80:60:5");
-        SelectParams(CBaseChainParams::REGTEST);
-    }
+    TestChainDATSetup() : TestChainSetup(window - 2, {"-vbparams=testdummy:0:999999999999:100:80:60:5"}) {}
 
     void signal(int num_blocks, bool expected_lockin)
     {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -259,7 +259,8 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     }
 }
 
-TestChainSetup::TestChainSetup(int blockCount)
+TestChainSetup::TestChainSetup(int blockCount, const std::vector<const char*>& extra_args)
+    : RegTestingSetup(extra_args)
 {
     // Generate a 100-block chain:
     coinbaseKey.MakeNewKey(true);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -261,11 +261,6 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
 
 TestChainSetup::TestChainSetup(int blockCount)
 {
-    // Make sure CreateAndProcessBlock() support building <deployment_name> blocks before activating it in these tests.
-    //gArgs.ForceSetArg("-vbparams", strprintf("deployment_name:0:%d", (int64_t)Consensus::BIP9Deployment::NO_TIMEOUT));
-    // Need to recreate chainparams
-    SelectParams(CBaseChainParams::REGTEST);
-
     // Generate a 100-block chain:
     coinbaseKey.MakeNewKey(true);
     CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -102,8 +102,8 @@ struct TestingSetup : public ChainTestingSetup {
 
 /** Identical to TestingSetup, but chain set to regtest */
 struct RegTestingSetup : public TestingSetup {
-    RegTestingSetup()
-        : TestingSetup{CBaseChainParams::REGTEST} {}
+    RegTestingSetup(const std::vector<const char*>& extra_args = {})
+        : TestingSetup{CBaseChainParams::REGTEST, extra_args} {}
 };
 
 class CBlock;
@@ -112,7 +112,7 @@ class CScript;
 
 struct TestChainSetup : public RegTestingSetup
 {
-    TestChainSetup(int blockCount);
+    TestChainSetup(int blockCount, const std::vector<const char*>& extra_args = {});
     ~TestChainSetup();
 
     /**


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should fix tasn build failures observed in #5365 

## What was done?
Complete 19775 backport + fix Dash-specific parts to follow the same logic ("avoid calling SelectParams twice")

## How Has This Been Tested?
https://gitlab.com/UdjinM6/dash/-/jobs/4297285595 + ran `test_dash` built with `--with-sanitizers=thread` on linux vps

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

