### PR TITLE
feat: mnlistdiff v20 CL sig quorums 

### DIFF
--- a/doc/release-notes-5377.md
+++ b/doc/release-notes-5377.md
@@ -1,0 +1,25 @@
+Updated RPCs
+--------
+
+- `protx diff` RPC returns a new field `quorumsCLSigs`.
+This field is a list of: Chainlock signature and the list of corresponding quorum indexes in `newQuorums`.
+
+`MNLISTDIFF` P2P message
+--------
+
+Starting with protocol version `70228`, the following fields is added to the `MNLISTDIFF` after `newQuorums`.
+
+| Field              | Type                  | Size     | Description                                                         |
+|--------------------|-----------------------|----------|---------------------------------------------------------------------|
+| quorumsCLSigsCount | compactSize uint      | 1-9      | Number of quorumsCLSigs elements                                    |
+| quorumsCLSigs      | quorumsCLSigsObject[] | variable | CL Sig used to calculate members per quorum indexes (in newQuorums) |
+
+The content of `quorumsCLSigsObject`:
+
+| Field         | Type             | Size     | Description                                                                                 |
+|---------------|------------------|----------|---------------------------------------------------------------------------------------------|
+| signature     | BLSSig           | 96       | Chainlock signature                                                                         |
+| indexSetCount | compactSize uint | 1-9      | Number of quorum indexes using the same `signature` for their member calculation            |
+| indexSet      | uint16_t[]       | variable | Quorum indexes corresponding in `newQuorums` using `signature` for their member calculation |
+
+Note: The field `quorumsCLSigs` in both RPC and P2P will be populated only after the v20 activation.

--- a/doc/release-notes-5377.md
+++ b/doc/release-notes-5377.md
@@ -7,7 +7,7 @@ This field is a list containing: a ChainLock signature and the list of correspon
 `MNLISTDIFF` P2P message
 --------
 
-Starting with protocol version `70228`, the following fields are added to the `MNLISTDIFF` after `newQuorums`.
+Starting with protocol version `70229`, the following fields are added to the `MNLISTDIFF` after `newQuorums`.
 
 | Field              | Type                  | Size     | Description                                                         |
 |--------------------|-----------------------|----------|---------------------------------------------------------------------|

--- a/doc/release-notes-5377.md
+++ b/doc/release-notes-5377.md
@@ -2,12 +2,12 @@ Updated RPCs
 --------
 
 - `protx diff` RPC returns a new field `quorumsCLSigs`.
-This field is a list of: Chainlock signature and the list of corresponding quorum indexes in `newQuorums`.
+This field is a list containing: a ChainLock signature and the list of corresponding quorum indexes in `newQuorums`.
 
 `MNLISTDIFF` P2P message
 --------
 
-Starting with protocol version `70228`, the following fields is added to the `MNLISTDIFF` after `newQuorums`.
+Starting with protocol version `70228`, the following fields are added to the `MNLISTDIFF` after `newQuorums`.
 
 | Field              | Type                  | Size     | Description                                                         |
 |--------------------|-----------------------|----------|---------------------------------------------------------------------|
@@ -18,8 +18,8 @@ The content of `quorumsCLSigsObject`:
 
 | Field         | Type             | Size     | Description                                                                                 |
 |---------------|------------------|----------|---------------------------------------------------------------------------------------------|
-| signature     | BLSSig           | 96       | Chainlock signature                                                                         |
+| signature     | BLSSig           | 96       | ChainLock signature                                                                         |
 | indexSetCount | compactSize uint | 1-9      | Number of quorum indexes using the same `signature` for their member calculation            |
 | indexSet      | uint16_t[]       | variable | Quorum indexes corresponding in `newQuorums` using `signature` for their member calculation |
 
-Note: The field `quorumsCLSigs` in both RPC and P2P will be populated only after the v20 activation.
+Note: The `quorumsCLSigs` field in both RPC and P2P will only be populated after the v20 activation.

--- a/doc/release-notes-5377.md
+++ b/doc/release-notes-5377.md
@@ -7,7 +7,7 @@ This field is a list containing: a ChainLock signature and the list of correspon
 `MNLISTDIFF` P2P message
 --------
 
-Starting with protocol version `70229`, the following fields are added to the `MNLISTDIFF` after `newQuorums`.
+Starting with protocol version `70230`, the following fields are added to the `MNLISTDIFF` after `newQuorums`.
 
 | Field              | Type                  | Size     | Description                                                         |
 |--------------------|-----------------------|----------|---------------------------------------------------------------------|

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -88,6 +88,10 @@ public:
     {
         return !((*this) == r);
     }
+    bool operator<(const C& r) const
+    {
+        return GetHash() < r.GetHash();
+    }
 
     bool IsValid() const
     {

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -24,6 +24,7 @@
 #include <validation.h>
 #include <key_io.h>
 #include <util/underlying.h>
+#include <util/enumerate.h>
 
 CSimplifiedMNListEntry::CSimplifiedMNListEntry(const CDeterministicMN& dmn) :
     proRegTxHash(dmn.proTxHash),
@@ -189,8 +190,7 @@ bool CSimplifiedMNListDiff::BuildQuorumChainlockInfo(const CBlockIndex* blockInd
     // We want to avoid to load CbTx now, as more than one quorum will target the same block: hence we want to load CbTxs once per block (heavy operation).
     std::multimap<const CBlockIndex*, uint16_t>  workBaseBlockIndexMap;
 
-    uint16_t idx = 0;
-    for (const auto& e : newQuorums) {
+    for (const auto [idx, e] : enumerate(newQuorums)) {
         auto quorum = llmq::quorumManager->GetQuorum(e.llmqType, e.quorumHash);
         // In case of rotation, all rotated quorums rely on the CL sig expected in the cycleBlock (the block of the first DKG) - 8
         // In case of non-rotation, quorums rely on the CL sig expected in the block of the DKG - 8
@@ -198,7 +198,6 @@ bool CSimplifiedMNListDiff::BuildQuorumChainlockInfo(const CBlockIndex* blockInd
                 blockIndex->GetAncestor(quorum->m_quorum_base_block_index->nHeight - quorum->qc->quorumIndex - 8);
 
         workBaseBlockIndexMap.insert(std::make_pair(pWorkBaseBlockIndex, idx));
-        idx++;
     }
 
     for(auto it = workBaseBlockIndexMap.begin(); it != workBaseBlockIndexMap.end(); ) {

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -191,19 +191,11 @@ bool CSimplifiedMNListDiff::BuildQuorumChainlockInfo(const CBlockIndex* blockInd
 
     uint16_t idx = 0;
     for (const auto& e : newQuorums) {
-        auto opt_params = llmq::GetLLMQParams(e.llmqType);
-        assert(opt_params.has_value());
-        Consensus::LLMQParams llmq_params = opt_params.value();
-        auto q = llmq::quorumManager->GetQuorum(e.llmqType, e.quorumHash);
-        const CBlockIndex* pWorkBaseBlockIndex = nullptr;
-        if (llmq_params.useRotation) {
-            // In case of rotation, all rotated quorums rely on the CL sig expected in the cycleBlock (the block of the first DKG) - 8
-            pWorkBaseBlockIndex = blockIndex->GetAncestor(q->m_quorum_base_block_index->nHeight - q->qc->quorumIndex - 8);
-        }
-        else {
-            // In case of non-rotation, quorums rely on the CL sig expected in the block of the DKG - 8
-            pWorkBaseBlockIndex = blockIndex->GetAncestor(q->m_quorum_base_block_index->nHeight - 8);
-        }
+        auto quorum = llmq::quorumManager->GetQuorum(e.llmqType, e.quorumHash);
+        // In case of rotation, all rotated quorums rely on the CL sig expected in the cycleBlock (the block of the first DKG) - 8
+        // In case of non-rotation, quorums rely on the CL sig expected in the block of the DKG - 8
+        const CBlockIndex* pWorkBaseBlockIndex =
+                blockIndex->GetAncestor(quorum->m_quorum_base_block_index->nHeight - quorum->qc->quorumIndex - 8);
 
         workBaseBlockIndexMap.insert(std::make_pair(pWorkBaseBlockIndex, idx));
         idx++;

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -209,22 +209,16 @@ bool CSimplifiedMNListDiff::BuildQuorumChainlockInfo(const CBlockIndex* blockInd
             sig = cbcl.value().first;
         }
         // Get the range of indexes (values) for the current key and merge them into a single std::set
-        const auto range = workBaseBlockIndexMap.equal_range(it->first);
+        const auto [begin, end] = workBaseBlockIndexMap.equal_range(it->first);
         std::set<uint16_t> idx_set;
-        for (auto jt = range.first; jt != range.second; ++jt) {
-            idx_set.insert(jt->second);
-        }
+        std::transform(begin, end, std::inserter(idx_set, idx_set.end()), [](const auto& pair) { return pair.second; });
         // Advance the iterator to the next key
-        it = range.second;
+        it = end;
 
         // Different CBlockIndex can contain the same CL sig in CbTx (both non-null or null during the first blocks after v20 activation)
         // Hence, we need to merge the std::set if another std::set already exists for the same sig.
-        auto it_sig = quorumsCLSigs.find(sig);
-        if (it_sig != quorumsCLSigs.end()) {
+        if (auto [it_sig, inserted] = quorumsCLSigs.insert({sig, idx_set}); !inserted) {
             it_sig->second.insert(idx_set.begin(), idx_set.end());
-        }
-        else {
-            quorumsCLSigs.insert(std::make_pair(sig, idx_set));
         }
     }
 

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -298,13 +298,13 @@ void CSimplifiedMNListDiff::ToJson(UniValue& obj, bool extended) const
 
     UniValue quorumsCLSigsArr(UniValue::VARR);
     for (const auto& [signature, quorumsIndexes] : quorumsCLSigs) {
-        UniValue obj(UniValue::VOBJ);
+        UniValue j(UniValue::VOBJ);
         UniValue idxArr(UniValue::VARR);
         for (const auto& idx : quorumsIndexes) {
             idxArr.push_back(idx);
         }
-        obj.pushKV(signature.ToString(),idxArr);
-        quorumsCLSigsArr.push_back(obj);
+        j.pushKV(signature.ToString(),idxArr);
+        quorumsCLSigsArr.push_back(j);
     }
     obj.pushKV("quorumsCLSigs", quorumsCLSigsArr);
 }

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -6,7 +6,6 @@
 
 #include <evo/cbtx.h>
 #include <core_io.h>
-#include <evo/cbtx.h>
 #include <evo/deterministicmns.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/commitment.h>

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -123,15 +123,6 @@ public:
 
 class CSimplifiedMNListDiff
 {
-private:
-    struct BLSSignatureCompare {
-        // CBLSSignature doesn't support operator< needed for std::map quorumsCLSigs
-        // Hence we compare instead the hash (uint256) of each CBLSSignature
-        // Hash of each CBLSSignature should already be calculated and cached: no perf penalty
-        bool operator() (const CBLSSignature& a, const CBLSSignature& b) const {
-            return a.GetHash() < b.GetHash();
-        }
-    };
 public:
     static constexpr uint16_t CURRENT_VERSION = 1;
 
@@ -148,7 +139,7 @@ public:
 
     // Map of Chainlock Signature used for shuffling per set of quorums
     // The set of quorums is the set of indexes corresponding to entries in newQuorums
-    std::map<CBLSSignature, std::set<uint16_t>, BLSSignatureCompare> quorumsCLSigs;
+    std::map<CBLSSignature, std::set<uint16_t>> quorumsCLSigs;
 
     SERIALIZE_METHODS(CSimplifiedMNListDiff, obj)
     {

--- a/src/version.h
+++ b/src/version.h
@@ -9,6 +9,8 @@
 /**
  * network protocol versioning
  */
+
+
 static const int PROTOCOL_VERSION = 70230;
 
 //! initial proto version, to be increased after version/verack negotiation

--- a/src/version.h
+++ b/src/version.h
@@ -18,7 +18,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION = 70215;
 
 //! minimum proto version of masternode to accept in DKGs
-static const int MIN_MASTERNODE_PROTO_VERSION = 70227;
+static const int MIN_MASTERNODE_PROTO_VERSION = 70230;
 
 //! protocol version is included in MNAUTH starting with this version
 static const int MNAUTH_NODE_VER_VERSION = 70218;

--- a/src/version.h
+++ b/src/version.h
@@ -9,9 +9,7 @@
 /**
  * network protocol versioning
  */
-
-
-static const int PROTOCOL_VERSION = 70229;
+static const int PROTOCOL_VERSION = 70230;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -54,6 +52,9 @@ static const int SMNLE_VERSIONED_PROTO_VERSION = 70228;
 
 //! Versioned Simplified Masternode List Entries were introduced in this version
 static const int MNLISTDIFF_VERSION_ORDER = 70229;
+
+//! Masternode type was introduced in this version
+static const int MNLISTDIFF_CHAINLOCKS_PROTO_VERSION = 70230;
 
 // Make sure that none of the values above collide with `ADDRV2_FORMAT`.
 

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -132,7 +132,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
 
         # And for the remaining blocks, enforce new CL in CbTx
         skip_count = 23 - (self.nodes[0].getblockcount() % 24)
-        for i in range(15):
+        for i in range(skip_count):
             self.nodes[0].generate(1)
             self.sync_blocks(nodes)
             self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -9,8 +9,6 @@ feature_llmq_rotation.py
 Checks LLMQs Quorum Rotation
 
 '''
-import hashlib
-import random
 import struct
 from io import BytesIO
 

--- a/test/lint/lint-cppcheck-dash.sh
+++ b/test/lint/lint-cppcheck-dash.sh
@@ -34,7 +34,7 @@ IGNORED_WARNINGS=(
     "src/test/dip0020opcodes_tests.cpp:.* warning: There is an unknown macro here somewhere. Configuration is required. If BOOST_FIXTURE_TEST_SUITE is a macro then please configure it."
     "src/ctpl_stl.h:.*22: warning: Dereferencing '_f' after it is deallocated / released"
     "src/cachemultimap.h:.*: warning: Variable 'mapIt' can be declared as reference to const"
-
+    "src/evo/simplifiedmns.cpp:304:20: warning: Consider using std::copy algorithm instead of a raw loop."
 #    "src/llmq/snapshot.cpp:.*:17: warning: Consider using std::copy algorithm instead of a raw loop."
 #    "src/llmq/snapshot.cpp:.*:18: warning: Consider using std::copy algorithm instead of a raw loop."
 

--- a/test/lint/lint-cppcheck-dash.sh
+++ b/test/lint/lint-cppcheck-dash.sh
@@ -34,7 +34,7 @@ IGNORED_WARNINGS=(
     "src/test/dip0020opcodes_tests.cpp:.* warning: There is an unknown macro here somewhere. Configuration is required. If BOOST_FIXTURE_TEST_SUITE is a macro then please configure it."
     "src/ctpl_stl.h:.*22: warning: Dereferencing '_f' after it is deallocated / released"
     "src/cachemultimap.h:.*: warning: Variable 'mapIt' can be declared as reference to const"
-    "src/evo/simplifiedmns.cpp:304:20: warning: Consider using std::copy algorithm instead of a raw loop."
+    "src/evo/simplifiedmns.cpp:.*:20: warning: Consider using std::copy algorithm instead of a raw loop."
 #    "src/llmq/snapshot.cpp:.*:17: warning: Consider using std::copy algorithm instead of a raw loop."
 #    "src/llmq/snapshot.cpp:.*:18: warning: Consider using std::copy algorithm instead of a raw loop."
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Implementation of Randomness Beacon Part 3.

Starting from v20 activation fork, members for quorums are sorted using (if available) the best CL signature found in Coinbase.
If no CL signature is present yet, then the usual way is used (By using Blockhash instead)

The actual new way to shuffle is already implemented in https://github.com/dashpay/dash/pull/5366.

SPV clients also need to calculate members, but they only know block headers. 
Since Coinbase is in the actual block, then they lack the required information to correctly calculate quorum members.

## What was done?
-  Message `MNLISTIDFF` is enriched with a new field `quorumsCLSigs`. This field holds the Chainlock Signature required for each set of indexes corresponding to quorums in field `newQuorums`.
-  Protocol version has been bumped to `70230`.
-  Clients with protocol version greater or equal to `70230` will receive the new field `quorumsCLSigs`.
- The same field is returned in `protx diff` RPC.

Note:
- Field `quorumsCLSigs` will populated only after v20 activation
- If for one or more quorums, no non-null CL sig was found in CbTx then a null signature is returned in `quorumsCLSigs`.

## How Has This Been Tested?
- Functional test mininode's protocol version was bumped to `70230`.
- `feature_llmq_rotation.py` checks that `quorumsCLSigs` match in both P2P and RPC messages.

## Breaking Changes
No

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

