### PR TITLE
backport: bitcoin#17725, #18304, #18392, #18430, #18438, #18441, #18477, #18562, #18569, #18683, #18899, #18912, #19159, #19669, partial #14794 - asan/valgrind CI changes

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ task:
   timeout_in: 60m
   env:
     MAKEJOBS: "-j9"
-    RUN_CI_ON_HOST: "1"
+    DANGER_RUN_CI_ON_HOST: "1"
     CCACHE_SIZE: "200M"
     CCACHE_DIR: "/tmp/ccache_dir"
   ccache_cache:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -279,14 +279,14 @@ linux64_nowallet-build:
   variables:
     BUILD_TARGET: linux64_nowallet
 
-linux64_valgrind-build:
-  extends:
-    - .build-template
-    - .skip-in-fast-mode-template
-  needs:
-    - x86_64-pc-linux-gnu-debug
-  variables:
-    BUILD_TARGET: linux64_valgrind
+#linux64_valgrind-build:
+#  extends:
+#    - .build-template
+#    - .skip-in-fast-mode-template
+#  needs:
+#    - x86_64-pc-linux-gnu-debug
+#  variables:
+#    BUILD_TARGET: linux64_valgrind
 
 mac-build:
   extends:
@@ -333,11 +333,11 @@ linux64_ubsan-test:
   variables:
     BUILD_TARGET: linux64_ubsan
 
-linux64_valgrind-test:
-  extends:
-    - .test-template
-    - .skip-in-fast-mode-template
-  needs:
-    - linux64_valgrind-build
-  variables:
-    BUILD_TARGET: linux64_valgrind
+#linux64_valgrind-test:
+#  extends:
+#    - .test-template
+#    - .skip-in-fast-mode-template
+#  needs:
+#    - linux64_valgrind-build
+#  variables:
+#    BUILD_TARGET: linux64_valgrind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -279,6 +279,15 @@ linux64_nowallet-build:
   variables:
     BUILD_TARGET: linux64_nowallet
 
+linux64_valgrind-build:
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
+  needs:
+    - x86_64-pc-linux-gnu-debug
+  variables:
+    BUILD_TARGET: linux64_valgrind
+
 mac-build:
   extends:
     - .build-template
@@ -323,3 +332,12 @@ linux64_ubsan-test:
     - linux64_ubsan-build
   variables:
     BUILD_TARGET: linux64_ubsan
+
+linux64_valgrind-test:
+  extends:
+    - .test-template
+    - .skip-in-fast-mode-template
+  needs:
+    - linux64_valgrind-build
+  variables:
+    BUILD_TARGET: linux64_valgrind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -252,6 +252,15 @@ linux64_fuzz-build:
   variables:
     BUILD_TARGET: linux64_fuzz
 
+linux64_asan-build:
+  extends:
+    - .build-template
+    - .skip-in-fast-mode-template
+  needs:
+    - x86_64-pc-linux-gnu-debug
+  variables:
+    BUILD_TARGET: linux64_asan
+
 linux64_tsan-build:
   extends:
     - .build-template
@@ -314,6 +323,15 @@ linux64_sqlite-test:
     - linux64_sqlite-build
   variables:
     BUILD_TARGET: linux64_sqlite
+
+linux64_asan-test:
+  extends:
+    - .test-template
+    - .skip-in-fast-mode-template
+  needs:
+    - linux64_asan-build
+  variables:
+    BUILD_TARGET: linux64_asan
 
 linux64_tsan-test:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -252,14 +252,14 @@ linux64_fuzz-build:
   variables:
     BUILD_TARGET: linux64_fuzz
 
-linux64_asan-build:
-  extends:
-    - .build-template
-    - .skip-in-fast-mode-template
-  needs:
-    - x86_64-pc-linux-gnu-debug
-  variables:
-    BUILD_TARGET: linux64_asan
+#linux64_asan-build:
+#  extends:
+#    - .build-template
+#    - .skip-in-fast-mode-template
+#  needs:
+#    - x86_64-pc-linux-gnu-debug
+#  variables:
+#    BUILD_TARGET: linux64_asan
 
 linux64_tsan-build:
   extends:
@@ -324,14 +324,14 @@ linux64_sqlite-test:
   variables:
     BUILD_TARGET: linux64_sqlite
 
-linux64_asan-test:
-  extends:
-    - .test-template
-    - .skip-in-fast-mode-template
-  needs:
-    - linux64_asan-build
-  variables:
-    BUILD_TARGET: linux64_asan
+#linux64_asan-test:
+#  extends:
+#    - .test-template
+#    - .skip-in-fast-mode-template
+#  needs:
+#    - linux64_asan-build
+#  variables:
+#    BUILD_TARGET: linux64_asan
 
 linux64_tsan-test:
   extends:

--- a/.travis.yml
+++ b/.travis.yml
@@ -265,6 +265,11 @@ after_success:
         FILE_ENV="./ci/test/00_setup_env_native_fuzz.sh"
 
     - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, fuzzers under valgrind]'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_native_fuzz_with_valgrind.sh"
+
+    - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [focal]  [no wallet]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_nowallet.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -225,7 +225,7 @@ after_success:
         FILE_ENV="./ci/test/00_setup_env_win64.sh"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [focal]  [uses qt5 dev package instead of depends Qt to speed up build and avoid timeout] [unsigned char]'
+      name: 'x86_64 Linux  [GOAL: install]  [focal]  [uses qt5 dev package and some depends packages] [unsigned char]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_qt5.sh"
 # x86_64 Linux (xenial, no depends, only system libs, sanitizers: thread (TSan))
@@ -239,6 +239,11 @@ after_success:
       name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, sanitizers: address/leak (ASan + LSan) + undefined (UBSan) + integer]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_asan.sh"
+
+    - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, valgrind]'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_native_valgrind.sh"
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [focal]  [no wallet]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@
 # will trigger cache-invalidation and rebuilds as necessary.
 #
 
+version: ~> 1.0
+
 dist: xenial
 
 os: linux
@@ -205,19 +207,19 @@ after_success:
 
     - stage: test
       name: 'ARM  [GOAL: install]  [focal]  [unit tests, functional tests]'
-      arch: arm64
+      arch: arm64  # Can disable QEMU_USER_CMD and run the tests natively without qemu
       env: >-
         FILE_ENV="./ci/test/00_setup_env_arm.sh"
-        QEMU_USER_CMD=""  # Can run the tests natively without qemu
+        QEMU_USER_CMD=""
 
 # s390 build was disabled temporarily because of disk space issues on the Travis VM
 #
 #    - stage: test
 #      name: 'S390x  [GOAL: install]  [focal]  [unit tests, functional tests]'
-#      arch: s390x
+#      arch: s390x  # Can disable QEMU_USER_CMD and run the tests natively without qemu
 #      env: >-
 #        FILE_ENV="./ci/test/00_setup_env_s390x.sh"
-#        QEMU_USER_CMD=""  # Can run the tests natively without qemu
+#        QEMU_USER_CMD=""
 
     - stage: test
       name: 'Win64  [GOAL: deploy]  [unit tests, no gui, no functional tests]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -259,8 +259,20 @@ after_success:
       name: 'macOS 10.14 native [GOAL: install] [GUI] [no depends]'
       os: osx
       # Use the most recent version:
-      # Xcode 11, macOS 10.14, JDK 12.0.1
+      # Xcode 11.3.1, macOS 10.14, SDK 10.15
       # https://docs.travis-ci.com/user/reference/osx/#macos-version
-      osx_image: xcode11
+      osx_image: xcode11.3
+      addons:
+        homebrew:
+          packages:
+          - libtool
+          - berkeley-db4
+          - boost
+          - miniupnpc
+          - qt
+          - qrencode
+          - python3
+          - ccache
+          - zeromq
       env: >-
         FILE_ENV="./ci/test/00_setup_env_mac_host.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -241,21 +241,12 @@ after_success:
         FILE_ENV="./ci/test/00_setup_env_native_asan.sh"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, valgrind]'
-      env: >-
-        FILE_ENV="./ci/test/00_setup_env_native_valgrind.sh"
-
-    - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [focal]  [no wallet]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_fuzz.sh"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, fuzzers under valgrind]'
-      env: >-
-        FILE_ENV="./ci/test/00_setup_env_native_fuzz_with_valgrind.sh"
-
-    - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [focal]  [no wallet]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_nowallet.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ cache:
   ccache: true
   directories:
     - $BASE_BUILD_DIR/ci/scratch/.ccache
-    # macOS
-    - $HOME/Library/Caches/Homebrew
-    - /usr/local/Homebrew
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 env:
@@ -212,6 +209,26 @@ after_success:
         FILE_ENV="./ci/test/00_setup_env_arm.sh"
         QEMU_USER_CMD=""
 
+    - stage: test
+      name: 's390x native BE [GOAL: install] [bionic] [no depends, no GUI]'
+      arch: s390x
+      dist: bionic
+      addons:
+        apt:
+          packages:
+            - bsdmainutils
+            - libboost-filesystem-dev
+            - libboost-system-dev
+            - libboost-test-dev
+            - libboost-thread-dev
+            - libdb++-dev
+            - libdb-dev
+            - libevent-dev
+      env: >-
+        DANGER_RUN_CI_ON_HOST=true
+        CI_USE_APT_INSTALL=no
+        FILE_ENV="./ci/test/00_setup_env_s390x_host.sh"
+
 # s390 build was disabled temporarily because of disk space issues on the Travis VM
 #
 #    - stage: test
@@ -264,6 +281,12 @@ after_success:
       # Xcode 11.3.1, macOS 10.14, SDK 10.15
       # https://docs.travis-ci.com/user/reference/osx/#macos-version
       osx_image: xcode11.3
+      cache:
+        directories:
+          - $TRAVIS_BUILD_DIR/ci/scratch/.ccache
+          - $TRAVIS_BUILD_DIR/releases/$HOST
+          - $HOME/Library/Caches/Homebrew
+          - /usr/local/Homebrew
       addons:
         homebrew:
           packages:
@@ -277,4 +300,6 @@ after_success:
           - ccache
           - zeromq
       env: >-
+        DANGER_RUN_CI_ON_HOST=true
+        CI_USE_APT_INSTALL=no
         FILE_ENV="./ci/test/00_setup_env_mac_host.sh"

--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -56,6 +56,11 @@ cd dashcore-$BUILD_TARGET
 
 make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
 
+if [ -n "$USE_VALGRIND" ]; then
+    echo "valgrind in USE!"
+    ${BASE_ROOT_DIR}/ci/test/wrap-valgrind.sh
+fi
+
 if [ "$RUN_SYMBOL_TESTS" = "true" ]; then
   make $MAKEJOBS -C src check-symbols
 fi

--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -32,6 +32,8 @@ elif [ "$BUILD_TARGET" = "linux64_sqlite" ]; then
   source ./ci/test/00_setup_env_native_sqlite.sh
 elif [ "$BUILD_TARGET" = "linux64_nowallet" ]; then
   source ./ci/test/00_setup_env_native_nowallet.sh
+elif [ "$BUILD_TARGET" = "linux64_valgrind" ]; then
+  source ./ci/test/00_setup_env_native_valgrind.sh
 elif [ "$BUILD_TARGET" = "mac" ]; then
   source ./ci/test/00_setup_env_mac.sh
 elif [ "$BUILD_TARGET" = "s390x" ]; then

--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -11,6 +11,8 @@ export LC_ALL=C.UTF-8
 source ./ci/test/00_setup_env.sh
 
 # Configure sanitizers options
+export ASAN_OPTIONS=""
+export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan"
 export TSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/tsan"
 export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan"
 
@@ -20,6 +22,8 @@ elif [ "$BUILD_TARGET" = "win64" ]; then
   source ./ci/test/00_setup_env_win64.sh
 elif [ "$BUILD_TARGET" = "linux64" ]; then
   source ./ci/test/00_setup_env_native_qt5.sh
+elif [ "$BUILD_TARGET" = "linux64_asan" ]; then
+  source ./ci/test/00_setup_env_native_asan.sh
 elif [ "$BUILD_TARGET" = "linux64_tsan" ]; then
   source ./ci/test/00_setup_env_native_tsan.sh
 elif [ "$BUILD_TARGET" = "linux64_ubsan" ]; then

--- a/ci/dash/test_unittests.sh
+++ b/ci/dash/test_unittests.sh
@@ -11,7 +11,7 @@ set -e
 
 source ./ci/dash/matrix.sh
 
-if [ "$RUN_UNIT_TESTS" != "true" ]; then
+if [ "$RUN_UNIT_TESTS" != "true" ] && [ "$RUN_UNIT_TESTS_SEQUENTIAL" != "true" ]; then
   echo "Skipping unit tests"
   exit 0
 fi
@@ -29,5 +29,9 @@ if [ "$DIRECT_WINE_EXEC_TESTS" = "true" ]; then
   # Inside Docker, binfmt isn't working so we can't trust in make invoking windows binaries correctly
   wine ./src/test/test_dash.exe
 else
-  make $MAKEJOBS check VERBOSE=1
+  if [ "$RUN_UNIT_TESTS_SEQUENTIAL" = "true" ]; then
+    ./src/test/test_dash --catch_system_errors=no -l test_suite
+  else
+      make $MAKEJOBS check VERBOSE=1
+  fi
 fi

--- a/ci/test/00_setup_env_mac_host.sh
+++ b/ci/test/00_setup_env_mac_host.sh
@@ -8,7 +8,6 @@ export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_macos
 export HOST=x86_64-apple-darwin19
-export BREW_PACKAGES="automake berkeley-db4 libtool boost miniupnpc pkg-config qt qrencode python3 ccache zeromq"
 export PIP_PACKAGES="zmq"
 export RUN_CI_ON_HOST=true
 export RUN_UNIT_TESTS=true

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-filesystem-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
+export NO_DEPENDS=1
+export FUNCTIONAL_TESTS_CONFIG="--exclude wallet_multiwallet.py" # Temporarily suppress ASan heap-use-after-free (see issue #14163)
+export RUN_BENCH=true
+export GOAL="install"
+export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --with-sanitizers=address,integer,undefined CC=clang CXX=clang++"

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export DOCKER_NAME_TAG="ubuntu:20.04"
 export CONTAINER_NAME=ci_native_fuzz
 export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-filesystem-dev libboost-test-dev libboost-thread-dev"
 export DEP_OPTS="NO_UPNP=1 DEBUG=1"

--- a/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
+++ b/ci/test/00_setup_env_native_fuzz_with_valgrind.sh
@@ -6,13 +6,13 @@
 
 export LC_ALL=C.UTF-8
 
+export DOCKER_NAME_TAG="ubuntu:20.04"
 export CONTAINER_NAME=ci_native_fuzz_valgrind
-export PACKAGES="clang-8 llvm-8 python3 libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev valgrind"
+export PACKAGES="clang llvm python3 libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev valgrind"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export FUZZ_TESTS_CONFIG="--valgrind"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer --enable-c++17 CC=clang-8 CXX=clang++-8"
-# Use clang-8, instead of default clang on bionic, which is clang-6 and does not come with libfuzzer on aarch64
+export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer --enable-c++17 CC=clang CXX=clang++"

--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -11,5 +11,7 @@ export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libhar
 export DEP_OPTS="NO_UPNP=1 DEBUG=1"
 # TODO: we have few rpcs that aren't covered by any test, re-enable the line below once it's fixed
 # export TEST_RUNNER_EXTRA="--coverage --extended --exclude feature_pruning,feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
+export RUN_UNIT_TESTS_SEQUENTIAL="true"
+export RUN_UNIT_TESTS="false"
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-glibc-back-compat --enable-zmq --enable-reduce-exports LDFLAGS=-static-libstdc++"

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -9,6 +9,10 @@ export LC_ALL=C.UTF-8
 export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
 export USE_VALGRIND=1
 export NO_DEPENDS=1
-export TEST_RUNNER_EXTRA="--exclude rpc_bind"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
+if [[ "${TRAVIS}" == "true" && "${TRAVIS_REPO_SLUG}" != "bitcoin/bitcoin" ]]; then
+  export TEST_RUNNER_EXTRA="wallet_disable"  # Only run wallet_disable as a smoke test to not hit the 50 min travis time limit
+else
+  export TEST_RUNNER_EXTRA="--exclude rpc_bind"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
+fi
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang CXX=clang++"  # TODO enable GUI

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
-export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
+export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
 export USE_VALGRIND=1
 export NO_DEPENDS=1
 export TEST_RUNNER_EXTRA="--exclude rpc_bind"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -9,7 +9,7 @@ export LC_ALL=C.UTF-8
 export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
 export USE_VALGRIND=1
 export NO_DEPENDS=1
-export TEST_RUNNER_EXTRA="p2p_instantsend.py"  # Only run one test for now. TODO enable all and bump timeouts
+export TEST_RUNNER_EXTRA="--exclude feature_abortnode,feature_block,rpc_bind"  # Excluded for now
 export RUN_FUNCTIONAL_TESTS=true
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang CXX=clang++"  # TODO enable GUI

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
+export USE_VALGRIND=1
+export NO_DEPENDS=1
+export TEST_RUNNER_EXTRA="p2p_instantsend.py"  # Only run one test for now. TODO enable all and bump timeouts
+export RUN_FUNCTIONAL_TESTS=true
+export GOAL="install"
+export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang CXX=clang++"  # TODO enable GUI

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -9,7 +9,6 @@ export LC_ALL=C.UTF-8
 export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
 export USE_VALGRIND=1
 export NO_DEPENDS=1
-export TEST_RUNNER_EXTRA="--exclude feature_abortnode,feature_block,rpc_bind"  # Excluded for now
-export RUN_FUNCTIONAL_TESTS=true
+export TEST_RUNNER_EXTRA="--exclude rpc_bind"  # Excluded for now, see https://github.com/bitcoin/bitcoin/issues/17765#issuecomment-602068547
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no CC=clang CXX=clang++"  # TODO enable GUI

--- a/ci/test/00_setup_env_s390x_host.sh
+++ b/ci/test/00_setup_env_s390x_host.sh
@@ -6,13 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-export CONTAINER_NAME=ci_macos
-export HOST=x86_64-apple-darwin19
-export PIP_PACKAGES="zmq"
-export RUN_UNIT_TESTS=true
-export RUN_INTEGRATION_TESTS=false
-export GOAL="install"
-export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --disable-miner --enable-werror"
-# Run without depends
+export HOST=s390x-linux-gnu
 export NO_DEPENDS=1
-export OSX_SDK=""
+export BITCOIN_CONFIG="--with-incompatible-bdb --enable-reduce-exports"
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=true
+export GOAL="install"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -103,7 +103,9 @@ else
 fi
 
 if [ ! -d ${DIR_QA_ASSETS} ]; then
+ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   DOCKER_EXEC git clone https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
+ fi
 fi
 export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
 

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -14,30 +14,8 @@ if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
 fi
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-  set +o errexit
-  pushd /usr/local/Homebrew || exit 1
-  git reset --hard origin/master
-  popd || exit 1
-  set -o errexit
-  ${CI_RETRY_EXE} brew unlink python@2
-  ${CI_RETRY_EXE} brew update
-  # brew upgrade returns an error if any of the packages is already up to date
-  # Failure is safe to ignore, unless we really need an update.
-  brew upgrade $BREW_PACKAGES || true
-
-  # install new packages (brew install returns an error if already installed)
-  for i in $BREW_PACKAGES; do
-    if ! brew list | grep -q $i; then
-      ${CI_RETRY_EXE} brew install $i
-    fi
-  done
-
   export PATH="/usr/local/opt/ccache/libexec:$PATH"
-  OPENSSL_PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
-  export PKG_CONFIG_PATH=$OPENSSL_PKG_CONFIG_PATH:$PKG_CONFIG_PATH
-
   ${CI_RETRY_EXE} pip3 install $PIP_PACKAGES
-
 fi
 
 mkdir -p "${BASE_SCRATCH_DIR}"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -34,7 +34,7 @@ fi
 
 export P_CI_DIR="$PWD"
 
-if [ -z "$RUN_CI_ON_HOST" ]; then
+if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   echo "Creating $DOCKER_NAME_TAG container to run in"
   ${CI_RETRY_EXE} docker pull "$DOCKER_NAME_TAG"
 
@@ -65,7 +65,7 @@ fi
 if [[ $DOCKER_NAME_TAG == centos* ]]; then
   ${CI_RETRY_EXE} DOCKER_EXEC yum -y install epel-release
   ${CI_RETRY_EXE} DOCKER_EXEC yum -y install $DOCKER_PACKAGES $PACKAGES
-elif [ "$TRAVIS_OS_NAME" != "osx" ]; then
+elif [ "$CI_USE_APT_INSTALL" != "no" ]; then
   ${CI_RETRY_EXE} DOCKER_EXEC apt-get update
   ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $DOCKER_PACKAGES
 fi
@@ -76,6 +76,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 else
   DOCKER_EXEC free -m -h
   DOCKER_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
+  DOCKER_EXEC echo $(lscpu | grep Endian)
   DOCKER_EXEC echo "Free disk space:"
   DOCKER_EXEC df -h
 fi
@@ -89,7 +90,7 @@ export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
 
 DOCKER_EXEC mkdir -p "${BASE_SCRATCH_DIR}/sanitizer-output/"
 
-if [ -z "$RUN_CI_ON_HOST" ]; then
+if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   echo "Create $BASE_ROOT_DIR"
   DOCKER_EXEC rsync -a /ro_base/ $BASE_ROOT_DIR
 fi

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -47,7 +47,7 @@ export ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=
 export LSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/lsan"
 export TSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/tsan"
 export UBSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"
-env | grep -E '^(QEMU_|CCACHE_|WINEDEBUG|LC_ALL|BOOST_TEST_RANDOM|CONFIG_SHELL|(ASAN|LSAN|TSAN|UBSAN)_OPTIONS)' | tee /tmp/env
+env | grep -E '^(BASE_|QEMU_|CCACHE_|WINEDEBUG|LC_ALL|BOOST_TEST_RANDOM|CONFIG_SHELL|(ASAN|LSAN|TSAN|UBSAN)_OPTIONS)' | tee /tmp/env
 if [[ $HOST = *-mingw32 ]]; then
   DOCKER_ADMIN="--cap-add SYS_ADMIN"
 elif [[ $BITCOIN_CONFIG = *--with-sanitizers=*address* ]]; then # If ran with (ASan + LSan), Docker needs access to ptrace (https://github.com/google/sanitizers/issues/764)

--- a/ci/test/wrap-valgrind.sh
+++ b/ci/test/wrap-valgrind.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+for b_name in "${BASE_OUTDIR}/bin"/*; do
+    # shellcheck disable=SC2044
+    for b in $(find "${BASE_ROOT_DIR}" -executable -type f -name $(basename $b_name)); do
+      echo "Wrap $b ..."
+      mv "$b" "${b}_orig"
+      echo '#!/usr/bin/env bash' > "$b"
+      echo "valgrind --gen-suppressions=all --quiet --error-exitcode=1 --suppressions=${BASE_ROOT_DIR}/contrib/valgrind.supp \"${b}_orig\" \"\$@\"" >> "$b"
+      chmod +x "$b"
+    done
+done

--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get update && apt-get install $APT_ARGS \
     nsis \
     python3-zmq \
     parallel \
+    valgrind \
     wine-stable \
     wine32 \
     wine64 \

--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -30,8 +30,18 @@
    Memcheck:Cond
    obj:*/libdb_cxx-*.so
    fun:__log_put
-   obj:*/libdb_cxx-*.so
-   fun:__log_put_record
+}
+{
+   Suppress libdb warning
+   Memcheck:Param
+   pwrite64(buf)
+   fun:pwrite
+   fun:__os_io
+}
+{
+   Suppress libdb warning
+   Memcheck:Cond
+   fun:__log_putr.isra.1
 }
 {
    Suppress libdb warning
@@ -40,6 +50,37 @@
    fun:pwrite
    fun:__os_io
    obj:*/libdb_cxx-*.so
+}
+{
+   Suppress uninitialized bytes warning in compat code
+   Memcheck:Param
+   ioctl(TCSET{S,SW,SF})
+   fun:tcsetattr
+}
+{
+   Suppress libdb warning
+   Memcheck:Leak
+   fun:malloc
+   ...
+   obj:*/libdb_cxx-*.so
+}
+{
+   Suppress leaks on init
+   Memcheck:Leak
+   ...
+   fun:_Z11AppInitMainR11NodeContext
+}
+{
+   Suppress leaks on shutdown
+   Memcheck:Leak
+   ...
+   fun:_Z8ShutdownR11NodeContext
+}
+{
+   Ignore GUI warning
+   Memcheck:Leak
+   ...
+   obj:/usr/lib64/libgdk-3.so.0.2404.7
 }
 {
    Suppress leveldb warning (leveldb::InitModule()) - https://github.com/google/leveldb/issues/113
@@ -57,16 +98,48 @@
    fun:_ZN7leveldbL14InitDefaultEnvEv
 }
 {
+   Suppress leveldb leak
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   ...
+   fun:_ZN7leveldb6DBImpl14BackgroundCallEv
+}
+{
+   Suppress leveldb leak
+   Memcheck:Leak
+   fun:_Znwm
+   ...
+   fun:GetCoin
+}
+{
    Suppress wcsnrtombs glibc SSE4 warning (could be related: https://stroika.atlassian.net/browse/STK-626)
    Memcheck:Addr16
    fun:__wcsnlen_sse4_1
    fun:wcsnrtombs
 }
 {
+   Suppress wcsnrtombs warning (remove after removing boost::fs)
+   Memcheck:Cond
+   ...
+   fun:_ZN5boost10filesystem6detail11unique_pathERKNS0_4pathEPNS_6system10error_codeE
+   fun:unique_path
+}
+{
+   Suppress boost warning
+   Memcheck:Leak
+   fun:_Znwm
+   ...
+   fun:_ZN5boost9unit_test9framework5state17execute_test_treeEmjPKNS2_23random_generator_helperE
+   fun:_ZN5boost9unit_test9framework3runEmb
+   fun:_ZN5boost9unit_test14unit_test_mainEPFbvEiPPc
+   fun:main
+}
+{
    Suppress boost::filesystem warning (fixed in boost 1.70: https://github.com/boostorg/filesystem/commit/bbe9d1771e5d679b3f10c42a58fc81f7e8c024a9)
    Memcheck:Cond
    fun:_ZN5boost10filesystem6detail28directory_iterator_incrementERNS0_18directory_iteratorEPNS_6system10error_codeE
-   fun:_ZN5boost10filesystem6detail28directory_iterator_constructERNS0_18directory_iteratorERKNS0_4pathEPNS_6system10error_codeE
+   ...
    obj:*/libboost_filesystem.so.*
 }
 {
@@ -74,6 +147,7 @@
    Memcheck:Leak
    match-leak-kinds: reachable
    fun:_Znwm
+   ...
    fun:_ZN5boost10filesystem8absoluteERKNS0_4pathES3_
 }
 {

--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -123,7 +123,6 @@
    Memcheck:Cond
    ...
    fun:_ZN5boost10filesystem6detail11unique_pathERKNS0_4pathEPNS_6system10error_codeE
-   fun:unique_path
 }
 {
    Suppress boost warning

--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -1,7 +1,5 @@
-# Valgrind suppressions file for Dash.
-#
-# Includes known Valgrind warnings in our dependencies that cannot be fixed
-# in-tree.
+# This valgrind suppressions file includes known Valgrind warnings in our
+# dependencies that cannot be fixed in-tree.
 #
 # Example use:
 # $ valgrind --suppressions=contrib/valgrind.supp src/test/test_dash
@@ -14,6 +12,9 @@
 #       --error-limit=no src/test/test_dash
 #
 # Note that suppressions may depend on OS and/or library versions.
+# Tested on:
+# * aarch64 (Ubuntu 20.04 system libs, without gui)
+# * x86_64  (Ubuntu 18.04 system libs, without gui)
 {
    Suppress libstdc++ warning - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65434
    Memcheck:Leak
@@ -47,8 +48,7 @@
    Suppress libdb warning
    Memcheck:Param
    pwrite64(buf)
-   fun:pwrite
-   fun:__os_io
+   ...
    obj:*/libdb_cxx-*.so
 }
 {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -795,7 +795,9 @@ void RPCConsole::setFontSize(int newSize)
 {
     QSettings settings;
 
-    newSize = std::min(std::max(newSize, FONT_RANGE.width()), FONT_RANGE.height());
+    //don't allow an insane font size
+    if (newSize < FONT_RANGE.width() || newSize > FONT_RANGE.height())
+        return;
 
     // temp. store the console content
     QString str = ui->messagesWidget->toHtml();

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -333,7 +333,7 @@ void TransactionView::chooseType(int idx)
     if(!transactionProxyModel)
         return;
     transactionProxyModel->setTypeFilter(
-        typeWidget->itemData(idx).toInt());
+        typeWidget->itemData(idx).toUInt());
     // Persist settings
     QSettings settings;
     settings.setValue("transactionType", idx);

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -14,11 +14,12 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import wait_until, get_datadir_path
 import os
 
-class AbortNodeTest(BitcoinTestFramework):
 
+class AbortNodeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
+        self.rpc_timeout = 240
 
     def setup_network(self):
         self.setup_nodes()
@@ -43,6 +44,7 @@ class AbortNodeTest(BitcoinTestFramework):
             wait_until(lambda: self.nodes[0].is_node_stopped(), timeout=200)
         self.log.info("Node crashed - now verifying restart fails")
         self.nodes[0].assert_start_raises_init_error()
+
 
 if __name__ == '__main__':
     AbortNodeTest().main()

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1272,7 +1272,7 @@ class FullBlockTest(BitcoinTestFramework):
             self.save_spendable_output()
             spend = self.get_spendable_output()
 
-        self.send_blocks(blocks, True, timeout=1920)
+        self.send_blocks(blocks, True, timeout=2440)
         chain1_tip = i
 
         # now create alt chain of same length
@@ -1284,14 +1284,14 @@ class FullBlockTest(BitcoinTestFramework):
 
         # extend alt chain to trigger re-org
         block = self.next_block("alt" + str(chain1_tip + 1), version=4)
-        self.send_blocks([block], True, timeout=1920)
+        self.send_blocks([block], True, timeout=2440)
 
         # ... and re-org back to the first chain
         self.move_tip(chain1_tip)
         block = self.next_block(chain1_tip + 1, version=4)
         self.send_blocks([block], False, force_send=True)
         block = self.next_block(chain1_tip + 2, version=4)
-        self.send_blocks([block], True, timeout=1920)
+        self.send_blocks([block], True, timeout=2440)
 
         self.log.info("Reject a block with an invalid block header version")
         b_v1 = self.next_block('b_v1', version=1)

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -62,7 +62,7 @@ class BIP65Test(BitcoinTestFramework):
             '-acceptnonstdtxn=1',  # cltv_invalidate is nonstandard
         ]]
         self.setup_clean_chain = True
-        self.rpc_timeout = 120
+        self.rpc_timeout = 480
 
     def test_cltv_info(self, *, is_active):
         assert_equal(self.nodes[0].getblockchaininfo()['softforks']['bip65'],

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -19,9 +19,8 @@ import datetime
 import os
 import time
 import shutil
-import signal
-import sys
 import subprocess
+import sys
 import tempfile
 import re
 import logging
@@ -416,11 +415,10 @@ def main():
         args=passon_args,
         combined_logs_len=args.combinedlogslen,
         failfast=args.failfast,
-        runs_ci=args.ci,
         use_term_control=args.ansi,
     )
 
-def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, attempts=1, enable_coverage=False, args=None, combined_logs_len=0,failfast=False, runs_ci=False, use_term_control):
+def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, attempts=1, enable_coverage=False, args=None, combined_logs_len=0,failfast=False, use_term_control):
     args = args or []
 
     # Warn if dashd is already running
@@ -473,7 +471,6 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, attempts=1, enab
         tmpdir=tmpdir,
         test_list=test_list,
         flags=flags,
-        timeout_duration= 90 * 60 if runs_ci else float('inf'),  # in seconds
         use_term_control=use_term_control,
         attempts=attempts,
     )
@@ -559,12 +556,11 @@ class TestHandler:
     Trigger the test scripts passed in via the list.
     """
 
-    def __init__(self, *, num_tests_parallel, tests_dir, tmpdir, test_list, flags, timeout_duration, use_term_control, attempts):
+    def __init__(self, *, num_tests_parallel, tests_dir, tmpdir, test_list, flags, use_term_control, attempts):
         assert num_tests_parallel >= 1
         self.num_jobs = num_tests_parallel
         self.tests_dir = tests_dir
         self.tmpdir = tmpdir
-        self.timeout_duration = timeout_duration
         self.test_list = test_list
         self.flags = flags
         self.num_running = 0
@@ -608,10 +604,6 @@ class TestHandler:
             time.sleep(.5)
             for job in self.jobs:
                 (name, start_time, proc, testdir, log_out, log_err, portseed, attempt) = job
-                if int(time.time() - start_time) > self.timeout_duration:
-                    # Timeout individual tests if timeout is specified (to stop
-                    # tests hanging and not providing useful output).
-                    proc.send_signal(signal.SIGINT)
                 if proc.poll() is not None:
                     log_out.seek(0), log_err.seek(0)
                     [stdout, stderr] = [log_file.read().decode('utf-8') for log_file in (log_out, log_err)]

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -79,7 +79,7 @@ class CreateWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", w4.getnewaddress)
         assert_raises_rpc_error(-4, "Error: This wallet has no available keys", w4.getrawchangeaddress)
         # Now set a seed and it should work. Wallet should also be encrypted
-        w4.walletpassphrase('pass', 2)
+        w4.walletpassphrase('pass', 60)
         w4.upgradetohd(walletpassphrase='pass')
         w4.getnewaddress()
         w4.getrawchangeaddress()

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -48,6 +48,7 @@ implicit-integer-sign-change:chain.*
 implicit-integer-sign-change:coins.h
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h
+implicit-integer-sign-change:crc32c/
 implicit-integer-sign-change:crypto/*
 implicit-integer-sign-change:key.cpp
 implicit-integer-sign-change:noui.cpp


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR is the next batch of bitcoin backports, mostly related to CI, address sanitizer and valgrind.

## What was done?
- bitcoin/bitcoin#17725
- bitcoin/bitcoin#18304
- bitcoin/bitcoin#18392
- bitcoin/bitcoin#19159
- bitcoin/bitcoin#18899
- bitcoin/bitcoin#18430
- bitcoin/bitcoin#18438
- bitcoin/bitcoin#18441
- bitcoin/bitcoin#18477
- bitcoin/bitcoin#18562
- bitcoin/bitcoin#18569
- bitcoin/bitcoin#18683
- bitcoin/bitcoin#18912
- bitcoin/bitcoin#19669
- **partial** bitcoin/bitcoin#14794

There are discovered 2 issues that won't let to enable Asan CI and valgrind CI at the moment.

**1. Asan (address sanitizer) generates a lot of failures like that both CI and locally:**
```
********* Finished testing of TrafficGraphDataTests *********
~BitcoinApplication : Stopping thread
~BitcoinApplication : Stopped thread
==28475==WARNING: invalid path to external symbolizer!
==28475==WARNING: Failed to use and restart external symbolizer!
=================================================================
==28475==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 520 byte(s) in 13 object(s) allocated from:
    #0 0x55fc08e2353d  (/builds/dashpay/dash/build-ci/dashcore-linux64_asan/src/qt/test/test_dash-qt+0x779153d)
    #1 0x7f7a7724bd85  (<unknown module>)
Direct leak of 432 byte(s) in 2 object(s) allocated from:
    #0 0x55fc08e2353d  (/builds/dashpay/dash/build-ci/dashcore-linux64_asan/src/qt/test/test_dash-qt+0x779153d)
    #1 0x55fc0dc63b63  (/builds/dashpay/dash/build-ci/dashcore-linux64_asan/src/qt/test/test_dash-qt+0xc5d1b63)
    #2 0x8604597ff0e8feff  (<unknown module>)
Direct leak of 176 byte(s) in 2 object(s) allocated from:
    #0 0x55fc08e52cad  (/builds/dashpay/dash/build-ci/dashcore-linux64_asan/src/qt/test/test_dash-qt+0x77c0cad)
    #1 0x55fc0d822372  (/builds/dashpay/dash/build-ci/dashcore-linux64_asan/src/qt/test/test_dash-qt+0xc190372)
Direct leak of 66 byte(s) in 3 object(s) allocated from:
    #0 0x55fc08e2353d  (/builds/dashpay/dash/build-ci/dashcore-linux64_asan/src/qt/test/test_dash-qt+0x779153d)
    #1 0x7f7a77243633  (<unknown module>)
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x55fc08e2353d  (/builds/dashpay/dash/build-ci/dashcore-linux64_asan/src/qt/test/test_dash-qt+0x779153d)
    #1 0x7f7a77245449  (<unknown module>)
```
Here's run on CI: https://gitlab.com/dashpay/dash/-/pipelines/883649210
I tried different ways to add more debug infos or check what is these addresses but I haven't localized issue at the moment.
So, ASAN build is disabled at the moment.

**2.  valgrind fails for each usage of std::optional when it passes as an argument in function params.**
```
==6024== Conditional jump or move depends on uninitialised value(s) 
==6024==    at 0xF6C314: CWallet::ScanForWalletTransactions(uint256 const&, int, std::optional<int>, WalletRescanReserver const&, bool) (wallet.cpp:1976)
==6024==    by 0x8245D8: wallet_tests::scan_for_wallet_transactions::test_method() (wallet_tests.cpp:106)
==6024==    by 0x8267B4: wallet_tests::scan_for_wallet_transactions_invoker() (wallet_tests.cpp:87)
==6024==    by 0x115D4F1: boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (in DASH/src/test/test_dash)
==6024==    by 0x115BB9C: boost::execution_monitor::catch_signals(boost::function<int ()> const&) (in DASH/src/test/test_dash)
==6024==    by 0x115BC24: boost::execution_monitor::execute(boost::function<int ()> const&) (in DASH/src/test/test_dash)
==6024==    by 0x115BD04: boost::execution_monitor::vexecute(boost::function<void ()> const&) (in DASH/src/test/test_dash)
==6024==    by 0x1122834: boost::unit_test::unit_test_monitor_t::execute_and_translate(boost::function<void ()> const&, unsigned long) (in DASH/src/test/test_dash)
==6024==    by 0x10FC18F: boost::unit_test::framework::state::execute_test_tree(unsigned long, unsigned long, boost::unit_test::framework::state::random_generator_helper const*) [clone .isra.0] (in DASH/src/test/test_dash)
==6024==    by 0x10FC489: boost::unit_test::framework::state::execute_test_tree(unsigned long, unsigned long, boost::unit_test::framework::state::random_generator_helper const*) [clone .isra.0] (in DASH/src/test/test_dash)
==6024==    by 0x10FC489: boost::unit_test::framework::state::execute_test_tree(unsigned long, unsigned long, boost::unit_test::framework::state::random_generator_helper const*) [clone .isra.0] (in DASH/src/test/test_dash)
==6024==    by 0x11004D6: boost::unit_test::framework::run(unsigned long, bool) (in DASH/src/test/test_dash)
```
There's only one example, but it happens for all other places with std::optional too.
`valgrind` CI is actually removed from bitcoin and super-seeded by address sanitizer, but it doesn't work anyway at the moment for dash's code.

## How Has This Been Tested?
Run functional and unit tests + build locally with valgrind/address sanitizer to see a result.
Based on local runs this PR includes several fixes of UB.

## Breaking Changes
No breaking changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone