### PR TITLE
refactor: move `BuildSimplifiedDiff` to `src/evo/simplifiedmns.cpp` to resolve 3 circular dependencies

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -28,7 +28,6 @@ class CConnman;
 class CBlock;
 class CBlockIndex;
 class TxValidationState;
-class CSimplifiedMNListDiff;
 
 extern CCriticalSection cs_main;
 
@@ -382,7 +381,6 @@ public:
     void PoSeDecrease(const uint256& proTxHash);
 
     [[nodiscard]] CDeterministicMNListDiff BuildDiff(const CDeterministicMNList& to) const;
-    [[nodiscard]] CSimplifiedMNListDiff BuildSimplifiedDiff(const CDeterministicMNList& to, bool extended) const;
     [[nodiscard]] CDeterministicMNList ApplyDiff(const CBlockIndex* pindex, const CDeterministicMNListDiff& diff) const;
 
     void RepopulateUniquePropertyMap();

--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <evo/dmnstate.h>
-#include <evo/simplifiedmns.h>
 #include <evo/providertx.h>
 
 #include <chainparams.h>

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -22,7 +22,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     # Dash
     "coinjoin/server -> net_processing -> coinjoin/server"
     "evo/cbtx -> evo/simplifiedmns -> evo/cbtx"
-    "evo/deterministicmns -> evo/simplifiedmns -> evo/deterministicmns"
     "evo/deterministicmns -> llmq/commitment -> evo/deterministicmns"
     "evo/deterministicmns -> llmq/utils -> evo/deterministicmns"
     "evo/mnauth -> net_processing -> evo/mnauth"
@@ -63,12 +62,10 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "coinjoin/client -> coinjoin/util -> wallet/wallet -> coinjoin/client"
     "qt/appearancewidget -> qt/guiutil -> qt/optionsdialog -> qt/appearancewidget"
     "qt/guiutil -> qt/optionsdialog -> qt/optionsmodel -> qt/guiutil"
-    "evo/deterministicmns -> evo/simplifiedmns -> llmq/blockprocessor -> net_processing -> evo/deterministicmns"
 
     "coinjoin/client -> net_processing -> coinjoin/client"
     "llmq/quorums -> net_processing -> llmq/quorums"
     "llmq/dkgsession -> llmq/dkgsessionmgr -> llmq/dkgsession"
-    "evo/deterministicmns -> evo/simplifiedmns -> llmq/blockprocessor -> net_processing -> txmempool -> evo/deterministicmns"
     "llmq/chainlocks -> validation -> llmq/chainlocks"
     "coinjoin/coinjoin -> llmq/chainlocks -> net -> coinjoin/coinjoin"
     "evo/deterministicmns -> llmq/utils -> net -> evo/deterministicmns"


### PR DESCRIPTION
## Issue being fixed or feature implemented
Move `BuildSimplifiedDiff` to the place it's actually used. This also resolves 3 circular dependencies we have atm.

## What was done?
mostly trivial move-only changes

## How Has This Been Tested?
it compiles and linter is happy locally

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

