### PR TITLE
fix: reduce inconsistancy and non-determinstic in initialization bls

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -407,7 +407,7 @@ private:
 
     mutable std::vector<uint8_t> vecBytes;
     mutable bool bufValid{false};
-    mutable bool bufLegacyScheme{true};
+    mutable bool bufLegacyScheme;
 
     mutable BLSObject obj;
     mutable bool objInitialized{false};
@@ -476,7 +476,7 @@ public:
     template<typename Stream>
     inline void Serialize(Stream& s) const
     {
-        Serialize(s, bls::bls_legacy_scheme.load());
+        Serialize(s, bufLegacyScheme);
     }
 
     template<typename Stream>
@@ -493,7 +493,7 @@ public:
     template<typename Stream>
     inline void Unserialize(Stream& s) const
     {
-        Unserialize(s, bls::bls_legacy_scheme.load());
+        Unserialize(s, bufLegacyScheme);
     }
 
     void Set(const BLSObject& _obj)
@@ -549,8 +549,11 @@ public:
         return !(*this == r);
     }
 
-    uint256 GetHash(const bool specificLegacyScheme = bls::bls_legacy_scheme.load()) const
-    {
+    uint256 GetHash() const {
+        return GetHash(bufLegacyScheme);
+    }
+
+    uint256 GetHash(const bool specificLegacyScheme) const {
         std::unique_lock<std::mutex> l(mutex);
         if (!bufValid || bufLegacyScheme != specificLegacyScheme) {
             vecBytes = obj.ToByteVector(specificLegacyScheme);


### PR DESCRIPTION
## Issue being fixed or feature implemented
It partially resolve issue with non-determinism in bls initialization of CBLSLazyWrapper

## What was done?
Using `bufLegacyScheme` internally instead calling `bls::bls_legacy_scheme.load()` every time.


## How Has This Been Tested?
Run unit and functional changes.

## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

