### PR TITLE
build: fix gmp detection on macos when building with no depends

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -715,6 +715,12 @@ case $host in
            export PKG_CONFIG_PATH
          fi
 
+         gmp_prefix=$($BREW --prefix gmp 2>/dev/null)
+         if test x$gmp_prefix != x; then
+           CPPFLAGS="$CPPFLAGS -I$gmp_prefix/include"
+           LDFLAGS="$LDFLAGS -L$gmp_prefix/lib"
+         fi
+
          case $host in
            *aarch64*)
              dnl The preferred Homebrew prefix for Apple Silicon is /opt/homebrew.


### PR DESCRIPTION
## Issue being fixed or feature implemented
gmp can't be detected on macos when installed via `brew` atm

## What was done?
detect package prefix and adjust CPPFLAGS and LDFLAGS accordingly


## How Has This Been Tested?
`./configure`

before: `configure: error: libgmp headers missing`
after: passes

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

