### PR TITLE
feat: calculate DISK_SNAPSHOTS at compile time

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -532,10 +532,20 @@ public:
 };
 
 
+constexpr int llmq_max_blocks() {
+    int max_blocks{0};
+    for (const auto& llmq : Consensus::available_llmqs) {
+        int blocks = llmq.useRotation ? llmq.dkgInterval * 4 : llmq.dkgInterval * llmq.signingActiveQuorumCount;
+        max_blocks = std::max(max_blocks, blocks);
+    }
+    return max_blocks;
+}
+
 class CDeterministicMNManager
 {
     static constexpr int DISK_SNAPSHOT_PERIOD = 576; // once per day
-    static constexpr int DISK_SNAPSHOTS = 5; // keep cache for 5 disk snapshots to have 4 full days covered
+    // keep cache for enough disk snapshots to have all active quourms covered
+    static constexpr int DISK_SNAPSHOTS = llmq_max_blocks() / DISK_SNAPSHOT_PERIOD + 1;
     static constexpr int LIST_DIFFS_CACHE_SIZE = DISK_SNAPSHOT_PERIOD * DISK_SNAPSHOTS;
 
 public:

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -535,7 +535,7 @@ public:
 class CDeterministicMNManager
 {
     static constexpr int DISK_SNAPSHOT_PERIOD = 576; // once per day
-    static constexpr int DISK_SNAPSHOTS = 3; // keep cache for 3 disk snapshots to have 2 full days covered
+    static constexpr int DISK_SNAPSHOTS = 5; // keep cache for 5 disk snapshots to have 4 full days covered
     static constexpr int LIST_DIFFS_CACHE_SIZE = DISK_SNAPSHOT_PERIOD * DISK_SNAPSHOTS;
 
 public:


### PR DESCRIPTION
## Issue being fixed or feature implemented
LLMQ_400_85 requires four days worth of LLMQs https://github.com/dashpay/dash/blob/master/src/llmq/params.h#L416

## What was done?

## How Has This Been Tested?
n/a

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

