### PR TITLE
feat: ability to disable clsig creation while retaining clsig enforcement

### DIFF
--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -249,6 +249,10 @@ void CChainLocksHandler::TrySignChainTip()
         return;
     }
 
+    if (!ChainLocksSigningEnabled(spork_manager)) {
+        return;
+    }
+
     const CBlockIndex* pindex = WITH_LOCK(cs_main, return ::ChainActive().Tip());
 
     if (pindex->pprev == nullptr) {
@@ -685,6 +689,11 @@ void CChainLocksHandler::Cleanup()
 bool AreChainLocksEnabled(const CSporkManager& sporkManager)
 {
     return sporkManager.IsSporkActive(SPORK_19_CHAINLOCKS_ENABLED);
+}
+
+bool ChainLocksSigningEnabled(const CSporkManager& sporkManager)
+{
+    return sporkManager.GetSporkValue(SPORK_19_CHAINLOCKS_ENABLED) == 0;
 }
 
 } // namespace llmq

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -128,6 +128,7 @@ private:
 extern std::unique_ptr<CChainLocksHandler> chainLocksHandler;
 
 bool AreChainLocksEnabled(const CSporkManager& sporkManager);
+bool ChainLocksSigningEnabled(const CSporkManager& sporkManager);
 
 } // namespace llmq
 

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -66,6 +66,21 @@ class LLMQChainLocksTest(DashTestFramework):
             block = self.nodes[0].getblock(self.nodes[0].getblockhash(h))
             assert block['chainlock']
 
+        # Update spork to SPORK_19_CHAINLOCKS_ENABLED and test its behaviour
+        self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", 1)
+        self.wait_for_sporks_same()
+
+        # Generate new blocks and verify that they are not chainlocked
+        previous_block_hash = self.nodes[0].getbestblockhash()
+        for _ in range(2):
+            self.nodes[0].generate(1)
+            block_hash = self.nodes[0].getbestblockhash()
+            self.wait_for_chainlocked_block_all_nodes(block_hash, expected=False)
+            assert self.nodes[0].getblock(previous_block_hash)["chainlock"]
+
+        self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", 0)
+        self.wait_for_sporks_same()
+
         self.log.info("Isolate node, mine on another, and reconnect")
         self.isolate_node(0)
         node0_mining_addr = self.nodes[0].getnewaddress()

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -73,8 +73,7 @@ class LLMQChainLocksTest(DashTestFramework):
         # Generate new blocks and verify that they are not chainlocked
         previous_block_hash = self.nodes[0].getbestblockhash()
         for _ in range(2):
-            self.nodes[0].generate(1)
-            block_hash = self.nodes[0].getbestblockhash()
+            block_hash = self.nodes[0].generate(1)[0]
             self.wait_for_chainlocked_block_all_nodes(block_hash, expected=False)
             assert self.nodes[0].getblock(previous_block_hash)["chainlock"]
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1513,9 +1513,9 @@ class DashTestFramework(BitcoinTestFramework):
         if wait_until(check_chainlocked_block, timeout=timeout, sleep=0.1, do_assert=expected) and not expected:
             raise AssertionError("waiting unexpectedly succeeded")
 
-    def wait_for_chainlocked_block_all_nodes(self, block_hash, timeout=15):
+    def wait_for_chainlocked_block_all_nodes(self, block_hash, timeout=15, expected=True):
         for node in self.nodes:
-            self.wait_for_chainlocked_block(node, block_hash, timeout=timeout)
+            self.wait_for_chainlocked_block(node, block_hash, expected=expected, timeout=timeout)
 
     def wait_for_best_chainlock(self, node, block_hash, timeout=15):
         wait_until(lambda: node.getbestchainlock()["blockhash"] == block_hash, timeout=timeout, sleep=0.1)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently, Chainlocks are either enabled or disabled. This PR adds a third state: enabled but we will not sign new ones.

Should probably backport this to v19.x

## What was done?
Spork state != 0 but active will now result in chain locks being enforced but not created.

## How Has This Been Tested?

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

