### PR TITLE
fix: follow-up backport bitcoin#14380 - remove debug logs

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -1356,7 +1356,6 @@ static size_t CalculateNestedKeyhashInputSize(bool use_max_sig)
 static constexpr size_t DUMMY_NESTED_P2PKH_INPUT_SIZE = 113;
 BOOST_FIXTURE_TEST_CASE(dummy_input_size_test, TestChain100Setup)
 {
-    std::cerr << "CDEF " << CalculateNestedKeyhashInputSize(false) << std::endl;
     BOOST_CHECK_EQUAL(CalculateNestedKeyhashInputSize(false), DUMMY_NESTED_P2PKH_INPUT_SIZE);
     BOOST_CHECK_EQUAL(CalculateNestedKeyhashInputSize(true), DUMMY_NESTED_P2PKH_INPUT_SIZE + 1);
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
There are useless debug logs "CDEF" in `wallet_tests` unit tests.

## What was done?
removes it

## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
n/a


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone