### PR TITLE
feat: use m_protxHash instead of masternodeOutpoint for hashing dsq and dstx after v19 activation

### DIFF
--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -219,7 +219,7 @@ public:
     {
         READWRITE(obj.nDenom);
 
-        if (s.GetVersion() < COINJOIN_PROTX_HASH_PROTO_VERSION || (s.GetType() & SER_GETHASH)) {
+        if (s.GetVersion() < COINJOIN_PROTX_HASH_PROTO_VERSION) {
             READWRITE(obj.masternodeOutpoint);
         } else {
             READWRITE(obj.m_protxHash);
@@ -230,7 +230,7 @@ public:
         }
     }
 
-    [[nodiscard]] uint256 GetSignatureHash() const;
+    [[nodiscard]] uint256 GetSignatureHash(bool legacy) const;
     /** Sign this mixing transaction
      *  return true if all conditions are met:
      *     1) we have an active Masternode,
@@ -292,7 +292,7 @@ public:
     {
         READWRITE(obj.tx);
 
-        if (s.GetVersion() < COINJOIN_PROTX_HASH_PROTO_VERSION || (s.GetType() & SER_GETHASH)) {
+        if (s.GetVersion() < COINJOIN_PROTX_HASH_PROTO_VERSION) {
             READWRITE(obj.masternodeOutpoint);
         } else {
             READWRITE(obj.m_protxHash);
@@ -317,7 +317,7 @@ public:
         return *this != CCoinJoinBroadcastTx();
     }
 
-    [[nodiscard]] uint256 GetSignatureHash() const;
+    [[nodiscard]] uint256 GetSignatureHash(bool legacy) const;
 
     bool Sign();
     [[nodiscard]] bool CheckSignature(const CBLSPublicKey& blsPubKey) const;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should fix #5401 with minimal potential coinjoin service interruption (~1 minute around v19 fork point) for up to date clients. Fully backwards compatible prior to v19 activation. Old clients won't be able to mix after v19 activation though until they implement similar changes. _EDIT: Actually, this is already the case cause bls sigs are going to change too._ And I think we should also be able to finally drop `masternodeOutpoint` from `CCoinJoinQueue` and `CCoinJoinBroadcastTx` once v19 is active because of that which would be a nice bonus.

cc @HashEngineering

## What was done?
re-use v19 activation to switch `GetSignatureHash` logic

## How Has This Been Tested?
mixing on mainnet

## Breaking Changes
mixing won't work on current testnet until MNs are updated 

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

