### PR TITLE
fix: resolve two DMNL cache issues

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1145,7 +1145,12 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
     std::vector<uint256> toDeleteDiffs;
     for (const auto& p : mnListsCache) {
         if (p.second.GetHeight() + LIST_DIFFS_CACHE_SIZE < nHeight) {
+            // too old, drop it
             toDeleteLists.emplace_back(p.first);
+            continue;
+        }
+        if (tipIndex != nullptr && p.first == tipIndex->GetBlockHash()) {
+            // it's a snapshot for the tip, keep it
             continue;
         }
         bool fQuorumCache = ranges::any_of(Params().GetConsensus().llmqs, [&nHeight, &p](const auto& params){
@@ -1156,13 +1161,8 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
             // at least one quorum could be using it, keep it
             continue;
         }
-        // no alive quorums using it, see if it was a cache for the tip or for a now outdated quorum
-        if (tipIndex && tipIndex->pprev && (p.first == tipIndex->pprev->GetBlockHash())) {
-            toDeleteLists.emplace_back(p.first);
-        } else if (ranges::any_of(Params().GetConsensus().llmqs,
-                                  [&p](const auto& llmqParams){ return p.second.GetHeight() % llmqParams.dkgInterval == 0; })) {
-            toDeleteLists.emplace_back(p.first);
-        }
+        // none of the above, drop it
+        toDeleteLists.emplace_back(p.first);
     }
     for (const auto& h : toDeleteLists) {
         mnListsCache.erase(h);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -555,7 +555,7 @@ public:
 constexpr int llmq_max_blocks() {
     int max_blocks{0};
     for (const auto& llmq : Consensus::available_llmqs) {
-        int blocks = llmq.useRotation ? llmq.dkgInterval * 4 : llmq.dkgInterval * llmq.signingActiveQuorumCount;
+        int blocks = (llmq.useRotation ? 1 : llmq.signingActiveQuorumCount) * llmq.dkgInterval;
         max_blocks = std::max(max_blocks, blocks);
     }
     return max_blocks;


### PR DESCRIPTION
## Issue being fixed or feature implemented
- useless cache was not dropped properly
- `llmq_max_blocks()` calculations were off

should probably fix #5409 

## What was done?
pls see individual commits


## How Has This Been Tested?
1. run tests
2. run a node, monitor mem usage (~in progress~)

EDIT: memory usage is pretty much constant at 2 GB for the past 4 days. I also see no unusual disk usage or anything suspicious. On a node without this patch: ~4-5 GB soon after node start and ~6 GB after a few days.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

