### PR TITLE
fix(ci): only run jobs when their ancestors on prevoius stages succeeded

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,10 @@ builder-image:
 
 .build-depends-template:
   stage: build-depends
+  rules:
+    - when: on_success
+  needs:
+    - builder-image
   image: $CI_REGISTRY_IMAGE:builder-$CI_COMMIT_REF_SLUG
   variables:
     SDK_URL: https://bitcoincore.org/depends-sources/sdks
@@ -78,6 +82,8 @@ builder-image:
 
 .base-template:
   image: $CI_REGISTRY_IMAGE:builder-$CI_COMMIT_REF_SLUG
+  rules:
+    - when: on_success
   before_script:
     - export CACHE_DIR=$CI_PROJECT_DIR/cache
     - echo BUILD_TARGET=$BUILD_TARGET
@@ -157,7 +163,7 @@ builder-image:
   rules:
     - if: '$FAST_MODE == "true"'
       when: never
-    - when: always
+    - when: on_success
 
 ###
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
We should not be running jobs if their ancestors failed. This was broken with the introduction of `FAST_MODE`/`.skip-in-fast-mode-template` I think (via #3635).

## What was done?
Adjust ci rules, make them explicit.

## How Has This Been Tested?
Compare `test` stages:
https://gitlab.com/dashpay/dash/-/pipelines/888510672 (note: some of `test` stage jobs were started, even though all related jobs from `build` stage have failed)
vs
https://gitlab.com/UdjinM6/dash/-/pipelines/888923382 (note: none of `test` stage jobs were started)


## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

