### PR TITLE
fix: follow-up #5403: remove double serialization in CDeterministicMNState

### DIFF
--- a/src/evo/dmnstate.h
+++ b/src/evo/dmnstate.h
@@ -231,7 +231,6 @@ public:
             obj.nRevocationReason,
             obj.confirmedHash,
             obj.confirmedHashWithProRegTxHash,
-            obj.keyIDOwner,
             obj.keyIDOwner);
         READWRITE(CBLSLazyPublicKeyVersionWrapper(const_cast<CBLSLazyPublicKey&>(obj.pubKeyOperator), obj.nVersion == CProRegTx::LEGACY_BLS_VERSION));
         READWRITE(


### PR DESCRIPTION
## Issue being fixed or feature implemented
Member obj.keyIDOwner is read & write twice



## What was done?
Fixed: it is serialized once

## How Has This Been Tested?
Unit/functional tests in CI


## Breaking Changes
Data format in database changed in incompatible way

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

