### PR TITLE
ci: use PR's HEAD in guix workflow

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
## Issue being fixed or feature implemented
Our guix workflow creates a merge commit instead of using HEAD from a PR itself which is why commit hash is different. That's exactly what is described in https://github.com/actions/checkout/issues/27 imo.

related: https://github.com/dashpay/dash/pull/5355#issuecomment-1578459628

## What was done?
adjust guix workflow

## How Has This Been Tested?
see this PR results: the HEAD looks correct now
this PR: https://github.com/dashpay/dash/actions/runs/5191152453/jobs/9358590629?pr=5416#step:2:482
#5355: https://github.com/dashpay/dash/actions/runs/5187698039/jobs/9350381761?pr=5355#step:2:489

## Breaking Changes
n/a hopefully 

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

