### PR TITLE
ci: more checksums in guix workflow

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -59,14 +59,6 @@ jobs:
             echo "Guix build failed!"
             exit 1
           fi
-      - name: Compute SHA1 checksums for binaries
-        run: |
-          ( \
-          SRC_PATH_PREFIX=guix-build-$(git rev-parse --short=12 HEAD)/distsrc- && \
-          sha1sum ${SRC_PATH_PREFIX}*/src/dash{d,-cli,-tx,-wallet}{,.exe} && \
-          sha1sum ${SRC_PATH_PREFIX}*/src/qt/dash-qt{,.exe} && \
-          sha1sum ${SRC_PATH_PREFIX}*/src/test/test_dash{,.exe} \
-          ) | sort -k 2
       - name: Compute SHA256 checksums for binaries
         run: |
           ( \

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -59,11 +59,22 @@ jobs:
             echo "Guix build failed!"
             exit 1
           fi
-      - name: Compute SHA1 checksum
+      - name: Compute SHA1 checksums for binaries
         run: |
-          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
-          sha1sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/qt/dash-qt{,.exe}
-      - name: Compute SHA256 checksum
+          ( \
+          SRC_PATH_PREFIX=guix-build-$(git rev-parse --short=12 HEAD)/distsrc- && \
+          sha1sum ${SRC_PATH_PREFIX}*/src/dash{d,-cli,-tx,-wallet}{,.exe} && \
+          sha1sum ${SRC_PATH_PREFIX}*/src/qt/dash-qt{,.exe} && \
+          sha1sum ${SRC_PATH_PREFIX}*/src/test/test_dash{,.exe} \
+          ) | sort -k 2
+      - name: Compute SHA256 checksums for binaries
         run: |
-          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/dashd{,.exe}
-          sha256sum guix-build-$(git rev-parse --short=12 HEAD)/distsrc-*/src/qt/dash-qt{,.exe}
+          ( \
+          SRC_PATH_PREFIX=guix-build-$(git rev-parse --short=12 HEAD)/distsrc- && \
+          sha256sum ${SRC_PATH_PREFIX}*/src/dash{d,-cli,-tx,-wallet}{,.exe} && \
+          sha256sum ${SRC_PATH_PREFIX}*/src/qt/dash-qt{,.exe} && \
+          sha256sum ${SRC_PATH_PREFIX}*/src/test/test_dash{,.exe} \
+          ) | sort -k 2
+      - name: Compute SHA256 checksums for archives
+        run: |
+          find guix-build-"$(git rev-parse --short=12 HEAD)"/output -type f | grep -v SHA256 | xargs sha256sum | sort -k 2


### PR DESCRIPTION
## Issue being fixed or feature implemented
1. not all binaries were covered with checksums
2. there were no checksums for archives

## What was done?
add missing checksums, also group and sort them

## How Has This Been Tested?
run commands after local guix build
see this PR results

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

