### PR TITLE
chore: update defaultAssumeValid, nMinimumChainWork, checkpointData and chainTxData for testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -393,10 +393,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;            // this corresponds to 10 periods
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000002d68cb6c090031f"); // 864000
+        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000002d68c89409f9383"); // 850000
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x0000005c35514190ef3c38d322f69412553dc7e1107ed5f92adc2935b90acc51"); // 864000
+        consensus.defaultAssumeValid = uint256S("0x0000003eddb94218e7a3f41b2ac6e26143f8a748b50cd26e86bdbbab9ebe50aa"); // 850000
 
         pchMessageStart[0] = 0xce;
         pchMessageStart[1] = 0xe2;
@@ -476,7 +476,7 @@ public:
                 {470000, uint256S("0x0000009303aeadf8cf3812f5c869691dbd4cb118ad20e9bf553be434bafe6a52")},
                 {794950, uint256S("0x000001860e4c7248a9c5cc3bc7106041750560dc5cd9b3a2641b49494bcff5f2")},
                 {808000, uint256S("0x00000104cb60a2b5e00a8a4259582756e5bf0dca201c0993c63f0e54971ea91a")},
-                {864000, uint256S("0x0000005c35514190ef3c38d322f69412553dc7e1107ed5f92adc2935b90acc51")},
+                {850000, uint256S("0x0000003eddb94218e7a3f41b2ac6e26143f8a748b50cd26e86bdbbab9ebe50aa")},
             }
         };
 
@@ -484,12 +484,12 @@ public:
             // TODO to be specified in a future patch.
         };
 
-        // getchaintxstats 17280 0000005c35514190ef3c38d322f69412553dc7e1107ed5f92adc2935b90acc51
+        // getchaintxstats 17280 0000003eddb94218e7a3f41b2ac6e26143f8a748b50cd26e86bdbbab9ebe50aa
         chainTxData = ChainTxData{
-                1680868209, // * UNIX timestamp of last known number of transactions (Block 771537)
-                5847013,    // * total number of transactions between genesis and that timestamp
+                1678858966, // * UNIX timestamp of last known number of transactions (Block 850000)
+                5796306,    // * total number of transactions between genesis and that timestamp
                             //   (the tx=... number in the ChainStateFlushed debug.log lines)
-                0.01994632331955769,       // * estimated number of transactions per second after that timestamp
+                0.01077368401768078,       // * estimated number of transactions per second after that timestamp
         };
     }
 };


### PR DESCRIPTION
## Issue being fixed or feature implemented
Having these above v19 forkpoint (850100) would result in v19.2 nodes forking at the wrong height (864000) when reindexing without `--assumevalid=<0 or some pre-v19 block height>`

## What was done?
Go back to pre-v19 block (850000) in chainparams

## How Has This Been Tested?
reindex

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

