### PR TITLE
feat: Allow mining blocks of a specific version on non-mainnet networks

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -135,9 +135,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     bool fDIP0008Active_context = nHeight >= chainparams.GetConsensus().DIP0008Height;
 
     pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus(), chainparams.BIP9CheckMasternodesUpgraded());
-    // -regtest only: allow overriding block.nVersion with
+    // Non-mainnet only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
-    if (chainparams.MineBlocksOnDemand())
+    if (Params().NetworkIDString() != CBaseChainParams::MAIN)
         pblock->nVersion = gArgs.GetArg("-blockversion", pblock->nVersion);
 
     pblock->nTime = GetAdjustedTime();


### PR DESCRIPTION
## Issue being fixed or feature implemented
Mining blocks with a specific version can be useful on testnet and devnets too

## What was done?
lift restrictions for `-blockversion`

## How Has This Been Tested?
it should just work :)

## Breaking Changes
n//a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

