### PR TITLE
chore: prettify json representations of CSimplifiedMNListEntry and CSimplifiedMNListDiff

### DIFF
--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -185,6 +185,7 @@ void CSimplifiedMNListDiff::ToJson(UniValue& obj, bool extended) const
 {
     obj.setObject();
 
+    obj.pushKV("nVersion", nVersion);
     obj.pushKV("baseBlockHash", baseBlockHash.ToString());
     obj.pushKV("blockHash", blockHash.ToString());
 
@@ -207,7 +208,6 @@ void CSimplifiedMNListDiff::ToJson(UniValue& obj, bool extended) const
         mnListArr.push_back(eObj);
     }
     obj.pushKV("mnList", mnListArr);
-    obj.pushKV("nVersion", nVersion);
 
     UniValue deletedQuorumsArr(UniValue::VARR);
     for (const auto& e : deletedQuorums) {

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -68,14 +68,13 @@ void CSimplifiedMNListEntry::ToJson(UniValue& obj, bool extended) const
     obj.clear();
     obj.setObject();
     obj.pushKV("nVersion", nVersion);
+    obj.pushKV("nType", ToUnderlying(nType));
     obj.pushKV("proRegTxHash", proRegTxHash.ToString());
     obj.pushKV("confirmedHash", confirmedHash.ToString());
     obj.pushKV("service", service.ToString(false));
     obj.pushKV("pubKeyOperator", pubKeyOperator.ToString());
     obj.pushKV("votingAddress", EncodeDestination(PKHash(keyIDVoting)));
     obj.pushKV("isValid", isValid);
-    obj.pushKV("nVersion", nVersion);
-    obj.pushKV("nType", ToUnderlying(nType));
     if (nType == MnType::HighPerformance) {
         obj.pushKV("platformHTTPPort", platformHTTPPort);
         obj.pushKV("platformNodeID", platformNodeID.ToString());


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should fix https://github.com/dashpay/dash/pull/5424#discussion_r1228654939 and make `CSimplifiedMNListEntry`'s json a bit more human-friendly (imo) by having `nVersion` and `nType` at the top of it.

Move `nVersion` up for `CSimplifiedMNListDiff` too.

NOTE: `nVersion` wasn't actually duplicated in rpc results, it was simply assigned twice inside. still not nice though.

Thanks @thephez ! 👍 

## What was done?

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

