### PR TITLE
perf: avoid rehashing block; use stored hash

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -645,7 +645,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
     return true;
 }
 
-bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* pindex)
+bool CDeterministicMNManager::UndoBlock(const CBlockIndex* pindex)
 {
     int nHeight = pindex->nHeight;
     uint256 blockHash = pindex->GetBlockHash();

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -648,7 +648,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
 bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* pindex)
 {
     int nHeight = pindex->nHeight;
-    uint256 blockHash = block.GetHash();
+    uint256 blockHash = pindex->GetBlockHash();
 
     CDeterministicMNList curList;
     CDeterministicMNList prevList;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -606,7 +606,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, const CBlockInde
             newList.SetHeight(nHeight);
         }
 
-        newList.SetBlockHash(block.GetHash());
+        newList.SetBlockHash(pindex->GetBlockHash());
 
         oldList = GetListForBlockInternal(pindex->pprev);
         diff = oldList.BuildDiff(newList);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -593,7 +593,7 @@ public:
 
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, BlockValidationState& state,
                       const CCoinsViewCache& view, bool fJustCheck) EXCLUSIVE_LOCKS_REQUIRED(cs_main) LOCKS_EXCLUDED(cs);
-    bool UndoBlock(const CBlock& block, const CBlockIndex* pindex) LOCKS_EXCLUDED(cs);
+    bool UndoBlock(const CBlockIndex* pindex) LOCKS_EXCLUDED(cs);
 
     void UpdatedBlockTip(const CBlockIndex* pindex) LOCKS_EXCLUDED(cs);
 

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -204,7 +204,7 @@ bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, llmq:
             }
         }
 
-        if (!deterministicMNManager->UndoBlock(block, pindex)) {
+        if (!deterministicMNManager->UndoBlock(pindex)) {
             return false;
         }
 


### PR DESCRIPTION
before 12%
<img width="1538" alt="image" src="https://github.com/dashpay/dash/assets/6443210/fa5043fb-4e48-4728-bfaf-8636d5c20a8c">
after 10%
<img width="1544" alt="image" src="https://github.com/dashpay/dash/assets/6443210/1df6aff4-2901-4af1-b421-3604f54df157">

## Issue being fixed or feature implemented
Redundant rehash

## What was done?
Avoid redundant rehash

## How Has This Been Tested?
Reindexed 0-500000 on testnet


## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

