### PR TITLE
chore(rpc): few cleanups in evo rpc help texts

### DIFF
--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -111,8 +111,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         },
         {"operatorReward",
             {"operatorReward", RPCArg::Type::STR, RPCArg::Optional::NO,
-                "The fraction in %% to share with the operator. The value must be\n"
-                "between 0.00 and 100.00."}
+                "The fraction in %% to share with the operator.\n"
+                "The value must be between 0 and 10000."}
         },
         {"ownerAddress",
             {"ownerAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
@@ -674,7 +674,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
         throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorReward must be a number");
     }
     if (operatorReward < 0 || operatorReward > 10000) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorReward must be between 0.00 and 100.00");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorReward must be between 0 and 10000");
     }
     ptx.nOperatorReward = operatorReward;
 

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -88,26 +88,26 @@ static RPCArg GetRpcArg(const std::string& strParamName)
                 "If set to an empty string, the currently active payout address is reused."}
         },
         {"operatorPubKey_register",
-            {"operatorPubKey_register", RPCArg::Type::STR, RPCArg::Optional::NO,
+            {"operatorPubKey", RPCArg::Type::STR, RPCArg::Optional::NO,
                 "The operator BLS public key. The BLS private key does not have to be known.\n"
                 "It has to match the BLS private key which is later used when operating the masternode."}
         },
         {"operatorPubKey_register_legacy",
-                {"operatorPubKey_register", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "The operator BLS public key in legacy scheme. The BLS private key does not have to be known.\n"
-                        "It has to match the BLS private key which is later used when operating the masternode.\n"}
+            {"operatorPubKey", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The operator BLS public key in legacy scheme. The BLS private key does not have to be known.\n"
+                "It has to match the BLS private key which is later used when operating the masternode.\n"}
         },
         {"operatorPubKey_update",
-            {"operatorPubKey_update", RPCArg::Type::STR, RPCArg::Optional::NO,
+            {"operatorPubKey", RPCArg::Type::STR, RPCArg::Optional::NO,
                 "The operator BLS public key. The BLS private key does not have to be known.\n"
                 "It has to match the BLS private key which is later used when operating the masternode.\n"
                 "If set to an empty string, the currently active operator BLS public key is reused."}
         },
         {"operatorPubKey_update_legacy",
-                {"operatorPubKey_update", RPCArg::Type::STR, RPCArg::Optional::NO,
-                        "The operator BLS public key in legacy scheme. The BLS private key does not have to be known.\n"
-                        "It has to match the BLS private key which is later used when operating the masternode.\n"
-                        "If set to an empty string, the currently active operator BLS public key is reused."}
+            {"operatorPubKey", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "The operator BLS public key in legacy scheme. The BLS private key does not have to be known.\n"
+                "It has to match the BLS private key which is later used when operating the masternode.\n"
+                "If set to an empty string, the currently active operator BLS public key is reused."}
         },
         {"operatorReward",
             {"operatorReward", RPCArg::Type::STR, RPCArg::Optional::NO,
@@ -121,11 +121,11 @@ static RPCArg GetRpcArg(const std::string& strParamName)
                 "The address must be unused and must differ from the collateralAddress."}
         },
         {"payoutAddress_register",
-            {"payoutAddress_register", RPCArg::Type::STR, RPCArg::Optional::NO,
+            {"payoutAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
                 "The dash address to use for masternode reward payments."}
         },
         {"payoutAddress_update",
-            {"payoutAddress_update", RPCArg::Type::STR, RPCArg::Optional::NO,
+            {"payoutAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
                 "The dash address to use for masternode reward payments.\n"
                 "If set to an empty string, the currently active payout address is reused."}
         },
@@ -142,13 +142,13 @@ static RPCArg GetRpcArg(const std::string& strParamName)
                 "If true, the resulting transaction is sent to the network."}
         },
         {"votingAddress_register",
-            {"votingAddress_register", RPCArg::Type::STR, RPCArg::Optional::NO,
+            {"votingAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
                 "The voting key address. The private key does not have to be known by your wallet.\n"
                 "It has to match the private key which is later used when voting on proposals.\n"
                 "If set to an empty string, ownerAddress will be used."}
         },
         {"votingAddress_update",
-            {"votingAddress_update", RPCArg::Type::STR, RPCArg::Optional::NO,
+            {"votingAddress", RPCArg::Type::STR, RPCArg::Optional::NO,
                 "The voting key address. The private key does not have to be known by your wallet.\n"
                 "It has to match the private key which is later used when voting on proposals.\n"
                 "If set to an empty string, the currently active voting key address is reused."}

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -69,8 +69,12 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         },
         {"ipAndPort",
             {"ipAndPort", RPCArg::Type::STR, RPCArg::Optional::NO,
-                "IP and port in the form \"IP:PORT\".\n"
-                "Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards."}
+                "IP and port in the form \"IP:PORT\". Must be unique on the network.\n"
+                "Can be set to an empty string, which will require a ProUpServTx afterwards."}
+        },
+        {"ipAndPort_update",
+            {"ipAndPort", RPCArg::Type::STR, RPCArg::Optional::NO,
+                "IP and port in the form \"IP:PORT\". Must be unique on the network."}
         },
         {"operatorKey",
             {"operatorKey", RPCArg::Type::STR, RPCArg::Optional::NO,
@@ -842,7 +846,7 @@ static void protx_update_service_help(const JSONRPCRequest& request)
         + HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("proTxHash"),
-            GetRpcArg("ipAndPort"),
+            GetRpcArg("ipAndPort_update"),
             GetRpcArg("operatorKey"),
             GetRpcArg("operatorPayoutAddress"),
             GetRpcArg("feeSourceAddress"),
@@ -866,7 +870,7 @@ static void protx_update_service_hpmn_help(const JSONRPCRequest& request)
             HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("proTxHash"),
-            GetRpcArg("ipAndPort"),
+            GetRpcArg("ipAndPort_update"),
             GetRpcArg("operatorKey"),
             GetRpcArg("platformNodeID"),
             GetRpcArg("platformP2PPort"),


### PR DESCRIPTION
## Issue being fixed or feature implemented
fix a couple of issues in help texts

develop:
```
protx register "collateralHash" collateralIndex "ipAndPort" "ownerAddress" "operatorPubKey_register" "votingAddress_register" "operatorReward" "payoutAddress_register" ( "feeSourceAddress" submit )
...
3. ipAndPort                  (string, required) IP and port in the form "IP:PORT".
                              Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards.
...
5. operatorPubKey_register    (string, required) The operator BLS public key. The BLS private key does not have to be known.
                              It has to match the BLS private key which is later used when operating the masternode.
6. votingAddress_register     (string, required) The voting key address. The private key does not have to be known by your wallet.
                              It has to match the private key which is later used when voting on proposals.
                              If set to an empty string, ownerAddress will be used.
7. operatorReward             (string, required) The fraction in %% to share with the operator. The value must be
                              between 0.00 and 100.00.
8. payoutAddress_register     (string, required) The dash address to use for masternode reward payments.
...
```
```
protx update_service "proTxHash" "ipAndPort" "operatorKey" ( "operatorPayoutAddress" "feeSourceAddress" )
...
2. ipAndPort                (string, required) IP and port in the form "IP:PORT".
                            Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards.
...
```
fe95dfdd7a97ae5150d8e28ea908f619c6080008:
```
protx register "collateralHash" collateralIndex "ipAndPort" "ownerAddress" "operatorPubKey" "votingAddress" "operatorReward" "payoutAddress" ( "feeSourceAddress" submit )
...
3. ipAndPort           (string, required) IP and port in the form "IP:PORT". Must be unique on the network.
                       Can be set to an empty string, which will require a ProUpServTx afterwards.
...
5. operatorPubKey      (string, required) The operator BLS public key. The BLS private key does not have to be known.
                       It has to match the BLS private key which is later used when operating the masternode.
6. votingAddress       (string, required) The voting key address. The private key does not have to be known by your wallet.
                       It has to match the private key which is later used when voting on proposals.
                       If set to an empty string, ownerAddress will be used.
7. operatorReward      (string, required) The fraction in %% to share with the operator.
                       The value must be between 0 and 10000.
8. payoutAddress       (string, required) The dash address to use for masternode reward payments.
...
```
```
protx update_service "proTxHash" "ipAndPort" "operatorKey" ( "operatorPayoutAddress" "feeSourceAddress" )
...
2. ipAndPort                (string, required) IP and port in the form "IP:PORT". Must be unique on the network.
...
```
## What was done?
pls see individual commits

## How Has This Been Tested?
run `dash-qt`, check `help <cmd>` response

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

