### PR TITLE
fix: lock cs_main in tryGetTxStatus

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -373,10 +373,13 @@ public:
         if (mi == m_wallet->mapWallet.end()) {
             return false;
         }
+        {
+        LOCK(cs_main);
         if (std::optional<int> height = m_wallet->chain().getHeight()) {
             block_time = m_wallet->chain().getBlockTime(*height);
         } else {
             block_time = -1;
+        }
         }
         tx_status = MakeWalletTxStatus(*m_wallet, mi->second);
         return true;


### PR DESCRIPTION
## Issue being fixed or feature implemented
it crashes on deep reorgs otherwise.

NOTE: this only happens on `v19.x`, `develop` doesn't have this issue (this piece of code was reworked via backports)

NOTE2: starting with `--nowallet` or `--disablewallet` "fixes" the issue

NOTE3: converted to draft because wallet test crashed https://gitlab.com/UdjinM6/dash/-/jobs/4491022699
```
/bin/bash: line 1: 32144 Segmentation fault      (core dumped) test/test_dash --catch_system_errors=no -l test_suite -t "`cat wallet/test/wallet_tests.cpp | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1`" -- DEBUG_LOG_OUT > wallet/test/wallet_tests.cpp.log 2>&1
```

## What was done?
by the time `getBlockTime` is called the chain can already be reorged deeper and `height` is no longer valid (we won't find a block at that height)


## How Has This Been Tested?
run `dash-qt` with any wallet loaded, `invalidateblock <some_deep_block>`

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

