### PR TITLE
refactor: deglobalization of bls_legacy_scheme 2/N

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -59,7 +59,7 @@ public:
     explicit CBLSWrapper() = default;
     explicit CBLSWrapper(const std::vector<unsigned char>& vecBytes) : CBLSWrapper<ImplType, _SerSize, C>()
     {
-        SetByteVector(vecBytes);
+        SetByteVector(vecBytes, bls::bls_legacy_scheme.load());
     }
 
     CBLSWrapper(const CBLSWrapper& ref) = default;
@@ -117,11 +117,6 @@ public:
             }
         }
         cachedHash.SetNull();
-    }
-
-    void SetByteVector(const std::vector<uint8_t>& vecBytes)
-    {
-        SetByteVector(vecBytes, bls::bls_legacy_scheme.load());
     }
 
     std::vector<uint8_t> ToByteVector(const bool specificLegacyScheme) const

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -160,11 +160,6 @@ public:
         return IsValid();
     }
 
-    bool SetHexStr(const std::string& str)
-    {
-        return SetHexStr(str, bls::bls_legacy_scheme.load());
-    }
-
     inline void Serialize(CSizeComputer& s) const
     {
         s.seek(SerSize);

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -308,7 +308,9 @@ bool CGovernanceObject::Sign(const CBLSSecretKey& key)
     if (!sig.IsValid()) {
         return false;
     }
-    vchSig = sig.ToByteVector();
+    const auto pindex = llmq::utils::V19ActivationIndex(::ChainActive().Tip());
+    bool is_bls_legacy_scheme = pindex == nullptr || nTime < pindex->pprev->nTime;
+    vchSig = sig.ToByteVector(is_bls_legacy_scheme);
     return true;
 }
 

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -230,7 +230,9 @@ bool CGovernanceVote::Sign(const CBLSSecretKey& key)
     if (!sig.IsValid()) {
         return false;
     }
-    vchSig = sig.ToByteVector();
+    const auto pindex = llmq::utils::V19ActivationIndex(::ChainActive().Tip());
+    bool is_bls_legacy_scheme = pindex == nullptr || nTime < pindex->pprev->nTime;
+    vchSig = sig.ToByteVector(is_bls_legacy_scheme);
     return true;
 }
 

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -989,14 +989,15 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
     qc.sig = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsKeyOperator->Sign(commitmentHash));
     qc.quorumSig = skShare.Sign(commitmentHash);
 
+    const bool is_bls_legacy = bls::bls_legacy_scheme.load();
     if (lieType == 3) {
         std::vector<uint8_t> buf = qc.sig.ToByteVector();
         buf[5]++;
-        qc.sig.SetByteVector(buf);
+        qc.sig.SetByteVector(buf, is_bls_legacy);
     } else if (lieType == 4) {
         std::vector<uint8_t> buf = qc.quorumSig.ToByteVector();
         buf[5]++;
-        qc.quorumSig.SetByteVector(buf);
+        qc.quorumSig.SetByteVector(buf, is_bls_legacy);
     }
 
     t3.stop();

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -989,13 +989,14 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
     qc.sig = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsKeyOperator->Sign(commitmentHash));
     qc.quorumSig = skShare.Sign(commitmentHash);
 
-    const bool is_bls_legacy = bls::bls_legacy_scheme.load();
     if (lieType == 3) {
-        std::vector<uint8_t> buf = qc.sig.ToByteVector();
+        const bool is_bls_legacy = bls::bls_legacy_scheme.load();
+        std::vector<uint8_t> buf = qc.sig.ToByteVector(is_bls_legacy);
         buf[5]++;
         qc.sig.SetByteVector(buf, is_bls_legacy);
     } else if (lieType == 4) {
-        std::vector<uint8_t> buf = qc.quorumSig.ToByteVector();
+        const bool is_bls_legacy = bls::bls_legacy_scheme.load();
+        std::vector<uint8_t> buf = qc.quorumSig.ToByteVector(is_bls_legacy);
         buf[5]++;
         qc.quorumSig.SetByteVector(buf, is_bls_legacy);
     }

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -7,6 +7,7 @@
 
 #include <batchedlogger.h>
 
+#include <bls/bls.h>
 #include <bls/bls_ies.h>
 #include <bls/bls_worker.h>
 

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -961,7 +961,7 @@ static UniValue verifyislock(const JSONRPCRequest& request)
         signHeight = pindexMined->nHeight;
     }
 
-    CBlockIndex* pBlockIndex;
+    CBlockIndex* pBlockIndex{nullptr};
     {
         LOCK(cs_main);
         if (signHeight == -1) {
@@ -971,17 +971,12 @@ static UniValue verifyislock(const JSONRPCRequest& request)
         }
     }
 
+    CHECK_NONFATAL(pBlockIndex != nullptr);
+
     CBLSSignature sig;
-    if (pindexMined != nullptr) {
-        const bool use_bls_legacy = !llmq::utils::IsV19Active(pindexMined);
-        if (!sig.SetHexStr(request.params[2].get_str(), use_bls_legacy)) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
-        }
-    } else {
-        if (!sig.SetHexStr(request.params[2].get_str(), false) &&
-                !sig.SetHexStr(request.params[2].get_str(), true)) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
-        }
+    const bool use_bls_legacy = !llmq::utils::IsV19Active(pBlockIndex);
+    if (!sig.SetHexStr(request.params[2].get_str(), use_bls_legacy)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
     }
 
     LLMQContext& llmq_ctx = EnsureLLMQContext(request.context);

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -576,8 +576,9 @@ static UniValue quorum_sigs_cmd(const JSONRPCRequest& request)
             return obj;
         }
     } else if (cmd == "quorumverify") {
+        const bool use_bls_legacy = bls::bls_legacy_scheme.load();
         CBLSSignature sig;
-        if (!sig.SetHexStr(request.params[3].get_str())) {
+        if (!sig.SetHexStr(request.params[3].get_str(), use_bls_legacy)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
         }
 
@@ -874,20 +875,37 @@ static UniValue verifychainlock(const JSONRPCRequest& request)
 
     const uint256 nBlockHash(ParseHashV(request.params[0], "blockHash"));
 
-    CBLSSignature sig;
-    if (!sig.SetHexStr(request.params[1].get_str())) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
-    }
-
     int nBlockHeight;
+    CBlockIndex* pIndex{nullptr};
     if (request.params[2].isNull()) {
-        const CBlockIndex* pIndex = WITH_LOCK(cs_main, return g_chainman.m_blockman.LookupBlockIndex(nBlockHash));
+        pIndex = WITH_LOCK(cs_main, return g_chainman.m_blockman.LookupBlockIndex(nBlockHash));
         if (pIndex == nullptr) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "blockHash not found");
         }
         nBlockHeight = pIndex->nHeight;
     } else {
         nBlockHeight = ParseInt32V(request.params[2], "blockHeight");
+        LOCK(cs_main);
+        if (nBlockHeight < 0) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
+        }
+        if (nBlockHeight <= ::ChainActive().Height()) {
+            pIndex = ::ChainActive()[nBlockHeight];
+        }
+    }
+
+    CBLSSignature sig;
+    if (pIndex) {
+        bool use_legacy_signature = !llmq::utils::IsV19Active(pIndex);
+        if (!sig.SetHexStr(request.params[1].get_str(), use_legacy_signature)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
+        }
+    } else {
+        if (!sig.SetHexStr(request.params[1].get_str(), false) &&
+                !sig.SetHexStr(request.params[1].get_str(), true)
+        ) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
+        }
     }
 
     LLMQContext& llmq_ctx = EnsureLLMQContext(request.context);
@@ -916,11 +934,6 @@ static UniValue verifyislock(const JSONRPCRequest& request)
 
     uint256 id(ParseHashV(request.params[0], "id"));
     uint256 txid(ParseHashV(request.params[1], "txid"));
-
-    CBLSSignature sig;
-    if (!sig.SetHexStr(request.params[2].get_str())) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
-    }
 
     if (g_txindex) {
         g_txindex->BlockUntilSyncedToCurrentChain();
@@ -955,6 +968,19 @@ static UniValue verifyislock(const JSONRPCRequest& request)
             pBlockIndex = ::ChainActive().Tip();
         } else {
             pBlockIndex = ::ChainActive()[signHeight];
+        }
+    }
+
+    CBLSSignature sig;
+    if (pindexMined != nullptr) {
+        const bool use_bls_legacy = !llmq::utils::IsV19Active(pindexMined);
+        if (!sig.SetHexStr(request.params[2].get_str(), use_bls_legacy)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
+        }
+    } else {
+        if (!sig.SetHexStr(request.params[2].get_str(), false) &&
+                !sig.SetHexStr(request.params[2].get_str(), true)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
         }
     }
 

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -64,16 +64,16 @@ void FuncSetHexStr(const bool legacy_scheme)
     CBLSSecretKey sk;
     std::string strValidSecret = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
     // Note: invalid string passed to SetHexStr() should cause it to fail and reset key internal data
-    BOOST_CHECK(sk.SetHexStr(strValidSecret));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1g")); // non-hex
+    BOOST_CHECK(sk.SetHexStr(strValidSecret, legacy_scheme));
+    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1g", legacy_scheme)); // non-hex
     BOOST_CHECK(!sk.IsValid());
     BOOST_CHECK(sk == CBLSSecretKey());
     // Try few more invalid strings
-    BOOST_CHECK(sk.SetHexStr(strValidSecret));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e")); // hex but too short
+    BOOST_CHECK(sk.SetHexStr(strValidSecret, legacy_scheme));
+    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e", legacy_scheme)); // hex but too short
     BOOST_CHECK(!sk.IsValid());
-    BOOST_CHECK(sk.SetHexStr(strValidSecret));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")); // hex but too long
+    BOOST_CHECK(sk.SetHexStr(strValidSecret, legacy_scheme));
+    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", legacy_scheme)); // hex but too long
     BOOST_CHECK(!sk.IsValid());
 
     return;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -17,7 +17,6 @@
 #include <addressindex.h>
 #include <spentindex.h>
 #include <amount.h>
-#include <bls/bls.h>
 #include <coins.h>
 #include <crypto/siphash.h>
 #include <indirectmap.h>
@@ -37,6 +36,11 @@
 class CBlockIndex;
 class CChainState;
 extern RecursiveMutex cs_main;
+
+// Forward declation for CBLSLazyPublicKey:
+template<typename T> class CBLSLazyWrapper;
+class CBLSPublicKey;
+using CBLSLazyPublicKey = CBLSLazyWrapper<CBLSPublicKey>;
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Many usages of `CBLS{Signature,PrivateKey,PublicKey}` assume using global variable, even if can be specified explicitly.
Some of these usages have been deglobalized in this PR.

Some prior improvements and fixes are here: [#5403](https://github.com/dashpay/dash/pull/5403)

## What was done?
 - Refactored the uses of global variable of `bls_legacy_scheme` from `SetHex`, `SetByteVector`, some rpc calls. 
 - Removed flag `checkMalleable` to simplify code because it's always `true`. 
 - Removed dependency from `txmempool.h` on `bls.h` to speed up compilation.

## How Has This Been Tested?
Run unit/functional tests.



## Breaking Changes
No breaking changes assumed. But in theory behaviour of some RPC can be more explicit and predictable.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

