### PR TITLE
feat: mnlistdiff move nversion to first position

### DIFF
--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -139,8 +139,11 @@ public:
 
     SERIALIZE_METHODS(CSimplifiedMNListDiff, obj)
     {
+        if ((s.GetType() & SER_NETWORK) && s.GetVersion() >= MNLISTDIFF_VERSION_ORDER) {
+            READWRITE(obj.nVersion);
+        }
         READWRITE(obj.baseBlockHash, obj.blockHash, obj.cbTxMerkleTree, obj.cbTx);
-        if ((s.GetType() & SER_NETWORK) && s.GetVersion() >= BLS_SCHEME_PROTO_VERSION) {
+        if ((s.GetType() & SER_NETWORK) && s.GetVersion() >= BLS_SCHEME_PROTO_VERSION && s.GetVersion() < MNLISTDIFF_VERSION_ORDER) {
             READWRITE(obj.nVersion);
         }
         READWRITE(obj.deletedMNs, obj.mnList);

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70228;
+static const int PROTOCOL_VERSION = 70229;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -51,6 +51,9 @@ static const int DMN_TYPE_PROTO_VERSION = 70227;
 
 //! Versioned Simplified Masternode List Entries were introduced in this version
 static const int SMNLE_VERSIONED_PROTO_VERSION = 70228;
+
+//! Versioned Simplified Masternode List Entries were introduced in this version
+static const int MNLISTDIFF_VERSION_ORDER = 70229;
 
 // Make sure that none of the values above collide with `ADDRV2_FORMAT`.
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -32,7 +32,7 @@ from test_framework.util import hex_str_to_bytes, assert_equal
 import dash_hash
 
 MIN_VERSION_SUPPORTED = 60001
-MY_VERSION = 70228  # SMNLE_VERSIONED_PROTO_VERSION
+MY_VERSION = 70229  # MNLISTDIFF_VERSION_ORDER
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3%s/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
@@ -2038,13 +2038,13 @@ class msg_mnlistdiff:
         self.newQuorums = []
 
     def deserialize(self, f):
+        self.nVersion = struct.unpack("<H", f.read(2))[0]
         self.baseBlockHash = deser_uint256(f)
         self.blockHash = deser_uint256(f)
         self.merkleProof.deserialize(f)
         self.cbTx = CTransaction()
         self.cbTx.deserialize(f)
         self.cbTx.rehash()
-        self.nVersion = struct.unpack("<H", f.read(2))[0]
         self.deletedMNs = deser_uint256_vector(f)
         self.mnList = []
         for i in range(deser_compact_size(f)):


### PR DESCRIPTION
## Issue being fixed or feature implemented

Version field should always be the first field of a message for better readibility.

## What was done?

- Introduced new protocol version `MNLISTDIFF_VERSION_ORDER` (`70229`).
- `nVersion` serialisation order is changed for clients with protocol version greater than or equal to `70229`.
- For clients with protocol version >= `70225` and < `70229` the old order is used: can be deprecated in the future.
- Increased functional test P2P mininode's protocol version to `70229`.

## How Has This Been Tested?
`feature_llmq_rotation.py` with new protocol version.

## Breaking Changes

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

