### PR TITLE
feat(gui): refresh the whole wallet instead of processing individual updates for huge notification queues

### DIFF
--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -113,6 +113,8 @@ private:
     QVariant txAddressDecoration(const TransactionRecord *wtx) const;
 
 public Q_SLOTS:
+    /* Refresh the whole wallet, helpful for huge notification queues */
+    void refreshWallet();
     /* New transaction, or transaction changed status */
     void updateTransaction(const QString &hash, int status, bool showTransaction);
     void updateAddressBook(const QString &address, const QString &label,


### PR DESCRIPTION
## Issue being fixed or feature implemented
It's super slow for wallets with 100.000s of txes to process lots of notifications produced by rescan. Skip them all and simply refresh the whole wallet instead. In my case (500k+ txes testnet wallet) gui update after `rescanblockchain` time is down from _forever_ to ~30 seconds. Same for `wipewallettxes true` (#5451 ). Gui update after `wipewallettxes`/`wipewallettxes false` is instant (cause there are no txes anymore).


## What was done?
refresh the whole wallet when notification queue is above 10K operations

actual changes (ignoring whitespaces): https://github.com/dashpay/dash/commit/d013cb4f5cf7627f75241a4a6bbfe345dd8a2dd1?w=1

## How Has This Been Tested?
running on top of #5451 and #5452 , wiping and rescanning w/ and w/out this patch.

## Breaking Changes
should be none


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

