### PR TITLE
feat(wallet): TopUpKeyPool improvements

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1446,7 +1446,7 @@ bool LegacyScriptPubKeyMan::TopUpInner(unsigned int kpSize)
             if (GetTime() >= progress_report_time + PROGRESS_REPORT_INTERVAL) {
                 const double dProgress = 100.f * current_index / total_missing;
                 progress_report_time = GetTime();
-                WalletLogPrintf("Still topping up. At key %i. Progress=%f\n", current_index, dProgress);
+                WalletLogPrintf("Still topping up. At key %lld. Progress=%f\n", current_index, dProgress);
                 if (should_show_progress) {
                     uiInterface.ShowProgress(strMsg, static_cast<int>(dProgress), false);
                 }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1444,11 +1444,11 @@ bool LegacyScriptPubKeyMan::TopUpInner(unsigned int kpSize)
             AddKeypoolPubkeyWithDB(pubkey, fInternal, batch);
 
             if (GetTime() >= progress_report_time + PROGRESS_REPORT_INTERVAL) {
-                const double dProgress = 100.f * current_index / (total_missing);
+                const double dProgress = 100.f * current_index / total_missing;
                 progress_report_time = GetTime();
                 WalletLogPrintf("Still topping up. At key %i. Progress=%f\n", current_index, dProgress);
-                if (should_show_progress && (int)dProgress > 0) {
-                    uiInterface.ShowProgress(strMsg, (int)dProgress, false);
+                if (should_show_progress) {
+                    uiInterface.ShowProgress(strMsg, static_cast<int>(dProgress), false);
                 }
             }
             if (ShutdownRequested()) break;


### PR DESCRIPTION
## Issue being fixed or feature implemented
- make progress calculations sane
- show progress in GUI but only when you need 100+ new keys
- make it stop on shutdown request
- spam less in debug.log

## What was done?


## How Has This Been Tested?
run tests, run `keypoolrefill` with `1100` (add 100 keys, no gui popup) and `10000` (100+ keys, progress bar) on testnet wallet, check logs, verify it can be interrupted on shutdown

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

