### PR TITLE
Compensate for errors in TimeOffset used to calculate AdjustedTime.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -854,6 +854,54 @@ size_t CConnman::SocketSendData(CNode *pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs
     auto it = pnode->vSendMsg.begin();
     size_t nSentSize = 0;
 
+/*  Begin queue send delay time offset fix
+    The Sendtime is not the time this message was put in the queue,
+    it is Now(). Observed queue delays of 30 seconds or more are introduced
+    on hosts with restricted resources during "tip" folloowing and chain
+    re-org operations. This delay corrupts AdjustedTime on the receiving host
+
+    format of VERSION message in std::deque, not contiguous
+    (4)     message start
+    (12)    command = version
+    (4)     size
+    (4)     checksum
+------- chunk 2 -------
+    (4)     nVersion
+    (8)     nServiceInt
+    (8)     nTime
+    (x)     CAddress    addrMe
+    (x)     CAddress    addrFrom
+    (8)     nNonce
+    ........ and so on...
+*/
+    const int bigint = 1;
+    auto& sh = *it;
+// at front of deque, hdrbuf is first
+    CMessageHeader * shdr = reinterpret_cast<CMessageHeader*>(sh.data());
+    std::string strCommand = shdr->GetCommand();
+    if (strCommand == NetMsgType::VERSION) {
+/*  do not increment "it", it corrupts deque
+    header and message are in 2 sequential non-contiguious chunks in the deque, see:
+    void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
+    ...
+        pnode->vSendMsg.push_back(std::move(serializedHeader));
+        if (nMessageSize)
+            pnode->vSendMsg.push_back(std::move(msg.data));
+*/
+        auto& sd = *(std::next(it, 1)); // point to next data chunk
+        int64_t * pnsTime = reinterpret_cast<int64_t*>(sd.data() + 12);
+        int64_t nSendtime = *pnsTime;
+        int64_t nNow = (pnode->fInbound) ? GetAdjustedTime() : GetTime();
+        int64_t nNewSendtime = nNow;
+        if (! *(char *)&bigint) {       // if bigendian
+            nSendtime = bswap_64(*pnsTime);
+            nNewSendtime = bswap_64(nNow);
+        }
+//        LogPrintf("HACK %s size %d %" PRId64 " %" PRId64 "\n", strCommand.c_str(), shdr->nMessageSize, nSendtime
+        if (nSendtime != nNow) *pnsTime = nNewSendtime;
+    }
+// end time offset fix
+
     while (it != pnode->vSendMsg.end()) {
         const auto &data = *it;
         assert(data.size() > pnode->nSendOffset);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2755,7 +2755,15 @@ void PeerLogicValidation::ProcessMessage(
                   pfrom.nStartingHeight, addrMe.ToString(), pfrom.GetId(),
                   remoteAddr);
 
-        int64_t nTimeOffset = nTime - GetTime();
+/*  Begin queue receive delay time offset fix
+    The receive time is not the time this message is processed, it it the time
+    it was put in the queue nTimeReceived.
+    Observed queue delays of 30 seconds or more are introduced
+    on hosts with restricted resources during "tip" folloowing and chain
+    re-org operations. This delay corrupts AdjustedTime/
+*/
+//        int64_t nTimeOffset = nTime - GetTime();
+        int64_t nTimeOffset = nTime - (nTimeReceived/1000000);
         pfrom.nTimeOffset = nTimeOffset;
         AddTimeData(pfrom.addr, nTimeOffset);
 


### PR DESCRIPTION

## What was done?
fix: Modify network send/receive code to eliminate queue delay  which corrupts AdjustedTime

## How Has This Been Tested?
tested under duress (2 thread processes max) during chain re-org logging the queue delay (see patch with commented out LogPrintf) delays in excess of 30 seconds detected pre-patch

This issue was inherited from bitcoin and has propagated to a vast number of other alt-coins that are descendent from dash.
I first noticed it in a pivx decendent and fixed it there. Now pushing it back to dash. I have multiple dash nodes running on an enterprise system.

Testing was done on an enterprise server 24 core hp 192gb 370 GS with the daemon restricted to 2 core threads
The receive queue is the worst offender with time offsets exceeding 30 seconds at least once a minute.
Log code
int nTToff = GetTime () - (nTimeReceived/1000000);
if (nTToff != 0) LogPrintf("TOFFSET %d\n", nTToff);

Errors were confirmed in that the log indicated multiple messages received from the "error hosts" without incident, and only showing errors when the cpu utilization for the logging daemon touched 100% or more indicating chain following or re-org activity underway that sucked up thread capacity and delayed the processing of the network queues.

Send queue error was observed only once in a day long test period. On that occasion the error was between the logging daemon and another daemon on the same host so the clock sync was known to be accurate. Error exceeded 30 seconds.


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

