### PR TITLE
refactor: removed flag `checkMalleable` from bls's related code

### DIFF
--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -183,13 +183,13 @@ public:
     }
 
     template <typename Stream>
-    inline void Unserialize(Stream& s, const bool specificLegacyScheme, bool checkMalleable = true)
+    inline void Unserialize(Stream& s, const bool specificLegacyScheme)
     {
         std::vector<uint8_t> vecBytes(SerSize, 0);
         s.read(reinterpret_cast<char*>(vecBytes.data()), SerSize);
         SetByteVector(vecBytes, specificLegacyScheme);
 
-        if (checkMalleable && !CheckMalleable(vecBytes, specificLegacyScheme)) {
+        if (!CheckMalleable(vecBytes, specificLegacyScheme)) {
             // If CheckMalleable failed with specificLegacyScheme, we need to try again with the opposite scheme.
             // Probably we received the BLS object sent with legacy scheme, but in the meanwhile the fork activated.
             SetByteVector(vecBytes, !specificLegacyScheme);
@@ -205,9 +205,9 @@ public:
     }
 
     template <typename Stream>
-    inline void Unserialize(Stream& s, bool checkMalleable = true)
+    inline void Unserialize(Stream& s)
     {
-        Unserialize(s, bls::bls_legacy_scheme.load(), checkMalleable);
+        Unserialize(s, bls::bls_legacy_scheme.load());
     }
 
     inline bool CheckMalleable(Span<uint8_t> vecBytes, const bool specificLegacyScheme) const
@@ -333,12 +333,10 @@ class CBLSPublicKeyVersionWrapper {
 private:
     CBLSPublicKey& obj;
     bool legacy;
-    bool checkMalleable;
 public:
-    CBLSPublicKeyVersionWrapper(CBLSPublicKey& obj, bool legacy, bool checkMalleable = true)
+    CBLSPublicKeyVersionWrapper(CBLSPublicKey& obj, bool legacy)
             : obj(obj)
             , legacy(legacy)
-            , checkMalleable(checkMalleable)
     {}
     template <typename Stream>
     inline void Serialize(Stream& s) const {
@@ -346,7 +344,7 @@ public:
     }
     template <typename Stream>
     inline void Unserialize(Stream& s) {
-        obj.Unserialize(s, legacy, checkMalleable);
+        obj.Unserialize(s, legacy);
     }
 };
 
@@ -381,12 +379,10 @@ class CBLSSignatureVersionWrapper {
 private:
     CBLSSignature& obj;
     bool legacy;
-    bool checkMalleable;
 public:
-    CBLSSignatureVersionWrapper(CBLSSignature& obj, bool legacy, bool checkMalleable = true)
+    CBLSSignatureVersionWrapper(CBLSSignature& obj, bool legacy)
             : obj(obj)
             , legacy(legacy)
-            , checkMalleable(checkMalleable)
     {}
     template <typename Stream>
     inline void Serialize(Stream& s) const {
@@ -394,7 +390,7 @@ public:
     }
     template <typename Stream>
     inline void Unserialize(Stream& s) {
-        obj.Unserialize(s, legacy, checkMalleable);
+        obj.Unserialize(s, legacy);
     }
 };
 

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -167,7 +167,7 @@ public:
         }
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(
-                    CBLSSignatureVersionWrapper(const_cast<CBLSSignature&>(obj.sig), (obj.nVersion == LEGACY_BLS_VERSION), true)
+                    CBLSSignatureVersionWrapper(const_cast<CBLSSignature&>(obj.sig), (obj.nVersion == LEGACY_BLS_VERSION))
             );
         }
     }
@@ -305,7 +305,7 @@ public:
         );
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(
-                    CBLSSignatureVersionWrapper(const_cast<CBLSSignature&>(obj.sig), (obj.nVersion == LEGACY_BLS_VERSION), true)
+                    CBLSSignatureVersionWrapper(const_cast<CBLSSignature&>(obj.sig), (obj.nVersion == LEGACY_BLS_VERSION))
             );
         }
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Current implementation of BLS wrapper has an unclear interface related to `checkMalleable` flag.

There are 2 methods Unserialize, that has both default arguments:

```
template
inline void Unserialize(Stream& s, const bool specificLegacyScheme, bool checkMalleable = true);
template
inline void Unserialize(Stream& s, bool checkMalleable = true);
```

Let's assume that I am calling `Unserialize(s, true)` - it's very non-obvious which one will be called and not error prune at all. 

It should be re-implemented, and there should not be default argument. 

Pasta noticed that this flag can be useful from performance point of view - let's have better new method such as `UnserializeNoMalleable` or similar and use it when reindexing/etc. It should be specified explicit.

Reverting this change and adding new interface in future won't be difficult task so far as changes are quite trivial.


## What was done?
Removed flag checkMalleable to simplify code because it's always true.
It splits from https://github.com/dashpay/dash/pull/5443


## How Has This Been Tested?
Run unit functional tests.

## Breaking Changes
No breaking changes - flag is always true.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

