### PR TITLE
fix: Fix trivial validation typo and test

### DIFF
--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -11,9 +11,9 @@
 #include <script/standard.h>
 #include <util/underlying.h>
 
-bool CProRegTx::IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const
+bool CProRegTx::IsTriviallyValid(bool is_basic_scheme_active, TxValidationState& state) const
 {
-    if (nVersion == 0 || nVersion > GetVersion(is_bls_legacy_scheme)) {
+    if (nVersion == 0 || nVersion > GetVersion(is_basic_scheme_active)) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-version");
     }
     if (!IsValidMnType(nType)) {
@@ -87,9 +87,9 @@ std::string CProRegTx::ToString() const
                      nVersion, ToUnderlying(nType), collateralOutpoint.ToStringShort(), addr.ToString(), (double)nOperatorReward / 100, EncodeDestination(PKHash(keyIDOwner)), pubKeyOperator.ToString(), EncodeDestination(PKHash(keyIDVoting)), payee, platformNodeID.ToString(), platformP2PPort, platformHTTPPort);
 }
 
-bool CProUpServTx::IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const
+bool CProUpServTx::IsTriviallyValid(bool is_basic_scheme_active, TxValidationState& state) const
 {
-    if (nVersion == 0 || nVersion > GetVersion(is_bls_legacy_scheme)) {
+    if (nVersion == 0 || nVersion > GetVersion(is_basic_scheme_active)) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-version");
     }
 
@@ -108,9 +108,9 @@ std::string CProUpServTx::ToString() const
                      nVersion, ToUnderlying(nType), proTxHash.ToString(), addr.ToString(), payee, platformNodeID.ToString(), platformP2PPort, platformHTTPPort);
 }
 
-bool CProUpRegTx::IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const
+bool CProUpRegTx::IsTriviallyValid(bool is_basic_scheme_active, TxValidationState& state) const
 {
-    if (nVersion == 0 || nVersion > GetVersion(is_bls_legacy_scheme)) {
+    if (nVersion == 0 || nVersion > GetVersion(is_basic_scheme_active)) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-version");
     }
     if (nMode != 0) {
@@ -141,9 +141,9 @@ std::string CProUpRegTx::ToString() const
         nVersion, proTxHash.ToString(), pubKeyOperator.ToString(), EncodeDestination(PKHash(keyIDVoting)), payee);
 }
 
-bool CProUpRevTx::IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const
+bool CProUpRevTx::IsTriviallyValid(bool is_basic_scheme_active, TxValidationState& state) const
 {
-    if (nVersion == 0 || nVersion > GetVersion(is_bls_legacy_scheme)) {
+    if (nVersion == 0 || nVersion > GetVersion(is_basic_scheme_active)) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-protx-version");
     }
 

--- a/src/test/evo_trivialvalidation.cpp
+++ b/src/test/evo_trivialvalidation.cpp
@@ -49,28 +49,28 @@ BOOST_AUTO_TEST_CASE(trivialvalidation_valid)
                     BOOST_CHECK_EQUAL(txType, "proregtx");
                     CProRegTx ptx;
                     BOOST_CHECK(GetTxPayload(tx, ptx, false));
-                    BOOST_CHECK(ptx.IsTriviallyValid(bls::bls_legacy_scheme.load(), dummy_state));
+                    BOOST_CHECK(ptx.IsTriviallyValid(!bls::bls_legacy_scheme.load(), dummy_state));
                     break;
                 }
                 case TRANSACTION_PROVIDER_UPDATE_SERVICE: {
                     BOOST_CHECK_EQUAL(txType, "proupservtx");
                     CProUpServTx ptx;
                     BOOST_CHECK(GetTxPayload(tx, ptx, false));
-                    BOOST_CHECK(ptx.IsTriviallyValid(bls::bls_legacy_scheme.load(), dummy_state));
+                    BOOST_CHECK(ptx.IsTriviallyValid(!bls::bls_legacy_scheme.load(), dummy_state));
                     break;
                 }
                 case TRANSACTION_PROVIDER_UPDATE_REGISTRAR: {
                     BOOST_CHECK_EQUAL(txType, "proupregtx");
                     CProUpRegTx ptx;
                     BOOST_CHECK(GetTxPayload(tx, ptx, false));
-                    BOOST_CHECK(ptx.IsTriviallyValid(bls::bls_legacy_scheme.load(), dummy_state));
+                    BOOST_CHECK(ptx.IsTriviallyValid(!bls::bls_legacy_scheme.load(), dummy_state));
                     break;
                 }
                 case TRANSACTION_PROVIDER_UPDATE_REVOKE: {
                     BOOST_CHECK_EQUAL(txType, "prouprevtx");
                     CProUpRevTx ptx;
                     BOOST_CHECK(GetTxPayload(tx, ptx, false));
-                    BOOST_CHECK(ptx.IsTriviallyValid(bls::bls_legacy_scheme.load(), dummy_state));
+                    BOOST_CHECK(ptx.IsTriviallyValid(!bls::bls_legacy_scheme.load(), dummy_state));
                     break;
                 }
                 default:
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(trivialvalidation_invalid)
             if (txType == "proregtx") {
                 CProRegTx ptx;
                 if (GetTxPayload(tx, ptx, false)) {
-                    BOOST_CHECK(!ptx.IsTriviallyValid(bls::bls_legacy_scheme.load(), dummy_state));
+                    BOOST_CHECK(!ptx.IsTriviallyValid(!bls::bls_legacy_scheme.load(), dummy_state));
                 } else {
                     BOOST_CHECK(tx.nType != TRANSACTION_PROVIDER_REGISTER || ptx.nVersion == 0);
                 }
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(trivialvalidation_invalid)
             else if (txType == "proupservtx") {
                 CProUpServTx ptx;
                 if (GetTxPayload(tx, ptx, false)) {
-                    BOOST_CHECK(!ptx.IsTriviallyValid(bls::bls_legacy_scheme.load(), dummy_state));
+                    BOOST_CHECK(!ptx.IsTriviallyValid(!bls::bls_legacy_scheme.load(), dummy_state));
                 } else {
                     BOOST_CHECK(tx.nType != TRANSACTION_PROVIDER_UPDATE_SERVICE || ptx.nVersion == 0);
                 }
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(trivialvalidation_invalid)
             else if (txType == "proupregtx") {
                 CProUpRegTx ptx;
                 if (GetTxPayload(tx, ptx, false)) {
-                    BOOST_CHECK(!ptx.IsTriviallyValid(bls::bls_legacy_scheme.load(), dummy_state));
+                    BOOST_CHECK(!ptx.IsTriviallyValid(!bls::bls_legacy_scheme.load(), dummy_state));
                 }
                 else {
                     BOOST_CHECK(tx.nType != TRANSACTION_PROVIDER_UPDATE_REGISTRAR || ptx.nVersion == 0);
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(trivialvalidation_invalid)
             else if (txType == "prouprevtx") {
                 CProUpRevTx ptx;
                 if (GetTxPayload(tx, ptx, false)) {
-                    BOOST_CHECK(!ptx.IsTriviallyValid(bls::bls_legacy_scheme.load(), dummy_state));
+                    BOOST_CHECK(!ptx.IsTriviallyValid(!bls::bls_legacy_scheme.load(), dummy_state));
                 } else {
                     BOOST_CHECK(tx.nType != TRANSACTION_PROVIDER_UPDATE_REVOKE || ptx.nVersion == 0);
                 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
`GetVersion` expects `is_basic_scheme_active`, not `is_bls_legacy_scheme`

## What was done?
see commits

## How Has This Been Tested?
`make check`

## Breaking Changes
luckily only tests are affected

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

