### PR TITLE
fix: gcc8 compatibility changes for guix 

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -235,22 +235,22 @@ public:
 
     [[nodiscard]] size_t GetValidMNsCount() const
     {
-        return ranges::count_if(mnMap, [](const auto& p){ return IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [this](const auto& p){ return IsMNValid(*p.second); });
     }
 
     [[nodiscard]] size_t GetAllHPMNsCount() const
     {
-        return ranges::count_if(mnMap, [](const auto& p) { return p.second->nType == MnType::HighPerformance; });
+        return ranges::count_if(mnMap, [this](const auto& p) { return p.second->nType == MnType::HighPerformance; });
     }
 
     [[nodiscard]] size_t GetValidHPMNsCount() const
     {
-        return ranges::count_if(mnMap, [](const auto& p) { return p.second->nType == MnType::HighPerformance && IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [this](const auto& p) { return p.second->nType == MnType::HighPerformance && IsMNValid(*p.second); });
     }
 
     [[nodiscard]] size_t GetValidWeightedMNsCount() const
     {
-        return std::accumulate(mnMap.begin(), mnMap.end(), 0, [](auto res, const auto& p) {
+        return std::accumulate(mnMap.begin(), mnMap.end(), 0, [this](auto res, const auto& p) {
                                                                 if (!IsMNValid(*p.second)) return res;
                                                                 return res + GetMnType(p.second->nType).voting_weight;
                                                             });


### PR DESCRIPTION
## Issue being fixed or feature implemented

As reported by @kittywhiskers, GCC version 8 complains with `error: 'this' was not captured for this lambda function`

In order to support old GCC compilers, `this` should be captured explicitly.

## What was done?

Captured `this` explicitly in affected functions: `GetValidMNsCount`, `GetAllHPMNsCount`, `GetValidHPMNsCount` and `GetValidWeightedMNsCount`.

## How Has This Been Tested?

`feature_llmq_hpmn.py` checks MNs count

## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

