### PR TITLE
feat!: masternode node hard-fork activation DIP-0023

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -118,8 +118,8 @@ bool CChainParams::UpdateMNActivationParam(int nBit, int height, int64_t timePas
                 LogPrintf("%s: trying to set MnEHF height=%d for non-masternode activation fork bit=%d\n", __func__, height, nBit);
                 return false;
             }
+            LogPrintf("%s: set MnEHF height=%d for bit=%d fJustCheck=%d is valid\n", __func__, height, nBit, fJustCheck);
             if (!fJustCheck) {
-                LogPrintf("%s: set MnEHF height=%d for bit=%d successfuly while fJustCheck=%d\n", __func__, height, nBit, fJustCheck);
                 deployment.nMNActivationHeight = height;
             }
             return true;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -105,6 +105,30 @@ static CBlock FindDevNetGenesisBlock(const CBlock &prevBlock, const CAmount& rew
     assert(false);
 }
 
+bool CChainParams::UpdateMNActivationParam(int nBit, int height, int64_t timePast, bool fJustCheck) const
+{
+    for (int index = 0; index < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++index) {
+        if (consensus.vDeployments[index].bit == nBit) {
+            auto& deployment = consensus.vDeployments[index];
+            if (timePast > deployment.nTimeout) {
+                LogPrintf("%s: activation by bit=%d time-outed at height=%d\n", __func__, nBit, height);
+                continue;
+            }
+            if (deployment.nMNActivationHeight < 0) {
+                LogPrintf("%s: trying to set MnEHF height=%d for non-masternode activation fork bit=%d\n", __func__, height, nBit);
+                return false;
+            }
+            if (!fJustCheck) {
+                LogPrintf("%s: set MnEHF height=%d for bit=%d successfuly while fJustCheck=%d\n", __func__, height, nBit, fJustCheck);
+                deployment.nMNActivationHeight = height;
+            }
+            return true;
+        }
+    }
+    LogPrintf("%s: not found MnEHF fork bit=%d\n", __func__, nBit);
+    return false;
+}
+
 void CChainParams::AddLLMQ(Consensus::LLMQType llmqType)
 {
     assert(!GetLLMQ(llmqType).has_value());
@@ -909,7 +933,7 @@ public:
     /**
      * Allows modifying the Version Bits regtest parameters.
      */
-    void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout, int64_t nWindowSize, int64_t nThresholdStart, int64_t nThresholdMin, int64_t nFalloffCoeff)
+    void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout, int64_t nWindowSize, int64_t nThresholdStart, int64_t nThresholdMin, int64_t nFalloffCoeff, int64_t nMNActivationHeight)
     {
         consensus.vDeployments[d].nStartTime = nStartTime;
         consensus.vDeployments[d].nTimeout = nTimeout;
@@ -924,6 +948,9 @@ public:
         }
         if (nFalloffCoeff != -1) {
             consensus.vDeployments[d].nFalloffCoeff = nFalloffCoeff;
+        }
+        if (nMNActivationHeight != -1) {
+            consensus.vDeployments[d].nMNActivationHeight = nMNActivationHeight;
         }
     }
     void UpdateActivationParametersFromArgs(const ArgsManager& args);
@@ -998,13 +1025,13 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
 
     for (const std::string& strDeployment : args.GetArgs("-vbparams")) {
         std::vector<std::string> vDeploymentParams = SplitString(strDeployment, ':');
-        if (vDeploymentParams.size() != 3 && vDeploymentParams.size() != 5 && vDeploymentParams.size() != 7) {
+        if (vDeploymentParams.size() != 3 && vDeploymentParams.size() != 5 && vDeploymentParams.size() != 8) {
             throw std::runtime_error("Version bits parameters malformed, expecting "
                     "<deployment>:<start>:<end> or "
                     "<deployment>:<start>:<end>:<window>:<threshold> or "
-                    "<deployment>:<start>:<end>:<window>:<thresholdstart>:<thresholdmin>:<falloffcoeff>");
+                    "<deployment>:<start>:<end>:<window>:<thresholdstart>:<thresholdmin>:<falloffcoeff>:<mnactivation>");
         }
-        int64_t nStartTime, nTimeout, nWindowSize = -1, nThresholdStart = -1, nThresholdMin = -1, nFalloffCoeff = -1;
+        int64_t nStartTime, nTimeout, nWindowSize = -1, nThresholdStart = -1, nThresholdMin = -1, nFalloffCoeff = -1, nMNActivationHeight = -1;
         if (!ParseInt64(vDeploymentParams[1], &nStartTime)) {
             throw std::runtime_error(strprintf("Invalid nStartTime (%s)", vDeploymentParams[1]));
         }
@@ -1019,21 +1046,24 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
                 throw std::runtime_error(strprintf("Invalid nThresholdStart (%s)", vDeploymentParams[4]));
             }
         }
-        if (vDeploymentParams.size() == 7) {
+        if (vDeploymentParams.size() == 8) {
             if (!ParseInt64(vDeploymentParams[5], &nThresholdMin)) {
                 throw std::runtime_error(strprintf("Invalid nThresholdMin (%s)", vDeploymentParams[5]));
             }
             if (!ParseInt64(vDeploymentParams[6], &nFalloffCoeff)) {
                 throw std::runtime_error(strprintf("Invalid nFalloffCoeff (%s)", vDeploymentParams[6]));
             }
+            if (!ParseInt64(vDeploymentParams[7], &nMNActivationHeight)) {
+                throw std::runtime_error(strprintf("Invalid nMNActivationHeight (%s)", vDeploymentParams[7]));
+            }
         }
         bool found = false;
         for (int j=0; j < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j) {
             if (vDeploymentParams[0] == VersionBitsDeploymentInfo[j].name) {
-                UpdateVersionBitsParameters(Consensus::DeploymentPos(j), nStartTime, nTimeout, nWindowSize, nThresholdStart, nThresholdMin, nFalloffCoeff);
+                UpdateVersionBitsParameters(Consensus::DeploymentPos(j), nStartTime, nTimeout, nWindowSize, nThresholdStart, nThresholdMin, nFalloffCoeff, nMNActivationHeight);
                 found = true;
-                LogPrintf("Setting version bits activation parameters for %s to start=%ld, timeout=%ld, window=%ld, thresholdstart=%ld, thresholdmin=%ld, falloffcoeff=%ld\n",
-                          vDeploymentParams[0], nStartTime, nTimeout, nWindowSize, nThresholdStart, nThresholdMin, nFalloffCoeff);
+                LogPrintf("Setting version bits activation parameters for %s to start=%ld, timeout=%ld, window=%ld, thresholdstart=%ld, thresholdmin=%ld, falloffcoeff=%ld, mnactivationHeight=%ld\n",
+                          vDeploymentParams[0], nStartTime, nTimeout, nWindowSize, nThresholdStart, nThresholdMin, nFalloffCoeff, nMNActivationHeight);
                 break;
             }
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -110,8 +110,8 @@ bool CChainParams::UpdateMNActivationParam(int nBit, int height, int64_t timePas
     for (int index = 0; index < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++index) {
         if (consensus.vDeployments[index].bit == nBit) {
             auto& deployment = consensus.vDeployments[index];
-            if (timePast > deployment.nTimeout) {
-                LogPrintf("%s: activation by bit=%d for deployment %s timed out at height=%d\n", __func__, nBit, VersionBitsDeploymentInfo[Consensus::DeploymentPos(index)].name, height);
+            if (timePast > deployment.nTimeout || timePast < deployment.nStartTime) {
+                LogPrintf("%s: activation by bit=%d height=%d deployment='%s' is out of time range start=%lld timeout=%lld\n", __func__, nBit, height, VersionBitsDeploymentInfo[Consensus::DeploymentPos(index)].name, deployment.nStartTime, deployment.nTimeout);
                 continue;
             }
             if (deployment.nMNActivationHeight < 0) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -192,6 +192,7 @@ public:
         consensus.DIP0024Height = 1737792; // 0000000000000001342be9c0b75ad40c276beaad91616423c4d9cb101b3db438
         consensus.V19Height = 1899072; // 0000000000000015e32e73052d663626327004c81c5c22cb8b42c361015c0eae
         consensus.MinBIP9WarningHeight = 1899072 + 2016; // V19 activation height + miner confirmation window
+        consensus.nExpireEHF = 576 * 365; // one year
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -389,6 +390,7 @@ public:
         consensus.DIP0024Height = 769700; // 0000008d84e4efd890ae95c70a7a6126a70a80e5c19e4cb264a5b3469aeef172
         consensus.V19Height = 850100; // 000004728b8ff2a16b9d4eebb0fd61eeffadc9c7fe4b0ec0b5a739869401ab5b
         consensus.MinBIP9WarningHeight = 850100 + 2016;  // v19 activation height + miner confirmation window
+        consensus.nExpireEHF = 576 * 365; // one year
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -560,6 +562,7 @@ public:
         consensus.DIP0024Height = 300;
         consensus.V19Height = 300;
         consensus.MinBIP9WarningHeight = 300 + 2016; // v19 activation height + miner confirmation window
+        consensus.nExpireEHF = 576 * 365; // one year
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -798,6 +801,7 @@ public:
         consensus.DIP0024Height = 900;
         consensus.V19Height = 900;
         consensus.MinBIP9WarningHeight = 0;
+        consensus.nExpireEHF = 576; // one day for RegTest
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,7 +125,7 @@ bool CChainParams::UpdateMNActivationParam(int nBit, int height, int64_t timePas
             return true;
         }
     }
-    LogPrintf("%s: not found MnEHF fork bit=%d\n", __func__, nBit);
+    LogPrintf("%s: WARNING: unknown MnEHF fork bit=%d\n", __func__, nBit);
     return true;
 }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -111,7 +111,7 @@ bool CChainParams::UpdateMNActivationParam(int nBit, int height, int64_t timePas
         if (consensus.vDeployments[index].bit == nBit) {
             auto& deployment = consensus.vDeployments[index];
             if (timePast > deployment.nTimeout) {
-                LogPrintf("%s: activation by bit=%d time-outed at height=%d\n", __func__, nBit, height);
+                LogPrintf("%s: activation by bit=%d for deployment %s timed out at height=%d\n", __func__, nBit, VersionBitsDeploymentInfo[Consensus::DeploymentPos(index)].name, height);
                 continue;
             }
             if (deployment.nMNActivationHeight < 0) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -126,7 +126,7 @@ bool CChainParams::UpdateMNActivationParam(int nBit, int height, int64_t timePas
         }
     }
     LogPrintf("%s: not found MnEHF fork bit=%d\n", __func__, nBit);
-    return false;
+    return true;
 }
 
 void CChainParams::AddLLMQ(Consensus::LLMQType llmqType)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -12,6 +12,7 @@
 #include <util/ranges.h>
 #include <util/system.h>
 #include <util/underlying.h>
+#include <versionbits.h>
 #include <versionbitsinfo.h>
 
 #include <arith_uint256.h>
@@ -107,6 +108,8 @@ static CBlock FindDevNetGenesisBlock(const CBlock &prevBlock, const CAmount& rew
 
 bool CChainParams::UpdateMNActivationParam(int nBit, int height, int64_t timePast, bool fJustCheck) const
 {
+    assert(nBit < VERSIONBITS_NUM_BITS);
+
     for (int index = 0; index < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++index) {
         if (consensus.vDeployments[index].bit == nBit) {
             auto& deployment = consensus.vDeployments[index];

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -195,7 +195,6 @@ public:
         consensus.DIP0024Height = 1737792; // 0000000000000001342be9c0b75ad40c276beaad91616423c4d9cb101b3db438
         consensus.V19Height = 1899072; // 0000000000000015e32e73052d663626327004c81c5c22cb8b42c361015c0eae
         consensus.MinBIP9WarningHeight = 1899072 + 2016; // V19 activation height + miner confirmation window
-        consensus.nExpireEHF = 576 * 365; // one year
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -393,7 +392,6 @@ public:
         consensus.DIP0024Height = 769700; // 0000008d84e4efd890ae95c70a7a6126a70a80e5c19e4cb264a5b3469aeef172
         consensus.V19Height = 850100; // 000004728b8ff2a16b9d4eebb0fd61eeffadc9c7fe4b0ec0b5a739869401ab5b
         consensus.MinBIP9WarningHeight = 850100 + 2016;  // v19 activation height + miner confirmation window
-        consensus.nExpireEHF = 576 * 365; // one year
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -565,7 +563,6 @@ public:
         consensus.DIP0024Height = 300;
         consensus.V19Height = 300;
         consensus.MinBIP9WarningHeight = 300 + 2016; // v19 activation height + miner confirmation window
-        consensus.nExpireEHF = 576 * 365; // one year
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -804,7 +801,6 @@ public:
         consensus.DIP0024Height = 900;
         consensus.V19Height = 900;
         consensus.MinBIP9WarningHeight = 0;
-        consensus.nExpireEHF = 576; // one day for RegTest
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -134,6 +134,15 @@ public:
     void UpdateDIP8Parameters(int nActivationHeight);
     void UpdateBudgetParameters(int nMasternodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock);
     void UpdateLLMQInstantSend(Consensus::LLMQType llmqType);
+    /**
+     * Update params for Masternodes EHF
+     *
+     * @param[in] nBit The version bit to update
+     * @param[in] height The height of block where that signal is mined
+     * @param[in] timePast The block time to validate if release is already time-outed
+     * @param[in] fJustCheck If true do not update any internal data, only validate params
+     * @return Whether params are legit and params are updated (if release is known)
+     */
     bool UpdateMNActivationParam(int nBit, int height, int64_t timePast, bool fJustCheck) const;
     int PoolMinParticipants() const { return nPoolMinParticipants; }
     int PoolMaxParticipants() const { return nPoolMaxParticipants; }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -134,6 +134,7 @@ public:
     void UpdateDIP8Parameters(int nActivationHeight);
     void UpdateBudgetParameters(int nMasternodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock);
     void UpdateLLMQInstantSend(Consensus::LLMQType llmqType);
+    bool UpdateMNActivationParam(int nBit, int height, int64_t timePast, bool fJustCheck) const;
     int PoolMinParticipants() const { return nPoolMinParticipants; }
     int PoolMaxParticipants() const { return nPoolMaxParticipants; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -36,9 +36,9 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                    "This is intended for regression testing tools and app development. Equivalent to -chain=regtest", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-vbparams=<deployment>:<start>:<end>(:<window>:<threshold/thresholdstart>(:<thresholdmin>:<falloffcoeff>))",
+    argsman.AddArg("-vbparams=<deployment>:<start>:<end>(:<window>:<threshold/thresholdstart>(:<thresholdmin>:<falloffcoeff>:<mnactivation>))",
                  "Use given start/end times for specified version bits deployment (regtest-only). "
-                 "Specifying window, threshold/thresholdstart, thresholdmin and falloffcoeff is optional.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+                 "Specifying window, threshold/thresholdstart, thresholdmin, falloffcoeff and mnactivation is optional.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
 
 }
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -48,6 +48,13 @@ struct BIP9Deployment {
      *  process (which takes at least 3 BIP9 intervals). Only tests that specifically test the
      *  behaviour during activation cannot use this. */
     static constexpr int64_t ALWAYS_ACTIVE = -1;
+
+    /** this value is used for forks activated by master nodes.
+      * negative values means it is regular fork, no masternodes confirmation is needed.
+      * 0 means that there's no approval from masternodes yet.
+      * Otherwise it shows minimum height when miner's signals for this block can be assumed
+      */
+    mutable int64_t nMNActivationHeight{-1};
 };
 
 /**

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -112,6 +112,8 @@ struct Params {
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and DIP activations. */
     int MinBIP9WarningHeight;
+    /** this value is used to expire signals of EHF */
+    int nExpireEHF;
     /**
      * Minimum blocks including miner confirmation of the total of nMinerConfirmationWindow blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -112,8 +112,6 @@ struct Params {
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and DIP activations. */
     int MinBIP9WarningHeight;
-    /** this value is used to expire signals of EHF */
-    int nExpireEHF;
     /**
      * Minimum blocks including miner confirmation of the total of nMinerConfirmationWindow blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -159,7 +159,7 @@ bool CMNHFManager::ProcessBlock(const CBlock& block, const CBlockIndex* const pi
         }
         Signals signals = GetSignalsStage(pindex->pprev);
         if (new_signals.empty()) {
-            if (fJustCheck) {
+            if (!fJustCheck) {
                 AddToCache(signals, pindex);
             }
             return true;

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -15,9 +15,12 @@
 #include <validation.h>
 #include <versionbits.h>
 
+#include <algorithm>
 #include <string>
+#include <vector>
 
 extern const std::string MNEHF_REQUESTID_PREFIX = "mnhf";
+static const std::string DB_SIGNALS = "mnhf_s";
 
 bool MNHFTx::Verify(const CBlockIndex* pQuorumIndex, const uint256& msgHash, TxValidationState& state) const
 {
@@ -78,6 +81,183 @@ bool CheckMNHFTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValida
     }
 
     return true;
+}
+
+static bool extractSignals(const CBlock& block, const CBlockIndex* const pindex, std::vector<uint8_t>& signals_to_process, BlockValidationState& state)
+{
+    AssertLockHeld(cs_main);
+
+    // we skip the coinbase
+    for (size_t i = 1; i < block.vtx.size(); ++i) {
+        const CTransaction& tx = *block.vtx[i];
+
+        if (tx.nVersion != 3 || tx.nType != TRANSACTION_MNHF_SIGNAL) {
+            // only interested in special TXs 'TRANSACTION_MNHF_SIGNAL'
+            continue;
+        }
+
+        TxValidationState tx_state;
+        if (!CheckMNHFTx(tx, pindex, tx_state)) {
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(), tx_state.GetDebugMessage());
+        }
+
+        MNHFTxPayload mnhfTx;
+        if (!GetTxPayload(tx, mnhfTx)) {
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-mnhf-tx-payload");
+        }
+        signals_to_process.push_back(mnhfTx.signal.versionBit);
+    }
+
+    // Checking that there's no any duplicates...
+    std::sort(signals_to_process.begin(), signals_to_process.end());
+    const auto it = std::unique(signals_to_process.begin(), signals_to_process.end());
+    if (std::distance(signals_to_process.begin(), it) != signals_to_process.size()) {
+        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-mnhf-duplicates");
+    }
+
+    return true;
+}
+
+bool CMNHFManager::ProcessBlock(const CBlock& block, const CBlockIndex* const pindex, bool fJustCheck, BlockValidationState& state)
+{
+    try {
+        std::vector<uint8_t> new_signals;
+        if (!extractSignals(block, pindex, new_signals, state)) {
+            // state is set inside extractSignals
+            return false;
+        }
+        if (new_signals.empty()) {
+            if (!fJustCheck) {
+                AddToCache(GetFromCache(pindex->pprev), pindex);
+            }
+            return true;
+        }
+
+        Signals signals = GetFromCache(pindex->pprev);
+        int mined_height = pindex->nHeight;
+
+        // Extra validation of signals to be sure that it can succeed
+        for (const auto& versionBit : new_signals) {
+            LogPrintf("%s: add mnhf bit=%d block:%s number of known signals:%lld\n", __func__, versionBit, pindex->GetBlockHash().ToString(), signals.size());
+            if (signals.find(versionBit) != signals.end()) {
+                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-mnhf-duplicate");
+            }
+
+            if (!Params().UpdateMNActivationParam(versionBit, mined_height, pindex->GetMedianTimePast(), true /* fJustCheck */)) {
+                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-mnhf-non-mn-fork");
+            }
+        }
+        if (fJustCheck) {
+            // We are done, no need actually update any params
+            return true;
+        }
+        for (const auto& versionBit : new_signals) {
+            signals.insert({versionBit, mined_height});
+
+            if (!Params().UpdateMNActivationParam(versionBit, mined_height, pindex->GetMedianTimePast(), false /* fJustCheck */)) {
+                // it should not ever fail - all checks are done above
+                assert(false);
+            }
+
+        }
+
+        AddToCache(signals, pindex);
+        return true;
+    } catch (const std::exception& e) {
+        LogPrintf("%s -- failed: %s\n", __func__, e.what());
+        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "failed-proc-mnhf-inblock");
+    }
+}
+
+bool CMNHFManager::UndoBlock(const CBlock& block, const CBlockIndex* const pindex)
+{
+    std::vector<uint8_t> excluded_signals;
+    BlockValidationState state;
+    if (!extractSignals(block, pindex, excluded_signals, state)) {
+        LogPrintf("%s: failed to extract signals\n", __func__);
+        return false;
+    }
+    if (excluded_signals.empty()) {
+        return true;
+    }
+
+    const Signals signals = GetFromCache(pindex);
+    for (const auto& versionBit : excluded_signals) {
+        assert(versionBit < VERSIONBITS_NUM_BITS);
+
+        LogPrintf("%s: exclude mnhf bit=%d block:%s number of known signals:%lld\n", __func__, versionBit, pindex->GetBlockHash().ToString(), signals.size());
+        assert(signals.find(versionBit) != signals.end());
+
+        bool update_ret = Params().UpdateMNActivationParam(versionBit, 0, pindex->GetMedianTimePast(), false /* fJustCheck */);
+        assert(update_ret);
+    }
+
+    return true;
+}
+
+void CMNHFManager::UpdateChainParams(const CBlockIndex* const pindex, const CBlockIndex* const pindexOld)
+{
+    LogPrintf("%s: update chain params %s -> %s\n", __func__, pindexOld ? pindexOld->GetBlockHash().ToString() : "", pindex ? pindex->GetBlockHash().ToString() : "");
+    Signals signals_old{GetFromCache(pindexOld)};
+    for (const auto& signal: signals_old) {
+        uint8_t versionBit = signal.first;
+        assert(versionBit < VERSIONBITS_NUM_BITS);
+
+        LogPrintf("%s: unload mnhf bit=%d block:%s number of known signals:%lld\n", __func__, versionBit, pindex->GetBlockHash().ToString(), signals_old.size());
+
+        bool update_ret = Params().UpdateMNActivationParam(versionBit, 0, pindex->GetMedianTimePast(), false);
+        assert(update_ret);
+    }
+
+    Signals signals{GetFromCache(pindex)};
+    for (const auto& signal: signals) {
+        uint8_t versionBit = signal.first;
+        int value = signal.second;
+        assert(versionBit < VERSIONBITS_NUM_BITS);
+
+        LogPrintf("%s: load mnhf bit=%d block:%s number of known signals:%lld\n", __func__, versionBit, pindex->GetBlockHash().ToString(), signals.size());
+
+        bool update_ret = Params().UpdateMNActivationParam(versionBit, value, pindex->GetMedianTimePast(), false);
+        assert(update_ret);
+    }
+}
+
+CMNHFManager::Signals CMNHFManager::GetFromCache(const CBlockIndex* const pindex)
+{
+    if (pindex == nullptr) return {};
+    const uint256& blockHash = pindex->GetBlockHash();
+    Signals signals{};
+    {
+        LOCK(cs_cache);
+        if (mnhfCache.get(blockHash, signals)) {
+            LogPrintf("CMNHFManager::GetFromCache: mnhf get for block %s from cache: %lld signals\n", pindex->GetBlockHash().ToString(), signals.size());
+            return signals;
+        }
+    }
+    if (VersionBitsState(pindex->pprev, Params().GetConsensus(), Consensus::DEPLOYMENT_V20, versionbitscache) != ThresholdState::ACTIVE) {
+        LOCK(cs_cache);
+        mnhfCache.insert(blockHash, signals);
+        LogPrintf("CMNHFManager::GetFromCache: mnhf feature is disabled: return empty for block %s\n", pindex->GetBlockHash().ToString());
+        return signals;
+    }
+    if (!m_evoDb.Read(std::make_pair(DB_SIGNALS, blockHash), signals)) {
+        LogPrintf("CMNHFManager::GetFromCache: failure: can't read MnEHF signals from db for %s\n", pindex->GetBlockHash().ToString());
+    }
+    LogPrintf("CMNHFManager::GetFromCache: mnhf for block %s read from evo: %lld\n", pindex->GetBlockHash().ToString(), signals.size());
+    LOCK(cs_cache);
+    mnhfCache.insert(blockHash, signals);
+    return signals;
+}
+
+void CMNHFManager::AddToCache(const Signals& signals, const CBlockIndex* const pindex)
+{
+    const uint256& blockHash = pindex->GetBlockHash();
+    {
+        LOCK(cs_cache);
+        LogPrintf("%s: mnhf for block %s add to cache: %lld\n", __func__, pindex->GetBlockHash().ToString(), signals.size());
+        mnhfCache.insert(blockHash, signals);
+    }
+    m_evoDb.Write(std::make_pair(DB_SIGNALS, blockHash), signals);
 }
 
 std::string MNHFTx::ToString() const

--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -80,6 +80,10 @@ bool CheckMNHFTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValida
         return false;
     }
 
+    if (!Params().UpdateMNActivationParam(mnhfTx.signal.versionBit, pindexPrev->nHeight, pindexPrev->GetMedianTimePast(), true /* fJustCheck */)) {
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-mnhf-non-ehf");
+    }
+
     return true;
 }
 

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -28,11 +28,11 @@ class MNHFTx
 {
 public:
     uint8_t versionBit{0};
-    uint256 quorumHash;
-    CBLSSignature sig;
+    uint256 quorumHash{0};
+    CBLSSignature sig{};
 
     MNHFTx() = default;
-    bool Verify(const CBlockIndex* const pQuorumIndex, const uint256& msgHash, TxValidationState& state) const;
+    bool Verify(const uint256& quorumHash, const uint256& msgHash, TxValidationState& state) const;
 
     SERIALIZE_METHODS(MNHFTx, obj)
     {

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -11,6 +11,7 @@
 #include <threadsafety.h>
 #include <univalue.h>
 
+#include <optional>
 #include <saltedhasher.h>
 #include <unordered_map>
 #include <unordered_lru_cache.h>
@@ -31,7 +32,7 @@ public:
     CBLSSignature sig;
 
     MNHFTx() = default;
-    bool Verify(const CBlockIndex* pQuorumIndex, const uint256& msgHash, TxValidationState& state) const;
+    bool Verify(const CBlockIndex* const pQuorumIndex, const uint256& msgHash, TxValidationState& state) const;
 
     SERIALIZE_METHODS(MNHFTx, obj)
     {
@@ -93,7 +94,7 @@ private:
     unordered_lru_cache<uint256, Signals, StaticSaltedHasher> mnhfCache GUARDED_BY(cs_cache) {MNHFCacheSize};
 
 public:
-    explicit  CMNHFManager(CEvoDB& evoDb) :
+    explicit CMNHFManager(CEvoDB& evoDb) :
         m_evoDb(evoDb) {}
     ~CMNHFManager() = default;
 
@@ -113,11 +114,25 @@ public:
      */
     void UpdateChainParams(const CBlockIndex* const pindex, const CBlockIndex* const pindexOld) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+    /**
+     * This function prepares signals for new block.
+     * This data is filterd expired signals from previous blocks.
+     * This member function is not const because it calls non-const GetFromCache()
+     */
+    Signals GetSignalsStage(const CBlockIndex* const pindexPrev);
 private:
     void AddToCache(const Signals& signals, const CBlockIndex* const pindex);
+
+    /**
+     * This function returns list of signals available on previous block.
+     * NOTE: that some signals could expired between blocks.
+     * validate them by
+     */
     Signals GetFromCache(const CBlockIndex* const pindex);
+
 };
 
+std::optional<uint8_t> extractEHFSignal(const CTransaction& tx);
 bool CheckMNHFTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 #endif // BITCOIN_EVO_MNHFTX_H

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -11,7 +11,14 @@
 #include <threadsafety.h>
 #include <univalue.h>
 
+#include <saltedhasher.h>
+#include <unordered_map>
+#include <unordered_lru_cache.h>
+
+class BlockValidationState;
+class CBlock;
 class CBlockIndex;
+class CEvoDB;
 class TxValidationState;
 extern RecursiveMutex cs_main;
 
@@ -70,6 +77,45 @@ public:
         obj.pushKV("signal", signal.ToJson());
         return obj;
     }
+};
+
+class CMNHFManager
+{
+public:
+    using Signals = std::unordered_map<uint8_t, int>;
+
+private:
+    CEvoDB& m_evoDb;
+
+    static constexpr size_t MNHFCacheSize = 1000;
+    Mutex cs_cache;
+    // versionBit <-> height
+    unordered_lru_cache<uint256, Signals, StaticSaltedHasher> mnhfCache GUARDED_BY(cs_cache) {MNHFCacheSize};
+
+public:
+    explicit  CMNHFManager(CEvoDB& evoDb) :
+        m_evoDb(evoDb) {}
+    ~CMNHFManager() = default;
+
+    /**
+     * Every new block should be processed when Tip() is updated by calling of CMNHFManager::ProcessBlock
+     */
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* const pindex, bool fJustCheck, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    /**
+     * Every undo block should be processed when Tip() is updated by calling of CMNHFManager::UndoBlock
+     */
+    bool UndoBlock(const CBlock& block, const CBlockIndex* const pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    /**
+     * Once app is started, need to initialize dictionary will all known signals at the current Tip()
+     * by calling UpdateChainParams()
+     */
+    void UpdateChainParams(const CBlockIndex* const pindex, const CBlockIndex* const pindexOld) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+private:
+    void AddToCache(const Signals& signals, const CBlockIndex* const pindex);
+    Signals GetFromCache(const CBlockIndex* const pindex);
 };
 
 bool CheckMNHFTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -13,6 +13,7 @@ class BlockValidationState;
 class CBlock;
 class CBlockIndex;
 class CCoinsViewCache;
+class CMNHFManager;
 class TxValidationState;
 namespace llmq {
 class CQuorumBlockProcessor;
@@ -26,10 +27,12 @@ extern RecursiveMutex cs_main;
 
 bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs,
                     TxValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, llmq::CQuorumBlockProcessor& quorum_block_processor, const llmq::CChainLocksHandler& chainlock_handler,
-                            const Consensus::Params& consensusParams, const CCoinsViewCache& view, bool fJustCheck, bool fCheckCbTxMerleRoots,
-                            BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, llmq::CQuorumBlockProcessor& quorum_block_processor) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CMNHFManager& mnhfManager,
+                              llmq::CQuorumBlockProcessor& quorum_block_processor, const llmq::CChainLocksHandler& chainlock_handler,
+                              const Consensus::Params& consensusParams, const CCoinsViewCache& view, bool fJustCheck, bool fCheckCbTxMerleRoots,
+                              BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CMNHFManager& mnhfManager,
+                           llmq::CQuorumBlockProcessor& quorum_block_processor) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams,
                                 const CAmount blockReward, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -477,6 +477,10 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         }
         if (std::optional<uint8_t> signal = extractEHFSignal(iter->GetTx()); signal != std::nullopt) {
             if (signals.find(*signal) != signals.end()) {
+                if (fUsingModified) {
+                    mapModifiedTx.get<ancestor_score>().erase(modit);
+                    failedTx.insert(iter);
+                }
                 LogPrintf("%s: ehf signal tx %s skipped due to duplicate %d\n",
                           __func__, iter->GetTx().GetHash().ToString(), *signal);
                 continue;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -175,7 +175,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         LogPrintf("%s: CCreditPool is %s\n", __func__, creditPool.ToString());
         creditPoolDiff.emplace(std::move(creditPool), pindexPrev, chainparams.GetConsensus());
     }
-    std::unordered_map<uint8_t, int> signals = m_chainstate.m_mnhfManager.GetSignalsStage(pindexPrev);
+    std::unordered_map<uint8_t, int> signals = m_chainstate.GetMNHFSignalsStage();
     addPackageTxs(nPackagesSelected, nDescendantsUpdated, creditPoolDiff, signals);
 
     int64_t nTime1 = GetTimeMicros();

--- a/src/miner.h
+++ b/src/miner.h
@@ -194,7 +194,8 @@ private:
     /** Add transactions based on feerate including unconfirmed ancestors
       * Increments nPackagesSelected / nDescendantsUpdated with corresponding
       * statistics from the package selection (for logging statistics). */
-    void addPackageTxs(int& nPackagesSelected, int& nDescendantsUpdated, std::optional<CCreditPoolDiff>& creditPoolDiff) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
+    void addPackageTxs(int& nPackagesSelected, int& nDescendantsUpdated,
+                       std::optional<CCreditPoolDiff>& creditPoolDiff, std::unordered_map<uint8_t, int>& signals) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -11,6 +11,7 @@
 #include <interfaces/chain.h>
 #include <llmq/context.h>
 #include <evo/evodb.h>
+#include <evo/mnhftx.h>
 #include <net.h>
 #include <net_processing.h>
 #include <policy/fees.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -20,6 +20,7 @@ class ChainstateManager;
 class CEvoDB;
 class CScheduler;
 class CTxMemPool;
+class CMNHFManager;
 class PeerManager;
 struct CJContext;
 struct LLMQContext;
@@ -60,6 +61,7 @@ struct NodeContext {
     //! Dash
     std::unique_ptr<LLMQContext> llmq_ctx;
     std::unique_ptr<CCreditPoolManager> creditPoolManager;
+    std::unique_ptr<CMNHFManager> mnhf_manager;
     std::unique_ptr<CJContext> cj_ctx;
 
     std::unique_ptr<CEvoDB> evodb;

--- a/src/test/dynamic_activation_thresholds_tests.cpp
+++ b/src/test/dynamic_activation_thresholds_tests.cpp
@@ -34,7 +34,7 @@ static constexpr int threshold(int attempt)
 
 struct TestChainDATSetup : public TestChainSetup
 {
-    TestChainDATSetup() : TestChainSetup(window - 2, {"-vbparams=testdummy:0:999999999999:100:80:60:5"}) {}
+    TestChainDATSetup() : TestChainSetup(window - 2, {"-vbparams=testdummy:0:999999999999:100:80:60:5:-1"}) {}
 
     void signal(int num_blocks, bool expected_lockin)
     {

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -42,6 +42,7 @@ public:
 
     bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const override { return Condition(pindex->nVersion); }
     int64_t BeginTime(const Consensus::Params& params) const override { return m_begin; }
+    int MasternodeBeginHeight(const Consensus::Params& params) const override { return 0; }
     int64_t EndTime(const Consensus::Params& params) const override { return m_end; }
     int Period(const Consensus::Params& params) const override { return m_period; }
     int Threshold(const Consensus::Params& params, int nAttempt) const override { return m_threshold; }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -67,6 +67,7 @@
 #include <evo/creditpool.h>
 #include <evo/deterministicmns.h>
 #include <evo/evodb.h>
+#include <evo/mnhftx.h>
 #include <evo/specialtx.h>
 
 #include <memory>
@@ -164,6 +165,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     g_wallet_init_interface.Construct(m_node);
     fCheckBlockIndex = true;
     m_node.evodb = std::make_unique<CEvoDB>(1 << 20, true, true);
+    m_node.mnhf_manager = std::make_unique<CMNHFManager>(*m_node.evodb);
     connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     llmq::quorumSnapshotManager.reset(new llmq::CQuorumSnapshotManager(*m_node.evodb));
     creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
@@ -180,6 +182,7 @@ BasicTestingSetup::~BasicTestingSetup()
     connman.reset();
     llmq::quorumSnapshotManager.reset();
     creditPoolManager.reset();
+    m_node.mnhf_manager.reset();
     m_node.evodb.reset();
 
     LogInstance().DisconnectTestLogger();
@@ -251,7 +254,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     // instead of unit tests, but for now we need these here.
     RegisterAllCoreRPCCommands(tableRPC);
 
-    m_node.chainman->InitializeChainstate(m_node.mempool.get(), *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
+    m_node.chainman->InitializeChainstate(m_node.mempool.get(), *m_node.mnhf_manager, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
     ::ChainstateActive().InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);
     assert(!::ChainstateActive().CanFlushToDisk());

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
         return outp;
     };
 
-    CChainState& c1 = *WITH_LOCK(cs_main, return &manager.InitializeChainstate(&mempool, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
+    CChainState& c1 = *WITH_LOCK(cs_main, return &manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
     c1.InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);
     WITH_LOCK(::cs_main, c1.InitCoinsCache(1 << 23));

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
 
     // Create a legacy (IBD) chainstate.
     //
-    CChainState& c1 = *WITH_LOCK(::cs_main, return &manager.InitializeChainstate(&mempool, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
+    CChainState& c1 = *WITH_LOCK(::cs_main, return &manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
     chainstates.push_back(&c1);
     c1.InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
     //
     const uint256 snapshot_blockhash = GetRandHash();
     CChainState& c2 = *WITH_LOCK(::cs_main, return &manager.InitializeChainstate(
-        &mempool, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor,
+        &mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor,
         snapshot_blockhash)
     );
     chainstates.push_back(&c2);
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
 
     // Create a legacy (IBD) chainstate.
     //
-    CChainState& c1 = *WITH_LOCK(cs_main, return &manager.InitializeChainstate(&mempool, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
+    CChainState& c1 = *WITH_LOCK(cs_main, return &manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
     chainstates.push_back(&c1);
     c1.InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
 
     // Create a snapshot-based chainstate.
     //
-    CChainState& c2 = *WITH_LOCK(cs_main, return &manager.InitializeChainstate(&mempool, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor, GetRandHash()));
+    CChainState& c2 = *WITH_LOCK(cs_main, return &manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor, GetRandHash()));
     chainstates.push_back(&c2);
     c2.InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 {
     CTxMemPool mempool;
     BlockManager blockman{};
-    CChainState chainstate(&mempool, blockman, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
+    CChainState chainstate(&mempool, blockman, *m_node.mnhf_manager, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
     chainstate.InitCoinsDB(/*cache_size_bytes*/ 1 << 10, /*in_memory*/ true, /*should_wipe*/ false);
     WITH_LOCK(::cs_main, chainstate.InitCoinsCache(1 << 10));
 

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -24,6 +24,7 @@ private:
 public:
     int64_t BeginTime(const Consensus::Params& params) const override { return TestTime(10000); }
     int64_t EndTime(const Consensus::Params& params) const override { return TestTime(20000); }
+    int MasternodeBeginHeight(const Consensus::Params& params) const override { return 0; }
     int Period(const Consensus::Params& params) const override { return 1000; }
     int Threshold(const Consensus::Params& params, int nAttempt) const override { return 900; }
     bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const override { return (pindex->nVersion & 0x100); }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -796,7 +796,11 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // No transactions are allowed below minRelayTxFee except from disconnected
     // blocks
-    if (!bypass_limits && !CheckFeeRate(nSize, nModifiedFees, state)) return false;
+    // Checking of fee for MNHF_SIGNAL should be skipped: mnhf does not have
+    // inputs, outputs, or fee
+    if (tx.nVersion != 3 || tx.nType != TRANSACTION_MNHF_SIGNAL) {
+        if (!bypass_limits && !CheckFeeRate(nSize, nModifiedFees, state)) return false;
+    }
 
     if (nAbsurdFee && nFees > nAbsurdFee)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -53,6 +53,7 @@
 #include <masternode/sync.h>
 
 #include <evo/evodb.h>
+#include <evo/mnhftx.h>
 #include <evo/specialtx.h>
 #include <evo/specialtxman.h>
 #include <governance/governance.h>
@@ -1260,12 +1261,14 @@ void CoinsViews::InitCache()
 
 CChainState::CChainState(CTxMemPool* mempool,
                          BlockManager& blockman,
+                         CMNHFManager& mnhfManager,
                          CEvoDB& evoDb,
                          const std::unique_ptr<llmq::CChainLocksHandler>& clhandler,
                          const std::unique_ptr<llmq::CInstantSendManager>& isman,
                          const std::unique_ptr<llmq::CQuorumBlockProcessor>& quorum_block_processor,
                          std::optional<uint256> from_snapshot_blockhash)
     : m_mempool(mempool),
+      m_mnhfManager(mnhfManager),
       m_params(::Params()),
       m_clhandler(clhandler),
       m_isman(isman),
@@ -1706,7 +1709,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
     std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > addressUnspentIndex;
     std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> > spentIndex;
 
-    if (!UndoSpecialTxsInBlock(block, pindex, *m_quorum_block_processor)) {
+    if (!UndoSpecialTxsInBlock(block, pindex, m_mnhfManager, *m_quorum_block_processor)) {
         error("DisconnectBlock(): UndoSpecialTxsInBlock failed");
         return DISCONNECT_FAILED;
     }
@@ -2186,7 +2189,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     bool fDIP0001Active_context = pindex->nHeight >= Params().GetConsensus().DIP0001Height;
 
     // MUST process special txes before updating UTXO to ensure consistency between mempool and block processing
-    if (!ProcessSpecialTxsInBlock(block, pindex, *m_quorum_block_processor, *m_clhandler, m_params.GetConsensus(), view, fJustCheck, fScriptChecks, state)) {
+    if (!ProcessSpecialTxsInBlock(block, pindex, m_mnhfManager, *m_quorum_block_processor, *m_clhandler, m_params.GetConsensus(), view, fJustCheck, fScriptChecks, state)) {
         return error("ConnectBlock(DASH): ProcessSpecialTxsInBlock for block %s failed with %s",
                      pindex->GetBlockHash().ToString(), state.ToString());
     }
@@ -4809,7 +4812,7 @@ bool CChainState::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& i
 
     // MUST process special txes before updating UTXO to ensure consistency between mempool and block processing
     BlockValidationState state;
-    if (!ProcessSpecialTxsInBlock(block, pindex, *m_quorum_block_processor, *m_clhandler, m_params.GetConsensus(), inputs, false /*fJustCheck*/, false /*fScriptChecks*/, state)) {
+    if (!ProcessSpecialTxsInBlock(block, pindex, m_mnhfManager, *m_quorum_block_processor, *m_clhandler, m_params.GetConsensus(), inputs, false /*fJustCheck*/, false /*fScriptChecks*/, state)) {
         return error("RollforwardBlock(DASH): ProcessSpecialTxsInBlock for block %s failed with %s",
             pindex->GetBlockHash().ToString(), state.ToString());
     }
@@ -5651,6 +5654,7 @@ std::vector<CChainState*> ChainstateManager::GetAll()
 }
 
 CChainState& ChainstateManager::InitializeChainstate(CTxMemPool* mempool,
+                                                     CMNHFManager& mnhfManager,
                                                      CEvoDB& evoDb,
                                                      const std::unique_ptr<llmq::CChainLocksHandler>& clhandler,
                                                      const std::unique_ptr<llmq::CInstantSendManager>& isman,
@@ -5665,7 +5669,7 @@ CChainState& ChainstateManager::InitializeChainstate(CTxMemPool* mempool,
         throw std::logic_error("should not be overwriting a chainstate");
     }
 
-    to_modify.reset(new CChainState(mempool, m_blockman, evoDb, clhandler, isman, quorum_block_processor, snapshot_blockhash));
+    to_modify.reset(new CChainState(mempool, m_blockman, mnhfManager, evoDb, clhandler, isman, quorum_block_processor, snapshot_blockhash));
 
     // Snapshot chainstates and initial IBD chaintates always become active.
     if (is_snapshot || (!is_snapshot && !m_active_chainstate)) {
@@ -5735,9 +5739,13 @@ bool ChainstateManager::ActivateSnapshot(
     }
 
     auto snapshot_chainstate = WITH_LOCK(::cs_main, return std::make_unique<CChainState>(
-            /* mempool */ nullptr, m_blockman, this->ActiveChainstate().m_evoDb,
-            this->ActiveChainstate().m_clhandler, this->ActiveChainstate().m_isman,
-            this->ActiveChainstate().m_quorum_block_processor, base_blockhash
+            /* mempool */ nullptr, m_blockman,
+            this->ActiveChainstate().m_mnhfManager,
+            this->ActiveChainstate().m_evoDb,
+            this->ActiveChainstate().m_clhandler,
+            this->ActiveChainstate().m_isman,
+            this->ActiveChainstate().m_quorum_block_processor,
+            base_blockhash
         )
     );
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1268,11 +1268,11 @@ CChainState::CChainState(CTxMemPool* mempool,
                          const std::unique_ptr<llmq::CQuorumBlockProcessor>& quorum_block_processor,
                          std::optional<uint256> from_snapshot_blockhash)
     : m_mempool(mempool),
-      m_mnhfManager(mnhfManager),
       m_params(::Params()),
       m_clhandler(clhandler),
       m_isman(isman),
       m_quorum_block_processor(quorum_block_processor),
+      m_mnhfManager(mnhfManager),
       m_evoDb(evoDb),
       m_blockman(blockman),
       m_from_snapshot_blockhash(from_snapshot_blockhash) {}

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2493,6 +2493,13 @@ CoinsCacheSizeState CChainState::GetCoinsCacheSizeState(
     return CoinsCacheSizeState::OK;
 }
 
+std::unordered_map<uint8_t, int> CChainState::GetMNHFSignalsStage()
+{
+    const CBlockIndex* const tip = m_chain.Tip();
+    if (tip == nullptr) return {};
+    return this->m_mnhfManager.GetSignalsStage(tip);
+}
+
 bool CChainState::FlushStateToDisk(
     BlockValidationState &state,
     FlushStateMode mode,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1927,6 +1927,7 @@ public:
 
     int64_t BeginTime(const Consensus::Params& params) const override { return 0; }
     int64_t EndTime(const Consensus::Params& params) const override { return std::numeric_limits<int64_t>::max(); }
+    int MasternodeBeginHeight(const Consensus::Params& params) const override { return 0; }
     int Period(const Consensus::Params& params) const override { return params.nMinerConfirmationWindow; }
     int Threshold(const Consensus::Params& params, int nAttempt) const override { return params.nRuleChangeActivationThreshold; }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -585,9 +585,7 @@ private:
     const std::unique_ptr<llmq::CChainLocksHandler>& m_clhandler;
     const std::unique_ptr<llmq::CInstantSendManager>& m_isman;
     const std::unique_ptr<llmq::CQuorumBlockProcessor>& m_quorum_block_processor;
-public:
     CMNHFManager& m_mnhfManager;
-private:
     CEvoDB& m_evoDb;
 
 public:
@@ -780,8 +778,10 @@ public:
         size_t max_coins_cache_size_bytes,
         size_t max_mempool_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    /** Return list of MN EHF signals for current Tip() */
+    std::unordered_map<uint8_t, int> GetMNHFSignalsStage() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 private:
     bool ActivateBestChainStep(BlockValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);
     bool ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions& disconnectpool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_mempool->cs);

--- a/src/validation.h
+++ b/src/validation.h
@@ -56,6 +56,7 @@ class CChainParams;
 struct CCheckpointData;
 class CInv;
 class CConnman;
+class CMNHFManager;
 class CScriptCheck;
 class CTxMemPool;
 class TxValidationState;
@@ -584,6 +585,7 @@ private:
     const std::unique_ptr<llmq::CChainLocksHandler>& m_clhandler;
     const std::unique_ptr<llmq::CInstantSendManager>& m_isman;
     const std::unique_ptr<llmq::CQuorumBlockProcessor>& m_quorum_block_processor;
+    CMNHFManager& m_mnhfManager;
     CEvoDB& m_evoDb;
 
 public:
@@ -593,6 +595,7 @@ public:
 
     explicit CChainState(CTxMemPool* mempool,
                          BlockManager& blockman,
+                         CMNHFManager& mnhfManager,
                          CEvoDB& evoDb,
                          const std::unique_ptr<llmq::CChainLocksHandler>& clhandler,
                          const std::unique_ptr<llmq::CInstantSendManager>& isman,
@@ -940,6 +943,7 @@ public:
     //! @param[in] snapshot_blockhash   If given, signify that this chainstate
     //!                                 is based on a snapshot.
     CChainState& InitializeChainstate(CTxMemPool* mempool,
+                                      CMNHFManager& mnhfManager,
                                       CEvoDB& evoDb,
                                       const std::unique_ptr<llmq::CChainLocksHandler>& clhandler,
                                       const std::unique_ptr<llmq::CInstantSendManager>& isman,

--- a/src/validation.h
+++ b/src/validation.h
@@ -585,7 +585,9 @@ private:
     const std::unique_ptr<llmq::CChainLocksHandler>& m_clhandler;
     const std::unique_ptr<llmq::CInstantSendManager>& m_isman;
     const std::unique_ptr<llmq::CQuorumBlockProcessor>& m_quorum_block_processor;
+public:
     CMNHFManager& m_mnhfManager;
+private:
     CEvoDB& m_evoDb;
 
 public:

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -56,6 +56,7 @@ class AbstractThresholdConditionChecker {
 protected:
     virtual bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const =0;
     virtual int64_t BeginTime(const Consensus::Params& params) const =0;
+    virtual int MasternodeBeginHeight(const Consensus::Params& params) const = 0;
     virtual int64_t EndTime(const Consensus::Params& params) const =0;
     virtual int Period(const Consensus::Params& params) const =0;
     virtual int Threshold(const Consensus::Params& params, int nAttempt) const =0;

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -24,7 +24,7 @@ llmq_type_strings = {llmq_test: 'llmq_test', llmq_test_v17: 'llmq_test_v17'}
 
 class QuorumDataRecoveryTest(DashTestFramework):
     def set_test_params(self):
-        extra_args = [["-vbparams=testdummy:0:999999999999:10:8:6:5"] for _ in range(9)]
+        extra_args = [["-vbparams=testdummy:0:999999999999:10:8:6:5:-1"] for _ in range(9)]
         self.set_dash_test_params(9, 7, fast_dip3_enforcement=True, extra_args=extra_args)
         self.set_dash_llmq_test_params(4, 3)
 

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2023 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import struct
+from io import BytesIO
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.key import ECKey
+from test_framework.messages import (
+    CMnEhf,
+    CTransaction,
+    hash256,
+    ser_string,
+)
+
+from test_framework.test_framework import DashTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    get_bip9_details,
+)
+
+class MnehfTest(DashTestFramework):
+    def set_test_params(self):
+        extra_args = [["-vbparams=testdummy:0:999999999999:12:12:12:5:0"] for _ in range(4)]
+        self.set_dash_test_params(4, 3, fast_dip3_enforcement=True, extra_args=extra_args)
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def restart_all_nodes(self):
+        for inode in range(self.num_nodes):
+            self.log.info(f"Restart node {inode} with {self.extra_args[inode]}")
+            self.restart_node(inode, self.extra_args[inode])
+        for i in range(self.num_nodes - 1):
+            self.connect_nodes(i + 1, i)
+
+    def create_mnehf(self, versionBit, pubkey=None):
+        # request ID = sha256("mnhf", versionBit)
+        request_id_buf = ser_string(b"mnhf") + struct.pack("<Q", versionBit)
+        request_id = hash256(request_id_buf)[::-1].hex()
+
+        quorumHash = self.mninfo[0].node.quorum("selectquorum", 100, request_id)["quorumHash"]
+        mnehf_payload = CMnEhf(
+            version = 1,
+            versionBit = versionBit,
+            quorumHash = int(quorumHash, 16),
+            quorumSig = b'\00' * 96)
+
+        mnehf_tx = CTransaction()
+        mnehf_tx.vin = []
+        mnehf_tx.vout = []
+        mnehf_tx.nVersion = 3
+        mnehf_tx.nType = 7 # mnehf signal
+        mnehf_tx.vExtraPayload = mnehf_payload.serialize()
+
+        mnehf_tx.calc_sha256()
+        msgHash = format(mnehf_tx.sha256, '064x')
+
+        self.log.info(f"Signing request_id: {request_id} msgHash: {msgHash}")
+        recsig = self.get_recovered_sig(request_id, msgHash)
+
+        mnehf_payload.quorumSig = bytearray.fromhex(recsig["sig"])
+        mnehf_tx.vExtraPayload = mnehf_payload.serialize()
+        return mnehf_tx
+
+
+    def set_sporks(self):
+        spork_enabled = 0
+        spork_disabled = 4070908800
+
+        self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", spork_enabled)
+        self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", spork_disabled)
+        self.nodes[0].sporkupdate("SPORK_3_INSTANTSEND_BLOCK_FILTERING", spork_disabled)
+        self.nodes[0].sporkupdate("SPORK_2_INSTANTSEND_ENABLED", spork_disabled)
+        self.wait_for_sporks_same()
+
+    def check_fork(self, expected):
+        status = get_bip9_details(self.nodes[0], 'testdummy')['status']
+        self.log.info(f"height: {self.nodes[0].getblockcount()} status: {status}")
+        assert_equal(status, expected)
+
+    def ensure_tx_is_not_mined(self, tx_id):
+        try:
+            self.nodes[0].gettransaction(tx_id)
+            raise AssertionError("Transaction should not be mined")
+        except JSONRPCException as e:
+            assert "Invalid or non-wallet transaction id" in e.error['message']
+
+    def send_tx(self, tx, expected_error = None, reason = None):
+        try:
+            self.log.info(f"Send tx with expected_error:'{expected_error}'...")
+            tx = self.nodes[0].sendrawtransaction(hexstring=tx.serialize().hex(), maxfeerate=0)
+            if expected_error is None:
+                return tx
+
+            # failure didn't happen, but expected:
+            message = "Transaction should not be accepted"
+            if reason is not None:
+                message += ": " + reason
+
+            raise AssertionError(message)
+        except JSONRPCException as e:
+            self.log.info(f"Send tx triggered an error: {e.error}")
+            assert expected_error in e.error['message']
+
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.set_sporks()
+        self.activate_v19()
+        self.log.info(f"After v19 activation should be plenty of blocks: {node.getblockcount()}")
+        assert_greater_than(node.getblockcount(), 900)
+        assert_equal(get_bip9_details(node, 'testdummy')['status'], 'defined')
+
+        self.log.info("Mine a quorum...")
+        self.mine_quorum()
+        assert_equal(get_bip9_details(node, 'testdummy')['status'], 'defined')
+
+        key = ECKey()
+        key.generate()
+        pubkey = key.get_pubkey().get_bytes()
+        tx = self.create_mnehf(28, pubkey)
+
+        self.log.info("Checking deserialization of CMnEhf by python's code")
+        mnehf_payload = CMnEhf()
+        mnehf_payload.deserialize(BytesIO(tx.vExtraPayload))
+        assert_equal(mnehf_payload.version, 1)
+        assert_equal(mnehf_payload.versionBit, 28)
+        self.log.info("Checking correctness of requestId and quorumHash")
+        assert_equal(mnehf_payload.quorumHash, int(self.mninfo[0].node.quorum("selectquorum", 100, 'a0eee872d7d3170dd20d5c5e8380c92b3aa887da5f63d8033289fafa35a90691')["quorumHash"], 16))
+
+        self.send_tx(tx, expected_error='mnhf-before-v20')
+
+        assert_equal(get_bip9_details(node, 'testdummy')['status'], 'defined')
+        self.activate_v20()
+        assert_equal(get_bip9_details(node, 'testdummy')['status'], 'defined')
+
+        tx_sent = self.send_tx(tx)
+        node.generate(1)
+        self.sync_all()
+
+        self.log.info(f"Check MnEhfTx {tx_sent} was mined...")
+        block = node.getblock(node.getbestblockhash())
+        assert tx_sent in block['tx']
+
+        self.log.info(f"MnEhf tx: '{tx}' is sent: {tx_sent}")
+        self.log.info(f"mempool: {node.getmempoolinfo()}")
+        assert_equal(node.getmempoolinfo()['size'], 0)
+
+        while (node.getblockcount() + 1) % 12 != 0:
+            self.check_fork('defined')
+            node.generate(1)
+            self.sync_all()
+
+
+        self.restart_all_nodes()
+
+        for i in range(12):
+            self.check_fork('started')
+            node.generate(1)
+            self.sync_all()
+
+
+        for i in range(12):
+            self.check_fork('locked_in')
+            node.generate(1)
+            self.sync_all()
+            if i == 7:
+                self.restart_all_nodes()
+
+
+        self.check_fork('active')
+        self.restart_all_nodes()
+        self.check_fork('active')
+
+
+
+if __name__ == '__main__':
+    MnehfTest().main()

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -31,12 +31,21 @@ class MnehfTest(DashTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
-    def restart_all_nodes(self):
+    def restart_all_nodes(self, params=None):
         for inode in range(self.num_nodes):
             self.log.info(f"Restart node {inode} with {self.extra_args[inode]}")
-            self.restart_node(inode, self.extra_args[inode])
-        for i in range(self.num_nodes - 1):
-            self.connect_nodes(i + 1, i)
+            if params is not None:
+                self.extra_args[inode][0] = f"-vbparams=testdummy:{params[0]}:{params[1]}:12:12:12:5:0"
+                self.log.info(f"Actual restart options: {self.extra_args[inode]}")
+
+        self.restart_node(0)
+        for mn in self.mninfo:
+            index = mn.node.index
+            self.stop_node(index)
+            self.start_masternode(mn)
+        for i in range(len(self.nodes)):
+                self.connect_nodes(i, 0)
+
 
     def create_mnehf(self, versionBit, pubkey=None):
         # request ID = sha256("mnhf", versionBit)
@@ -218,6 +227,26 @@ class MnehfTest(DashTestFramework):
         self.check_fork('active')
         self.restart_all_nodes()
         self.check_fork('active')
+
+        self.bump_mocktime(int(60 * 60 * 24 * 14))
+        node.generate(1)
+        self.sync_all()
+        self.restart_all_nodes(params=[self.mocktime, self.mocktime + 1000000])
+        self.mine_quorum()
+
+        ehf_tx_second = self.create_mnehf(28, pubkey)
+        assert_equal(get_bip9_details(node, 'testdummy')['status'], 'defined')
+        ehf_tx_sent = self.send_tx(ehf_tx_second)
+        node.generate(1)
+        self.sync_all()
+
+        self.check_fork('defined')
+        for i in range(10):
+            self.log.info(f"Generating {i} ...")
+            self.bump_mocktime(next)
+            node.generate(next)
+            self.sync_all()
+        self.check_fork('started')
 
 
 

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -103,9 +103,9 @@ class MnehfTest(DashTestFramework):
 
     def ensure_tx_is_not_mined(self, tx_id):
         try:
-            assert_equal(self.nodes[0].getrawtransaction(tx_id, 1)['height'], -1);
+            assert_equal(self.nodes[0].getrawtransaction(tx_id, 1)['height'], -1)
             raise AssertionError("Transaction should not be mined")
-        except KeyError as e:
+        except KeyError:
             # KeyError is expected
             pass
 
@@ -249,7 +249,7 @@ class MnehfTest(DashTestFramework):
         assert_equal(get_bip9_details(node, 'testdummy')['status'], 'defined')
 
         self.log.info("Testing EHF signal with same bit")
-        self.log.info(f"Previous signal at height={ehf_height}, total blocks={node.getblockcount()}, should success at {ehf_hight + 576}")
+        self.log.info(f"Previous signal at height={ehf_height}, total blocks={node.getblockcount()}, should success at {ehf_height + 576}")
         self.slowly_generate_batch(576 - (node.getblockcount() - ehf_height) - 1)
         ehf_tx_sent = self.send_tx(ehf_tx_second)
         self.log.info("Mine block and ensure not mined yet...")

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -248,16 +248,16 @@ class MnehfTest(DashTestFramework):
         ehf_tx_second = self.create_mnehf(28, pubkey)
         assert_equal(get_bip9_details(node, 'testdummy')['status'], 'defined')
 
-        self.log.info("Ehf with same bit signal should fail after 575 blocks but be accepted after 576 on regnet.")
-        self.log.info(f"Current progress is from {ehf_height} to {node.getblockcount()}")
-        self.slowly_generate_batch(576 - (node.getblockcount() - ehf_height))
+        self.log.info("Testing EHF signal with same bit")
+        self.log.info(f"Previous signal at height={ehf_height}, total blocks={node.getblockcount()}, should success at {ehf_hight + 576}")
+        self.slowly_generate_batch(576 - (node.getblockcount() - ehf_height) - 1)
         ehf_tx_sent = self.send_tx(ehf_tx_second)
-        self.log.info(f"ehf tx sent: {ehf_tx_sent}")
-        self.log.info(f"block: {node.getblock(node.getbestblockhash())}")
+        self.log.info("Mine block and ensure not mined yet...")
+        node.generate(1)
         self.ensure_tx_is_not_mined(ehf_tx_sent)
         node.generate(1)
         self.sync_all()
-        self.log.info(f"block: {node.getblock(node.getbestblockhash())}")
+        self.log.info("Mine one more block and ensure it is mined")
         block = node.getblock(node.getbestblockhash())
         assert ehf_tx_sent in block['tx']
 

--- a/test/functional/feature_new_quorum_type_activation.py
+++ b/test/functional/feature_new_quorum_type_activation.py
@@ -17,7 +17,7 @@ class NewQuorumTypeActivationTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-vbparams=testdummy:0:999999999999:10:8:6:5"]]
+        self.extra_args = [["-vbparams=testdummy:0:999999999999:10:8:6:5:-1"]]
 
     def run_test(self):
         self.log.info(get_bip9_details(self.nodes[0], 'testdummy'))

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -121,10 +121,10 @@ BASE_SCRIPTS = [
     'feature_llmq_dkgerrors.py', # NOTE: needs dash_hash to pass
     'feature_dip4_coinbasemerkleroots.py', # NOTE: needs dash_hash to pass
     'feature_asset_locks.py', # NOTE: needs dash_hash to pass
+    'feature_mnehf.py', # NOTE: needs dash_hash to pass
     # vv Tests less than 60s vv
     'p2p_sendheaders.py', # NOTE: needs dash_hash to pass
     'p2p_sendheaders_compressed.py', # NOTE: needs dash_hash to pass
-    'feature_mnehf.py', # NOTE: needs dash_hash to pass
     'wallet_importmulti.py',
     'mempool_limit.py',
     'rpc_txoutproof.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -124,6 +124,7 @@ BASE_SCRIPTS = [
     # vv Tests less than 60s vv
     'p2p_sendheaders.py', # NOTE: needs dash_hash to pass
     'p2p_sendheaders_compressed.py', # NOTE: needs dash_hash to pass
+    'feature_mnehf.py', # NOTE: needs dash_hash to pass
     'wallet_importmulti.py',
     'mempool_limit.py',
     'rpc_txoutproof.py',

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -104,6 +104,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "llmq/debug -> llmq/dkgsessionhandler -> llmq/debug"
     "llmq/debug -> llmq/dkgsessionhandler -> llmq/dkgsession -> llmq/debug"
     "llmq/utils -> validation -> llmq/utils"
+    "evo/mnhftx -> validation -> evo/mnhftx"
 )
 
 EXIT_CODE=0


### PR DESCRIPTION
It implements DIP-0023 Masternode EHF: https://github.com/dashpay/dips/blob/master/dip-0023.md

## What was done?
Implemented new logic of Hard-fork that takes into account signal from Masternodes.
New manager that processes blocks and extract information about signals and saves them.
+extra fix for by-passing fee limits for this tx.


## How Has This Been Tested?
There's new functional test `feature_mnehf.py`


## Breaking Changes
It changes logic of hard-fork accordingly DIP-0023

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

----
## TODO:
 [x] serialization/deserialization to evoDb
 [x] fix issue with index validation for case `ConnectBlock`: one block can be connected to different `chainstate` but chainparams are global variables.
