### PR TITLE
fix: follow-up #5393 - should be used `[dash.dash_ents]`

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[dash.qt-translation-020x]
+[dash.dash_ents]
 file_filter = src/qt/locale/dash_<lang>.ts
 source_file = src/qt/locale/dash_en.xlf
 source_lang = en


### PR DESCRIPTION
## Issue being fixed or feature implemented
As noticed by Udjin in #5393, there should be `dash_ents` in the config.

## What was done?
Updated config `.tx/config`


## How Has This Been Tested?
@UdjinM6 please help to test, I have no access to `https://www.transifex.com` translations



## Breaking Changes
n/a


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

