### PR TITLE
refactor: cleanup CChainParams unused data and functions

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -274,7 +274,6 @@ public:
 
         vSporkAddresses = {"Xgtyuk76vhuFW2iT7UAiHgNdWXCf3J34wh"};
         nMinSporkKeys = 1;
-        fBIP9CheckMasternodesUpgraded = true;
 
         checkpointData = {
             {
@@ -464,7 +463,6 @@ public:
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
         nMinSporkKeys = 1;
-        fBIP9CheckMasternodesUpgraded = true;
 
         checkpointData = {
             {
@@ -644,8 +642,6 @@ public:
 
         vSporkAddresses = {"yjPtiKh2uwk3bDutTEA2q9mCtXyiZRWn55"};
         nMinSporkKeys = 1;
-        // devnets are started with no blocks and no MN, so we can't check for upgraded MN (as there are none)
-        fBIP9CheckMasternodesUpgraded = false;
 
         checkpointData = (CCheckpointData) {
             {
@@ -846,8 +842,6 @@ public:
         // privKey: cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK
         vSporkAddresses = {"yj949n1UH6fDhw6HtVE5VMj2iSTaSWBMcW"};
         nMinSporkKeys = 1;
-        // regtest usually has no masternodes in most tests, so don't check for upgraged MNs
-        fBIP9CheckMasternodesUpgraded = false;
 
         checkpointData = {
             {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -135,7 +135,6 @@ public:
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
     const std::vector<std::string>& SporkAddresses() const { return vSporkAddresses; }
     int MinSporkKeys() const { return nMinSporkKeys; }
-    bool BIP9CheckMasternodesUpgraded() const { return fBIP9CheckMasternodesUpgraded; }
     std::optional<Consensus::LLMQParams> GetLLMQ(Consensus::LLMQType llmqType) const;
 
 protected:
@@ -170,7 +169,6 @@ protected:
     int nFulfilledRequestExpireTime;
     std::vector<std::string> vSporkAddresses;
     int nMinSporkKeys;
-    bool fBIP9CheckMasternodesUpgraded;
     uint16_t nDefaultPlatformP2PPort;
     uint16_t nDefaultPlatformHTTPPort;
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -129,11 +129,7 @@ public:
     void UpdateDIP3Parameters(int nActivationHeight, int nEnforcementHeight);
     void UpdateDIP8Parameters(int nActivationHeight);
     void UpdateBudgetParameters(int nMasternodePaymentsStartBlock, int nBudgetPaymentsStartBlock, int nSuperblockStartBlock);
-    void UpdateSubsidyAndDiffParams(int nMinimumDifficultyBlocks, int nHighSubsidyBlocks, int nHighSubsidyFactor);
-    void UpdateLLMQChainLocks(Consensus::LLMQType llmqType);
     void UpdateLLMQInstantSend(Consensus::LLMQType llmqType);
-    void UpdateLLMQTestParams(int size, int threshold);
-    void UpdateLLMQDevnetParams(int size, int threshold);
     int PoolMinParticipants() const { return nPoolMinParticipants; }
     int PoolMaxParticipants() const { return nPoolMaxParticipants; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     bool fDIP0003Active_context = nHeight >= chainparams.GetConsensus().DIP0003Height;
     bool fDIP0008Active_context = nHeight >= chainparams.GetConsensus().DIP0008Height;
 
-    pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus(), chainparams.BIP9CheckMasternodesUpgraded());
+    pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
     // Non-mainnet only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
     if (Params().NetworkIDString() != CBaseChainParams::MAIN)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -45,7 +45,6 @@
 #include <util/translation.h>
 #include <util/system.h>
 #include <validationinterface.h>
-#include <versionbitsinfo.h>
 #include <warnings.h>
 
 #include <masternode/payments.h>
@@ -1960,7 +1959,7 @@ void StopScriptCheckWorkerThreads()
 
 VersionBitsCache versionbitscache GUARDED_BY(cs_main);
 
-int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, bool fCheckMasternodesUpgraded)
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params)
 {
     LOCK(cs_main);
     int32_t nVersion = VERSIONBITS_TOP_BITS;
@@ -1968,10 +1967,6 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
     for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++) {
         Consensus::DeploymentPos pos = Consensus::DeploymentPos(i);
         ThresholdState state = VersionBitsState(pindexPrev, params, pos, versionbitscache);
-        const struct VBDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
-        if (vbinfo.check_mn_protocol && state == ThresholdState::STARTED && fCheckMasternodesUpgraded) {
-            // TODO implement new logic for MN upgrade checks (e.g. with LLMQ based feature/version voting)
-        }
         if (state == ThresholdState::LOCKED_IN || state == ThresholdState::STARTED) {
             nVersion |= VersionBitsMask(params, static_cast<Consensus::DeploymentPos>(i));
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -1069,7 +1069,7 @@ extern VersionBitsCache versionbitscache;
 /**
  * Determine what nVersion a new block should use.
  */
-int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, bool fCheckMasternodesUpgraded = false);
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
 /**
  * Return true if hash can be found in ::ChainActive() at nBlockHeight height.

--- a/src/versionbitsinfo.cpp
+++ b/src/versionbitsinfo.cpp
@@ -10,16 +10,13 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
     {
         /*.name =*/ "testdummy",
         /*.gbt_force =*/ true,
-        /*.check_mn_protocol =*/ false,
     },
     {
         /*.name =*/"v19",
         /*.gbt_force =*/true,
-        /*.check_mn_protocol =*/false,
     },
     {
         /*.name =*/"v20",
         /*.gbt_force =*/true,
-        /*.check_mn_protocol =*/false,
     },
 };

--- a/src/versionbitsinfo.h
+++ b/src/versionbitsinfo.h
@@ -10,8 +10,6 @@ struct VBDeploymentInfo {
     const char *name;
     /** Whether GBT clients can safely ignore this rule in simplified usage */
     bool gbt_force;
-    /** Whether to check current MN protocol or not */
-    bool check_mn_protocol;
 };
 
 extern const struct VBDeploymentInfo VersionBitsDeploymentInfo[];


### PR DESCRIPTION
## Issue being fixed or feature implemented
During implementation #5469 (master node hard-fork) I noticed that some parts of `CChainParams` are deprecated and can be removed.

## What was done?
1. removed methods from `CChainParams` that have no implementation at all:
 - UpdateSubsidyAndDiffParams
 - UpdateLLMQChainLocks
 - UpdateLLMQTestParams
 - UpdateLLMQDevnetParams
2. removed method `BIP9CheckMasternodesUpgraded` from `CChainParams` and a flag `check_mn_protocol` from `versionbitsinfo`.
(to follow-up dashpay/dash#2594)


## How Has This Been Tested?
Run functional/unit tests.

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

