### PR TITLE
fix: start client-side CoinJoin scheduler even when CoinJoin is disabled

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2411,7 +2411,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         node.scheduler->scheduleEvery(std::bind(&CCoinJoinServer::DoMaintenance, std::ref(*::coinJoinServer)), std::chrono::seconds{1});
         node.scheduler->scheduleEvery(std::bind(&llmq::CDKGSessionManager::CleanupOldContributions, std::ref(*node.llmq_ctx->qdkgsman)), std::chrono::hours{1});
 #ifdef ENABLE_WALLET
-    } else if (!ignores_incoming_txs && CCoinJoinClientOptions::IsEnabled()) {
+    } else if (!ignores_incoming_txs) {
         node.scheduler->scheduleEvery(std::bind(&DoCoinJoinMaintenance, std::ref(*node.connman), std::ref(*node.fee_estimator), std::ref(*node.mempool)), std::chrono::seconds{1});
 #endif // ENABLE_WALLET
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
`IsEnabled()` is checked inside anyway. Not starting the scheduler on init results in no mixing on nodes with dynamically loaded wallets.

## What was done?


## How Has This Been Tested?

## Breaking Changes

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

