### PR TITLE
fix: Resolve warnings in Guix GitHub workflow

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -15,7 +15,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Commit variables
         id: dockerfile

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Commit variables
         id: dockerfile
         run: |
-          echo "::set-output name=hash::$(sha256sum ./contrib/containers/guix/Dockerfile | cut -d ' ' -f1)"
-          echo "::set-output name=host_user_id::$(id -u)"
-          echo "::set-output name=host_group_id::$(id -g)"
+          echo "hash=$(sha256sum ./contrib/containers/guix/Dockerfile | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+          echo "host_user_id=$(id -u)" >> $GITHUB_OUTPUT
+          echo "host_group_id=$(id -g)" >> $GITHUB_OUTPUT
 
       - name: Cache Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ${{ github.workspace }}
           build-args: |


### PR DESCRIPTION
## Issue being fixed or feature implemented
see warnings in https://github.com/dashpay/dash/actions/runs/5462770856

## What was done?
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## How Has This Been Tested?
n/a

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

