### PR TITLE
chore: Drop `MSG_LEGACY_TXLOCK_REQUEST`/`LEGACYTXLOCKREQUEST`

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1783,7 +1783,6 @@ bool PeerManagerImpl::AlreadyHave(const CInv& inv)
     {
     case MSG_TX:
     case MSG_DSTX:
-    case MSG_LEGACY_TXLOCK_REQUEST: // we treat legacy IX messages as TX messages
         {
             assert(recentRejects);
             if (m_chainman.ActiveChain().Tip()->GetBlockHash() != hashRecentRejectsChainTip)
@@ -3502,16 +3501,13 @@ void PeerManagerImpl::ProcessMessage(
         return;
     }
 
-    if (msg_type == NetMsgType::TX || msg_type == NetMsgType::DSTX || msg_type == NetMsgType::LEGACYTXLOCKREQUEST) {
+    if (msg_type == NetMsgType::TX || msg_type == NetMsgType::DSTX) {
         CTransactionRef ptx;
         CCoinJoinBroadcastTx dstx;
         int nInvType = MSG_TX;
 
         // Read data and assign inv type
         if(msg_type == NetMsgType::TX) {
-            vRecv >> ptx;
-        } else if(msg_type == NetMsgType::LEGACYTXLOCKREQUEST) {
-            // we keep processing the legacy IX message here but revert to handling it as a regular TX
             vRecv >> ptx;
         } else if (msg_type == NetMsgType::DSTX) {
             vRecv >> dstx;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -47,7 +47,6 @@ MAKE_MSG(CFHEADERS, "cfheaders");
 MAKE_MSG(GETCFCHECKPT, "getcfcheckpt");
 MAKE_MSG(CFCHECKPT, "cfcheckpt");
 // Dash message types
-MAKE_MSG(LEGACYTXLOCKREQUEST, "ix");
 MAKE_MSG(SPORK, "spork");
 MAKE_MSG(GETSPORKS, "getsporks");
 MAKE_MSG(DSACCEPT, "dsa");
@@ -129,7 +128,6 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::CFCHECKPT,
     // Dash message types
     // NOTE: do NOT include non-implmented here, we want them to be "Unknown command" in ProcessMessage()
-    NetMsgType::LEGACYTXLOCKREQUEST,
     NetMsgType::SPORK,
     NetMsgType::GETSPORKS,
     NetMsgType::SENDDSQUEUE,
@@ -186,7 +184,6 @@ const static std::string netMessageTypesViolateBlocksOnly[] = {
     NetMsgType::DSSTATUSUPDATE,
     NetMsgType::DSTX,
     NetMsgType::DSVIN,
-    NetMsgType::LEGACYTXLOCKREQUEST,
     NetMsgType::QBSIGSHARES,
     NetMsgType::QCOMPLAINT,
     NetMsgType::QCONTRIB,
@@ -312,7 +309,6 @@ const char* CInv::GetCommandInternal() const
         case MSG_TX:                            return NetMsgType::TX;
         case MSG_BLOCK:                         return NetMsgType::BLOCK;
         case MSG_FILTERED_BLOCK:                return NetMsgType::MERKLEBLOCK;
-        case MSG_LEGACY_TXLOCK_REQUEST:         return NetMsgType::LEGACYTXLOCKREQUEST;
         case MSG_CMPCT_BLOCK:                   return NetMsgType::CMPCTBLOCK;
         case MSG_SPORK:                         return NetMsgType::SPORK;
         case MSG_DSTX:                          return NetMsgType::DSTX;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -253,7 +253,6 @@ extern const char *CFCHECKPT;
 // Dash message types
 // NOTE: do NOT declare non-implmented here, we don't want them to be exposed to the outside
 // TODO: add description
-extern const char *LEGACYTXLOCKREQUEST; // only present for backwards compatibility
 extern const char *SPORK;
 extern const char *GETSPORKS;
 extern const char *DSACCEPT;
@@ -448,9 +447,9 @@ enum GetDataMsg {
     // The following can only occur in getdata. Invs always use TX or BLOCK.
     MSG_FILTERED_BLOCK = 3,  //!< Defined in BIP37
     // Dash message types
-    // NOTE: declare non-implmented here, we must keep this enum consistent and backwards compatible
-    MSG_LEGACY_TXLOCK_REQUEST = 4,
-    /* MSG_TXLOCK_VOTE = 5, Legacy InstantSend and not used anymore  */
+    // NOTE: we must keep this enum consistent and backwards compatible
+    /* MSG_LEGACY_TXLOCK_REQUEST = 4, */ // Legacy InstantSend and not used anymore
+    /* MSG_TXLOCK_VOTE = 5, */ // Legacy InstantSend and not used anymore
     MSG_SPORK = 6,
     /* 7 - 15 were used in old Dash versions and were mainly budget and MN broadcast/ping related*/
     MSG_DSTX = 16,


### PR DESCRIPTION
## Issue being fixed or feature implemented
Legacy IS messages are gone long time ago, no need to keep them in code.

## What was done?
Drop `MSG_LEGACY_TXLOCK_REQUEST`/`LEGACYTXLOCKREQUEST`

## How Has This Been Tested?
Run tests

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

