### PR TITLE
perf: actually only process each dsq once

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -134,9 +134,9 @@ void CCoinJoinClientQueueManager::ProcessDSQueue(const CNode& peer, PeerManager&
                            [&dsq](const auto &pair) { return pair.second->MarkAlreadyJoinedQueueAsTried(dsq); });
 
             WITH_LOCK(cs_vecqueue, vecCoinJoinQueue.push_back(dsq));
-            dsq.Relay(connman);
         }
     } // cs_ProcessDSQueue
+    dsq.Relay(connman);
 }
 
 void CCoinJoinClientManager::ProcessMessage(CNode& peer, PeerManager& peerman, CConnman& connman, const CTxMemPool& mempool, std::string_view msg_type, CDataStream& vRecv)

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -79,7 +79,7 @@ void CCoinJoinClientQueueManager::ProcessDSQueue(const CNode& peer, PeerManager&
                 }
                 if (q.fReady == dsq.fReady && q.masternodeOutpoint == dsq.masternodeOutpoint) {
                     // no way the same mn can send another dsq with the same readiness this soon
-                    LogPrint(BCLog::COINJOIN,
+                    LogPrint(BCLog::COINJOIN, /* Continued */
                              "DSQUEUE -- Peer %s is sending WAY too many dsq messages for a masternode with collateral %s\n",
                              peer.GetLogString(), dsq.masternodeOutpoint.ToStringShort());
                     return;

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -85,7 +85,7 @@ void CCoinJoinClientQueueManager::ProcessDSQueue(const CNode& peer, PeerManager&
                     return;
                 }
             }
-        }
+        } // cs_vecqueue
 
         LogPrint(BCLog::COINJOIN, "DSQUEUE -- %s new\n", dsq.ToString());
 

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -159,6 +159,7 @@ class CCoinJoinClientQueueManager : public CCoinJoinBaseManager
 private:
     CConnman& connman;
     const CMasternodeSync& m_mn_sync;
+    mutable Mutex cs_ProcessDSQueue;
 
 public:
     explicit CCoinJoinClientQueueManager(CConnman& _connman, const CMasternodeSync& mn_sync) :


### PR DESCRIPTION
5 minute profiling shows previous usage around ~7% and current usage around ~2%

## Issue being fixed or feature implemented
Due to us rapidly receiving multiple duplicates of DSQueue's, we start processing them before it's added the the vector of processed ones, we probably at one point tried to minimize locked time, but that's not productive here

## What was done?
Expand the locked scope to ensure we don't double process. 

## How Has This Been Tested?
Ran full node for 5-10 minutes

## Breaking Changes
Should be none

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

