### PR TITLE
feat: v20 evonodes payment adjustment

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -188,6 +188,13 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdMin = 2420;         // 60% of 4032
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;            // this corresponds to 10 periods
 
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].bit = 10;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nStartTime = 19999999999;   // TODO: To be determined later
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize = 4032;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nThresholdStart = 3226;     // 80% of 4032
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nThresholdMin = 2420;       // 60% of 4032
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nFalloffCoeff = 5;          // this corresponds to 10 periods
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000008677827656704520eb39"); // 1889000
@@ -377,6 +384,14 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdMin = 60;           // 60% of 100
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;            // this corresponds to 10 periods
 
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].bit = 10;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nStartTime = 19999999999;   // TODO: To be determined later
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize = 100;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nThresholdStart = 80;       // 80% of 100
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nThresholdMin = 60;         // 60% of 100
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nFalloffCoeff = 5;          // this corresponds to 10 periods
+
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000002d68c8cc1b8e54b"); // 851000
 
@@ -538,6 +553,14 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdStart = 80; // 80% of 100
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdMin = 60;   // 60% of 100
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;     // this corresponds to 10 periods
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].bit = 10;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nStartTime = 1661990400; // Sep 1st, 2022
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize = 120;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nThresholdStart = 80; // 80% of 100
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nThresholdMin = 60;   // 60% of 100
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nFalloffCoeff = 5;     // this corresponds to 10 periods
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000000000000000000");
@@ -766,6 +789,14 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdStart = 384; // 80% of 480
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdMin = 288;   // 60% of 480
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;     // this corresponds to 10 periods
+
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].bit = 10;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize = 1030;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nThresholdStart = 800; // 80% of 1000
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nThresholdMin = 600;   // 60% of 1000
+        consensus.vDeployments[Consensus::DEPLOYMENT_MN_RR].nFalloffCoeff = 5;     // this corresponds to 10 periods
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -16,6 +16,7 @@ namespace Consensus {
 enum DeploymentPos {
     DEPLOYMENT_TESTDUMMY,
     DEPLOYMENT_V20,     // Deployment of EHF, LLMQ Randomness Beacon
+    DEPLOYMENT_MN_RR,   // Deployment of Masternode Reward Location Reallocation
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -182,10 +182,10 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
     }
 
     bool isv19Active = llmq::utils::IsV19Active(pIndex);
+    bool isv20Active = llmq::utils::IsV20Active(pIndex);
     // Starting from v19 and until v20 (Platform release), HPMN will be rewarded 4 blocks in a row
-    // TODO: Skip this code once v20 is active
     CDeterministicMNCPtr best = nullptr;
-    if (isv19Active) {
+    if (isv19Active && !isv20Active) {
         ForEachMNShared(true, [&](const CDeterministicMNCPtr& dmn) {
             if (dmn->pdmnState->nLastPaidHeight == nHeight) {
                 // We found the last MN Payee.
@@ -211,7 +211,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
     return best;
 }
 
-std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int nCount) const
+std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int nCount, bool isV20Active) const
 {
     if (nCount < 0 ) {
         return {};
@@ -227,7 +227,7 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int
         if (dmn->pdmnState->nLastPaidHeight == nHeight) {
             // We found the last MN Payee.
             // If the last payee is a HPMN, we need to check its consecutive payments and pay him again if needed
-            if (dmn->nType == MnType::HighPerformance && dmn->pdmnState->nConsecutivePayments < dmn_types::HighPerformance.voting_weight) {
+            if (!isV20Active && dmn->nType == MnType::HighPerformance && dmn->pdmnState->nConsecutivePayments < dmn_types::HighPerformance.voting_weight) {
                 remaining_hpmn_payments = dmn_types::HighPerformance.voting_weight - dmn->pdmnState->nConsecutivePayments;
                 for ([[maybe_unused]] auto _ : irange::range(remaining_hpmn_payments)) {
                     result.emplace_back(dmn);
@@ -720,6 +720,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
 
     DecreasePoSePenalties(newList);
 
+    bool isv20Active = llmq::utils::IsV20Active(pindexPrev);
+
     // we skip the coinbase
     for (int i = 1; i < (int)block.vtx.size(); i++) {
         const CTransaction& tx = *block.vtx[i];
@@ -939,9 +941,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
         newState->nLastPaidHeight = nHeight;
         // Starting from v19 and until v20, HPMN will be paid 4 blocks in a row
         // No need to check if v19 is active, since HPMN ProRegTx are allowed only after v19 activation
-        // TODO: Skip this code once v20 is active
         // Note: If the payee wasn't found in the current block that's fine
-        if (dmn->nType == MnType::HighPerformance) {
+        if (dmn->nType == MnType::HighPerformance && !isv20Active) {
             ++newState->nConsecutivePayments;
             if (debugLogs) {
                 LogPrint(BCLog::MNPAYMENTS, "CDeterministicMNManager::%s -- MN %s is a HPMN, bumping nConsecutivePayments to %d\n",
@@ -959,8 +960,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
     // reset nConsecutivePayments on non-paid HPMNs
     auto newList2 = newList;
     newList2.ForEachMN(false, [&](auto& dmn) {
-        if (payee != nullptr && dmn.proTxHash == payee->proTxHash) return;
         if (dmn.nType != MnType::HighPerformance) return;
+        if (payee != nullptr && dmn.proTxHash == payee->proTxHash && !isv20Active) return;
         if (dmn.pdmnState->nConsecutivePayments == 0) return;
         if (debugLogs) {
             LogPrint(BCLog::MNPAYMENTS, "CDeterministicMNManager::%s -- MN %s, reset nConsecutivePayments %d->0\n",

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -211,7 +211,12 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
     return best;
 }
 
-std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int nCount, bool isV20Active) const
+std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayeesAtChainTip(int nCount) const
+{
+    return GetProjectedMNPayees(::ChainActive()[nHeight], nCount);
+}
+
+std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(const CBlockIndex* const pindex, int nCount) const
 {
     if (nCount < 0 ) {
         return {};
@@ -223,6 +228,7 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(int
 
     auto remaining_hpmn_payments = 0;
     CDeterministicMNCPtr hpmn_to_be_skipped = nullptr;
+    bool isV20Active = llmq::utils::IsV20Active(pindex);
     ForEachMNShared(true, [&](const CDeterministicMNCPtr& dmn) {
         if (dmn->pdmnState->nLastPaidHeight == nHeight) {
             // We found the last MN Payee.

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -342,7 +342,7 @@ public:
      * @param nCount the number of payees to return. "nCount = max()"" means "all", use it to avoid calling GetValidWeightedMNsCount twice.
      * @return
      */
-    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(int nCount = std::numeric_limits<int>::max()) const;
+    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(int nCount = std::numeric_limits<int>::max(), bool isV20Active = false) const;
 
     /**
      * Calculate a quorum based on the modifier. The resulting list is deterministically sorted by score

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -342,7 +342,8 @@ public:
      * @param nCount the number of payees to return. "nCount = max()"" means "all", use it to avoid calling GetValidWeightedMNsCount twice.
      * @return
      */
-    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(int nCount = std::numeric_limits<int>::max(), bool isV20Active = false) const;
+    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(const CBlockIndex* const pindex, int nCount = std::numeric_limits<int>::max()) const;
+    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayeesAtChainTip(int nCount = std::numeric_limits<int>::max()) const;
 
     /**
      * Calculate a quorum based on the modifier. The resulting list is deterministically sorted by score

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -724,6 +724,15 @@ bool IsV20Active(const CBlockIndex* pindex)
     return VersionBitsState(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20, llmq_versionbitscache) == ThresholdState::ACTIVE;
 }
 
+bool IsMNRewardReallocationActive(const CBlockIndex* pindex)
+{
+    assert(pindex);
+    if (!IsV20Active(pindex)) return false;
+
+    LOCK(cs_llmq_vbc);
+    return VersionBitsState(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_MN_RR, llmq_versionbitscache) == ThresholdState::ACTIVE;
+}
+
 bool IsInstantSendLLMQTypeShared()
 {
     if (Params().GetConsensus().llmqTypeInstantSend == Params().GetConsensus().llmqTypeChainLocks ||

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -76,6 +76,7 @@ bool IsDIP0024Active(const CBlockIndex* pindex);
 bool IsV19Active(const CBlockIndex* pindex);
 const CBlockIndex* V19ActivationIndex(const CBlockIndex* pindex);
 bool IsV20Active(const CBlockIndex* pindex);
+bool IsMNRewardReallocationActive(const CBlockIndex* pindex);
 
 /// Returns the state of `-llmq-data-recovery`
 bool QuorumDataRecoveryEnabled();

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -191,7 +191,7 @@ void MasternodeList::updateDIP3List()
 
     nTimeUpdatedDIP3 = GetTime();
 
-    auto projectedPayees = mnList.GetProjectedMNPayees();
+    auto projectedPayees = mnList.GetProjectedMNPayeesAtChainTip();
     std::map<uint256, int> nextPayments;
     for (size_t i = 0; i < projectedPayees.size(); i++) {
         const auto& dmn = projectedPayees[i];

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1642,6 +1642,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BuriedForkDescPushBack(softforks, "realloc", consensusParams.BRRHeight, height);
     BuriedForkDescPushBack(softforks, "v19", consensusParams.V19Height, height);
     BIP9SoftForkDescPushBack(tip, softforks, "v20", consensusParams, Consensus::DEPLOYMENT_V20);
+    BIP9SoftForkDescPushBack(softforks, "mn_rr", consensusParams, Consensus::DEPLOYMENT_MN_RR);
     BIP9SoftForkDescPushBack(tip, softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
 
     obj.pushKV("softforks",             softforks);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1642,7 +1642,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BuriedForkDescPushBack(softforks, "realloc", consensusParams.BRRHeight, height);
     BuriedForkDescPushBack(softforks, "v19", consensusParams.V19Height, height);
     BIP9SoftForkDescPushBack(tip, softforks, "v20", consensusParams, Consensus::DEPLOYMENT_V20);
-    BIP9SoftForkDescPushBack(softforks, "mn_rr", consensusParams, Consensus::DEPLOYMENT_MN_RR);
+    BIP9SoftForkDescPushBack(tip, softforks, "mn_rr", consensusParams, Consensus::DEPLOYMENT_MN_RR);
     BIP9SoftForkDescPushBack(tip, softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
 
     obj.pushKV("softforks",             softforks);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -13,6 +13,7 @@
 #include <masternode/payments.h>
 #include <net.h>
 #include <netbase.h>
+#include <llmq/utils.h>
 #include <rpc/blockchain.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
@@ -362,7 +363,8 @@ static UniValue masternode_winners(const JSONRPCRequest& request, const Chainsta
         obj.pushKV(strprintf("%d", h), strPayments);
     }
 
-    auto projection = deterministicMNManager->GetListForBlock(pindexTip).GetProjectedMNPayees(20);
+    bool isV20Active = llmq::utils::IsV20Active(pindexTip);
+    auto projection = deterministicMNManager->GetListForBlock(pindexTip).GetProjectedMNPayees(20, isV20Active);
     for (size_t i = 0; i < projection.size(); i++) {
         int h = nChainTipHeight + 1 + i;
         std::string strPayments = GetRequiredPaymentsString(h, projection[i]);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -13,7 +13,6 @@
 #include <masternode/payments.h>
 #include <net.h>
 #include <netbase.h>
-#include <llmq/utils.h>
 #include <rpc/blockchain.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
@@ -137,7 +136,7 @@ static UniValue masternode_count(const JSONRPCRequest& request)
 static UniValue GetNextMasternodeForPayment(int heightShift)
 {
     auto mnList = deterministicMNManager->GetListAtChainTip();
-    auto payees = mnList.GetProjectedMNPayees(heightShift);
+    auto payees = mnList.GetProjectedMNPayeesAtChainTip(heightShift);
     if (payees.empty())
         return "unknown";
     auto payee = payees.back();
@@ -363,8 +362,7 @@ static UniValue masternode_winners(const JSONRPCRequest& request, const Chainsta
         obj.pushKV(strprintf("%d", h), strPayments);
     }
 
-    bool isV20Active = llmq::utils::IsV20Active(pindexTip);
-    auto projection = deterministicMNManager->GetListForBlock(pindexTip).GetProjectedMNPayees(20, isV20Active);
+    auto projection = deterministicMNManager->GetListForBlock(pindexTip).GetProjectedMNPayees(pindexTip, 20);
     for (size_t i = 0; i < projection.size(); i++) {
         int h = nChainTipHeight + 1 + i;
         std::string strPayments = GetRequiredPaymentsString(h, projection[i]);

--- a/src/versionbitsinfo.cpp
+++ b/src/versionbitsinfo.cpp
@@ -15,4 +15,8 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.name =*/"v20",
         /*.gbt_force =*/true,
     },
+    {
+            /*.name =*/"mn_rr",
+            /*.gbt_force =*/true,
+    },
 };

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -114,41 +114,54 @@ class LLMQHPMNTest(DashTestFramework):
         self.log.info("Test that HPMNs are paid 4x blocks in a row")
         self.test_hpmn_payments(window_analysis=256)
 
+        self.activate_v20(expected_activation_height=1440)
+        self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
+
+        self.bump_mocktime(1)
+        self.nodes[0].generate(8)
+        self.sync_blocks()
+
+        self.log.info("Test that HPMNs are paid 1 block in a row after v20 activation")
+        self.test_hpmn_payments(window_analysis=256, v20active=True)
+
         self.log.info(self.nodes[0].masternodelist())
 
         return
 
-    def test_hpmn_payments(self, window_analysis):
+    def test_hpmn_payments(self, window_analysis, v20active=False):
         current_hpmn = None
         consecutive_payments = 0
+        n_payments = 0 if v20active else 4
         for i in range(0, window_analysis):
             payee = self.get_mn_payee_for_block(self.nodes[0].getbestblockhash())
             if payee is not None and payee.hpmn:
                 if current_hpmn is not None and payee.proTxHash == current_hpmn.proTxHash:
                     # same HPMN
                     assert consecutive_payments > 0
-                    consecutive_payments += 1
+                    if not v20active:
+                        consecutive_payments += 1
                     consecutive_payments_rpc = self.nodes[0].protx('info', current_hpmn.proTxHash)['state']['consecutivePayments']
                     assert_equal(consecutive_payments, consecutive_payments_rpc)
                 else:
                     # new HPMN
                     if current_hpmn is not None:
-                        # make sure the old one was paid 4 times in a row
-                        assert_equal(consecutive_payments, 4)
+                        # make sure the old one was paid N times in a row
+                        assert_equal(consecutive_payments, n_payments)
                         consecutive_payments_rpc = self.nodes[0].protx('info', current_hpmn.proTxHash)['state']['consecutivePayments']
                         # old HPMN should have its nConsecutivePayments reset to 0
                         assert_equal(consecutive_payments_rpc, 0)
                     consecutive_payments_rpc = self.nodes[0].protx('info', payee.proTxHash)['state']['consecutivePayments']
                     # if hpmn is the one we start "for" loop with,
                     # we have no idea how many times it was paid before - rely on rpc results here
-                    consecutive_payments = consecutive_payments_rpc if i == 0 and current_hpmn is None else 1
+                    new_payment_value = 0 if v20active else 1
+                    consecutive_payments = consecutive_payments_rpc if i == 0 and current_hpmn is None else new_payment_value
                     current_hpmn = payee
                     assert_equal(consecutive_payments, consecutive_payments_rpc)
             else:
                 # not a HPMN
                 if current_hpmn is not None:
-                    # make sure the old one was paid 4 times in a row
-                    assert_equal(consecutive_payments, 4)
+                    # make sure the old one was paid N times in a row
+                    assert_equal(consecutive_payments, n_payments)
                     consecutive_payments_rpc = self.nodes[0].protx('info', current_hpmn.proTxHash)['state']['consecutivePayments']
                     # old HPMN should have its nConsecutivePayments reset to 0
                     assert_equal(consecutive_payments_rpc, 0)

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -117,8 +117,9 @@ class LLMQHPMNTest(DashTestFramework):
         self.activate_v20(expected_activation_height=1440)
         self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
 
+        # Generate a few blocks to make HPMN/MN analysis on a pure v20 window
         self.bump_mocktime(1)
-        self.nodes[0].generate(8)
+        self.nodes[0].generate(4)
         self.sync_blocks()
 
         self.log.info("Test that HPMNs are paid 1 block in a row after v20 activation")

--- a/test/functional/feature_llmq_hpmn.py
+++ b/test/functional/feature_llmq_hpmn.py
@@ -114,15 +114,15 @@ class LLMQHPMNTest(DashTestFramework):
         self.log.info("Test that HPMNs are paid 4x blocks in a row")
         self.test_hpmn_payments(window_analysis=256)
 
-        self.activate_v20(expected_activation_height=1440)
-        self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
+        self.activate_mn_rr()
+        self.log.info("Activated MN RewardReallocation at height:" + str(self.nodes[0].getblockcount()))
 
-        # Generate a few blocks to make HPMN/MN analysis on a pure v20 window
+        # Generate a few blocks to make HPMN/MN analysis on a pure MN RewardReallocation window
         self.bump_mocktime(1)
         self.nodes[0].generate(4)
         self.sync_blocks()
 
-        self.log.info("Test that HPMNs are paid 1 block in a row after v20 activation")
+        self.log.info("Test that HPMNs are paid 1 block in a row after MN RewardReallocation activation")
         self.test_hpmn_payments(window_analysis=256, v20active=True)
 
         self.log.info(self.nodes[0].masternodelist())

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -148,6 +148,15 @@ class BlockchainTest(BitcoinTestFramework):
                     'timeout': 999999999999,
                     'since': 0
                 }, 'active': False},
+            'mn_rr': {
+                'type': 'bip9',
+                'bip9': {
+                    'status': 'defined',
+                    'start_time': 0,
+                    'timeout': 999999999999,
+                    'since': 0
+                },
+                'active': False},
             'testdummy': {
                 'type': 'bip9',
                 'bip9': {

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1093,6 +1093,8 @@ class DashTestFramework(BitcoinTestFramework):
 
     def activate_v20(self, expected_activation_height=None):
         self.activate_by_name('v20', expected_activation_height)
+    def activate_mn_rr(self, expected_activation_height=None):
+        self.activate_by_name('mn_rr', expected_activation_height)
 
     def set_dash_llmq_test_params(self, llmq_size, llmq_threshold):
         self.llmq_size = llmq_size


### PR DESCRIPTION
## Issue being fixed or feature implemented
Since v19, Evo nodes are paid 4x blocks in a row.
This needs to be reverted when MN Reward Reallocation activates.

## What was done?
Starting from MN Reward Reallocation activation, Evo nodes are paid one block in a row (like regular masternodes).
In addition, `nConsecutivePayments` isn't incremented anymore for Evo nodes.

## How Has This Been Tested?
`feature_llmq_hpmn.py` with MN Reward Reallocation activation.

## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

