### PR TITLE
feat: bury v19 activation

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -165,7 +165,8 @@ public:
         consensus.BRRHeight = 1374912; // 000000000000000c5a124f3eccfbe6e17876dca79cec9e63dfa70d269113c926
         consensus.DIP0020Height = 1516032; // 000000000000000f64ed3bd9af1078177ac026f6aa2677aa4d8beeae43be56cc
         consensus.DIP0024Height = 1737792; // 0000000000000001342be9c0b75ad40c276beaad91616423c4d9cb101b3db438
-        consensus.MinBIP9WarningHeight = 1737792 + 2016; // dip0024 activation height + miner confirmation window
+        consensus.V19Height = 1899072; // 0000000000000015e32e73052d663626327004c81c5c22cb8b42c361015c0eae
+        consensus.MinBIP9WarningHeight = 1899072 + 2016; // V19 activation height + miner confirmation window
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -178,15 +179,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
-
-        // Deployment of Deployment of Basic BLS, AssetLocks, EHF
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].bit = 8;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nStartTime = 1686700800;     // Wednesday, June 14, 2023 12:00:00 AM
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nTimeout = 1718323200;       // Friday, June 14, 2024 12:00:00 AM
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nWindowSize = 4032;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nThresholdStart = 3226;       // 80% of 4032
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nThresholdMin = 2420;         // 60% of 4032
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nFalloffCoeff = 5;            // this corresponds to 10 periods
 
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nStartTime = 19999999999;     // TODO: To be determined later
@@ -361,7 +353,8 @@ public:
         consensus.BRRHeight = 387500; // 0000001537dbfd09dea69f61c1f8b2afa27c8dc91c934e144797761c9f10367b
         consensus.DIP0020Height = 414100; // 000000cf961868662fbfbb5d1af6f1caa1809f6a4e390efe5f8cd3031adea668
         consensus.DIP0024Height = 769700; // 0000008d84e4efd890ae95c70a7a6126a70a80e5c19e4cb264a5b3469aeef172
-        consensus.MinBIP9WarningHeight = 769700 + 2016;  // dip0024 activation height + miner confirmation window
+        consensus.V19Height = 850100; // 000004728b8ff2a16b9d4eebb0fd61eeffadc9c7fe4b0ec0b5a739869401ab5b
+        consensus.MinBIP9WarningHeight = 850100 + 2016;  // v19 activation height + miner confirmation window
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -374,15 +367,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
-
-        // Deployment of Deployment of Basic BLS, AssetLocks, EHF
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].bit = 8;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nStartTime = 1678838400;     // Wed, March 15, 2023 0:00:00
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nTimeout = 999999999999ULL;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nWindowSize = 100;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nThresholdStart = 80;         // 80% of 100
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nThresholdMin = 60;           // 60% of 100
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nFalloffCoeff = 5;            // this corresponds to 10 periods
 
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nStartTime = 19999999999;     // TODO: To be determined later
@@ -530,7 +514,8 @@ public:
         consensus.BRRHeight = 300;
         consensus.DIP0020Height = 300;
         consensus.DIP0024Height = 300;
-        consensus.MinBIP9WarningHeight = 300 + 2016; // dip0024 activation height + miner confirmation window
+        consensus.V19Height = 300;
+        consensus.MinBIP9WarningHeight = 300 + 2016; // v19 activation height + miner confirmation window
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
         consensus.nPowTargetSpacing = 2.5 * 60; // Dash: 2.5 minutes
@@ -543,15 +528,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
-
-        // Deployment of Deployment of Basic BLS, AssetLocks, EHF
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].bit = 8;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nStartTime = 1661990400; // Sep 1st, 2022
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nTimeout = 999999999999ULL;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nWindowSize = 100;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nThresholdStart = 80; // 80% of 100
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nThresholdMin = 60;   // 60% of 100
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nFalloffCoeff = 5;     // this corresponds to 10 periods
 
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nStartTime = 1661990400; // Sep 1st, 2022
@@ -765,6 +741,7 @@ public:
         consensus.BRRHeight = 2500; // see block_reward_reallocation_tests
         consensus.DIP0020Height = 300;
         consensus.DIP0024Height = 900;
+        consensus.V19Height = 900;
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 1
         consensus.nPowTargetTimespan = 24 * 60 * 60; // Dash: 1 day
@@ -778,15 +755,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 999999999999ULL;
-
-        // Deployment of Deployment of Basic BLS, AssetLocks, EHF
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].bit = 8;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nTimeout = 999999999999ULL;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nWindowSize = 300;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nThresholdStart = 240; // 80% of 300
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nThresholdMin = 180;   // 60% of 300
-        consensus.vDeployments[Consensus::DEPLOYMENT_V19].nFalloffCoeff = 5;     // this corresponds to 10 periods
 
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nStartTime = 0;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -88,7 +88,7 @@ struct Params {
     int DIP0020Height;
     /** Block height at which DIP0024 (Quorum Rotation) and decreased governance proposal fee becomes active */
     int DIP0024Height;
-    /** Block height at which V19 (Basic BLS) becomes active */
+    /** Block height at which V19 (Basic BLS and HPMNs/EvoNodes) becomes active */
     int V19Height;
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and DIP activations. */

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -15,7 +15,6 @@ namespace Consensus {
 
 enum DeploymentPos {
     DEPLOYMENT_TESTDUMMY,
-    DEPLOYMENT_V19,     // Deployment of Basic BLS, AssetLocks
     DEPLOYMENT_V20,     // Deployment of EHF, LLMQ Randomness Beacon
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
@@ -89,6 +88,8 @@ struct Params {
     int DIP0020Height;
     /** Block height at which DIP0024 (Quorum Rotation) and decreased governance proposal fee becomes active */
     int DIP0024Height;
+    /** Block height at which V19 (Basic BLS) becomes active */
+    int V19Height;
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and DIP activations. */
     int MinBIP9WarningHeight;

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -169,7 +169,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, ll
         nTimeCbTxCL += nTime6 - nTime5;
         LogPrint(BCLog::BENCHMARK, "        - CheckCbTxBestChainlock: %.2fms [%.2fs]\n", 0.001 * (nTime6 - nTime5), nTimeCbTxCL * 0.000001);
 
-        if (llmq::utils::V19ActivationHeight(pindex) == pindex->nHeight + 1) {
+        if (Params().GetConsensus().V19Height == pindex->nHeight + 1) {
             // NOTE: The block next to the activation is the one that is using new rules.
             // V19 activated just activated, so we must switch to the new rules here.
             bls::bls_legacy_scheme.store(false);
@@ -190,7 +190,7 @@ bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, llmq:
     auto bls_legacy_scheme = bls::bls_legacy_scheme.load();
 
     try {
-        if (llmq::utils::V19ActivationHeight(pindex) == pindex->nHeight + 1) {
+        if (Params().GetConsensus().V19Height == pindex->nHeight + 1) {
             // NOTE: The block next to the activation is the one that is using new rules.
             // Removing the activation block here, so we must switch back to the old rules.
             bls::bls_legacy_scheme.store(true);

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -707,26 +707,13 @@ bool IsDIP0024Active(const CBlockIndex* pindex)
 bool IsV19Active(const CBlockIndex* pindex)
 {
     assert(pindex);
-
-    LOCK(cs_llmq_vbc);
-    return VersionBitsState(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V19, llmq_versionbitscache) == ThresholdState::ACTIVE;
-}
-
-const int V19ActivationHeight(const CBlockIndex* pindex)
-{
-    assert(pindex);
-
-   LOCK(cs_llmq_vbc);
-   if (VersionBitsState(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V19, llmq_versionbitscache) != ThresholdState::ACTIVE) {
-       return -1;
-   }
-   return VersionBitsStateSinceHeight(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V19, llmq_versionbitscache);
+    return pindex->nHeight + 1 >= Params().GetConsensus().V19Height;
 }
 
 const CBlockIndex* V19ActivationIndex(const CBlockIndex* pindex)
 {
     assert(pindex);
-    return pindex->GetAncestor(V19ActivationHeight(pindex));
+    return pindex->GetAncestor(Params().GetConsensus().V19Height);
 }
 
 bool IsV20Active(const CBlockIndex* pindex)

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -74,7 +74,6 @@ Consensus::LLMQType GetInstantSendLLMQType(const CQuorumManager& qman, const CBl
 Consensus::LLMQType GetInstantSendLLMQType(bool deterministic);
 bool IsDIP0024Active(const CBlockIndex* pindex);
 bool IsV19Active(const CBlockIndex* pindex);
-const int V19ActivationHeight(const CBlockIndex* pindex);
 const CBlockIndex* V19ActivationIndex(const CBlockIndex* pindex);
 bool IsV20Active(const CBlockIndex* pindex);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1570,7 +1570,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BuriedForkDescPushBack(softforks, "dip0020", consensusParams.DIP0020Height);
     BuriedForkDescPushBack(softforks, "dip0024", consensusParams.DIP0024Height);
     BuriedForkDescPushBack(softforks, "realloc", consensusParams.BRRHeight);
-    BIP9SoftForkDescPushBack(softforks, "v19", consensusParams, Consensus::DEPLOYMENT_V19);
+    BuriedForkDescPushBack(softforks, "v19", consensusParams.V19Height);
     BIP9SoftForkDescPushBack(softforks, "v20", consensusParams, Consensus::DEPLOYMENT_V20);
     BIP9SoftForkDescPushBack(softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -276,15 +276,15 @@ TestChainSetup::TestChainSetup(int num_blocks, const std::vector<const char*>& e
             /* TestChain100Setup */
             {  100, uint256S("0x6ffb83129c19ebdf1ae3771be6a67fe34b35f4c956326b9ba152fac1649f65ae") },
             /* TestChainDIP3BeforeActivationSetup */
-            {  430, uint256S("0x20c025ce708233d05280099f82f09def00ed5aaf5430316070e0dd8807897c41") },
+            {  430, uint256S("0x0bcefaa33fec56cd84d05d0e76cd6a78badcc20f627d91903646de6a07930a14") },
             /* TestChainDIP3Setup */
-            {  431, uint256S("0x7ca56efe77e768762cc94644828b5824a19f77568440abd851efa644079bd6eb") },
+            {  431, uint256S("0x5fd3aa5ef29464839499d7f847edd9362e3e73392b79d3bd88b1591f5fb17d4e") },
             /* TestChainBRRBeforeActivationSetup */
-            {  497, uint256S("0x1333458713817f35d7c03677755fbcbc3e2fe253b90b5ff32b0187653c4df8db") },
+            {  497, uint256S("0x5d3a646bb53416543e409d2aa99b93ba619c8394ac68868e1b65a57cb8d0ce7d") },
             /* TestChainV19BeforeActivationSetup */
-            {  894, uint256S("0x3516790dd9a6491f0e9462870df3d840c2a134788df39bf95fff07a91e98d26d") },
+            {  894, uint256S("0x4e01ffea7482da6bbc581f16a62e04d7a20c8789b6bfe581c60016bb79d8d267") },
             /* TestChainDIP3V19Setup */
-            { 1000, uint256S("0x0d6e2df0c68ca0385e48a748776ec582b85dec58ce74e9bf679976138fd6e192") },
+            { 1000, uint256S("0x610be429a3d38c4e2ec15fb6c0bfe368b537eb0f75d3bc0456b698017536634a") },
         }
     };
 

--- a/src/versionbitsinfo.cpp
+++ b/src/versionbitsinfo.cpp
@@ -12,10 +12,6 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.gbt_force =*/ true,
     },
     {
-        /*.name =*/"v19",
-        /*.gbt_force =*/true,
-    },
-    {
         /*.name =*/"v20",
         /*.gbt_force =*/true,
     },

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -139,15 +139,7 @@ class BlockchainTest(BitcoinTestFramework):
             'dip0020': { 'type': 'buried', 'active': False, 'height': 300},
             'dip0024': { 'type': 'buried', 'active': False, 'height': 900},
             'realloc': { 'type': 'buried', 'active': False, 'height': 2500},
-            'v19': {
-                'type': 'bip9',
-                'bip9': {
-                    'status': 'defined',
-                    'start_time': 0,
-                    'timeout': 999999999999,
-                    'since': 0
-                },
-                'active': False},
+            'v19': { 'type': 'buried', 'active': False, 'height': 900},
             'v20': {
                 'type': 'bip9',
                 'bip9': {


### PR DESCRIPTION
## Issue being fixed or feature implemented
V19 is active on mainnet/testnet now, no need to check activation bits anymore. This PR also bumps `MinBIP9WarningHeight` to post-v19-activation height which should stop `unknown new rules activated (versionbit 8)` warning from appearing.

## What was done?
Bury v19, bump `MinBIP9WarningHeight`

## How Has This Been Tested?
Run tests, reindex on mainnet/testnet.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

