### PR TITLE
fix: Process `dsq` messages even when CJ is disabled locally or disk space is low

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -34,13 +34,7 @@ std::unique_ptr<CCoinJoinClientQueueManager> coinJoinClientQueueManager;
 void CCoinJoinClientQueueManager::ProcessMessage(const CNode& peer, PeerManager& peerman, std::string_view msg_type, CDataStream& vRecv)
 {
     if (fMasternodeMode) return;
-    if (!CCoinJoinClientOptions::IsEnabled()) return;
     if (!m_mn_sync.IsBlockchainSynced()) return;
-
-    if (!CheckDiskSpace(GetDataDir())) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinClientQueueManager::ProcessMessage -- Not enough disk space, disabling CoinJoin.\n");
-        return;
-    }
 
     if (msg_type == NetMsgType::DSQUEUE) {
         CCoinJoinClientQueueManager::ProcessDSQueue(peer, peerman, vRecv);

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1821,7 +1821,6 @@ void CCoinJoinClientManager::UpdatedBlockTip(const CBlockIndex* pindex)
 
 void CCoinJoinClientQueueManager::DoMaintenance()
 {
-    if (!CCoinJoinClientOptions::IsEnabled()) return;
     if (fMasternodeMode) return; // no client-side mixing on masternodes
 
     if (!m_mn_sync.IsBlockchainSynced() || ShutdownRequested()) return;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Refusing to process `dsq` will result in node not being able to process `dstx`es later.

## What was done?

## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

