### PR TITLE
feat: Check if settings file is empty

### DIFF
--- a/src/util/settings.cpp
+++ b/src/util/settings.cpp
@@ -70,6 +70,18 @@ bool ReadSettings(const fs::path& path, std::map<std::string, SettingsValue>& va
       return false;
     }
 
+    // Check if settings file is empty
+    if (file.peek() == std::ifstream::traits_type::eof()) {
+        // In that case delete it and return true: it will be created with default value later
+        file.close();
+        if (!boost::filesystem::remove(path)) {
+            // Return false only if it failed to delete the empty settings file
+            errors.emplace_back(strprintf("Unable to delete empty settings file %s", path.string()));
+            return false;
+        }
+        return true;
+    }
+
     SettingsValue in;
     if (!in.read(std::string{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()})) {
         errors.emplace_back(strprintf("Unable to parse settings file %s", path.string()));


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes issue #5497.

## What was done?
Checks if settings file is empty, and deletes it if that's the case.

It will will be generated with default value `{}` afterwards.

## How Has This Been Tested?
Running Dash Qt on regtest masternode with `--nocleanup` and `./src/qt/dash-qt --regtest --datadir=`

## Breaking Changes
No

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

