### PR TITLE
feat: Enable `fallbackfee` by default on all networks

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -67,7 +67,7 @@ std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, cons
 //! -paytxfee default
 constexpr CAmount DEFAULT_PAY_TX_FEE = 0;
 //! -fallbackfee default
-static const CAmount DEFAULT_FALLBACK_FEE = 0;
+static const CAmount DEFAULT_FALLBACK_FEE = 1000;
 //! -discardfee default
 static const CAmount DEFAULT_DISCARD_FEE = 10000;
 //! -mintxfee default


### PR DESCRIPTION
## Issue being fixed or feature implemented
We have plenty of block space. Having `fallbackfee` disabled by default is needlessly annoying.

## What was done?
Bump `DEFAULT_FALLBACK_FEE` to `1000`, same as it is on `master` https://github.com/dashpay/dash/blob/master/src/wallet/wallet.h#L68

## How Has This Been Tested?
run tests, send txes on testnet

## Breaking Changes
should be none

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

