### PR TITLE
refactor: Global renaming from hpmn to evo

### DIFF
--- a/doc/release-notes-5508.md
+++ b/doc/release-notes-5508.md
@@ -6,7 +6,8 @@ Updated RPCs
 - `protx register_prepare_hpmn` is renamed to `protx register_prepare_evo`.
 - `protx update_service_hpmn` is renamed to `protx update_service_evo`.
 
-Please note that both versions will be accepted for now. Deprecation will be done in the future for backward compatibility.
+Please note that _hpmn RPCs are deprecated. 
+Although, they can still be enabled by adding `-deprecatedrpc=hpmn`.
 
 - `masternodelist` filter `hpmn` is renamed to `evo`.
 - `masternode count` return total number of EvoNodes under field `evo` instead of `hpmn`.

--- a/doc/release-notes-5508.md
+++ b/doc/release-notes-5508.md
@@ -1,0 +1,13 @@
+Updated RPCs
+--------
+
+- `protx register_hpmn` is renamed to `protx register_evo`.
+- `protx register_fund_hpmn` is renamed to `protx register_fund_evo`.
+- `protx register_prepare_hpmn` is renamed to `protx register_prepare_evo`.
+- `protx update_service_hpmn` is renamed to `protx update_service_evo`.
+
+Please note that both versions will be accepted fow now. Deprecation will be done in the future for backward compatibility.
+
+- `masternodelist` filter `hpmn` is renamed to `evo`.
+- `masternode count` return total number of EvoNodes under field `evo` instead of `hpmn`.
+-  Description type string `HighPerformance` is renamed to `Evo`: affects most RPCs return MNs details.

--- a/doc/release-notes-5508.md
+++ b/doc/release-notes-5508.md
@@ -6,7 +6,7 @@ Updated RPCs
 - `protx register_prepare_hpmn` is renamed to `protx register_prepare_evo`.
 - `protx update_service_hpmn` is renamed to `protx update_service_evo`.
 
-Please note that both versions will be accepted fow now. Deprecation will be done in the future for backward compatibility.
+Please note that both versions will be accepted for now. Deprecation will be done in the future for backward compatibility.
 
 - `masternodelist` filter `hpmn` is renamed to `evo`.
 - `masternode count` return total number of EvoNodes under field `evo` instead of `hpmn`.

--- a/doc/release-notes-5508.md
+++ b/doc/release-notes-5508.md
@@ -6,7 +6,7 @@ Updated RPCs
 - `protx register_prepare_hpmn` is renamed to `protx register_prepare_evo`.
 - `protx update_service_hpmn` is renamed to `protx update_service_evo`.
 
-Please note that _hpmn RPCs are deprecated. 
+Please note that _hpmn RPCs are deprecated.
 Although, they can still be enabled by adding `-deprecatedrpc=hpmn`.
 
 - `masternodelist` filter `hpmn` is renamed to `evo`.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -89,7 +89,7 @@ struct Params {
     int DIP0020Height;
     /** Block height at which DIP0024 (Quorum Rotation) and decreased governance proposal fee becomes active */
     int DIP0024Height;
-    /** Block height at which V19 (Basic BLS and HPMNs/EvoNodes) becomes active */
+    /** Block height at which V19 (Basic BLS and EvoNodes) becomes active */
     int V19Height;
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and DIP activations. */

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -183,14 +183,14 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
 
     bool isv19Active = llmq::utils::IsV19Active(pIndex);
     bool isMNRewardReallocation = llmq::utils::IsMNRewardReallocationActive(pIndex);
-    // Starting from v19 and until MNRewardReallocation (Platform release), HPMN will be rewarded 4 blocks in a row
+    // Starting from v19 and until MNRewardReallocation (Platform release), EvoNodes will be rewarded 4 blocks in a row
     CDeterministicMNCPtr best = nullptr;
     if (isv19Active && !isMNRewardReallocation) {
         ForEachMNShared(true, [&](const CDeterministicMNCPtr& dmn) {
             if (dmn->pdmnState->nLastPaidHeight == nHeight) {
                 // We found the last MN Payee.
-                // If the last payee is a HPMN, we need to check its consecutive payments and pay him again if needed
-                if (dmn->nType == MnType::HighPerformance && dmn->pdmnState->nConsecutivePayments < dmn_types::HighPerformance.voting_weight) {
+                // If the last payee is a Evo, we need to check its consecutive payments and pay him again if needed
+                if (dmn->nType == MnType::Evo && dmn->pdmnState->nConsecutivePayments < dmn_types::Evo.voting_weight) {
                     best = dmn;
                 }
             }
@@ -198,7 +198,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
 
         if (best != nullptr) return best;
 
-        // Note: If the last payee was a regular MN or if the payee is a HPMN that was removed from the mnList then that's fine.
+        // Note: If the last payee was a regular MN or if the payee is a Evo that was removed from the mnList then that's fine.
         // We can proceed with classic MN payee selection
     }
 
@@ -226,18 +226,18 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(con
     std::vector<CDeterministicMNCPtr> result;
     result.reserve(nCount);
 
-    auto remaining_hpmn_payments = 0;
-    CDeterministicMNCPtr hpmn_to_be_skipped = nullptr;
+    auto remaining_evo_payments = 0;
+    CDeterministicMNCPtr evo_to_be_skipped = nullptr;
     bool isMNRewardReallocation = llmq::utils::IsMNRewardReallocationActive(pindex);
     ForEachMNShared(true, [&](const CDeterministicMNCPtr& dmn) {
         if (dmn->pdmnState->nLastPaidHeight == nHeight) {
             // We found the last MN Payee.
-            // If the last payee is a HPMN, we need to check its consecutive payments and pay him again if needed
-            if (!isMNRewardReallocation && dmn->nType == MnType::HighPerformance && dmn->pdmnState->nConsecutivePayments < dmn_types::HighPerformance.voting_weight) {
-                remaining_hpmn_payments = dmn_types::HighPerformance.voting_weight - dmn->pdmnState->nConsecutivePayments;
-                for ([[maybe_unused]] auto _ : irange::range(remaining_hpmn_payments)) {
+            // If the last payee is an EvoNode, we need to check its consecutive payments and pay him again if needed
+            if (!isMNRewardReallocation && dmn->nType == MnType::Evo && dmn->pdmnState->nConsecutivePayments < dmn_types::Evo.voting_weight) {
+                remaining_evo_payments = dmn_types::Evo.voting_weight - dmn->pdmnState->nConsecutivePayments;
+                for ([[maybe_unused]] auto _ : irange::range(remaining_evo_payments)) {
                     result.emplace_back(dmn);
-                    hpmn_to_be_skipped = dmn;
+                    evo_to_be_skipped = dmn;
                 }
             }
         }
@@ -245,20 +245,20 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(con
     });
 
     ForEachMNShared(true, [&](const CDeterministicMNCPtr& dmn) {
-        if (dmn == hpmn_to_be_skipped) return;
+        if (dmn == evo_to_be_skipped) return;
         for ([[maybe_unused]] auto _ : irange::range(GetMnType(dmn->nType).voting_weight)) {
             result.emplace_back(dmn);
         }
     });
 
-    if (hpmn_to_be_skipped != nullptr) {
-        // if hpmn is in the middle of payments, add entries for already paid ones to the end of the list
-        for ([[maybe_unused]] auto _ : irange::range(hpmn_to_be_skipped->pdmnState->nConsecutivePayments)) {
-            result.emplace_back(hpmn_to_be_skipped);
+    if (evo_to_be_skipped != nullptr) {
+        // if EvoNode is in the middle of payments, add entries for already paid ones to the end of the list
+        for ([[maybe_unused]] auto _ : irange::range(evo_to_be_skipped->pdmnState->nConsecutivePayments)) {
+            result.emplace_back(evo_to_be_skipped);
         }
     }
 
-    std::sort(result.begin() + remaining_hpmn_payments, result.end(), [&](const CDeterministicMNCPtr& a, const CDeterministicMNCPtr& b) {
+    std::sort(result.begin() + remaining_evo_payments, result.end(), [&](const CDeterministicMNCPtr& a, const CDeterministicMNCPtr& b) {
         return CompareByLastPaid(a.get(), b.get());
     });
 
@@ -267,9 +267,9 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(con
     return result;
 }
 
-std::vector<CDeterministicMNCPtr> CDeterministicMNList::CalculateQuorum(size_t maxSize, const uint256& modifier, const bool onlyHighPerformanceMasternodes) const
+std::vector<CDeterministicMNCPtr> CDeterministicMNList::CalculateQuorum(size_t maxSize, const uint256& modifier, const bool onlyEvoNodes) const
 {
-    auto scores = CalculateScores(modifier, onlyHighPerformanceMasternodes);
+    auto scores = CalculateScores(modifier, onlyEvoNodes);
 
     // sort is descending order
     std::sort(scores.rbegin(), scores.rend(), [](const std::pair<arith_uint256, CDeterministicMNCPtr>& a, const std::pair<arith_uint256, CDeterministicMNCPtr>& b) {
@@ -289,7 +289,7 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::CalculateQuorum(size_t m
     return result;
 }
 
-std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CDeterministicMNList::CalculateScores(const uint256& modifier, const bool onlyHighPerformanceMasternodes) const
+std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CDeterministicMNList::CalculateScores(const uint256& modifier, const bool onlyEvoNodes) const
 {
     std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> scores;
     scores.reserve(GetAllMNsCount());
@@ -299,8 +299,8 @@ std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CDeterministicMNList
             // future quorums
             return;
         }
-        if (onlyHighPerformanceMasternodes) {
-            if (dmn->nType != MnType::HighPerformance)
+        if (onlyEvoNodes) {
+            if (dmn->nType != MnType::Evo)
                 return;
         }
         // calculate sha256(sha256(proTxHash, confirmedHash), modifier) per MN
@@ -467,7 +467,7 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTota
                 dmn->proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.ToString())));
     }
 
-    if (dmn->nType == MnType::HighPerformance) {
+    if (dmn->nType == MnType::Evo) {
         if (dmn->pdmnState->platformNodeID != uint160() && !AddUniqueProperty(*dmn, dmn->pdmnState->platformNodeID)) {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
             throw(std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate platformNodeID=%s", __func__,
@@ -507,7 +507,7 @@ void CDeterministicMNList::UpdateMN(const CDeterministicMN& oldDmn, const std::s
         throw(std::runtime_error(strprintf("%s: Can't update a masternode %s with a duplicate pubKeyOperator=%s", __func__,
                 oldDmn.proTxHash.ToString(), pdmnState->pubKeyOperator.ToString())));
     }
-    if (dmn->nType == MnType::HighPerformance) {
+    if (dmn->nType == MnType::Evo) {
         if (!UpdateUniqueProperty(*dmn, oldState->platformNodeID, pdmnState->platformNodeID)) {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
             throw(std::runtime_error(strprintf("%s: Can't update a masternode %s with a duplicate platformNodeID=%s", __func__,
@@ -568,7 +568,7 @@ void CDeterministicMNList::RemoveMN(const uint256& proTxHash)
                 proTxHash.ToString(), dmn->pdmnState->pubKeyOperator.ToString())));
     }
 
-    if (dmn->nType == MnType::HighPerformance) {
+    if (dmn->nType == MnType::Evo) {
         if (dmn->pdmnState->platformNodeID != uint160() && !DeleteUniqueProperty(*dmn, dmn->pdmnState->platformNodeID)) {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
             throw(std::runtime_error(strprintf("%s: Can't delete a masternode %s with a duplicate platformNodeID=%s", __func__,
@@ -743,7 +743,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-payload");
             }
 
-            if (proTx.nType == MnType::HighPerformance && !llmq::utils::IsV19Active(pindexPrev)) {
+            if (proTx.nType == MnType::Evo && !llmq::utils::IsV19Active(pindexPrev)) {
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-payload");
             }
 
@@ -806,7 +806,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-payload");
             }
 
-            if (proTx.nType == MnType::HighPerformance && !llmq::utils::IsV19Active(pindexPrev)) {
+            if (proTx.nType == MnType::Evo && !llmq::utils::IsV19Active(pindexPrev)) {
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-payload");
             }
 
@@ -828,7 +828,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
             auto newState = std::make_shared<CDeterministicMNState>(*dmn->pdmnState);
             newState->addr = proTx.addr;
             newState->scriptOperatorPayout = proTx.scriptOperatorPayout;
-            if (proTx.nType == MnType::HighPerformance) {
+            if (proTx.nType == MnType::Evo) {
                 newState->platformNodeID = proTx.platformNodeID;
                 newState->platformP2PPort = proTx.platformP2PPort;
                 newState->platformHTTPPort = proTx.platformHTTPPort;
@@ -948,10 +948,10 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
         // Starting from v19 and until MNRewardReallocation, HPMN will be paid 4 blocks in a row
         // No need to check if v19 is active, since HPMN ProRegTx are allowed only after v19 activation
         // Note: If the payee wasn't found in the current block that's fine
-        if (dmn->nType == MnType::HighPerformance && !isMNRewardReallocation) {
+        if (dmn->nType == MnType::Evo && !isMNRewardReallocation) {
             ++newState->nConsecutivePayments;
             if (debugLogs) {
-                LogPrint(BCLog::MNPAYMENTS, "CDeterministicMNManager::%s -- MN %s is a HPMN, bumping nConsecutivePayments to %d\n",
+                LogPrint(BCLog::MNPAYMENTS, "CDeterministicMNManager::%s -- MN %s is an EvoNode, bumping nConsecutivePayments to %d\n",
                           __func__, dmn->proTxHash.ToString(), newState->nConsecutivePayments);
             }
         }
@@ -963,10 +963,10 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
         }
     }
 
-    // reset nConsecutivePayments on non-paid HPMNs
+    // reset nConsecutivePayments on non-paid EvoNodes
     auto newList2 = newList;
     newList2.ForEachMN(false, [&](auto& dmn) {
-        if (dmn.nType != MnType::HighPerformance) return;
+        if (dmn.nType != MnType::Evo) return;
         if (payee != nullptr && dmn.proTxHash == payee->proTxHash && !isMNRewardReallocation) return;
         if (dmn.pdmnState->nConsecutivePayments == 0) return;
         if (debugLogs) {
@@ -1496,7 +1496,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxVali
         return false;
     }
 
-    if (ptx.nType == MnType::HighPerformance) {
+    if (ptx.nType == MnType::Evo) {
         if (!CheckPlatformFields(ptx, state)) {
             return false;
         }
@@ -1560,8 +1560,8 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxVali
             return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
         }
 
-        // never allow duplicate platformNodeIds for HPMNs
-        if (ptx.nType == MnType::HighPerformance) {
+        // never allow duplicate platformNodeIds for EvoNodes
+        if (ptx.nType == MnType::Evo) {
             if (mnList.HasUniqueProperty(ptx.platformNodeID)) {
                 return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-platformnodeid");
             }
@@ -1616,7 +1616,7 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxV
         return false;
     }
 
-    if (ptx.nType == MnType::HighPerformance) {
+    if (ptx.nType == MnType::Evo) {
         if (!CheckPlatformFields(ptx, state)) {
             return false;
         }
@@ -1634,8 +1634,8 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxV
             return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-addr");
         }
 
-        // don't allow updating to platformNodeIds already used by other HPMNs
-        if (ptx.nType == MnType::HighPerformance) {
+        // don't allow updating to platformNodeIds already used by other EvoNodes
+        if (ptx.nType == MnType::Evo) {
             if (mnList.HasUniqueProperty(ptx.platformNodeID)  && mnList.GetUniquePropertyMN(ptx.platformNodeID)->proTxHash != ptx.proTxHash) {
                 return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-platformnodeid");
             }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -189,7 +189,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
         ForEachMNShared(true, [&](const CDeterministicMNCPtr& dmn) {
             if (dmn->pdmnState->nLastPaidHeight == nHeight) {
                 // We found the last MN Payee.
-                // If the last payee is a Evo, we need to check its consecutive payments and pay him again if needed
+                // If the last payee is an EvoNode, we need to check its consecutive payments and pay him again if needed
                 if (dmn->nType == MnType::Evo && dmn->pdmnState->nConsecutivePayments < dmn_types::Evo.voting_weight) {
                     best = dmn;
                 }
@@ -198,7 +198,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(const CBlockIndex* pIndex)
 
         if (best != nullptr) return best;
 
-        // Note: If the last payee was a regular MN or if the payee is a Evo that was removed from the mnList then that's fine.
+        // Note: If the last payee was a regular MN or if the payee is an EvoNode that was removed from the mnList then that's fine.
         // We can proceed with classic MN payee selection
     }
 
@@ -945,8 +945,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
         auto dmn = newList.GetMN(payee->proTxHash);
         auto newState = std::make_shared<CDeterministicMNState>(*dmn->pdmnState);
         newState->nLastPaidHeight = nHeight;
-        // Starting from v19 and until MNRewardReallocation, HPMN will be paid 4 blocks in a row
-        // No need to check if v19 is active, since HPMN ProRegTx are allowed only after v19 activation
+        // Starting from v19 and until MNRewardReallocation, EvoNodes will be paid 4 blocks in a row
+        // No need to check if v19 is active, since EvoNode ProRegTxes are allowed only after v19 activation
         // Note: If the payee wasn't found in the current block that's fine
         if (dmn->nType == MnType::Evo && !isMNRewardReallocation) {
             ++newState->nConsecutivePayments;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -238,14 +238,14 @@ public:
         return ranges::count_if(mnMap, [this](const auto& p){ return IsMNValid(*p.second); });
     }
 
-    [[nodiscard]] size_t GetAllHPMNsCount() const
+    [[nodiscard]] size_t GetAllEvoCount() const
     {
-        return ranges::count_if(mnMap, [this](const auto& p) { return p.second->nType == MnType::HighPerformance; });
+        return ranges::count_if(mnMap, [this](const auto& p) { return p.second->nType == MnType::Evo; });
     }
 
-    [[nodiscard]] size_t GetValidHPMNsCount() const
+    [[nodiscard]] size_t GetValidEvoCount() const
     {
-        return ranges::count_if(mnMap, [this](const auto& p) { return p.second->nType == MnType::HighPerformance && IsMNValid(*p.second); });
+        return ranges::count_if(mnMap, [this](const auto& p) { return p.second->nType == MnType::Evo && IsMNValid(*p.second); });
     }
 
     [[nodiscard]] size_t GetValidWeightedMNsCount() const
@@ -351,8 +351,8 @@ public:
      * @param modifier
      * @return
      */
-    [[nodiscard]] std::vector<CDeterministicMNCPtr> CalculateQuorum(size_t maxSize, const uint256& modifier, const bool onlyHighPerformanceMasternodes = false) const;
-    [[nodiscard]] std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CalculateScores(const uint256& modifier, const bool onlyHighPerformanceMasternodes) const;
+    [[nodiscard]] std::vector<CDeterministicMNCPtr> CalculateQuorum(size_t maxSize, const uint256& modifier, const bool onlyEvoNodes = false) const;
+    [[nodiscard]] std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CalculateScores(const uint256& modifier, const bool onlyEvoNodes) const;
 
     /**
      * Calculates the maximum penalty which is allowed at the height of this MN list. It is dynamic and might change

--- a/src/evo/dmn_types.h
+++ b/src/evo/dmn_types.h
@@ -13,7 +13,7 @@
 
 enum class MnType : uint16_t {
     Regular = 0,
-    HighPerformance = 1,
+    Evo = 1,
     COUNT,
     Invalid = std::numeric_limits<uint16_t>::max(),
 };
@@ -34,10 +34,10 @@ constexpr auto Regular = mntype_struct{
     .collat_amount = 1000 * COIN,
     .description = "Regular",
 };
-constexpr auto HighPerformance = mntype_struct{
+constexpr auto Evo = mntype_struct{
     .voting_weight = 4,
     .collat_amount = 4000 * COIN,
-    .description = "HighPerformance",
+    .description = "Evo",
 };
 constexpr auto Invalid = mntype_struct{
     .voting_weight = 0,
@@ -48,7 +48,7 @@ constexpr auto Invalid = mntype_struct{
 [[nodiscard]] static constexpr bool IsCollateralAmount(CAmount amount)
 {
     return amount == Regular.collat_amount ||
-        amount == HighPerformance.collat_amount;
+        amount == Evo.collat_amount;
 }
 
 } // namespace dmn_types
@@ -57,7 +57,7 @@ constexpr auto Invalid = mntype_struct{
 {
     switch (type) {
         case MnType::Regular: return dmn_types::Regular;
-        case MnType::HighPerformance: return dmn_types::HighPerformance;
+        case MnType::Evo: return dmn_types::Evo;
         default: return dmn_types::Invalid;
     }
 }

--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -46,7 +46,7 @@ void CDeterministicMNState::ToJson(UniValue& obj, MnType nType) const
     obj.pushKV("revocationReason", nRevocationReason);
     obj.pushKV("ownerAddress", EncodeDestination(PKHash(keyIDOwner)));
     obj.pushKV("votingAddress", EncodeDestination(PKHash(keyIDVoting)));
-    if (nType == MnType::HighPerformance) {
+    if (nType == MnType::Evo) {
         obj.pushKV("platformNodeID", platformNodeID.ToString());
         obj.pushKV("platformP2PPort", platformP2PPort);
         obj.pushKV("platformHTTPPort", platformHTTPPort);
@@ -114,7 +114,7 @@ void CDeterministicMNStateDiff::ToJson(UniValue& obj, MnType nType) const
     if (fields & Field_pubKeyOperator) {
         obj.pushKV("pubKeyOperator", state.pubKeyOperator.ToString());
     }
-    if (nType == MnType::HighPerformance) {
+    if (nType == MnType::Evo) {
         if (fields & Field_platformNodeID) {
             obj.pushKV("platformNodeID", state.platformNodeID.ToString());
         }

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -71,7 +71,7 @@ public:
                 obj.scriptPayout,
                 obj.inputsHash
         );
-        if (obj.nVersion == BASIC_BLS_VERSION && obj.nType == MnType::HighPerformance) {
+        if (obj.nVersion == BASIC_BLS_VERSION && obj.nType == MnType::Evo) {
             READWRITE(
                 obj.platformNodeID,
                 obj.platformP2PPort,
@@ -106,7 +106,7 @@ public:
         }
         obj.pushKV("pubKeyOperator", pubKeyOperator.ToString());
         obj.pushKV("operatorReward", (double)nOperatorReward / 100);
-        if (nType == MnType::HighPerformance) {
+        if (nType == MnType::Evo) {
             obj.pushKV("platformNodeID", platformNodeID.ToString());
             obj.pushKV("platformP2PPort", platformP2PPort);
             obj.pushKV("platformHTTPPort", platformHTTPPort);
@@ -159,7 +159,7 @@ public:
                 obj.scriptOperatorPayout,
                 obj.inputsHash
         );
-        if (obj.nVersion == BASIC_BLS_VERSION && obj.nType == MnType::HighPerformance) {
+        if (obj.nVersion == BASIC_BLS_VERSION && obj.nType == MnType::Evo) {
             READWRITE(
                 obj.platformNodeID,
                 obj.platformP2PPort,
@@ -186,7 +186,7 @@ public:
         if (ExtractDestination(scriptOperatorPayout, dest)) {
             obj.pushKV("operatorPayoutAddress", EncodeDestination(dest));
         }
-        if (nType == MnType::HighPerformance) {
+        if (nType == MnType::Evo) {
             obj.pushKV("platformNodeID", platformNodeID.ToString());
             obj.pushKV("platformP2PPort", platformP2PPort);
             obj.pushKV("platformHTTPPort", platformHTTPPort);

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -78,7 +78,7 @@ void CSimplifiedMNListEntry::ToJson(UniValue& obj, bool extended) const
     obj.pushKV("pubKeyOperator", pubKeyOperator.ToString());
     obj.pushKV("votingAddress", EncodeDestination(PKHash(keyIDVoting)));
     obj.pushKV("isValid", isValid);
-    if (nType == MnType::HighPerformance) {
+    if (nType == MnType::Evo) {
         obj.pushKV("platformHTTPPort", platformHTTPPort);
         obj.pushKV("platformNodeID", platformNodeID.ToString());
     }

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -81,7 +81,7 @@ public:
         }
         if (obj.nVersion == BASIC_BLS_VERSION) {
             READWRITE(obj.nType);
-            if (obj.nType == MnType::HighPerformance) {
+            if (obj.nType == MnType::Evo) {
                 READWRITE(obj.platformHTTPPort);
                 READWRITE(obj.platformNodeID);
             }

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -629,7 +629,7 @@ int CGovernanceObject::CountMatchingVotes(vote_signal_enum_t eVoteSignalIn, vote
         const vote_rec_t& recVote = votepair.second;
         auto it2 = recVote.mapInstances.find(eVoteSignalIn);
         if (it2 != recVote.mapInstances.end() && it2->second.eOutcome == eVoteOutcomeIn) {
-            // 4x times weight vote for EvoNodes owners.
+            // 4x times weight vote for EvoNode owners.
             // No need to check if v19 is active since no EvoNode are allowed to register before v19s
             auto dmn = mnList.GetMNByCollateral(votepair.first);
             if (dmn != nullptr) nCount += GetMnType(dmn->nType).voting_weight;

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -629,8 +629,8 @@ int CGovernanceObject::CountMatchingVotes(vote_signal_enum_t eVoteSignalIn, vote
         const vote_rec_t& recVote = votepair.second;
         auto it2 = recVote.mapInstances.find(eVoteSignalIn);
         if (it2 != recVote.mapInstances.end() && it2->second.eOutcome == eVoteOutcomeIn) {
-            // 4x times weight vote for HPMN owners.
-            // No need to check if v19 is active since no HPMN are allowed to register before v19s
+            // 4x times weight vote for EvoNodes owners.
+            // No need to check if v19 is active since no EvoNode are allowed to register before v19s
             auto dmn = mnList.GetMNByCollateral(votepair.first);
             if (dmn != nullptr) nCount += GetMnType(dmn->nType).voting_weight;
         }

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -164,7 +164,7 @@ std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqTy
 
 std::vector<CDeterministicMNCPtr> ComputeQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex)
 {
-    bool HPMNOnly = (Params().GetConsensus().llmqTypePlatform == llmqType) && IsV19Active(pQuorumBaseBlockIndex);
+    bool EvoOnly = (Params().GetConsensus().llmqTypePlatform == llmqType) && IsV19Active(pQuorumBaseBlockIndex);
     const auto& llmq_params_opt = GetLLMQParams(llmqType);
     assert(llmq_params_opt.has_value());
     if (llmq_params_opt->useRotation || pQuorumBaseBlockIndex->nHeight % llmq_params_opt->dkgInterval != 0) {
@@ -177,7 +177,7 @@ std::vector<CDeterministicMNCPtr> ComputeQuorumMembers(Consensus::LLMQType llmqT
             pQuorumBaseBlockIndex;
     const auto modifier = GetHashModifier(llmq_params_opt.value(), pQuorumBaseBlockIndex);
     auto allMns = deterministicMNManager->GetListForBlock(pWorkBlockIndex);
-    return allMns.CalculateQuorum(llmq_params_opt->size, modifier, HPMNOnly);
+    return allMns.CalculateQuorum(llmq_params_opt->size, modifier, EvoOnly);
 }
 
 std::vector<std::vector<CDeterministicMNCPtr>> ComputeQuorumMembersByQuarterRotation(const Consensus::LLMQParams& llmqParams, const CBlockIndex* pCycleQuorumBaseBlockIndex)

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -317,14 +317,14 @@
         </widget>
        </item>
        <item row="10" column="0">
-        <widget class="QLabel" name="hpmnCountLabel">
+        <widget class="QLabel" name="evoCountLabel">
          <property name="text">
-          <string>Number of HPMNs</string>
+          <string>Number of EvoNodes</string>
          </property>
         </widget>
        </item>
        <item row="10" column="1">
-        <widget class="QLabel" name="hpmnCount">
+        <widget class="QLabel" name="evoCount">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -973,16 +973,16 @@ void RPCConsole::updateMasternodeCount()
     auto mnList = clientModel->getMasternodeList();
     size_t total_mn_count = mnList.GetAllMNsCount();
     size_t total_enabled_mn_count = mnList.GetValidMNsCount();
-    size_t total_hpmn_count = mnList.GetAllHPMNsCount();
-    size_t total_enabled_hpmn_count = mnList.GetValidHPMNsCount();
+    size_t total_evo_count = mnList.GetAllEvoCount();
+    size_t total_enabled_evo_count = mnList.GetValidEvoCount();
     QString strMasternodeCount = tr("Total: %1 (Enabled: %2)")
-        .arg(QString::number(total_mn_count - total_hpmn_count))
-        .arg(QString::number(total_enabled_mn_count - total_enabled_hpmn_count));
+        .arg(QString::number(total_mn_count - total_evo_count))
+        .arg(QString::number(total_enabled_mn_count - total_enabled_evo_count));
     ui->masternodeCount->setText(strMasternodeCount);
-    QString strHPMNCount = tr("Total: %1 (Enabled: %2)")
-            .arg(QString::number(total_hpmn_count))
-            .arg(QString::number(total_enabled_hpmn_count));
-    ui->hpmnCount->setText(strHPMNCount);
+    QString strEvoCount = tr("Total: %1 (Enabled: %2)")
+            .arg(QString::number(total_evo_count))
+            .arg(QString::number(total_enabled_evo_count));
+    ui->evoCount->setText(strEvoCount);
 }
 
 void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1616,7 +1616,7 @@ static UniValue protx(const JSONRPCRequest& request)
 #ifdef ENABLE_WALLET
     if (command == "protxregister" || command == "protxregister_fund" || command == "protxregister_prepare") {
         return protx_register(new_request, chainman);
-    } else if (command == "protxregister_evo" || command == "protxregister_fund_evo" || command == "protxregister_prepare_evo") {
+    } else if (command == "protxregister_evo" || command == "protxregister_fund_evo" || command == "protxregister_prepare_evo" || command == "protxregister_hpmn" || command == "protxregister_fund_hpmn" || command == "protxregister_prepare_hpmn") {
         return protx_register_evo(new_request, chainman);
     } else if (command == "protxregister_legacy" || command == "protxregister_fund_legacy" || command == "protxregister_prepare_legacy") {
         return protx_register_legacy(new_request, chainman);
@@ -1624,7 +1624,7 @@ static UniValue protx(const JSONRPCRequest& request)
         return protx_register_submit(new_request, chainman);
     } else if (command == "protxupdate_service") {
         return protx_update_service_common_wrapper(new_request, chainman, MnType::Regular);
-    } else if (command == "protxupdate_service_evo") {
+    } else if (command == "protxupdate_service_evo" || command == "protxupdate_service_hpmn") {
         return protx_update_service_common_wrapper(new_request, chainman, MnType::Evo);
     } else if (command == "protxupdate_registrar") {
         return protx_update_registrar(new_request, chainman);

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -902,7 +902,7 @@ static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& reques
 {
     if (request.strMethod.find("_hpmn") != std::string::npos) {
         if (!IsDeprecatedRPCEnabled("hpmn")) {
-            throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated, set -deprecatedrpc=hpmn to enable them");
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated. Use the related *_evo methods or set -deprecatedrpc=hpmn to enable them");
         }
     }
 

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -795,7 +795,7 @@ static UniValue protx_register_evo(const JSONRPCRequest& request, const Chainsta
     bool isPrepareRegister = request.strMethod == "protxregister_prepare_evo";
     if (request.strMethod.find("_hpmn") != std::string::npos) {
         if (!IsDeprecatedRPCEnabled("hpmn")) {
-            throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated, set -deprecatedrpc=hpmn to enable them");
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated. Use the related *_evo methods or set -deprecatedrpc=hpmn to enable them");
         }
         isExternalRegister = request.strMethod == "protxregister_hpmn";
         isFundRegister = request.strMethod == "protxregister_fund_hpmn";

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -615,7 +615,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
     }
 
     bool isV19active = llmq::utils::IsV19Active(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();));
-    if (isHPMNrequested && !isV19active) {
+    if (isEvoRequested && !isV19active) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "EvoNodes aren't allowed yet");
     }
 

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -480,13 +480,13 @@ static void protx_register_submit_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static void protx_register_fund_hpmn_help(const JSONRPCRequest& request)
+static void protx_register_fund_evo_help(const JSONRPCRequest& request)
 {
     RPCHelpMan{
-        "protx register_fund_hpmn",
+        "protx register_fund_evo",
         "\nCreates, funds and sends a ProTx to the network. The resulting transaction will move 4000 Dash\n"
         "to the address specified by collateralAddress and will then function as the collateral of your\n"
-        "HPMN.\n"
+        "EvoNode.\n"
         "A few of the limitations you see in the arguments are temporary and might be lifted after DIP3\n"
         "is fully deployed.\n" +
             HELP_REQUIRING_PASSPHRASE,
@@ -511,15 +511,15 @@ static void protx_register_fund_hpmn_help(const JSONRPCRequest& request)
                       RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
         },
         RPCExamples{
-            HelpExampleCli("protx", "register_fund_hpmn \"" + EXAMPLE_ADDRESS[0] + "\" \"1.2.3.4:1234\" \"" + EXAMPLE_ADDRESS[1] + "\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"" + EXAMPLE_ADDRESS[1] + "\" 0 \"" + EXAMPLE_ADDRESS[0] + "\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
+            HelpExampleCli("protx", "register_fund_evo \"" + EXAMPLE_ADDRESS[0] + "\" \"1.2.3.4:1234\" \"" + EXAMPLE_ADDRESS[1] + "\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"" + EXAMPLE_ADDRESS[1] + "\" 0 \"" + EXAMPLE_ADDRESS[0] + "\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
     }.Check(request);
 }
 
-static void protx_register_hpmn_help(const JSONRPCRequest& request)
+static void protx_register_evo_help(const JSONRPCRequest& request)
 {
     RPCHelpMan{
-        "protx register_hpmn",
-        "\nSame as \"protx register_fund_hpmn\", but with an externally referenced collateral.\n"
+        "protx register_evo",
+        "\nSame as \"protx register_fund_evo\", but with an externally referenced collateral.\n"
         "The collateral is specified through \"collateralHash\" and \"collateralIndex\" and must be an unspent\n"
         "transaction output spendable by this wallet. It must also not be used by any other masternode.\n" +
             HELP_REQUIRING_PASSPHRASE,
@@ -545,14 +545,14 @@ static void protx_register_hpmn_help(const JSONRPCRequest& request)
                       RPCResult::Type::STR_HEX, "hex", "The serialized signed ProTx in hex format"},
         },
         RPCExamples{
-            HelpExampleCli("protx", "register_hpmn \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"" + EXAMPLE_ADDRESS[1] + "\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"" + EXAMPLE_ADDRESS[1] + "\" 0 \"" + EXAMPLE_ADDRESS[0] + "\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
+            HelpExampleCli("protx", "register_evo \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"" + EXAMPLE_ADDRESS[1] + "\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"" + EXAMPLE_ADDRESS[1] + "\" 0 \"" + EXAMPLE_ADDRESS[0] + "\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
     }.Check(request);
 }
 
-static void protx_register_prepare_hpmn_help(const JSONRPCRequest& request)
+static void protx_register_prepare_evo_help(const JSONRPCRequest& request)
 {
     RPCHelpMan{
-        "protx register_prepare_hpmn",
+        "protx register_prepare_evo",
         "\nCreates an unsigned ProTx and a message that must be signed externally\n"
         "with the private key that corresponds to collateralAddress to prove collateral ownership.\n"
         "The prepared transaction will also contain inputs and outputs to cover fees.\n",
@@ -576,7 +576,7 @@ static void protx_register_prepare_hpmn_help(const JSONRPCRequest& request)
                                               {RPCResult::Type::STR_HEX, "collateralAddress", "The collateral address"},
                                               {RPCResult::Type::STR_HEX, "signMessage", "The string message that needs to be signed with the collateral key"},
                                           }},
-        RPCExamples{HelpExampleCli("protx", "register_prepare_hpmn \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"" + EXAMPLE_ADDRESS[1] + "\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"" + EXAMPLE_ADDRESS[1] + "\" 0 \"" + EXAMPLE_ADDRESS[0] + "\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
+        RPCExamples{HelpExampleCli("protx", "register_prepare_evo \"0123456701234567012345670123456701234567012345670123456701234567\" 0 \"1.2.3.4:1234\" \"" + EXAMPLE_ADDRESS[1] + "\" \"93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4\" \"" + EXAMPLE_ADDRESS[1] + "\" 0 \"" + EXAMPLE_ADDRESS[0] + "\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
     }.Check(request);
 }
 
@@ -588,14 +588,14 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
                                               const bool isPrepareRegister,
                                               const MnType mnType)
 {
-    const bool isHPMNrequested = mnType == MnType::HighPerformance;
-    if (isHPMNrequested) {
+    const bool isEvoRequested = mnType == MnType::Evo;
+    if (isEvoRequested) {
         if (isFundRegister && (request.fHelp || (request.params.size() < 10 || request.params.size() > 12))) {
-            protx_register_fund_hpmn_help(request);
+            protx_register_fund_evo_help(request);
         } else if (isExternalRegister && (request.fHelp || (request.params.size() < 11 || request.params.size() > 13))) {
-            protx_register_hpmn_help(request);
+            protx_register_evo_help(request);
         } else if (isPrepareRegister && (request.fHelp || (request.params.size() != 11 && request.params.size() != 12))) {
-            protx_register_prepare_hpmn_help(request);
+            protx_register_prepare_evo_help(request);
         }
     } else {
         if (isFundRegister && (request.fHelp || (request.params.size() < 7 || request.params.size() > 9))) {
@@ -616,7 +616,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
 
     bool isV19active = llmq::utils::IsV19Active(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();));
     if (isHPMNrequested && !isV19active) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "HPMN aren't allowed yet");
+        throw JSONRPCError(RPC_INVALID_REQUEST, "EvoNodes aren't allowed yet");
     }
 
     size_t paramIdx = 0;
@@ -688,7 +688,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("invalid payout address: %s", request.params[paramIdx + 5].get_str()));
     }
 
-    if (isHPMNrequested) {
+    if (isEvoRequested) {
         if (!IsHex(request.params[paramIdx + 6].get_str())) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "platformNodeID must be hexadecimal string");
         }
@@ -788,12 +788,12 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
     }
 }
 
-static UniValue protx_register_hpmn(const JSONRPCRequest& request, const ChainstateManager& chainman)
+static UniValue protx_register_evo(const JSONRPCRequest& request, const ChainstateManager& chainman)
 {
-    bool isExternalRegister = request.strMethod == "protxregister_hpmn";
-    bool isFundRegister = request.strMethod == "protxregister_fund_hpmn";
-    bool isPrepareRegister = request.strMethod == "protxregister_prepare_hpmn";
-    return protx_register_common_wrapper(request, chainman, false, isExternalRegister, isFundRegister, isPrepareRegister, MnType::HighPerformance);
+    bool isExternalRegister = request.strMethod == "protxregister_evo";
+    bool isFundRegister = request.strMethod == "protxregister_fund_evo";
+    bool isPrepareRegister = request.strMethod == "protxregister_prepare_evo";
+    return protx_register_common_wrapper(request, chainman, false, isExternalRegister, isFundRegister, isPrepareRegister, MnType::Evo);
 }
 
 static UniValue protx_register(const JSONRPCRequest& request, const ChainstateManager& chainman)
@@ -865,13 +865,13 @@ static void protx_update_service_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static void protx_update_service_hpmn_help(const JSONRPCRequest& request)
+static void protx_update_service_evo_help(const JSONRPCRequest& request)
 {
     RPCHelpMan{
-        "protx update_service_hpmn",
+        "protx update_service_evo",
         "\nCreates and sends a ProUpServTx to the network. This will update the IP address and the Platform fields\n"
-        "of a HPMN.\n"
-        "If this is done for a HPMN that got PoSe-banned, the ProUpServTx will also revive this HPMN.\n" +
+        "of an EvoNode.\n"
+        "If this is done for an EvoNode that got PoSe-banned, the ProUpServTx will also revive this EvoNode.\n" +
             HELP_REQUIRING_PASSPHRASE,
         {
             GetRpcArg("proTxHash"),
@@ -886,15 +886,15 @@ static void protx_update_service_hpmn_help(const JSONRPCRequest& request)
         RPCResult{
             RPCResult::Type::STR_HEX, "txid", "The transaction id"},
         RPCExamples{
-            HelpExampleCli("protx", "update_service_hpmn \"0123456701234567012345670123456701234567012345670123456701234567\" \"1.2.3.4:1234\" \"5a2e15982e62f1e0b7cf9783c64cf7e3af3f90a52d6c40f6f95d624c0b1621cd\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
+            HelpExampleCli("protx", "update_service_evo \"0123456701234567012345670123456701234567012345670123456701234567\" \"1.2.3.4:1234\" \"5a2e15982e62f1e0b7cf9783c64cf7e3af3f90a52d6c40f6f95d624c0b1621cd\" \"f2dbd9b0a1f541a7c44d34a58674d0262f5feca5\" 22821 22822")},
     }.Check(request);
 }
 
 static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& request, const ChainstateManager& chainman, const MnType mnType)
 {
-    const bool isHPMNrequested = mnType == MnType::HighPerformance;
-    if (isHPMNrequested) {
-        protx_update_service_hpmn_help(request);
+    const bool isEvoRequested = mnType == MnType::Evo;
+    if (isEvoRequested) {
+        protx_update_service_evo_help(request);
     } else {
         protx_update_service_help(request);
     }
@@ -906,8 +906,8 @@ static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& reques
 
     const bool isV19active = llmq::utils::IsV19Active(WITH_LOCK(cs_main, return chainman.ActiveChain().Tip();));
     const bool is_bls_legacy = !isV19active;
-    if (isHPMNrequested && !isV19active) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "HPMN aren't allowed yet");
+    if (isEvoRequested && !isV19active) {
+        throw JSONRPCError(RPC_INVALID_REQUEST, "EvoNodes aren't allowed yet");
     }
 
     CProUpServTx ptx;
@@ -921,7 +921,7 @@ static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& reques
     CBLSSecretKey keyOperator = ParseBLSSecretKey(request.params[2].get_str(), "operatorKey", is_bls_legacy);
 
     size_t paramIdx = 3;
-    if (isHPMNrequested) {
+    if (isEvoRequested) {
         if (!IsHex(request.params[paramIdx].get_str())) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "platformNodeID must be hexadecimal string");
         }
@@ -1211,7 +1211,7 @@ static void protx_list_help(const JSONRPCRequest& request)
                 "  registered   - List all ProTx which are registered at the given chain height.\n"
                 "                 This will also include ProTx which failed PoSe verification.\n"
                 "  valid        - List only ProTx which are active/valid at the given chain height.\n"
-                "  hpmn         - List only ProTx corresponding to HPMNs at the given chain height.\n"
+                "  evo          - List only ProTx corresponding to EvoNodes at the given chain height.\n"
 #ifdef ENABLE_WALLET
                 "  wallet       - List only ProTx which are found in your wallet at the given chain height.\n"
                 "                 This will also include ProTx which failed PoSe verification.\n"
@@ -1357,7 +1357,7 @@ static UniValue protx_list(const JSONRPCRequest& request, const ChainstateManage
             }
         });
 #endif
-    } else if (type == "valid" || type == "registered" || type == "hpmn") {
+    } else if (type == "valid" || type == "registered" || type == "evo") {
         if (request.params.size() > 3) {
             protx_list_help(request);
         }
@@ -1373,9 +1373,9 @@ static UniValue protx_list(const JSONRPCRequest& request, const ChainstateManage
 
         CDeterministicMNList mnList = deterministicMNManager->GetListForBlock(chainman.ActiveChain()[height]);
         bool onlyValid = type == "valid";
-        bool onlyHPMN = type == "hpmn";
+        bool onlyEvoNodes = type == "evo";
         mnList.ForEachMN(onlyValid, [&](const auto& dmn) {
-            if (onlyHPMN && dmn.nType != MnType::HighPerformance) return;
+            if (onlyEvoNodes && dmn.nType != MnType::Evo) return;
             ret.push_back(BuildDMNListEntry(wallet.get(), dmn, detailed));
         });
     } else {
@@ -1579,9 +1579,9 @@ static UniValue protx_listdiff(const JSONRPCRequest& request, const ChainstateMa
         "  register                 - Create and send ProTx to network\n"
         "  register_fund            - Fund, create and send ProTx to network\n"
         "  register_prepare         - Create an unsigned ProTx\n"
-        "  register_hpmn            - Create and send ProTx to network for a HPMN\n"
-        "  register_fund_hpmn       - Fund, create and send ProTx to network for a HPMN\n"
-        "  register_prepare_hpmn    - Create an unsigned ProTx for a HPMN\n"
+        "  register_evo             - Create and send ProTx to network for an EvoNode\n"
+        "  register_fund_evo        - Fund, create and send ProTx to network for an EvoNode\n"
+        "  register_prepare_evo     - Create an unsigned ProTx for an EvoNode\n"
         "  register_legacy          - Create a ProTx by parsing BLS using the legacy scheme and send it to network\n"
         "  register_fund_legacy     - Fund and create a ProTx by parsing BLS using the legacy scheme, then send it to network\n"
         "  register_prepare_legacy  - Create an unsigned ProTx by parsing BLS using the legacy scheme\n"
@@ -1591,7 +1591,7 @@ static UniValue protx_listdiff(const JSONRPCRequest& request, const ChainstateMa
         "  info                     - Return information about a ProTx\n"
 #ifdef ENABLE_WALLET
         "  update_service           - Create and send ProUpServTx to network\n"
-        "  update_service_hpmn      - Create and send ProUpServTx to network for a HPMN\n"
+        "  update_service_evo       - Create and send ProUpServTx to network for an EvoNode\n"
         "  update_registrar         - Create and send ProUpRegTx to network\n"
         "  update_registrar_legacy  - Create ProUpRegTx by parsing BLS using the legacy scheme, then send it to network\n"
         "  revoke                   - Create and send ProUpRevTx to network\n"
@@ -1616,16 +1616,16 @@ static UniValue protx(const JSONRPCRequest& request)
 #ifdef ENABLE_WALLET
     if (command == "protxregister" || command == "protxregister_fund" || command == "protxregister_prepare") {
         return protx_register(new_request, chainman);
-    } else if (command == "protxregister_hpmn" || command == "protxregister_fund_hpmn" || command == "protxregister_prepare_hpmn") {
-        return protx_register_hpmn(new_request, chainman);
+    } else if (command == "protxregister_evo" || command == "protxregister_fund_evo" || command == "protxregister_prepare_evo") {
+        return protx_register_evo(new_request, chainman);
     } else if (command == "protxregister_legacy" || command == "protxregister_fund_legacy" || command == "protxregister_prepare_legacy") {
         return protx_register_legacy(new_request, chainman);
     } else if (command == "protxregister_submit") {
         return protx_register_submit(new_request, chainman);
     } else if (command == "protxupdate_service") {
         return protx_update_service_common_wrapper(new_request, chainman, MnType::Regular);
-    } else if (command == "protxupdate_service_hpmn") {
-        return protx_update_service_common_wrapper(new_request, chainman, MnType::HighPerformance);
+    } else if (command == "protxupdate_service_evo") {
+        return protx_update_service_common_wrapper(new_request, chainman, MnType::Evo);
     } else if (command == "protxupdate_registrar") {
         return protx_update_registrar(new_request, chainman);
     } else if (command == "protxupdate_registrar_legacy") {

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -793,6 +793,14 @@ static UniValue protx_register_evo(const JSONRPCRequest& request, const Chainsta
     bool isExternalRegister = request.strMethod == "protxregister_evo";
     bool isFundRegister = request.strMethod == "protxregister_fund_evo";
     bool isPrepareRegister = request.strMethod == "protxregister_prepare_evo";
+    if (request.strMethod.find("_hpmn") != std::string::npos) {
+        if (!IsDeprecatedRPCEnabled("hpmn")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated, set -deprecatedrpc=hpmn to enable them");
+        }
+        isExternalRegister = request.strMethod == "protxregister_hpmn";
+        isFundRegister = request.strMethod == "protxregister_fund_hpmn";
+        isPrepareRegister = request.strMethod == "protxregister_prepare_hpmn";
+    }
     return protx_register_common_wrapper(request, chainman, false, isExternalRegister, isFundRegister, isPrepareRegister, MnType::Evo);
 }
 
@@ -892,6 +900,12 @@ static void protx_update_service_evo_help(const JSONRPCRequest& request)
 
 static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& request, const ChainstateManager& chainman, const MnType mnType)
 {
+    if (request.strMethod.find("_hpmn") != std::string::npos) {
+        if (!IsDeprecatedRPCEnabled("hpmn")) {
+            throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated, set -deprecatedrpc=hpmn to enable them");
+        }
+    }
+
     const bool isEvoRequested = mnType == MnType::Evo;
     if (isEvoRequested) {
         protx_update_service_evo_help(request);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -38,7 +38,7 @@ static void masternode_list_help(const JSONRPCRequest& request)
         "Available modes:\n"
         "  addr           - Print ip address associated with a masternode (can be additionally filtered, partial match)\n"
         "  recent         - Print info in JSON format for active and recently banned masternodes (can be additionally filtered, partial match)\n"
-        "  hpmn           - Print info in JSON format for HPMNs only\n"
+        "  evo            - Print info in JSON format for EvoNodes only\n"
         "  full           - Print info in format 'status payee lastpaidtime lastpaidblock IP'\n"
         "                   (can be additionally filtered, partial match)\n"
         "  info           - Print info in format 'status payee IP'\n"
@@ -114,20 +114,20 @@ static UniValue masternode_count(const JSONRPCRequest& request)
     obj.pushKV("total", total);
     obj.pushKV("enabled", enabled);
 
-    int hpmn_total = mnList.GetAllHPMNsCount();
-    int hpmn_enabled = mnList.GetValidHPMNsCount();
+    int evo_total = mnList.GetAllEvoCount();
+    int evo_enabled = mnList.GetValidEvoCount();
 
-    UniValue hpmnObj(UniValue::VOBJ);
-    hpmnObj.pushKV("total", hpmn_total);
-    hpmnObj.pushKV("enabled", hpmn_enabled);
+    UniValue evoObj(UniValue::VOBJ);
+    evoObj.pushKV("total", evo_total);
+    evoObj.pushKV("enabled", evo_enabled);
 
     UniValue regularObj(UniValue::VOBJ);
-    regularObj.pushKV("total", total - hpmn_total);
-    regularObj.pushKV("enabled", enabled - hpmn_enabled);
+    regularObj.pushKV("total", total - evo_total);
+    regularObj.pushKV("enabled", enabled - evo_enabled);
 
     UniValue detailedObj(UniValue::VOBJ);
     detailedObj.pushKV("regular", regularObj);
-    detailedObj.pushKV("hpmn", hpmnObj);
+    detailedObj.pushKV("evo", evoObj);
     obj.pushKV("detailed", detailedObj);
 
     return obj;
@@ -585,7 +585,7 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
                 strMode != "owneraddress" && strMode != "votingaddress" &&
                 strMode != "lastpaidtime" && strMode != "lastpaidblock" &&
                 strMode != "payee" && strMode != "pubkeyoperator" &&
-                strMode != "status" && strMode != "recent" && strMode != "hpmn"))
+                strMode != "status" && strMode != "recent" && strMode != "evo"))
     {
         masternode_list_help(request);
     }
@@ -613,7 +613,7 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
     };
 
     bool showRecentMnsOnly = strMode == "recent";
-    bool showHPMNsOnly = strMode == "hpmn";
+    bool showEvoOnly = strMode == "evo";
     int tipHeight = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip()->nHeight);
     mnList.ForEachMN(false, [&](auto& dmn) {
         if (showRecentMnsOnly && mnList.IsMNPoSeBanned(dmn)) {
@@ -621,7 +621,7 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
                 return;
             }
         }
-        if (showHPMNsOnly && dmn.nType != MnType::HighPerformance) {
+        if (showEvoOnly && dmn.nType != MnType::Evo) {
             return;
         }
 
@@ -671,7 +671,7 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
             if (strFilter !="" && strInfo.find(strFilter) == std::string::npos &&
                 strOutpoint.find(strFilter) == std::string::npos) return;
             obj.pushKV(strOutpoint, strInfo);
-        } else if (strMode == "json" || strMode == "recent" || strMode == "hpmn") {
+        } else if (strMode == "json" || strMode == "recent" || strMode == "evo") {
             std::ostringstream streamInfo;
             streamInfo <<  dmn.proTxHash.ToString() << " " <<
                            dmn.pdmnState->addr.ToString() << " " <<
@@ -693,7 +693,7 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
             objMN.pushKV("payee", payeeStr);
             objMN.pushKV("status", dmnToStatus(dmn));
             objMN.pushKV("type", std::string(GetMnType(dmn.nType).description));
-            if (dmn.nType == MnType::HighPerformance) {
+            if (dmn.nType == MnType::Evo) {
                 objMN.pushKV("platformNodeID", dmn.pdmnState->platformNodeID.ToString());
                 objMN.pushKV("platformP2PPort", dmn.pdmnState->platformP2PPort);
                 objMN.pushKV("platformHTTPPort", dmn.pdmnState->platformHTTPPort);

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -43,7 +43,7 @@ class TestP2PConn(P2PInterface):
 
 class DIP3V19Test(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True, hpmn_count=2)
+        self.set_dash_test_params(6, 5, fast_dip3_enforcement=True, evo_count=2)
 
     def run_test(self):
         # Connect all nodes to node1 so that we always have the whole network connected
@@ -87,22 +87,22 @@ class DIP3V19Test(DashTestFramework):
 
         self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
 
-        hpmn_info_0 = self.dynamically_add_masternode(hpmn=True, rnd=7)
-        assert hpmn_info_0 is not None
+        evo_info_0 = self.dynamically_add_masternode(evo=True, rnd=7)
+        assert evo_info_0 is not None
         self.nodes[0].generate(8)
         self.sync_blocks(self.nodes)
 
-        self.log.info("Checking that protxs with duplicate HPMN fields are rejected")
-        hpmn_info_1 = self.dynamically_add_masternode(hpmn=True, rnd=7, should_be_rejected=True)
-        assert hpmn_info_1 is None
-        self.dynamically_hpmn_update_service(hpmn_info_0, 8)
-        hpmn_info_2 = self.dynamically_add_masternode(hpmn=True, rnd=8, should_be_rejected=True)
-        assert hpmn_info_2 is None
-        hpmn_info_3 = self.dynamically_add_masternode(hpmn=True, rnd=9)
-        assert hpmn_info_3 is not None
+        self.log.info("Checking that protxs with duplicate EvoNodes fields are rejected")
+        evo_info_1 = self.dynamically_add_masternode(evo=True, rnd=7, should_be_rejected=True)
+        assert evo_info_1 is None
+        self.dynamically_evo_update_service(evo_info_0, 8)
+        evo_info_2 = self.dynamically_add_masternode(evo=True, rnd=8, should_be_rejected=True)
+        assert evo_info_2 is None
+        evo_info_3 = self.dynamically_add_masternode(evo=True, rnd=9)
+        assert evo_info_3 is not None
         self.nodes[0].generate(8)
         self.sync_blocks(self.nodes)
-        self.dynamically_hpmn_update_service(hpmn_info_0, 9, should_be_rejected=True)
+        self.dynamically_evo_update_service(evo_info_0, 9, should_be_rejected=True)
 
         revoke_protx = self.mninfo[-1].proTxHash
         revoke_keyoperator = self.mninfo[-1].keyOperator
@@ -111,12 +111,12 @@ class DIP3V19Test(DashTestFramework):
 
         self.mine_quorum(llmq_type_name='llmq_test', llmq_type=100)
         # revoking a MN results in disconnects, reconnect it back to let sync_blocks finish correctly
-        self.connect_nodes(hpmn_info_3.nodeIdx, 0)
+        self.connect_nodes(evo_info_3.nodeIdx, 0)
 
         self.log.info("Checking that adding more regular MNs after v19 doesn't break DKGs and IS/CLs")
 
         for i in range(6):
-            new_mn = self.dynamically_add_masternode(hpmn=False, rnd=(10 + i))
+            new_mn = self.dynamically_add_masternode(evo=False, rnd=(10 + i))
             assert new_mn is not None
 
         # mine more quorums and make sure everything still works

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -4,9 +4,9 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 '''
-feature_llmq_hpmn.py
+feature_llmq_evo.py
 
-Checks HPMNs
+Checks EvoNodes
 
 '''
 from _decimal import Decimal
@@ -44,9 +44,9 @@ class TestP2PConn(P2PInterface):
         self.wait_for_mnlistdiff()
         return self.last_mnlistdiff
 
-class LLMQHPMNTest(DashTestFramework):
+class LLMQEvoNodesTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(5, 4, fast_dip3_enforcement=True, hpmn_count=7)
+        self.set_dash_test_params(5, 4, fast_dip3_enforcement=True, evo_count=7)
         self.set_dash_llmq_test_params(4, 4)
 
     def run_test(self):
@@ -72,10 +72,10 @@ class LLMQHPMNTest(DashTestFramework):
 
         self.mine_quorum(llmq_type_name='llmq_test', llmq_type=100)
 
-        self.log.info("Test that HPMN registration is rejected before v19")
-        self.test_hpmn_is_rejected_before_v19()
+        self.log.info("Test that EvoNodes registration is rejected before v19")
+        self.test_evo_is_rejected_before_v19()
 
-        self.test_masternode_count(expected_mns_count=4, expected_hpmns_count=0)
+        self.test_masternode_count(expected_mns_count=4, expected_evo_count=0)
 
         self.activate_v19(expected_activation_height=900)
         self.log.info("Activated v19 at height:" + str(self.nodes[0].getblockcount()))
@@ -89,30 +89,30 @@ class LLMQHPMNTest(DashTestFramework):
 
         (quorum_info_i_0, quorum_info_i_1) = self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
 
-        hpmn_protxhash_list = list()
+        evo_protxhash_list = list()
         for i in range(5):
-            hpmn_info = self.dynamically_add_masternode(hpmn=True)
-            hpmn_protxhash_list.append(hpmn_info.proTxHash)
+            evo_info = self.dynamically_add_masternode(evo=True)
+            evo_protxhash_list.append(evo_info.proTxHash)
             self.nodes[0].generate(8)
             self.sync_blocks(self.nodes)
 
-            expectedUpdated.append(hpmn_info.proTxHash)
+            expectedUpdated.append(evo_info.proTxHash)
             b_i = self.nodes[0].getbestblockhash()
             self.test_getmnlistdiff(null_hash, b_i, {}, [], expectedUpdated)
 
-            self.test_masternode_count(expected_mns_count=4, expected_hpmns_count=i+1)
-            self.dynamically_hpmn_update_service(hpmn_info)
+            self.test_masternode_count(expected_mns_count=4, expected_evo_count=i+1)
+            self.dynamically_evo_update_service(evo_info)
 
-        self.log.info("Test llmq_platform are formed only with HPMNs")
+        self.log.info("Test llmq_platform are formed only with EvoNodes")
         for i in range(3):
             quorum_i_hash = self.mine_quorum(llmq_type_name='llmq_test_platform', llmq_type=106, expected_connections=2, expected_members=3, expected_contributions=3, expected_complaints=0, expected_justifications=0, expected_commitments=3 )
-            self.test_quorum_members_are_high_performance(quorum_i_hash, llmq_type=106)
+            self.test_quorum_members_are_evo_nodes(quorum_i_hash, llmq_type=106)
 
-        self.log.info("Test that HPMNs are present in MN list")
-        self.test_hpmn_protx_are_in_mnlist(hpmn_protxhash_list)
+        self.log.info("Test that EvoNodes are present in MN list")
+        self.test_evo_protx_are_in_mnlist(evo_protxhash_list)
 
-        self.log.info("Test that HPMNs are paid 4x blocks in a row")
-        self.test_hpmn_payments(window_analysis=256)
+        self.log.info("Test that EvoNodes are paid 4x blocks in a row")
+        self.test_evo_payments(window_analysis=256)
 
         self.activate_mn_rr()
         self.log.info("Activated MN RewardReallocation at height:" + str(self.nodes[0].getblockcount()))
@@ -129,44 +129,44 @@ class LLMQHPMNTest(DashTestFramework):
 
         return
 
-    def test_hpmn_payments(self, window_analysis, v20active=False):
-        current_hpmn = None
+    def test_evo_payments(self, window_analysis, v20active=False):
+        current_evo = None
         consecutive_payments = 0
         n_payments = 0 if v20active else 4
         for i in range(0, window_analysis):
             payee = self.get_mn_payee_for_block(self.nodes[0].getbestblockhash())
-            if payee is not None and payee.hpmn:
-                if current_hpmn is not None and payee.proTxHash == current_hpmn.proTxHash:
-                    # same HPMN
+            if payee is not None and payee.evo:
+                if current_evo is not None and payee.proTxHash == current_evo.proTxHash:
+                    # same EvoNode
                     assert consecutive_payments > 0
                     if not v20active:
                         consecutive_payments += 1
-                    consecutive_payments_rpc = self.nodes[0].protx('info', current_hpmn.proTxHash)['state']['consecutivePayments']
+                    consecutive_payments_rpc = self.nodes[0].protx('info', current_evo.proTxHash)['state']['consecutivePayments']
                     assert_equal(consecutive_payments, consecutive_payments_rpc)
                 else:
-                    # new HPMN
-                    if current_hpmn is not None:
+                    # new EvoNode
+                    if current_evo is not None:
                         # make sure the old one was paid N times in a row
                         assert_equal(consecutive_payments, n_payments)
-                        consecutive_payments_rpc = self.nodes[0].protx('info', current_hpmn.proTxHash)['state']['consecutivePayments']
-                        # old HPMN should have its nConsecutivePayments reset to 0
+                        consecutive_payments_rpc = self.nodes[0].protx('info', current_evo.proTxHash)['state']['consecutivePayments']
+                        # old EvoNode should have its nConsecutivePayments reset to 0
                         assert_equal(consecutive_payments_rpc, 0)
                     consecutive_payments_rpc = self.nodes[0].protx('info', payee.proTxHash)['state']['consecutivePayments']
-                    # if hpmn is the one we start "for" loop with,
+                    # if EvoNode is the one we start "for" loop with,
                     # we have no idea how many times it was paid before - rely on rpc results here
                     new_payment_value = 0 if v20active else 1
-                    consecutive_payments = consecutive_payments_rpc if i == 0 and current_hpmn is None else new_payment_value
-                    current_hpmn = payee
+                    consecutive_payments = consecutive_payments_rpc if i == 0 and current_evo is None else new_payment_value
+                    current_evo = payee
                     assert_equal(consecutive_payments, consecutive_payments_rpc)
             else:
-                # not a HPMN
-                if current_hpmn is not None:
+                # not a EvoNode
+                if current_evo is not None:
                     # make sure the old one was paid N times in a row
                     assert_equal(consecutive_payments, n_payments)
-                    consecutive_payments_rpc = self.nodes[0].protx('info', current_hpmn.proTxHash)['state']['consecutivePayments']
-                    # old HPMN should have its nConsecutivePayments reset to 0
+                    consecutive_payments_rpc = self.nodes[0].protx('info', current_evo.proTxHash)['state']['consecutivePayments']
+                    # old EvoNode should have its nConsecutivePayments reset to 0
                     assert_equal(consecutive_payments_rpc, 0)
-                current_hpmn = None
+                current_evo = None
                 consecutive_payments = 0
 
             self.nodes[0].generate(1)
@@ -183,7 +183,7 @@ class LLMQHPMNTest(DashTestFramework):
                 return mn_info
         return None
 
-    def test_quorum_members_are_high_performance(self, quorum_hash, llmq_type):
+    def test_quorum_members_are_evo_nodes(self, quorum_hash, llmq_type):
         quorum_info = self.nodes[0].quorum("info", llmq_type, quorum_hash)
         quorum_members = extract_quorum_members(quorum_info)
         mninfos_online = self.mninfo.copy()
@@ -191,22 +191,22 @@ class LLMQHPMNTest(DashTestFramework):
             found = False
             for mn in mninfos_online:
                 if mn.proTxHash == qm:
-                    assert_equal(mn.hpmn, True)
+                    assert_equal(mn.evo, True)
                     found = True
                     break
             assert_equal(found, True)
 
-    def test_hpmn_protx_are_in_mnlist(self, hpmn_protx_list):
+    def test_evo_protx_are_in_mnlist(self, evo_protx_list):
         mn_list = self.nodes[0].masternodelist()
-        for hpmn_protx in hpmn_protx_list:
+        for evo_protx in evo_protx_list:
             found = False
             for mn in mn_list:
-                if mn_list.get(mn)['proTxHash'] == hpmn_protx:
+                if mn_list.get(mn)['proTxHash'] == evo_protx:
                     found = True
-                    assert_equal(mn_list.get(mn)['type'], "HighPerformance")
+                    assert_equal(mn_list.get(mn)['type'], "Evo")
             assert_equal(found, True)
 
-    def test_hpmn_is_rejected_before_v19(self):
+    def test_evo_is_rejected_before_v19(self):
         bls = self.nodes[0].bls('generate')
         collateral_address = self.nodes[0].getnewaddress()
         funds_address = self.nodes[0].getnewaddress()
@@ -234,18 +234,18 @@ class LLMQHPMNTest(DashTestFramework):
         operatorReward = len(self.nodes)
 
         try:
-            self.nodes[0].protx('register_hpmn', collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, funds_address, True)
+            self.nodes[0].protx('register_evo', collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, funds_address, True)
             # this should never succeed
             assert False
         except:
-            self.log.info("protx_hpmn rejected")
+            self.log.info("protx_evo rejected")
 
-    def test_masternode_count(self, expected_mns_count, expected_hpmns_count):
+    def test_masternode_count(self, expected_mns_count, expected_evo_count):
         mn_count = self.nodes[0].masternode('count')
-        assert_equal(mn_count['total'], expected_mns_count + expected_hpmns_count)
+        assert_equal(mn_count['total'], expected_mns_count + expected_evo_count)
         detailed_count = mn_count['detailed']
         assert_equal(detailed_count['regular']['total'], expected_mns_count)
-        assert_equal(detailed_count['hpmn']['total'], expected_hpmns_count)
+        assert_equal(detailed_count['evo']['total'], expected_evo_count)
 
     def test_getmnlistdiff(self, baseBlockHash, blockHash, baseMNList, expectedDeleted, expectedUpdated):
         d = self.test_getmnlistdiff_base(baseBlockHash, blockHash)
@@ -300,4 +300,4 @@ class LLMQHPMNTest(DashTestFramework):
         return d
 
 if __name__ == '__main__':
-    LLMQHPMNTest().main()
+    LLMQEvoNodesTest().main()

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -122,8 +122,8 @@ class LLMQEvoNodesTest(DashTestFramework):
         self.nodes[0].generate(4)
         self.sync_blocks()
 
-        self.log.info("Test that HPMNs are paid 1 block in a row after MN RewardReallocation activation")
-        self.test_hpmn_payments(window_analysis=256, v20active=True)
+        self.log.info("Test that EvoNodes are paid 1 block in a row after MN RewardReallocation activation")
+        self.test_evo_payments(window_analysis=256, v20active=True)
 
         self.log.info(self.nodes[0].masternodelist())
 

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -117,7 +117,7 @@ class LLMQEvoNodesTest(DashTestFramework):
         self.activate_mn_rr()
         self.log.info("Activated MN RewardReallocation at height:" + str(self.nodes[0].getblockcount()))
 
-        # Generate a few blocks to make HPMN/MN analysis on a pure MN RewardReallocation window
+        # Generate a few blocks to make EvoNode/MN analysis on a pure MN RewardReallocation window
         self.bump_mocktime(1)
         self.nodes[0].generate(4)
         self.sync_blocks()
@@ -159,7 +159,7 @@ class LLMQEvoNodesTest(DashTestFramework):
                     current_evo = payee
                     assert_equal(consecutive_payments, consecutive_payments_rpc)
             else:
-                # not a EvoNode
+                # not an EvoNode
                 if current_evo is not None:
                     # make sure the old one was paid N times in a row
                     assert_equal(consecutive_payments, n_payments)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -968,7 +968,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         return self.config["components"].getboolean("USE_BDB")
 
 MASTERNODE_COLLATERAL = 1000
-EVONODE_MASTERNODE_COLLATERAL = 4000
+EVONODE_COLLATERAL = 4000
 
 class MasternodeInfo:
     def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout, addr, evo=False):
@@ -1162,7 +1162,7 @@ class DashTestFramework(BitcoinTestFramework):
         platform_p2p_port = '%d' % (node_p2p_port + 101)
         platform_http_port = '%d' % (node_p2p_port + 102)
 
-        collateral_amount = EVONODE_MASTERNODE_COLLATERAL if evo else MASTERNODE_COLLATERAL
+        collateral_amount = EVONODE_COLLATERAL if evo else MASTERNODE_COLLATERAL
         outputs = {collateral_address: collateral_amount, funds_address: 1}
         collateral_txid = self.nodes[0].sendmany("", outputs)
         self.wait_for_instantlock(collateral_txid, self.nodes[0])
@@ -1244,7 +1244,7 @@ class DashTestFramework(BitcoinTestFramework):
         bls = self.nodes[0].bls('generate')
         address = self.nodes[0].getnewaddress()
 
-        collateral_amount = EVONODE_MASTERNODE_COLLATERAL if evo else MASTERNODE_COLLATERAL
+        collateral_amount = EVONODE_COLLATERAL if evo else MASTERNODE_COLLATERAL
         txid = None
         txid = self.nodes[0].sendtoaddress(address, collateral_amount)
         collateral_vout = 0
@@ -1373,7 +1373,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.add_nodes(1, extra_args=[self.extra_args[0]])
         self.start_node(0)
         self.import_deterministic_coinbase_privkeys()
-        required_balance = EVONODE_MASTERNODE_COLLATERAL * self.evo_count
+        required_balance = EVONODE_COLLATERAL * self.evo_count
         required_balance += MASTERNODE_COLLATERAL * (self.mn_count - self.evo_count) + 100
         self.log.info("Generating %d coins" % required_balance)
         while self.nodes[0].getbalance() < required_balance:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -968,10 +968,10 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         return self.config["components"].getboolean("USE_BDB")
 
 MASTERNODE_COLLATERAL = 1000
-HIGHPERFORMANCE_MASTERNODE_COLLATERAL = 4000
+EVONODE_MASTERNODE_COLLATERAL = 4000
 
 class MasternodeInfo:
-    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout, addr, hpmn=False):
+    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout, addr, evo=False):
         self.proTxHash = proTxHash
         self.ownerAddr = ownerAddr
         self.votingAddr = votingAddr
@@ -981,7 +981,7 @@ class MasternodeInfo:
         self.collateral_txid = collateral_txid
         self.collateral_vout = collateral_vout
         self.addr = addr
-        self.hpmn = hpmn
+        self.evo = evo
 
 
 class DashTestFramework(BitcoinTestFramework):
@@ -996,9 +996,9 @@ class DashTestFramework(BitcoinTestFramework):
         """Tests must override this method to define test logic"""
         raise NotImplementedError
 
-    def set_dash_test_params(self, num_nodes, masterodes_count, extra_args=None, fast_dip3_enforcement=False, hpmn_count=0):
+    def set_dash_test_params(self, num_nodes, masterodes_count, extra_args=None, fast_dip3_enforcement=False, evo_count=0):
         self.mn_count = masterodes_count
-        self.hpmn_count = hpmn_count
+        self.evo_count = evo_count
         self.num_nodes = num_nodes
         self.mninfo = []
         self.setup_clean_chain = True
@@ -1111,7 +1111,7 @@ class DashTestFramework(BitcoinTestFramework):
         for i in range(0, idx):
             self.connect_nodes(i, idx)
 
-    def dynamically_add_masternode(self, hpmn=False, rnd=None, should_be_rejected=False):
+    def dynamically_add_masternode(self, evo=False, rnd=None, should_be_rejected=False):
         mn_idx = len(self.nodes)
 
         node_p2p_port = p2p_port(mn_idx)
@@ -1119,7 +1119,7 @@ class DashTestFramework(BitcoinTestFramework):
 
         protx_success = False
         try:
-            created_mn_info = self.dynamically_prepare_masternode(mn_idx, node_p2p_port, hpmn, rnd)
+            created_mn_info = self.dynamically_prepare_masternode(mn_idx, node_p2p_port, evo, rnd)
             protx_success = True
         except:
             self.log.info("dynamically_prepare_masternode failed")
@@ -1150,7 +1150,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.log.info("Successfully started and synced proTx:"+str(created_mn_info.proTxHash))
         return created_mn_info
 
-    def dynamically_prepare_masternode(self, idx, node_p2p_port, hpmn=False, rnd=None):
+    def dynamically_prepare_masternode(self, idx, node_p2p_port, evo=False, rnd=None):
         bls = self.nodes[0].bls('generate')
         collateral_address = self.nodes[0].getnewaddress()
         funds_address = self.nodes[0].getnewaddress()
@@ -1162,7 +1162,7 @@ class DashTestFramework(BitcoinTestFramework):
         platform_p2p_port = '%d' % (node_p2p_port + 101)
         platform_http_port = '%d' % (node_p2p_port + 102)
 
-        collateral_amount = 4000 if hpmn else 1000
+        collateral_amount = EVONODE_MASTERNODE_COLLATERAL if evo else MASTERNODE_COLLATERAL
         outputs = {collateral_address: collateral_amount, funds_address: 1}
         collateral_txid = self.nodes[0].sendmany("", outputs)
         self.wait_for_instantlock(collateral_txid, self.nodes[0])
@@ -1182,8 +1182,8 @@ class DashTestFramework(BitcoinTestFramework):
         operatorReward = idx
 
         protx_result = None
-        if hpmn:
-            protx_result = self.nodes[0].protx("register_hpmn", collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, platform_node_id, platform_p2p_port, platform_http_port, funds_address, True)
+        if evo:
+            protx_result = self.nodes[0].protx("register_evo", collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, platform_node_id, platform_p2p_port, platform_http_port, funds_address, True)
         else:
             protx_result = self.nodes[0].protx("register", collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, funds_address, True)
 
@@ -1192,14 +1192,14 @@ class DashTestFramework(BitcoinTestFramework):
         self.sync_all(self.nodes)
 
         assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
-        mn_info = MasternodeInfo(protx_result, owner_address, voting_address, bls['public'], bls['secret'], collateral_address, collateral_txid, collateral_vout, ipAndPort, hpmn)
+        mn_info = MasternodeInfo(protx_result, owner_address, voting_address, bls['public'], bls['secret'], collateral_address, collateral_txid, collateral_vout, ipAndPort, evo)
         self.mninfo.append(mn_info)
 
-        mn_type_str = "HPMN" if hpmn else "MN"
+        mn_type_str = "EvoNode" if evo else "MN"
         self.log.info("Prepared %s %d: collateral_txid=%s, collateral_vout=%d, protxHash=%s" % (mn_type_str, idx, collateral_txid, collateral_vout, protx_result))
         return mn_info
 
-    def dynamically_hpmn_update_service(self, hpmn_info, rnd=None, should_be_rejected=False):
+    def dynamically_evo_update_service(self, evo_info, rnd=None, should_be_rejected=False):
         funds_address = self.nodes[0].getnewaddress()
         operator_reward_address = self.nodes[0].getnewaddress()
 
@@ -1217,15 +1217,15 @@ class DashTestFramework(BitcoinTestFramework):
 
         protx_success = False
         try:
-            protx_result = self.nodes[0].protx('update_service_hpmn', hpmn_info.proTxHash, hpmn_info.addr, hpmn_info.keyOperator, platform_node_id, platform_p2p_port, platform_http_port, operator_reward_address, funds_address)
+            protx_result = self.nodes[0].protx('update_service_evo', evo_info.proTxHash, evo_info.addr, evo_info.keyOperator, platform_node_id, platform_p2p_port, platform_http_port, operator_reward_address, funds_address)
             self.wait_for_instantlock(protx_result, self.nodes[0])
             tip = self.nodes[0].generate(1)[0]
             assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
             self.sync_all(self.nodes)
-            self.log.info("Updated HPMN %s: platformNodeID=%s, platformP2PPort=%s, platformHTTPPort=%s" % (hpmn_info.proTxHash, platform_node_id, platform_p2p_port, platform_http_port))
+            self.log.info("Updated EvoNode %s: platformNodeID=%s, platformP2PPort=%s, platformHTTPPort=%s" % (evo_info.proTxHash, platform_node_id, platform_p2p_port, platform_http_port))
             protx_success = True
         except:
-            self.log.info("protx_hpmn rejected")
+            self.log.info("protx_evo rejected")
 
         assert_equal(protx_success, not should_be_rejected)
 
@@ -1237,14 +1237,14 @@ class DashTestFramework(BitcoinTestFramework):
             self.prepare_masternode(idx, rewardsAddr, False)
         self.sync_all()
 
-    def prepare_masternode(self, idx, rewardsAddr=None, hpmn=False):
+    def prepare_masternode(self, idx, rewardsAddr=None, evo=False):
 
         register_fund = (idx % 2) == 0
 
         bls = self.nodes[0].bls('generate')
         address = self.nodes[0].getnewaddress()
 
-        collateral_amount = HIGHPERFORMANCE_MASTERNODE_COLLATERAL if hpmn else MASTERNODE_COLLATERAL
+        collateral_amount = EVONODE_MASTERNODE_COLLATERAL if evo else MASTERNODE_COLLATERAL
         txid = None
         txid = self.nodes[0].sendtoaddress(address, collateral_amount)
         collateral_vout = 0
@@ -1289,10 +1289,10 @@ class DashTestFramework(BitcoinTestFramework):
             operatorPayoutAddress = self.nodes[0].getnewaddress()
             self.nodes[0].protx('update_service', proTxHash, ipAndPort, bls['secret'], operatorPayoutAddress, address)
 
-        self.mninfo.append(MasternodeInfo(proTxHash, ownerAddr, votingAddr, bls['public'], bls['secret'], address, txid, collateral_vout, ipAndPort, hpmn))
+        self.mninfo.append(MasternodeInfo(proTxHash, ownerAddr, votingAddr, bls['public'], bls['secret'], address, txid, collateral_vout, ipAndPort, evo))
         # self.sync_all()
 
-        mn_type_str = "HPMN" if hpmn else "MN"
+        mn_type_str = "EvoNode" if evo else "MN"
         self.log.info("Prepared %s %d: collateral_txid=%s, collateral_vout=%d, protxHash=%s" % (mn_type_str, idx, txid, collateral_vout, proTxHash))
 
     def remove_masternode(self, idx):
@@ -1373,8 +1373,8 @@ class DashTestFramework(BitcoinTestFramework):
         self.add_nodes(1, extra_args=[self.extra_args[0]])
         self.start_node(0)
         self.import_deterministic_coinbase_privkeys()
-        required_balance = HIGHPERFORMANCE_MASTERNODE_COLLATERAL * self.hpmn_count
-        required_balance += MASTERNODE_COLLATERAL * (self.mn_count - self.hpmn_count) + 100
+        required_balance = EVONODE_MASTERNODE_COLLATERAL * self.evo_count
+        required_balance += MASTERNODE_COLLATERAL * (self.mn_count - self.evo_count) + 100
         self.log.info("Generating %d coins" % required_balance)
         while self.nodes[0].getbalance() < required_balance:
             self.bump_mocktime(1)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -113,7 +113,7 @@ BASE_SCRIPTS = [
     'feature_llmq_chainlocks.py', # NOTE: needs dash_hash to pass
     'feature_llmq_rotation.py', # NOTE: needs dash_hash to pass
     'feature_llmq_connections.py', # NOTE: needs dash_hash to pass
-    'feature_llmq_hpmn.py', # NOTE: needs dash_hash to pass
+    'feature_llmq_evo.py', # NOTE: needs dash_hash to pass
     'feature_llmq_simplepose.py', # NOTE: needs dash_hash to pass
     'feature_llmq_is_cl_conflicts.py', # NOTE: needs dash_hash to pass
     'feature_llmq_is_migration.py', # NOTE: needs dash_hash to pass


### PR DESCRIPTION
## Issue being fixed or feature implemented

## What was done?
Renaming of all classes/variables/functions/rpcs from `hpmn` to `evo`.

## How Has This Been Tested?
All unit and func tests are passing.
Sync of Testnet.

## Breaking Changes
All protx RPCs ending with `_hpmn` were converted to `_evo`.
`_hpmn` RPCs are now deprecated.
Although, they can still be enabled by adding `-deprecatedrpc=hpmn`.


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

