### PR TITLE
ci: multi-runner guix builds

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -3,10 +3,11 @@ name: Guix Build
 on:
   pull_request:
     types: [ labeled ]
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [ "self-hosted", "linux", "x64", "ubuntu-core" ]
     if: contains(github.event.pull_request.labels.*.name, 'guix-build')
     steps:
       - name: Checkout


### PR DESCRIPTION
## Issue being fixed or feature implemented
 - We want to enable use of the AWS-hosted GitHub Actions runners, now that [corresponding infra](https://github.com/dcginfra/tf-aws-gh-runner/pull/8/files#diff-ad98d33884a302f6c747dc6b326c6b3af3887f2ec25e0bd7a0395f10444818f3) exists to deploy these runners


## What was done?
Add new labels and workflow dispatch button to allow runner testing


## How Has This Been Tested?
Pending testing in CI


## Breaking Changes
None


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

