### PR TITLE
ci: Disable creation of `combined.html`

### DIFF
--- a/ci/dash/test_integrationtests.sh
+++ b/ci/dash/test_integrationtests.sh
@@ -51,7 +51,8 @@ if [ "$BASEDIR" != "" ]; then
     [[ "$d" != "cache" ]] || continue # skip cache dir
     mkdir testlogs/$d
     PYTHONIOENCODING=UTF-8 ./test/functional/combine_logs.py -c ./testdatadirs/$BASEDIR/$d > ./testlogs/$d/combined.log
-    PYTHONIOENCODING=UTF-8 ./test/functional/combine_logs.py --html ./testdatadirs/$BASEDIR/$d > ./testlogs/$d/combined.html
+    # Disabled creation of combined.html: 40% smaller CI job artifacts
+    # PYTHONIOENCODING=UTF-8 ./test/functional/combine_logs.py --html ./testdatadirs/$BASEDIR/$d > ./testlogs/$d/combined.html
     cd testdatadirs/$BASEDIR/$d
     LOGFILES="$(find . -name 'debug.log' -or -name "test_framework.log")"
     cd ../../..


### PR DESCRIPTION
## Issue being fixed or feature implemented
40% smaller CI job artifacts. Should help with issues like https://gitlab.com/dashpay/dash/-/jobs/4759700026 in #5493.

## What was done?

## How Has This Been Tested?
https://gitlab.com/UdjinM6/dash/-/jobs/4773517599

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

