### PR TITLE
ci: bump `actions/checkout` and `actions/cache` to v3

### DIFF
--- a/.github/workflows/clang-diff-format.yml
+++ b/.github/workflows/clang-diff-format.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Fetch git
         run: git fetch
       - name: Run Clang-Format-Diff.py

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -11,7 +11,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'guix-build')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -26,7 +26,7 @@ jobs:
           echo "host_group_id=$(id -g)" >> $GITHUB_OUTPUT
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ steps.dockerfile.outputs.hash }}

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           ghToken: "${{ secrets.GITHUB_TOKEN }}"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: validate potential conflicts
         run: pip3 install hjson && .github/workflows/handle_potential_conflicts.py "$conflicts"

--- a/.github/workflows/release_alpha.yml
+++ b/.github/workflows/release_alpha.yml
@@ -13,23 +13,23 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: dash
     - name: Checkout Gitian builder
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: devrandom/gitian-builder
         path: gitian-builder
 
     - name: Checkout detached sigs
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: dashpay/dash-detached-sigs
         path: dash-detached-sigs
 
     - name: Checkout gitian sigs
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: dashpay/gitian.sigs
         path: gitian.sigs

--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should fix warnings like
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/cache@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

https://github.com/dashpay/dash/actions/runs/5705358251?pr=5448
https://github.com/dashpay/dash/actions/runs/5705358315?pr=5448
https://github.com/dashpay/dash/actions/runs/5705358316?pr=5448
https://github.com/dashpay/dash/actions/runs/5715249078?pr=5448

## What was done?

## How Has This Been Tested?

## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

