### PR TITLE
feat: add bloom filter for Asset Lock transactions

### DIFF
--- a/src/bloom.h
+++ b/src/bloom.h
@@ -12,6 +12,7 @@
 class COutPoint;
 class CScript;
 class CTransaction;
+class CTxOut;
 class uint256;
 class uint160;
 
@@ -55,6 +56,8 @@ private:
 
     // Check matches for arbitrary script data elements
     bool CheckScript(const CScript& script) const;
+    // Check particular CTxOut helper
+    bool ProcessTxOut(const CTxOut& txout, const uint256& hash, unsigned int index);
     // Check additional matches for special transactions
     bool CheckSpecialTransactionMatchesAndUpdate(const CTransaction& tx);
 public:

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -67,6 +67,11 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "qt/appearancewidget -> qt/guiutil -> qt/optionsdialog -> qt/appearancewidget"
     "qt/guiutil -> qt/optionsdialog -> qt/optionsmodel -> qt/guiutil"
 
+    "bloom -> evo/assetlocktx -> llmq/quorums -> net -> bloom"
+    "banman -> bloom -> evo/assetlocktx -> llmq/quorums -> net -> banman"
+    "banman -> bloom -> evo/assetlocktx -> llmq/quorums -> net_processing -> banman"
+    "bloom -> evo/assetlocktx -> llmq/quorums -> net_processing -> merkleblock -> bloom"
+
     "coinjoin/client -> net_processing -> coinjoin/client"
     "llmq/quorums -> net_processing -> llmq/quorums"
     "llmq/dkgsession -> llmq/dkgsessionmgr -> llmq/dkgsession"


### PR DESCRIPTION
## Issue being fixed or feature implemented
There's one type of output that potentially can be useful for bloom filter.
It's follow-up for TODO for dashpay/dash#4857.

Asset  Lock transactions have:
 - standard inputs (covered by regular bloom filter implementation)
 - standard outputs (covered by regular bloom filter implementation)
 - special outputs that have public key to proof owing this credits on platform and claiming it.

Asset Unlock transactions have:
 - no inputs (no need bloom)
 - standard outputs (covered by regular bloom filter implementation)

So far as there's only one special case, let's have this data in the bloom filter because it can potentially help to show information such as "Deposit to platform" on mobile clients.

## What was done?
 - added special case for Asset Lock transactions for bloom filter

## How Has This Been Tested?
Run unit/functional tests. Doesn't actually tested how bloom filter works.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

