### PR TITLE
refactor: rename `assetLockedAmount` in CbTx to `creditPoolBalance`

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -432,9 +432,9 @@ bool CalcCbTxBestChainlock(const llmq::CChainLocksHandler& chainlock_handler, co
 
 std::string CCbTx::ToString() const
 {
-    return strprintf("CCbTx(nVersion=%d, nHeight=%d, merkleRootMNList=%s, merkleRootQuorums=%s, bestCLHeightDiff=%d, bestCLSig=%s, assetLockedAmount=%d.%08d)",
+    return strprintf("CCbTx(nVersion=%d, nHeight=%d, merkleRootMNList=%s, merkleRootQuorums=%s, bestCLHeightDiff=%d, bestCLSig=%s, creditPoolBalance=%d.%08d)",
         nVersion, nHeight, merkleRootMNList.ToString(), merkleRootQuorums.ToString(), bestCLHeightDiff, bestCLSignature.ToString(),
-        assetLockedAmount / COIN, assetLockedAmount % COIN);
+        creditPoolBalance / COIN, creditPoolBalance % COIN);
 }
 
 std::optional<CCbTx> GetCoinbaseTx(const CBlockIndex* pindex)

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -37,7 +37,7 @@ public:
     uint256 merkleRootQuorums;
     uint32_t bestCLHeightDiff;
     CBLSSignature bestCLSignature;
-    CAmount assetLockedAmount{0};
+    CAmount creditPoolBalance{0};
 
     SERIALIZE_METHODS(CCbTx, obj)
     {
@@ -48,7 +48,7 @@ public:
             if (obj.nVersion >= CB_V20_VERSION) {
                 READWRITE(COMPACTSIZE(obj.bestCLHeightDiff));
                 READWRITE(obj.bestCLSignature);
-                READWRITE(obj.assetLockedAmount);
+                READWRITE(obj.creditPoolBalance);
             }
         }
 
@@ -68,7 +68,7 @@ public:
             if (nVersion >= CB_V20_VERSION) {
                 obj.pushKV("bestCLHeightDiff", static_cast<int>(bestCLHeightDiff));
                 obj.pushKV("bestCLSignature", bestCLSignature.ToString());
-                obj.pushKV("assetLockedAmount", ValueFromAmount(assetLockedAmount));
+                obj.pushKV("creditPoolBalance", ValueFromAmount(creditPoolBalance));
             }
         }
     }

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -142,7 +142,7 @@ CCreditPool CCreditPoolManager::ConstructCreditPool(const CBlockIndex* const blo
         if (!GetTxPayload(block->vtx[0]->vExtraPayload, cbTx)) {
             throw std::runtime_error(strprintf("%s: failed-getcreditpool-cbtx-payload", __func__));
         }
-        locked = cbTx.assetLockedAmount;
+        locked = cbTx.creditPoolBalance;
     }
 
     // We use here sliding window with LimitBlocksToTrace to determine
@@ -226,7 +226,7 @@ bool CCreditPoolDiff::SetTarget(const CTransaction& tx, TxValidationState& state
     }
 
     if (cbTx.nVersion == 3) {
-        targetLocked = cbTx.assetLockedAmount;
+        targetBalance = cbTx.creditPoolBalance;
     }
     return true;
 }

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -69,7 +69,7 @@ private:
     CAmount sessionUnlocked{0};
 
     // target value is used to validate CbTx. If values mismatched, block is invalid
-    std::optional<CAmount> targetLocked;
+    std::optional<CAmount> targetBalance;
 
     const CBlockIndex *pindex{nullptr};
 public:
@@ -86,12 +86,12 @@ public:
         return pool.locked + sessionLocked - sessionUnlocked;
     }
 
-    const std::optional<CAmount>& GetTargetLocked() const {
-        return targetLocked;
+    const std::optional<CAmount>& GetTargetBalance() const {
+        return targetBalance;
     }
 
     std::string ToString() const {
-        return strprintf("CCreditPoolDiff(target=%lld, sessionLocked=%lld, sessionUnlocked=%lld, newIndexes=%lld, pool=%s)", GetTargetLocked() ? *GetTargetLocked() : -1, sessionLocked, sessionUnlocked, newIndexes.size(), pool.ToString());
+        return strprintf("CCreditPoolDiff(target=%lld, sessionLocked=%lld, sessionUnlocked=%lld, newIndexes=%lld, pool=%s)", GetTargetBalance() ? *GetTargetBalance() : -1, sessionLocked, sessionUnlocked, newIndexes.size(), pool.ToString());
     }
 
 private:

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -160,7 +160,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, ll
         }
         if (creditPoolDiff != std::nullopt) {
             CAmount locked_proposed{0};
-            if(creditPoolDiff->GetTargetLocked()) locked_proposed = *creditPoolDiff->GetTargetLocked();
+            if(creditPoolDiff->GetTargetBalance()) locked_proposed = *creditPoolDiff->GetTargetBalance();
 
             CAmount locked_calculated = creditPoolDiff->GetTotalLocked();
             if (locked_proposed != locked_calculated) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -231,7 +231,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
                     LogPrintf("CreateNewBlock() h[%d] CbTx failed to find best CL. Inserting null CL\n", nHeight);
                 }
                 assert(creditPoolDiff != std::nullopt);
-                cbTx.assetLockedAmount = creditPoolDiff->GetTotalLocked();
+                cbTx.creditPoolBalance = creditPoolDiff->GetTotalLocked();
             }
         }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Bad naming is noticed in https://github.com/dashpay/dash/pull/5026 by thephez

## What was done?
Renamed `assetLockedAmount` in CbTx to `creditPoolBalance`
Renamed also some local variables and functions to make it matched also.

## How Has This Been Tested?
Run functional/unit tests - succeed
Called python's rpc binding `node.getblock(block_hash)['cbTx']`:
Got this result:
```
{'version': 3, 'height': 1556, 'merkleRootMNList': '978b2b4d1b884de62799b9eaee75c7812fea59f98f80d5ff9c963b0f0f195e14', 'merkleRootQuorums': 'bc7a34eb114f4e4bf38a11080b5d8ac41bdb36dd41e17467bae23c94ba06b013', 'bestCLHeightDiff': 0, 'bestCLSignature': '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', 'creditPoolBalance': Decimal('7.00141421')}
```

## Breaking Changes
Renamed `assetLockedAmount` in CbTx to `creditPoolBalance`. @shumkov be informed


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

