### PR TITLE
feat: various Asset Locks improvement

### DIFF
--- a/src/evo/assetlocktx.h
+++ b/src/evo/assetlocktx.h
@@ -14,8 +14,10 @@
 #include <tinyformat.h>
 #include <univalue.h>
 
+#include <optional>
+
 class CBlockIndex;
-struct CCreditPool;
+class CRangesSet;
 
 class CAssetLockPayload
 {
@@ -166,8 +168,8 @@ public:
 };
 
 bool CheckAssetLockTx(const CTransaction& tx, TxValidationState& state);
-bool CheckAssetUnlockTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCreditPool& creditPool, TxValidationState& state);
-bool CheckAssetLockUnlockTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCreditPool& creditPool, TxValidationState& state);
+bool CheckAssetUnlockTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state);
+bool CheckAssetLockUnlockTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state);
 bool GetAssetUnlockFee(const CTransaction& tx, CAmount& txfee, TxValidationState& state);
 
 #endif // BITCOIN_EVO_ASSETLOCKTX_H

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -278,7 +278,7 @@ bool CCreditPoolDiff::ProcessTransaction(const CTransaction& tx, TxValidationSta
 
     if (tx.nType != TRANSACTION_ASSET_LOCK && tx.nType != TRANSACTION_ASSET_UNLOCK) return true;
 
-    if (!CheckAssetLockUnlockTx(tx, pindex, this->pool, state)) {
+    if (!CheckAssetLockUnlockTx(tx, pindex, pool.indexes, state)) {
         // pass the state returned by the function above
         return false;
     }

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -70,7 +70,7 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const
     return CheckSpecialTxInner(tx, pindexPrev, view, std::nullopt, check_sigs, state);
 }
 
-bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, TxValidationState& state)
+static bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, TxValidationState& state)
 {
     if (tx.nVersion != 3 || tx.nType == TRANSACTION_NORMAL) {
         return true;
@@ -96,7 +96,7 @@ bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, TxValid
     return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-tx-type-proc");
 }
 
-bool UndoSpecialTx(const CTransaction& tx, const CBlockIndex* pindex)
+static bool UndoSpecialTx(const CTransaction& tx, const CBlockIndex* pindex)
 {
     if (tx.nVersion != 3 || tx.nType == TRANSACTION_NORMAL) {
         return true;

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -19,7 +19,7 @@
 #include <primitives/block.h>
 #include <validation.h>
 
-bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, const CCreditPool& creditPool, bool check_sigs, TxValidationState& state)
+static bool CheckSpecialTxInner(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, const std::optional<CRangesSet>& indexes, bool check_sigs, TxValidationState& state)
 {
     AssertLockHeld(cs_main);
 
@@ -54,7 +54,7 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const
             if (!llmq::utils::IsV20Active(pindexPrev)) {
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetlocks-before-v20");
             }
-            return CheckAssetLockUnlockTx(tx, pindexPrev, creditPool, state);
+            return CheckAssetLockUnlockTx(tx, pindexPrev, indexes, state);
         }
     } catch (const std::exception& e) {
         LogPrintf("%s -- failed: %s\n", __func__, e.what());
@@ -62,6 +62,12 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const
     }
 
     return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-tx-type-check");
+}
+
+bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs, TxValidationState& state)
+{
+    AssertLockHeld(cs_main);
+    return CheckSpecialTxInner(tx, pindexPrev, view, std::nullopt, check_sigs, state);
 }
 
 bool ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, TxValidationState& state)
@@ -142,7 +148,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, ll
             TxValidationState tx_state;
             // At this moment CheckSpecialTx() and ProcessSpecialTx() may fail by 2 possible ways:
             // consensus failures and "TX_BAD_SPECIAL"
-            if (!CheckSpecialTx(*ptr_tx, pindex->pprev, view, creditPool, fCheckCbTxMerleRoots, tx_state)) {
+            if (!CheckSpecialTxInner(*ptr_tx, pindex->pprev, view, creditPool.indexes, fCheckCbTxMerleRoots, tx_state)) {
                 assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS || tx_state.GetResult() == TxValidationResult::TX_BAD_SPECIAL);
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(),
                                  strprintf("Special Transaction check failed (tx hash %s) %s", ptr_tx->GetHash().ToString(), tx_state.GetDebugMessage()));

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -12,7 +12,6 @@
 class BlockValidationState;
 class CBlock;
 class CBlockIndex;
-struct CCreditPool;
 class CCoinsViewCache;
 class TxValidationState;
 namespace llmq {
@@ -25,7 +24,7 @@ struct Params;
 
 extern RecursiveMutex cs_main;
 
-bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, const CCreditPool& pool, bool check_sigs,
+bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs,
                     TxValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, llmq::CQuorumBlockProcessor& quorum_block_processor, const llmq::CChainLocksHandler& chainlock_handler,
                             const Consensus::Params& consensusParams, const CCoinsViewCache& view, bool fJustCheck, bool fCheckCbTxMerleRoots,

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -7,7 +7,6 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <core_io.h>
-#include <evo/creditpool.h>
 #include <evo/deterministicmns.h>
 #include <evo/dmn_types.h>
 #include <evo/providertx.h>
@@ -329,10 +328,8 @@ static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, const Cha
     {
     LOCK(cs_main);
 
-    CCreditPool creditPool = creditPoolManager->GetCreditPool(chainman.ActiveChain().Tip(), Params().GetConsensus());
-
     TxValidationState state;
-    if (!CheckSpecialTx(CTransaction(tx), chainman.ActiveChain().Tip(), chainman.ActiveChainstate().CoinsTip(), creditPool, true, state)) {
+    if (!CheckSpecialTx(CTransaction(tx), chainman.ActiveChain().Tip(), chainman.ActiveChainstate().CoinsTip(), true, state)) {
         throw std::runtime_error(state.ToString());
     }
     } // cs_main

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -52,7 +52,6 @@
 #include <masternode/payments.h>
 #include <masternode/sync.h>
 
-#include <evo/creditpool.h>
 #include <evo/evodb.h>
 #include <evo/specialtx.h>
 #include <evo/specialtxman.h>
@@ -712,7 +711,6 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             }
         }
     }
-    CCreditPool creditPool = creditPoolManager->GetCreditPool(::ChainActive().Tip(), chainparams.GetConsensus());
     LockPoints lp;
     m_view.SetBackend(m_viewmempool);
 
@@ -827,7 +825,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // DoS scoring a node for non-critical errors, e.g. duplicate keys because a TX is received that was already
     // mined
     // NOTE: we use UTXO here and do NOT allow mempool txes as masternode collaterals
-    if (!CheckSpecialTx(tx, m_active_chainstate.m_chain.Tip(), m_active_chainstate.CoinsTip(), creditPool, true, state))
+    if (!CheckSpecialTx(tx, m_active_chainstate.m_chain.Tip(), m_active_chainstate.CoinsTip(), true, state))
         return false;
 
     if (m_pool.existsProviderTxConflict(tx)) {

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -60,13 +60,18 @@ class AssetLocksTest(DashTestFramework):
 
         inputs = [CTxIn(COutPoint(int(coin["txid"], 16), coin["vout"]))]
 
-        credit_outputs = CTxOut(amount, CScript([OP_DUP, OP_HASH160, hash160(pubkey), OP_EQUALVERIFY, OP_CHECKSIG]))
+        credit_outputs = []
+        tmp_amount = amount
+        if tmp_amount > COIN:
+            tmp_amount -= COIN
+            credit_outputs.append(CTxOut(COIN, CScript([OP_DUP, OP_HASH160, hash160(pubkey), OP_EQUALVERIFY, OP_CHECKSIG])))
+        credit_outputs.append(CTxOut(tmp_amount, CScript([OP_DUP, OP_HASH160, hash160(pubkey), OP_EQUALVERIFY, OP_CHECKSIG])))
 
-        lockTx_payload = CAssetLockTx(1, [credit_outputs])
+        lockTx_payload = CAssetLockTx(1, credit_outputs)
 
-        remaining = int(COIN * coin['amount']) - tiny_amount - credit_outputs.nValue
+        remaining = int(COIN * coin['amount']) - tiny_amount - amount
 
-        tx_output_ret = CTxOut(credit_outputs.nValue, CScript([OP_RETURN, b""]))
+        tx_output_ret = CTxOut(amount, CScript([OP_RETURN, b""]))
         tx_output = CTxOut(remaining, CScript([pubkey, OP_CHECKSIG]))
 
         lock_tx = CTransaction()

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -81,10 +81,8 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "evo/deterministicmns -> llmq/utils -> net -> evo/deterministicmns"
     "policy/policy -> policy/settings -> policy/policy"
     "evo/specialtxman -> validation -> evo/specialtxman"
-    "evo/creditpool -> validation -> evo/creditpool"
     "consensus/tx_verify -> evo/assetlocktx -> validation -> consensus/tx_verify"
     "consensus/tx_verify -> evo/assetlocktx -> llmq/quorums -> net_processing -> txmempool -> consensus/tx_verify"
-    "evo/assetlocktx -> evo/creditpool -> evo/assetlocktx"
     "evo/assetlocktx -> llmq/quorums -> net_processing -> txmempool -> evo/assetlocktx"
 
     "evo/simplifiedmns -> llmq/blockprocessor -> net_processing -> llmq/snapshot -> evo/simplifiedmns"


### PR DESCRIPTION
## What was done?
 - remove dependency of Asset Lock txes on CCreditPool
 - new case for functional tests of Asset Locks - more than one output for Asset Lock tx.


## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
Slightly changes behaviour of TxMempool. Tx can be accepted in mempool even if Asset Unlock transaction with same index is already mined. But final consensus rules are same.


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone