### PR TITLE
fix: Update conditions and unify calculations for the number of "winners" to skip when mixing

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1046,7 +1046,7 @@ static int WinnersToSkip()
 {
     return (Params().NetworkIDString() == CBaseChainParams::DEVNET ||
             Params().NetworkIDString() == CBaseChainParams::REGTEST)
-            ? 0 : 8;
+            ? 1 : 8;
 }
 
 bool CCoinJoinClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman)

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1042,7 +1042,7 @@ CDeterministicMNCPtr CCoinJoinClientManager::GetRandomNotUsedMasternode()
     return nullptr;
 }
 
-int CCoinJoinClientSession::WinnersToSkip()
+static int WinnersToSkip()
 {
     return (Params().NetworkIDString() == CBaseChainParams::DEVNET ||
             Params().NetworkIDString() == CBaseChainParams::REGTEST)

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -99,6 +99,7 @@ private:
 
     bool CreateCollateralTransaction(CMutableTransaction& txCollateral, std::string& strReason);
 
+    int WinnersToSkip();
     bool JoinExistingQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman);
     bool StartNewQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman);
 

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -99,7 +99,6 @@ private:
 
     bool CreateCollateralTransaction(CMutableTransaction& txCollateral, std::string& strReason);
 
-    int WinnersToSkip();
     bool JoinExistingQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman);
     bool StartNewQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman);
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
`JoinExistingQueue` was tweaked for regtest/devnets in #4394 but we have "skipping winners" logic in `StartNewQueue` too. We should also use weighted count when checking "skip winners" conditions.

## What was done?
Add a helper to calculate the number and use it in both methods. Adjust logic.

## How Has This Been Tested?
Running a local mixing node on devnet ~- no "skipping winners" in logs anymore.~ and testnet

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

