### PR TITLE
fix: Lock masternode collaterals when a wallet is opened

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -118,6 +118,7 @@ bool AddWallet(const std::shared_ptr<CWallet>& wallet)
         vpwallets.push_back(wallet);
     }
     wallet->ConnectScriptPubKeyManNotifiers();
+    wallet->AutoLockMasternodeCollaterals();
     assert(::masternodeSync != nullptr);
     coinJoinClientManagers.emplace(std::make_pair(wallet->GetName(), std::make_shared<CCoinJoinClientManager>(*wallet, *::masternodeSync)));
     g_wallet_init_interface.InitCoinJoinSettings();


### PR DESCRIPTION
## Issue being fixed or feature implemented
We only lock them on node load atm.

Fixes #5535 

## What was done?

## How Has This Been Tested?
close and open a wallet with a mn collateral

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

