### PR TITLE
fix: Do not use nHeight when trying to identify the very first/initial snapshot

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -187,6 +187,7 @@ public:
         nHeight(_height),
         nTotalRegisteredCount(_totalRegisteredCount)
     {
+        assert(nHeight >= 0);
     }
 
     template <typename Stream, typename Operation>
@@ -299,10 +300,12 @@ public:
     }
     [[nodiscard]] int GetHeight() const
     {
+        assert(nHeight >= 0);
         return nHeight;
     }
     void SetHeight(int _height)
     {
+        assert(_height >= 0);
         nHeight = _height;
     }
     [[nodiscard]] uint32_t GetTotalRegisteredCount() const
@@ -586,6 +589,7 @@ private:
     std::unordered_map<uint256, CDeterministicMNList, StaticSaltedHasher> mnListsCache GUARDED_BY(cs);
     std::unordered_map<uint256, CDeterministicMNListDiff, StaticSaltedHasher> mnListDiffsCache GUARDED_BY(cs);
     const CBlockIndex* tipIndex GUARDED_BY(cs) {nullptr};
+    const CBlockIndex* m_initial_snapshot_index GUARDED_BY(cs) {nullptr};
 
 public:
     explicit CDeterministicMNManager(CEvoDB& evoDb, CConnman& _connman) :


### PR DESCRIPTION
## Issue being fixed or feature implemented

`-1` will only mean `not initialized` from now

Should fix crashes like https://gitlab.com/dashpay/dash/-/jobs/4893359925
This fix applied on top of #5525 https://gitlab.com/UdjinM6/dash/-/pipelines/972154075

## What was done?
Introduce and use `m_initial_snapshot_index` instead of re-using `nHeight`. Added a couple of asserts to make sure:
1. we never create mn lists with `nHeight` set to `-1` _explicitly_ (but it's ok for ctor with no params to do so)
2. we never set `nHeight` to `-1` for an existing mn list
3. we never try to get a height for a non-initialized list
4. `GetListForBlockInternal` never returns non-initialized mn lists

## How Has This Been Tested?
Run tests, run regtest/testnet wallets.

## Breaking Changes
We never stored snapshots with `nHeight == -1`, should be no breaking changes I think.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

