### PR TITLE
docs: improved Docker documentation

### DIFF
--- a/contrib/containers/README.md
+++ b/contrib/containers/README.md
@@ -2,7 +2,7 @@
 
 This directory contains configuration files for containerization utilities.
 
-Currently two Docker containers exist, `ci` defines how Dash's GitLab CI container is built and the `dev` builds on top of the `ci` to provide a containerized development environment that is as close as possible to CI for contributors!
+Currently two Docker containers exist, `ci` defines how Dash's GitLab CI container is built and the `dev` builds on top of the `ci` to provide a containerized development environment that is as close as possible to CI for contributors! See also [Dash on Docker Hub](https://hub.docker.com/u/dashpay) i.e. for the [dashd container](https://hub.docker.com/r/dashpay/dashd).
 
 ### Usage Guide
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Make Dash on Docker Hub easier to find, a search on `dash` there does not provide the result.

## What was done?
Improved Docker documentation in `contrib/containers/README.md`

## How Has This Been Tested?
n/a

## Breaking Changes
n/a

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_