### PR TITLE
backport: merge bitcoin#23842, #24714, #21059, #23994, #19866, #19935, #23756, #19064, #23411, #20080 (util backports)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,12 @@ AC_ARG_WITH([bdb],
   [use_bdb=$withval],
   [use_bdb=auto])
 
+AC_ARG_ENABLE([ebpf],
+  [AS_HELP_STRING([--enable-ebpf],
+  [enable eBPF tracing (default is yes if sys/sdt.h is found)])],
+  [use_ebpf=$enableval],
+  [use_ebpf=yes])
+
 AC_ARG_WITH([miniupnpc],
   [AS_HELP_STRING([--with-miniupnpc],
   [enable UPNP (default is yes if libminiupnpc is found)])],
@@ -1368,6 +1374,16 @@ if test x$enable_wallet != xno; then
     fi
 fi
 
+if test x$use_ebpf != xno; then
+  AC_CHECK_HEADER([sys/sdt.h], [have_sdt=yes], [have_sdt=no])
+else
+  have_sdt=no
+fi
+
+if test x$have_sdt = xyes; then
+  AC_DEFINE([ENABLE_TRACING], [1], [Define to 1 to enable eBPF user static defined tracepoints])
+fi
+
 dnl Check for libminiupnpc (optional)
 if test x$use_upnp != xno; then
   AC_CHECK_HEADERS(
@@ -1740,6 +1756,7 @@ AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
 AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
 AM_CONDITIONAL([USE_SQLITE], [test "x$use_sqlite" = "xyes"])
 AM_CONDITIONAL([USE_BDB], [test "x$use_bdb" = "xyes"])
+AM_CONDITIONAL([ENABLE_TRACING],[test x$have_sdt = xyes])
 AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xyes])
 AM_CONDITIONAL([ENABLE_FUZZ],[test x$enable_fuzz = xyes])
 AM_CONDITIONAL([ENABLE_FUZZ_BINARY],[test x$enable_fuzz_binary = xyes])
@@ -1905,6 +1922,7 @@ echo "  with bench    = $use_bench"
 echo "  with upnp           = $use_upnp"
 echo "  with natpmp         = $use_natpmp"
 echo "  use asm             = $use_asm"
+echo "  ebpf tracing        = $have_sdt"
 echo "  sanitizers          = $use_sanitizers"
 echo "  debug enabled       = $enable_debug"
 echo "  stacktraces enabled = $enable_stacktraces"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -332,6 +332,7 @@ BITCOIN_CORE_H = \
   util/string.h \
   util/time.h \
   util/threadnames.h \
+  util/trace.h \
   util/translation.h \
   util/vector.h \
   util/url.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -735,6 +735,7 @@ libbitcoin_util_a_SOURCES = \
   util/asmap.cpp \
   util/bip32.cpp \
   util/bytevectorhash.cpp \
+  util/check.cpp \
   util/error.cpp \
   util/fees.cpp \
   util/getuniquepath.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -313,6 +313,7 @@ BITCOIN_CORE_H = \
   util/fastrange.h \
   util/fees.h \
   util/golombrice.h \
+  util/hasher.h \
   util/hash_type.h \
   util/irange.h \
   util/spanparsing.h \
@@ -740,6 +741,7 @@ libbitcoin_util_a_SOURCES = \
   util/check.cpp \
   util/error.cpp \
   util/fees.cpp \
+  util/hasher.cpp \
   util/getuniquepath.cpp \
   util/sock.cpp \
   util/system.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -310,6 +310,7 @@ BITCOIN_CORE_H = \
   util/check.h \
   util/enumerate.h \
   util/error.h \
+  util/fastrange.h \
   util/fees.h \
   util/golombrice.h \
   util/hash_type.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -323,6 +323,7 @@ BITCOIN_CORE_H = \
   util/macros.h \
   util/message.h \
   util/moneystr.h \
+  util/overflow.h \
   util/ranges.h \
   util/readwritefile.h \
   util/underlying.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -332,6 +332,7 @@ BITCOIN_CORE_H = \
   util/sock.h \
   util/string.h \
   util/time.h \
+  util/thread.h \
   util/threadnames.h \
   util/trace.h \
   util/translation.h \
@@ -755,6 +756,7 @@ libbitcoin_util_a_SOURCES = \
   util/time.cpp \
   util/serfloat.cpp \
   util/string.cpp \
+  util/thread.cpp \
   util/threadnames.cpp \
   $(BITCOIN_CORE_H)
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_BENCH_BENCH_H
 #define BITCOIN_BENCH_BENCH_H
 
+#include <util/macros.h>
+
 #include <chrono>
 #include <functional>
 #include <map>
@@ -12,8 +14,6 @@
 #include <vector>
 
 #include <bench/nanobench.h>
-#include <boost/preprocessor/cat.hpp>
-#include <boost/preprocessor/stringize.hpp>
 
 /*
  * Usage:
@@ -56,8 +56,8 @@ public:
     static void RunAll(const Args& args);
 };
 }
-// BENCHMARK(foo) expands to:  benchmark::BenchRunner bench_11foo("foo");
+// BENCHMARK(foo) expands to:  benchmark::BenchRunner bench_11foo("foo", foo);
 #define BENCHMARK(n) \
-    benchmark::BenchRunner BOOST_PP_CAT(bench_, BOOST_PP_CAT(__LINE__, n))(BOOST_PP_STRINGIZE(n), n);
+    benchmark::BenchRunner PASTE2(bench_, PASTE2(__LINE__, n))(STRINGIZE(n), n);
 
 #endif // BITCOIN_BENCH_BENCH_H

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -29,7 +29,7 @@ uint64_t GCSFilter::HashToRange(const Element& element) const
     uint64_t hash = CSipHasher(m_params.m_siphash_k0, m_params.m_siphash_k1)
         .Write(element.data(), element.size())
         .Finalize();
-    return MapIntoRange(hash, m_F);
+    return FastRange64(hash, m_F);
 }
 
 std::vector<uint64_t> GCSFilter::BuildHashedSet(const ElementSet& elements) const

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -14,6 +14,7 @@
 #include <script/standard.h>
 #include <random.h>
 #include <streams.h>
+#include <util/fastrange.h>
 
 #include <math.h>
 #include <stdlib.h>
@@ -307,14 +308,6 @@ static inline uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, 
     return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash);
 }
 
-
-// A replacement for x % n. This assumes that x and n are 32bit integers, and x is a uniformly random distributed 32bit value
-// which should be the case for a good hash.
-// See https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
-static inline uint32_t FastMod(uint32_t x, size_t n) {
-    return ((uint64_t)x * (uint64_t)n) >> 32;
-}
-
 void CRollingBloomFilter::insert(const std::vector<unsigned char>& vKey)
 {
     if (nEntriesThisGeneration == nEntriesPerGeneration) {
@@ -339,7 +332,7 @@ void CRollingBloomFilter::insert(const std::vector<unsigned char>& vKey)
         uint32_t h = RollingBloomHash(n, nTweak, vKey);
         int bit = h & 0x3F;
         /* FastMod works with the upper bits of h, so it is safe to ignore that the lower bits of h are already used for bit. */
-        uint32_t pos = FastMod(h, data.size());
+        uint32_t pos = FastRange32(h, data.size());
         /* The lowest bit of pos is ignored, and set to zero for the first bit, and to one for the second. */
         data[pos & ~1] = (data[pos & ~1] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration & 1)) << bit;
         data[pos | 1] = (data[pos | 1] & ~(((uint64_t)1) << bit)) | ((uint64_t)(nGeneration >> 1)) << bit;
@@ -357,7 +350,7 @@ bool CRollingBloomFilter::contains(const std::vector<unsigned char>& vKey) const
     for (int n = 0; n < nHashFuncs; n++) {
         uint32_t h = RollingBloomHash(n, nTweak, vKey);
         int bit = h & 0x3F;
-        uint32_t pos = FastMod(h, data.size());
+        uint32_t pos = FastRange32(h, data.size());
         /* If the relevant bit is not set in either data[pos & ~1] or data[pos | 1], the filter does not contain vKey */
         if (!(((data[pos & ~1] | data[pos | 1]) >> bit) & 1)) {
             return false;

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CLIENTVERSION_H
 #define BITCOIN_CLIENTVERSION_H
 
+#include <util/macros.h>
+
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>
 #endif //HAVE_CONFIG_H
@@ -13,13 +15,6 @@
 #if !defined(CLIENT_VERSION_MAJOR) || !defined(CLIENT_VERSION_MINOR) || !defined(CLIENT_VERSION_BUILD) || !defined(CLIENT_VERSION_IS_RELEASE) || !defined(COPYRIGHT_YEAR)
 #error Client version information missing: version is not defined by bitcoin-config.h or in any other way
 #endif
-
-/**
- * Converts the parameter X to a string after macro replacement on X has been performed.
- * Don't merge these into one macro!
- */
-#define STRINGIZE(X) DO_STRINGIZE(X)
-#define DO_STRINGIZE(X) #X
 
 //! Copyright string used in Windows .rc files
 #define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " The Bitcoin Core Developers, 2014-" STRINGIZE(COPYRIGHT_YEAR) " " COPYRIGHT_HOLDERS_FINAL

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -31,8 +31,6 @@ bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock)
 CCoinsViewCursor *CCoinsViewBacked::Cursor() const { return base->Cursor(); }
 size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
-SaltedOutpointHasher::SaltedOutpointHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
-
 CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn), cachedCoinsUsage(0) {}
 
 size_t CCoinsViewCache::DynamicMemoryUsage() const {

--- a/src/coins.h
+++ b/src/coins.h
@@ -8,11 +8,11 @@
 
 #include <compressor.h>
 #include <core_memusage.h>
-#include <crypto/siphash.h>
 #include <memusage.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
+#include <util/hasher.h>
 
 #include <assert.h>
 #include <stdint.h>
@@ -82,33 +82,6 @@ public:
 
     size_t DynamicMemoryUsage() const {
         return memusage::DynamicUsage(out.scriptPubKey);
-    }
-};
-
-class SaltedOutpointHasher
-{
-private:
-    /** Salt */
-    const uint64_t k0, k1;
-
-public:
-    SaltedOutpointHasher();
-
-    /**
-     * This *must* return size_t. With Boost 1.46 on 32-bit systems the
-     * unordered_map will behave unpredictably if the custom hasher returns a
-     * uint64_t, resulting in failures when syncing the chain (#4634).
-     *
-     * Having the hash noexcept allows libstdc++'s unordered_map to recalculate
-     * the hash during rehash, so it does not have to cache the value. This
-     * reduces node's memory by sizeof(size_t). The required recalculation has
-     * a slight performance penalty (around 1.6%), but this is compensated by
-     * memory savings of about 9% which allow for a larger dbcache setting.
-     *
-     * @see https://gcc.gnu.org/onlinedocs/gcc-9.2.0/libstdc++/manual/manual/unordered_associative.html
-     */
-    size_t operator()(const COutPoint& id) const noexcept {
-        return SipHashUint256Extra(k0, k1, id.hash, id.n);
     }
 };
 

--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CUCKOOCACHE_H
 #define BITCOIN_CUCKOOCACHE_H
 
+#include <util/fastrange.h>
+
 #include <array>
 #include <algorithm> // std::find
 #include <atomic>
@@ -219,13 +221,8 @@ private:
      * One option would be to implement the same trick the compiler uses and compute the
      *  constants for exact division based on the size, as described in "{N}-bit Unsigned
      *  Division via {N}-bit Multiply-Add" by Arch D. Robison in 2005. But that code is
-     *  somewhat complicated and the result is still slower than other options:
-     *
-     * Instead we treat the 32-bit random number as a Q32 fixed-point number in the range
-     *  [0, 1) and simply multiply it by the size. Then we just shift the result down by
-     *  32-bits to get our bucket number. The result has non-uniformity the same as a
-     *  mod, but it is much faster to compute. More about this technique can be found at
-     *  http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/ .
+     *  somewhat complicated and the result is still slower than an even simpler option:
+     *  see the FastRange32 function in util/fastrange.h.
      *
      * The resulting non-uniformity is also more equally distributed which would be
      *  advantageous for something like linear probing, though it shouldn't matter
@@ -241,14 +238,14 @@ private:
      */
     inline std::array<uint32_t, 8> compute_hashes(const Element& e) const
     {
-        return {{(uint32_t)(((uint64_t)hash_function.template operator()<0>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)(((uint64_t)hash_function.template operator()<1>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)(((uint64_t)hash_function.template operator()<2>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)(((uint64_t)hash_function.template operator()<3>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)(((uint64_t)hash_function.template operator()<4>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)(((uint64_t)hash_function.template operator()<5>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)(((uint64_t)hash_function.template operator()<6>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)(((uint64_t)hash_function.template operator()<7>(e) * (uint64_t)size) >> 32)}};
+        return {{FastRange32(hash_function.template operator()<0>(e), size),
+                 FastRange32(hash_function.template operator()<1>(e), size),
+                 FastRange32(hash_function.template operator()<2>(e), size),
+                 FastRange32(hash_function.template operator()<3>(e), size),
+                 FastRange32(hash_function.template operator()<4>(e), size),
+                 FastRange32(hash_function.template operator()<5>(e), size),
+                 FastRange32(hash_function.template operator()<6>(e), size),
+                 FastRange32(hash_function.template operator()<7>(e), size)}};
     }
 
     /** invalid returns a special index that can never be inserted to

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -8,6 +8,7 @@
 #include <shutdown.h>
 #include <tinyformat.h>
 #include <ui_interface.h>
+#include <util/thread.h>
 #include <util/translation.h>
 #include <validation.h> // For g_chainman
 #include <warnings.h>
@@ -353,8 +354,7 @@ bool BaseIndex::Start(CChainState& active_chainstate)
         return false;
     }
 
-    m_thread_sync = std::thread(&TraceThread<std::function<void()>>, GetName(),
-                                std::bind(&BaseIndex::ThreadSync, this));
+    m_thread_sync = std::thread(&util::TraceThread, GetName(), [this] { ThreadSync(); });
     return true;
 }
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -9,14 +9,10 @@
 #include <chain.h>
 #include <flatfile.h>
 #include <index/base.h>
+#include <util/hasher.h>
 
 /** Interval between compact filter checkpoints. See BIP 157. */
 static constexpr int CFCHECKPT_INTERVAL = 1000;
-
-struct FilterHeaderHasher
-{
-    size_t operator()(const uint256& hash) const { return ReadLE64(hash.begin()); }
-};
 
 /**
  * BlockFilterIndex is used to store and retrieve block filters, hashes, and headers for a range of

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -321,7 +321,7 @@ bool CoinStatsIndex::LookUpStats(const CBlockIndex* block_index, CCoinsStats& co
     coins_stats.hashSerialized = entry.muhash;
     coins_stats.nTransactionOutputs = entry.transaction_output_count;
     coins_stats.nBogoSize = entry.bogo_size;
-    coins_stats.nTotalAmount = entry.total_amount;
+    coins_stats.total_amount = entry.total_amount;
     coins_stats.total_subsidy = entry.total_subsidy;
     coins_stats.total_unspendable_amount = entry.total_unspendable_amount;
     coins_stats.total_prevout_spent_amount = entry.total_prevout_spent_amount;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -61,6 +61,7 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>
+#include <util/thread.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
 #include <validation.h>
@@ -1618,7 +1619,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     node.scheduler = std::make_unique<CScheduler>();
 
     // Start the lightweight task scheduler thread
-    node.scheduler->m_service_thread = std::thread([&] { TraceThread("scheduler", [&] { node.scheduler->serviceQueue(); }); });
+    node.scheduler->m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { node.scheduler->serviceQueue(); });
 
     // Gather some entropy once per minute.
     node.scheduler->scheduleEvery([]{
@@ -2391,7 +2392,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         vImportFiles.push_back(strFile);
     }
 
-    chainman.m_load_block = std::thread(&TraceThread<std::function<void()>>, "loadblk", [=, &chainman, &args] {
+    chainman.m_load_block = std::thread(&util::TraceThread, "loadblk", [=, &chainman, &args] {
         ThreadImport(chainman, *pdsNotificationInterface ,vImportFiles, args);
     });
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -885,7 +885,9 @@ static void PeriodicStats(ArgsManager& args, const CTxMemPool& mempool)
         statsClient.gauge("utxoset.txOutputs", stats.nTransactionOutputs, 1.0f);
         statsClient.gauge("utxoset.dbSizeBytes", stats.nDiskSize, 1.0f);
         statsClient.gauge("utxoset.blockHeight", stats.nHeight, 1.0f);
-        statsClient.gauge("utxoset.totalAmount", (double)stats.nTotalAmount / (double)COIN, 1.0f);
+        if (stats.total_amount.has_value()) {
+            statsClient.gauge("utxoset.totalAmount", (double)stats.total_amount.value() / (double)COIN, 1.0f);
+        }
     } else {
         // something went wrong
         LogPrintf("%s: GetUTXOStats failed\n", __func__);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -296,7 +296,7 @@ void PrepareShutdown(NodeContext& node)
     node.banman.reset();
     node.addrman.reset();
 
-    if (node.mempool && node.mempool->IsLoaded() && node.args->GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
+    if (node.mempool && node.mempool->IsLoaded() && node.args->GetBoolArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         DumpMempool(*node.mempool);
     }
 
@@ -1231,10 +1231,10 @@ bool AppInitParameterInteraction(const ArgsManager& args)
 
     if (args.IsArgSet("-devnet")) {
         // Require setting of ports when running devnet
-        if (args.GetArg("-listen", DEFAULT_LISTEN) && !args.IsArgSet("-port")) {
+        if (args.GetBoolArg("-listen", DEFAULT_LISTEN) && !args.IsArgSet("-port")) {
             return InitError(_("-port must be specified when -devnet and -listen are specified"));
         }
-        if (args.GetArg("-server", false) && !args.IsArgSet("-rpcport")) {
+        if (args.GetBoolArg("-server", false) && !args.IsArgSet("-rpcport")) {
             return InitError(_("-rpcport must be specified when -devnet and -server are specified"));
         }
         if (args.GetArgs("-devnet").size() > 1) {

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -37,7 +37,7 @@ struct NodeContext;
 
 namespace interfaces {
 class Handler;
-class WalletClient;
+class WalletLoader;
 struct BlockTip;
 
 //! Interface for the src/evo part of a dash node (dashd process).
@@ -284,8 +284,8 @@ public:
     //! Get unspent outputs associated with a transaction.
     virtual bool getUnspentOutput(const COutPoint& output, Coin& coin) = 0;
 
-    //! Get wallet client.
-    virtual WalletClient& walletClient() = 0;
+    //! Get wallet loader.
+    virtual WalletLoader& walletLoader() = 0;
 
     //! Return interface for accessing evo related handler.
     virtual EVO& evo() = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -349,7 +349,7 @@ public:
 //! Wallet chain client that in addition to having chain client methods for
 //! starting up, shutting down, and registering RPCs, also has additional
 //! methods (called by the GUI) to load and create wallets.
-class WalletClient : public ChainClient
+class WalletLoader : public ChainClient
 {
 public:
     //! Create new wallet.
@@ -456,9 +456,9 @@ struct WalletTxOut
 //! dummywallet.cpp and throws if the wallet component is not compiled.
 std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet);
 
-//! Return implementation of ChainClient interface for a wallet client. This
+//! Return implementation of ChainClient interface for a wallet loader. This
 //! function will be undefined in builds where ENABLE_WALLET is false.
-std::unique_ptr<WalletClient> MakeWalletClient(Chain& chain, ArgsManager& args);
+std::unique_ptr<WalletLoader> MakeWalletLoader(Chain& chain, ArgsManager& args);
 
 } // namespace interfaces
 

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -18,6 +18,7 @@
 #include <spork.h>
 #include <txmempool.h>
 #include <ui_interface.h>
+#include <util/thread.h>
 #include <validation.h>
 
 namespace llmq
@@ -37,7 +38,7 @@ CChainLocksHandler::CChainLocksHandler(CChainState& chainstate, CConnman& _connm
     mempool(_mempool),
     m_peerman(peerman),
     scheduler(std::make_unique<CScheduler>()),
-    scheduler_thread(std::make_unique<std::thread>([&] { TraceThread("cl-schdlr", [&] { scheduler->serviceQueue(); }); }))
+    scheduler_thread(std::make_unique<std::thread>(std::thread(util::TraceThread, "cl-schdlr", [&] { scheduler->serviceQueue(); })))
 {
 }
 

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -16,6 +16,7 @@
 #include <chainparams.h>
 #include <net_processing.h>
 #include <validation.h>
+#include <util/thread.h>
 #include <util/underlying.h>
 
 namespace llmq
@@ -151,8 +152,8 @@ void CDKGSessionHandler::StartThread()
         throw std::runtime_error("Tried to start an already started CDKGSessionHandler thread.");
     }
 
-    std::string threadName = strprintf("llmq-%d-%d", ToUnderlying(params.type), quorumIndex);
-    phaseHandlerThread = std::thread(&TraceThread<std::function<void()> >, threadName, std::function<void()>(std::bind(&CDKGSessionHandler::PhaseHandlerThread, this)));
+    m_thread_name = strprintf("llmq-%d-%d", ToUnderlying(params.type), quorumIndex);
+    phaseHandlerThread = std::thread(util::TraceThread, m_thread_name.c_str(), [this] { PhaseHandlerThread(); });
 }
 
 void CDKGSessionHandler::StopThread()

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -127,6 +127,7 @@ private:
 
     std::unique_ptr<CDKGSession> curSession;
     std::thread phaseHandlerThread;
+    std::string m_thread_name;
 
     // Do not guard these, they protect their internals themselves
     CDKGPendingMessages pendingContributions;

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -20,6 +20,7 @@
 #include <txmempool.h>
 #include <util/irange.h>
 #include <util/ranges.h>
+#include <util/thread.h>
 #include <validation.h>
 
 #include <cxxtimer.hpp>
@@ -459,7 +460,7 @@ void CInstantSendManager::Start()
         assert(false);
     }
 
-    workThread = std::thread(&TraceThread<std::function<void()> >, "isman", std::function<void()>(std::bind(&CInstantSendManager::WorkThreadMain, this)));
+    workThread = std::thread(&util::TraceThread, "isman", [this] { WorkThreadMain(); });
 
     sigman.RegisterRecoveredSigsListener(this);
 }

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -17,6 +17,7 @@
 #include <netmessagemaker.h>
 #include <spork.h>
 #include <util/irange.h>
+#include <util/thread.h>
 #include <util/underlying.h>
 
 #include <cxxtimer.hpp>
@@ -183,9 +184,7 @@ void CSigSharesManager::StartWorkerThread()
         assert(false);
     }
 
-    workThread = std::thread(&TraceThread<std::function<void()> >,
-        "sigshares",
-        std::function<void()>(std::bind(&CSigSharesManager::WorkThreadMain, this)));
+    workThread = std::thread(&util::TraceThread, "sigshares", [this] { WorkThreadMain(); });
 }
 
 void CSigSharesManager::StopWorkerThread()

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -15,6 +15,7 @@
 #include <netbase.h>
 #include <threadinterrupt.h>
 #include <util/system.h>
+#include <util/thread.h>
 
 #ifdef USE_NATPMP
 #include <compat.h>
@@ -255,7 +256,7 @@ void StartThreadMapPort()
 {
     if (!g_mapport_thread.joinable()) {
         assert(!g_mapport_interrupt);
-        g_mapport_thread = std::thread(std::bind(&TraceThread<void (*)()>, "mapport", &ThreadMapPort));
+        g_mapport_thread = std::thread(&util::TraceThread, "mapport", &ThreadMapPort);
     }
 }
 

--- a/src/node/coinstats.h
+++ b/src/node/coinstats.h
@@ -24,9 +24,10 @@ enum class CoinStatsHashType {
     NONE,
 };
 
-struct CCoinsStats
-{
-    CoinStatsHashType m_hash_type;
+struct CCoinsStats {
+    //! Which hash type to use
+    const CoinStatsHashType m_hash_type;
+
     int nHeight{0};
     uint256 hashBlock{};
     uint64_t nTransactions{0};
@@ -34,7 +35,8 @@ struct CCoinsStats
     uint64_t nBogoSize{0};
     uint256 hashSerialized{};
     uint64_t nDiskSize{0};
-    CAmount nTotalAmount{0};
+    //! The total amount, or nullopt if an overflow occurred calculating it
+    std::optional<CAmount> total_amount{0};
 
     //! The number of coins contained.
     uint64_t coins_count{0};

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -25,7 +25,7 @@ class CEvoDB;
 namespace interfaces {
 class Chain;
 class ChainClient;
-class WalletClient;
+class WalletLoader;
 } // namespace interfaces
 
 //! NodeContext struct containing references to chain state and connection
@@ -52,7 +52,7 @@ struct NodeContext {
     std::vector<std::unique_ptr<interfaces::ChainClient>> chain_clients;
     //! Reference to chain client that should used to load or create wallets
     //! opened by the gui.
-    interfaces::WalletClient* wallet_client{nullptr};
+    interfaces::WalletLoader* wallet_loader{nullptr};
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};
     //! Dash

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -71,7 +71,7 @@ using interfaces::Handler;
 using interfaces::LLMQ;
 using interfaces::MakeHandler;
 using interfaces::Node;
-using interfaces::WalletClient;
+using interfaces::WalletLoader;
 
 namespace node {
 namespace {
@@ -431,9 +431,9 @@ public:
         assert(std::addressof(::ChainstateActive()) == std::addressof(chainman().ActiveChainstate()));
         return chainman().ActiveChainstate().CoinsTip().GetCoin(output, coin);
     }
-    WalletClient& walletClient() override
+    WalletLoader& walletLoader() override
     {
-        return *Assert(m_context->wallet_client);
+        return *Assert(m_context->wallet_loader);
     }
 
     EVO& evo() override { return m_evo; }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -37,6 +37,7 @@
 #include <ui_interface.h>
 #include <uint256.h>
 #include <util/system.h>
+#include <util/threadnames.h>
 #include <util/translation.h>
 
 #include <memory>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1357,7 +1357,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QStri
     bool disableAppNap = !m_node.masternodeSync().isSynced();
 #ifdef ENABLE_WALLET
     if (enableWallet) {
-        for (const auto& wallet : m_node.walletClient().getWallets()) {
+        for (const auto& wallet : m_node.walletLoader().getWallets()) {
             disableAppNap |= wallet->coinJoin().isMixing();
         }
     }
@@ -1725,7 +1725,7 @@ void BitcoinGUI::showIncomingTransactions()
             // On new transaction, make an info balloon
             QString msg = tr("Date: %1\n").arg(itx.date) +
                           tr("Amount: %1\n").arg(BitcoinUnits::formatWithUnit(itx.unit, itx.amount, true));
-            if (m_node.walletClient().getWallets().size() > 1 && !itx.walletName.isEmpty()) {
+            if (m_node.walletLoader().getWallets().size() > 1 && !itx.walletName.isEmpty()) {
                 msg += tr("Wallet: %1\n").arg(itx.walletName);
             }
             msg += tr("Type: %1\n").arg(itx.type);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -404,7 +404,7 @@ void OptionsDialog::on_okButton_clicked()
     appearance->accept();
 #ifdef ENABLE_WALLET
     if (m_enable_wallet) {
-        for (auto& wallet : model->node().walletClient().getWallets()) {
+        for (auto& wallet : model->node().walletLoader().getWallets()) {
             wallet->coinJoin().resetCachedBlocks();
             wallet->markDirty();
         }

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -189,7 +189,7 @@ void SplashScreen::handleLoadWallet()
 {
 #ifdef ENABLE_WALLET
     if (!WalletModel::isWalletEnabled()) return;
-    m_handler_load_wallet = m_node.walletClient().handleLoadWallet([this](std::unique_ptr<interfaces::Wallet> wallet) {
+    m_handler_load_wallet = m_node.walletLoader().handleLoadWallet([this](std::unique_ptr<interfaces::Wallet> wallet) {
         m_connected_wallet_handlers.emplace_back(wallet->handleShowProgress(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2, false)));
         m_connected_wallets.emplace_back(std::move(wallet));
     });

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -34,11 +34,11 @@ WalletController::WalletController(ClientModel& client_model, QObject* parent)
     , m_node(client_model.node())
     , m_options_model(client_model.getOptionsModel())
 {
-    m_handler_load_wallet = m_node.walletClient().handleLoadWallet([this](std::unique_ptr<interfaces::Wallet> wallet) {
+    m_handler_load_wallet = m_node.walletLoader().handleLoadWallet([this](std::unique_ptr<interfaces::Wallet> wallet) {
         getOrCreateWallet(std::move(wallet));
     });
 
-    for (std::unique_ptr<interfaces::Wallet>& wallet : m_node.walletClient().getWallets()) {
+    for (std::unique_ptr<interfaces::Wallet>& wallet : m_node.walletLoader().getWallets()) {
         getOrCreateWallet(std::move(wallet));
     }
 
@@ -65,7 +65,7 @@ std::map<std::string, bool> WalletController::listWalletDir() const
 {
     QMutexLocker locker(&m_mutex);
     std::map<std::string, bool> wallets;
-    for (const std::string& name : m_node.walletClient().listWalletDir()) {
+    for (const std::string& name : m_node.walletLoader().listWalletDir()) {
         wallets[name] = false;
     }
     for (WalletModel* wallet_model : m_wallets) {
@@ -228,7 +228,7 @@ void CreateWalletActivity::createWallet()
     }
 
     QTimer::singleShot(500, worker(), [this, name, flags] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_passphrase, flags, m_error_message, m_warning_message);
+        std::unique_ptr<interfaces::Wallet> wallet = node().walletLoader().createWallet(name, m_passphrase, flags, m_error_message, m_warning_message);
 
         if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
 
@@ -299,7 +299,7 @@ void OpenWalletActivity::open(const std::string& path)
     showProgressDialog(tr("Opening Wallet <b>%1</b>...").arg(name.toHtmlEscaped()));
 
     QTimer::singleShot(0, worker(), [this, path] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().loadWallet(path, m_error_message, m_warning_message);
+        std::unique_ptr<interfaces::Wallet> wallet = node().walletLoader().loadWallet(path, m_error_message, m_warning_message);
 
         if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -606,7 +606,7 @@ QString WalletModel::getDisplayName() const
 
 bool WalletModel::isMultiwallet()
 {
-    return m_node.walletClient().getWallets().size() > 1;
+    return m_node.walletLoader().getWallets().size() > 1;
 }
 
 uint256 WalletModel::getLastBlockProcessed() const

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1423,9 +1423,10 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
             ret.pushKV("hash_serialized_2", stats.hashSerialized.GetHex());
         }
         if (hash_type == CoinStatsHashType::MUHASH) {
-              ret.pushKV("muhash", stats.hashSerialized.GetHex());
+            ret.pushKV("muhash", stats.hashSerialized.GetHex());
         }
-        ret.pushKV("total_amount", ValueFromAmount(stats.nTotalAmount));
+        CHECK_NONFATAL(stats.total_amount.has_value());
+        ret.pushKV("total_amount", ValueFromAmount(stats.total_amount.value()));
         if (!stats.index_used) {
             ret.pushKV("transactions", static_cast<int64_t>(stats.nTransactions));
             ret.pushKV("disk_size", stats.nDiskSize);

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -7,6 +7,7 @@
 #define BITCOIN_SCRIPT_SIGCACHE_H
 
 #include <script/interpreter.h>
+#include <util/hasher.h>
 
 #include <vector>
 
@@ -18,27 +19,6 @@ static const unsigned int DEFAULT_MAX_SIG_CACHE_SIZE = 32;
 static const int64_t MAX_MAX_SIG_CACHE_SIZE = 16384;
 
 class CPubKey;
-
-/**
- * We're hashing a nonce into the entries themselves, so we don't need extra
- * blinding in the set hash computation.
- *
- * This may exhibit platform endian dependent behavior but because these are
- * nonced hashes (random) and this state is only ever used locally it is safe.
- * All that matters is local consistency.
- */
-class SignatureCacheHasher
-{
-public:
-    template <uint8_t hash_select>
-    uint32_t operator()(const uint256& key) const
-    {
-        static_assert(hash_select <8, "SignatureCacheHasher only has 8 hashes available.");
-        uint32_t u;
-        std::memcpy(&u, key.begin()+4*hash_select, 4);
-        return u;
-    }
-};
 
 class CachingTransactionSignatureChecker : public TransactionSignatureChecker
 {

--- a/src/test/fuzz/addition_overflow.cpp
+++ b/src/test/fuzz/addition_overflow.cpp
@@ -5,6 +5,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/overflow.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
+++ b/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
@@ -7,6 +7,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/overflow.h>
 
 #include <cassert>
 #include <cstdint>

--- a/src/test/fuzz/golomb_rice.cpp
+++ b/src/test/fuzz/golomb_rice.cpp
@@ -25,7 +25,7 @@ uint64_t HashToRange(const std::vector<uint8_t>& element, const uint64_t f)
     const uint64_t hash = CSipHasher(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL)
                               .Write(element.data(), element.size())
                               .Finalize();
-    return MapIntoRange(hash, f);
+    return FastRange64(hash, f);
 }
 
 std::vector<uint64_t> BuildHashedSet(const std::unordered_set<std::vector<uint8_t>, ByteVectorHash>& elements, const uint64_t f)

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -27,6 +27,7 @@
 #include <uint256.h>
 #include <util/check.h>
 #include <util/moneystr.h>
+#include <util/overflow.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -9,6 +9,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <util/overflow.h>
 
 #include <cstdint>
 #include <optional>

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -3,6 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <test/fuzz/util.h>
+
+#include <util/overflow.h>
 #include <version.h>
 
 FuzzedSock::FuzzedSock(FuzzedDataProvider& fuzzed_data_provider)

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -27,6 +27,7 @@
 #include <test/util/setup_common.h>
 #include <txmempool.h>
 #include <uint256.h>
+#include <util/overflow.h>
 #include <util/time.h>
 #include <util/vector.h>
 #include <version.h>
@@ -215,17 +216,6 @@ template <typename T>
     } else {
         return j != 0 && i > std::numeric_limits<T>::max() / j;
     }
-}
-
-template <class T>
-[[ nodiscard ]] bool AdditionOverflow(const T i, const T j) noexcept
-{
-    static_assert(std::is_integral<T>::value, "Integral required.");
-    if (std::numeric_limits<T>::is_signed) {
-        return (i > 0 && j > std::numeric_limits<T>::max() - i) ||
-               (i < 0 && j < std::numeric_limits<T>::min() - i);
-    }
-    return std::numeric_limits<T>::max() - i < j;
 }
 
 [[ nodiscard ]] inline bool ContainsSpentInput(const CTransaction& tx, const CCoinsViewCache& inputs) noexcept

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -43,6 +43,8 @@
 #include <txdb.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <util/thread.h>
+#include <util/threadnames.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <util/url.h>
@@ -188,7 +190,7 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     // We have to run a scheduler thread to prevent ActivateBestChain
     // from blocking due to queue overrun.
     m_node.scheduler = std::make_unique<CScheduler>();
-    m_node.scheduler->m_service_thread = std::thread([&] { TraceThread("scheduler", [&] { m_node.scheduler->serviceQueue(); }); });
+    m_node.scheduler->m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { m_node.scheduler->serviceQueue(); });
     GetMainSignals().RegisterBackgroundSignalScheduler(*m_node.scheduler);
 
     pblocktree.reset(new CBlockTreeDB(1 << 20, true));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -51,6 +51,31 @@ namespace BCLog {
 
 BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
+namespace {
+class NoCopyOrMove
+{
+public:
+    int i;
+    explicit NoCopyOrMove(int i) : i{i} { }
+
+    NoCopyOrMove() = delete;
+    NoCopyOrMove(const NoCopyOrMove&) = delete;
+    NoCopyOrMove(NoCopyOrMove&&) = delete;
+    NoCopyOrMove& operator=(const NoCopyOrMove&) = delete;
+    NoCopyOrMove& operator=(NoCopyOrMove&&) = delete;
+
+    operator bool() const { return i != 0; }
+
+    int get_ip1() { return i + 1; }
+    bool test()
+    {
+        // Check that Assume can be used within a lambda and still call methods
+        [&]() { Assume(get_ip1()); }();
+        return Assume(get_ip1() != 5);
+    }
+};
+} // namespace
+
 BOOST_AUTO_TEST_CASE(util_check)
 {
     // Check that Assert can forward
@@ -62,6 +87,14 @@ BOOST_AUTO_TEST_CASE(util_check)
     // Check that Assume can be used as unary expression
     const bool result{Assume(two == 2)};
     Assert(result);
+
+    // Check that Assert doesn't require copy/move
+    NoCopyOrMove x{9};
+    Assert(x).i += 3;
+    Assert(x).test();
+
+    // Check nested Asserts
+    BOOST_CHECK_EQUAL(Assert((Assert(x).test() ? 3 : 0)), 3);
 }
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -15,6 +15,7 @@
 #include <util/getuniquepath.h>
 #include <util/message.h> // For MessageSign(), MessageVerify(), MESSAGE_MAGIC
 #include <util/moneystr.h>
+#include <util/overflow.h>
 #include <util/ranges_set.h>
 #include <util/spanparsing.h>
 #include <util/strencodings.h>
@@ -1447,6 +1448,38 @@ BOOST_AUTO_TEST_CASE(test_IsDigit)
     BOOST_CHECK_EQUAL(IsDigit(1), false);
     BOOST_CHECK_EQUAL(IsDigit(8), false);
     BOOST_CHECK_EQUAL(IsDigit(9), false);
+}
+
+/* Check for overflow */
+template <typename T>
+static void TestAddMatrixOverflow()
+{
+    constexpr T MAXI{std::numeric_limits<T>::max()};
+    BOOST_CHECK(!CheckedAdd(T{1}, MAXI));
+    BOOST_CHECK(!CheckedAdd(MAXI, MAXI));
+    BOOST_CHECK_EQUAL(0, CheckedAdd(T{0}, T{0}).value());
+    BOOST_CHECK_EQUAL(MAXI, CheckedAdd(T{0}, MAXI).value());
+    BOOST_CHECK_EQUAL(MAXI, CheckedAdd(T{1}, MAXI - 1).value());
+}
+
+/* Check for overflow or underflow */
+template <typename T>
+static void TestAddMatrix()
+{
+    TestAddMatrixOverflow<T>();
+    constexpr T MINI{std::numeric_limits<T>::min()};
+    constexpr T MAXI{std::numeric_limits<T>::max()};
+    BOOST_CHECK(!CheckedAdd(T{-1}, MINI));
+    BOOST_CHECK(!CheckedAdd(MINI, MINI));
+    BOOST_CHECK_EQUAL(MINI, CheckedAdd(T{0}, MINI).value());
+    BOOST_CHECK_EQUAL(MINI, CheckedAdd(T{-1}, MINI + 1).value());
+    BOOST_CHECK_EQUAL(-1, CheckedAdd(MINI, MAXI).value());
+}
+
+BOOST_AUTO_TEST_CASE(util_overflow)
+{
+    TestAddMatrixOverflow<unsigned>();
+    TestAddMatrix<signed>();
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseInt32)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -52,6 +52,28 @@ namespace BCLog {
 
 BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(util_datadir)
+{
+    ClearDatadirCache();
+    const fs::path dd_norm = GetDataDir();
+
+    gArgs.ForceSetArg("-datadir", dd_norm.string() + "/");
+    ClearDatadirCache();
+    BOOST_CHECK_EQUAL(dd_norm, GetDataDir());
+
+    gArgs.ForceSetArg("-datadir", dd_norm.string() + "/.");
+    ClearDatadirCache();
+    BOOST_CHECK_EQUAL(dd_norm, GetDataDir());
+
+    gArgs.ForceSetArg("-datadir", dd_norm.string() + "/./");
+    ClearDatadirCache();
+    BOOST_CHECK_EQUAL(dd_norm, GetDataDir());
+
+    gArgs.ForceSetArg("-datadir", dd_norm.string() + "/.//");
+    ClearDatadirCache();
+    BOOST_CHECK_EQUAL(dd_norm, GetDataDir());
+}
+
 namespace {
 class NoCopyOrMove
 {

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -15,6 +15,7 @@
 #include <util/readwritefile.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/thread.h>
 #include <util/time.h>
 
 #include <vector>
@@ -601,7 +602,7 @@ void StartTorControl(CService onion_service_target)
         return;
     }
 
-    torControlThread = std::thread(&TraceThread<std::function<void()>>, "torcontrol", [onion_service_target] {
+    torControlThread = std::thread(&util::TraceThread, "torcontrol", [onion_service_target] {
         TorControlThread(onion_service_target);
     });
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1682,5 +1682,3 @@ void CTxMemPool::SetIsLoaded(bool loaded)
     LOCK(cs);
     m_is_loaded = loaded;
 }
-
-SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -25,6 +25,7 @@
 #include <evo/deterministicmns.h>
 #include <llmq/instantsend.h>
 
+#include <cmath>
 #include <optional>
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -18,7 +18,6 @@
 #include <spentindex.h>
 #include <amount.h>
 #include <coins.h>
-#include <crypto/siphash.h>
 #include <indirectmap.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
@@ -26,6 +25,7 @@
 #include <random.h>
 #include <netaddress.h>
 #include <pubkey.h>
+#include <util/hasher.h>
 
 #include <boost/optional.hpp>
 #include <boost/multi_index_container.hpp>
@@ -366,20 +366,6 @@ enum class MemPoolRemovalReason {
     BLOCK,       //!< Removed for block
     CONFLICT,    //!< Removed for conflict with in-block transaction
     MANUAL       //!< Removed manually
-};
-
-class SaltedTxidHasher
-{
-private:
-    /** Salt */
-    const uint64_t k0, k1;
-
-public:
-    SaltedTxidHasher();
-
-    size_t operator()(const uint256& txid) const {
-        return SipHashUint256(k0, k1, txid);
-    }
 };
 
 /**

--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/check.h>
+
+#include <tinyformat.h>
+
+void assertion_fail(const char* file, int line, const char* func, const char* assertion)
+{
+    auto str = strprintf("%s:%s %s: Assertion `%s' failed.\n", file, line, func, assertion);
+    fwrite(str.data(), 1, str.size(), stderr);
+    std::abort();
+}

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -47,14 +47,26 @@ class NonFatalCheckError : public std::runtime_error
 #endif
 
 /** Helper for Assert() */
-template <typename T>
-T get_pure_r_value(T&& val)
+void assertion_fail(const char* file, int line, const char* func, const char* assertion);
+
+/** Helper for Assert()/Assume() */
+template <bool IS_ASSERT, typename T>
+T&& inline_assertion_check(T&& val, const char* file, int line, const char* func, const char* assertion)
 {
+    if constexpr (IS_ASSERT
+#ifdef ABORT_ON_FAILED_ASSUME
+                  || true
+#endif
+    ) {
+        if (!val) {
+            assertion_fail(file, line, func, assertion);
+        }
+    }
     return std::forward<T>(val);
 }
 
 /** Identity function. Abort if the value compares equal to zero */
-#define Assert(val) ([&]() -> decltype(get_pure_r_value(val)) { auto&& check = (val); assert(#val && check); return std::forward<decltype(get_pure_r_value(val))>(check); }())
+#define Assert(val) inline_assertion_check<true>(val, __FILE__, __LINE__, __func__, #val)
 
 /**
  * Assume is the identity function.
@@ -66,10 +78,6 @@ T get_pure_r_value(T&& val)
  * - For non-fatal errors in interactive sessions (e.g. RPC or command line
  *   interfaces), CHECK_NONFATAL() might be more appropriate.
  */
-#ifdef ABORT_ON_FAILED_ASSUME
-#define Assume(val) Assert(val)
-#else
-#define Assume(val) ([&]() -> decltype(get_pure_r_value(val)) { auto&& check = (val); return std::forward<decltype(get_pure_r_value(val))>(check); }())
-#endif
+#define Assume(val) inline_assertion_check<false>(val, __FILE__, __LINE__, __func__, #val)
 
 #endif // BITCOIN_UTIL_CHECK_H

--- a/src/util/fastrange.h
+++ b/src/util/fastrange.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2018-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_FASTRANGE_H
+#define BITCOIN_UTIL_FASTRANGE_H
+
+#include <cstdint>
+
+/* This file offers implementations of the fast range reduction technique described
+ * in https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+ *
+ * In short, they take an integer x and a range n, and return the upper bits of
+ * (x * n). If x is uniformly distributed over its domain, the result is as close to
+ * uniformly distributed over [0, n) as (x mod n) would be, but significantly faster.
+ */
+
+/** Fast range reduction with 32-bit input and 32-bit range. */
+static inline uint32_t FastRange32(uint32_t x, uint32_t n)
+{
+    return (uint64_t{x} * n) >> 32;
+}
+
+/** Fast range reduction with 64-bit input and 64-bit range. */
+static inline uint64_t FastRange64(uint64_t x, uint64_t n)
+{
+#ifdef __SIZEOF_INT128__
+    return (static_cast<unsigned __int128>(x) * static_cast<unsigned __int128>(n)) >> 64;
+#else
+    // To perform the calculation on 64-bit numbers without losing the
+    // result to overflow, split the numbers into the most significant and
+    // least significant 32 bits and perform multiplication piece-wise.
+    //
+    // See: https://stackoverflow.com/a/26855440
+    const uint64_t x_hi = x >> 32;
+    const uint64_t x_lo = x & 0xFFFFFFFF;
+    const uint64_t n_hi = n >> 32;
+    const uint64_t n_lo = n & 0xFFFFFFFF;
+
+    const uint64_t ac = x_hi * n_hi;
+    const uint64_t ad = x_hi * n_lo;
+    const uint64_t bc = x_lo * n_hi;
+    const uint64_t bd = x_lo * n_lo;
+
+    const uint64_t mid34 = (bd >> 32) + (bc & 0xFFFFFFFF) + (ad & 0xFFFFFFFF);
+    const uint64_t upper64 = ac + (bc >> 32) + (ad >> 32) + (mid34 >> 32);
+    return upper64;
+#endif
+}
+
+#endif // BITCOIN_UTIL_FASTRANGE_H

--- a/src/util/golombrice.h
+++ b/src/util/golombrice.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_UTIL_GOLOMBRICE_H
 #define BITCOIN_UTIL_GOLOMBRICE_H
 
+#include <util/fastrange.h>
+
 #include <streams.h>
 
 #include <cstdint>
@@ -38,37 +40,6 @@ uint64_t GolombRiceDecode(BitStreamReader<IStream>& bitreader, uint8_t P)
     uint64_t r = bitreader.Read(P);
 
     return (q << P) + r;
-}
-
-// Map a value x that is uniformly distributed in the range [0, 2^64) to a
-// value uniformly distributed in [0, n) by returning the upper 64 bits of
-// x * n.
-//
-// See: https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
-static inline uint64_t MapIntoRange(uint64_t x, uint64_t n)
-{
-#ifdef __SIZEOF_INT128__
-    return (static_cast<unsigned __int128>(x) * static_cast<unsigned __int128>(n)) >> 64;
-#else
-    // To perform the calculation on 64-bit numbers without losing the
-    // result to overflow, split the numbers into the most significant and
-    // least significant 32 bits and perform multiplication piece-wise.
-    //
-    // See: https://stackoverflow.com/a/26855440
-    const uint64_t x_hi = x >> 32;
-    const uint64_t x_lo = x & 0xFFFFFFFF;
-    const uint64_t n_hi = n >> 32;
-    const uint64_t n_lo = n & 0xFFFFFFFF;
-
-    const uint64_t ac = x_hi * n_hi;
-    const uint64_t ad = x_hi * n_lo;
-    const uint64_t bc = x_lo * n_hi;
-    const uint64_t bd = x_lo * n_lo;
-
-    const uint64_t mid34 = (bd >> 32) + (bc & 0xFFFFFFFF) + (ad & 0xFFFFFFFF);
-    const uint64_t upper64 = ac + (bc >> 32) + (ad >> 32) + (mid34 >> 32);
-    return upper64;
-#endif
 }
 
 #endif // BITCOIN_UTIL_GOLOMBRICE_H

--- a/src/util/hasher.cpp
+++ b/src/util/hasher.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <random.h>
+#include <util/hasher.h>
+
+#include <limits>
+
+SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
+
+SaltedOutpointHasher::SaltedOutpointHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
+
+SaltedSipHasher::SaltedSipHasher() : m_k0(GetRand(std::numeric_limits<uint64_t>::max())), m_k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
+
+size_t SaltedSipHasher::operator()(const Span<const unsigned char>& script) const
+{
+    return CSipHasher(m_k0, m_k1).Write(script.data(), script.size()).Finalize();
+}

--- a/src/util/hasher.h
+++ b/src/util/hasher.h
@@ -1,0 +1,99 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_HASHER_H
+#define BITCOIN_UTIL_HASHER_H
+
+#include <crypto/siphash.h>
+#include <primitives/transaction.h>
+#include <uint256.h>
+
+class SaltedTxidHasher
+{
+private:
+    /** Salt */
+    const uint64_t k0, k1;
+
+public:
+    SaltedTxidHasher();
+
+    size_t operator()(const uint256& txid) const {
+        return SipHashUint256(k0, k1, txid);
+    }
+};
+
+class SaltedOutpointHasher
+{
+private:
+    /** Salt */
+    const uint64_t k0, k1;
+
+public:
+    SaltedOutpointHasher();
+
+    /**
+     * This *must* return size_t. With Boost 1.46 on 32-bit systems the
+     * unordered_map will behave unpredictably if the custom hasher returns a
+     * uint64_t, resulting in failures when syncing the chain (#4634).
+     *
+     * Having the hash noexcept allows libstdc++'s unordered_map to recalculate
+     * the hash during rehash, so it does not have to cache the value. This
+     * reduces node's memory by sizeof(size_t). The required recalculation has
+     * a slight performance penalty (around 1.6%), but this is compensated by
+     * memory savings of about 9% which allow for a larger dbcache setting.
+     *
+     * @see https://gcc.gnu.org/onlinedocs/gcc-9.2.0/libstdc++/manual/manual/unordered_associative.html
+     */
+    size_t operator()(const COutPoint& id) const noexcept {
+        return SipHashUint256Extra(k0, k1, id.hash, id.n);
+    }
+};
+
+struct FilterHeaderHasher
+{
+    size_t operator()(const uint256& hash) const { return ReadLE64(hash.begin()); }
+};
+
+/**
+ * We're hashing a nonce into the entries themselves, so we don't need extra
+ * blinding in the set hash computation.
+ *
+ * This may exhibit platform endian dependent behavior but because these are
+ * nonced hashes (random) and this state is only ever used locally it is safe.
+ * All that matters is local consistency.
+ */
+class SignatureCacheHasher
+{
+public:
+    template <uint8_t hash_select>
+    uint32_t operator()(const uint256& key) const
+    {
+        static_assert(hash_select <8, "SignatureCacheHasher only has 8 hashes available.");
+        uint32_t u;
+        std::memcpy(&u, key.begin()+4*hash_select, 4);
+        return u;
+    }
+};
+
+struct BlockHasher
+{
+    // this used to call `GetCheapHash()` in uint256, which was later moved; the
+    // cheap hash function simply calls ReadLE64() however, so the end result is
+    // identical
+    size_t operator()(const uint256& hash) const { return ReadLE64(hash.begin()); }
+};
+
+class SaltedSipHasher
+{
+private:
+    /** Salt */
+    const uint64_t m_k0, m_k1;
+
+public:
+    SaltedSipHasher();
+
+    size_t operator()(const Span<const unsigned char>& script) const;
+};
+
+#endif // BITCOIN_UTIL_HASHER_H

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -8,4 +8,11 @@
 #define PASTE(x, y) x ## y
 #define PASTE2(x, y) PASTE(x, y)
 
+/**
+ * Converts the parameter X to a string after macro replacement on X has been performed.
+ * Don't merge these into one macro!
+ */
+#define STRINGIZE(X) DO_STRINGIZE(X)
+#define DO_STRINGIZE(X) #X
+
 #endif // BITCOIN_UTIL_MACROS_H

--- a/src/util/overflow.h
+++ b/src/util/overflow.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_OVERFLOW_H
+#define BITCOIN_UTIL_OVERFLOW_H
+
+#include <limits>
+#include <type_traits>
+
+template <class T>
+[[nodiscard]] bool AdditionOverflow(const T i, const T j) noexcept
+{
+    static_assert(std::is_integral<T>::value, "Integral required.");
+    if (std::numeric_limits<T>::is_signed) {
+        return (i > 0 && j > std::numeric_limits<T>::max() - i) ||
+               (i < 0 && j < std::numeric_limits<T>::min() - i);
+    }
+    return std::numeric_limits<T>::max() - i < j;
+}
+
+template <class T>
+[[nodiscard]] std::optional<T> CheckedAdd(const T i, const T j) noexcept
+{
+    if (AdditionOverflow(i, j)) {
+        return std::nullopt;
+    }
+    return i + j;
+}
+
+#endif // BITCOIN_UTIL_OVERFLOW_H

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -91,7 +91,7 @@ std::vector<unsigned char> ParseHex(const char* psz)
         signed char c = HexDigit(*psz++);
         if (c == (signed char)-1)
             break;
-        unsigned char n = (c << 4);
+        auto n{uint8_t(c << 4)};
         c = HexDigit(*psz++);
         if (c == (signed char)-1)
             break;
@@ -145,8 +145,7 @@ std::string EncodeBase64(const std::string& str)
 
 std::vector<unsigned char> DecodeBase64(const char* p, bool* pf_invalid)
 {
-    static const int decode64_table[256] =
-    {
+    static const int8_t decode64_table[256]{
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, 62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1,
@@ -168,7 +167,7 @@ std::vector<unsigned char> DecodeBase64(const char* p, bool* pf_invalid)
     while (*p != 0) {
         int x = decode64_table[(unsigned char)*p];
         if (x == -1) break;
-        val.push_back(x);
+        val.push_back(uint8_t(x));
         ++p;
     }
 
@@ -224,8 +223,7 @@ std::string EncodeBase32(const std::string& str, bool pad)
 
 std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid)
 {
-    static const int decode32_table[256] =
-    {
+    static const int8_t decode32_table[256]{
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31, -1, -1, -1, -1,
@@ -247,7 +245,7 @@ std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid)
     while (*p != 0) {
         int x = decode32_table[(unsigned char)*p];
         if (x == -1) break;
-        val.push_back(x);
+        val.push_back(uint8_t(x));
         ++p;
     }
 
@@ -540,14 +538,14 @@ std::string HexStr(const Span<const uint8_t> s)
 std::string ToLower(const std::string& str)
 {
     std::string r;
-    for (auto ch : str) r += ToLower((unsigned char)ch);
+    for (auto ch : str) r += ToLower(ch);
     return r;
 }
 
 std::string ToUpper(const std::string& str)
 {
     std::string r;
-    for (auto ch : str) r += ToUpper((unsigned char)ch);
+    for (auto ch : str) r += ToUpper(ch);
     return r;
 }
 

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -212,7 +212,7 @@ bool TimingResistantEqual(const T& a, const T& b)
     if (b.size() == 0) return a.size() == 0;
     size_t accumulator = a.size() ^ b.size();
     for (size_t i = 0; i < a.size(); i++)
-        accumulator |= a[i] ^ b[i%b.size()];
+        accumulator |= size_t(a[i] ^ b[i%b.size()]);
     return accumulator == 0;
 }
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -13,6 +13,7 @@
 #include <util/getuniquepath.h>
 #include <util/strencodings.h>
 #include <util/string.h>
+#include <util/threadnames.h>
 #include <util/translation.h>
 
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -35,6 +35,7 @@
 #endif // __linux__
 
 #include <algorithm>
+#include <cassert>
 #include <fcntl.h>
 #include <sched.h>
 #include <sys/resource.h>
@@ -693,10 +694,9 @@ void PrintExceptionContinue(const std::exception_ptr pex, const char* pszExcepti
 
 fs::path GetDefaultDataDir()
 {
-    // Windows < Vista: C:\Documents and Settings\Username\Application Data\DashCore
-    // Windows >= Vista: C:\Users\Username\AppData\Roaming\DashCore
-    // Mac: ~/Library/Application Support/DashCore
-    // Unix: ~/.dashcore
+    // Windows: C:\Users\Username\AppData\Roaming\DashCore
+    // macOS: ~/Library/Application Support/DashCore
+    // Unix-like: ~/.dashcore
 #ifdef WIN32
     // Windows
     return GetSpecialFolderPath(CSIDL_APPDATA) / "DashCore";
@@ -708,14 +708,27 @@ fs::path GetDefaultDataDir()
     else
         pathRet = fs::path(pszHome);
 #ifdef MAC_OSX
-    // Mac
+    // macOS
     return pathRet / "Library/Application Support/DashCore";
 #else
-    // Unix
+    // Unix-like
     return pathRet / ".dashcore";
 #endif
 #endif
 }
+
+namespace {
+fs::path StripRedundantLastElementsOfPath(const fs::path& path)
+{
+    auto result = path;
+    while (result.filename().string() == ".") {
+        result = result.parent_path();
+    }
+
+    assert(fs::equivalent(result, path));
+    return result;
+}
+} // namespace
 
 static fs::path g_blocks_path_cache_net_specific;
 static fs::path pathCached;
@@ -744,6 +757,7 @@ const fs::path &GetBlocksDir()
     path /= BaseParams().DataDir();
     path /= "blocks";
     fs::create_directories(path);
+    path = StripRedundantLastElementsOfPath(path);
     return path;
 }
 
@@ -774,6 +788,7 @@ const fs::path &GetDataDir(bool fNetSpecific)
         fs::create_directories(path / "wallets");
     }
 
+    path = StripRedundantLastElementsOfPath(path);
     return path;
 }
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -23,7 +23,6 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <util/settings.h>
-#include <util/threadnames.h>
 #include <util/time.h>
 #include <amount.h>
 
@@ -467,24 +466,6 @@ namespace ctpl {
     class thread_pool;
 }
 void RenameThreadPool(ctpl::thread_pool& tp, const char* baseName);
-
-/**
- * .. and a wrapper that just calls func once
- */
-template <typename Callable> void TraceThread(const std::string name,  Callable func)
-{
-    util::ThreadRename(name.c_str());
-    try
-    {
-        LogPrintf("%s thread start\n", name);
-        func();
-        LogPrintf("%s thread exit\n", name);
-    }
-    catch (...) {
-        PrintExceptionContinue(std::current_exception(), name.c_str());
-        throw;
-    }
-}
 
 std::string CopyrightHolders(const std::string& strPrefix, unsigned int nStartYear, unsigned int nEndYear);
 

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/thread.h>
+
+#include <logging.h>
+#include <util/system.h>
+#include <util/threadnames.h>
+
+#include <exception>
+
+void util::TraceThread(const char* thread_name, std::function<void()> thread_func)
+{
+    util::ThreadRename(thread_name);
+    try {
+        LogPrintf("%s thread start\n", thread_name);
+        thread_func();
+        LogPrintf("%s thread exit\n", thread_name);
+    } catch (...) {
+        PrintExceptionContinue(std::current_exception(), thread_name);
+        throw;
+    }
+}

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_THREAD_H
+#define BITCOIN_UTIL_THREAD_H
+
+#include <functional>
+
+namespace util {
+/**
+ * A wrapper for do-something-once thread functions.
+ */
+void TraceThread(const char* thread_name, std::function<void()> thread_func);
+
+} // namespace util
+
+#endif // BITCOIN_UTIL_THREAD_H

--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_TRACE_H
+#define BITCOIN_UTIL_TRACE_H
+
+#ifdef ENABLE_TRACING
+
+#include <sys/sdt.h>
+
+#define TRACE(context, event) DTRACE_PROBE(context, event)
+#define TRACE1(context, event, a) DTRACE_PROBE1(context, event, a)
+#define TRACE2(context, event, a, b) DTRACE_PROBE2(context, event, a, b)
+#define TRACE3(context, event, a, b, c) DTRACE_PROBE3(context, event, a, b, c)
+#define TRACE4(context, event, a, b, c, d) DTRACE_PROBE4(context, event, a, b, c, d)
+#define TRACE5(context, event, a, b, c, d, e) DTRACE_PROBE5(context, event, a, b, c, d, e)
+#define TRACE6(context, event, a, b, c, d, e, f) DTRACE_PROBE6(context, event, a, b, c, d, e, f)
+#define TRACE7(context, event, a, b, c, d, e, f, g) DTRACE_PROBE7(context, event, a, b, c, d, e, f, g)
+#define TRACE8(context, event, a, b, c, d, e, f, g, h) DTRACE_PROBE8(context, event, a, b, c, d, e, f, g, h)
+#define TRACE9(context, event, a, b, c, d, e, f, g, h, i) DTRACE_PROBE9(context, event, a, b, c, d, e, f, g, h, i)
+#define TRACE10(context, event, a, b, c, d, e, f, g, h, i, j) DTRACE_PROBE10(context, event, a, b, c, d, e, f, g, h, i, j)
+#define TRACE11(context, event, a, b, c, d, e, f, g, h, i, j, k) DTRACE_PROBE11(context, event, a, b, c, d, e, f, g, h, i, j, k)
+#define TRACE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l) DTRACE_PROBE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l)
+
+#else
+
+#define TRACE(context, event)
+#define TRACE1(context, event, a)
+#define TRACE2(context, event, a, b)
+#define TRACE3(context, event, a, b, c)
+#define TRACE4(context, event, a, b, c, d)
+#define TRACE5(context, event, a, b, c, d, e)
+#define TRACE6(context, event, a, b, c, d, e, f)
+#define TRACE7(context, event, a, b, c, d, e, f, g)
+#define TRACE8(context, event, a, b, c, d, e, f, g, h)
+#define TRACE9(context, event, a, b, c, d, e, f, g, h, i)
+#define TRACE10(context, event, a, b, c, d, e, f, g, h, i, j)
+#define TRACE11(context, event, a, b, c, d, e, f, g, h, i, j, k)
+#define TRACE12(context, event, a, b, c, d, e, f, g, h, i, j, k, l)
+
+#endif
+
+
+#endif /* BITCOIN_UTIL_TRACE_H */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4668,7 +4668,7 @@ bool CChainState::LoadBlockIndexDB()
 void CChainState::LoadMempool(const ArgsManager& args)
 {
     if (!m_mempool) return;
-    if (args.GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
+    if (args.GetBoolArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         assert(std::addressof(::ChainstateActive()) == std::addressof(*this));
         ::LoadMempool(*m_mempool, *this);
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -26,6 +26,7 @@
 #include <versionbits.h>
 #include <serialize.h>
 #include <spentindex.h>
+#include <util/hasher.h>
 
 #include <atomic>
 #include <map>
@@ -125,14 +126,6 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // one 128 MiB block file + added 15% undo data = 147 MiB greater for a total of 941 MiB
 // Setting the target to > than 945 MiB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 945 * 1024 * 1024;
-
-struct BlockHasher
-{
-    // this used to call `GetCheapHash()` in uint256, which was later moved; the
-    // cheap hash function simply calls ReadLE64() however, so the end result is
-    // identical
-    size_t operator()(const uint256& hash) const { return ReadLE64(hash.begin()); }
-};
 
 extern RecursiveMutex cs_main;
 typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -185,9 +185,9 @@ void WalletInit::Construct(NodeContext& node) const
         LogPrintf("Wallet disabled!\n");
         return;
     }
-    auto wallet_client = interfaces::MakeWalletClient(*node.chain, args);
-    node.wallet_client = wallet_client.get();
-    node.chain_clients.emplace_back(std::move(wallet_client));
+    auto wallet_loader = interfaces::MakeWalletLoader(*node.chain, args);
+    node.wallet_loader = wallet_loader.get();
+    node.chain_clients.emplace_back(std::move(wallet_loader));
 }
 
 

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -38,7 +38,7 @@ using interfaces::MakeHandler;
 using interfaces::Wallet;
 using interfaces::WalletAddress;
 using interfaces::WalletBalances;
-using interfaces::WalletClient;
+using interfaces::WalletLoader;
 using interfaces::WalletOrderForm;
 using interfaces::WalletTx;
 using interfaces::WalletTxOut;
@@ -601,15 +601,15 @@ public:
     CoinJoinImpl m_coinjoin;
 };
 
-class WalletClientImpl : public WalletClient
+class WalletLoaderImpl : public WalletLoader
 {
 public:
-    WalletClientImpl(Chain& chain, ArgsManager& args)
+    WalletLoaderImpl(Chain& chain, ArgsManager& args)
     {
         m_context.chain = &chain;
         m_context.args = &args;
     }
-    ~WalletClientImpl() override { UnloadWallets(); }
+    ~WalletLoaderImpl() override { UnloadWallets(); }
 
     //! ChainClient methods
     void registerRpcs() override
@@ -628,7 +628,7 @@ public:
     void stop() override { return StopWallets(); }
     void setMockTime(int64_t time) override { return SetMockTime(time); }
 
-    //! WalletClient methods
+    //! WalletLoader methods
     std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& passphrase, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) override
     {
         std::shared_ptr<CWallet> wallet;
@@ -681,7 +681,7 @@ public:
 
 namespace interfaces {
 std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet) { return wallet ? std::make_unique<wallet::WalletImpl>(wallet) : nullptr; }
-std::unique_ptr<WalletClient> MakeWalletClient(Chain& chain, ArgsManager& args) {
-    return std::make_unique<wallet::WalletClientImpl>(chain, args);
+std::unique_ptr<WalletLoader> MakeWalletLoader(Chain& chain, ArgsManager& args) {
+    return std::make_unique<wallet::WalletLoaderImpl>(chain, args);
 }
 } // namespace interfaces

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -10,7 +10,7 @@
 
 InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)
 {
-    m_wallet_client = MakeWalletClient(*m_node.chain, *Assert(m_node.args));
+    m_wallet_loader = MakeWalletLoader(*m_node.chain, *Assert(m_node.args));
 
     std::string sep;
     sep += fs::path::preferred_separator;

--- a/src/wallet/test/init_test_fixture.h
+++ b/src/wallet/test/init_test_fixture.h
@@ -19,7 +19,7 @@ struct InitWalletDirTestingSetup: public BasicTestingSetup {
     fs::path m_datadir;
     fs::path m_cwd;
     std::map<std::string, fs::path> m_walletdir_path_cases;
-    std::unique_ptr<interfaces::WalletClient> m_wallet_client;
+    std::unique_ptr<interfaces::WalletLoader> m_wallet_loader;
 };
 
 #endif // BITCOIN_WALLET_TEST_INIT_TEST_FIXTURE_H

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_default)
     SetWalletDir(m_walletdir_path_cases["default"]);
     {
         ASSERT_DEBUG_LOG("");
-        bool result = m_wallet_client->verify();
+        bool result = m_wallet_loader->verify();
         BOOST_CHECK(result == true);
     }
     fs::path walletdir = gArgs.GetArg("-walletdir", "");
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_custom)
     SetWalletDir(m_walletdir_path_cases["custom"]);
     {
         ASSERT_DEBUG_LOG("");
-        bool result = m_wallet_client->verify();
+        bool result = m_wallet_loader->verify();
         BOOST_CHECK(result == true);
     }
     fs::path walletdir = gArgs.GetArg("-walletdir", "");
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_does_not_exist)
     SetWalletDir(m_walletdir_path_cases["nonexistent"]);
     {
         ASSERT_DEBUG_LOG("does not exist");
-        bool result = m_wallet_client->verify();
+        bool result = m_wallet_loader->verify();
         BOOST_CHECK(result == false);
     }
 }
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_is_not_directory)
     SetWalletDir(m_walletdir_path_cases["file"]);
     {
         ASSERT_DEBUG_LOG("is not a directory");
-        bool result = m_wallet_client->verify();
+        bool result = m_wallet_loader->verify();
         BOOST_CHECK(result == false);
     }
 }
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_is_not_relative)
     SetWalletDir(m_walletdir_path_cases["relative"]);
     {
         ASSERT_DEBUG_LOG("is a relative path");
-        bool result = m_wallet_client->verify();
+        bool result = m_wallet_loader->verify();
         BOOST_CHECK(result == false);
     }
 }
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing)
     SetWalletDir(m_walletdir_path_cases["trailing"]);
     {
         ASSERT_DEBUG_LOG("");
-        bool result = m_wallet_client->verify();
+        bool result = m_wallet_loader->verify();
         BOOST_CHECK(result == true);
     }
     fs::path walletdir = gArgs.GetArg("-walletdir", "");
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing2)
     SetWalletDir(m_walletdir_path_cases["trailing2"]);
     {
         ASSERT_DEBUG_LOG("");
-        bool result = m_wallet_client->verify();
+        bool result = m_wallet_loader->verify();
         BOOST_CHECK(result == true);
     }
     fs::path walletdir = gArgs.GetArg("-walletdir", "");

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -7,6 +7,7 @@
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
     : TestingSetup(chainName),
+      m_wallet_loader{interfaces::MakeWalletLoader(*m_node.chain, *Assert(m_node.args))},
       m_wallet(m_node.chain.get(), "", CreateMockWalletDatabase())
 {
     bool fFirstRun;

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -12,5 +12,5 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
     bool fFirstRun;
     m_wallet.LoadWallet(fFirstRun);
     m_chain_notifications_handler = m_node.chain->handleNotifications({ &m_wallet, [](CWallet*) {} });
-    m_wallet_client->registerRpcs();
+    m_wallet_loader->registerRpcs();
 }

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -20,7 +20,7 @@
 struct WalletTestingSetup : public TestingSetup {
     explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
 
-    std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(*m_node.chain, *Assert(m_node.args));
+    std::unique_ptr<interfaces::WalletLoader> m_wallet_loader = interfaces::MakeWalletLoader(*m_node.chain, *Assert(m_node.args));
     CWallet m_wallet;
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 };

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -20,7 +20,7 @@
 struct WalletTestingSetup : public TestingSetup {
     explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
 
-    std::unique_ptr<interfaces::WalletLoader> m_wallet_loader = interfaces::MakeWalletLoader(*m_node.chain, *Assert(m_node.args));
+    std::unique_ptr<interfaces::WalletLoader> m_wallet_loader;
     CWallet m_wallet;
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 };

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -49,7 +49,7 @@ using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wall
 
 //! Explicitly unload and delete the wallet.
 //  Blocks the current thread after signaling the unload intent so that all
-//  wallet clients release the wallet.
+//  wallet pointer owners release the wallet.
 //  Note that, when blocking is not required, the wallet is implicitly unloaded
 //  by the shared pointer deleter.
 void UnloadWallet(std::shared_ptr<CWallet>&& wallet);

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -61,8 +61,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/multi_index_container.hpp
     boost/optional.hpp
     boost/pool/pool_alloc.hpp
-    boost/preprocessor/cat.hpp
-    boost/preprocessor/stringize.hpp
     boost/signals2/connection.hpp
     boost/signals2/optional_last_value.hpp
     boost/signals2/signal.hpp

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -59,7 +59,6 @@ implicit-integer-sign-change:test/sighash_tests.cpp
 implicit-integer-sign-change:test/streams_tests.cpp
 implicit-integer-sign-change:test/transaction_tests.cpp
 implicit-integer-sign-change:txmempool.cpp
-implicit-integer-sign-change:util/strencodings.*
 implicit-integer-sign-change:validation.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
 implicit-signed-integer-truncation,implicit-integer-sign-change:chain.h


### PR DESCRIPTION
### Additional Information

* Dependency for #5337
* Earlier variants of backporting [bitcoin#19064](https://github.com/bitcoin/bitcoin/pull/19064) resulted in consistent `UnicodeDecodeError` terminations when running `combine_logs.py` ([GitLab build](https://gitlab.com/dashpay/dash/-/jobs/4938814052#L465), [again](https://gitlab.com/dashpay/dash/-/jobs/4938020244#L462) and [again](https://gitlab.com/dashpay/dash/-/jobs/4937781814#L463))
  * This has been resolved with squashing changes from 208abd4668ed3265f97f4844c43c36aa057773d4 into the backport (Thanks @UdjinM6!)