### PR TITLE
ci: set CCACHE_SIZE to 400M for Gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,6 +115,8 @@ builder-image:
 .build-template:
   stage: build
   extends: .base-template
+  variables:
+    CCACHE_SIZE: "400M"
   script:
     - ./ci/dash/build_src.sh
     - ./ci/dash/test_unittests.sh # Run unit tests in build stage to avoid creating too many parallel jobs

--- a/ci/dash/build_src.sh
+++ b/ci/dash/build_src.sh
@@ -14,9 +14,6 @@ source ./ci/dash/matrix.sh
 unset CC; unset CXX
 unset DISPLAY
 
-export CCACHE_COMPRESS=${CCACHE_COMPRESS:-1}
-export CCACHE_SIZE=${CCACHE_SIZE:-400M}
-
 if [ "$PULL_REQUEST" != "false" ]; then test/lint/commit-script-check.sh $COMMIT_RANGE; fi
 
 if [ "$CHECK_DOC" = 1 ]; then


### PR DESCRIPTION
## Issue being fixed or feature implemented
Make CI builds faster.

We have this https://github.com/dashpay/dash/blob/develop/ci/dash/build_src.sh#L18 but by that time `CCACHE_SIZE` is set to 100M via https://github.com/dashpay/dash/blob/develop/ci/test/00_setup_env.sh#L51 already.

## What was done?
set `CCACHE_SIZE` variable in `.gitlab-ci.yml`, drop confusing and useless lines from `ci/dash/build_src.sh` (`CCACHE_SIZE` and `CCACHE_COMPRESS` defaults are handled by `ci/test/00_setup_env.sh`)

## How Has This Been Tested?
I set `CCACHE_SIZE` to 400M yesterday via Gitlab UI to test it.

results:
before, trivial doc change, 100M: https://gitlab.com/dashpay/dash/-/jobs/4931233566#L59 (~17 minutes)
after, trivial code change, 400M: https://gitlab.com/dashpay/dash/-/jobs/4935764148#L80 (~12 minutes)

Removed it from Gitlab UI now but it should still say `Set cache size limit to 400.0 MB` in logs for this PR.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

