### PR TITLE
feat(qt): Expose `-coinjoinsessions`, `-coinjoindenomsgoal` and `-coinjoindenomshardcap` in CoinJoin Options

### DIFF
--- a/src/coinjoin/options.cpp
+++ b/src/coinjoin/options.cpp
@@ -31,6 +31,12 @@ void CCoinJoinClientOptions::SetMultiSessionEnabled(bool fEnabled)
     options.fCoinJoinMultiSession = fEnabled;
 }
 
+void CCoinJoinClientOptions::SetSessions(int sessions)
+{
+    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
+    options.nCoinJoinSessions = sessions;
+}
+
 void CCoinJoinClientOptions::SetRounds(int nRounds)
 {
     CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
@@ -41,6 +47,18 @@ void CCoinJoinClientOptions::SetAmount(CAmount amount)
 {
     CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
     options.nCoinJoinAmount = amount;
+}
+
+void CCoinJoinClientOptions::SetDenomsGoal(int denoms_goal)
+{
+    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
+    options.nCoinJoinDenomsGoal = denoms_goal;
+}
+
+void CCoinJoinClientOptions::SetDenomsHardCap(int denoms_hardcap)
+{
+    CCoinJoinClientOptions& options = CCoinJoinClientOptions::Get();
+    options.nCoinJoinDenomsHardCap = denoms_hardcap;
 }
 
 void CCoinJoinClientOptions::Init()

--- a/src/coinjoin/options.h
+++ b/src/coinjoin/options.h
@@ -61,8 +61,11 @@ public:
 
     static void SetEnabled(bool fEnabled);
     static void SetMultiSessionEnabled(bool fEnabled);
+    static void SetSessions(int sessions);
     static void SetRounds(int nRounds);
     static void SetAmount(CAmount amount);
+    static void SetDenomsGoal(int denoms_goal);
+    static void SetDenomsHardCap(int denoms_hardcap);
 
     static bool IsEnabled() { return CCoinJoinClientOptions::Get().fEnableCoinJoin; }
     static bool IsMultiSessionEnabled() { return CCoinJoinClientOptions::Get().fCoinJoinMultiSession; }

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -82,13 +82,19 @@ namespace CoinJoin {
 class Options
 {
 public:
+    virtual int getSessions() = 0;
     virtual int getRounds() = 0;
     virtual int getAmount() = 0;
+    virtual int getDenomsGoal() = 0;
+    virtual int getDenomsHardCap() = 0;
 
     virtual void setEnabled(bool fEnabled) = 0;
     virtual void setMultiSessionEnabled(bool fEnabled) = 0;
+    virtual void setSessions(int sessions) = 0;
     virtual void setRounds(int nRounds) = 0;
     virtual void setAmount(CAmount amount) = 0;
+    virtual void setDenomsGoal(int denoms_goal) = 0;
+    virtual void setDenomsHardCap(int denoms_hardcap) = 0;
 
     virtual bool isMultiSessionEnabled() = 0;
     virtual bool isEnabled() = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -125,6 +125,10 @@ namespace CoinJoin = interfaces::CoinJoin;
 class CoinJoinOptionsImpl : public CoinJoin::Options
 {
 public:
+    int getSessions() override
+    {
+        return CCoinJoinClientOptions::GetSessions();
+    }
     int getRounds() override
     {
         return CCoinJoinClientOptions::GetRounds();
@@ -132,6 +136,14 @@ public:
     int getAmount() override
     {
         return CCoinJoinClientOptions::GetAmount();
+    }
+    int getDenomsGoal() override
+    {
+        return CCoinJoinClientOptions::GetDenomsGoal();
+    }
+    int getDenomsHardCap() override
+    {
+        return CCoinJoinClientOptions::GetDenomsHardCap();
     }
     void setEnabled(bool fEnabled) override
     {
@@ -141,6 +153,10 @@ public:
     {
         CCoinJoinClientOptions::SetMultiSessionEnabled(fEnabled);
     }
+    void setSessions(int sessions) override
+    {
+        CCoinJoinClientOptions::SetSessions(sessions);
+    }
     void setRounds(int nRounds) override
     {
         CCoinJoinClientOptions::SetRounds(nRounds);
@@ -148,6 +164,14 @@ public:
     void setAmount(CAmount amount) override
     {
         CCoinJoinClientOptions::SetAmount(amount);
+    }
+    void setDenomsGoal(int denoms_goal) override
+    {
+        CCoinJoinClientOptions::SetDenomsGoal(denoms_goal);
+    }
+    void setDenomsHardCap(int denoms_hardcap) override
+    {
+        CCoinJoinClientOptions::SetDenomsHardCap(denoms_hardcap);
     }
     bool isEnabled() override
     {

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -428,6 +428,33 @@
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel" name="lblCoinJoinSessionsText">
+           <property name="text">
+            <string>Parallel sessions</string>
+           </property>
+           <property name="toolTip">
+            <string>Use this many separate masternodes in parallel to mix funds.&lt;br/&gt;Note: You must use this feature carefully.&lt;br/&gt;Make sure you always have recent wallet (auto)backup in a safe place!</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="coinJoinSessions">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>10</number>
+           </property>
+           <property name="value">
+            <number>4</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4_Wallet">
          <item>
           <widget class="QLabel" name="lblCoinJoinRoundsText">
@@ -491,6 +518,88 @@
            </property>
            <property name="value">
             <number>1000</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel" name="lblCoinJoinDenoms">
+           <property name="text">
+            <string>Same denominated amount</string>
+           </property>
+           <property name="toolTip">
+            <string>How many inputs of each denominated amount are created.&lt;br/&gt;Lower these numbers if you want less smaller denoms.</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel">
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblCoinJoinDenomsTarget">
+           <property name="text">
+            <string>Target</string>
+           </property>
+           <property name="toolTip">
+            <string>Try to create at least this many inputs of each denominated amount.&lt;br/&gt;Lower this number if you want less smaller denoms.</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblCoinJoinDenomsMaximum">
+           <property name="text">
+            <string>Maximum</string>
+           </property>
+           <property name="toolTip">
+            <string>Create up to this many inputs of each denominated amount.&lt;br/&gt;Lower this number if you want less smaller denoms.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QLabel">
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel">
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="coinJoinDenomsGoal">
+           <property name="minimum">
+            <number>10</number>
+           </property>
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+           <property name="singleStep">
+            <number>10</number>
+           </property>
+           <property name="value">
+            <number>50</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="coinJoinDenomsHardCap">
+           <property name="minimum">
+            <number>10</number>
+           </property>
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+           <property name="singleStep">
+            <number>10</number>
+           </property>
+           <property name="value">
+            <number>300</number>
            </property>
           </widget>
          </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -288,6 +288,9 @@ void OptionsDialog::setModel(OptionsModel *_model)
             ui->coinJoinEnabled->click();
         }
     });
+
+    connect(ui->coinJoinDenomsGoal, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &OptionsDialog::updateCoinJoinDenomGoal);
+    connect(ui->coinJoinDenomsHardCap, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &OptionsDialog::updateCoinJoinDenomHardCap);
 #endif
 }
 
@@ -323,8 +326,11 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->lowKeysWarning, OptionsModel::LowKeysWarning);
     mapper->addMapping(ui->coinJoinMultiSession, OptionsModel::CoinJoinMultiSession);
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
+    mapper->addMapping(ui->coinJoinSessions, OptionsModel::CoinJoinSessions);
     mapper->addMapping(ui->coinJoinRounds, OptionsModel::CoinJoinRounds);
     mapper->addMapping(ui->coinJoinAmount, OptionsModel::CoinJoinAmount);
+    mapper->addMapping(ui->coinJoinDenomsGoal, OptionsModel::CoinJoinDenomsGoal);
+    mapper->addMapping(ui->coinJoinDenomsHardCap, OptionsModel::CoinJoinDenomsHardCap);
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);
@@ -504,6 +510,20 @@ void OptionsDialog::updateCoinJoinVisibility()
 #endif
     ui->btnCoinJoin->setVisible(fEnabled);
     GUIUtil::updateButtonGroupShortcuts(pageButtons);
+}
+
+void OptionsDialog::updateCoinJoinDenomGoal()
+{
+    if (ui->coinJoinDenomsGoal->value() > ui->coinJoinDenomsHardCap->value()) {
+        ui->coinJoinDenomsGoal->setValue(ui->coinJoinDenomsHardCap->value());
+    }
+}
+
+void OptionsDialog::updateCoinJoinDenomHardCap()
+{
+    if (ui->coinJoinDenomsGoal->value() > ui->coinJoinDenomsHardCap->value()) {
+        ui->coinJoinDenomsHardCap->setValue(ui->coinJoinDenomsGoal->value());
+    }
 }
 
 void OptionsDialog::updateWidth()

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -74,6 +74,8 @@ private Q_SLOTS:
     void updateDefaultProxyNets();
 
     void updateCoinJoinVisibility();
+    void updateCoinJoinDenomGoal();
+    void updateCoinJoinDenomHardCap();
 
     void updateWidth();
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -221,6 +221,10 @@ void OptionsModel::Init(bool resetSettings)
         addOverriddenOption("-spendzeroconfchange");
 
     // CoinJoin
+    if (!settings.contains("nCoinJoinSessions"))
+        settings.setValue("nCoinJoinSessions", DEFAULT_COINJOIN_SESSIONS);
+    m_node.coinJoinOptions().setSessions(settings.value("nCoinJoinSessions").toInt());
+
     if (!settings.contains("nCoinJoinRounds"))
         settings.setValue("nCoinJoinRounds", DEFAULT_COINJOIN_ROUNDS);
     if (!m_node.softSetArg("-coinjoinrounds", settings.value("nCoinJoinRounds").toString().toStdString()))
@@ -243,6 +247,14 @@ void OptionsModel::Init(bool resetSettings)
     if (!m_node.softSetBoolArg("-coinjoinmultisession", settings.value("fCoinJoinMultiSession").toBool()))
         addOverriddenOption("-coinjoinmultisession");
     m_node.coinJoinOptions().setMultiSessionEnabled(settings.value("fCoinJoinMultiSession").toBool());
+
+    if (!settings.contains("nCoinJoinDenomsGoal"))
+        settings.setValue("nCoinJoinDenomsGoal", DEFAULT_COINJOIN_DENOMS_GOAL);
+    m_node.coinJoinOptions().setDenomsGoal(settings.value("nCoinJoinDenomsGoal").toInt());
+
+    if (!settings.contains("nCoinJoinDenomsHardCap"))
+        settings.setValue("nCoinJoinDenomsHardCap", DEFAULT_COINJOIN_DENOMS_HARDCAP);
+    m_node.coinJoinOptions().setDenomsHardCap(settings.value("nCoinJoinDenomsHardCap").toInt());
 #endif
 
     // Network
@@ -458,10 +470,16 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("fShowCoinJoinPopups");
         case LowKeysWarning:
             return settings.value("fLowKeysWarning");
+        case CoinJoinSessions:
+            return settings.value("nCoinJoinSessions");
         case CoinJoinRounds:
             return settings.value("nCoinJoinRounds");
         case CoinJoinAmount:
             return settings.value("nCoinJoinAmount");
+        case CoinJoinDenomsGoal:
+            return settings.value("nCoinJoinDenomsGoal");
+        case CoinJoinDenomsHardCap:
+            return settings.value("nCoinJoinDenomsHardCap");
         case CoinJoinMultiSession:
             return settings.value("fCoinJoinMultiSession");
 #endif
@@ -640,6 +658,13 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case LowKeysWarning:
             settings.setValue("fLowKeysWarning", value);
             break;
+        case CoinJoinSessions:
+            if (settings.value("nCoinJoinSessions") != value) {
+                m_node.coinJoinOptions().setSessions(value.toInt());
+                settings.setValue("nCoinJoinSessions", m_node.coinJoinOptions().getSessions());
+                Q_EMIT coinJoinRoundsChanged();
+            }
+            break;
         case CoinJoinRounds:
             if (settings.value("nCoinJoinRounds") != value)
             {
@@ -654,6 +679,18 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 m_node.coinJoinOptions().setAmount(value.toInt());
                 settings.setValue("nCoinJoinAmount", m_node.coinJoinOptions().getAmount());
                 Q_EMIT coinJoinAmountChanged();
+            }
+            break;
+        case CoinJoinDenomsGoal:
+            if (settings.value("nCoinJoinDenomsGoal") != value) {
+                m_node.coinJoinOptions().setDenomsGoal(value.toInt());
+                settings.setValue("nCoinJoinDenomsGoal", m_node.coinJoinOptions().getDenomsGoal());
+            }
+            break;
+        case CoinJoinDenomsHardCap:
+            if (settings.value("nCoinJoinDenomsHardCap") != value) {
+                m_node.coinJoinOptions().setDenomsHardCap(value.toInt());
+                settings.setValue("nCoinJoinDenomsHardCap", m_node.coinJoinOptions().getDenomsHardCap());
             }
             break;
         case CoinJoinMultiSession:

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -77,8 +77,11 @@ public:
         ShowAdvancedCJUI,     // bool
         ShowCoinJoinPopups,   // bool
         LowKeysWarning,       // bool
+        CoinJoinSessions,     // int
         CoinJoinRounds,       // int
         CoinJoinAmount,       // int
+        CoinJoinDenomsGoal,   // int
+        CoinJoinDenomsHardCap,// int
         CoinJoinMultiSession, // bool
         Listen,               // bool
         OptionIDRowCount,


### PR DESCRIPTION
## Issue being fixed or feature implemented
Let GUI users control all CJ params (on the fly) without the need to edit `dash.conf`.

<img width="643" alt="Screenshot 2023-08-27 at 12 29 07" src="https://github.com/dashpay/dash/assets/1935069/2d90db0d-c7b2-43a9-9f7f-1c4ad9517408">

## What was done?
Add a checkbox and 2 corresponding spin boxes in Options (with a simple sanity check). I tried my best to come up with the least confusing labels/tooltips for these, not sure if I'm 100% happy with the result though.

## How Has This Been Tested?
Run qt wallet, play with values and make sure they are saved/loaded/used in mixing correctly.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

