### PR TITLE
fix: reorder CGovernanceManager field

### DIFF
--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -172,8 +172,6 @@ private:
     // keep track of the scanning errors
     std::map<uint256, CGovernanceObject> mapObjects;
 
-    std::optional<uint256> votedFundingYesTriggerHash;
-
     // mapErasedGovernanceObjects contains key-value pairs, where
     //   key   - governance object's hash
     //   value - expiration time for deleted objects
@@ -198,6 +196,8 @@ private:
 
     // used to check for changed voting keys
     CDeterministicMNListPtr lastMNListForVotingKeys;
+
+    std::optional<uint256> votedFundingYesTriggerHash;
 
     class ScopedLockBool
     {


### PR DESCRIPTION
## Issue being fixed or feature implemented
When building with `-Wreorder-ctor` capture, the build fails with `error: field 'lastMNListForVotingKeys' will be initialized after field 'votedFundingYesTriggerHash'`

## What was done?
Moved down `votedFundingYesTriggerHash` to last position in `CGovernanceManager`.

## How Has This Been Tested?

## Breaking Changes
 no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

