### PR TITLE
feat(rpc): Disable submission of triggers and gobject vote-conf RPC

### DIFF
--- a/doc/release-notes-5552.md
+++ b/doc/release-notes-5552.md
@@ -1,0 +1,4 @@
+Updated RPCs
+--------
+
+- `gobject submit` will no longer accept submission of triggers.

--- a/doc/release-notes-5552.md
+++ b/doc/release-notes-5552.md
@@ -2,3 +2,4 @@ Updated RPC
 --------
 
 - `gobject submit` will no longer accept submission of triggers.
+- `gobject vote-conf` will no longer allow voting for triggers.

--- a/doc/release-notes-5552.md
+++ b/doc/release-notes-5552.md
@@ -1,4 +1,4 @@
-Updated RPCs
+Updated RPC
 --------
 
 - `gobject submit` will no longer accept submission of triggers.

--- a/doc/release-notes-5552.md
+++ b/doc/release-notes-5552.md
@@ -2,4 +2,4 @@ Updated RPC
 --------
 
 - `gobject submit` will no longer accept submission of triggers.
-- `gobject vote-conf` will no longer allow voting for triggers.
+- `gobject vote-conf` is no longer available.

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -438,6 +438,10 @@ static UniValue gobject_vote_conf(const JSONRPCRequest& request)
         return pGovObj->GetObjectType();
     }());
 
+    if (govObjType == GovernanceObject::TRIGGER) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Voting for triggers is not available");
+    }
+
     int nSuccessful = 0;
     int nFailed = 0;
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -295,7 +295,7 @@ static void gobject_submit_help(const JSONRPCRequest& request)
             {"revision", RPCArg::Type::NUM, RPCArg::Optional::NO, "object revision in the system"},
             {"time", RPCArg::Type::NUM, RPCArg::Optional::NO, "time this object was created"},
             {"data-hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "data in hex string form"},
-            {"fee-txid", RPCArg::Type::STR_HEX, /* default */ "", "fee-tx id, required for all objects except triggers"},
+            {"fee-txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "txid of the corresponding proposal fee transaction"},
         },
         RPCResults{},
         RPCExamples{""}
@@ -352,11 +352,6 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
         if (!validator.Validate()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid proposal data, error messages:" + validator.GetErrorMessages());
         }
-    }
-
-    if (request.params.size() != 5) {
-        LogPrintf("gobject(submit) -- Object submission rejected because fee tx not provided\n");
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "The fee-txid parameter must be included to submit this type of object");
     }
 
     std::string strHash = govobj.GetHash().ToString();


### PR DESCRIPTION
## Issue being fixed or feature implemented
With #5525 , MNs shouldn't use Sentinel anymore. 

## What was done?
In order to force them to remove Sentinel:
-  `gobject submit` RPC won't accept triggers anymore.
-  `gobject vote-conf` RPC isn't available anymore.


## How Has This Been Tested?
`feature_governance.py` and `feature_governance_object.py`

## Breaking Changes
Normally, only Sentinel should be broken.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

