### PR TITLE
refactor: decouple db hooks from CFlatDB-based C*Manager objects, migrate to *Store structs

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -106,18 +106,18 @@ void CCoinJoinClientQueueManager::ProcessDSQueue(const CNode& peer, PeerManager&
                      dmn->pdmnState->addr.ToString());
             return;
         } else {
-            int64_t nLastDsq = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastDsq();
-            int64_t nDsqThreshold = mmetaman.GetDsqThreshold(dmn->proTxHash, mnList.GetValidMNsCount());
+            int64_t nLastDsq = mmetaman->GetMetaInfo(dmn->proTxHash)->GetLastDsq();
+            int64_t nDsqThreshold = mmetaman->GetDsqThreshold(dmn->proTxHash, mnList.GetValidMNsCount());
             LogPrint(BCLog::COINJOIN, "DSQUEUE -- nLastDsq: %d  nDsqThreshold: %d  nDsqCount: %d\n", nLastDsq,
-                     nDsqThreshold, mmetaman.GetDsqCount());
+                     nDsqThreshold, mmetaman->GetDsqCount());
             // don't allow a few nodes to dominate the queuing process
-            if (nLastDsq != 0 && nDsqThreshold > mmetaman.GetDsqCount()) {
+            if (nLastDsq != 0 && nDsqThreshold > mmetaman->GetDsqCount()) {
                 LogPrint(BCLog::COINJOIN, "DSQUEUE -- Masternode %s is sending too many dsq messages\n",
                          dmn->proTxHash.ToString());
                 return;
             }
 
-            mmetaman.AllowMixing(dmn->proTxHash);
+            mmetaman->AllowMixing(dmn->proTxHash);
 
             LogPrint(BCLog::COINJOIN, "DSQUEUE -- new CoinJoin queue (%s) from masternode %s\n", dsq.ToString(),
                      dmn->pdmnState->addr.ToString());
@@ -1144,13 +1144,13 @@ bool CCoinJoinClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, CCon
             continue;
         }
 
-        int64_t nLastDsq = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastDsq();
-        int64_t nDsqThreshold = mmetaman.GetDsqThreshold(dmn->proTxHash, nMnCount);
-        if (nLastDsq != 0 && nDsqThreshold > mmetaman.GetDsqCount()) {
+        int64_t nLastDsq = mmetaman->GetMetaInfo(dmn->proTxHash)->GetLastDsq();
+        int64_t nDsqThreshold = mmetaman->GetDsqThreshold(dmn->proTxHash, nMnCount);
+        if (nLastDsq != 0 && nDsqThreshold > mmetaman->GetDsqCount()) {
             WalletCJLogPrint(m_wallet, "CCoinJoinClientSession::StartNewQueue -- Too early to mix on this masternode!" /* Continued */
                       " masternode=%s  addr=%s  nLastDsq=%d  nDsqThreshold=%d  nDsqCount=%d\n",
                 dmn->proTxHash.ToString(), dmn->pdmnState->addr.ToString(), nLastDsq,
-                nDsqThreshold, mmetaman.GetDsqCount());
+                nDsqThreshold, mmetaman->GetDsqCount());
             nTries++;
             continue;
         }

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -78,9 +78,9 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
             }
         }
 
-        int64_t nLastDsq = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastDsq();
-        int64_t nDsqThreshold = mmetaman.GetDsqThreshold(dmn->proTxHash, mnList.GetValidMNsCount());
-        if (nLastDsq != 0 && nDsqThreshold > mmetaman.GetDsqCount()) {
+        int64_t nLastDsq = mmetaman->GetMetaInfo(dmn->proTxHash)->GetLastDsq();
+        int64_t nDsqThreshold = mmetaman->GetDsqThreshold(dmn->proTxHash, mnList.GetValidMNsCount());
+        if (nLastDsq != 0 && nDsqThreshold > mmetaman->GetDsqCount()) {
             if (fLogIPs) {
                 LogPrint(BCLog::COINJOIN, "DSACCEPT -- last dsq too recent, must wait: peer=%d, addr=%s\n", peer.GetId(), peer.addr.ToString());
             } else {
@@ -161,15 +161,15 @@ void CCoinJoinServer::ProcessDSQUEUE(const CNode& peer, PeerManager& peerman, CD
     }
 
     if (!dsq.fReady) {
-        int64_t nLastDsq = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastDsq();
-        int64_t nDsqThreshold = mmetaman.GetDsqThreshold(dmn->proTxHash, mnList.GetValidMNsCount());
-        LogPrint(BCLog::COINJOIN, "DSQUEUE -- nLastDsq: %d  nDsqThreshold: %d  nDsqCount: %d\n", nLastDsq, nDsqThreshold, mmetaman.GetDsqCount());
+        int64_t nLastDsq = mmetaman->GetMetaInfo(dmn->proTxHash)->GetLastDsq();
+        int64_t nDsqThreshold = mmetaman->GetDsqThreshold(dmn->proTxHash, mnList.GetValidMNsCount());
+        LogPrint(BCLog::COINJOIN, "DSQUEUE -- nLastDsq: %d  nDsqThreshold: %d  nDsqCount: %d\n", nLastDsq, nDsqThreshold, mmetaman->GetDsqCount());
         //don't allow a few nodes to dominate the queuing process
-        if (nLastDsq != 0 && nDsqThreshold > mmetaman.GetDsqCount()) {
+        if (nLastDsq != 0 && nDsqThreshold > mmetaman->GetDsqCount()) {
             LogPrint(BCLog::COINJOIN, "DSQUEUE -- Masternode %s is sending too many dsq messages\n", dmn->pdmnState->addr.ToString());
             return;
         }
-        mmetaman.AllowMixing(dmn->proTxHash);
+        mmetaman->AllowMixing(dmn->proTxHash);
 
         LogPrint(BCLog::COINJOIN, "DSQUEUE -- new CoinJoin queue (%s) from masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
 

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -123,7 +123,7 @@ void CMNAuth::ProcessMessage(CNode& peer, PeerManager& peerman, CConnman& connma
     }
 
     if (!peer.fInbound) {
-        mmetaman.GetMetaInfo(mnauth.proRegTxHash)->SetLastOutboundSuccess(GetAdjustedTime());
+        mmetaman->GetMetaInfo(mnauth.proRegTxHash)->SetLastOutboundSuccess(GetAdjustedTime());
         if (peer.m_masternode_probe_connection) {
             LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- Masternode probe successful for %s, disconnecting. peer=%d\n",
                      mnauth.proRegTxHash.ToString(), peer.GetId());

--- a/src/flat-database.h
+++ b/src/flat-database.h
@@ -36,7 +36,7 @@ private:
     std::string strFilename;
     std::string strMagicMessage;
 
-    bool Write(const T& objToSave)
+    bool CoreWrite(const T& objToSave)
     {
         // LOCK(objToSave.cs);
 
@@ -71,7 +71,7 @@ private:
         return true;
     }
 
-    ReadResult Read(T& objToLoad, bool fDryRun = false)
+    ReadResult CoreRead(T& objToLoad)
     {
         //LOCK(objToLoad.cs);
 
@@ -152,28 +152,13 @@ private:
 
         LogPrintf("Loaded info from %s  %dms\n", strFilename, GetTimeMillis() - nStart);
         LogPrintf("     %s\n", objToLoad.ToString());
-        if(!fDryRun) {
-            LogPrintf("%s: Cleaning....\n", __func__);
-            objToLoad.CheckAndRemove();
-            LogPrintf("     %s\n", objToLoad.ToString());
-        }
 
         return Ok;
     }
 
-
-public:
-    CFlatDB(std::string strFilenameIn, std::string strMagicMessageIn)
+    bool Read(T& objToLoad)
     {
-        pathDB = GetDataDir() / strFilenameIn;
-        strFilename = strFilenameIn;
-        strMagicMessage = strMagicMessageIn;
-    }
-
-    bool Load(T& objToLoad)
-    {
-        LogPrintf("Reading info from %s...\n", strFilename);
-        ReadResult readResult = Read(objToLoad);
+        ReadResult readResult = CoreRead(objToLoad);
         if (readResult == FileError)
             LogPrintf("Missing file %s, will try to recreate\n", strFilename);
         else if (readResult != Ok)
@@ -192,36 +177,34 @@ public:
         return true;
     }
 
-    bool Dump(T& objToSave)
+public:
+    CFlatDB(std::string strFilenameIn, std::string strMagicMessageIn)
     {
-        int64_t nStart = GetTimeMillis();
+        pathDB = GetDataDir() / strFilenameIn;
+        strFilename = strFilenameIn;
+        strMagicMessage = strMagicMessageIn;
+    }
 
+    bool Load(T& objToLoad)
+    {
+        LogPrintf("Reading info from %s...\n", strFilename);
+        return Read(objToLoad);
+    }
+
+    bool Store(T& objToSave)
+    {
         LogPrintf("Verifying %s format...\n", strFilename);
         T tmpObjToLoad;
-        ReadResult readResult = Read(tmpObjToLoad, true);
+        if (!Read(tmpObjToLoad)) return false;
 
-        // there was an error and it was not an error on file opening => do not proceed
-        if (readResult == FileError)
-            LogPrintf("Missing file %s, will try to recreate\n", strFilename);
-        else if (readResult != Ok)
-        {
-            LogPrintf("Error reading %s: ", strFilename);
-            if(readResult == IncorrectFormat)
-                LogPrintf("%s: Magic is ok but data has invalid format, will try to recreate\n", __func__);
-            else
-            {
-                LogPrintf("%s: File format is unknown or invalid, please fix it manually\n", __func__);
-                return false;
-            }
-        }
+        int64_t nStart = GetTimeMillis();
 
         LogPrintf("Writing info to %s...\n", strFilename);
-        Write(objToSave);
+        CoreWrite(objToSave);
         LogPrintf("%s dump finished  %dms\n", strFilename, GetTimeMillis() - nStart);
 
         return true;
     }
-
 };
 
 

--- a/src/flat-database.h
+++ b/src/flat-database.h
@@ -6,6 +6,7 @@
 #define BITCOIN_FLAT_DATABASE_H
 
 #include <clientversion.h>
+#include <chainparams.h>
 #include <fs.h>
 #include <hash.h>
 #include <streams.h>

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -872,13 +872,13 @@ void CGovernanceManager::SyncObjects(CNode& peer, PeerManager& peerman, CConnman
     // do not provide any data until our node is synced
     if (!::masternodeSync->IsSynced()) return;
 
-    if (netfulfilledman.HasFulfilledRequest(peer.addr, NetMsgType::MNGOVERNANCESYNC)) {
+    if (netfulfilledman->HasFulfilledRequest(peer.addr, NetMsgType::MNGOVERNANCESYNC)) {
         // Asking for the whole list multiple times in a short period of time is no good
         LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s -- peer already asked me for the list\n", __func__);
         peerman.Misbehaving(peer.GetId(), 20);
         return;
     }
-    netfulfilledman.AddFulfilledRequest(peer.addr, NetMsgType::MNGOVERNANCESYNC);
+    netfulfilledman->AddFulfilledRequest(peer.addr, NetMsgType::MNGOVERNANCESYNC);
 
     int nObjCount = 0;
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -340,7 +340,7 @@ void CGovernanceManager::UpdateCachesAndClean()
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::UpdateCachesAndClean\n");
 
-    std::vector<uint256> vecDirtyHashes = mmetaman.GetAndClearDirtyGovernanceObjectHashes();
+    std::vector<uint256> vecDirtyHashes = mmetaman->GetAndClearDirtyGovernanceObjectHashes();
 
     LOCK2(cs_main, cs);
 
@@ -390,7 +390,7 @@ void CGovernanceManager::UpdateCachesAndClean()
         if ((pObj->IsSetCachedDelete() || pObj->IsSetExpired()) &&
             (nTimeSinceDeletion >= GOVERNANCE_DELETION_DELAY)) {
             LogPrint(BCLog::GOBJECT, "CGovernanceManager::UpdateCachesAndClean -- erase obj %s\n", (*it).first.ToString());
-            mmetaman.RemoveGovernanceObject(pObj->GetHash());
+            mmetaman->RemoveGovernanceObject(pObj->GetHash());
 
             // Remove vote references
             const object_ref_cm_t::list_t& listItems = cmapVoteToObject.GetItemList();

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -26,24 +26,28 @@ std::unique_ptr<CGovernanceManager> governance;
 
 int nSubmittedFinalBudget;
 
-const std::string CGovernanceManager::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-16";
+const std::string GovernanceStore::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-16";
 const int CGovernanceManager::MAX_TIME_FUTURE_DEVIATION = 60 * 60;
 const int CGovernanceManager::RELIABLE_PROPAGATION_TIME = 60;
 
-CGovernanceManager::CGovernanceManager() :
-    nTimeLastDiff(0),
-    nCachedBlockHeight(0),
+GovernanceStore::GovernanceStore() :
+    cs(),
     mapObjects(),
     mapErasedGovernanceObjects(),
     cmapVoteToObject(MAX_CACHE_SIZE),
     cmapInvalidVotes(MAX_CACHE_SIZE),
     cmmapOrphanVotes(MAX_CACHE_SIZE),
     mapLastMasternodeObject(),
+    lastMNListForVotingKeys(std::make_shared<CDeterministicMNList>())
+{
+}
+
+CGovernanceManager::CGovernanceManager() :
+    nTimeLastDiff(0),
+    nCachedBlockHeight(0),
     setRequestedObjects(),
     fRateChecksEnabled(true),
-    lastMNListForVotingKeys(std::make_shared<CDeterministicMNList>()),
-    votedFundingYesTriggerHash(std::nullopt),
-    cs()
+    votedFundingYesTriggerHash(std::nullopt)
 {
 }
 
@@ -1323,7 +1327,7 @@ void CGovernanceManager::InitOnLoad()
     LogPrintf("     %s\n", ToString());
 }
 
-std::string CGovernanceManager::ToString() const
+std::string GovernanceStore::ToString() const
 {
     LOCK(cs);
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -56,14 +56,15 @@ CGovernanceManager::CGovernanceManager() :
 CGovernanceManager::~CGovernanceManager()
 {
     if (!is_valid) return;
-    m_db->Dump(*this);
+    m_db->Store(*this);
 }
 
 bool CGovernanceManager::LoadCache(bool load_cache)
 {
     assert(m_db != nullptr);
-    is_valid = load_cache ? m_db->Load(*this) : m_db->Dump(*this);
+    is_valid = load_cache ? m_db->Load(*this) : m_db->Store(*this);
     if (is_valid && load_cache) {
+        CheckAndRemove();
         InitOnLoad();
     }
     return is_valid;

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -221,7 +221,6 @@ public:
         mapLastMasternodeObject.clear();
     }
 
-    void CheckAndRemove() { /* TODO: replace stub with means to call db cleanup function */ return; };
     std::string ToString() const;
 };
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -13,6 +13,8 @@
 
 class CBloomFilter;
 class CBlockIndex;
+template<typename T>
+class CFlatDB;
 class CInv;
 
 class CGovernanceManager;
@@ -232,6 +234,7 @@ class CGovernanceManager : public GovernanceStore
 
 private:
     using hash_s_t = std::set<uint256>;
+    using db_type = CFlatDB<GovernanceStore>;
 
     class ScopedLockBool
     {
@@ -258,6 +261,9 @@ private:
     static const int RELIABLE_PROPAGATION_TIME;
 
 private:
+    const std::unique_ptr<db_type> m_db;
+    bool is_valid{false};
+
     int64_t nTimeLastDiff;
     // keep track of current block height
     int nCachedBlockHeight;
@@ -270,7 +276,11 @@ private:
 
 public:
     CGovernanceManager();
-    ~CGovernanceManager() = default;
+    ~CGovernanceManager();
+
+    bool LoadCache(bool load_cache);
+
+    bool IsValid() const { return is_valid; }
 
     /**
      * This is called by AlreadyHave in net_processing.cpp as part of the inventory

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -124,14 +124,9 @@ public:
     }
 };
 
-//
-// Governance Manager : Contains all proposals for the budget
-//
-class CGovernanceManager
+class GovernanceStore
 {
-    friend class CGovernanceObject;
-
-public: // Types
+protected:
     struct last_object_rec {
         explicit last_object_rec(bool fStatusOKIn = true) :
             triggerBuffer(),
@@ -148,57 +143,95 @@ public: // Types
         bool fStatusOK;
     };
 
-
     using object_ref_cm_t = CacheMap<uint256, CGovernanceObject*>;
-
+    using txout_m_t = std::map<COutPoint, last_object_rec>;
     using vote_cmm_t = CacheMultiMap<uint256, vote_time_pair_t>;
 
-    using txout_m_t = std::map<COutPoint, last_object_rec>;
-
-    using hash_s_t = std::set<uint256>;
-
-private:
+protected:
     static constexpr int MAX_CACHE_SIZE = 1000000;
-
     static const std::string SERIALIZATION_VERSION_STRING;
 
-    static const int MAX_TIME_FUTURE_DEVIATION;
-    static const int RELIABLE_PROPAGATION_TIME;
+public:
+    // critical section to protect the inner data structures
+    mutable RecursiveMutex cs;
 
-    int64_t nTimeLastDiff;
-
-    // keep track of current block height
-    int nCachedBlockHeight;
-
+protected:
     // keep track of the scanning errors
     std::map<uint256, CGovernanceObject> mapObjects GUARDED_BY(cs);
-
     // mapErasedGovernanceObjects contains key-value pairs, where
     //   key   - governance object's hash
     //   value - expiration time for deleted objects
     std::map<uint256, int64_t> mapErasedGovernanceObjects;
-
-    std::map<uint256, CGovernanceObject> mapPostponedObjects;
-    hash_s_t setAdditionalRelayObjects;
-
     object_ref_cm_t cmapVoteToObject;
-
     CacheMap<uint256, CGovernanceVote> cmapInvalidVotes;
-
     vote_cmm_t cmmapOrphanVotes;
-
     txout_m_t mapLastMasternodeObject;
-
-    hash_s_t setRequestedObjects;
-
-    hash_s_t setRequestedVotes;
-
-    bool fRateChecksEnabled;
-
     // used to check for changed voting keys
     CDeterministicMNListPtr lastMNListForVotingKeys;
 
-    std::optional<uint256> votedFundingYesTriggerHash;
+public:
+    GovernanceStore();
+    ~GovernanceStore() = default;
+
+    template<typename Stream>
+    void Serialize(Stream &s) const
+    {
+        LOCK(cs);
+        s   << SERIALIZATION_VERSION_STRING
+            << mapErasedGovernanceObjects
+            << cmapInvalidVotes
+            << cmmapOrphanVotes
+            << mapObjects
+            << mapLastMasternodeObject
+            << *lastMNListForVotingKeys;
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream &s)
+    {
+        Clear();
+
+        LOCK(cs);
+        std::string strVersion;
+        s >> strVersion;
+        if (strVersion != SERIALIZATION_VERSION_STRING) {
+            return;
+        }
+
+        s   >> mapErasedGovernanceObjects
+            >> cmapInvalidVotes
+            >> cmmapOrphanVotes
+            >> mapObjects
+            >> mapLastMasternodeObject
+            >> *lastMNListForVotingKeys;
+    }
+
+    void Clear()
+    {
+        LOCK(cs);
+
+        LogPrint(BCLog::GOBJECT, "Governance object manager was cleared\n");
+        mapObjects.clear();
+        mapErasedGovernanceObjects.clear();
+        cmapVoteToObject.Clear();
+        cmapInvalidVotes.Clear();
+        cmmapOrphanVotes.Clear();
+        mapLastMasternodeObject.clear();
+    }
+
+    void CheckAndRemove() { /* TODO: replace stub with means to call db cleanup function */ return; };
+    std::string ToString() const;
+};
+
+//
+// Governance Manager : Contains all proposals for the budget
+//
+class CGovernanceManager : public GovernanceStore
+{
+    friend class CGovernanceObject;
+
+private:
+    using hash_s_t = std::set<uint256>;
 
     class ScopedLockBool
     {
@@ -220,13 +253,24 @@ private:
         }
     };
 
+private:
+    static const int MAX_TIME_FUTURE_DEVIATION;
+    static const int RELIABLE_PROPAGATION_TIME;
+
+private:
+    int64_t nTimeLastDiff;
+    // keep track of current block height
+    int nCachedBlockHeight;
+    std::map<uint256, CGovernanceObject> mapPostponedObjects;
+    hash_s_t setAdditionalRelayObjects;
+    hash_s_t setRequestedObjects;
+    hash_s_t setRequestedVotes;
+    bool fRateChecksEnabled;
+    std::optional<uint256> votedFundingYesTriggerHash;
+
 public:
-    // critical section to protect the inner data structures
-    mutable RecursiveMutex cs;
-
     CGovernanceManager();
-
-    virtual ~CGovernanceManager() = default;
+    ~CGovernanceManager() = default;
 
     /**
      * This is called by AlreadyHave in net_processing.cpp as part of the inventory
@@ -263,54 +307,7 @@ public:
 
     void CheckAndRemove() { UpdateCachesAndClean(); }
 
-    void Clear()
-    {
-        LOCK(cs);
-
-        LogPrint(BCLog::GOBJECT, "Governance object manager was cleared\n");
-        mapObjects.clear();
-        mapErasedGovernanceObjects.clear();
-        cmapVoteToObject.Clear();
-        cmapInvalidVotes.Clear();
-        cmmapOrphanVotes.Clear();
-        mapLastMasternodeObject.clear();
-    }
-
-    std::string ToString() const;
     UniValue ToJson() const;
-
-    template<typename Stream>
-    void Serialize(Stream &s) const
-    {
-        LOCK(cs);
-        s   << SERIALIZATION_VERSION_STRING
-            << mapErasedGovernanceObjects
-            << cmapInvalidVotes
-            << cmmapOrphanVotes
-            << mapObjects
-            << mapLastMasternodeObject
-            << *lastMNListForVotingKeys;
-    }
-
-    template<typename Stream>
-    void Unserialize(Stream &s)
-    {
-        LOCK(cs);
-        Clear();
-
-        std::string strVersion;
-        s >> strVersion;
-        if (strVersion != SERIALIZATION_VERSION_STRING) {
-            return;
-        }
-
-        s   >> mapErasedGovernanceObjects
-            >> cmapInvalidVotes
-            >> cmmapOrphanVotes
-            >> mapObjects
-            >> mapLastMasternodeObject
-            >> *lastMNListForVotingKeys;
-    }
 
     void UpdatedBlockTip(const CBlockIndex* pindex, CConnman& connman);
     int64_t GetLastDiffTime() const { return nTimeLastDiff; }

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -199,7 +199,7 @@ bool CGovernanceObject::ProcessVote(const CGovernanceVote& vote, CGovernanceExce
         return false;
     }
 
-    if (!mmetaman.AddGovernanceVote(dmn->proTxHash, vote.GetParentHash())) {
+    if (!mmetaman->AddGovernanceVote(dmn->proTxHash, vote.GetParentHash())) {
         std::ostringstream ostr;
         ostr << "CGovernanceObject::ProcessVote -- Unable to add governance vote"
              << ", MN outpoint = " << vote.GetMasternodeOutpoint().ToStringShort()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -280,7 +280,7 @@ void PrepareShutdown(NodeContext& node)
     if (!fRPCInWarmup) {
         // STORE DATA CACHES INTO SERIALIZED DAT FILES
         CFlatDB<CMasternodeMetaMan> flatdb1("mncache.dat", "magicMasternodeCache");
-        flatdb1.Dump(mmetaman);
+        flatdb1.Dump(*mmetaman);
         CFlatDB<CNetFulfilledRequestManager> flatdb4("netfulfilled.dat", "magicFulfilledCache");
         flatdb4.Dump(netfulfilledman);
     }
@@ -318,6 +318,7 @@ void PrepareShutdown(NodeContext& node)
     ::governance.reset();
     ::sporkManager.reset();
     ::masternodeSync.reset();
+    ::mmetaman.reset();
 
     // Stop and delete all indexes only after flushing background callbacks.
     if (g_txindex) {
@@ -1726,6 +1727,8 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         }
     }
 
+    assert(!::mmetaman);
+    ::mmetaman = std::make_unique<CMasternodeMetaMan>();
     ::masternodeSync = std::make_unique<CMasternodeSync>(*node.connman, *::governance);
 
     // sanitize comments per BIP-0014, format user agent and check total size
@@ -2283,7 +2286,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     uiInterface.InitMessage(_("Loading masternode cache...").translated);
     CFlatDB<CMasternodeMetaMan> flatdb1(strDBName, "magicMasternodeCache");
     if (fLoadCacheFiles) {
-        if(!flatdb1.Load(mmetaman)) {
+        if(!flatdb1.Load(*mmetaman)) {
             return InitError(strprintf(_("Failed to load masternode cache from %s"), (pathDB / strDBName).string()));
         }
     } else {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1702,11 +1702,6 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     assert(!::sporkManager);
     ::sporkManager = std::make_unique<CSporkManager>();
 
-    if (!::sporkManager->IsValid()) {
-        auto file_path = (GetDataDir() / "sporks.dat").string();
-        return InitError(strprintf(_("Failed to load sporks cache from %s"), file_path));
-    }
-
     std::vector<std::string> vSporkAddresses;
     if (args.IsArgSet("-sporkaddr")) {
         vSporkAddresses = args.GetArgs("-sporkaddr");
@@ -1868,7 +1863,10 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     // ********************************************************* Step 7a: Load sporks
 
-    /* TODO: decouple db init and move here */
+    if (!::sporkManager->LoadCache()) {
+        auto file_path = (GetDataDir() / "sporks.dat").string();
+        return InitError(strprintf(_("Failed to load sporks cache from %s"), file_path));
+    }
 
     // ********************************************************* Step 7b: load block chain
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -286,7 +286,7 @@ void PrepareShutdown(NodeContext& node)
         CFlatDB<CSporkManager> flatdb6("sporks.dat", "magicSporkCache");
         flatdb6.Dump(*::sporkManager);
         if (!fDisableGovernance) {
-            CFlatDB<CGovernanceManager> flatdb3("governance.dat", "magicGovernanceCache");
+            CFlatDB<GovernanceStore> flatdb3("governance.dat", "magicGovernanceCache");
             flatdb3.Dump(*::governance);
         }
     }
@@ -2287,7 +2287,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     strDBName = "governance.dat";
     uiInterface.InitMessage(_("Loading governance cache...").translated);
-    CFlatDB<CGovernanceManager> flatdb3(strDBName, "magicGovernanceCache");
+    CFlatDB<GovernanceStore> flatdb3(strDBName, "magicGovernanceCache");
     if (fLoadCacheFiles && !fDisableGovernance) {
         if(!flatdb3.Load(*::governance)) {
             return InitError(strprintf(_("Failed to load governance cache from %s"), (pathDB / strDBName).string()));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -279,7 +279,7 @@ void PrepareShutdown(NodeContext& node)
 
     if (!fRPCInWarmup) {
         // STORE DATA CACHES INTO SERIALIZED DAT FILES
-        CFlatDB<CMasternodeMetaMan> flatdb1("mncache.dat", "magicMasternodeCache");
+        CFlatDB<MasternodeMetaStore> flatdb1("mncache.dat", "magicMasternodeCache");
         flatdb1.Dump(*mmetaman);
         CFlatDB<CNetFulfilledRequestManager> flatdb4("netfulfilled.dat", "magicFulfilledCache");
         flatdb4.Dump(netfulfilledman);
@@ -2284,7 +2284,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     strDBName = "mncache.dat";
     uiInterface.InitMessage(_("Loading masternode cache...").translated);
-    CFlatDB<CMasternodeMetaMan> flatdb1(strDBName, "magicMasternodeCache");
+    CFlatDB<MasternodeMetaStore> flatdb1(strDBName, "magicMasternodeCache");
     if (fLoadCacheFiles) {
         if(!flatdb1.Load(*mmetaman)) {
             return InitError(strprintf(_("Failed to load masternode cache from %s"), (pathDB / strDBName).string()));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -279,7 +279,7 @@ void PrepareShutdown(NodeContext& node)
 
     if (!fRPCInWarmup) {
         // STORE DATA CACHES INTO SERIALIZED DAT FILES
-        CFlatDB<CNetFulfilledRequestManager> flatdb4("netfulfilled.dat", "magicFulfilledCache");
+        CFlatDB<NetFulfilledRequestStore> flatdb4("netfulfilled.dat", "magicFulfilledCache");
         flatdb4.Dump(*netfulfilledman);
     }
 
@@ -2292,7 +2292,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     strDBName = "netfulfilled.dat";
     uiInterface.InitMessage(_("Loading fulfilled requests cache...").translated);
-    CFlatDB<CNetFulfilledRequestManager> flatdb4(strDBName, "magicFulfilledCache");
+    CFlatDB<NetFulfilledRequestStore> flatdb4(strDBName, "magicFulfilledCache");
     if (fLoadCacheFiles) {
         if(!flatdb4.Load(*netfulfilledman)) {
             return InitError(strprintf(_("Failed to load fulfilled requests cache from %s"),(pathDB / strDBName).string()));

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -463,7 +463,7 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions() const
             logger.Batch("%s does not have min proto version %d (has %d)", m->dmn->proTxHash.ToString(), MIN_MASTERNODE_PROTO_VERSION, it->second);
         }
 
-        if (mmetaman.GetMetaInfo(m->dmn->proTxHash)->OutboundFailedTooManyTimes()) {
+        if (mmetaman->GetMetaInfo(m->dmn->proTxHash)->OutboundFailedTooManyTimes()) {
             m->badConnection = true;
             logger.Batch("%s failed to connect to it too many times", m->dmn->proTxHash.ToString());
         }

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -924,7 +924,7 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, const CBlo
 }
 
 void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, const CBlockIndex *pQuorumBaseBlockIndex,
-                                           CConnman& connman, const uint256 &myProTxHash)
+                               CConnman& connman, const uint256 &myProTxHash)
 {
     if (!IsQuorumPoseEnabled(llmqParams.type)) {
         return;
@@ -938,7 +938,7 @@ void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, const CB
         if (dmn->proTxHash == myProTxHash) {
             continue;
         }
-        auto lastOutbound = mmetaman.GetMetaInfo(dmn->proTxHash)->GetLastOutboundSuccess();
+        auto lastOutbound = mmetaman->GetMetaInfo(dmn->proTxHash)->GetLastOutboundSuccess();
         if (curTime - lastOutbound < 10 * 60) {
             // avoid re-probing nodes too often
             continue;

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -18,7 +18,7 @@ CMasternodeMetaMan::CMasternodeMetaMan(bool load_cache) :
     is_valid{
         [&]() -> bool {
             assert(m_db != nullptr);
-            return load_cache ? m_db->Load(*this) : m_db->Dump(*this);
+            return load_cache ? m_db->Load(*this) : m_db->Store(*this);
         }()
     }
 {
@@ -27,7 +27,7 @@ CMasternodeMetaMan::CMasternodeMetaMan(bool load_cache) :
 CMasternodeMetaMan::~CMasternodeMetaMan()
 {
     if (!is_valid) return;
-    m_db->Dump(*this);
+    m_db->Store(*this);
 }
 
 UniValue CMasternodeMetaInfo::ToJson() const

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -4,6 +4,7 @@
 
 #include <masternode/meta.h>
 
+#include <flat-database.h>
 #include <timedata.h>
 
 #include <sstream>
@@ -11,6 +12,23 @@
 std::unique_ptr<CMasternodeMetaMan> mmetaman;
 
 const std::string MasternodeMetaStore::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-3";
+
+CMasternodeMetaMan::CMasternodeMetaMan(bool load_cache) :
+    m_db{std::make_unique<db_type>("mncache.dat", "magicMasternodeCache")},
+    is_valid{
+        [&]() -> bool {
+            assert(m_db != nullptr);
+            return load_cache ? m_db->Load(*this) : m_db->Dump(*this);
+        }()
+    }
+{
+}
+
+CMasternodeMetaMan::~CMasternodeMetaMan()
+{
+    if (!is_valid) return;
+    m_db->Dump(*this);
+}
 
 UniValue CMasternodeMetaInfo::ToJson() const
 {

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -10,7 +10,7 @@
 
 std::unique_ptr<CMasternodeMetaMan> mmetaman;
 
-const std::string CMasternodeMetaMan::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-3";
+const std::string MasternodeMetaStore::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-3";
 
 UniValue CMasternodeMetaInfo::ToJson() const
 {
@@ -110,14 +110,7 @@ std::vector<uint256> CMasternodeMetaMan::GetAndClearDirtyGovernanceObjectHashes(
     return vecTmp;
 }
 
-void CMasternodeMetaMan::Clear()
-{
-    LOCK(cs);
-    metaInfos.clear();
-    vecDirtyGovernanceObjectHashes.clear();
-}
-
-std::string CMasternodeMetaMan::ToString() const
+std::string MasternodeMetaStore::ToString() const
 {
     std::ostringstream info;
     LOCK(cs);

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -8,7 +8,7 @@
 
 #include <sstream>
 
-CMasternodeMetaMan mmetaman;
+std::unique_ptr<CMasternodeMetaMan> mmetaman;
 
 const std::string CMasternodeMetaMan::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-3";
 

--- a/src/masternode/meta.h
+++ b/src/masternode/meta.h
@@ -15,6 +15,8 @@
 #include <memory>
 
 class CConnman;
+template<typename T>
+class CFlatDB;
 
 static constexpr int MASTERNODE_MAX_MIXING_TXES{5};
 static constexpr int MASTERNODE_MAX_FAILED_OUTBOUND_ATTEMPTS{5};
@@ -145,11 +147,19 @@ public:
 class CMasternodeMetaMan : public MasternodeMetaStore
 {
 private:
+    using db_type = CFlatDB<MasternodeMetaStore>;
+
+private:
+    const std::unique_ptr<db_type> m_db;
+    const bool is_valid{false};
+
     std::vector<uint256> vecDirtyGovernanceObjectHashes GUARDED_BY(cs);
 
 public:
-    CMasternodeMetaMan() = default;
-    ~CMasternodeMetaMan() = default;
+    explicit CMasternodeMetaMan(bool load_cache);
+    ~CMasternodeMetaMan();
+
+    bool IsValid() const { return is_valid; }
 
     CMasternodeMetaInfoPtr GetMetaInfo(const uint256& proTxHash, bool fCreate = true);
 

--- a/src/masternode/meta.h
+++ b/src/masternode/meta.h
@@ -6,12 +6,13 @@
 #define BITCOIN_MASTERNODE_META_H
 
 #include <serialize.h>
+#include <sync.h>
+#include <uint256.h>
 
 #include <univalue.h>
 
 #include <atomic>
-#include <uint256.h>
-#include <sync.h>
+#include <memory>
 
 class CConnman;
 
@@ -153,6 +154,6 @@ public:
     std::string ToString() const;
 };
 
-extern CMasternodeMetaMan mmetaman;
+extern std::unique_ptr<CMasternodeMetaMan> mmetaman;
 
 #endif // BITCOIN_MASTERNODE_META_H

--- a/src/masternode/meta.h
+++ b/src/masternode/meta.h
@@ -140,7 +140,6 @@ public:
         metaInfos.clear();
     }
 
-    void CheckAndRemove() { return; };
     std::string ToString() const;
 };
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2731,6 +2731,8 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& peer, CDataStream& vRecv, const
 
 std::pair<bool /*ret*/, bool /*do_return*/> static ValidateDSTX(CTxMemPool& mempool, ChainstateManager& chainman, CCoinJoinBroadcastTx& dstx, uint256 hashTx)
 {
+    assert(::mmetaman != nullptr);
+
     if (!dstx.IsValidStructure()) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Invalid DSTX structure: %s\n", hashTx.ToString());
         return {false, true};
@@ -2773,7 +2775,7 @@ std::pair<bool /*ret*/, bool /*do_return*/> static ValidateDSTX(CTxMemPool& memp
         return {false, true};
     }
 
-    if (!mmetaman.GetMetaInfo(dmn->proTxHash)->IsValidForMixingTxes()) {
+    if (!mmetaman->GetMetaInfo(dmn->proTxHash)->IsValidForMixingTxes()) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Masternode %s is sending too many transactions %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
         return {true, true};
         // TODO: Not an error? Could it be that someone is relaying old DSTXes
@@ -2787,7 +2789,7 @@ std::pair<bool /*ret*/, bool /*do_return*/> static ValidateDSTX(CTxMemPool& memp
 
     LogPrint(BCLog::COINJOIN, "DSTX -- Got Masternode transaction %s\n", hashTx.ToString());
     mempool.PrioritiseTransaction(hashTx, 0.1*COIN);
-    mmetaman.DisallowMixing(dmn->proTxHash);
+    mmetaman->DisallowMixing(dmn->proTxHash);
 
     return {true, false};
 }

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -7,7 +7,9 @@
 #include <shutdown.h>
 #include <util/system.h>
 
-CNetFulfilledRequestManager netfulfilledman;
+#include <memory>
+
+std::unique_ptr<CNetFulfilledRequestManager> netfulfilledman;
 
 void CNetFulfilledRequestManager::AddFulfilledRequest(const CService& addr, const std::string& strRequest)
 {

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -40,7 +40,7 @@ void CNetFulfilledRequestManager::RemoveAllFulfilledRequests(const CService& add
     }
 }
 
-void CNetFulfilledRequestManager::CheckAndRemove()
+void NetFulfilledRequestStore::CheckAndRemove()
 {
     LOCK(cs_mapFulfilledRequests);
 
@@ -64,13 +64,13 @@ void CNetFulfilledRequestManager::CheckAndRemove()
     }
 }
 
-void CNetFulfilledRequestManager::Clear()
+void NetFulfilledRequestStore::Clear()
 {
     LOCK(cs_mapFulfilledRequests);
     mapFulfilledRequests.clear();
 }
 
-std::string CNetFulfilledRequestManager::ToString() const
+std::string NetFulfilledRequestStore::ToString() const
 {
     std::ostringstream info;
     info << "Nodes with fulfilled requests: " << (int)mapFulfilledRequests.size();

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -3,13 +3,29 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <flat-database.h>
 #include <netfulfilledman.h>
 #include <shutdown.h>
 #include <util/system.h>
 
-#include <memory>
-
 std::unique_ptr<CNetFulfilledRequestManager> netfulfilledman;
+
+CNetFulfilledRequestManager::CNetFulfilledRequestManager(bool load_cache) :
+    m_db{std::make_unique<db_type>("netfulfilled.dat", "magicFulfilledCache")},
+    is_valid{
+        [&]() -> bool {
+            assert(m_db != nullptr);
+            return load_cache ? m_db->Load(*this) : m_db->Dump(*this);
+        }()
+    }
+{
+}
+
+CNetFulfilledRequestManager::~CNetFulfilledRequestManager()
+{
+    if (!is_valid) return;
+    m_db->Dump(*this);
+}
 
 void CNetFulfilledRequestManager::AddFulfilledRequest(const CService& addr, const std::string& strRequest)
 {

--- a/src/netfulfilledman.cpp
+++ b/src/netfulfilledman.cpp
@@ -15,16 +15,19 @@ CNetFulfilledRequestManager::CNetFulfilledRequestManager(bool load_cache) :
     is_valid{
         [&]() -> bool {
             assert(m_db != nullptr);
-            return load_cache ? m_db->Load(*this) : m_db->Dump(*this);
+            return load_cache ? m_db->Load(*this) : m_db->Store(*this);
         }()
     }
 {
+    if (is_valid && load_cache) {
+        CheckAndRemove();
+    }
 }
 
 CNetFulfilledRequestManager::~CNetFulfilledRequestManager()
 {
     if (!is_valid) return;
-    m_db->Dump(*this);
+    m_db->Store(*this);
 }
 
 void CNetFulfilledRequestManager::AddFulfilledRequest(const CService& addr, const std::string& strRequest)
@@ -56,7 +59,7 @@ void CNetFulfilledRequestManager::RemoveAllFulfilledRequests(const CService& add
     }
 }
 
-void NetFulfilledRequestStore::CheckAndRemove()
+void CNetFulfilledRequestManager::CheckAndRemove()
 {
     LOCK(cs_mapFulfilledRequests);
 

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -9,6 +9,10 @@
 #include <serialize.h>
 #include <sync.h>
 
+#include <memory>
+
+template<typename T>
+class CFlatDB;
 class CNetFulfilledRequestManager;
 
 class NetFulfilledRequestStore
@@ -39,9 +43,18 @@ public:
 // and from being banned for doing so too often.
 class CNetFulfilledRequestManager : public NetFulfilledRequestStore
 {
+private:
+    using db_type = CFlatDB<NetFulfilledRequestStore>;
+
+private:
+    const std::unique_ptr<db_type> m_db;
+    const bool is_valid{false};
+
 public:
-    CNetFulfilledRequestManager() = default;
-    ~CNetFulfilledRequestManager() = default;
+    explicit CNetFulfilledRequestManager(bool load_cache);
+    ~CNetFulfilledRequestManager();
+
+    bool IsValid() const { return is_valid; }
 
     void AddFulfilledRequest(const CService& addr, const std::string& strRequest);
     bool HasFulfilledRequest(const CService& addr, const std::string& strRequest);

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -10,7 +10,6 @@
 #include <sync.h>
 
 class CNetFulfilledRequestManager;
-extern CNetFulfilledRequestManager netfulfilledman;
 
 // Fulfilled requests are used to prevent nodes from asking for the same data on sync
 // and from being banned for doing so too often.
@@ -45,5 +44,7 @@ public:
 
     void DoMaintenance();
 };
+
+extern std::unique_ptr<CNetFulfilledRequestManager> netfulfilledman;
 
 #endif // BITCOIN_NETFULFILLEDMAN_H

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -33,7 +33,6 @@ public:
         READWRITE(obj.mapFulfilledRequests);
     }
 
-    void CheckAndRemove();
     void Clear();
 
     std::string ToString() const;
@@ -55,6 +54,7 @@ public:
     ~CNetFulfilledRequestManager();
 
     bool IsValid() const { return is_valid; }
+    void CheckAndRemove();
 
     void AddFulfilledRequest(const CService& addr, const std::string& strRequest);
     bool HasFulfilledRequest(const CService& addr, const std::string& strRequest);

--- a/src/netfulfilledman.h
+++ b/src/netfulfilledman.h
@@ -11,36 +11,42 @@
 
 class CNetFulfilledRequestManager;
 
-// Fulfilled requests are used to prevent nodes from asking for the same data on sync
-// and from being banned for doing so too often.
-class CNetFulfilledRequestManager
+class NetFulfilledRequestStore
 {
-private:
+protected:
     typedef std::map<std::string, int64_t> fulfilledreqmapentry_t;
     typedef std::map<CService, fulfilledreqmapentry_t> fulfilledreqmap_t;
 
+protected:
     //keep track of what node has/was asked for and when
     fulfilledreqmap_t mapFulfilledRequests;
     mutable RecursiveMutex cs_mapFulfilledRequests;
 
 public:
-    CNetFulfilledRequestManager() {}
-
-    SERIALIZE_METHODS(CNetFulfilledRequestManager, obj)
+    SERIALIZE_METHODS(NetFulfilledRequestStore, obj)
     {
         LOCK(obj.cs_mapFulfilledRequests);
         READWRITE(obj.mapFulfilledRequests);
     }
 
-    void AddFulfilledRequest(const CService& addr, const std::string& strRequest);
-    bool HasFulfilledRequest(const CService& addr, const std::string& strRequest);
-
-    void RemoveAllFulfilledRequests(const CService& addr);
-
     void CheckAndRemove();
     void Clear();
 
     std::string ToString() const;
+};
+
+// Fulfilled requests are used to prevent nodes from asking for the same data on sync
+// and from being banned for doing so too often.
+class CNetFulfilledRequestManager : public NetFulfilledRequestStore
+{
+public:
+    CNetFulfilledRequestManager() = default;
+    ~CNetFulfilledRequestManager() = default;
+
+    void AddFulfilledRequest(const CService& addr, const std::string& strRequest);
+    bool HasFulfilledRequest(const CService& addr, const std::string& strRequest);
+
+    void RemoveAllFulfilledRequests(const CService& addr);
 
     void DoMaintenance();
 };

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1303,7 +1303,8 @@ static UniValue BuildDMNListEntry(CWallet* pwallet, const CDeterministicMN& dmn,
     }
 #endif
 
-    auto metaInfo = mmetaman.GetMetaInfo(dmn.proTxHash);
+    CHECK_NONFATAL(mmetaman != nullptr);
+    auto metaInfo = mmetaman->GetMetaInfo(dmn.proTxHash);
     o.pushKV("metaInfo", metaInfo->ToJson());
 
     return o;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -68,6 +68,22 @@ void SporkStore::Clear()
     // we should not alter them here.
 }
 
+CSporkManager::CSporkManager() :
+    m_db{std::make_unique<db_type>("sporks.dat", "magicSporkCache")},
+    is_valid{
+        [&]() -> bool {
+            assert(m_db != nullptr);
+            return m_db->Load(*this);
+        }()
+    }
+{
+}
+
+CSporkManager::~CSporkManager()
+{
+    m_db->Dump(*this);
+}
+
 void CSporkManager::CheckAndRemove()
 {
     LOCK(cs);

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -76,20 +76,24 @@ CSporkManager::CSporkManager() :
 CSporkManager::~CSporkManager()
 {
     if (!is_valid) return;
-    m_db->Dump(*this);
+    m_db->Store(*this);
 }
 
 bool CSporkManager::LoadCache()
 {
     assert(m_db != nullptr);
     is_valid = m_db->Load(*this);
-    return IsValid();
+    if (is_valid) {
+        CheckAndRemove();
+    }
+    return is_valid;
 }
 
 void CSporkManager::CheckAndRemove()
 {
     LOCK(cs);
-    assert(!setSporkPubKeyIDs.empty());
+
+    if (setSporkPubKeyIDs.empty()) return;
 
     for (auto itActive = mapSporksActive.begin(); itActive != mapSporksActive.end();) {
         auto itSignerPair = itActive->second.begin();

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -69,19 +69,21 @@ void SporkStore::Clear()
 }
 
 CSporkManager::CSporkManager() :
-    m_db{std::make_unique<db_type>("sporks.dat", "magicSporkCache")},
-    is_valid{
-        [&]() -> bool {
-            assert(m_db != nullptr);
-            return m_db->Load(*this);
-        }()
-    }
+    m_db{std::make_unique<db_type>("sporks.dat", "magicSporkCache")}
 {
 }
 
 CSporkManager::~CSporkManager()
 {
+    if (!is_valid) return;
     m_db->Dump(*this);
+}
+
+bool CSporkManager::LoadCache()
+{
+    assert(m_db != nullptr);
+    is_valid = m_db->Load(*this);
+    return IsValid();
 }
 
 void CSporkManager::CheckAndRemove()

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <consensus/params.h>
+#include <flat-database.h>
 #include <key_io.h>
 #include <logging.h>
 #include <messagesigner.h>
@@ -24,6 +25,8 @@
 #include <string>
 
 std::unique_ptr<CSporkManager> sporkManager;
+
+const std::string SporkStore::SERIALIZATION_VERSION_STRING = "CSporkManager-Version-2";
 
 std::optional<SporkValue> CSporkManager::SporkValueIfActive(SporkId nSporkID) const
 {
@@ -56,7 +59,7 @@ std::optional<SporkValue> CSporkManager::SporkValueIfActive(SporkId nSporkID) co
     return std::nullopt;
 }
 
-void CSporkManager::Clear()
+void SporkStore::Clear()
 {
     LOCK(cs);
     mapSporksActive.clear();
@@ -327,7 +330,7 @@ bool CSporkManager::SetPrivKey(const std::string& strPrivKey)
     return true;
 }
 
-std::string CSporkManager::ToString() const
+std::string SporkStore::ToString() const
 {
     LOCK(cs);
     return strprintf("Sporks: %llu", mapSporksActive.size());

--- a/src/spork.h
+++ b/src/spork.h
@@ -219,7 +219,7 @@ private:
 
 private:
     const std::unique_ptr<db_type> m_db;
-    const bool is_valid{false};
+    bool is_valid{false};
 
     mutable Mutex cs_mapSporksCachedActive;
     mutable std::unordered_map<const SporkId, bool> mapSporksCachedActive GUARDED_BY(cs_mapSporksCachedActive);
@@ -240,6 +240,8 @@ private:
 public:
     CSporkManager();
     ~CSporkManager();
+
+    bool LoadCache();
 
     bool IsValid() const { return is_valid; }
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -199,8 +199,6 @@ public:
      */
     void Clear() LOCKS_EXCLUDED(cs);
 
-    void CheckAndRemove() { /* TODO: replace stub with means to call db cleanup function */ return; };
-
     /**
      * ToString returns the string representation of the SporkManager.
      */

--- a/src/spork.h
+++ b/src/spork.h
@@ -155,41 +155,17 @@ public:
     void Relay(CConnman& connman) const;
 };
 
-/**
- * CSporkManager is a higher-level class which manages the node's spork
- * messages, rules for which sporks should be considered active/inactive, and
- * processing for certain sporks (e.g. spork 12).
- */
-class CSporkManager
+class SporkStore
 {
-private:
-    static constexpr std::string_view SERIALIZATION_VERSION_STRING = "CSporkManager-Version-2";
-
-    mutable Mutex cs_mapSporksCachedActive;
-    mutable std::unordered_map<const SporkId, bool> mapSporksCachedActive GUARDED_BY(cs_mapSporksCachedActive);
-
-    mutable Mutex cs_mapSporksCachedValues;
-    mutable std::unordered_map<SporkId, SporkValue> mapSporksCachedValues GUARDED_BY(cs_mapSporksCachedValues);
+protected:
+    static const std::string SERIALIZATION_VERSION_STRING;
 
     mutable Mutex cs;
 
     std::unordered_map<uint256, CSporkMessage, StaticSaltedHasher> mapSporksByHash GUARDED_BY(cs);
     std::unordered_map<SporkId, std::map<CKeyID, CSporkMessage> > mapSporksActive GUARDED_BY(cs);
 
-    std::set<CKeyID> setSporkPubKeyIDs GUARDED_BY(cs);
-    int nMinSporkKeys GUARDED_BY(cs) {std::numeric_limits<int>::max()};
-    CKey sporkPrivKey GUARDED_BY(cs);
-
-    /**
-     * SporkValueIfActive is used to get the value agreed upon by the majority
-     * of signed spork messages for a given Spork ID.
-     */
-    std::optional<SporkValue> SporkValueIfActive(SporkId nSporkID) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-
 public:
-
-    CSporkManager() = default;
-
     template<typename Stream>
     void Serialize(Stream &s) const LOCKS_EXCLUDED(cs)
     {
@@ -221,6 +197,42 @@ public:
      */
     void Clear() LOCKS_EXCLUDED(cs);
 
+    void CheckAndRemove() { /* TODO: replace stub with means to call db cleanup function */ return; };
+
+    /**
+     * ToString returns the string representation of the SporkManager.
+     */
+    std::string ToString() const LOCKS_EXCLUDED(cs);
+};
+
+/**
+ * CSporkManager is a higher-level class which manages the node's spork
+ * messages, rules for which sporks should be considered active/inactive, and
+ * processing for certain sporks (e.g. spork 12).
+ */
+class CSporkManager : public SporkStore
+{
+private:
+    mutable Mutex cs_mapSporksCachedActive;
+    mutable std::unordered_map<const SporkId, bool> mapSporksCachedActive GUARDED_BY(cs_mapSporksCachedActive);
+
+    mutable Mutex cs_mapSporksCachedValues;
+    mutable std::unordered_map<SporkId, SporkValue> mapSporksCachedValues GUARDED_BY(cs_mapSporksCachedValues);
+
+    std::set<CKeyID> setSporkPubKeyIDs GUARDED_BY(cs);
+    int nMinSporkKeys GUARDED_BY(cs) {std::numeric_limits<int>::max()};
+    CKey sporkPrivKey GUARDED_BY(cs);
+
+    /**
+     * SporkValueIfActive is used to get the value agreed upon by the majority
+     * of signed spork messages for a given Spork ID.
+     */
+    std::optional<SporkValue> SporkValueIfActive(SporkId nSporkID) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+public:
+    CSporkManager() = default;
+    ~CSporkManager() = default;
+
     /**
      * CheckAndRemove is defined to fulfill an interface as part of the on-disk
      * cache used to cache sporks between runs. If sporks that are restored
@@ -243,7 +255,6 @@ public:
      * performs any necessary processing.
      */
     void ProcessSpork(const CNode& peer, PeerManager& peerman, CConnman& connman, CDataStream& vRecv) LOCKS_EXCLUDED(cs);
-
 
     /**
      * ProcessGetSporks is used to handle the 'getsporks' p2p message.
@@ -315,11 +326,6 @@ public:
      * address in the set of valid spork signers (see SetSporkAddress).
      */
     bool SetPrivKey(const std::string& strPrivKey) LOCKS_EXCLUDED(cs);
-
-    /**
-     * ToString returns the string representation of the SporkManager.
-     */
-    std::string ToString() const LOCKS_EXCLUDED(cs);
 };
 
 #endif // BITCOIN_SPORK_H

--- a/src/spork.h
+++ b/src/spork.h
@@ -20,6 +20,8 @@
 #include <vector>
 
 class CConnman;
+template<typename T>
+class CFlatDB;
 class CNode;
 class CDataStream;
 class PeerManager;
@@ -213,6 +215,12 @@ public:
 class CSporkManager : public SporkStore
 {
 private:
+    using db_type = CFlatDB<SporkStore>;
+
+private:
+    const std::unique_ptr<db_type> m_db;
+    const bool is_valid{false};
+
     mutable Mutex cs_mapSporksCachedActive;
     mutable std::unordered_map<const SporkId, bool> mapSporksCachedActive GUARDED_BY(cs_mapSporksCachedActive);
 
@@ -230,8 +238,10 @@ private:
     std::optional<SporkValue> SporkValueIfActive(SporkId nSporkID) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
 public:
-    CSporkManager() = default;
-    ~CSporkManager() = default;
+    CSporkManager();
+    ~CSporkManager();
+
+    bool IsValid() const { return is_valid; }
 
     /**
      * CheckAndRemove is defined to fulfill an interface as part of the on-disk

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -208,7 +208,7 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     ::sporkManager = std::make_unique<CSporkManager>();
     ::governance = std::make_unique<CGovernanceManager>();
     ::masternodeSync = std::make_unique<CMasternodeSync>(*m_node.connman, *::governance);
-    ::mmetaman = std::make_unique<CMasternodeMetaMan>();
+    ::mmetaman = std::make_unique<CMasternodeMetaMan>(/* load_cache */ false);
 
     m_node.creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -210,7 +210,7 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     ::governance = std::make_unique<CGovernanceManager>();
     ::masternodeSync = std::make_unique<CMasternodeSync>(*m_node.connman, *::governance);
     ::mmetaman = std::make_unique<CMasternodeMetaMan>(/* load_cache */ false);
-    ::netfulfilledman = std::make_unique<CNetFulfilledRequestManager>();
+    ::netfulfilledman = std::make_unique<CNetFulfilledRequestManager>(/* load_cache */ false);
 
     m_node.creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -17,6 +17,7 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <masternode/meta.h>
+#include <netfulfilledman.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/chainlocks.h>
 #include <llmq/context.h>
@@ -209,6 +210,7 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     ::governance = std::make_unique<CGovernanceManager>();
     ::masternodeSync = std::make_unique<CMasternodeSync>(*m_node.connman, *::governance);
     ::mmetaman = std::make_unique<CMasternodeMetaMan>(/* load_cache */ false);
+    ::netfulfilledman = std::make_unique<CNetFulfilledRequestManager>();
 
     m_node.creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
 
@@ -225,6 +227,7 @@ ChainTestingSetup::~ChainTestingSetup()
     StopScriptCheckWorkerThreads();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
+    ::netfulfilledman.reset();
     ::mmetaman.reset();
     ::masternodeSync.reset();
     ::governance.reset();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -16,6 +16,7 @@
 #include <index/txindex.h>
 #include <init.h>
 #include <interfaces/chain.h>
+#include <masternode/meta.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/chainlocks.h>
 #include <llmq/context.h>
@@ -207,6 +208,7 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     ::sporkManager = std::make_unique<CSporkManager>();
     ::governance = std::make_unique<CGovernanceManager>();
     ::masternodeSync = std::make_unique<CMasternodeSync>(*m_node.connman, *::governance);
+    ::mmetaman = std::make_unique<CMasternodeMetaMan>();
 
     m_node.creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
 
@@ -223,6 +225,7 @@ ChainTestingSetup::~ChainTestingSetup()
     StopScriptCheckWorkerThreads();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
+    ::mmetaman.reset();
     ::masternodeSync.reset();
     ::governance.reset();
     ::sporkManager.reset();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -11,6 +11,7 @@
 #include <consensus/params.h>
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
+#include <flat-database.h>
 #include <governance/governance.h>
 #include <index/txindex.h>
 #include <init.h>


### PR DESCRIPTION
## Motivation

As highlighted in https://github.com/dashpay/dash-issues/issues/52, decoupling of `CFlatDB`-interacting components from managers of objects like `CGovernanceManager` and `CSporkManager` is a key task for achieving deglobalization of Dash-specific components.

The design of `CFlatDB` as a flat database agent relies on hooking into the object's state its meant to load and store, using its (de)serialization routines and other miscellaneous functions (notably, without defining an interface) to achieve those ends. This approach was taken predominantly for components that want a single-file cache. 

Because of the method it uses to hook into the object (templates and the use of temporary objects), it explicitly prevented passing arguments into the object constructor, an explicit requirement for storing references to other components during construction. This, in turn, created an explicit dependency on those same components being available in the global context, which would block the backport of bitcoin#21866, a requirement for future backports meant to achieve parity in `assumeutxo` support.

The design of these objects made no separation between persistent (i.e. cached) and ephemeral (i.e. generated/fetched during initialization or state transitions) data and the design of `CFlatDB` attempts to "clean" the database by breaching this separation and attempting to access this ephemeral data.

This might be acceptable if it is contained within the manager itself, like `CSporkManager`'s `CheckAndRemove()` but is utterly unacceptable when it relies on other managers (that, as a reminder, are only accessible through the global state because of restrictions caused by existing design), like `CGovernanceManager`'s `UpdateCachesAndClean()`.

This pull request aims to separate the `CFlatDB`-interacting portions of these managers into a struct, with `CFlatDB` interacting only with this struct, while the manager inherits the struct and manages load/store/update of the database through the `CFlatDB` instance initialized within its scope, though the instance only has knowledge of what is exposed through the limited parent struct. 

## Additional information

* As regards to existing behaviour, `CFlatDB` is written entirely as a header as it relies on templates to specialize itself for the object it hooks into. Attempting to split the logic and function definitions into separate files will require you to explicitly define template specializations, which is tedious.

* `m_db` is defined as a pointer as you cannot instantiate a forward-declared template (see [this Stack Overflow answer](https://stackoverflow.com/a/12797282) for more information), which is done when defined as a member in the object scope.

* The conditional cache flush predicating on RPC _not_ being in the warm-up state has been replaced with unconditional flushing of the database on object destruction (@UdjinM6, is this acceptable?)

## TODOs

This is a list of things that aren't within the scope of this pull request but should be addressed in subsequent pull requests

* [ ] Definition of an interface that `CFlatDB` stores are expected to implement
* [ ] Lock annotations for all potential uses of members protected by the `cs` mutex in each manager object and store
* [ ] Additional comments documenting what each function and member does
* [ ] Deglobalization of affected managers