### PR TITLE
fix: adjusted nSuperblockMaturityWindow to new logic for devnet/testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -345,7 +345,7 @@ public:
         consensus.nSuperblockStartBlock = 4200; // NOTE: Should satisfy nSuperblockStartBlock > nBudgetPeymentsStartBlock
         consensus.nSuperblockStartHash = uint256(); // do not check this on testnet
         consensus.nSuperblockCycle = 24; // Superblocks can be issued hourly on testnet
-        consensus.nSuperblockMaturityWindow = 24; // This is equal to SB cycle on testnet
+        consensus.nSuperblockMaturityWindow = 8;
         consensus.nGovernanceMinQuorum = 1;
         consensus.nGovernanceFilterElements = 500;
         consensus.nMasternodeMinimumConfirmations = 1;
@@ -517,7 +517,7 @@ public:
         consensus.nSuperblockStartBlock = 4200; // NOTE: Should satisfy nSuperblockStartBlock > nBudgetPeymentsStartBlock
         consensus.nSuperblockStartHash = uint256(); // do not check this on devnet
         consensus.nSuperblockCycle = 24; // Superblocks can be issued hourly on devnet
-        consensus.nSuperblockMaturityWindow = 24; // This is equal to SB cycle on devnet
+        consensus.nSuperblockMaturityWindow = 8;
         consensus.nGovernanceMinQuorum = 1;
         consensus.nGovernanceFilterElements = 500;
         consensus.nMasternodeMinimumConfirmations = 1;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Since #5525, MNs during the maturity window, will propose new triggers. 

In `CGovernanceManager::CreateSuperblockCandidate`, SuperBlock creation is skipped when the bellow check is true:

`if (nHeight % Params().GetConsensus().nSuperblockCycle < Params().GetConsensus().nSuperblockCycle - Params().GetConsensus().nSuperblockMaturityWindow) return std::nullopt;
    `
    
Hence, the value of `nSuperblockMaturityWindow` must be less than `nSuperblockCycle` and greater than 0.

## What was done?
Changed `nSuperblockMaturityWindow` for devnet and Testnet chain parameters to the following values:

`nSuperblockCycle` = 24
`nSuperblockMaturityWindow` = 8

## How Has This Been Tested?

## Breaking Changes
 
## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

