### PR TITLE
fix: improve `gfd` script to make it works for more cases.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,8 +295,8 @@ before and after commits must be present locally.
 
 ```
 function gfd() {
-        local fp1=$(git merge-base --fork-point develop $1)
-        local fp2=$(git merge-base --fork-point develop $2)
+        local fp1=$(git show-branch --merge-base develop $1)
+        local fp2=$(git show-branch --merge-base develop $2)
         echo fp1=$fp1
         echo fp2=$fp2
         diff --color=always -u -I'^[^-+]' <(git diff $fp1..$1) <(git diff $fp2..$2)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Seems as old command `git merge-base --fork-point` doesn't work for some cases of tree structure 

Particularly it didn't worked for PR #5546:
>  @kwvg kwvg force-pushed the utilbps branch from 82d8a61 to f1bc1c3

Basically, one of the step `gfb` script -- `git merge-base --fork-point develop 82d8a61d227fb66e2c6d4402ebb88e5740271eb9` returned me wrong commit. After pulling origin/develop it returns just an empty string.

But `git show-branch --merge-base develop 82d8a61d227fb66e2c6d4402ebb88e5740271eb9` worked and returned correct commit:
  "3e1c6dd731 fix: reorder initializations (#5545)" which is the last common commit with develop branch


## What was done?
Updated recommended function `function gfd()` in doc

## How Has This Been Tested?
Tested on PR #5546 that failed before and returned wrong diff for me


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone