### PR TITLE
fix: add missing includes and remove obsolete includes

### DIFF
--- a/src/bench/addrman.cpp
+++ b/src/bench/addrman.cpp
@@ -7,7 +7,6 @@
 #include <random.h>
 #include <util/time.h>
 
-#include <optional>
 #include <vector>
 
 /* A "source" is a source address from which we have received a bunch of other addresses. */

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -25,6 +25,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <stdio.h>
 
 #include <stacktraces.h>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -26,7 +26,6 @@
 #include <util/url.h>
 
 #include <functional>
-#include <optional>
 #include <stdio.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -15,6 +15,7 @@
 #include <util/hash_type.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -9,8 +9,9 @@
 #include <coinjoin/coinjoin.h>
 #include <util/translation.h>
 
-#include <utility>
 #include <atomic>
+#include <deque>
+#include <utility>
 
 class CDeterministicMN;
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -17,6 +17,7 @@
 #include <util/translation.h>
 #include <version.h>
 
+#include <atomic>
 #include <optional>
 #include <utility>
 

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -17,6 +17,7 @@
 #include <util/translation.h>
 #include <version.h>
 
+#include <optional>
 #include <utility>
 
 class CCoinJoin;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -10,7 +10,6 @@
 #include <llmq/params.h>
 
 #include <limits>
-#include <map>
 
 namespace Consensus {
 

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -13,6 +13,7 @@
 #include <memenv.h>
 #include <stdint.h>
 #include <algorithm>
+#include <optional>
 
 class CBitcoinLevelDBLogger : public leveldb::Logger {
 public:

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -9,6 +9,8 @@
 #include <primitives/transaction.h>
 #include <univalue.h>
 
+#include <optional>
+
 class BlockValidationState;
 class CBlock;
 class CBlockIndex;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -19,6 +19,7 @@
 
 #include <immer/map.hpp>
 
+#include <atomic>
 #include <limits>
 #include <numeric>
 #include <unordered_map>

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -17,8 +17,6 @@
 #include <netmessagemaker.h>
 #include <validation.h>
 
-#include <unordered_set>
-
 void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip)
 {
     LOCK(activeMasternodeInfoCs);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -11,6 +11,8 @@
 #include <threadinterrupt.h>
 #include <validationinterface.h>
 
+#include <atomic>
+
 class CBlockIndex;
 class CChainState;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -102,6 +102,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <memory>
+#include <optional>
 #include <set>
 #include <thread>
 #include <vector>

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -17,6 +17,7 @@
 #include <sync.h>
 
 #include <atomic>
+#include <map>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -17,6 +17,7 @@
 #include <sync.h>
 
 #include <atomic>
+#include <unordered_map>
 #include <unordered_set>
 
 class CChainState;

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -19,6 +19,7 @@
 #include <validation.h>
 
 #include <cxxtimer.hpp>
+#include <atomic>
 #include <memory>
 #include <util/irange.h>
 #include <util/underlying.h>

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -9,6 +9,7 @@
 #include <ctpl_stl.h>
 #include <net.h>
 
+#include <atomic>
 #include <optional>
 
 class CBlockIndex;

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -10,6 +10,7 @@
 #include <net.h>
 
 #include <atomic>
+#include <map>
 #include <optional>
 
 class CBlockIndex;

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -10,6 +10,9 @@
 #include <bls/bls.h>
 #include <bls/bls_worker.h>
 
+#include <map>
+#include <memory>
+
 class CBlockIndex;
 class CChainState;
 class CDKGDebugManager;

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -15,6 +15,7 @@
 #include <threadinterrupt.h>
 #include <txmempool.h>
 
+#include <atomic>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -16,6 +16,8 @@
 
 #include <evo/evodb.h>
 
+#include <atomic>
+
 class CBlockIndex;
 class CChainState;
 class CConnman;

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -17,6 +17,7 @@
 #include <evo/evodb.h>
 
 #include <atomic>
+#include <map>
 
 class CBlockIndex;
 class CChainState;

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -14,6 +14,7 @@
 #include <sync.h>
 #include <uint256.h>
 
+#include <atomic>
 #include <optional>
 #include <thread>
 #include <unordered_map>

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -22,6 +22,7 @@
 #include <validation.h>
 #include <versionbits.h>
 
+#include <atomic>
 #include <optional>
 
 static constexpr int TESTNET_LLMQ_25_67_ACTIVATION_HEIGHT = 847000;

--- a/src/net.h
+++ b/src/net.h
@@ -36,7 +36,6 @@
 #include <thread>
 #include <memory>
 #include <condition_variable>
-#include <unordered_set>
 #include <optional>
 #include <queue>
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -34,6 +34,7 @@
 
 #include <list>
 #include <memory>
+#include <optional>
 #include <typeinfo>
 
 #include <spork.h>

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -10,6 +10,8 @@
 #include <sync.h>
 #include <validationinterface.h>
 
+#include <atomic>
+
 class CAddrMan;
 class CTxMemPool;
 class ChainstateManager;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -8,7 +8,6 @@
 #include <fs.h>
 #include <protocol.h> // For CMessageHeader::MessageStartChars
 
-#include <atomic>
 #include <cstdint>
 #include <vector>
 

--- a/src/node/coinstats.h
+++ b/src/node/coinstats.h
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 
 class BlockManager;
 class CCoinsView;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -60,6 +60,7 @@
 #include <boost/signals2/signal.hpp>
 
 #include <memory>
+#include <optional>
 #include <utility>
 
 using interfaces::BlockTip;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -7,6 +7,8 @@
 
 #include <util/system.h>
 
+#include <atomic>
+
 static std::atomic<bool> g_initial_block_download_completed(false);
 
 #define MAKE_MSG(var_name, p2p_name_str)   \

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -51,6 +51,7 @@
 
 #include <merkleblock.h>
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -33,7 +33,6 @@
 #include <spork.h>
 
 #include <stdint.h>
-#include <tuple>
 #ifdef HAVE_MALLOC_INFO
 #include <malloc.h>
 #endif

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -27,8 +27,6 @@
 #include <version.h>
 #include <warnings.h>
 
-#include <optional>
-
 #include <univalue.h>
 
 static UniValue getconnectioncount(const JSONRPCRequest& request)

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -25,6 +25,7 @@
 #include <llmq/snapshot.h>
 
 #include <iomanip>
+#include <optional>
 
 namespace llmq {
 extern const std::string CLSIG_REQUESTID_PREFIX;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -17,6 +17,7 @@
 #include <boost/signals2/signal.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <memory> // for unique_ptr
 #include <unordered_map>
 

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -15,8 +15,6 @@
 #include <util/string.h>
 #include <util/translation.h>
 
-#include <tuple>
-
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
 const std::string EXAMPLE_ADDRESS[2] = {"XunLY9Tf7Zsef8gMGL2fhWA9ZmMjt4KPw0", "XwQQkwA4FYkq2XERzMY2CiAZhJTEDAbtc0"};
 

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -13,7 +13,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <optional>
 #include <string>
 
 class CAddrManTest : public CAddrMan

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -14,7 +14,6 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/src/test/evo_assetlocks_tests.cpp
+++ b/src/test/evo_assetlocks_tests.cpp
@@ -16,7 +16,6 @@
 #include <boost/test/unit_test.hpp>
 
 
-#include <optional>
 //
 // Helper: create two dummy transactions, each with
 // two outputs.  The first has 11 and 50 CENT outputs

--- a/src/test/fuzz/autofile.cpp
+++ b/src/test/fuzz/autofile.cpp
@@ -10,7 +10,6 @@
 #include <array>
 #include <cstdint>
 #include <iostream>
-#include <optional>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -38,6 +38,7 @@
 #include <chrono>
 #include <ctime>
 #include <limits>
+#include <optional>
 #include <set>
 #include <vector>
 

--- a/src/test/fuzz/rolling_bloom_filter.cpp
+++ b/src/test/fuzz/rolling_bloom_filter.cpp
@@ -10,7 +10,6 @@
 
 #include <cassert>
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/script_descriptor_cache.cpp
+++ b/src/test/fuzz/script_descriptor_cache.cpp
@@ -9,7 +9,6 @@
 #include <test/fuzz/util.h>
 
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <vector>
 

--- a/src/util/enumerate.h
+++ b/src/util/enumerate.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_UTIL_ENUMERATE_H
 #define BITCOIN_UTIL_ENUMERATE_H
 
-#include <tuple>
 #include <iterator>
 
 /**

--- a/src/util/overflow.h
+++ b/src/util/overflow.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_OVERFLOW_H
 
 #include <limits>
+#include <optional>
 #include <type_traits>
 
 template <class T>

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -35,6 +35,7 @@
 #endif // __linux__
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <fcntl.h>
 #include <sched.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -62,6 +62,7 @@
 
 #include <statsd_client.h>
 
+#include <deque>
 #include <optional>
 #include <string>
 

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -13,7 +13,6 @@
 #include <util/system.h>
 #include <wallet/db.h>
 
-#include <atomic>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -46,6 +46,7 @@
 
 #include <univalue.h>
 
+#include <optional>
 
 using interfaces::FoundBlock;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -18,6 +18,8 @@
 
 #include <boost/signals2/signal.hpp>
 
+#include <optional>
+
 // Wallet storage things that ScriptPubKeyMans need in order to be able to store things to the wallet database.
 // It provides access to things that are part of the entire wallet and not specific to a ScriptPubKeyMan such as
 // wallet flags, wallet version, encryption keys, encryption status, and the database itself. This allows a

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -39,6 +39,7 @@
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -31,7 +31,6 @@
 
 #include <algorithm>
 #include <atomic>
-#include <deque>
 #include <map>
 #include <memory>
 #include <optional>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -34,6 +34,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <stdint.h>


### PR DESCRIPTION
## Issue being fixed or feature implemented
Some headers or modules are used objects from STL without including it directly, it cause compilation failures on some platforms for some specific compilers such as #5554

## What was done?
Added missing includes and removed obsolete includes for `optional`, `deque`, `tuple`, `unordered_set`, `unordered_map`, `set` and `atomic`.

Please, note, that this PR doesn't cover all cases, only cases when it is obviously missing or obviously obsolete.

Also most of changes belongs to to dash specific code; but for cases of original bitcoin code I keep it untouched, such as missing <map> in `src/psbt.h`

I used this script to get a list of files/headers which looks suspicious `./headers-scanner.sh std::optional optional`:
```bash
#!/bin/bash

set -e

function check_includes() {
    obj=$1
    header=$2
    file=$3

    used=0
    included=0

    grep "$obj" "$file" >/dev/null 2>/dev/null && used=1
    grep "include <$header>" $file >/dev/null 2>/dev/null && included=1
    if [ $used == 1 ] && [ $included == 0 ]
        then echo "missing <$header> in $file"
    fi
    if [ $used == 0 ] && [ $included == 1 ]
        then echo "obsolete <$header> in $file"
    fi
}
export -f check_includes

obj=$1
header=$2

find src \( -name '*.h' -or -name '*.cpp' -or -name '*.hpp' \) -exec bash -c 'check_includes "$0" "$1" "$2"'  "$obj" "$header"  {} \;
```

## How Has This Been Tested?
Built code locally

## Breaking Changes
n/a


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

