### PR TITLE
feat: forbid temporary Asset Locks txes everywhere except RegTest

### DIFF
--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -51,6 +51,9 @@ static bool CheckSpecialTxInner(const CTransaction& tx, const CBlockIndex* pinde
             return CheckMNHFTx(tx, pindexPrev, state);
         case TRANSACTION_ASSET_LOCK:
         case TRANSACTION_ASSET_UNLOCK:
+            if (Params().NetworkIDString() != CBaseChainParams::REGTEST) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-assetlock-regtest-only");
+            }
             if (!llmq::utils::IsV20Active(pindexPrev)) {
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetlocks-before-v20");
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -391,6 +391,11 @@ static bool ContextualCheckTransaction(const CTransaction& tx, TxValidationState
                 tx.nType != TRANSACTION_ASSET_UNLOCK) {
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-type");
             }
+            if (Params().NetworkIDString() != CBaseChainParams::REGTEST &&
+                    (tx.nType == TRANSACTION_ASSET_LOCK || tx.nType == TRANSACTION_ASSET_UNLOCK)) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-assetlock-regtest-only");
+            }
+
             if (tx.IsCoinBase() && tx.nType != TRANSACTION_COINBASE)
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-cb-type");
         } else if (tx.nType != TRANSACTION_NORMAL) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
PR to disable asset lock/unlock txes until platform is ready


## What was done?
Forbidden Asset Lock and Asset Unlock txes (types 8, 9) for accept to mempool `ContextualCheckTransaction` and for mining in block `CheckSpecialTx`.


## How Has This Been Tested?
Run unit/functional tests; **hasn't been tested at any devnet.**


## Breaking Changes
It is breaking changes for testnet/mainnet/devnets but assetlocks are not deployed anyway yet to testnet/mainnet.


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

