### PR TITLE
fix: vote funding yes when receiving triggers if hasn't created own trigger

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -310,7 +310,7 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
     // SEND NOTIFICATION TO SCRIPT/ZMQ
     GetMainSignals().NotifyGovernanceObject(std::make_shared<const CGovernanceObject>(govobj));
 
-    if (govobj.GetObjectType() == GovernanceObject::TRIGGER && HasAlreadyVotedFundingTrigger()) {
+    if (govobj.GetObjectType() == GovernanceObject::TRIGGER) {
         vote_outcome_enum_t funding_vote = HasAlreadyVotedFundingTrigger() ? VOTE_OUTCOME_NO : VOTE_OUTCOME_YES;
         VoteFundingTrigger(govobj.GetHash(), funding_vote, connman);
     }

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -311,7 +311,8 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
     GetMainSignals().NotifyGovernanceObject(std::make_shared<const CGovernanceObject>(govobj));
 
     if (govobj.GetObjectType() == GovernanceObject::TRIGGER && HasAlreadyVotedFundingTrigger()) {
-        VoteFundingTrigger(govobj.GetHash(), VOTE_OUTCOME_NO, connman);
+        vote_outcome_enum_t funding_vote = HasAlreadyVotedFundingTrigger() ? VOTE_OUTCOME_NO : VOTE_OUTCOME_YES;
+        VoteFundingTrigger(govobj.GetHash(), funding_vote, connman);
     }
 }
 

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -131,6 +131,8 @@ class DashGovernanceTest (DashTestFramework):
         time.sleep(1)
 
         assert_equal(len(self.nodes[0].gobject("list", "valid", "triggers")), 1)
+        trigger_data = list(self.nodes[0].gobject("list", "valid", "triggers").values())[0]
+        assert_equal(trigger_data['YesCount'], self.mn_count)
 
         block_count = self.nodes[0].getblockcount()
         n = sb_cycle - block_count % sb_cycle

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -130,8 +130,9 @@ class DashGovernanceTest (DashTestFramework):
         self.sync_blocks()
         time.sleep(1)
 
-        assert_equal(len(self.nodes[0].gobject("list", "valid", "triggers")), 1)
-        trigger_data = list(self.nodes[0].gobject("list", "valid", "triggers").values())[0]
+        valid_triggers = self.nodes[0].gobject("list", "valid", "triggers")
+        assert_equal(len(valid_triggers), 1)
+        trigger_data = list(valid_triggers.values())[0]
         assert_equal(trigger_data['YesCount'], self.mn_count)
 
         block_count = self.nodes[0].getblockcount()


### PR DESCRIPTION
## Issue being fixed or feature implemented
In case MNs didn't submit their own trigger, should vote for funding yes when receiving triggers from other nodes.

## What was done?
Check if already submitted theirs and vote accordingly. 

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

