### PR TITLE
fix: Only approve triggers that match our expectations

### DIFF
--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -249,7 +249,7 @@ public:
     void DoMaintenance(CConnman& connman);
 
     CGovernanceObject* FindGovernanceObject(const uint256& nHash);
-    bool HasGovernanceObjectByDataHash(const uint256& nHash);
+    CGovernanceObject* FindGovernanceObjectByDataHash(const uint256& nDataHash);
     void DeleteGovernanceObject(const uint256& nHash);
 
     // These commands are only used in RPC

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -130,9 +130,21 @@ class DashGovernanceTest (DashTestFramework):
         self.sync_blocks()
         time.sleep(1)
 
+        # The "winner" should submit new trigger and vote for it, no one else should vote yet
         valid_triggers = self.nodes[0].gobject("list", "valid", "triggers")
         assert_equal(len(valid_triggers), 1)
         trigger_data = list(valid_triggers.values())[0]
+        assert_equal(trigger_data['YesCount'], 1)
+
+        # Move 1 block inside the Superblock maturity window
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+        time.sleep(1)
+
+        # Every MN should vote for the same trigger now, no new triggers should be created
+        triggers_rpc = self.nodes[0].gobject("list", "valid", "triggers")
+        assert_equal(len(triggers_rpc), 1)
+        trigger_data = list(triggers_rpc.values())[0]
         assert_equal(trigger_data['YesCount'], self.mn_count)
 
         block_count = self.nodes[0].getblockcount()


### PR DESCRIPTION
## Issue being fixed or feature implemented
#5564 is a bit too optimistic about incoming triggers

## What was done?
Rework governance logic to only approve triggers that match our expectations i.e. have the same data hash as our own trigger would have if we would have to submit it.

## How Has This Been Tested?
Run tests

## Breaking Changes
Voting is done in `CreateGovernanceTrigger` only now meaning that it only happens on next block for incoming triggers. Tweaked tests accordingly.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

