### PR TITLE
fix: add/tweak thread safety annotations around governance objects map, add missing lock

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -423,7 +423,7 @@ void CGovernanceManager::UpdateCachesAndClean()
 
 CGovernanceObject* CGovernanceManager::FindGovernanceObject(const uint256& nHash)
 {
-    LOCK(cs);
+    AssertLockHeld(cs);
 
     if (mapObjects.count(nHash)) return &mapObjects[nHash];
 
@@ -432,7 +432,7 @@ CGovernanceObject* CGovernanceManager::FindGovernanceObject(const uint256& nHash
 
 CGovernanceObject* CGovernanceManager::FindGovernanceObjectByDataHash(const uint256 &nDataHash)
 {
-    LOCK(cs);
+    AssertLockHeld(cs);
 
     for (const auto& [nHash, object] : mapObjects) {
         if (object.GetDataHash() == nDataHash) return &mapObjects[nHash];

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -632,12 +632,12 @@ std::optional<CSuperblock> CGovernanceManager::CreateSuperblockCandidate(int nHe
 void CGovernanceManager::CreateGovernanceTrigger(const CSuperblock& sb, CConnman& connman)
 {
     //TODO: Check if nHashParentIn, nRevision and nCollateralHashIn are correct
-    LOCK2(cs_main, governance->cs);
+    LOCK2(cs_main, cs);
 
     // Check if identical trigger (equal DataHash()) is already created (signed by other masternode)
     CGovernanceObject* gov_sb_voting{nullptr};
     CGovernanceObject gov_sb(uint256(), 1, GetAdjustedTime(), uint256(), sb.GetHexStrData());
-    const auto identical_sb = governance->FindGovernanceObjectByDataHash(gov_sb.GetDataHash());
+    const auto identical_sb = FindGovernanceObjectByDataHash(gov_sb.GetDataHash());
 
     if (identical_sb == nullptr) {
         // Nobody submitted a trigger we'd like to see,
@@ -655,12 +655,12 @@ void CGovernanceManager::CreateGovernanceTrigger(const CSuperblock& sb, CConnman
             LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Created trigger is invalid:%s\n", __func__, strError);
             return;
         }
-        if (!governance->MasternodeRateCheck(gov_sb)) {
+        if (!MasternodeRateCheck(gov_sb)) {
             LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Trigger rejected because of rate check failure hash(%s)\n", __func__, gov_sb.GetHash().ToString());
             return;
         }
         // The trigger we just created looks good, submit it
-        governance->AddGovernanceObject(gov_sb, connman);
+        AddGovernanceObject(gov_sb, connman);
         gov_sb_voting = &gov_sb;
     } else {
         // Somebody submitted a trigger with the same data, support it instead of submitting a duplicate
@@ -699,7 +699,7 @@ bool CGovernanceManager::VoteFundingTrigger(const uint256& nHash, const vote_out
     }
 
     CGovernanceException exception;
-    if (!governance->ProcessVoteAndRelay(vote, exception, connman)) {
+    if (!ProcessVoteAndRelay(vote, exception, connman)) {
         LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Vote FUNDING %d for trigger:%s failed:%s\n", __func__, outcome, nHash.ToString(), exception.what());
         return false;
     }

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -171,7 +171,7 @@ private:
     int nCachedBlockHeight;
 
     // keep track of the scanning errors
-    std::map<uint256, CGovernanceObject> mapObjects;
+    std::map<uint256, CGovernanceObject> mapObjects GUARDED_BY(cs);
 
     // mapErasedGovernanceObjects contains key-value pairs, where
     //   key   - governance object's hash
@@ -248,8 +248,8 @@ public:
 
     void DoMaintenance(CConnman& connman);
 
-    CGovernanceObject* FindGovernanceObject(const uint256& nHash);
-    CGovernanceObject* FindGovernanceObjectByDataHash(const uint256& nDataHash);
+    CGovernanceObject* FindGovernanceObject(const uint256& nHash) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    CGovernanceObject* FindGovernanceObjectByDataHash(const uint256& nDataHash) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void DeleteGovernanceObject(const uint256& nHash);
 
     // These commands are only used in RPC

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -965,6 +965,7 @@ static UniValue voteraw(const JSONRPCRequest& request)
     }
 
     GovernanceObject govObjType = WITH_LOCK(governance->cs, return [&](){
+        AssertLockHeld(governance->cs);
         CGovernanceObject *pGovObj = governance->FindGovernanceObject(hashGovObj);
         if (!pGovObj) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Governance object not found");


### PR DESCRIPTION
## Issue being fixed or feature implemented
Tidy up things a bit, address concerns expressed in https://github.com/dashpay/dash/pull/5565#discussion_r1315258917

## What was done?
Implemented changes to make sure `mapObjects` is protected

## How Has This Been Tested?
Run tests, run local node

## Breaking Changes
n/a
## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

