### PR TITLE
fix: actually erase old evodb data on db migration

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1181,17 +1181,17 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
 
 }
 
-[[nodiscard]] static bool EraseOldDBData(CDBWrapper& db, const std::vector<std::string>& db_keys)
+[[nodiscard]] static bool EraseOldDBData(CDBWrapper& db, const std::vector<std::string>& db_key_prefixes)
 {
     bool erased{false};
-    for(const auto& db_key : db_keys) {
+    for(const auto& db_key_prefix : db_key_prefixes) {
         CDBBatch batch(db);
         auto it = std::unique_ptr<CDBIterator>(db.NewIterator());
-        auto firstKey = std::make_pair(db_key, uint256());
+        auto firstKey = std::make_pair(db_key_prefix, uint256());
         it->Seek(firstKey);
         while (it->Valid()) {
             decltype(firstKey) curKey;
-            if (!it->GetKey(curKey) || std::get<0>(curKey) != db_key) {
+            if (!it->GetKey(curKey) || std::get<0>(curKey) != db_key_prefix) {
                 break;
             }
             batch.Erase(curKey);
@@ -1200,7 +1200,7 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
         }
         if (erased) {
             db.WriteBatch(batch);
-            LogPrintf("CDeterministicMNManager::%s -- done cleaning old data for %s\n", __func__, db_key);
+            LogPrintf("CDeterministicMNManager::%s -- done cleaning old data for %s\n", __func__, db_key_prefix);
         }
     }
     return erased;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1185,9 +1185,9 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
 {
     bool erased{false};
     for(const auto& db_key_prefix : db_key_prefixes) {
-        CDBBatch batch(db);
-        auto it = std::unique_ptr<CDBIterator>(db.NewIterator());
-        auto firstKey = std::make_pair(db_key_prefix, uint256());
+        CDBBatch batch{db};
+        std::unique_ptr<CDBIterator> it{db.NewIterator()};
+        std::pair firstKey{db_key_prefix, uint256()};
         it->Seek(firstKey);
         while (it->Valid()) {
             decltype(firstKey) curKey;
@@ -1199,6 +1199,7 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
             it->Next();
         }
         if (erased) {
+            LogPrintf("CDeterministicMNManager::%s -- updating db...\n", __func__);
             db.WriteBatch(batch);
             LogPrintf("CDeterministicMNManager::%s -- done cleaning old data for %s\n", __func__, db_key_prefix);
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
The old evodb data wasn't dropped on db migration really. `Erase(<db_key_prefix>)` does nothing.

## What was done?
Loop through the old data and drop it in batches per db key. Do this both for nodes that are doing migration for the first time and for nodes that did migration in the past already.

## How Has This Been Tested?
Running different versions on testnet
```
# reindex with 18.2.2 till block 850000 (pre-v19 block)
$ du -hd1 ~/.dashcore/testnet3/evodb/
276M	.dashcore/testnet3/evodb

# continue with develop, migration just finished, keep syncing till current tip, block 901000+
$ du -hd1 ~/.dashcore/testnet3/evodb/
469M	.dashcore/testnet3/evodb

# continue with this PR, start at current tip, "migration already done. cleaned old data."
$ du -hd1 ~/.dashcore/testnet3/evodb/
302M	.dashcore/testnet3/evodb
```

## Breaking Changes
Should be none.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

