### PR TITLE
feat: Remove outdated quorum data from evodb

### DIFF
--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -274,6 +274,8 @@ private:
 
     void StartCachePopulatorThread(const CQuorumCPtr pQuorum) const;
     void StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, const CBlockIndex* pIndex, uint16_t nDataMask) const;
+
+    void CleanupOldQuorumData(const CBlockIndex* pIndex) const;
 };
 
 extern std::unique_ptr<CQuorumManager> quorumManager;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Grabbed this from #5480. 

## What was done?
Cleans quorum data from evoDB for old quorums.

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

