### PR TITLE
rpc: add fundingthreshold to output of getgovernanceinfo

### DIFF
--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -1022,6 +1022,7 @@ static UniValue getgovernanceinfo(const JSONRPCRequest& request)
                 {RPCResult::Type::NUM, "superblockmaturitywindow", "the superblock trigger creation window"},
                 {RPCResult::Type::NUM, "lastsuperblock", "the block number of the last superblock"},
                 {RPCResult::Type::NUM, "nextsuperblock", "the block number of the next superblock"},
+                {RPCResult::Type::NUM, "fundingthreshold", "the number of absolute yes votes required for a proposal to be passing"},
             }},
         RPCExamples{
             HelpExampleCli("getgovernanceinfo", "")
@@ -1045,6 +1046,7 @@ static UniValue getgovernanceinfo(const JSONRPCRequest& request)
     obj.pushKV("superblockmaturitywindow", Params().GetConsensus().nSuperblockMaturityWindow);
     obj.pushKV("lastsuperblock", nLastSuperblock);
     obj.pushKV("nextsuperblock", nNextSuperblock);
+    obj.pushKV("fundingthreshold", int(deterministicMNManager->GetListAtChainTip().GetValidWeightedMNsCount() / 10));
 
     return obj;
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
DashCentral and DMT are both providing incorrect funding thresholds; output this from core to communicate this more clearly

## What was done?
Added RPC output

## How Has This Been Tested?
Running on main net

## Breaking Changes
none

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

