### PR TITLE
fix: Do not relay/store/count votes from pose-banned MNs

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<CGovernanceManager> governance;
 
 int nSubmittedFinalBudget;
 
-const std::string GovernanceStore::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-16";
+const std::string GovernanceStore::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-17";
 const int CGovernanceManager::MAX_TIME_FUTURE_DEVIATION = 60 * 60;
 const int CGovernanceManager::RELIABLE_PROPAGATION_TIME = 60;
 
@@ -1500,6 +1500,8 @@ void CGovernanceManager::RemoveInvalidVotes()
         if ((p.second.fields & CDeterministicMNStateDiff::Field_keyIDVoting) && p.second.state.keyIDVoting != oldDmn->pdmnState->keyIDVoting) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         } else if ((p.second.fields & CDeterministicMNStateDiff::Field_pubKeyOperator) && p.second.state.pubKeyOperator != oldDmn->pdmnState->pubKeyOperator) {
+            changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
+        } else if ((p.second.fields & CDeterministicMNStateDiff::Field_nPoSeBanHeight) && p.second.state.IsBanned()) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         }
     }

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1501,14 +1501,17 @@ void CGovernanceManager::RemoveInvalidVotes()
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         } else if ((p.second.fields & CDeterministicMNStateDiff::Field_pubKeyOperator) && p.second.state.pubKeyOperator != oldDmn->pdmnState->pubKeyOperator) {
             changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
-        } else if ((p.second.fields & CDeterministicMNStateDiff::Field_nPoSeBanHeight) && p.second.state.IsBanned()) {
-            changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
         }
     }
     for (const auto& id : diff.removedMns) {
         auto oldDmn = lastMNListForVotingKeys->GetMNByInternalId(id);
         changedKeyMNs.emplace_back(oldDmn->collateralOutpoint);
     }
+    curMNList.ForEachMN(false, [&](const auto& dmn) {
+        if (dmn.pdmnState->IsBanned() && curMNList.GetHeight() - dmn.pdmnState->GetBannedHeight() > Params().GetConsensus().nSuperblockCycle) {
+            changedKeyMNs.emplace_back(dmn.collateralOutpoint);
+        }
+    });
 
     for (const auto& outpoint : changedKeyMNs) {
         for (auto& p : mapObjects) {

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -123,9 +123,9 @@ bool CGovernanceObject::ProcessVote(const CGovernanceVote& vote, CGovernanceExce
         return false;
     }
 
-    if (dmn->pdmnState->IsBanned()) {
+    if (dmn->pdmnState->IsBanned() && mnList.GetHeight() - dmn->pdmnState->GetBannedHeight() > Params().GetConsensus().nSuperblockCycle) {
         std::ostringstream ostr;
-        ostr << "CGovernanceObject::ProcessVote -- Masternode " << vote.GetMasternodeOutpoint().ToStringShort() << " is banned";
+        ostr << "CGovernanceObject::ProcessVote -- Masternode " << vote.GetMasternodeOutpoint().ToStringShort() << " is long-time banned";
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
         return false;
     }

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -123,6 +123,13 @@ bool CGovernanceObject::ProcessVote(const CGovernanceVote& vote, CGovernanceExce
         return false;
     }
 
+    if (dmn->pdmnState->IsBanned()) {
+        std::ostringstream ostr;
+        ostr << "CGovernanceObject::ProcessVote -- Masternode " << vote.GetMasternodeOutpoint().ToStringShort() << " is banned";
+        exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
+        return false;
+    }
+
     auto it = mapCurrentMNVotes.emplace(vote_m_t::value_type(vote.GetMasternodeOutpoint(), vote_rec_t())).first;
     vote_rec_t& voteRecordRef = it->second;
     vote_signal_enum_t eSignal = vote.GetSignal();

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -268,14 +268,15 @@ bool CGovernanceVote::IsValid(bool useVotingKey) const
         return false;
     }
 
-    auto dmn = deterministicMNManager->GetListAtChainTip().GetMNByCollateral(masternodeOutpoint);
+    const auto mnList = deterministicMNManager->GetListAtChainTip();
+    const auto dmn = mnList.GetMNByCollateral(masternodeOutpoint);
     if (!dmn) {
         LogPrint(BCLog::GOBJECT, "CGovernanceVote::IsValid -- Unknown Masternode - %s\n", masternodeOutpoint.ToStringShort());
         return false;
     }
 
-    if (dmn->pdmnState->IsBanned()) {
-        LogPrint(BCLog::GOBJECT, "CGovernanceVote::IsValid -- Invalid Masternode - %s\n", masternodeOutpoint.ToStringShort());
+    if (dmn->pdmnState->IsBanned() && mnList.GetHeight() - dmn->pdmnState->GetBannedHeight() > Params().GetConsensus().nSuperblockCycle) {
+        LogPrint(BCLog::GOBJECT, "CGovernanceVote::IsValid -- Long-time banned Masternode - %s\n", masternodeOutpoint.ToStringShort());
         return false;
     }
 

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -274,6 +274,11 @@ bool CGovernanceVote::IsValid(bool useVotingKey) const
         return false;
     }
 
+    if (dmn->pdmnState->IsBanned()) {
+        LogPrint(BCLog::GOBJECT, "CGovernanceVote::IsValid -- Invalid Masternode - %s\n", masternodeOutpoint.ToStringShort());
+        return false;
+    }
+
     if (useVotingKey) {
         return CheckSignature(dmn->pdmnState->keyIDVoting);
     } else {


### PR DESCRIPTION
## Issue being fixed or feature implemented
We only count enabled MNs when calculating voting threshold, so ignore non-enabled MNs when counting votes.

(_Alternative solution would be to count all MNs (not just enabled ones) when calculating voting threshold but it would make it harder for proposals to pass given the low MNO activity. Also feels unfair that active MNOs would suffer because of non-active ones. But if you see it as collateral==right_to_vote then it's actually ok. Here is the implementation https://github.com/dashpay/dash/pull/5584_)

kudos to demo for discovering the issue https://www.dash.org/forum/index.php?threads/bug-report-should-the-votes-of-a-former-masternode-that-just-keeps-his-collateral-be-counted.53370/

## What was done?
Implement conditions to ignore new and drop old votes from pose-banned MNs. Bump `SERIALIZATION_VERSION_STRING` to force vote re-downloading/reprocessing.

## How Has This Been Tested?
Run on testnet/mainnet. There are 39 votes from invalid MNs on mainnet atm.

## Breaking Changes
It will introduce slight discrepancy in vote count but it makes no difference atm (same proposals pass in both versions with a large enough margin).

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

