### PR TITLE
fix: `debug` rpc should return a list of active debug categories, not all of them

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -197,7 +197,7 @@ bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str)
     return false;
 }
 
-std::vector<LogCategory> BCLog::Logger::LogCategoriesList() const
+std::vector<LogCategory> BCLog::Logger::LogCategoriesList(bool enabled_only) const
 {
     std::vector<LogCategory> ret;
     for (const CLogCategoryDesc& category_desc : LogCategories) {
@@ -206,7 +206,9 @@ std::vector<LogCategory> BCLog::Logger::LogCategoriesList() const
             LogCategory catActive;
             catActive.category = category_desc.category;
             catActive.active = WillLogCategory(category_desc.flag);
-            ret.push_back(catActive);
+            if (!enabled_only || catActive.active) {
+                ret.push_back(catActive);
+            }
         }
     }
     return ret;

--- a/src/logging.h
+++ b/src/logging.h
@@ -158,11 +158,11 @@ namespace BCLog {
 
         bool WillLogCategory(LogFlags category) const;
         /** Returns a vector of the log categories */
-        std::vector<LogCategory> LogCategoriesList() const;
+        std::vector<LogCategory> LogCategoriesList(bool enabled_only = false) const;
         /** Returns a string with the log categories */
-        std::string LogCategoriesString() const
+        std::string LogCategoriesString(bool enabled_only = false) const
         {
-            return Join(LogCategoriesList(), ", ", [&](const LogCategory& i) { return i.category; });
+            return Join(LogCategoriesList(enabled_only), ", ", [&](const LogCategory& i) { return i.category; });
         };
 
         bool DefaultShrinkDebugFile() const;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -71,7 +71,7 @@ static UniValue debug(const JSONRPCRequest& request)
         }
     }
 
-    return "Debug mode: " + LogInstance().LogCategoriesString(/*enabled_only*/ true);
+    return "Debug mode: " + LogInstance().LogCategoriesString(/*enabled_only=*/true);
 }
 
 static UniValue mnsync(const JSONRPCRequest& request)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -71,7 +71,7 @@ static UniValue debug(const JSONRPCRequest& request)
         }
     }
 
-    return "Debug mode: " + LogInstance().LogCategoriesString();
+    return "Debug mode: " + LogInstance().LogCategoriesString(/*enabled_only*/ true);
 }
 
 static UniValue mnsync(const JSONRPCRequest& request)


### PR DESCRIPTION
## Issue being fixed or feature implemented
This restores previous behaviour which was changed/broken here https://github.com/dashpay/dash/commit/e554d3a02e58a298c9f2b10a8bee443cbfc8ed54#diff-0ba691cbdd97c095286e9373ed8d5be87d559234440487956326965e16cbb421R75

## What was done?
Fix `debug` rpc results

## How Has This Been Tested?
Run rpc, check results

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

