### PR TITLE
refactor: make all ToJson functions return a UniValue instead of return by reference; add nodiscard

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -264,67 +264,40 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
     }
 
     if (tx.nType == TRANSACTION_PROVIDER_REGISTER) {
-        CProRegTx proTx;
-        if (GetTxPayload(tx, proTx)) {
-            UniValue obj;
-            proTx.ToJson(obj);
-            entry.pushKV("proRegTx", obj);
+        if (CProRegTx proTx; GetTxPayload(tx, proTx)) {
+            entry.pushKV("proRegTx", proTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_SERVICE) {
-        CProUpServTx proTx;
-        if (GetTxPayload(tx, proTx)) {
-            UniValue obj;
-            proTx.ToJson(obj);
-            entry.pushKV("proUpServTx", obj);
+        if (CProUpServTx proTx; GetTxPayload(tx, proTx)) {
+            entry.pushKV("proUpServTx", proTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_REGISTRAR) {
-        CProUpRegTx proTx;
-        if (GetTxPayload(tx, proTx)) {
-            UniValue obj;
-            proTx.ToJson(obj);
-            entry.pushKV("proUpRegTx", obj);
+        if (CProUpRegTx proTx; GetTxPayload(tx, proTx)) {
+            entry.pushKV("proUpRegTx", proTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_PROVIDER_UPDATE_REVOKE) {
-        CProUpRevTx proTx;
-        if (GetTxPayload(tx, proTx)) {
-            UniValue obj;
-            proTx.ToJson(obj);
-            entry.pushKV("proUpRevTx", obj);
+        if (CProUpRevTx proTx; GetTxPayload(tx, proTx)) {
+            entry.pushKV("proUpRevTx", proTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_COINBASE) {
-        CCbTx cbTx;
-        if (GetTxPayload(tx, cbTx)) {
-            UniValue obj;
-            cbTx.ToJson(obj);
-            entry.pushKV("cbTx", obj);
+        if (CCbTx cbTx; GetTxPayload(tx, cbTx)) {
+            entry.pushKV("cbTx", cbTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_QUORUM_COMMITMENT) {
-        llmq::CFinalCommitmentTxPayload qcTx;
-        if (GetTxPayload(tx, qcTx)) {
-            UniValue obj;
-            qcTx.ToJson(obj);
-            entry.pushKV("qcTx", obj);
+        if (llmq::CFinalCommitmentTxPayload qcTx; GetTxPayload(tx, qcTx)) {
+            entry.pushKV("qcTx", qcTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_MNHF_SIGNAL) {
-        MNHFTxPayload mnhfTx;
-        if (GetTxPayload(tx, mnhfTx)) {
-            UniValue obj;
-            mnhfTx.ToJson(obj);
-            entry.pushKV("mnhfTx", obj);
+        if (MNHFTxPayload mnhfTx; GetTxPayload(tx, mnhfTx)) {
+            entry.pushKV("mnhfTx", mnhfTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_ASSET_LOCK) {
-        CAssetLockPayload assetLockTx;
-        if (!GetTxPayload(tx, assetLockTx)) {
-            UniValue obj;
-            assetLockTx.ToJson(obj);
-            entry.pushKV("assetLockTx", obj);
+        if (CAssetLockPayload assetLockTx; !GetTxPayload(tx, assetLockTx)) {
+            entry.pushKV("assetLockTx", assetLockTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_ASSET_UNLOCK) {
-        CAssetUnlockPayload assetUnlockTx;
-        if (!GetTxPayload(tx, assetUnlockTx)) {
-            UniValue obj;
-            assetUnlockTx.ToJson(obj);
-            entry.pushKV("assetUnlockTx", obj);
+        if (CAssetUnlockPayload assetUnlockTx; !GetTxPayload(tx, assetUnlockTx)) {
+            entry.pushKV("assetUnlockTx", assetUnlockTx.ToJson());
         }
     }
 

--- a/src/evo/assetlocktx.h
+++ b/src/evo/assetlocktx.h
@@ -46,9 +46,9 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
-        obj.clear();
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", int(nVersion));
         UniValue outputs;
@@ -57,6 +57,7 @@ public:
             outputs.push_back(out.ToString());
         }
         obj.pushKV("creditOutputs", outputs);
+        return obj;
     }
 
     // getters
@@ -114,9 +115,9 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
-        obj.clear();
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", int(nVersion));
         obj.pushKV("index", int(index));
@@ -124,6 +125,7 @@ public:
         obj.pushKV("requestedHeight", int(requestedHeight));
         obj.pushKV("quorumHash", quorumHash.ToString());
         obj.pushKV("quorumSig", quorumSig.ToString());
+        return obj;
     }
 
     bool VerifySig(const uint256& msgHash, const CBlockIndex* pindexTip, TxValidationState& state) const;

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -58,9 +58,9 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
-        obj.clear();
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", (int)nVersion);
         obj.pushKV("height", nHeight);
@@ -73,6 +73,7 @@ public:
                 obj.pushKV("creditPoolBalance", ValueFromAmount(creditPoolBalance));
             }
         }
+        return obj;
     }
 };
 

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -40,13 +40,10 @@ std::string CDeterministicMN::ToString() const
     return strprintf("CDeterministicMN(proTxHash=%s, collateralOutpoint=%s, nOperatorReward=%f, state=%s", proTxHash.ToString(), collateralOutpoint.ToStringShort(), (double)nOperatorReward / 100, pdmnState->ToString());
 }
 
-void CDeterministicMN::ToJson(UniValue& obj) const
+UniValue CDeterministicMN::ToJson() const
 {
-    obj.clear();
+    UniValue obj;
     obj.setObject();
-
-    UniValue stateObj;
-    pdmnState->ToJson(stateObj, nType);
 
     obj.pushKV("type", std::string(GetMnType(nType).description));
     obj.pushKV("proTxHash", proTxHash.ToString());
@@ -62,7 +59,8 @@ void CDeterministicMN::ToJson(UniValue& obj) const
     }
 
     obj.pushKV("operatorReward", (double)nOperatorReward / 100);
-    obj.pushKV("state", stateObj);
+    obj.pushKV("state", pdmnState->ToJson(nType));
+    return obj;
 }
 
 bool CDeterministicMNList::IsMNValid(const uint256& proTxHash) const

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -117,7 +117,7 @@ public:
     [[nodiscard]] uint64_t GetInternalId() const;
 
     [[nodiscard]] std::string ToString() const;
-    void ToJson(UniValue& obj) const;
+    [[nodiscard]] UniValue ToJson() const;
 };
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
 

--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -31,9 +31,9 @@ std::string CDeterministicMNState::ToString() const
                      EncodeDestination(PKHash(keyIDOwner)), pubKeyOperator.ToString(), EncodeDestination(PKHash(keyIDVoting)), addr.ToStringIPPort(false), payoutAddress, operatorPayoutAddress);
 }
 
-void CDeterministicMNState::ToJson(UniValue& obj, MnType nType) const
+UniValue CDeterministicMNState::ToJson(MnType nType) const
 {
-    obj.clear();
+    UniValue obj;
     obj.setObject();
     obj.pushKV("version", nVersion);
     obj.pushKV("service", addr.ToStringIPPort(false));
@@ -60,11 +60,12 @@ void CDeterministicMNState::ToJson(UniValue& obj, MnType nType) const
     if (ExtractDestination(scriptOperatorPayout, dest)) {
         obj.pushKV("operatorPayoutAddress", EncodeDestination(dest));
     }
+    return obj;
 }
 
-void CDeterministicMNStateDiff::ToJson(UniValue& obj, MnType nType) const
+UniValue CDeterministicMNStateDiff::ToJson(MnType nType) const
 {
-    obj.clear();
+    UniValue obj;
     obj.setObject();
     if (fields & Field_nVersion) {
         obj.pushKV("version", state.nVersion);
@@ -125,4 +126,5 @@ void CDeterministicMNStateDiff::ToJson(UniValue& obj, MnType nType) const
             obj.pushKV("platformHTTPPort", state.platformHTTPPort);
         }
     }
+    return obj;
 }

--- a/src/evo/dmnstate.h
+++ b/src/evo/dmnstate.h
@@ -283,7 +283,7 @@ public:
 
 public:
     std::string ToString() const;
-    void ToJson(UniValue& obj, MnType nType) const;
+    [[nodiscard]] UniValue ToJson(MnType nType) const;
 };
 
 class CDeterministicMNStateDiff
@@ -347,7 +347,7 @@ public:
         if (fields & Field_pubKeyOperator) { state.nVersion = b.nVersion; fields |= Field_nVersion; }
     }
 
-    void ToJson(UniValue& obj, MnType nType) const;
+    [[nodiscard]] UniValue ToJson(MnType nType) const;
 
     SERIALIZE_METHODS(CDeterministicMNStateDiff, obj)
     {

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -34,13 +34,15 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
+        UniValue obj;
         obj.clear();
         obj.setObject();
         obj.pushKV("versionBit", (int)versionBit);
         obj.pushKV("quorumHash", quorumHash.ToString());
         obj.pushKV("sig", sig.ToString());
+        return obj;
     }
 };
 
@@ -60,14 +62,13 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", (int)nVersion);
-
-        UniValue mnhfObj;
-        signal.ToJson(mnhfObj);
-        obj.pushKV("signal", mnhfObj);
+        obj.pushKV("signal", signal.ToJson());
+        return obj;
     }
 };
 

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -88,9 +88,9 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
-        obj.clear();
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", nVersion);
         obj.pushKV("type", ToUnderlying(nType));
@@ -112,6 +112,7 @@ public:
             obj.pushKV("platformHTTPPort", platformHTTPPort);
         }
         obj.pushKV("inputsHash", inputsHash.ToString());
+        return obj;
     }
 
     bool IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const;
@@ -174,9 +175,9 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
-        obj.clear();
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", nVersion);
         obj.pushKV("type", ToUnderlying(nType));
@@ -192,6 +193,7 @@ public:
             obj.pushKV("platformHTTPPort", platformHTTPPort);
         }
         obj.pushKV("inputsHash", inputsHash.ToString());
+        return obj;
     }
 
     bool IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const;
@@ -244,9 +246,9 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
-        obj.clear();
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", nVersion);
         obj.pushKV("proTxHash", proTxHash.ToString());
@@ -257,6 +259,7 @@ public:
         }
         obj.pushKV("pubKeyOperator", pubKeyOperator.ToString());
         obj.pushKV("inputsHash", inputsHash.ToString());
+        return obj;
     }
 
     bool IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const;
@@ -312,14 +315,15 @@ public:
 
     std::string ToString() const;
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
-        obj.clear();
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", nVersion);
         obj.pushKV("proTxHash", proTxHash.ToString());
         obj.pushKV("reason", (int)nReason);
         obj.pushKV("inputsHash", inputsHash.ToString());
+        return obj;
     }
 
     bool IsTriviallyValid(bool is_bls_legacy_scheme, TxValidationState& state) const;

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -91,7 +91,7 @@ public:
     uint256 CalcHash() const;
 
     std::string ToString() const;
-    void ToJson(UniValue& obj, bool extended = false) const;
+    [[nodiscard]] UniValue ToJson(bool extended = false) const;
 };
 
 class CSimplifiedMNList
@@ -164,7 +164,7 @@ public:
                           const llmq::CQuorumBlockProcessor& quorum_block_processor);
     bool BuildQuorumChainlockInfo(const CBlockIndex* blockIndex);
 
-    void ToJson(UniValue& obj, bool extended = false) const;
+    [[nodiscard]] UniValue ToJson(bool extended = false) const;
 };
 
 bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& blockHash, CSimplifiedMNListDiff& mnListDiffRet,

--- a/src/llmq/commitment.h
+++ b/src/llmq/commitment.h
@@ -111,8 +111,9 @@ public:
         return true;
     }
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", int{nVersion});
         obj.pushKV("llmqType", ToUnderlying(llmqType));
@@ -126,6 +127,7 @@ public:
         obj.pushKV("quorumVvecHash", quorumVvecHash.ToString());
         obj.pushKV("quorumSig", quorumSig.ToString(nVersion == LEGACY_BLS_NON_INDEXED_QUORUM_VERSION || nVersion == LEGACY_BLS_INDEXED_QUORUM_VERSION));
         obj.pushKV("membersSig", membersSig.ToString(nVersion == LEGACY_BLS_NON_INDEXED_QUORUM_VERSION || nVersion == LEGACY_BLS_INDEXED_QUORUM_VERSION));
+        return obj;
     }
 
 private:
@@ -156,15 +158,14 @@ public:
         READWRITE(obj.nVersion, obj.nHeight, obj.commitment);
     }
 
-    void ToJson(UniValue& obj) const
+    [[nodiscard]] UniValue ToJson() const
     {
+        UniValue obj;
         obj.setObject();
         obj.pushKV("version", int{nVersion});
         obj.pushKV("height", int(nHeight));
-
-        UniValue qcObj;
-        commitment.ToJson(qcObj);
-        obj.pushKV("commitment", qcObj);
+        obj.pushKV("commitment", commitment.ToJson());
+        return obj;
     }
 };
 

--- a/src/llmq/snapshot.cpp
+++ b/src/llmq/snapshot.cpp
@@ -23,9 +23,9 @@ static const std::string DB_QUORUM_SNAPSHOT = "llmq_S";
 
 std::unique_ptr<CQuorumSnapshotManager> quorumSnapshotManager;
 
-void CQuorumSnapshot::ToJson(UniValue& obj) const
+UniValue CQuorumSnapshot::ToJson() const
 {
-    //TODO Check this function if correct
+    UniValue obj;
     obj.setObject();
     UniValue activeQ(UniValue::VARR);
     for (const bool h : activeQuorumMembers) {
@@ -40,81 +40,50 @@ void CQuorumSnapshot::ToJson(UniValue& obj) const
         skipList.push_back(h);
     }
     obj.pushKV("mnSkipList", skipList);
+    return obj;
 }
 
-void CQuorumRotationInfo::ToJson(UniValue& obj) const
+UniValue CQuorumRotationInfo::ToJson() const
 {
+    UniValue obj;
     obj.setObject();
     obj.pushKV("extraShare", extraShare);
 
-    UniValue objc;
-    quorumSnapshotAtHMinusC.ToJson(objc);
-    obj.pushKV("quorumSnapshotAtHMinusC", objc);
-
-    UniValue obj2c;
-    quorumSnapshotAtHMinus2C.ToJson(obj2c);
-    obj.pushKV("quorumSnapshotAtHMinus2C", obj2c);
-
-    UniValue obj3c;
-    quorumSnapshotAtHMinus3C.ToJson(obj3c);
-    obj.pushKV("quorumSnapshotAtHMinus3C", obj3c);
+    obj.pushKV("quorumSnapshotAtHMinusC", quorumSnapshotAtHMinusC.ToJson());
+    obj.pushKV("quorumSnapshotAtHMinus2C", quorumSnapshotAtHMinus2C.ToJson());
+    obj.pushKV("quorumSnapshotAtHMinus3C", quorumSnapshotAtHMinus3C.ToJson());
 
     if (extraShare && quorumSnapshotAtHMinus4C.has_value()) {
-        UniValue obj4c;
-        quorumSnapshotAtHMinus4C.value().ToJson(obj4c);
-        obj.pushKV("quorumSnapshotAtHMinus4C", obj4c);
+        obj.pushKV("quorumSnapshotAtHMinus4C", quorumSnapshotAtHMinus4C->ToJson());
     }
 
-    UniValue objdifftip;
-    mnListDiffTip.ToJson(objdifftip);
-    obj.pushKV("mnListDiffTip", objdifftip);
-
-    UniValue objdiffh;
-    mnListDiffH.ToJson(objdiffh);
-    obj.pushKV("mnListDiffH", objdiffh);
-
-    UniValue objdiffc;
-    mnListDiffAtHMinusC.ToJson(objdiffc);
-    obj.pushKV("mnListDiffAtHMinusC", objdiffc);
-
-    UniValue objdiff2c;
-    mnListDiffAtHMinus2C.ToJson(objdiff2c);
-    obj.pushKV("mnListDiffAtHMinus2C", objdiff2c);
-
-    UniValue objdiff3c;
-    mnListDiffAtHMinus3C.ToJson(objdiff3c);
-    obj.pushKV("mnListDiffAtHMinus3C", objdiff3c);
+    obj.pushKV("mnListDiffTip", mnListDiffTip.ToJson());
+    obj.pushKV("mnListDiffH", mnListDiffH.ToJson());
+    obj.pushKV("mnListDiffAtHMinusC", mnListDiffAtHMinusC.ToJson());
+    obj.pushKV("mnListDiffAtHMinus2C", mnListDiffAtHMinus2C.ToJson());
+    obj.pushKV("mnListDiffAtHMinus3C", mnListDiffAtHMinus3C.ToJson());
 
     if (extraShare && mnListDiffAtHMinus4C.has_value()) {
-        UniValue objdiff4c;
-        mnListDiffAtHMinus4C.value().ToJson(objdiff4c);
-        obj.pushKV("mnListDiffAtHMinus4C", objdiff4c);
+        obj.pushKV("mnListDiffAtHMinus4C", mnListDiffAtHMinus4C->ToJson());
     }
     UniValue hqclists(UniValue::VARR);
     for (const auto& qc : lastCommitmentPerIndex) {
-        UniValue objqc;
-        qc.ToJson(objqc);
-        hqclists.push_back(objqc);
+        hqclists.push_back(qc.ToJson());
     }
     obj.pushKV("lastCommitmentPerIndex", hqclists);
 
     UniValue snapshotlist(UniValue::VARR);
     for (const auto& snap : quorumSnapshotList) {
-        UniValue o;
-        o.setObject();
-        snap.ToJson(o);
-        snapshotlist.push_back(o);
+        snapshotlist.push_back(snap.ToJson());
     }
     obj.pushKV("quorumSnapshotList", snapshotlist);
 
     UniValue mnlistdifflist(UniValue::VARR);
     for (const auto& mnlist : mnListDiffList) {
-        UniValue o;
-        o.setObject();
-        mnlist.ToJson(o);
-        mnlistdifflist.push_back(o);
+        mnlistdifflist.push_back(mnlist.ToJson());
     }
     obj.pushKV("mnListDiffList", mnlistdifflist);
+    return obj;
 }
 
 bool BuildQuorumRotationInfo(const CGetQuorumRotationInfo& request, CQuorumRotationInfo& response,

--- a/src/llmq/snapshot.h
+++ b/src/llmq/snapshot.h
@@ -82,7 +82,7 @@ public:
         }
     }
 
-    void ToJson(UniValue& obj) const;
+    [[nodiscard]] UniValue ToJson() const;
 };
 
 class CGetQuorumRotationInfo
@@ -204,7 +204,7 @@ public:
     CQuorumRotationInfo() = default;
     CQuorumRotationInfo(const CQuorumRotationInfo& dmn) {}
 
-    void ToJson(UniValue& obj) const;
+    [[nodiscard]] UniValue ToJson() const;
 };
 
 bool BuildQuorumRotationInfo(const CGetQuorumRotationInfo& request, CQuorumRotationInfo& response,

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -360,8 +360,7 @@ void MasternodeList::extraInfoDIP3_clicked()
         return;
     }
 
-    UniValue json(UniValue::VOBJ);
-    dmn->ToJson(json);
+    UniValue json = dmn->ToJson();
 
     // Title of popup window
     QString strWindowtitle = tr("Additional information for DIP3 Masternode %1").arg(QString::fromStdString(dmn->proTxHash.ToString()));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -242,9 +242,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
     if (!block.vtx[0]->vExtraPayload.empty()) {
         CCbTx cbTx;
         if (GetTxPayload(block.vtx[0]->vExtraPayload, cbTx)) {
-            UniValue cbTxObj;
-            cbTx.ToJson(cbTxObj);
-            result.pushKV("cbTx", cbTxObj);
+            result.pushKV("cbTx", cbTx.ToJson());
         }
     }
     result.pushKV("time", block.GetBlockTime());

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1273,9 +1273,7 @@ static UniValue BuildDMNListEntry(CWallet* pwallet, const CDeterministicMN& dmn,
         return dmn.proTxHash.ToString();
     }
 
-    UniValue o(UniValue::VOBJ);
-
-    dmn.ToJson(o);
+    UniValue o = dmn.ToJson();
 
     int confirmations = GetUTXOConfirmations(dmn.collateralOutpoint);
     o.pushKV("confirmations", confirmations);
@@ -1489,9 +1487,7 @@ static UniValue protx_diff(const JSONRPCRequest& request, const ChainstateManage
         throw std::runtime_error(strError);
     }
 
-    UniValue ret;
-    mnListDiff.ToJson(ret, extended);
-    return ret;
+    return mnListDiff.ToJson(extended);
 }
 
 static void protx_listdiff_help(const JSONRPCRequest& request)
@@ -1553,9 +1549,7 @@ static UniValue protx_listdiff(const JSONRPCRequest& request, const ChainstateMa
 
     UniValue jaddedMNs(UniValue::VARR);
     for(const auto& mn : mnDiff.addedMNs) {
-        UniValue obj;
-        mn->ToJson(obj);
-        jaddedMNs.push_back(obj);
+        jaddedMNs.push_back(mn->ToJson());
     }
     ret.pushKV("addedMNs", jaddedMNs);
 
@@ -1569,10 +1563,8 @@ static UniValue protx_listdiff(const JSONRPCRequest& request, const ChainstateMa
     UniValue jupdatedMNs(UniValue::VARR);
     for(const auto& [internal_id, stateDiff] : mnDiff.updatedMNs) {
         auto dmn = baseBlockMNList.GetMNByInternalId(internal_id);
-        UniValue s(UniValue::VOBJ);
-        stateDiff.ToJson(s, dmn->nType);
         UniValue obj(UniValue::VOBJ);
-        obj.pushKV(dmn->proTxHash.ToString(), s);
+        obj.pushKV(dmn->proTxHash.ToString(), stateDiff.ToJson(dmn->nType));
         jupdatedMNs.push_back(obj);
     }
     ret.pushKV("updatedMNs", jupdatedMNs);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -268,9 +268,7 @@ static UniValue masternode_status(const JSONRPCRequest& request)
         mnObj.pushKV("type", std::string(GetMnType(dmn->nType).description));
         mnObj.pushKV("collateralHash", dmn->collateralOutpoint.hash.ToString());
         mnObj.pushKV("collateralIndex", (int)dmn->collateralOutpoint.n);
-        UniValue stateObj;
-        dmn->pdmnState->ToJson(stateObj, dmn->nType);
-        mnObj.pushKV("dmnState", stateObj);
+        mnObj.pushKV("dmnState", dmn->pdmnState->ToJson(dmn->nType));
     }
     mnObj.pushKV("state", activeMasternodeManager->GetStateString());
     mnObj.pushKV("status", activeMasternodeManager->GetStatus());

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -349,9 +349,7 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request, const Chainstate
         std::optional<std::vector<llmq::CFinalCommitment>> vfqc = llmq_ctx.quorum_block_processor->GetMineableCommitments(llmq_params, tipHeight);
         if (vfqc.has_value()) {
             for (const auto& fqc : vfqc.value()) {
-                UniValue obj(UniValue::VOBJ);
-                fqc.ToJson(obj);
-                minableCommitments.push_back(obj);
+                minableCommitments.push_back(fqc.ToJson());
             }
         }
     }
@@ -780,9 +778,7 @@ static UniValue quorum_rotationinfo(const JSONRPCRequest& request, const LLMQCon
         throw JSONRPCError(RPC_INVALID_REQUEST, strError);
     }
 
-    UniValue ret(UniValue::VOBJ);
-    quorumRotationInfoRet.ToJson(ret);
-    return ret;
+    return quorumRotationInfoRet.ToJson();
 }
 
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Return by reference is generally not ideal, and especially as there is only one return path per function, all returns will be done via NRVO. Additionally, call sites are simpler now.

## What was done?
Refactored to return by value


## How Has This Been Tested?
Building

## Breaking Changes
Should be none

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

