### PR TITLE
fix: Move `CreditPoolDiff` checks out of `ProcessSpecialTxsInBlock`, use correct block reward

### DIFF
--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -287,15 +287,18 @@ bool CCreditPoolDiff::Unlock(const CTransaction& tx, TxValidationState& state)
     return true;
 }
 
-bool CCreditPoolDiff::ProcessTransaction(const CTransaction& tx, const std::optional<CAmount> blockReward, TxValidationState& state)
+bool CCreditPoolDiff::ProcessCoinbaseTransaction(const CTransaction& tx, const CAmount blockReward, TxValidationState& state)
 {
     if (tx.nVersion != 3) return true;
 
-    if (tx.nType == TRANSACTION_COINBASE) {
-        assert(blockReward.has_value());
-        return SetTarget(tx, blockReward.value(), state);
-    }
+    assert(tx.nType == TRANSACTION_COINBASE);
 
+    return SetTarget(tx, blockReward, state);
+}
+
+bool CCreditPoolDiff::ProcessLockUnlockTransaction(const CTransaction& tx, TxValidationState& state)
+{
+    if (tx.nVersion != 3) return true;
     if (tx.nType != TRANSACTION_ASSET_LOCK && tx.nType != TRANSACTION_ASSET_UNLOCK) return true;
 
     if (!CheckAssetLockUnlockTx(tx, pindex, pool.indexes, state)) {

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -228,7 +228,7 @@ void CCreditPoolDiff::AddRewardRealloced(const CAmount reward) {
     platformReward += reward;
 }
 
-bool CCreditPoolDiff::SetTarget(const CTransaction& tx, TxValidationState& state)
+bool CCreditPoolDiff::SetTarget(const CTransaction& tx, const std::optional<CAmount> blockReward, TxValidationState& state)
 {
     CCbTx cbTx;
     if (!GetTxPayload(tx, cbTx)) {
@@ -239,14 +239,11 @@ bool CCreditPoolDiff::SetTarget(const CTransaction& tx, TxValidationState& state
 
     targetBalance = cbTx.creditPoolBalance;
 
-
     if (!llmq::utils::IsMNRewardReallocationActive(pindex)) return true;
 
-    CAmount blockReward = 0;
-    for (const CTxOut& txout : tx.vout) {
-        blockReward += txout.nValue;
-    }
-    platformReward = MasternodePayments::PlatformShare(GetMasternodePayment(cbTx.nHeight, blockReward, params.BRRHeight, true));
+    assert(blockReward.has_value());
+
+    platformReward = MasternodePayments::PlatformShare(GetMasternodePayment(cbTx.nHeight, blockReward.value(), params.BRRHeight, true));
     LogPrintf("CreditPool: set target to %lld with MN reward %lld\n", *targetBalance, platformReward);
 
     return true;
@@ -292,10 +289,10 @@ bool CCreditPoolDiff::Unlock(const CTransaction& tx, TxValidationState& state)
     return true;
 }
 
-bool CCreditPoolDiff::ProcessTransaction(const CTransaction& tx, TxValidationState& state)
+bool CCreditPoolDiff::ProcessTransaction(const CTransaction& tx, const std::optional<CAmount> blockReward, TxValidationState& state)
 {
     if (tx.nVersion != 3) return true;
-    if (tx.nType == TRANSACTION_COINBASE) return SetTarget(tx, state);
+    if (tx.nType == TRANSACTION_COINBASE) return SetTarget(tx, blockReward, state);
 
     if (tx.nType != TRANSACTION_ASSET_LOCK && tx.nType != TRANSACTION_ASSET_UNLOCK) return true;
 

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -228,7 +228,7 @@ void CCreditPoolDiff::AddRewardRealloced(const CAmount reward) {
     platformReward += reward;
 }
 
-bool CCreditPoolDiff::SetTarget(const CTransaction& tx, const std::optional<CAmount> blockReward, TxValidationState& state)
+bool CCreditPoolDiff::SetTarget(const CTransaction& tx, const CAmount blockReward, TxValidationState& state)
 {
     CCbTx cbTx;
     if (!GetTxPayload(tx, cbTx)) {
@@ -241,9 +241,7 @@ bool CCreditPoolDiff::SetTarget(const CTransaction& tx, const std::optional<CAmo
 
     if (!llmq::utils::IsMNRewardReallocationActive(pindex)) return true;
 
-    assert(blockReward.has_value());
-
-    platformReward = MasternodePayments::PlatformShare(GetMasternodePayment(cbTx.nHeight, blockReward.value(), params.BRRHeight, true));
+    platformReward = MasternodePayments::PlatformShare(GetMasternodePayment(cbTx.nHeight, blockReward, params.BRRHeight, true));
     LogPrintf("CreditPool: set target to %lld with MN reward %lld\n", *targetBalance, platformReward);
 
     return true;
@@ -292,7 +290,11 @@ bool CCreditPoolDiff::Unlock(const CTransaction& tx, TxValidationState& state)
 bool CCreditPoolDiff::ProcessTransaction(const CTransaction& tx, const std::optional<CAmount> blockReward, TxValidationState& state)
 {
     if (tx.nVersion != 3) return true;
-    if (tx.nType == TRANSACTION_COINBASE) return SetTarget(tx, blockReward, state);
+
+    if (tx.nType == TRANSACTION_COINBASE) {
+        assert(blockReward.has_value());
+        return SetTarget(tx, blockReward.value(), state);
+    }
 
     if (tx.nType != TRANSACTION_ASSET_LOCK && tx.nType != TRANSACTION_ASSET_UNLOCK) return true;
 

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -82,7 +82,7 @@ public:
      * to change amount of credit pool
      * @return true if transaction can be included in this block
      */
-    bool ProcessTransaction(const CTransaction& tx, TxValidationState& state);
+    bool ProcessTransaction(const CTransaction& tx, std::optional<CAmount> blockReward, TxValidationState& state);
 
     /**
      * This function should be called by miner for initialization of MasterNode reward
@@ -102,7 +102,7 @@ public:
     }
 
 private:
-    bool SetTarget(const CTransaction& tx, TxValidationState& state);
+    bool SetTarget(const CTransaction& tx, const std::optional<CAmount> blockReward, TxValidationState& state);
     bool Lock(const CTransaction& tx, TxValidationState& state);
     bool Unlock(const CTransaction& tx, TxValidationState& state);
 };

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -102,7 +102,7 @@ public:
     }
 
 private:
-    bool SetTarget(const CTransaction& tx, const std::optional<CAmount> blockReward, TxValidationState& state);
+    bool SetTarget(const CTransaction& tx, const CAmount blockReward, TxValidationState& state);
     bool Lock(const CTransaction& tx, TxValidationState& state);
     bool Unlock(const CTransaction& tx, TxValidationState& state);
 };

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -78,11 +78,18 @@ public:
     explicit CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindex, const Consensus::Params& consensusParams);
 
     /**
+     * This function should be called for each block's coinbase transaction
+     * to change amount of credit pool
+     * coinbase transaction's Payload must be valid if nVersion of coinbase transaction equals 3
+     */
+    bool ProcessCoinbaseTransaction(const CTransaction& tx, const CAmount blockReward, TxValidationState& state);
+
+    /**
      * This function should be called for each Asset Lock/Unlock tx
      * to change amount of credit pool
      * @return true if transaction can be included in this block
      */
-    bool ProcessTransaction(const CTransaction& tx, std::optional<CAmount> blockReward, TxValidationState& state);
+    bool ProcessLockUnlockTransaction(const CTransaction& tx, TxValidationState& state);
 
     /**
      * This function should be called by miner for initialization of MasterNode reward

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -138,10 +138,8 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, ll
         int64_t nTime1 = GetTimeMicros();
 
         const CCreditPool creditPool = creditPoolManager->GetCreditPool(pindex->pprev, consensusParams);
-        std::optional<CCreditPoolDiff> creditPoolDiff;
-        if (bool fV20Active_context = llmq::utils::IsV20Active(pindex->pprev); fV20Active_context) {
+        if (llmq::utils::IsV20Active(pindex->pprev)) {
             LogPrintf("%s: CCreditPool is %s\n", __func__, creditPool.ToString());
-            creditPoolDiff.emplace(creditPool, pindex->pprev, consensusParams);
         }
 
         for (const auto& ptr_tx : block.vtx) {
@@ -157,21 +155,6 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, ll
                 assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS || tx_state.GetResult() == TxValidationResult::TX_BAD_SPECIAL);
                 return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(),
                                  strprintf("Process Special Transaction failed (tx hash %s) %s", ptr_tx->GetHash().ToString(), tx_state.GetDebugMessage()));
-            }
-            if (creditPoolDiff != std::nullopt && !creditPoolDiff->ProcessTransaction(*ptr_tx, tx_state)) {
-                assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS || tx_state.GetResult() == TxValidationResult::TX_BAD_SPECIAL);
-                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(),
-                                 strprintf("Process Special Transaction failed at Credit Pool (tx hash %s) %s", ptr_tx->GetHash().ToString(), tx_state.GetDebugMessage()));
-            }
-        }
-        if (creditPoolDiff != std::nullopt) {
-            CAmount locked_proposed{0};
-            if(creditPoolDiff->GetTargetBalance()) locked_proposed = *creditPoolDiff->GetTargetBalance();
-
-            CAmount locked_calculated = creditPoolDiff->GetTotalLocked();
-            if (locked_proposed != locked_calculated) {
-                LogPrintf("%s: mismatched locked amount in CbTx: %lld against re-calculated: %lld\n", __func__, locked_proposed, locked_calculated);
-                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-assetlocked-amount");
             }
         }
 
@@ -261,6 +244,44 @@ bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, llmq:
         bls::bls_legacy_scheme.store(bls_legacy_scheme);
         LogPrintf("%s: bls_legacy_scheme=%d\n", __func__, bls::bls_legacy_scheme.load());
         return error(strprintf("%s -- failed: %s\n", __func__, e.what()).c_str());
+    }
+
+    return true;
+}
+
+bool CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams,
+                                const CAmount blockReward, BlockValidationState& state)
+{
+    AssertLockHeld(cs_main);
+
+    try {
+
+        if (!llmq::utils::IsV20Active(pindex->pprev)) return true;
+
+        const CCreditPool creditPool = creditPoolManager->GetCreditPool(pindex->pprev, consensusParams);
+        LogPrintf("%s: CCreditPool is %s\n", __func__, creditPool.ToString());
+        CCreditPoolDiff creditPoolDiff(creditPool, pindex->pprev, consensusParams);
+
+        for (const auto& ptr_tx : block.vtx) {
+            TxValidationState tx_state;
+            if (!creditPoolDiff.ProcessTransaction(*ptr_tx, blockReward, tx_state)) {
+                assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS || tx_state.GetResult() == TxValidationResult::TX_BAD_SPECIAL);
+                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(),
+                                 strprintf("Process Special Transaction failed at Credit Pool (tx hash %s) %s", ptr_tx->GetHash().ToString(), tx_state.GetDebugMessage()));
+            }
+        }
+        CAmount locked_proposed{0};
+        if (creditPoolDiff.GetTargetBalance()) locked_proposed = *creditPoolDiff.GetTargetBalance();
+
+        CAmount locked_calculated = creditPoolDiff.GetTotalLocked();
+        if (locked_proposed != locked_calculated) {
+            LogPrintf("%s: mismatched locked amount in CbTx: %lld against re-calculated: %lld\n", __func__, locked_proposed, locked_calculated);
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-assetlocked-amount");
+        }
+
+    } catch (const std::exception& e) {
+        LogPrintf("%s -- failed: %s\n", __func__, e.what());
+        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "failed-checkcreditpooldiff");
     }
 
     return true;

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -30,5 +30,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, ll
                             const Consensus::Params& consensusParams, const CCoinsViewCache& view, bool fJustCheck, bool fCheckCbTxMerleRoots,
                             BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, llmq::CQuorumBlockProcessor& quorum_block_processor) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams,
+                                const CAmount blockReward, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 #endif // BITCOIN_EVO_SPECIALTXMAN_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -463,7 +463,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             // `state` is local here because used to log info about this specific tx
             TxValidationState state;
 
-            if (!creditPoolDiff->ProcessTransaction(iter->GetTx(), state)) {
+            if (!creditPoolDiff->ProcessTransaction(iter->GetTx(), std::nullopt, state)) {
                 if (fUsingModified) {
                     mapModifiedTx.get<ancestor_score>().erase(modit);
                     failedTx.insert(iter);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -463,7 +463,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             // `state` is local here because used to log info about this specific tx
             TxValidationState state;
 
-            if (!creditPoolDiff->ProcessTransaction(iter->GetTx(), std::nullopt, state)) {
+            if (!creditPoolDiff->ProcessLockUnlockTransaction(iter->GetTx(), state)) {
                 if (fUsingModified) {
                     mapModifiedTx.get<ancestor_score>().erase(modit);
                     failedTx.insert(iter);


### PR DESCRIPTION
## Issue being fixed or feature implemented
The block reward calculation logic in `SetTarget` doesn't work on superblocks.

## What was done?
Move `CreditPoolDiff` checks out of `ProcessSpecialTxsInBlock` to use correct block reward.

## How Has This Been Tested?
run tests

## Breaking Changes
n/a, sb blocks should now be processed correctly, non-sb blocks shouldn't be affected

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

