### PR TITLE
refactor: make CService and CNetAddr constexpr (when in cpp20)

### DIFF
--- a/src/constexpr_if_cxx20.h
+++ b/src/constexpr_if_cxx20.h
@@ -1,5 +1,9 @@
-#ifndef DASH_CONSTEXPR_IF_CXX20_H
-#define DASH_CONSTEXPR_IF_CXX20_H
+// Copyright (c) 2023 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSTEXPR_IF_CXX20_H
+#define BITCOIN_CONSTEXPR_IF_CXX20_H
 
 #if __cplusplus >= 202002L
 #define CONSTEXPR_IF_CPP20 constexpr
@@ -7,4 +11,4 @@
 #define CONSTEXPR_IF_CPP20
 #endif
 
-#endif //DASH_CONSTEXPR_IF_CXX20_H
+#endif //BITCOIN_CONSTEXPR_IF_CXX20_H

--- a/src/constexpr_if_cxx20.h
+++ b/src/constexpr_if_cxx20.h
@@ -1,0 +1,10 @@
+#ifndef DASH_CONSTEXPR_IF_CXX20_H
+#define DASH_CONSTEXPR_IF_CXX20_H
+
+#if __cplusplus >= 202002L
+#define CONSTEXPR_IF_CPP20 constexpr
+#else
+#define CONSTEXPR_IF_CPP20
+#endif
+
+#endif //DASH_CONSTEXPR_IF_CXX20_H

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -99,36 +99,6 @@ bool CNetAddr::SetNetFromBIP155Network(uint8_t possible_bip155_net, size_t addre
 bool fAllowPrivateNet = DEFAULT_ALLOWPRIVATENET;
 
 
-void CNetAddr::SetIP(const CNetAddr& ipIn)
-{
-    // Size check.
-    switch (ipIn.m_net) {
-    case NET_IPV4:
-        assert(ipIn.m_addr.size() == ADDR_IPV4_SIZE);
-        break;
-    case NET_IPV6:
-        assert(ipIn.m_addr.size() == ADDR_IPV6_SIZE);
-        break;
-    case NET_ONION:
-        assert(ipIn.m_addr.size() == ADDR_TORV3_SIZE);
-        break;
-    case NET_I2P:
-        assert(ipIn.m_addr.size() == ADDR_I2P_SIZE);
-        break;
-    case NET_CJDNS:
-        assert(ipIn.m_addr.size() == ADDR_CJDNS_SIZE);
-        break;
-    case NET_INTERNAL:
-        assert(ipIn.m_addr.size() == ADDR_INTERNAL_SIZE);
-        break;
-    case NET_UNROUTABLE:
-    case NET_MAX:
-        assert(false);
-    } // no default case, so the compiler can warn about missing cases
-
-    m_net = ipIn.m_net;
-    m_addr = ipIn.m_addr;
-}
 
 void CNetAddr::SetLegacyIPv6(Span<const uint8_t> ipv6)
 {

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -265,7 +265,7 @@ public:
             return std::bit_cast<std::array<uint8_t, sizeof(decltype(pipv6Addr))>>(pipv6Addr);
 #else
             auto ptr = reinterpret_cast<const uint8_t*>(&pipv6Addr);
-            return Span{ptr, ADDR_IPV4_SIZE};
+            return Span{ptr, ADDR_IPV6_SIZE};
 #endif
         };
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -171,7 +171,15 @@ public:
         m_addr.fill(0);
         std::copy(byte_arr.data(), byte_arr.data() + ADDR_SIZES[NET_IPV4], m_addr.begin());
     }
-    void SetIP(const CNetAddr& ip);
+    constexpr void SetIP(const CNetAddr& ipIn)
+    {
+        // Size check.
+        assert(ipIn.m_net != NET_UNROUTABLE && ipIn.m_net != NET_MAX);
+        assert(ipIn.m_addr.size() == ADDR_SIZES[ipIn.m_net]);
+
+        m_net = ipIn.m_net;
+        m_addr = ipIn.m_addr;
+    }
 
     constexpr auto get_addr_span() const -> Span<const uint8_t> {
         return Span{m_addr}.first(ADDR_SIZES[m_net]);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Underlying motivation is making a lot of other potential stuff constexpr; CService and CNetAddr is used by quite a few things, and making it fully stack allocated (and constexpr) can be quite valuable I think

Also, I think I would like to PR this to bitcoin, so please provide review as if you were a bitcoin core developer and had very high standards :D

## What was done?
In c++20, CService and CNetAddr will always be constexpr, in c++17 some of it's constructors are constexpr; removes use of prevector, so we know that CService and CNetAddr will be fully on the stack in both 17 and 20; however certain constructors that need std::copy or reinterpret_cast cannot be c++17 constexpr

## How Has This Been Tested?
Building with c++17 and c++20 and ensuring that I was able to connect to ipv4 v6 and tor nodes

## Breaking Changes
Should be none; this is mostly for conceptual review (and running it); I'm not positive this is completely bug free; I want to test a bit more.

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

