### PR TITLE
ci: switch to using gha cache api for guix builds

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -11,12 +11,12 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'guix-build')
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Commit variables
         id: dockerfile
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ${{ github.workspace }}
           build-args: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -25,14 +25,6 @@ jobs:
           echo "host_user_id=$(id -u)" >> $GITHUB_OUTPUT
           echo "host_group_id=$(id -g)" >> $GITHUB_OUTPUT
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ steps.dockerfile.outputs.hash }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
@@ -45,8 +37,8 @@ jobs:
           file: ./contrib/containers/guix/Dockerfile
           load: true
           tags: guix_ubuntu:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run Guix build
         run: |


### PR DESCRIPTION
## Issue being fixed or feature implemented
 - Using `actions/cache` with a local buildx cache without the "move cache" workaround will result in constant growth in cache size: https://docs.docker.com/build/ci/github-actions/cache/#local-cache

## What was done?
- Docker natively supports the GHA Cache API, so we should use it for faster and more efficient cache usage
- Actions were also bumped to current stable versions


## How Has This Been Tested?
Devs please test this by running a test Guix build from workflow dispatch

## Breaking Changes
None


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

