### PR TITLE
test: correct calculation of `coinbasevalue` in feature_asset_locks.py

### DIFF
--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -513,8 +513,7 @@ class AssetLocksTest(DashTestFramework):
         owner_reward = bt['masternode'][1]['amount']
         operator_reward = bt['masternode'][2]['amount'] if len(bt['masternode']) == 3 else 0
         all_mn_rewards = platform_reward + owner_reward + operator_reward
-        all_mn_rewards += 1 * 0.75
-        assert_equal(all_mn_rewards, int(bt['coinbasevalue'] * 0.75))  # 75/25 mn/miner reward split
+        assert_equal(all_mn_rewards, int(bt['coinbasevalue'] * 3 // 4))  # 75/25 mn/miner reward split
         assert_equal(platform_reward, all_mn_rewards * 375 // 1000)  # 0.375 platform share
         assert_equal(platform_reward, 2555399792)
         assert_equal(new_total, self.get_credit_pool_balance())

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -514,7 +514,7 @@ class AssetLocksTest(DashTestFramework):
         operator_reward = bt['masternode'][2]['amount'] if len(bt['masternode']) == 3 else 0
         all_mn_rewards = platform_reward + owner_reward + operator_reward
         all_mn_rewards += 1 * 0.75
-        assert_equal(all_mn_rewards, bt['coinbasevalue'] * 0.75)  # 75/25 mn/miner reward split
+        assert_equal(all_mn_rewards, int(bt['coinbasevalue'] * 0.75))  # 75/25 mn/miner reward split
         assert_equal(platform_reward, all_mn_rewards * 375 // 1000)  # 0.375 platform share
         assert_equal(platform_reward, 2555399792)
         assert_equal(new_total, self.get_credit_pool_balance())

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -513,7 +513,7 @@ class AssetLocksTest(DashTestFramework):
         owner_reward = bt['masternode'][1]['amount']
         operator_reward = bt['masternode'][2]['amount'] if len(bt['masternode']) == 3 else 0
         all_mn_rewards = platform_reward + owner_reward + operator_reward
-        assert_equal(all_mn_rewards, int(bt['coinbasevalue'] * 3 // 4))  # 75/25 mn/miner reward split
+        assert_equal(all_mn_rewards, bt['coinbasevalue'] * 3 // 4)  # 75/25 mn/miner reward split
         assert_equal(platform_reward, all_mn_rewards * 375 // 1000)  # 0.375 platform share
         assert_equal(platform_reward, 2555399792)
         assert_equal(new_total, self.get_credit_pool_balance())


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixed a problem forgotten in #5588 in feature_asset_locks.py.

## What was done?
Avoid floating operations when calculating `coinbasevalue`

## How Has This Been Tested?

## Breaking Changes

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

