### PR TITLE
fix!: avoid float calculations in PlatformShare

### DIFF
--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -344,10 +344,9 @@ void FillBlockPayments(const CSporkManager& sporkManager, CGovernanceManager& go
 
 CAmount PlatformShare(const CAmount reward)
 {
-    constexpr double platformShare = 0.375;
-    const CAmount platformReward = reward * platformShare;
-    assert(MoneyRange(platformReward));
-
+    const CAmount platformReward = reward * 375 / 1000;
+    bool ok = MoneyRange(platformReward);
+    assert(ok);
     return platformReward;
 }
 

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -515,7 +515,7 @@ class AssetLocksTest(DashTestFramework):
         all_mn_rewards = platform_reward + owner_reward + operator_reward
         all_mn_rewards += 1 * 0.75
         assert_equal(all_mn_rewards, bt['coinbasevalue'] * 0.75)  # 75/25 mn/miner reward split
-        assert_equal(platform_reward, int(all_mn_rewards * 0.375))  # 0.375 platform share
+        assert_equal(platform_reward, int(all_mn_rewards * 375 // 1000))  # 0.375 platform share
         assert_equal(platform_reward, 2555399792)
         assert_equal(new_total, self.get_credit_pool_balance())
         node.generate(1)

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -515,7 +515,7 @@ class AssetLocksTest(DashTestFramework):
         all_mn_rewards = platform_reward + owner_reward + operator_reward
         all_mn_rewards += 1 * 0.75
         assert_equal(all_mn_rewards, bt['coinbasevalue'] * 0.75)  # 75/25 mn/miner reward split
-        assert_equal(platform_reward, int(all_mn_rewards * 375 // 1000))  # 0.375 platform share
+        assert_equal(platform_reward, all_mn_rewards * 375 // 1000)  # 0.375 platform share
         assert_equal(platform_reward, 2555399792)
         assert_equal(new_total, self.get_credit_pool_balance())
         node.generate(1)


### PR DESCRIPTION
## Issue being fixed or feature implemented
avoid potential discrepancies in block reward calculations

## What was done?
use integers (int64_t) only when dealing with block rewards, no float/double

## How Has This Been Tested?
run tests

## Breaking Changes
might fork off on devnets that use previous version

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

