### PR TITLE
fix: Testnet syncing mn_rr

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1167,6 +1167,8 @@ CAmount GetBlockSubsidyInner(int nPrevBits, int nPrevHeight, const Consensus::Pa
     // Hard fork to reduce the block reward by 10 extra percent (allowing budget/superblocks)
     if (nPrevHeight > consensusParams.nBudgetPaymentsStartBlock) {
         // Once MNRewardReallocated is active, the treasury is 20% instead of 10%
+        // TODO remove this when we re-organize testnet
+        if (Params().NetworkIDString() == CBaseChainParams::TESTNET) fMNRewardReallocated = false;
         nSuperblockPart = nSubsidy / (fMNRewardReallocated ? 5 : 10);
     }
     return fSuperblockPartOnly ? nSuperblockPart : nSubsidy - nSuperblockPart;
@@ -1210,6 +1212,8 @@ CAmount GetMasternodePayment(int nHeight, CAmount blockValue, int nReallocActiva
         return ret;
     }
 
+    // TODO remove this when we re-organize testnet
+    if (Params().NetworkIDString() == CBaseChainParams::TESTNET) fMNRewardReallocated = false;
     if (fMNRewardReallocated) {
         // Once MNRewardReallocated activates, block reward is 80% of block subsidy (+ tx fees) since treasury is 20%
         // Since the MN reward needs to be equal to 60% of the block subsidy (according to the proposal), MN reward is set to 75% of the block reward.


### PR DESCRIPTION
## Issue being fixed or feature implemented
Since `mn_rr` is already active on Testnet, because of #5588, syncing from develop is broken.

## What was done?
Temporary disabled changes of #5588 for Testnet.
This should be dropped when Testnet will be re-organised for Platform.

## How Has This Been Tested?
Syncing Testnet

## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

