### PR TITLE
feat: Asset withdraw adr2 implementation

### DIFF
--- a/src/evo/assetlocktx.cpp
+++ b/src/evo/assetlocktx.cpp
@@ -106,7 +106,7 @@ std::string CAssetLockPayload::ToString() const
  * Asset Unlock Transaction (withdrawals)
  */
 
-const std::string ASSETUNLOCK_REQUESTID_PREFIX = "plwdtx";
+const std::string ASSETUNLOCK_REQUESTID_PREFIX = "dpevote";
 
 bool CAssetUnlockPayload::VerifySig(const uint256& msgHash, const CBlockIndex* pindexTip, TxValidationState& state) const
 {
@@ -133,7 +133,7 @@ bool CAssetUnlockPayload::VerifySig(const uint256& msgHash, const CBlockIndex* p
     const auto quorum = llmq::quorumManager->GetQuorum(llmqType, quorumHash);
     assert(quorum);
 
-    const uint256 requestId = ::SerializeHash(std::make_pair(ASSETUNLOCK_REQUESTID_PREFIX, index));
+    const uint256 requestId = ::SerializeHash(std::make_tuple(ASSETUNLOCK_REQUESTID_PREFIX, platformHeight, platformRound, voteIndex));
 
     const uint256 signHash = llmq::utils::BuildSignHash(llmqType, quorum->qc->quorumHash, requestId, msgHash);
     if (quorumSig.VerifyInsecure(quorum->qc->quorumPublicKey, signHash)) {
@@ -179,7 +179,7 @@ bool CheckAssetUnlockTx(const CTransaction& tx, const CBlockIndex* pindexPrev, c
 
     // Copy transaction except `quorumSig` field to calculate hash
     CMutableTransaction tx_copy(tx);
-    const CAssetUnlockPayload payload_copy{assetUnlockTx.getVersion(), assetUnlockTx.getIndex(), assetUnlockTx.getFee(), assetUnlockTx.getRequestedHeight(), assetUnlockTx.getQuorumHash(), CBLSSignature{}};
+    const CAssetUnlockPayload payload_copy{assetUnlockTx.getVersion(), assetUnlockTx.getIndex(), assetUnlockTx.getFee(), assetUnlockTx.getRequestedHeight(), assetUnlockTx.getPlatformHeight(), assetUnlockTx.getPlatformRound(), assetUnlockTx.getVoteIndex(), assetUnlockTx.getQuorumHash(), CBLSSignature{}};
     SetTxPayload(tx_copy, payload_copy);
 
     uint256 msgHash = tx_copy.GetHash();
@@ -203,6 +203,6 @@ bool GetAssetUnlockFee(const CTransaction& tx, CAmount& txfee, TxValidationState
 
 std::string CAssetUnlockPayload::ToString() const
 {
-    return strprintf("CAssetUnlockPayload(nVersion=%d,index=%d,fee=%d.%08d,requestedHeight=%d,quorumHash=%d,quorumSig=%s",
-            nVersion, index, fee / COIN, fee % COIN, requestedHeight, quorumHash.GetHex(), quorumSig.ToString().c_str());
+    return strprintf("CAssetUnlockPayload(nVersion=%d,index=%d,fee=%d.%08d,requestedHeight=%d,platformHeight=%d,platformRound=%d,voteIndex=%d,quorumHash=%d,quorumSig=%s",
+            nVersion, index, fee / COIN, fee % COIN, requestedHeight, platformHeight, platformRound, voteIndex, quorumHash.GetHex(), quorumSig.ToString().c_str());
 }

--- a/src/evo/assetlocktx.h
+++ b/src/evo/assetlocktx.h
@@ -85,16 +85,22 @@ private:
     uint64_t index{0};
     uint32_t fee{0};
     uint32_t requestedHeight{0};
+    uint64_t platformHeight{0};
+    uint32_t platformRound{0};
+    uint32_t voteIndex{0};
     uint256 quorumHash{0};
     CBLSSignature quorumSig{};
 
 public:
-    CAssetUnlockPayload(uint8_t nVersion, uint64_t index, uint32_t fee, uint32_t requestedHeight,
-            uint256 quorumHash, CBLSSignature quorumSig) :
+    CAssetUnlockPayload(uint8_t nVersion, uint64_t index, uint32_t fee, uint32_t requestedHeight, uint64_t platformHeight, uint32_t platformRound, uint32_t voteIndex,
+                        uint256 quorumHash, CBLSSignature quorumSig) :
         nVersion(nVersion),
         index(index),
         fee(fee),
         requestedHeight(requestedHeight),
+        platformHeight{platformHeight},
+        platformRound{platformRound},
+        voteIndex(voteIndex),
         quorumHash(quorumHash),
         quorumSig(quorumSig)
     {}
@@ -108,6 +114,9 @@ public:
             obj.index,
             obj.fee,
             obj.requestedHeight,
+            obj.platformHeight,
+            obj.platformRound,
+            obj.voteIndex,
             obj.quorumHash,
             obj.quorumSig
         );
@@ -123,6 +132,9 @@ public:
         obj.pushKV("index", int(index));
         obj.pushKV("fee", int(fee));
         obj.pushKV("requestedHeight", int(requestedHeight));
+        obj.pushKV("platformHeight", int(platformHeight));
+        obj.pushKV("platformRound", int(platformRound));
+        obj.pushKV("voteIndex", int(voteIndex));
         obj.pushKV("quorumHash", quorumHash.ToString());
         obj.pushKV("quorumSig", quorumSig.ToString());
         return obj;
@@ -149,6 +161,21 @@ public:
     uint32_t getRequestedHeight() const
     {
         return requestedHeight;
+    }
+
+    uint64_t getPlatformHeight() const
+    {
+        return platformHeight;
+    }
+
+    uint32_t getPlatformRound() const
+    {
+        return platformRound;
+    }
+
+    uint32_t getVoteIndex() const
+    {
+        return voteIndex;
     }
 
     const uint256& getQuorumHash() const

--- a/src/test/evo_assetlocks_tests.cpp
+++ b/src/test/evo_assetlocks_tests.cpp
@@ -98,9 +98,12 @@ static CMutableTransaction CreateAssetUnlockTx(FillableSigningProvider& keystore
     uint32_t fee = 2000'000'000u;
     // just big enough to overflow uint16_t
     uint32_t requestedHeight = 1000'000;
+    uint64_t platformHeight;
+    uint32_t platformRound;
+    uint32_t voteIndex;
     uint256 quorumHash;
     CBLSSignature quorumSig;
-    CAssetUnlockPayload assetUnlockTx(nVersion, index, fee, requestedHeight, quorumHash, quorumSig);
+    CAssetUnlockPayload assetUnlockTx(nVersion, index, fee, requestedHeight, platformHeight, platformRound, voteIndex, quorumHash, quorumSig);
 
     CMutableTransaction tx;
     tx.nVersion = 3;
@@ -358,6 +361,9 @@ BOOST_FIXTURE_TEST_CASE(evo_assetunlock, TestChain100Setup)
                 unlockPayload.getIndex(),
                 unlockPayload.getFee(),
                 unlockPayload.getRequestedHeight(),
+                unlockPayload.getPlatformHeight(),
+                unlockPayload.getPlatformRound(),
+                unlockPayload.getVoteIndex(),
                 unlockPayload.getQuorumHash(),
                 unlockPayload.getQuorumSig()};
             CMutableTransaction txWrongVersion = tx;

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -92,18 +92,27 @@ class AssetLocksTest(DashTestFramework):
         mninfo = self.mninfo
         assert_greater_than(int(withdrawal), fee)
         tx_output = CTxOut(int(withdrawal) - fee, CScript([pubkey, OP_CHECKSIG]))
+        height = node_wallet.getblockcount()
 
-        # request ID = sha256("plwdtx", index)
-        request_id_buf = ser_string(b"plwdtx") + struct.pack("<Q", index)
+        # request ID = sha256("dpevote", platformHeight, platformRound, voteIndex)
+        # For this test, those values don't have a real meaning.
+        # Assigning core height to platformHeight, 1 to platformRound and index to voteIndex
+        # (platformHeight, platformRound, voteIndex) must be unique
+        platformHeight = height
+        platformRound = 1
+        voteIndex = index
+        request_id_buf = ser_string(b"dpevote") + struct.pack("<Q", platformHeight) + struct.pack("<I", platformRound) + struct.pack("<I", voteIndex)
         request_id = hash256(request_id_buf)[::-1].hex()
 
-        height = node_wallet.getblockcount()
         quorumHash = mninfo[0].node.quorum("selectquorum", llmq_type_test, request_id)["quorumHash"]
         unlockTx_payload = CAssetUnlockTx(
             version = 1,
             index = index,
             fee = fee,
             requestedHeight = height,
+            platformHeight = platformHeight,
+            platformRound = platformRound,
+            voteIndex = voteIndex,
             quorumHash = int(quorumHash, 16),
             quorumSig = b'\00' * 96)
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1129,9 +1129,9 @@ class CAssetLockTx:
 
 
 class CAssetUnlockTx:
-    __slots__ = ("version", "index", "fee", "requestedHeight", "quorumHash", "quorumSig")
+    __slots__ = ("version", "index", "fee", "requestedHeight", "platformHeight", "platformRound", "voteIndex", "quorumHash", "quorumSig")
 
-    def __init__(self, version=None, index=None, fee=None, requestedHeight=None, quorumHash = 0, quorumSig = None):
+    def __init__(self, version=None, index=None, fee=None, requestedHeight=None, platformHeight=None, platformRound=None, voteIndex=None, quorumHash = 0, quorumSig = None):
         self.set_null()
         if version is not None:
             self.version = version
@@ -1141,6 +1141,12 @@ class CAssetUnlockTx:
             self.fee = fee
         if requestedHeight is not None:
             self.requestedHeight = requestedHeight
+        if platformHeight is not None:
+            self.platformHeight = platformHeight
+        if platformRound is not None:
+            self.platformRound = platformRound
+        if voteIndex is not None:
+            self.voteIndex = voteIndex
         if quorumHash is not None:
             self.quorumHash = quorumHash
         if quorumSig is not None:
@@ -1151,6 +1157,9 @@ class CAssetUnlockTx:
         self.index = 0
         self.fee = None
         self.requestedHeight = 0
+        self.platformHeight = 0
+        self.platformRound = 0
+        self.voteIndex = 0
         self.quorumHash = 0
         self.quorumSig = b'\x00' * 96
 
@@ -1159,6 +1168,9 @@ class CAssetUnlockTx:
         self.index = struct.unpack("<Q", f.read(8))[0]
         self.fee = struct.unpack("<I", f.read(4))[0]
         self.requestedHeight = struct.unpack("<I", f.read(4))[0]
+        self.platformHeight = struct.unpack("<Q", f.read(8))[0]
+        self.platformRound = struct.unpack("<I", f.read(4))[0]
+        self.voteIndex = struct.unpack("<I", f.read(4))[0]
         self.quorumHash = deser_uint256(f)
         self.quorumSig = f.read(96)
 
@@ -1168,13 +1180,16 @@ class CAssetUnlockTx:
         r += struct.pack("<Q", self.index)
         r += struct.pack("<I", self.fee)
         r += struct.pack("<I", self.requestedHeight)
+        r += struct.pack("<Q", self.platformHeight)
+        r += struct.pack("<I", self.platformRound)
+        r += struct.pack("<I", self.voteIndex)
         r += ser_uint256(self.quorumHash)
         r += self.quorumSig
         return r
 
     def __repr__(self):
-        return "CAssetUnlockTx(version={} index={} fee={} requestedHeight={} quorumHash={:x} quorumSig={}" \
-            .format(self.version, self.index, self.fee, self.requestedHeight, self.quorumHash, self.quorumSig.hex())
+        return "CAssetUnlockTx(version={} index={} fee={} requestedHeight={} platformHeight={} platformRound={} voteIndex={} quorumHash={:x} quorumSig={}" \
+            .format(self.version, self.index, self.fee, self.requestedHeight, self.platformHeight, self.platformRound, self.voteIndex, self.quorumHash, self.quorumSig.hex())
 
 
 class CMnEhf:


### PR DESCRIPTION
## Issue being fixed or feature implemented


## What was done?
`CAssetUnlockPayload` now holds three additional fields: `platformHeight`, `platformRound` and `voteIndex`.
When signing Asset Unlocks, the requestID is: `SHA256("dpevote", platformHeight, platformRound, voteIndex)`


## How Has This Been Tested?
`feature_asset_locks.py`

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

