### PR TITLE
build: make depends compilable with Xcode 15 on macos

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -21,8 +21,12 @@ $(package)_config_opts_i686_android=address-model=32
 $(package)_config_opts_aarch64_android=address-model=64
 $(package)_config_opts_x86_64_android=address-model=64
 $(package)_config_opts_armv7a_android=address-model=32
+unary_function=unary_function
 ifneq (,$(findstring clang,$($(package)_cxx)))
 $(package)_toolset_$(host_os)=clang
+ifeq ($(build_os),darwin)
+unary_function=__unary_function
+endif
 else
 $(package)_toolset_$(host_os)=gcc
 endif
@@ -36,8 +40,10 @@ $(package)_cxxflags_x86_64=-fcf-protection=full
 endef
 
 # Fix unused variable in boost_process, can be removed after upgrading to 1.72
+# Fix missing unary_function in clang15 on macos, can be removed after upgrading to 1.81
 define $(package)_preprocess_cmds
   sed -i.old "s/int ret_sig = 0;//" boost/process/detail/posix/wait_group.hpp && \
+  sed -i.old "s/unary_function/$(unary_function)/" boost/container_hash/hash.hpp && \
   echo "using $($(package)_toolset_$(host_os)) : : $($(package)_cxx) : <cflags>\"$($(package)_cflags)\" <cxxflags>\"$($(package)_cxxflags)\" <compileflags>\"$($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$($(package)_ar)\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -266,8 +266,7 @@ define $(package)_preprocess_cmds
   echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   sed -i.old "s|QMAKE_CC                = \$$$$\$$$${CROSS_COMPILE}clang|QMAKE_CC                = $($(package)_cc)|" qtbase/mkspecs/common/clang.conf && \
-  sed -i.old "s|QMAKE_CXX               = \$$$$\$$$${CROSS_COMPILE}clang++|QMAKE_CXX               = $($(package)_cxx)|" qtbase/mkspecs/common/clang.conf && \
-  sed -i.old "s/error(\"failed to parse default search paths from compiler output\")/\!darwin: error(\"failed to parse default search paths from compiler output\")/g" qtbase/mkspecs/features/toolchain.prf
+  sed -i.old "s|QMAKE_CXX               = \$$$$\$$$${CROSS_COMPILE}clang++|QMAKE_CXX               = $($(package)_cxx)|" qtbase/mkspecs/common/clang.conf
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -24,6 +24,7 @@ $(package)_patches += duplicate_lcqpafonts.patch
 $(package)_patches += guix_cross_lib_path.patch
 $(package)_patches += fast_fixed_dtoa_no_optimize.patch
 $(package)_patches += fix-macos-linker.patch
+$(package)_patches += memory_resource.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=c92af4171397a0ed272330b4fa0669790fcac8d050b07c8b8cc565ebeba6735e
@@ -254,6 +255,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/dont_hardcode_x86_64.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_montery_include.patch && \
   patch -p1 -i $($(package)_patch_dir)/use_android_ndk23.patch && \
+  patch -p1 -i $($(package)_patch_dir)/memory_resource.patch && \
   patch -p1 -i $($(package)_patch_dir)/rcc_hardcode_timestamp.patch && \
   patch -p1 -i $($(package)_patch_dir)/duplicate_lcqpafonts.patch && \
   patch -p1 -i $($(package)_patch_dir)/qtbase-moc-ignore-gcc-macro.patch && \

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -23,6 +23,7 @@ $(package)_patches += rcc_hardcode_timestamp.patch
 $(package)_patches += duplicate_lcqpafonts.patch
 $(package)_patches += guix_cross_lib_path.patch
 $(package)_patches += fast_fixed_dtoa_no_optimize.patch
+$(package)_patches += fix-macos-linker.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=c92af4171397a0ed272330b4fa0669790fcac8d050b07c8b8cc565ebeba6735e
@@ -244,6 +245,7 @@ endef
 define $(package)_preprocess_cmds
   cp $($(package)_patch_dir)/qt.pro qt.pro && \
   cp $($(package)_patch_dir)/qttools_src.pro qttools/src/src.pro && \
+  patch -p1 -i $($(package)_patch_dir)/fix-macos-linker.patch && \
   patch -p1 -i $($(package)_patch_dir)/dont_hardcode_pwd.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_qt_pkgconfig.patch && \
   patch -p1 -i $($(package)_patch_dir)/fix_qt_placeholders.patch && \

--- a/depends/patches/qt/fix-macos-linker.patch
+++ b/depends/patches/qt/fix-macos-linker.patch
@@ -1,0 +1,55 @@
+qmake: Don't error out if QMAKE_DEFAULT_LIBDIRS is empty on macOS
+
+The new linker in Xcode 15 doesn't provide any default linker or
+framework paths when requested via -v, but still seems to use the
+default paths documented in the ld man page.
+
+We trust that linker will do the right thing, even if we don't
+know of its default linker paths.
+
+We also need to opt out of the default fallback logic to
+set the libdirs to /lib and /usr/lib.
+
+This may result in UnixMakefileGenerator::findLibraries finding
+different libraries than expected, if additional paths are
+passed with -L, which will then take precedence for qmake,
+even if the linker itself will use the library from the
+SDK's default paths. This should hopefully not be an issue
+in practice, as we don't turn -lFoo into absolute paths in
+qmake, so the only risk is that we're picking up the wrong
+prl files and adding additional dependencies that the lib
+in the SDK doesn't have.
+
+Upstream commits:
+ - Qt 5.15.16: Not yet publicly available.
+ - Qt dev: cdf64b0e47115cc473e1afd1472b4b09e130b2a5
+
+For other Qt branches see
+https://codereview.qt-project.org/q/I2347b26e2df0828471373b0e15b8c9089274c65d
+
+--- old/qtbase/mkspecs/features/toolchain.prf
++++ new/qtbase/mkspecs/features/toolchain.prf
+@@ -283,9 +283,12 @@ isEmpty($${target_prefix}.INCDIRS) {
+                 }
+             }
+         }
+-        isEmpty(QMAKE_DEFAULT_LIBDIRS)|isEmpty(QMAKE_DEFAULT_INCDIRS): \
++        isEmpty(QMAKE_DEFAULT_INCDIRS): \
+             !integrity: \
+-                error("failed to parse default search paths from compiler output")
++                error("failed to parse default include paths from compiler output")
++        isEmpty(QMAKE_DEFAULT_LIBDIRS): \
++            !integrity:!darwin: \
++                error("failed to parse default library paths from compiler output")
+         QMAKE_DEFAULT_LIBDIRS = $$unique(QMAKE_DEFAULT_LIBDIRS)
+     } else: ghs {
+         cmd = $$QMAKE_CXX $$QMAKE_CXXFLAGS -$${LITERAL_HASH} -o /tmp/fake_output /tmp/fake_input.cpp
+@@ -407,7 +410,7 @@ isEmpty($${target_prefix}.INCDIRS) {
+         QMAKE_DEFAULT_INCDIRS = $$split(INCLUDE, $$QMAKE_DIRLIST_SEP)
+     }
+ 
+-    unix:if(!cross_compile|host_build) {
++    unix:!darwin:if(!cross_compile|host_build) {
+         isEmpty(QMAKE_DEFAULT_INCDIRS): QMAKE_DEFAULT_INCDIRS = /usr/include /usr/local/include
+         isEmpty(QMAKE_DEFAULT_LIBDIRS): QMAKE_DEFAULT_LIBDIRS = /lib /usr/lib
+     }

--- a/depends/patches/qt/memory_resource.patch
+++ b/depends/patches/qt/memory_resource.patch
@@ -1,0 +1,49 @@
+Fix unusable memory_resource on macos
+
+See https://bugreports.qt.io/browse/QTBUG-117484
+and https://bugreports.qt.io/browse/QTBUG-114316
+
+--- a/qtbase/src/corelib/tools/qduplicatetracker_p.h
++++ b/qtbase/src/corelib/tools/qduplicatetracker_p.h
+@@ -52,7 +52,7 @@
+ 
+ #include <qglobal.h>
+ 
+-#if QT_HAS_INCLUDE(<memory_resource>) && __cplusplus > 201402L
++#ifdef __cpp_lib_memory_resource
+ #  include <unordered_set>
+ #  include <memory_resource>
+ #else
+
+--- a/qtbase/src/corelib/global/qcompilerdetection.h
++++ b/qtbase/src/corelib/global/qcompilerdetection.h
+@@ -1041,16 +1041,22 @@
+ #   endif // !_HAS_CONSTEXPR
+ #  endif // !__GLIBCXX__ && !_LIBCPP_VERSION
+ # endif // Q_OS_QNX
+-# if (defined(Q_CC_CLANG) || defined(Q_CC_INTEL)) && defined(Q_OS_MAC) && defined(__GNUC_LIBSTD__) \
+-    && ((__GNUC_LIBSTD__-0) * 100 + __GNUC_LIBSTD_MINOR__-0 <= 402)
++# if (defined(Q_CC_CLANG) || defined(Q_CC_INTEL)) && defined(Q_OS_MAC)
++#  if defined(__GNUC_LIBSTD__) && ((__GNUC_LIBSTD__-0) * 100 + __GNUC_LIBSTD_MINOR__-0 <= 402)
+ // Apple has not updated libstdc++ since 2007, which means it does not have
+ // <initializer_list> or std::move. Let's disable these features
+-#  undef Q_COMPILER_INITIALIZER_LISTS
+-#  undef Q_COMPILER_RVALUE_REFS
+-#  undef Q_COMPILER_REF_QUALIFIERS
++#   undef Q_COMPILER_INITIALIZER_LISTS
++#   undef Q_COMPILER_RVALUE_REFS
++#   undef Q_COMPILER_REF_QUALIFIERS
+ // Also disable <atomic>, since it's clearly not there
+-#  undef Q_COMPILER_ATOMICS
+-# endif
++#   undef Q_COMPILER_ATOMICS
++#  endif
++#  if defined(__cpp_lib_memory_resource) \
++    && ((defined(__MAC_OS_X_VERSION_MIN_REQUIRED)  && __MAC_OS_X_VERSION_MIN_REQUIRED  < 140000) \
++     || (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 170000))
++#   undef __cpp_lib_memory_resource // Only supported on macOS 14 and iOS 17
++#  endif
++# endif // (defined(Q_CC_CLANG) || defined(Q_CC_INTEL)) && defined(Q_OS_MAC)
+ # if defined(Q_CC_CLANG) && defined(Q_CC_INTEL) && Q_CC_INTEL >= 1500
+ // ICC 15.x and 16.0 have their own implementation of std::atomic, which is activated when in Clang mode
+ // (probably because libc++'s <atomic> on OS X failed to compile), but they're missing some


### PR DESCRIPTION
## Issue being fixed or feature implemented
Building depends fails on macos with Xcode 15 atm.

## What was done?
revert old qt fix, backport qt fixes, patch boost

## How Has This Been Tested?
compiles locally (macos 13.6 + Xcode 15) and in CI, tests are green

## Breaking Changes
~n/a~ not 100% sure about aa7ba58, pls test on macs with newer/older clang versions

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

