### PR TITLE
feat!: constant subsidy base for blocks in v20

### DIFF
--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -37,7 +37,7 @@ static void DuplicateInputs(benchmark::Bench& bench)
     coinbaseTx.vin[0].prevout.SetNull();
     coinbaseTx.vout.resize(1);
     coinbaseTx.vout[0].scriptPubKey = SCRIPT_PUB;
-    coinbaseTx.vout[0].nValue = GetBlockSubsidyInner(block.nBits, nHeight, chainparams.GetConsensus(), false);
+    coinbaseTx.vout[0].nValue = GetBlockSubsidyInner(block.nBits, nHeight, chainparams.GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
 
     naughtyTx.vout.resize(1);

--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -496,19 +496,23 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
 
     const CBlockIndex* tipIndex = ::ChainActive().Tip();
     bool fMNRewardReallocated = llmq::utils::IsMNRewardReallocationActive(tipIndex);
+    bool fV20Active = llmq::utils::IsV20Active(tipIndex);
     if (!fMNRewardReallocated && nBlockHeight > tipIndex->nHeight) {
         // If fMNRewardReallocated isn't active yet and nBlockHeight refers to a future SuperBlock
         // then we need to check if the fork is locked_in and see if it will be active by the time of the future SuperBlock
         if (llmq::utils::GetMNRewardReallocationState(tipIndex) == ThresholdState::LOCKED_IN) {
             int activation_height = llmq::utils::GetMNRewardReallocationSince(tipIndex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize);
-            if (nBlockHeight >= activation_height) fMNRewardReallocated = true;
+            if (nBlockHeight >= activation_height) {
+                fMNRewardReallocated = true;
+                fV20Active = true;
+            }
         }
     }
 
     // min subsidy for high diff networks and vice versa
     int nBits = consensusParams.fPowAllowMinDifficultyBlocks ? UintToArith256(consensusParams.powLimit).GetCompact() : 1;
     // some part of all blocks issued during the cycle goes to superblock, see GetBlockSubsidy
-    CAmount nSuperblockPartOfSubsidy = GetSuperblockSubsidyInner(nBits, nBlockHeight - 1, consensusParams, fMNRewardReallocated);
+    CAmount nSuperblockPartOfSubsidy = GetSuperblockSubsidyInner(nBits, nBlockHeight - 1, consensusParams, fV20Active, fMNRewardReallocated);
     CAmount nPaymentsLimit = nSuperblockPartOfSubsidy * consensusParams.nSuperblockCycle;
     LogPrint(BCLog::GOBJECT, "CSuperblock::GetPaymentsLimit -- Valid superblock height %d, payments max %lld\n", nBlockHeight, nPaymentsLimit);
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -193,7 +193,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // NOTE: unlike in bitcoin, we need to pass PREVIOUS block height here
     bool fMNRewardReallocated = llmq::utils::IsMNRewardReallocationActive(pindexPrev);
-    CAmount blockReward = nFees + GetBlockSubsidyInner(pindexPrev->nBits, pindexPrev->nHeight, Params().GetConsensus(), fMNRewardReallocated);
+    bool fV20Active = llmq::utils::IsV20Active(pindexPrev);
+    CAmount blockReward = nFees + GetBlockSubsidyInner(pindexPrev->nBits, pindexPrev->nHeight, Params().GetConsensus(), fV20Active, fMNRewardReallocated);
 
     // Compute regular coinbase transaction.
     coinbaseTx.vout[0].nValue = blockReward;

--- a/src/test/subsidy_tests.cpp
+++ b/src/test/subsidy_tests.cpp
@@ -22,43 +22,50 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
     // details for block 4249 (subsidy returned will be for block 4250)
     nPrevBits = 0x1c4a47c4;
     nPrevHeight = 4249;
-    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), false);
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     BOOST_CHECK_EQUAL(nSubsidy, 50000000000ULL);
+
+    // details for block 4249 (subsidy returned will be for block 4250)
+    // v20 should make difference for blocks with low diff, regardless of their height
+    nPrevBits = 0x1c4a47c4;
+    nPrevHeight = 4249;
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ true, /*fMNRewardReallocated=*/ false);
+    BOOST_CHECK_EQUAL(nSubsidy, 500000000ULL);
 
     // details for block 4501 (subsidy returned will be for block 4502)
     nPrevBits = 0x1c4a47c4;
     nPrevHeight = 4501;
-    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), false);
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     BOOST_CHECK_EQUAL(nSubsidy, 5600000000ULL);
 
     // details for block 5464 (subsidy returned will be for block 5465)
     nPrevBits = 0x1c29ec00;
     nPrevHeight = 5464;
-    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), false);
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     BOOST_CHECK_EQUAL(nSubsidy, 2100000000ULL);
 
     // details for block 5465 (subsidy returned will be for block 5466)
     nPrevBits = 0x1c29ec00;
     nPrevHeight = 5465;
-    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), false);
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     BOOST_CHECK_EQUAL(nSubsidy, 12200000000ULL);
 
     // details for block 17588 (subsidy returned will be for block 17589)
     nPrevBits = 0x1c08ba34;
     nPrevHeight = 17588;
-    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), false);
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     BOOST_CHECK_EQUAL(nSubsidy, 6100000000ULL);
 
     // details for block 99999 (subsidy returned will be for block 100000)
     nPrevBits = 0x1b10cf42;
     nPrevHeight = 99999;
-    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), false);
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     BOOST_CHECK_EQUAL(nSubsidy, 500000000ULL);
 
     // details for block 210239 (subsidy returned will be for block 210240)
     nPrevBits = 0x1b11548e;
     nPrevHeight = 210239;
-    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), false);
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     BOOST_CHECK_EQUAL(nSubsidy, 500000000ULL);
 
     // 1st subsidy reduction happens here
@@ -66,8 +73,35 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
     // details for block 210240 (subsidy returned will be for block 210241)
     nPrevBits = 0x1b10d50b;
     nPrevHeight = 210240;
-    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), false);
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
     BOOST_CHECK_EQUAL(nSubsidy, 464285715ULL);
+
+    // details for block 210240 (subsidy returned will be for block 210241)
+    // no budgets yet, same results
+    nPrevBits = 0x1b10d50b;
+    nPrevHeight = 210240;
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ true);
+    BOOST_CHECK_EQUAL(nSubsidy, 464285715ULL);
+
+    // details for block 210240 (subsidy returned will be for block 210241)
+    // v20 makes no differ for blocks with high enough diff
+    nPrevBits = 0x1b10d50b;
+    nPrevHeight = 210240;
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ true, /*fMNRewardReallocated=*/ false);
+    BOOST_CHECK_EQUAL(nSubsidy, 464285715ULL);
+
+    // details for block 420480 (subsidy returned will be for block 210241)
+    nPrevBits = 0x1b10d50b;
+    nPrevHeight = 420480;
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ false);
+    BOOST_CHECK_EQUAL(nSubsidy, 388010205ULL);
+
+    // details for block 420480 (subsidy returned will be for block 210241)
+    // budgets are active, reallocation matters now
+    nPrevBits = 0x1b10d50b;
+    nPrevHeight = 420480;
+    nSubsidy = GetBlockSubsidyInner(nPrevBits, nPrevHeight, chainParams->GetConsensus(), /*fV20Active=*/ false, /*fMNRewardReallocated=*/ true);
+    BOOST_CHECK_EQUAL(nSubsidy, 344897960ULL);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.h
+++ b/src/validation.h
@@ -207,8 +207,8 @@ double ConvertBitsToDouble(unsigned int nBits);
  * When pindex points to a genesis block GetBlockSubsidy() returns a pre-calculated value.
  * For other blocks it calls GetBlockSubsidyInner() using nBits and nHeight of a pindex->pprev block.
  */
-CAmount GetBlockSubsidyInner(int nPrevBits, int nPrevHeight, const Consensus::Params& consensusParams, bool fMNRewardReallocated);
-CAmount GetSuperblockSubsidyInner(int nPrevBits, int nPrevHeight, const Consensus::Params& consensusParams, bool fMNRewardReallocated);
+CAmount GetBlockSubsidyInner(int nPrevBits, int nPrevHeight, const Consensus::Params& consensusParams, bool fV20Active, bool fMNRewardReallocated);
+CAmount GetSuperblockSubsidyInner(int nPrevBits, int nPrevHeight, const Consensus::Params& consensusParams, bool fV20Active, bool fMNRewardReallocated);
 CAmount GetBlockSubsidy(const CBlockIndex* const pindex, const Consensus::Params& consensusParams);
 /** fMNRewardReallocated refers to Masternode Reward Location Reallocation activation. */
 CAmount GetMasternodePayment(int nHeight, CAmount blockValue, bool fMNRewardReallocated);

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -515,7 +515,7 @@ class AssetLocksTest(DashTestFramework):
         all_mn_rewards = platform_reward + owner_reward + operator_reward
         assert_equal(all_mn_rewards, bt['coinbasevalue'] * 3 // 4)  # 75/25 mn/miner reward split
         assert_equal(platform_reward, all_mn_rewards * 375 // 1000)  # 0.375 platform share
-        assert_equal(platform_reward, 2555399792)
+        assert_equal(platform_reward, 25553999)
         assert_equal(new_total, self.get_credit_pool_balance())
         node.generate(1)
         self.sync_all()


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently, the `nSubsidyBase` calculation relies on difficulty. This leads to variable Block Subsidity.
When Platform will be live, it would constantly require blocks difficulty in order to calculate the `platformReward` (which relies on Block Subsidy)

cc @QuantumExplorer 

## What was done?
Starting from v20 activation,  `nSubsidyBase` will no longer rely on difficulty and will be constant to 5.

## How Has This Been Tested?


## Breaking Changes
Block rewards will differ.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

