### PR TITLE
perf: pass around a cached block hash during block validation

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -447,7 +447,7 @@ public:
     /** Clear all data members. */
     void Unload() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    CBlockIndex* AddToBlockIndex(const CBlockHeader& block, enum BlockStatus nStatus = BLOCK_VALID_TREE) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    CBlockIndex* AddToBlockIndex(const CBlockHeader& block, const uint256& hash, enum BlockStatus nStatus = BLOCK_VALID_TREE) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Create a new block index entry for a given block hash */
     CBlockIndex* InsertBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 


### PR DESCRIPTION
this change saw a ~38% performance improvement in header sync reindex

reproduce via `time ./src/qt/dash-qt --nowallet --testnet --reindex --stopatheight=5`

On Develop this took average of 1:48 to finish, on this branch it took 1:07

## Issue being fixed or feature implemented
Slow header / block validation

## What was done?
Pass around cached block hash

## How Has This Been Tested?
Reindexed testnet

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

