### PR TITLE
refactor: move DecreaseScores method to be inside CDeterministicMNList class

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -366,7 +366,8 @@ void CDeterministicMNList::PoSePunish(const uint256& proTxHash, int penalty, boo
     UpdateMN(proTxHash, newState);
 }
 
-void CDeterministicMNList::DecreaseScores() {
+void CDeterministicMNList::DecreaseScores()
+{
     std::vector<CDeterministicMNCPtr> toDecrease;
     toDecrease.reserve(GetAllMNsCount() / 10);
     // only iterate and decrease for valid ones (not PoSe banned yet)

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -366,17 +366,30 @@ void CDeterministicMNList::PoSePunish(const uint256& proTxHash, int penalty, boo
     UpdateMN(proTxHash, newState);
 }
 
-void CDeterministicMNList::PoSeDecrease(const uint256& proTxHash)
-{
-    auto dmn = GetMN(proTxHash);
-    if (!dmn) {
-        throw(std::runtime_error(strprintf("%s: Can't find a masternode with proTxHash=%s", __func__, proTxHash.ToString())));
-    }
-    assert(dmn->pdmnState->nPoSePenalty > 0 && !dmn->pdmnState->IsBanned());
+void CDeterministicMNList::DecreaseScores() {
+    std::vector<CDeterministicMNCPtr> toDecrease;
+    toDecrease.reserve(GetAllMNsCount() / 10);
+    // only iterate and decrease for valid ones (not PoSe banned yet)
+    // if a MN ever reaches the maximum, it stays in PoSe banned state until revived
+    ForEachMNShared(true /* onlyValid */, [&toDecrease](auto& dmn) {
+        // There is no reason to check if this MN is banned here since onlyValid=true will only run on non-banned MNs
+        if (dmn->pdmnState->nPoSePenalty > 0) {
+            toDecrease.emplace_back(dmn);
+        }
+    });
 
-    auto newState = std::make_shared<CDeterministicMNState>(*dmn->pdmnState);
+    for (const auto& proTxHash : toDecrease) {
+        PoSeDecrease(*proTxHash);
+    }
+}
+
+void CDeterministicMNList::PoSeDecrease(const CDeterministicMN& dmn)
+{
+    assert(dmn.pdmnState->nPoSePenalty > 0 && !dmn.pdmnState->IsBanned());
+
+    auto newState = std::make_shared<CDeterministicMNState>(*dmn.pdmnState);
     newState->nPoSePenalty--;
-    UpdateMN(proTxHash, newState);
+    UpdateMN(dmn, newState);
 }
 
 CDeterministicMNListDiff CDeterministicMNList::BuildDiff(const CDeterministicMNList& to) const
@@ -723,7 +736,7 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
         }
     });
 
-    DecreasePoSePenalties(newList);
+    newList.DecreaseScores();
 
     bool isMNRewardReallocation = llmq::utils::IsMNRewardReallocationActive(pindexPrev);
 
@@ -999,24 +1012,6 @@ void CDeterministicMNManager::HandleQuorumCommitment(const llmq::CFinalCommitmen
             // If it however fails 3 times in the timespan of a single payment cycle, it should definitely get banned
             mnList.PoSePunish(members[i]->proTxHash, mnList.CalcPenalty(66), debugLogs);
         }
-    }
-}
-
-void CDeterministicMNManager::DecreasePoSePenalties(CDeterministicMNList& mnList)
-{
-    std::vector<uint256> toDecrease;
-    toDecrease.reserve(mnList.GetAllMNsCount() / 10);
-    // only iterate and decrease for valid ones (not PoSe banned yet)
-    // if a MN ever reaches the maximum, it stays in PoSe banned state until revived
-    mnList.ForEachMN(true /* onlyValid */, [&toDecrease](auto& dmn) {
-        // There is no reason to check if this MN is banned here since onlyValid=true will only run on non-banned MNs
-        if (dmn.pdmnState->nPoSePenalty > 0) {
-            toDecrease.emplace_back(dmn.proTxHash);
-        }
-    });
-
-    for (const auto& proTxHash : toDecrease) {
-        mnList.PoSeDecrease(proTxHash);
     }
 }
 

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -274,6 +274,7 @@ public:
             }
         }
     }
+public:
 
     /**
      * Prefer ForEachMN. Execute a callback on all masternodes in the mnList.
@@ -385,12 +386,12 @@ public:
      */
     void PoSePunish(const uint256& proTxHash, int penalty, bool debugLogs);
 
+    void DecreaseScores();
     /**
      * Decrease penalty score of MN by 1.
      * Only allowed on non-banned MNs.
-     * @param proTxHash
      */
-    void PoSeDecrease(const uint256& proTxHash);
+    void PoSeDecrease(const CDeterministicMN& dmn);
 
     [[nodiscard]] CDeterministicMNListDiff BuildDiff(const CDeterministicMNList& to) const;
     [[nodiscard]] CDeterministicMNList ApplyDiff(const CBlockIndex* pindex, const CDeterministicMNListDiff& diff) const;
@@ -609,7 +610,6 @@ public:
     bool BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, BlockValidationState& state, const CCoinsViewCache& view,
                                CDeterministicMNList& mnListRet, bool debugLogs) EXCLUSIVE_LOCKS_REQUIRED(cs);
     static void HandleQuorumCommitment(const llmq::CFinalCommitment& qc, const CBlockIndex* pQuorumBaseBlockIndex, CDeterministicMNList& mnList, bool debugLogs);
-    static void DecreasePoSePenalties(CDeterministicMNList& mnList);
 
     CDeterministicMNList GetListForBlock(const CBlockIndex* pindex) LOCKS_EXCLUDED(cs) {
         LOCK(cs);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -274,7 +274,6 @@ public:
             }
         }
     }
-public:
 
     /**
      * Prefer ForEachMN. Execute a callback on all masternodes in the mnList.


### PR DESCRIPTION
## Issue being fixed or feature implemented
It makes more sense for DecreaseScores to be inside of the MNList itself imo

## What was done?
Refactored as such


## How Has This Been Tested?
Reindexed

I had originally expected some performance improvements due to the removal of `GetMN` but in my benchmarking I didn't see any noticeable perf changes. I do still think the removal of `GetMN` and using a shared_ptr the whole time is better as it removes the chance of the master node disappearing from the list (which would have previously thrown, but is now impossible).

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

