### PR TITLE
fix: correct quorum for Asset Unlock (withdrawal) transactions

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -285,7 +285,7 @@ public:
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_60_75;
         consensus.llmqTypePlatform = Consensus::LLMQType::LLMQ_100_67;
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_400_85;
-        consensus.llmqTypeAssetLocks = Consensus::LLMQType::LLMQ_400_85;
+        consensus.llmqTypeAssetLocks = consensus.llmqTypePlatform;
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
@@ -476,7 +476,7 @@ public:
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_60_75;
         consensus.llmqTypePlatform = Consensus::LLMQType::LLMQ_25_67;
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_50_60;
-        consensus.llmqTypeAssetLocks = Consensus::LLMQType::LLMQ_50_60;
+        consensus.llmqTypeAssetLocks = consensus.llmqTypePlatform;
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
@@ -650,7 +650,7 @@ public:
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_60_75;
         consensus.llmqTypePlatform = Consensus::LLMQType::LLMQ_100_67;
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_50_60;
-        consensus.llmqTypeAssetLocks = Consensus::LLMQType::LLMQ_50_60;
+        consensus.llmqTypeAssetLocks = consensus.llmqTypePlatform;
 
         UpdateDevnetLLMQChainLocksFromArgs(args);
         UpdateDevnetLLMQInstantSendFromArgs(args);
@@ -731,6 +731,7 @@ public:
     void UpdateDevnetLLMQPlatform(Consensus::LLMQType llmqType)
     {
         consensus.llmqTypePlatform = llmqType;
+        consensus.llmqTypeAssetLocks = llmqType;
     }
 
     /**


### PR DESCRIPTION
## Issue being fixed or feature implemented
Signature for withdrawal (asset unlock) transaction should be validated against platform quorum (100_67) but not same as currently against EHF quorum (400_85).



## What was done?
Updates type of quorum in chainparams for Asset Unlock (withdrawal) transactions to same as platform's quorum.

It is first part of changes to fix devnet, testnet and mainnet. For regnet is still used incorrect quorum due to non-trivial changes in functional test `feature_assetlocks.py`; these changes would be provided in next PR.

## How Has This Been Tested?
Run unit/functional test.

## Breaking Changes
Yes, quorum for validation of Asset Unlock (withdrawal) transaction is changed.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

