### PR TITLE
feat(rpc): return `activation_height` in `getblockchaininfo` for BIP9 softforks

### DIFF
--- a/doc/release-notes-5624.md
+++ b/doc/release-notes-5624.md
@@ -1,0 +1,4 @@
+Updated RPCs
+------------
+
+- `getblockchaininfo` RPC returns the field `activation_height` for each softsposk in `locked_in` status: indicating the expected activation height.

--- a/doc/release-notes-5624.md
+++ b/doc/release-notes-5624.md
@@ -1,4 +1,4 @@
 Updated RPCs
 ------------
 
-- `getblockchaininfo` RPC returns the field `activation_height` for each softsposk in `locked_in` status: indicating the expected activation height.
+- `getblockchaininfo` RPC returns the field `activation_height` for each softforks in `locked_in` status: indicating the expected activation height.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1676,6 +1676,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
                         {RPCResult::Type::NUM_TIME, "start_time", "the minimum median time past of a block at which the bit gains its meaning"},
                         {RPCResult::Type::NUM_TIME, "timeout", "the median time past of a block at which the deployment is considered failed if not yet locked in"},
                         {RPCResult::Type::NUM, "since", "height of the first block to which the status applies"},
+                        {RPCResult::Type::NUM, "activation_height", "expected activation height for this softfork (only for \"locked_in\" status)"},
                         {RPCResult::Type::OBJ, "statistics", "numeric statistics about BIP9 signalling for a softfork",
                         {
                             {RPCResult::Type::NUM, "period", "the length in blocks of the BIP9 signalling period"},

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1628,15 +1628,15 @@ static void BIP9SoftForkDescPushBack(const CBlockIndex* active_chain_tip, UniVal
         statsUV.pushKV("possible", statsStruct.possible);
         bip9.pushKV("statistics", statsUV);
     }
+    else if (ThresholdState::LOCKED_IN == thresholdState) {
+        bip9.pushKV("activation_height", since_height + static_cast<int>(consensusParams.vDeployments[id].nWindowSize));
+    }
 
     UniValue rv(UniValue::VOBJ);
     rv.pushKV("type", "bip9");
     rv.pushKV("bip9", bip9);
     if (ThresholdState::ACTIVE == thresholdState) {
         rv.pushKV("height", since_height);
-    }
-    else if (ThresholdState::LOCKED_IN == thresholdState) {
-        rv.pushKV("activation_height", since_height + static_cast<int>(consensusParams.vDeployments[id].nWindowSize));
     }
     rv.pushKV("active", ThresholdState::ACTIVE == thresholdState);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1635,6 +1635,9 @@ static void BIP9SoftForkDescPushBack(const CBlockIndex* active_chain_tip, UniVal
     if (ThresholdState::ACTIVE == thresholdState) {
         rv.pushKV("height", since_height);
     }
+    else if (ThresholdState::LOCKED_IN == thresholdState) {
+        rv.pushKV("activation_height", since_height + static_cast<int>(consensusParams.vDeployments[id].nWindowSize));
+    }
     rv.pushKV("active", ThresholdState::ACTIVE == thresholdState);
 
     softforks.pushKV(name, rv);


### PR DESCRIPTION
## Issue being fixed or feature implemented
When expecting a hard fork, we manually calculate activation heights.

## What was done?
Returning expected activation height for BIP9 softporks in `locked_in` status in `getblockchaininfo` RPC.

## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

