### PR TITLE
fix: properly detect future state of v20 in GetPaymentsLimit

### DIFF
--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -496,11 +496,12 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
 
     const CBlockIndex* tipIndex = ::ChainActive().Tip();
 
-    bool fV20Active = llmq::utils::IsV20Active(tipIndex);
+    const auto v20_state = llmq::utils::GetV20State(tipIndex);
+    bool fV20Active{v20_state == ThresholdState::ACTIVE};
     if (!fV20Active && nBlockHeight > tipIndex->nHeight) {
         // If fV20Active isn't active yet and nBlockHeight refers to a future SuperBlock
         // then we need to check if the fork is locked_in and see if it will be active by the time of the future SuperBlock
-        if (llmq::utils::GetV20State(tipIndex) == ThresholdState::LOCKED_IN) {
+        if (v20_state == ThresholdState::LOCKED_IN) {
             int activation_height = llmq::utils::GetV20Since(tipIndex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize);
             if (nBlockHeight >= activation_height) {
                 fV20Active = true;
@@ -508,11 +509,12 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
         }
     }
 
-    bool fMNRewardReallocated = llmq::utils::IsMNRewardReallocationActive(tipIndex);
+    const auto mn_rr_state = llmq::utils::GetMNRewardReallocationState(tipIndex);
+    bool fMNRewardReallocated{mn_rr_state == ThresholdState::ACTIVE};
     if (!fMNRewardReallocated && nBlockHeight > tipIndex->nHeight) {
         // If fMNRewardReallocated isn't active yet and nBlockHeight refers to a future SuperBlock
         // then we need to check if the fork is locked_in and see if it will be active by the time of the future SuperBlock
-        if (llmq::utils::GetMNRewardReallocationState(tipIndex) == ThresholdState::LOCKED_IN) {
+        if (mn_rr_state == ThresholdState::LOCKED_IN) {
             int activation_height = llmq::utils::GetMNRewardReallocationSince(tipIndex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize);
             if (nBlockHeight >= activation_height) {
                 fMNRewardReallocated = true;

--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -495,17 +495,6 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
     }
 
     const CBlockIndex* tipIndex = ::ChainActive().Tip();
-    bool fMNRewardReallocated = llmq::utils::IsMNRewardReallocationActive(tipIndex);
-    if (!fMNRewardReallocated && nBlockHeight > tipIndex->nHeight) {
-        // If fMNRewardReallocated isn't active yet and nBlockHeight refers to a future SuperBlock
-        // then we need to check if the fork is locked_in and see if it will be active by the time of the future SuperBlock
-        if (llmq::utils::GetMNRewardReallocationState(tipIndex) == ThresholdState::LOCKED_IN) {
-            int activation_height = llmq::utils::GetMNRewardReallocationSince(tipIndex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize);
-            if (nBlockHeight >= activation_height) {
-                fMNRewardReallocated = true;
-            }
-        }
-    }
 
     bool fV20Active = llmq::utils::IsV20Active(tipIndex);
     if (!fV20Active && nBlockHeight > tipIndex->nHeight) {
@@ -515,6 +504,18 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
             int activation_height = llmq::utils::GetV20Since(tipIndex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize);
             if (nBlockHeight >= activation_height) {
                 fV20Active = true;
+            }
+        }
+    }
+
+    bool fMNRewardReallocated = llmq::utils::IsMNRewardReallocationActive(tipIndex);
+    if (!fMNRewardReallocated && nBlockHeight > tipIndex->nHeight) {
+        // If fMNRewardReallocated isn't active yet and nBlockHeight refers to a future SuperBlock
+        // then we need to check if the fork is locked_in and see if it will be active by the time of the future SuperBlock
+        if (llmq::utils::GetMNRewardReallocationState(tipIndex) == ThresholdState::LOCKED_IN) {
+            int activation_height = llmq::utils::GetMNRewardReallocationSince(tipIndex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize);
+            if (nBlockHeight >= activation_height) {
+                fMNRewardReallocated = true;
             }
         }
     }

--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -496,7 +496,6 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
 
     const CBlockIndex* tipIndex = ::ChainActive().Tip();
     bool fMNRewardReallocated = llmq::utils::IsMNRewardReallocationActive(tipIndex);
-    bool fV20Active = llmq::utils::IsV20Active(tipIndex);
     if (!fMNRewardReallocated && nBlockHeight > tipIndex->nHeight) {
         // If fMNRewardReallocated isn't active yet and nBlockHeight refers to a future SuperBlock
         // then we need to check if the fork is locked_in and see if it will be active by the time of the future SuperBlock
@@ -504,6 +503,17 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
             int activation_height = llmq::utils::GetMNRewardReallocationSince(tipIndex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_MN_RR].nWindowSize);
             if (nBlockHeight >= activation_height) {
                 fMNRewardReallocated = true;
+            }
+        }
+    }
+
+    bool fV20Active = llmq::utils::IsV20Active(tipIndex);
+    if (!fV20Active && nBlockHeight > tipIndex->nHeight) {
+        // If fV20Active isn't active yet and nBlockHeight refers to a future SuperBlock
+        // then we need to check if the fork is locked_in and see if it will be active by the time of the future SuperBlock
+        if (llmq::utils::GetV20State(tipIndex) == ThresholdState::LOCKED_IN) {
+            int activation_height = llmq::utils::GetV20Since(tipIndex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize);
+            if (nBlockHeight >= activation_height) {
                 fV20Active = true;
             }
         }

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -729,11 +729,25 @@ bool IsMNRewardReallocationActive(const CBlockIndex* pindex)
     return VersionBitsState(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_MN_RR, llmq_versionbitscache) == ThresholdState::ACTIVE;
 }
 
+ThresholdState GetV20State(const CBlockIndex* pindex)
+{
+    assert(pindex);
+    LOCK(cs_llmq_vbc);
+    return VersionBitsState(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20, llmq_versionbitscache);
+}
+
 ThresholdState GetMNRewardReallocationState(const CBlockIndex* pindex)
 {
     assert(pindex);
     LOCK(cs_llmq_vbc);
     return VersionBitsState(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_MN_RR, llmq_versionbitscache);
+}
+
+int GetV20Since(const CBlockIndex* pindex)
+{
+    assert(pindex);
+    LOCK(cs_llmq_vbc);
+    return VersionBitsStateSinceHeight(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20, llmq_versionbitscache);
 }
 
 int GetMNRewardReallocationSince(const CBlockIndex* pindex)

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -76,7 +76,9 @@ bool IsDIP0024Active(const CBlockIndex* pindex);
 bool IsV19Active(const CBlockIndex* pindex);
 bool IsV20Active(const CBlockIndex* pindex);
 bool IsMNRewardReallocationActive(const CBlockIndex* pindex);
+ThresholdState GetV20State(const CBlockIndex* pindex);
 ThresholdState GetMNRewardReallocationState(const CBlockIndex* pindex);
+int GetV20Since(const CBlockIndex* pindex);
 int GetMNRewardReallocationSince(const CBlockIndex* pindex);
 
 /// Returns the state of `-llmq-data-recovery`

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -13,7 +13,7 @@ from test_framework.util import assert_equal, satoshi_round
 
 class DashGovernanceTest (DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 5, [["-budgetparams=10:10:10"]] * 6)
+        self.set_dash_test_params(6, 5, [["-budgetparams=10:10:10", "-vbparams=v20:0:999999999999:180:150:110:5:-1"]] * 6)
 
     def prepare_object(self, object_type, parent_hash, creation_time, revision, name, amount, payment_address):
         proposal_rev = revision
@@ -177,6 +177,13 @@ class DashGovernanceTest (DashTestFramework):
                     assert False
 
         assert_equal(payments_found, 2)
+
+        # v20 is expected to be activated at block 540
+        assert self.nodes[0].getblockcount() < 540
+        assert_equal(self.nodes[0].getblockchaininfo()["softforks"]["v20"]["active"], False)
+        assert_equal(self.nodes[0].getsuperblockbudget(530), satoshi_round("400.32798830"))
+        assert_equal(self.nodes[0].getsuperblockbudget(540), satoshi_round("4.00327990"))
+        assert_equal(self.nodes[0].getsuperblockbudget(550), satoshi_round("4.00327990"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Issue being fixed or feature implemented
should fix the issue with the first sb after v20 (as observed on devnet)

## What was done?
add 2 helpers for v20, split conditions in GetPaymentsLimit

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

