### PR TITLE
fix: v19 activation unit tests should use the block v19 was activated at

### DIFF
--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -813,7 +813,7 @@ BOOST_AUTO_TEST_CASE(dip3_protx_legacy)
 
 BOOST_AUTO_TEST_CASE(dip3_protx_basic)
 {
-    TestChainDIP3V19Setup setup;
+    TestChainV19Setup setup;
     FuncDIP3Protx(setup);
 }
 
@@ -825,7 +825,7 @@ BOOST_AUTO_TEST_CASE(test_mempool_reorg_legacy)
 
 BOOST_AUTO_TEST_CASE(test_mempool_reorg_basic)
 {
-    TestChainDIP3V19Setup setup;
+    TestChainV19Setup setup;
     FuncTestMempoolReorg(setup);
 }
 
@@ -837,7 +837,7 @@ BOOST_AUTO_TEST_CASE(test_mempool_dual_proregtx_legacy)
 
 BOOST_AUTO_TEST_CASE(test_mempool_dual_proregtx_basic)
 {
-    TestChainDIP3V19Setup setup;
+    TestChainV19Setup setup;
     FuncTestMempoolDualProregtx(setup);
 }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -315,8 +315,8 @@ TestChainSetup::TestChainSetup(int num_blocks, const std::vector<const char*>& e
             {  497, uint256S("0x5d3a646bb53416543e409d2aa99b93ba619c8394ac68868e1b65a57cb8d0ce7d") },
             /* TestChainV19BeforeActivationSetup */
             {  894, uint256S("0x4e01ffea7482da6bbc581f16a62e04d7a20c8789b6bfe581c60016bb79d8d267") },
-            /* TestChainDIP3V19Setup */
-            { 1000, uint256S("0x610be429a3d38c4e2ec15fb6c0bfe368b537eb0f75d3bc0456b698017536634a") },
+            /* TestChainV19Setup */
+            {  899, uint256S("0x539da638600839a24c7a7ac408d22d85f20b3ab913176c80a37a1793eb32e0d9") },
         }
     };
 
@@ -462,6 +462,14 @@ CBlock getBlock13b8a()
     return block;
 }
 
+TestChainV19Setup::TestChainV19Setup() : TestChainSetup(899)
+{
+    bool v19_just_activated = llmq::utils::IsV19Active(::ChainActive().Tip()) &&
+                              !llmq::utils::IsV19Active(::ChainActive().Tip()->pprev);
+    assert(v19_just_activated);
+}
+
+// 5 blocks earlier
 TestChainV19BeforeActivationSetup::TestChainV19BeforeActivationSetup() : TestChainSetup(894)
 {
     bool v19_active = llmq::utils::IsV19Active(::ChainActive().Tip());

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -150,9 +150,9 @@ struct TestChainDIP3Setup : public TestChainSetup
     TestChainDIP3Setup() : TestChainSetup(431) {}
 };
 
-struct TestChainDIP3V19Setup : public TestChainSetup
+struct TestChainV19Setup : public TestChainSetup
 {
-    TestChainDIP3V19Setup() : TestChainSetup(1000) {}
+    TestChainV19Setup();
 };
 
 struct TestChainDIP3BeforeActivationSetup : public TestChainSetup


### PR DESCRIPTION
## Issue being fixed or feature implemented
We should be testing from the very first v19 block, not from some random one 100 blocks after

## What was done?
Implement that, make sure we start at v19 activation.

## How Has This Been Tested?
`make check`

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

