### PR TITLE
fix: Avoid using `GetAdjustedTime()` where adjusted time is not really needed or can be harmful

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -15,6 +15,7 @@
 #include <net.h>
 #include <net_processing.h>
 #include <netmessagemaker.h>
+#include <util/time.h>
 #include <validation.h>
 
 void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip)
@@ -123,7 +124,7 @@ void CMNAuth::ProcessMessage(CNode& peer, PeerManager& peerman, CConnman& connma
     }
 
     if (!peer.fInbound) {
-        mmetaman->GetMetaInfo(mnauth.proRegTxHash)->SetLastOutboundSuccess(GetAdjustedTime());
+        mmetaman->GetMetaInfo(mnauth.proRegTxHash)->SetLastOutboundSuccess(GetTime());
         if (peer.m_masternode_probe_connection) {
             LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- Masternode probe successful for %s, disconnecting. peer=%d\n",
                      mnauth.proRegTxHash.ToString(), peer.GetId());

--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -12,11 +12,11 @@
 #include <llmq/utils.h>
 #include <primitives/transaction.h>
 #include <script/standard.h>
-#include <timedata.h>
-#include <util/strencodings.h>
-#include <validation.h>
 #include <util/moneystr.h>
+#include <util/strencodings.h>
+#include <util/time.h>
 #include <util/underlying.h>
+#include <validation.h>
 
 #include <univalue.h>
 
@@ -186,7 +186,7 @@ void CGovernanceTriggerManager::CleanAndRemove()
             if (pObj) {
                 strDataAsPlainString = pObj->GetDataAsPlainString();
                 // mark corresponding object for deletion
-                pObj->PrepareDeletion(GetAdjustedTime());
+                pObj->PrepareDeletion(GetTime());
             }
             LogPrint(BCLog::GOBJECT, "CGovernanceTriggerManager::CleanAndRemove -- Removing trigger object %s\n", strDataAsPlainString);
             // delete the trigger

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -15,6 +15,8 @@
 #include <masternode/sync.h>
 #include <messagesigner.h>
 #include <net.h>
+#include <timedata.h>
+#include <util/time.h>
 #include <validation.h>
 #include <validationinterface.h>
 
@@ -734,7 +736,7 @@ void CGovernanceObject::UpdateSentinelVariables()
     if ((GetAbsoluteYesCount(VOTE_SIGNAL_DELETE) >= nAbsDeleteReq) && !fCachedDelete) {
         fCachedDelete = true;
         if (nDeletionTime == 0) {
-            nDeletionTime = GetAdjustedTime();
+            nDeletionTime = GetTime();
         }
     }
     if (GetAbsoluteYesCount(VOTE_SIGNAL_ENDORSED) >= nAbsVoteReq) fCachedEndorsed = true;

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -19,6 +19,7 @@
 #include <txmempool.h>
 #include <ui_interface.h>
 #include <util/thread.h>
+#include <util/time.h>
 #include <validation.h>
 
 namespace llmq
@@ -319,7 +320,7 @@ void CChainLocksHandler::TrySignChainTip()
                     LOCK(cs);
                     auto it = txFirstSeenTime.find(txid);
                     if (it != txFirstSeenTime.end()) {
-                        txAge = GetAdjustedTime() - it->second;
+                        txAge = GetTime() - it->second;
                     }
                 }
 
@@ -381,7 +382,7 @@ void CChainLocksHandler::BlockConnected(const std::shared_ptr<const CBlock>& pbl
     }
     auto& txids = *it->second;
 
-    int64_t curTime = GetAdjustedTime();
+    int64_t curTime = GetTime();
 
     for (const auto& tx : pblock->vtx) {
         if (tx->IsCoinBase() || tx->vin.empty()) {
@@ -456,7 +457,7 @@ bool CChainLocksHandler::IsTxSafeForMining(const uint256& txid) const
         LOCK(cs);
         auto it = txFirstSeenTime.find(txid);
         if (it != txFirstSeenTime.end()) {
-            txAge = GetAdjustedTime() - it->second;
+            txAge = GetTime() - it->second;
         }
     }
 

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -20,6 +20,7 @@
 #include <netmessagemaker.h>
 #include <univalue.h>
 #include <util/irange.h>
+#include <util/time.h>
 #include <util/underlying.h>
 #include <validation.h>
 
@@ -899,7 +900,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                 break;
             }
 
-            if ((GetAdjustedTime() - nTimeLastSuccess) > nRequestTimeout) {
+            if ((GetTime() - nTimeLastSuccess) > nRequestTimeout) {
                 if (nTries >= vecMemberHashes.size()) {
                     printLog("All tried but failed");
                     break;
@@ -917,7 +918,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                 }
                 // Sleep a bit depending on the start offset to balance out multiple requests to same masternode
                 quorumThreadInterrupt.sleep_for(std::chrono::milliseconds(nMyStartOffset * 100));
-                nTimeLastSuccess = GetAdjustedTime();
+                nTimeLastSuccess = GetTime();
                 connman.AddPendingMasternode(*pCurrentMemberHash);
                 printLog("Connect");
             }
@@ -930,7 +931,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                 }
 
                 if (RequestQuorumData(pNode, pQuorum->qc->llmqType, pQuorum->m_quorum_base_block_index, nDataMask, proTxHash)) {
-                    nTimeLastSuccess = GetAdjustedTime();
+                    nTimeLastSuccess = GetTime();
                     printLog("Requested");
                 } else {
                     LOCK(cs_data_requests);

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -17,6 +17,7 @@
 #include <netmessagemaker.h>
 #include <scheduler.h>
 #include <util/irange.h>
+#include <util/time.h>
 #include <util/underlying.h>
 #include <validation.h>
 
@@ -322,7 +323,7 @@ void CRecoveredSigsDb::WriteRecoveredSig(const llmq::CRecoveredSig& recSig)
 {
     CDBBatch batch(*db);
 
-    uint32_t curTime = GetAdjustedTime();
+    uint32_t curTime = GetTime();
 
     // we put these close to each other to leverage leveldb's key compaction
     // this way, the second key can be used for fast HasRecoveredSig checks while the first key stores the recSig
@@ -410,7 +411,7 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
     std::unique_ptr<CDBIterator> pcursor(db->NewIterator());
 
     auto start = std::make_tuple(std::string("rs_t"), (uint32_t)0, (Consensus::LLMQType)0, uint256());
-    uint32_t endTime = (uint32_t)(GetAdjustedTime() - maxAge);
+    uint32_t endTime = (uint32_t)(GetTime() - maxAge);
     pcursor->Seek(start);
 
     std::vector<std::pair<Consensus::LLMQType, uint256>> toDelete;
@@ -474,7 +475,7 @@ bool CRecoveredSigsDb::GetVoteForId(Consensus::LLMQType llmqType, const uint256&
 void CRecoveredSigsDb::WriteVoteForId(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash)
 {
     auto k1 = std::make_tuple(std::string("rs_v"), llmqType, id);
-    auto k2 = std::make_tuple(std::string("rs_vt"), (uint32_t)htobe32(GetAdjustedTime()), llmqType, id);
+    auto k2 = std::make_tuple(std::string("rs_vt"), (uint32_t)htobe32(GetTime()), llmqType, id);
 
     CDBBatch batch(*db);
     batch.Write(k1, msgHash);
@@ -488,7 +489,7 @@ void CRecoveredSigsDb::CleanupOldVotes(int64_t maxAge)
     std::unique_ptr<CDBIterator> pcursor(db->NewIterator());
 
     auto start = std::make_tuple(std::string("rs_vt"), (uint32_t)0, (Consensus::LLMQType)0, uint256());
-    uint32_t endTime = (uint32_t)(GetAdjustedTime() - maxAge);
+    uint32_t endTime = (uint32_t)(GetTime() - maxAge);
     pcursor->Seek(start);
 
     CDBBatch batch(*db);

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -18,6 +18,7 @@
 #include <spork.h>
 #include <util/irange.h>
 #include <util/thread.h>
+#include <util/time.h>
 #include <util/underlying.h>
 
 #include <cxxtimer.hpp>
@@ -716,7 +717,7 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CConnma
         }
 
         // Update the time we've seen the last sigShare
-        timeSeenForSessions[sigShare.GetSignHash()] = GetAdjustedTime();
+        timeSeenForSessions[sigShare.GetSignHash()] = GetTime();
 
         if (!quorumNodes.empty()) {
             // don't announce and wait for other nodes to request this share and directly send it to them
@@ -822,7 +823,7 @@ void CSigSharesManager::CollectSigSharesToRequest(std::unordered_map<NodeId, std
 {
     AssertLockHeld(cs);
 
-    int64_t now = GetAdjustedTime();
+    int64_t now = GetTime();
     const size_t maxRequestsForNode = 32;
 
     // avoid requesting from same nodes all the time
@@ -1240,7 +1241,7 @@ CSigShare CSigSharesManager::RebuildSigShare(const CSigSharesNodeState::SessionI
 
 void CSigSharesManager::Cleanup()
 {
-    int64_t now = GetAdjustedTime();
+    int64_t now = GetTime();
     if (now - lastCleanupTime < 5) {
         return;
     }
@@ -1364,7 +1365,7 @@ void CSigSharesManager::Cleanup()
         nodeStates.erase(nodeId);
     }
 
-    lastCleanupTime = GetAdjustedTime();
+    lastCleanupTime = GetTime();
 }
 
 void CSigSharesManager::RemoveSigSharesForSession(const uint256& signHash)

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -15,9 +15,9 @@
 #include <net.h>
 #include <random.h>
 #include <spork.h>
-#include <timedata.h>
 #include <util/irange.h>
 #include <util/ranges.h>
+#include <util/time.h>
 #include <util/underlying.h>
 #include <validation.h>
 #include <versionbits.h>
@@ -939,7 +939,7 @@ void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, const CB
     }
 
     auto members = GetAllQuorumMembers(llmqParams.type, pQuorumBaseBlockIndex);
-    auto curTime = GetAdjustedTime();
+    auto curTime = GetTime();
 
     std::set<uint256> probeConnections;
     for (const auto& dmn : members) {

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -5,7 +5,7 @@
 #include <masternode/meta.h>
 
 #include <flat-database.h>
-#include <timedata.h>
+#include <util/time.h>
 
 #include <sstream>
 
@@ -34,7 +34,7 @@ UniValue CMasternodeMetaInfo::ToJson() const
 {
     UniValue ret(UniValue::VOBJ);
 
-    auto now = GetAdjustedTime();
+    auto now = GetTime();
 
     ret.pushKV("lastDSQ", nLastDsq);
     ret.pushKV("mixingTxCount", nMixingTxCount);

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -11,6 +11,7 @@
 #include <shutdown.h>
 #include <ui_interface.h>
 #include <validation.h>
+#include <util/time.h>
 #include <util/translation.h>
 
 class CMasternodeSync;
@@ -335,7 +336,7 @@ void CMasternodeSync::NotifyHeaderTip(const CBlockIndex *pindexNew, bool fInitia
 void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload)
 {
     LogPrint(BCLog::MNSYNC, "CMasternodeSync::UpdatedBlockTip -- pindexNew->nHeight: %d fInitialDownload=%d\n", pindexNew->nHeight, fInitialDownload);
-    nTimeLastUpdateBlockTip = GetAdjustedTime();
+    nTimeLastUpdateBlockTip = GetTime();
 
     CBlockIndex* pindexTip = WITH_LOCK(cs_main, return pindexBestHeader);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -26,6 +26,7 @@
 #include <util/sock.h>
 #include <util/strencodings.h>
 #include <util/thread.h>
+#include <util/time.h>
 #include <util/translation.h>
 #include <validation.h>
 
@@ -2567,7 +2568,7 @@ void CConnman::ThreadOpenMasternodeConnections()
         if (interruptNet)
             return;
 
-        int64_t nANow = GetAdjustedTime();
+        int64_t nANow = GetTime();
         constexpr const auto &_func_ = __func__;
 
         // NOTE: Process only one pending masternode at a time


### PR DESCRIPTION
## Issue being fixed or feature implemented
`GetAdjustedTime()` can be manipulated by our peers, we should avoid using it for our internal data structures/logic.

## What was done?
Use `GetTime()` instead, fix some includes while at it.

## How Has This Been Tested?
run tests, run a node

## Breaking Changes
should be none

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

