### PR TITLE
fix: actually show json for assetlock/unlock txes

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -292,11 +292,11 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
             entry.pushKV("mnhfTx", mnhfTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_ASSET_LOCK) {
-        if (CAssetLockPayload assetLockTx; !GetTxPayload(tx, assetLockTx)) {
+        if (CAssetLockPayload assetLockTx; GetTxPayload(tx, assetLockTx)) {
             entry.pushKV("assetLockTx", assetLockTx.ToJson());
         }
     } else if (tx.nType == TRANSACTION_ASSET_UNLOCK) {
-        if (CAssetUnlockPayload assetUnlockTx; !GetTxPayload(tx, assetUnlockTx)) {
+        if (CAssetUnlockPayload assetUnlockTx; GetTxPayload(tx, assetUnlockTx)) {
             entry.pushKV("assetUnlockTx", assetUnlockTx.ToJson());
         }
     }

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -256,6 +256,7 @@ class AssetLocksTest(DashTestFramework):
         self.check_mempool_result(tx=asset_lock_tx, result_expected={'allowed': True})
         self.validate_credit_pool_balance(0)
         txid_in_block = self.send_tx(asset_lock_tx)
+        assert "assetLockTx" in node.getrawtransaction(txid_in_block, 1)
         self.validate_credit_pool_balance(0)
         node.generate(1)
         assert_equal(self.get_credit_pool_balance(node=node_wallet), 0)
@@ -327,7 +328,8 @@ class AssetLocksTest(DashTestFramework):
 
         assert_equal(asset_unlock_tx_payload.quorumHash, int(self.mninfo[0].node.quorum("selectquorum", llmq_type_test, 'e6c7a809d79f78ea85b72d5df7e9bd592aecf151e679d6e976b74f053a7f9056')["quorumHash"], 16))
 
-        self.send_tx(asset_unlock_tx)
+        txid = self.send_tx(asset_unlock_tx)
+        assert "assetUnlockTx" in node.getrawtransaction(txid, 1)
         self.mempool_size += 1
         self.check_mempool_size()
         self.validate_credit_pool_balance(locked_1)


### PR DESCRIPTION
## Issue being fixed or feature implemented
The bug was introduced in the original PR #5026 and refactored later (which is good actually cause we shouldn't mix refactoring and bug-fixing :) )

## What was done?
fix conditions, add tests

## How Has This Been Tested?
`feature_asset_locks.py`

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

