### PR TITLE
chore: `-llmqinstantsend` and `-llmqinstantsenddip0024` are devnet-only

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -934,8 +934,6 @@ public:
 
         UpdateLLMQTestParametersFromArgs(args, Consensus::LLMQType::LLMQ_TEST);
         UpdateLLMQTestParametersFromArgs(args, Consensus::LLMQType::LLMQ_TEST_INSTANTSEND);
-        UpdateLLMQInstantSendFromArgs(args);
-        UpdateLLMQInstantSendDIP0024FromArgs(args);
     }
 
     /**
@@ -1004,22 +1002,6 @@ public:
         params->minSize = threshold;
         params->threshold = threshold;
         params->dkgBadVotesThreshold = threshold;
-    }
-
-    /**
-     * Allows modifying the LLMQ type for InstantSend.
-     */
-    void UpdateLLMQInstantSend(Consensus::LLMQType llmqType)
-    {
-        consensus.llmqTypeInstantSend = llmqType;
-    }
-
-    /**
-     * Allows modifying the LLMQ type for InstantSend (DIP0024).
-     */
-    void UpdateLLMQDIP0024InstantSend(Consensus::LLMQType llmqType)
-    {
-        consensus.llmqTypeDIP0024InstantSend = llmqType;
     }
 
     void UpdateLLMQTestParametersFromArgs(const ArgsManager& args, const Consensus::LLMQType llmqType);
@@ -1167,50 +1149,6 @@ void CRegTestParams::UpdateLLMQTestParametersFromArgs(const ArgsManager& args, c
     }
     LogPrintf("Setting %s parameters to size=%ld, threshold=%ld\n", llmq_name, size, threshold);
     UpdateLLMQTestParameters(size, threshold, llmqType);
-}
-
-void CRegTestParams::UpdateLLMQInstantSendFromArgs(const ArgsManager& args)
-{
-    if (!args.IsArgSet("-llmqinstantsend")) return;
-
-    const auto& llmq_params_opt = GetLLMQ(consensus.llmqTypeInstantSend);
-    assert(llmq_params_opt.has_value());
-
-    std::string strLLMQType = gArgs.GetArg("-llmqinstantsend", std::string(llmq_params_opt->name));
-
-    Consensus::LLMQType llmqType = Consensus::LLMQType::LLMQ_NONE;
-    for (const auto& params : consensus.llmqs) {
-        if (params.name == strLLMQType) {
-            llmqType = params.type;
-        }
-    }
-    if (llmqType == Consensus::LLMQType::LLMQ_NONE) {
-        throw std::runtime_error("Invalid LLMQ type specified for -llmqinstantsend.");
-    }
-    LogPrintf("Setting llmqinstantsend to size=%ld\n", ToUnderlying(llmqType));
-    UpdateLLMQInstantSend(llmqType);
-}
-
-void CRegTestParams::UpdateLLMQInstantSendDIP0024FromArgs(const ArgsManager& args)
-{
-    if (!args.IsArgSet("-llmqinstantsenddip0024")) return;
-
-    const auto& llmq_params_opt = GetLLMQ(consensus.llmqTypeDIP0024InstantSend);
-    assert(llmq_params_opt.has_value());
-
-    std::string strLLMQType = gArgs.GetArg("-llmqinstantsenddip0024", std::string(llmq_params_opt->name));
-
-    Consensus::LLMQType llmqType = Consensus::LLMQType::LLMQ_NONE;
-    for (const auto& params : consensus.llmqs) {
-        if (params.name == strLLMQType) {
-            llmqType = params.type;
-        }
-    }
-    if (llmqType == Consensus::LLMQType::LLMQ_NONE) {
-        throw std::runtime_error("Invalid LLMQ type specified for -llmqinstantsenddip0024.");
-    }
-    LogPrintf("Setting llmqinstantsenddip0024 to size=%ld\n", ToUnderlying(llmqType));
-    UpdateLLMQDIP0024InstantSend(llmqType);
 }
 
 void CDevNetParams::UpdateDevnetSubsidyAndDiffParametersFromArgs(const ArgsManager& args)


### PR DESCRIPTION
## Issue being fixed or feature implemented
there is no reason for devnet-only params to exist on regtest

## What was done?
remove them

## How Has This Been Tested?
run tests

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

