### PR TITLE
fix!: mn_rr features only for v21+

### DIFF
--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -56,6 +56,7 @@ static bool CheckSpecialTxInner(const CTransaction& tx, const CBlockIndex* pinde
             return CheckAssetLockUnlockTx(tx, pindexPrev, indexes, state);
         case TRANSACTION_ASSET_UNLOCK:
             if (Params().NetworkIDString() == CBaseChainParams::REGTEST && !llmq::utils::IsV20Active(pindexPrev)) {
+                // TODO:  adjust functional tests to make it activated by MN_RR on regtest too
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetunlocks-before-v20");
             }
             if (Params().NetworkIDString() != CBaseChainParams::REGTEST && !llmq::utils::IsMNRewardReallocationActive(pindexPrev)) {

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -50,9 +50,16 @@ static bool CheckSpecialTxInner(const CTransaction& tx, const CBlockIndex* pinde
             }
             return CheckMNHFTx(tx, pindexPrev, state);
         case TRANSACTION_ASSET_LOCK:
-        case TRANSACTION_ASSET_UNLOCK:
             if (!llmq::utils::IsV20Active(pindexPrev)) {
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetlocks-before-v20");
+            }
+            return CheckAssetLockUnlockTx(tx, pindexPrev, indexes, state);
+        case TRANSACTION_ASSET_UNLOCK:
+            if (Params().NetworkIDString() == CBaseChainParams::REGTEST && !llmq::utils::IsV20Active(pindexPrev)) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetunlocks-before-v20");
+            }
+            if (Params().NetworkIDString() != CBaseChainParams::REGTEST && !llmq::utils::IsMNRewardReallocationActive(pindexPrev)) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "assetunlocks-before-mn_rr");
             }
             return CheckAssetLockUnlockTx(tx, pindexPrev, indexes, state);
         }

--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -48,6 +48,10 @@ void CEHFSignalsHandler::UpdatedBlockTip(const CBlockIndex* const pindexNew)
         return;
     }
 
+    if (Params().NetworkIDString() == CBaseChainParams::MAIN) {
+        // TODO: v20 will never attempt to create EHF messages on main net; if this is needed it will be done by v20.1 or v21 nodes
+        return;
+    }
     // TODO: should do this for all not-yet-signied bits
     trySignEHFSignal(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_MN_RR].bit, pindexNew);
 }
@@ -91,6 +95,10 @@ void CEHFSignalsHandler::trySignEHFSignal(int bit, const CBlockIndex* const pind
 
 void CEHFSignalsHandler::HandleNewRecoveredSig(const CRecoveredSig& recoveredSig)
 {
+    if (Params().NetworkIDString() == CBaseChainParams::MAIN) {
+        // TODO: v20 will never attempt to create EHF messages on main net; if this is needed it will be done by v20.1 or v21 nodes
+        return;
+    }
     if (g_txindex) {
         g_txindex->BlockUntilSyncedToCurrentChain();
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should not be 2 forks in one version

## What was done?
 - Asset Unlock transactions (withdrawals) should be available only in MN_RR fork
 - MN_RR should not be auto-activated on Main net without intentional release of code (and not by spork), but they are need on test net to test platform.

## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
Yes (see "what was done")


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

