### PR TITLE
fix: do not trim values in `payment_amounts`

### DIFF
--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -748,7 +748,7 @@ std::string CSuperblock::GetHexStrData() const
         return EncodeDestination(dest);
     });
     std::string str_amounts = Join(vecPayments, "|", [&](const auto& payment) {
-        return FormatMoney(payment.nAmount);
+        return ValueFromAmount(payment.nAmount).write();
     });
     std::string str_hashes = Join(vecPayments, "|", [&](const auto& payment) { return payment.proposalHash.ToString(); });
 

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -136,6 +136,13 @@ class DashGovernanceTest (DashTestFramework):
         trigger_data = list(valid_triggers.values())[0]
         assert_equal(trigger_data['YesCount'], 1)
 
+        # Make sure amounts aren't trimmed
+        payment_amounts_expected = [str(satoshi_round(str(p0_amount))), str(satoshi_round(str(p1_amount))), str(satoshi_round(str(p2_amount)))]
+        data_string = list(self.nodes[0].gobject("list", "valid", "triggers").values())[0]["DataString"]
+        payment_amounts_trigger = json.loads(data_string)["payment_amounts"].split("|")
+        for amount_str in payment_amounts_trigger:
+            assert(amount_str in payment_amounts_expected)
+
         # Move 1 block inside the Superblock maturity window
         self.nodes[0].generate(1)
         self.sync_blocks()


### PR DESCRIPTION
## Issue being fixed or feature implemented
sb produced by sentinel:
>"DataString": ... \"payment_amounts\": \"20.00000000|20.00000000\", ...
>...
> "YesCount": 83,

sb produced by core:
>"DataString": ... \"payment_amounts\": \"20.00|20.00\", ...
> "YesCount": 13,

These 2 triggers are for the same block (900552), proposal hashes and addresses are also the same but the difference in `payment_amounts` format makes it look like a different trigger for core and this creates a race.

## What was done?
Use `ValueFromAmount` instead of `FormatMoney` to avoid trimming

## How Has This Been Tested?
run tests

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

