### PR TITLE
refactor: avoid cs_main

### DIFF
--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -219,11 +219,10 @@ void CChainLocksHandler::UpdatedBlockTip()
 
 void CChainLocksHandler::CheckActiveState()
 {
-    bool oldIsEnforced = isEnforced;
+    bool oldIsEnabled = isEnabled;
     isEnabled = AreChainLocksEnabled(spork_manager);
-    isEnforced = isEnabled.load();
 
-    if (!oldIsEnforced && isEnforced) {
+    if (!oldIsEnabled && isEnabled) {
         // ChainLocks got activated just recently, but it's possible that it was already running before, leaving
         // us with some stale values which we should not try to enforce anymore (there probably was a good reason
         // to disable spork19)
@@ -475,7 +474,7 @@ void CChainLocksHandler::EnforceBestChainLock()
     {
         LOCK(cs);
 
-        if (!isEnforced) {
+        if (!isEnabled) {
             return;
         }
 
@@ -561,7 +560,7 @@ bool CChainLocksHandler::InternalHasChainLock(int nHeight, const uint256& blockH
 {
     AssertLockHeld(cs);
 
-    if (!isEnforced) {
+    if (!isEnabled) {
         return false;
     }
 
@@ -591,7 +590,7 @@ bool CChainLocksHandler::InternalHasConflictingChainLock(int nHeight, const uint
 {
     AssertLockHeld(cs);
 
-    if (!isEnforced) {
+    if (!isEnabled) {
         return false;
     }
 

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -219,11 +219,9 @@ void CChainLocksHandler::UpdatedBlockTip()
 
 void CChainLocksHandler::CheckActiveState()
 {
-    const bool fDIP0008Active = WITH_LOCK(cs_main, return (m_chainstate.m_chain.Tip() != nullptr) && (m_chainstate.m_chain.Tip()->pprev != nullptr) && m_chainstate.m_chain.Tip()->pprev->nHeight >= Params().GetConsensus().DIP0008Height);
-
     bool oldIsEnforced = isEnforced;
     isEnabled = AreChainLocksEnabled(spork_manager);
-    isEnforced = (fDIP0008Active && isEnabled);
+    isEnforced = isEnabled.load();
 
     if (!oldIsEnforced && isEnforced) {
         // ChainLocks got activated just recently, but it's possible that it was already running before, leaving

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -59,7 +59,6 @@ private:
     mutable Mutex cs;
     std::atomic<bool> tryLockChainTipScheduled{false};
     std::atomic<bool> isEnabled{false};
-    std::atomic<bool> isEnforced{false};
 
     uint256 bestChainLockHash GUARDED_BY(cs);
     CChainLockSig bestChainLock GUARDED_BY(cs);

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -1387,7 +1387,7 @@ void CSigSharesManager::RemoveBannedNodeStates()
 {
     // Called regularly to cleanup local node states for banned nodes
 
-    LOCK2(cs_main, cs);
+    LOCK(cs);
     for (auto it = nodeStates.begin(); it != nodeStates.end();) {
         if (m_peerman->IsBanned(it->first)) {
             // re-request sigshares from other nodes

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -338,9 +338,7 @@ void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitia
     LogPrint(BCLog::MNSYNC, "CMasternodeSync::UpdatedBlockTip -- pindexNew->nHeight: %d fInitialDownload=%d\n", pindexNew->nHeight, fInitialDownload);
     nTimeLastUpdateBlockTip = GetTime<std::chrono::seconds>().count();
 
-    CBlockIndex* pindexTip = WITH_LOCK(cs_main, return pindexBestHeader);
-
-    if (IsSynced() || !pindexTip)
+    if (IsSynced())
         return;
 
     if (!IsBlockchainSynced()) {
@@ -359,6 +357,8 @@ void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitia
     }
 
     // Note: since we sync headers first, it should be ok to use this
+    CBlockIndex* pindexTip = WITH_LOCK(cs_main, return pindexBestHeader);
+    if (pindexTip == nullptr) return;
     bool fReachedBestHeaderNew = pindexNew->GetBlockHash() == pindexTip->GetBlockHash();
 
     if (fReachedBestHeader && !fReachedBestHeaderNew) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Avoid locking cs_main in high volume call locations; I'm not fully sure the removal in signature_shares.cpp is okay; but it compiles.

## What was done?
Removed or reduced scope

## How Has This Been Tested?
Running with enable-debug

## Breaking Changes
Should be done

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

