### PR TITLE
fix: adjust `LLMQ_TEST_DIP0024` params, `mine_cycle_quorum` should use correct size

### DIFF
--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -32,7 +32,7 @@ enum class LLMQType : uint8_t {
     LLMQ_TEST_V17 = 102, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
 
     // for testing only
-    LLMQ_TEST_DIP0024 = 103,     // 4 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
+    LLMQ_TEST_DIP0024 = 103,     // 4 members, 3 (75%) threshold, one per hour.
     LLMQ_TEST_INSTANTSEND = 104, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestinstantsendparams is used
     LLMQ_TEST_PLATFORM = 106,    // 3 members, 2 (66%) threshold, one per hour.
 
@@ -202,7 +202,7 @@ static constexpr std::array<LLMQParams, 14> available_llmqs = {
         .useRotation = true,
         .size = 4,
         .minSize = 4,
-        .threshold = 2,
+        .threshold = 3,
 
         .dkgInterval = 24, // DKG cycle
         .dkgPhaseBlocks = 2,

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1047,6 +1047,7 @@ class DashTestFramework(BitcoinTestFramework):
         # LLMQ default test params (no need to pass -llmqtestparams)
         self.llmq_size = 3
         self.llmq_threshold = 2
+        self.llmq_size_dip0024 = 4
 
         # This is nRequestTimeout in dash-q-recovery thread
         self.quorum_data_thread_request_timeout_seconds = 10
@@ -1813,13 +1814,13 @@ class DashTestFramework(BitcoinTestFramework):
         spork23_active = self.nodes[0].spork('show')['SPORK_23_QUORUM_POSE'] <= 1
 
         if expected_connections is None:
-            expected_connections = (self.llmq_size - 1) if spork21_active else 2
+            expected_connections = (self.llmq_size_dip0024 - 1) if spork21_active else 2
         if expected_members is None:
-            expected_members = self.llmq_size
+            expected_members = self.llmq_size_dip0024
         if expected_contributions is None:
-            expected_contributions = self.llmq_size
+            expected_contributions = self.llmq_size_dip0024
         if expected_commitments is None:
-            expected_commitments = self.llmq_size
+            expected_commitments = self.llmq_size_dip0024
         if mninfos_online is None:
             mninfos_online = self.mninfo.copy()
         if mninfos_valid is None:


### PR DESCRIPTION
## Issue being fixed or feature implemented
Small dip0024 related cleanups, regtest only.

## What was done?
pls see individual commits

## How Has This Been Tested?
run tests

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

