### PR TITLE
fix: a couple of fixes for the way mnauth and probe nodes work

### DIFF
--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -147,12 +147,14 @@ void CMNAuth::ProcessMessage(CNode& peer, PeerManager& peerman, CConnman& connma
                 LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- Masternode %s has already verified as peer %d, deterministicOutbound=%s. peer=%d\n",
                          mnauth.proRegTxHash.ToString(), pnode2->GetId(), deterministicOutbound.ToString(), peer.GetId());
                 if (deterministicOutbound == myProTxHash) {
+                    // NOTE: do not drop inbound nodes here, mark them as probes so that
+                    // they would be disconnected later in CMasternodeUtils::DoMaintenance
                     if (pnode2->fInbound) {
-                        LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- dropping old inbound, peer=%d\n", pnode2->GetId());
-                        pnode2->fDisconnect = true;
+                        LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- marking old inbound for dropping it later, peer=%d\n", pnode2->GetId());
+                        pnode2->m_masternode_probe_connection = true;
                     } else if (peer.fInbound) {
-                        LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- dropping new inbound, peer=%d\n", peer.GetId());
-                        peer.fDisconnect = true;
+                        LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- marking new inbound for dropping it later, peer=%d\n", peer.GetId());
+                        peer.m_masternode_probe_connection = true;
                     }
                 } else {
                     if (!pnode2->fInbound) {

--- a/src/masternode/utils.cpp
+++ b/src/masternode/utils.cpp
@@ -46,30 +46,33 @@ void CMasternodeUtils::DoMaintenance(CConnman& connman, const CMasternodeSync& m
     }
 
     connman.ForEachNode(CConnman::AllNodes, [&](CNode* pnode) {
-        // we're only disconnecting m_masternode_connection connections
-        if (!pnode->m_masternode_connection) return;
-        if (!pnode->GetVerifiedProRegTxHash().IsNull()) {
-            // keep _verified_ LLMQ connections
-            if (connman.IsMasternodeQuorumNode(pnode)) {
+        if (pnode->m_masternode_probe_connection) {
+            // we're not disconnecting masternode probes for at least a few seconds
+            if (GetSystemTimeInSeconds() - pnode->nTimeConnected < 5) return;
+        } else {
+            // we're only disconnecting m_masternode_connection connections
+            if (!pnode->m_masternode_connection) return;
+            if (!pnode->GetVerifiedProRegTxHash().IsNull()) {
+                // keep _verified_ LLMQ connections
+                if (connman.IsMasternodeQuorumNode(pnode)) {
+                    return;
+                }
+                // keep _verified_ LLMQ relay connections
+                if (connman.IsMasternodeQuorumRelayMember(pnode->GetVerifiedProRegTxHash())) {
+                    return;
+                }
+                // keep _verified_ inbound connections
+                if (pnode->fInbound) {
+                    return;
+                }
+            } else if (GetSystemTimeInSeconds() - pnode->nTimeConnected < 5) {
+                // non-verified, give it some time to verify itself
+                return;
+            } else if (pnode->qwatch) {
+                // keep watching nodes
                 return;
             }
-            // keep _verified_ LLMQ relay connections
-            if (connman.IsMasternodeQuorumRelayMember(pnode->GetVerifiedProRegTxHash())) {
-                return;
-            }
-            // keep _verified_ inbound connections
-            if (pnode->fInbound) {
-                return;
-            }
-        } else if (GetSystemTimeInSeconds() - pnode->nTimeConnected < 5) {
-            // non-verified, give it some time to verify itself
-            return;
-        } else if (pnode->qwatch) {
-            // keep watching nodes
-            return;
         }
-        // we're not disconnecting masternode probes for at least a few seconds
-        if (pnode->m_masternode_probe_connection && GetSystemTimeInSeconds() - pnode->nTimeConnected < 5) return;
 
 #ifdef ENABLE_WALLET
         bool fFound = ranges::any_of(vecDmns, [&pnode](const auto& dmn){ return pnode->addr == dmn->pdmnState->addr; });

--- a/src/masternode/utils.cpp
+++ b/src/masternode/utils.cpp
@@ -47,8 +47,8 @@ void CMasternodeUtils::DoMaintenance(CConnman& connman, const CMasternodeSync& m
 
     connman.ForEachNode(CConnman::AllNodes, [&](CNode* pnode) {
         if (pnode->m_masternode_probe_connection) {
-            // we're not disconnecting masternode probes for at least a few seconds
-            if (GetSystemTimeInSeconds() - pnode->nTimeConnected < 5) return;
+            // we're not disconnecting masternode probes for at least PROBE_WAIT_INTERVAL seconds
+            if (GetSystemTimeInSeconds() - pnode->nTimeConnected < PROBE_WAIT_INTERVAL) return;
         } else {
             // we're only disconnecting m_masternode_connection connections
             if (!pnode->m_masternode_connection) return;

--- a/src/net.h
+++ b/src/net.h
@@ -55,6 +55,8 @@ static const bool DEFAULT_WHITELISTFORCERELAY = false;
 
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */
 static const int TIMEOUT_INTERVAL = 20 * 60;
+/** Time to wait since nTimeConnected before disconnecting a probe node. **/
+static const int PROBE_WAIT_INTERVAL = 5;
 /** Minimum time between warnings printed to log. */
 static const int WARNING_INTERVAL = 10 * 60;
 /** Run the feeler connection loop once every 2 minutes or 120 seconds. **/
@@ -1105,7 +1107,7 @@ public:
     std::atomic<bool> m_masternode_connection{false};
     /**
      * If 'true' this node will be disconnected after MNAUTH (outbound only) or
-     * after 5 seconds since nTimeConnected
+     * after PROBE_WAIT_INTERVAL seconds since nTimeConnected
      */
     std::atomic<bool> m_masternode_probe_connection{false};
     // If 'true', we identified it as an intra-quorum relay connection

--- a/src/net.h
+++ b/src/net.h
@@ -1103,7 +1103,10 @@ public:
     bool fSentAddr{false};
     // If 'true' this node will be disconnected on CMasternodeMan::ProcessMasternodeConnections()
     std::atomic<bool> m_masternode_connection{false};
-    // If 'true' this node will be disconnected after MNAUTH
+    /**
+     * If 'true' this node will be disconnected after MNAUTH (outbound only) or
+     * after 5 seconds since nTimeConnected
+     */
     std::atomic<bool> m_masternode_probe_connection{false};
     // If 'true', we identified it as an intra-quorum relay connection
     std::atomic<bool> m_masternode_iqr_connection{false};


### PR DESCRIPTION
## Issue being fixed or feature implemented
1. inactive MNs (`activeMasternodeInfo.proTxHash.IsNull() == true`) should simply drop duplicated connections like regular nodes do.
2. we should not instantly drop inbound (potentially probe) connections (even if `DeterministicOutboundConnection` results would say so), should let `CMasternodeUtils::DoMaintenance` do that. This way a probing peer should have a chance to get our `mnauth` back and mark this attempt as a success. This should hopefully reduce the number of random unexplained pose-punishments.
3. probe nodes must be disconnected ignoring everything else, quorum nodes and relay members connect using their own logic which should not interfere with the way probe nodes work. (meaningful changes only: https://github.com/dashpay/dash/commit/9134d964a010e42f5d93d090d348a4b285bb6046?w=1)

## What was done?
pls see individual commits

as a side-effect `activeMasternodeInfoCs` lock is moved out of `ForEachNode`

## How Has This Been Tested?
run tests, run a testnet mn

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

