### PR TITLE
feat!: reuse `nHighSubsidyBlocks` as a starting point for a fixed nSubsidyBase value to better mimic mainnet

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -21,7 +21,7 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-devnet=<name>", "Use devnet chain with provided name", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-dip3params=<activation>:<enforcement>", "Override DIP3 activation and enforcement heights (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-dip8params=<activation>", "Override DIP8 activation height (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
-    argsman.AddArg("-highsubsidyblocks=<n>", "The number of blocks with a higher than normal subsidy to mine at the start of a chain (default: 0, devnet-only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-highsubsidyblocks=<n>", "The number of blocks with a higher than normal subsidy to mine at the start of a chain. Block after that height will have fixed subsidy base. (default: 0, devnet-only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-highsubsidyfactor=<n>", "The factor to multiply the normal block subsidy by while in the highsubsidyblocks window of a chain (default: 1, devnet-only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-llmqchainlocks=<quorum name>", "Override the default LLMQ type used for ChainLocks. Allows using ChainLocks with smaller LLMQs. (default: llmq_devnet, devnet-only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-llmqdevnetparams=<size>:<threshold>", "Override the default LLMQ size for the LLMQ_DEVNET quorum (default: 3:2, devnet-only)", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1129,8 +1129,8 @@ static std::pair<CAmount, CAmount> GetBlockSubsidyHelper(int nPrevBits, int nPre
         dDiff = ConvertBitsToDouble(nPrevBits);
     }
 
-    bool isDevnet = Params().NetworkIDString() == CBaseChainParams::DEVNET;
-    bool force_fixed_base_subsidy = fV20Active || (isDevnet && nPrevHeight >= consensusParams.nHighSubsidyBlocks);
+    const bool isDevnet = Params().NetworkIDString() == CBaseChainParams::DEVNET;
+    const bool force_fixed_base_subsidy = fV20Active || (isDevnet && nPrevHeight >= consensusParams.nHighSubsidyBlocks);
     if (force_fixed_base_subsidy) {
         // Originally, nSubsidyBase calculations relied on difficulty. Once Platform is live,
         // it must be able to calculate platformReward. However, we don't want it to constantly

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1166,8 +1166,7 @@ static std::pair<CAmount, CAmount> GetBlockSubsidyHelper(int nPrevBits, int nPre
         nSubsidy -= nSubsidy/14;
     }
 
-    // this is only active on devnets
-    if (nPrevHeight < consensusParams.nHighSubsidyBlocks) {
+    if (isDevnet && nPrevHeight < consensusParams.nHighSubsidyBlocks) {
         nSubsidy *= consensusParams.nHighSubsidyFactor;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1166,7 +1166,8 @@ static std::pair<CAmount, CAmount> GetBlockSubsidyHelper(int nPrevBits, int nPre
         nSubsidy -= nSubsidy/14;
     }
 
-    if (isDevnet && nPrevHeight < consensusParams.nHighSubsidyBlocks) {
+    if (nPrevHeight < consensusParams.nHighSubsidyBlocks) {
+        assert(isDevnet);
         nSubsidy *= consensusParams.nHighSubsidyFactor;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1129,11 +1129,15 @@ static std::pair<CAmount, CAmount> GetBlockSubsidyHelper(int nPrevBits, int nPre
         dDiff = ConvertBitsToDouble(nPrevBits);
     }
 
-    if (fV20Active) {
-        // Starting from V20 Activation, subsidybase should be stable.
-        // Currently, nSubsidyBase calculate relies on difficulty.
-        // Once Platform is live, it must constantly get blocks difficulty in order to calculate platformReward.
-        // This can not be continued so we set the nSubsidyBase to a fixed value.
+    bool isDevnet = Params().NetworkIDString() == CBaseChainParams::DEVNET;
+    bool force_fixed_base_subsidy = fV20Active || (isDevnet && nPrevHeight >= consensusParams.nHighSubsidyBlocks);
+    if (force_fixed_base_subsidy) {
+        // Originally, nSubsidyBase calculations relied on difficulty. Once Platform is live,
+        // it must be able to calculate platformReward. However, we don't want it to constantly
+        // get blocks difficulty from the payment chain, so we set the nSubsidyBase to a fixed
+        // value starting from V20 activation. Note, that it doesn't affect mainnet really
+        // because blocks difficulty there is very high already.
+        // Devnets get fixed nSubsidyBase starting from nHighSubsidyBlocks to better mimic mainnet.
         nSubsidyBase = 5;
     } else if (nPrevHeight < 5465) {
         // Early ages...


### PR DESCRIPTION
## Issue being fixed or feature implemented
We need some network that mimics v20 governance budget changes a bit better. All our networks _lower_ the budget after v20 activation while mainnet would actually rise it.

## What was done?
Reuse `nHighSubsidyBlocks` as a starting point for a fixed nSubsidyBase value to better mimic mainnet changes on v20.

## How Has This Been Tested?
That's a devnet-only change, so no testing yet

## Breaking Changes
Won't sync on old devnets after these changes

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

