### PR TITLE
test: `getblockchaininfo` projected `activation_height` test

### DIFF
--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -18,7 +18,7 @@ from test_framework.mininode import P2PInterface
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
-    wait_until,
+    wait_until, assert_greater_than, get_bip9_details,
 )
 
 
@@ -97,8 +97,17 @@ class LLMQQuorumRotationTest(DashTestFramework):
         expectedNew = [h_100_0, h_106_0, h_104_0, h_100_1, h_106_1, h_104_1]
         quorumList = self.test_getmnlistdiff_quorums(b_h_0, b_h_1, {}, expectedDeleted, expectedNew, testQuorumsCLSigs=False)
 
-        self.activate_v20(expected_activation_height=1440, test_locked_in_phase=True)
+        self.log.info(f"Wait for v20 locked_in phase")
+        # Expected locked_in phase starts at 1440 - 480 (window size in regtest) + 1
+        projected_activation_height = self.advance_to_locked_in_for_v20(expected_locked_in_height=961)
+
+        self.activate_v20(expected_activation_height=1440)
         self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
+
+        softfork_info = get_bip9_details(self.nodes[0], 'v20')
+        assert_equal(softfork_info['status'], 'active')
+        assert 'since' in softfork_info
+        assert_equal(projected_activation_height, softfork_info['since'])
 
         # v20 is active for the next block, not for the tip
         self.nodes[0].generate(1)
@@ -367,6 +376,40 @@ class LLMQQuorumRotationTest(DashTestFramework):
                 return False
             return True
         return False
+
+    def advance_to_locked_in_for_v20(self, expected_locked_in_height):
+        # disable spork17 while mining blocks to activate "name" to prevent accidental quorum formation
+        spork17_value = self.nodes[0].spork('show')['SPORK_17_QUORUM_DKG_ENABLED']
+        self.bump_mocktime(1)
+        self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 4070908800)
+        self.wait_for_sporks_same()
+
+        # mine blocks in batches
+        batch_size = 10
+        height = self.nodes[0].getblockcount()
+        assert_greater_than(expected_locked_in_height, height)
+        while expected_locked_in_height - height >= batch_size:
+            self.bump_mocktime(batch_size)
+            self.nodes[0].generate(batch_size)
+            height += batch_size
+            self.sync_blocks()
+        blocks_left = expected_locked_in_height - height
+        assert_greater_than(batch_size, blocks_left)
+        self.bump_mocktime(blocks_left)
+        self.nodes[0].generate(blocks_left)
+        self.sync_blocks()
+
+        softfork_info = get_bip9_details(self.nodes[0], 'v20')
+        assert_equal(softfork_info['status'], 'locked_in')
+        assert 'activation_height' in softfork_info
+        projected_activation_height = softfork_info['activation_height']
+
+        # revert spork17 changes
+        self.bump_mocktime(1)
+        self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", spork17_value)
+        self.wait_for_sporks_same()
+
+        return projected_activation_height
 
 if __name__ == '__main__':
     LLMQQuorumRotationTest().main()

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -97,7 +97,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         expectedNew = [h_100_0, h_106_0, h_104_0, h_100_1, h_106_1, h_104_1]
         quorumList = self.test_getmnlistdiff_quorums(b_h_0, b_h_1, {}, expectedDeleted, expectedNew, testQuorumsCLSigs=False)
 
-        self.activate_v20(expected_activation_height=1440)
+        self.activate_v20(expected_activation_height=1440, test_locked_in_phase=True)
         self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
 
         # v20 is active for the next block, not for the tip

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1088,7 +1088,7 @@ class DashTestFramework(BitcoinTestFramework):
             self.nodes[0].generate(batch_size)
             height += batch_size
             self.sync_blocks()
-        blocks_left = expected_locked_in_height - height - 2
+        blocks_left = expected_locked_in_height - height
         assert blocks_left < batch_size
         self.bump_mocktime(blocks_left)
         self.nodes[0].generate(blocks_left)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1072,7 +1072,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.sync_blocks()
 
     def advance_to_locked_in_softfork(self, name, expected_locked_in_height):
-        self.log.info("Wait for " + name + " locked_in phase")
+        self.log.info(f"Wait for {name} locked_in phase")
         # disable spork17 while mining blocks to activate "name" to prevent accidental quorum formation
         spork17_value = self.nodes[0].spork('show')['SPORK_17_QUORUM_DKG_ENABLED']
         self.bump_mocktime(1)
@@ -1082,20 +1082,20 @@ class DashTestFramework(BitcoinTestFramework):
         # mine blocks in batches
         batch_size = 10
         height = self.nodes[0].getblockcount()
-        assert height < expected_locked_in_height
+        assert_greater_than(expected_locked_in_height, height)
         while expected_locked_in_height - height >= batch_size:
             self.bump_mocktime(batch_size)
             self.nodes[0].generate(batch_size)
             height += batch_size
             self.sync_blocks()
         blocks_left = expected_locked_in_height - height
-        assert blocks_left < batch_size
+        assert_greater_than(batch_size, blocks_left)
         self.bump_mocktime(blocks_left)
         self.nodes[0].generate(blocks_left)
         self.sync_blocks()
 
         softfork_info = get_bip9_details(self.nodes[0], name)
-        assert softfork_info['status'] == 'locked_in'
+        assert_equal(softfork_info['status'], 'locked_in')
         assert 'activation_height' in softfork_info
         rpc_activation_height = softfork_info['activation_height']
 
@@ -1163,7 +1163,7 @@ class DashTestFramework(BitcoinTestFramework):
             projected_activation_height = self.advance_to_locked_in_softfork('v20', expected_locked_in_height=961)
             self.activate_by_name('v20', expected_activation_height)
             softfork_info = get_bip9_details(self.nodes[0], 'v20')
-            assert softfork_info['status'] == 'active'
+            assert_equal(softfork_info['status'], 'active')
             assert 'since' in softfork_info
             assert projected_activation_height == softfork_info['since']
         else:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1071,41 +1071,6 @@ class DashTestFramework(BitcoinTestFramework):
                 self.sync_blocks()
         self.sync_blocks()
 
-    def advance_to_locked_in_softfork(self, name, expected_locked_in_height):
-        self.log.info(f"Wait for {name} locked_in phase")
-        # disable spork17 while mining blocks to activate "name" to prevent accidental quorum formation
-        spork17_value = self.nodes[0].spork('show')['SPORK_17_QUORUM_DKG_ENABLED']
-        self.bump_mocktime(1)
-        self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 4070908800)
-        self.wait_for_sporks_same()
-
-        # mine blocks in batches
-        batch_size = 10
-        height = self.nodes[0].getblockcount()
-        assert_greater_than(expected_locked_in_height, height)
-        while expected_locked_in_height - height >= batch_size:
-            self.bump_mocktime(batch_size)
-            self.nodes[0].generate(batch_size)
-            height += batch_size
-            self.sync_blocks()
-        blocks_left = expected_locked_in_height - height
-        assert_greater_than(batch_size, blocks_left)
-        self.bump_mocktime(blocks_left)
-        self.nodes[0].generate(blocks_left)
-        self.sync_blocks()
-
-        softfork_info = get_bip9_details(self.nodes[0], name)
-        assert_equal(softfork_info['status'], 'locked_in')
-        assert 'activation_height' in softfork_info
-        rpc_activation_height = softfork_info['activation_height']
-
-        # revert spork17 changes
-        self.bump_mocktime(1)
-        self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", spork17_value)
-        self.wait_for_sporks_same()
-
-        return rpc_activation_height
-
     def activate_by_name(self, name, expected_activation_height=None):
         assert not softfork_active(self.nodes[0], name)
         self.log.info("Wait for " + name + " activation")
@@ -1157,17 +1122,8 @@ class DashTestFramework(BitcoinTestFramework):
     def activate_v19(self, expected_activation_height=None):
         self.activate_by_name('v19', expected_activation_height)
 
-    def activate_v20(self, expected_activation_height=None, test_locked_in_phase=False):
-        if test_locked_in_phase:
-            # Expected locked_in phase starts at 1440 - 480 (window size in regtest) + 1
-            projected_activation_height = self.advance_to_locked_in_softfork('v20', expected_locked_in_height=961)
-            self.activate_by_name('v20', expected_activation_height)
-            softfork_info = get_bip9_details(self.nodes[0], 'v20')
-            assert_equal(softfork_info['status'], 'active')
-            assert 'since' in softfork_info
-            assert projected_activation_height == softfork_info['since']
-        else:
-            self.activate_by_name('v20', expected_activation_height)
+    def activate_v20(self, expected_activation_height=None):
+        self.activate_by_name('v20', expected_activation_height)
 
     def activate_mn_rr(self, expected_activation_height=None):
         self.nodes[0].sporkupdate("SPORK_24_EHF", 0)


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash/issues/5640

## What was done?
Tests that `activation_height` projected by `getblockchaininfo` during locked_in phase.
Now, this test is only possible with v20 activation since v19, dip0024 are buried and mn_rr uses MNEF.

Enabled this test only in `feature_llmq_rotation.py`.

## How Has This Been Tested?
tests

## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

