### PR TITLE
fix: FundTransaction should follow the same bip69 rules CreateTransaction does

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3067,6 +3067,12 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
 {
     std::vector<CRecipient> vecSend;
 
+    // If no specific change position was requested, apply BIP69
+    if (nChangePosInOut == -1) {
+        std::sort(tx.vin.begin(), tx.vin.end(), CompareInputBIP69());
+        std::sort(tx.vout.begin(), tx.vout.end(), CompareOutputBIP69());
+    }
+
     // Turn the txout set into a CRecipient vector.
     for (size_t idx = 0; idx < tx.vout.size(); idx++) {
         const CTxOut& txOut = tx.vout[idx];

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -14,6 +14,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     count_bytes,
     find_vout_for_address,
+    satoshi_round,
 )
 
 
@@ -158,6 +159,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         totalOut = 0
         for out in dec_tx['vout']:
             totalOut += out['value']
+            address = out['scriptPubKey']['addresses'][0]
+            if address in outputs.keys():
+                assert_equal(satoshi_round(outputs[address]), out['value'])
 
         assert len(dec_tx['vin']) > 0
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')


### PR DESCRIPTION
## Issue being fixed or feature implemented
fixes #5666

kudos to @tinshen for discovering the issue 👍 

## What was done?
add missing logic in FundTransaction

## How Has This Been Tested?
implement/run tests, test rpc manually

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

