### PR TITLE
test: v20 earlier activation for regtest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -833,7 +833,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize = 480;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize = 400;
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdStart = 384; // 80% of 480
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nThresholdMin = 288;   // 60% of 480
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;     // this corresponds to 10 periods

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -308,15 +308,15 @@ TestChainSetup::TestChainSetup(int num_blocks, const std::vector<const char*>& e
             /* TestChain100Setup */
             {  100, uint256S("0x6ffb83129c19ebdf1ae3771be6a67fe34b35f4c956326b9ba152fac1649f65ae") },
             /* TestChainDIP3BeforeActivationSetup */
-            {  430, uint256S("0x0bcefaa33fec56cd84d05d0e76cd6a78badcc20f627d91903646de6a07930a14") },
+            {  430, uint256S("0x592b23a8882162ea48606e40c9ee00b2166ddae092c691d7f1b1758ec13647d9") },
             /* TestChainDIP3Setup */
-            {  431, uint256S("0x5fd3aa5ef29464839499d7f847edd9362e3e73392b79d3bd88b1591f5fb17d4e") },
+            {  431, uint256S("0x49db248651517f3fc3725fbbc7087db90552d487d11e0962b0148fc4788aeb77") },
             /* TestChainBRRBeforeActivationSetup */
-            {  497, uint256S("0x5d3a646bb53416543e409d2aa99b93ba619c8394ac68868e1b65a57cb8d0ce7d") },
+            {  497, uint256S("0x15445246f9f9fd4fdb1021dd8278ace7246b3e3cb545e1632a277d3a02eb011f") },
             /* TestChainV19BeforeActivationSetup */
-            {  894, uint256S("0x4e01ffea7482da6bbc581f16a62e04d7a20c8789b6bfe581c60016bb79d8d267") },
+            {  894, uint256S("0x03cbf1871d7d915cda10aded00ced45f71a4e2acf6a3c7a77a1ff488267dd1cd") },
             /* TestChainV19Setup */
-            {  899, uint256S("0x539da638600839a24c7a7ac408d22d85f20b3ab913176c80a37a1793eb32e0d9") },
+            {  899, uint256S("0x405a630e16d0ca0efe3abb0e24c9a157a69ec2e07b04333cc5d004efa634ac89") },
         }
     };
 

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -521,7 +521,7 @@ class AssetLocksTest(DashTestFramework):
         all_mn_rewards = platform_reward + owner_reward + operator_reward
         assert_equal(all_mn_rewards, bt['coinbasevalue'] * 3 // 4)  # 75/25 mn/miner reward split
         assert_equal(platform_reward, all_mn_rewards * 375 // 1000)  # 0.375 platform share
-        assert_equal(platform_reward, 29636590)
+        assert_equal(platform_reward, 31916328)
         assert_equal(new_total, self.get_credit_pool_balance())
         node.generate(1)
         self.sync_all()

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -60,6 +60,7 @@ class BIP65Test(BitcoinTestFramework):
             '-dip3params=9000:9000',
             '-par=1',  # Use only one script thread to get the exact reject reason for testing
             '-acceptnonstdtxn=1',  # cltv_invalidate is nonstandard
+            '-vbparams=v20:0:999999999999:480:384:288:5:-1' # Delay v20 for this test as we don't need it
         ]]
         self.setup_clean_chain = True
         self.rpc_timeout = 480

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -40,7 +40,7 @@ def unDERify(tx):
 class BIP66Test(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [['-whitelist=noban@127.0.0.1', '-dip3params=9000:9000', '-par=1']]  # Use only one script thread to get the exact reject reason for testing
+        self.extra_args = [['-whitelist=noban@127.0.0.1', '-dip3params=9000:9000', '-par=1', '-vbparams=v20:0:999999999999:480:384:288:5:-1']]  # Use only one script thread to get the exact reject reason for testing
         self.setup_clean_chain = True
         self.rpc_timeout = 240
 

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -33,7 +33,7 @@ class LLMQChainLocksTest(DashTestFramework):
 
         self.test_coinbase_best_cl(self.nodes[0], expected_cl_in_cb=False)
 
-        self.activate_v20(expected_activation_height=1440)
+        self.activate_v20(expected_activation_height=1200)
         self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
 
         # v20 is active for the next block, not for the tip

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -112,7 +112,7 @@ class LLMQEvoNodesTest(DashTestFramework):
         self.test_evo_protx_are_in_mnlist(evo_protxhash_list)
 
         self.log.info("Test that EvoNodes are paid 4x blocks in a row")
-        self.test_evo_payments(window_analysis=256)
+        self.test_evo_payments(window_analysis=48)
 
         self.activate_v20()
         self.activate_mn_rr()
@@ -124,7 +124,7 @@ class LLMQEvoNodesTest(DashTestFramework):
         self.sync_blocks()
 
         self.log.info("Test that EvoNodes are paid 1 block in a row after MN RewardReallocation activation")
-        self.test_evo_payments(window_analysis=256, v20active=True)
+        self.test_evo_payments(window_analysis=48, v20active=True)
 
         self.log.info(self.nodes[0].masternodelist())
 

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -98,10 +98,10 @@ class LLMQQuorumRotationTest(DashTestFramework):
         quorumList = self.test_getmnlistdiff_quorums(b_h_0, b_h_1, {}, expectedDeleted, expectedNew, testQuorumsCLSigs=False)
 
         self.log.info(f"Wait for v20 locked_in phase")
-        # Expected locked_in phase starts at 1440 - 480 (window size in regtest)
-        projected_activation_height = self.advance_to_locked_in_for_v20(expected_locked_in_height=960)
+        # Expected locked_in phase starts at 1200 - 400 (window size in regtest)
+        projected_activation_height = self.advance_to_locked_in_for_v20(expected_locked_in_height=800)
 
-        self.activate_v20(expected_activation_height=1440)
+        self.activate_v20(expected_activation_height=1200)
         self.log.info("Activated v20 at height:" + str(self.nodes[0].getblockcount()))
 
         softfork_info = get_bip9_details(self.nodes[0], 'v20')


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently, on functional tests v20 activates at height 1440 which is later than needed.

## What was done?
Reduced the window size of v20 from 480 to 400 which activates v20 at 1200.
Adjusted tests to this change.

Note regarding the window analysis for MN payments in `feature_llmq_evo.py` (reduced from 256 to 48 blocks):
48 window is enough to analyse 4 MNs and 5 EvoNodes (Weighted count=24)

On my machine using develop:
`python3 feature_llmq_rotation.py  145.45s user 30.00s system 68% cpu 4:16.93 total`

With this PR:
`python3 feature_llmq_rotation.py  119.26s user 24.61s system 62% cpu 3:50.89 total`


## How Has This Been Tested?
all tests


## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

