### PR TITLE
feat: reduce spamming logs with messages from v20 features

### DIFF
--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -232,7 +232,7 @@ bool CMNHFManager::UndoBlock(const CBlock& block, const CBlockIndex* const pinde
     std::vector<uint8_t> excluded_signals;
     BlockValidationState state;
     if (!extractSignals(block, pindex, excluded_signals, state)) {
-        LogPrintf("%s: failed to extract signals\n", __func__);
+        LogPrintf("CMNHFManager::ProcessBlock: failed to extract signals\n");
         return false;
     }
     if (excluded_signals.empty()) {
@@ -284,20 +284,17 @@ CMNHFManager::Signals CMNHFManager::GetFromCache(const CBlockIndex* const pindex
     {
         LOCK(cs_cache);
         if (mnhfCache.get(blockHash, signals)) {
-            LogPrintf("CMNHFManager::GetFromCache: mnhf get for block %s from cache: %lld signals\n", pindex->GetBlockHash().ToString(), signals.size());
             return signals;
         }
     }
     if (VersionBitsState(pindex->pprev, Params().GetConsensus(), Consensus::DEPLOYMENT_V20, versionbitscache) != ThresholdState::ACTIVE) {
         LOCK(cs_cache);
         mnhfCache.insert(blockHash, {});
-        LogPrintf("CMNHFManager::GetFromCache: mnhf feature is disabled: return empty for block %s\n", pindex->GetBlockHash().ToString());
         return {};
     }
     if (!m_evoDb.Read(std::make_pair(DB_SIGNALS, blockHash), signals)) {
         LogPrintf("CMNHFManager::GetFromCache: failure: can't read MnEHF signals from db for %s\n", pindex->GetBlockHash().ToString());
     }
-    LogPrintf("CMNHFManager::GetFromCache: mnhf for block %s read from evo: %lld\n", pindex->GetBlockHash().ToString(), signals.size());
     LOCK(cs_cache);
     mnhfCache.insert(blockHash, signals);
     return signals;
@@ -308,7 +305,6 @@ void CMNHFManager::AddToCache(const Signals& signals, const CBlockIndex* const p
     const uint256& blockHash = pindex->GetBlockHash();
     {
         LOCK(cs_cache);
-        LogPrintf("CMNHFManager::AddToCache: mnhf for block %s add to cache: %lld\n", pindex->GetBlockHash().ToString(), signals.size());
         mnhfCache.insert(blockHash, signals);
     }
     m_evoDb.Write(std::make_pair(DB_SIGNALS, blockHash), signals);

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -149,7 +149,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CM
 
         const CCreditPool creditPool = creditPoolManager->GetCreditPool(pindex->pprev, consensusParams);
         if (llmq::utils::IsV20Active(pindex->pprev)) {
-            LogPrintf("%s: CCreditPool is %s\n", __func__, creditPool.ToString());
+            LogPrint(BCLog::VALIDATION, "%s: CCreditPool is %s\n", __func__, creditPool.ToString());
         }
 
         for (const auto& ptr_tx : block.vtx) {

--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -62,8 +62,6 @@ void CEHFSignalsHandler::trySignEHFSignal(int bit, const CBlockIndex* const pind
     mnhfPayload.signal.versionBit = bit;
     const uint256 requestId = mnhfPayload.GetRequestId();
 
-    LogPrintf("CEHFSignalsHandler::trySignEHFSignal: bit=%d at height=%d id=%s\n", bit, pindex->nHeight, requestId.ToString());
-
     const Consensus::LLMQType& llmqType = Params().GetConsensus().llmqTypeMnhf;
     const auto& llmq_params_opt = llmq::GetLLMQParams(llmqType);
     if (!llmq_params_opt.has_value()) {
@@ -83,6 +81,7 @@ void CEHFSignalsHandler::trySignEHFSignal(int bit, const CBlockIndex* const pind
         return;
     }
 
+    LogPrintf("CEHFSignalsHandler::trySignEHFSignal: bit=%d at height=%d id=%s\n", bit, pindex->nHeight, requestId.ToString());
     mnhfPayload.signal.quorumHash = quorum->qc->quorumHash;
     const uint256 msgHash = mnhfPayload.PrepareTx().GetHash();
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -403,7 +403,6 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
     std::optional<CCreditPoolDiff> creditPoolDiff;
     if (llmq::utils::IsV20Active(pindexPrev)) {
         CCreditPool creditPool = creditPoolManager->GetCreditPool(pindexPrev, chainparams.GetConsensus());
-        LogPrintf("%s: CCreditPool is %s\n", __func__, creditPool.ToString());
         creditPoolDiff.emplace(std::move(creditPool), pindexPrev, chainparams.GetConsensus(), 0);
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
There's too much spamming log items related to new v20 features: credit pool, asset locks, EHF manager, EHF Signaling for MN_RR.

See logs are still spamming after this PR but it is not changed due to removed/edited code in https://github.com/dashpay/dash/pull/5658

## What was done?
Removed some log items, tidy-up other.

## How Has This Been Tested?
Run unit/functional tests, reviewed log output

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
