### PR TITLE
fix: avoid some crashes on `invalidateblock`

### DIFF
--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -519,10 +519,9 @@ void CInstantSendManager::ProcessTx(const CTransaction& tx, bool fRetroactive, c
     // block after we retroactively locked all transactions.
     if (!IsInstantSendMempoolSigningEnabled() && !fRetroactive) return;
 
-    const auto llmqType_opt{GetInstantSendLLMQTypeAtTip(qman, m_chainstate)};
-    if (!llmqType_opt.has_value()) return;
-
-    if (!TrySignInputLocks(tx, fRetroactive, llmqType_opt.value(), params)) {
+    if (auto llmqType_opt{GetInstantSendLLMQTypeAtTip(qman, m_chainstate)}; !llmqType_opt.has_value()) {
+        return;
+    } else if (!TrySignInputLocks(tx, fRetroactive, llmqType_opt.value(), params)) {
         return;
     }
 

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -868,11 +868,10 @@ bool CInstantSendLock::TriviallyValid() const
 
 bool CInstantSendManager::ProcessPendingInstantSendLocks()
 {
-    const auto llmqType_opt{GetInstantSendLLMQTypeAtTip(qman, m_chainstate)};
-    if (!llmqType_opt.has_value()) return true; // not an error
-
-    if (llmqType_opt.value() == Params().GetConsensus().llmqTypeDIP0024InstantSend) {
-        // Don't short circuit. Try to process both deterministic and not deterministic islocks independable
+    if (auto llmqType_opt{GetInstantSendLLMQTypeAtTip(qman, m_chainstate)}; !llmqType_opt.has_value()) {
+        return true; // not an error
+    } else if (llmqType_opt.value() == Params().GetConsensus().llmqTypeDIP0024InstantSend) {
+         // Don't short circuit. Try to process both deterministic and not deterministic islocks independable
         bool deterministicRes = ProcessPendingInstantSendLocks(true);
         bool nondeterministicRes = ProcessPendingInstantSendLocks(false);
         return deterministicRes && nondeterministicRes;


### PR DESCRIPTION
## Issue being fixed or feature implemented
```
Assertion failure:
  assertion: quorum != nullptr
  file: quorums.cpp, line: 547
  function: ScanQuorums
```

## What was done?
Hold cs_main while scanning to make sure tip doesn't move. Happened in `ProcessPendingInstantSendLocks()` only for me but I thought that it would probably make sense to apply the same fix in other places too.

## How Has This Been Tested?
run `invalidateblock` for a deep enough height (100s of blocks)

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

