### PR TITLE
test: ensure that mining is possible without CL info

### DIFF
--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -187,6 +187,45 @@ class LLMQChainLocksTest(DashTestFramework):
         self.reconnect_isolated_node(0, 1)
         self.wait_for_chainlocked_block(self.nodes[0], self.nodes[0].getbestblockhash(), timeout=30)
 
+        self.log.info("Add a new node and let it sync")
+        added_mn_info_0 = self.dynamically_add_masternode(evo=False)
+        has_chainlock_info = False
+        try:
+            self.log.info(f'{self.nodes[added_mn_info_0.idx].getbestchainlock()}')
+            has_chainlock_info = True
+        except:
+            self.log.info("getbestchainlock() failed on the new node as expected")
+        assert not has_chainlock_info
+        self.log.info("Test that new node can mine without Chainlock info")
+        tip_0 = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)
+        self.nodes[added_mn_info_0.idx].generate(1)
+        self.sync_blocks(self.nodes)
+        tip_1 = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)
+        assert_equal(tip_1['cbTx']['bestCLSignature'], tip_0['cbTx']['bestCLSignature'])
+        assert_equal(tip_1['cbTx']['bestCLHeightDiff'], tip_0['cbTx']['bestCLHeightDiff'] + 1)
+
+        self.log.info("Disable Chainlock")
+        self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", 4070908800)
+        self.wait_for_sporks_same()
+
+        self.log.info("Add a new node and let it sync")
+        added_mn_info_1 = self.dynamically_add_masternode(evo=False)
+        has_chainlock_info = False
+        try:
+            self.log.info(f'{self.nodes[added_mn_info_1.idx].getbestchainlock()}')
+            has_chainlock_info = True
+        except:
+            self.log.info("getbestchainlock() failed on the new node as expected")
+        assert not has_chainlock_info
+        self.log.info("Test that new node can mine without Chainlock info")
+        tip_0 = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)
+        self.nodes[added_mn_info_1.idx].generate(1)
+        self.sync_blocks(self.nodes)
+        tip_1 = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)
+        assert_equal(tip_1['cbTx']['bestCLSignature'], tip_0['cbTx']['bestCLSignature'])
+        assert_equal(tip_1['cbTx']['bestCLHeightDiff'], tip_0['cbTx']['bestCLHeightDiff'] + 1)
+
+
     def create_chained_txs(self, node, amount):
         txid = node.sendtoaddress(node.getnewaddress(), amount)
         tx = node.getrawtransaction(txid, 1)

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -13,7 +13,7 @@ Checks LLMQs based ChainLocks
 import time
 
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import force_finish_mnsync, assert_equal
+from test_framework.util import force_finish_mnsync, assert_equal, assert_raises_rpc_error
 
 
 class LLMQChainLocksTest(DashTestFramework):
@@ -189,13 +189,8 @@ class LLMQChainLocksTest(DashTestFramework):
 
         self.log.info("Add a new node and let it sync")
         added_mn_info_0 = self.dynamically_add_masternode(evo=False)
-        has_chainlock_info = False
-        try:
-            self.log.info(f'{self.nodes[added_mn_info_0.idx].getbestchainlock()}')
-            has_chainlock_info = True
-        except:
-            self.log.info("getbestchainlock() failed on the new node as expected")
-        assert not has_chainlock_info
+        assert_raises_rpc_error(-32603, "Unable to find any chainlock", self.nodes[added_mn_info_0.idx].getbestchainlock)
+
         self.log.info("Test that new node can mine without Chainlock info")
         tip_0 = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)
         self.nodes[added_mn_info_0.idx].generate(1)
@@ -210,13 +205,8 @@ class LLMQChainLocksTest(DashTestFramework):
 
         self.log.info("Add a new node and let it sync")
         added_mn_info_1 = self.dynamically_add_masternode(evo=False)
-        has_chainlock_info = False
-        try:
-            self.log.info(f'{self.nodes[added_mn_info_1.idx].getbestchainlock()}')
-            has_chainlock_info = True
-        except:
-            self.log.info("getbestchainlock() failed on the new node as expected")
-        assert not has_chainlock_info
+        assert_raises_rpc_error(-32603, "Unable to find any chainlock", self.nodes[added_mn_info_1.idx].getbestchainlock)
+
         self.log.info("Test that new node can mine without Chainlock info")
         tip_0 = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)
         self.nodes[added_mn_info_1.idx].generate(1)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -999,7 +999,7 @@ MASTERNODE_COLLATERAL = 1000
 EVONODE_COLLATERAL = 4000
 
 class MasternodeInfo:
-    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout, addr, idx, evo=False):
+    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout, addr, evo=False):
         self.proTxHash = proTxHash
         self.ownerAddr = ownerAddr
         self.votingAddr = votingAddr
@@ -1009,7 +1009,6 @@ class MasternodeInfo:
         self.collateral_txid = collateral_txid
         self.collateral_vout = collateral_vout
         self.addr = addr
-        self.idx = idx
         self.evo = evo
 
 
@@ -1232,7 +1231,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.sync_all(self.nodes)
 
         assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
-        mn_info = MasternodeInfo(protx_result, owner_address, voting_address, bls['public'], bls['secret'], collateral_address, collateral_txid, collateral_vout, ipAndPort, idx, evo)
+        mn_info = MasternodeInfo(protx_result, owner_address, voting_address, bls['public'], bls['secret'], collateral_address, collateral_txid, collateral_vout, ipAndPort, evo)
         self.mninfo.append(mn_info)
 
         mn_type_str = "EvoNode" if evo else "MN"

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -999,7 +999,7 @@ MASTERNODE_COLLATERAL = 1000
 EVONODE_COLLATERAL = 4000
 
 class MasternodeInfo:
-    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout, addr, evo=False):
+    def __init__(self, proTxHash, ownerAddr, votingAddr, pubKeyOperator, keyOperator, collateral_address, collateral_txid, collateral_vout, addr, idx, evo=False):
         self.proTxHash = proTxHash
         self.ownerAddr = ownerAddr
         self.votingAddr = votingAddr
@@ -1009,6 +1009,7 @@ class MasternodeInfo:
         self.collateral_txid = collateral_txid
         self.collateral_vout = collateral_vout
         self.addr = addr
+        self.idx = idx
         self.evo = evo
 
 
@@ -1231,7 +1232,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.sync_all(self.nodes)
 
         assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
-        mn_info = MasternodeInfo(protx_result, owner_address, voting_address, bls['public'], bls['secret'], collateral_address, collateral_txid, collateral_vout, ipAndPort, evo)
+        mn_info = MasternodeInfo(protx_result, owner_address, voting_address, bls['public'], bls['secret'], collateral_address, collateral_txid, collateral_vout, ipAndPort, idx, evo)
         self.mninfo.append(mn_info)
 
         mn_type_str = "EvoNode" if evo else "MN"


### PR DESCRIPTION
## Issue being fixed or feature implemented
With DIP29 added to v20, miners include best CL Signature in CbTx.
The purpose of this test, is to ensure that mining is still possible when CL information isn't available.
In such case, miners are expected to copy best CL Signature from CbTx of previous block.

## What was done?
Two scenarios are implemented:

- Add dynamically a node, make sure `getbestchainlock()` fails, let it mine a block.
- Disable `SPORK_19_CHAINLOCKS_ENABLED`, add dynamically a node, make sure `getbestchainlock()` fails, let it mine a block.

In both tests, we make sure the block is accepted by everyone and that the `bestCLSignature` in CbTx is copied from previous block.

## How Has This Been Tested?
`feature_llmq_chainlocks.py`

## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

