### PR TITLE
fix: keep platform quorum data for 2 months

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -1006,10 +1006,10 @@ void CQuorumManager::CleanupOldQuorumData(const CBlockIndex* pIndex) const
     std::set<uint256> dbKeysToSkip;
 
     LogPrint(BCLog::LLMQ, "CQuorumManager::%d -- start\n", __func__);
-    // Platform quorums in all networks are newed every 24h (LLMQ_100_67, LLMQ_25_67, LLMQ_DEVNET_PLATFORM and LLMQ_REGTEST_PLATFORM)
-    // During a month, 24 x 30 quorums are created
-    // We want to keep data for Platform quorums no older than 2 months since Platform can be restarted and needs to re-sign stuff
-    // Hence, we should not clean secret key shares and vvec for those quorums.
+    // Platform quorums in all networks are created every 24 blocks (~1h).
+    // Unlike for other quorum types we want to keep data (secret key shares and vvec)
+    // for Platform quorums for at least 2 months because Platform can be restarted and
+    // it must be able to re-sign stuff. During a month, 24 * 30 quorums are created.
     constexpr auto numPlatformQuorumsDataToKeep = 24 * 30 * 2;
 
     for (const auto& params : Params().GetConsensus().llmqs) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -1007,7 +1007,7 @@ void CQuorumManager::CleanupOldQuorumData(const CBlockIndex* pIndex) const
 
     LogPrint(BCLog::LLMQ, "CQuorumManager::%d -- start\n", __func__);
     // Platform quorums in all networks are newed every 24h (LLMQ_100_67, LLMQ_25_67, LLMQ_DEVNET_PLATFORM and LLMQ_REGTEST_PLATFORM)
-    // Every month, 24 x 30 quorums are created
+    // During a month, 24 x 30 quorums are created
     // We want to keep data for Platform quorums no older than 2 months since Platform can be restarted and needs to re-sign stuff
     // Hence, we should not clean secret key shares and vvec for those quorums.
     constexpr auto numPlatformQuorumsDataToKeep = 24 * 30 * 2;


### PR DESCRIPTION
## Issue being fixed or feature implemented
When Platform restarts on a network, it needs to sign requests using old quorums. 
We shouldn't remove data (secret key shares, vvec) for old Platform quorums as we do with the rest of the llmqs.

## What was done?
We skip removing for Platform quorums younger than 2 months.

## How Has This Been Tested?


## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

