### PR TITLE
fix: rename SPORK_24_EHF to SPORK_24_TEST_EHF, make sure it has no effect on mainnet

### DIFF
--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -44,7 +44,7 @@ CEHFSignalsHandler::~CEHFSignalsHandler()
 
 void CEHFSignalsHandler::UpdatedBlockTip(const CBlockIndex* const pindexNew)
 {
-    if (!fMasternodeMode || !llmq::utils::IsV20Active(pindexNew) || !sporkman.IsSporkActive(SPORK_24_EHF)) {
+    if (!fMasternodeMode || !llmq::utils::IsV20Active(pindexNew) || !sporkman.IsSporkActive(SPORK_24_TEST_EHF)) {
         return;
     }
 

--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -44,7 +44,7 @@ CEHFSignalsHandler::~CEHFSignalsHandler()
 
 void CEHFSignalsHandler::UpdatedBlockTip(const CBlockIndex* const pindexNew)
 {
-    if (!fMasternodeMode || !llmq::utils::IsV20Active(pindexNew) || !sporkman.IsSporkActive(SPORK_24_TEST_EHF)) {
+    if (!fMasternodeMode || !llmq::utils::IsV20Active(pindexNew) || (Params().IsTestChain() && !sporkman.IsSporkActive(SPORK_24_TEST_EHF))) {
         return;
     }
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -41,7 +41,7 @@ enum SporkId : int32_t {
     SPORK_19_CHAINLOCKS_ENABLED                            = 10018,
     SPORK_21_QUORUM_ALL_CONNECTED                          = 10020,
     SPORK_23_QUORUM_POSE                                   = 10022,
-    SPORK_24_EHF                                           = 10023,
+    SPORK_24_TEST_EHF                                      = 10023,
 
     SPORK_INVALID                                          = -1,
 };
@@ -75,7 +75,7 @@ struct CSporkDef
     MAKE_SPORK_DEF(SPORK_19_CHAINLOCKS_ENABLED,            4070908800ULL), // OFF
     MAKE_SPORK_DEF(SPORK_21_QUORUM_ALL_CONNECTED,          4070908800ULL), // OFF
     MAKE_SPORK_DEF(SPORK_23_QUORUM_POSE,                   4070908800ULL), // OFF
-    MAKE_SPORK_DEF(SPORK_24_EHF,                           4070908800ULL), // OFF
+    MAKE_SPORK_DEF(SPORK_24_TEST_EHF,                      4070908800ULL), // OFF
 };
 #undef MAKE_SPORK_DEF
 extern std::unique_ptr<CSporkManager> sporkManager;

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -259,7 +259,7 @@ class MnehfTest(DashTestFramework):
 
         self.log.info("activate MN_RR also by enabling spork 24")
         assert_equal(get_bip9_details(node, 'mn_rr')['status'], 'defined')
-        self.nodes[0].sporkupdate("SPORK_24_EHF", 0)
+        self.nodes[0].sporkupdate("SPORK_24_TEST_EHF", 0)
         self.wait_for_sporks_same()
 
         self.check_fork('defined')

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1126,7 +1126,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.activate_by_name('v20', expected_activation_height)
 
     def activate_mn_rr(self, expected_activation_height=None):
-        self.nodes[0].sporkupdate("SPORK_24_EHF", 0)
+        self.nodes[0].sporkupdate("SPORK_24_TEST_EHF", 0)
         self.wait_for_sporks_same()
         mn_rr_height = 0
         while mn_rr_height == 0:


### PR DESCRIPTION
## Issue being fixed or feature implemented
Be more explicit about the fact that spork24 is for non-mainnet only, enforce it in code.

NOTE: I know we have EHF signalling disabled for mainnet in v20 but I think it still makes sense to make sure spork24 condition won't slip into mainnet in some future version accidentally.

## What was done?
pls see individual commits

## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

