### PR TITLE
fix: TODO related fixes for post-v20 release

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -259,7 +259,7 @@ void CCoinsViewCache::ReallocateCache()
     ::new (&cacheCoins) CCoinsMap();
 }
 
-static const size_t MAX_OUTPUTS_PER_BLOCK = MaxBlockSize() /  ::GetSerializeSize(CTxOut(), PROTOCOL_VERSION); // TODO: merge with similar definition in undo.h.
+static const size_t MAX_OUTPUTS_PER_BLOCK = MaxBlockSize() /  ::GetSerializeSize(CTxOut(), PROTOCOL_VERSION);
 
 const Coin& AccessByTxid(const CCoinsViewCache& view, const uint256& txid)
 {

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -4,17 +4,16 @@
 
 #include <consensus/tx_verify.h>
 
-#include <consensus/consensus.h>
-#include <primitives/transaction.h>
-#include <script/interpreter.h>
-#include <consensus/validation.h>
-#include <evo/assetlocktx.h>
-#include <tinyformat.h>
-
-// TODO remove the following dependencies
 #include <chain.h>
 #include <coins.h>
+#include <consensus/consensus.h>
+#include <consensus/validation.h>
+#include <evo/assetlocktx.h>
+#include <primitives/transaction.h>
+#include <script/interpreter.h>
+#include <tinyformat.h>
 #include <util/moneystr.h>
+
 
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -464,25 +464,13 @@ public:
             return false;
         }
 
-        if (curIsParent) {
-            try {
-                // TODO try to avoid this copy (we need a stream that allows reading from external buffers)
-                CDataStream ssKey = parentKey;
-                ssKey >> key;
-            } catch (const std::exception&) {
-                return false;
-            }
-            return true;
-        } else {
-            try {
-                // TODO try to avoid this copy (we need a stream that allows reading from external buffers)
-                CDataStream ssKey = transactionIt->first;
-                ssKey >> key;
-            } catch (const std::exception&) {
-                return false;
-            }
-            return true;
+        try {
+            // TODO try to avoid copy transactionIt->first (we need a stream that allows reading from external buffers)
+            (curIsParent ? parentKey : CDataStream{transactionIt->first}) >> key;
+        } catch (const std::exception&) {
+            return false;
         }
+        return true;
     }
 
     CDataStream GetKey() {

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -98,14 +98,6 @@ void CDSNotificationInterface::TransactionRemovedFromMempool(const CTransactionR
 
 void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
 {
-    // TODO: Temporarily ensure that mempool removals are notified before
-    // connected transactions.  This shouldn't matter, but the abandoned
-    // state of transactions in our wallet is currently cleared when we
-    // receive another notification and there is a race condition where
-    // notification of a connected conflict might cause an outside process
-    // to abandon a transaction and then have it inadvertently cleared by
-    // the notification that the conflicted transaction was evicted.
-
     llmq_ctx->isman->BlockConnected(pblock, pindex);
     llmq_ctx->clhandler->BlockConnected(pblock, pindex);
     CCoinJoin::BlockConnected(pblock, pindex);

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -95,12 +95,11 @@ UniValue CSimplifiedMNListEntry::ToJson(bool extended) const
     return obj;
 }
 
-// TODO: Invistigate if we can delete this constructor
 CSimplifiedMNList::CSimplifiedMNList(const std::vector<CSimplifiedMNListEntry>& smlEntries)
 {
-    mnList.resize(smlEntries.size());
-    for (size_t i = 0; i < smlEntries.size(); i++) {
-        mnList[i] = std::make_unique<CSimplifiedMNListEntry>(smlEntries[i]);
+    mnList.reserve(smlEntries.size());
+    for (const auto& entry : smlEntries) {
+        mnList.emplace_back(std::make_unique<CSimplifiedMNListEntry>(entry));
     }
 
     std::sort(mnList.begin(), mnList.end(), [&](const std::unique_ptr<CSimplifiedMNListEntry>& a, const std::unique_ptr<CSimplifiedMNListEntry>& b) {
@@ -110,11 +109,9 @@ CSimplifiedMNList::CSimplifiedMNList(const std::vector<CSimplifiedMNListEntry>& 
 
 CSimplifiedMNList::CSimplifiedMNList(const CDeterministicMNList& dmnList)
 {
-    mnList.resize(dmnList.GetAllMNsCount());
-
-    size_t i = 0;
-    dmnList.ForEachMN(false, [this, &i](auto& dmn) {
-        mnList[i++] = std::make_unique<CSimplifiedMNListEntry>(dmn);
+    mnList.reserve(dmnList.GetAllMNsCount());
+    dmnList.ForEachMN(false, [this](auto& dmn) {
+        mnList.emplace_back(std::make_unique<CSimplifiedMNListEntry>(dmn));
     });
 
     std::sort(mnList.begin(), mnList.end(), [&](const std::unique_ptr<CSimplifiedMNListEntry>& a, const std::unique_ptr<CSimplifiedMNListEntry>& b) {

--- a/src/evo/simplifiedmns.h
+++ b/src/evo/simplifiedmns.h
@@ -100,8 +100,10 @@ public:
     std::vector<std::unique_ptr<CSimplifiedMNListEntry>> mnList;
 
     CSimplifiedMNList() = default;
-    explicit CSimplifiedMNList(const std::vector<CSimplifiedMNListEntry>& smlEntries);
     explicit CSimplifiedMNList(const CDeterministicMNList& dmnList);
+
+    // This constructor from std::vector is used in unit-tests
+    explicit CSimplifiedMNList(const std::vector<CSimplifiedMNListEntry>& smlEntries);
 
     uint256 CalcMerkleRoot(bool* pmutated = nullptr) const;
     bool operator==(const CSimplifiedMNList& rhs) const;

--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -354,10 +354,8 @@ bool CSuperblockManager::GetSuperblockPayments(CGovernanceManager& governanceMan
             CTxDestination dest;
             ExtractDestination(payment.script, dest);
 
-            // TODO: PRINT NICE N.N DASH OUTPUT
-
-            LogPrint(BCLog::GOBJECT, "CSuperblockManager::GetSuperblockPayments -- NEW Superblock: output %d (addr %s, amount %lld)\n",
-                        i, EncodeDestination(dest), payment.nAmount);
+            LogPrint(BCLog::GOBJECT, "CSuperblockManager::GetSuperblockPayments -- NEW Superblock: output %d (addr %s, amount %d.%08d)\n",
+                        i, EncodeDestination(dest), payment.nAmount / COIN, payment.nAmount % COIN);
         } else {
             LogPrint(BCLog::GOBJECT, "CSuperblockManager::GetSuperblockPayments -- Payment not found\n");
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2074,11 +2074,6 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                     break;
                 }
 
-                if (!llmq::quorumBlockProcessor->UpgradeDB()) {
-                    strLoadError = _("Error upgrading evo database");
-                    break;
-                }
-
                 for (CChainState* chainstate : chainman.GetAll()) {
                     if (!is_coinsview_empty(chainstate)) {
                         uiInterface.InitMessage(_("Verifying blocks...").translated);

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -51,8 +51,6 @@ private:
 public:
     explicit CQuorumBlockProcessor(CChainState& chainstate, CConnman& _connman, CEvoDB& evoDb, const std::unique_ptr<PeerManager>& peerman);
 
-    bool UpgradeDB();
-
     void ProcessMessage(const CNode& peer, std::string_view msg_type, CDataStream& vRecv);
 
     bool ProcessBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, BlockValidationState& state, bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -41,7 +41,6 @@ private:
     CEvoDB& m_evoDb;
     const std::unique_ptr<PeerManager>& m_peerman;
 
-    // TODO cleanup
     mutable RecursiveMutex minableCommitmentsCs;
     std::map<std::pair<Consensus::LLMQType, uint256>, uint256> minableCommitmentsByQuorum GUARDED_BY(minableCommitmentsCs);
     std::map<uint256, CFinalCommitment> minableCommitments GUARDED_BY(minableCommitmentsCs);

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -121,8 +121,15 @@ public:
     Consensus::LLMQType llmqType;
     uint256 quorumHash;
     uint256 proTxHash;
-    // TODO make this pair a struct with named fields
-    std::vector<std::pair<uint32_t, CBLSSecretKey>> contributions;
+    struct Contribution {
+        uint32_t index;
+        CBLSSecretKey key;
+        SERIALIZE_METHODS(Contribution, obj)
+        {
+            READWRITE(obj.index, obj.key);
+        }
+    };
+    std::vector<Contribution> contributions;
     CBLSSignature sig;
 
 public:


### PR DESCRIPTION
## Issue being fixed or feature implemented
Multiple TODO is reviewed and fixes in this PR

## What was done?
 - Dropped un-actionable or out-dated TODO (including backport bitcoin#2387)
 - refactored CDBTransactionIterator
 - refactored constructors of CSimplifiedMNList
 - dropped CQuorumBlockProcessor::UpgradeDB
 - refactored CDKGJustification's contribution from pair to dedicated struct
 - improved logging Amount in governance's related code

## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
Db for BlockProcessor can't be upgraded from v0.15- version


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

