### PR TITLE
fix: add missing log categories

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -178,6 +178,8 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::COINJOIN, "coinjoin"},
     {BCLog::SPORK, "spork"},
     {BCLog::NETCONN, "netconn"},
+    {BCLog::CREDITPOOL, "creditpool"},
+    {BCLog::EHF, "ehf"},
     {BCLog::DASH, "dash"},
     //End Dash
 };


### PR DESCRIPTION
## Issue being fixed or feature implemented
`creditpool` and `ehf` categories are missing in `logging`/`debug` RPCs 😞 

## What was done?


## How Has This Been Tested?
run `debug` and `logging` RPCs and make sure these categories are listed now

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

