### PR TITLE
fix: make `CONFIGFLAGS` optional

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -27,11 +27,15 @@ Required environment variables as seen inside the container:
     DIST_ARCHIVE_BASE: ${DIST_ARCHIVE_BASE:?not set}
     DISTNAME: ${DISTNAME:?not set}
     HOST: ${HOST:?not set}
-    CONFIGFLAGS: ${CONFIGFLAGS:?not set}
     SOURCE_DATE_EPOCH: ${SOURCE_DATE_EPOCH:?not set}
     JOBS: ${JOBS:?not set}
     DISTSRC: ${DISTSRC:?not set}
     OUTDIR: ${OUTDIR:?not set}
+EOF
+
+cat << EOF
+Optional environment variables as seen inside the container:
+    CONFIGFLAGS: ${CONFIGFLAGS}
 EOF
 
 ACTUAL_OUTDIR="${OUTDIR}"


### PR DESCRIPTION
## Issue being fixed or feature implemented
make it possible to run `./contrib/guix/guix-build` without specifying `CONFIGFLAGS`

## What was done?

## How Has This Been Tested?
run `./contrib/guix/guix-build` w/ and w/out this patch

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

