### PR TITLE
ci: change Dockerfile.GitHubActions.Release to use local repo and not always dashpay/dash

### DIFF
--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -24,7 +24,7 @@ RUN apt-get update && \
 
 RUN mach=$(uname -m) \
       && case $mach in aarch64) arch="aarch64-linux-gnu"; ;; x86_64) arch="x86_64-linux-gnu"; ;;  *) echo "ERROR: Machine type $mach not supported."; ;; esac \
-      && wget https://github.com/dashpay/dash/releases/download/v${TAG}/dashcore-${TAG}-$arch.tar.gz -P /tmp \
+      && wget https://github.com/${GITHUB_REPOSITORY}/releases/download/v${TAG}/dashcore-${TAG}-$arch.tar.gz -P /tmp \
       && tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/ \
       && cp /tmp/dashcore*/bin/*  /usr/local/bin \
       && rm -rf /tmp/dashcore* \


### PR DESCRIPTION
## Issue being fixed or feature implemented
In order to provide nightly builds over at dash-dev-branches we need to be able to run this automation with other REPOs

## What was done?
Make it repo specific.

## How Has This Been Tested?
Hasn't yet

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

