### PR TITLE
fix: should avoid implicit conversions in `pushKV` params

### DIFF
--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -34,7 +34,7 @@ UniValue CMasternodeMetaInfo::ToJson() const
 {
     UniValue ret(UniValue::VOBJ);
 
-    auto now = GetTime<std::chrono::seconds>().count();
+    int64_t now = GetTime<std::chrono::seconds>().count();
 
     ret.pushKV("lastDSQ", nLastDsq);
     ret.pushKV("mixingTxCount", nMixingTxCount);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should fix compilation errors like
```
masternode/meta.cpp:43:9: error: call to member function 'pushKV' is ambiguous
    ret.pushKV("lastOutboundAttemptElapsed", now - lastOutboundAttempt);
    ^~
masternode/meta.cpp:45:9: error: call to member function 'pushKV' is ambiguous
    ret.pushKV("lastOutboundSuccessElapsed", now - lastOutboundSuccess);
    ^~
```
on FreeBSD + clang-15

kudos to @MrDefacto for finding the issue and testing the fix


## What was done?
Specify `now` variable type explicitly instead of relying on `auto`


## How Has This Been Tested?
MrDefacto confirmed it compiles with no issues on FreeBSD now

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

