### PR TITLE
fix: pass `GITHUB_REPOSITORY` into `Dockerfile.GitHubActions.Release`

### DIFF
--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -67,7 +67,9 @@ jobs:
         push: true
         tags: ${{ steps.docker_meta.outputs.tags }}
         labels: ${{ steps.docker_meta.outputs.labels }}
-        build-args: TAG=${{ steps.get_tag.outputs.build_tag }}
+        build-args: |
+          TAG=${{ steps.get_tag.outputs.build_tag }}
+          GITHUB_REPOSITORY=${{ GITHUB_REPOSITORY }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         platforms: linux/amd64,linux/arm64

--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -5,6 +5,7 @@ LABEL description="Dockerised DashCore"
 ARG USER_ID
 ARG GROUP_ID
 ARG TAG
+ARG GITHUB_REPOSITORY
 
 ENV HOME /home/dash
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Should hopefully fix https://github.com/dashpay/dash-dev-branches/actions/runs/6939402277/job/18876687119

#5716 follow-up

## What was done?
`$GITHUB_REPOSITORY` is not available inside docker, pass it inside

## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

