### PR TITLE
refactor: introduce CbTx version enum class, adjust version names

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -48,7 +48,7 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidati
         }
 
         bool isV20 = llmq::utils::IsV20Active(pindexPrev);
-        if ((isV20 && cbTx.nVersion < CbTxVersion::CLSIG_AND_CP_BALANCE) || (!isV20 && cbTx.nVersion >= CbTxVersion::CLSIG_AND_CP_BALANCE)) {
+        if ((isV20 && cbTx.nVersion < CbTxVersion::CLSIG_AND_BALANCE) || (!isV20 && cbTx.nVersion >= CbTxVersion::CLSIG_AND_BALANCE)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
         }
     }
@@ -332,7 +332,7 @@ bool CheckCbTxBestChainlock(const CBlock& block, const CBlockIndex* pindex, cons
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-payload");
     }
 
-    if (cbTx.nVersion < CbTxVersion::CLSIG_AND_CP_BALANCE) {
+    if (cbTx.nVersion < CbTxVersion::CLSIG_AND_BALANCE) {
         return true;
     }
 
@@ -467,7 +467,7 @@ std::optional<std::pair<CBLSSignature, uint32_t>> GetNonNullCoinbaseChainlock(co
 
     CCbTx& cbtx = opt_cbtx.value();
 
-    if (cbtx.nVersion < CbTxVersion::CLSIG_AND_CP_BALANCE) {
+    if (cbtx.nVersion < CbTxVersion::CLSIG_AND_BALANCE) {
         return std::nullopt;
     }
 

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -33,7 +33,7 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidati
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-payload");
     }
 
-    if (cbTx.nVersion == 0 || cbTx.nVersion > CCbTx::CB_V20_VERSION) {
+    if (cbTx.nVersion == CbTxVersion::INVALID || cbTx.nVersion >= CbTxVersion::UNKNOWN) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
     }
 
@@ -43,12 +43,12 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidati
         }
 
         bool fDIP0008Active = pindexPrev->nHeight >= Params().GetConsensus().DIP0008Height;
-        if (fDIP0008Active && cbTx.nVersion < CCbTx::CB_V19_VERSION) {
+        if (fDIP0008Active && cbTx.nVersion < CbTxVersion::MERKLE_ROOT_QUORUMS) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
         }
 
         bool isV20 = llmq::utils::IsV20Active(pindexPrev);
-        if ((isV20 && cbTx.nVersion < CCbTx::CB_V20_VERSION) || (!isV20 && cbTx.nVersion >= CCbTx::CB_V20_VERSION)) {
+        if ((isV20 && cbTx.nVersion < CbTxVersion::BEST_CHAINLOCK) || (!isV20 && cbTx.nVersion >= CbTxVersion::BEST_CHAINLOCK)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
         }
     }
@@ -91,7 +91,7 @@ bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, const 
         int64_t nTime3 = GetTimeMicros(); nTimeMerkleMNL += nTime3 - nTime2;
         LogPrint(BCLog::BENCHMARK, "          - CalcCbTxMerkleRootMNList: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeMerkleMNL * 0.000001);
 
-        if (cbTx.nVersion >= 2) {
+        if (cbTx.nVersion >= CbTxVersion::MERKLE_ROOT_QUORUMS) {
             if (!CalcCbTxMerkleRootQuorums(block, pindex->pprev, quorum_block_processor, calculatedMerkleRoot, state)) {
                 // pass the state returned by the function above
                 return false;
@@ -332,7 +332,7 @@ bool CheckCbTxBestChainlock(const CBlock& block, const CBlockIndex* pindex, cons
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-payload");
     }
 
-    if (cbTx.nVersion < CCbTx::CB_V20_VERSION) {
+    if (cbTx.nVersion < CbTxVersion::BEST_CHAINLOCK) {
         return true;
     }
 
@@ -433,7 +433,7 @@ bool CalcCbTxBestChainlock(const llmq::CChainLocksHandler& chainlock_handler, co
 std::string CCbTx::ToString() const
 {
     return strprintf("CCbTx(nVersion=%d, nHeight=%d, merkleRootMNList=%s, merkleRootQuorums=%s, bestCLHeightDiff=%d, bestCLSig=%s, creditPoolBalance=%d.%08d)",
-        nVersion, nHeight, merkleRootMNList.ToString(), merkleRootQuorums.ToString(), bestCLHeightDiff, bestCLSignature.ToString(),
+        static_cast<uint16_t>(nVersion), nHeight, merkleRootMNList.ToString(), merkleRootQuorums.ToString(), bestCLHeightDiff, bestCLSignature.ToString(),
         creditPoolBalance / COIN, creditPoolBalance % COIN);
 }
 
@@ -467,7 +467,7 @@ std::optional<std::pair<CBLSSignature, uint32_t>> GetNonNullCoinbaseChainlock(co
 
     CCbTx& cbtx = opt_cbtx.value();
 
-    if (cbtx.nVersion < CCbTx::CB_V20_VERSION) {
+    if (cbtx.nVersion < CbTxVersion::BEST_CHAINLOCK) {
         return std::nullopt;
     }
 

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -48,7 +48,7 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidati
         }
 
         bool isV20 = llmq::utils::IsV20Active(pindexPrev);
-        if ((isV20 && cbTx.nVersion < CbTxVersion::BEST_CHAINLOCK) || (!isV20 && cbTx.nVersion >= CbTxVersion::BEST_CHAINLOCK)) {
+        if ((isV20 && cbTx.nVersion < CbTxVersion::CLSIG_AND_CP_BALANCE) || (!isV20 && cbTx.nVersion >= CbTxVersion::CLSIG_AND_CP_BALANCE)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
         }
     }
@@ -332,7 +332,7 @@ bool CheckCbTxBestChainlock(const CBlock& block, const CBlockIndex* pindex, cons
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-payload");
     }
 
-    if (cbTx.nVersion < CbTxVersion::BEST_CHAINLOCK) {
+    if (cbTx.nVersion < CbTxVersion::CLSIG_AND_CP_BALANCE) {
         return true;
     }
 
@@ -467,7 +467,7 @@ std::optional<std::pair<CBLSSignature, uint32_t>> GetNonNullCoinbaseChainlock(co
 
     CCbTx& cbtx = opt_cbtx.value();
 
-    if (cbtx.nVersion < CbTxVersion::BEST_CHAINLOCK) {
+    if (cbtx.nVersion < CbTxVersion::CLSIG_AND_CP_BALANCE) {
         return std::nullopt;
     }
 

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -33,7 +33,7 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidati
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-payload");
     }
 
-    if (cbTx.nVersion == CbTxVersion::INVALID || cbTx.nVersion >= CbTxVersion::UNKNOWN) {
+    if (cbTx.nVersion == CCbTx::Version::INVALID || cbTx.nVersion >= CCbTx::Version::UNKNOWN) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
     }
 
@@ -43,12 +43,12 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidati
         }
 
         bool fDIP0008Active = pindexPrev->nHeight >= Params().GetConsensus().DIP0008Height;
-        if (fDIP0008Active && cbTx.nVersion < CbTxVersion::MERKLE_ROOT_QUORUMS) {
+        if (fDIP0008Active && cbTx.nVersion < CCbTx::Version::MERKLE_ROOT_QUORUMS) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
         }
 
         bool isV20 = llmq::utils::IsV20Active(pindexPrev);
-        if ((isV20 && cbTx.nVersion < CbTxVersion::CLSIG_AND_BALANCE) || (!isV20 && cbTx.nVersion >= CbTxVersion::CLSIG_AND_BALANCE)) {
+        if ((isV20 && cbTx.nVersion < CCbTx::Version::CLSIG_AND_BALANCE) || (!isV20 && cbTx.nVersion >= CCbTx::Version::CLSIG_AND_BALANCE)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
         }
     }
@@ -91,7 +91,7 @@ bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, const 
         int64_t nTime3 = GetTimeMicros(); nTimeMerkleMNL += nTime3 - nTime2;
         LogPrint(BCLog::BENCHMARK, "          - CalcCbTxMerkleRootMNList: %.2fms [%.2fs]\n", 0.001 * (nTime3 - nTime2), nTimeMerkleMNL * 0.000001);
 
-        if (cbTx.nVersion >= CbTxVersion::MERKLE_ROOT_QUORUMS) {
+        if (cbTx.nVersion >= CCbTx::Version::MERKLE_ROOT_QUORUMS) {
             if (!CalcCbTxMerkleRootQuorums(block, pindex->pprev, quorum_block_processor, calculatedMerkleRoot, state)) {
                 // pass the state returned by the function above
                 return false;
@@ -332,7 +332,7 @@ bool CheckCbTxBestChainlock(const CBlock& block, const CBlockIndex* pindex, cons
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cbtx-payload");
     }
 
-    if (cbTx.nVersion < CbTxVersion::CLSIG_AND_BALANCE) {
+    if (cbTx.nVersion < CCbTx::Version::CLSIG_AND_BALANCE) {
         return true;
     }
 
@@ -467,7 +467,7 @@ std::optional<std::pair<CBLSSignature, uint32_t>> GetNonNullCoinbaseChainlock(co
 
     CCbTx& cbtx = opt_cbtx.value();
 
-    if (cbtx.nVersion < CbTxVersion::CLSIG_AND_BALANCE) {
+    if (cbtx.nVersion < CCbTx::Version::CLSIG_AND_BALANCE) {
         return std::nullopt;
     }
 

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -29,7 +29,7 @@ enum class CbTxVersion : uint16_t {
     INVALID = 0,
     MERKLE_ROOT_MNLIST = 1,
     MERKLE_ROOT_QUORUMS = 2,
-    CLSIG_AND_CP_BALANCE = 3,
+    CLSIG_AND_BALANCE = 3,
     UNKNOWN,
 };
 template<> struct is_serializable_enum<CbTxVersion> : std::true_type {};
@@ -53,7 +53,7 @@ public:
 
         if (obj.nVersion >= CbTxVersion::MERKLE_ROOT_QUORUMS) {
             READWRITE(obj.merkleRootQuorums);
-            if (obj.nVersion >= CbTxVersion::CLSIG_AND_CP_BALANCE) {
+            if (obj.nVersion >= CbTxVersion::CLSIG_AND_BALANCE) {
                 READWRITE(COMPACTSIZE(obj.bestCLHeightDiff));
                 READWRITE(obj.bestCLSignature);
                 READWRITE(obj.creditPoolBalance);
@@ -73,7 +73,7 @@ public:
         obj.pushKV("merkleRootMNList", merkleRootMNList.ToString());
         if (nVersion >= CbTxVersion::MERKLE_ROOT_QUORUMS) {
             obj.pushKV("merkleRootQuorums", merkleRootQuorums.ToString());
-            if (nVersion >= CbTxVersion::CLSIG_AND_CP_BALANCE) {
+            if (nVersion >= CbTxVersion::CLSIG_AND_BALANCE) {
                 obj.pushKV("bestCLHeightDiff", static_cast<int>(bestCLHeightDiff));
                 obj.pushKV("bestCLSignature", bestCLSignature.ToString());
                 obj.pushKV("creditPoolBalance", ValueFromAmount(creditPoolBalance));

--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -29,7 +29,7 @@ enum class CbTxVersion : uint16_t {
     INVALID = 0,
     MERKLE_ROOT_MNLIST = 1,
     MERKLE_ROOT_QUORUMS = 2,
-    BEST_CHAINLOCK = 3,
+    CLSIG_AND_CP_BALANCE = 3,
     UNKNOWN,
 };
 template<> struct is_serializable_enum<CbTxVersion> : std::true_type {};
@@ -53,7 +53,7 @@ public:
 
         if (obj.nVersion >= CbTxVersion::MERKLE_ROOT_QUORUMS) {
             READWRITE(obj.merkleRootQuorums);
-            if (obj.nVersion >= CbTxVersion::BEST_CHAINLOCK) {
+            if (obj.nVersion >= CbTxVersion::CLSIG_AND_CP_BALANCE) {
                 READWRITE(COMPACTSIZE(obj.bestCLHeightDiff));
                 READWRITE(obj.bestCLSignature);
                 READWRITE(obj.creditPoolBalance);
@@ -73,7 +73,7 @@ public:
         obj.pushKV("merkleRootMNList", merkleRootMNList.ToString());
         if (nVersion >= CbTxVersion::MERKLE_ROOT_QUORUMS) {
             obj.pushKV("merkleRootQuorums", merkleRootQuorums.ToString());
-            if (nVersion >= CbTxVersion::BEST_CHAINLOCK) {
+            if (nVersion >= CbTxVersion::CLSIG_AND_CP_BALANCE) {
                 obj.pushKV("bestCLHeightDiff", static_cast<int>(bestCLHeightDiff));
                 obj.pushKV("bestCLSignature", bestCLSignature.ToString());
                 obj.pushKV("creditPoolBalance", ValueFromAmount(creditPoolBalance));

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -269,7 +269,7 @@ UniValue CSimplifiedMNListDiff::ToJson(bool extended) const
     CCbTx cbTxPayload;
     if (GetTxPayload(*cbTx, cbTxPayload)) {
         obj.pushKV("merkleRootMNList", cbTxPayload.merkleRootMNList.ToString());
-        if (cbTxPayload.nVersion >= CbTxVersion::MERKLE_ROOT_QUORUMS) {
+        if (cbTxPayload.nVersion >= CCbTx::Version::MERKLE_ROOT_QUORUMS) {
             obj.pushKV("merkleRootQuorums", cbTxPayload.merkleRootQuorums.ToString());
         }
     }

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -269,7 +269,7 @@ UniValue CSimplifiedMNListDiff::ToJson(bool extended) const
     CCbTx cbTxPayload;
     if (GetTxPayload(*cbTx, cbTxPayload)) {
         obj.pushKV("merkleRootMNList", cbTxPayload.merkleRootMNList.ToString());
-        if (cbTxPayload.nVersion >= 2) {
+        if (cbTxPayload.nVersion >= CbTxVersion::MERKLE_ROOT_QUORUMS) {
             obj.pushKV("merkleRootQuorums", cbTxPayload.merkleRootQuorums.ToString());
         }
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -202,11 +202,11 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         CCbTx cbTx;
 
         if (fV20Active_context) {
-            cbTx.nVersion = CbTxVersion::CLSIG_AND_BALANCE;
+            cbTx.nVersion = CCbTx::Version::CLSIG_AND_BALANCE;
         } else if (fDIP0008Active_context) {
-            cbTx.nVersion = CbTxVersion::MERKLE_ROOT_QUORUMS;
+            cbTx.nVersion = CCbTx::Version::MERKLE_ROOT_QUORUMS;
         } else {
-            cbTx.nVersion = CbTxVersion::MERKLE_ROOT_MNLIST;
+            cbTx.nVersion = CCbTx::Version::MERKLE_ROOT_MNLIST;
         }
 
         cbTx.nHeight = nHeight;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -202,7 +202,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         CCbTx cbTx;
 
         if (fV20Active_context) {
-            cbTx.nVersion = CbTxVersion::BEST_CHAINLOCK;
+            cbTx.nVersion = CbTxVersion::CLSIG_AND_CP_BALANCE;
         } else if (fDIP0008Active_context) {
             cbTx.nVersion = CbTxVersion::MERKLE_ROOT_QUORUMS;
         } else {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -202,7 +202,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         CCbTx cbTx;
 
         if (fV20Active_context) {
-            cbTx.nVersion = CbTxVersion::CLSIG_AND_CP_BALANCE;
+            cbTx.nVersion = CbTxVersion::CLSIG_AND_BALANCE;
         } else if (fDIP0008Active_context) {
             cbTx.nVersion = CbTxVersion::MERKLE_ROOT_QUORUMS;
         } else {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -202,11 +202,11 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         CCbTx cbTx;
 
         if (fV20Active_context) {
-            cbTx.nVersion = CCbTx::CB_V20_VERSION;
+            cbTx.nVersion = CbTxVersion::BEST_CHAINLOCK;
         } else if (fDIP0008Active_context) {
-            cbTx.nVersion = CCbTx::CB_V19_VERSION;
+            cbTx.nVersion = CbTxVersion::MERKLE_ROOT_QUORUMS;
         } else {
-            cbTx.nVersion = 1;
+            cbTx.nVersion = CbTxVersion::MERKLE_ROOT_MNLIST;
         }
 
         cbTx.nHeight = nHeight;


### PR DESCRIPTION
## Issue being fixed or feature implemented
- The name `CB_V19_VERSION` is confusing because CbTx v2 was introduced in v14, not v19 https://github.com/dashpay/dash/blob/master/doc/release-notes/dash/release-notes-0.14.0.md#dip0004---coinbase-payload-v2
- There are magic numbers instead of constants in some places
- `CheckCbTx` should check whatever the upper limit is, not `CB_V20_VERSION` specifically

## What was done?
Turn CbTx versions into enum using self-describing names

## How Has This Been Tested?
Run tests

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

