### PR TITLE
ci: Bump Guix build timeout and implement cacheing

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: [ "self-hosted", "linux", "x64", "ubuntu-core" ]
     if: contains(github.event.pull_request.labels.*.name, 'guix-build')
+    timeout-minutes: 480
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,6 +42,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Guix build
+        timeout-minutes: 480
         run: |
           docker run --privileged -d --rm -t \
             --name guix-daemon \

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -42,6 +42,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Restore Guix cache and depends
+        id: guix-cache-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ${{ github.workspace }}/.cache
+            ${{ github.workspace }}/dash/depends/built
+            ${{ github.workspace }}/dash/depends/sources
+            ${{ github.workspace }}/dash/depends/work
+          key: ${{ runner.os }}-guix
+
+      - name: Create .cache folder if missing
+        if: steps.guix-cache-restore.outputs.cache-hit != 'true'
+        run: mkdir -p .cache
+
       - name: Run Guix build
         timeout-minutes: 480
         run: |
@@ -49,6 +64,7 @@ jobs:
             --name guix-daemon \
             -e ADDITIONAL_GUIX_COMMON_FLAGS="--max-jobs=$(nproc --all)" \
             -v ${{ github.workspace }}/dash:/src/dash \
+            -v ${{ github.workspace }}/.cache:/home/ubuntu/.cache \
             -w /src/dash \
             guix_ubuntu:latest && \
           docker exec guix-daemon bash -c '/usr/local/bin/guix-start'
@@ -59,6 +75,17 @@ jobs:
             echo "Guix build failed!"
             exit 1
           fi
+
+      - name: Save Guix cache and depends
+        id: guix-cache-save
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ${{ github.workspace }}/.cache
+            ${{ github.workspace }}/dash/depends/built
+            ${{ github.workspace }}/dash/depends/sources
+            ${{ github.workspace }}/dash/depends/work
+          key: ${{ steps.guix-cache-restore.outputs.cache-primary-key }}
 
       - name: Compute SHA256 checksums
         run: |

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          path: dash
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -22,20 +23,20 @@ jobs:
       - name: Commit variables
         id: dockerfile
         run: |
-          echo "hash=$(sha256sum ./contrib/containers/guix/Dockerfile | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
+          echo "hash=$(sha256sum ./dash/contrib/containers/guix/Dockerfile | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
           echo "host_user_id=$(id -u)" >> $GITHUB_OUTPUT
           echo "host_group_id=$(id -g)" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
-          context: ${{ github.workspace }}
+          context: ${{ github.workspace }}/dash
           build-args: |
             USER_ID=${{ steps.dockerfile.outputs.host_user_id }}
             GROUP_ID=${{ steps.dockerfile.outputs.host_group_id }}
           build-contexts: |
-            docker_root=${{ github.workspace }}/contrib/containers/guix
-          file: ./contrib/containers/guix/Dockerfile
+            docker_root=${{ github.workspace }}/dash/contrib/containers/guix
+          file: ./dash/contrib/containers/guix/Dockerfile
           load: true
           tags: guix_ubuntu:latest
           cache-from: type=gha
@@ -47,7 +48,7 @@ jobs:
           docker run --privileged -d --rm -t \
             --name guix-daemon \
             -e ADDITIONAL_GUIX_COMMON_FLAGS="--max-jobs=$(nproc --all)" \
-            -v ${{ github.workspace }}:/src/dash \
+            -v ${{ github.workspace }}/dash:/src/dash \
             -w /src/dash \
             guix_ubuntu:latest && \
           docker exec guix-daemon bash -c '/usr/local/bin/guix-start'
@@ -61,4 +62,4 @@ jobs:
 
       - name: Compute SHA256 checksums
         run: |
-          ./contrib/containers/guix/scripts/guix-check ${{ github.workspace }}
+          ./dash/contrib/containers/guix/scripts/guix-check ${{ github.workspace }}/dash

--- a/contrib/containers/guix/Dockerfile
+++ b/contrib/containers/guix/Dockerfile
@@ -79,9 +79,14 @@ COPY --from=docker_root ./scripts/entrypoint /usr/local/bin/entrypoint
 COPY --from=docker_root ./scripts/guix-check /usr/local/bin/guix-check
 COPY --from=docker_root ./scripts/guix-start /usr/local/bin/guix-start
 
-# Create directory for mounting and grant necessary permissions
-RUN mkdir -p /src/dash && \
-    chown -R ${USER_ID}:${GROUP_ID} /src
+# Create directories for mounting to save/restore cache and grant necessary permissions
+RUN mkdir -p \
+        /home/${USERNAME}/.cache \
+        /src/dash/depends/{built,sources,work} && \
+    chown -R ${USER_ID}:${GROUP_ID} \
+        /home/${USERNAME}/.cache \
+        /src
+
 WORKDIR "/src/dash"
 
 # Switch to unprivileged context


### PR DESCRIPTION
## Issue being fixed or feature implemented
Hopefully fixes issues like
>The job running on runner ubuntu-core-x64_i-05ed4263b8e049c7a has exceeded the maximum execution time of 360 minutes

https://github.com/dashpay/dash/actions/runs/6932017275

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

## What was done?
Bump timeouts for the job itself and for the corresponding step. Also, implemented caching for `.cache` and `depends` folders.

## How Has This Been Tested?
#5729

https://github.com/dashpay/dash/actions/runs/6996271543/job/19031968814?pr=5729

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

