### PR TITLE
fix: use correct interruption condition in `StartCachePopulatorThread`

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -823,7 +823,7 @@ void CQuorumManager::StartCachePopulatorThread(const CQuorumCPtr pQuorum) const
     // when then later some other thread tries to get keys, it will be much faster
     workerPool.push([pQuorum, t, this](int threadId) {
         for (const auto i : irange::range(pQuorum->members.size())) {
-            if (!quorumThreadInterrupt) {
+            if (quorumThreadInterrupt) {
                 break;
             }
             if (pQuorum->qc->validMembers[i]) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash/pull/4788#discussion_r854468664

noticed while working on #5731

## What was done?

## How Has This Been Tested?
run a node, check logs - there is a meaningful time span between `start` and `done` now and not just zeros all the time.

## Breaking Changes

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

