### PR TITLE
fix: pass GITHUB_REPOSITORY into Dockerfile.GitHubActions.Release (2nd attempt)

### DIFF
--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -69,7 +69,7 @@ jobs:
         labels: ${{ steps.docker_meta.outputs.labels }}
         build-args: |
           TAG=${{ steps.get_tag.outputs.build_tag }}
-          GITHUB_REPOSITORY=${{ GITHUB_REPOSITORY }}
+          GITHUB_REPOSITORY=$GITHUB_REPOSITORY
         cache-from: type=gha
         cache-to: type=gha,mode=max
         platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Issue being fixed or feature implemented
I was probably using `GITHUB_REPOSITORY` incorrectly, let's try it this way

#5724 follow-up

## What was done?

## How Has This Been Tested?
n/a

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

