### PR TITLE
feat(rpc): `gettxchainlocks` should return `mempool=false` when tx not in mempool

### DIFF
--- a/doc/release-notes-5742.md
+++ b/doc/release-notes-5742.md
@@ -1,0 +1,4 @@
+RPC changes
+-----------
+
+RPC `gettxchainlocks` will also return the status `mempool` indicating wether the transaction is in the mempool or not.

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -317,7 +317,13 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         int height{-1};
         bool chainLock{false};
 
-        GetTransaction(nullptr, nullptr, txid, Params().GetConsensus(), hash_block);
+        auto tx_ref = GetTransaction(nullptr, node.mempool.get(), txid, Params().GetConsensus(), hash_block);
+
+        if (tx_ref == nullptr) {
+            UniValue r(UniValue::VNULL);
+            result_arr.push_back(r);
+            continue;
+        }
 
         if (!hash_block.IsNull()) {
             LOCK(cs_main);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -337,6 +337,7 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         }
         if (height != -1) {
             chainLock = llmq_ctx.clhandler->HasChainLock(height, hash_block);
+            result.pushKV("mempool", false);
         }
         else {
             result.pushKV("mempool", true);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -317,14 +317,13 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         uint256 hash_block;
         int height{-1};
         bool chainLock{false};
-        bool mempool{false};
 
         const auto tx_ref = GetTransaction(nullptr, node.mempool.get(), txid, Params().GetConsensus(), hash_block);
 
         if (tx_ref == nullptr) {
-            result.pushKV("height", height);
-            result.pushKV("chainlock", chainLock);
-            result.pushKV("mempool", mempool);
+            result.pushKV("height", -1);
+            result.pushKV("chainlock", false);
+            result.pushKV("mempool", false);
             result_arr.push_back(result);
             continue;
         }
@@ -339,12 +338,9 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         if (height != -1) {
             chainLock = llmq_ctx.clhandler->HasChainLock(height, hash_block);
         }
-        else {
-            result.pushKV("mempool", true);
-        }
         result.pushKV("height", height);
         result.pushKV("chainlock", chainLock);
-        result.pushKV("mempool", mempool);
+        result.pushKV("mempool", height == -1);
         result_arr.push_back(result);
     }
     return result_arr;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -317,13 +317,14 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         uint256 hash_block;
         int height{-1};
         bool chainLock{false};
+        bool mempool{false};
 
         const auto tx_ref = GetTransaction(nullptr, node.mempool.get(), txid, Params().GetConsensus(), hash_block);
 
         if (tx_ref == nullptr) {
             result.pushKV("height", height);
             result.pushKV("chainlock", chainLock);
-            result.pushKV("mempool", false);
+            result.pushKV("mempool", mempool);
             result_arr.push_back(result);
             continue;
         }
@@ -337,13 +338,13 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         }
         if (height != -1) {
             chainLock = llmq_ctx.clhandler->HasChainLock(height, hash_block);
-            result.pushKV("mempool", false);
         }
         else {
             result.pushKV("mempool", true);
         }
         result.pushKV("height", height);
         result.pushKV("chainlock", chainLock);
+        result.pushKV("mempool", mempool);
         result_arr.push_back(result);
     }
     return result_arr;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -266,7 +266,7 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
 {
     RPCHelpMan{
         "gettxchainlocks",
-        "\nReturns the block height each transaction was mined at and whether it is chainlocked or not.\n",
+        "\nReturns the block height at which each transaction was mined, and indicates whether it is in the mempool, chainlocked, or neither.\n",
         {
             {"txids", RPCArg::Type::ARR, RPCArg::Optional::NO, "The transaction ids (no more than 100)",
                 {
@@ -281,6 +281,7 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
                 {
                     {RPCResult::Type::NUM, "height", "The block height"},
                     {RPCResult::Type::BOOL, "chainlock", "Chainlock status for the block containing the transaction"},
+                    {RPCResult::Type::BOOL, "mempool", "Mempool status for the transaction"},
                 }},
             }
         },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -317,7 +317,7 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         int height{-1};
         bool chainLock{false};
 
-        auto tx_ref = GetTransaction(nullptr, node.mempool.get(), txid, Params().GetConsensus(), hash_block);
+        const auto tx_ref = GetTransaction(nullptr, node.mempool.get(), txid, Params().GetConsensus(), hash_block);
 
         if (tx_ref == nullptr) {
             UniValue r(UniValue::VNULL);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -320,8 +320,10 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         const auto tx_ref = GetTransaction(nullptr, node.mempool.get(), txid, Params().GetConsensus(), hash_block);
 
         if (tx_ref == nullptr) {
-            UniValue r(UniValue::VNULL);
-            result_arr.push_back(r);
+            result.pushKV("height", height);
+            result.pushKV("chainlock", chainLock);
+            result.pushKV("mempool", false);
+            result_arr.push_back(result);
             continue;
         }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -338,6 +338,9 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         if (height != -1) {
             chainLock = llmq_ctx.clhandler->HasChainLock(height, hash_block);
         }
+        else {
+            result.pushKV("mempool", true);
+        }
         result.pushKV("height", height);
         result.pushKV("chainlock", chainLock);
         result_arr.push_back(result);

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -71,10 +71,7 @@ class RPCVerifyChainLockTest(DashTestFramework):
 
         tx3 = node0.sendtoaddress(node0.getnewaddress(), 1)
         locks0 = node0.gettxchainlocks([tx3])
-        self.sync_mempools()
-        locks1 = node1.gettxchainlocks([tx3])
-        assert_equal(locks0, [{'mempool': True, 'height': -1, 'chainlock': False}])
-        assert_equal(locks1, [{'mempool': True, 'height': -1, 'chainlock': False}])
+        assert_equal(locks0, [{'height': -1, 'chainlock': False, 'mempool': True}])
 
 if __name__ == '__main__':
     RPCVerifyChainLockTest().main()

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -71,7 +71,8 @@ class RPCVerifyChainLockTest(DashTestFramework):
 
         tx3 = node0.sendtoaddress(node0.getnewaddress(), 1)
         locks0 = node0.gettxchainlocks([tx3])
-        locks1 = node0.gettxchainlocks([tx3])
+        self.sync_mempools()
+        locks1 = node1.gettxchainlocks([tx3])
         assert_equal(locks0, [{'mempool': True, 'height': -1, 'chainlock': False}])
         assert_equal(locks1, [{'mempool': True, 'height': -1, 'chainlock': False}])
 

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -22,6 +22,9 @@ class RPCVerifyChainLockTest(DashTestFramework):
         self.set_dash_test_params(5, 3, [["-whitelist=127.0.0.1"], [], [], [], []], fast_dip3_enforcement=True)
         self.set_dash_llmq_test_params(3, 2)
 
+    def cl_helper(self, height, chainlock, mempool):
+        return {'height': height, 'chainlock': chainlock, 'mempool': mempool}
+
     def run_test(self):
         node0 = self.nodes[0]
         node1 = self.nodes[1]
@@ -63,15 +66,12 @@ class RPCVerifyChainLockTest(DashTestFramework):
         height1 = node1.getblockcount()
         tx0 = node0.getblock(node0.getbestblockhash())['tx'][0]
         tx1 = node1.getblock(node1.getbestblockhash())['tx'][0]
-        locks0 = node0.gettxchainlocks([tx0, tx1])
-        locks1 = node1.gettxchainlocks([tx0, tx1])
-        unknown_cl_helper = {'height': -1, 'chainlock': False, 'mempool': False}
-        assert_equal(locks0, [{'mempool': False, 'height': height, 'chainlock': True}, unknown_cl_helper])
-        assert_equal(locks1, [unknown_cl_helper, {'mempool': False, 'height': height1, 'chainlock': False}])
-
-        tx3 = node0.sendtoaddress(node0.getnewaddress(), 1)
-        locks0 = node0.gettxchainlocks([tx3])
-        assert_equal(locks0, [{'height': -1, 'chainlock': False, 'mempool': True}])
+        tx2 = node0.sendtoaddress(node0.getnewaddress(), 1)
+        locks0 = node0.gettxchainlocks([tx0, tx1, tx2])
+        locks1 = node1.gettxchainlocks([tx0, tx1, tx2])
+        unknown_cl_helper = self.cl_helper(-1, False, False)
+        assert_equal(locks0, [self.cl_helper(height, True, False), unknown_cl_helper, self.cl_helper(-1, False, True)])
+        assert_equal(locks1, [unknown_cl_helper, self.cl_helper(height1, False, False), unknown_cl_helper])
 
 if __name__ == '__main__':
     RPCVerifyChainLockTest().main()

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -65,7 +65,7 @@ class RPCVerifyChainLockTest(DashTestFramework):
         tx1 = node1.getblock(node1.getbestblockhash())['tx'][0]
         locks0 = node0.gettxchainlocks([tx0, tx1])
         locks1 = node1.gettxchainlocks([tx0, tx1])
-        unknown_cl_helper = None
+        unknown_cl_helper = {'height': -1, 'chainlock': False, 'mempool': False}
         assert_equal(locks0, [{'height': height, 'chainlock': True}, unknown_cl_helper])
         assert_equal(locks1, [unknown_cl_helper, {'height': height1, 'chainlock': False}])
 

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -66,9 +66,14 @@ class RPCVerifyChainLockTest(DashTestFramework):
         locks0 = node0.gettxchainlocks([tx0, tx1])
         locks1 = node1.gettxchainlocks([tx0, tx1])
         unknown_cl_helper = {'height': -1, 'chainlock': False, 'mempool': False}
-        assert_equal(locks0, [{'height': height, 'chainlock': True}, unknown_cl_helper])
-        assert_equal(locks1, [unknown_cl_helper, {'height': height1, 'chainlock': False}])
+        assert_equal(locks0, [{'mempool': False, 'height': height, 'chainlock': True}, unknown_cl_helper])
+        assert_equal(locks1, [unknown_cl_helper, {'mempool': False, 'height': height1, 'chainlock': False}])
 
+        tx3 = node0.sendtoaddress(node0.getnewaddress(), 1)
+        locks0 = node0.gettxchainlocks([tx3])
+        locks1 = node0.gettxchainlocks([tx3])
+        assert_equal(locks0, [{'mempool': True, 'height': -1, 'chainlock': False}])
+        assert_equal(locks1, [{'mempool': True, 'height': -1, 'chainlock': False}])
 
 if __name__ == '__main__':
     RPCVerifyChainLockTest().main()

--- a/test/functional/rpc_verifychainlock.py
+++ b/test/functional/rpc_verifychainlock.py
@@ -65,7 +65,7 @@ class RPCVerifyChainLockTest(DashTestFramework):
         tx1 = node1.getblock(node1.getbestblockhash())['tx'][0]
         locks0 = node0.gettxchainlocks([tx0, tx1])
         locks1 = node1.gettxchainlocks([tx0, tx1])
-        unknown_cl_helper = {'height': -1, 'chainlock': False}
+        unknown_cl_helper = None
         assert_equal(locks0, [{'height': height, 'chainlock': True}, unknown_cl_helper])
         assert_equal(locks1, [unknown_cl_helper, {'height': height1, 'chainlock': False}])
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Platform (in the scope of Withdrawals) need to be aware if a tx isn't in mempool when requesting status of a tx using RPC `gettxchainlocks`.
cc @markin-io

## What was done?

- mempool is passed to `GetTransaction` and saving the result for checking latter.
- If the returned tx_ref is nullptr, then the RPC returns null for the corresponding tx in the array. 

Example: 
`tx1` is mined and chainlocked, `tx2` is in mempool and `tx3` doesn't exist.
The result now is:
`[
  {
    "height": 830,
    "chainlock": false,
    "mempool": true
  },
  {
    "height": -1,
    "chainlock": false,
    "mempool": true
  },
  {
    "height": -1,
    "chainlock": false,
    "mempool": false
  }
]`

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

