### PR TITLE
refactor: pull libbitcoin_server code out of wallet code 3/N

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -141,6 +141,8 @@ public:
     //! Check if block is chainlocked.
     virtual bool hasChainLock(int height, const uint256& hash) = 0;
 
+    //! Return list of MN Collateral from outputs
+    virtual std::vector<COutPoint> listMNCollaterials(const std::vector<std::pair<const CTransactionRef&, unsigned int>>& outputs) = 0;
     //! Return whether node has the block and optionally return block metadata
     //! or contents.
     virtual bool findBlock(const uint256& hash, const FoundBlock& block={}) = 0;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -135,6 +135,9 @@ public:
     //! Check if transaction will be final given chain height current time.
     virtual bool checkFinalTx(const CTransaction& tx) = 0;
 
+    //! Check if transaction is locked by InstantSendManager
+    virtual bool isInstantSendLockedTx(const uint256& hash) = 0;
+
     //! Return whether node has the block and optionally return block metadata
     //! or contents.
     virtual bool findBlock(const uint256& hash, const FoundBlock& block={}) = 0;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -138,6 +138,9 @@ public:
     //! Check if transaction is locked by InstantSendManager
     virtual bool isInstantSendLockedTx(const uint256& hash) = 0;
 
+    //! Check if block is chainlocked.
+    virtual bool hasChainLock(int height, const uint256& hash) = 0;
+
     //! Return whether node has the block and optionally return block metadata
     //! or contents.
     virtual bool findBlock(const uint256& hash, const FoundBlock& block={}) = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -16,6 +16,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <interfaces/wallet.h>
+#include <llmq/chainlocks.h>
 #include <llmq/context.h>
 #include <llmq/instantsend.h>
 #include <mapport.h>
@@ -720,6 +721,11 @@ public:
     {
         if (m_node.llmq_ctx == nullptr || m_node.llmq_ctx->isman == nullptr) return false;
         return m_node.llmq_ctx->isman->IsLocked(hash);
+    }
+    bool hasChainLock(int height, const uint256& hash) override
+    {
+        if (m_node.llmq_ctx == nullptr || m_node.llmq_ctx->clhandler == nullptr) return false;
+        return m_node.llmq_ctx->clhandler->HasChainLock(height, hash);
     }
     bool findBlock(const uint256& hash, const FoundBlock& block) override
     {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -16,6 +16,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <interfaces/wallet.h>
+#include <llmq/context.h>
 #include <llmq/instantsend.h>
 #include <mapport.h>
 #include <masternode/sync.h>
@@ -714,6 +715,11 @@ public:
         LOCK(cs_main);
         assert(std::addressof(::ChainActive()) == std::addressof(m_node.chainman->ActiveChain()));
         return CheckFinalTx(m_node.chainman->ActiveChain().Tip(), tx);
+    }
+    bool isInstantSendLockedTx(const uint256& hash) override
+    {
+        if (m_node.llmq_ctx == nullptr || m_node.llmq_ctx->isman == nullptr) return false;
+        return m_node.llmq_ctx->isman->IsLocked(hash);
     }
     bool findBlock(const uint256& hash, const FoundBlock& block) override
     {

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -8,7 +8,6 @@
 #include <util/system.h>
 #include <util/moneystr.h>
 
-#include <llmq/instantsend.h>
 #include <coinjoin/coinjoin.h>
 
 #include <optional>
@@ -391,18 +390,9 @@ std::vector<CInputCoin>::iterator OutputGroup::Discard(const CInputCoin& output)
     return m_outputs.erase(it);
 }
 
-bool OutputGroup::IsLockedByInstantSend() const
+bool OutputGroup::EligibleForSpending(const CoinEligibilityFilter& eligibility_filter, bool isISLocked) const
 {
-    for (const auto& output : m_outputs) {
-        if (!llmq::quorumInstantSendManager->IsLocked(output.outpoint.hash))
-            return false;
-    }
-    return true;
-}
-
-bool OutputGroup::EligibleForSpending(const CoinEligibilityFilter& eligibility_filter) const
-{
-    return (m_depth >= (m_from_me ? eligibility_filter.conf_mine : eligibility_filter.conf_theirs) || IsLockedByInstantSend())
+    return (m_depth >= (m_from_me ? eligibility_filter.conf_mine : eligibility_filter.conf_theirs) || isISLocked)
         && m_ancestors <= eligibility_filter.max_ancestors
         && m_descendants <= eligibility_filter.max_descendants;
 }

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -94,8 +94,7 @@ struct OutputGroup
     }
     void Insert(const CInputCoin& output, int depth, bool from_me, size_t ancestors, size_t descendants);
     std::vector<CInputCoin>::iterator Discard(const CInputCoin& output);
-    bool IsLockedByInstantSend() const;
-    bool EligibleForSpending(const CoinEligibilityFilter& eligibility_filter) const;
+    bool EligibleForSpending(const CoinEligibilityFilter& eligibility_filter, bool isISLocked) const;
 
     //! Update the OutputGroup's fee, long_term_fee, and effective_value based on the given feerates
     void SetFees(const CFeeRate effective_feerate, const CFeeRate long_term_feerate);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -638,7 +638,7 @@ UniValue importelectrumwallet(const JSONRPCRequest& request)
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
 
-    if (fPruneMode)
+    if (pwallet->chain().havePruned())
         throw JSONRPCError(RPC_WALLET_ERROR, "Importing wallets is disabled in pruned mode");
 
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -40,7 +40,6 @@
 #include <coinjoin/client.h>
 #include <coinjoin/options.h>
 #include <llmq/chainlocks.h>
-#include <llmq/instantsend.h>
 
 #include <stdint.h>
 
@@ -158,7 +157,7 @@ WalletContext& EnsureWalletContext(const CoreContext& context)
 static void WalletTxToJSON(interfaces::Chain& chain, const CWalletTx& wtx, UniValue& entry)
 {
     int confirms = wtx.GetDepthInMainChain();
-    bool fLocked = llmq::quorumInstantSendManager->IsLocked(wtx.GetHash());
+    bool fLocked = chain.isInstantSendLockedTx(wtx.GetHash());
     bool chainlock = false;
     if (confirms > 0) {
         chainlock = wtx.IsChainLocked();

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1460,7 +1460,6 @@ bool LegacyScriptPubKeyMan::TopUpInner(unsigned int kpSize)
                     m_storage.UpdateProgress(strMsg, static_cast<int>(dProgress));
                 }
             }
-            if (ShutdownRequested()) break;
         }
         WalletLogPrintf("Keypool added %d keys, size=%u (%u internal)\n",
                   current_index + 1, setInternalKeyPool.size() + setExternalKeyPool.size(), setInternalKeyPool.size());

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -8,7 +8,6 @@
 #include <script/descriptor.h>
 #include <script/sign.h>
 #include <shutdown.h>
-#include <ui_interface.h>
 #include <util/bip32.h>
 #include <util/strencodings.h>
 #include <util/system.h>
@@ -1437,7 +1436,7 @@ bool LegacyScriptPubKeyMan::TopUpInner(unsigned int kpSize)
         int64_t progress_report_time = GetTime();
         WalletLogPrintf("%s\n", strMsg);
         if (should_show_progress) {
-            uiInterface.ShowProgress(strMsg, 0, false);
+            m_storage.UpdateProgress(strMsg, 0);
         }
 
         bool fInternal = false;
@@ -1458,7 +1457,7 @@ bool LegacyScriptPubKeyMan::TopUpInner(unsigned int kpSize)
                 progress_report_time = GetTime();
                 WalletLogPrintf("Still topping up. At key %lld. Progress=%f\n", current_index, dProgress);
                 if (should_show_progress) {
-                    uiInterface.ShowProgress(strMsg, static_cast<int>(dProgress), false);
+                    m_storage.UpdateProgress(strMsg, static_cast<int>(dProgress));
                 }
             }
             if (ShutdownRequested()) break;
@@ -1466,7 +1465,7 @@ bool LegacyScriptPubKeyMan::TopUpInner(unsigned int kpSize)
         WalletLogPrintf("Keypool added %d keys, size=%u (%u internal)\n",
                   current_index + 1, setInternalKeyPool.size() + setExternalKeyPool.size(), setInternalKeyPool.size());
         if (should_show_progress) {
-            uiInterface.ShowProgress("", 100, false);
+            m_storage.UpdateProgress("", 100);
         }
     }
     NotifyCanGetAddressesChanged();

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -39,6 +39,9 @@ public:
     virtual bool HasEncryptionKeys() const = 0;
     virtual bool IsLocked(bool fForMixing = false) const = 0;
 
+    // for LegacyScriptPubKeyMan::TopUpInner needs:
+    virtual void UpdateProgress(const std::string&, int) = 0;
+
     // methods below are unique from Dash due to different implementation of HD
     virtual void NewKeyPoolCallback() = 0;
     virtual void KeepDestinationCallback(bool erased) = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -52,8 +52,6 @@
 
 #include <evo/providertx.h>
 
-#include <llmq/instantsend.h>
-#include <llmq/chainlocks.h>
 #include <assert.h>
 
 using interfaces::FoundBlock;
@@ -5155,7 +5153,7 @@ bool CWalletTx::IsChainLocked() const
         bool active;
         int height;
         if (pwallet->chain().findBlock(m_confirm.hashBlock, FoundBlock().inActiveChain(active).height(height)) && active) {
-            fIsChainlocked = llmq::chainLocksHandler->HasChainLock(height, m_confirm.hashBlock);
+            fIsChainlocked = pwallet->chain().hasChainLock(height, m_confirm.hashBlock);
         }
     }
     return fIsChainlocked;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -44,14 +44,14 @@
 
 #include <coinjoin/client.h>
 #include <coinjoin/options.h>
+#include <evo/providertx.h>
 #include <governance/governance.h>
 #include <evo/deterministicmns.h>
 #include <masternode/sync.h>
 
 #include <univalue.h>
 
-#include <evo/providertx.h>
-
+#include <algorithm>
 #include <assert.h>
 
 using interfaces::FoundBlock;
@@ -2720,10 +2720,9 @@ struct CompareByPriority
 
 static bool isGroupISLocked(const OutputGroup& group, interfaces::Chain& chain)
 {
-    for (const auto& output : group.m_outputs) {
-        if (!chain.isInstantSendLockedTx(output.outpoint.hash)) return false;
-    }
-    return true;
+    return std::all_of(group.m_outputs.begin(), group.m_outputs.end(), [&chain](const auto& output) {
+        return chain.isInstantSendLockedTx(output.outpoint.hash);
+    });
 }
 
 bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, std::vector<OutputGroup> groups,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4299,18 +4299,17 @@ void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts) const
 
 void CWallet::ListProTxCoins(std::vector<COutPoint>& vOutpts) const
 {
-    auto mnList = deterministicMNManager->GetListAtChainTip();
+    std::vector<std::pair<const CTransactionRef&, unsigned int>> outputs;
 
     AssertLockHeld(cs_wallet);
     for (const auto &o : setWalletUTXO) {
         auto it = mapWallet.find(o.hash);
         if (it != mapWallet.end()) {
-            const auto &p = it->second;
-            if (CDeterministicMNManager::IsProTxWithCollateral(p.tx, o.n) || mnList.HasMNByCollateral(o)) {
-                vOutpts.emplace_back(o);
-            }
+            const auto &ptx = it->second;
+            outputs.emplace_back(ptx.tx, o.n);
         }
     }
+    vOutpts = m_chain->listMNCollaterials(outputs);
 }
 
 /** @} */ // end of Actions

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -884,7 +884,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const CWalletTx::Confirmatio
         for(unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
             if (IsMine(wtx.tx->vout[i]) && !IsSpent(hash, i)) {
                 setWalletUTXO.insert(COutPoint(hash, i));
-                if (deterministicMNManager->IsProTxWithCollateral(wtx.tx, i) || mnList.HasMNByCollateral(COutPoint(hash, i))) {
+                if (CDeterministicMNManager::IsProTxWithCollateral(wtx.tx, i) || mnList.HasMNByCollateral(COutPoint(hash, i))) {
                     LockCoin(COutPoint(hash, i));
                 }
             }
@@ -909,7 +909,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const CWalletTx::Confirmatio
         for (unsigned int i = 0; i < wtx.tx->vout.size(); ++i) {
             if (IsMine(wtx.tx->vout[i]) && !IsSpent(hash, i)) {
                 bool new_utxo = setWalletUTXO.insert(COutPoint(hash, i)).second;
-                if (new_utxo && (deterministicMNManager->IsProTxWithCollateral(wtx.tx, i) || mnList.HasMNByCollateral(COutPoint(hash, i)))) {
+                if (new_utxo && (CDeterministicMNManager::IsProTxWithCollateral(wtx.tx, i) || mnList.HasMNByCollateral(COutPoint(hash, i)))) {
                     LockCoin(COutPoint(hash, i));
                 }
                 fUpdated |= new_utxo;
@@ -3869,7 +3869,7 @@ void CWallet::AutoLockMasternodeCollaterals()
     for (const auto& pair : mapWallet) {
         for (unsigned int i = 0; i < pair.second.tx->vout.size(); ++i) {
             if (IsMine(pair.second.tx->vout[i]) && !IsSpent(pair.first, i)) {
-                if (deterministicMNManager->IsProTxWithCollateral(pair.second.tx, i) || mnList.HasMNByCollateral(COutPoint(pair.first, i))) {
+                if (CDeterministicMNManager::IsProTxWithCollateral(pair.second.tx, i) || mnList.HasMNByCollateral(COutPoint(pair.first, i))) {
                     LockCoin(COutPoint(pair.first, i));
                 }
             }
@@ -4306,7 +4306,7 @@ void CWallet::ListProTxCoins(std::vector<COutPoint>& vOutpts) const
         auto it = mapWallet.find(o.hash);
         if (it != mapWallet.end()) {
             const auto &p = it->second;
-            if (deterministicMNManager->IsProTxWithCollateral(p.tx, o.n) || mnList.HasMNByCollateral(o)) {
+            if (CDeterministicMNManager::IsProTxWithCollateral(p.tx, o.n) || mnList.HasMNByCollateral(o)) {
                 vOutpts.emplace_back(o);
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5501,3 +5501,8 @@ bool CWallet::GenerateNewHDChainEncrypted(const SecureString& secureMnemonic, co
 
     return false;
 }
+
+void CWallet::UpdateProgress(const std::string& title, int nProgress)
+{
+    ShowProgress(title, nProgress);
+}

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -855,6 +855,8 @@ public:
     bool IsLocked(bool fForMixing = false) const override;
     bool Lock(bool fForMixing = false);
 
+    void UpdateProgress(const std::string& title, int nProgress) override;
+
     std::map<uint256, CWalletTx> mapWallet GUARDED_BY(cs_wallet);
 
     typedef std::multimap<int64_t, CWalletTx*> TxItems;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Wallet library should not depends on server code (libbitcoin_server).

Untie this library will help to finish backport bitcoin#15639 and will unblock multiprocess: bitcoin#18677

Prior work:
 - https://github.com/dashpay/dash/pull/4560 (1/N)
 - https://github.com/dashpay/dash/pull/5178/ (2/N)


## What was done?
 - using `havePruned` from interface instead direct `fPrune`
 - removed dependency scriptpubkeyman on `uiInterface`
 - removed usage `fShutdown` from scriptpubkeyman
 - usages `llmq::quorumInstantSendManager`/`llmq::chainLocksHandler` are wrapper in interface
 - dropped direct usages of `deterministicMNManager` from wallet code

## How Has This Been Tested?

Amount of linkage errors is decreased from 196 to 141 if `libbitcoin_server` is excluded during linkage:
```
diff --git a/src/Makefile.am b/src/Makefile.am
index fb4850429f..c9c9c331a7 100644
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -865,9 +865,7 @@ endif
 # https://eli.thegreenplace.net/2013/07/09/library-order-in-static-linking#circular-dependency)
 dash_wallet_LDADD = \
   $(LIBBITCOIN_WALLET_TOOL) \
-  $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_WALLET) \
-  $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_CONSENSUS) \
   $(LIBBITCOIN_UTIL) \
```


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

