### PR TITLE
fix: avoid a crash on -reindex-chainstate

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2112,6 +2112,10 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                             LogPrintf("%s: bls_legacy_scheme=%d\n", __func__, bls::bls_legacy_scheme.load());
                         }
 
+                        if (args.GetArg("-checklevel", DEFAULT_CHECKLEVEL) >= 3) {
+                            chainstate->ResetBlockFailureFlags(nullptr);
+                        }
+
                     } else {
                         // TODO: CEvoDB instance should probably be a part of CChainState
                         // (for multiple chainstates to actually work in parallel)
@@ -2122,10 +2126,6 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                             failed_verification = true;
                             break;
                         }
-                    }
-
-                    if (args.GetArg("-checklevel", DEFAULT_CHECKLEVEL) >= 3) {
-                        ::ChainstateActive().ResetBlockFailureFlags(nullptr);
                     }
                 }
             } catch (const std::exception& e) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Avoid a crash on -reindex-chainstate.

## What was done?
`ResetBlockFailureFlags` is crashing when `m_chain.Tip()` is null. Call `ResetBlockFailureFlags` inside `if (!is_coinsview_empty(chainstate)) {...}` block - we know `m_chain.Tip()` is not null there.

## How Has This Been Tested?
Try running a  node with `-reindex-chainstate` cmd-line param w/ and w/out this patch.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

