### PR TITLE
fix: actually use `to_calculate` stack in `CMNHFManager::GetForBlock`

### DIFF
--- a/src/evo/mnhftx.cpp
+++ b/src/evo/mnhftx.cpp
@@ -278,12 +278,13 @@ CMNHFManager::Signals CMNHFManager::GetForBlock(const CBlockIndex* pindex)
 
     const Consensus::Params& consensusParams{Params().GetConsensus()};
     while (!to_calculate.empty()) {
+        const CBlockIndex* pindex_top{to_calculate.top()};
         CBlock block;
-        if (!ReadBlockFromDisk(block, pindex, consensusParams)) {
+        if (!ReadBlockFromDisk(block, pindex_top, consensusParams)) {
             throw std::runtime_error("failed-getehfforblock-read");
         }
         BlockValidationState state;
-        signalsTmp = ProcessBlock(block, pindex, false, state);
+        signalsTmp = ProcessBlock(block, pindex_top, false, state);
         if (!signalsTmp.has_value()) {
             LogPrintf("%s: process block failed due to %s\n", __func__, state.ToString());
             throw std::runtime_error("failed-getehfforblock-construct");


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes a bug we missed in #5736

## What was done?
Use all collected indexes, not just the last one

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

