### PR TITLE
refactor: drop usages of llmq/utils to check if hard-fork is active

### DIFF
--- a/src/deploymentstatus.h
+++ b/src/deploymentstatus.h
@@ -52,4 +52,10 @@ inline bool DeploymentEnabled(const Consensus::Params& params, Consensus::Deploy
     return params.vDeployments[dep].nTimeout != 0;
 }
 
+/** this function is convenient helper for DIP0003 because 'active' and 'enforced' are different statuses for DIP0003 */
+constexpr bool DeploymentDIP0003Enforced(const int nHeight, const Consensus::Params& params)
+{
+    return nHeight >= params.DIP0003EnforcementHeight;
+}
+
 #endif // BITCOIN_DEPLOYMENTSTATUS_H

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -16,6 +16,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/merkle.h>
+#include <deploymentstatus.h>
 #include <validation.h>
 
 bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidationState& state)
@@ -42,12 +43,12 @@ bool CheckCbTx(const CTransaction& tx, const CBlockIndex* pindexPrev, TxValidati
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-height");
         }
 
-        bool fDIP0008Active = pindexPrev->nHeight >= Params().GetConsensus().DIP0008Height;
+        const bool fDIP0008Active{DeploymentActiveAt(*pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0008)};
         if (fDIP0008Active && cbTx.nVersion < CCbTx::Version::MERKLE_ROOT_QUORUMS) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
         }
 
-        bool isV20 = llmq::utils::IsV20Active(pindexPrev);
+        const bool isV20{DeploymentActiveAfter(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_V20)};
         if ((isV20 && cbTx.nVersion < CCbTx::Version::CLSIG_AND_BALANCE) || (!isV20 && cbTx.nVersion >= CCbTx::Version::CLSIG_AND_BALANCE)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cbtx-version");
         }

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -218,16 +218,16 @@ CCreditPoolManager::CCreditPoolManager(CEvoDB& _evoDb)
 {
 }
 
-CCreditPoolDiff::CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindex, const Consensus::Params& consensusParams, const CAmount blockSubsidy) :
+CCreditPoolDiff::CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindexPrev, const Consensus::Params& consensusParams, const CAmount blockSubsidy) :
     pool(std::move(starter)),
-    pindex(pindex),
+    pindexPrev(pindexPrev),
     params(consensusParams)
 {
-    assert(pindex);
+    assert(pindexPrev);
 
-    if (llmq::utils::IsMNRewardReallocationActive(pindex)) {
+    if (llmq::utils::IsMNRewardReallocationActive(pindexPrev)) {
         // We consider V20 active if mn_rr is active
-        platformReward = MasternodePayments::PlatformShare(GetMasternodePayment(pindex->nHeight, blockSubsidy, /*fV20Active=*/ true));
+        platformReward = MasternodePayments::PlatformShare(GetMasternodePayment(pindexPrev->nHeight + 1, blockSubsidy, /*fV20Active=*/ true));
     }
 }
 
@@ -274,7 +274,7 @@ bool CCreditPoolDiff::ProcessLockUnlockTransaction(const CTransaction& tx, TxVal
     if (tx.nVersion != 3) return true;
     if (tx.nType != TRANSACTION_ASSET_LOCK && tx.nType != TRANSACTION_ASSET_UNLOCK) return true;
 
-    if (!CheckAssetLockUnlockTx(tx, pindex, pool.indexes, state)) {
+    if (!CheckAssetLockUnlockTx(tx, pindexPrev, pool.indexes, state)) {
         // pass the state returned by the function above
         return false;
     }

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -70,10 +70,10 @@ private:
     CAmount sessionUnlocked{0};
     CAmount platformReward{0};
 
-    const CBlockIndex *pindex{nullptr};
+    const CBlockIndex *pindexPrev{nullptr};
     const Consensus::Params& params;
 public:
-    explicit CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindex,
+    explicit CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindexPrev,
                              const Consensus::Params& consensusParams,
                              const CAmount blockSubsidy);
 

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -128,7 +128,7 @@ public:
     CCreditPool GetCreditPool(const CBlockIndex* block, const Consensus::Params& consensusParams);
 
 private:
-    std::optional<CCreditPool> GetFromCache(const CBlockIndex* const block_index);
+    std::optional<CCreditPool> GetFromCache(const CBlockIndex& block_index);
     void AddToCache(const uint256& block_hash, int height, const CCreditPool& pool);
 
     CCreditPool ConstructCreditPool(const CBlockIndex* block_index, CCreditPool prev, const Consensus::Params& consensusParams);

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1118,11 +1118,6 @@ bool CDeterministicMNManager::IsProTxWithCollateral(const CTransactionRef& tx, u
     return true;
 }
 
-bool CDeterministicMNManager::IsDIP3Enforced(int nHeight)
-{
-    return nHeight >= Params().GetConsensus().DIP0003EnforcementHeight;
-}
-
 void CDeterministicMNManager::CleanupCache(int nHeight)
 {
     AssertLockHeld(cs);
@@ -1612,7 +1607,7 @@ bool CheckProRegTx(const CTransaction& tx, gsl::not_null<const CBlockIndex*> pin
             }
         }
 
-        if (!deterministicMNManager->IsDIP3Enforced(pindexPrev->nHeight)) {
+        if (!DeploymentDIP0003Enforced(pindexPrev->nHeight, Params().GetConsensus())) {
             if (ptx.keyIDOwner != ptx.keyIDVoting) {
                 return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-key-not-same");
             }
@@ -1749,7 +1744,7 @@ bool CheckProUpRegTx(const CTransaction& tx, gsl::not_null<const CBlockIndex*> p
         }
     }
 
-    if (!deterministicMNManager->IsDIP3Enforced(pindexPrev->nHeight)) {
+    if (!DeploymentDIP0003Enforced(pindexPrev->nHeight, Params().GetConsensus())) {
         if (dmn->pdmnState->keyIDOwner != ptx.keyIDVoting) {
             return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-key-not-same");
         }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1120,16 +1120,6 @@ bool CDeterministicMNManager::IsProTxWithCollateral(const CTransactionRef& tx, u
 
 bool CDeterministicMNManager::IsDIP3Enforced(int nHeight)
 {
-    if (nHeight == -1) {
-        LOCK(cs);
-        if (tipIndex == nullptr) {
-            // Since EnforcementHeight can be set to block 1, we shouldn't just return false here
-            nHeight = 1;
-        } else {
-            nHeight = tipIndex->nHeight;
-        }
-    }
-
     return nHeight >= Params().GetConsensus().DIP0003EnforcementHeight;
 }
 

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -178,14 +178,14 @@ static bool CompareByLastPaid(const CDeterministicMN* _a, const CDeterministicMN
     return CompareByLastPaid(*_a, *_b);
 }
 
-CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(gsl::not_null<const CBlockIndex*> pIndex) const
+CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(gsl::not_null<const CBlockIndex*> pindexPrev) const
 {
     if (mnMap.size() == 0) {
         return nullptr;
     }
 
-    bool isv19Active = llmq::utils::IsV19Active(pIndex);
-    bool isMNRewardReallocation = llmq::utils::IsMNRewardReallocationActive(pIndex);
+    bool isv19Active = llmq::utils::IsV19Active(pindexPrev);
+    bool isMNRewardReallocation = llmq::utils::IsMNRewardReallocationActive(pindexPrev);
     // Starting from v19 and until MNRewardReallocation (Platform release), EvoNodes will be rewarded 4 blocks in a row
     CDeterministicMNCPtr best = nullptr;
     if (isv19Active && !isMNRewardReallocation) {
@@ -214,7 +214,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNPayee(gsl::not_null<const CBlock
     return best;
 }
 
-std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(gsl::not_null<const CBlockIndex* const> pindex, int nCount) const
+std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(gsl::not_null<const CBlockIndex* const> pindexPrev, int nCount) const
 {
     if (nCount < 0 ) {
         return {};
@@ -227,7 +227,7 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNList::GetProjectedMNPayees(gsl
 
     int remaining_evo_payments{0};
     CDeterministicMNCPtr evo_to_be_skipped{nullptr};
-    const bool isMNRewardReallocation = llmq::utils::IsMNRewardReallocationActive(pindex);
+    const bool isMNRewardReallocation = llmq::utils::IsMNRewardReallocationActive(pindexPrev);
     if (!isMNRewardReallocation) {
         ForEachMNShared(true, [&](const CDeterministicMNCPtr& dmn) {
             if (dmn->pdmnState->nLastPaidHeight == nHeight) {

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -622,7 +622,7 @@ public:
     // Test if given TX is a ProRegTx which also contains the collateral at index n
     static bool IsProTxWithCollateral(const CTransactionRef& tx, uint32_t n);
 
-    bool IsDIP3Enforced(int nHeight = -1) LOCKS_EXCLUDED(cs);
+    bool IsDIP3Enforced(int nHeight);
 
     bool MigrateDBIfNeeded();
     bool MigrateDBIfNeeded2();

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -340,7 +340,7 @@ public:
     [[nodiscard]] CDeterministicMNCPtr GetValidMNByCollateral(const COutPoint& collateralOutpoint) const;
     [[nodiscard]] CDeterministicMNCPtr GetMNByService(const CService& service) const;
     [[nodiscard]] CDeterministicMNCPtr GetMNByInternalId(uint64_t internalId) const;
-    [[nodiscard]] CDeterministicMNCPtr GetMNPayee(gsl::not_null<const CBlockIndex*> pIndex) const;
+    [[nodiscard]] CDeterministicMNCPtr GetMNPayee(gsl::not_null<const CBlockIndex*> pindexPrev) const;
 
     /**
      * Calculates the projected MN payees for the next *count* blocks. The result is not guaranteed to be correct
@@ -348,7 +348,7 @@ public:
      * @param nCount the number of payees to return. "nCount = max()"" means "all", use it to avoid calling GetValidWeightedMNsCount twice.
      * @return
      */
-    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(gsl::not_null<const CBlockIndex* const> pindex, int nCount = std::numeric_limits<int>::max()) const;
+    [[nodiscard]] std::vector<CDeterministicMNCPtr> GetProjectedMNPayees(gsl::not_null<const CBlockIndex* const> pindexPrev, int nCount = std::numeric_limits<int>::max()) const;
 
     /**
      * Calculate a quorum based on the modifier. The resulting list is deterministically sorted by score

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -622,8 +622,6 @@ public:
     // Test if given TX is a ProRegTx which also contains the collateral at index n
     static bool IsProTxWithCollateral(const CTransactionRef& tx, uint32_t n);
 
-    bool IsDIP3Enforced(int nHeight);
-
     bool MigrateDBIfNeeded();
     bool MigrateDBIfNeeded2();
 

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -6,11 +6,11 @@
 
 #include <evo/cbtx.h>
 #include <core_io.h>
+#include <deploymentstatus.h>
 #include <evo/deterministicmns.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/commitment.h>
 #include <llmq/quorums.h>
-#include <llmq/utils.h>
 #include <node/blockstorage.h>
 #include <evo/specialtx.h>
 
@@ -363,7 +363,7 @@ bool BuildSimplifiedMNListDiff(const uint256& baseBlockHash, const uint256& bloc
         return false;
     }
 
-    if (llmq::utils::IsV20Active(blockIndex)) {
+    if (DeploymentActiveAfter(blockIndex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20)) {
         if (!mnListDiffRet.BuildQuorumChainlockInfo(blockIndex)) {
             errorRet = strprintf("failed to build quorums chainlocks info");
             return false;

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <deploymentstatus.h>
 #include <evo/cbtx.h>
 #include <evo/creditpool.h>
 #include <evo/deterministicmns.h>
@@ -276,7 +277,7 @@ bool CheckCreditPoolDiffForBlock(const CBlock& block, const CBlockIndex* pindex,
                                 const CAmount blockSubsidy, BlockValidationState& state)
 {
     try {
-        if (!llmq::utils::IsV20Active(pindex)) return true;
+        if (!DeploymentActiveAt(*pindex, consensusParams, Consensus::DEPLOYMENT_V20)) return true;
 
         auto creditPoolDiff = GetCreditPoolDiffForBlock(block, pindex->pprev, consensusParams, blockSubsidy, state);
         if (!creditPoolDiff.has_value()) return false;

--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -7,9 +7,9 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <core_io.h>
+#include <deploymentstatus.h>
 #include <governance/governance.h>
 #include <key_io.h>
-#include <llmq/utils.h>
 #include <primitives/transaction.h>
 #include <script/standard.h>
 #include <util/moneystr.h>
@@ -496,13 +496,13 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
     const CBlockIndex* pindex = ::ChainActive().Tip();
     if (pindex->nHeight > nBlockHeight) pindex = pindex->GetAncestor(nBlockHeight);
 
-    const auto v20_state = llmq::utils::GetV20State(pindex);
+    const auto v20_state = g_versionbitscache.State(pindex, consensusParams, Consensus::DEPLOYMENT_V20);
     bool fV20Active{v20_state == ThresholdState::ACTIVE};
     if (!fV20Active && nBlockHeight > pindex->nHeight) {
         // If fV20Active isn't active yet and nBlockHeight refers to a future SuperBlock
         // then we need to check if the fork is locked_in and see if it will be active by the time of the future SuperBlock
         if (v20_state == ThresholdState::LOCKED_IN) {
-            int activation_height = llmq::utils::GetV20Since(pindex) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize);
+            int activation_height = g_versionbitscache.StateSinceHeight(pindex, consensusParams, Consensus::DEPLOYMENT_V20) + static_cast<int>(Params().GetConsensus().vDeployments[Consensus::DEPLOYMENT_V20].nWindowSize);
             if (nBlockHeight >= activation_height) {
                 fV20Active = true;
             }

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -8,6 +8,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <deploymentstatus.h>
 #include <evo/deterministicmns.h>
 #include <flat-database.h>
 #include <governance/classes.h>
@@ -1461,7 +1462,7 @@ void CGovernanceManager::UpdatedBlockTip(const CBlockIndex* pindex, CConnman& co
     nCachedBlockHeight = pindex->nHeight;
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::UpdatedBlockTip -- nCachedBlockHeight: %d\n", nCachedBlockHeight);
 
-    if (deterministicMNManager->IsDIP3Enforced(pindex->nHeight)) {
+    if (DeploymentDIP0003Enforced(pindex->nHeight, Params().GetConsensus())) {
         RemoveInvalidVotes();
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -18,6 +18,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <context.h>
+#include <deploymentstatus.h>
 #include <node/coinstats.h>
 #include <fs.h>
 #include <hash.h>
@@ -2109,9 +2110,8 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                             failed_verification = true;
                             break;
                         }
-
-                        bool v19active = llmq::utils::IsV19Active(tip);
-                        if (llmq::utils::IsV19Active(tip)) {
+                        const bool v19active{DeploymentActiveAfter(tip, chainparams.GetConsensus(), Consensus::DEPLOYMENT_V19)};
+                        if (v19active) {
                             bls::bls_legacy_scheme.store(false);
                             LogPrintf("%s: bls_legacy_scheme=%d\n", __func__, bls::bls_legacy_scheme.load());
                         }

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -13,6 +13,7 @@
 #include <chainparams.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
+#include <deploymentstatus.h>
 #include <net.h>
 #include <net_processing.h>
 #include <primitives/block.h>
@@ -708,7 +709,7 @@ std::optional<std::vector<CFinalCommitment>> CQuorumBlockProcessor::GetMineableC
     const auto *const pindex = m_chainstate.m_chain.Height() < nHeight ? m_chainstate.m_chain.Tip() : m_chainstate.m_chain.Tip()->GetAncestor(nHeight);
 
     bool rotation_enabled = utils::IsQuorumRotationEnabled(llmqParams, pindex);
-    bool basic_bls_enabled = utils::IsV19Active(pindex);
+    bool basic_bls_enabled{DeploymentActiveAfter(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
     size_t quorums_num = rotation_enabled ? llmqParams.signingActiveQuorumCount : 1;
 
     std::stringstream ss;

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -60,7 +60,6 @@ LLMQContext::~LLMQContext() {
     llmq::chainLocksHandler.reset();
     llmq::quorumManager.reset();
     llmq::quorumBlockProcessor.reset();
-    llmq::llmq_versionbitscache.Clear();
 }
 
 void LLMQContext::Interrupt() {

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -12,6 +12,7 @@
 
 #include <evo/deterministicmns.h>
 
+#include <deploymentstatus.h>
 #include <masternode/node.h>
 #include <chainparams.h>
 #include <net_processing.h>
@@ -168,7 +169,7 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
 {
     curSession = std::make_unique<CDKGSession>(params, blsWorker, dkgManager, dkgDebugManager, connman);
 
-    if (!deterministicMNManager->IsDIP3Enforced(pQuorumBaseBlockIndex->nHeight)) {
+    if (!DeploymentDIP0003Enforced(pQuorumBaseBlockIndex->nHeight, Params().GetConsensus())) {
         return false;
     }
 

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -7,10 +7,10 @@
 #include <llmq/quorums.h>
 #include <llmq/utils.h>
 
-#include <evo/deterministicmns.h>
-
 #include <chainparams.h>
 #include <dbwrapper.h>
+#include <deploymentstatus.h>
+#include <evo/deterministicmns.h>
 #include <net_processing.h>
 #include <spork.h>
 #include <util/irange.h>
@@ -162,7 +162,7 @@ void CDKGSessionManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fIni
 
     if (fInitialDownload)
         return;
-    if (!deterministicMNManager->IsDIP3Enforced(pindexNew->nHeight))
+    if (!DeploymentDIP0003Enforced(pindexNew->nHeight, Params().GetConsensus()))
         return;
     if (!IsQuorumDKGEnabled(spork_manager))
         return;

--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -3,15 +3,16 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <llmq/ehf_signals.h>
-#include <llmq/utils.h>
 #include <llmq/quorums.h>
 #include <llmq/signing_shares.h>
 #include <llmq/commitment.h>
+#include <llmq/utils.h>
 
 #include <evo/mnhftx.h>
 #include <evo/specialtx.h>
 
 #include <consensus/validation.h>
+#include <deploymentstatus.h>
 #include <index/txindex.h> // g_txindex
 #include <primitives/transaction.h>
 #include <spork.h>
@@ -43,7 +44,9 @@ CEHFSignalsHandler::~CEHFSignalsHandler()
 
 void CEHFSignalsHandler::UpdatedBlockTip(const CBlockIndex* const pindexNew)
 {
-    if (!fMasternodeMode || !llmq::utils::IsV20Active(pindexNew) || (Params().IsTestChain() && !sporkman.IsSporkActive(SPORK_24_TEST_EHF))) {
+    if (!DeploymentActiveAfter(pindexNew, Params().GetConsensus(), Consensus::DEPLOYMENT_V20)) return;
+
+    if (!fMasternodeMode || (Params().IsTestChain() && !sporkman.IsSporkActive(SPORK_24_TEST_EHF))) {
         return;
     }
 

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -38,6 +38,11 @@ static bool IsV19Active(gsl::not_null<const CBlockIndex*> pindexPrev)
     return DeploymentActiveAfter(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_V19);
 }
 
+static bool IsV20Active(gsl::not_null<const CBlockIndex*> pindexPrev)
+{
+    return llmq_versionbitscache.State(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_V20) == ThresholdState::ACTIVE;
+}
+
 namespace llmq
 {
 
@@ -684,11 +689,6 @@ bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_n
     }
     // It should activate at least 1 block prior to the cycle start
     return DeploymentActiveAfter(pindex->GetAncestor(cycleQuorumBaseHeight - 1), Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0024);
-}
-
-bool IsV20Active(gsl::not_null<const CBlockIndex*> pindex)
-{
-    return llmq_versionbitscache.State(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20) == ThresholdState::ACTIVE;
 }
 
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2)

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -692,13 +692,6 @@ bool IsV20Active(gsl::not_null<const CBlockIndex*> pindex)
     return llmq_versionbitscache.State(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20) == ThresholdState::ACTIVE;
 }
 
-bool IsMNRewardReallocationActive(gsl::not_null<const CBlockIndex*> pindex)
-{
-    if (!IsV20Active(pindex)) return false;
-
-    return llmq_versionbitscache.State(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_MN_RR) == ThresholdState::ACTIVE;
-}
-
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2)
 {
     // We need to deterministically select who is going to initiate the connection. The naive way would be to simply

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -948,7 +948,7 @@ bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const CQuorumMana
 {
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
-    bool fDIP0024IsActive = optDIP0024IsActive.has_value() ? *optDIP0024IsActive : DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DIP0024);
+    const bool fDIP0024IsActive{optDIP0024IsActive.value_or(DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DIP0024))};
     switch (llmqType)
     {
         case Consensus::LLMQType::LLMQ_DEVNET:
@@ -959,9 +959,8 @@ bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const CQuorumMana
         case Consensus::LLMQType::LLMQ_TEST_INSTANTSEND: {
             if (!fDIP0024IsActive) return true;
 
-            bool fHaveDIP0024Quorums = optHaveDIP0024Quorums.has_value() ? *optHaveDIP0024Quorums
-                                                                         : !qman.ScanQuorums(
-                            consensusParams.llmqTypeDIP0024InstantSend, pindexPrev, 1).empty();
+            const bool fHaveDIP0024Quorums{optHaveDIP0024Quorums.value_or(!qman.ScanQuorums(
+                            consensusParams.llmqTypeDIP0024InstantSend, pindexPrev, 1).empty())};
             return !fHaveDIP0024Quorums;
         }
         case Consensus::LLMQType::LLMQ_TEST:

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -34,6 +34,11 @@ static constexpr int TESTNET_LLMQ_25_67_ACTIVATION_HEIGHT = 847000;
  */
 std::optional<std::pair<CBLSSignature, uint32_t>> GetNonNullCoinbaseChainlock(const CBlockIndex* pindex);
 
+static bool IsV19Active(gsl::not_null<const CBlockIndex*> pindexPrev)
+{
+    return DeploymentActiveAfter(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_V19);
+}
+
 namespace llmq
 {
 
@@ -680,11 +685,6 @@ bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_n
     }
     // It should activate at least 1 block prior to the cycle start
     return DeploymentActiveAfter(pindex->GetAncestor(cycleQuorumBaseHeight - 1), Params().GetConsensus(), Consensus::DEPLOYMENT_DIP0024);
-}
-
-bool IsV19Active(gsl::not_null<const CBlockIndex*> pindex)
-{
-    return pindex->nHeight + 1 >= Params().GetConsensus().V19Height;
 }
 
 bool IsV20Active(gsl::not_null<const CBlockIndex*> pindex)

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -40,13 +40,11 @@ static bool IsV19Active(gsl::not_null<const CBlockIndex*> pindexPrev)
 
 static bool IsV20Active(gsl::not_null<const CBlockIndex*> pindexPrev)
 {
-    return llmq_versionbitscache.State(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_V20) == ThresholdState::ACTIVE;
+    return DeploymentActiveAfter(pindexPrev, Params().GetConsensus(), Consensus::DEPLOYMENT_V20);
 }
 
 namespace llmq
 {
-
-VersionBitsCache llmq_versionbitscache;
 
 namespace utils
 
@@ -953,10 +951,10 @@ bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const CQuorumMana
             return true;
 
         case Consensus::LLMQType::LLMQ_TEST_V17: {
-            return llmq_versionbitscache.State(pindexPrev, consensusParams, Consensus::DEPLOYMENT_TESTDUMMY) == ThresholdState::ACTIVE;
+            return DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
         }
         case Consensus::LLMQType::LLMQ_100_67:
-            return pindexPrev->nHeight + 1 >= consensusParams.DIP0020Height;
+            return DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DIP0020);
 
         case Consensus::LLMQType::LLMQ_60_75:
         case Consensus::LLMQType::LLMQ_DEVNET_DIP0024:

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <optional>
 
+// TODO remove this const
 static constexpr int TESTNET_LLMQ_25_67_ACTIVATION_HEIGHT = 847000;
 
 /**

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -26,7 +26,6 @@
 #include <atomic>
 #include <optional>
 
-// TODO remove this const
 static constexpr int TESTNET_LLMQ_25_67_ACTIVATION_HEIGHT = 847000;
 
 /**

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -699,16 +699,6 @@ bool IsMNRewardReallocationActive(gsl::not_null<const CBlockIndex*> pindex)
     return llmq_versionbitscache.State(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_MN_RR) == ThresholdState::ACTIVE;
 }
 
-ThresholdState GetV20State(gsl::not_null<const CBlockIndex*> pindex)
-{
-    return llmq_versionbitscache.State(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20);
-}
-
-int GetV20Since(gsl::not_null<const CBlockIndex*> pindex)
-{
-    return llmq_versionbitscache.StateSinceHeight(pindex, Params().GetConsensus(), Consensus::DEPLOYMENT_V20);
-}
-
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2)
 {
     // We need to deterministically select who is going to initiate the connection. The naive way would be to simply

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -77,8 +77,6 @@ std::vector<std::reference_wrapper<const Consensus::LLMQParams>> GetEnabledQuoru
 
 // TODO options
 bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pindex);
-// TODO deployments
-bool IsV20Active(gsl::not_null<const CBlockIndex*> pindex);
 
 /// Returns the state of `-llmq-data-recovery`
 // TODO options

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -78,8 +78,6 @@ std::vector<std::reference_wrapper<const Consensus::LLMQParams>> GetEnabledQuoru
 // TODO options
 bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pindex);
 // TODO deployments
-bool IsV19Active(gsl::not_null<const CBlockIndex*> pindex);
-// TODO deployments
 bool IsV20Active(gsl::not_null<const CBlockIndex*> pindex);
 
 /// Returns the state of `-llmq-data-recovery`

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -29,11 +29,6 @@ namespace llmq
 class CQuorumManager;
 class CQuorumSnapshot;
 
-// A separate cache instance instead of versionbitscache has been introduced to avoid locking cs_main
-// and dealing with all kinds of deadlocks.
-// TODO: drop llmq_versionbitscache completely so far as VersionBitsCache do not uses anymore cs_main
-extern VersionBitsCache llmq_versionbitscache;
-
 static const bool DEFAULT_ENABLE_QUORUM_DATA_RECOVERY = true;
 
 enum class QvvecSyncMode {

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -47,9 +47,7 @@ uint256 GetHashModifier(const Consensus::LLMQParams& llmqParams, gsl::not_null<c
 uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash);
 uint256 BuildSignHash(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& id, const uint256& msgHash);
 
-// TODO options
 bool IsAllMembersConnectedEnabled(Consensus::LLMQType llmqType);
-// TODO options
 bool IsQuorumPoseEnabled(Consensus::LLMQType llmqType);
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2);
 std::set<uint256> GetQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& forMember, bool onlyOutbound);
@@ -60,24 +58,17 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_n
 void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, CConnman& connman, const uint256& myProTxHash);
 
 bool IsQuorumActive(Consensus::LLMQType llmqType, const CQuorumManager& qman, const uint256& quorumHash);
-// TODO options maybe not
 bool IsQuorumTypeEnabled(Consensus::LLMQType llmqType, const CQuorumManager& qman, gsl::not_null<const CBlockIndex*> pindexPrev);
-// TODO options maybe not
 bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const CQuorumManager& qman, gsl::not_null<const CBlockIndex*> pindexPrev, std::optional<bool> optDIP0024IsActive, std::optional<bool> optHaveDIP0024Quorums);
 
-// TODO options maybe not
 std::vector<Consensus::LLMQType> GetEnabledQuorumTypes(gsl::not_null<const CBlockIndex*> pindex);
-// TODO options maybe not
 std::vector<std::reference_wrapper<const Consensus::LLMQParams>> GetEnabledQuorumParams(gsl::not_null<const CBlockIndex*> pindex);
 
-// TODO options
 bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pindex);
 
 /// Returns the state of `-llmq-data-recovery`
-// TODO options
 bool QuorumDataRecoveryEnabled();
 
-// TODO options
 /// Returns the state of `-watchquorums`
 bool IsWatchQuorumsEnabled();
 

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -52,7 +52,9 @@ uint256 GetHashModifier(const Consensus::LLMQParams& llmqParams, gsl::not_null<c
 uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash);
 uint256 BuildSignHash(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& id, const uint256& msgHash);
 
+// TODO options
 bool IsAllMembersConnectedEnabled(Consensus::LLMQType llmqType);
+// TODO options
 bool IsQuorumPoseEnabled(Consensus::LLMQType llmqType);
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2);
 std::set<uint256> GetQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& forMember, bool onlyOutbound);
@@ -63,23 +65,36 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_n
 void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, CConnman& connman, const uint256& myProTxHash);
 
 bool IsQuorumActive(Consensus::LLMQType llmqType, const CQuorumManager& qman, const uint256& quorumHash);
+// TODO options maybe not
 bool IsQuorumTypeEnabled(Consensus::LLMQType llmqType, const CQuorumManager& qman, gsl::not_null<const CBlockIndex*> pindex);
+// TODO options maybe not
 bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const CQuorumManager& qman, gsl::not_null<const CBlockIndex*> pindex, std::optional<bool> optDIP0024IsActive, std::optional<bool> optHaveDIP0024Quorums);
 
+// TODO options maybe not
 std::vector<Consensus::LLMQType> GetEnabledQuorumTypes(gsl::not_null<const CBlockIndex*> pindex);
+// TODO options maybe not
 std::vector<std::reference_wrapper<const Consensus::LLMQParams>> GetEnabledQuorumParams(gsl::not_null<const CBlockIndex*> pindex);
 
+// TODO options
 bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pindex);
+// TODO deployments
 bool IsDIP0024Active(gsl::not_null<const CBlockIndex*> pindex);
+// TODO deployments
 bool IsV19Active(gsl::not_null<const CBlockIndex*> pindex);
+// TODO deployments
 bool IsV20Active(gsl::not_null<const CBlockIndex*> pindex);
+// TODO deployments
 bool IsMNRewardReallocationActive(gsl::not_null<const CBlockIndex*> pindex);
+// TODO deployments
 ThresholdState GetV20State(gsl::not_null<const CBlockIndex*> pindex);
+// TODO deployments
 int GetV20Since(gsl::not_null<const CBlockIndex*> pindex);
 
 /// Returns the state of `-llmq-data-recovery`
+// TODO options
 bool QuorumDataRecoveryEnabled();
 
+// TODO options
 /// Returns the state of `-watchquorums`
 bool IsWatchQuorumsEnabled();
 

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -81,8 +81,6 @@ bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_n
 bool IsV19Active(gsl::not_null<const CBlockIndex*> pindex);
 // TODO deployments
 bool IsV20Active(gsl::not_null<const CBlockIndex*> pindex);
-// TODO deployments
-bool IsMNRewardReallocationActive(gsl::not_null<const CBlockIndex*> pindex);
 
 /// Returns the state of `-llmq-data-recovery`
 // TODO options

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -66,9 +66,9 @@ void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, gsl::not
 
 bool IsQuorumActive(Consensus::LLMQType llmqType, const CQuorumManager& qman, const uint256& quorumHash);
 // TODO options maybe not
-bool IsQuorumTypeEnabled(Consensus::LLMQType llmqType, const CQuorumManager& qman, gsl::not_null<const CBlockIndex*> pindex);
+bool IsQuorumTypeEnabled(Consensus::LLMQType llmqType, const CQuorumManager& qman, gsl::not_null<const CBlockIndex*> pindexPrev);
 // TODO options maybe not
-bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const CQuorumManager& qman, gsl::not_null<const CBlockIndex*> pindex, std::optional<bool> optDIP0024IsActive, std::optional<bool> optHaveDIP0024Quorums);
+bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, const CQuorumManager& qman, gsl::not_null<const CBlockIndex*> pindexPrev, std::optional<bool> optDIP0024IsActive, std::optional<bool> optHaveDIP0024Quorums);
 
 // TODO options maybe not
 std::vector<Consensus::LLMQType> GetEnabledQuorumTypes(gsl::not_null<const CBlockIndex*> pindex);
@@ -77,8 +77,6 @@ std::vector<std::reference_wrapper<const Consensus::LLMQParams>> GetEnabledQuoru
 
 // TODO options
 bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pindex);
-// TODO deployments
-bool IsDIP0024Active(gsl::not_null<const CBlockIndex*> pindex);
 // TODO deployments
 bool IsV19Active(gsl::not_null<const CBlockIndex*> pindex);
 // TODO deployments

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -83,10 +83,6 @@ bool IsV19Active(gsl::not_null<const CBlockIndex*> pindex);
 bool IsV20Active(gsl::not_null<const CBlockIndex*> pindex);
 // TODO deployments
 bool IsMNRewardReallocationActive(gsl::not_null<const CBlockIndex*> pindex);
-// TODO deployments
-ThresholdState GetV20State(gsl::not_null<const CBlockIndex*> pindex);
-// TODO deployments
-int GetV20Since(gsl::not_null<const CBlockIndex*> pindex);
 
 /// Returns the state of `-llmq-data-recovery`
 // TODO options

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -7,6 +7,7 @@
 #include <evo/deterministicmns.h>
 
 #include <chainparams.h>
+#include <deploymentstatus.h>
 #include <net.h>
 #include <netbase.h>
 #include <protocol.h>
@@ -68,7 +69,7 @@ void CActiveMasternodeManager::Init(const CBlockIndex* pindex)
 
     if (!fMasternodeMode) return;
 
-    if (!deterministicMNManager->IsDIP3Enforced(pindex->nHeight)) return;
+    if (!DeploymentDIP0003Enforced(pindex->nHeight, Params().GetConsensus())) return;
 
     // Check that our local network configuration is correct
     if (!fListen && Params().RequireRoutableExternalIP()) {
@@ -141,7 +142,7 @@ void CActiveMasternodeManager::UpdatedBlockTip(const CBlockIndex* pindexNew, con
 
     if (!fMasternodeMode) return;
 
-    if (!deterministicMNManager->IsDIP3Enforced(pindexNew->nHeight)) return;
+    if (!DeploymentDIP0003Enforced(pindexNew->nHeight, Params().GetConsensus())) return;
 
     if (state == MASTERNODE_READY) {
         auto oldMNList = deterministicMNManager->GetListForBlock(pindexNew->pprev);

--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -98,7 +98,7 @@
 [[nodiscard]] static bool IsTransactionValid(const CTransaction& txNew, const CBlockIndex* const pindexPrev, const CAmount blockSubsidy, const CAmount feeReward)
 {
     const int nBlockHeight = pindexPrev  == nullptr ? 0 : pindexPrev->nHeight + 1;
-    if (!deterministicMNManager->IsDIP3Enforced(nBlockHeight)) {
+    if (!DeploymentDIP0003Enforced(nBlockHeight, Params().GetConsensus())) {
         // can't verify historical blocks here
         return true;
     }

--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -7,12 +7,12 @@
 #include <amount.h>
 #include <chain.h>
 #include <chainparams.h>
+#include <deploymentstatus.h>
 #include <evo/deterministicmns.h>
 #include <governance/classes.h>
 #include <governance/governance.h>
 #include <key_io.h>
 #include <logging.h>
-#include <llmq/utils.h>
 #include <masternode/sync.h>
 #include <primitives/block.h>
 #include <script/standard.h>
@@ -29,11 +29,12 @@
     voutMasternodePaymentsRet.clear();
 
     const int nBlockHeight = pindexPrev  == nullptr ? 0 : pindexPrev->nHeight + 1;
+    const Consensus::Params& consensusParams = Params().GetConsensus();
 
-    bool fV20Active =  llmq::utils::IsV20Active(pindexPrev);
+    bool fV20Active = DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_V20);
     CAmount masternodeReward = GetMasternodePayment(nBlockHeight, blockSubsidy + feeReward, fV20Active);
 
-    if (llmq::utils::IsMNRewardReallocationActive(pindexPrev)) {
+    if (DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_MN_RR)) {
         CAmount masternodeSubsidyReward = GetMasternodePayment(nBlockHeight, blockSubsidy, fV20Active);
         const CAmount platformReward = MasternodePayments::PlatformShare(masternodeSubsidyReward);
         masternodeReward -= platformReward;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -135,7 +135,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     bool fDIP0003Active_context = DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0003);
     bool fDIP0008Active_context = DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0008);
-    bool fV20Active_context = llmq::utils::IsV20Active(pindexPrev);
+    const bool fV20Active_context{DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_V20)};
 
     pblock->nVersion = g_versionbitscache.ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
     // Non-mainnet only: allow overriding block.nVersion with
@@ -402,7 +402,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
     // This credit pool is used only to check withdrawal limits and to find
     // duplicates of indexes. There's used `BlockSubsidy` equaled to 0
     std::optional<CCreditPoolDiff> creditPoolDiff;
-    if (llmq::utils::IsV20Active(pindexPrev)) {
+    if (DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_V20)) {
         CCreditPool creditPool = creditPoolManager->GetCreditPool(pindexPrev, chainparams.GetConsensus());
         creditPoolDiff.emplace(std::move(creditPool), pindexPrev, chainparams.GetConsensus(), 0);
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -133,8 +133,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     assert(pindexPrev != nullptr);
     nHeight = pindexPrev->nHeight + 1;
 
-    bool fDIP0003Active_context = DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0003);
-    bool fDIP0008Active_context = DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0008);
+    const bool fDIP0003Active_context{DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0003)};
+    const bool fDIP0008Active_context{DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0008)};
     const bool fV20Active_context{DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_V20)};
 
     pblock->nVersion = g_versionbitscache.ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
@@ -396,7 +396,6 @@ void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, std::ve
 // transaction package to work on next.
 void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated, const CBlockIndex* const pindexPrev)
 {
-    AssertLockHeld(cs_main); // for GetMNHFSignalsStage()
     AssertLockHeld(m_mempool.cs);
 
     // This credit pool is used only to check withdrawal limits and to find

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -35,6 +35,7 @@
 #include <llmq/utils.h>
 #include <masternode/payments.h>
 #include <spork.h>
+#include <validation.h>
 
 #include <algorithm>
 #include <utility>
@@ -72,8 +73,7 @@ BlockAssembler::BlockAssembler(const CSporkManager& sporkManager, CGovernanceMan
       m_evoDb(evoDb)
 {
     blockMinFeeRate = options.blockMinFeeRate;
-    // Limit size to between 1K and MaxBlockSize()-1K for sanity:
-    nBlockMaxSize = std::max((unsigned int)1000, std::min((unsigned int)(MaxBlockSize(fDIP0001ActiveAtTip) - 1000), (unsigned int)options.nBlockMaxSize));
+    nBlockMaxSize = options.nBlockMaxSize;
 }
 
 static BlockAssembler::Options DefaultOptions()
@@ -133,9 +133,14 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     assert(pindexPrev != nullptr);
     nHeight = pindexPrev->nHeight + 1;
 
+    const bool fDIP0001Active_context{DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0001)};
     const bool fDIP0003Active_context{DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0003)};
     const bool fDIP0008Active_context{DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_DIP0008)};
     const bool fV20Active_context{DeploymentActiveAfter(pindexPrev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_V20)};
+
+    // Limit size to between 1K and MaxBlockSize()-1K for sanity:
+    nBlockMaxSize = std::max<unsigned int>(1000, std::min<unsigned int>(MaxBlockSize(fDIP0001Active_context) - 1000, nBlockMaxSize));
+    nBlockMaxSigOps = MaxBlockSigOps(fDIP0001Active_context);
 
     pblock->nVersion = g_versionbitscache.ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
     // Non-mainnet only: allow overriding block.nVersion with
@@ -284,7 +289,7 @@ bool BlockAssembler::TestPackage(uint64_t packageSize, unsigned int packageSigOp
 {
     if (nBlockSize + packageSize >= nBlockMaxSize)
         return false;
-    if (nBlockSigOps + packageSigOps >= MaxBlockSigOps(fDIP0001ActiveAtTip))
+    if (nBlockSigOps + packageSigOps >= nBlockMaxSigOps)
         return false;
     return true;
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -8,7 +8,6 @@
 
 #include <primitives/block.h>
 #include <txmempool.h>
-#include <validation.h>
 
 #include <memory>
 #include <optional>
@@ -20,6 +19,7 @@
 class CBlockIndex;
 class CChainParams;
 class CConnman;
+class CEvoDB;
 class CGovernanceManager;
 class CScript;
 class CSporkManager;
@@ -142,6 +142,7 @@ private:
 
     // Configuration parameters for the block size
     unsigned int nBlockMaxSize;
+    unsigned int nBlockMaxSigOps;
     CFeeRate blockMinFeeRate;
 
     // Information on the current status of the block

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -29,7 +29,7 @@
 #include <util/thread.h>
 #include <util/time.h>
 #include <util/translation.h>
-#include <validation.h>
+#include <validation.h> // for fDIP0001ActiveAtTip
 
 #include <masternode/meta.h>
 #include <masternode/sync.h>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -903,6 +903,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
         aMutable.push_back("version/force");
     }
 
+    const bool fDIP0001Active_context{DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DIP0001)};
     result.pushKV("previousblockhash", pblock->hashPrevBlock.GetHex());
     result.pushKV("transactions", transactions);
     result.pushKV("coinbaseaux", aux);
@@ -912,8 +913,8 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
     result.pushKV("mutable", aMutable);
     result.pushKV("noncerange", "00000000ffffffff");
-    result.pushKV("sigoplimit", (int64_t)MaxBlockSigOps(fDIP0001ActiveAtTip));
-    result.pushKV("sizelimit", (int64_t)MaxBlockSize(fDIP0001ActiveAtTip));
+    result.pushKV("sigoplimit", (int64_t)MaxBlockSigOps(fDIP0001Active_context));
+    result.pushKV("sizelimit", (int64_t)MaxBlockSize(fDIP0001Active_context));
     result.pushKV("curtime", pblock->GetBlockTime());
     result.pushKV("bits", strprintf("%08x", pblock->nBits));
     result.pushKV("previousbits", strprintf("%08x", pblocktemplate->nPrevBits));

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -7,6 +7,7 @@
 #include <addressindex.h>
 #include <chainparams.h>
 #include <consensus/consensus.h>
+#include <deploymentstatus.h>
 #include <evo/mnauth.h>
 #include <httpserver.h>
 #include <index/blockfilterindex.h>
@@ -15,7 +16,6 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
-#include <llmq/utils.h>
 #include <net.h>
 #include <node/context.h>
 #include <rpc/blockchain.h>
@@ -581,7 +581,7 @@ static UniValue mnauth(const JSONRPCRequest& request)
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
 
     CBLSPublicKey publicKey;
-    bool bls_legacy_scheme = !llmq::utils::IsV19Active(chainman.ActiveChain().Tip());
+    const bool bls_legacy_scheme{!DeploymentActiveAfter(chainman.ActiveChain().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
     publicKey.SetHexStr(request.params[2].get_str(), bls_legacy_scheme);
     if (!publicKey.IsValid()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "publicKey invalid");

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <deploymentstatus.h>
 #include <index/txindex.h>
 #include <node/context.h>
 #include <rpc/blockchain.h>
@@ -896,7 +897,7 @@ static UniValue verifychainlock(const JSONRPCRequest& request)
 
     CBLSSignature sig;
     if (pIndex) {
-        bool use_legacy_signature = !llmq::utils::IsV19Active(pIndex);
+        const bool use_legacy_signature{!DeploymentActiveAfter(pIndex, Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
         if (!sig.SetHexStr(request.params[1].get_str(), use_legacy_signature)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
         }
@@ -976,7 +977,7 @@ static UniValue verifyislock(const JSONRPCRequest& request)
     CHECK_NONFATAL(pBlockIndex != nullptr);
 
     CBLSSignature sig;
-    const bool use_bls_legacy = !llmq::utils::IsV19Active(pBlockIndex);
+    const bool use_bls_legacy{!DeploymentActiveAfter(pBlockIndex, Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
     if (!sig.SetHexStr(request.params[2].get_str(), use_bls_legacy)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid signature format");
     }

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -7,6 +7,7 @@
 #include <bls/bls.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <deploymentstatus.h>
 #include <messagesigner.h>
 #include <miner.h>
 #include <netbase.h>
@@ -26,7 +27,6 @@
 #include <llmq/chainlocks.h>
 #include <llmq/context.h>
 #include <llmq/instantsend.h>
-#include <llmq/utils.h>
 #include <masternode/payments.h>
 #include <util/enumerate.h>
 #include <util/irange.h>
@@ -206,7 +206,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         // next block should be signaling by default
         LOCK(cs_main);
         const CBlockIndex* const tip{m_node.chainman->ActiveChain().Tip()};
-        const bool isV20Active{llmq::utils::IsV20Active(tip)};
+        const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
         deterministicMNManager->UpdatedBlockTip(tip);
         BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
@@ -222,7 +222,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
     {
         LOCK(cs_main);
         const CBlockIndex* const tip{m_node.chainman->ActiveChain().Tip()};
-        const bool isV20Active{llmq::utils::IsV20Active(tip)};
+        const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
         const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
@@ -240,20 +240,20 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
             }
             LOCK(cs_main);
             const CBlockIndex* const tip{m_node.chainman->ActiveChain().Tip()};
-            const bool isV20Active{llmq::utils::IsV20Active(tip)};
+            const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
             const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
             const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
             const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         }
     }
-    BOOST_CHECK(llmq::utils::IsV20Active(m_node.chainman->ActiveChain().Tip()));
+    BOOST_CHECK(DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), consensus_params, Consensus::DEPLOYMENT_V20));
     // Allocation of block subsidy is 60% MN, 20% miners and 20% treasury
     {
         // Reward split should reach ~75/25 after reallocation is done
         LOCK(cs_main);
         const CBlockIndex* const tip{m_node.chainman->ActiveChain().Tip()};
-        const bool isV20Active{llmq::utils::IsV20Active(tip)};
+        const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         const CAmount block_subsidy_sb = GetSuperblockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         CAmount block_subsidy_potential = block_subsidy + block_subsidy_sb;
@@ -267,7 +267,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 50662764); // 0.75
     }
-    BOOST_CHECK(!llmq::utils::IsMNRewardReallocationActive(m_node.chainman->ActiveChain().Tip()));
+    BOOST_CHECK(!DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), consensus_params, Consensus::DEPLOYMENT_MN_RR));
 
     // Activate EHF "MN_RR"
     {
@@ -283,8 +283,8 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         }
         LOCK(cs_main);
         const CBlockIndex* const tip{m_node.chainman->ActiveChain().Tip()};
-        const bool isV20Active{llmq::utils::IsV20Active(tip)};
-        const bool isMNRewardReallocated{llmq::utils::IsMNRewardReallocationActive(tip)};
+        const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
+        const bool isMNRewardReallocated{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_MN_RR)};
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
         const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
@@ -298,12 +298,12 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[payment_index].nValue, masternode_payment);
     }
 
-    BOOST_CHECK(llmq::utils::IsMNRewardReallocationActive(m_node.chainman->ActiveChain().Tip()));
+    BOOST_CHECK(DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), consensus_params, Consensus::DEPLOYMENT_MN_RR));
     { // At this moment Masternode reward should be reallocated to platform
         // Allocation of block subsidy is 60% MN, 20% miners and 20% treasury
         LOCK(cs_main);
         const CBlockIndex* const tip{m_node.chainman->ActiveChain().Tip()};
-        const bool isV20Active{llmq::utils::IsV20Active(tip)};
+        const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         const CAmount block_subsidy_sb = GetSuperblockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -150,7 +150,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
 
     CScript coinbasePubKey = CScript() <<  ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
 
-    BOOST_ASSERT(deterministicMNManager->IsDIP3Enforced(WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Height())));
+    BOOST_ASSERT(DeploymentDIP0003Enforced(WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Height()), consensus_params));
 
     // Register one MN
     CKey ownerKey;

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -7,6 +7,7 @@
 #include <base58.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <deploymentstatus.h>
 #include <messagesigner.h>
 #include <netbase.h>
 #include <policy/policy.h>
@@ -21,7 +22,6 @@
 #include <evo/deterministicmns.h>
 #include <evo/providertx.h>
 #include <evo/specialtx.h>
-#include <llmq/utils.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -267,7 +267,7 @@ void FuncDIP3Activation(TestChainSetup& setup)
 
 void FuncV19Activation(TestChainSetup& setup)
 {
-    BOOST_ASSERT(!llmq::utils::IsV19Active(::ChainActive().Tip()));
+    BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
 
     // create
     auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
@@ -283,7 +283,7 @@ void FuncV19Activation(TestChainSetup& setup)
 
     auto block = std::make_shared<CBlock>(setup.CreateBlock({tx_reg}, setup.coinbaseKey));
     BOOST_ASSERT(Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-    BOOST_ASSERT(!llmq::utils::IsV19Active(::ChainActive().Tip()));
+    BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
     deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
@@ -301,7 +301,7 @@ void FuncV19Activation(TestChainSetup& setup)
 
     block = std::make_shared<CBlock>(setup.CreateBlock({tx_upreg}, setup.coinbaseKey));
     BOOST_ASSERT(Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-    BOOST_ASSERT(!llmq::utils::IsV19Active(::ChainActive().Tip()));
+    BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
     deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
@@ -321,7 +321,7 @@ void FuncV19Activation(TestChainSetup& setup)
     BOOST_ASSERT(SignSignature(signing_provider, CTransaction(tx_reg), tx_spend, 0, SIGHASH_ALL));
     block = std::make_shared<CBlock>(setup.CreateBlock({tx_spend}, setup.coinbaseKey));
     BOOST_ASSERT(Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-    BOOST_ASSERT(!llmq::utils::IsV19Active(::ChainActive().Tip()));
+    BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
     deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
@@ -333,7 +333,7 @@ void FuncV19Activation(TestChainSetup& setup)
 
     // mine another block so that it's not the last one before V19
     setup.CreateAndProcessBlock({}, setup.coinbaseKey);
-    BOOST_ASSERT(!llmq::utils::IsV19Active(::ChainActive().Tip()));
+    BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
     deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
@@ -345,7 +345,7 @@ void FuncV19Activation(TestChainSetup& setup)
 
     // this block should activate V19
     setup.CreateAndProcessBlock({}, setup.coinbaseKey);
-    BOOST_ASSERT(llmq::utils::IsV19Active(::ChainActive().Tip()));
+    BOOST_ASSERT(DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
     deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
@@ -365,7 +365,7 @@ void FuncV19Activation(TestChainSetup& setup)
     for (int i = 0; i < 10; ++i)
     {
         setup.CreateAndProcessBlock({}, setup.coinbaseKey);
-        BOOST_ASSERT(llmq::utils::IsV19Active(::ChainActive().Tip()));
+        BOOST_ASSERT(DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
         BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1 + i);
         deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
         deterministicMNManager->DoMaintenance();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -10,6 +10,7 @@
 #include <consensus/consensus.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
+#include <deploymentstatus.h>
 #include <crypto/sha256.h>
 #include <flat-database.h>
 #include <governance/governance.h>
@@ -27,7 +28,6 @@
 #include <llmq/signing.h>
 #include <llmq/signing_shares.h>
 #include <llmq/snapshot.h>
-#include <llmq/utils.h>
 #include <masternode/sync.h>
 #include <miner.h>
 #include <net.h>
@@ -464,14 +464,14 @@ CBlock getBlock13b8a()
 
 TestChainV19Setup::TestChainV19Setup() : TestChainSetup(899)
 {
-    bool v19_just_activated = llmq::utils::IsV19Active(::ChainActive().Tip()) &&
-                              !llmq::utils::IsV19Active(::ChainActive().Tip()->pprev);
+    bool v19_just_activated{DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19) &&
+                            !DeploymentActiveAt(*::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
     assert(v19_just_activated);
 }
 
 // 5 blocks earlier
 TestChainV19BeforeActivationSetup::TestChainV19BeforeActivationSetup() : TestChainSetup(894)
 {
-    bool v19_active = llmq::utils::IsV19Active(::ChainActive().Tip());
+    bool v19_active{DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
     assert(!v19_active);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -156,7 +156,7 @@ bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 uint64_t nPruneTarget = 0;
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
 
-// TODO: drop this global variable
+// TODO: drop this global variable. Used by net.cpp module only
 std::atomic<bool> fDIP0001ActiveAtTip{false};
 
 uint256 hashAssumeValid;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -61,7 +61,6 @@
 
 #include <llmq/instantsend.h>
 #include <llmq/chainlocks.h>
-#include <llmq/utils.h>
 
 #include <statsd_client.h>
 
@@ -1171,7 +1170,7 @@ CAmount GetBlockSubsidyInner(int nPrevBits, int nPrevHeight, const Consensus::Pa
 CAmount GetBlockSubsidy(const CBlockIndex* const pindex, const Consensus::Params& consensusParams)
 {
     if (pindex->pprev == nullptr) return Params().GenesisBlock().vtx[0]->GetValueOut();
-    bool isV20Active = llmq::utils::IsV20Active(pindex->pprev);
+    const bool isV20Active{DeploymentActiveAt(*pindex, consensusParams, Consensus::DEPLOYMENT_V20)};
     return GetBlockSubsidyInner(pindex->pprev->nBits, pindex->pprev->nHeight, consensusParams, isV20Active);
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -766,7 +766,7 @@ public:
         size_t max_mempool_size_bytes) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Return list of MN EHF signals for current Tip() */
-    std::unordered_map<uint8_t, int> GetMNHFSignalsStage(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    std::unordered_map<uint8_t, int> GetMNHFSignalsStage(const CBlockIndex* pindex);
 
     std::string ToString() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 private:

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -100,7 +100,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "governance/object -> validationinterface -> governance/object"
     "governance/vote -> validation -> validationinterface -> governance/vote"
     "llmq/signing -> masternode/node -> validationinterface -> llmq/signing"
-    "llmq/utils -> validation -> llmq/utils"
     "evo/mnhftx -> validation -> evo/mnhftx"
     "evo/deterministicmns -> validation -> evo/deterministicmns"
 )


### PR DESCRIPTION
## Issue being fixed or feature implemented
That's a follow-up changes for #5749 and #5740 (bitcoin/bitcoin#19438)

## What was done?
Dropped all usages of llmq/utils to check if any hard-fork is active; as well dropped all direct usages of `chainparams` in favor of a new interface `deploymentstatus`

As positive side effect it removes circular dependency `validation` <-> `llmq/utils` and it exclude including llmq/utils from many other compilation units.

## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone