### PR TITLE
backport: partial merge bitcoin#26532: wallet: bugfix, invalid crypted key "checksum_valid" set

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -395,7 +395,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             if (!ssValue.eof()) {
                 uint256 checksum;
                 ssValue >> checksum;
-                if ((checksum_valid = Hash(vchPrivKey) != checksum)) {
+                if (!(checksum_valid = Hash(vchPrivKey) == checksum)) {
                     strErr = "Error reading wallet database: Crypted key corrupt";
                     return false;
                 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Backports the actual fix only (cc5a5e81217506ec6f9fff34056290f8f40a7396) because of merge conflicts.

```
wallet: bugfix, invalid crypted key "checksum_valid" set

At wallet load time, we set the crypted key "checksum_valid" variable always to false.
Which, on every wallet decryption call, forces the process to re-write the entire ckeys to db when
it's not needed.
```

The bug was ~introduced~ backported via c0c00f92953d9e3732d5ac7e7ae3b882e61d7fb7 from #5360.

## What was done?


## How Has This Been Tested?
try to unlock a wallet with lots of keys w/ and w/out this patch

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

