### PR TITLE
refactor: pull libbitcoin_server (governance) code out of wallet code 4/N

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -187,6 +187,7 @@ BITCOIN_CORE_H = \
   dsnotificationinterface.h \
   governance/governance.h \
   governance/classes.h \
+  governance/common.h \
   governance/exceptions.h \
   governance/object.h \
   governance/validators.h \
@@ -702,6 +703,7 @@ libbitcoin_common_a_SOURCES = \
   core_read.cpp \
   core_write.cpp \
   deploymentinfo.cpp \
+  governance/common.cpp \
   key.cpp \
   key_io.cpp \
   merkleblock.cpp \

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -8,6 +8,7 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
+#include <governance/common.h>
 #include <llmq/chainlocks.h>
 #include <llmq/instantsend.h>
 #include <llmq/utils.h>

--- a/src/governance/common.cpp
+++ b/src/governance/common.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2014-2023 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <governance/common.h>
+
+#include <util/strencodings.h>
+#include <util/underlying.h>
+#include <hash.h>
+#include <univalue.h>
+
+namespace Governance
+{
+
+Object::Object(const uint256& nHashParent, int nRevision, int64_t nTime, const uint256& nCollateralHash, const std::string& strDataHex) :
+    hashParent{nHashParent},
+    revision{nRevision},
+    time{nTime},
+    collateralHash{nCollateralHash},
+    masternodeOutpoint{},
+    vchSig{},
+    vchData{ParseHex(strDataHex)}
+{
+}
+
+uint256 Object::GetHash() const
+{
+    // Note: doesn't match serialization
+
+    // CREATE HASH OF ALL IMPORTANT PIECES OF DATA
+
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << hashParent;
+    ss << revision;
+    ss << time;
+    ss << HexStr(vchData);
+    ss << masternodeOutpoint << uint8_t{} << 0xffffffff; // adding dummy values here to match old hashing
+    ss << vchSig;
+    // fee_tx is left out on purpose
+
+    return ss.GetHash();
+}
+
+UniValue Object::ToJson() const
+{
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("objectHash", GetHash().ToString());
+    obj.pushKV("parentHash", hashParent.ToString());
+    obj.pushKV("collateralHash", collateralHash.ToString());
+    obj.pushKV("createdAt", time);
+    obj.pushKV("revision", revision);
+    UniValue data;
+    if (!data.read(GetDataAsPlainString())) {
+        data.clear();
+        data.setObject();
+        data.pushKV("plain", GetDataAsPlainString());
+    }
+    data.pushKV("hex", GetDataAsHexString());
+    obj.pushKV("data", data);
+    return obj;
+}
+
+std::string Object::GetDataAsHexString() const
+{
+    return HexStr(vchData);
+}
+
+std::string Object::GetDataAsPlainString() const
+{
+    return std::string(vchData.begin(), vchData.end());
+}
+
+} // namespace Governance

--- a/src/governance/common.h
+++ b/src/governance/common.h
@@ -31,15 +31,8 @@ namespace Governance
 {
 class Object
 {
-    Object() :
-        type{GovernanceObject::UNKNOWN},
-        hashParent{},
-        revision{0},
-        time{0},
-        collateralHash{},
-        vchData{}
-    {
-    }
+public:
+    Object() = default;
 
     Object(const uint256& nHashParent, int nRevision, int64_t nTime, const uint256& nCollateralHash, const std::string& strDataHex);
 
@@ -51,23 +44,23 @@ class Object
     std::string GetDataAsPlainString() const;
 
     /// Object typecode
-    GovernanceObject type;
+    GovernanceObject type{GovernanceObject::UNKNOWN};
 
     /// parent object, 0 is root
-    uint256 hashParent;
+    uint256 hashParent{};
 
     /// object revision in the system
-    int revision;
+    int revision{0};
 
     /// time this object was created
-    int64_t time;
+    int64_t time{0};
 
     /// fee-tx
-    uint256 collateralHash;
+    uint256 collateralHash{};
 
     /// Masternode info for signed objects
     COutPoint masternodeOutpoint;
-    std::vector<unsigned char> vchSig;
+    std::vector<unsigned char> vchSig{};
 
     /// Data field - can be used for anything
     std::vector<unsigned char> vchData;

--- a/src/governance/common.h
+++ b/src/governance/common.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2014-2023 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_GOVERNANCE_COMMON_H
+#define BITCOIN_GOVERNANCE_COMMON_H
+
+#include <primitives/transaction.h>
+#include <uint256.h>
+
+#include <serialize.h>
+
+#include <string>
+#include <vector>
+
+/**
+ * This module is a public interface of governance module that can be used
+ * in other components such as wallet
+ */
+
+class UniValue;
+
+enum class GovernanceObject : int {
+    UNKNOWN = 0,
+    PROPOSAL,
+    TRIGGER
+};
+template<> struct is_serializable_enum<GovernanceObject> : std::true_type {};
+
+namespace Governance
+{
+class Object
+{
+    Object() :
+        type{GovernanceObject::UNKNOWN},
+        hashParent{},
+        revision{0},
+        time{0},
+        collateralHash{},
+        vchData{}
+    {
+    }
+
+    Object(const uint256& nHashParent, int nRevision, int64_t nTime, const uint256& nCollateralHash, const std::string& strDataHex);
+
+    UniValue ToJson() const;
+
+    uint256 GetHash() const;
+
+    std::string GetDataAsHexString() const;
+    std::string GetDataAsPlainString() const;
+
+    /// Object typecode
+    GovernanceObject type;
+
+    /// parent object, 0 is root
+    uint256 hashParent;
+
+    /// object revision in the system
+    int revision;
+
+    /// time this object was created
+    int64_t time;
+
+    /// fee-tx
+    uint256 collateralHash;
+
+    /// Masternode info for signed objects
+    COutPoint masternodeOutpoint;
+    std::vector<unsigned char> vchSig;
+
+    /// Data field - can be used for anything
+    std::vector<unsigned char> vchData;
+
+    SERIALIZE_METHODS(Object, obj)
+    {
+        READWRITE(
+                obj.hashParent,
+                obj.revision,
+                obj.time,
+                obj.collateralHash,
+                obj.vchData,
+                obj.type,
+                obj.masternodeOutpoint
+                );
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(obj.vchSig);
+        }
+    }
+};
+
+} // namespace Governance
+#endif

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -12,6 +12,7 @@
 #include <evo/deterministicmns.h>
 #include <flat-database.h>
 #include <governance/classes.h>
+#include <governance/common.h>
 #include <governance/validators.h>
 #include <masternode/meta.h>
 #include <masternode/node.h>
@@ -333,7 +334,7 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
     CheckOrphanVotes(govobj, connman);
 
     // SEND NOTIFICATION TO SCRIPT/ZMQ
-    GetMainSignals().NotifyGovernanceObject(std::make_shared<const CGovernanceObject>(govobj));
+    GetMainSignals().NotifyGovernanceObject(std::make_shared<const Governance::Object>(govobj.Object()));
 }
 
 void CGovernanceManager::UpdateCachesAndClean()

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -145,6 +145,11 @@ public:
 
     // Public Getter methods
 
+    const Governance::Object& Object() const
+    {
+        return m_obj;
+    }
+
     int64_t GetCreationTime() const
     {
         return m_obj.time;

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_GOVERNANCE_OBJECT_H
 #define BITCOIN_GOVERNANCE_OBJECT_H
 
+#include <governance/common.h>
 #include <governance/exceptions.h>
 #include <governance/vote.h>
 #include <governance/votedb.h>
 #include <sync.h>
-#include <util/underlying.h>
 
 #include <univalue.h>
 
@@ -25,13 +25,6 @@ class CGovernanceVote;
 extern RecursiveMutex cs_main;
 
 static constexpr double GOVERNANCE_FILTER_FP_RATE = 0.001;
-
-enum class GovernanceObject : int {
-    UNKNOWN = 0,
-    PROPOSAL,
-    TRIGGER
-};
-template<> struct is_serializable_enum<GovernanceObject> : std::true_type {};
 
 
 static constexpr CAmount GOVERNANCE_PROPOSAL_FEE_TX = (1 * COIN);
@@ -104,30 +97,11 @@ private:
     /// critical section to protect the inner data structures
     mutable RecursiveMutex cs;
 
-    /// Object typecode
-    GovernanceObject nObjectType;
-
-    /// parent object, 0 is root
-    uint256 nHashParent;
-
-    /// object revision in the system
-    int nRevision;
-
-    /// time this object was created
-    int64_t nTime;
+    Governance::Object m_obj;
 
     /// time this object was marked for deletion
     int64_t nDeletionTime;
 
-    /// fee-tx
-    uint256 nCollateralHash;
-
-    /// Data field - can be used for anything
-    std::vector<unsigned char> vchData;
-
-    /// Masternode info for signed objects
-    COutPoint masternodeOutpoint;
-    std::vector<unsigned char> vchSig;
 
     /// is valid by blockchain
     bool fCachedLocalValidity;
@@ -173,7 +147,7 @@ public:
 
     int64_t GetCreationTime() const
     {
-        return nTime;
+        return m_obj.time;
     }
 
     int64_t GetDeletionTime() const
@@ -183,17 +157,17 @@ public:
 
     GovernanceObject GetObjectType() const
     {
-        return nObjectType;
+        return m_obj.type;
     }
 
     const uint256& GetCollateralHash() const
     {
-        return nCollateralHash;
+        return m_obj.collateralHash;
     }
 
     const COutPoint& GetMasternodeOutpoint() const
     {
-        return masternodeOutpoint;
+        return m_obj.masternodeOutpoint;
     }
 
     bool IsSetCachedFunding() const
@@ -296,18 +270,7 @@ public:
     SERIALIZE_METHODS(CGovernanceObject, obj)
     {
         // SERIALIZE DATA FOR SAVING/LOADING OR NETWORK FUNCTIONS
-        READWRITE(
-                obj.nHashParent,
-                obj.nRevision,
-                obj.nTime,
-                obj.nCollateralHash,
-                obj.vchData,
-                obj.nObjectType,
-                obj.masternodeOutpoint
-                );
-        if (!(s.GetType() & SER_GETHASH)) {
-            READWRITE(obj.vchSig);
-        }
+        READWRITE(obj.m_obj);
         if (s.GetType() & SER_DISK) {
             // Only include these for the disk file format
             READWRITE(obj.nDeletionTime, obj.fExpired, obj.mapCurrentMNVotes, obj.fileVotes);

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -17,8 +17,6 @@ class CBLSSecretKey;
 class CBLSPublicKey;
 class CNode;
 
-class CGovernanceManager;
-class CGovernanceTriggerManager;
 class CGovernanceObject;
 class CGovernanceVote;
 

--- a/src/governance/validators.cpp
+++ b/src/governance/validators.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <governance/object.h>
+#include <governance/common.h>
 #include <governance/validators.h>
 
 #include <key_io.h>

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -29,6 +29,7 @@ class CFeeRate;
 class CJClientManager;
 class CKey;
 class CWallet;
+class UniValue;
 enum class FeeReason;
 enum class TransactionError;
 enum isminetype : unsigned int;

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -271,16 +271,13 @@ static UniValue gobject_list_prepared(const JSONRPCRequest& request)
     std::vector<const Governance::Object*> vecObjects = wallet->GetGovernanceObjects();
     // Sort the vector by the object creation time/hex data
     std::sort(vecObjects.begin(), vecObjects.end(), [](const Governance::Object* a, const Governance::Object* b) {
-        bool fGreater = a->time > b->time;
-        bool fEqual = a->time == b->time;
-        bool fHexGreater = a->GetDataAsHexString() > b->GetDataAsHexString();
-        return fGreater || (fEqual && fHexGreater);
+        if (a->time != b->time) return a->time < b->time;
+        return a->GetDataAsHexString() < b->GetDataAsHexString();
     });
 
     UniValue jsonArray(UniValue::VARR);
-    auto it = vecObjects.rbegin() + std::max<int>(0, vecObjects.size() - nCount);
-    while (it != vecObjects.rend()) {
-        jsonArray.push_back((*it++)->ToJson());
+    for (auto it = vecObjects.begin() + std::max<int>(0, vecObjects.size() - nCount); it != vecObjects.end(); ++it) {
+        jsonArray.push_back((*it)->ToJson());
     }
 
     return jsonArray;

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -18,6 +18,7 @@
 #include <rpc/blockchain.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
+#include <governance/common.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <validation.h>
@@ -227,7 +228,7 @@ static UniValue gobject_prepare(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INTERNAL_ERROR, err);
     }
 
-    if (!wallet->WriteGovernanceObject({hashParent, nRevision, nTime, tx->GetHash(), strDataHex})) {
+    if (!wallet->WriteGovernanceObject(Governance::Object{hashParent, nRevision, nTime, tx->GetHash(), strDataHex})) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "WriteGovernanceObject failed");
     }
 
@@ -267,11 +268,11 @@ static UniValue gobject_list_prepared(const JSONRPCRequest& request)
     }
     // Get a list of all prepared governance objects stored in the wallet
     LOCK(wallet->cs_wallet);
-    std::vector<const CGovernanceObject*> vecObjects = wallet->GetGovernanceObjects();
+    std::vector<const Governance::Object*> vecObjects = wallet->GetGovernanceObjects();
     // Sort the vector by the object creation time/hex data
-    std::sort(vecObjects.begin(), vecObjects.end(), [](const CGovernanceObject* a, const CGovernanceObject* b) {
-        bool fGreater = a->GetCreationTime() > b->GetCreationTime();
-        bool fEqual = a->GetCreationTime() == b->GetCreationTime();
+    std::sort(vecObjects.begin(), vecObjects.end(), [](const Governance::Object* a, const Governance::Object* b) {
+        bool fGreater = a->time > b->time;
+        bool fEqual = a->time == b->time;
         bool fHexGreater = a->GetDataAsHexString() > b->GetDataAsHexString();
         return fGreater || (fEqual && fHexGreater);
     });

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -7,12 +7,12 @@
 
 #include <chain.h>
 #include <consensus/validation.h>
+#include <governance/common.h>
 #include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <scheduler.h>
 
-#include <governance/object.h>
 #include <governance/vote.h>
 #include <llmq/clsig.h>
 #include <llmq/signing.h>
@@ -295,7 +295,7 @@ void CMainSignals::NotifyGovernanceVote(const std::shared_ptr<const CGovernanceV
     ENQUEUE_AND_LOG_EVENT(event, "%s: notify governance vote: %s", __func__, vote->GetHash().ToString());
 }
 
-void CMainSignals::NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& object) {
+void CMainSignals::NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& object) {
     auto event = [object, this] {
         m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NotifyGovernanceObject(object); });
     };

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -20,12 +20,16 @@ struct CBlockLocator;
 class CConnman;
 class CValidationInterface;
 class CGovernanceVote;
-class CGovernanceObject;
 class CDeterministicMNList;
 class CDeterministicMNListDiff;
 class uint256;
 class CScheduler;
 enum class MemPoolRemovalReason;
+
+namespace Governance
+{
+    class Object;
+}
 
 namespace llmq {
     class CChainLockSig;
@@ -162,7 +166,7 @@ protected:
     virtual void NotifyTransactionLock(const CTransactionRef &tx, const std::shared_ptr<const llmq::CInstantSendLock>& islock) {}
     virtual void NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const llmq::CChainLockSig>& clsig) {}
     virtual void NotifyGovernanceVote(const std::shared_ptr<const CGovernanceVote>& vote) {}
-    virtual void NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& object) {}
+    virtual void NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& object) {}
     virtual void NotifyInstantSendDoubleSpendAttempt(const CTransactionRef& currentTx, const CTransactionRef& previousTx) {}
     virtual void NotifyRecoveredSig(const std::shared_ptr<const llmq::CRecoveredSig>& sig) {}
     virtual void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) {}
@@ -229,7 +233,7 @@ public:
     void NotifyTransactionLock(const CTransactionRef &tx, const std::shared_ptr<const llmq::CInstantSendLock>& islock);
     void NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const llmq::CChainLockSig>& clsig);
     void NotifyGovernanceVote(const std::shared_ptr<const CGovernanceVote>& vote);
-    void NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& object);
+    void NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& object);
     void NotifyInstantSendDoubleSpendAttempt(const CTransactionRef &currentTx, const CTransactionRef &previousTx);
     void NotifyRecoveredSig(const std::shared_ptr<const llmq::CRecoveredSig> &sig);
     void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -45,7 +45,6 @@
 #include <coinjoin/client.h>
 #include <coinjoin/options.h>
 #include <evo/providertx.h>
-#include <governance/governance.h>
 #include <masternode/sync.h>
 
 #include <univalue.h>
@@ -5091,23 +5090,23 @@ void CWallet::notifyChainLock(const CBlockIndex* pindexChainLock, const std::sha
     NotifyChainLockReceived(pindexChainLock->nHeight);
 }
 
-bool CWallet::LoadGovernanceObject(const CGovernanceObject& obj)
+bool CWallet::LoadGovernanceObject(const Governance::Object& obj)
 {
     AssertLockHeld(cs_wallet);
     return m_gobjects.emplace(obj.GetHash(), obj).second;
 }
 
-bool CWallet::WriteGovernanceObject(const CGovernanceObject& obj)
+bool CWallet::WriteGovernanceObject(const Governance::Object& obj)
 {
     AssertLockHeld(cs_wallet);
     WalletBatch batch(GetDatabase());
     return batch.WriteGovernanceObject(obj) && LoadGovernanceObject(obj);
 }
 
-std::vector<const CGovernanceObject*> CWallet::GetGovernanceObjects()
+std::vector<const Governance::Object*> CWallet::GetGovernanceObjects()
 {
     AssertLockHeld(cs_wallet);
-    std::vector<const CGovernanceObject*> vecObjects;
+    std::vector<const Governance::Object*> vecObjects;
     vecObjects.reserve(m_gobjects.size());
     for (auto& obj : m_gobjects) {
         vecObjects.push_back(&obj.second);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -8,6 +8,7 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include <amount.h>
+#include <governance/common.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <policy/feerate.h>
@@ -26,8 +27,6 @@
 #include <wallet/scriptpubkeyman.h>
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>
-
-#include <governance/object.h>
 
 #include <algorithm>
 #include <atomic>
@@ -828,7 +827,7 @@ public:
     const std::string& GetName() const { return m_name; }
 
     // Map from governance object hash to governance object, they are added by gobject_prepare.
-    std::map<uint256, CGovernanceObject> m_gobjects;
+    std::map<uint256, Governance::Object> m_gobjects;
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys;
@@ -1278,11 +1277,11 @@ public:
     void notifyChainLock(const CBlockIndex* pindexChainLock, const std::shared_ptr<const llmq::CChainLockSig>& clsig) override;
 
     /** Load a CGovernanceObject into m_gobjects. */
-    bool LoadGovernanceObject(const CGovernanceObject& obj);
+    bool LoadGovernanceObject(const Governance::Object& obj);
     /** Store a CGovernanceObject in the wallet database. This should only be used by governance objects that are created by this wallet via `gobject prepare`. */
-    bool WriteGovernanceObject(const CGovernanceObject& obj);
+    bool WriteGovernanceObject(const Governance::Object& obj);
     /** Returns a vector containing pointers to the governance objects in m_gobjects */
-    std::vector<const CGovernanceObject*> GetGovernanceObjects();
+    std::vector<const Governance::Object*> GetGovernanceObjects();
 
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -8,7 +8,7 @@
 
 #include <key_io.h>
 #include <fs.h>
-#include <governance/object.h>
+#include <governance/common.h>
 #include <hdchain.h>
 #include <protocol.h>
 #include <serialize.h>
@@ -216,7 +216,7 @@ bool WalletBatch::WriteCoinJoinSalt(const uint256& salt)
     return WriteIC(DBKeys::COINJOIN_SALT, salt);
 }
 
-bool WalletBatch::WriteGovernanceObject(const CGovernanceObject& obj)
+bool WalletBatch::WriteGovernanceObject(const Governance::Object& obj)
 {
     return WriteIC(std::make_pair(DBKeys::G_OBJECT, obj.GetHash()), obj, false);
 }
@@ -493,7 +493,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
         } else if (strType == DBKeys::G_OBJECT) {
             uint256 nObjectHash;
-            CGovernanceObject obj;
+            Governance::Object obj;
             ssKey >> nObjectHash;
             ssValue >> obj;
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -30,7 +30,6 @@
 static const bool DEFAULT_FLUSHWALLET = true;
 
 struct CBlockLocator;
-class CGovernanceObject;
 class CHDChain;
 class CHDPubKey;
 class CKeyPool;
@@ -40,6 +39,11 @@ class CWallet;
 class CWalletTx;
 class uint160;
 class uint256;
+
+namespace Governance
+{
+    class Object;
+} // namespace Governance
 
 /** Error statuses for the wallet database */
 enum class DBErrors
@@ -200,7 +204,7 @@ public:
     bool WriteCoinJoinSalt(const uint256& salt);
 
     /** Write a CGovernanceObject to the database */
-    bool WriteGovernanceObject(const CGovernanceObject& obj);
+    bool WriteGovernanceObject(const Governance::Object& obj);
 
     /// Write destination data key,value tuple to database
     bool WriteDestData(const std::string &address, const std::string &key, const std::string &value);

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -38,7 +38,7 @@ bool CZMQAbstractNotifier::NotifyGovernanceVote(const std::shared_ptr<const CGov
     return true;
 }
 
-bool CZMQAbstractNotifier::NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject> & /*object*/)
+bool CZMQAbstractNotifier::NotifyGovernanceObject(const std::shared_ptr<const Governance::Object> & /*object*/)
 {
     return true;
 }

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -10,12 +10,16 @@
 #include <string>
 
 class CBlockIndex;
-class CGovernanceObject;
 class CGovernanceVote;
 class CTransaction;
 class CZMQAbstractNotifier;
 
 typedef std::shared_ptr<const CTransaction> CTransactionRef;
+
+namespace Governance
+{
+    class Object;
+} //namespace Governance
 
 namespace llmq {
     class CChainLockSig;
@@ -58,7 +62,7 @@ public:
     virtual bool NotifyTransaction(const CTransaction &transaction);
     virtual bool NotifyTransactionLock(const CTransactionRef& transaction, const std::shared_ptr<const llmq::CInstantSendLock>& islock);
     virtual bool NotifyGovernanceVote(const std::shared_ptr<const CGovernanceVote>& vote);
-    virtual bool NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& object);
+    virtual bool NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& object);
     virtual bool NotifyInstantSendDoubleSpendAttempt(const CTransactionRef& currentTx, const CTransactionRef& previousTx);
     virtual bool NotifyRecoveredSig(const std::shared_ptr<const llmq::CRecoveredSig>& sig);
 

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -198,7 +198,7 @@ void CZMQNotificationInterface::NotifyGovernanceVote(const std::shared_ptr<const
     });
 }
 
-void CZMQNotificationInterface::NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject> &object)
+void CZMQNotificationInterface::NotifyGovernanceObject(const std::shared_ptr<const Governance::Object> &object)
 {
     TryForEachAndRemoveFailed(notifiers, [&object](CZMQAbstractNotifier* notifier) {
         return notifier->NotifyGovernanceObject(object);

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -33,7 +33,7 @@ protected:
     void NotifyChainLock(const CBlockIndex *pindex, const std::shared_ptr<const llmq::CChainLockSig>& clsig) override;
     void NotifyTransactionLock(const CTransactionRef &tx, const std::shared_ptr<const llmq::CInstantSendLock>& islock) override;
     void NotifyGovernanceVote(const std::shared_ptr<const CGovernanceVote>& vote) override;
-    void NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& object) override;
+    void NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& object) override;
     void NotifyInstantSendDoubleSpendAttempt(const CTransactionRef& currentTx, const CTransactionRef& previousTx) override;
     void NotifyRecoveredSig(const std::shared_ptr<const llmq::CRecoveredSig>& sig) override;
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -11,7 +11,7 @@
 #include <validation.h>
 #include <zmq/zmqutil.h>
 
-#include <governance/object.h>
+#include <governance/common.h>
 #include <governance/vote.h>
 
 #include <llmq/chainlocks.h>
@@ -245,7 +245,7 @@ bool CZMQPublishHashGovernanceVoteNotifier::NotifyGovernanceVote(const std::shar
     return SendZmqMessage(MSG_HASHGVOTE, data, 32);
 }
 
-bool CZMQPublishHashGovernanceObjectNotifier::NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& object)
+bool CZMQPublishHashGovernanceObjectNotifier::NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& object)
 {
     uint256 hash = object->GetHash();
     LogPrint(BCLog::ZMQ, "zmq: Publish hashgovernanceobject %s\n", hash.GetHex());
@@ -378,10 +378,10 @@ bool CZMQPublishRawGovernanceVoteNotifier::NotifyGovernanceVote(const std::share
     return SendZmqMessage(MSG_RAWGVOTE, &(*ss.begin()), ss.size());
 }
 
-bool CZMQPublishRawGovernanceObjectNotifier::NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& govobj)
+bool CZMQPublishRawGovernanceObjectNotifier::NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& govobj)
 {
     uint256 nHash = govobj->GetHash();
-    LogPrint(BCLog::ZMQ, "zmq: Publish rawgovernanceobject: hash = %s to %s, type = %d\n", nHash.ToString(), this->address, ToUnderlying(govobj->GetObjectType()));
+    LogPrint(BCLog::ZMQ, "zmq: Publish rawgovernanceobject: hash = %s to %s, type = %d\n", nHash.ToString(), this->address, ToUnderlying(govobj->type));
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << *govobj;
     return SendZmqMessage(MSG_RAWGOBJ, &(*ss.begin()), ss.size());

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -9,7 +9,12 @@
 
 class CBlockIndex;
 class CGovernanceVote;
-class CGovernanceObject;
+
+namespace Governance
+{
+    class Object;
+} //namespace Governance
+
 
 class CZMQAbstractPublishNotifier : public CZMQAbstractNotifier
 {
@@ -63,7 +68,7 @@ public:
 class CZMQPublishHashGovernanceObjectNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& object) override;
+    bool NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& object) override;
 };
 
 class CZMQPublishHashInstantSendDoubleSpendNotifier : public CZMQAbstractPublishNotifier
@@ -123,7 +128,7 @@ public:
 class CZMQPublishRawGovernanceObjectNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyGovernanceObject(const std::shared_ptr<const CGovernanceObject>& object) override;
+    bool NotifyGovernanceObject(const std::shared_ptr<const Governance::Object>& object) override;
 };
 
 class CZMQPublishRawInstantSendDoubleSpendNotifier : public CZMQAbstractPublishNotifier

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -97,7 +97,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "spork -> validation -> spork"
     "governance/governance -> validation -> governance/governance"
     "evo/deterministicmns -> validationinterface -> governance/vote -> evo/deterministicmns"
-    "governance/object -> validationinterface -> governance/object"
     "governance/vote -> validation -> validationinterface -> governance/vote"
     "llmq/signing -> masternode/node -> validationinterface -> llmq/signing"
     "evo/mnhftx -> validation -> evo/mnhftx"

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -34,7 +34,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "governance/governance -> governance/object -> governance/governance"
     "governance/governance -> masternode/sync -> governance/governance"
     "governance/governance -> net_processing -> governance/governance"
-    "governance/object -> governance/validators -> governance/object"
     "llmq/quorums -> llmq/utils -> llmq/quorums"
     "llmq/blockprocessor -> net_processing -> llmq/blockprocessor"
     "llmq/chainlocks -> llmq/instantsend -> llmq/chainlocks"


### PR DESCRIPTION
## Issue being fixed or feature implemented
Wallet library should not depends on server code (libbitcoin_server).

Untie this library will help to finish backport https://github.com/bitcoin/bitcoin/pull/15639 and will unblock multiprocess: https://github.com/bitcoin/bitcoin/pull/18677

Prior work:

 - https://github.com/dashpay/dash/pull/4560 (1/N)
 - https://github.com/dashpay/dash/pull/5178 (2/N)
 - https://github.com/dashpay/dash/pull/5743

## What was done?
The class `CGovernanceObject` is doing too many things and doesn't have any public interface that can be used outside of governance module. This PR move publicly used functionality of `CGovernanceObject` to a new simple `Governance::Object`  that can be used outside of governance module as a public interface for serialization/deserialization and can be used inside wallet.

As side effect have been removed 2 circular dependency:
```
-    "governance/object -> governance/validators -> governance/object"
-    "governance/object -> validationinterface -> governance/object"
```

## How Has This Been Tested?
Amount of linkage errors is decreased from 141 to 66 if libbitcoin_server is excluded during linkage:

```diff
diff --git a/src/Makefile.am b/src/Makefile.am
index fb4850429f..c9c9c331a7 100644
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -865,9 +865,7 @@ endif
 # https://eli.thegreenplace.net/2013/07/09/library-order-in-static-linking#circular-dependency)
 dash_wallet_LDADD = \
   $(LIBBITCOIN_WALLET_TOOL) \
-  $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_WALLET) \
-  $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_CONSENSUS) \
   $(LIBBITCOIN_UTIL) \
```

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

