### PR TITLE
feat(rpc): submit chainlock signature if needed RPC

### DIFF
--- a/doc/release-notes-5765.md
+++ b/doc/release-notes-5765.md
@@ -1,0 +1,5 @@
+Added RPC
+--------
+
+- `submitchainlock` RPC allows the submission of Chainlock signature.
+Note: This PRC is whitelisted for Platform RPC user.

--- a/doc/release-notes-5765.md
+++ b/doc/release-notes-5765.md
@@ -1,5 +1,5 @@
 Added RPC
 --------
 
-- `submitchainlock` RPC allows the submission of Chainlock signature.
-Note: This PRC is whitelisted for Platform RPC user.
+- `submitchainlock` RPC allows the submission of a ChainLock signature.
+Note: This RPC is whitelisted for the Platform RPC user.

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -993,7 +993,7 @@ static void submitchainlock_help(const JSONRPCRequest& request)
                "Submit a ChainLock signature if needed\n",
                {
                        {"blockHash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash of the ChainLock."},
-                       {"signature", RPCArg::Type::STR, RPCArg::Optional::NO, "The signature of the ChainLock."},
+                       {"signature", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The signature of the ChainLock."},
                        {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::NO, "The height of the ChainLock."},
                },
                RPCResults{},

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -994,7 +994,7 @@ static void submitchainlock_help(const JSONRPCRequest& request)
                {
                        {"blockHash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash of the ChainLock."},
                        {"signature", RPCArg::Type::STR, RPCArg::Optional::NO, "The signature of the ChainLock."},
-                       {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::NO, "The height of the ChainLock.."},
+                       {"blockHeight", RPCArg::Type::NUM, RPCArg::Optional::NO, "The height of the ChainLock."},
                },
                RPCResults{},
                RPCExamples{""},

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -989,7 +989,7 @@ static UniValue verifyislock(const JSONRPCRequest& request)
 
 static void addchainlock_help(const JSONRPCRequest& request)
 {
-    RPCHelpMan{"adchainlock",
+    RPCHelpMan{"addchainlock",
                "Add a ChainLock signature if needed\n",
                {
                        {"blockHash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash of the ChainLock."},

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -1036,9 +1036,9 @@ static const CRPCCommand commands[] =
 { //  category              name                      actor (function)
   //  --------------------- ------------------------  -----------------------
     { "evo",                "quorum",                 &_quorum,                 {}  },
+    { "evo",                "submitchainlock",        &submitchainlock,        {"blockHash", "signature", "blockHeight"}  },
     { "evo",                "verifychainlock",        &verifychainlock,        {"blockHash", "signature", "blockHeight"} },
     { "evo",                "verifyislock",           &verifyislock,           {"id", "txid", "signature", "maxHeight"}  },
-    { "evo",                "submitchainlock",        &submitchainlock,        {"blockHash", "signature", "blockHeight"}  },
 };
 // clang-format on
     for (const auto& command : commands) {

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -987,10 +987,10 @@ static UniValue verifyislock(const JSONRPCRequest& request)
            llmq_ctx.sigman->VerifyRecoveredSig(llmqType, *llmq_ctx.qman, signHeight, id, txid, sig, signOffset);
 }
 
-static void addchainlock_help(const JSONRPCRequest& request)
+static void submitchainlock_help(const JSONRPCRequest& request)
 {
-    RPCHelpMan{"addchainlock",
-               "Add a ChainLock signature if needed\n",
+    RPCHelpMan{"submitchainlock",
+               "Submit a ChainLock signature if needed\n",
                {
                        {"blockHash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash of the ChainLock."},
                        {"signature", RPCArg::Type::STR, RPCArg::Optional::NO, "The signature of the ChainLock."},
@@ -1001,9 +1001,9 @@ static void addchainlock_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static UniValue addchainlock(const JSONRPCRequest& request)
+static UniValue submitchainlock(const JSONRPCRequest& request)
 {
-    addchainlock_help(request);
+    submitchainlock_help(request);
 
     const uint256 nBlockHash(ParseHashV(request.params[0], "blockHash"));
 
@@ -1064,7 +1064,7 @@ static const CRPCCommand commands[] =
     { "evo",                "quorum",                 &_quorum,                 {}  },
     { "evo",                "verifychainlock",        &verifychainlock,        {"blockHash", "signature", "blockHeight"} },
     { "evo",                "verifyislock",           &verifyislock,           {"id", "txid", "signature", "maxHeight"}  },
-    { "evo",                "addchainlock",           &addchainlock,           {"blockHash", "signature", "blockHeight"}  },
+    { "evo",                "submitchainlock",        &submitchainlock,        {"blockHash", "signature", "blockHeight"}  },
 };
 // clang-format on
     for (const auto& command : commands) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -148,7 +148,7 @@ void CRPCTable::InitPlatformRestrictions()
         {"quorum", {"sign", static_cast<uint8_t>(Params().GetConsensus().llmqTypePlatform)}},
         {"quorum", {"verify"}},
         {"verifyislock", {}},
-        {"addchainlock", {}},
+        {"submitchainlock", {}},
     };
 }
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -147,8 +147,8 @@ void CRPCTable::InitPlatformRestrictions()
         {"getbestchainlock", {}},
         {"quorum", {"sign", static_cast<uint8_t>(Params().GetConsensus().llmqTypePlatform)}},
         {"quorum", {"verify"}},
-        {"verifyislock", {}},
         {"submitchainlock", {}},
+        {"verifyislock", {}},
     };
 }
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -148,6 +148,7 @@ void CRPCTable::InitPlatformRestrictions()
         {"quorum", {"sign", static_cast<uint8_t>(Params().GetConsensus().llmqTypePlatform)}},
         {"quorum", {"verify"}},
         {"verifyislock", {}},
+        {"addchainlock", {}},
     };
 }
 

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -115,6 +115,7 @@ class LLMQChainLocksTest(DashTestFramework):
         assert_equal(best_0['signature'], best_1['signature'])
         assert_equal(best_0['known_block'], False)
         self.reconnect_isolated_node(0, 1)
+        self.sync_all()
         
         self.log.info("Isolate node, mine on both parts of the network, and reconnect")
         self.isolate_node(0)

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -102,20 +102,20 @@ class LLMQChainLocksTest(DashTestFramework):
         self.isolate_node(0)
         self.nodes[1].generate(1)
         self.wait_for_chainlocked_block(self.nodes[1], self.nodes[1].getbestblockhash())
-        self.reconnect_isolated_node(0, 1)
-        time.sleep(1)
         best_0 = self.nodes[0].getbestchainlock()
         best_1 = self.nodes[1].getbestchainlock()
         assert best_0['blockhash'] != best_1['blockhash']
         assert best_0['height'] != best_1['height']
         assert best_0['signature'] != best_1['signature']
-        self.log.info(self.nodes[0].submitchainlock(best_1['blockhash'], best_1['signature'], best_1['height']))
+        assert_equal(best_0['known_block'], True)
+        self.nodes[0].submitchainlock(best_1['blockhash'], best_1['signature'], best_1['height'])
         best_0 = self.nodes[0].getbestchainlock()
-        best_1 = self.nodes[1].getbestchainlock()
-        assert best_0['blockhash'] == best_1['blockhash']
-        assert best_0['height'] == best_1['height']
-        assert best_0['signature'] == best_1['signature']
-
+        assert_equal(best_0['blockhash'], best_1['blockhash'])
+        assert_equal(best_0['height'], best_1['height'])
+        assert_equal(best_0['signature'], best_1['signature'])
+        assert_equal(best_0['known_block'], False)
+        self.reconnect_isolated_node(0, 1)
+        
         self.log.info("Isolate node, mine on both parts of the network, and reconnect")
         self.isolate_node(0)
         bad_tip = self.nodes[0].generate(5)[-1]

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -116,7 +116,7 @@ class LLMQChainLocksTest(DashTestFramework):
         assert_equal(best_0['known_block'], False)
         self.reconnect_isolated_node(0, 1)
         self.sync_all()
-        
+
         self.log.info("Isolate node, mine on both parts of the network, and reconnect")
         self.isolate_node(0)
         bad_tip = self.nodes[0].generate(5)[-1]

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -98,7 +98,7 @@ class LLMQChainLocksTest(DashTestFramework):
         self.wait_for_chainlocked_block_all_nodes(self.nodes[1].getbestblockhash())
         self.test_coinbase_best_cl(self.nodes[0])
 
-        self.log.info("Isolate node, mine on another, reconnect and insert CL via RPC")
+        self.log.info("Isolate node, mine on another, reconnect and submit CL via RPC")
         self.isolate_node(0)
         self.nodes[1].generate(1)
         self.wait_for_chainlocked_block(self.nodes[1], self.nodes[1].getbestblockhash())
@@ -109,7 +109,7 @@ class LLMQChainLocksTest(DashTestFramework):
         assert best_0['blockhash'] != best_1['blockhash']
         assert best_0['height'] != best_1['height']
         assert best_0['signature'] != best_1['signature']
-        self.log.info(self.nodes[0].addchainlock(best_1['blockhash'], best_1['signature'], best_1['height']))
+        self.log.info(self.nodes[0].submitchainlock(best_1['blockhash'], best_1['signature'], best_1['height']))
         best_0 = self.nodes[0].getbestchainlock()
         best_1 = self.nodes[1].getbestchainlock()
         assert best_0['blockhash'] == best_1['blockhash']

--- a/test/functional/rpc_platform_filter.py
+++ b/test/functional/rpc_platform_filter.py
@@ -62,7 +62,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
                        "getbestchainlock",
                        "quorum",
                        "verifyislock",
-                       "addchainlock"]
+                       "submitchainlock"]
 
         help_output = self.nodes[0].help().split('\n')
         nonwhitelisted = set()

--- a/test/functional/rpc_platform_filter.py
+++ b/test/functional/rpc_platform_filter.py
@@ -61,7 +61,8 @@ class HTTPBasicsTest(BitcoinTestFramework):
                        "getblockcount",
                        "getbestchainlock",
                        "quorum",
-                       "verifyislock"]
+                       "verifyislock",
+                       "addchainlock"]
 
         help_output = self.nodes[0].help().split('\n')
         nonwhitelisted = set()

--- a/test/functional/rpc_platform_filter.py
+++ b/test/functional/rpc_platform_filter.py
@@ -61,8 +61,8 @@ class HTTPBasicsTest(BitcoinTestFramework):
                        "getblockcount",
                        "getbestchainlock",
                        "quorum",
-                       "verifyislock",
-                       "submitchainlock"]
+                       "submitchainlock",
+                       "verifyislock"]
 
         help_output = self.nodes[0].help().split('\n')
         nonwhitelisted = set()


### PR DESCRIPTION
## Issue being fixed or feature implemented
Once Platform is live, there could be an edge case where the CL could arrive to an EvoNode faster through Platform quorum than regular P2P propagation.

## What was done?
This PR introduces a new RPC `submitchainlock` with the following 3 mandatory parameters:
- `blockHash`, `signature` and `height`.

Besides some basic tests:
- If the block is unknown then the RPC returns an error (could happen if the node is stucked)
- If the signature is not verified then the RPC return an error.
- If the node already has this CL, the RPC returns true.
- If the node doesn't have this CL, it inserts it, broadcast it through the inv system and return true.

## How Has This Been Tested?
`feature_llmq_chainlocks.py` was modified with the following scenario:

1. node0 is isolated from the rest of the network
2. node1 mines a new block and waits for CL
3. Make sure node0 doesn't know the new block/CL (by checking `getbestchainlock()`)
4. CL is submitted via the new RPC on node0
5. checking `getbestchainlock()` and make sure the CL was processed + 'known_block' is false
6. reconnect node0

## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

