### PR TITLE
fix(rpc)!: require `proTxHash` to be unspecified when not asking for `ENCRYPTED_CONTRIBUTIONS` in `quorum getdata` rpc

### DIFF
--- a/doc/release-notes-5772.md
+++ b/doc/release-notes-5772.md
@@ -1,0 +1,4 @@
+RPC changes
+-----------
+
+`quorum getdata` RPC will no longer allow `proTxHash` to be specified when `dataMask` is set to `1`.

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -813,8 +813,8 @@ static RPCHelpMan quorum_getdata()
     uint16_t nDataMask = static_cast<uint16_t>(ParseInt32V(request.params[3], "dataMask"));
     uint256 proTxHash;
 
-    // Check if request wants ENCRYPTED_CONTRIBUTIONS data
     if (nDataMask & llmq::CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS) {
+        // Require proTxHash if request wants ENCRYPTED_CONTRIBUTIONS data
         if (!request.params[4].isNull()) {
             proTxHash = ParseHashV(request.params[4], "proTxHash");
             if (proTxHash.IsNull()) {
@@ -823,6 +823,9 @@ static RPCHelpMan quorum_getdata()
         } else {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "proTxHash missing");
         }
+    } else if (!request.params[4].isNull()) {
+        // Require no proTxHash otherwise
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Should not specify proTxHash");
     }
 
     const auto quorum = llmq_ctx.qman->GetQuorum(llmqType, quorumHash);

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -395,6 +395,8 @@ class QuorumDataMessagesTest(DashTestFramework):
 
         def test_rpc_quorum_getdata_protx_hash():
             self.log.info("Test optional proTxHash of `quorum getdata`")
+            assert_raises_rpc_error(-8, "Should not specify proTxHash",
+                                    mn1.get_node(self).quorum, "getdata", 0, 100, quorum_hash, 0x01, mn1.proTxHash)
             assert_raises_rpc_error(-8, "proTxHash missing",
                                     mn1.get_node(self).quorum, "getdata", 0, 100, quorum_hash, 0x02)
             assert_raises_rpc_error(-8, "proTxHash invalid",


### PR DESCRIPTION
## Issue being fixed or feature implemented
Because when we ask for a quorum wide data only (`QUORUM_VERIFICATION_VECTOR`) and not for a data about one specific MN `proTxHash` is not used in any way in this case and should not be provided. If it still was provided then maybe user doesn't quite understand what he is doing exactly or maybe he made a typo in `dataMask`.

## What was done?

## How Has This Been Tested?

## Breaking Changes
`quorum getdata` RPC will no longer allow `proTxHash` to be specified when `dataMask` is set to `1`.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

