### PR TITLE
fix(rpc): pass blockhash into `TxToJSON` so that `getspecialtxes` could show correct `instantlock`/`chainlock` values

### DIFF
--- a/doc/release-notes-5774.md
+++ b/doc/release-notes-5774.md
@@ -1,0 +1,4 @@
+RPC changes
+-----------
+
+In `getspecialtxes` `instantlock` and `chainlock` fields were always `false`. They should show actual values now.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2464,7 +2464,7 @@ static UniValue getspecialtxes(const JSONRPCRequest& request)
     CTxMemPool& mempool = EnsureMemPool(node);
     LLMQContext& llmq_ctx = EnsureLLMQContext(node);
 
-    uint256 hash(ParseHashV(request.params[0], "blockhash"));
+    uint256 blockhash(ParseHashV(request.params[0], "blockhash"));
 
     int nTxType = -1;
     if (!request.params[1].isNull()) {
@@ -2493,7 +2493,7 @@ static UniValue getspecialtxes(const JSONRPCRequest& request)
         }
     }
 
-    const CBlockIndex* pblockindex = chainman.m_blockman.LookupBlockIndex(hash);
+    const CBlockIndex* pblockindex = chainman.m_blockman.LookupBlockIndex(blockhash);
     if (!pblockindex) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
     }
@@ -2521,7 +2521,7 @@ static UniValue getspecialtxes(const JSONRPCRequest& request)
             case 2 :
                 {
                     UniValue objTx(UniValue::VOBJ);
-                    TxToJSON(*tx, uint256(), mempool, chainman.ActiveChainstate(), *llmq_ctx.clhandler, *llmq_ctx.isman, objTx);
+                    TxToJSON(*tx, blockhash, mempool, chainman.ActiveChainstate(), *llmq_ctx.clhandler, *llmq_ctx.isman, objTx);
                     result.push_back(objTx);
                     break;
                 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
`instantlock` and `chainlock` are broken in `getspecialtxes`

kudos to @thephez for finding the issue

## What was done?
pass the hash and also rename the variable to self-describing

## How Has This Been Tested?
run `getspecialtxes` on a node with and without the patch

## Breaking Changes
`instantlock` and `chainlock` will show actual values and not just `false` all the time now (not sure if that qualifies for "breaking" though)

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

