### PR TITLE
chore: do not include dash-qt in the docker images

### DIFF
--- a/contrib/containers/deploy/Dockerfile.GitHubActions.Release
+++ b/contrib/containers/deploy/Dockerfile.GitHubActions.Release
@@ -29,7 +29,7 @@ RUN mach=$(uname -m) \
       && case $mach in aarch64) arch="aarch64-linux-gnu"; ;; x86_64) arch="x86_64-linux-gnu"; ;;  *) echo "ERROR: Machine type $mach not supported."; ;; esac \
       && wget https://github.com/${GITHUB_REPOSITORY}/releases/download/v${TAG}/dashcore-${TAG}-$arch.tar.gz -P /tmp \
       && tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/ \
-      && cp /tmp/dashcore*/bin/*  /usr/local/bin \
+      && find /tmp/dashcore*/bin -type f ! -name 'dash-qt' -exec cp {} /usr/local/bin \; \
       && rm -rf /tmp/dashcore* \
       && chmod a+x /usr/local/bin/*
 

--- a/doc/release-notes-5775.md
+++ b/doc/release-notes-5775.md
@@ -1,0 +1,7 @@
+Docker Build System
+-------------------
+
+Modified the Dockerfile to exclude the `dash-qt` graphical wallet interface from the set of binaries copied to
+`/usr/local/bin` during the Docker image build process. This change streamlines the Docker image, making it more
+suitable for server environments and headless applications, where the graphical user interface of `dash-qt` is not
+required. The update enhances the Docker image's efficiency by reducing its size and minimizing unnecessary components.


### PR DESCRIPTION
## Issue being fixed or feature implemented
Remove dash-qt from docker images; save ~41MB

## What was done?


## How Has This Been Tested?
Hasn't

## Breaking Changes
I guess in theory someone could've been relying on dash-qt from docker 🤷 

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

