### PR TITLE
feat(rpc): Asset Unlock status by index

### DIFF
--- a/doc/release-notes-5776.md
+++ b/doc/release-notes-5776.md
@@ -1,10 +1,10 @@
 Added RPC
 --------
 
-- `getassetunlockchainlocks` RPC allows to fetch Asset Unlock txs by their withdrawal index. The RPC accepts an array of indexes and returns status for each index.
+- `getassetunlockstatuses` RPC allows fetching of Asset Unlock txs by their withdrawal index. The RPC accepts an array of indexes and returns status for each index.
 The possible outcomes per each index are:
-- "chainlocked": If the Asset Unlock index is mined on a Chainlocked block.
-- "mined": If no Chainlock information is available, and the Asset Unlock index is mined.
+- "chainlocked": If the Asset Unlock index is mined on a ChainLocked block.
+- "mined": If no ChainLock information is available, and the Asset Unlock index is mined.
 - "mempooled": If the Asset Unlock index is in the mempool.
 - null: If none of the above are valid.
 

--- a/doc/release-notes-5776.md
+++ b/doc/release-notes-5776.md
@@ -1,0 +1,11 @@
+Added RPC
+--------
+
+- `getassetunlockchainlocks` RPC allows to fetch Asset Unlock txs by their withdrawal index. The RPC accepts an array of indexes and returns status for each index.
+The possible outcomes per each index are:
+- "chainlocked": If the Asset Unlock index is mined on a Chainlocked block.
+- "mined": If no Chainlock information is available, and the Asset Unlock index is mined.
+- "mempooled": If the Asset Unlock index is in the mempool.
+- null: If none of the above are valid.
+
+Note: This RPC is whitelisted for the Platform RPC user.

--- a/doc/release-notes-5776.md
+++ b/doc/release-notes-5776.md
@@ -6,6 +6,6 @@ The possible outcomes per each index are:
 - "chainlocked": If the Asset Unlock index is mined on a ChainLocked block.
 - "mined": If no ChainLock information is available, and the Asset Unlock index is mined.
 - "mempooled": If the Asset Unlock index is in the mempool.
-- "unknown"": If none of the above are valid.
+- "unknown": If none of the above are valid.
 
 Note: This RPC is whitelisted for the Platform RPC user.

--- a/doc/release-notes-5776.md
+++ b/doc/release-notes-5776.md
@@ -6,6 +6,6 @@ The possible outcomes per each index are:
 - "chainlocked": If the Asset Unlock index is mined on a ChainLocked block.
 - "mined": If no ChainLock information is available, and the Asset Unlock index is mined.
 - "mempooled": If the Asset Unlock index is in the mempool.
-- null: If none of the above are valid.
+- "unknown"": If none of the above are valid.
 
 Note: This RPC is whitelisted for the Platform RPC user.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1924,6 +1924,8 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                 node.evodb = std::make_unique<CEvoDB>(nEvoDbCache, false, fReset || fReindexChainState);
                 node.mnhf_manager.reset();
                 node.mnhf_manager = std::make_unique<CMNHFManager>(*node.evodb);
+                node.creditPoolManager.reset();
+                node.creditPoolManager = std::make_unique<CCreditPoolManager>(*node.evodb);
 
                 chainman.Reset();
                 chainman.InitializeChainstate(Assert(node.mempool.get()), *node.mnhf_manager, *node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -339,6 +339,7 @@ void PrepareShutdown(NodeContext& node)
         llmq::quorumSnapshotManager.reset();
         deterministicMNManager.reset();
         creditPoolManager.reset();
+        node.creditPoolManager = nullptr;
         node.mnhf_manager.reset();
         node.evodb.reset();
     }
@@ -1924,8 +1925,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                 node.evodb = std::make_unique<CEvoDB>(nEvoDbCache, false, fReset || fReindexChainState);
                 node.mnhf_manager.reset();
                 node.mnhf_manager = std::make_unique<CMNHFManager>(*node.evodb);
-                node.creditPoolManager.reset();
-                node.creditPoolManager = std::make_unique<CCreditPoolManager>(*node.evodb);
+
 
                 chainman.Reset();
                 chainman.InitializeChainstate(Assert(node.mempool.get()), *node.mnhf_manager, *node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
@@ -1943,7 +1943,8 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                 deterministicMNManager.reset();
                 deterministicMNManager.reset(new CDeterministicMNManager(chainman.ActiveChainstate(), *node.connman, *node.evodb));
                 creditPoolManager.reset();
-                creditPoolManager.reset(new CCreditPoolManager(*node.evodb));
+                creditPoolManager = std::make_unique<CCreditPoolManager>(*node.evodb);
+                node.creditPoolManager = creditPoolManager.get();
                 llmq::quorumSnapshotManager.reset();
                 llmq::quorumSnapshotManager.reset(new llmq::CQuorumSnapshotManager(*node.evodb));
 

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -60,7 +60,7 @@ struct NodeContext {
     std::function<void()> rpc_interruption_point = [] {};
     //! Dash
     std::unique_ptr<LLMQContext> llmq_ctx;
-    std::unique_ptr<CCreditPoolManager> creditPoolManager;
+    CCreditPoolManager* creditPoolManager;
     std::unique_ptr<CMNHFManager> mnhf_manager;
     std::unique_ptr<CJContext> cj_ctx;
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -424,7 +424,7 @@ static UniValue getassetunlockchainlocks(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid index");
         }
         if (pool.indexes.Contains(index)) {
-            obj.pushKV(std::to_string(index), chainlock_info ? "chainlocked" : "mined");
+            obj.pushKV(str_indexes[i].get_str(), chainlock_info ? "chainlocked" : "mined");
             result_arr.push_back(obj);
             continue;
         }
@@ -444,10 +444,10 @@ static UniValue getassetunlockchainlocks(const JSONRPCRequest& request)
                 }
             }
             if (is_mempooled)
-                obj.pushKV(std::to_string(index), "mempooled");
+                obj.pushKV(str_indexes[i].get_str(), "mempooled");
             else {
                 UniValue jnull(UniValue::VNULL);
-                obj.pushKV(std::to_string(index), jnull);
+                obj.pushKV(str_indexes[i].get_str(), jnull);
             }
             result_arr.push_back(obj);
         }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -354,9 +354,10 @@ static void getassetunlockstatuses_help(const JSONRPCRequest& request)
             RPCResult{
                     RPCResult::Type::ARR, "", "Response is an array with the same size as the input txids",
                     {
-                            {RPCResult::Type::OBJ, "xxxx", "Asset Unlock index.",
+                            {RPCResult::Type::OBJ, "", "",
                              {
-                                     {RPCResult::Type::STR, "", "Status of the Asset Unlock index: {chainlocked|mined|mempooled|null}"},
+                                {RPCResult::Type::NUM, "index", "The Asset Unlock index"},
+                                {RPCResult::Type::STR, "status", "Status of the Asset Unlock index: {chainlocked|mined|mempooled|null}"},
                              }},
                     }
             },
@@ -413,15 +414,16 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
         if (!ParseUInt64(str_indexes[i].get_str(), &index)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid index");
         }
+        obj.pushKV("index", index);
         if (poolCL.has_value() && poolCL->indexes.Contains(index)) {
-            obj.pushKV(str_indexes[i].get_str(), "chainlocked");
+            obj.pushKV("status", "chainlocked");
             result_arr.push_back(obj);
             continue;
         }
         if (pTipBlockIndex != pBlockIndexBestCL) {
             if (!poolOnTip.has_value()) poolOnTip = node.creditPoolManager->GetCreditPool(pTipBlockIndex, Params().GetConsensus());
             if (poolOnTip->indexes.Contains(index)) {
-                obj.pushKV(str_indexes[i].get_str(), "mined");
+                obj.pushKV("status", "mined");
                 result_arr.push_back(obj);
                 continue;
             }
@@ -441,10 +443,10 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
             }
         }
         if (is_mempooled)
-            obj.pushKV(str_indexes[i].get_str(), "mempooled");
+            obj.pushKV("status", "mempooled");
         else {
             UniValue jnull(UniValue::VNULL);
-            obj.pushKV(str_indexes[i].get_str(), jnull);
+            obj.pushKV("status", jnull);
         }
         result_arr.push_back(obj);
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -375,10 +375,10 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const CTxMemPool& mempool = EnsureMemPool(node);
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
-    ChainstateManager& chainman = EnsureChainman(node);
+    const ChainstateManager& chainman = EnsureChainman(node);
 
     UniValue result_arr(UniValue::VARR);
-    UniValue str_indexes = request.params[0].get_array();
+    const UniValue str_indexes = request.params[0].get_array();
     if (str_indexes.size() > 100) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Up to 100 indexes only");
     }
@@ -387,7 +387,7 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
         g_txindex->BlockUntilSyncedToCurrentChain();
     }
 
-    CBlockIndex* pTipBlockIndex{WITH_LOCK(cs_main, return chainman.ActiveChain().Tip())};
+    const CBlockIndex* pTipBlockIndex{WITH_LOCK(cs_main, return chainman.ActiveChain().Tip())};
 
     if (!pTipBlockIndex) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No blocks in chain");
@@ -395,7 +395,7 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
 
     const auto pBlockIndexBestCL = [&]() -> const CBlockIndex* {
         if (llmq_ctx.clhandler->GetBestChainLock().IsNull()) {
-        // If no CL info is available, try to use CbTx CL information
+            // If no CL info is available, try to use CbTx CL information
             if (const auto cbtx_best_cl = GetNonNullCoinbaseChainlock(pTipBlockIndex)) {
                 return pTipBlockIndex->GetAncestor(pTipBlockIndex->nHeight - cbtx_best_cl->second - 1);
             }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -141,7 +141,7 @@ std::string CRPCTable::help(const std::string& strCommand, const std::string& st
 void CRPCTable::InitPlatformRestrictions()
 {
     mapPlatformRestrictions = {
-        {"getassetunlockchainlocks", {}},
+        {"getassetunlockstatuses", {}},
         {"getbestblockhash", {}},
         {"getblockhash", {}},
         {"getblockcount", {}},

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -141,6 +141,7 @@ std::string CRPCTable::help(const std::string& strCommand, const std::string& st
 void CRPCTable::InitPlatformRestrictions()
 {
     mapPlatformRestrictions = {
+        {"getassetunlockchainlocks", {}},
         {"getbestblockhash", {}},
         {"getblockhash", {}},
         {"getblockcount", {}},

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -169,6 +169,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     llmq::quorumSnapshotManager.reset(new llmq::CQuorumSnapshotManager(*m_node.evodb));
     creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
+    m_node.creditPoolManager = creditPoolManager.get();
     static bool noui_connected = false;
     if (!noui_connected) {
         noui_connect();
@@ -182,6 +183,7 @@ BasicTestingSetup::~BasicTestingSetup()
     connman.reset();
     llmq::quorumSnapshotManager.reset();
     creditPoolManager.reset();
+    m_node.creditPoolManager = nullptr;
     m_node.mnhf_manager.reset();
     m_node.evodb.reset();
 
@@ -215,7 +217,9 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     ::mmetaman = std::make_unique<CMasternodeMetaMan>(/* load_cache */ false);
     ::netfulfilledman = std::make_unique<CNetFulfilledRequestManager>(/* load_cache */ false);
 
-    m_node.creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
+    creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
+    m_node.creditPoolManager = creditPoolManager.get();
+
 
     // Start script-checking threads. Set g_parallel_script_checks to true so they are used.
     constexpr int script_check_threads = 2;
@@ -226,7 +230,8 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
 ChainTestingSetup::~ChainTestingSetup()
 {
     m_node.scheduler->stop();
-    m_node.creditPoolManager.reset();
+    creditPoolManager.reset();
+    m_node.creditPoolManager = nullptr;
     StopScriptCheckWorkerThreads();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -330,6 +330,16 @@ class AssetLocksTest(DashTestFramework):
 
         txid = self.send_tx(asset_unlock_tx)
         assert "assetUnlockTx" in node.getrawtransaction(txid, 1)
+
+        indexes_statuses = self.nodes[0].getassetunlockchainlocks(["101", "102", "300"])
+        self.log.info(f'{indexes_statuses}')
+        assert any('101' in d for d in indexes_statuses)
+        assert_equal(next((d['101'] for d in indexes_statuses if '101' in d), None), "mempooled")
+        assert any('102' in d for d in indexes_statuses)
+        assert_equal(next((d['102'] for d in indexes_statuses if '102' in d), None), None)
+        assert any('300' in d for d in indexes_statuses)
+        assert_equal(next((d['300'] for d in indexes_statuses if '300' in d), None), None)
+
         self.mempool_size += 1
         self.check_mempool_size()
         self.validate_credit_pool_balance(locked_1)
@@ -501,6 +511,15 @@ class AssetLocksTest(DashTestFramework):
         self.send_tx(asset_unlock_tx)
         node.generate(1)
         self.sync_all()
+
+        indexes_statuses = self.nodes[0].getassetunlockchainlocks(["101", "102", "103"])
+        self.log.info(f'{indexes_statuses}')
+        assert any('101' in d for d in indexes_statuses)
+        assert_equal(next((d['101'] for d in indexes_statuses if '101' in d), None), "mined")
+        assert any('102' in d for d in indexes_statuses)
+        assert_equal(next((d['102'] for d in indexes_statuses if '102' in d), None), "mined")
+        assert any('103' in d for d in indexes_statuses)
+        assert_equal(next((d['103'] for d in indexes_statuses if '103' in d), None), None)
 
         self.log.info("generate many blocks to be sure that mempool is empty after expiring txes...")
         self.slowly_generate_batch(60)

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -331,7 +331,7 @@ class AssetLocksTest(DashTestFramework):
         txid = self.send_tx(asset_unlock_tx)
         assert "assetUnlockTx" in node.getrawtransaction(txid, 1)
 
-        indexes_statuses = self.nodes[0].getassetunlockchainlocks(["101", "102", "300"])
+        indexes_statuses = self.nodes[0].getassetunlockstatuses(["101", "102", "300"])
         self.log.info(f'{indexes_statuses}')
         assert any('101' in d for d in indexes_statuses)
         assert_equal(next((d['101'] for d in indexes_statuses if '101' in d), None), "mempooled")
@@ -512,7 +512,7 @@ class AssetLocksTest(DashTestFramework):
         node.generate(1)
         self.sync_all()
 
-        indexes_statuses = self.nodes[0].getassetunlockchainlocks(["101", "102", "103"])
+        indexes_statuses = self.nodes[0].getassetunlockstatuses(["101", "102", "103"])
         self.log.info(f'{indexes_statuses}')
         assert any('101' in d for d in indexes_statuses)
         assert_equal(next((d['101'] for d in indexes_statuses if '101' in d), None), "mined")

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -332,7 +332,7 @@ class AssetLocksTest(DashTestFramework):
         assert "assetUnlockTx" in node.getrawtransaction(txid, 1)
 
         indexes_statuses = self.nodes[0].getassetunlockstatuses(["101", "102", "300"])
-        assert_equal([{'101': 'mempooled'}, {'102': None}, {'300': None}], indexes_statuses)
+        assert_equal([{'index': 101, 'status': 'mempooled'}, {'index': 102, 'status': None}, {'index': 300, 'status': None}], indexes_statuses)
 
         self.mempool_size += 1
         self.check_mempool_size()
@@ -507,7 +507,7 @@ class AssetLocksTest(DashTestFramework):
         self.sync_all()
 
         indexes_statuses = self.nodes[0].getassetunlockstatuses(["101", "102", "103"])
-        assert_equal([{'101': 'mined'}, {'102': 'mined'}, {'103': None}], indexes_statuses)
+        assert_equal([{'index': 101, 'status': 'mined'}, {'index': 102, 'status': 'mined'}, {'index': 103, 'status': None}], indexes_statuses)
 
         self.log.info("generate many blocks to be sure that mempool is empty after expiring txes...")
         self.slowly_generate_batch(60)

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -332,7 +332,7 @@ class AssetLocksTest(DashTestFramework):
         assert "assetUnlockTx" in node.getrawtransaction(txid, 1)
 
         indexes_statuses = self.nodes[0].getassetunlockstatuses(["101", "102", "300"])
-        assert_equal([{'index': 101, 'status': 'mempooled'}, {'index': 102, 'status': None}, {'index': 300, 'status': None}], indexes_statuses)
+        assert_equal([{'index': 101, 'status': 'mempooled'}, {'index': 102, 'status': 'unknown'}, {'index': 300, 'status': 'unknown'}], indexes_statuses)
 
         self.mempool_size += 1
         self.check_mempool_size()
@@ -507,7 +507,7 @@ class AssetLocksTest(DashTestFramework):
         self.sync_all()
 
         indexes_statuses = self.nodes[0].getassetunlockstatuses(["101", "102", "103"])
-        assert_equal([{'index': 101, 'status': 'mined'}, {'index': 102, 'status': 'mined'}, {'index': 103, 'status': None}], indexes_statuses)
+        assert_equal([{'index': 101, 'status': 'mined'}, {'index': 102, 'status': 'mined'}, {'index': 103, 'status': 'unknown'}], indexes_statuses)
 
         self.log.info("generate many blocks to be sure that mempool is empty after expiring txes...")
         self.slowly_generate_batch(60)

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -332,13 +332,7 @@ class AssetLocksTest(DashTestFramework):
         assert "assetUnlockTx" in node.getrawtransaction(txid, 1)
 
         indexes_statuses = self.nodes[0].getassetunlockstatuses(["101", "102", "300"])
-        self.log.info(f'{indexes_statuses}')
-        assert any('101' in d for d in indexes_statuses)
-        assert_equal(next((d['101'] for d in indexes_statuses if '101' in d), None), "mempooled")
-        assert any('102' in d for d in indexes_statuses)
-        assert_equal(next((d['102'] for d in indexes_statuses if '102' in d), None), None)
-        assert any('300' in d for d in indexes_statuses)
-        assert_equal(next((d['300'] for d in indexes_statuses if '300' in d), None), None)
+        assert_equal([{'101': 'mempooled'}, {'102': None}, {'300': None}], indexes_statuses)
 
         self.mempool_size += 1
         self.check_mempool_size()
@@ -513,13 +507,7 @@ class AssetLocksTest(DashTestFramework):
         self.sync_all()
 
         indexes_statuses = self.nodes[0].getassetunlockstatuses(["101", "102", "103"])
-        self.log.info(f'{indexes_statuses}')
-        assert any('101' in d for d in indexes_statuses)
-        assert_equal(next((d['101'] for d in indexes_statuses if '101' in d), None), "mined")
-        assert any('102' in d for d in indexes_statuses)
-        assert_equal(next((d['102'] for d in indexes_statuses if '102' in d), None), "mined")
-        assert any('103' in d for d in indexes_statuses)
-        assert_equal(next((d['103'] for d in indexes_statuses if '103' in d), None), None)
+        assert_equal([{'101': 'mined'}, {'102': 'mined'}, {'103': None}], indexes_statuses)
 
         self.log.info("generate many blocks to be sure that mempool is empty after expiring txes...")
         self.slowly_generate_batch(60)

--- a/test/functional/rpc_platform_filter.py
+++ b/test/functional/rpc_platform_filter.py
@@ -56,7 +56,7 @@ class HTTPBasicsTest(BitcoinTestFramework):
                 assert_equal(resp.status, expexted_status)
             conn.close()
 
-        whitelisted = ["getassetunlockchainlocks",
+        whitelisted = ["getassetunlockstatuses",
                        "getbestblockhash",
                        "getblockhash",
                        "getblockcount",

--- a/test/functional/rpc_platform_filter.py
+++ b/test/functional/rpc_platform_filter.py
@@ -56,7 +56,8 @@ class HTTPBasicsTest(BitcoinTestFramework):
                 assert_equal(resp.status, expexted_status)
             conn.close()
 
-        whitelisted = ["getbestblockhash",
+        whitelisted = ["getassetunlockchainlocks",
+                       "getbestblockhash",
                        "getblockhash",
                        "getblockcount",
                        "getbestchainlock",


### PR DESCRIPTION
## Issue being fixed or feature implemented
Platform in the scope of credit withdrawals, need a way to get the status of an Asset Unlock by index.

## What was done?
A new RPC was created `getassetunlockchainlocks` that accepts Asset Unlock indexes array as parameter and return corresponding status for each index.

The possible outcomes per each index are:
- `chainlocked`: If the Asset Unlock index is mined on a Chainlocked block.
- `mined`: If no Chainlock information is available, and the Asset Unlock index is mined.
- `mempooled`: If the Asset Unlock index is in the mempool.
- `unknown`: If none of the above are valid.

Note: This RPC is whitelisted for the Platform RPC user.

## How Has This Been Tested?
Inserted on `feature_asset_locks.py` covering cases where Asset Unlock txs are in mempool, mined and not present.

## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

