### PR TITLE
feat: process/accept CbTx CL as new CL

### DIFF
--- a/src/evo/cbtx.h
+++ b/src/evo/cbtx.h
@@ -89,7 +89,7 @@ bool CheckCbTxMerkleRoots(const CBlock& block, const CBlockIndex* pindex, const 
 bool CalcCbTxMerkleRootMNList(const CBlock& block, const CBlockIndex* pindexPrev, uint256& merkleRootRet, BlockValidationState& state, const CCoinsViewCache& view);
 bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPrev, const llmq::CQuorumBlockProcessor& quorum_block_processor, uint256& merkleRootRet, BlockValidationState& state);
 
-bool CheckCbTxBestChainlock(const CBlock& block, const CBlockIndex* pindexPrev, const llmq::CChainLocksHandler& chainlock_handler, BlockValidationState& state);
+bool CheckCbTxBestChainlock(const CBlock& block, const CBlockIndex* pindexPrev, llmq::CChainLocksHandler& chainlock_handler, BlockValidationState& state);
 bool CalcCbTxBestChainlock(const llmq::CChainLocksHandler& chainlock_handler, const CBlockIndex* pindexPrev, uint32_t& bestCLHeightDiff, CBLSSignature& bestCLSignature);
 
 std::optional<CCbTx> GetCoinbaseTx(const CBlockIndex* pindex);

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -131,7 +131,7 @@ static bool UndoSpecialTx(const CTransaction& tx, const CBlockIndex* pindex)
 }
 
 bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CMNHFManager& mnhfManager,
-                              llmq::CQuorumBlockProcessor& quorum_block_processor, const llmq::CChainLocksHandler& chainlock_handler,
+                              llmq::CQuorumBlockProcessor& quorum_block_processor, llmq::CChainLocksHandler& chainlock_handler,
                               const Consensus::Params& consensusParams, const CCoinsViewCache& view, bool fJustCheck, bool fCheckCbTxMerleRoots,
                               BlockValidationState& state, std::optional<MNListUpdates>& updatesRet)
 {

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -31,7 +31,7 @@ extern RecursiveMutex cs_main;
 bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs,
                     TxValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CMNHFManager& mnhfManager,
-                              llmq::CQuorumBlockProcessor& quorum_block_processor, const llmq::CChainLocksHandler& chainlock_handler,
+                              llmq::CQuorumBlockProcessor& quorum_block_processor, llmq::CChainLocksHandler& chainlock_handler,
                               const Consensus::Params& consensusParams, const CCoinsViewCache& view, bool fJustCheck, bool fCheckCbTxMerleRoots,
                               BlockValidationState& state, std::optional<MNListUpdates>& updatesRet) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, CMNHFManager& mnhfManager,

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -107,6 +107,11 @@ void CChainLocksHandler::ProcessMessage(const CNode& pfrom, const std::string& m
 
 void CChainLocksHandler::ProcessNewChainLock(const NodeId from, const llmq::CChainLockSig& clsig, const uint256& hash)
 {
+    if (!m_mn_sync.IsBlockchainSynced()) {
+        // too early to do anything
+        return;
+    }
+
     CheckActiveState();
 
     CInv clsigInv(MSG_CLSIG, hash);

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -156,6 +156,7 @@ class LLMQChainLocksTest(DashTestFramework):
         self.log.info("Restart it so that it forgets all the chainlock messages from the past")
         self.restart_node(0)
         self.connect_nodes(0, 1)
+        force_finish_mnsync(self.nodes[0])
         assert self.nodes[0].getbestblockhash() == good_tip
         self.nodes[0].invalidateblock(good_tip)
         self.log.info("Now try to reorg the chain")


### PR DESCRIPTION
## Issue being fixed or feature implemented
We should process/accept CbTx CL as new CL as we process/accept new blocks.

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

