### PR TITLE
chore: update ∋ to Ð in test_runner.py output

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -343,7 +343,7 @@ def main():
     logging.basicConfig(format='%(message)s', level=logging_level)
 
     # Create base test directory
-    tmpdir = "%s/test_runner_∋_🏃_%s" % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+    tmpdir = "%s/test_runner_Ð_🏃_%s" % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
 
     os.makedirs(tmpdir)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Bitcoin has his own character ₿ in Unicode in Currency set. Unfortunately, there's no Dash currency in unicode. Let's take a stroke Ð.

## What was done?
Replaced `∋` to `Ð`
There's several other options:
```
Đ Latin Letter D with Stroke (used in PR)
Ð Latin Capital Letter Eth
ↄ Latin Small Letter Reversed C
ꜿ Latin Small Letter Reversed C with Dot
Ꜿ Latin capital letter reversed c with dot
⋻ Contains with Vertical Bar at End of Horizontal Stroke
⪾ Superset with dot
ᑝ Canadian syllabics two (poor support in fonts)
ᕭ Canadian syllabics ttho (poor support in fonts)
ᑔ Canadian syllabics carrier di (poor support in fonts)
ⅅ Double-Struck Italic Capital D
```


## How Has This Been Tested?
Run test/functional/test_runner.py and see output

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
