### PR TITLE
fix: withdrawal (asset unlock) txes to use Platform Quorum on RegTest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -283,7 +283,6 @@ public:
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_60_75;
         consensus.llmqTypePlatform = Consensus::LLMQType::LLMQ_100_67;
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_400_85;
-        consensus.llmqTypeAssetLocks = consensus.llmqTypePlatform;
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
@@ -475,7 +474,6 @@ public:
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_60_75;
         consensus.llmqTypePlatform = Consensus::LLMQType::LLMQ_25_67;
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_50_60;
-        consensus.llmqTypeAssetLocks = consensus.llmqTypePlatform;
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
@@ -650,7 +648,6 @@ public:
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_DEVNET_DIP0024;
         consensus.llmqTypePlatform = Consensus::LLMQType::LLMQ_DEVNET_PLATFORM;
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_DEVNET;
-        consensus.llmqTypeAssetLocks = consensus.llmqTypePlatform;
 
         UpdateDevnetLLMQChainLocksFromArgs(args);
         UpdateDevnetLLMQInstantSendDIP0024FromArgs(args);
@@ -723,7 +720,6 @@ public:
     void UpdateDevnetLLMQPlatform(Consensus::LLMQType llmqType)
     {
         consensus.llmqTypePlatform = llmqType;
-        consensus.llmqTypeAssetLocks = llmqType;
     }
 
     /**
@@ -927,7 +923,6 @@ public:
         consensus.llmqTypeDIP0024InstantSend = Consensus::LLMQType::LLMQ_TEST_DIP0024;
         consensus.llmqTypePlatform = Consensus::LLMQType::LLMQ_TEST_PLATFORM;
         consensus.llmqTypeMnhf = Consensus::LLMQType::LLMQ_TEST;
-        consensus.llmqTypeAssetLocks = Consensus::LLMQType::LLMQ_TEST;
 
         UpdateLLMQTestParametersFromArgs(args, Consensus::LLMQType::LLMQ_TEST);
         UpdateLLMQTestParametersFromArgs(args, Consensus::LLMQType::LLMQ_TEST_INSTANTSEND);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -162,7 +162,6 @@ struct Params {
     LLMQType llmqTypeDIP0024InstantSend{LLMQType::LLMQ_NONE};
     LLMQType llmqTypePlatform{LLMQType::LLMQ_NONE};
     LLMQType llmqTypeMnhf{LLMQType::LLMQ_NONE};
-    LLMQType llmqTypeAssetLocks{LLMQType::LLMQ_NONE};
 
     int DeploymentHeight(BuriedDeployment dep) const
     {

--- a/src/evo/assetlocktx.cpp
+++ b/src/evo/assetlocktx.cpp
@@ -114,7 +114,7 @@ bool CAssetUnlockPayload::VerifySig(const uint256& msgHash, gsl::not_null<const 
     // and at the quorumHash must be active in either the current or previous quorum cycle
     // and the sig must validate against that specific quorumHash.
 
-    Consensus::LLMQType llmqType = Params().GetConsensus().llmqTypeAssetLocks;
+    Consensus::LLMQType llmqType = Params().GetConsensus().llmqTypePlatform;
 
     // We check at most 2 quorums
     const auto quorums = llmq::quorumManager->ScanQuorums(llmqType, pindexTip, 2);

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -258,9 +258,9 @@ class AssetLocksTest(DashTestFramework):
         self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
 
         for i in range(3):
-            evo_info = self.dynamically_add_masternode(evo=True)
+            self.dynamically_add_masternode(evo=True)
             node.generate(8)
-            self.sync_blocks(self.nodes)
+            self.sync_blocks()
 
         self.set_sporks()
         self.activate_v20()

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -51,7 +51,7 @@ blocks_in_one_day = 576
 
 class AssetLocksTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(5, 3, evo_count=3)
+        self.set_dash_test_params(6, 4, evo_count=5)
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -245,7 +245,19 @@ class AssetLocksTest(DashTestFramework):
         self.activate_v19(expected_activation_height=900)
         self.log.info("Activated v19 at height:" + str(node.getblockcount()))
 
-        for i in range(3):
+        self.nodes[0].sporkupdate("SPORK_2_INSTANTSEND_ENABLED", 0)
+        self.wait_for_sporks_same()
+
+        self.move_to_next_cycle()
+        self.log.info("Cycle H height:" + str(self.nodes[0].getblockcount()))
+        self.move_to_next_cycle()
+        self.log.info("Cycle H+C height:" + str(self.nodes[0].getblockcount()))
+        self.move_to_next_cycle()
+        self.log.info("Cycle H+2C height:" + str(self.nodes[0].getblockcount()))
+
+        self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
+
+        for i in range(5):
             evo_info = self.dynamically_add_masternode(evo=True)
             node.generate(8)
             self.sync_blocks(self.nodes)

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -51,7 +51,7 @@ blocks_in_one_day = 576
 
 class AssetLocksTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 4, evo_count=5)
+        self.set_dash_test_params(6, 4, evo_count=3)
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -257,7 +257,7 @@ class AssetLocksTest(DashTestFramework):
 
         self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
 
-        for i in range(5):
+        for i in range(3):
             evo_info = self.dynamically_add_masternode(evo=True)
             node.generate(8)
             self.sync_blocks(self.nodes)

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -289,6 +289,7 @@ class AssetLocksTest(DashTestFramework):
         assert "assetLockTx" in node.getrawtransaction(txid_in_block, 1)
         self.validate_credit_pool_balance(0)
         node.generate(1)
+        assert_equal(self.get_credit_pool_balance(node=node_wallet), 0)
         assert_equal(self.get_credit_pool_balance(node=node), locked_1)
         self.log.info("Generate a number of blocks to ensure this is the longest chain for later in the test when we reconsiderblock")
         node.generate(12)

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -289,7 +289,6 @@ class AssetLocksTest(DashTestFramework):
         assert "assetLockTx" in node.getrawtransaction(txid_in_block, 1)
         self.validate_credit_pool_balance(0)
         node.generate(1)
-        assert_equal(self.get_credit_pool_balance(node=node_wallet), 0)
         assert_equal(self.get_credit_pool_balance(node=node), locked_1)
         self.log.info("Generate a number of blocks to ensure this is the longest chain for later in the test when we reconsiderblock")
         node.generate(12)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1155,6 +1155,7 @@ class DashTestFramework(BitcoinTestFramework):
         for i in range(0, idx):
             self.connect_nodes(i, idx)
 
+    # TODO: to let creating Evo Nodes without instant-send available
     def dynamically_add_masternode(self, evo=False, rnd=None, should_be_rejected=False):
         mn_idx = len(self.nodes)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1982,11 +1982,11 @@ class DashTestFramework(BitcoinTestFramework):
         # Note: recsigs aren't relayed to regular nodes by default,
         # make sure to pick a mn as a node to query for recsigs.
         try:
-            quorumHash = self.mninfo[0].node.quorum("selectquorum", llmq_type, rec_sig_id)["quorumHash"]
+            quorumHash = self.mninfo[1].node.quorum("selectquorum", llmq_type, rec_sig_id)["quorumHash"]
             for mn in self.mninfo:
                 mn.node.quorum("sign", llmq_type, rec_sig_id, rec_sig_msg_hash, quorumHash)
             self.wait_for_recovered_sig(rec_sig_id, rec_sig_msg_hash, llmq_type, 10)
-            return self.mninfo[0].node.quorum("getrecsig", llmq_type, rec_sig_id, rec_sig_msg_hash)
+            return self.mninfo[1].node.quorum("getrecsig", llmq_type, rec_sig_id, rec_sig_msg_hash)
         except JSONRPCException as e:
             self.log.info(f"getrecsig failed with '{e}'")
         assert False

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1161,17 +1161,14 @@ class DashTestFramework(BitcoinTestFramework):
         node_p2p_port = p2p_port(mn_idx)
         node_rpc_port = rpc_port(mn_idx)
 
-        created_mn_info = self.dynamically_prepare_masternode(mn_idx, node_p2p_port, evo, rnd)
-        #protx_success = False
-        #try:
-        #    created_mn_info = self.dynamically_prepare_masternode(mn_idx, node_p2p_port, evo, rnd)
-        #    protx_success = True
-        #except Exception as e:
-        #    self.log.info(f"dynamically_prepare_masternode failed: {e}")
-        #    if not should_be_rejected:
-        #        raise e
+        protx_success = False
+        try:
+            created_mn_info = self.dynamically_prepare_masternode(mn_idx, node_p2p_port, evo, rnd)
+            protx_success = True
+        except:
+            self.log.info("dynamically_prepare_masternode failed")
 
-        #assert_equal(protx_success, not should_be_rejected)
+        assert_equal(protx_success, not should_be_rejected)
 
         if should_be_rejected:
             # nothing to do
@@ -1212,16 +1209,9 @@ class DashTestFramework(BitcoinTestFramework):
         collateral_amount = EVONODE_COLLATERAL if evo else MASTERNODE_COLLATERAL
         outputs = {collateral_address: collateral_amount, funds_address: 1}
         collateral_txid = self.nodes[0].sendmany("", outputs)
-        self.log.info(f"collateral: {collateral_txid}")
-        self.log.info(f"top block: {self.nodes[0].getblock(self.nodes[0].getbestblockhash())}")
-        
-#        self.send_tx(collateral_txid)
-        self.bump_mocktime(1)
-#        self.wait_for_instantlock(collateral_txid, self.nodes[0])
+        self.wait_for_instantlock(collateral_txid, self.nodes[0])
         tip = self.nodes[0].generate(1)[0]
-        self.sync_all()
-        self.log.info(f"top block-expected: {self.nodes[0].getblock(self.nodes[0].getbestblockhash())}")
-        
+        self.sync_all(self.nodes)
 
         rawtx = self.nodes[0].getrawtransaction(collateral_txid, 1, tip)
         assert_equal(rawtx['confirmations'], 1)
@@ -1241,11 +1231,9 @@ class DashTestFramework(BitcoinTestFramework):
         else:
             protx_result = self.nodes[0].protx("register", collateral_txid, collateral_vout, ipAndPort, owner_address, bls['public'], voting_address, operatorReward, reward_address, funds_address, True)
 
-        self.bump_mocktime(1)
-#        self.send_tx(collateral_txid)
-#        self.wait_for_instantlock(protx_result, self.nodes[0])
+        self.wait_for_instantlock(protx_result, self.nodes[0])
         tip = self.nodes[0].generate(1)[0]
-        self.sync_all()
+        self.sync_all(self.nodes)
 
         assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
         mn_info = MasternodeInfo(protx_result, owner_address, voting_address, reward_address, operatorReward, bls['public'], bls['secret'], collateral_address, collateral_txid, collateral_vout, ipAndPort, evo)
@@ -1982,11 +1970,11 @@ class DashTestFramework(BitcoinTestFramework):
         # Note: recsigs aren't relayed to regular nodes by default,
         # make sure to pick a mn as a node to query for recsigs.
         try:
-            quorumHash = self.mninfo[1].node.quorum("selectquorum", llmq_type, rec_sig_id)["quorumHash"]
+            quorumHash = self.mninfo[0].node.quorum("selectquorum", llmq_type, rec_sig_id)["quorumHash"]
             for mn in self.mninfo:
                 mn.node.quorum("sign", llmq_type, rec_sig_id, rec_sig_msg_hash, quorumHash)
             self.wait_for_recovered_sig(rec_sig_id, rec_sig_msg_hash, llmq_type, 10)
-            return self.mninfo[1].node.quorum("getrecsig", llmq_type, rec_sig_id, rec_sig_msg_hash)
+            return self.mninfo[0].node.quorum("getrecsig", llmq_type, rec_sig_id, rec_sig_msg_hash)
         except JSONRPCException as e:
             self.log.info(f"getrecsig failed with '{e}'")
         assert False


### PR DESCRIPTION
## Issue being fixed or feature implemented
Asset Unlock tx uses platform's quorum on devnets, testnet, mainnet, but still quorum type "Test (100)" on Reg Tests
That's part II PR, prior work is here: https://github.com/dashpay/dash/pull/5618

## What was done?
 - Removed `consensus.llmqTypeAssetLocks` which has been kept only for RegTest - use `consensus.llmqTypePlatform` instead.
 - Functional test `feature_asset_locks.py` uses `llmq_type_test = 106` instead `llmq_type_test = 100` for asset unlock tx
 - there's 4 MNs + 3 evo nodes instead 3 MNs as before: evo nodes requires to have IS to be active


## How Has This Been Tested?
Run unit/functional tests


## Breaking Changes
Asset Unlock tx uses correct quorum "106 llmq_test_platform" on reg test instead "100 llmq_test"

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

