### PR TITLE
build: Disable miner for Windows binaries built via Guix

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -237,6 +237,7 @@ mkdir -p "$OUTDIR"
 CONFIGFLAGS+=" --enable-reduce-exports --disable-bench --disable-gui-tests --disable-fuzz-binary"
 case "$HOST" in
     *linux*) CONFIGFLAGS+=" --disable-threadlocal" ;;
+    *mingw*) CONFIGFLAGS+=" --disable-miner" ;;
 esac
 
 # CFLAGS


### PR DESCRIPTION
## Issue being fixed or feature implemented
We had this in Gitian https://github.com/dashpay/dash/blob/master/contrib/gitian-descriptors/gitian-win.yml#L38. We also had it for macos https://github.com/dashpay/dash/blob/master/contrib/gitian-descriptors/gitian-osx.yml#L42 but it looks like it's no longer an issue there (or at least I did not see anyone complaining about it).

## What was done?
tweak `CONFIGFLAGS` for `mingw` host

## How Has This Been Tested?
n/a

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

