### PR TITLE
feat: enable HD wallets by default

### DIFF
--- a/doc/release-notes-5807.md
+++ b/doc/release-notes-5807.md
@@ -1,0 +1,7 @@
+# Notable changes
+
+## HD Wallets Enabled by Default
+
+In this release, we are taking a significant step towards enhancing the Dash wallet's usability by enabling Hierarchical Deterministic (HD) wallets by default. This change aligns the behavior of `dashd` and `dash-qt` with the previously optional `-usehd=1` flag, making HD wallets the standard for all users.
+
+While HD wallets are now enabled by default to improve user experience, Dash Core still allows for the creation of non-HD wallets by using the `-usehd=0` flag. However, users should be aware that this option is intended for legacy support and will be removed in future releases. Importantly, even with an HD wallet, users can still import non-HD private keys, ensuring flexibility in managing their funds.

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -50,7 +50,7 @@
       <string>Encrypt Wallet</string>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4897,8 +4897,8 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
         return false;
     }
 
-    // Discourage users to skip passphrase for HD wallets
-    if (nMaxVersion >= FEATURE_HD && !IsHDEnabled()) {
+    // TODO: consider discourage users to skip passphrase for HD wallets for v21
+    if (false && nMaxVersion >= FEATURE_HD && !IsHDEnabled()) {
         error = Untranslated("You should use upgradetohd RPC to upgrade non-HD wallet to HD");
         return false;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -298,7 +298,7 @@ std::shared_ptr<CWallet> CreateWallet(interfaces::Chain& chain, interfaces::Coin
         return nullptr;
     }
     if (gArgs.GetBoolArg("-usehd", DEFAULT_USE_HD_WALLET)) {
-        LogPrintf("set HD by default\n");
+        wallet->WalletLogPrintf("Set HD by default\n");
         wallet->SetMinVersion(FEATURE_HD);
     }
 
@@ -310,13 +310,6 @@ std::shared_ptr<CWallet> CreateWallet(interfaces::Chain& chain, interfaces::Coin
             return nullptr;
         }
         if (!create_blank) {
-            // Unlock the wallet
-            if (!wallet->Unlock(passphrase)) {
-                error = Untranslated("Error: Wallet was encrypted but could not be unlocked");
-                status = DatabaseStatus::FAILED_ENCRYPT;
-                return nullptr;
-            }
-
             {
                 // TODO: drop this condition after removing option to create non-HD wallets
                 // related backport bitcoin#11250
@@ -327,6 +320,13 @@ std::shared_ptr<CWallet> CreateWallet(interfaces::Chain& chain, interfaces::Coin
                        return nullptr;
                     }
                 }
+            }
+
+            // Unlock the wallet
+            if (!wallet->Unlock(passphrase)) {
+                error = Untranslated("Error: Wallet was encrypted but could not be unlocked");
+                status = DatabaseStatus::FAILED_ENCRYPT;
+                return nullptr;
             }
 
             // backup the wallet we just encrypted

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4897,7 +4897,14 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
         return false;
     }
 
+    // Discourage users to skip passphrase for HD wallets
+    if (nMaxVersion >= FEATURE_HD && !IsHDEnabled()) {
+        error = Untranslated("You should use upgradetohd RPC to upgrade non-HD wallet to HD");
+        return false;
+    }
+
     SetMaxVersion(nMaxVersion);
+
     return true;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1331,6 +1331,9 @@ public:
     /** Upgrade the wallet */
     bool UpgradeWallet(int version, bilingual_str& error);
 
+    /** Upgrade non-HD wallet to HD wallet */
+    bool UpgradeToHD(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase, const SecureString& secureWalletPassphrase, bilingual_str& error);
+
     //! Returns all unique ScriptPubKeyMans in m_internal_spk_managers and m_external_spk_managers
     std::set<ScriptPubKeyMan*> GetActiveScriptPubKeyMans() const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -91,7 +91,7 @@ static const CAmount HIGH_TX_FEE_PER_KB = COIN / 100;
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;
 
 //! if set, all keys will be derived by using BIP39/BIP44
-static const bool DEFAULT_USE_HD_WALLET = false;
+static const bool DEFAULT_USE_HD_WALLET = true;
 
 class CCoinControl;
 class CKey;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1278,6 +1278,7 @@ public:
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const;
 
+    // TODO: move it to scriptpubkeyman
     /* Generates a new HD chain */
     bool GenerateNewHDChainEncrypted(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase, const SecureString& secureWalletPassphrase);
 

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -28,9 +28,11 @@ static void WalletCreate(CWallet* wallet_instance)
 
     // generate a new HD seed
     wallet_instance->SetupLegacyScriptPubKeyMan();
-    // NOTE: we do not yet create HD wallets by default
-    // auto spk_man = wallet_instance->GetLegacyScriptPubKeyMan();
-    // spk_man->GenerateNewHDChain("", "");
+    auto spk_man = wallet_instance->GetLegacyScriptPubKeyMan();
+    // NOTE: drop this condition after removing option to create non-HD wallets
+    if (spk_man->IsHDEnabled()) {
+        spk_man->GenerateNewHDChain(/*secureMnemonic=*/"", /*secureMnemonicPassphrase=*/"");
+    }
 
     tfm::format(std::cout, "Topping up keypool...\n");
     wallet_instance->TopUpKeyPool();

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -101,27 +101,13 @@ class ToolWalletTest(BitcoinTestFramework):
             Wallet info
             ===========
             Encrypted: no
-            HD (hd seed available): no
-            Keypool Size: 1
-            Transactions: 0
-            Address Book: 1
-        ''')
-        self.assert_tool_output(out, '-wallet=' + self.default_wallet_name, 'info')
-
-        self.start_node(0)
-        self.nodes[0].upgradetohd()
-        self.stop_node(0)
-
-        out = textwrap.dedent('''\
-            Wallet info
-            ===========
-            Encrypted: no
             HD (hd seed available): yes
             Keypool Size: 2
             Transactions: 0
             Address Book: 1
         ''')
         self.assert_tool_output(out, '-wallet=' + self.default_wallet_name, 'info')
+
         timestamp_after = self.wallet_timestamp()
         self.log.debug('Wallet file timestamp after calling info: {}'.format(timestamp_after))
         self.log_wallet_timestamp_comparison(timestamp_before, timestamp_after)

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -113,9 +113,7 @@ class CreateWalletTest(BitcoinTestFramework):
         # There should only be 1 key
         walletinfo = w6.getwalletinfo()
         assert_equal(walletinfo['keypoolsize'], 1)
-        # TODO: re-enable  this when HD is the default mode
-        # assert_equal(walletinfo['keypoolsize_hd_internal'], 1)
-        # end TODO
+        assert_equal(walletinfo['keypoolsize_hd_internal'], 1)
         # Allow empty passphrase, but there should be a warning
         resp = self.nodes[0].createwallet(wallet_name='w7', disable_private_keys=False, blank=False, passphrase='')
         assert_equal(resp['warning'], 'Empty string given as passphrase, wallet will not be encrypted.')

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -190,7 +190,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         node.stop()
         node.wait_until_stopped()
         self.start_node(0, extra_args=['-rescan'])
-        assert_raises_rpc_error(-14, "Cannot upgrade encrypted wallet to HD without the wallet passphrase", node.upgradetohd, mnemonic)
+        assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.", node.upgradetohd, mnemonic)
         assert_raises_rpc_error(-14, "The wallet passphrase entered was incorrect", node.upgradetohd, mnemonic, "", "wrongpass")
         assert node.upgradetohd(mnemonic, "", walletpass)
         assert_raises_rpc_error(-13, "Error: Please enter the wallet passphrase with walletpassphrase first.", node.dumphdinfo)

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -21,12 +21,13 @@ from test_framework.util import (
 class WalletUpgradeToHDTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        self.extra_args = [['-usehd=0']]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
     def setup_network(self):
-        self.add_nodes(self.num_nodes)
+        self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
         self.import_deterministic_coinbase_privkeys()
 
@@ -69,7 +70,8 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         self.log.info("Should no longer be able to start it with HD disabled")
         self.stop_node(0)
         node.assert_start_raises_init_error(['-usehd=0'], "Error: Error loading %s: You can't disable HD on an already existing HD wallet" % self.default_wallet_name)
-        self.start_node(0)
+        self.extra_args = []
+        self.start_node(0, [])
         balance_after = node.getbalance()
 
         self.recover_non_hd()

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -15,9 +15,9 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_greater_than_or_equal,
     assert_is_hex_string,
-    assert_raises_rpc_error,
 )
 
 
@@ -127,14 +127,15 @@ class UpgradeWalletTest(BitcoinTestFramework):
         assert_equal('hdseedid' in wallet.getwalletinfo(), False)
         # calling upgradewallet with explicit version number
         # should return nothing if successful
-        assert_raises_rpc_error(-4, "You should use upgradetohd RPC to upgrade non-HD wallet to HD", wallet.upgradewallet, 120200)
+        assert_equal(wallet.upgradewallet(120200), "")
 
+        new_version = wallet.getwalletinfo()["walletversion"]
+        # upgraded wallet would not have 120200 version until HD seed actually appeared
+        assert_greater_than(120200, new_version)
+        # after conversion master key hash should not be present yet
         assert 'hdchainid' not in wallet.getwalletinfo()
-
         assert_equal(wallet.upgradetohd(), True)
         new_version = wallet.getwalletinfo()["walletversion"]
-        # after conversion master key hash should not be present yet
-        assert 'hdchainid' in wallet.getwalletinfo()
         assert_equal(new_version, 120200)
         assert_is_hex_string(wallet.getwalletinfo()['hdchainid'])
 

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -12,10 +12,10 @@ import os
 import shutil
 
 from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.test_framework import (BitcoinTestFramework, SkipTest)
+from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
+    assert_greater_than_or_equal,
     assert_is_hex_string,
 )
 
@@ -26,26 +26,20 @@ class UpgradeWalletTest(BitcoinTestFramework):
         self.num_nodes = 3
         self.extra_args = [
             [], # current wallet version
-            ["-usehd=1"],            # v0.16.3 wallet
-            ["-usehd=0"]             # v0.15.2 wallet
+            ["-usehd=1"],            # v20.0.1 wallet
+            ["-usehd=0"]             # v19.3.0 wallet
         ]
-        self.wallet_names = [self.default_wallet_name]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
         self.skip_if_no_bdb()
         self.skip_if_no_previous_releases()
-        # TODO: this test doesn't work yet
-        raise SkipTest("Test wallet_upgradewallet.py is not adapted for Dash Core yet.")
-
-    def setup_network(self):
-        self.setup_nodes()
 
     def setup_nodes(self):
         self.add_nodes(self.num_nodes, extra_args=self.extra_args, versions=[
             None,
-            160300,
-            150200,
+            20000100,
+            19030000,
         ])
         self.start_nodes()
         self.import_deterministic_coinbase_privkeys()
@@ -61,13 +55,13 @@ class UpgradeWalletTest(BitcoinTestFramework):
         Further info: https://github.com/bitcoin/bitcoin/pull/18774#discussion_r416967844
         """
         node_from = self.nodes[0]
-        v16_3_node = self.nodes[1]
+        v20_0_node = self.nodes[1]
         to_height = node_from.getblockcount()
         height = self.nodes[1].getblockcount()
         for i in range(height, to_height+1):
             b = node_from.getblock(blockhash=node_from.getblockhash(i), verbose=0)
-            v16_3_node.submitblock(b)
-        assert_equal(v16_3_node.getblockcount(), to_height)
+            v20_0_node.submitblock(b)
+        assert_equal(v20_0_node.getblockcount(), to_height)
 
     def run_test(self):
         self.nodes[0].generatetoaddress(COINBASE_MATURITY + 1, self.nodes[0].getnewaddress())
@@ -76,28 +70,28 @@ class UpgradeWalletTest(BitcoinTestFramework):
         res = self.nodes[0].getblockchaininfo()
         assert_equal(res['blocks'], COINBASE_MATURITY + 1)
         node_master = self.nodes[0]
-        v16_3_node  = self.nodes[1]
-        v15_2_node  = self.nodes[2]
+        v20_0_node  = self.nodes[1]
+        v19_3_node  = self.nodes[2]
 
         # Send coins to old wallets for later conversion checks.
-        v16_3_wallet  = v16_3_node.get_wallet_rpc('wallet.dat')
-        v16_3_address = v16_3_wallet.getnewaddress()
-        node_master.generatetoaddress(COINBASE_MATURITY + 1, v16_3_address)
+        v20_0_wallet  = v20_0_node.get_wallet_rpc(self.default_wallet_name)
+        v20_0_address = v20_0_wallet.getnewaddress()
+        node_master.generatetoaddress(COINBASE_MATURITY + 1, v20_0_address)
         self.dumb_sync_blocks()
-        v16_3_balance = v16_3_wallet.getbalance()
+        v20_0_balance = v20_0_wallet.getbalance()
 
         self.log.info("Test upgradewallet RPC...")
         # Prepare for copying of the older wallet
         node_master_wallet_dir = os.path.join(node_master.datadir, "regtest/wallets")
-        v16_3_wallet       = os.path.join(v16_3_node.datadir, "regtest/wallets/wallet.dat")
-        v15_2_wallet       = os.path.join(v15_2_node.datadir, "regtest/wallet.dat")
+        v20_0_wallet       = os.path.join(v20_0_node.datadir, "regtest/wallets/wallet.dat")
+        v19_3_wallet       = os.path.join(v19_3_node.datadir, "regtest/wallets/wallet.dat")
         self.stop_nodes()
 
         # Copy the 0.16.3 wallet to the last Dash Core version and open it:
         shutil.rmtree(node_master_wallet_dir)
         os.mkdir(node_master_wallet_dir)
         shutil.copy(
-            v16_3_wallet,
+            v20_0_wallet,
             node_master_wallet_dir
         )
         self.restart_node(0, ['-nowallet'])
@@ -111,16 +105,16 @@ class UpgradeWalletTest(BitcoinTestFramework):
         assert_equal(wallet.upgradewallet(), "")
         new_version = wallet.getwalletinfo()["walletversion"]
         # upgraded wallet version should be greater than older one
-        assert_greater_than(new_version, old_version)
+        assert_greater_than_or_equal(new_version, old_version)
         # wallet should still contain the same balance
-        assert_equal(wallet.getbalance(), v16_3_balance)
+        assert_equal(wallet.getbalance(), v20_0_balance)
 
         self.stop_node(0)
-        # Copy the 0.15.2 wallet to the last Dash Core version and open it:
+        # Copy the 19.3.0 wallet to the last Dash Core version and open it:
         shutil.rmtree(node_master_wallet_dir)
         os.mkdir(node_master_wallet_dir)
         shutil.copy(
-            v15_2_wallet,
+            v19_3_wallet,
             node_master_wallet_dir
         )
         self.restart_node(0, ['-nowallet'])
@@ -131,12 +125,16 @@ class UpgradeWalletTest(BitcoinTestFramework):
         assert_equal('hdseedid' in wallet.getwalletinfo(), False)
         # calling upgradewallet with explicit version number
         # should return nothing if successful
-        assert_equal(wallet.upgradewallet(169900), "")
+        assert_equal(wallet.upgradewallet(120200), "")
+
         new_version = wallet.getwalletinfo()["walletversion"]
-        # upgraded wallet should have version 169900
-        assert_equal(new_version, 169900)
-        # after conversion master key hash should be present
-        assert_is_hex_string(wallet.getwalletinfo()['hdseedid'])
+        # upgraded wallet should have version 120200
+        #assert_equal(new_version, 120200)
+        # after conversion master key hash should not be present yet
+        assert 'hdchainid' not in wallet.getwalletinfo()
+        assert_equal(wallet.upgradetohd(), True)
+        assert_equal(new_version, 120200)
+        assert_is_hex_string(wallet.getwalletinfo()['hdchainid'])
 
 if __name__ == '__main__':
     UpgradeWalletTest().main()

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -17,6 +17,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
     assert_is_hex_string,
+    assert_raises_rpc_error,
 )
 
 
@@ -125,14 +126,14 @@ class UpgradeWalletTest(BitcoinTestFramework):
         assert_equal('hdseedid' in wallet.getwalletinfo(), False)
         # calling upgradewallet with explicit version number
         # should return nothing if successful
-        assert_equal(wallet.upgradewallet(120200), "")
+        assert_raises_rpc_error(-4, "You should use upgradetohd RPC to upgrade non-HD wallet to HD", wallet.upgradewallet, 120200)
 
-        new_version = wallet.getwalletinfo()["walletversion"]
-        # upgraded wallet should have version 120200
-        #assert_equal(new_version, 120200)
-        # after conversion master key hash should not be present yet
         assert 'hdchainid' not in wallet.getwalletinfo()
+
         assert_equal(wallet.upgradetohd(), True)
+        new_version = wallet.getwalletinfo()["walletversion"]
+        # after conversion master key hash should not be present yet
+        assert 'hdchainid' in wallet.getwalletinfo()
         assert_equal(new_version, 120200)
         assert_is_hex_string(wallet.getwalletinfo()['hdchainid'])
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
HD wallets are old-existsing feature, appeared in Dash years ago, but enabling HD wallets is not trivial task that requires multiple steps and command line/rpc calls.
Let's have them enabled by default.

## What was done?
 - HD wallets are enabled by default. Currently behavior `dashd`, `dash-qt` are similar to run with option `-usehd=1`
 - the rpc `upgradewallet` do not let to upgrade from non-HD wallet to HD wallet to don't encourage user use non-crypted wallets (postponed till v21)
 - the initialization of ScriptPubKey is updated to be sure that encypted HD seed is never written on disk (if passphrase is provided)
 - enabled and dashified a script `wallet_upgradewallet.py` which test compatibility between different versions of wallet


## What is not done?
 - wallet tool still does not support passhprase, HD seed can appear on disk
 - there's no dialog that show user a mnemonic phrase and encourage him to make a paper backup
 
Before removing a command line 'usehd' (backport bitcoin#11250) need to make at least one major release for fail-over option (if someone wish to use non-HD wallets only).


## How Has This Been Tested?
Run unit and functional tests.
Enabled new functional test `wallet_upgradewallet.py` that has been backported long time ago but waited this PR to be enabled.

## Breaking Changes
HD wallets are created by default. 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone