### PR TITLE
fix: linter error in depends/config.site.in

### DIFF
--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -63,7 +63,7 @@ if test -n "@debug@" && test -z "@no_qt@" && test "x$with_gui" != xno; then
   with_gui=qt5_debug
 fi
 
-if test "x@host_os@" = xdarwin; then
+if test "@host_os@" = darwin; then
   BREW=no
 fi
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fix linter error:
```
In depends/config.site.in line 66:
if test "x@host_os@" = xdarwin; then
        ^----------^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean: 
if test "@host_os@" = darwin; then

For more information:
  https://www.shellcheck.net/wiki/SC2268 -- Avoid x-prefix in comparisons as ...
^---- failure generated from test/lint/lint-shell.sh
```


## How Has This Been Tested?
run linter `test/lint/lint-all.sh`

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

