### PR TITLE
fix: qt's way to do stretching columns after bitcoin-core/gui#204

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -77,11 +77,10 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
         tableView->setColumnWidth(RecentRequestsTableModel::Label, LABEL_COLUMN_WIDTH);
         tableView->setColumnWidth(RecentRequestsTableModel::Amount, AMOUNT_MINIMUM_COLUMN_WIDTH);
         tableView->horizontalHeader()->setMinimumSectionSize(MINIMUM_COLUMN_WIDTH);
-        tableView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
-        tableView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
-        tableView->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
-        tableView->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Fixed);
-        tableView->horizontalHeader()->setStretchLastSection(false);
+        tableView->horizontalHeader()->setSectionResizeMode(RecentRequestsTableModel::Date, QHeaderView::Interactive);
+        tableView->horizontalHeader()->setSectionResizeMode(RecentRequestsTableModel::Label, QHeaderView::Stretch);
+        tableView->horizontalHeader()->setSectionResizeMode(RecentRequestsTableModel::Message, QHeaderView::Stretch);
+        tableView->horizontalHeader()->setSectionResizeMode(RecentRequestsTableModel::Amount, QHeaderView::Fixed);
 
         connect(tableView->selectionModel(),
             &QItemSelectionModel::selectionChanged, this,

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -77,7 +77,11 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
         tableView->setColumnWidth(RecentRequestsTableModel::Label, LABEL_COLUMN_WIDTH);
         tableView->setColumnWidth(RecentRequestsTableModel::Amount, AMOUNT_MINIMUM_COLUMN_WIDTH);
         tableView->horizontalHeader()->setMinimumSectionSize(MINIMUM_COLUMN_WIDTH);
-        tableView->horizontalHeader()->setStretchLastSection(true);
+        tableView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
+        tableView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+        tableView->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+        tableView->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Fixed);
+        tableView->horizontalHeader()->setStretchLastSection(false);
 
         connect(tableView->selectionModel(),
             &QItemSelectionModel::selectionChanged, this,

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -236,13 +236,12 @@ void TransactionView::setModel(WalletModel *_model)
         connect(transactionView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &TransactionView::computeSum);
 
         transactionView->horizontalHeader()->setMinimumSectionSize(MINIMUM_COLUMN_WIDTH);
-        transactionView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
-        transactionView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Fixed);
-        transactionView->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Fixed);
-        transactionView->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Fixed);
-        transactionView->horizontalHeader()->setSectionResizeMode(4, QHeaderView::Stretch);
-        transactionView->horizontalHeader()->setSectionResizeMode(5, QHeaderView::Fixed);
-        transactionView->horizontalHeader()->setStretchLastSection(false);
+        transactionView->horizontalHeader()->setSectionResizeMode(TransactionTableModel::Status, QHeaderView::Fixed);
+        transactionView->horizontalHeader()->setSectionResizeMode(TransactionTableModel::Watchonly, QHeaderView::Fixed);
+        transactionView->horizontalHeader()->setSectionResizeMode(TransactionTableModel::Date, QHeaderView::Interactive);
+        transactionView->horizontalHeader()->setSectionResizeMode(TransactionTableModel::Type, QHeaderView::Interactive);
+        transactionView->horizontalHeader()->setSectionResizeMode(TransactionTableModel::ToAddress, QHeaderView::Stretch);
+        transactionView->horizontalHeader()->setSectionResizeMode(TransactionTableModel::Amount, QHeaderView::Fixed);
 
         if (_model->getOptionsModel())
         {

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -236,7 +236,13 @@ void TransactionView::setModel(WalletModel *_model)
         connect(transactionView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &TransactionView::computeSum);
 
         transactionView->horizontalHeader()->setMinimumSectionSize(MINIMUM_COLUMN_WIDTH);
-        transactionView->horizontalHeader()->setStretchLastSection(true);
+        transactionView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
+        transactionView->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Fixed);
+        transactionView->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Fixed);
+        transactionView->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Fixed);
+        transactionView->horizontalHeader()->setSectionResizeMode(4, QHeaderView::Stretch);
+        transactionView->horizontalHeader()->setSectionResizeMode(5, QHeaderView::Fixed);
+        transactionView->horizontalHeader()->setStretchLastSection(false);
 
         if (_model->getOptionsModel())
         {


### PR DESCRIPTION
## Issue being fixed or feature implemented
After bitcoin-core/gui#204 is wrong column is stretched as mentioned in #5829 

It's not the last column that must be stretched, it's the one before it. The size of "Address / Label" column should also be adjusted accordingly on window resize. gui#204 broke this behaviour. 

## What was done?
This PR uses QT internal features to aim same behaviour as before gui-204


## How Has This Been Tested?
Run, resize window - seems as proper column changing size.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

