### PR TITLE
fix: make llmq_test_instantsend great again

### DIFF
--- a/src/llmq/options.cpp
+++ b/src/llmq/options.cpp
@@ -131,9 +131,12 @@ bool IsQuorumTypeEnabledInternal(Consensus::LLMQType llmqType, gsl::not_null<con
             return true;
         case Consensus::LLMQType::LLMQ_50_60:
             if (Params().NetworkIDString() == CBaseChainParams::TESTNET) return true;
-            // fall through
-        case Consensus::LLMQType::LLMQ_TEST_INSTANTSEND:
             return !fDIP0024IsActive;
+
+        case Consensus::LLMQType::LLMQ_TEST_INSTANTSEND:
+            if (!fDIP0024IsActive) return true;
+
+            return consensusParams.llmqTypeDIP0024InstantSend == Consensus::LLMQType::LLMQ_TEST_INSTANTSEND;
 
         case Consensus::LLMQType::LLMQ_TEST:
         case Consensus::LLMQType::LLMQ_TEST_PLATFORM:

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -51,7 +51,7 @@ blocks_in_one_day = 576
 
 class AssetLocksTest(DashTestFramework):
     def set_test_params(self):
-        self.set_dash_test_params(6, 4, evo_count=3)
+        self.set_dash_test_params(5, 3, [["-whitelist=127.0.0.1", "-llmqtestinstantsenddip0024=llmq_test_instantsend"]] * 5, evo_count=3)
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -241,21 +241,10 @@ class AssetLocksTest(DashTestFramework):
         self.activate_v19(expected_activation_height=900)
         self.log.info("Activated v19 at height:" + str(node.getblockcount()))
 
-        # TODO: need to refactor this part to common code
-        # enabling instantsend -> 3 rotating quorums -> new 103 quorum
-        # with following dynamically adding evo nodes one-by-one seems
-        # as little too much complex for functional test (each which use Evo nodes)
         self.nodes[0].sporkupdate("SPORK_2_INSTANTSEND_ENABLED", 0)
         self.wait_for_sporks_same()
 
-        self.move_to_next_cycle()
-        self.log.info("Cycle H height:" + str(self.nodes[0].getblockcount()))
-        self.move_to_next_cycle()
-        self.log.info("Cycle H+C height:" + str(self.nodes[0].getblockcount()))
-        self.move_to_next_cycle()
-        self.log.info("Cycle H+2C height:" + str(self.nodes[0].getblockcount()))
-
-        self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
+        self.mine_quorum(llmq_type_name='llmq_test_instantsend', llmq_type=104)
 
         for i in range(3):
             self.dynamically_add_masternode(evo=True)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Running 3 nodes on RegTest as platform does uses do not let to create `llmq_test_instantsend` quorum:

```
1. switch to `llmq_test_instantsend`:
+        self.extra_args = [["-llmqtestinstantsenddip0024=llmq_test_instantsend"]] * 5

2. removed cycle-quorum related code:

-        self.move_to_next_cycle()
-        self.log.info("Cycle H height:" + str(self.nodes[0].getblockcount()))
-        self.move_to_next_cycle()
-        self.log.info("Cycle H+C height:" + str(self.nodes[0].getblockcount()))
-        self.move_to_next_cycle()
-        self.log.info("Cycle H+2C height:" + str(self.nodes[0].getblockcount()))
-
-        self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)

3. added new quorum:

+        self.mine_quorum(llmq_type_name='llmq_test_instantsend', llmq_type=104)

and eventually it stucked, no quorum happens

2024-01-13T19:18:49.317000Z TestFramework (INFO): Expected quorum_0 at:984
2024-01-13T19:18:49.317000Z TestFramework (INFO): Expected quorum_0 hash:6788e18f0235a5c85f3d3c6233fe132a80e74a2912256db3ad876a8ebf026048
2024-01-13T19:18:49.317000Z TestFramework (INFO): quorumIndex 0: Waiting for phase 1 (init)
<frozen>
```

## What was done?
Updated condition to enable "llmq_test_instantsend":
 - it is RegTest and DIP0024 is not active
 - it is RegTest, DIP0024 is active, and specified as `llmqTypeDIP0024InstantSend`

## How Has This Been Tested?
Run unit and functional tests.
Beside that functional test feature_asset_locks.py now uses this quorum for instant send and that's an arrow that hit 2 birds: we have test for command line option `-llmqtestinstantsenddip0024` and code of feature_asset_locks.py is simplified.


## Breaking Changes
yes, that's a bugfix that fix quorum `llmq_test_instantsend` absentance on regtest after dip-0024 activation.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

