### PR TITLE
backport: bitcoin#19552, #19674, #19752, #19760 (functional tests)

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -130,8 +130,8 @@ Base class for functional tests.
 #### [util.py](test_framework/util.py)
 Generally useful functions.
 
-#### [mininode.py](test_framework/mininode.py)
-Basic code to support P2P connectivity to a dashd.
+#### [p2p.py](test_framework/p2p.py)
+Test objects for interacting with a dashd node over the p2p interface.
 
 #### [script.py](test_framework/script.py)
 Utilities for manipulating transaction scripts (originally from python-bitcoinlib)

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -168,7 +168,7 @@ class ExampleTest(BitcoinTestFramework):
 
         height = self.nodes[0].getblockcount()
 
-        for i in range(10):
+        for _ in range(10):
             # Use the mininode and blocktools functionality to manually build a block
             # Calling the generate() rpc is easier, but this allows us to exactly
             # control the blocks and transactions.

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -16,11 +16,11 @@ from collections import defaultdict
 # Avoid wildcard * imports
 from test_framework.blocktools import (create_block, create_coinbase)
 from test_framework.messages import CInv, MSG_BLOCK
-from test_framework.mininode import (
+from test_framework.p2p import (
     P2PInterface,
-    mininode_lock,
     msg_block,
     msg_getdata,
+    p2p_lock,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -169,7 +169,7 @@ class ExampleTest(BitcoinTestFramework):
         height = self.nodes[0].getblockcount()
 
         for _ in range(10):
-            # Use the mininode and blocktools functionality to manually build a block
+            # Use the blocktools functionality to manually build a block.
             # Calling the generate() rpc is easier, but this allows us to exactly
             # control the blocks and transactions.
             block = create_block(self.tip, create_coinbase(height+1), self.block_time)
@@ -205,13 +205,13 @@ class ExampleTest(BitcoinTestFramework):
 
         # wait_until() will loop until a predicate condition is met. Use it to test properties of the
         # P2PInterface objects.
-        wait_until(lambda: sorted(blocks) == sorted(list(self.nodes[2].p2p.block_receive_map.keys())), timeout=5, lock=mininode_lock)
+        wait_until(lambda: sorted(blocks) == sorted(list(self.nodes[2].p2p.block_receive_map.keys())), timeout=5, lock=p2p_lock)
 
         self.log.info("Check that each block was received only once")
         # The network thread uses a global lock on data access to the P2PConnection objects when sending and receiving
         # messages. The test thread should acquire the global lock before accessing any P2PConnection data to avoid locking
         # and synchronization issues. Note wait_until() acquires this global lock when testing the predicate.
-        with mininode_lock:
+        with p2p_lock:
             for block in self.nodes[2].p2p.block_receive_map.values():
                 assert_equal(block, 1)
 

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -25,7 +25,6 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
 
 # P2PInterface is a class containing callbacks to be executed when a P2P
@@ -205,7 +204,7 @@ class ExampleTest(BitcoinTestFramework):
 
         # wait_until() will loop until a predicate condition is met. Use it to test properties of the
         # P2PInterface objects.
-        wait_until(lambda: sorted(blocks) == sorted(list(self.nodes[2].p2p.block_receive_map.keys())), timeout=5, lock=p2p_lock)
+        self.nodes[2].p2p.wait_until(lambda: sorted(blocks) == sorted(list(self.nodes[2].p2p.block_receive_map.keys())), timeout=5)
 
         self.log.info("Check that each block was received only once")
         # The network thread uses a global lock on data access to the P2PConnection objects when sending and receiving

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -11,7 +11,7 @@
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import wait_until, get_datadir_path
+from test_framework.util import get_datadir_path
 import os
 
 
@@ -41,7 +41,7 @@ class AbortNodeTest(BitcoinTestFramework):
 
             # Check that node0 aborted
             self.log.info("Waiting for crash")
-            wait_until(lambda: self.nodes[0].is_node_stopped(), timeout=200)
+            self.nodes[0].wait_until_stopped(timeout=200)
         self.log.info("Node crashed - now verifying restart fails")
         self.nodes[0].assert_start_raises_init_error()
 

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -246,7 +246,7 @@ class AssetLocksTest(DashTestFramework):
 
         self.mine_quorum(llmq_type_name='llmq_test_instantsend', llmq_type=104)
 
-        for i in range(3):
+        for _ in range(3):
             self.dynamically_add_masternode(evo=True)
             node.generate(8)
             self.sync_blocks()

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -48,7 +48,7 @@ from test_framework.messages import (
 from test_framework.p2p import P2PInterface
 from test_framework.script import (CScript, OP_TRUE)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (assert_equal, set_node_times, wait_until)
+from test_framework.util import (assert_equal, set_node_times)
 
 
 class BaseNode(P2PInterface):
@@ -172,7 +172,7 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Send blocks to node0. Block 102 will be rejected.
         self.send_blocks_until_disconnected(p2p0)
-        wait_until(lambda: self.nodes[0].getblockcount() >= COINBASE_MATURITY + 1)
+        self.wait_until(lambda: self.nodes[0].getblockcount() >= COINBASE_MATURITY + 1)
         assert_equal(self.nodes[0].getblockcount(), COINBASE_MATURITY + 1)
 
         # Send 200 blocks to node1. All blocks, including block 102, will be accepted.
@@ -184,7 +184,7 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Send blocks to node2. Block 102 will be rejected.
         self.send_blocks_until_disconnected(p2p2)
-        wait_until(lambda: self.nodes[2].getblockcount() >= COINBASE_MATURITY + 1)
+        self.wait_until(lambda: self.nodes[2].getblockcount() >= COINBASE_MATURITY + 1)
         assert_equal(self.nodes[2].getblockcount(), COINBASE_MATURITY + 1)
 
 

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -45,7 +45,7 @@ from test_framework.messages import (
     msg_block,
     msg_headers,
 )
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.script import (CScript, OP_TRUE)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (assert_equal, set_node_times, wait_until)

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -109,7 +109,7 @@ class AssumeValidTest(BitcoinTestFramework):
         height += 1
 
         # Bury the block 100 deep so the coinbase output is spendable
-        for i in range(100):
+        for _ in range(100):
             block = create_block(self.tip, create_coinbase(height), self.block_time)
             block.solve()
             self.blocks.append(block)
@@ -135,7 +135,7 @@ class AssumeValidTest(BitcoinTestFramework):
         height += 1
 
         # Bury the assumed valid block 8400 deep (Dash needs 4x as much blocks to allow -assumevalid to work)
-        for i in range(8400):
+        for _ in range(8400):
             block = create_block(self.tip, create_coinbase(height), self.block_time)
             block.nVersion = 4
             block.solve()

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -136,7 +136,7 @@ class BIP68Test(BitcoinTestFramework):
         # some of those inputs to be sequence locked (and randomly choose
         # between height/time locking). Small random chance of making the locks
         # all pass.
-        for i in range(400):
+        for _ in range(400):
             # Randomly choose up to 10 inputs
             num_inputs = random.randint(1, 10)
             random.shuffle(utxos)
@@ -255,7 +255,7 @@ class BIP68Test(BitcoinTestFramework):
         # Use prioritisetransaction to lower the effective feerate to 0
         self.nodes[0].prioritisetransaction(tx2.hash, int(-self.relayfee*COIN))
         cur_time = self.mocktime
-        for i in range(10):
+        for _ in range(10):
             self.nodes[0].setmocktime(cur_time + 600)
             self.nodes[0].generate(1)
             cur_time += 600

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -26,7 +26,7 @@ from test_framework.messages import (
     uint256_from_compact,
     uint256_from_str,
 )
-from test_framework.mininode import P2PDataStore
+from test_framework.p2p import P2PDataStore
 from test_framework.script import (
     CScript,
     MAX_SCRIPT_ELEMENT_SIZE,
@@ -53,7 +53,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 from data import invalid_txs
 
-#  Use this class for tests that require behavior other than normal "mininode" behavior.
+#  Use this class for tests that require behavior other than normal p2p behavior.
 #  For now, it is used to serialize a bloated varint (b64).
 class CBrokenBlock(CBlock):
     def initialize(self, base_block):

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -130,7 +130,7 @@ class FullBlockTest(BitcoinTestFramework):
 
         # collect spendable outputs now to avoid cluttering the code later on
         out = []
-        for i in range(NUM_OUTPUTS_TO_COLLECT):
+        for _ in range(NUM_OUTPUTS_TO_COLLECT):
             out.append(self.get_spendable_output())
 
         # Start by building a couple of blocks on top (which output is spent is

--- a/test/functional/feature_blockfilterindex_prune.py
+++ b/test/functional/feature_blockfilterindex_prune.py
@@ -8,7 +8,6 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
-    wait_until
 )
 
 
@@ -19,7 +18,7 @@ class FeatureBlockfilterindexPruneTest(BitcoinTestFramework):
 
     def sync_index(self, height):
         expected = {'basic block filter index': {'synced': True, 'best_block_height': height}}
-        wait_until(lambda: self.nodes[0].getindexinfo() == expected)
+        self.wait_until(lambda: self.nodes[0].getindexinfo() == expected)
 
     def run_test(self):
         self.log.info("check if we can access a blockfilter when pruning is enabled but no blocks are actually pruned")

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -10,7 +10,7 @@ Test that the CHECKLOCKTIMEVERIFY soft-fork activates at (regtest) block height
 
 from test_framework.blocktools import create_coinbase, create_block, create_transaction
 from test_framework.messages import CTransaction, msg_block, ToHex
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.script import CScript, OP_1NEGATE, OP_CHECKLOCKTIMEVERIFY, OP_DROP, CScriptNum
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -43,7 +43,7 @@ from io import BytesIO
 
 from test_framework.blocktools import create_coinbase, create_block, create_transaction, TIME_GENESIS_BLOCK
 from test_framework.messages import ToHex, CTransaction
-from test_framework.mininode import P2PDataStore
+from test_framework.p2p import P2PDataStore
 from test_framework.script import (
     CScript,
     OP_CHECKSEQUENCEVERIFY,

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -165,7 +165,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
 
     def generate_blocks(self, number):
         test_blocks = []
-        for i in range(number):
+        for _ in range(number):
             block = self.create_test_block([])
             test_blocks.append(block)
             self.last_block_time += 600
@@ -213,22 +213,22 @@ class BIP68_112_113Test(BitcoinTestFramework):
         # Note we reuse inputs for v1 and v2 txs so must test these separately
         # 16 normal inputs
         bip68inputs = []
-        for i in range(16):
+        for _ in range(16):
             bip68inputs.append(send_generic_input_tx(self.nodes[0], self.coinbase_blocks, self.nodeaddress))
 
         # 2 sets of 16 inputs with 10 OP_CSV OP_DROP (actually will be prepended to spending scriptSig)
         bip112basicinputs = []
-        for j in range(2):
+        for _ in range(2):
             inputs = []
-            for i in range(16):
+            for _ in range(16):
                 inputs.append(send_generic_input_tx(self.nodes[0], self.coinbase_blocks, self.nodeaddress))
             bip112basicinputs.append(inputs)
 
         # 2 sets of 16 varied inputs with (relative_lock_time) OP_CSV OP_DROP (actually will be prepended to spending scriptSig)
         bip112diverseinputs = []
-        for j in range(2):
+        for _ in range(2):
             inputs = []
-            for i in range(16):
+            for _ in range(16):
                 inputs.append(send_generic_input_tx(self.nodes[0], self.coinbase_blocks, self.nodeaddress))
             bip112diverseinputs.append(inputs)
 

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -194,7 +194,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         while len(utxo_list) >= 2 and num_transactions < count:
             tx = CTransaction()
             input_amount = 0
-            for i in range(2):
+            for _ in range(2):
                 utxo = utxo_list.pop()
                 tx.vin.append(CTxIn(COutPoint(int(utxo['txid'], 16), utxo['vout'])))
                 input_amount += int(utxo['amount'] * COIN)
@@ -204,7 +204,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
                 # Sanity check -- if we chose inputs that are too small, skip
                 continue
 
-            for i in range(3):
+            for _ in range(3):
                 tx.vout.append(CTxOut(output_amount, hex_str_to_bytes(utxo['scriptPubKey'])))
 
             # Sign and send the transaction to get into the mempool

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -9,7 +9,7 @@ Test that the DERSIG soft-fork activates at (regtest) height 1251.
 
 from test_framework.blocktools import create_coinbase, create_block, create_transaction
 from test_framework.messages import msg_block
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.script import CScript
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -16,7 +16,7 @@ from test_framework.messages import CBlock, CBlockHeader, CCbTx, CMerkleBlock, F
     QuorumId, ser_uint256
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
-    assert_equal, wait_until
+    assert_equal
 )
 
 
@@ -31,7 +31,7 @@ class TestP2PConn(P2PInterface):
     def wait_for_mnlistdiff(self, timeout=30):
         def received_mnlistdiff():
             return self.last_mnlistdiff is not None
-        return wait_until(received_mnlistdiff, timeout=timeout)
+        return self.wait_until(received_mnlistdiff, timeout=timeout)
 
     def getmnlistdiff(self, base_block_hash, block_hash):
         msg = msg_getmnlistd(base_block_hash, block_hash)

--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -11,7 +11,7 @@ Checks DIP3 for v19
 '''
 from io import BytesIO
 
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.messages import CBlock, CBlockHeader, CCbTx, CMerkleBlock, FromHex, hash256, msg_getmnlistd, \
     QuorumId, ser_uint256
 from test_framework.test_framework import DashTestFramework

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -13,7 +13,7 @@ Checks DIP4 merkle roots in coinbases
 from io import BytesIO
 
 from test_framework.messages import CBlock, CBlockHeader, CCbTx, CMerkleBlock, FromHex, hash256, msg_getmnlistd, QuorumId, ser_uint256
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import assert_equal, wait_until
 

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -15,9 +15,10 @@ from io import BytesIO
 from test_framework.messages import CBlock, CBlockHeader, CCbTx, CMerkleBlock, FromHex, hash256, msg_getmnlistd, QuorumId, ser_uint256
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import assert_equal, wait_until
+from test_framework.util import assert_equal
 
 
+# TODO: this helper used in many tests, find a new home for it
 class TestP2PConn(P2PInterface):
     def __init__(self):
         super().__init__()
@@ -29,7 +30,7 @@ class TestP2PConn(P2PInterface):
     def wait_for_mnlistdiff(self, timeout=30):
         def received_mnlistdiff():
             return self.last_mnlistdiff is not None
-        return wait_until(received_mnlistdiff, timeout=timeout)
+        self.wait_until(received_mnlistdiff, timeout=timeout)
 
     def getmnlistdiff(self, baseBlockHash, blockHash):
         msg = msg_getmnlistd(baseBlockHash, blockHash)

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -179,9 +179,9 @@ class EstimateFeeTest(BitcoinTestFramework):
         # We shuffle our confirmed txout set before each set of transactions
         # small_txpuzzle_randfee will use the transactions that have inputs already in the chain when possible
         # resorting to tx's that depend on the mempool when those run out
-        for i in range(numblocks):
+        for _ in range(numblocks):
             random.shuffle(self.confutxo)
-            for j in range(random.randrange(100 - 50, 100 + 50)):
+            for _ in range(random.randrange(100 - 50, 100 + 50)):
                 from_index = random.randint(1, 2)
                 (txhex, fee) = small_txpuzzle_randfee(self.nodes[from_index], self.confutxo,
                                                       self.memutxo, Decimal("0.005"), min_fee, min_fee)
@@ -246,7 +246,7 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.confutxo = self.txouts  # Start with the set of confirmed txouts after splitting
         self.log.info("Will output estimates for 1/2/3/6/15/25 blocks")
 
-        for i in range(2):
+        for _ in range(2):
             self.log.info("Creating transactions and mining them with a block size that can't keep up")
             # Create transactions and mine 10 small blocks with node 2, but create txs faster than we can mine
             self.transact_and_mine(10, self.nodes[2])

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -317,7 +317,7 @@ class DashGovernanceTest (DashTestFramework):
         n = sb_cycle - block_count % sb_cycle
 
         # Move remaining n blocks until the next Superblock
-        for i in range(n):
+        for _ in range(n):
             self.nodes[0].generate(1)
             self.bump_mocktime(1)
             self.sync_blocks()

--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -214,9 +214,9 @@ class DashGovernanceTest (DashTestFramework):
         isolated.generate(1)
         self.bump_mocktime(1)
         # The isolated "winner" should submit new trigger and vote for it
-        wait_until(lambda: len(isolated.gobject("list", "valid", "triggers")) == 1, timeout=5)
+        self.wait_until(lambda: len(isolated.gobject("list", "valid", "triggers")) == 1, timeout=5)
         isolated_trigger_hash = list(isolated.gobject("list", "valid", "triggers").keys())[0]
-        wait_until(lambda: list(isolated.gobject("list", "valid", "triggers").values())[0]['YesCount'] == 1, timeout=5)
+        self.wait_until(lambda: list(isolated.gobject("list", "valid", "triggers").values())[0]['YesCount'] == 1, timeout=5)
         more_votes = wait_until(lambda: list(isolated.gobject("list", "valid", "triggers").values())[0]['YesCount'] > 1, timeout=5, do_assert=False)
         assert_equal(more_votes, False)
 
@@ -236,9 +236,9 @@ class DashGovernanceTest (DashTestFramework):
         self.bump_mocktime(1)
 
         # There is now new "winner" who should submit new trigger and vote for it
-        wait_until(lambda: len(self.nodes[0].gobject("list", "valid", "triggers")) == 1, timeout=5)
+        self.wait_until(lambda: len(self.nodes[0].gobject("list", "valid", "triggers")) == 1, timeout=5)
         winning_trigger_hash = list(self.nodes[0].gobject("list", "valid", "triggers").keys())[0]
-        wait_until(lambda: list(self.nodes[0].gobject("list", "valid", "triggers").values())[0]['YesCount'] == 1, timeout=5)
+        self.wait_until(lambda: list(self.nodes[0].gobject("list", "valid", "triggers").values())[0]['YesCount'] == 1, timeout=5)
         more_votes = wait_until(lambda: list(self.nodes[0].gobject("list", "valid", "triggers").values())[0]['YesCount'] > 1, timeout=5, do_assert=False)
         assert_equal(more_votes, False)
 
@@ -254,7 +254,7 @@ class DashGovernanceTest (DashTestFramework):
         self.bump_mocktime(1)
 
         # Every non-isolated MN should vote for the same trigger now, no new triggers should be created
-        wait_until(lambda: list(self.nodes[0].gobject("list", "valid", "triggers").values())[0]['YesCount'] == self.mn_count - 1, timeout=5)
+        self.wait_until(lambda: list(self.nodes[0].gobject("list", "valid", "triggers").values())[0]['YesCount'] == self.mn_count - 1, timeout=5)
         more_triggers = wait_until(lambda: len(self.nodes[0].gobject("list", "valid", "triggers")) > 1, timeout=5, do_assert=False)
         assert_equal(more_triggers, False)
 
@@ -272,11 +272,11 @@ class DashGovernanceTest (DashTestFramework):
             node.mnsync("reset")
             # fast-forward to governance sync
             node.mnsync("next")
-            wait_until(lambda: sync_gov(node))
+            self.wait_until(lambda: sync_gov(node))
 
         # Should see two triggers now
-        wait_until(lambda: len(isolated.gobject("list", "valid", "triggers")) == 2, timeout=5)
-        wait_until(lambda: len(self.nodes[0].gobject("list", "valid", "triggers")) == 2, timeout=5)
+        self.wait_until(lambda: len(isolated.gobject("list", "valid", "triggers")) == 2, timeout=5)
+        self.wait_until(lambda: len(self.nodes[0].gobject("list", "valid", "triggers")) == 2, timeout=5)
         more_triggers = wait_until(lambda: len(self.nodes[0].gobject("list", "valid", "triggers")) > 2, timeout=5, do_assert=False)
         assert_equal(more_triggers, False)
 
@@ -286,8 +286,8 @@ class DashGovernanceTest (DashTestFramework):
         self.sync_blocks()
 
         # Should see NO votes on both triggers now
-        wait_until(lambda: self.nodes[0].gobject("list", "valid", "triggers")[winning_trigger_hash]['NoCount'] == 1, timeout=5)
-        wait_until(lambda: self.nodes[0].gobject("list", "valid", "triggers")[isolated_trigger_hash]['NoCount'] == self.mn_count - 1, timeout=5)
+        self.wait_until(lambda: self.nodes[0].gobject("list", "valid", "triggers")[winning_trigger_hash]['NoCount'] == 1, timeout=5)
+        self.wait_until(lambda: self.nodes[0].gobject("list", "valid", "triggers")[isolated_trigger_hash]['NoCount'] == self.mn_count - 1, timeout=5)
 
         block_count = self.nodes[0].getblockcount()
         n = sb_cycle - block_count % sb_cycle

--- a/test/functional/feature_llmq_chainlocks.py
+++ b/test/functional/feature_llmq_chainlocks.py
@@ -195,7 +195,7 @@ class LLMQChainLocksTest(DashTestFramework):
         force_finish_mnsync(self.nodes[0])
         self.isolate_node(0)
         txs = []
-        for i in range(3):
+        for _ in range(3):
             txs.append(self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1))
         txs += self.create_chained_txs(self.nodes[0], 1)
         self.log.info("Assert that after block generation these TXs are NOT included (as they are \"unsafe\")")

--- a/test/functional/feature_llmq_connections.py
+++ b/test/functional/feature_llmq_connections.py
@@ -13,7 +13,7 @@ Checks intra quorum connections
 import time
 
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import assert_greater_than_or_equal, wait_until
+from test_framework.util import assert_greater_than_or_equal
 
 class LLMQConnections(DashTestFramework):
     def set_test_params(self):
@@ -53,17 +53,17 @@ class LLMQConnections(DashTestFramework):
 
         self.log.info("checking that all MNs got probed")
         for mn in self.get_quorum_masternodes(q):
-            wait_until(lambda: self.get_mn_probe_count(mn.node, q, False) == 4)
+            self.wait_until(lambda: self.get_mn_probe_count(mn.node, q, False) == 4)
 
         self.log.info("checking that probes age")
         self.bump_mocktime(self.MAX_AGE)
         for mn in self.get_quorum_masternodes(q):
-            wait_until(lambda: self.get_mn_probe_count(mn.node, q, False) == 0)
+            self.wait_until(lambda: self.get_mn_probe_count(mn.node, q, False) == 0)
 
         self.log.info("mine a new quorum and re-check probes")
         q = self.mine_quorum()
         for mn in self.get_quorum_masternodes(q):
-            wait_until(lambda: self.get_mn_probe_count(mn.node, q, True) == 4)
+            self.wait_until(lambda: self.get_mn_probe_count(mn.node, q, True) == 4)
 
         self.log.info("Activating SPORK_21_QUORUM_ALL_CONNECTED")
         self.nodes[0].sporkupdate("SPORK_21_QUORUM_ALL_CONNECTED", 0)
@@ -121,7 +121,7 @@ class LLMQConnections(DashTestFramework):
         for mn in self.mninfo:
             mn.node.setnetworkactive(False)
         for mn in self.mninfo:
-            wait_until(lambda: len(mn.node.getpeerinfo()) == 0)
+            self.wait_until(lambda: len(mn.node.getpeerinfo()) == 0)
         for mn in self.mninfo:
             mn.node.setnetworkactive(True)
         self.bump_mocktime(60)
@@ -138,7 +138,7 @@ class LLMQConnections(DashTestFramework):
         # wait for ping/pong so that we can be sure that spork propagation works
         time.sleep(1) # needed to make sure we don't check before the ping is actually sent (fPingQueued might be true but SendMessages still not called)
         for i in range(1, len(self.nodes)):
-            wait_until(lambda: all('pingwait' not in peer for peer in self.nodes[i].getpeerinfo()))
+            self.wait_until(lambda: all('pingwait' not in peer for peer in self.nodes[i].getpeerinfo()))
 
     def get_mn_connection_count(self, node):
         peers = node.getpeerinfo()

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 import time
-from test_framework.mininode import logger
+from test_framework.p2p import logger
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import force_finish_mnsync, wait_until
 

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -6,7 +6,7 @@
 import time
 from test_framework.p2p import logger
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import force_finish_mnsync, wait_until
+from test_framework.util import force_finish_mnsync
 
 '''
 feature_llmq_data_recovery.py
@@ -39,7 +39,7 @@ class QuorumDataRecoveryTest(DashTestFramework):
             args.append('-reindex')
             bb_hash = mn.node.getbestblockhash()
             self.restart_node(mn.node.index, args)
-            wait_until(lambda: mn.node.getbestblockhash() == bb_hash)
+            self.wait_until(lambda: mn.node.getbestblockhash() == bb_hash)
         else:
             self.restart_node(mn.node.index, args)
         force_finish_mnsync(mn.node)

--- a/test/functional/feature_llmq_dkgerrors.py
+++ b/test/functional/feature_llmq_dkgerrors.py
@@ -85,7 +85,7 @@ class LLMQDKGErrors(DashTestFramework):
         # We're not testing PoSe here, so lets heal the MNs :)
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 4070908800)
         self.wait_for_sporks_same()
-        for i in range(blockCount):
+        for _ in range(blockCount):
             self.bump_mocktime(1)
             self.nodes[0].generate(1)
         self.sync_all()

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -106,7 +106,7 @@ class LLMQEvoNodesTest(DashTestFramework):
             self.dynamically_evo_update_service(evo_info)
 
         self.log.info("Test llmq_platform are formed only with EvoNodes")
-        for i in range(3):
+        for _ in range(3):
             quorum_i_hash = self.mine_quorum(llmq_type_name='llmq_test_platform', llmq_type=106, expected_connections=2, expected_members=3, expected_contributions=3, expected_complaints=0, expected_justifications=0, expected_commitments=3 )
             self.test_quorum_members_are_evo_nodes(quorum_i_hash, llmq_type=106)
 

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -12,7 +12,7 @@ Checks EvoNodes
 from _decimal import Decimal
 from io import BytesIO
 
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.messages import CBlock, CBlockHeader, CCbTx, CMerkleBlock, FromHex, hash256, msg_getmnlistd, \
     QuorumId, ser_uint256
 from test_framework.test_framework import DashTestFramework

--- a/test/functional/feature_llmq_evo.py
+++ b/test/functional/feature_llmq_evo.py
@@ -17,7 +17,7 @@ from test_framework.messages import CBlock, CBlockHeader, CCbTx, CMerkleBlock, F
     QuorumId, ser_uint256
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
-    assert_equal, p2p_port, wait_until
+    assert_equal, p2p_port
 )
 
 
@@ -35,7 +35,7 @@ class TestP2PConn(P2PInterface):
     def wait_for_mnlistdiff(self, timeout=30):
         def received_mnlistdiff():
             return self.last_mnlistdiff is not None
-        return wait_until(received_mnlistdiff, timeout=timeout)
+        return self.wait_until(received_mnlistdiff, timeout=timeout)
 
     def getmnlistdiff(self, baseBlockHash, blockHash):
         msg = msg_getmnlistd(baseBlockHash, blockHash)

--- a/test/functional/feature_llmq_is_cl_conflicts.py
+++ b/test/functional/feature_llmq_is_cl_conflicts.py
@@ -14,7 +14,7 @@ import struct
 
 from test_framework.blocktools import create_block_with_mnpayments
 from test_framework.messages import CInv, CTransaction, FromHex, hash256, msg_clsig, msg_inv, ser_string, ToHex, uint256_from_str
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error, hex_str_to_bytes, wait_until
 

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -141,7 +141,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
 
         # And for the remaining blocks, enforce new CL in CbTx
         skip_count = 23 - (self.nodes[0].getblockcount() % 24)
-        for i in range(skip_count):
+        for _ in range(skip_count):
             self.nodes[0].generate(1)
             self.sync_blocks(nodes)
             self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -41,7 +41,7 @@ class TestP2PConn(P2PInterface):
     def wait_for_mnlistdiff(self, timeout=30):
         def received_mnlistdiff():
             return self.last_mnlistdiff is not None
-        return wait_until(received_mnlistdiff, timeout=timeout)
+        return self.wait_until(received_mnlistdiff, timeout=timeout)
 
     def getmnlistdiff(self, baseBlockHash, blockHash):
         msg = msg_getmnlistd(baseBlockHash, blockHash)

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -14,7 +14,7 @@ from io import BytesIO
 
 from test_framework.test_framework import DashTestFramework
 from test_framework.messages import CBlock, CBlockHeader, CCbTx, CMerkleBlock, FromHex, hash256, msg_getmnlistd, QuorumId, ser_uint256, sha256
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,

--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -11,7 +11,7 @@ Checks LLMQs signing sessions
 '''
 
 from test_framework.messages import CSigShare, msg_qsigshare, uint256_to_string
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error, force_finish_mnsync, hex_str_to_bytes, wait_until
 

--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -52,7 +52,7 @@ class LLMQSigningTest(DashTestFramework):
             return True
 
         def wait_for_sigs(hasrecsigs, isconflicting1, isconflicting2, timeout):
-            wait_until(lambda: check_sigs(hasrecsigs, isconflicting1, isconflicting2), timeout = timeout)
+            self.wait_until(lambda: check_sigs(hasrecsigs, isconflicting1, isconflicting2), timeout = timeout)
 
         def assert_sigs_nochange(hasrecsigs, isconflicting1, isconflicting2, timeout):
             assert not wait_until(lambda: not check_sigs(hasrecsigs, isconflicting1, isconflicting2), timeout = timeout, do_assert = False)
@@ -178,7 +178,7 @@ class LLMQSigningTest(DashTestFramework):
             q = self.nodes[0].quorum('selectquorum', 104, id)
             mn = self.get_mninfo(q['recoveryMembers'][0])
             mn.node.setnetworkactive(False)
-            wait_until(lambda: mn.node.getconnectioncount() == 0)
+            self.wait_until(lambda: mn.node.getconnectioncount() == 0)
             for i in range(4):
                 self.mninfo[i].node.quorum("sign", 104, id, msgHash)
             assert_sigs_nochange(False, False, False, 3)
@@ -190,7 +190,7 @@ class LLMQSigningTest(DashTestFramework):
             self.bump_mocktime(1)  # need this to bypass quorum connection retry timeout
             wait_until(lambda: mn.node.getconnectioncount() == self.llmq_size, timeout=10, sleep=2)
             mn.node.ping()
-            wait_until(lambda: all('pingwait' not in peer for peer in mn.node.getpeerinfo()))
+            self.wait_until(lambda: all('pingwait' not in peer for peer in mn.node.getpeerinfo()))
             # Let 2 seconds pass so that the next node is used for recovery, which should succeed
             self.bump_mocktime(2)
             wait_for_sigs(True, False, True, 2)

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -87,7 +87,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         return False, True
 
     def test_no_banning(self, expected_connections=None):
-        for i in range(3):
+        for _ in range(3):
             self.mine_quorum(expected_connections=expected_connections)
         for mn in self.mninfo:
             assert not self.check_punished(mn) and not self.check_banned(mn)
@@ -157,7 +157,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         mninfos_online = self.mninfo.copy()
         mninfos_valid = self.mninfo.copy()
         expected_contributors = len(mninfos_online)
-        for i in range(2):
+        for _ in range(2):
             mn = mninfos_valid.pop()
             went_offline, instant_ban = invalidate_proc(mn)
             if went_offline:
@@ -172,7 +172,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
             else:
                 # It's ok to miss probes/quorum connections up to 5 times.
                 # 6th time is when it should be banned for sure.
-                for i in range(6):
+                for _ in range(6):
                     self.reset_probe_timeouts()
                     self.mine_quorum_no_check(expected_contributors - 1, mninfos_online)
 

--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -13,7 +13,7 @@ Checks simple PoSe system based on LLMQ commitments
 import time
 
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import assert_equal, force_finish_mnsync, p2p_port, wait_until
+from test_framework.util import assert_equal, force_finish_mnsync, p2p_port
 
 
 class LLMQSimplePoSeTest(DashTestFramework):
@@ -65,7 +65,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
 
     def isolate_mn(self, mn):
         mn.node.setnetworkactive(False)
-        wait_until(lambda: mn.node.getconnectioncount() == 0)
+        self.wait_until(lambda: mn.node.getconnectioncount() == 0)
         return True, True
 
     def close_mn_port(self, mn):
@@ -205,7 +205,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
         # Isolate and re-connect all MNs (otherwise there might be open connections with no MNAUTH for MNs which were banned before)
         for mn in self.mninfo:
             mn.node.setnetworkactive(False)
-            wait_until(lambda: mn.node.getconnectioncount() == 0)
+            self.wait_until(lambda: mn.node.getconnectioncount() == 0)
             mn.node.setnetworkactive(True)
             force_finish_mnsync(mn.node)
             self.connect_nodes(mn.node.index, 0)

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -105,7 +105,7 @@ class MaxUploadTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[0].getpeerinfo()), 3)
         # At most a couple more tries should succeed (depending on how long
         # the test has been running so far).
-        for i in range(3):
+        for _ in range(3):
             p2p_conns[0].send_message(getdata_request)
         p2p_conns[0].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -13,7 +13,7 @@ if uploadtarget has been reached.
 from collections import defaultdict
 
 from test_framework.messages import CInv, MAX_BLOCK_SIZE, MSG_BLOCK, msg_getdata
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, mine_large_block, set_node_times
 

--- a/test/functional/feature_mnehf.py
+++ b/test/functional/feature_mnehf.py
@@ -189,7 +189,7 @@ class MnehfTest(DashTestFramework):
 
         self.restart_all_nodes()
 
-        for i in range(12):
+        for _ in range(12):
             self.check_fork('started')
             node.generate(1)
             self.sync_all()
@@ -210,7 +210,7 @@ class MnehfTest(DashTestFramework):
             inode.invalidateblock(ehf_blockhash)
 
         self.log.info("Expecting for fork to be defined in next blocks because no MnEHF tx here")
-        for i in range(12):
+        for _ in range(12):
             self.check_fork('defined')
             node.generate(1)
             self.sync_all()
@@ -225,7 +225,7 @@ class MnehfTest(DashTestFramework):
         assert tx_sent_2 in node.getblock(ehf_blockhash_2)['tx']
 
         self.log.info(f"Generate some more block to jump to `started` status")
-        for i in range(12):
+        for _ in range(12):
             node.generate(1)
         self.check_fork('started')
         self.restart_all_nodes()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -11,7 +11,6 @@ from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
     assert_equal,
     force_finish_mnsync,
-    wait_until,
 )
 
 # Linux allow all characters other than \x00
@@ -70,7 +69,7 @@ class NotificationsTest(DashTestFramework):
         blocks = self.nodes[1].generatetoaddress(block_count, self.nodes[1].getnewaddress() if self.is_wallet_compiled() else ADDRESS_BCRT1_UNSPENDABLE)
 
         # wait at most 10 seconds for expected number of files before reading the content
-        wait_until(lambda: len(os.listdir(self.blocknotify_dir)) == block_count, timeout=10)
+        self.wait_until(lambda: len(os.listdir(self.blocknotify_dir)) == block_count, timeout=10)
 
         # directory content should equal the generated blocks hashes
         assert_equal(sorted(blocks), sorted(os.listdir(self.blocknotify_dir)))
@@ -78,7 +77,7 @@ class NotificationsTest(DashTestFramework):
         if self.is_wallet_compiled():
             self.log.info("test -walletnotify")
             # wait at most 10 seconds for expected number of files before reading the content
-            wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
+            self.wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 
             # directory content should equal the generated transaction hashes
             txids_rpc = list(map(lambda t: notify_outputname(self.wallet, t['txid']), self.nodes[1].listtransactions("*", block_count)))
@@ -94,7 +93,7 @@ class NotificationsTest(DashTestFramework):
             force_finish_mnsync(self.nodes[1])
             self.connect_nodes(0, 1)
 
-            wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
+            self.wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 
             # directory content should equal the generated transaction hashes
             txids_rpc = list(map(lambda t: notify_outputname(self.wallet, t['txid']), self.nodes[1].listtransactions("*", block_count)))
@@ -137,7 +136,7 @@ class NotificationsTest(DashTestFramework):
                 self.wait_for_instantlock(txid, self.nodes[1])
 
             # wait at most 10 seconds for expected number of files before reading the content
-            wait_until(lambda: len(os.listdir(self.instantsendnotify_dir)) == tx_count, timeout=10)
+            self.wait_until(lambda: len(os.listdir(self.instantsendnotify_dir)) == tx_count, timeout=10)
 
             # directory content should equal the generated transaction hashes
             txids_rpc = list(map(lambda t: notify_outputname(self.wallet, t['txid']), self.nodes[1].listtransactions("*", tx_count)))

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -14,7 +14,11 @@ from test_framework.blocktools import create_coinbase
 from test_framework.messages import CBlock, ToHex
 from test_framework.script import CScript, OP_RETURN, OP_NOP
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, wait_until
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+)
 
 # Rescans start at the earliest block up to 2 hours before a key timestamp, so
 # the manual prune RPC avoids pruning blocks in the same window to be
@@ -156,7 +160,7 @@ class PruneTest(BitcoinTestFramework):
         mine_large_blocks(self.nodes[0], 25)
 
         # Wait for blk00000.dat to be pruned
-        wait_until(lambda: not os.path.isfile(os.path.join(self.prunedir, "blk00000.dat")), timeout=30)
+        self.wait_until(lambda: not os.path.isfile(os.path.join(self.prunedir, "blk00000.dat")), timeout=30)
 
         self.log.info("Success")
         usage = calc_usage(self.prunedir)
@@ -272,7 +276,7 @@ class PruneTest(BitcoinTestFramework):
 
         self.log.info("Verify node 2 reorged back to the main chain, some blocks of which it had to redownload")
         # Wait for Node 2 to reorg to proper height
-        wait_until(lambda: self.nodes[2].getblockcount() >= goalbestheight, timeout=900)
+        self.wait_until(lambda: self.nodes[2].getblockcount() >= goalbestheight, timeout=900)
         assert_equal(self.nodes[2].getbestblockhash(), goalbesthash)
         # Verify we can now have the data for a block previously pruned
         assert_equal(self.nodes[2].getblock(self.forkhash)["height"], self.forkheight)

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -167,7 +167,7 @@ class PruneTest(BitcoinTestFramework):
         # Create stale blocks in manageable sized chunks
         self.log.info("Mine 24 (stale) blocks on Node 1, followed by 25 (main chain) block reorg from Node 0, for 12 rounds")
 
-        for j in range(12):
+        for _ in range(12):
             # Disconnect node 0 so it can mine a longer reorg chain without knowing about node 1's soon-to-be-stale chain
             # Node 2 stays connected, so it hears about the stale blocks and then reorg's when node0 reconnects
             self.disconnect_nodes(0, 1)

--- a/test/functional/feature_shutdown.py
+++ b/test/functional/feature_shutdown.py
@@ -5,7 +5,7 @@
 """Test dashd shutdown."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, get_rpc_proxy, wait_until
+from test_framework.util import assert_equal, get_rpc_proxy
 from threading import Thread
 
 def test_long_call(node):
@@ -25,7 +25,7 @@ class ShutdownTest(BitcoinTestFramework):
         node.getblockcount()
         Thread(target=test_long_call, args=(node,)).start()
         # Wait until the server is executing the above `waitfornewblock`.
-        wait_until(lambda: len(self.nodes[0].getrpcinfo()['active_commands']) == 2)
+        self.wait_until(lambda: len(self.nodes[0].getrpcinfo()['active_commands']) == 2)
         # Wait 1 second after requesting shutdown but not before the `stop` call
         # finishes. This is to ensure event loop waits for current connections
         # to close.

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -14,7 +14,6 @@ from test_framework.blocktools import create_block, create_coinbase
 from test_framework.messages import msg_block
 from test_framework.p2p import p2p_lock, P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import wait_until
 
 VB_PERIOD = 144           # versionbits period length for regtest
 VB_THRESHOLD = 108        # versionbits activation threshold for regtest
@@ -91,14 +90,14 @@ class VersionBitsWarningTest(BitcoinTestFramework):
 
         # Generating one block guarantees that we'll get out of IBD
         node.generatetoaddress(1, node_deterministic_address)
-        wait_until(lambda: not node.getblockchaininfo()['initialblockdownload'], timeout=10, lock=p2p_lock)
+        self.wait_until(lambda: not node.getblockchaininfo()['initialblockdownload'], timeout=10, lock=p2p_lock)
         # Generating one more block will be enough to generate an error.
         node.generatetoaddress(1, node_deterministic_address)
         # Check that get*info() shows the versionbits unknown rules warning
         assert WARN_UNKNOWN_RULES_ACTIVE in node.getmininginfo()["warnings"]
         assert WARN_UNKNOWN_RULES_ACTIVE in node.getnetworkinfo()["warnings"]
         # Check that the alert file shows the versionbits unknown rules warning
-        wait_until(lambda: self.versionbits_in_alert_file(), timeout=60)
+        self.wait_until(lambda: self.versionbits_in_alert_file())
 
 if __name__ == '__main__':
     VersionBitsWarningTest().main()

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -12,7 +12,7 @@ import re
 
 from test_framework.blocktools import create_block, create_coinbase
 from test_framework.messages import msg_block
-from test_framework.mininode import P2PInterface, mininode_lock
+from test_framework.p2p import p2p_lock, P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import wait_until
 
@@ -91,7 +91,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
 
         # Generating one block guarantees that we'll get out of IBD
         node.generatetoaddress(1, node_deterministic_address)
-        wait_until(lambda: not node.getblockchaininfo()['initialblockdownload'], timeout=10, lock=mininode_lock)
+        wait_until(lambda: not node.getblockchaininfo()['initialblockdownload'], timeout=10, lock=p2p_lock)
         # Generating one more block will be enough to generate an error.
         node.generatetoaddress(1, node_deterministic_address)
         # Check that get*info() shows the versionbits unknown rules warning

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -13,7 +13,7 @@ import struct
 import time
 
 from test_framework.test_framework import DashTestFramework
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.util import assert_equal, assert_raises_rpc_error
 from test_framework.messages import (
     CBlock,

--- a/test/functional/mempool_package_onemore.py
+++ b/test/functional/mempool_package_onemore.py
@@ -32,7 +32,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         for (txid, vout) in zip(parent_txids, vouts):
             inputs.append({'txid' : txid, 'vout' : vout})
         outputs = {}
-        for i in range(num_outputs):
+        for _ in range(num_outputs):
             outputs[node.getnewaddress()] = send_value
         rawtx = node.createrawtransaction(inputs, outputs)
         signedtx = node.signrawtransactionwithwallet(rawtx)

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -49,7 +49,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         send_value = satoshi_round((value - fee)/num_outputs)
         inputs = [ {'txid' : parent_txid, 'vout' : vout} ]
         outputs = {}
-        for i in range(num_outputs):
+        for _ in range(num_outputs):
             outputs[node.getnewaddress()] = send_value
         rawtx = node.createrawtransaction(inputs, outputs)
         signedtx = node.signrawtransactionwithwallet(rawtx)
@@ -70,7 +70,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         fee = Decimal("0.0001")
         # MAX_ANCESTORS transactions off a confirmed tx should be fine
         chain = []
-        for i in range(MAX_ANCESTORS):
+        for _ in range(MAX_ANCESTORS):
             (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, 0, value, fee, 1)
             value = sent_value
             chain.append(txid)
@@ -241,7 +241,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
         # Sign and send up to MAX_DESCENDANT transactions chained off the parent tx
         chain = [] # save sent txs for the purpose of checking node1's mempool later (see below)
-        for i in range(MAX_DESCENDANTS - 1):
+        for _ in range(MAX_DESCENDANTS - 1):
             utxo = transaction_package.pop(0)
             (txid, sent_value) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
             chain.append(txid)
@@ -308,7 +308,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         send_value = satoshi_round((value - fee)/2)
         inputs = [ {'txid' : txid, 'vout' : vout} ]
         outputs = {}
-        for i in range(2):
+        for _ in range(2):
             outputs[self.nodes[0].getnewaddress()] = send_value
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx)
@@ -322,7 +322,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # Create tx2-7
         vout = 1
         txid = tx0_id
-        for i in range(6):
+        for _ in range(6):
             (txid, sent_value) = self.chain_transaction(self.nodes[0], txid, vout, value, fee, 1)
             vout = 0
             value = sent_value

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.messages import COIN
-from test_framework.mininode import P2PTxInvStore
+from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -14,7 +14,6 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
     satoshi_round,
-    wait_until,
 )
 
 # default limits
@@ -265,8 +264,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
         # - txs from previous ancestor test (-> custom ancestor limit)
         # - parent tx for descendant test
         # - txs chained off parent tx (-> custom descendant limit)
-        wait_until(lambda: len(self.nodes[1].getrawmempool(False)) ==
-                           MAX_ANCESTORS_CUSTOM + 1 + MAX_DESCENDANTS_CUSTOM, timeout=10)
+        self.wait_until(lambda: len(self.nodes[1].getrawmempool(False)) ==
+                                MAX_ANCESTORS_CUSTOM + 1 + MAX_DESCENDANTS_CUSTOM, timeout=10)
         mempool0 = self.nodes[0].getrawmempool(False)
         mempool1 = self.nodes[1].getrawmempool(False)
         assert set(mempool1).issubset(set(mempool0))

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -173,7 +173,7 @@ class MempoolPersistTest(BitcoinTestFramework):
         # check that txn gets broadcast due to unbroadcast logic
         # conn = node0.add_p2p_connection(P2PTxInvStore())
         # node0.mockscheduler(16*60) # 15 min + 1 for buffer
-        # wait_until(lambda: len(conn.get_invs()) == 1)
+        # self.wait_until(lambda: len(conn.get_invs()) == 1)
 
 if __name__ == '__main__':
     MempoolPersistTest().main()

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -57,7 +57,7 @@ class MempoolPersistTest(BitcoinTestFramework):
     def run_test(self):
         self.log.debug("Send 5 transactions from node2 (to its own address)")
         tx_creation_time_lower = self.mocktime
-        for i in range(5):
+        for _ in range(5):
             last_txid = self.nodes[2].sendtoaddress(self.nodes[2].getnewaddress(), Decimal("10"))
         node2_balance = self.nodes[2].getbalance()
         self.sync_all()

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -38,8 +38,8 @@ Test is as follows:
 from decimal import Decimal
 import os
 
+# from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
-# from test_framework.mininode import P2PTxInvStore
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal, assert_raises_rpc_error,

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -7,7 +7,7 @@ to peers until a GETDATA is received."""
 
 import time
 
-from test_framework.mininode import P2PTxInvStore
+from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -73,7 +73,7 @@ class MempoolUpdateFromBlockTest(BitcoinTestFramework):
                 n_outputs = size - tx_count
                 output_value = ((inputs_value - fee) / Decimal(n_outputs)).quantize(Decimal('0.00000001'))
                 outputs = {}
-                for n in range(0, n_outputs):
+                for _ in range(n_outputs):
                     outputs[self.nodes[0].getnewaddress()] = output_value
             else:
                 output_value = (inputs_value - fee).quantize(Decimal('0.00000001'))

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -45,7 +45,7 @@ class MiningTest(BitcoinTestFramework):
 
     def mine_chain(self):
         self.log.info('Create some old blocks')
-        for _ in range(0, 200):
+        for _ in range(200):
             self.bump_mocktime(156)
             self.nodes[0].generate(1)
         mining_info = self.nodes[0].getmininginfo()

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -19,7 +19,7 @@ from test_framework.messages import (
     CBlockHeader,
     BLOCK_HEADER_SIZE,
 )
-from test_framework.mininode import P2PDataStore
+from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -11,9 +11,7 @@ from test_framework.messages import (
     NODE_NETWORK,
     msg_addr,
 )
-from test_framework.mininode import (
-    P2PInterface,
-)
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -11,7 +11,7 @@ from test_framework.messages import (
     msg_addrv2,
     NODE_NETWORK,
 )
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, wait_until
 

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -13,7 +13,7 @@ from test_framework.messages import (
 )
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, wait_until
+from test_framework.util import assert_equal
 
 
 class AddrReceiver(P2PInterface):
@@ -30,7 +30,7 @@ class AddrReceiver(P2PInterface):
         self.addrv2_received_and_checked = True
 
     def wait_for_addrv2(self):
-        wait_until(lambda: "addrv2" in self.last_message)
+        self.wait_until(lambda: "addrv2" in self.last_message)
 
 
 class AddrTest(BitcoinTestFramework):

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -18,7 +18,7 @@ from test_framework.messages import (
     ser_uint256,
     uint256_from_str,
 )
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -22,7 +22,6 @@ from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
 
 class CFiltersClient(P2PInterface):
@@ -63,11 +62,11 @@ class CompactFiltersTest(BitcoinTestFramework):
         self.disconnect_nodes(0, 1)
 
         self.nodes[0].generate(1)
-        wait_until(lambda: self.nodes[0].getblockcount() == 1000)
+        self.wait_until(lambda: self.nodes[0].getblockcount() == 1000)
         stale_block_hash = self.nodes[0].getblockhash(1000)
 
         self.nodes[1].generate(1001)
-        wait_until(lambda: self.nodes[1].getblockcount() == 2000)
+        self.wait_until(lambda: self.nodes[1].getblockcount() == 2000)
 
         # Check that nodes have signalled NODE_COMPACT_FILTERS correctly.
         assert node0.nServices & NODE_COMPACT_FILTERS != 0

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -5,7 +5,7 @@
 """Test p2p blocksonly"""
 
 from test_framework.messages import msg_tx, CTransaction, FromHex
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -12,7 +12,7 @@ from test_framework.messages import BlockTransactions, BlockTransactionsRequest,
 from test_framework.p2p import p2p_lock, P2PInterface
 from test_framework.script import CScript, OP_TRUE, OP_DROP
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, wait_until
+from test_framework.util import assert_equal
 
 # TestP2PConn: A peer we use to send messages to dashd, and store responses.
 class TestP2PConn(P2PInterface):
@@ -71,7 +71,7 @@ class TestP2PConn(P2PInterface):
     def request_headers_and_sync(self, locator, hashstop=0):
         self.clear_block_announcement()
         self.get_headers(locator, hashstop)
-        wait_until(self.received_block_announcement, timeout=30, lock=p2p_lock)
+        self.wait_until(self.received_block_announcement, timeout=30)
         self.clear_block_announcement()
 
     # Block until a block announcement for a particular block hash is
@@ -79,7 +79,7 @@ class TestP2PConn(P2PInterface):
     def wait_for_block_announcement(self, block_hash, timeout=30):
         def received_hash():
             return (block_hash in self.announced_blockhashes)
-        wait_until(received_hash, timeout=timeout, lock=p2p_lock)
+        self.wait_until(received_hash, timeout=timeout)
 
     def send_await_disconnect(self, message, timeout=30):
         """Sends a message to the node and wait for disconnect.
@@ -87,7 +87,7 @@ class TestP2PConn(P2PInterface):
         This is used when we want to send a message into the node that we expect
         will get us disconnected, eg an invalid block."""
         self.send_message(message)
-        wait_until(lambda: not self.is_connected, timeout=timeout, lock=p2p_lock)
+        self.wait_for_disconnect(timeout)
 
 class CompactBlocksTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -149,7 +149,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Make sure we get a SENDCMPCT message from our peer
         def received_sendcmpct():
             return (len(test_node.last_sendcmpct) > 0)
-        wait_until(received_sendcmpct, timeout=30, lock=p2p_lock)
+        test_node.wait_until(received_sendcmpct, timeout=30)
         with p2p_lock:
             # Check that the first version received is the preferred one
             assert_equal(test_node.last_sendcmpct[0].version, preferred_version)
@@ -272,7 +272,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         block.rehash()
 
         # Wait until the block was announced (via compact blocks)
-        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=p2p_lock)
+        test_node.wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30)
 
         # Now fetch and check the compact block
         header_and_shortids = None
@@ -287,7 +287,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         inv = CInv(MSG_CMPCT_BLOCK, block_hash)  # 20 == "CompactBlock"
         test_node.send_message(msg_getdata([inv]))
 
-        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=p2p_lock)
+        test_node.wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30)
 
         # Now fetch and check the compact block
         header_and_shortids = None
@@ -345,7 +345,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             if announce == "inv":
                 test_node.send_message(msg_inv([CInv(MSG_BLOCK, block.sha256)]))
                 getheaders_key = "getheaders2" if test_node.nServices & NODE_HEADERS_COMPRESSED else "getheaders"
-                wait_until(lambda: getheaders_key in test_node.last_message, timeout=30, lock=p2p_lock)
+                test_node.wait_until(lambda: getheaders_key in test_node.last_message, timeout=30)
                 test_node.send_header_for_blocks([block])
             else:
                 test_node.send_header_for_blocks([block])
@@ -538,7 +538,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             num_to_request = random.randint(1, len(block.vtx))
             msg.block_txn_request.from_absolute(sorted(random.sample(range(len(block.vtx)), num_to_request)))
             test_node.send_message(msg)
-            wait_until(lambda: "blocktxn" in test_node.last_message, timeout=10, lock=p2p_lock)
+            test_node.wait_until(lambda: "blocktxn" in test_node.last_message, timeout=10)
 
             [tx.calc_sha256() for tx in block.vtx]
             with p2p_lock:
@@ -572,20 +572,20 @@ class CompactBlocksTest(BitcoinTestFramework):
         for _ in range(MAX_CMPCTBLOCK_DEPTH + 1):
             test_node.clear_block_announcement()
             new_blocks.append(node.generate(1)[0])
-            wait_until(test_node.received_block_announcement, timeout=30, lock=p2p_lock)
+            test_node.wait_until(test_node.received_block_announcement, timeout=30)
 
         test_node.clear_block_announcement()
         test_node.send_message(msg_getdata([CInv(MSG_CMPCT_BLOCK, int(new_blocks[0], 16))]))
-        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=p2p_lock)
+        test_node.wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30)
 
         test_node.clear_block_announcement()
         node.generate(1)
-        wait_until(test_node.received_block_announcement, timeout=30, lock=p2p_lock)
+        test_node.wait_until(test_node.received_block_announcement, timeout=30)
         test_node.clear_block_announcement()
         with p2p_lock:
             test_node.last_message.pop("block", None)
         test_node.send_message(msg_getdata([CInv(MSG_CMPCT_BLOCK, int(new_blocks[0], 16))]))
-        wait_until(lambda: "block" in test_node.last_message, timeout=30, lock=p2p_lock)
+        test_node.wait_until(lambda: "block" in test_node.last_message, timeout=30)
         with p2p_lock:
             test_node.last_message["block"].block.calc_sha256()
             assert_equal(test_node.last_message["block"].block.sha256, int(new_blocks[0], 16))
@@ -631,7 +631,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         node.submitblock(ToHex(block))
 
         for l in listeners:
-            wait_until(lambda: "cmpctblock" in l.last_message, timeout=30, lock=p2p_lock)
+            l.wait_until(lambda: "cmpctblock" in l.last_message, timeout=30)
         with p2p_lock:
             for l in listeners:
                 assert "cmpctblock" in l.last_message

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -9,7 +9,7 @@ import random
 
 from test_framework.blocktools import COINBASE_MATURITY, create_block, create_coinbase
 from test_framework.messages import BlockTransactions, BlockTransactionsRequest, calculate_shortid, CBlock, CBlockHeader, CInv, COutPoint, CTransaction, CTxIn, CTxOut, FromHex, HeaderAndShortIDs, msg_block, msg_blocktxn, msg_cmpctblock, msg_getblocktxn, msg_getdata, msg_getheaders, msg_headers, msg_inv, msg_sendcmpct, msg_sendheaders, msg_tx, MSG_BLOCK, MSG_CMPCT_BLOCK, NODE_NETWORK, P2PHeaderAndShortIDs, PrefilledTransaction, ToHex, NODE_HEADERS_COMPRESSED
-from test_framework.mininode import mininode_lock, P2PInterface
+from test_framework.p2p import p2p_lock, P2PInterface
 from test_framework.script import CScript, OP_TRUE, OP_DROP
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, wait_until
@@ -46,12 +46,12 @@ class TestP2PConn(P2PInterface):
                 self.block_announced = True
                 self.announced_blockhashes.add(x.hash)
 
-    # Requires caller to hold mininode_lock
+    # Requires caller to hold p2p_lock
     def received_block_announcement(self):
         return self.block_announced
 
     def clear_block_announcement(self):
-        with mininode_lock:
+        with p2p_lock:
             self.block_announced = False
             self.last_message.pop("inv", None)
             self.last_message.pop("headers", None)
@@ -71,7 +71,7 @@ class TestP2PConn(P2PInterface):
     def request_headers_and_sync(self, locator, hashstop=0):
         self.clear_block_announcement()
         self.get_headers(locator, hashstop)
-        wait_until(self.received_block_announcement, timeout=30, lock=mininode_lock)
+        wait_until(self.received_block_announcement, timeout=30, lock=p2p_lock)
         self.clear_block_announcement()
 
     # Block until a block announcement for a particular block hash is
@@ -79,7 +79,7 @@ class TestP2PConn(P2PInterface):
     def wait_for_block_announcement(self, block_hash, timeout=30):
         def received_hash():
             return (block_hash in self.announced_blockhashes)
-        wait_until(received_hash, timeout=timeout, lock=mininode_lock)
+        wait_until(received_hash, timeout=timeout, lock=p2p_lock)
 
     def send_await_disconnect(self, message, timeout=30):
         """Sends a message to the node and wait for disconnect.
@@ -87,7 +87,7 @@ class TestP2PConn(P2PInterface):
         This is used when we want to send a message into the node that we expect
         will get us disconnected, eg an invalid block."""
         self.send_message(message)
-        wait_until(lambda: not self.is_connected, timeout=timeout, lock=mininode_lock)
+        wait_until(lambda: not self.is_connected, timeout=timeout, lock=p2p_lock)
 
 class CompactBlocksTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -149,8 +149,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Make sure we get a SENDCMPCT message from our peer
         def received_sendcmpct():
             return (len(test_node.last_sendcmpct) > 0)
-        wait_until(received_sendcmpct, timeout=30, lock=mininode_lock)
-        with mininode_lock:
+        wait_until(received_sendcmpct, timeout=30, lock=p2p_lock)
+        with p2p_lock:
             # Check that the first version received is the preferred one
             assert_equal(test_node.last_sendcmpct[0].version, preferred_version)
             # And that we receive versions down to 1.
@@ -165,7 +165,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             peer.wait_for_block_announcement(block_hash, timeout=30)
             assert peer.block_announced
 
-            with mininode_lock:
+            with p2p_lock:
                 assert predicate(peer), (
                     "block_hash={!r}, cmpctblock={!r}, inv={!r}".format(
                         block_hash, peer.last_message.get("cmpctblock", None), peer.last_message.get("inv", None)))
@@ -272,11 +272,11 @@ class CompactBlocksTest(BitcoinTestFramework):
         block.rehash()
 
         # Wait until the block was announced (via compact blocks)
-        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=mininode_lock)
+        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=p2p_lock)
 
         # Now fetch and check the compact block
         header_and_shortids = None
-        with mininode_lock:
+        with p2p_lock:
             assert "cmpctblock" in test_node.last_message
             # Convert the on-the-wire representation to absolute indexes
             header_and_shortids = HeaderAndShortIDs(test_node.last_message["cmpctblock"].header_and_shortids)
@@ -287,11 +287,11 @@ class CompactBlocksTest(BitcoinTestFramework):
         inv = CInv(MSG_CMPCT_BLOCK, block_hash)  # 20 == "CompactBlock"
         test_node.send_message(msg_getdata([inv]))
 
-        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=mininode_lock)
+        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=p2p_lock)
 
         # Now fetch and check the compact block
         header_and_shortids = None
-        with mininode_lock:
+        with p2p_lock:
             assert "cmpctblock" in test_node.last_message
             # Convert the on-the-wire representation to absolute indexes
             header_and_shortids = HeaderAndShortIDs(test_node.last_message["cmpctblock"].header_and_shortids)
@@ -345,7 +345,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             if announce == "inv":
                 test_node.send_message(msg_inv([CInv(MSG_BLOCK, block.sha256)]))
                 getheaders_key = "getheaders2" if test_node.nServices & NODE_HEADERS_COMPRESSED else "getheaders"
-                wait_until(lambda: getheaders_key in test_node.last_message, timeout=30, lock=mininode_lock)
+                wait_until(lambda: getheaders_key in test_node.last_message, timeout=30, lock=p2p_lock)
                 test_node.send_header_for_blocks([block])
             else:
                 test_node.send_header_for_blocks([block])
@@ -362,7 +362,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
             assert_equal(int(node.getbestblockhash(), 16), block.hashPrevBlock)
             # Expect a getblocktxn message.
-            with mininode_lock:
+            with p2p_lock:
                 assert "getblocktxn" in test_node.last_message
                 absolute_indexes = test_node.last_message["getblocktxn"].block_txn_request.to_absolute()
             assert_equal(absolute_indexes, [0])  # should be a coinbase request
@@ -399,7 +399,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         def test_getblocktxn_response(compact_block, peer, expected_result):
             msg = msg_cmpctblock(compact_block.to_p2p())
             peer.send_and_ping(msg)
-            with mininode_lock:
+            with p2p_lock:
                 assert "getblocktxn" in peer.last_message
                 absolute_indexes = peer.last_message["getblocktxn"].block_txn_request.to_absolute()
             assert_equal(absolute_indexes, expected_result)
@@ -462,13 +462,13 @@ class CompactBlocksTest(BitcoinTestFramework):
             assert tx.hash in mempool
 
         # Clear out last request.
-        with mininode_lock:
+        with p2p_lock:
             test_node.last_message.pop("getblocktxn", None)
 
         # Send compact block
         comp_block.initialize_from_block(block, prefill_list=[0])
         test_tip_after_message(node, test_node, msg_cmpctblock(comp_block.to_p2p()), block.sha256)
-        with mininode_lock:
+        with p2p_lock:
             # Shouldn't have gotten a request for any transaction
             assert "getblocktxn" not in test_node.last_message
 
@@ -494,7 +494,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         comp_block.initialize_from_block(block, prefill_list=[0])
         test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
         absolute_indexes = []
-        with mininode_lock:
+        with p2p_lock:
             assert "getblocktxn" in test_node.last_message
             absolute_indexes = test_node.last_message["getblocktxn"].block_txn_request.to_absolute()
         assert_equal(absolute_indexes, [6, 7, 8, 9, 10])
@@ -538,10 +538,10 @@ class CompactBlocksTest(BitcoinTestFramework):
             num_to_request = random.randint(1, len(block.vtx))
             msg.block_txn_request.from_absolute(sorted(random.sample(range(len(block.vtx)), num_to_request)))
             test_node.send_message(msg)
-            wait_until(lambda: "blocktxn" in test_node.last_message, timeout=10, lock=mininode_lock)
+            wait_until(lambda: "blocktxn" in test_node.last_message, timeout=10, lock=p2p_lock)
 
             [tx.calc_sha256() for tx in block.vtx]
-            with mininode_lock:
+            with p2p_lock:
                 assert_equal(test_node.last_message["blocktxn"].block_transactions.blockhash, int(block_hash, 16))
                 all_indices = msg.block_txn_request.to_absolute()
                 for index in all_indices:
@@ -555,11 +555,11 @@ class CompactBlocksTest(BitcoinTestFramework):
         # allowed depth for a blocktxn response.
         block_hash = node.getblockhash(current_height)
         msg.block_txn_request = BlockTransactionsRequest(int(block_hash, 16), [0])
-        with mininode_lock:
+        with p2p_lock:
             test_node.last_message.pop("block", None)
             test_node.last_message.pop("blocktxn", None)
         test_node.send_and_ping(msg)
-        with mininode_lock:
+        with p2p_lock:
             test_node.last_message["block"].block.calc_sha256()
             assert_equal(test_node.last_message["block"].block.sha256, int(block_hash, 16))
             assert "blocktxn" not in test_node.last_message
@@ -572,21 +572,21 @@ class CompactBlocksTest(BitcoinTestFramework):
         for _ in range(MAX_CMPCTBLOCK_DEPTH + 1):
             test_node.clear_block_announcement()
             new_blocks.append(node.generate(1)[0])
-            wait_until(test_node.received_block_announcement, timeout=30, lock=mininode_lock)
+            wait_until(test_node.received_block_announcement, timeout=30, lock=p2p_lock)
 
         test_node.clear_block_announcement()
         test_node.send_message(msg_getdata([CInv(MSG_CMPCT_BLOCK, int(new_blocks[0], 16))]))
-        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=mininode_lock)
+        wait_until(lambda: "cmpctblock" in test_node.last_message, timeout=30, lock=p2p_lock)
 
         test_node.clear_block_announcement()
         node.generate(1)
-        wait_until(test_node.received_block_announcement, timeout=30, lock=mininode_lock)
+        wait_until(test_node.received_block_announcement, timeout=30, lock=p2p_lock)
         test_node.clear_block_announcement()
-        with mininode_lock:
+        with p2p_lock:
             test_node.last_message.pop("block", None)
         test_node.send_message(msg_getdata([CInv(MSG_CMPCT_BLOCK, int(new_blocks[0], 16))]))
-        wait_until(lambda: "block" in test_node.last_message, timeout=30, lock=mininode_lock)
-        with mininode_lock:
+        wait_until(lambda: "block" in test_node.last_message, timeout=30, lock=p2p_lock)
+        with p2p_lock:
             test_node.last_message["block"].block.calc_sha256()
             assert_equal(test_node.last_message["block"].block.sha256, int(new_blocks[0], 16))
 
@@ -614,10 +614,10 @@ class CompactBlocksTest(BitcoinTestFramework):
         # (to avoid fingerprinting attacks).
         msg = msg_getblocktxn()
         msg.block_txn_request = BlockTransactionsRequest(block.sha256, [0])
-        with mininode_lock:
+        with p2p_lock:
             test_node.last_message.pop("blocktxn", None)
         test_node.send_and_ping(msg)
-        with mininode_lock:
+        with p2p_lock:
             assert "blocktxn" not in test_node.last_message
 
     def test_end_to_end_block_relay(self, listeners):
@@ -631,8 +631,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         node.submitblock(ToHex(block))
 
         for l in listeners:
-            wait_until(lambda: "cmpctblock" in l.last_message, timeout=30, lock=mininode_lock)
-        with mininode_lock:
+            wait_until(lambda: "cmpctblock" in l.last_message, timeout=30, lock=p2p_lock)
+        with p2p_lock:
             for l in listeners:
                 assert "cmpctblock" in l.last_message
                 l.last_message["cmpctblock"].header_and_shortids.header.calc_sha256()
@@ -681,7 +681,7 @@ class CompactBlocksTest(BitcoinTestFramework):
             cmpct_block.initialize_from_block(block)
             msg = msg_cmpctblock(cmpct_block.to_p2p())
             peer.send_and_ping(msg)
-            with mininode_lock:
+            with p2p_lock:
                 assert "getblocktxn" in peer.last_message
             return block, cmpct_block
 

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -121,7 +121,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         out_value = total_value // 10
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(block.vtx[0].sha256, 0), b''))
-        for i in range(10):
+        for _ in range(10):
             tx.vout.append(CTxOut(out_value, CScript([OP_TRUE])))
         tx.rehash()
 
@@ -249,7 +249,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         num_transactions = 25
         address = node.getnewaddress()
 
-        for i in range(num_transactions):
+        for _ in range(num_transactions):
             txid = node.sendtoaddress(address, 0.1)
             hex_tx = node.gettransaction(txid)["hex"]
             tx = FromHex(CTransaction(), hex_tx)
@@ -378,7 +378,7 @@ class CompactBlocksTest(BitcoinTestFramework):
     def build_block_with_transactions(self, node, utxo, num_transactions):
         block = self.build_block_on_tip(node)
 
-        for i in range(num_transactions):
+        for _ in range(num_transactions):
             tx = CTransaction()
             tx.vin.append(CTxIn(COutPoint(utxo[0], utxo[1]), b''))
             tx.vout.append(CTxOut(utxo[2] - 1000, CScript([OP_TRUE, OP_DROP] * 15 + [OP_TRUE])))
@@ -569,7 +569,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         # Test that requesting old compactblocks doesn't work.
         MAX_CMPCTBLOCK_DEPTH = 5
         new_blocks = []
-        for i in range(MAX_CMPCTBLOCK_DEPTH + 1):
+        for _ in range(MAX_CMPCTBLOCK_DEPTH + 1):
             test_node.clear_block_announcement()
             new_blocks.append(node.generate(1)[0])
             wait_until(test_node.received_block_announcement, timeout=30, lock=mininode_lock)

--- a/test/functional/p2p_connect_to_devnet.py
+++ b/test/functional/p2p_connect_to_devnet.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test being able to connect to the same devnet"""
 
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -8,7 +8,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    wait_until,
 )
 
 class DisconnectBanTest(BitcoinTestFramework):
@@ -26,7 +25,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("setban: successfully ban single IP address")
         assert_equal(len(self.nodes[1].getpeerinfo()), 2)  # node1 should have 2 connections to node0 at this point
         self.nodes[1].setban(subnet="127.0.0.1", command="add")
-        wait_until(lambda: len(self.nodes[1].getpeerinfo()) == 0, timeout=10)
+        self.wait_until(lambda: len(self.nodes[1].getpeerinfo()) == 0, timeout=10)
         assert_equal(len(self.nodes[1].getpeerinfo()), 0)  # all nodes must be disconnected at this point
         assert_equal(len(self.nodes[1].listbanned()), 1)
 
@@ -61,7 +60,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         listBeforeShutdown = self.nodes[1].listbanned()
         assert_equal("192.168.0.1/32", listBeforeShutdown[2]['address'])
         self.bump_mocktime(2)
-        wait_until(lambda: len(self.nodes[1].listbanned()) == 3, timeout=10)
+        self.wait_until(lambda: len(self.nodes[1].listbanned()) == 3, timeout=10)
 
         self.restart_node(1)
 
@@ -89,7 +88,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("disconnectnode: successfully disconnect node by address")
         address1 = self.nodes[0].getpeerinfo()[0]['addr']
         self.nodes[0].disconnectnode(address=address1)
-        wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
         assert not [node for node in self.nodes[0].getpeerinfo() if node['addr'] == address1]
 
         self.log.info("disconnectnode: successfully reconnect node")
@@ -100,7 +99,7 @@ class DisconnectBanTest(BitcoinTestFramework):
         self.log.info("disconnectnode: successfully disconnect node by node id")
         id1 = self.nodes[0].getpeerinfo()[0]['id']
         self.nodes[0].disconnectnode(nodeid=id1)
-        wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
+        self.wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 1, timeout=10)
         assert not [node for node in self.nodes[0].getpeerinfo() if node['id'] == id1]
 
 if __name__ == '__main__':

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -19,7 +19,7 @@ from test_framework.blocktools import COINBASE_MATURITY, create_block, create_co
 from test_framework.messages import CTransaction, FromHex, msg_pong, msg_tx
 from test_framework.p2p import P2PDataStore, P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, wait_until
+from test_framework.util import assert_equal
 
 
 class SlowP2PDataStore(P2PDataStore):
@@ -92,7 +92,7 @@ class P2PEvict(BitcoinTestFramework):
         for _ in range(8):
             fastpeer = node.add_p2p_connection(P2PInterface())
             current_peer += 1
-            wait_until(lambda: "ping" in fastpeer.last_message, timeout=10)
+            self.wait_until(lambda: "ping" in fastpeer.last_message, timeout=10)
 
         # Make sure by asking the node what the actual min pings are
         peerinfo = node.getpeerinfo()

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -15,11 +15,11 @@ Therefore, this test is limited to the remaining protection criteria.
 
 import time
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.mininode import P2PInterface, P2PDataStore
-from test_framework.util import assert_equal, wait_until
 from test_framework.blocktools import COINBASE_MATURITY, create_block, create_coinbase
 from test_framework.messages import CTransaction, FromHex, msg_pong, msg_tx
+from test_framework.p2p import P2PDataStore, P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, wait_until
 
 
 class SlowP2PDataStore(P2PDataStore):

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -19,7 +19,7 @@ from test_framework.messages import (
     msg_mempool,
     msg_version,
 )
-from test_framework.mininode import P2PInterface, mininode_lock
+from test_framework.p2p import P2PInterface, p2p_lock
 from test_framework.script import MAX_SCRIPT_ELEMENT_SIZE
 from test_framework.test_framework import BitcoinTestFramework
 
@@ -60,22 +60,22 @@ class P2PBloomFilter(P2PInterface):
 
     @property
     def tx_received(self):
-        with mininode_lock:
+        with p2p_lock:
             return self._tx_received
 
     @tx_received.setter
     def tx_received(self, value):
-        with mininode_lock:
+        with p2p_lock:
             self._tx_received = value
 
     @property
     def merkleblock_received(self):
-        with mininode_lock:
+        with p2p_lock:
             return self._merkleblock_received
 
     @merkleblock_received.setter
     def merkleblock_received(self, value):
-        with mininode_lock:
+        with p2p_lock:
             self._merkleblock_received = value
 
 

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -11,7 +11,7 @@ import time
 
 from test_framework.blocktools import (create_block, create_coinbase)
 from test_framework.messages import CInv, MSG_BLOCK
-from test_framework.mininode import (
+from test_framework.p2p import (
     P2PInterface,
     msg_headers,
     msg_block,

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -21,8 +21,8 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
+
 
 class P2PFingerprintTest(BitcoinTestFramework):
 
@@ -102,12 +102,12 @@ class P2PFingerprintTest(BitcoinTestFramework):
         # Check that getdata request for stale block succeeds
         self.send_block_request(stale_hash, node0)
         test_function = lambda: self.last_block_equals(stale_hash, node0)
-        wait_until(test_function, timeout=3)
+        self.wait_until(test_function, timeout=3)
 
         # Check that getheader request for stale block header succeeds
         self.send_header_request(stale_hash, node0)
         test_function = lambda: self.last_header_equals(stale_hash, node0)
-        wait_until(test_function, timeout=3)
+        self.wait_until(test_function, timeout=3)
 
         # Longest chain is extended so stale is much older than chain tip
         self.nodes[0].setmocktime(0)
@@ -138,11 +138,11 @@ class P2PFingerprintTest(BitcoinTestFramework):
 
         self.send_block_request(block_hash, node0)
         test_function = lambda: self.last_block_equals(block_hash, node0)
-        wait_until(test_function, timeout=3)
+        self.wait_until(test_function, timeout=3)
 
         self.send_header_request(block_hash, node0)
         test_function = lambda: self.last_header_equals(block_hash, node0)
-        wait_until(test_function, timeout=3)
+        self.wait_until(test_function, timeout=3)
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -5,9 +5,9 @@
 """Test addr response caching"""
 
 from test_framework.messages import msg_getaddr
-from test_framework.mininode import (
+from test_framework.p2p import (
     P2PInterface,
-    mininode_lock
+    p2p_lock
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -27,7 +27,7 @@ class AddrReceiver(P2PInterface):
         self.received_addrs = None
 
     def get_received_addrs(self):
-        with mininode_lock:
+        with p2p_lock:
             return self.received_addrs
 
     def on_addr(self, message):

--- a/test/functional/p2p_getdata.py
+++ b/test/functional/p2p_getdata.py
@@ -9,7 +9,7 @@ from test_framework.messages import (
     CInv,
     msg_getdata,
 )
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 
 

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -14,7 +14,7 @@ import copy
 
 from test_framework.blocktools import create_block, create_coinbase, create_tx_with_script
 from test_framework.messages import COIN
-from test_framework.mininode import P2PDataStore
+from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -6,7 +6,7 @@
 """
 
 from test_framework.messages import msg_getheaders, msg_getblocks, MAX_LOCATOR_SZ
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 
 

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -15,7 +15,7 @@ from test_framework.messages import (
     msg_inv,
     MSG_TX,
 )
-from test_framework.mininode import (
+from test_framework.p2p import (
     P2PDataStore, P2PInterface
 )
 from test_framework.test_framework import BitcoinTestFramework

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -21,7 +21,6 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
 
 MSG_LIMIT = 3 * 1024 * 1024  # 3MB, per MAX_PROTOCOL_MESSAGE_LENGTH
@@ -66,7 +65,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         before = int(self.nodes[0].getnettotals()['totalbytesrecv'])
         conn.send_raw_message(msg[:cut_pos])
         # Wait until node has processed the first half of the message
-        wait_until(lambda: int(self.nodes[0].getnettotals()['totalbytesrecv']) != before)
+        self.wait_until(lambda: int(self.nodes[0].getnettotals()['totalbytesrecv']) != before)
         middle = int(self.nodes[0].getnettotals()['totalbytesrecv'])
         # If this assert fails, we've hit an unlikely race
         # where the test framework sent a message in between the two halves

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -14,7 +14,7 @@ from test_framework.messages import (
     CTxIn,
     CTxOut,
 )
-from test_framework.mininode import P2PDataStore
+from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -18,7 +18,6 @@ from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
 from data import invalid_txs
 
@@ -182,7 +181,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
             # This TX has appeared in a block instead of being broadcasted via the mempool
             expected_mempool.remove(tx_withhold.hash)
 
-        wait_until(lambda: 1 == len(node.getpeerinfo()), timeout=12)  # p2ps[1] is no longer connected
+        self.wait_until(lambda: 1 == len(node.getpeerinfo()), timeout=12)  # p2ps[1] is no longer connected
         assert_equal(expected_mempool, set(node.getrawmempool()))
 
         self.log.info('Test orphan pool overflow')

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -19,7 +19,7 @@ from test_framework.messages import (
     msg_verack,
     msg_version,
 )
-from test_framework.mininode import mininode_lock, P2PInterface
+from test_framework.p2p import p2p_lock, P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -121,9 +121,9 @@ class P2PLeakTest(BitcoinTestFramework):
         # verack, since we never sent one
         no_verack_idlenode.wait_for_verack()
 
-        wait_until(lambda: no_version_bannode.ever_connected, timeout=10, lock=mininode_lock)
-        wait_until(lambda: no_version_idlenode.ever_connected, timeout=10, lock=mininode_lock)
-        wait_until(lambda: no_verack_idlenode.version_received, timeout=10, lock=mininode_lock)
+        wait_until(lambda: no_version_bannode.ever_connected, timeout=10, lock=p2p_lock)
+        wait_until(lambda: no_version_idlenode.ever_connected, timeout=10, lock=p2p_lock)
+        wait_until(lambda: no_verack_idlenode.version_received, timeout=10, lock=p2p_lock)
 
         # Mine a block and make sure that it's not sent to the connected nodes
         self.nodes[0].generatetoaddress(1, self.nodes[0].get_deterministic_priv_key().address)

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -24,7 +24,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
-    wait_until,
 )
 
 banscore = 10
@@ -121,9 +120,9 @@ class P2PLeakTest(BitcoinTestFramework):
         # verack, since we never sent one
         no_verack_idlenode.wait_for_verack()
 
-        wait_until(lambda: no_version_bannode.ever_connected, timeout=10, lock=p2p_lock)
-        wait_until(lambda: no_version_idlenode.ever_connected, timeout=10, lock=p2p_lock)
-        wait_until(lambda: no_verack_idlenode.version_received, timeout=10, lock=p2p_lock)
+        self.wait_until(lambda: no_version_bannode.ever_connected, timeout=10, lock=p2p_lock)
+        self.wait_until(lambda: no_version_idlenode.ever_connected, timeout=10, lock=p2p_lock)
+        self.wait_until(lambda: no_verack_idlenode.version_received, timeout=10, lock=p2p_lock)
 
         # Mine a block and make sure that it's not sent to the connected nodes
         self.nodes[0].generatetoaddress(1, self.nodes[0].get_deterministic_priv_key().address)
@@ -156,7 +155,7 @@ class P2PLeakTest(BitcoinTestFramework):
         p2p_old_node = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
         old_version_msg = msg_version()
         old_version_msg.nVersion = 31799
-        wait_until(lambda: p2p_old_node.is_connected)
+        self.wait_until(lambda: p2p_old_node.is_connected)
         with self.nodes[0].assert_debug_log(['peer=4 using obsolete version 31799; disconnecting']):
             p2p_old_node.send_message(old_version_msg)
             p2p_old_node.wait_for_disconnect()

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -70,7 +70,7 @@ class CNodeNoVersionBan(CLazyNode):
     # NOTE: implementation-specific check here. Remove if dashd ban behavior changes
     def on_open(self):
         super().on_open()
-        for i in range(banscore):
+        for _ in range(banscore):
             self.send_message(msg_verack())
 
 # Node that never sends a version. This one just sits idle and hopes to receive

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -5,7 +5,7 @@
 """Test that we don't leak txs to inbound peers that we haven't yet announced to"""
 
 from test_framework.messages import msg_getdata, CInv, MSG_TX
-from test_framework.mininode import P2PDataStore
+from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/p2p_nobloomfilter_messages.py
+++ b/test/functional/p2p_nobloomfilter_messages.py
@@ -12,7 +12,7 @@ Test that, when bloom filters are not enabled, peers are disconnected if:
 """
 
 from test_framework.messages import msg_mempool, msg_filteradd, msg_filterload, msg_filterclear
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -9,9 +9,9 @@ and that it responds to getdata requests for blocks correctly:
     - send a block within 288 + 2 of the tip
     - disconnect peers who request blocks older than that."""
 from test_framework.messages import CInv, MSG_BLOCK, msg_getdata, NODE_BLOOM, NODE_NETWORK_LIMITED, NODE_HEADERS_COMPRESSED, msg_verack
-from test_framework.p2p import P2PInterface, p2p_lock
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, wait_until
+from test_framework.util import assert_equal
 
 class P2PIgnoreInv(P2PInterface):
     firstAddrnServices = 0
@@ -22,7 +22,7 @@ class P2PIgnoreInv(P2PInterface):
         self.firstAddrnServices = message.addrs[0].nServices
     def wait_for_addr(self, timeout=5):
         test_function = lambda: self.last_message.get("addr")
-        wait_until(test_function, timeout=timeout, lock=p2p_lock)
+        self.wait_until(test_function, timeout=timeout)
     def send_getdata_for_block(self, blockhash):
         getdata_request = msg_getdata()
         getdata_request.inv.append(CInv(MSG_BLOCK, int(blockhash, 16)))

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -9,7 +9,7 @@ and that it responds to getdata requests for blocks correctly:
     - send a block within 288 + 2 of the tip
     - disconnect peers who request blocks older than that."""
 from test_framework.messages import CInv, MSG_BLOCK, msg_getdata, NODE_BLOOM, NODE_NETWORK_LIMITED, NODE_HEADERS_COMPRESSED, msg_verack
-from test_framework.mininode import P2PInterface, mininode_lock
+from test_framework.p2p import P2PInterface, p2p_lock
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, wait_until
 
@@ -22,7 +22,7 @@ class P2PIgnoreInv(P2PInterface):
         self.firstAddrnServices = message.addrs[0].nServices
     def wait_for_addr(self, timeout=5):
         test_function = lambda: self.last_message.get("addr")
-        wait_until(test_function, timeout=timeout, lock=mininode_lock)
+        wait_until(test_function, timeout=timeout, lock=p2p_lock)
     def send_getdata_for_block(self, blockhash):
         getdata_request = msg_getdata()
         getdata_request.inv.append(CInv(MSG_BLOCK, int(blockhash, 16)))

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -22,7 +22,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     p2p_port,
-    wait_until,
 )
 
 
@@ -139,7 +138,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
 
         with self.nodes[1].assert_debug_log(["Force relaying tx {} from peer=0".format(txid)]):
             p2p_rebroadcast_wallet.send_txs_and_test([tx], self.nodes[1])
-            wait_until(in_mempool)
+            self.wait_until(in_mempool)
 
         self.log.debug("Check that node[1] will not send an invalid tx to node[0]")
         tx.vout[0].nValue += 1

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -12,7 +12,7 @@ from test_framework.messages import (
     CTransaction,
     FromHex,
 )
-from test_framework.mininode import P2PDataStore
+from test_framework.p2p import P2PDataStore
 from test_framework.script import (
     CScript,
     OP_TRUE,
@@ -107,7 +107,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
         self.sync_all()
 
         self.log.debug("Create a connection from a forcerelay peer that rebroadcasts raw txs")
-        # A python mininode is needed to send the raw transaction directly. If a full node was used, it could only
+        # A test framework p2p connection is needed to send the raw transaction directly. If a full node was used, it could only
         # rebroadcast via the inv-getdata mechanism. However, even for forcerelay connections, a full node would
         # currently not request a txid that is already in the mempool.
         self.restart_node(1, extra_args=["-whitelist=forcerelay@127.0.0.1"])

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -6,8 +6,8 @@
 import time
 
 from test_framework.messages import msg_qgetdata, msg_qwatch
-from test_framework.mininode import (
-    mininode_lock,
+from test_framework.p2p import (
+    p2p_lock,
     P2PInterface,
 )
 from test_framework.test_framework import DashTestFramework
@@ -106,7 +106,7 @@ class QuorumDataInterface(P2PInterface):
             assert_qdata(self.get_qdata(), qgetdata, expected_error, len_vvec, len_contributions)
 
     def wait_for_qmessage(self, message=None, timeout=3, message_expected=True):
-        wait_until(lambda: self.message_count[message] > 0, timeout=timeout, lock=mininode_lock, do_assert=message_expected)
+        wait_until(lambda: self.message_count[message] > 0, timeout=timeout, lock=p2p_lock, do_assert=message_expected)
         if not message_expected:
             assert self.message_count[message] == 0
         self.message_count[message] = 0

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -338,7 +338,7 @@ class QuorumDataMessagesTest(DashTestFramework):
             # mn1 should still have a score of 75
             wait_for_banscore(mn3.node, id_p2p_mn3_1, 75)
             # mn2 should be "banned" now
-            wait_until(lambda: not p2p_mn3_2.is_connected, timeout=10)
+            self.wait_until(lambda: not p2p_mn3_2.is_connected, timeout=10)
             mn3.node.disconnect_p2ps()
 
         # Test that QWATCH connections are also allowed to query data but all

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -327,7 +327,7 @@ class SendHeadersTest(BitcoinTestFramework):
             for j in range(2):
                 self.log.debug("Part 2.{}.{}: starting...".format(i, j))
                 blocks = []
-                for b in range(i + 1):
+                for _ in range(i + 1):
                     blocks.append(create_block(tip, create_coinbase(height), block_time))
                     blocks[-1].solve()
                     tip = blocks[-1].sha256
@@ -442,7 +442,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # Create 2 blocks.  Send the blocks, then send the headers.
         blocks = []
-        for b in range(2):
+        for _ in range(2):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
@@ -460,7 +460,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # This time, direct fetch should work
         blocks = []
-        for b in range(3):
+        for _ in range(3):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
@@ -481,7 +481,7 @@ class SendHeadersTest(BitcoinTestFramework):
         blocks = []
 
         # Create extra blocks for later
-        for b in range(20):
+        for _ in range(20):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
@@ -528,7 +528,7 @@ class SendHeadersTest(BitcoinTestFramework):
             test_node.last_message.pop("getdata", None)
             blocks = []
             # Create two more blocks.
-            for j in range(2):
+            for _ in range(2):
                 blocks.append(create_block(tip, create_coinbase(height), block_time))
                 blocks[-1].solve()
                 tip = blocks[-1].sha256
@@ -549,7 +549,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # Now we test that if we repeatedly don't send connecting headers, we
         # don't go into an infinite loop trying to get them to connect.
         MAX_UNCONNECTING_HEADERS = 10
-        for j in range(MAX_UNCONNECTING_HEADERS + 1):
+        for _ in range(MAX_UNCONNECTING_HEADERS + 1):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -103,7 +103,6 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
 
 DIRECT_FETCH_RESPONSE_TIME = 0.05
@@ -146,7 +145,7 @@ class BaseNode(P2PInterface):
 
     def wait_for_block_announcement(self, block_hash, timeout=60):
         test_function = lambda: self.last_blockhash_announced == block_hash
-        wait_until(test_function, timeout=timeout, lock=p2p_lock)
+        self.wait_until(test_function, timeout=timeout)
 
     def on_inv(self, message):
         self.block_announced = True
@@ -173,7 +172,7 @@ class BaseNode(P2PInterface):
         """Test whether the last headers announcements received are right.
            Headers may be announced across more than one message."""
         test_function = lambda: (len(self.recent_headers_announced) >= len(headers))
-        wait_until(test_function, timeout=60, lock=p2p_lock)
+        self.wait_until(test_function)
         with p2p_lock:
             assert_equal(self.recent_headers_announced, headers)
             self.block_announced = False
@@ -185,7 +184,7 @@ class BaseNode(P2PInterface):
         inv should be a list of block hashes."""
 
         test_function = lambda: self.block_announced
-        wait_until(test_function, timeout=60, lock=p2p_lock)
+        self.wait_until(test_function)
 
         with p2p_lock:
             compare_inv = []
@@ -297,7 +296,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 test_node.send_header_for_blocks([new_block])
                 test_node.wait_for_getdata([new_block.sha256])
                 test_node.send_and_ping(msg_block(new_block))  # make sure this block is processed
-                wait_until(lambda: inv_node.block_announced, timeout=60, lock=p2p_lock)
+                inv_node.wait_until(lambda: inv_node.block_announced)
                 inv_node.clear_block_announcements()
                 test_node.clear_block_announcements()
 

--- a/test/functional/p2p_sendheaders_compressed.py
+++ b/test/functional/p2p_sendheaders_compressed.py
@@ -30,7 +30,6 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
 
 DIRECT_FETCH_RESPONSE_TIME = 0.05
@@ -77,11 +76,11 @@ class BaseNode(P2PInterface):
             return
 
         test_function = lambda: "getdata" in self.last_message and [inv.hash for inv in self.last_message["getdata"].inv] == hash_list
-        wait_until(test_function, timeout=timeout, lock=p2p_lock)
+        self.wait_until(test_function, timeout=timeout)
 
     def wait_for_block_announcement(self, block_hash, timeout=60):
         test_function = lambda: self.last_blockhash_announced == block_hash
-        wait_until(test_function, timeout=timeout, lock=p2p_lock)
+        self.wait_until(test_function, timeout=timeout)
 
     def on_inv(self, message):
         self.block_announced = True
@@ -107,7 +106,7 @@ class BaseNode(P2PInterface):
         """Test whether the last headers announcements received are right.
            Headers may be announced across more than one message."""
         test_function = lambda: (len(self.recent_headers_announced) >= len(headers))
-        wait_until(test_function, timeout=60, lock=p2p_lock)
+        self.wait_until(test_function, timeout=60)
         with p2p_lock:
             assert_equal(self.recent_headers_announced, headers)
             self.block_announced = False
@@ -119,7 +118,7 @@ class BaseNode(P2PInterface):
         inv should be a list of block hashes."""
 
         test_function = lambda: self.block_announced
-        wait_until(test_function, timeout=60, lock=p2p_lock)
+        self.wait_until(test_function, timeout=60)
 
         with p2p_lock:
             compare_inv = []
@@ -304,7 +303,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 test_node.send_header_for_blocks([new_block])
                 test_node.wait_for_getdata([new_block.sha256])
                 test_node.send_and_ping(msg_block(new_block))  # make sure this block is processed
-                wait_until(lambda: inv_node.block_announced, timeout=60, lock=p2p_lock)
+                self.wait_until(lambda: inv_node.block_announced, timeout=60)
                 inv_node.clear_block_announcements()
                 test_node.clear_block_announcements()
 

--- a/test/functional/p2p_sendheaders_compressed.py
+++ b/test/functional/p2p_sendheaders_compressed.py
@@ -14,10 +14,10 @@ Setup:
 """
 from test_framework.blocktools import create_block, create_coinbase
 from test_framework.messages import CInv, NODE_HEADERS_COMPRESSED
-from test_framework.mininode import (
+from test_framework.p2p import (
     CompressibleBlockHeader,
     P2PInterface,
-    mininode_lock,
+    p2p_lock,
     msg_block,
     msg_getblocks,
     msg_getdata,
@@ -77,11 +77,11 @@ class BaseNode(P2PInterface):
             return
 
         test_function = lambda: "getdata" in self.last_message and [inv.hash for inv in self.last_message["getdata"].inv] == hash_list
-        wait_until(test_function, timeout=timeout, lock=mininode_lock)
+        wait_until(test_function, timeout=timeout, lock=p2p_lock)
 
     def wait_for_block_announcement(self, block_hash, timeout=60):
         test_function = lambda: self.last_blockhash_announced == block_hash
-        wait_until(test_function, timeout=timeout, lock=mininode_lock)
+        wait_until(test_function, timeout=timeout, lock=p2p_lock)
 
     def on_inv(self, message):
         self.block_announced = True
@@ -97,7 +97,7 @@ class BaseNode(P2PInterface):
             self.last_blockhash_announced = message.headers[-1].sha256
 
     def clear_block_announcements(self):
-        with mininode_lock:
+        with p2p_lock:
             self.block_announced = False
             self.last_message.pop("inv", None)
             self.last_message.pop("headers2", None)
@@ -107,8 +107,8 @@ class BaseNode(P2PInterface):
         """Test whether the last headers announcements received are right.
            Headers may be announced across more than one message."""
         test_function = lambda: (len(self.recent_headers_announced) >= len(headers))
-        wait_until(test_function, timeout=60, lock=mininode_lock)
-        with mininode_lock:
+        wait_until(test_function, timeout=60, lock=p2p_lock)
+        with p2p_lock:
             assert_equal(self.recent_headers_announced, headers)
             self.block_announced = False
             self.last_message.pop("headers2", None)
@@ -119,9 +119,9 @@ class BaseNode(P2PInterface):
         inv should be a list of block hashes."""
 
         test_function = lambda: self.block_announced
-        wait_until(test_function, timeout=60, lock=mininode_lock)
+        wait_until(test_function, timeout=60, lock=p2p_lock)
 
-        with mininode_lock:
+        with p2p_lock:
             compare_inv = []
             if "inv" in self.last_message:
                 compare_inv = [inv.hash for inv in self.last_message["inv"].inv]
@@ -304,7 +304,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 test_node.send_header_for_blocks([new_block])
                 test_node.wait_for_getdata([new_block.sha256])
                 test_node.send_and_ping(msg_block(new_block))  # make sure this block is processed
-                wait_until(lambda: inv_node.block_announced, timeout=60, lock=mininode_lock)
+                wait_until(lambda: inv_node.block_announced, timeout=60, lock=p2p_lock)
                 inv_node.clear_block_announcements()
                 test_node.clear_block_announcements()
 
@@ -462,7 +462,7 @@ class SendHeadersTest(BitcoinTestFramework):
         test_node.send_header_for_blocks(blocks)
         test_node.sync_with_ping()
         # should not have received any getdata messages
-        with mininode_lock:
+        with p2p_lock:
             assert "getdata" not in test_node.last_message
 
         # This time, direct fetch should work
@@ -500,7 +500,7 @@ class SendHeadersTest(BitcoinTestFramework):
         test_node.last_message.pop("getdata", None)
         test_node.send_header_for_blocks(blocks[0:1])
         test_node.sync_with_ping()
-        with mininode_lock:
+        with p2p_lock:
             assert "getdata" not in test_node.last_message
 
         # Announcing one more block on fork should trigger direct fetch for
@@ -519,7 +519,7 @@ class SendHeadersTest(BitcoinTestFramework):
         test_node.last_message.pop("getdata", None)
         test_node.send_header_for_blocks(blocks[18:19])
         test_node.sync_with_ping()
-        with mininode_lock:
+        with p2p_lock:
             assert "getdata" not in test_node.last_message
 
         self.log.info("Part 4: success!")
@@ -542,7 +542,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 block_time += 1
                 height += 1
             # Send the header of the second block -> this won't connect.
-            with mininode_lock:
+            with p2p_lock:
                 test_node.last_message.pop("getheaders2", None)
             test_node.send_header_for_blocks([blocks[1]])
             test_node.wait_for_getheaders()
@@ -565,7 +565,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         for i in range(1, MAX_UNCONNECTING_HEADERS):
             # Send a header that doesn't connect, check that we get a getheaders.
-            with mininode_lock:
+            with p2p_lock:
                 test_node.last_message.pop("getheaders2", None)
             test_node.send_header_for_blocks([blocks[i]])
             test_node.wait_for_getheaders()
@@ -580,7 +580,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # before we get disconnected.  Should be 5*MAX_UNCONNECTING_HEADERS
         for i in range(5 * MAX_UNCONNECTING_HEADERS - 1):
             # Send a header that doesn't connect, check that we get a getheaders.
-            with mininode_lock:
+            with p2p_lock:
                 test_node.last_message.pop("getheaders2", None)
             test_node.send_header_for_blocks([blocks[i % len(blocks)]])
             test_node.wait_for_getheaders()

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -24,7 +24,7 @@
 from time import sleep
 
 from test_framework.messages import msg_ping
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 
 

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -160,7 +160,7 @@ class TxDownloadTest(BitcoinTestFramework):
         # Setup the p2p connections
         self.peers = []
         for node in self.nodes:
-            for i in range(NUM_INBOUND):
+            for _ in range(NUM_INBOUND):
                 self.peers.append(node.add_p2p_connection(TestP2PConn()))
 
         self.log.info("Nodes are setup with {} incoming connections each".format(NUM_INBOUND))

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -22,7 +22,6 @@ from test_framework.p2p import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 
@@ -73,7 +72,7 @@ class TxDownloadTest(BitcoinTestFramework):
 
         while outstanding_peer_index:
             self.bump_mocktime(MAX_GETDATA_INBOUND_WAIT)
-            wait_until(lambda: any(getdata_found(i) for i in outstanding_peer_index))
+            self.wait_until(lambda: any(getdata_found(i) for i in outstanding_peer_index))
             for i in outstanding_peer_index:
                 if getdata_found(i):
                     outstanding_peer_index.remove(i)
@@ -136,21 +135,21 @@ class TxDownloadTest(BitcoinTestFramework):
             self.bump_mocktime(1)
             return p.tx_getdata_count >= target
 
-        wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT), lock=p2p_lock)
+        p.wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT))
 
         with p2p_lock:
             assert_equal(p.tx_getdata_count, MAX_GETDATA_IN_FLIGHT)
 
         self.log.info("Now check that if we send a NOTFOUND for a transaction, we'll get one more request")
         p.send_message(msg_notfound(vec=[CInv(t=1, h=txids[0])]))
-        wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT + 1), timeout=10, lock=p2p_lock)
+        p.wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT + 1), timeout=10)
         with p2p_lock:
             assert_equal(p.tx_getdata_count, MAX_GETDATA_IN_FLIGHT + 1)
 
         WAIT_TIME = TX_EXPIRY_INTERVAL // 2 + TX_EXPIRY_INTERVAL
         self.log.info("if we wait about {} minutes, we should eventually get more requests".format(WAIT_TIME / 60))
         self.bump_mocktime(WAIT_TIME)
-        wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT + 2))
+        p.wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT + 2))
 
     def test_spurious_notfound(self):
         self.log.info('Check that spurious notfound is ignored')

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -15,9 +15,9 @@ from test_framework.messages import (
     msg_inv,
     msg_notfound,
 )
-from test_framework.mininode import (
+from test_framework.p2p import (
     P2PInterface,
-    mininode_lock,
+    p2p_lock,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -68,7 +68,7 @@ class TxDownloadTest(BitcoinTestFramework):
 
         def getdata_found(peer_index):
             p = self.nodes[0].p2ps[peer_index]
-            with mininode_lock:
+            with p2p_lock:
                 return p.last_message.get("getdata") and p.last_message["getdata"].inv[-1].hash == txid
 
         while outstanding_peer_index:
@@ -127,7 +127,7 @@ class TxDownloadTest(BitcoinTestFramework):
 
         p = self.nodes[0].p2ps[0]
 
-        with mininode_lock:
+        with p2p_lock:
             p.tx_getdata_count = 0
 
         p.send_message(msg_inv([CInv(t=1, h=i) for i in txids]))
@@ -136,15 +136,15 @@ class TxDownloadTest(BitcoinTestFramework):
             self.bump_mocktime(1)
             return p.tx_getdata_count >= target
 
-        wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT), lock=mininode_lock)
+        wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT), lock=p2p_lock)
 
-        with mininode_lock:
+        with p2p_lock:
             assert_equal(p.tx_getdata_count, MAX_GETDATA_IN_FLIGHT)
 
         self.log.info("Now check that if we send a NOTFOUND for a transaction, we'll get one more request")
         p.send_message(msg_notfound(vec=[CInv(t=1, h=txids[0])]))
-        wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT + 1), timeout=10, lock=mininode_lock)
-        with mininode_lock:
+        wait_until(lambda: wait_for_tx_getdata(MAX_GETDATA_IN_FLIGHT + 1), timeout=10, lock=p2p_lock)
+        with p2p_lock:
             assert_equal(p.tx_getdata_count, MAX_GETDATA_IN_FLIGHT + 1)
 
         WAIT_TIME = TX_EXPIRY_INTERVAL // 2 + TX_EXPIRY_INTERVAL

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -54,7 +54,7 @@ Node1 is unused in tests 3-7:
 
 from test_framework.blocktools import create_block, create_coinbase, create_tx_with_script
 from test_framework.messages import CBlockHeader, CInv, MSG_BLOCK, msg_block, msg_headers, msg_inv
-from test_framework.mininode import mininode_lock, P2PInterface
+from test_framework.p2p import p2p_lock, P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
@@ -194,13 +194,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         # 6. Try to get node to request the missing block.
         # Poke the node with an inv for block at height 3 and see if that
         # triggers a getdata on block 2 (it should if block 2 is missing).
-        with mininode_lock:
+        with p2p_lock:
             # Clear state so we can check the getdata request
             test_node.last_message.pop("getdata", None)
             test_node.send_message(msg_inv([CInv(MSG_BLOCK, block_h3.sha256)]))
 
         test_node.sync_with_ping()
-        with mininode_lock:
+        with p2p_lock:
             getdata = test_node.last_message["getdata"]
 
         # Check that the getdata includes the right block

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -22,17 +22,6 @@ from decimal import Decimal
 import http.client
 import subprocess
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    assert_equal,
-    assert_greater_than,
-    assert_greater_than_or_equal,
-    assert_raises,
-    assert_raises_rpc_error,
-    assert_is_hex_string,
-    assert_is_hash_string,
-    set_node_times,
-)
 from test_framework.blocktools import (
     create_block,
     create_coinbase,
@@ -43,8 +32,17 @@ from test_framework.messages import (
     FromHex,
     msg_block,
 )
-from test_framework.mininode import (
-    P2PInterface,
+from test_framework.p2p import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_greater_than_or_equal,
+    assert_raises,
+    assert_raises_rpc_error,
+    assert_is_hex_string,
+    assert_is_hash_string,
+    set_node_times,
 )
 
 

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -539,7 +539,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].generate(1)
         self.sync_all()
 
-        for i in range(0,20):
+        for _ in range(20):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
         self.nodes[0].generate(1)
         self.sync_all()
@@ -567,7 +567,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].generate(1)
         self.sync_all()
 
-        for i in range(0,20):
+        for _ in range(20):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
         self.nodes[0].generate(1)
         self.sync_all()

--- a/test/functional/rpc_generateblock.py
+++ b/test/functional/rpc_generateblock.py
@@ -46,7 +46,7 @@ class GenerateBlockTest(BitcoinTestFramework):
         node.generatetoaddress(110, address)
 
         # Generate some extra mempool transactions to verify they don't get mined
-        for i in range(10):
+        for _ in range(10):
             node.sendtoaddress(address, 0.001)
 
         self.log.info('Generate block with txid')

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -8,7 +8,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR
 from test_framework.util import (
     assert_equal,
-    wait_until,
 )
 
 
@@ -56,9 +55,9 @@ class InvalidateTest(BitcoinTestFramework):
         self.log.info("..and then mine a block")
         self.nodes[2].generatetoaddress(1, self.nodes[2].get_deterministic_priv_key().address)
         self.log.info("Verify all nodes are at the right height")
-        wait_until(lambda: self.nodes[2].getblockcount() == 3, timeout=5)
-        wait_until(lambda: self.nodes[0].getblockcount() == 4, timeout=5)
-        wait_until(lambda: self.nodes[1].getblockcount() == 4, timeout=5)
+        self.wait_until(lambda: self.nodes[2].getblockcount() == 3, timeout=5)
+        self.wait_until(lambda: self.nodes[0].getblockcount() == 4, timeout=5)
+        self.wait_until(lambda: self.nodes[1].getblockcount() == 4, timeout=5)
 
         self.log.info("Make sure ResetBlockFailureFlags does the job correctly")
         self.restart_node(0, extra_args=["-checkblocks=5"])
@@ -83,7 +82,7 @@ class InvalidateTest(BitcoinTestFramework):
 
         assert_equal(self.nodes[1].getblockcount(), newheight)
         self.restart_node(1, extra_args=["-checkblocks=5"])
-        wait_until(lambda: self.nodes[1].getblockcount() == newheight + 20)
+        self.wait_until(lambda: self.nodes[1].getblockcount() == newheight + 20)
         assert_equal(tip, self.nodes[1].getbestblockhash())
 
         self.log.info("Verify that we reconsider all ancestors as well")

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -11,7 +11,6 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_greater_than_or_equal,
-    wait_until
 )
 
 from test_framework.authproxy import JSONRPCException
@@ -83,7 +82,7 @@ class RpcMiscTest(BitcoinTestFramework):
 
         # Restart the node with indices and wait for them to sync
         self.restart_node(0, ["-txindex", "-blockfilterindex", "-coinstatsindex"])
-        wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
+        self.wait_until(lambda: all(i["synced"] for i in node.getindexinfo().values()))
 
         # Returns a list of all running indices by default
         values = {"synced": True, "best_block_height": 200}

--- a/test/functional/rpc_mnauth.py
+++ b/test/functional/rpc_mnauth.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 from test_framework.messages import hash256
-from test_framework.mininode import P2PInterface
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error, hex_str_to_bytes
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -7,6 +7,11 @@
 Tests correspond to code in rpc/net.cpp.
 """
 
+from test_framework.p2p import P2PInterface
+import test_framework.messages
+from test_framework.messages import (
+    NODE_NETWORK,
+)
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
     assert_equal,
@@ -15,11 +20,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     p2p_port,
     wait_until,
-)
-from test_framework.mininode import P2PInterface
-import test_framework.messages
-from test_framework.messages import (
-    NODE_NETWORK,
 )
 
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -19,7 +19,6 @@ from test_framework.util import (
     assert_greater_than,
     assert_raises_rpc_error,
     p2p_port,
-    wait_until,
 )
 
 
@@ -45,7 +44,7 @@ class NetTest(DashTestFramework):
         # Wait for one ping/pong to finish so that we can be sure that there is no chatter between nodes for some time
         # Especially the exchange of messages like getheaders and friends causes test failures here
         self.nodes[0].ping()
-        wait_until(lambda: all(['pingtime' in n for n in self.nodes[0].getpeerinfo()]))
+        self.wait_until(lambda: all(['pingtime' in n for n in self.nodes[0].getpeerinfo()]))
         self.log.info('Connect nodes both way')
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 0)
@@ -87,8 +86,8 @@ class NetTest(DashTestFramework):
         # the bytes sent/received should change
         # note ping and pong are 32 bytes each
         self.nodes[0].ping()
-        wait_until(lambda: (self.nodes[0].getnettotals()['totalbytessent'] >= net_totals_after['totalbytessent'] + 32 * 2), timeout=1)
-        wait_until(lambda: (self.nodes[0].getnettotals()['totalbytesrecv'] >= net_totals_after['totalbytesrecv'] + 32 * 2), timeout=1)
+        self.wait_until(lambda: (self.nodes[0].getnettotals()['totalbytessent'] >= net_totals_after['totalbytessent'] + 32 * 2), timeout=1)
+        self.wait_until(lambda: (self.nodes[0].getnettotals()['totalbytesrecv'] >= net_totals_after['totalbytesrecv'] + 32 * 2), timeout=1)
 
         peer_info_after_ping = self.nodes[0].getpeerinfo()
         for before, after in zip(peer_info, peer_info_after_ping):
@@ -102,8 +101,8 @@ class NetTest(DashTestFramework):
         self.nodes[0].setnetworkactive(state=False)
         assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], False)
         # Wait a bit for all sockets to close
-        wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == 0, timeout=3)
-        wait_until(lambda: self.nodes[1].getnetworkinfo()['connections'] == 0, timeout=3)
+        self.wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == 0, timeout=3)
+        self.wait_until(lambda: self.nodes[1].getnetworkinfo()['connections'] == 0, timeout=3)
 
         self.nodes[0].setnetworkactive(state=True)
         self.log.info('Connect nodes both way')
@@ -124,7 +123,7 @@ class NetTest(DashTestFramework):
         self.log.info('Test extended connections info')
         self.connect_nodes(1, 2)
         self.nodes[1].ping()
-        wait_until(lambda: all(['pingtime' in n for n in self.nodes[1].getpeerinfo()]))
+        self.wait_until(lambda: all(['pingtime' in n for n in self.nodes[1].getpeerinfo()]))
         assert_equal(self.nodes[1].getnetworkinfo()['connections'], 3)
         assert_equal(self.nodes[1].getnetworkinfo()['inboundconnections'], 1)
         assert_equal(self.nodes[1].getnetworkinfo()['outboundconnections'], 2)

--- a/test/functional/rpc_verifyislock.py
+++ b/test/functional/rpc_verifyislock.py
@@ -5,7 +5,7 @@
 
 from test_framework.messages import CTransaction, FromHex, hash256, ser_compact_size, ser_string
 from test_framework.test_framework import DashTestFramework
-from test_framework.util import assert_raises_rpc_error, satoshi_round, wait_until
+from test_framework.util import assert_raises_rpc_error, satoshi_round
 
 '''
 rpc_verifyislock.py
@@ -51,7 +51,7 @@ class RPCVerifyISLockTest(DashTestFramework):
         self.wait_for_instantlock(txid, node)
 
         request_id = self.get_request_id(self.nodes[0].getrawtransaction(txid))
-        wait_until(lambda: node.quorum("hasrecsig", 103, request_id, txid))
+        self.wait_until(lambda: node.quorum("hasrecsig", 103, request_id, txid))
 
         rec_sig = node.quorum("getrecsig", 103, request_id, txid)['sig']
         assert node.verifyislock(request_id, txid, rec_sig)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -110,7 +110,7 @@ def deser_uint256(f):
 
 def ser_uint256(u):
     rs = b""
-    for i in range(8):
+    for _ in range(8):
         rs += struct.pack("<I", u & 0xFFFFFFFF)
         u >>= 32
     return rs
@@ -139,7 +139,7 @@ def uint256_from_compact(c):
 def deser_vector(f, c, deser_function_name=None):
     nit = deser_compact_size(f)
     r = []
-    for i in range(nit):
+    for _ in range(nit):
         t = c()
         if deser_function_name:
             getattr(t, deser_function_name)(f)
@@ -164,7 +164,7 @@ def ser_vector(l, ser_function_name=None):
 def deser_uint256_vector(f):
     nit = deser_compact_size(f)
     r = []
-    for i in range(nit):
+    for _ in range(nit):
         t = deser_uint256(f)
         r.append(t)
     return r
@@ -852,7 +852,7 @@ class P2PHeaderAndShortIDs:
         self.header.deserialize(f)
         self.nonce = struct.unpack("<Q", f.read(8))[0]
         self.shortids_length = deser_compact_size(f)
-        for i in range(self.shortids_length):
+        for _ in range(self.shortids_length):
             # shortids are defined to be 6 bytes in the spec, so append
             # two zero bytes and read it in as an 8-byte number
             self.shortids.append(struct.unpack("<Q", f.read(6) + b'\x00\x00')[0])
@@ -949,7 +949,7 @@ class BlockTransactionsRequest:
     def deserialize(self, f):
         self.blockhash = deser_uint256(f)
         indexes_length = deser_compact_size(f)
-        for i in range(indexes_length):
+        for _ in range(indexes_length):
             self.indexes.append(deser_compact_size(f))
 
     def serialize(self):
@@ -2171,26 +2171,26 @@ class msg_mnlistdiff:
         self.cbTx.rehash()
         self.deletedMNs = deser_uint256_vector(f)
         self.mnList = []
-        for i in range(deser_compact_size(f)):
+        for _ in range(deser_compact_size(f)):
             e = CSimplifiedMNListEntry()
             e.deserialize(f)
             self.mnList.append(e)
 
         self.deletedQuorums = []
-        for i in range(deser_compact_size(f)):
+        for _ in range(deser_compact_size(f)):
             llmqType = struct.unpack("<B", f.read(1))[0]
             quorumHash = deser_uint256(f)
             self.deletedQuorums.append(QuorumId(llmqType, quorumHash))
         self.newQuorums = []
-        for i in range(deser_compact_size(f)):
+        for _ in range(deser_compact_size(f)):
             qc = CFinalCommitment()
             qc.deserialize(f)
             self.newQuorums.append(qc)
         self.quorumsCLSigs = {}
-        for i in range(deser_compact_size(f)):
+        for _ in range(deser_compact_size(f)):
             signature = f.read(96)
             idx_set = set()
-            for j in range(deser_compact_size(f)):
+            for _ in range(deser_compact_size(f)):
                 set_element = struct.unpack('H', f.read(2))[0]
                 idx_set.add(set_element)
             self.quorumsCLSigs[signature] = idx_set

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -33,7 +33,7 @@ import dash_hash
 
 MIN_VERSION_SUPPORTED = 60001
 MY_VERSION = 70230  # MNLISTDIFF_CHAINLOCKS_PROTO_VERSION
-MY_SUBVERSION = b"/python-mininode-tester:0.0.3%s/"
+MY_SUBVERSION = b"/python-p2p-tester:0.0.3%s/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
 MAX_LOCATOR_SZ = 101

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -646,7 +646,7 @@ def SignatureHash(script, txTo, inIdx, hashtype):
 
         tmp = txtmp.vout[outIdx]
         txtmp.vout = []
-        for i in range(outIdx):
+        for _ in range(outIdx):
             txtmp.vout.append(CTxOut(-1))
         txtmp.vout.append(tmp)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -814,6 +814,9 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         for node in self.nodes:
             node.mocktime = self.mocktime
 
+    def wait_until(self, test_function, timeout=60, lock=None):
+        return wait_until(test_function, timeout=timeout, lock=lock, timeout_factor=self.options.timeout_factor)
+
     # Private helper methods. These should not be accessed by the subclass test scripts.
 
     def _start_logging(self):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -35,8 +35,8 @@ from .messages import (
     ser_string,
 )
 from .script import hash160
+from .p2p import NetworkThread
 from .test_node import TestNode
-from .mininode import NetworkThread
 from .util import (
     PortSeed,
     MAX_NODES,

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -572,7 +572,7 @@ class TestNode():
         assert self.p2ps, self._node_msg("No p2p connection")
         return self.p2ps[0]
 
-    def num_connected_mininodes(self):
+    def num_test_p2p_connections(self):
         """Return number of test framework p2p connections to the node."""
         return len([peer for peer in self.getpeerinfo() if peer['subver'] == MY_SUBVERSION.decode("utf-8")])
 
@@ -591,7 +591,7 @@ class TestNode():
         wait_until(check_peers, timeout=5)
 
         del self.p2ps[:]
-        wait_until(lambda: self.num_connected_mininodes() == 0)
+        wait_until(lambda: self.num_test_p2p_connections() == 0)
 
 
 class TestNodeCLIAttr:

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -229,6 +229,14 @@ def satoshi_round(amount):
 
 
 def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), sleep=0.5, timeout_factor=1.0, lock=None, do_assert=True, allow_exception=False):
+    """Sleep until the predicate resolves to be True.
+
+    Warning: Note that this method is not recommended to be used in tests as it is
+    not aware of the context of the test framework. Using `wait_until()` counterpart
+    from `BitcoinTestFramework` or `P2PInterface` class ensures an understandable
+    amount of timeout and a common shared timeout_factor. Furthermore, `wait_until()`
+    from `P2PInterface` class in `mininode.py` has a preset lock.
+    """
     if attempts == float('inf') and timeout == float('inf'):
         timeout = 60
     timeout = timeout * timeout_factor

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -558,7 +558,7 @@ def create_confirmed_utxos(fee, node, count):
     addr2 = node.getnewaddress()
     if iterations <= 0:
         return utxos
-    for i in range(iterations):
+    for _ in range(iterations):
         t = utxos.pop()
         inputs = []
         inputs.append({"txid": t["txid"], "vout": t["vout"]})
@@ -585,7 +585,7 @@ def gen_return_txouts():
     # So we have big transactions (and therefore can't fit very many into each block)
     # create one script_pubkey
     script_pubkey = "6a4d0200"  # OP_RETURN OP_PUSH2 512 bytes
-    for i in range(512):
+    for _ in range(512):
         script_pubkey = script_pubkey + "01"
     # concatenate 128 txouts of above script_pubkey which we'll insert before the txout for change
     txouts = []
@@ -593,7 +593,7 @@ def gen_return_txouts():
     txout = CTxOut()
     txout.nValue = 0
     txout.scriptPubKey = hex_str_to_bytes(script_pubkey)
-    for k in range(128):
+    for _ in range(128):
         txouts.append(txout)
     return txouts
 

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -130,7 +130,7 @@ class WalletBackupTest(BitcoinTestFramework):
 
         self.log.info("Creating transactions")
         # Five rounds of sending each other transactions.
-        for i in range(5):
+        for _ in range(5):
             self.do_one_round()
 
         self.log.info("Backing up")
@@ -143,7 +143,7 @@ class WalletBackupTest(BitcoinTestFramework):
         self.nodes[2].dumpwallet(os.path.join(self.nodes[2].datadir, 'wallet.dump'))
 
         self.log.info("More transactions")
-        for i in range(5):
+        for _ in range(5):
             self.do_one_round()
 
         # Generate 101 more blocks, so any fees paid mature

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -564,7 +564,7 @@ class WalletTest(BitcoinTestFramework):
         # So we should be able to generate exactly chainlimit txs for each original output
         sending_addr = self.nodes[1].getnewaddress()
         txid_list = []
-        for i in range(chainlimit * 2):
+        for _ in range(chainlimit * 2):
             txid_list.append(self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001')))
         assert_equal(self.nodes[0].getmempoolinfo()['size'], chainlimit * 2)
         assert_equal(len(txid_list), chainlimit * 2)

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -37,7 +37,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
 
     def test_tx_size_too_large(self):
         # More than 10kB of outputs, so that we hit -maxtxfee with a high feerate
-        outputs = {self.nodes[0].getnewaddress(): 0.000025 for i in range(400)}
+        outputs = {self.nodes[0].getnewaddress(): 0.000025 for _ in range(400)}
         raw_tx = self.nodes[0].createrawtransaction(inputs=[], outputs=outputs)
 
         for fee_setting in ['-minrelaytxfee=0.01', '-mintxfee=0.01', '-paytxfee=0.01']:

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -106,7 +106,7 @@ class WalletDumpTest(BitcoinTestFramework):
         # generate 20 addresses to compare against the dump
         test_addr_count = 20
         addrs = []
-        for i in range(0,test_addr_count):
+        for _ in range(test_addr_count):
             addr = self.nodes[0].getnewaddress()
             vaddr= self.nodes[0].getaddressinfo(addr) #required to get hd keypath
             addrs.append(vaddr)

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -28,8 +28,8 @@ class WalletGroupTest(BitcoinTestFramework):
         self.nodes[0].generate(COINBASE_MATURITY + 10)
 
         # Get some addresses from the two nodes
-        addr1 = [self.nodes[1].getnewaddress() for i in range(3)]
-        addr2 = [self.nodes[2].getnewaddress() for i in range(3)]
+        addr1 = [self.nodes[1].getnewaddress() for _ in range(3)]
+        addr2 = [self.nodes[2].getnewaddress() for _ in range(3)]
         addrs = addr1 + addr2
 
         # Send 1 + 0.5 coin to each address
@@ -72,7 +72,7 @@ class WalletGroupTest(BitcoinTestFramework):
 
         # Fill node2's wallet with 10000 outputs corresponding to the same
         # scriptPubKey
-        for i in range(5):
+        for _ in range(5):
             raw_tx = self.nodes[0].createrawtransaction([{"txid":"0"*64, "vout":0}], [{addr2[0]: 0.05}])
             tx = FromHex(CTransaction(), raw_tx)
             tx.vin = []

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -120,7 +120,7 @@ class WalletLabelsTest(BitcoinTestFramework):
         # Check that addmultisigaddress can assign labels.
         for label in labels:
             addresses = []
-            for x in range(10):
+            for _ in range(10):
                 addresses.append(node.getnewaddress())
             multisig_address = node.addmultisigaddress(5, addresses, label.name)['address']
             label.add_address(multisig_address)

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -7,9 +7,9 @@ import time
 
 from test_framework.blocktools import create_block, create_coinbase
 from test_framework.messages import ToHex
-from test_framework.p2p import P2PTxInvStore, p2p_lock
+from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, wait_until
+from test_framework.util import assert_equal
 
 class ResendWalletTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -24,7 +24,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.add_p2p_connection(P2PTxInvStore())
 
         self.log.info("Create a new transaction and wait until it's broadcast")
-        txid = int(node.sendtoaddress(node.getnewaddress(), 1), 16)
+        txid = node.sendtoaddress(node.getnewaddress(), 1)
 
         # Wallet rebroadcast is first scheduled 1 sec after startup (see
         # nNextResend in ResendWalletTransactions()). Sleep for just over a
@@ -35,8 +35,8 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         # Can take a few seconds due to transaction trickling
         def wait_p2p():
             self.bump_mocktime(1)
-            return node.p2p.tx_invs_received[txid] >= 1
-        wait_until(wait_p2p, lock=p2p_lock)
+            return node.p2p.tx_invs_received[int(txid, 16)] >= 1
+        self.wait_until(wait_p2p)
 
         # Add a second peer since txs aren't rebroadcast to the same peer (see filterInventoryKnown)
         node.add_p2p_connection(P2PTxInvStore())
@@ -62,7 +62,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.setmocktime(self.mocktime + twelve_hrs - two_min)
         self.mocktime = self.mocktime + twelve_hrs - two_min
         time.sleep(2) # ensure enough time has passed for rebroadcast attempt to occur
-        assert_equal(txid in node.p2ps[1].get_invs(), False)
+        assert_equal(int(txid, 16) in node.p2ps[1].get_invs(), False)
 
         self.log.info("Bump time & check that transaction is rebroadcast")
         # Transaction should be rebroadcast approximately 2 hours in the future,
@@ -71,10 +71,9 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.setmocktime(rebroadcast_time)
         self.mocktime = rebroadcast_time
 
-        def wait_p2p_1():
-            self.bump_mocktime(1)
-            return node.p2ps[1].tx_invs_received[txid] >= 1
-        wait_until(wait_p2p_1, lock=p2p_lock)
+        # Transaction should be rebroadcast approximately 24 hours in the future,
+        # but can range from 12-36. So bump 36 hours to be sure.
+        node.p2p.wait_for_broadcast([txid])
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -7,7 +7,7 @@ import time
 
 from test_framework.blocktools import create_block, create_coinbase
 from test_framework.messages import ToHex
-from test_framework.mininode import P2PTxInvStore, mininode_lock
+from test_framework.p2p import P2PTxInvStore, p2p_lock
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, wait_until
 
@@ -36,7 +36,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         def wait_p2p():
             self.bump_mocktime(1)
             return node.p2p.tx_invs_received[txid] >= 1
-        wait_until(wait_p2p, lock=mininode_lock)
+        wait_until(wait_p2p, lock=p2p_lock)
 
         # Add a second peer since txs aren't rebroadcast to the same peer (see filterInventoryKnown)
         node.add_p2p_connection(P2PTxInvStore())
@@ -74,7 +74,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         def wait_p2p_1():
             self.bump_mocktime(1)
             return node.p2ps[1].tx_invs_received[txid] >= 1
-        wait_until(wait_p2p_1, lock=mininode_lock)
+        wait_until(wait_p2p_1, lock=p2p_lock)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Issue being fixed or feature implemented
Big batch of refactorings from v21 related to functional tests.
Please notice, that bitcoin#19752 changes many usages of wait_until but that backport doesn't require to update ALL wait_until usages yet. Remaining usages are stayed until bitcoin#19816 (test: Rename wait until helper to wait_until_helper) is merged

Backport bitcoin#19552 has only util releated code, because we do not have fee-filter message

## What was done?
 - bitcoin/bitcoin#19674
 - bitcoin/bitcoin#19760
 - bitcoin/bitcoin#19552
 - bitcoin/bitcoin#19752

## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone