### PR TITLE
backport: bitcoin#19124, #19800, #19922, #19963, #20126, #20159, #20168, #20276, #20385, #20688, #20876

### DIFF
--- a/contrib/testgen/gen_key_io_test_vectors.py
+++ b/contrib/testgen/gen_key_io_test_vectors.py
@@ -15,7 +15,6 @@ import os
 from itertools import islice
 from base58 import b58encode_chk, b58decode_chk, b58chars
 import random
-from binascii import b2a_hex
 
 # key types
 PUBKEY_ADDRESS = 76
@@ -96,9 +95,7 @@ def gen_valid_vectors():
             rv, payload = valid_vector_generator(template)
             assert is_valid(rv)
             metadata = {x: y for x, y in zip(metadata_keys,template[3]) if y is not None}
-            hexrepr = b2a_hex(payload)
-            if isinstance(hexrepr, bytes):
-                hexrepr = hexrepr.decode('utf8')
+            hexrepr = payload.hex()
             yield (rv, hexrepr, metadata)
 
 def gen_invalid_base58_vector(template):

--- a/depends/README.md
+++ b/depends/README.md
@@ -106,6 +106,9 @@ The following can be set when running make: `make FOO=bar`
 - `NO_BDB`: Don't download/build/cache BerkeleyDB
 - `NO_SQLITE`: Don't download/build/cache SQLite
 - `NO_UPNP`: Don't download/build/cache packages needed for enabling UPnP
+- `ALLOW_HOST_PACKAGES`: Packages that are missed in dependencies (due to `NO_*` option or
+  build script logic) are searched for among the host system packages using
+  `pkg-config`. It allows building with packages of other (newer) versions
 - `NO_NATPMP`: Don't download/build/cache packages needed for enabling NAT-PMP
 - `MULTIPROCESS`: build libmultiprocess (experimental, requires cmake)
 - `DEBUG`: Disable some optimizations and enable more runtime checking

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -13,15 +13,15 @@ The previous release v0.15.0.0 is required by this test, see test/README.md.
 import os
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.wallet import MiniWallet
 
 
 class MempoolCompatibilityTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.wallet_names = [None, self.default_wallet_name]
+        self.wallet_names = [None]
 
     def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
         self.skip_if_no_previous_releases()
 
     def setup_network(self):
@@ -39,8 +39,15 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Test that mempool.dat is compatible between versions")
 
-        old_node = self.nodes[0]
-        new_node = self.nodes[1]
+        old_node, new_node = self.nodes
+        new_wallet = MiniWallet(new_node)
+        new_wallet.generate(1)
+        new_node.generate(100)
+        # Sync the nodes to ensure old_node has the block that contains the coinbase that new_wallet will spend.
+        # Otherwise, because coinbases are only valid in a block and not as loose txns, if the nodes aren't synced
+        # unbroadcasted_tx won't pass old_node's `MemPoolAccept::PreChecks`.
+        self.connect_nodes(0, 1)
+        self.sync_blocks()
         recipient = old_node.getnewaddress()
         self.stop_node(1)
 
@@ -59,7 +66,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
         assert old_tx_hash in new_node.getrawmempool()
 
         self.log.info("Add unbroadcasted tx to mempool on new node and shutdown")
-        unbroadcasted_tx_hash = new_node.sendtoaddress(recipient, 0.0001)
+        unbroadcasted_tx_hash = new_wallet.send_self_transfer(from_node=new_node)['txid']
         assert unbroadcasted_tx_hash in new_node.getrawmempool()
         mempool = new_node.getrawmempool(True)
         assert mempool[unbroadcasted_tx_hash]['unbroadcast']

--- a/test/functional/mempool_expiry.py
+++ b/test/functional/mempool_expiry.py
@@ -16,8 +16,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    find_vout_for_address,
 )
+from test_framework.wallet import MiniWallet
 
 DEFAULT_MEMPOOL_EXPIRY = 336  # hours
 CUSTOM_MEMPOOL_EXPIRY = 10  # hours
@@ -26,44 +26,50 @@ CUSTOM_MEMPOOL_EXPIRY = 10  # hours
 class MempoolExpiryTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
+        self.setup_clean_chain = True
 
     def test_transaction_expiry(self, timeout):
         """Tests that a transaction expires after the expiry timeout and its
         children are removed as well."""
         node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+
+        # Add enough mature utxos to the wallet so that all txs spend confirmed coins.
+        self.wallet.generate(4)
+        node.generate(100)
 
         # Send a parent transaction that will expire.
-        parent_address = node.getnewaddress()
-        parent_txid = node.sendtoaddress(parent_address, 1.0)
+        parent_txid = self.wallet.send_self_transfer(from_node=node)['txid']
+        parent_utxo = self.wallet.get_utxo(txid=parent_txid)
+        independent_utxo = self.wallet.get_utxo()
+
+        # Ensure the transactions we send to trigger the mempool check spend utxos that are independent of
+        # the transactions being tested for expiration.
+        trigger_utxo1 = self.wallet.get_utxo()
+        trigger_utxo2 = self.wallet.get_utxo()
 
         # Set the mocktime to the arrival time of the parent transaction.
         entry_time = node.getmempoolentry(parent_txid)['time']
         node.setmocktime(entry_time)
 
-        # Create child transaction spending the parent transaction
-        vout = find_vout_for_address(node, parent_txid, parent_address)
-        inputs = [{'txid': parent_txid, 'vout': vout}]
-        outputs = {node.getnewaddress(): 0.99}
-        child_raw = node.createrawtransaction(inputs, outputs)
-        child_signed = node.signrawtransactionwithwallet(child_raw)['hex']
-
-        # Let half of the timeout elapse and broadcast the child transaction.
+        # Let half of the timeout elapse and broadcast the child transaction spending the parent transaction.
         half_expiry_time = entry_time + int(60 * 60 * timeout/2)
         node.setmocktime(half_expiry_time)
-        child_txid = node.sendrawtransaction(child_signed)
+        child_txid = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=parent_utxo)['txid']
+        assert_equal(parent_txid, node.getmempoolentry(child_txid)['depends'][0])
         self.log.info('Broadcast child transaction after {} hours.'.format(
             timedelta(seconds=(half_expiry_time-entry_time))))
+
+        # Broadcast another (independent) transaction.
+        independent_txid = self.wallet.send_self_transfer(from_node=node, utxo_to_spend=independent_utxo)['txid']
 
         # Let most of the timeout elapse and check that the parent tx is still
         # in the mempool.
         nearly_expiry_time = entry_time + 60 * 60 * timeout - 5
         node.setmocktime(nearly_expiry_time)
-        # Expiry of mempool transactions is only checked when a new transaction
-        # is added to the to the mempool.
-        node.sendtoaddress(node.getnewaddress(), 1.0)
+        # Broadcast a transaction as the expiry of transactions in the mempool is only checked
+        # when a new transaction is added to the mempool.
+        self.wallet.send_self_transfer(from_node=node, utxo_to_spend=trigger_utxo1)
         self.log.info('Test parent tx not expired after {} hours.'.format(
             timedelta(seconds=(nearly_expiry_time-entry_time))))
         assert_equal(entry_time, node.getmempoolentry(parent_txid)['time'])
@@ -72,9 +78,8 @@ class MempoolExpiryTest(BitcoinTestFramework):
         # has passed.
         expiry_time = entry_time + 60 * 60 * timeout + 5
         node.setmocktime(expiry_time)
-        # Expiry of mempool transactions is only checked when a new transaction
-        # is added to the to the mempool.
-        node.sendtoaddress(node.getnewaddress(), 1.0)
+        # Again, broadcast a transaction so the expiry of transactions in the mempool is checked.
+        self.wallet.send_self_transfer(from_node=node, utxo_to_spend=trigger_utxo2)
         self.log.info('Test parent tx expiry after {} hours.'.format(
             timedelta(seconds=(expiry_time-entry_time))))
         assert_raises_rpc_error(-5, 'Transaction not in mempool',
@@ -84,6 +89,11 @@ class MempoolExpiryTest(BitcoinTestFramework):
         self.log.info('Test child tx is evicted as well.')
         assert_raises_rpc_error(-5, 'Transaction not in mempool',
                                 node.getmempoolentry, child_txid)
+
+        # Check that the independent tx is still in the mempool.
+        self.log.info('Test the independent tx not expired after {} hours.'.format(
+            timedelta(seconds=(expiry_time-half_expiry_time))))
+        assert_equal(half_expiry_time, node.getmempoolentry(independent_txid)['time'])
 
     def run_test(self):
         self.log.info('Test default mempool expiry timeout of %d hours.' %

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -12,47 +12,49 @@ in the next block are accepted into the memory pool,
 but less mature coinbase spends are NOT.
 """
 
-from decimal import Decimal
-
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.blocktools import create_raw_transaction
 from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.wallet import MiniWallet
 
 
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
+        self.setup_clean_chain = True
 
     def run_test(self):
+        wallet = MiniWallet(self.nodes[0])
+
+        wallet.generate(200)
         chain_height = self.nodes[0].getblockcount()
         assert_equal(chain_height, 200)
-        node0_address = self.nodes[0].getnewaddress()
 
         # Coinbase at height chain_height-100+1 ok in mempool, should
         # get mined. Coinbase at height chain_height-100+2 is
-        # is too immature to spend.
-        b = [ self.nodes[0].getblockhash(n) for n in range(101, 103) ]
-        coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
-        spends_raw = [ create_raw_transaction(self.nodes[0], txid, node0_address, amount=500 - Decimal('0.00001')) for txid in coinbase_txids ]
+        # too immature to spend.
+        b = [self.nodes[0].getblockhash(n) for n in range(101, 103)]
+        coinbase_txids = [self.nodes[0].getblock(h)['tx'][0] for h in b]
+        utxo_101 = wallet.get_utxo(txid=coinbase_txids[0])
+        utxo_102 = wallet.get_utxo(txid=coinbase_txids[1])
 
-        spend_101_id = self.nodes[0].sendrawtransaction(spends_raw[0])
+        spend_101_id = wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_101)["txid"]
 
         # coinbase at height 102 should be too immature to spend
-        assert_raises_rpc_error(-26,"bad-txns-premature-spend-of-coinbase", self.nodes[0].sendrawtransaction, spends_raw[1])
+        assert_raises_rpc_error(-26,
+                                "bad-txns-premature-spend-of-coinbase",
+                                lambda: wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_102))
 
         # mempool should have just spend_101:
-        assert_equal(self.nodes[0].getrawmempool(), [ spend_101_id ])
+        assert_equal(self.nodes[0].getrawmempool(), [spend_101_id])
 
         # mine a block, spend_101 should get confirmed
         self.nodes[0].generate(1)
         assert_equal(set(self.nodes[0].getrawmempool()), set())
 
         # ... and now height 102 can be spent:
-        spend_102_id = self.nodes[0].sendrawtransaction(spends_raw[1])
-        assert_equal(self.nodes[0].getrawmempool(), [ spend_102_id ])
+        spend_102_id = wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_102)["txid"]
+        assert_equal(self.nodes[0].getrawmempool(), [spend_102_id])
+
 
 if __name__ == '__main__':
     MempoolSpendCoinbaseTest().main()

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -5,11 +5,13 @@
 """Test longpolling with getblocktemplate."""
 
 from decimal import Decimal
+import random
+import threading
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import get_rpc_proxy, random_transaction, wait_until
+from test_framework.util import get_rpc_proxy, wait_until
+from test_framework.wallet import MiniWallet
 
-import threading
 
 class LongpollThread(threading.Thread):
     def __init__(self, node):
@@ -29,45 +31,48 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.supports_cli = False
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
         self.log.info("Warning: this test will take about 70 seconds in the best case. Be patient.")
+        self.log.info("Test that longpollid doesn't change between successive getblocktemplate() invocations if nothing else happens")
         self.nodes[0].generate(10)
         template = self.nodes[0].getblocktemplate()
         longpollid = template['longpollid']
-        # longpollid should not change between successive invocations if nothing else happens
         template2 = self.nodes[0].getblocktemplate()
         assert template2['longpollid'] == longpollid
 
-        # Test 1: test that the longpolling wait if we do nothing
+        self.log.info("Test that longpoll waits if we do nothing")
         thr = LongpollThread(self.nodes[0])
         thr.start()
         # check that thread still lives
         thr.join(5)  # wait 5 seconds or until thread exits
         assert thr.is_alive()
 
-        # Test 2: test that longpoll will terminate if another node generates a block
-        self.nodes[1].generate(1)  # generate a block on another node
+        miniwallets = [ MiniWallet(node) for node in self.nodes ]
+        self.log.info("Test that longpoll will terminate if another node generates a block")
+        miniwallets[1].generate(1)  # generate a block on another node
         # check that thread will exit now that new transaction entered mempool
         thr.join(5)  # wait 5 seconds or until thread exits
         assert not thr.is_alive()
 
-        # Test 3: test that longpoll will terminate if we generate a block ourselves
+        self.log.info("Test that longpoll will terminate if we generate a block ourselves")
         thr = LongpollThread(self.nodes[0])
         thr.start()
-        self.nodes[0].generate(1)  # generate a block on another node
+        miniwallets[0].generate(1)  # generate a block on own node
         thr.join(5)  # wait 5 seconds or until thread exits
         assert not thr.is_alive()
 
-        # Test 4: test that introducing a new transaction into the mempool will terminate the longpoll
+        # Add enough mature utxos to the wallets, so that all txs spend confirmed coins
+        self.nodes[0].generate(100)
+        self.sync_blocks()
+
+        self.log.info("Test that introducing a new transaction into the mempool will terminate the longpoll")
         thr = LongpollThread(self.nodes[0])
         thr.start()
         # generate a random transaction and submit it
         min_relay_fee = self.nodes[0].getnetworkinfo()["relayfee"]
-        # min_relay_fee is fee per 1000 bytes, which should be more than enough.
-        (txid, txhex, fee) = random_transaction(self.nodes, Decimal("1.1"), min_relay_fee, Decimal("0.001"), 20)
+        fee_rate = min_relay_fee + Decimal('0.00000010') * random.randint(0,20)
+        miniwallets[0].send_self_transfer(from_node=random.choice(self.nodes),
+                                          fee_rate=fee_rate)
         # after one minute, every 10 seconds the mempool is probed, so in 80 seconds it should have returned
 
         def check():

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -57,29 +57,34 @@ class P2PBlocksOnly(BitcoinTestFramework):
             self.nodes[0].p2p.wait_for_tx(txid)
             assert_equal(self.nodes[0].getmempoolinfo()['size'], 1)
 
-        self.log.info('Check that txs from forcerelay peers are not rejected and relayed to others')
-        self.log.info("Restarting node 0 with forcerelay permission and blocksonly")
-        self.restart_node(0, ["-persistmempool=0", "-whitelist=127.0.0.1", "-whitelistforcerelay", "-blocksonly"])
+        self.log.info('Check that txs from peers with relay-permission are not rejected and relayed to others')
+        self.log.info("Restarting node 0 with relay permission and blocksonly")
+        self.restart_node(0, ["-persistmempool=0", "-whitelist=relay@127.0.0.1", "-blocksonly"])
         assert_equal(self.nodes[0].getrawmempool(), [])
         first_peer = self.nodes[0].add_p2p_connection(P2PInterface())
         second_peer = self.nodes[0].add_p2p_connection(P2PInterface())
         peer_1_info = self.nodes[0].getpeerinfo()[0]
-        assert_equal(peer_1_info['whitelisted'], True)
-        assert_equal(peer_1_info['permissions'], ['noban', 'forcerelay', 'relay', 'mempool', 'download'])
+        assert_equal(peer_1_info['permissions'], ['relay'])
         peer_2_info = self.nodes[0].getpeerinfo()[1]
-        assert_equal(peer_2_info['whitelisted'], True)
-        assert_equal(peer_2_info['permissions'], ['noban', 'forcerelay', 'relay', 'mempool', 'download'])
+        assert_equal(peer_2_info['permissions'], ['relay'])
         assert_equal(self.nodes[0].testmempoolaccept([sigtx])[0]['allowed'], True)
         txid = self.nodes[0].testmempoolaccept([sigtx])[0]['txid']
 
-        self.log.info('Check that the tx from forcerelay first_peer is relayed to others (ie.second_peer)')
+        self.log.info('Check that the tx from first_peer with relay-permission is relayed to others (ie.second_peer)')
         with self.nodes[0].assert_debug_log(["received getdata"]):
+            # Note that normally, first_peer would never send us transactions since we're a blocksonly node.
+            # By activating blocksonly, we explicitly tell our peers that they should not send us transactions,
+            # and Bitcoin Core respects that choice and will not send transactions.
+            # But if, for some reason, first_peer decides to relay transactions to us anyway, we should relay them to
+            # second_peer since we gave relay permission to first_peer.
+            # See https://github.com/bitcoin/bitcoin/issues/19943 for details.
             first_peer.send_message(msg_tx(FromHex(CTransaction(), sigtx)))
-            self.log.info('Check that the forcerelay peer is still connected after sending the transaction')
+            self.log.info('Check that the peer with relay-permission is still connected after sending the transaction')
             assert_equal(first_peer.is_connected, True)
+            self.bump_mocktime(60)
             second_peer.wait_for_tx(txid)
             assert_equal(self.nodes[0].getmempoolinfo()['size'], 1)
-        self.log.info("Forcerelay peer's transaction is accepted and relayed")
+        self.log.info("Relay-permission peer's transaction is accepted and relayed")
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -5,11 +5,12 @@
 """Test that we don't leak txs to inbound peers that we haven't yet announced to"""
 
 from test_framework.messages import msg_getdata, CInv, MSG_TX
-from test_framework.p2p import P2PDataStore
+from test_framework.p2p import p2p_lock, P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
 )
+from test_framework.wallet import MiniWallet
 
 
 class P2PNode(P2PDataStore):
@@ -21,12 +22,12 @@ class P2PLeakTxTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
         gen_node = self.nodes[0]  # The block and tx generating node
-        gen_node.generate(1)
+        miniwallet = MiniWallet(gen_node)
+        # Add enough mature utxos to the wallet, so that all txs spend confirmed coins
+        miniwallet.generate(1)
+        gen_node.generate(100)
 
         inbound_peer = self.nodes[0].add_p2p_connection(P2PNode())  # An "attacking" inbound peer
 
@@ -34,18 +35,20 @@ class P2PLeakTxTest(BitcoinTestFramework):
         self.log.info("Running test up to {} times.".format(MAX_REPEATS))
         for i in range(MAX_REPEATS):
             self.log.info('Run repeat {}'.format(i + 1))
-            txid = gen_node.sendtoaddress(gen_node.getnewaddress(), 0.01)
+            txid = miniwallet.send_self_transfer(from_node=gen_node)['txid']
 
             want_tx = msg_getdata()
             want_tx.inv.append(CInv(t=MSG_TX, h=int(txid, 16)))
-            inbound_peer.last_message.pop('notfound', None)
+            with p2p_lock:
+                inbound_peer.last_message.pop('notfound', None)
             inbound_peer.send_and_ping(want_tx)
 
             if inbound_peer.last_message.get('notfound'):
                 self.log.debug('tx {} was not yet announced to us.'.format(txid))
                 self.log.debug("node has responded with a notfound message. End test.")
                 assert_equal(inbound_peer.last_message['notfound'].vec[0].hash, int(txid, 16))
-                inbound_peer.last_message.pop('notfound')
+                with p2p_lock:
+                    inbound_peer.last_message.pop('notfound')
                 break
             else:
                 self.log.debug('tx {} was already announced to us. Try test again.'.format(txid))

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -4,47 +4,36 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test gettxoutproof and verifytxoutproof RPCs."""
 
-from decimal import Decimal
-
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.messages import CMerkleBlock, FromHex, ToHex
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.wallet import MiniWallet
+
 
 class MerkleBlockTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 4
+        self.num_nodes = 2
         self.setup_clean_chain = True
         # Nodes 0/1 are "wallet" nodes, Nodes 2/3 are used for testing
-        self.extra_args = [[], [], [], ["-txindex"]]
+        self.extra_args = [
+            [],
+            ["-txindex"],
+        ]
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
-    def setup_network(self):
-        self.setup_nodes()
-        self.connect_nodes(0, 1)
-        self.connect_nodes(0, 2)
-        self.connect_nodes(0, 3)
-
-        self.sync_all()
 
     def run_test(self):
-        self.log.info("Mining blocks...")
-        self.nodes[0].generate(COINBASE_MATURITY + 5)
+        miniwallet = MiniWallet(self.nodes[0])
+        # Add enough mature utxos to the wallet, so that all txs spend confirmed coins
+        miniwallet.generate(5)
+        self.nodes[0].generate(COINBASE_MATURITY)
         self.sync_all()
 
         chain_height = self.nodes[1].getblockcount()
-        assert_equal(chain_height, 105)
-        assert_equal(self.nodes[1].getbalance(), 0)
-        assert_equal(self.nodes[2].getbalance(), 0)
+        assert_equal(chain_height, 5 + COINBASE_MATURITY)
 
-        tx_fee = Decimal('0.00001')
-        node0utxos = self.nodes[0].listunspent(1)
-        tx1 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 500 - tx_fee})
-        txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransactionwithwallet(tx1)["hex"])
-        tx2 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 500 - tx_fee})
-        txid2 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransactionwithwallet(tx2)["hex"])
+        txid1 = miniwallet.send_self_transfer(from_node=self.nodes[0])['txid']
+        txid2 = miniwallet.send_self_transfer(from_node=self.nodes[0])['txid']
         # This will raise an exception because the transaction is not yet in a block
         assert_raises_rpc_error(-5, "Transaction not yet in block", self.nodes[0].gettxoutproof, [txid1])
 
@@ -57,51 +46,55 @@ class MerkleBlockTest(BitcoinTestFramework):
         txlist.append(blocktxn[1])
         txlist.append(blocktxn[2])
 
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid1])), [txid1])
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid1, txid2])), txlist)
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid1, txid2], blockhash)), txlist)
+        assert_equal(self.nodes[0].verifytxoutproof(self.nodes[0].gettxoutproof([txid1])), [txid1])
+        assert_equal(self.nodes[0].verifytxoutproof(self.nodes[0].gettxoutproof([txid1, txid2])), txlist)
+        assert_equal(self.nodes[0].verifytxoutproof(self.nodes[0].gettxoutproof([txid1, txid2], blockhash)), txlist)
 
-        txin_spent = self.nodes[1].listunspent(1).pop()
-        tx3 = self.nodes[1].createrawtransaction([txin_spent], {self.nodes[0].getnewaddress(): 500 - tx_fee*2})
-        txid3 = self.nodes[0].sendrawtransaction(self.nodes[1].signrawtransactionwithwallet(tx3)["hex"])
+        txin_spent = miniwallet.get_utxo()  # Get the change from txid2
+        tx3 = miniwallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=txin_spent)
+        txid3 = tx3['txid']
         self.nodes[0].generate(1)
         self.sync_all()
 
         txid_spent = txin_spent["txid"]
-        txid_unspent = txid1 if txin_spent["txid"] != txid1 else txid2
+        txid_unspent = txid1  # Input was change from txid2, so txid1 should be unspent
 
         # Invalid txids
-        assert_raises_rpc_error(-8, "txid must be of length 64 (not 32, for '00000000000000000000000000000000')", self.nodes[2].gettxoutproof, ["00000000000000000000000000000000"], blockhash)
-        assert_raises_rpc_error(-8, "txid must be hexadecimal string (not 'ZZZ0000000000000000000000000000000000000000000000000000000000000')", self.nodes[2].gettxoutproof, ["ZZZ0000000000000000000000000000000000000000000000000000000000000"], blockhash)
+        assert_raises_rpc_error(-8, "txid must be of length 64 (not 32, for '00000000000000000000000000000000')", self.nodes[0].gettxoutproof, ["00000000000000000000000000000000"], blockhash)
+        assert_raises_rpc_error(-8, "txid must be hexadecimal string (not 'ZZZ0000000000000000000000000000000000000000000000000000000000000')", self.nodes[0].gettxoutproof, ["ZZZ0000000000000000000000000000000000000000000000000000000000000"], blockhash)
         # Invalid blockhashes
-        assert_raises_rpc_error(-8, "blockhash must be of length 64 (not 32, for '00000000000000000000000000000000')", self.nodes[2].gettxoutproof, [txid_spent], "00000000000000000000000000000000")
-        assert_raises_rpc_error(-8, "blockhash must be hexadecimal string (not 'ZZZ0000000000000000000000000000000000000000000000000000000000000')", self.nodes[2].gettxoutproof, [txid_spent], "ZZZ0000000000000000000000000000000000000000000000000000000000000")
+        assert_raises_rpc_error(-8, "blockhash must be of length 64 (not 32, for '00000000000000000000000000000000')", self.nodes[0].gettxoutproof, [txid_spent], "00000000000000000000000000000000")
+        assert_raises_rpc_error(-8, "blockhash must be hexadecimal string (not 'ZZZ0000000000000000000000000000000000000000000000000000000000000')", self.nodes[0].gettxoutproof, [txid_spent], "ZZZ0000000000000000000000000000000000000000000000000000000000000")
         # We can't find the block from a fully-spent tx
         # Doesn't apply to Dash Core - we have txindex always on
         # assert_raises_rpc_error(-5, "Transaction not yet in block", self.nodes[2].gettxoutproof, [txid_spent])
         # We can get the proof if we specify the block
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid_spent], blockhash)), [txid_spent])
+        assert_equal(self.nodes[0].verifytxoutproof(self.nodes[0].gettxoutproof([txid_spent], blockhash)), [txid_spent])
         # We can't get the proof if we specify a non-existent block
-        assert_raises_rpc_error(-5, "Block not found", self.nodes[2].gettxoutproof, [txid_spent], "0000000000000000000000000000000000000000000000000000000000000000")
+        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].gettxoutproof, [txid_spent], "0000000000000000000000000000000000000000000000000000000000000000")
         # We can get the proof if the transaction is unspent
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid_unspent])), [txid_unspent])
+        assert_equal(self.nodes[0].verifytxoutproof(self.nodes[0].gettxoutproof([txid_unspent])), [txid_unspent])
         # We can get the proof if we provide a list of transactions and one of them is unspent. The ordering of the list should not matter.
-        assert_equal(sorted(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid1, txid2]))), sorted(txlist))
-        assert_equal(sorted(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid2, txid1]))), sorted(txlist))
+        assert_equal(sorted(self.nodes[0].verifytxoutproof(self.nodes[0].gettxoutproof([txid1, txid2]))), sorted(txlist))
+        assert_equal(sorted(self.nodes[0].verifytxoutproof(self.nodes[0].gettxoutproof([txid2, txid1]))), sorted(txlist))
         # We can always get a proof if we have a -txindex
-        assert_equal(self.nodes[2].verifytxoutproof(self.nodes[3].gettxoutproof([txid_spent])), [txid_spent])
+        assert_equal(self.nodes[0].verifytxoutproof(self.nodes[1].gettxoutproof([txid_spent])), [txid_spent])
         # We can't get a proof if we specify transactions from different blocks
-        assert_raises_rpc_error(-5, "Not all transactions found in specified or retrieved block", self.nodes[2].gettxoutproof, [txid1, txid3])
+        assert_raises_rpc_error(-5, "Not all transactions found in specified or retrieved block", self.nodes[0].gettxoutproof, [txid1, txid3])
+        # Test empty list
+        assert_raises_rpc_error(-5, "Transaction not yet in block", self.nodes[0].gettxoutproof, [])
+        # Test duplicate txid
+        assert_raises_rpc_error(-8, 'Invalid parameter, duplicated txid', self.nodes[0].gettxoutproof, [txid1, txid1])
 
         # Now we'll try tweaking a proof.
-        proof = self.nodes[3].gettxoutproof([txid1, txid2])
+        proof = self.nodes[1].gettxoutproof([txid1, txid2])
         assert txid1 in self.nodes[0].verifytxoutproof(proof)
         assert txid2 in self.nodes[1].verifytxoutproof(proof)
 
         tweaked_proof = FromHex(CMerkleBlock(), proof)
 
         # Make sure that our serialization/deserialization is working
-        assert txid1 in self.nodes[2].verifytxoutproof(ToHex(tweaked_proof))
+        assert txid1 in self.nodes[0].verifytxoutproof(ToHex(tweaked_proof))
 
         # Check to see if we can go up the merkle tree and pass this off as a
         # single-transaction block

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -13,7 +13,6 @@ import inspect
 import json
 import logging
 import os
-import random
 import shutil
 import re
 import time
@@ -495,62 +494,6 @@ def find_output(node, txid, amount, *, blockhash=None):
         if txdata["vout"][i]["value"] == amount:
             return i
     raise RuntimeError("find_output txid %s : %s not found" % (txid, str(amount)))
-
-
-def gather_inputs(from_node, amount_needed, confirmations_required=1):
-    """
-    Return a random set of unspent txouts that are enough to pay amount_needed
-    """
-    assert confirmations_required >= 0
-    utxo = from_node.listunspent(confirmations_required)
-    random.shuffle(utxo)
-    inputs = []
-    total_in = Decimal("0.00000000")
-    while total_in < amount_needed and len(utxo) > 0:
-        t = utxo.pop()
-        total_in += t["amount"]
-        inputs.append({"txid": t["txid"], "vout": t["vout"], "address": t["address"]})
-    if total_in < amount_needed:
-        raise RuntimeError("Insufficient funds: need %d, have %d" % (amount_needed, total_in))
-    return (total_in, inputs)
-
-
-def make_change(from_node, amount_in, amount_out, fee):
-    """
-    Create change output(s), return them
-    """
-    outputs = {}
-    amount = amount_out + fee
-    change = amount_in - amount
-    if change > amount * 2:
-        # Create an extra change output to break up big inputs
-        change_address = from_node.getnewaddress()
-        # Split change in two, being careful of rounding:
-        outputs[change_address] = Decimal(change / 2).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
-        change = amount_in - amount - outputs[change_address]
-    if change > 0:
-        outputs[from_node.getnewaddress()] = change
-    return outputs
-
-
-def random_transaction(nodes, amount, min_fee, fee_increment, fee_variants):
-    """
-    Create a random transaction.
-    Returns (txid, hex-encoded-transaction-data, fee)
-    """
-    from_node = random.choice(nodes)
-    to_node = random.choice(nodes)
-    fee = min_fee + fee_increment * random.randint(0, fee_variants)
-
-    (total_in, inputs) = gather_inputs(from_node, amount + fee)
-    outputs = make_change(from_node, total_in, amount, fee)
-    outputs[to_node.getnewaddress()] = float(amount)
-
-    rawtx = from_node.createrawtransaction(inputs, outputs)
-    signresult = from_node.signrawtransactionwithwallet(rawtx)
-    txid = from_node.sendrawtransaction(signresult["hex"], 0)
-
-    return (txid, signresult["hex"], fee)
 
 
 # Helper to create at least "count" utxos

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -39,9 +39,20 @@ class MiniWallet:
             self._utxos.append({'txid': cb_tx['txid'], 'vout': 0, 'value': cb_tx['vout'][0]['value']})
         return blocks
 
-    def get_utxo(self):
-        """Return the last utxo. Can be used to get the change output immediately after a send_self_transfer"""
-        return self._utxos.pop()
+    def get_utxo(self, *, txid=''):
+        """
+        Returns a utxo and marks it as spent (pops it from the internal list)
+
+        Args:
+        txid (string), optional: get the first utxo we find from a specific transaction
+
+        Note: Can be used to get the change output immediately after a send_self_transfer
+        """
+        index = -1  # by default the last utxo
+        if txid:
+            utxo = next(filter(lambda utxo: txid == utxo['txid'], self._utxos))
+            index = self._utxos.index(utxo)
+        return self._utxos.pop(index)
 
     def send_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node, utxo_to_spend=None):
         """Create and send a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -39,17 +39,21 @@ class MiniWallet:
             self._utxos.append({'txid': cb_tx['txid'], 'vout': 0, 'value': cb_tx['vout'][0]['value']})
         return blocks
 
-    def send_self_transfer(self, *, fee_rate, from_node):
+    def get_utxo(self):
+        """Return the last utxo. Can be used to get the change output immediately after a send_self_transfer"""
+        return self._utxos.pop()
+
+    def send_self_transfer(self, *, fee_rate=Decimal("0.003"), from_node, utxo_to_spend=None):
         """Create and send a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
-        self._utxos = sorted(self._utxos, key=lambda k: -k['value'])
-        largest_utxo = self._utxos.pop()  # Pick the largest utxo and hope it covers the fee
+        self._utxos = sorted(self._utxos, key=lambda k: k['value'])
+        utxo_to_spend = utxo_to_spend or self._utxos.pop()  # Pick the largest utxo (if none provided) and hope it covers the fee
         vsize = Decimal(85)
-        send_value = satoshi_round(largest_utxo['value'] - fee_rate * (vsize / 1000))
-        fee = largest_utxo['value'] - send_value
-        assert (send_value > 0)
+        send_value = satoshi_round(utxo_to_spend['value'] - fee_rate * (vsize / 1000))
+        fee = utxo_to_spend['value'] - send_value
+        assert send_value > 0
 
         tx = CTransaction()
-        tx.vin = [CTxIn(COutPoint(int(largest_utxo['txid'], 16), largest_utxo['vout']))]
+        tx.vin = [CTxIn(COutPoint(int(utxo_to_spend['txid'], 16), utxo_to_spend['vout']))]
         tx.vout = [CTxOut(int(send_value * COIN), self._scriptPubKey)]
         tx.vin[0].scriptSig = CScript([CScript([OP_TRUE])])
         tx_hex = tx.serialize().hex()

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""A limited-functionality wallet, which may replace a real wallet in tests"""
+
+from decimal import Decimal
+from test_framework.address import ADDRESS_BCRT1_P2SH_OP_TRUE
+from test_framework.messages import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+)
+from test_framework.script import (
+    CScript,
+    OP_TRUE,
+)
+from test_framework.util import (
+    assert_equal,
+    hex_str_to_bytes,
+    satoshi_round,
+)
+
+
+class MiniWallet:
+    def __init__(self, test_node):
+        self._test_node = test_node
+        self._utxos = []
+        self._address = ADDRESS_BCRT1_P2SH_OP_TRUE
+        self._scriptPubKey = hex_str_to_bytes(self._test_node.validateaddress(self._address)['scriptPubKey'])
+
+    def generate(self, num_blocks):
+        """Generate blocks with coinbase outputs to the internal address, and append the outputs to the internal list"""
+        blocks = self._test_node.generatetoaddress(num_blocks, self._address)
+        for b in blocks:
+            cb_tx = self._test_node.getblock(blockhash=b, verbosity=2)['tx'][0]
+            self._utxos.append({'txid': cb_tx['txid'], 'vout': 0, 'value': cb_tx['vout'][0]['value']})
+        return blocks
+
+    def send_self_transfer(self, *, fee_rate, from_node):
+        """Create and send a tx with the specified fee_rate. Fee may be exact or at most one satoshi higher than needed."""
+        self._utxos = sorted(self._utxos, key=lambda k: -k['value'])
+        largest_utxo = self._utxos.pop()  # Pick the largest utxo and hope it covers the fee
+        vsize = Decimal(85)
+        send_value = satoshi_round(largest_utxo['value'] - fee_rate * (vsize / 1000))
+        fee = largest_utxo['value'] - send_value
+        assert (send_value > 0)
+
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(largest_utxo['txid'], 16), largest_utxo['vout']))]
+        tx.vout = [CTxOut(int(send_value * COIN), self._scriptPubKey)]
+        tx.vin[0].scriptSig = CScript([CScript([OP_TRUE])])
+        tx_hex = tx.serialize().hex()
+
+        txid = from_node.sendrawtransaction(tx_hex)
+        self._utxos.append({'txid': txid, 'vout': 0, 'value': send_value})
+        tx_info = from_node.getmempoolentry(txid)
+        assert_equal(tx_info['vsize'], vsize)
+        assert_equal(tx_info['fee'], fee)
+        return {'txid': txid, 'hex': tx_hex}


### PR DESCRIPTION
## Issue being fixed or feature implemented
Just regular bitcoin backports, mostly from v21

## What was done?
 - bitcoin/bitcoin#19800
 - bitcoin/bitcoin#19922
 - bitcoin/bitcoin#20688
 - bitcoin/bitcoin#20876
 - bitcoin/bitcoin#20168
 - bitcoin/bitcoin#20159
 - bitcoin/bitcoin#19124
 - bitcoin/bitcoin#19963
 - bitcoin/bitcoin#20126
 - bitcoin/bitcoin#20276
 - bitcoin/bitcoin#20385

## Notes for reviewers
Please notice that we have no fee-filter message, due to that backport bitcoin#19800 is not partial even doesn't have fee filter related code.

## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone