### PR TITLE
fix: solve qt segfault

### DIFF
--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -66,8 +66,8 @@ private:
     SendCoinsDialog* coinJoinCoinsPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
-    MasternodeList *masternodeListPage;
-    GovernanceList* governanceListPage;
+    MasternodeList* masternodeListPage{nullptr};
+    GovernanceList* governanceListPage{nullptr};
 
     TransactionView *transactionView;
 


### PR DESCRIPTION

## Issue being fixed or feature implemented

In the constructor of `WalletView` the pointer `masternodeListPage` is initialized only if the setting `"fShowMasternodesTab"` is true.
```
if (settings.value("fShowMasternodesTab").toBool()) {
        masternodeListPage = new MasternodeList();
        addWidget(masternodeListPage);
 }
```
When closing the wallet  this check is done:
```
 if (settings.value("fShowMasternodesTab").toBool() && masternodeListPage != nullptr) {
        masternodeListPage->setClientModel(_clientModel);
    }
```

it can happen that the `"fShowMasternodesTab"`  becomes true  after calling the `WalletView` constructor and it leaves `masterNodeListPage` uninitialized and this caused segfault on my pc. 

And same happens for `governanceListPage`

## What was done?
The fix is trivial, I just set by default the two pointers to `nullptr`


## How Has This Been Tested?
  wallet does not segfault anymore

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

