### PR TITLE
backport: bitcoin#19731 and related fixes for DashTestFramework

### DIFF
--- a/doc/release-notes-19731.md
+++ b/doc/release-notes-19731.md
@@ -1,0 +1,6 @@
+Updated RPCs
+------------
+
+- The `getpeerinfo` RPC now has additional `last_block` and `last_transaction`
+  fields that return the UNIX epoch time of the last block and the last valid
+  transaction received from each peer. (#19731)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -654,6 +654,8 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
     }
     X(nLastSend);
     X(nLastRecv);
+    X(nLastTXTime);
+    X(nLastBlockTime);
     X(nTimeConnected);
     X(nTimeOffset);
     stats.addrName = GetAddrName();

--- a/src/net.h
+++ b/src/net.h
@@ -944,6 +944,8 @@ public:
     bool fRelayTxes;
     int64_t nLastSend;
     int64_t nLastRecv;
+    int64_t nLastTXTime;
+    int64_t nLastBlockTime;
     int64_t nTimeConnected;
     int64_t nTimeOffset;
     std::string addrName;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -116,6 +116,8 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
                     {RPCResult::Type::BOOL, "relaytxes", "Whether peer has asked us to relay transactions to it"},
                     {RPCResult::Type::NUM_TIME, "lastsend", "The " + UNIX_EPOCH_TIME + " of the last send"},
                     {RPCResult::Type::NUM_TIME, "lastrecv", "The " + UNIX_EPOCH_TIME + " of the last receive"},
+                    {RPCResult::Type::NUM_TIME, "last_transaction", "The " + UNIX_EPOCH_TIME + " of the last valid transaction received from this peer"},
+                    {RPCResult::Type::NUM_TIME, "last_block", "The " + UNIX_EPOCH_TIME + " of the last block received from this peer"},
                     {RPCResult::Type::NUM, "bytessent", "The total bytes sent"},
                     {RPCResult::Type::NUM, "bytesrecv", "The total bytes received"},
                     {RPCResult::Type::NUM_TIME, "conntime", "The " + UNIX_EPOCH_TIME + " of the connection"},
@@ -197,6 +199,8 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         obj.pushKV("relaytxes", stats.fRelayTxes);
         obj.pushKV("lastsend", stats.nLastSend);
         obj.pushKV("lastrecv", stats.nLastRecv);
+        obj.pushKV("last_transaction", stats.nLastTXTime);
+        obj.pushKV("last_block", stats.nLastBlockTime);
         obj.pushKV("bytessent", stats.nSendBytes);
         obj.pushKV("bytesrecv", stats.nRecvBytes);
         obj.pushKV("conntime", stats.nTimeConnected);

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -52,6 +52,7 @@ class NotificationsTest(DashTestFramework):
         self.extra_args[0].append("-chainlocknotify=echo > {}".format(os.path.join(self.chainlocknotify_dir, '%s')))
         self.extra_args[1].append("-instantsendnotify=echo > {}".format(os.path.join(self.instantsendnotify_dir, notify_outputname('%w', '%s'))))
 
+        self.wallet_names = [self.default_wallet_name, self.wallet]
         super().setup_network()
 
     def run_test(self):
@@ -60,9 +61,6 @@ class NotificationsTest(DashTestFramework):
             os.remove(os.path.join(self.blocknotify_dir, block_file))
         for tx_file in os.listdir(self.walletnotify_dir):
             os.remove(os.path.join(self.walletnotify_dir, tx_file))
-
-        if self.is_wallet_compiled():
-            self.nodes[1].createwallet(wallet_name=self.wallet, load_on_startup=True)
 
         self.log.info("test -blocknotify")
         block_count = 10

--- a/test/functional/p2p_instantsend.py
+++ b/test/functional/p2p_instantsend.py
@@ -32,9 +32,6 @@ class InstantSendTest(DashTestFramework):
         self.move_to_next_cycle()
         self.log.info("Cycle H+2C height:" + str(self.nodes[0].getblockcount()))
         (quorum_info_i_0, quorum_info_i_1) = self.mine_cycle_quorum(llmq_type_name='llmq_test_dip0024', llmq_type=103)
-        self.nodes[self.isolated_idx].createwallet(self.default_wallet_name)
-        self.nodes[self.receiver_idx].createwallet(self.default_wallet_name)
-        self.nodes[self.sender_idx].createwallet(self.default_wallet_name)
 
         self.test_mempool_doublespend()
         self.test_block_doublespend()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -164,14 +164,14 @@ class NetTest(DashTestFramework):
         assert "(ipv4, ipv6, onion, i2p, not_publicly_routable)" in self.nodes[0].help("getpeerinfo")
         # This part is slightly different comparing to the Bitcoin implementation. This is expected because we create connections on network setup a bit differently too.
         # We also create more connection during the test itself to test mn specific stats
-        assert_equal(peer_info[0][0]['connection_type'], 'manual')
+        assert_equal(peer_info[0][0]['connection_type'], 'inbound')
         assert_equal(peer_info[0][1]['connection_type'], 'inbound')
+        assert_equal(peer_info[0][2]['connection_type'], 'manual')
 
-        assert_equal(peer_info[1][0]['connection_type'], 'inbound')
-        assert_equal(peer_info[1][1]['connection_type'], 'manual')
-        assert_equal(peer_info[1][2]['connection_type'], 'manual')
+        assert_equal(peer_info[1][0]['connection_type'], 'manual')
+        assert_equal(peer_info[1][1]['connection_type'], 'inbound')
 
-        assert_equal(peer_info[2][0]['connection_type'], 'inbound')
+        assert_equal(peer_info[2][0]['connection_type'], 'manual')
 
     def test_service_flags(self):
         self.nodes[0].add_p2p_connection(P2PInterface(), services=(1 << 4) | (1 << 63))

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -12,8 +12,12 @@ import test_framework.messages
 from test_framework.messages import (
     NODE_NETWORK,
 )
+
+from itertools import product
+
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import (
+    assert_approx,
     assert_equal,
     assert_greater_than_or_equal,
     assert_greater_than,
@@ -41,6 +45,8 @@ class NetTest(DashTestFramework):
         self.supports_cli = False
 
     def run_test(self):
+        # Get out of IBD for the getpeerinfo tests.
+        self.nodes[0].generate(101)
         # Wait for one ping/pong to finish so that we can be sure that there is no chatter between nodes for some time
         # Especially the exchange of messages like getheaders and friends causes test failures here
         self.nodes[0].ping()
@@ -50,21 +56,23 @@ class NetTest(DashTestFramework):
         self.connect_nodes(1, 0)
         self.sync_all()
 
-        self._test_connection_count()
-        self._test_getnettotals()
-        self._test_getnetworkinfo()
-        self._test_getaddednodeinfo()
-        self._test_getpeerinfo()
+        self.test_connection_count()
+        self.test_getpeerinfo()
+        self.test_getnettotals()
+        self.test_getnetworkinfo()
+        self.test_getaddednodeinfo()
         self.test_service_flags()
-        self._test_getnodeaddresses()
+        self.test_getnodeaddresses()
 
-    def _test_connection_count(self):
-        # connect_nodes connects each node to the other
+    def test_connection_count(self):
+        self.log.info("Test getconnectioncount")
+        # After using `connect_nodes` to connect nodes 0 and 1 to each other.
         # and node0 was also connected to node2 (a masternode)
         # during network setup
         assert_equal(self.nodes[0].getconnectioncount(), 3)
 
-    def _test_getnettotals(self):
+    def test_getnettotals(self):
+        self.log.info("Test getnettotals")
         # getnettotals totalbytesrecv and totalbytessent should be
         # consistent with getpeerinfo. Since the RPC calls are not atomic,
         # and messages might have been recvd or sent between RPC calls, call
@@ -94,7 +102,9 @@ class NetTest(DashTestFramework):
             assert_greater_than_or_equal(after['bytesrecv_per_msg'].get('pong', 0), before['bytesrecv_per_msg'].get('pong', 0) + 32)
             assert_greater_than_or_equal(after['bytessent_per_msg'].get('ping', 0), before['bytessent_per_msg'].get('ping', 0) + 32)
 
-    def _test_getnetworkinfo(self):
+    def test_getnetworkinfo(self):
+        self.log.info("Test getnetworkinfo")
+        info = self.nodes[0].getnetworkinfo()
         assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], True)
         assert_equal(self.nodes[0].getnetworkinfo()['connections'], 3)
 
@@ -105,7 +115,7 @@ class NetTest(DashTestFramework):
         self.wait_until(lambda: self.nodes[1].getnetworkinfo()['connections'] == 0, timeout=3)
 
         self.nodes[0].setnetworkactive(state=True)
-        self.log.info('Connect nodes both way')
+        # Connect nodes both ways.
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 0)
 
@@ -131,7 +141,8 @@ class NetTest(DashTestFramework):
         assert_equal(self.nodes[1].getnetworkinfo()['inboundmnconnections'], 0)
         assert_equal(self.nodes[1].getnetworkinfo()['outboundmnconnections'], 1)
 
-    def _test_getaddednodeinfo(self):
+    def test_getaddednodeinfo(self):
+        self.log.info("Test getaddednodeinfo")
         assert_equal(self.nodes[0].getaddednodeinfo(), [])
         # add a node (node2) to node0
         ip_port = "127.0.0.1:{}".format(p2p_port(2))
@@ -150,8 +161,20 @@ class NetTest(DashTestFramework):
         # check that a non-existent node returns an error
         assert_raises_rpc_error(-24, "Node has not been added", self.nodes[0].getaddednodeinfo, '1.1.1.1')
 
-    def _test_getpeerinfo(self):
+    def test_getpeerinfo(self):
+        self.log.info("Test getpeerinfo")
+        # Create a few getpeerinfo last_block/last_transaction values.
+        if self.is_wallet_compiled():
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        self.nodes[1].generate(1)
+        self.sync_all()
+        time_now = self.mocktime
         peer_info = [x.getpeerinfo() for x in self.nodes]
+        # Verify last_block and last_transaction keys/values.
+        for node, peer, field in product(range(self.num_nodes - self.mn_count), range(2), ['last_block', 'last_transaction']):
+            assert field in peer_info[node][peer].keys()
+            if peer_info[node][peer][field] != 0:
+                assert_approx(peer_info[node][peer][field], time_now, vspan=60)
         # check both sides of bidirectional connection between nodes
         # the address bound to on one side will be the source address for the other node
         assert_equal(peer_info[0][0]['addrbind'], peer_info[1][0]['addr'])
@@ -174,11 +197,13 @@ class NetTest(DashTestFramework):
         assert_equal(peer_info[2][0]['connection_type'], 'manual')
 
     def test_service_flags(self):
+        self.log.info("Test service flags")
         self.nodes[0].add_p2p_connection(P2PInterface(), services=(1 << 4) | (1 << 63))
         assert_equal(['UNKNOWN[2^4]', 'UNKNOWN[2^63]'], self.nodes[0].getpeerinfo()[-1]['servicesnames'])
         self.nodes[0].disconnect_p2ps()
 
-    def _test_getnodeaddresses(self):
+    def test_getnodeaddresses(self):
+        self.log.info("Test getnodeaddresses")
         self.nodes[0].add_p2p_connection(P2PInterface())
 
         # Add some addresses to the Address Manager over RPC. Due to the way

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -422,6 +422,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     def setup_nodes(self):
         """Override this method to customize test node setup"""
+
+        """If this method is updated - backport changes to  DashTestFramework.setup_nodes"""
         extra_args = None
         if hasattr(self, "extra_args"):
             extra_args = self.extra_args
@@ -1158,9 +1160,9 @@ class DashTestFramework(BitcoinTestFramework):
             self.extra_args[i].append("-llmqtestparams=%d:%d" % (self.llmq_size, self.llmq_threshold))
             self.extra_args[i].append("-llmqtestinstantsendparams=%d:%d" % (self.llmq_size, self.llmq_threshold))
 
-    def create_simple_node(self):
+    def create_simple_node(self, extra_args=None):
         idx = len(self.nodes)
-        self.add_nodes(1, extra_args=[self.extra_args[idx]])
+        self.add_nodes(1, extra_args=[extra_args[idx]])
         self.start_node(idx)
         for i in range(0, idx):
             self.connect_nodes(i, idx)
@@ -1415,21 +1417,23 @@ class DashTestFramework(BitcoinTestFramework):
         self.start_node(mnidx, extra_args=args)
         force_finish_mnsync(self.nodes[mnidx])
 
-    def setup_network(self):
+    def setup_nodes(self):
+        extra_args = None
+        if hasattr(self, "extra_args"):
+            extra_args = self.extra_args
         self.log.info("Creating and starting controller node")
-        self.add_nodes(1, extra_args=[self.extra_args[0]])
-        self.start_node(0)
-        self.import_deterministic_coinbase_privkeys()
+        num_simple_nodes = self.num_nodes - self.mn_count
+        self.log.info("Creating and starting %s simple nodes", num_simple_nodes)
+        for i in range(0, num_simple_nodes):
+            self.create_simple_node(extra_args)
+        if self.requires_wallet:
+            self.import_deterministic_coinbase_privkeys()
         required_balance = EVONODE_COLLATERAL * self.evo_count
         required_balance += MASTERNODE_COLLATERAL * (self.mn_count - self.evo_count) + 100
         self.log.info("Generating %d coins" % required_balance)
         while self.nodes[0].getbalance() < required_balance:
             self.bump_mocktime(1)
             self.nodes[0].generate(10)
-        num_simple_nodes = self.num_nodes - self.mn_count - 1
-        self.log.info("Creating and starting %s simple nodes", num_simple_nodes)
-        for i in range(0, num_simple_nodes):
-            self.create_simple_node()
 
         self.log.info("Activating DIP3")
         if not self.fast_dip3_enforcement:
@@ -1442,8 +1446,12 @@ class DashTestFramework(BitcoinTestFramework):
         self.prepare_datadirs()
         self.start_masternodes()
 
+    def setup_network(self):
+        self.setup_nodes()
+
         # non-masternodes where disconnected from the control node during prepare_datadirs,
         # let's reconnect them back to make sure they receive updates
+        num_simple_nodes = self.num_nodes - self.mn_count - 1
         for i in range(0, num_simple_nodes):
             self.connect_nodes(i+1, 0)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1444,7 +1444,6 @@ class DashTestFramework(BitcoinTestFramework):
         # create masternodes
         self.prepare_masternodes()
         self.prepare_datadirs()
-        self.start_masternodes()
 
     def setup_network(self):
         self.setup_nodes()
@@ -1454,6 +1453,8 @@ class DashTestFramework(BitcoinTestFramework):
         num_simple_nodes = self.num_nodes - self.mn_count - 1
         for i in range(0, num_simple_nodes):
             self.connect_nodes(i+1, 0)
+
+        self.start_masternodes()
 
         self.bump_mocktime(1)
         self.nodes[0].generate(1)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Some functional tests that uses DashTestFramework fails without manual call of `createwallet` or `self.import_deterministic_coinbase_privkeys` even though same code with BitconTestFramework works just fine.

## What was done?
 - bitcoin/bitcoin#19731

During bitcoin#19731 has been localized issue with wallet initialization due to different implementation of `setup_nodes` for BitcoinTestFramework and DashTestFramework. This PR fixes difference between our frameworks, removes workarounds for existing code and backports bitcoin#19731 which can't run correctly without these fixes.

Also this PR changes an order of creating connections to unify with bitcoin - regular nodes are connecting before masternodes.

 
## How Has This Been Tested?
Run unit/functional tests.
Backport #19731 tests new behaviour for DashTestFramework fixes.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone