### PR TITLE
fix(rpc): fix for `getassetunlockstatuses` parameters parsing

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -58,6 +58,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listreceivedbylabel", 1, "addlocked" },
     { "listreceivedbylabel", 2, "include_empty" },
     { "listreceivedbylabel", 3, "include_watchonly" },
+    { "getassetunlockstatuses", 0, "indexes" },
     { "getbalance", 1, "minconf" },
     { "getbalance", 2, "addlocked" },
     { "getbalance", 3, "include_watchonly" },


### PR DESCRIPTION
## Issue being fixed or feature implemented
`getassetunlockstatuses` was failing to parse parameters when calling from CLI.

Credits to knst 

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
