### PR TITLE
fix(rpc): correct handling of CL info in `getassetunlockstatuses`.

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -495,6 +495,9 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
                 return pTipBlockIndex->GetAncestor(pTipBlockIndex->nHeight - cbtx_best_cl->second - 1);
             }
         }
+        else {
+            return pTipBlockIndex->GetAncestor(llmq_ctx.clhandler->GetBestChainLock().getHeight());
+        }
         return nullptr;
     }();
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
RPC `getassetunlockstatuses` wasn't constructing CBlockIndex when CL info is available. 

## What was done?
Now the RPC returns the correct status when the AssetUnlock is mined in a CLocked block.

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

