### PR TITLE
fix: don't make keypool refill spam progress bars

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1447,10 +1447,11 @@ bool LegacyScriptPubKeyMan::TopUpInner(unsigned int kpSize)
 
             if (GetTime() >= progress_report_time + PROGRESS_REPORT_INTERVAL) {
                 const double dProgress = 100.f * current_index / total_missing;
+                const int iProgress = static_cast<int>(dProgress);
                 progress_report_time = GetTime();
                 WalletLogPrintf("Still topping up. At key %lld. Progress=%f\n", current_index, dProgress);
-                if (should_show_progress) {
-                    m_storage.UpdateProgress(strMsg, static_cast<int>(dProgress));
+                if (should_show_progress && iProgress > 0) {
+                    m_storage.UpdateProgress(strMsg, iProgress);
                 }
             }
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
 
Trivial bug:  `keypoolrefill` internally updates the status of the progress bar each second.
```
m_storage.UpdateProgress(strMsg, static_cast<int>(dProgress));
```
 However it can happen that one second is not enough time to make significant progress and 
 `static_cast<int>(dProgress) = 0`. 
Calling the function with `0` as progress opens a new progress bar and this led to problems like #5730



## What was done?

  trivially make sure to update the progress only if the parameter is >0


## How Has This Been Tested?

  rpc does not spam anymore


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

