### PR TITLE
feat(rpc): `quorum dkginfo` rpc

### DIFF
--- a/doc/release-notes-5853.md
+++ b/doc/release-notes-5853.md
@@ -1,8 +1,6 @@
 Added RPC
 --------
 
-- `dkginfo` RPC returns information about DKGs:
-`nActiveDKGs`: Total number of active DKG sessions.
-`nextDKG`: If `nActiveDKGs` is 0, then `nextDKG` indicates the number of blocks until the next potential DKG session.
-
-Note: This RPC is enabled only for Masternodes, and it is expected to work only when `SPORK_17_QUORUM_DKG_ENABLED` spork is ON.
+- `quorum dkginfo` RPC returns information about DKGs:
+  - `active_dkgs`: Total number of active DKG sessions this node is participating in right now.
+  - `next_dkg`: The number of blocks until the next potential DKG session.

--- a/doc/release-notes-5853.md
+++ b/doc/release-notes-5853.md
@@ -1,0 +1,8 @@
+Added RPC
+--------
+
+- `dkginfo` RPC returns information about DKGs:
+`nActiveDKGs`: Total number of active DKG sessions.
+`nextDKG`: If `nActiveDKGs` is 0, then `nextDKG` indicates the number of blocks until the next potential DKG session.
+
+Note: This RPC is enabled only for Masternodes, and it is expected to work only when `SPORK_17_QUORUM_DKG_ENABLED` spork is ON.

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -816,7 +816,7 @@ static UniValue quorum_dkginfo(const JSONRPCRequest& request, const LLMQContext&
     llmq_ctx.dkg_debugman->GetLocalDebugStatus(status);
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("active_dkgs", int(status.sessions.size()));
-    
+
     const int nTipHeight{WITH_LOCK(cs_main, return chainman.ActiveChain().Height())};
     auto minNextDKG = [](const Consensus::Params& consensusParams, int nTipHeight) {
         int minDkgWindow{std::numeric_limits<int>::max()};

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -793,7 +793,7 @@ static void quorum_dkginfo_help(const JSONRPCRequest& request)
 {
     RPCHelpMan{
         "quorum dkginfo",
-        "Return information regarding DKGs.\n"
+        "Return information regarding DKGs.\n",
         {
             {},
         },

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -1073,6 +1073,16 @@ static UniValue dkginfo(const JSONRPCRequest& request)
         for (const auto &params: consensus_params.llmqs) {
             if (!params.useRotation)
                 minDkgWindow = std::min(minDkgWindow, params.dkgInterval - (nTipHeight % params.dkgInterval));
+            else {
+                if (nTipHeight % params.dkgInterval > params.signingActiveQuorumCount) {
+                    // Next potential DKG is the DKG for quorumIndex 0
+                    minDkgWindow = std::min(minDkgWindow, params.dkgInterval - (nTipHeight % params.dkgInterval));
+                }
+                // We are currently during a rotation cycle. Since sessions.empty(), next we return next potential DKG is 1 (next block for next quorumIndex)
+                else {
+                    minDkgWindow = std::min(minDkgWindow, 1);
+                }
+            }
         }
         ret.pushKV("nextDKG", minDkgWindow);
     }

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -77,9 +77,11 @@ class LLMQQuorumRotationTest(DashTestFramework):
         b_h_0 = self.nodes[0].getbestblockhash()
 
         tip = self.nodes[0].getblockcount()
-        assert_equal(self.nodes[1].quorum("dkginfo")['nextDKG'], int(24 - (tip % 24)))
-        assert_equal(self.nodes[2].quorum("dkginfo")['nextDKG'], int(24 - (tip % 24)))
-        assert_equal(self.nodes[3].quorum("dkginfo")['nextDKG'], int(24 - (tip % 24)))
+        next_dkg = 24 - (tip % 24);
+        for node in self.nodes:
+            dkg_info = node.quorum("dkginfo")
+            assert_equal(dkg_info['active_dkgs'], 0)
+            assert_equal(dkg_info['next_dkg'], next_dkg)
 
         #Mine 2 quorums so that Chainlocks can be available: Need them to include CL in CbTx as soon as v20 activates
         self.log.info("Mining 2 quorums")
@@ -97,6 +99,18 @@ class LLMQQuorumRotationTest(DashTestFramework):
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
 
         b_h_1 = self.nodes[0].getbestblockhash()
+
+        tip = self.nodes[0].getblockcount()
+        next_dkg = 24 - (tip % 24);
+        assert next_dkg < 24
+        nonzero_dkgs = 0
+        for i in range(len(self.nodes)):
+            dkg_info = self.nodes[i].quorum("dkginfo")
+            if i == 0:
+                assert_equal(dkg_info['active_dkgs'], 0)
+            nonzero_dkgs += dkg_info['active_dkgs']
+            assert_equal(dkg_info['next_dkg'], next_dkg)
+        assert_equal(nonzero_dkgs, 11) # 2 quorums 4 nodes each and 1 quorum of 3 nodes
 
         expectedDeleted = []
         expectedNew = [h_100_0, h_106_0, h_104_0, h_100_1, h_106_1, h_104_1]

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -77,9 +77,9 @@ class LLMQQuorumRotationTest(DashTestFramework):
         b_h_0 = self.nodes[0].getbestblockhash()
 
         tip = self.nodes[0].getblockcount()
-        assert_equal(self.nodes[1].dkginfo()['nextDKG'], int(24 - (tip % 24)))
-        assert_equal(self.nodes[2].dkginfo()['nextDKG'], int(24 - (tip % 24)))
-        assert_equal(self.nodes[3].dkginfo()['nextDKG'], int(24 - (tip % 24)))
+        assert_equal(self.nodes[1].quorum("dkginfo")['nextDKG'], int(24 - (tip % 24)))
+        assert_equal(self.nodes[2].quorum("dkginfo")['nextDKG'], int(24 - (tip % 24)))
+        assert_equal(self.nodes[3].quorum("dkginfo")['nextDKG'], int(24 - (tip % 24)))
 
         #Mine 2 quorums so that Chainlocks can be available: Need them to include CL in CbTx as soon as v20 activates
         self.log.info("Mining 2 quorums")

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -77,7 +77,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         b_h_0 = self.nodes[0].getbestblockhash()
 
         tip = self.nodes[0].getblockcount()
-        next_dkg = 24 - (tip % 24);
+        next_dkg = 24 - (tip % 24)
         for node in self.nodes:
             dkg_info = node.quorum("dkginfo")
             assert_equal(dkg_info['active_dkgs'], 0)
@@ -101,7 +101,7 @@ class LLMQQuorumRotationTest(DashTestFramework):
         b_h_1 = self.nodes[0].getbestblockhash()
 
         tip = self.nodes[0].getblockcount()
-        next_dkg = 24 - (tip % 24);
+        next_dkg = 24 - (tip % 24)
         assert next_dkg < 24
         nonzero_dkgs = 0
         for i in range(len(self.nodes)):

--- a/test/functional/feature_llmq_rotation.py
+++ b/test/functional/feature_llmq_rotation.py
@@ -76,6 +76,11 @@ class LLMQQuorumRotationTest(DashTestFramework):
 
         b_h_0 = self.nodes[0].getbestblockhash()
 
+        tip = self.nodes[0].getblockcount()
+        assert_equal(self.nodes[1].dkginfo()['nextDKG'], int(24 - (tip % 24)))
+        assert_equal(self.nodes[2].dkginfo()['nextDKG'], int(24 - (tip % 24)))
+        assert_equal(self.nodes[3].dkginfo()['nextDKG'], int(24 - (tip % 24)))
+
         #Mine 2 quorums so that Chainlocks can be available: Need them to include CL in CbTx as soon as v20 activates
         self.log.info("Mining 2 quorums")
         h_0 = self.mine_quorum()


### PR DESCRIPTION
## Issue being fixed or feature implemented
Dashmate wanted a way to know if it is safe to restart the masternode.
This new RPC indicates the number of active DKG sessions, and the number of blocks until next potential DKG.

## What was done?
Examples of responses:
`{'active_dkgs': 0, 'next_dkg': 22}`

## How Has This Been Tested?
`feature_llmq_rotation.py` was updated

## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

