### PR TITLE
refactor: move HD code from CWallet to LegacyScriptPubKeyMan

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -138,8 +138,6 @@ BITCOIN_CORE_H = \
   base58.h \
   batchedlogger.h \
   bech32.h \
-  bip39.h \
-  bip39_english.h \
   blockencodings.h \
   bloom.h \
   cachemap.h \
@@ -364,6 +362,8 @@ BITCOIN_CORE_H = \
   validationinterface.h \
   versionbits.h \
   wallet/bdb.h \
+  wallet/bip39.h \
+  wallet/bip39_english.h \
   wallet/coincontrol.h \
   wallet/coinselection.h \
   wallet/context.h \
@@ -540,6 +540,7 @@ libbitcoin_wallet_a_SOURCES = \
   coinjoin/client.cpp \
   coinjoin/interfaces.cpp \
   coinjoin/util.cpp \
+  wallet/bip39.cpp \
   wallet/coincontrol.cpp \
   wallet/context.cpp \
   wallet/crypter.cpp \
@@ -708,7 +709,6 @@ libbitcoin_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_common_a_SOURCES = \
   base58.cpp \
   bech32.cpp \
-  bip39.cpp \
   bloom.cpp \
   chainparams.cpp \
   coins.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -203,7 +203,6 @@ BITCOIN_CORE_H = \
   gsl/assert.h \
   gsl/pointers.h \
   flat-database.h \
-  hdchain.h \
   flatfile.h \
   fs.h \
   httprpc.h \
@@ -371,6 +370,7 @@ BITCOIN_CORE_H = \
   wallet/crypter.h \
   wallet/db.h \
   wallet/fees.h \
+  wallet/hdchain.h \
   wallet/ismine.h \
   wallet/load.h \
   wallet/rpcwallet.h \
@@ -540,12 +540,12 @@ libbitcoin_wallet_a_SOURCES = \
   coinjoin/client.cpp \
   coinjoin/interfaces.cpp \
   coinjoin/util.cpp \
-  hdchain.cpp \
   wallet/coincontrol.cpp \
   wallet/context.cpp \
   wallet/crypter.cpp \
   wallet/db.cpp \
   wallet/fees.cpp \
+  wallet/hdchain.cpp \
   wallet/interfaces.cpp \
   wallet/load.cpp \
   wallet/rpcdump.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -46,8 +46,8 @@ FUZZ_SUITE_LD_COMMON = \
  $(LIBTEST_FUZZ) \
  $(LIBTEST_UTIL) \
  $(LIBBITCOIN_CONSENSUS) \
- $(LIBBITCOIN_CRYPTO) \
  $(LIBBITCOIN_WALLET) \
+ $(LIBBITCOIN_CRYPTO) \
  $(LIBBITCOIN_CLI) \
  $(LIBDASHBLS) \
  $(BDB_LIBS) \
@@ -83,7 +83,6 @@ BITCOIN_TESTS =\
   test/base64_tests.cpp \
   test/bech32_tests.cpp \
   test/bip32_tests.cpp \
-  test/bip39_tests.cpp \
   test/block_reward_reallocation_tests.cpp \
   test/blockchain_tests.cpp \
   test/blockencodings_tests.cpp \
@@ -181,6 +180,7 @@ BITCOIN_TESTS =\
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \
+  wallet/test/bip39_tests.cpp \
   wallet/test/coinjoin_tests.cpp \
   wallet/test/psbt_wallet_tests.cpp \
   wallet/test/wallet_tests.cpp \

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_SCRIPT_SIGNINGPROVIDER_H
 #define BITCOIN_SCRIPT_SIGNINGPROVIDER_H
 
-#include <hdchain.h>
 #include <key.h>
 #include <pubkey.h>
 #include <script/script.h>

--- a/src/wallet/bip39.cpp
+++ b/src/wallet/bip39.cpp
@@ -24,8 +24,8 @@
 // Source:
 // https://github.com/trezor/trezor-crypto
 
-#include <bip39.h>
-#include <bip39_english.h>
+#include <wallet/bip39.h>
+#include <wallet/bip39_english.h>
 #include <crypto/pkcs5_pbkdf2_hmac_sha512.h>
 #include <crypto/sha256.h>
 #include <random.h>

--- a/src/wallet/bip39.h
+++ b/src/wallet/bip39.h
@@ -21,8 +21,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef BITCOIN_BIP39_H
-#define BITCOIN_BIP39_H
+#ifndef BITCOIN_WALLET_BIP39_H
+#define BITCOIN_WALLET_BIP39_H
 
 #include <support/allocators/secure.h>
 
@@ -36,4 +36,4 @@ public:
     static void ToSeed(SecureString mnemonic, SecureString passphrase, SecureVector& seedRet);
 };
 
-#endif // BITCOIN_BIP39_H
+#endif // BITCOIN_WALLET_BIP39_H

--- a/src/wallet/bip39_english.h
+++ b/src/wallet/bip39_english.h
@@ -21,8 +21,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef BITCOIN_BIP39_ENGLISH_H
-#define BITCOIN_BIP39_ENGLISH_H
+#ifndef BITCOIN_WALLET_BIP39_ENGLISH_H
+#define BITCOIN_WALLET_BIP39_ENGLISH_H
 
 const char * const wordlist[] = {
 "abandon",
@@ -2076,4 +2076,4 @@ const char * const wordlist[] = {
 0,
 };
 
-#endif // BITCOIN_BIP39_ENGLISH_H
+#endif // BITCOIN_WALLET_BIP39_ENGLISH_H

--- a/src/wallet/hdchain.cpp
+++ b/src/wallet/hdchain.cpp
@@ -3,7 +3,7 @@
 
 #include <wallet/hdchain.h>
 
-#include <bip39.h>
+#include <wallet/bip39.h>
 #include <chainparams.h>
 #include <key_io.h>
 #include <tinyformat.h>

--- a/src/wallet/hdchain.cpp
+++ b/src/wallet/hdchain.cpp
@@ -1,9 +1,10 @@
 // Copyright (c) 2014-2023 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
 
+#include <wallet/hdchain.h>
+
 #include <bip39.h>
 #include <chainparams.h>
-#include <hdchain.h>
 #include <key_io.h>
 #include <tinyformat.h>
 #include <util/system.h>

--- a/src/wallet/hdchain.h
+++ b/src/wallet/hdchain.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2023 The Dash Core developers
 // Distributed under the MIT software license, see the accompanying
-#ifndef BITCOIN_HDCHAIN_H
-#define BITCOIN_HDCHAIN_H
+#ifndef BITCOIN_WALLET_HDCHAIN_H
+#define BITCOIN_WALLET_HDCHAIN_H
 
 #include <key.h>
 #include <script/keyorigin.h>
@@ -142,4 +142,4 @@ public:
     std::string GetKeyPath() const;
 };
 
-#endif // BITCOIN_HDCHAIN_H
+#endif // BITCOIN_WALLET_HDCHAIN_H

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -20,12 +20,12 @@
 #ifdef USE_BDB
 #include <wallet/bdb.h>
 #endif
+#include <wallet/bip39.h>
 #include <wallet/coincontrol.h>
 #include <wallet/hdchain.h>
 #include <wallet/wallet.h>
 #include <walletinitinterface.h>
 
-#include <bip39.h>
 #include <coinjoin/client.h>
 #include <coinjoin/options.h>
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -21,13 +21,13 @@
 #include <wallet/bdb.h>
 #endif
 #include <wallet/coincontrol.h>
+#include <wallet/hdchain.h>
 #include <wallet/wallet.h>
 #include <walletinitinterface.h>
 
 #include <bip39.h>
 #include <coinjoin/client.h>
 #include <coinjoin/options.h>
-#include <hdchain.h>
 
 class WalletInit : public WalletInitInterface
 {

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -442,7 +442,7 @@ bool LegacyScriptPubKeyMan::SetCryptedHDChain(WalletBatch &batch, const CHDChain
 {
     LOCK(cs_KeyStore);
 
-    if (!SetCryptedHDChain(chain))
+    if (!SetHDChain(chain))
         return false;
 
     if (!memonly) {
@@ -1118,26 +1118,14 @@ bool LegacyScriptPubKeyMan::AddWatchOnly(const CScript& dest, int64_t nCreateTim
 bool LegacyScriptPubKeyMan::SetHDChain(const CHDChain& chain)
 {
     LOCK(cs_KeyStore);
-    if (m_storage.HasEncryptionKeys())
-        return false;
 
-    if (chain.IsCrypted())
-        return false;
+    if (m_storage.HasEncryptionKeys() != chain.IsCrypted()) return false;
 
-    hdChain = chain;
-    return true;
-}
-
-bool LegacyScriptPubKeyMan::SetCryptedHDChain(const CHDChain& chain)
-{
-    LOCK(cs_KeyStore);
-    if (!m_storage.HasEncryptionKeys())
-        return false;
-
-    if (!chain.IsCrypted())
-        return false;
-
-    cryptedHDChain = chain;
+    if (chain.IsCrypted()) {
+        cryptedHDChain = chain;
+    } else {
+        hdChain = chain;
+    }
     return true;
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -391,8 +391,8 @@ void LegacyScriptPubKeyMan::GenerateNewCryptedHDChain(const SecureString& secure
 
     hdChainCrypted.Debug(__func__);
 
-    if (!SetCryptedHDChainSingle(hdChainCrypted, false)) {
-        throw std::runtime_error(std::string(__func__) + ": SetCryptedHDChainSingle failed");
+    if (!SetHDChainSingle(hdChainCrypted, false)) {
+        throw std::runtime_error(std::string(__func__) + ": SetHDChainSingle failed");
     }
 }
 
@@ -444,12 +444,6 @@ bool LegacyScriptPubKeyMan::SetHDChain(WalletBatch &batch, const CHDChain& chain
 }
 
 bool LegacyScriptPubKeyMan::SetHDChainSingle(const CHDChain& chain, bool memonly)
-{
-    WalletBatch batch(m_storage.GetDatabase());
-    return SetHDChain(batch, chain, memonly);
-}
-
-bool LegacyScriptPubKeyMan::SetCryptedHDChainSingle(const CHDChain& chain, bool memonly)
 {
     WalletBatch batch(m_storage.GetDatabase());
     return SetHDChain(batch, chain, memonly);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -458,7 +458,7 @@ bool LegacyScriptPubKeyMan::SetHDChain(WalletBatch &batch, const CHDChain& chain
     if (!memonly) {
         if (chain.IsCrypted() && encrypted_batch) {
             if (!encrypted_batch->WriteHDChain(chain))
-                throw std::runtime_error(std::string(__func__) + ": WriteHDChain failed");
+                throw std::runtime_error(std::string(__func__) + ": WriteHDChain failed for encrypted batch");
         } else {
             if (!batch.WriteHDChain(chain)) {
                 throw std::runtime_error(std::string(__func__) + ": WriteHDChain failed");

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -267,7 +267,7 @@ bool LegacyScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, WalletBat
     }
 
     if (!hdChainCurrent.IsNull()) {
-        assert(EncryptHDChain(master_key));
+        assert(EncryptAndSetHDChain(master_key));
 
         CHDChain hdChainCrypted;
         assert(GetHDChain(hdChainCrypted));
@@ -396,7 +396,7 @@ void LegacyScriptPubKeyMan::GenerateNewCryptedHDChain(const SecureString& secure
     hdChainTmp.AddAccount();
     hdChainTmp.Debug(__func__);
 
-    bool res = EncryptHDChain(vMasterKey, hdChainTmp);
+    bool res = EncryptAndSetHDChain(vMasterKey, hdChainTmp);
     assert(res);
 
     CHDChain hdChainCrypted;
@@ -494,7 +494,7 @@ bool LegacyScriptPubKeyMan::GetDecryptedHDChain(CHDChain& hdChainRet)
     return true;
 }
 
-bool LegacyScriptPubKeyMan::EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain)
+bool LegacyScriptPubKeyMan::EncryptAndSetHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain)
 {
     LOCK(cs_KeyStore);
     // should call EncryptKeys first

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -447,11 +447,11 @@ bool LegacyScriptPubKeyMan::SetCryptedHDChain(WalletBatch &batch, const CHDChain
 
     if (!memonly) {
         if (encrypted_batch) {
-            if (!encrypted_batch->WriteCryptedHDChain(chain))
-                throw std::runtime_error(std::string(__func__) + ": WriteCryptedHDChain failed");
+            if (!encrypted_batch->WriteHDChain(chain))
+                throw std::runtime_error(std::string(__func__) + ": WriteHDChain failed");
         } else {
-            if (!batch.WriteCryptedHDChain(chain))
-                throw std::runtime_error(std::string(__func__) + ": WriteCryptedHDChain failed");
+            if (!batch.WriteHDChain(chain))
+                throw std::runtime_error(std::string(__func__) + ": WriteHDChain failed");
         }
         m_storage.UnsetBlankWalletFlag(batch);
     }

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -388,7 +388,9 @@ public:
     CPubKey GenerateNewKey(WalletBatch& batch, uint32_t nAccountIndex, bool fInternal /*= false*/) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
     /* Set the HD chain model (chain child index counters) */
+private:
     bool SetHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
+public:
     /**
      * Set the HD chain model (chain child index counters) using temporary wallet db object
      * which causes db flush every time these methods are used

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -389,7 +389,6 @@ public:
 
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
-    bool SetCryptedHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
     /**
      * Set the HD chain model (chain child index counters) using temporary wallet db object
      * which causes db flush every time these methods are used

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -451,8 +451,8 @@ public:
      */
 
     bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
-    bool DecryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& hdChainRet) const;
 private:
+    bool DecryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& hdChainRet) const;
     bool SetHDChain(const CHDChain& chain);
 public:
     bool GetHDChain(CHDChain& hdChainRet) const;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -277,7 +277,7 @@ private:
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
 
-    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
+    bool EncryptAndSetHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
     bool DecryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& hdChainRet) const;
     bool SetHDChain(const CHDChain& chain);
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -277,13 +277,12 @@ private:
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
 
-    bool EncryptAndSetHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
+    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& chain);
     bool DecryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& hdChainRet) const;
     bool SetHDChain(const CHDChain& chain);
 
     /* the HD chain data model (external chain counters) */
     CHDChain hdChain GUARDED_BY(cs_KeyStore);
-    CHDChain cryptedHDChain GUARDED_BY(cs_KeyStore);
 
     /* HD derive new child key (on internal or external chain) */
     void DeriveNewChildKey(WalletBatch& batch, CKeyMetadata& metadata, CKey& secretRet, uint32_t nAccountIndex, bool fInternal /*= false*/) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -394,7 +394,6 @@ public:
      * which causes db flush every time these methods are used
      */
     bool SetHDChainSingle(const CHDChain& chain, bool memonly);
-    bool SetCryptedHDChainSingle(const CHDChain& chain, bool memonly);
 
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
     bool LoadWatchOnly(const CScript &dest);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -460,6 +460,7 @@ public:
     bool GetDecryptedHDChain(CHDChain& hdChainRet);
 
     /* Generates a new HD chain */
+    void GenerateNewCryptedHDChain(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase, CKeyingMaterial vMasterKey);
     void GenerateNewHDChain(const SecureString& secureMnemonic, const SecureString& secureMnemonicPassphrase);
 
     /**

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -450,8 +450,8 @@ public:
      * HD Wallet Functions
      */
 
-    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
 private:
+    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
     bool DecryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& hdChainRet) const;
     bool SetHDChain(const CHDChain& chain);
 public:

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -454,9 +454,10 @@ public:
 
     bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
     bool DecryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& hdChainRet) const;
+private:
     bool SetHDChain(const CHDChain& chain);
+public:
     bool GetHDChain(CHDChain& hdChainRet) const;
-    bool SetCryptedHDChain(const CHDChain& chain);
     bool GetDecryptedHDChain(CHDChain& hdChainRet);
 
     /* Generates a new HD chain */

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -12,6 +12,7 @@
 #include <util/message.h>
 #include <util/time.h>
 #include <wallet/crypter.h>
+#include <wallet/hdchain.h>
 #include <wallet/ismine.h>
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -274,6 +274,13 @@ private:
     /** Add a KeyOriginInfo to the wallet */
     bool AddKeyOriginWithDB(WalletBatch& batch, const CPubKey& pubkey, const KeyOriginInfo& info);
 
+    /* Set the HD chain model (chain child index counters) */
+    bool SetHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
+
+    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
+    bool DecryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& hdChainRet) const;
+    bool SetHDChain(const CHDChain& chain);
+
     /* the HD chain data model (external chain counters) */
     CHDChain hdChain GUARDED_BY(cs_KeyStore);
     CHDChain cryptedHDChain GUARDED_BY(cs_KeyStore);
@@ -387,10 +394,6 @@ public:
     //! Generate a new key
     CPubKey GenerateNewKey(WalletBatch& batch, uint32_t nAccountIndex, bool fInternal /*= false*/) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
-    /* Set the HD chain model (chain child index counters) */
-private:
-    bool SetHDChain(WalletBatch &batch, const CHDChain& chain, bool memonly);
-public:
     /**
      * Set the HD chain model (chain child index counters) using temporary wallet db object
      * which causes db flush every time these methods are used
@@ -452,11 +455,6 @@ public:
      * HD Wallet Functions
      */
 
-private:
-    bool EncryptHDChain(const CKeyingMaterial& vMasterKeyIn, const CHDChain& chain = CHDChain());
-    bool DecryptHDChain(const CKeyingMaterial& vMasterKeyIn, CHDChain& hdChainRet) const;
-    bool SetHDChain(const CHDChain& chain);
-public:
     bool GetHDChain(CHDChain& hdChainRet) const;
     bool GetDecryptedHDChain(CHDChain& hdChainRet);
 

--- a/src/wallet/test/bip39_tests.cpp
+++ b/src/wallet/test/bip39_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <test/data/bip39_vectors.json.h>
 
-#include <bip39.h>
+#include <wallet/bip39.h>
 #include <key.h>
 #include <key_io.h>
 #include <test/util/setup_common.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5597,6 +5597,9 @@ bool CWallet::GenerateNewHDChainEncrypted(const SecureString& secureMnemonic, co
             }
             Lock();
             return true;
+        } else {
+            // this should never happen
+            throw std::runtime_error(std::string(__func__) + ": SetCryptedHDChainSingle failed");
         }
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -675,7 +675,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
                 assert(hdChainCurrent.GetID() == hdChainCrypted.GetID());
                 assert(hdChainCurrent.GetSeedHash() != hdChainCrypted.GetSeedHash());
 
-                assert(spk_man_legacy->SetCryptedHDChain(*encrypted_batch, hdChainCrypted, false));
+                assert(spk_man_legacy->SetHDChain(*encrypted_batch, hdChainCrypted, false));
             }
         }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -800,17 +800,15 @@ bool WalletBatch::EraseDestData(const std::string &address, const std::string &k
 
 bool WalletBatch::WriteHDChain(const CHDChain& chain)
 {
+    if (chain.IsCrypted()) {
+        if (!WriteIC(DBKeys::CRYPTED_HDCHAIN, chain))
+            return false;
+
+        EraseIC(DBKeys::HDCHAIN);
+
+        return true;
+    }
     return WriteIC(DBKeys::HDCHAIN, chain);
-}
-
-bool WalletBatch::WriteCryptedHDChain(const CHDChain& chain)
-{
-    if (!WriteIC(DBKeys::CRYPTED_HDCHAIN, chain))
-        return false;
-
-    EraseIC(DBKeys::HDCHAIN);
-
-    return true;
 }
 
 bool WalletBatch::WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& keyMeta)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -9,7 +9,6 @@
 #include <key_io.h>
 #include <fs.h>
 #include <governance/common.h>
-#include <hdchain.h>
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>
@@ -22,6 +21,7 @@
 #ifdef USE_SQLITE
 #include <wallet/sqlite.h>
 #endif
+#include <wallet/hdchain.h>
 #include <wallet/wallet.h>
 #include <validation.h>
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -457,20 +457,13 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssKey >> strKey;
             ssValue >> strValue;
             pwallet->LoadDestData(DecodeDestination(strAddress), strKey, strValue);
-        } else if (strType == DBKeys::HDCHAIN) {
+        } else if (strType == DBKeys::HDCHAIN || strType == DBKeys::CRYPTED_HDCHAIN) {
             CHDChain chain;
             ssValue >> chain;
+            assert ((strType == DBKeys::CRYPTED_HDCHAIN) == chain.IsCrypted());
             if (!pwallet->GetOrCreateLegacyScriptPubKeyMan()->SetHDChainSingle(chain, true))
             {
                 strErr = "Error reading wallet database: SetHDChain failed";
-                return false;
-            }
-        } else if (strType == DBKeys::CRYPTED_HDCHAIN) {
-            CHDChain chain;
-            ssValue >> chain;
-            if (!pwallet->GetOrCreateLegacyScriptPubKeyMan()->SetCryptedHDChainSingle(chain, true))
-            {
-                strErr = "Error reading wallet database: SetHDCryptedChain failed";
                 return false;
             }
         } else if (strType == DBKeys::HDPUBKEY) {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -219,7 +219,6 @@ public:
 
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain& chain);
-    bool WriteCryptedHDChain(const CHDChain& chain);
     bool WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& keyMeta);
 
     bool WriteWalletFlags(const uint64_t flags);

--- a/test/lint/lint-cppcheck-dash.sh
+++ b/test/lint/lint-cppcheck-dash.sh
@@ -63,7 +63,6 @@ FILES=$(git ls-files -- "src/batchedlogger.*" \
                         "src/evo/*.h" \
                         "src/governance/*.cpp" \
                         "src/governance/*.h" \
-                        "src/hdchain.*" \
                         "src/keepass.*" \
                         "src/llmq/*.cpp" \
                         "src/llmq/*.h" \
@@ -88,6 +87,7 @@ FILES=$(git ls-files -- "src/batchedlogger.*" \
                         "src/test/dynamic_activation*.cpp" \
                         "src/test/evo*.cpp" \
                         "src/test/governance*.cpp" \
+                        "src/wallet/hdchain.*" \
                         "src/unordered_lru_cache.h")
 
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
During backport bitcoin#17261 significant part of HD chain has been forgotten in CWallet due to our own implementation.

This PR do not change behaviour of HD wallets, it's just refactoring.

## What was done?
This PR refactor HD wallets implementation:
 - key related stuff is moved from CWallet to LegacyScriptPubKeyMan (to follow-up bitcoin#17261)
 - refactored duplicated code between hdChain and hdCryptedChain 
 - modules hdchain and bip39 related moved to wallet/ module


## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone