### PR TITLE
refactor: alias Dash-specific globals to NodeContext, reduce globals use in GUI, interface, RPC and test logic

### DIFF
--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -7,6 +7,7 @@
 
 #include <consensus/validation.h>
 #include <llmq/chainlocks.h>
+#include <llmq/context.h>
 #include <llmq/instantsend.h>
 #include <rpc/blockchain.h>
 #include <streams.h>
@@ -42,8 +43,9 @@ struct TestBlockAndIndex {
 static void BlockToJsonVerbose(benchmark::Bench& bench)
 {
     TestBlockAndIndex data;
+    const LLMQContext& llmq_ctx = *data.test_setup.m_node.llmq_ctx;
     bench.run([&] {
-        auto univalue = blockToJSON(data.block, &data.blockindex, &data.blockindex, *llmq::chainLocksHandler, *llmq::quorumInstantSendManager, /*verbose*/ true);
+        auto univalue = blockToJSON(data.block, &data.blockindex, &data.blockindex, *llmq_ctx.clhandler, *llmq_ctx.isman, /*verbose*/ true);
         ankerl::nanobench::doNotOptimizeAway(univalue);
     });
 }
@@ -53,7 +55,8 @@ BENCHMARK(BlockToJsonVerbose);
 static void BlockToJsonVerboseWrite(benchmark::Bench& bench)
 {
     TestBlockAndIndex data;
-    auto univalue = blockToJSON(data.block, &data.blockindex, &data.blockindex, *llmq::chainLocksHandler, *llmq::quorumInstantSendManager, /*verbose*/ true);
+    const LLMQContext& llmq_ctx = *data.test_setup.m_node.llmq_ctx;
+    auto univalue = blockToJSON(data.block, &data.blockindex, &data.blockindex, *llmq_ctx.clhandler, *llmq_ctx.isman, /*verbose*/ true);
     bench.run([&] {
         auto str = univalue.write();
         ankerl::nanobench::doNotOptimizeAway(str);

--- a/src/governance/vote.h
+++ b/src/governance/vote.h
@@ -16,7 +16,7 @@ class CKey;
 class CKeyID;
 
 // INTENTION OF MASTERNODES REGARDING ITEM
-enum vote_outcome_enum_t {
+enum vote_outcome_enum_t : uint8_t {
     VOTE_OUTCOME_NONE      = 0,
     VOTE_OUTCOME_YES       = 1,
     VOTE_OUTCOME_NO        = 2,
@@ -25,7 +25,7 @@ enum vote_outcome_enum_t {
 
 
 // SIGNAL VARIOUS THINGS TO HAPPEN:
-enum vote_signal_enum_t {
+enum vote_signal_enum_t : uint8_t {
     VOTE_SIGNAL_NONE       = 0,
     VOTE_SIGNAL_FUNDING    = 1, //   -- fund this object for it's stated amount
     VOTE_SIGNAL_VALID      = 2, //   -- this object checks out in sentinel engine

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -350,8 +350,8 @@ void PrepareShutdown(NodeContext& node)
         llmq::quorumSnapshotManager.reset();
         node.dmnman = nullptr;
         deterministicMNManager.reset();
+        node.cpoolman = nullptr;
         creditPoolManager.reset();
-        node.creditPoolManager = nullptr;
         node.mnhf_manager.reset();
         node.evodb.reset();
     }
@@ -1969,7 +1969,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                 node.dmnman = deterministicMNManager.get();
                 creditPoolManager.reset();
                 creditPoolManager = std::make_unique<CCreditPoolManager>(*node.evodb);
-                node.creditPoolManager = creditPoolManager.get();
+                node.cpoolman = creditPoolManager.get();
                 llmq::quorumSnapshotManager.reset();
                 llmq::quorumSnapshotManager.reset(new llmq::CQuorumSnapshotManager(*node.evodb));
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1716,7 +1716,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(chainparams, *node.connman, *node.addrman, node.banman.get(),
-                                     *node.scheduler, chainman, *node.mempool, *::governance,
+                                     *node.scheduler, chainman, *node.mempool, *node.govman,
                                      node.cj_ctx, node.llmq_ctx, ignores_incoming_txs);
     RegisterValidationInterface(node.peerman.get());
 
@@ -1731,25 +1731,25 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         vSporkAddresses = Params().SporkAddresses();
     }
     for (const auto& address: vSporkAddresses) {
-        if (!::sporkManager->SetSporkAddress(address)) {
+        if (!node.sporkman->SetSporkAddress(address)) {
             return InitError(_("Invalid spork address specified with -sporkaddr"));
         }
     }
 
     int minsporkkeys = args.GetArg("-minsporkkeys", Params().MinSporkKeys());
-    if (!::sporkManager->SetMinSporkKeys(minsporkkeys)) {
+    if (!node.sporkman->SetMinSporkKeys(minsporkkeys)) {
         return InitError(_("Invalid minimum number of spork signers specified with -minsporkkeys"));
     }
 
 
     if (args.IsArgSet("-sporkkey")) { // spork priv key
-        if (!::sporkManager->SetPrivKey(args.GetArg("-sporkkey", ""))) {
+        if (!node.sporkman->SetPrivKey(args.GetArg("-sporkkey", ""))) {
             return InitError(_("Unable to sign spork message, wrong key?"));
         }
     }
 
     assert(!::masternodeSync);
-    ::masternodeSync = std::make_unique<CMasternodeSync>(*node.connman, *::governance);
+    ::masternodeSync = std::make_unique<CMasternodeSync>(*node.connman, *node.govman);
     node.mn_sync = ::masternodeSync.get();
 
     // sanitize comments per BIP-0014, format user agent and check total size
@@ -1873,7 +1873,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 #endif
 
     pdsNotificationInterface = new CDSNotificationInterface(
-        *node.connman, *::masternodeSync, ::deterministicMNManager, *::governance, node.llmq_ctx, node.cj_ctx
+        *node.connman, *node.mn_sync, ::deterministicMNManager, *node.govman, node.llmq_ctx, node.cj_ctx
     );
     RegisterValidationInterface(pdsNotificationInterface);
 
@@ -1885,7 +1885,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     // ********************************************************* Step 7a: Load sporks
 
-    if (!::sporkManager->LoadCache()) {
+    if (!node.sporkman->LoadCache()) {
         auto file_path = (GetDataDir() / "sporks.dat").string();
         return InitError(strprintf(_("Failed to load sporks cache from %s"), file_path));
     }
@@ -1978,7 +1978,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                     node.llmq_ctx->Stop();
                 }
                 node.llmq_ctx.reset();
-                node.llmq_ctx.reset(new LLMQContext(chainman.ActiveChainstate(), *node.connman, *node.evodb, *::sporkManager, *node.mempool, node.peerman, false, fReset || fReindexChainState));
+                node.llmq_ctx.reset(new LLMQContext(chainman.ActiveChainstate(), *node.connman, *node.evodb, *node.sporkman, *node.mempool, node.peerman, false, fReset || fReindexChainState));
                 // Have to start it early to let VerifyDB check ChainLock signatures in coinbase
                 node.llmq_ctx->Start();
 
@@ -2111,11 +2111,11 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                     break; // out of the chainstate activation do-while
                 }
 
-                if (!deterministicMNManager->MigrateDBIfNeeded()) {
+                if (!node.dmnman->MigrateDBIfNeeded()) {
                     strLoadError = _("Error upgrading evo database");
                     break;
                 }
-                if (!deterministicMNManager->MigrateDBIfNeeded2()) {
+                if (!node.dmnman->MigrateDBIfNeeded2()) {
                     strLoadError = _("Error upgrading evo database");
                     break;
                 }
@@ -2219,7 +2219,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     // ********************************************************* Step 7c: Setup CoinJoin
 
-    node.cj_ctx = std::make_unique<CJContext>(chainman.ActiveChainstate(), *node.connman, *node.mempool, *::masternodeSync, !ignores_incoming_txs);
+    node.cj_ctx = std::make_unique<CJContext>(chainman.ActiveChainstate(), *node.connman, *node.mempool, *node.mn_sync, !ignores_incoming_txs);
 
 #ifdef ENABLE_WALLET
     node.coinjoin_loader = interfaces::MakeCoinJoinLoader(*node.cj_ctx->walletman);
@@ -2231,7 +2231,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     bool fLoadCacheFiles = !(fReindex || fReindexChainState) && (::ChainActive().Tip() != nullptr);
 
     if (!fDisableGovernance) {
-        if (!::governance->LoadCache(fLoadCacheFiles)) {
+        if (!node.govman->LoadCache(fLoadCacheFiles)) {
             auto file_path = (GetDataDir() / "governance.dat").string();
             if (fLoadCacheFiles && !fDisableGovernance) {
                 return InitError(strprintf(_("Failed to load governance cache from %s"), file_path));
@@ -2247,7 +2247,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     assert(!::mmetaman);
     ::mmetaman = std::make_unique<CMasternodeMetaMan>(fLoadCacheFiles);
     node.mn_metaman = ::mmetaman.get();
-    if (!::mmetaman->IsValid()) {
+    if (!node.mn_metaman->IsValid()) {
         auto file_path = (GetDataDir() / "mncache.dat").string();
         if (fLoadCacheFiles) {
             return InitError(strprintf(_("Failed to load masternode cache from %s"), file_path));
@@ -2258,7 +2258,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     assert(!::netfulfilledman);
     ::netfulfilledman = std::make_unique<CNetFulfilledRequestManager>(fLoadCacheFiles);
     node.netfulfilledman = ::netfulfilledman.get();
-    if (!::netfulfilledman->IsValid()) {
+    if (!node.netfulfilledman->IsValid()) {
         auto file_path = (GetDataDir() / "netfulfilled.dat").string();
         if (fLoadCacheFiles) {
             return InitError(strprintf(_("Failed to load fulfilled requests cache from %s"), file_path));
@@ -2329,13 +2329,13 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     // ********************************************************* Step 10a: schedule Dash-specific tasks
 
-    node.scheduler->scheduleEvery(std::bind(&CNetFulfilledRequestManager::DoMaintenance, std::ref(*netfulfilledman)), std::chrono::minutes{1});
-    node.scheduler->scheduleEvery(std::bind(&CMasternodeSync::DoMaintenance, std::ref(*::masternodeSync)), std::chrono::seconds{1});
-    node.scheduler->scheduleEvery(std::bind(&CMasternodeUtils::DoMaintenance, std::ref(*node.connman), std::ref(*::masternodeSync), std::ref(*node.cj_ctx)), std::chrono::minutes{1});
-    node.scheduler->scheduleEvery(std::bind(&CDeterministicMNManager::DoMaintenance, std::ref(*deterministicMNManager)), std::chrono::seconds{10});
+    node.scheduler->scheduleEvery(std::bind(&CNetFulfilledRequestManager::DoMaintenance, std::ref(*node.netfulfilledman)), std::chrono::minutes{1});
+    node.scheduler->scheduleEvery(std::bind(&CMasternodeSync::DoMaintenance, std::ref(*node.mn_sync)), std::chrono::seconds{1});
+    node.scheduler->scheduleEvery(std::bind(&CMasternodeUtils::DoMaintenance, std::ref(*node.connman), std::ref(*node.mn_sync), std::ref(*node.cj_ctx)), std::chrono::minutes{1});
+    node.scheduler->scheduleEvery(std::bind(&CDeterministicMNManager::DoMaintenance, std::ref(*node.dmnman)), std::chrono::seconds{10});
 
     if (!fDisableGovernance) {
-        node.scheduler->scheduleEvery(std::bind(&CGovernanceManager::DoMaintenance, std::ref(*::governance), std::ref(*node.connman)), std::chrono::minutes{5});
+        node.scheduler->scheduleEvery(std::bind(&CGovernanceManager::DoMaintenance, std::ref(*node.govman), std::ref(*node.connman)), std::chrono::minutes{5});
     }
 
     if (fMasternodeMode) {

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -53,6 +53,7 @@ class EVO
 public:
     virtual ~EVO() {}
     virtual std::pair<CDeterministicMNList, const CBlockIndex*> getListAtChainTip() = 0;
+    virtual void setContext(NodeContext* context) {}
 };
 
 //! Interface for the src/governance part of a dash node (dashd process).
@@ -63,6 +64,7 @@ public:
     virtual void getAllNewerThan(std::vector<CGovernanceObject> &objs, int64_t nMoreThanTime) = 0;
     virtual int32_t getObjAbsYesCount(const CGovernanceObject& obj, vote_signal_enum_t vote_signal) = 0;
     virtual bool getObjLocalValidity(const CGovernanceObject& obj, std::string& error, bool check_collateral) = 0;
+    virtual void setContext(NodeContext* context) {}
 };
 
 //! Interface for the src/llmq part of a dash node (dashd process).
@@ -71,6 +73,7 @@ class LLMQ
 public:
     virtual ~LLMQ() {}
     virtual size_t getInstantSentLockCount() = 0;
+    virtual void setContext(NodeContext* context) {}
 };
 
 //! Interface for the src/masternode part of a dash node (dashd process).
@@ -83,6 +86,7 @@ public:
     virtual bool isBlockchainSynced() = 0;
     virtual bool isSynced() = 0;
     virtual std::string getSyncStatus() =  0;
+    virtual void setContext(NodeContext* context) {}
 };
 }
 

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -37,6 +37,8 @@ enum class SynchronizationState;
 struct CNodeStateStats;
 struct NodeContext;
 
+enum vote_signal_enum_t : uint8_t;
+
 namespace interfaces {
 class Handler;
 class WalletLoader;
@@ -59,6 +61,8 @@ class GOV
 public:
     virtual ~GOV() {}
     virtual void getAllNewerThan(std::vector<CGovernanceObject> &objs, int64_t nMoreThanTime) = 0;
+    virtual int32_t getObjAbsYesCount(const CGovernanceObject& obj, vote_signal_enum_t vote_signal) = 0;
+    virtual bool getObjLocalValidity(const CGovernanceObject& obj, std::string& error, bool check_collateral) = 0;
 };
 
 //! Interface for the src/llmq part of a dash node (dashd process).

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -16,9 +16,16 @@ class CAddrMan;
 class CBlockPolicyEstimator;
 class CConnman;
 class CCreditPoolManager;
+class CDeterministicMNManager;
 class ChainstateManager;
+class CDSTXManager;
 class CEvoDB;
+class CGovernanceManager;
+class CMasternodeMetaMan;
+class CMasternodeSync;
+class CNetFulfilledRequestManager;
 class CScheduler;
+class CSporkManager;
 class CTxMemPool;
 class CMNHFManager;
 class PeerManager;
@@ -63,12 +70,18 @@ struct NodeContext {
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};
     //! Dash
-    std::unique_ptr<LLMQContext> llmq_ctx;
-    CCreditPoolManager* creditPoolManager;
-    std::unique_ptr<CMNHFManager> mnhf_manager;
-    std::unique_ptr<CJContext> cj_ctx;
-
     std::unique_ptr<CEvoDB> evodb;
+    std::unique_ptr<CJContext> cj_ctx;
+    std::unique_ptr<CMNHFManager> mnhf_manager;
+    std::unique_ptr<LLMQContext> llmq_ctx;
+    CCreditPoolManager* creditPoolManager{nullptr};
+    CDeterministicMNManager* dmnman{nullptr};
+    CDSTXManager* dstxman{nullptr};
+    CGovernanceManager* govman{nullptr};
+    CMasternodeMetaMan* mn_metaman{nullptr};
+    CMasternodeSync* mn_sync{nullptr};
+    CNetFulfilledRequestManager* netfulfilledman{nullptr};
+    CSporkManager* sporkman{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -74,7 +74,7 @@ struct NodeContext {
     std::unique_ptr<CJContext> cj_ctx;
     std::unique_ptr<CMNHFManager> mnhf_manager;
     std::unique_ptr<LLMQContext> llmq_ctx;
-    CCreditPoolManager* creditPoolManager{nullptr};
+    CCreditPoolManager* cpoolman{nullptr};
     CDeterministicMNManager* dmnman{nullptr};
     CDSTXManager* dstxman{nullptr};
     CGovernanceManager* govman{nullptr};

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -100,8 +100,29 @@ class GOVImpl : public GOV
 public:
     void getAllNewerThan(std::vector<CGovernanceObject> &objs, int64_t nMoreThanTime) override
     {
-        if (governance == nullptr) return;
-        governance->GetAllNewerThan(objs, nMoreThanTime);
+        if (::governance != nullptr) {
+            return ::governance->GetAllNewerThan(objs, nMoreThanTime);
+        }
+        return;
+    }
+    int32_t getObjAbsYesCount(const CGovernanceObject& obj, vote_signal_enum_t vote_signal) override
+    {
+        // TODO: Move GetListAtChainTip query outside CGovernanceObject, query requires
+        //       active CDeterministicMNManager instance
+        if (::governance != nullptr && ::deterministicMNManager != nullptr) {
+            return obj.GetAbsoluteYesCount(vote_signal);
+        }
+        return 0;
+    }
+    bool getObjLocalValidity(const CGovernanceObject& obj, std::string& error, bool check_collateral) override
+    {
+        // TODO: Move GetListAtChainTip query outside CGovernanceObject, query requires
+        //       active CDeterministicMNManager instance
+        if (::governance != nullptr && ::deterministicMNManager != nullptr) {
+            LOCK(cs_main);
+            return obj.IsValidLocally(error, check_collateral);
+        }
+        return false;
     }
 };
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -83,33 +83,46 @@ namespace node {
 namespace {
 class EVOImpl : public EVO
 {
+private:
+    ChainstateManager& chainman() { return *Assert(m_context->chainman); }
+    NodeContext& context() { return *Assert(m_context); }
+
 public:
     std::pair<CDeterministicMNList, const CBlockIndex*> getListAtChainTip() override
     {
-        const CBlockIndex *tip = WITH_LOCK(::cs_main, return ::ChainActive().Tip());
+        const CBlockIndex *tip = WITH_LOCK(::cs_main, return chainman().ActiveChain().Tip());
         CDeterministicMNList mnList{};
-        if  (tip != nullptr && deterministicMNManager != nullptr) {
-            mnList = deterministicMNManager->GetListForBlock(tip);
+        if (tip != nullptr && context().dmnman != nullptr) {
+            mnList = context().dmnman->GetListForBlock(tip);
         }
         return {std::move(mnList), tip};
     }
+    void setContext(NodeContext* context) override
+    {
+        m_context = context;
+    }
+
+private:
+    NodeContext* m_context{nullptr};
 };
 
 class GOVImpl : public GOV
 {
+private:
+    NodeContext& context() { return *Assert(m_context); }
+
 public:
     void getAllNewerThan(std::vector<CGovernanceObject> &objs, int64_t nMoreThanTime) override
     {
-        if (::governance != nullptr) {
-            return ::governance->GetAllNewerThan(objs, nMoreThanTime);
+        if (context().govman != nullptr) {
+            context().govman->GetAllNewerThan(objs, nMoreThanTime);
         }
-        return;
     }
     int32_t getObjAbsYesCount(const CGovernanceObject& obj, vote_signal_enum_t vote_signal) override
     {
         // TODO: Move GetListAtChainTip query outside CGovernanceObject, query requires
         //       active CDeterministicMNManager instance
-        if (::governance != nullptr && ::deterministicMNManager != nullptr) {
+        if (context().govman != nullptr && context().dmnman != nullptr) {
             return obj.GetAbsoluteYesCount(vote_signal);
         }
         return 0;
@@ -118,39 +131,78 @@ public:
     {
         // TODO: Move GetListAtChainTip query outside CGovernanceObject, query requires
         //       active CDeterministicMNManager instance
-        if (::governance != nullptr && ::deterministicMNManager != nullptr) {
+        if (context().govman != nullptr && context().dmnman != nullptr) {
             LOCK(cs_main);
             return obj.IsValidLocally(error, check_collateral);
         }
         return false;
     }
+    void setContext(NodeContext* context) override
+    {
+        m_context = context;
+    }
+
+private:
+    NodeContext* m_context{nullptr};
 };
 
 class LLMQImpl : public LLMQ
 {
+private:
+    NodeContext& context() { return *Assert(m_context); }
+
 public:
     size_t getInstantSentLockCount() override
     {
-        return llmq::quorumInstantSendManager == nullptr ? 0 : llmq::quorumInstantSendManager->GetInstantSendLockCount();
+        if (context().llmq_ctx->isman != nullptr) {
+            return context().llmq_ctx->isman->GetInstantSendLockCount();
+        }
+        return 0;
     }
+    void setContext(NodeContext* context) override
+    {
+        m_context = context;
+    }
+
+private:
+    NodeContext* m_context{nullptr};
 };
 
 namespace Masternode = interfaces::Masternode;
 class MasternodeSyncImpl : public Masternode::Sync
 {
+private:
+    NodeContext& context() { return *Assert(m_context); }
+
 public:
     bool isSynced() override
     {
-        return ::masternodeSync == nullptr ? false : ::masternodeSync->IsSynced();
+        if (context().mn_sync != nullptr) {
+            return context().mn_sync->IsSynced();
+        }
+        return false;
     }
     bool isBlockchainSynced() override
     {
-        return ::masternodeSync == nullptr ? false : ::masternodeSync->IsBlockchainSynced();
+        if (context().mn_sync != nullptr) {
+            return context().mn_sync->IsBlockchainSynced();
+        }
+        return false;
     }
     std::string getSyncStatus() override
     {
-        return ::masternodeSync == nullptr ? "" : ::masternodeSync->GetSyncStatus();
+        if (context().mn_sync != nullptr) {
+            return context().mn_sync->GetSyncStatus();
+        }
+        return "";
     }
+    void setContext(NodeContext* context) override
+    {
+        m_context = context;
+    }
+
+private:
+    NodeContext* m_context{nullptr};
 };
 
 namespace CoinJoin = interfaces::CoinJoin;
@@ -539,6 +591,11 @@ public:
     void setContext(NodeContext* context) override
     {
         m_context = context;
+        m_evo.setContext(context);
+        m_gov.setContext(context);
+        m_llmq.setContext(context);
+        m_masternodeSync.setContext(context);
+
         if (context) {
             m_context_ref = *context;
         } else {
@@ -748,8 +805,8 @@ public:
     {
         const CBlockIndex *tip = WITH_LOCK(::cs_main, return ::ChainActive().Tip());
         CDeterministicMNList mnList{};
-        if  (tip != nullptr && deterministicMNManager != nullptr) {
-            mnList = deterministicMNManager->GetListForBlock(tip);
+        if  (tip != nullptr && m_node.dmnman != nullptr) {
+            mnList = m_node.dmnman->GetListForBlock(tip);
         }
         std::vector<COutPoint> listRet;
         for (const auto& [tx, index]: outputs) {

--- a/src/qt/governancelist.h
+++ b/src/qt/governancelist.h
@@ -59,7 +59,9 @@ class Proposal : public QObject
 private:
     Q_OBJECT
 
+    ClientModel* clientModel;
     const CGovernanceObject govObj;
+
     QString m_title;
     QDateTime m_startDate;
     QDateTime m_endDate;
@@ -67,7 +69,7 @@ private:
     QString m_url;
 
 public:
-    explicit Proposal(const CGovernanceObject& _govObj, QObject* parent = nullptr);
+    explicit Proposal(ClientModel* _clientModel, const CGovernanceObject& _govObj, QObject* parent = nullptr);
     QString title() const;
     QString hash() const;
     QDateTime startDate() const;

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -52,7 +52,8 @@ static UniValue gobject_count(const JSONRPCRequest& request)
     if (strMode != "json" && strMode != "all")
         gobject_count_help(request);
 
-    return strMode == "json" ? governance->ToJson() : governance->ToString();
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    return strMode == "json" ? node.govman->ToJson() : node.govman->ToString();
 }
 
 static void gobject_deserialize_help(const JSONRPCRequest& request)
@@ -304,11 +305,13 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 {
     gobject_submit_help(request);
 
-    if(!::masternodeSync->IsBlockchainSynced()) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+
+    if(!node.mn_sync->IsBlockchainSynced()) {
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Must wait for client to sync with masternode network. Try again in a minute or so.");
     }
 
-    auto mnList = deterministicMNManager->GetListAtChainTip();
+    auto mnList = node.dmnman->GetListAtChainTip();
     bool fMnFound = WITH_LOCK(activeMasternodeInfoCs, return mnList.HasValidMNByCollateral(activeMasternodeInfo.outpoint));
 
     LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
@@ -354,7 +357,6 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 
     std::string strHash = govobj.GetHash().ToString();
 
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
     const CTxMemPool& mempool = EnsureMemPool(node);
     bool fMissingConfirmations;
     {
@@ -372,7 +374,7 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 
     // RELAY THIS OBJECT
     // Reject if rate check fails but don't update buffer
-    if (!governance->MasternodeRateCheck(govobj)) {
+    if (!node.govman->MasternodeRateCheck(govobj)) {
         LogPrintf("gobject(submit) -- Object submission rejected because of rate check failure - hash = %s\n", strHash);
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Object creation rate limit exceeded");
     }
@@ -380,10 +382,10 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
     LogPrintf("gobject(submit) -- Adding locally created governance object - %s\n", strHash);
 
     if (fMissingConfirmations) {
-        governance->AddPostponedObject(govobj);
+        node.govman->AddPostponedObject(govobj);
         govobj.Relay(*node.connman);
     } else {
-        governance->AddGovernanceObject(govobj, *node.connman);
+        node.govman->AddGovernanceObject(govobj, *node.connman);
     }
 
     return govobj.GetHash().ToString();
@@ -395,8 +397,8 @@ static UniValue VoteWithMasternodes(const JSONRPCRequest& request, const std::ma
 {
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     {
-        LOCK(governance->cs);
-        const CGovernanceObject *pGovObj = governance->FindConstGovernanceObject(hash);
+        LOCK(node.govman->cs);
+        const CGovernanceObject *pGovObj = node.govman->FindConstGovernanceObject(hash);
         if (!pGovObj) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Governance object not found");
         }
@@ -405,7 +407,7 @@ static UniValue VoteWithMasternodes(const JSONRPCRequest& request, const std::ma
     int nSuccessful = 0;
     int nFailed = 0;
 
-    auto mnList = deterministicMNManager->GetListAtChainTip();
+    auto mnList = node.dmnman->GetListAtChainTip();
 
     UniValue resultsObj(UniValue::VOBJ);
 
@@ -434,7 +436,7 @@ static UniValue VoteWithMasternodes(const JSONRPCRequest& request, const std::ma
         }
 
         CGovernanceException exception;
-        if (governance->ProcessVoteAndRelay(vote, exception, *node.connman)) {
+        if (node.govman->ProcessVoteAndRelay(vote, exception, *node.connman)) {
             nSuccessful++;
             statusObj.pushKV("result", "success");
         } else {
@@ -476,6 +478,8 @@ static UniValue gobject_vote_many(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
 
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+
     uint256 hash(ParseHashV(request.params[0], "Object hash"));
     std::string strVoteSignal = request.params[1].get_str();
     std::string strVoteOutcome = request.params[2].get_str();
@@ -501,7 +505,7 @@ static UniValue gobject_vote_many(const JSONRPCRequest& request)
 
     std::map<uint256, CKey> votingKeys;
 
-    auto mnList = deterministicMNManager->GetListAtChainTip();
+    auto mnList = node.dmnman->GetListAtChainTip();
     mnList.ForEachMN(true, [&](auto& dmn) {
         CKey votingKey;
         if (spk_man->GetKey(dmn.pdmnState->keyIDVoting, votingKey)) {
@@ -535,6 +539,8 @@ static UniValue gobject_vote_alias(const JSONRPCRequest& request)
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
 
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+
     uint256 hash(ParseHashV(request.params[0], "Object hash"));
     std::string strVoteSignal = request.params[1].get_str();
     std::string strVoteOutcome = request.params[2].get_str();
@@ -554,7 +560,7 @@ static UniValue gobject_vote_alias(const JSONRPCRequest& request)
     EnsureWalletIsUnlocked(wallet.get());
 
     uint256 proTxHash(ParseHashV(request.params[3], "protx-hash"));
-    auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMN(proTxHash);
+    auto dmn = node.dmnman->GetListAtChainTip().GetValidMN(proTxHash);
     if (!dmn) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid or unknown proTxHash");
     }
@@ -576,7 +582,8 @@ static UniValue gobject_vote_alias(const JSONRPCRequest& request)
 }
 #endif
 
-static UniValue ListObjects(const std::string& strCachedSignal, const std::string& strType, int nStartTime)
+static UniValue ListObjects(CGovernanceManager& govman, const std::string& strCachedSignal,
+                            const std::string& strType, int nStartTime)
 {
     UniValue objResult(UniValue::VOBJ);
 
@@ -586,12 +593,12 @@ static UniValue ListObjects(const std::string& strCachedSignal, const std::strin
         g_txindex->BlockUntilSyncedToCurrentChain();
     }
 
-    LOCK2(cs_main, governance->cs);
+    LOCK2(cs_main, govman.cs);
 
     std::vector<CGovernanceObject> objs;
-    governance->GetAllNewerThan(objs, nStartTime);
+    govman.GetAllNewerThan(objs, nStartTime);
 
-    governance->UpdateLastDiffTime(GetTime());
+    govman.UpdateLastDiffTime(GetTime());
     // CREATE RESULTS FOR USER
 
     for (const auto& govObj : objs) {
@@ -667,7 +674,8 @@ static UniValue gobject_list(const JSONRPCRequest& request)
     if (strType != "proposals" && strType != "triggers" && strType != "all")
         return "Invalid type, should be 'proposals', 'triggers' or 'all'";
 
-    return ListObjects(strCachedSignal, strType, 0);
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    return ListObjects(*node.govman, strCachedSignal, strType, 0);
 }
 
 static void gobject_diff_help(const JSONRPCRequest& request)
@@ -701,7 +709,8 @@ static UniValue gobject_diff(const JSONRPCRequest& request)
     if (strType != "proposals" && strType != "triggers" && strType != "all")
         return "Invalid type, should be 'proposals', 'triggers' or 'all'";
 
-    return ListObjects(strCachedSignal, strType, governance->GetLastDiffTime());
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    return ListObjects(*node.govman, strCachedSignal, strType, node.govman->GetLastDiffTime());
 }
 
 static void gobject_get_help(const JSONRPCRequest& request)
@@ -728,8 +737,10 @@ static UniValue gobject_get(const JSONRPCRequest& request)
     }
 
     // FIND THE GOVERNANCE OBJECT THE USER IS LOOKING FOR
-    LOCK2(cs_main, governance->cs);
-    const CGovernanceObject* pGovObj = governance->FindConstGovernanceObject(hash);
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+
+    LOCK2(cs_main, node.govman->cs);
+    const CGovernanceObject* pGovObj = node.govman->FindConstGovernanceObject(hash);
 
     if (pGovObj == nullptr) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown governance object");
@@ -824,10 +835,10 @@ static UniValue gobject_getcurrentvotes(const JSONRPCRequest& request)
     }
 
     // FIND OBJECT USER IS LOOKING FOR
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
 
-    LOCK(governance->cs);
-
-    const CGovernanceObject* pGovObj = governance->FindConstGovernanceObject(hash);
+    LOCK(node.govman->cs);
+    const CGovernanceObject* pGovObj = node.govman->FindConstGovernanceObject(hash);
 
     if (pGovObj == nullptr) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Unknown governance-hash");
@@ -839,9 +850,9 @@ static UniValue gobject_getcurrentvotes(const JSONRPCRequest& request)
 
     // GET MATCHING VOTES BY HASH, THEN SHOW USERS VOTE INFORMATION
 
-    std::vector<CGovernanceVote> vecVotes = governance->GetCurrentVotes(hash, mnCollateralOutpoint);
+    std::vector<CGovernanceVote> vecVotes = node.govman->GetCurrentVotes(hash, mnCollateralOutpoint);
     for (const auto& vote : vecVotes) {
-        bResult.pushKV(vote.GetHash().ToString(),  vote.ToString());
+        bResult.pushKV(vote.GetHash().ToString(), vote.ToString());
     }
 
     return bResult;
@@ -962,9 +973,10 @@ static UniValue voteraw(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid vote outcome. Please use one of the following: 'yes', 'no' or 'abstain'");
     }
 
-    GovernanceObject govObjType = WITH_LOCK(governance->cs, return [&](){
-        AssertLockHeld(governance->cs);
-        const CGovernanceObject *pGovObj = governance->FindConstGovernanceObject(hashGovObj);
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    GovernanceObject govObjType = WITH_LOCK(node.govman->cs, return [&](){
+        AssertLockHeld(node.govman->cs);
+        const CGovernanceObject *pGovObj = node.govman->FindConstGovernanceObject(hashGovObj);
         if (!pGovObj) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Governance object not found");
         }
@@ -981,7 +993,7 @@ static UniValue voteraw(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Malformed base64 encoding");
     }
 
-    auto dmn = deterministicMNManager->GetListAtChainTip().GetValidMNByCollateral(outpoint);
+    auto dmn = node.dmnman->GetListAtChainTip().GetValidMNByCollateral(outpoint);
 
     if (!dmn) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Failure to find masternode in list : " + outpoint.ToStringShort());
@@ -998,8 +1010,7 @@ static UniValue voteraw(const JSONRPCRequest& request)
     }
 
     CGovernanceException exception;
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    if (governance->ProcessVoteAndRelay(vote, exception, *node.connman)) {
+    if (node.govman->ProcessVoteAndRelay(vote, exception, *node.connman)) {
         return "Voted successfully";
     } else {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Error voting : " + exception.GetMessage());
@@ -1032,7 +1043,9 @@ static UniValue getgovernanceinfo(const JSONRPCRequest& request)
 
     int nLastSuperblock = 0, nNextSuperblock = 0;
 
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
     const ChainstateManager& chainman = EnsureAnyChainman(request.context);
+
     const auto* pindex = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip());
     int nBlockHeight = pindex->nHeight;
 
@@ -1045,7 +1058,7 @@ static UniValue getgovernanceinfo(const JSONRPCRequest& request)
     obj.pushKV("superblockmaturitywindow", Params().GetConsensus().nSuperblockMaturityWindow);
     obj.pushKV("lastsuperblock", nLastSuperblock);
     obj.pushKV("nextsuperblock", nNextSuperblock);
-    obj.pushKV("fundingthreshold", int(deterministicMNManager->GetListAtChainTip().GetValidWeightedMNsCount() / 10));
+    obj.pushKV("fundingthreshold", int(node.dmnman->GetListAtChainTip().GetValidWeightedMNsCount() / 10));
     obj.pushKV("governancebudget", ValueFromAmount(CSuperblock::GetPaymentsLimit(nNextSuperblock)));
 
     return obj;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -106,7 +106,9 @@ static UniValue masternode_count(const JSONRPCRequest& request)
 {
     masternode_count_help(request);
 
-    auto mnList = deterministicMNManager->GetListAtChainTip();
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+
+    auto mnList = node.dmnman->GetListAtChainTip();
     int total = mnList.GetAllMNsCount();
     int enabled = mnList.GetValidMNsCount();
 
@@ -133,10 +135,10 @@ static UniValue masternode_count(const JSONRPCRequest& request)
     return obj;
 }
 
-static UniValue GetNextMasternodeForPayment(int heightShift)
+static UniValue GetNextMasternodeForPayment(CDeterministicMNManager& dmnman, int heightShift)
 {
     const CBlockIndex *tip = WITH_LOCK(::cs_main, return ::ChainActive().Tip());
-    auto mnList = deterministicMNManager->GetListForBlock(tip);
+    auto mnList = dmnman.GetListForBlock(tip);
     auto payees = mnList.GetProjectedMNPayees(tip, heightShift);
     if (payees.empty())
         return "unknown";
@@ -173,7 +175,9 @@ static void masternode_winner_help(const JSONRPCRequest& request)
 static UniValue masternode_winner(const JSONRPCRequest& request)
 {
     masternode_winner_help(request);
-    return GetNextMasternodeForPayment(10);
+
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    return GetNextMasternodeForPayment(*node.dmnman, 10);
 }
 
 static void masternode_current_help(const JSONRPCRequest& request)
@@ -193,7 +197,9 @@ static void masternode_current_help(const JSONRPCRequest& request)
 static UniValue masternode_current(const JSONRPCRequest& request)
 {
     masternode_current_help(request);
-    return GetNextMasternodeForPayment(1);
+
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    return GetNextMasternodeForPayment(*node.dmnman, 1);
 }
 
 #ifdef ENABLE_WALLET
@@ -253,8 +259,9 @@ static UniValue masternode_status(const JSONRPCRequest& request)
     if (!fMasternodeMode)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "This is not a masternode");
 
-    UniValue mnObj(UniValue::VOBJ);
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
 
+    UniValue mnObj(UniValue::VOBJ);
     CDeterministicMNCPtr dmn;
     {
         LOCK(activeMasternodeInfoCs);
@@ -262,7 +269,7 @@ static UniValue masternode_status(const JSONRPCRequest& request)
         // keep compatibility with legacy status for now (might get deprecated/removed later)
         mnObj.pushKV("outpoint", activeMasternodeInfo.outpoint.ToStringShort());
         mnObj.pushKV("service", activeMasternodeInfo.service.ToString());
-        dmn = deterministicMNManager->GetListAtChainTip().GetMN(activeMasternodeInfo.proTxHash);
+        dmn = node.dmnman->GetListAtChainTip().GetMN(activeMasternodeInfo.proTxHash);
     }
     if (dmn) {
         mnObj.pushKV("proTxHash", dmn->proTxHash.ToString());
@@ -277,7 +284,7 @@ static UniValue masternode_status(const JSONRPCRequest& request)
     return mnObj;
 }
 
-static std::string GetRequiredPaymentsString(int nBlockHeight, const CDeterministicMNCPtr &payee)
+static std::string GetRequiredPaymentsString(CGovernanceManager& govman, int nBlockHeight, const CDeterministicMNCPtr &payee)
 {
     std::string strPayments = "Unknown";
     if (payee) {
@@ -293,9 +300,9 @@ static std::string GetRequiredPaymentsString(int nBlockHeight, const CDeterminis
             strPayments += ", " + EncodeDestination(dest);
         }
     }
-    if (CSuperblockManager::IsSuperblockTriggered(*governance, nBlockHeight)) {
+    if (CSuperblockManager::IsSuperblockTriggered(govman, nBlockHeight)) {
         std::vector<CTxOut> voutSuperblock;
-        if (!CSuperblockManager::GetSuperblockPayments(*governance, nBlockHeight, voutSuperblock)) {
+        if (!CSuperblockManager::GetSuperblockPayments(govman, nBlockHeight, voutSuperblock)) {
             return strPayments + ", error";
         }
         std::string strSBPayees = "Unknown";
@@ -353,24 +360,26 @@ static UniValue masternode_winners(const JSONRPCRequest& request, const Chainsta
     int nChainTipHeight = pindexTip->nHeight;
     int nStartHeight = std::max(nChainTipHeight - nCount, 1);
 
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
     for (int h = nStartHeight; h <= nChainTipHeight; h++) {
         const CBlockIndex* pIndex = pindexTip->GetAncestor(h - 1);
-        auto payee = deterministicMNManager->GetListForBlock(pIndex).GetMNPayee(pIndex);
-        std::string strPayments = GetRequiredPaymentsString(h, payee);
+        auto payee = node.dmnman->GetListForBlock(pIndex).GetMNPayee(pIndex);
+        std::string strPayments = GetRequiredPaymentsString(*node.govman, h, payee);
         if (strFilter != "" && strPayments.find(strFilter) == std::string::npos) continue;
         obj.pushKV(strprintf("%d", h), strPayments);
     }
 
-    auto projection = deterministicMNManager->GetListForBlock(pindexTip).GetProjectedMNPayees(pindexTip, 20);
+    auto projection = node.dmnman->GetListForBlock(pindexTip).GetProjectedMNPayees(pindexTip, 20);
     for (size_t i = 0; i < projection.size(); i++) {
         int h = nChainTipHeight + 1 + i;
-        std::string strPayments = GetRequiredPaymentsString(h, projection[i]);
+        std::string strPayments = GetRequiredPaymentsString(*node.govman, h, projection[i]);
         if (strFilter != "" && strPayments.find(strFilter) == std::string::npos) continue;
         obj.pushKV(strprintf("%d", h), strPayments);
     }
 
     return obj;
 }
+
 static void masternode_payments_help(const JSONRPCRequest& request)
 {
     RPCHelpMan{"masternode payments",
@@ -432,8 +441,8 @@ static UniValue masternode_payments(const JSONRPCRequest& request, const Chainst
     // A temporary vector which is used to sort results properly (there is no "reverse" in/for UniValue)
     std::vector<UniValue> vecPayments;
 
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
     while (vecPayments.size() < uint64_t(std::abs(nCount)) && pindex != nullptr) {
-
         CBlock block;
         if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
@@ -459,7 +468,7 @@ static UniValue masternode_payments(const JSONRPCRequest& request, const Chainst
         std::vector<CTxOut> voutMasternodePayments, voutDummy;
         CMutableTransaction dummyTx;
         CAmount blockSubsidy = GetBlockSubsidy(pindex, Params().GetConsensus());
-        MasternodePayments::FillBlockPayments(*sporkManager, *governance, dummyTx, pindex->pprev, blockSubsidy, nBlockFees, voutMasternodePayments, voutDummy);
+        MasternodePayments::FillBlockPayments(*node.sporkman, *node.govman, dummyTx, pindex->pprev, blockSubsidy, nBlockFees, voutMasternodePayments, voutDummy);
 
         UniValue blockObj(UniValue::VOBJ);
         CAmount payedPerBlock{0};
@@ -481,7 +490,7 @@ static UniValue masternode_payments(const JSONRPCRequest& request, const Chainst
         }
 
         // NOTE: we use _previous_ block to find a payee for the current one
-        const auto dmnPayee = deterministicMNManager->GetListForBlock(pindex->pprev).GetMNPayee(pindex->pprev);
+        const auto dmnPayee = node.dmnman->GetListForBlock(pindex->pprev).GetMNPayee(pindex->pprev);
         protxObj.pushKV("proTxHash", dmnPayee == nullptr ? "" : dmnPayee->proTxHash.ToString());
         protxObj.pushKV("amount", payedPerMasternode);
         protxObj.pushKV("payees", payeesArr);
@@ -589,9 +598,11 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
         masternode_list_help(request);
     }
 
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+
     UniValue obj(UniValue::VOBJ);
 
-    auto mnList = deterministicMNManager->GetListAtChainTip();
+    auto mnList = node.dmnman->GetListAtChainTip();
     auto dmnToStatus = [&](auto& dmn) {
         if (mnList.IsMNValid(dmn)) {
             return "ENABLED";

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -381,7 +381,7 @@ static void quorum_memberof_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static UniValue quorum_memberof(const JSONRPCRequest& request, const ChainstateManager& chainman, const LLMQContext& llmq_ctx)
+static UniValue quorum_memberof(const JSONRPCRequest& request, const ChainstateManager& chainman, const NodeContext& node, const LLMQContext& llmq_ctx)
 {
     quorum_memberof_help(request);
 
@@ -395,8 +395,7 @@ static UniValue quorum_memberof(const JSONRPCRequest& request, const ChainstateM
     }
 
     const CBlockIndex* pindexTip = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip());
-
-    auto mnList = deterministicMNManager->GetListForBlock(pindexTip);
+    auto mnList = node.dmnman->GetListForBlock(pindexTip);
     auto dmn = mnList.GetMN(protxHash);
     if (!dmn) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "masternode not found");
@@ -885,7 +884,7 @@ static UniValue _quorum(const JSONRPCRequest& request)
     } else if (command == "quorumdkgstatus") {
         return quorum_dkgstatus(new_request, chainman, llmq_ctx);
     } else if (command == "quorummemberof") {
-        return quorum_memberof(new_request, chainman, llmq_ctx);
+        return quorum_memberof(new_request, chainman, node, llmq_ctx);
     } else if (command == "quorumsign" || command == "quorumverify" || command == "quorumhasrecsig" || command == "quorumgetrecsig" || command == "quorumisconflicting") {
         return quorum_sigs_cmd(new_request, llmq_ctx);
     } else if (command == "quorumselectquorum") {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -499,7 +499,7 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
         if (nSpecificCoreHeight.value() < 0 || nSpecificCoreHeight.value() > chainman.ActiveChain().Height()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
         }
-        poolCL = std::make_optional(node.creditPoolManager->GetCreditPool(chainman.ActiveChain()[nSpecificCoreHeight.value()], Params().GetConsensus()));
+        poolCL = std::make_optional(node.cpoolman->GetCreditPool(chainman.ActiveChain()[nSpecificCoreHeight.value()], Params().GetConsensus()));
     }
     else {
         const auto pBlockIndexBestCL = [&]() -> const CBlockIndex* {
@@ -517,12 +517,12 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
         // We need in 2 credit pools: at tip of chain and on best CL to know if tx is mined or chainlocked
         // Sometimes that's two different blocks, sometimes not and we need to initialize 2nd creditPoolManager
         poolCL = pBlockIndexBestCL ?
-                 std::make_optional(node.creditPoolManager->GetCreditPool(pBlockIndexBestCL, Params().GetConsensus())) :
+                 std::make_optional(node.cpoolman->GetCreditPool(pBlockIndexBestCL, Params().GetConsensus())) :
                  std::nullopt;
 
         poolOnTip = [&]() -> std::optional<CCreditPool> {
             if (pTipBlockIndex != pBlockIndexBestCL) {
-                return std::make_optional(node.creditPoolManager->GetCreditPool(pTipBlockIndex, Params().GetConsensus()));
+                return std::make_optional(node.cpoolman->GetCreditPool(pTipBlockIndex, Params().GetConsensus()));
             }
             return std::nullopt;
         }();

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -182,7 +182,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_ASSERT(dmnman.GetListAtChainTip().HasMN(tx.GetHash()));
         BOOST_CHECK(tip->nHeight < Params().GetConsensus().BRRHeight);
         // Creating blocks by different ways
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
     }
     for ([[maybe_unused]] auto _ : irange::range(1999)) {
         CreateAndProcessBlock({}, coinbaseKey);
@@ -212,7 +212,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_ASSERT(dmnman.GetListAtChainTip().HasMN(tx.GetHash()));
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
     }
 
@@ -226,7 +226,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 122209530);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 61104762); // 0.4999999755
@@ -244,7 +244,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
             const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
             const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
             const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-            const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         }
     }
@@ -262,7 +262,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         CAmount expected_block_reward = block_subsidy_potential - block_subsidy_potential / 5;
 
         const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), expected_block_reward);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 67550353);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
@@ -288,7 +288,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         const bool isMNRewardReallocated{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_MN_RR)};
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
 
         if (isMNRewardReallocated) {
             const CAmount platform_payment = MasternodePayments::PlatformShare(masternode_payment);
@@ -310,7 +310,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
         const CAmount platform_payment = MasternodePayments::PlatformShare(masternode_payment);
         masternode_payment -= platform_payment;
-        const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
 
         CAmount block_subsidy_potential = block_subsidy + block_subsidy_sb;
         BOOST_CHECK_EQUAL(tip->nHeight, 3858);

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -69,7 +69,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *governance, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     // Mock an outbound peer
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<CConnmanTest>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *governance, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *governance, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     banman->ClearBanned();
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *governance, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     banman->ClearBanned();
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *governance, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     banman->ClearBanned();

--- a/src/test/dynamic_activation_thresholds_tests.cpp
+++ b/src/test/dynamic_activation_thresholds_tests.cpp
@@ -81,7 +81,7 @@ struct TestChainDATSetup : public TestChainSetup
             BOOST_CHECK_EQUAL(g_versionbitscache.State(::ChainActive().Tip(), consensus_params, deployment_id), ThresholdState::STARTED);
             BOOST_CHECK_EQUAL(g_versionbitscache.Statistics(::ChainActive().Tip(), consensus_params, deployment_id).threshold, threshold(0));
             // Next block should be signaling by default
-            const auto pblocktemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             const uint32_t bitmask = ((uint32_t)1) << consensus_params.vDeployments[deployment_id].bit;
             BOOST_CHECK_EQUAL(::ChainActive().Tip()->nVersion & bitmask, 0);
             BOOST_CHECK_EQUAL(pblocktemplate->block.nVersion & bitmask, bitmask);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -202,9 +202,9 @@ static CScript GenerateRandomAddress()
     return GetScriptForDestination(PKHash(key.GetPubKey()));
 }
 
-static CDeterministicMNCPtr FindPayoutDmn(const CBlock& block)
+static CDeterministicMNCPtr FindPayoutDmn(CDeterministicMNManager& dmnman, const CBlock& block)
 {
-    auto dmnList = deterministicMNManager->GetListAtChainTip();
+    auto dmnList = dmnman.GetListAtChainTip();
 
     for (const auto& txout : block.vtx[0]->vout) {
         CDeterministicMNCPtr found;
@@ -238,6 +238,8 @@ static bool CheckTransactionSignature(const CTxMemPool& mempool, const CMutableT
 
 void FuncDIP3Activation(TestChainSetup& setup)
 {
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+
     auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
     CKey ownerKey;
     CBLSSecretKey operatorKey;
@@ -252,7 +254,7 @@ void FuncDIP3Activation(TestChainSetup& setup)
     Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr);
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
     BOOST_ASSERT(block->GetHash() != ::ChainActive().Tip()->GetBlockHash());
-    BOOST_ASSERT(!deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
+    BOOST_ASSERT(!dmnman.GetListAtChainTip().HasMN(tx.GetHash()));
 
     // This block should activate DIP3
     setup.CreateAndProcessBlock({}, setup.coinbaseKey);
@@ -260,15 +262,17 @@ void FuncDIP3Activation(TestChainSetup& setup)
     // Mining a block with a DIP3 transaction should succeed now
     block = std::make_shared<CBlock>(setup.CreateBlock(txns, setup.coinbaseKey));
     BOOST_ASSERT(Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 2);
     BOOST_CHECK_EQUAL(block->GetHash(), ::ChainActive().Tip()->GetBlockHash());
-    BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
+    BOOST_ASSERT(dmnman.GetListAtChainTip().HasMN(tx.GetHash()));
 };
 
 void FuncV19Activation(TestChainSetup& setup)
 {
     BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
+
+    auto& dmnman = *Assert(setup.m_node.dmnman);
 
     // create
     auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
@@ -287,12 +291,12 @@ void FuncV19Activation(TestChainSetup& setup)
     BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
-    deterministicMNManager->DoMaintenance();
-    auto tip_list = deterministicMNManager->GetListAtChainTip();
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.DoMaintenance();
+    auto tip_list = dmnman.GetListAtChainTip();
     BOOST_ASSERT(tip_list.HasMN(tx_reg_hash));
     auto pindex_create = ::ChainActive().Tip();
-    auto base_list = deterministicMNManager->GetListForBlock(pindex_create);
+    auto base_list = dmnman.GetListForBlock(pindex_create);
     std::vector<CDeterministicMNListDiff> diffs;
 
     // update
@@ -305,9 +309,9 @@ void FuncV19Activation(TestChainSetup& setup)
     BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
-    deterministicMNManager->DoMaintenance();
-    tip_list = deterministicMNManager->GetListAtChainTip();
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.DoMaintenance();
+    tip_list = dmnman.GetListAtChainTip();
     BOOST_ASSERT(tip_list.HasMN(tx_reg_hash));
     diffs.push_back(base_list.BuildDiff(tip_list));
 
@@ -325,36 +329,36 @@ void FuncV19Activation(TestChainSetup& setup)
     BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
-    deterministicMNManager->DoMaintenance();
-    diffs.push_back(tip_list.BuildDiff(deterministicMNManager->GetListAtChainTip()));
-    tip_list = deterministicMNManager->GetListAtChainTip();
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.DoMaintenance();
+    diffs.push_back(tip_list.BuildDiff(dmnman.GetListAtChainTip()));
+    tip_list = dmnman.GetListAtChainTip();
     BOOST_ASSERT(!tip_list.HasMN(tx_reg_hash));
-    BOOST_ASSERT(deterministicMNManager->GetListForBlock(pindex_create).HasMN(tx_reg_hash));
+    BOOST_ASSERT(dmnman.GetListForBlock(pindex_create).HasMN(tx_reg_hash));
 
     // mine another block so that it's not the last one before V19
     setup.CreateAndProcessBlock({}, setup.coinbaseKey);
     BOOST_ASSERT(!DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
-    deterministicMNManager->DoMaintenance();
-    diffs.push_back(tip_list.BuildDiff(deterministicMNManager->GetListAtChainTip()));
-    tip_list = deterministicMNManager->GetListAtChainTip();
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.DoMaintenance();
+    diffs.push_back(tip_list.BuildDiff(dmnman.GetListAtChainTip()));
+    tip_list = dmnman.GetListAtChainTip();
     BOOST_ASSERT(!tip_list.HasMN(tx_reg_hash));
-    BOOST_ASSERT(deterministicMNManager->GetListForBlock(pindex_create).HasMN(tx_reg_hash));
+    BOOST_ASSERT(dmnman.GetListForBlock(pindex_create).HasMN(tx_reg_hash));
 
     // this block should activate V19
     setup.CreateAndProcessBlock({}, setup.coinbaseKey);
     BOOST_ASSERT(DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
     ++nHeight;
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
-    deterministicMNManager->DoMaintenance();
-    diffs.push_back(tip_list.BuildDiff(deterministicMNManager->GetListAtChainTip()));
-    tip_list = deterministicMNManager->GetListAtChainTip();
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.DoMaintenance();
+    diffs.push_back(tip_list.BuildDiff(dmnman.GetListAtChainTip()));
+    tip_list = dmnman.GetListAtChainTip();
     BOOST_ASSERT(!tip_list.HasMN(tx_reg_hash));
-    BOOST_ASSERT(deterministicMNManager->GetListForBlock(pindex_create).HasMN(tx_reg_hash));
+    BOOST_ASSERT(dmnman.GetListForBlock(pindex_create).HasMN(tx_reg_hash));
 
     // check mn list/diff
     CDeterministicMNListDiff dummy_diff = base_list.BuildDiff(tip_list);
@@ -368,17 +372,17 @@ void FuncV19Activation(TestChainSetup& setup)
         setup.CreateAndProcessBlock({}, setup.coinbaseKey);
         BOOST_ASSERT(DeploymentActiveAfter(::ChainActive().Tip(), Params().GetConsensus(), Consensus::DEPLOYMENT_V19));
         BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1 + i);
-        deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
-        deterministicMNManager->DoMaintenance();
-        diffs.push_back(tip_list.BuildDiff(deterministicMNManager->GetListAtChainTip()));
-        tip_list = deterministicMNManager->GetListAtChainTip();
+        dmnman.UpdatedBlockTip(::ChainActive().Tip());
+        dmnman.DoMaintenance();
+        diffs.push_back(tip_list.BuildDiff(dmnman.GetListAtChainTip()));
+        tip_list = dmnman.GetListAtChainTip();
         BOOST_ASSERT(!tip_list.HasMN(tx_reg_hash));
-        BOOST_ASSERT(deterministicMNManager->GetListForBlock(pindex_create).HasMN(tx_reg_hash));
+        BOOST_ASSERT(dmnman.GetListForBlock(pindex_create).HasMN(tx_reg_hash));
     }
 
     // check mn list/diff
     const CBlockIndex* v19_index = ::ChainActive().Tip()->GetAncestor(Params().GetConsensus().V19Height);
-    auto v19_list = deterministicMNManager->GetListForBlock(v19_index);
+    auto v19_list = dmnman.GetListForBlock(v19_index);
     dummy_diff = v19_list.BuildDiff(tip_list);
     dummmy_list = v19_list.ApplyDiff(::ChainActive().Tip(), dummy_diff);
     BOOST_ASSERT(dummmy_list == tip_list);
@@ -398,6 +402,8 @@ void FuncV19Activation(TestChainSetup& setup)
 
 void FuncDIP3Protx(TestChainSetup& setup)
 {
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+
     CKey sporkKey;
     sporkKey.MakeNewKey(false);
     sporkManager->SetSporkAddress(EncodeDestination(PKHash(sporkKey.GetPubKey())));
@@ -438,10 +444,10 @@ void FuncDIP3Protx(TestChainSetup& setup)
         BOOST_ASSERT(!CheckTransactionSignature(*(setup.m_node.mempool), tx2));
 
         setup.CreateAndProcessBlock({tx}, setup.coinbaseKey);
-        deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+        dmnman.UpdatedBlockTip(::ChainActive().Tip());
 
         BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1);
-        BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx.GetHash()));
+        BOOST_ASSERT(dmnman.GetListAtChainTip().HasMN(tx.GetHash()));
 
         nHeight++;
     }
@@ -449,18 +455,18 @@ void FuncDIP3Protx(TestChainSetup& setup)
     int DIP0003EnforcementHeightBackup = Params().GetConsensus().DIP0003EnforcementHeight;
     const_cast<Consensus::Params&>(Params().GetConsensus()).DIP0003EnforcementHeight = ::ChainActive().Height() + 1;
     setup.CreateAndProcessBlock({}, setup.coinbaseKey);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     nHeight++;
 
     // check MN reward payments
     for (size_t i = 0; i < 20; i++) {
-        auto dmnExpectedPayee = deterministicMNManager->GetListAtChainTip().GetMNPayee(::ChainActive().Tip());
+        auto dmnExpectedPayee = dmnman.GetListAtChainTip().GetMNPayee(::ChainActive().Tip());
 
         CBlock block = setup.CreateAndProcessBlock({}, setup.coinbaseKey);
-        deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+        dmnman.UpdatedBlockTip(::ChainActive().Tip());
         BOOST_ASSERT(!block.vtx.empty());
 
-        auto dmnPayout = FindPayoutDmn(block);
+        auto dmnPayout = FindPayoutDmn(dmnman, block);
         BOOST_ASSERT(dmnPayout != nullptr);
         BOOST_CHECK_EQUAL(dmnPayout->proTxHash.ToString(), dmnExpectedPayee->proTxHash.ToString());
 
@@ -480,11 +486,11 @@ void FuncDIP3Protx(TestChainSetup& setup)
             txns.emplace_back(tx);
         }
         setup.CreateAndProcessBlock(txns, setup.coinbaseKey);
-        deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+        dmnman.UpdatedBlockTip(::ChainActive().Tip());
         BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1);
 
         for (size_t j = 0; j < 3; j++) {
-            BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(txns[j].GetHash()));
+            BOOST_ASSERT(dmnman.GetListAtChainTip().HasMN(txns[j].GetHash()));
         }
 
         nHeight++;
@@ -493,33 +499,33 @@ void FuncDIP3Protx(TestChainSetup& setup)
     // test ProUpServTx
     auto tx = CreateProUpServTx(*(setup.m_node.mempool), utxos, dmnHashes[0], operatorKeys[dmnHashes[0]], 1000, CScript(), setup.coinbaseKey);
     setup.CreateAndProcessBlock({tx}, setup.coinbaseKey);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1);
     nHeight++;
 
-    auto dmn = deterministicMNManager->GetListAtChainTip().GetMN(dmnHashes[0]);
+    auto dmn = dmnman.GetListAtChainTip().GetMN(dmnHashes[0]);
     BOOST_ASSERT(dmn != nullptr && dmn->pdmnState->addr.GetPort() == 1000);
 
     // test ProUpRevTx
     tx = CreateProUpRevTx(*(setup.m_node.mempool), utxos, dmnHashes[0], operatorKeys[dmnHashes[0]], setup.coinbaseKey);
     setup.CreateAndProcessBlock({tx}, setup.coinbaseKey);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1);
     nHeight++;
 
-    dmn = deterministicMNManager->GetListAtChainTip().GetMN(dmnHashes[0]);
+    dmn = dmnman.GetListAtChainTip().GetMN(dmnHashes[0]);
     BOOST_ASSERT(dmn != nullptr && dmn->pdmnState->GetBannedHeight() == nHeight);
 
     // test that the revoked MN does not get paid anymore
     for (size_t i = 0; i < 20; i++) {
-        auto dmnExpectedPayee = deterministicMNManager->GetListAtChainTip().GetMNPayee(::ChainActive().Tip());
+        auto dmnExpectedPayee = dmnman.GetListAtChainTip().GetMNPayee(::ChainActive().Tip());
         BOOST_ASSERT(dmnExpectedPayee->proTxHash != dmnHashes[0]);
 
         CBlock block = setup.CreateAndProcessBlock({}, setup.coinbaseKey);
-        deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+        dmnman.UpdatedBlockTip(::ChainActive().Tip());
         BOOST_ASSERT(!block.vtx.empty());
 
-        auto dmnPayout = FindPayoutDmn(block);
+        auto dmnPayout = FindPayoutDmn(dmnman, block);
         BOOST_ASSERT(dmnPayout != nullptr);
         BOOST_CHECK_EQUAL(dmnPayout->proTxHash.ToString(), dmnExpectedPayee->proTxHash.ToString());
 
@@ -529,7 +535,7 @@ void FuncDIP3Protx(TestChainSetup& setup)
     // test reviving the MN
     CBLSSecretKey newOperatorKey;
     newOperatorKey.MakeNewKey();
-    dmn = deterministicMNManager->GetListAtChainTip().GetMN(dmnHashes[0]);
+    dmn = dmnman.GetListAtChainTip().GetMN(dmnHashes[0]);
     tx = CreateProUpRegTx(*(setup.m_node.mempool), utxos, dmnHashes[0], ownerKeys[dmnHashes[0]], newOperatorKey.GetPublicKey(), ownerKeys[dmnHashes[0]].GetPubKey().GetID(), dmn->pdmnState->scriptPayout, setup.coinbaseKey);
     // check malleability protection again, but this time by also relying on the signature inside the ProUpRegTx
     auto tx2 = MalleateProTxPayout<CProUpRegTx>(tx);
@@ -543,33 +549,33 @@ void FuncDIP3Protx(TestChainSetup& setup)
     BOOST_ASSERT(!CheckTransactionSignature(*(setup.m_node.mempool), tx2));
     // now process the block
     setup.CreateAndProcessBlock({tx}, setup.coinbaseKey);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1);
     nHeight++;
 
     tx = CreateProUpServTx(*(setup.m_node.mempool), utxos, dmnHashes[0], newOperatorKey, 100, CScript(), setup.coinbaseKey);
     setup.CreateAndProcessBlock({tx}, setup.coinbaseKey);
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1);
     nHeight++;
 
-    dmn = deterministicMNManager->GetListAtChainTip().GetMN(dmnHashes[0]);
+    dmn = dmnman.GetListAtChainTip().GetMN(dmnHashes[0]);
     BOOST_ASSERT(dmn != nullptr && dmn->pdmnState->addr.GetPort() == 100);
     BOOST_ASSERT(dmn != nullptr && !dmn->pdmnState->IsBanned());
 
     // test that the revived MN gets payments again
     bool foundRevived = false;
     for (size_t i = 0; i < 20; i++) {
-        auto dmnExpectedPayee = deterministicMNManager->GetListAtChainTip().GetMNPayee(::ChainActive().Tip());
+        auto dmnExpectedPayee = dmnman.GetListAtChainTip().GetMNPayee(::ChainActive().Tip());
         if (dmnExpectedPayee->proTxHash == dmnHashes[0]) {
             foundRevived = true;
         }
 
         CBlock block = setup.CreateAndProcessBlock({}, setup.coinbaseKey);
-        deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+        dmnman.UpdatedBlockTip(::ChainActive().Tip());
         BOOST_ASSERT(!block.vtx.empty());
 
-        auto dmnPayout = FindPayoutDmn(block);
+        auto dmnPayout = FindPayoutDmn(dmnman, block);
         BOOST_ASSERT(dmnPayout != nullptr);
         BOOST_CHECK_EQUAL(dmnPayout->proTxHash.ToString(), dmnExpectedPayee->proTxHash.ToString());
 
@@ -605,7 +611,7 @@ void FuncTestMempoolReorg(TestChainSetup& setup)
 
     auto block = std::make_shared<CBlock>(setup.CreateBlock({tx_collateral}, setup.coinbaseKey));
     BOOST_ASSERT(Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    setup.m_node.dmnman->UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1);
     BOOST_CHECK_EQUAL(block->GetHash(), ::ChainActive().Tip()->GetBlockHash());
 
@@ -713,6 +719,8 @@ void FuncTestMempoolDualProregtx(TestChainSetup& setup)
 
 void FuncVerifyDB(TestChainSetup& setup)
 {
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+
     int nHeight = ::ChainActive().Height();
     auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
 
@@ -736,7 +744,7 @@ void FuncVerifyDB(TestChainSetup& setup)
 
     auto block = std::make_shared<CBlock>(setup.CreateBlock({tx_collateral}, setup.coinbaseKey));
     BOOST_ASSERT(Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 1);
     BOOST_CHECK_EQUAL(block->GetHash(), ::ChainActive().Tip()->GetBlockHash());
 
@@ -768,10 +776,10 @@ void FuncVerifyDB(TestChainSetup& setup)
 
     block = std::make_shared<CBlock>(setup.CreateBlock({tx_reg}, setup.coinbaseKey));
     BOOST_ASSERT(Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 2);
     BOOST_CHECK_EQUAL(block->GetHash(), ::ChainActive().Tip()->GetBlockHash());
-    BOOST_ASSERT(deterministicMNManager->GetListAtChainTip().HasMN(tx_reg_hash));
+    BOOST_ASSERT(dmnman.GetListAtChainTip().HasMN(tx_reg_hash));
 
     // Now spend the collateral while updating the same MN
     SimpleUTXOMap collateral_utxos;
@@ -780,10 +788,10 @@ void FuncVerifyDB(TestChainSetup& setup)
 
     block = std::make_shared<CBlock>(setup.CreateBlock({proUpRevTx}, setup.coinbaseKey));
     BOOST_ASSERT(Assert(setup.m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-    deterministicMNManager->UpdatedBlockTip(::ChainActive().Tip());
+    dmnman.UpdatedBlockTip(::ChainActive().Tip());
     BOOST_CHECK_EQUAL(::ChainActive().Height(), nHeight + 3);
     BOOST_CHECK_EQUAL(block->GetHash(), ::ChainActive().Tip()->GetBlockHash());
-    BOOST_ASSERT(!deterministicMNManager->GetListAtChainTip().HasMN(tx_reg_hash));
+    BOOST_ASSERT(!dmnman.GetListAtChainTip().HasMN(tx_reg_hash));
 
     // Verify db consistency
     LOCK(cs_main);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -406,8 +406,8 @@ void FuncDIP3Protx(TestChainSetup& setup)
 
     CKey sporkKey;
     sporkKey.MakeNewKey(false);
-    sporkManager->SetSporkAddress(EncodeDestination(PKHash(sporkKey.GetPubKey())));
-    sporkManager->SetPrivKey(EncodeSecret(sporkKey));
+    setup.m_node.sporkman->SetSporkAddress(EncodeDestination(PKHash(sporkKey.GetPubKey())));
+    setup.m_node.sporkman->SetPrivKey(EncodeSecret(sporkKey));
 
     auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -52,7 +52,7 @@ BlockAssembler MinerTestingSetup::AssemblerForTest(const CChainParams& params)
 
     options.nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
     options.blockMinFeeRate = blockMinFeeRate;
-    return BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, params, options);
+    return BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, params, options);
 }
 
 constexpr static struct {

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coi
 {
     assert(node.mempool);
     auto block = std::make_shared<CBlock>(
-        BlockAssembler{*sporkManager, *governance, *node.llmq_ctx, *node.evodb, ::ChainstateActive(), *node.mempool, Params()}
+        BlockAssembler{*node.sporkman, *node.govman, *node.llmq_ctx, *node.evodb, ::ChainstateActive(), *node.mempool, Params()}
             .CreateNewBlock(coinbase_scriptPubKey)
             ->block);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -177,7 +177,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
     connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     llmq::quorumSnapshotManager.reset(new llmq::CQuorumSnapshotManager(*m_node.evodb));
     creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
-    m_node.creditPoolManager = creditPoolManager.get();
+    m_node.cpoolman = creditPoolManager.get();
     static bool noui_connected = false;
     if (!noui_connected) {
         noui_connect();
@@ -190,8 +190,8 @@ BasicTestingSetup::~BasicTestingSetup()
 {
     connman.reset();
     llmq::quorumSnapshotManager.reset();
+    m_node.cpoolman = nullptr;
     creditPoolManager.reset();
-    m_node.creditPoolManager = nullptr;
     m_node.mnhf_manager.reset();
     m_node.evodb.reset();
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -232,10 +232,6 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     ::netfulfilledman = std::make_unique<CNetFulfilledRequestManager>(/* load_cache */ false);
     m_node.netfulfilledman = ::netfulfilledman.get();
 
-    creditPoolManager = std::make_unique<CCreditPoolManager>(*m_node.evodb);
-    m_node.creditPoolManager = creditPoolManager.get();
-
-
     // Start script-checking threads. Set g_parallel_script_checks to true so they are used.
     constexpr int script_check_threads = 2;
     StartScriptCheckWorkerThreads(script_check_threads);
@@ -245,8 +241,6 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
 ChainTestingSetup::~ChainTestingSetup()
 {
     m_node.scheduler->stop();
-    creditPoolManager.reset();
-    m_node.creditPoolManager = nullptr;
     StopScriptCheckWorkerThreads();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     CScript pubKey;
     pubKey << i++ << OP_TRUE;
 
-    auto ptemplate = BlockAssembler(*sporkManager, *governance, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(pubKey);
+    auto ptemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(pubKey);
     auto pblock = std::make_shared<CBlock>(ptemplate->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;


### PR DESCRIPTION
## Additional Notes

* In some limited circumstances, we need to pass a reference to a smart pointer _before_ it is initialized. This is permissible if we know for sure that the pointer will be dereferenced _after_ it is initialized (usually, by `assert`'ing `!= nullptr`). This requires us to pass the const ref of the smart pointer object, to ensure that when dereferenced, we get access to the updated value that is set later on the initialization sequence.
  
  This means we cannot use the bare pointer alias as an argument as it would remain `nullptr` and will not be updated.
  
  Currently known examples are:
  * `CChainState` through `ChainstateManager::InitializeChainstate`
    * `llmq::CChainLocksHandler` (as `llmq::chainLocksHandler`)
    * `llmq::CInstantSendManager` (as `llmq::quorumInstantSendManager`)
    * `llmq::CQuorumBlockProcessor` (as `llmq::quorumBlockProcessor`)
  * `CDSNotificationInterface`
    * `CDeterministicMNManager` (as `deterministicMNManager`)
    * `CJContext` (as `NodeContext::cj_ctx`)
    * `LLMQContext` (as `NodeContext::llmq_ctx`)

* We can verify the absence of globals in GUI, interface, RPC and test logic with the commands below (the above caveat applies)

  ```bash
  $ function make_filter() { echo "$1->|\*$1|::$1"; }
  $ PROHIBITED_TERMS="$(make_filter creditPoolManager)|$(make_filter deterministicMNManager)|$(make_filter dstxManager)|$(make_filter governance)|$(make_filter mmetaman)|$(make_filter netfulfilledman)|$(make_filter sporkManager)";
  $ PROHIBITED_LLMQ_TERMS="$(make_filter quorumBlockProcessor)|$(make_filter quorumManager)|$(make_filter chainLocksHandler)|$(make_filter quorumInstantSendManager)";
  $ grep -E "$PROHIBITED_TERMS|$PROHIBITED_LLMQ_TERMS" src/bench/*.{cpp,h} src/node/interfaces.cpp src/qt/*.{cpp,h} src/qt/test/*.{cpp,h} src/rpc/*.{cpp,h} src/test/*.{cpp,h} src/wallet/rpc*.{cpp,h};
  src/test/validation_chainstate_tests.cpp:    CChainState& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
  src/test/validation_chainstatemanager_tests.cpp:    CChainState& c1 = WITH_LOCK(::cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
  src/test/validation_chainstatemanager_tests.cpp:        &mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor,
  src/test/validation_chainstatemanager_tests.cpp:    CChainState& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
  src/test/validation_chainstatemanager_tests.cpp:    CChainState& c2 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor, GetRandHash()));
  src/test/validation_flush_tests.cpp:    CChainState chainstate(&mempool, blockman, *m_node.mnhf_manager, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
  ```

* We can also check the usage of globals in (test) initialization logic (it will also include all the actual (de)initialization logic and any usage of the bare pointer alias if the name of the global and the alias are the same, as is the case with `netfulfilledman`)

  ```bash
  $ grep -E "$PROHIBITED_TERMS|$PROHIBITED_LLMQ_TERMS" src/init.cpp src/test/util/setup_common.cpp;
  src/init.cpp:    ::netfulfilledman.reset();
  src/init.cpp:    ::mmetaman.reset();
  src/init.cpp:    ::dstxManager.reset();
  src/init.cpp:    ::sporkManager.reset();
  src/init.cpp:    ::governance.reset();
  src/init.cpp:    assert(!::governance);
  src/init.cpp:    ::governance = std::make_unique<CGovernanceManager>();
  src/init.cpp:    node.govman = ::governance.get();
  src/init.cpp:    assert(!::sporkManager);
  src/init.cpp:    ::sporkManager = std::make_unique<CSporkManager>();
  src/init.cpp:    node.sporkman = ::sporkManager.get();
  src/init.cpp:        *node.connman, *node.mn_sync, ::deterministicMNManager, *node.govman, node.llmq_ctx, node.cj_ctx
  src/init.cpp:                chainman.InitializeChainstate(Assert(node.mempool.get()), *node.mnhf_manager, *node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
  src/init.cpp:    assert(!::dstxManager);
  src/init.cpp:    ::dstxManager = std::make_unique<CDSTXManager>();
  src/init.cpp:    node.dstxman = ::dstxManager.get();
  src/init.cpp:    assert(!::mmetaman);
  src/init.cpp:    ::mmetaman = std::make_unique<CMasternodeMetaMan>(fLoadCacheFiles);
  src/init.cpp:    node.mn_metaman = ::mmetaman.get();
  src/init.cpp:    assert(!::netfulfilledman);
  src/init.cpp:    ::netfulfilledman = std::make_unique<CNetFulfilledRequestManager>(fLoadCacheFiles);
  src/init.cpp:    node.netfulfilledman = ::netfulfilledman.get();
  src/init.cpp:    if (!node.netfulfilledman->IsValid()) {
  src/test/util/setup_common.cpp:    ::deterministicMNManager = std::make_unique<CDeterministicMNManager>(chainstate, *node.connman, *node.evodb);
  src/test/util/setup_common.cpp:    node.dmnman = ::deterministicMNManager.get();
  src/test/util/setup_common.cpp:    ::deterministicMNManager.reset();
  src/test/util/setup_common.cpp:    ::sporkManager = std::make_unique<CSporkManager>();
  src/test/util/setup_common.cpp:    m_node.sporkman = ::sporkManager.get();
  src/test/util/setup_common.cpp:    ::governance = std::make_unique<CGovernanceManager>();
  src/test/util/setup_common.cpp:    m_node.govman = ::governance.get();
  src/test/util/setup_common.cpp:    ::dstxManager = std::make_unique<CDSTXManager>();
  src/test/util/setup_common.cpp:    m_node.dstxman = ::dstxManager.get();
  src/test/util/setup_common.cpp:    ::mmetaman = std::make_unique<CMasternodeMetaMan>(/* load_cache */ false);
  src/test/util/setup_common.cpp:    m_node.mn_metaman = ::mmetaman.get();
  src/test/util/setup_common.cpp:    ::netfulfilledman = std::make_unique<CNetFulfilledRequestManager>(/* load_cache */ false);
  src/test/util/setup_common.cpp:    m_node.netfulfilledman = ::netfulfilledman.get();
  src/test/util/setup_common.cpp:    ::netfulfilledman.reset();
  src/test/util/setup_common.cpp:    ::mmetaman.reset();
  src/test/util/setup_common.cpp:    ::dstxManager.reset();
  src/test/util/setup_common.cpp:    ::governance.reset();
  src/test/util/setup_common.cpp:    ::sporkManager.reset();
  src/test/util/setup_common.cpp:    m_node.chainman->InitializeChainstate(m_node.mempool.get(), *m_node.mnhf_manager, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
  ```

## Breaking Changes
None, changes are limited to refactoring and do not logically change behaviour.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
