### PR TITLE
fix: intermittent failures in `feature_asset_locks.py`

### DIFF
--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -273,10 +273,8 @@ class AssetLocksTest(DashTestFramework):
         locked_1 = 10 * COIN + 141421
         locked_2 = 10 * COIN + 314159
 
-        coins = node_wallet.listunspent()
-        coin = None
-        while coin is None or COIN * coin['amount'] < locked_2:
-            coin = coins.pop()
+        coins = node_wallet.listunspent(query_options={'minimumAmount': Decimal(str(locked_2 / COIN))})
+        coin = coins.pop()
         asset_lock_tx = self.create_assetlock(coin, locked_1, pubkey)
 
 
@@ -604,7 +602,7 @@ class AssetLocksTest(DashTestFramework):
         locked += platform_reward
         assert_equal(locked, self.get_credit_pool_balance())
 
-        coins = node_wallet.listunspent()
+        coins = node_wallet.listunspent(query_options={'minimumAmount': 1})
         coin = coins.pop()
         self.send_tx(self.create_assetlock(coin, COIN, pubkey))
         locked += platform_reward + COIN


### PR DESCRIPTION
## Issue being fixed or feature implemented
fix failures like https://gitlab.com/dashpay/dash/-/jobs/6175160403

## What was done?
use `minimumAmount` option in `listunspent` rpc call to avoid picking coins that are too small for asset lock txes

## How Has This Been Tested?
run `feature_asset_locks.py`

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

