### PR TITLE
trivial: use WITH_LOCK when possible

### DIFF
--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -70,8 +70,7 @@ void CEHFSignalsHandler::trySignEHFSignal(int bit, const CBlockIndex* const pind
         return;
     }
     if (sigman.HasRecoveredSigForId(llmqType, requestId)) {
-        LOCK(cs);
-        ids.insert(requestId);
+        WITH_LOCK(cs, ids.insert(requestId));
 
         LogPrint(BCLog::EHF, "CEHFSignalsHandler::trySignEHFSignal: already signed bit=%d at height=%d id=%s\n", bit, pindex->nHeight, requestId.ToString());
         // no need to sign same message one more time
@@ -88,10 +87,7 @@ void CEHFSignalsHandler::trySignEHFSignal(int bit, const CBlockIndex* const pind
     mnhfPayload.signal.quorumHash = quorum->qc->quorumHash;
     const uint256 msgHash = mnhfPayload.PrepareTx().GetHash();
 
-    {
-        LOCK(cs);
-        ids.insert(requestId);
-    }
+    WITH_LOCK(cs, ids.insert(requestId));
     sigman.AsyncSignIfMember(llmqType, shareman, requestId, msgHash);
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Trivial PR for minor issue found when reviewing generalized EHF

## What was done?
Use WITH_LOCK

## How Has This Been Tested?
Building Locally

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

