### PR TITLE
refactor: use atomic to avoid blocking chainlocks cs on each call to cleanup

### DIFF
--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -617,11 +617,8 @@ void CChainLocksHandler::Cleanup()
         return;
     }
 
-    {
-        LOCK(cs);
-        if (GetTimeMillis() - lastCleanupTime < CLEANUP_INTERVAL) {
-            return;
-        }
+    if (GetTimeMillis() - lastCleanupTime < CLEANUP_INTERVAL) {
+        return;
     }
 
     // need mempool.cs due to GetTransaction calls

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -82,7 +82,7 @@ private:
 
     std::map<uint256, int64_t> seenChainLocks GUARDED_BY(cs);
 
-    int64_t lastCleanupTime GUARDED_BY(cs) {0};
+    std::atomic<int64_t> lastCleanupTime{0};
 
 public:
     explicit CChainLocksHandler(CChainState& chainstate, CConnman& _connman, CMasternodeSync& mn_sync, CQuorumManager& _qman,


### PR DESCRIPTION
## Issue being fixed or feature implemented
Avoid needing to lock CS on each call to cleanup. Cleanup only gets called once every 5 seconds it seems; but maybe that'll change in the future. 

## What was done?
Make `lastCleanupTime` atomic instead of CS guarded

## How Has This Been Tested?
Building

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

