### PR TITLE
fix: fallback to a commit hash in `codesign.sh`

### DIFF
--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -38,7 +38,7 @@ ACTUAL_OUTDIR="${OUTDIR}"
 OUTDIR="${DISTSRC}/output"
 
 git_head_version() {
-    recent_tag="$(git -C "$1" describe --abbrev=12 --dirty 2> /dev/null)"
+    recent_tag="$(git -C "$1" describe --abbrev=12 --dirty --always 2> /dev/null)"
     echo "${recent_tag#v}"
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
We don't use tags in https://github.com/dashpay/dash-detached-sigs repo, we use branches so `git describe` fails...

## What was done?
Add `--always` option to fallback to commit hash. Could do
```
git_head_version() {
    git -C "$1" rev-parse --short=12 HEAD`
}
```
instead but using `describe` allows us to start using tags one day with no additional patches.

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

