### PR TITLE
fix: adjust verify-binaries script to properly handle RCs

### DIFF
--- a/contrib/verifybinaries/verify.py
+++ b/contrib/verifybinaries/verify.py
@@ -93,9 +93,7 @@ def main(args):
 
     # determine remote dir dependent on provided version string
     version_base, version_rc, os_filter = parse_version_string(args[0])
-    remote_dir = f"{VERSIONPREFIX}{version_base}/"
-    if version_rc:
-        remote_dir += f"test.{version_rc}/"
+    remote_dir = f"{VERSIONPREFIX}{version_base}{f'-{version_rc}' if version_rc else ''}/"
     remote_sigfile = remote_dir + SIGNATUREFILENAME
 
     # create working directory


### PR DESCRIPTION
## What was done?
Adjusted verify.py to properly handle RC

## How Has This Been Tested?
Ran verify on both 20.0.4 and 20.1.0-rc.1

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
