### PR TITLE
fix: drop symlinks in immer subtree

### DIFF
--- a/src/immer/doc/guile.rst
+++ b/src/immer/doc/guile.rst
@@ -1,1 +1,0 @@
-../extra/guile/README.rst

--- a/src/immer/doc/python.rst
+++ b/src/immer/doc/python.rst
@@ -1,1 +1,0 @@
-../extra/python/README.rst


### PR DESCRIPTION
## Issue being fixed or feature implemented
I've been playing around recently with the `github-merge.py` script recently; and while I've been able to create merges with it (see 73c90c8370c7c2b8d684c707337a46b76001c3f2 and 10ddf62dfb2c0ae673c182ea840d9ce0a1b3e635) it complains / refuses to trivially work with symlinks. I haven't been able to figure out exactly why it doesn't want symlinks, but I think it's related to the sha512sum hash that gets created.

I'm not sure if we'll start using `github-merge.py` more or not; but I guess we should "fix" this anyhow in order to learn more how these work. It may be useful to move to merging commits locally and not relying on github being a good actor? :shrug:

## What was done?

## How Has This Been Tested?
Ran `github-merge.py` locally and it no longer complains about symlinks

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

