### PR TITLE
chore: bump cppcheck to 2.13 version

### DIFF
--- a/contrib/containers/ci/Dockerfile
+++ b/contrib/containers/ci/Dockerfile
@@ -116,7 +116,7 @@ RUN apt-get update && apt-get install $APT_ARGS \
     wine64 \
     xorriso
 
-ARG CPPCHECK_VERSION=2.10
+ARG CPPCHECK_VERSION=2.13.0
 RUN curl -sL "https://github.com/danmar/cppcheck/archive/${CPPCHECK_VERSION}.tar.gz" | tar -xvzf - --directory /tmp/
 RUN cd /tmp/cppcheck-${CPPCHECK_VERSION} && mkdir build && cd build && cmake .. && cmake --build . -j 8
 ENV PATH "/tmp/cppcheck-${CPPCHECK_VERSION}/build/bin:${PATH}"

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1417,14 +1417,11 @@ bool CCoinJoinClientSession::MakeCollateralAmounts(const CBlockPolicyEstimator& 
     });
 
     // First try to use only non-denominated funds
-    for (const auto& item : vecTally) {
-        if (!MakeCollateralAmounts(fee_estimator, item, false)) continue;
+    if (std::any_of(vecTally.begin(), vecTally.end(), [&](const auto& item) { return MakeCollateralAmounts(fee_estimator, item, false); })) {
         return true;
     }
-
     // There should be at least some denominated funds we should be able to break in pieces to continue mixing
-    for (const auto& item : vecTally) {
-        if (!MakeCollateralAmounts(fee_estimator, item, true)) continue;
+    if (std::any_of(vecTally.begin(), vecTally.end(), [&](const auto& item) { return MakeCollateralAmounts(fee_estimator, item, true); })) {
         return true;
     }
 

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -16,7 +16,6 @@
 #include <memory>
 #include <utility>
 
-class CBlockPolicyEstimator;
 class CCoinJoinClientManager;
 class CCoinJoinClientQueueManager;
 class CConnman;
@@ -82,7 +81,7 @@ public:
     }
 
     void Add(CWallet& wallet);
-    void DoMaintenance(CBlockPolicyEstimator& fee_estimator);
+    void DoMaintenance();
 
     void Remove(const std::string& name);
     void Flush(const std::string& name);
@@ -123,12 +122,12 @@ private:
     CKeyHolderStorage keyHolderStorage; // storage for keys used in PrepareDenominate
 
     /// Create denominations
-    bool CreateDenominated(CBlockPolicyEstimator& fee_estimator, CAmount nBalanceToDenominate);
-    bool CreateDenominated(CBlockPolicyEstimator& fee_estimator, CAmount nBalanceToDenominate, const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals);
+    bool CreateDenominated(CAmount nBalanceToDenominate);
+    bool CreateDenominated(CAmount nBalanceToDenominate, const CompactTallyItem& tallyItem, bool fCreateMixingCollaterals);
 
     /// Split up large inputs or make fee sized inputs
-    bool MakeCollateralAmounts(const CBlockPolicyEstimator& fee_estimator);
-    bool MakeCollateralAmounts(const CBlockPolicyEstimator& fee_estimator, const CompactTallyItem& tallyItem, bool fTryDenominated);
+    bool MakeCollateralAmounts();
+    bool MakeCollateralAmounts(const CompactTallyItem& tallyItem, bool fTryDenominated);
 
     bool CreateCollateralTransaction(CMutableTransaction& txCollateral, std::string& strReason);
 
@@ -171,7 +170,7 @@ public:
     bool GetMixingMasternodeInfo(CDeterministicMNCPtr& ret) const;
 
     /// Passively run mixing in the background according to the configuration in settings
-    bool DoAutomaticDenominating(CConnman& connman, CBlockPolicyEstimator& fee_estimator, CTxMemPool& mempool, bool fDryRun = false) LOCKS_EXCLUDED(cs_coinjoin);
+    bool DoAutomaticDenominating(CConnman& connman, CTxMemPool& mempool, bool fDryRun = false) LOCKS_EXCLUDED(cs_coinjoin);
 
     /// As a client, submit part of a future mixing transaction to a Masternode to start the process
     bool SubmitDenominate(CConnman& connman);
@@ -259,7 +258,7 @@ public:
     bool GetMixingMasternodesInfo(std::vector<CDeterministicMNCPtr>& vecDmnsRet) const LOCKS_EXCLUDED(cs_deqsessions);
 
     /// Passively run mixing in the background according to the configuration in settings
-    bool DoAutomaticDenominating(CConnman& connman, CBlockPolicyEstimator& fee_estimator, CTxMemPool& mempool, bool fDryRun = false) LOCKS_EXCLUDED(cs_deqsessions);
+    bool DoAutomaticDenominating(CConnman& connman, CTxMemPool& mempool, bool fDryRun = false) LOCKS_EXCLUDED(cs_deqsessions);
 
     bool TrySubmitDenominate(const CService& mnAddr, CConnman& connman) LOCKS_EXCLUDED(cs_deqsessions);
     bool MarkAlreadyJoinedQueueAsTried(CCoinJoinQueue& dsq) const LOCKS_EXCLUDED(cs_deqsessions);
@@ -275,7 +274,7 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex* pindex);
 
-    void DoMaintenance(CConnman& connman, CBlockPolicyEstimator& fee_estimator, CTxMemPool& mempool);
+    void DoMaintenance(CConnman& connman, CTxMemPool& mempool);
 
     void GetJsonInfo(UniValue& obj) const LOCKS_EXCLUDED(cs_deqsessions);
 };

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -154,7 +154,7 @@ private:
 
     void RelayIn(const CCoinJoinEntry& entry, CConnman& connman) const;
 
-    void SetNull() EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
+    void SetNull() override EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
 public:
     explicit CCoinJoinClientSession(CWallet& wallet, CoinJoinWalletManager& walletman, const CMasternodeSync& mn_sync,

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -307,7 +307,7 @@ protected:
 
     CMutableTransaction finalMutableTransaction GUARDED_BY(cs_coinjoin); // the finalized transaction ready for signing
 
-    void SetNull() EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
+    virtual void SetNull() EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
     bool IsValidInOuts(const CTxMemPool& mempool, const std::vector<CTxIn>& vin, const std::vector<CTxOut>& vout, PoolMessage& nMessageIDRet, bool* fConsumeCollateralRet) const;
 

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -77,7 +77,7 @@ private:
     void ProcessDSVIN(CNode& peer, CDataStream& vRecv) LOCKS_EXCLUDED(cs_coinjoin);
     void ProcessDSSIGNFINALTX(CDataStream& vRecv) LOCKS_EXCLUDED(cs_coinjoin);
 
-    void SetNull() EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
+    void SetNull() override EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
 
 public:
     explicit CCoinJoinServer(CChainState& chainstate, CConnman& _connman, CTxMemPool& mempool, const CMasternodeSync& mn_sync) :

--- a/src/coinjoin/util.cpp
+++ b/src/coinjoin/util.cpp
@@ -108,7 +108,7 @@ bool CTransactionBuilderOutput::UpdateAmount(const CAmount nNewAmount)
     return true;
 }
 
-CTransactionBuilder::CTransactionBuilder(std::shared_ptr<CWallet> pwalletIn, const CompactTallyItem& tallyItemIn, const CBlockPolicyEstimator& fee_estimator) :
+CTransactionBuilder::CTransactionBuilder(std::shared_ptr<CWallet> pwalletIn, const CompactTallyItem& tallyItemIn) :
     pwallet(pwalletIn),
     dummyReserveDestination(pwalletIn.get()),
     tallyItem(tallyItemIn)
@@ -116,7 +116,7 @@ CTransactionBuilder::CTransactionBuilder(std::shared_ptr<CWallet> pwalletIn, con
     // Generate a feerate which will be used to consider if the remainder is dust and will go into fees or not
     coinControl.m_discard_feerate = ::GetDiscardRate(*pwallet);
     // Generate a feerate which will be used by calculations of this class and also by CWallet::CreateTransaction
-    coinControl.m_feerate = std::max(fee_estimator.estimateSmartFee(int(pwallet->m_confirm_target), nullptr, true), pwallet->m_pay_tx_fee);
+    coinControl.m_feerate = std::max(pwallet->chain().estimateSmartFee(int(pwallet->m_confirm_target), true, nullptr), pwallet->m_pay_tx_fee);
     // Change always goes back to origin
     coinControl.destChange = tallyItemIn.txdest;
     // Only allow tallyItems inputs for tx creation

--- a/src/coinjoin/util.h
+++ b/src/coinjoin/util.h
@@ -7,7 +7,6 @@
 
 #include <wallet/wallet.h>
 
-class CBlockPolicyEstimator;
 class CTransactionBuilder;
 struct bilingual_str;
 
@@ -101,7 +100,7 @@ class CTransactionBuilder
     friend class CTransactionBuilderOutput;
 
 public:
-    CTransactionBuilder(std::shared_ptr<CWallet> pwalletIn, const CompactTallyItem& tallyItemIn, const CBlockPolicyEstimator& fee_estimator);
+    CTransactionBuilder(std::shared_ptr<CWallet> pwalletIn, const CompactTallyItem& tallyItemIn);
     ~CTransactionBuilder();
     /// Check it would be possible to add a single output with the amount nAmount. Returns true if its possible and false if not.
     bool CouldAddOutput(CAmount nAmountOutput) const;

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -120,11 +120,12 @@ static std::optional<CBlock> GetBlockForCreditPool(const CBlockIndex* const bloc
     if (!ReadBlockFromDisk(block, block_index, consensusParams)) {
         throw std::runtime_error("failed-getcbforblock-read");
     }
+
+    assert(!block.vtx.empty());
+
     // Should not fail if V20 (DIP0027) is active but it happens for RegChain (unit tests)
     if (block.vtx[0]->nVersion != 3) return std::nullopt;
 
-    assert(!block.vtx.empty());
-    assert(block.vtx[0]->nVersion == 3);
     assert(!block.vtx[0]->vExtraPayload.empty());
 
     return block;

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1048,13 +1048,13 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
 
 bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, CGovernanceException& exception, CConnman& connman)
 {
-    ENTER_CRITICAL_SECTION(cs)
+    ENTER_CRITICAL_SECTION(cs);
     uint256 nHashVote = vote.GetHash();
     uint256 nHashGovobj = vote.GetParentHash();
 
     if (cmapVoteToObject.HasKey(nHashVote)) {
         LogPrint(BCLog::GOBJECT, "CGovernanceObject::ProcessVote -- skipping known valid vote %s for object %s\n", nHashVote.ToString(), nHashGovobj.ToString());
-        LEAVE_CRITICAL_SECTION(cs)
+        LEAVE_CRITICAL_SECTION(cs);
         return false;
     }
 
@@ -1065,7 +1065,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
              << ", governance object hash = " << nHashGovobj.ToString();
         LogPrint(BCLog::GOBJECT, "%s\n", ostr.str());
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
-        LEAVE_CRITICAL_SECTION(cs)
+        LEAVE_CRITICAL_SECTION(cs);
         return false;
     }
 
@@ -1076,14 +1076,14 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
              << ", MN outpoint = " << vote.GetMasternodeOutpoint().ToStringShort();
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
         if (cmmapOrphanVotes.Insert(nHashGovobj, vote_time_pair_t(vote, GetTime<std::chrono::seconds>().count() + GOVERNANCE_ORPHAN_EXPIRATION_TIME))) {
-            LEAVE_CRITICAL_SECTION(cs)
+            LEAVE_CRITICAL_SECTION(cs);
             RequestGovernanceObject(pfrom, nHashGovobj, connman);
             LogPrint(BCLog::GOBJECT, "%s\n", ostr.str());
             return false;
         }
 
         LogPrint(BCLog::GOBJECT, "%s\n", ostr.str());
-        LEAVE_CRITICAL_SECTION(cs)
+        LEAVE_CRITICAL_SECTION(cs);
         return false;
     }
 
@@ -1091,12 +1091,12 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
 
     if (govobj.IsSetCachedDelete() || govobj.IsSetExpired()) {
         LogPrint(BCLog::GOBJECT, "CGovernanceObject::ProcessVote -- ignoring vote for expired or deleted object, hash = %s\n", nHashGovobj.ToString());
-        LEAVE_CRITICAL_SECTION(cs)
+        LEAVE_CRITICAL_SECTION(cs);
         return false;
     }
 
     bool fOk = govobj.ProcessVote(vote, exception) && cmapVoteToObject.Insert(nHashVote, &govobj);
-    LEAVE_CRITICAL_SECTION(cs)
+    LEAVE_CRITICAL_SECTION(cs);
     return fOk;
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2345,7 +2345,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 #ifdef ENABLE_WALLET
     } else if (!ignores_incoming_txs) {
         node.scheduler->scheduleEvery(std::bind(&CCoinJoinClientQueueManager::DoMaintenance, std::ref(*node.cj_ctx->queueman)), std::chrono::seconds{1});
-        node.scheduler->scheduleEvery(std::bind(&CoinJoinWalletManager::DoMaintenance, std::ref(*node.cj_ctx->walletman), std::ref(*node.fee_estimator)), std::chrono::seconds{1});
+        node.scheduler->scheduleEvery(std::bind(&CoinJoinWalletManager::DoMaintenance, std::ref(*node.cj_ctx->walletman)), std::chrono::seconds{1});
 #endif // ENABLE_WALLET
     }
 

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -297,10 +297,10 @@ struct SaltedHasherImpl<llmq::CQuorumDataRequestKey>
     static std::size_t CalcHash(const llmq::CQuorumDataRequestKey& v, uint64_t k0, uint64_t k1)
     {
         CSipHasher c(k0, k1);
-        c.Write((unsigned char*)&(v.proRegTx), sizeof(v.proRegTx));
-        c.Write((unsigned char*)&(v.m_we_requested), sizeof(v.m_we_requested));
-        c.Write((unsigned char*)&(v.quorumHash), sizeof(v.quorumHash));
-        c.Write((unsigned char*)&(v.llmqType), sizeof(v.llmqType));
+        c.Write(reinterpret_cast<const unsigned char*>(&v.proRegTx), sizeof(v.proRegTx));
+        c.Write(reinterpret_cast<const unsigned char*>(&v.m_we_requested), sizeof(v.m_we_requested));
+        c.Write(reinterpret_cast<const unsigned char*>(&v.quorumHash), sizeof(v.quorumHash));
+        c.Write(reinterpret_cast<const unsigned char*>(&v.llmqType), sizeof(v.llmqType));
         return c.Finalize();
     }
 };

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -220,7 +220,7 @@ bool CActiveMasternodeManager::GetLocalAddress(CService& addrRet)
     return true;
 }
 
-bool CActiveMasternodeManager::IsValidNetAddr(CService addrIn)
+bool CActiveMasternodeManager::IsValidNetAddr(const CService& addrIn)
 {
     // TODO: regtest is fine with any addresses for now,
     // should probably be a bit smarter if one day we start to implement tests for this

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -61,7 +61,7 @@ public:
     std::string GetStateString() const;
     std::string GetStatus() const;
 
-    static bool IsValidNetAddr(CService addrIn);
+    static bool IsValidNetAddr(const CService& addrIn);
 
 private:
     bool GetLocalAddress(CService& addrRet);

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -76,7 +76,7 @@ void CMasternodeSync::SwitchToNextAsset()
             nCurrentAsset = MASTERNODE_SYNC_FINISHED;
             uiInterface.NotifyAdditionalDataSyncProgressChanged(1);
 
-            connman.ForEachNode(CConnman::AllNodes, [](CNode* pnode) {
+            connman.ForEachNode(CConnman::AllNodes, [](const CNode* pnode) {
                 netfulfilledman->AddFulfilledRequest(pnode->addr, "full-sync");
             });
             LogPrintf("CMasternodeSync::SwitchToNextAsset -- Sync has finished\n");
@@ -260,7 +260,7 @@ void CMasternodeSync::ProcessTick()
     }
 
     // request votes on per-obj basis from each node
-    for (auto& pnode : vNodesCopy) {
+    for (const auto& pnode : vNodesCopy) {
         if(!netfulfilledman->HasFulfilledRequest(pnode->addr, "governance-sync")) {
             continue; // to early for this node
         }

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -68,8 +68,7 @@ static UniValue coinjoin(const JSONRPCRequest& request)
         }
 
         CTxMemPool& mempool = EnsureMemPool(node);
-        CBlockPolicyEstimator& fee_estimator = EnsureFeeEstimator(node);
-        bool result = cj_clientman->DoAutomaticDenominating(*node.connman, fee_estimator, mempool);
+        bool result = cj_clientman->DoAutomaticDenominating(*node.connman, mempool);
         return "Mixing " + (result ? "started successfully" : ("start failed: " + cj_clientman->GetStatuses().original + ", will retry"));
     }
 

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1262,22 +1262,22 @@ static void protx_list_help(const JSONRPCRequest& request)
 }
 
 #ifdef ENABLE_WALLET
-static bool CheckWalletOwnsKey(CWallet* pwallet, const CKeyID& keyID) {
+static bool CheckWalletOwnsKey(const CWallet* const pwallet, const CKeyID& keyID) {
     if (!pwallet) {
         return false;
     }
-    LegacyScriptPubKeyMan* spk_man = pwallet->GetLegacyScriptPubKeyMan();
+    const LegacyScriptPubKeyMan* const spk_man = pwallet->GetLegacyScriptPubKeyMan();
     if (!spk_man) {
         return false;
     }
     return spk_man->HaveKey(keyID);
 }
 
-static bool CheckWalletOwnsScript(CWallet* pwallet, const CScript& script) {
+static bool CheckWalletOwnsScript(const CWallet* const pwallet, const CScript& script) {
     if (!pwallet) {
         return false;
     }
-    LegacyScriptPubKeyMan* spk_man = pwallet->GetLegacyScriptPubKeyMan();
+    const LegacyScriptPubKeyMan* const spk_man = pwallet->GetLegacyScriptPubKeyMan();
     if (!spk_man) {
         return false;
     }
@@ -1292,7 +1292,7 @@ static bool CheckWalletOwnsScript(CWallet* pwallet, const CScript& script) {
 }
 #endif
 
-static UniValue BuildDMNListEntry(CWallet* pwallet, const CDeterministicMN& dmn, CMasternodeMetaMan& mn_metaman, bool detailed, const ChainstateManager& chainman, const CBlockIndex* pindex = nullptr)
+static UniValue BuildDMNListEntry(const CWallet* const pwallet, const CDeterministicMN& dmn, CMasternodeMetaMan& mn_metaman, bool detailed, const ChainstateManager& chainman, const CBlockIndex* pindex = nullptr)
 {
     if (!detailed) {
         return dmn.proTxHash.ToString();

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -775,7 +775,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
                 return ret;
             } else {
                 // lets prove we own the collateral
-                LegacyScriptPubKeyMan* spk_man = wallet->GetLegacyScriptPubKeyMan();
+                const LegacyScriptPubKeyMan* spk_man = wallet->GetLegacyScriptPubKeyMan();
                 if (!spk_man) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "This type of wallet does not support this command");
                 }
@@ -1511,7 +1511,7 @@ static void protx_diff_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static uint256 ParseBlock(const UniValue& v, const ChainstateManager& chainman, std::string strName) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+static uint256 ParseBlock(const UniValue& v, const ChainstateManager& chainman, const std::string& strName) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -1561,7 +1561,7 @@ static void protx_listdiff_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static const CBlockIndex* ParseBlockIndex(const UniValue& v, const ChainstateManager& chainman, std::string strName) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+static const CBlockIndex* ParseBlockIndex(const UniValue& v, const ChainstateManager& chainman, const std::string& strName) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -602,8 +602,8 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
 
     UniValue obj(UniValue::VOBJ);
 
-    auto mnList = node.dmnman->GetListAtChainTip();
-    auto dmnToStatus = [&](auto& dmn) {
+    const auto mnList = node.dmnman->GetListAtChainTip();
+    const auto dmnToStatus = [&](const auto& dmn) {
         if (mnList.IsMNValid(dmn)) {
             return "ENABLED";
         }
@@ -612,7 +612,7 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
         }
         return "UNKNOWN";
     };
-    auto dmnToLastPaidTime = [&](auto& dmn) {
+    const auto dmnToLastPaidTime = [&](const auto& dmn) {
         if (dmn.pdmnState->nLastPaidHeight == 0) {
             return (int)0;
         }
@@ -622,9 +622,9 @@ static UniValue masternodelist(const JSONRPCRequest& request, ChainstateManager&
         return (int)pindex->nTime;
     };
 
-    bool showRecentMnsOnly = strMode == "recent";
-    bool showEvoOnly = strMode == "evo";
-    int tipHeight = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip()->nHeight);
+    const bool showRecentMnsOnly = strMode == "recent";
+    const bool showEvoOnly = strMode == "evo";
+    const int tipHeight = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip()->nHeight);
     mnList.ForEachMN(false, [&](auto& dmn) {
         if (showRecentMnsOnly && mnList.IsMNPoSeBanned(dmn)) {
             if (tipHeight - dmn.pdmnState->GetBannedHeight() > Params().GetConsensus().nSuperblockCycle) {

--- a/src/statsd_client.cpp
+++ b/src/statsd_client.cpp
@@ -231,7 +231,7 @@ int StatsdClient::send(const std::string& message)
     {
         return ret;
     }
-    ret = sendto(d->sock, message.data(), message.size(), 0, (struct sockaddr *) &d->server, sizeof(d->server));
+    ret = sendto(d->sock, message.data(), message.size(), 0, reinterpret_cast<const sockaddr*>(&d->server), sizeof(d->server));
     if ( ret == -1) {
         snprintf(d->errmsg, sizeof(d->errmsg),
                 "sendto server fail, host=%s:%d, err=%m", d->host.c_str(), d->port);

--- a/src/statsd_client.h
+++ b/src/statsd_client.h
@@ -61,7 +61,7 @@ class StatsdClient {
         static void cleanup(std::string& key);
 
     protected:
-        std::unique_ptr<struct _StatsdClientData> d;
+        const std::unique_ptr<struct _StatsdClientData> d;
 };
 
 } // namespace statsd

--- a/src/sync.h
+++ b/src/sync.h
@@ -244,7 +244,7 @@ using DebugLock = UniqueLock<typename std::remove_reference<typename std::remove
 #define LEAVE_CRITICAL_SECTION(cs)                                          \
     {                                                                       \
         std::string lockname;                                               \
-        CheckLastCritical((void*)(&cs), lockname, #cs, __FILE__, __LINE__); \
+        CheckLastCritical(reinterpret_cast<void*>(&cs), lockname, #cs, __FILE__, __LINE__); \
         (cs).unlock();                                                      \
         LeaveCritical();                                                    \
     }

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -231,7 +231,7 @@ BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
     // Tests with single outpoint tallyItem
     {
         CompactTallyItem tallyItem = GetTallyItem({4999});
-        CTransactionBuilder txBuilder(wallet, tallyItem, *m_node.fee_estimator);
+        CTransactionBuilder txBuilder(wallet, tallyItem);
 
         BOOST_CHECK_EQUAL(txBuilder.CountOutputs(), 0);
         BOOST_CHECK_EQUAL(txBuilder.GetAmountInitial(), tallyItem.nAmount);
@@ -268,7 +268,7 @@ BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
     // Tests with multiple outpoint tallyItem
     {
         CompactTallyItem tallyItem = GetTallyItem({10000, 20000, 30000, 40000, 50000});
-        CTransactionBuilder txBuilder(wallet, tallyItem, *m_node.fee_estimator);
+        CTransactionBuilder txBuilder(wallet, tallyItem);
         std::vector<CTransactionBuilderOutput*> vecOutputs;
         bilingual_str strResult;
 

--- a/test/lint/lint-cppcheck-dash.sh
+++ b/test/lint/lint-cppcheck-dash.sh
@@ -30,6 +30,8 @@ IGNORED_WARNINGS=(
     "src/rpc/masternode.cpp:.*:21: warning: Consider using std::copy algorithm instead of a raw loop." # UniValue doesn't support std::copy
     "src/cachemultimap.h:.*: warning: Variable 'mapIt' can be declared as reference to const"
     "src/evo/simplifiedmns.cpp:.*:20: warning: Consider using std::copy algorithm instead of a raw loop."
+    "src/llmq/commitment.cpp.* warning: Consider using std::all_of or std::none_of algorithm instead of a raw loop. \[useStlAlgorithm\]"
+
 # General catchall, for some reason any value named 'hash' is viewed as never used.
     "Variable 'hash' is assigned a value that is never used."
 
@@ -37,7 +39,8 @@ IGNORED_WARNINGS=(
 #    "Consider performing initialization in initialization list."
     "Consider using std::transform algorithm instead of a raw loop."
     "Consider using std::accumulate algorithm instead of a raw loop."
-#    "Consider using std::any_of algorithm instead of a raw loop."
+    "Consider using std::any_of algorithm instead of a raw loop."
+    "Consider using std::copy_if algorithm instead of a raw loop."
 #    "Consider using std::count_if algorithm instead of a raw loop."
 #    "Consider using std::find_if algorithm instead of a raw loop."
 #    "Member variable '.*' is not initialized in the constructor."

--- a/test/lint/lint-cppcheck-dash.sh
+++ b/test/lint/lint-cppcheck-dash.sh
@@ -31,6 +31,8 @@ IGNORED_WARNINGS=(
     "src/cachemultimap.h:.*: warning: Variable 'mapIt' can be declared as reference to const"
     "src/evo/simplifiedmns.cpp:.*:20: warning: Consider using std::copy algorithm instead of a raw loop."
     "src/llmq/commitment.cpp.* warning: Consider using std::all_of or std::none_of algorithm instead of a raw loop. \[useStlAlgorithm\]"
+    "[note|warning]: Return value 'state.Invalid(.*)' is always false"
+    "note: Calling function 'Invalid' returns 0"
 
 # General catchall, for some reason any value named 'hash' is viewed as never used.
     "Variable 'hash' is assigned a value that is never used."
@@ -48,8 +50,6 @@ IGNORED_WARNINGS=(
     "unusedFunction"
     "unknownMacro"
     "unusedStructMember"
-    "note: Calling function 'Invalid' returns 0"
-    "[note|warning]: Return value 'state.Invalid(.*)' is always false"
 )
 
 # We should attempt to update this with all dash specific code

--- a/test/lint/lint-cppcheck-dash.sh
+++ b/test/lint/lint-cppcheck-dash.sh
@@ -45,6 +45,8 @@ IGNORED_WARNINGS=(
     "unusedFunction"
     "unknownMacro"
     "unusedStructMember"
+    "note: Calling function 'Invalid' returns 0"
+    "[note|warning]: Return value 'state.Invalid(.*)' is always false"
 )
 
 # We should attempt to update this with all dash specific code
@@ -77,8 +79,8 @@ FILES=$(git ls-files -- "src/batchedlogger.*" \
                         "src/rpc/governance.cpp" \
                         "src/rpc/masternode.cpp" \
                         "src/rpc/quorums.cpp" \
-                        "src/spork.*" \
                         "src/saltedhasher.*" \
+                        "src/spork.*" \
                         "src/stacktraces.*" \
                         "src/statsd_client.*" \
                         "src/test/block_reward_reallocation_tests.cpp" \
@@ -88,7 +90,8 @@ FILES=$(git ls-files -- "src/batchedlogger.*" \
                         "src/test/evo*.cpp" \
                         "src/test/governance*.cpp" \
                         "src/wallet/hdchain.*" \
-                        "src/unordered_lru_cache.h")
+                        "src/unordered_lru_cache.h" \
+                        )
 
 
 if ! command -v cppcheck > /dev/null; then

--- a/test/lint/lint-cppcheck-dash.sh
+++ b/test/lint/lint-cppcheck-dash.sh
@@ -31,6 +31,12 @@ IGNORED_WARNINGS=(
     "src/cachemultimap.h:.*: warning: Variable 'mapIt' can be declared as reference to const"
     "src/evo/simplifiedmns.cpp:.*:20: warning: Consider using std::copy algorithm instead of a raw loop."
     "src/llmq/commitment.cpp.* warning: Consider using std::all_of or std::none_of algorithm instead of a raw loop. \[useStlAlgorithm\]"
+    "src/rpc/.*cpp:.*: note: Function pointer used here."
+    "src/masternode/sync.cpp:.*: warning: Variable 'pnode' can be declared as pointer to const \[constVariableReference\]"
+
+    "src/stacktraces.cpp:.*: .*: Parameter 'info' can be declared as pointer to const"
+    "src/stacktraces.cpp:.*: note: You might need to cast the function pointer here"
+
     "[note|warning]: Return value 'state.Invalid(.*)' is always false"
     "note: Calling function 'Invalid' returns 0"
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash-issues/issues/67

See also https://github.com/dashpay/dash/pull/5880 for prior work.
There's too many false alarm warnings with new kubuntu 23.10 (cppcheck 2.11)

## What was done?
Bump cppcheck to version 2.13 and fix related warnings or suppressing them if they are false-alarm.


## How Has This Been Tested?
Run `test/lint/lint-cppcheck-dash.sh` and see no output.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

