### PR TITLE
feat: allow squash merges in github-merge.py script

### DIFF
--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -303,7 +303,12 @@ def main():
         message += subprocess.check_output([GIT,'log','--no-merges','--topo-order','--pretty=format:%H %s (%an)',base_branch+'..'+head_branch]).decode('utf-8')
         message += '\n\nPull request description:\n\n  ' + body.replace('\n', '\n  ') + '\n'
         try:
-            subprocess.check_call([GIT,'merge','-q','--commit','--no-edit','--no-ff','--no-gpg-sign','-m',message.encode('utf-8'),head_branch])
+            squash = input("Enter s for squash; anything else for regular merge commit: ").lower() == 's'
+            if squash:
+                subprocess.check_call([GIT,'merge','-q','--squash','--no-gpg-sign',head_branch])
+                subprocess.check_call([GIT,'commit','-q','--no-gpg-sign','-m',message.encode('utf-8')])
+            else:
+                subprocess.check_call([GIT,'merge','-q','--commit','--no-edit','--no-ff','--no-gpg-sign','-m',message.encode('utf-8'),head_branch])
         except subprocess.CalledProcessError:
             print("ERROR: Cannot be merged cleanly.",file=stderr)
             subprocess.check_call([GIT,'merge','--abort'])

--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -303,7 +303,7 @@ def main():
         message += subprocess.check_output([GIT,'log','--no-merges','--topo-order','--pretty=format:%H %s (%an)',base_branch+'..'+head_branch]).decode('utf-8')
         message += '\n\nPull request description:\n\n  ' + body.replace('\n', '\n  ') + '\n'
         try:
-            squash = input("Enter s for squash; anything else for regular merge commit: ").lower() == 's'
+            squash = ask_prompt("Enter s for squash; anything else for regular merge commit.").lower() == 's'
             if squash:
                 subprocess.check_call([GIT,'merge','-q','--squash','--no-gpg-sign',head_branch])
                 subprocess.check_call([GIT,'commit','-q','--no-gpg-sign','-m',message.encode('utf-8')])


### PR DESCRIPTION
## Issue being fixed or feature implemented
We like to squash merge sometimes when the PRs git history is not useful to preserve in the main repo's history. If I want to use github-merge.py more in future it needs ability to squash. 

## What was done?
This modifies the github-merge.py script to allow optionally squash merging. 

## How Has This Been Tested?
Did a local only squash merge

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

