### PR TITLE
backport: merge bitcoin#21000, #21586, #21599, #21604, #23859, partial bitcoin#21798, #26341 (auxiliary backports: part 13)

### DIFF
--- a/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
+++ b/src/test/fuzz/crypto_chacha20_poly1305_aead.cpp
@@ -46,18 +46,24 @@ FUZZ_TARGET(crypto_chacha20_poly1305_aead)
                 assert(ok);
             },
             [&] {
+                if (AdditionOverflow(seqnr_payload, static_cast<uint64_t>(1))) {
+                    return;
+                }
                 seqnr_payload += 1;
                 aad_pos += CHACHA20_POLY1305_AEAD_AAD_LEN;
                 if (aad_pos + CHACHA20_POLY1305_AEAD_AAD_LEN > CHACHA20_ROUND_OUTPUT) {
                     aad_pos = 0;
+                    if (AdditionOverflow(seqnr_aad, static_cast<uint64_t>(1))) {
+                        return;
+                    }
                     seqnr_aad += 1;
                 }
             },
             [&] {
-                seqnr_payload = fuzzed_data_provider.ConsumeIntegral<int>();
+                seqnr_payload = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
             },
             [&] {
-                seqnr_aad = fuzzed_data_provider.ConsumeIntegral<int>();
+                seqnr_aad = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
             },
             [&] {
                 is_encrypt = fuzzed_data_provider.ConsumeBool();

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -44,7 +44,10 @@ FUZZ_TARGET_INIT(pow, initialize_pow)
                 current_block.nHeight = current_height;
             }
             if (fuzzed_data_provider.ConsumeBool()) {
-                current_block.nTime = fixed_time + current_height * consensus_params.nPowTargetSpacing;
+                const uint32_t seconds = current_height * consensus_params.nPowTargetSpacing;
+                if (!AdditionOverflow(fixed_time, seconds)) {
+                    current_block.nTime = fixed_time + seconds;
+                }
             }
             if (fuzzed_data_provider.ConsumeBool()) {
                 current_block.nBits = fixed_bits;

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -76,13 +76,21 @@ void SetMempoolConstraints(ArgsManager& args, FuzzedDataProvider& fuzzed_data_pr
                      ToString(fuzzed_data_provider.ConsumeIntegralInRange<unsigned>(0, 999)));
 }
 
+void MockTime(FuzzedDataProvider& fuzzed_data_provider, const CChainState& chainstate)
+{
+    const auto time = ConsumeTime(fuzzed_data_provider,
+                                  chainstate.m_chain.Tip()->GetMedianTimePast() + 1,
+                                  std::numeric_limits<decltype(chainstate.m_chain.Tip()->nTime)>::max());
+    SetMockTime(time);
+}
+
 FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const auto& node = g_setup->m_node;
     auto& chainstate = node.chainman->ActiveChainstate();
 
-    SetMockTime(ConsumeTime(fuzzed_data_provider));
+    MockTime(fuzzed_data_provider, chainstate);
     SetMempoolConstraints(*node.args, fuzzed_data_provider);
 
     // All RBF-spendable outpoints
@@ -161,7 +169,7 @@ FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
         }();
 
         if (fuzzed_data_provider.ConsumeBool()) {
-            SetMockTime(ConsumeTime(fuzzed_data_provider));
+            MockTime(fuzzed_data_provider, chainstate);
         }
         if (fuzzed_data_provider.ConsumeBool()) {
             SetMempoolConstraints(*node.args, fuzzed_data_provider);
@@ -262,6 +270,10 @@ FUZZ_TARGET_INIT(tx_pool, initialize_tx_pool)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const auto& node = g_setup->m_node;
+    auto& chainstate = node.chainman->ActiveChainstate();
+
+    MockTime(fuzzed_data_provider, chainstate);
+    SetMempoolConstraints(*node.args, fuzzed_data_provider);
 
     std::vector<uint256> txids;
     for (const auto& outpoint : g_outpoints_coinbase_init_mature) {
@@ -273,11 +285,29 @@ FUZZ_TARGET_INIT(tx_pool, initialize_tx_pool)
         txids.push_back(ConsumeUInt256(fuzzed_data_provider));
     }
 
-    CTxMemPool tx_pool{/* estimator */ nullptr, /* check_ratio */ 1};
+    CTxMemPool tx_pool_{/* estimator */ nullptr, /* check_ratio */ 1};
+    MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(&tx_pool_);
 
     LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 300)
     {
         const auto mut_tx = ConsumeTransaction(fuzzed_data_provider, txids);
+
+        if (fuzzed_data_provider.ConsumeBool()) {
+            MockTime(fuzzed_data_provider, chainstate);
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            SetMempoolConstraints(*node.args, fuzzed_data_provider);
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            tx_pool.RollingFeeUpdate();
+        }
+        if (fuzzed_data_provider.ConsumeBool()) {
+            const auto& txid = fuzzed_data_provider.ConsumeBool() ?
+                                   mut_tx.GetHash() :
+                                   PickValue(fuzzed_data_provider, txids);
+            const auto delta = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(-50 * COIN, +50 * COIN);
+            tx_pool.PrioritiseTransaction(txid, delta);
+        }
 
         const auto tx = MakeTransactionRef(mut_tx);
         const bool bypass_limits = fuzzed_data_provider.ConsumeBool();

--- a/test/functional/test_framework/blockfilter.py
+++ b/test/functional/test_framework/blockfilter.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Helper routines relevant for compact block filters (BIP158).
+"""
+from .siphash import siphash
+
+
+def bip158_basic_element_hash(script_pub_key, N, block_hash):
+    """ Calculates the ranged hash of a filter element as defined in BIP158:
+
+    'The first step in the filter construction is hashing the variable-sized
+    raw items in the set to the range [0, F), where F = N * M.'
+
+    'The items are first passed through the pseudorandom function SipHash, which takes a
+    128-bit key k and a variable-sized byte vector and produces a uniformly random 64-bit
+    output. Implementations of this BIP MUST use the SipHash parameters c = 2 and d = 4.'
+
+    'The parameter k MUST be set to the first 16 bytes of the hash (in standard
+    little-endian representation) of the block for which the filter is constructed. This
+    ensures the key is deterministic while still varying from block to block.'
+    """
+    M = 784931
+    block_hash_bytes = bytes.fromhex(block_hash)[::-1]
+    k0 = int.from_bytes(block_hash_bytes[0:8], 'little')
+    k1 = int.from_bytes(block_hash_bytes[8:16], 'little')
+    return (siphash(k0, k1, script_pub_key) * (N * M)) >> 64
+
+
+def bip158_relevant_scriptpubkeys(node, block_hash):
+    """ Determines the basic filter relvant scriptPubKeys as defined in BIP158:
+
+    'A basic filter MUST contain exactly the following items for each transaction in a block:
+       - The previous output script (the script being spent) for each input, except for
+         the coinbase transaction.
+       - The scriptPubKey of each output, aside from all OP_RETURN output scripts.'
+    """
+    spks = set()
+    for tx in node.getblock(blockhash=block_hash, verbosity=3)['tx']:
+        # gather prevout scripts
+        for i in tx['vin']:
+            if 'prevout' in i:
+                spks.add(bytes.fromhex(i['prevout']['scriptPubKey']['hex']))
+        # gather output scripts
+        for o in tx['vout']:
+            if o['scriptPubKey']['type'] != 'nulldata':
+                spks.add(bytes.fromhex(o['scriptPubKey']['hex']))
+    return spks

--- a/test/functional/test_framework/siphash.py
+++ b/test/functional/test_framework/siphash.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
-# Copyright (c) 2016 The Bitcoin Core developers
+# Copyright (c) 2016-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Specialized SipHash-2-4 implementations.
+"""SipHash-2-4 implementation.
 
-This implements SipHash-2-4 for 256-bit integers.
+This implements SipHash-2-4. For convenience, an interface taking 256-bit
+integers is provided in addition to the one accepting generic data.
 """
 
 def rotl64(n, b):
     return n >> (64 - b) | (n & ((1 << (64 - b)) - 1)) << b
+
 
 def siphash_round(v0, v1, v2, v3):
     v0 = (v0 + v1) & ((1 << 64) - 1)
@@ -27,37 +29,37 @@ def siphash_round(v0, v1, v2, v3):
     v2 = rotl64(v2, 32)
     return (v0, v1, v2, v3)
 
-def siphash256(k0, k1, h):
-    n0 = h & ((1 << 64) - 1)
-    n1 = (h >> 64) & ((1 << 64) - 1)
-    n2 = (h >> 128) & ((1 << 64) - 1)
-    n3 = (h >> 192) & ((1 << 64) - 1)
+
+def siphash(k0, k1, data):
+    assert(type(data) == bytes)
     v0 = 0x736f6d6570736575 ^ k0
     v1 = 0x646f72616e646f6d ^ k1
     v2 = 0x6c7967656e657261 ^ k0
-    v3 = 0x7465646279746573 ^ k1 ^ n0
+    v3 = 0x7465646279746573 ^ k1
+    c = 0
+    t = 0
+    for d in data:
+        t |= d << (8 * (c % 8))
+        c = (c + 1) & 0xff
+        if (c & 7) == 0:
+            v3 ^= t
+            v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+            v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
+            v0 ^= t
+            t = 0
+    t = t | (c << 56)
+    v3 ^= t
     v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
     v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0 ^= n0
-    v3 ^= n1
-    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0 ^= n1
-    v3 ^= n2
-    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0 ^= n2
-    v3 ^= n3
-    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0 ^= n3
-    v3 ^= 0x2000000000000000
-    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
-    v0 ^= 0x2000000000000000
-    v2 ^= 0xFF
+    v0 ^= t
+    v2 ^= 0xff
     v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
     v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
     v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
     v0, v1, v2, v3 = siphash_round(v0, v1, v2, v3)
     return v0 ^ v1 ^ v2 ^ v3
+
+
+def siphash256(k0, k1, num):
+    assert(type(num) == int)
+    return siphash(k0, k1, num.to_bytes(32, 'little'))

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -5,6 +5,8 @@
 # names can be used.
 # See https://github.com/google/sanitizers/issues/1364
 signed-integer-overflow:txmempool.cpp
+# https://github.com/bitcoin/bitcoin/pull/21798#issuecomment-829180719
+signed-integer-overflow:policy/feerate.cpp
 
 # -fsanitize=integer suppressions
 # ===============================

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,6 +1,10 @@
 # -fsanitize=undefined suppressions
 # =================================
-signed-integer-overflow:CTxMemPool::PrioritiseTransaction
+# This would be `signed-integer-overflow:CTxMemPool::PrioritiseTransaction`,
+# however due to a bug in clang the symbolizer is disabled and thus no symbol
+# names can be used.
+# See https://github.com/google/sanitizers/issues/1364
+signed-integer-overflow:txmempool.cpp
 
 # -fsanitize=integer suppressions
 # ===============================

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -100,4 +100,5 @@ shift-base:leveldb/
 shift-base:net_processing.cpp
 shift-base:streams.h
 shift-base:util/bip32.cpp
+signed-integer-overflow:txmempool.cpp
 vptr:bls/bls.h

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,6 +1,6 @@
 # -fsanitize=undefined suppressions
 # =================================
-# No suppressions at the moment. Hooray!
+signed-integer-overflow:CTxMemPool::PrioritiseTransaction
 
 # -fsanitize=integer suppressions
 # ===============================
@@ -100,5 +100,4 @@ shift-base:leveldb/
 shift-base:net_processing.cpp
 shift-base:streams.h
 shift-base:util/bip32.cpp
-signed-integer-overflow:txmempool.cpp
 vptr:bls/bls.h

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,3 +1,7 @@
+# -fsanitize=undefined suppressions
+# =================================
+# No suppressions at the moment. Hooray!
+
 # -fsanitize=integer suppressions
 # ===============================
 # Unsigned integer overflow occurs when the result of an unsigned integer
@@ -6,7 +10,8 @@
 # contains files in which we expect unsigned integer overflows to occur. The
 # list is used to suppress -fsanitize=integer warnings when running our CI UBSan
 # job.
-unsigned-integer-overflow:*/include/c++/*/bits/basic_string.tcc
+unsigned-integer-overflow:*/include/c++/
+unsigned-integer-overflow:addrman.cpp
 unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:basic_string.h
 unsigned-integer-overflow:bench/bench.h
@@ -15,39 +20,42 @@ unsigned-integer-overflow:bloom.cpp
 unsigned-integer-overflow:chain.cpp
 unsigned-integer-overflow:chain.h
 unsigned-integer-overflow:coded_stream.h
+unsigned-integer-overflow:coins.cpp
+unsigned-integer-overflow:compressor.cpp
 unsigned-integer-overflow:core_write.cpp
-unsigned-integer-overflow:crypto/*
+unsigned-integer-overflow:crypto/
+# unsigned-integer-overflow in FuzzedDataProvider's ConsumeIntegralInRange
+unsigned-integer-overflow:FuzzedDataProvider.h
 unsigned-integer-overflow:hash.cpp
-unsigned-integer-overflow:leveldb/db/log_reader.cc
-unsigned-integer-overflow:leveldb/util/bloom.cc
-unsigned-integer-overflow:leveldb/util/crc32c.h
-unsigned-integer-overflow:leveldb/util/hash.cc
+unsigned-integer-overflow:leveldb/
 unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
+unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:stl_bvector.h
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
 unsigned-integer-overflow:xoroshiro128plusplus.h
-# std::variant warning fixed in https://github.com/gcc-mirror/gcc/commit/074436cf8cdd2a9ce75cadd36deb8301f00e55b9
-implicit-unsigned-integer-truncation:std::__detail::__variant::_Variant_storage
-vptr:bls/bls.h
-
-implicit-integer-sign-change:*/include/c++/*/bits/*.h
+implicit-integer-sign-change:*/include/boost/
+implicit-integer-sign-change:*/include/c++/
 implicit-integer-sign-change:*/new_allocator.h
-implicit-integer-sign-change:/usr/include/boost/date_time/format_date_parser.hpp
+implicit-integer-sign-change:addrman.h
 implicit-integer-sign-change:arith_uint256.cpp
 implicit-integer-sign-change:bech32.cpp
 implicit-integer-sign-change:bloom.cpp
-implicit-integer-sign-change:chain.*
+implicit-integer-sign-change:chain.cpp
+implicit-integer-sign-change:chain.h
 implicit-integer-sign-change:coins.h
 implicit-integer-sign-change:compat/stdin.cpp
 implicit-integer-sign-change:compressor.h
 implicit-integer-sign-change:crc32c/
-implicit-integer-sign-change:crypto/*
+implicit-integer-sign-change:crypto/
+# implicit-integer-sign-change in FuzzedDataProvider's ConsumeIntegralInRange
+implicit-integer-sign-change:FuzzedDataProvider.h
 implicit-integer-sign-change:key.cpp
 implicit-integer-sign-change:noui.cpp
+implicit-integer-sign-change:policy/fees.cpp
 implicit-integer-sign-change:prevector.h
 implicit-integer-sign-change:script/bitcoinconsensus.cpp
 implicit-integer-sign-change:script/interpreter.cpp
@@ -57,20 +65,39 @@ implicit-integer-sign-change:test/coins_tests.cpp
 implicit-integer-sign-change:test/pow_tests.cpp
 implicit-integer-sign-change:test/prevector_tests.cpp
 implicit-integer-sign-change:test/sighash_tests.cpp
+implicit-integer-sign-change:test/skiplist_tests.cpp
 implicit-integer-sign-change:test/streams_tests.cpp
 implicit-integer-sign-change:test/transaction_tests.cpp
 implicit-integer-sign-change:txmempool.cpp
+implicit-integer-sign-change:util/strencodings.cpp
+implicit-integer-sign-change:util/strencodings.h
+implicit-integer-sign-change:validation.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp
 implicit-signed-integer-truncation,implicit-integer-sign-change:chain.h
 implicit-signed-integer-truncation,implicit-integer-sign-change:test/skiplist_tests.cpp
+implicit-signed-integer-truncation:addrman.cpp
+implicit-signed-integer-truncation:addrman.h
 implicit-signed-integer-truncation:chain.h
-implicit-signed-integer-truncation:crypto/*
+implicit-signed-integer-truncation:crypto/
 implicit-signed-integer-truncation:cuckoocache.h
-implicit-signed-integer-truncation:leveldb/*
+implicit-signed-integer-truncation:leveldb/
+implicit-signed-integer-truncation:net.cpp
+implicit-signed-integer-truncation:net_processing.cpp
 implicit-signed-integer-truncation:streams.h
 implicit-signed-integer-truncation:test/arith_uint256_tests.cpp
 implicit-signed-integer-truncation:test/skiplist_tests.cpp
 implicit-signed-integer-truncation:torcontrol.cpp
-implicit-unsigned-integer-truncation:crypto/*
-implicit-unsigned-integer-truncation:leveldb/*
+implicit-unsigned-integer-truncation:crypto/
+implicit-unsigned-integer-truncation:leveldb/
+# std::variant warning fixed in https://github.com/gcc-mirror/gcc/commit/074436cf8cdd2a9ce75cadd36deb8301f00e55b9
+implicit-unsigned-integer-truncation:std::__detail::__variant::_Variant_storage
 shift-base:xoroshiro128plusplus.h
+shift-base:*/include/c++/
+shift-base:arith_uint256.cpp
+shift-base:crypto/
+shift-base:hash.cpp
+shift-base:leveldb/
+shift-base:net_processing.cpp
+shift-base:streams.h
+shift-base:util/bip32.cpp
+vptr:bls/bls.h

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -39,6 +39,7 @@ unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:pubkey.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:stl_bvector.h
+unsigned-integer-overflow:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
@@ -95,6 +96,7 @@ implicit-signed-integer-truncation:test/skiplist_tests.cpp
 implicit-signed-integer-truncation:torcontrol.cpp
 implicit-unsigned-integer-truncation:crypto/
 implicit-unsigned-integer-truncation:leveldb/
+implicit-unsigned-integer-truncation:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 # std::variant warning fixed in https://github.com/gcc-mirror/gcc/commit/074436cf8cdd2a9ce75cadd36deb8301f00e55b9
 implicit-unsigned-integer-truncation:std::__detail::__variant::_Variant_storage
 shift-base:xoroshiro128plusplus.h
@@ -105,5 +107,6 @@ shift-base:hash.cpp
 shift-base:leveldb/
 shift-base:net_processing.cpp
 shift-base:streams.h
+shift-base:test/fuzz/crypto_diff_fuzz_chacha20.cpp
 shift-base:util/bip32.cpp
 vptr:bls/bls.h


### PR DESCRIPTION
## Additional Information

* Dependency for https://github.com/dashpay/dash/pull/5902
* [bitcoin#21586](https://github.com/bitcoin/bitcoin/pull/21586) was listed as DNM in the backports Google Sheet as listed below as it is `reverted as #23059`
  ![Listing of bitcoin#21586 as DNM](https://github.com/dashpay/dash/assets/63189531/413c116a-b3cb-4b58-becd-0d731b0e4b0b)
  * [bitcoin#23059](https://github.com/bitcoin/bitcoin/pull/23059) actually reverts [bitcoin#22925](https://github.com/bitcoin/bitcoin/pull/22925) (which deals with `addrman.cpp`), not [bitcoin#21586](https://github.com/bitcoin/bitcoin/pull/21586) (which deals with `txmempool.cpp`).

## Breaking Changes

None, changes are limited to fuzzing, functional tests and undefined behavior exclusions

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

