### PR TITLE
fix: actually run rpc_fundrawtransaction with and without HD feature

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -28,17 +28,16 @@ class RawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
         self.setup_clean_chain = True
-        self.extra_args = [[f'-usehd={self.options.usehd}']] * self.num_nodes
         # This test isn't testing tx relay. Set whitelist on the peers for
         # instant tx relay.
-        self.extra_args = [['-whitelist=noban@127.0.0.1']] * self.num_nodes
+        self.extra_args = [[f'-usehd={not self.options.nohd}',  '-whitelist=noban@127.0.0.1']] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
     def add_options(self, parser):
-        parser.add_argument("--usehd", dest="usehd", default=False, action="store_true",
-                            help="Test with -usehd enabled")
+        parser.add_argument("--nohd", dest="nohd", default=False, action="store_true",
+                            help="Test with -nohd enabled")
 
     def setup_network(self):
         self.setup_nodes()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -98,7 +98,7 @@ BASE_SCRIPTS = [
     'feature_maxuploadtarget.py',
     'feature_block.py', # NOTE: needs dash_hash to pass
     'rpc_fundrawtransaction.py',
-    'rpc_fundrawtransaction.py --usehd',
+    'rpc_fundrawtransaction.py --nohd',
     'wallet_multiwallet.py --usecli',
     'p2p_quorum_data.py',
     # vv Tests less than 2m vv


### PR DESCRIPTION
## Issue being fixed or feature implemented
Due to double initialization of `extra_args` rpc_fundrawtransaction always test with enabled or disabled HD wallets (which is enabled by default). 

## What was done?
Fixes double initialization and inversion of condition due to hd wallets enabled by default since #5807

## How Has This Been Tested?
Run functional tests and watch `ps aux` during running to ensure that `-usehd` is set properly.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

