### PR TITLE
refactor: move masternode payments processing to helper class, move C{Governance,Spork}Manager to NodeContext

### DIFF
--- a/contrib/auto_gdb/debug.gdb
+++ b/contrib/auto_gdb/debug.gdb
@@ -7,6 +7,6 @@ source test_used_size.gdb
 #logsize mnodeman "memlog.txt"
 logsize mnpayments "memlog.txt"
 #logsize instantsend "memlog.txt"
-#logsize sporkManager "memlog.txt"
+#logsize sporkman "memlog.txt"
 #logsize masternodeSync "memlog.txt"
 #logsize governance "memlog.txt"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -180,6 +180,7 @@ BITCOIN_CORE_H = \
   evo/assetlocktx.h \
   evo/dmn_types.h \
   evo/cbtx.h \
+  evo/chainhelper.h \
   evo/creditpool.h \
   evo/deterministicmns.h \
   evo/dmnstate.h \
@@ -423,6 +424,7 @@ libbitcoin_server_a_SOURCES = \
   evo/assetlocktx.cpp \
   evo/cbtx.cpp \
   evo/creditpool.cpp \
+  evo/chainhelper.cpp \
   evo/deterministicmns.cpp \
   evo/dmnstate.cpp \
   evo/evodb.cpp \

--- a/src/evo/chainhelper.cpp
+++ b/src/evo/chainhelper.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2024 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <evo/chainhelper.h>
+
+#include <consensus/params.h>
+#include <masternode/payments.h>
+
+CChainstateHelper::CChainstateHelper(CGovernanceManager& govman, const Consensus::Params& consensus_params, const CMasternodeSync& mn_sync,
+                                     const CSporkManager& sporkman)
+    : mn_payments{std::make_unique<CMNPaymentsProcessor>(govman, consensus_params, mn_sync, sporkman)}
+{}
+
+CChainstateHelper::~CChainstateHelper() = default;

--- a/src/evo/chainhelper.h
+++ b/src/evo/chainhelper.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_EVO_CHAINHELPER_H
+#define BITCOIN_EVO_CHAINHELPER_H
+
+#include <memory>
+
+class CMNPaymentsProcessor;
+class CMasternodeSync;
+class CGovernanceManager;
+class CSporkManager;
+
+namespace Consensus { struct Params; }
+
+class CChainstateHelper
+{
+public:
+    explicit CChainstateHelper(CGovernanceManager& govman, const Consensus::Params& consensus_params, const CMasternodeSync& mn_sync,
+                               const CSporkManager& sporkman);
+    ~CChainstateHelper();
+
+    CChainstateHelper() = delete;
+    CChainstateHelper(const CChainstateHelper&) = delete;
+
+public:
+    const std::unique_ptr<CMNPaymentsProcessor> mn_payments;
+};
+
+#endif // BITCOIN_EVO_CHAINHELPER_H

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -22,9 +22,7 @@
 #include <stack>
 
 // Forward declaration to prevent a new circular dependencies through masternode/payments.h
-namespace MasternodePayments {
 CAmount PlatformShare(const CAmount masternodeReward);
-} // namespace MasternodePayments
 
 static const std::string DB_CREDITPOOL_SNAPSHOT = "cpm_S";
 
@@ -229,7 +227,7 @@ CCreditPoolDiff::CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindexP
 
     if (DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_MN_RR)) {
         // We consider V20 active if mn_rr is active
-        platformReward = MasternodePayments::PlatformShare(GetMasternodePayment(pindexPrev->nHeight + 1, blockSubsidy, /*fV20Active=*/ true));
+        platformReward = PlatformShare(GetMasternodePayment(pindexPrev->nHeight + 1, blockSubsidy, /*fV20Active=*/ true));
     }
 }
 

--- a/src/governance/classes.cpp
+++ b/src/governance/classes.cpp
@@ -224,16 +224,16 @@ std::vector<CSuperblock_sptr> CGovernanceManager::GetActiveTriggers()
 *   - Does this block have a non-executed and activated trigger?
 */
 
-bool CSuperblockManager::IsSuperblockTriggered(CGovernanceManager& governanceManager, int nBlockHeight)
+bool CSuperblockManager::IsSuperblockTriggered(CGovernanceManager& govman, int nBlockHeight)
 {
     LogPrint(BCLog::GOBJECT, "CSuperblockManager::IsSuperblockTriggered -- Start nBlockHeight = %d\n", nBlockHeight);
     if (!CSuperblock::IsValidBlockHeight(nBlockHeight)) {
         return false;
     }
 
-    LOCK(governanceManager.cs);
+    LOCK(govman.cs);
     // GET ALL ACTIVE TRIGGERS
-    std::vector<CSuperblock_sptr> vecTriggers = governanceManager.GetActiveTriggers();
+    std::vector<CSuperblock_sptr> vecTriggers = govman.GetActiveTriggers();
 
     LogPrint(BCLog::GOBJECT, "CSuperblockManager::IsSuperblockTriggered -- vecTriggers.size() = %d\n", vecTriggers.size());
 
@@ -243,7 +243,7 @@ bool CSuperblockManager::IsSuperblockTriggered(CGovernanceManager& governanceMan
             continue;
         }
 
-        CGovernanceObject* pObj = pSuperblock->GetGovernanceObject(governanceManager);
+        CGovernanceObject* pObj = pSuperblock->GetGovernanceObject(govman);
 
         if (!pObj) {
             LogPrintf("CSuperblockManager::IsSuperblockTriggered -- pObj == nullptr, continuing\n");
@@ -277,14 +277,14 @@ bool CSuperblockManager::IsSuperblockTriggered(CGovernanceManager& governanceMan
 }
 
 
-bool CSuperblockManager::GetBestSuperblock(CGovernanceManager& governanceManager, CSuperblock_sptr& pSuperblockRet, int nBlockHeight)
+bool CSuperblockManager::GetBestSuperblock(CGovernanceManager& govman, CSuperblock_sptr& pSuperblockRet, int nBlockHeight)
 {
     if (!CSuperblock::IsValidBlockHeight(nBlockHeight)) {
         return false;
     }
 
-    AssertLockHeld(governanceManager.cs);
-    std::vector<CSuperblock_sptr> vecTriggers = governanceManager.GetActiveTriggers();
+    AssertLockHeld(govman.cs);
+    std::vector<CSuperblock_sptr> vecTriggers = govman.GetActiveTriggers();
     int nYesCount = 0;
 
     for (const auto& pSuperblock : vecTriggers) {
@@ -292,7 +292,7 @@ bool CSuperblockManager::GetBestSuperblock(CGovernanceManager& governanceManager
             continue;
         }
 
-        const CGovernanceObject* pObj = pSuperblock->GetGovernanceObject(governanceManager);
+        const CGovernanceObject* pObj = pSuperblock->GetGovernanceObject(govman);
 
         if (!pObj) {
             continue;
@@ -316,14 +316,14 @@ bool CSuperblockManager::GetBestSuperblock(CGovernanceManager& governanceManager
 *   - Returns payments for superblock
 */
 
-bool CSuperblockManager::GetSuperblockPayments(CGovernanceManager& governanceManager, int nBlockHeight, std::vector<CTxOut>& voutSuperblockRet)
+bool CSuperblockManager::GetSuperblockPayments(CGovernanceManager& govman, int nBlockHeight, std::vector<CTxOut>& voutSuperblockRet)
 {
-    LOCK(governanceManager.cs);
+    LOCK(govman.cs);
 
     // GET THE BEST SUPERBLOCK FOR THIS BLOCK HEIGHT
 
     CSuperblock_sptr pSuperblock;
-    if (!CSuperblockManager::GetBestSuperblock(governanceManager, pSuperblock, nBlockHeight)) {
+    if (!CSuperblockManager::GetBestSuperblock(govman, pSuperblock, nBlockHeight)) {
         LogPrint(BCLog::GOBJECT, "CSuperblockManager::GetSuperblockPayments -- Can't find superblock for height %d\n", nBlockHeight);
         return false;
     }
@@ -362,29 +362,29 @@ bool CSuperblockManager::GetSuperblockPayments(CGovernanceManager& governanceMan
     return true;
 }
 
-bool CSuperblockManager::IsValid(CGovernanceManager& governanceManager, const CTransaction& txNew, int nBlockHeight, CAmount blockReward)
+bool CSuperblockManager::IsValid(CGovernanceManager& govman, const CTransaction& txNew, int nBlockHeight, CAmount blockReward)
 {
     // GET BEST SUPERBLOCK, SHOULD MATCH
-    LOCK(governanceManager.cs);
+    LOCK(govman.cs);
 
     CSuperblock_sptr pSuperblock;
-    if (CSuperblockManager::GetBestSuperblock(governanceManager, pSuperblock, nBlockHeight)) {
-        return pSuperblock->IsValid(governanceManager, txNew, nBlockHeight, blockReward);
+    if (CSuperblockManager::GetBestSuperblock(govman, pSuperblock, nBlockHeight)) {
+        return pSuperblock->IsValid(govman, txNew, nBlockHeight, blockReward);
     }
 
     return false;
 }
 
-void CSuperblockManager::ExecuteBestSuperblock(CGovernanceManager& governanceManager, int nBlockHeight)
+void CSuperblockManager::ExecuteBestSuperblock(CGovernanceManager& govman, int nBlockHeight)
 {
-    LOCK(governanceManager.cs);
+    LOCK(govman.cs);
 
     CSuperblock_sptr pSuperblock;
-    if (GetBestSuperblock(governanceManager, pSuperblock, nBlockHeight)) {
+    if (GetBestSuperblock(govman, pSuperblock, nBlockHeight)) {
         // All checks are done in CSuperblock::IsValid via IsBlockValueValid and IsBlockPayeeValid,
         // tip wouldn't be updated if anything was wrong. Mark this trigger as executed.
         pSuperblock->SetExecuted();
-        governanceManager.ResetVotedFundingTrigger();
+        govman.ResetVotedFundingTrigger();
     }
 }
 
@@ -442,10 +442,10 @@ CSuperblock::CSuperblock(int nBlockHeight, std::vector<CGovernancePayment> vecPa
     nGovObjHash = GetHash();
 }
 
-CGovernanceObject* CSuperblock::GetGovernanceObject(CGovernanceManager& governanceManager)
+CGovernanceObject* CSuperblock::GetGovernanceObject(CGovernanceManager& govman)
 {
-    AssertLockHeld(governanceManager.cs);
-    CGovernanceObject* pObj = governanceManager.FindGovernanceObject(nGovObjHash);
+    AssertLockHeld(govman.cs);
+    CGovernanceObject* pObj = govman.FindGovernanceObject(nGovObjHash);
     return pObj;
 }
 
@@ -695,7 +695,7 @@ bool CSuperblock::IsValid(CGovernanceManager& govman, const CTransaction& txNew,
     return true;
 }
 
-bool CSuperblock::IsExpired(const CGovernanceManager& governanceManager) const
+bool CSuperblock::IsExpired(const CGovernanceManager& govman) const
 {
     int nExpirationBlocks;
     // Executed triggers are kept for another superblock cycle (approximately 1 month for mainnet).
@@ -717,14 +717,14 @@ bool CSuperblock::IsExpired(const CGovernanceManager& governanceManager) const
 
     LogPrint(BCLog::GOBJECT, "CSuperblock::IsExpired -- nBlockHeight = %d, nExpirationBlock = %d\n", nBlockHeight, nExpirationBlock);
 
-    if (governanceManager.GetCachedBlockHeight() > nExpirationBlock) {
+    if (govman.GetCachedBlockHeight() > nExpirationBlock) {
         LogPrint(BCLog::GOBJECT, "CSuperblock::IsExpired -- Outdated trigger found\n");
         return true;
     }
 
     if (Params().NetworkIDString() != CBaseChainParams::MAIN) {
         // NOTE: this can happen on testnet/devnets due to reorgs, should never happen on mainnet
-        if (governanceManager.GetCachedBlockHeight() + Params().GetConsensus().nSuperblockCycle * 2 < nBlockHeight) {
+        if (govman.GetCachedBlockHeight() + Params().GetConsensus().nSuperblockCycle * 2 < nBlockHeight) {
             LogPrint(BCLog::GOBJECT, "CSuperblock::IsExpired -- Trigger is too far into the future\n");
             return true;
         }

--- a/src/governance/classes.h
+++ b/src/governance/classes.h
@@ -101,7 +101,7 @@ private:
 public:
     CSuperblock();
     CSuperblock(int nBlockHeight, std::vector<CGovernancePayment> vecPayments);
-    explicit CSuperblock(uint256& nHash);
+    explicit CSuperblock(CGovernanceManager& govman, uint256& nHash);
 
     static bool IsValidBlockHeight(int nBlockHeight);
     static void GetNearestSuperblocksHeights(int nBlockHeight, int& nLastSuperblockRet, int& nNextSuperblockRet);
@@ -126,7 +126,7 @@ public:
     bool GetPayment(int nPaymentIndex, CGovernancePayment& paymentRet);
     CAmount GetPaymentsTotalAmount();
 
-    bool IsValid(const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
+    bool IsValid(CGovernanceManager& govman, const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
     bool IsExpired(const CGovernanceManager& governanceManager) const;
 
     std::vector<uint256> GetProposalHashes() const;

--- a/src/governance/classes.h
+++ b/src/governance/classes.h
@@ -30,15 +30,15 @@ CAmount ParsePaymentAmount(const std::string& strAmount);
 class CSuperblockManager
 {
 private:
-    static bool GetBestSuperblock(CGovernanceManager& governanceManager, CSuperblock_sptr& pSuperblockRet, int nBlockHeight);
+    static bool GetBestSuperblock(CGovernanceManager& govman, CSuperblock_sptr& pSuperblockRet, int nBlockHeight);
 
 public:
-    static bool IsSuperblockTriggered(CGovernanceManager& governanceManager, int nBlockHeight);
+    static bool IsSuperblockTriggered(CGovernanceManager& govman, int nBlockHeight);
 
-    static bool GetSuperblockPayments(CGovernanceManager& governanceManager, int nBlockHeight, std::vector<CTxOut>& voutSuperblockRet);
-    static void ExecuteBestSuperblock(CGovernanceManager& governanceManager, int nBlockHeight);
+    static bool GetSuperblockPayments(CGovernanceManager& govman, int nBlockHeight, std::vector<CTxOut>& voutSuperblockRet);
+    static void ExecuteBestSuperblock(CGovernanceManager& govman, int nBlockHeight);
 
-    static bool IsValid(CGovernanceManager& governanceManager, const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
+    static bool IsValid(CGovernanceManager& govman, const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
 };
 
 /**
@@ -115,7 +115,7 @@ public:
     // TELL THE ENGINE WE EXECUTED THIS EVENT
     void SetExecuted() { nStatus = SeenObjectStatus::Executed; }
 
-    CGovernanceObject* GetGovernanceObject(CGovernanceManager& governanceManager);
+    CGovernanceObject* GetGovernanceObject(CGovernanceManager& govman);
 
     int GetBlockHeight() const
     {
@@ -127,7 +127,7 @@ public:
     CAmount GetPaymentsTotalAmount();
 
     bool IsValid(CGovernanceManager& govman, const CTransaction& txNew, int nBlockHeight, CAmount blockReward);
-    bool IsExpired(const CGovernanceManager& governanceManager) const;
+    bool IsExpired(const CGovernanceManager& govman) const;
 
     std::vector<uint256> GetProposalHashes() const;
 };

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1563,7 +1563,7 @@ void CGovernanceManager::RemoveInvalidVotes()
     lastMNListForVotingKeys = std::make_shared<CDeterministicMNList>(curMNList);
 }
 
-bool AreSuperblocksEnabled(const CSporkManager& sporkManager)
+bool AreSuperblocksEnabled(const CSporkManager& sporkman)
 {
-    return sporkManager.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED);
+    return sporkman.IsSporkActive(SPORK_9_SUPERBLOCKS_ENABLED);
 }

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -25,8 +25,6 @@
 #include <util/time.h>
 #include <validation.h>
 
-std::unique_ptr<CGovernanceManager> governance;
-
 int nSubmittedFinalBudget;
 
 const std::string GovernanceStore::SERIALIZATION_VERSION_STRING = "CGovernanceManager-Version-16";
@@ -270,7 +268,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj, CConnman& c
         CGovernanceException e;
         if (pairVote.second < nNow) {
             fRemove = true;
-        } else if (govobj.ProcessVote(vote, e)) {
+        } else if (govobj.ProcessVote(*this, vote, e)) {
             vote.Relay(connman);
             fRemove = true;
         }
@@ -1095,7 +1093,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
         return false;
     }
 
-    bool fOk = govobj.ProcessVote(vote, exception) && cmapVoteToObject.Insert(nHashVote, &govobj);
+    bool fOk = govobj.ProcessVote(*this, vote, exception) && cmapVoteToObject.Insert(nHashVote, &govobj);
     LEAVE_CRITICAL_SECTION(cs);
     return fOk;
 }

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -25,8 +25,6 @@ class CGovernanceObject;
 class CGovernanceVote;
 class CSporkManager;
 
-extern std::unique_ptr<CGovernanceManager> governance;
-
 static constexpr int RATE_BUFFER_SIZE = 5;
 
 class CDeterministicMNList;

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -403,6 +403,6 @@ private:
 
 };
 
-bool AreSuperblocksEnabled(const CSporkManager& sporkManager);
+bool AreSuperblocksEnabled(const CSporkManager& sporkman);
 
 #endif // BITCOIN_GOVERNANCE_GOVERNANCE_H

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -79,7 +79,7 @@ CGovernanceObject::CGovernanceObject(const CGovernanceObject& other) :
 {
 }
 
-bool CGovernanceObject::ProcessVote(const CGovernanceVote& vote, CGovernanceException& exception)
+bool CGovernanceObject::ProcessVote(CGovernanceManager& govman, const CGovernanceVote& vote, CGovernanceException& exception)
 {
     LOCK(cs);
 
@@ -149,7 +149,7 @@ bool CGovernanceObject::ProcessVote(const CGovernanceVote& vote, CGovernanceExce
 
     int64_t nNow = GetAdjustedTime();
     int64_t nVoteTimeUpdate = voteInstanceRef.nTime;
-    if (governance->AreRateChecksEnabled()) {
+    if (govman.AreRateChecksEnabled()) {
         int64_t nTimeDelta = nNow - voteInstanceRef.nTime;
         if (nTimeDelta < GOVERNANCE_UPDATE_MIN) {
             std::ostringstream ostr;
@@ -175,7 +175,7 @@ bool CGovernanceObject::ProcessVote(const CGovernanceVote& vote, CGovernanceExce
              << ", vote hash = " << vote.GetHash().ToString();
         LogPrintf("%s\n", ostr.str());
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
-        governance->AddInvalidVote(vote);
+        govman.AddInvalidVote(vote);
         return false;
     }
 

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -15,10 +15,10 @@
 
 class CBLSSecretKey;
 class CBLSPublicKey;
-class CNode;
-
+class CGovernanceManager;
 class CGovernanceObject;
 class CGovernanceVote;
+class CNode;
 
 extern RecursiveMutex cs_main;
 
@@ -288,7 +288,7 @@ public:
     void LoadData();
     void GetData(UniValue& objResult) const;
 
-    bool ProcessVote(const CGovernanceVote& vote, CGovernanceException& exception);
+    bool ProcessVote(CGovernanceManager& govman, const CGovernanceVote& vote, CGovernanceException& exception);
 
     /// Called when MN's which have voted on this object have been removed
     void ClearMasternodeVotes();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -314,8 +314,7 @@ void PrepareShutdown(NodeContext& node)
     node.mn_sync = nullptr;
     ::masternodeSync.reset();
     node.sporkman.reset();
-    node.govman = nullptr;
-    ::governance.reset();
+    node.govman.reset();
 
     // Stop and delete all indexes only after flushing background callbacks.
     if (g_txindex) {
@@ -1712,9 +1711,8 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     node.chainman = &g_chainman;
     ChainstateManager& chainman = *Assert(node.chainman);
 
-    assert(!::governance);
-    ::governance = std::make_unique<CGovernanceManager>();
-    node.govman = ::governance.get();
+    assert(!node.govman);
+    node.govman = std::make_unique<CGovernanceManager>();
 
     assert(!node.sporkman);
     node.sporkman = std::make_unique<CSporkManager>();

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -26,7 +26,7 @@ namespace llmq
 std::unique_ptr<CChainLocksHandler> chainLocksHandler;
 
 CChainLocksHandler::CChainLocksHandler(CChainState& chainstate, CConnman& _connman, CMasternodeSync& mn_sync, CQuorumManager& _qman,
-                                       CSigningManager& _sigman, CSigSharesManager& _shareman, CSporkManager& sporkManager,
+                                       CSigningManager& _sigman, CSigSharesManager& _shareman, CSporkManager& sporkman,
                                        CTxMemPool& _mempool) :
     m_chainstate(chainstate),
     connman(_connman),
@@ -34,7 +34,7 @@ CChainLocksHandler::CChainLocksHandler(CChainState& chainstate, CConnman& _connm
     qman(_qman),
     sigman(_sigman),
     shareman(_shareman),
-    spork_manager(sporkManager),
+    spork_manager(sporkman),
     mempool(_mempool),
     scheduler(std::make_unique<CScheduler>()),
     scheduler_thread(std::make_unique<std::thread>(std::thread(util::TraceThread, "cl-schdlr", [&] { scheduler->serviceQueue(); })))
@@ -668,14 +668,14 @@ void CChainLocksHandler::Cleanup()
     lastCleanupTime = GetTimeMillis();
 }
 
-bool AreChainLocksEnabled(const CSporkManager& sporkManager)
+bool AreChainLocksEnabled(const CSporkManager& sporkman)
 {
-    return sporkManager.IsSporkActive(SPORK_19_CHAINLOCKS_ENABLED);
+    return sporkman.IsSporkActive(SPORK_19_CHAINLOCKS_ENABLED);
 }
 
-bool ChainLocksSigningEnabled(const CSporkManager& sporkManager)
+bool ChainLocksSigningEnabled(const CSporkManager& sporkman)
 {
-    return sporkManager.GetSporkValue(SPORK_19_CHAINLOCKS_ENABLED) == 0;
+    return sporkman.GetSporkValue(SPORK_19_CHAINLOCKS_ENABLED) == 0;
 }
 
 } // namespace llmq

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -86,7 +86,7 @@ private:
 
 public:
     explicit CChainLocksHandler(CChainState& chainstate, CConnman& _connman, CMasternodeSync& mn_sync, CQuorumManager& _qman,
-                                CSigningManager& _sigman, CSigSharesManager& _shareman, CSporkManager& sporkManager,
+                                CSigningManager& _sigman, CSigSharesManager& _shareman, CSporkManager& sporkman,
                                 CTxMemPool& _mempool);
     ~CChainLocksHandler();
 
@@ -128,8 +128,8 @@ private:
 
 extern std::unique_ptr<CChainLocksHandler> chainLocksHandler;
 
-bool AreChainLocksEnabled(const CSporkManager& sporkManager);
-bool ChainLocksSigningEnabled(const CSporkManager& sporkManager);
+bool AreChainLocksEnabled(const CSporkManager& sporkman);
+bool ChainLocksSigningEnabled(const CSporkManager& sporkman);
 
 } // namespace llmq
 

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -31,11 +31,11 @@ LLMQContext::LLMQContext(CChainState& chainstate, CConnman& connman, CEvoDB& evo
     qdkgsman{std::make_unique<llmq::CDKGSessionManager>(*bls_worker, chainstate, connman, *dkg_debugman, *quorum_block_processor, sporkman, unit_tests, wipe)},
     qman{[&]() -> llmq::CQuorumManager* const {
         assert(llmq::quorumManager == nullptr);
-        llmq::quorumManager = std::make_unique<llmq::CQuorumManager>(*bls_worker, chainstate, connman, *qdkgsman, evo_db, *quorum_block_processor, ::masternodeSync);
+        llmq::quorumManager = std::make_unique<llmq::CQuorumManager>(*bls_worker, chainstate, connman, *qdkgsman, evo_db, *quorum_block_processor, sporkman, ::masternodeSync);
         return llmq::quorumManager.get();
     }()},
     sigman{std::make_unique<llmq::CSigningManager>(connman, *llmq::quorumManager, unit_tests, wipe)},
-    shareman{std::make_unique<llmq::CSigSharesManager>(connman, *llmq::quorumManager, *sigman, peerman)},
+    shareman{std::make_unique<llmq::CSigSharesManager>(connman, *sigman, *llmq::quorumManager, sporkman, peerman)},
     clhandler{[&]() -> llmq::CChainLocksHandler* const {
         assert(llmq::chainLocksHandler == nullptr);
         llmq::chainLocksHandler = std::make_unique<llmq::CChainLocksHandler>(chainstate, connman, *::masternodeSync, *llmq::quorumManager, *sigman, *shareman, sporkman, mempool);

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -450,7 +450,7 @@ void CDKGSession::VerifyAndComplain(CDKGPendingMessages& pendingMessages)
 
 void CDKGSession::VerifyConnectionAndMinProtoVersions() const
 {
-    if (!IsQuorumPoseEnabled(params.type)) {
+    if (!IsQuorumPoseEnabled(params.type, m_sporkman)) {
         return;
     }
 
@@ -465,7 +465,7 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions() const
         protoMap.emplace(verifiedProRegTxHash, pnode->nVersion);
     });
 
-    bool fShouldAllMembersBeConnected = IsAllMembersConnectedEnabled(params.type);
+    bool fShouldAllMembersBeConnected = IsAllMembersConnectedEnabled(params.type, m_sporkman);
     for (const auto& m : members) {
         if (m->dmn->proTxHash == myProTxHash) {
             continue;

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -19,6 +19,7 @@ class UniValue;
 class CInv;
 class CConnman;
 class CDeterministicMN;
+class CSporkManager;
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
 
 namespace llmq
@@ -271,6 +272,7 @@ private:
     CBLSWorkerCache cache;
     CDKGSessionManager& dkgManager;
     CDKGDebugManager& dkgDebugManager;
+    const CSporkManager& m_sporkman;
 
     const CBlockIndex* m_quorum_base_block_index{nullptr};
     int quorumIndex{0};
@@ -311,8 +313,8 @@ private:
     std::set<uint256> validCommitments GUARDED_BY(invCs);
 
 public:
-    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager, CConnman& _connman) :
-        params(_params), blsWorker(_blsWorker), cache(_blsWorker), dkgManager(_dkgManager), dkgDebugManager(_dkgDebugManager), connman(_connman) {}
+    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager, CConnman& _connman, const CSporkManager& sporkman) :
+        params(_params), blsWorker(_blsWorker), cache(_blsWorker), dkgManager(_dkgManager), dkgDebugManager(_dkgDebugManager), m_sporkman(sporkman), connman(_connman) {}
 
     bool Init(gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex);
 

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -17,6 +17,7 @@
 class CBlockIndex;
 class CBLSWorker;
 class CChainState;
+class CSporkManager;
 class PeerManager;
 
 namespace llmq
@@ -122,6 +123,7 @@ private:
     CDKGDebugManager& dkgDebugManager;
     CDKGSessionManager& dkgManager;
     CQuorumBlockProcessor& quorumBlockProcessor;
+    const CSporkManager& m_sporkman;
     const Consensus::LLMQParams params;
     const int quorumIndex;
 
@@ -141,7 +143,7 @@ private:
 
 public:
     CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDKGDebugManager& _dkgDebugManager,
-                       CDKGSessionManager& _dkgManager, CQuorumBlockProcessor& _quorumBlockProcessor,
+                       CDKGSessionManager& _dkgManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman,
                        const Consensus::LLMQParams& _params, int _quorumIndex);
     ~CDKGSessionHandler() = default;
 

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -25,7 +25,7 @@ static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
 CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDKGDebugManager& _dkgDebugManager,
-                                       CQuorumBlockProcessor& _quorumBlockProcessor, CSporkManager& sporkManager,
+                                       CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkManager,
                                        bool unitTests, bool fWipe) :
     db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
     blsWorker(_blsWorker),
@@ -48,7 +48,7 @@ CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chai
         for (const auto i : irange::range(session_count)) {
             dkgSessionHandlers.emplace(std::piecewise_construct,
                                        std::forward_as_tuple(params.type, i),
-                                       std::forward_as_tuple(blsWorker, m_chainstate, connman, dkgDebugManager, *this, quorumBlockProcessor, params, i));
+                                       std::forward_as_tuple(blsWorker, m_chainstate, connman, dkgDebugManager, *this, quorumBlockProcessor, spork_manager, params, i));
         }
     }
 }

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -25,7 +25,7 @@ static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
 CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDKGDebugManager& _dkgDebugManager,
-                                       CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkManager,
+                                       CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman,
                                        bool unitTests, bool fWipe) :
     db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
     blsWorker(_blsWorker),
@@ -33,7 +33,7 @@ CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chai
     connman(_connman),
     dkgDebugManager(_dkgDebugManager),
     quorumBlockProcessor(_quorumBlockProcessor),
-    spork_manager(sporkManager)
+    spork_manager(sporkman)
 {
     if (!fMasternodeMode && !IsWatchQuorumsEnabled()) {
         // Regular nodes do not care about any DKG internals, bail out
@@ -520,9 +520,9 @@ void CDKGSessionManager::CleanupOldContributions() const
     }
 }
 
-bool IsQuorumDKGEnabled(const CSporkManager& sporkManager)
+bool IsQuorumDKGEnabled(const CSporkManager& sporkman)
 {
-    return sporkManager.IsSporkActive(SPORK_17_QUORUM_DKG_ENABLED);
+    return sporkman.IsSporkActive(SPORK_17_QUORUM_DKG_ENABLED);
 }
 
 } // namespace llmq

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -38,7 +38,7 @@ private:
     CConnman& connman;
     CDKGDebugManager& dkgDebugManager;
     CQuorumBlockProcessor& quorumBlockProcessor;
-    CSporkManager& spork_manager;
+    const CSporkManager& spork_manager;
 
     //TODO name struct instead of std::pair
     std::map<std::pair<Consensus::LLMQType, int>, CDKGSessionHandler> dkgSessionHandlers;
@@ -64,7 +64,7 @@ private:
 
 public:
     CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDKGDebugManager& _dkgDebugManager,
-                       CQuorumBlockProcessor& _quorumBlockProcessor, CSporkManager& sporkManager,
+                       CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkManager,
                        bool unitTests, bool fWipe);
     ~CDKGSessionManager() = default;
 

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -64,7 +64,7 @@ private:
 
 public:
     CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDKGDebugManager& _dkgDebugManager,
-                       CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkManager,
+                       CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman,
                        bool unitTests, bool fWipe);
     ~CDKGSessionManager() = default;
 
@@ -96,7 +96,7 @@ private:
     void CleanupCache() const;
 };
 
-bool IsQuorumDKGEnabled(const CSporkManager& sporkManager);
+bool IsQuorumDKGEnabled(const CSporkManager& sporkman);
 } // namespace llmq
 
 #endif // BITCOIN_LLMQ_DKGSESSIONMGR_H

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -256,11 +256,11 @@ private:
 public:
     explicit CInstantSendManager(CChainLocksHandler& _clhandler, CChainState& chainstate, CConnman& _connman,
                                  CQuorumManager& _qman, CSigningManager& _sigman, CSigSharesManager& _shareman,
-                                 CSporkManager& sporkManager, CTxMemPool& _mempool, const CMasternodeSync& mn_sync,
+                                 CSporkManager& sporkman, CTxMemPool& _mempool, const CMasternodeSync& mn_sync,
                                  bool unitTests, bool fWipe) :
         db(unitTests, fWipe),
         clhandler(_clhandler), m_chainstate(chainstate), connman(_connman), qman(_qman), sigman(_sigman),
-        shareman(_shareman), spork_manager(sporkManager), mempool(_mempool), m_mn_sync(mn_sync)
+        shareman(_shareman), spork_manager(sporkman), mempool(_mempool), m_mn_sync(mn_sync)
     {
         workInterrupt.reset();
     }

--- a/src/llmq/options.cpp
+++ b/src/llmq/options.cpp
@@ -20,7 +20,7 @@ static constexpr int TESTNET_LLMQ_25_67_ACTIVATION_HEIGHT = 847000;
 namespace llmq
 {
 
-static bool EvalSpork(Consensus::LLMQType llmqType, int64_t spork_value)
+static bool EvalSpork(const Consensus::LLMQType llmqType, const int64_t spork_value)
 {
     if (spork_value == 0) {
         return true;
@@ -31,14 +31,14 @@ static bool EvalSpork(Consensus::LLMQType llmqType, int64_t spork_value)
     return false;
 }
 
-bool IsAllMembersConnectedEnabled(Consensus::LLMQType llmqType)
+bool IsAllMembersConnectedEnabled(const Consensus::LLMQType llmqType, const CSporkManager& sporkman)
 {
-    return EvalSpork(llmqType, sporkManager->GetSporkValue(SPORK_21_QUORUM_ALL_CONNECTED));
+    return EvalSpork(llmqType, sporkman.GetSporkValue(SPORK_21_QUORUM_ALL_CONNECTED));
 }
 
-bool IsQuorumPoseEnabled(Consensus::LLMQType llmqType)
+bool IsQuorumPoseEnabled(const Consensus::LLMQType llmqType, const CSporkManager& sporkman)
 {
-    return EvalSpork(llmqType, sporkManager->GetSporkValue(SPORK_23_QUORUM_POSE));
+    return EvalSpork(llmqType, sporkman.GetSporkValue(SPORK_23_QUORUM_POSE));
 }
 
 

--- a/src/llmq/options.h
+++ b/src/llmq/options.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 class CBlockIndex;
+class CSporkManager;
 
 namespace llmq
 {
@@ -28,8 +29,8 @@ static constexpr bool DEFAULT_ENABLE_QUORUM_DATA_RECOVERY{true};
 // If true, we will connect to all new quorums and watch their communication
 static constexpr bool DEFAULT_WATCH_QUORUMS{false};
 
-bool IsAllMembersConnectedEnabled(Consensus::LLMQType llmqType);
-bool IsQuorumPoseEnabled(Consensus::LLMQType llmqType);
+bool IsAllMembersConnectedEnabled(const Consensus::LLMQType llmqType, const CSporkManager& sporkman);
+bool IsQuorumPoseEnabled(const Consensus::LLMQType llmqType, const CSporkManager& sporkman);
 
 bool IsQuorumRotationEnabled(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pindex);
 

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -206,13 +206,14 @@ bool CQuorum::ReadContributions(CEvoDB& evoDb)
 }
 
 CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDKGSessionManager& _dkgManager,
-                               CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor, const std::unique_ptr<CMasternodeSync>& mn_sync) :
+                               CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync) :
     blsWorker(_blsWorker),
     m_chainstate(chainstate),
     connman(_connman),
     dkgManager(_dkgManager),
     m_evoDb(_evoDb),
     quorumBlockProcessor(_quorumBlockProcessor),
+    m_sporkman(sporkman),
     m_mn_sync(mn_sync)
 {
     utils::InitQuorumsCache(mapQuorumsCache, false);
@@ -348,7 +349,7 @@ void CQuorumManager::CheckQuorumConnections(const Consensus::LLMQParams& llmqPar
                     });
 
     for (const auto& quorum : lastQuorums) {
-        if (utils::EnsureQuorumConnections(llmqParams, quorum->m_quorum_base_block_index, connman, myProTxHash)) {
+        if (utils::EnsureQuorumConnections(llmqParams, connman, m_sporkman, quorum->m_quorum_base_block_index, myProTxHash)) {
             if (connmanQuorumsToDelete.erase(quorum->qc->quorumHash) > 0) {
                 LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- llmqType[%d] h[%d] keeping mn quorum connections for quorum: [%d:%s]\n", __func__, ToUnderlying(llmqParams.type), pindexNew->nHeight, quorum->m_quorum_base_block_index->nHeight, quorum->m_quorum_base_block_index->GetBlockHash().ToString());
             }

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -27,6 +27,7 @@ class CConnman;
 class CDeterministicMN;
 class CMasternodeSync;
 class CNode;
+class CSporkManager;
 
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
 
@@ -220,6 +221,7 @@ private:
     CDKGSessionManager& dkgManager;
     CEvoDB& m_evoDb;
     CQuorumBlockProcessor& quorumBlockProcessor;
+    const CSporkManager& m_sporkman;
     const std::unique_ptr<CMasternodeSync>& m_mn_sync;
 
     mutable RecursiveMutex cs_map_quorums;
@@ -234,7 +236,7 @@ private:
 
 public:
     CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDKGSessionManager& _dkgManager,
-                   CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor, const std::unique_ptr<CMasternodeSync>& mn_sync);
+                   CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync);
     ~CQuorumManager() { Stop(); };
 
     void Start();

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -215,14 +215,14 @@ void CSigSharesManager::InterruptWorkerThread()
     workInterrupt();
 }
 
-void CSigSharesManager::ProcessMessage(const CNode& pfrom, const CSporkManager& sporkManager, const std::string& msg_type, CDataStream& vRecv)
+void CSigSharesManager::ProcessMessage(const CNode& pfrom, const CSporkManager& sporkman, const std::string& msg_type, CDataStream& vRecv)
 {
     // non-masternodes are not interested in sigshares
     if (!fMasternodeMode || WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) {
         return;
     }
 
-    if (sporkManager.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && msg_type == NetMsgType::QSIGSHARE) {
+    if (sporkman.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && msg_type == NetMsgType::QSIGSHARE) {
         std::vector<CSigShare> receivedSigShares;
         vRecv >> receivedSigShares;
 

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -424,7 +424,7 @@ public:
     void UnregisterAsRecoveredSigsListener();
     void InterruptWorkerThread();
 
-    void ProcessMessage(const CNode& pnode, const CSporkManager& sporkManager, const std::string& msg_type, CDataStream& vRecv);
+    void ProcessMessage(const CNode& pnode, const CSporkManager& sporkman, const std::string& msg_type, CDataStream& vRecv);
 
     void AsyncSign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
     std::optional<CSigShare> CreateSigShare(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash) const;

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -400,8 +400,9 @@ private:
     FastRandomContext rnd GUARDED_BY(cs);
 
     CConnman& connman;
-    const CQuorumManager& qman;
     CSigningManager& sigman;
+    const CQuorumManager& qman;
+    const CSporkManager& m_sporkman;
 
     const std::unique_ptr<PeerManager>& m_peerman;
 
@@ -409,8 +410,8 @@ private:
     std::atomic<uint32_t> recoveredSigsCounter{0};
 
 public:
-    explicit CSigSharesManager(CConnman& _connman, CQuorumManager& _qman, CSigningManager& _sigman, const std::unique_ptr<PeerManager>& peerman) :
-        connman(_connman), qman(_qman), sigman(_sigman), m_peerman(peerman)
+    explicit CSigSharesManager(CConnman& _connman, CSigningManager& _sigman, const CQuorumManager& _qman, const CSporkManager& sporkman, const std::unique_ptr<PeerManager>& peerman) :
+        connman(_connman), sigman(_sigman), qman(_qman), m_sporkman(sporkman), m_peerman(peerman)
     {
         workInterrupt.reset();
     };

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -649,10 +649,10 @@ uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256
     return proTxHash2;
 }
 
-std::set<uint256> GetQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
-                                                   const uint256& forMember, bool onlyOutbound)
+std::set<uint256> GetQuorumConnections(const Consensus::LLMQParams& llmqParams, const CSporkManager& sporkman,
+                                       gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& forMember, bool onlyOutbound)
 {
-    if (IsAllMembersConnectedEnabled(llmqParams.type)) {
+    if (IsAllMembersConnectedEnabled(llmqParams.type, sporkman)) {
         auto mns = GetAllQuorumMembers(llmqParams.type, pQuorumBaseBlockIndex);
         std::set<uint256> result;
 
@@ -749,8 +749,8 @@ std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType,
     return result;
 }
 
-bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
-                                         CConnman& connman, const uint256& myProTxHash)
+bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, const CSporkManager& sporkman,
+                             gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& myProTxHash)
 {
     if (!fMasternodeMode && !IsWatchQuorumsEnabled()) {
         return false;
@@ -773,7 +773,7 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_n
     std::set<uint256> connections;
     std::set<uint256> relayMembers;
     if (isMember) {
-        connections = GetQuorumConnections(llmqParams, pQuorumBaseBlockIndex, myProTxHash, true);
+        connections = GetQuorumConnections(llmqParams, sporkman, pQuorumBaseBlockIndex, myProTxHash, true);
         relayMembers = GetQuorumRelayMembers(llmqParams, pQuorumBaseBlockIndex, myProTxHash, true);
     } else {
         auto cindexes = CalcDeterministicWatchConnections(llmqParams.type, pQuorumBaseBlockIndex, members.size(), 1);
@@ -804,10 +804,10 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_n
     return true;
 }
 
-void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
-                               CConnman& connman, const uint256 &myProTxHash)
+void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, const CSporkManager& sporkman,
+                               gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256 &myProTxHash)
 {
-    if (!IsQuorumPoseEnabled(llmqParams.type)) {
+    if (!IsQuorumPoseEnabled(llmqParams.type, sporkman)) {
         return;
     }
 

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -19,6 +19,7 @@ class CBlockIndex;
 class CDeterministicMN;
 class CDeterministicMNList;
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
+class CSporkManager;
 
 namespace llmq
 {
@@ -30,12 +31,12 @@ namespace utils
 std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, bool reset_cache = false);
 
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2);
-std::set<uint256> GetQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& forMember, bool onlyOutbound);
+std::set<uint256> GetQuorumConnections(const Consensus::LLMQParams& llmqParams, const CSporkManager& sporkman, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& forMember, bool onlyOutbound);
 std::set<uint256> GetQuorumRelayMembers(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& forMember, bool onlyOutbound);
 std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, size_t memberCount, size_t connectionCount);
 
-bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, CConnman& connman, const uint256& myProTxHash);
-void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, CConnman& connman, const uint256& myProTxHash);
+bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, const CSporkManager& sporkman, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& myProTxHash);
+void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, const CSporkManager& sporkman, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& myProTxHash);
 
 template <typename CacheType>
 void InitQuorumsCache(CacheType& cache, bool limit_by_connections = true);

--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -149,8 +149,7 @@ CAmount PlatformShare(const CAmount reward)
     // all we know is predefined budget cycle and window
 
     int nOffset = nBlockHeight % m_consensus_params.nBudgetPaymentsCycleBlocks;
-    if(nBlockHeight >= m_consensus_params.nBudgetPaymentsStartBlock &&
-       nOffset < m_consensus_params.nBudgetPaymentsWindowBlocks) {
+    if (nOffset < m_consensus_params.nBudgetPaymentsWindowBlocks) {
         // NOTE: old budget system is disabled since 12.1
         if(m_mn_sync.IsSynced()) {
             // no old budget blocks should be accepted here on mainnet,

--- a/src/miner.h
+++ b/src/miner.h
@@ -20,9 +20,8 @@ class CBlockIndex;
 class CChainParams;
 class CConnman;
 class CEvoDB;
-class CGovernanceManager;
+class CChainstateHelper;
 class CScript;
-class CSporkManager;
 struct LLMQContext;
 
 namespace Consensus { struct Params; };
@@ -158,8 +157,7 @@ private:
     const CChainParams& chainparams;
     const CTxMemPool& m_mempool;
     CChainState& m_chainstate;
-    const CSporkManager& spork_manager;
-    CGovernanceManager& governance_manager;
+    CChainstateHelper& m_chain_helper;
     const llmq::CQuorumBlockProcessor& quorum_block_processor;
     llmq::CChainLocksHandler& m_clhandler;
     llmq::CInstantSendManager& m_isman;
@@ -172,10 +170,10 @@ public:
         CFeeRate blockMinFeeRate;
     };
 
-    explicit BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
-                            LLMQContext& llmq_ctx, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params);
-    explicit BlockAssembler(const CSporkManager& sporkManager, CGovernanceManager& governanceManager,
-                            LLMQContext& llmq_ctx, CEvoDB& evoDb, CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params, const Options& options);
+    explicit BlockAssembler(CChainState& chainstate, CEvoDB& evoDb, CChainstateHelper& chain_helper, LLMQContext& llmq_ctx,
+                            const CTxMemPool& mempool, const CChainParams& params);
+    explicit BlockAssembler(CChainState& chainstate, CEvoDB& evoDb, CChainstateHelper& chain_helper, LLMQContext& llmq_ctx,
+                            const CTxMemPool& mempool, const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
     std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -16,9 +16,10 @@ class CAddrMan;
 class CTxMemPool;
 class ChainstateManager;
 class CCoinJoinServer;
+class CGovernanceManager;
+class CSporkManager;
 struct CJContext;
 struct LLMQContext;
-class CGovernanceManager;
 
 extern RecursiveMutex cs_main;
 extern RecursiveMutex g_cs_orphans;
@@ -42,7 +43,8 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman,
                                              BanMan* banman, CScheduler &scheduler, ChainstateManager& chainman,
-                                             CTxMemPool& pool, CGovernanceManager& govman, const std::unique_ptr<CJContext>& cj_ctx,
+                                             CTxMemPool& pool, CGovernanceManager& govman, CSporkManager& sporkman,
+                                             const std::unique_ptr<CJContext>& cj_ctx,
                                              const std::unique_ptr<LLMQContext>& llmq_ctx, bool ignore_incoming_txs);
     virtual ~PeerManager() { }
 

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -8,6 +8,7 @@
 #include <banman.h>
 #include <coinjoin/context.h>
 #include <evo/creditpool.h>
+#include <evo/chainhelper.h>
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
 #include <llmq/context.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -9,6 +9,7 @@
 #include <coinjoin/context.h>
 #include <evo/creditpool.h>
 #include <evo/chainhelper.h>
+#include <governance/governance.h>
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
 #include <llmq/context.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -18,6 +18,7 @@
 #include <net_processing.h>
 #include <policy/fees.h>
 #include <scheduler.h>
+#include <spork.h>
 #include <txmempool.h>
 
 NodeContext::NodeContext() {}

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -73,6 +73,7 @@ struct NodeContext {
     //! Dash
     std::unique_ptr<CEvoDB> evodb;
     std::unique_ptr<CChainstateHelper> chain_helper;
+    std::unique_ptr<CGovernanceManager> govman;
     std::unique_ptr<CJContext> cj_ctx;
     std::unique_ptr<CMNHFManager> mnhf_manager;
     std::unique_ptr<CSporkManager> sporkman;
@@ -80,7 +81,6 @@ struct NodeContext {
     CCreditPoolManager* cpoolman{nullptr};
     CDeterministicMNManager* dmnman{nullptr};
     CDSTXManager* dstxman{nullptr};
-    CGovernanceManager* govman{nullptr};
     CMasternodeMetaMan* mn_metaman{nullptr};
     CMasternodeSync* mn_sync{nullptr};
     CNetFulfilledRequestManager* netfulfilledman{nullptr};

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -17,6 +17,7 @@ class CBlockPolicyEstimator;
 class CConnman;
 class CCreditPoolManager;
 class CDeterministicMNManager;
+class CChainstateHelper;
 class ChainstateManager;
 class CDSTXManager;
 class CEvoDB;
@@ -71,6 +72,7 @@ struct NodeContext {
     std::function<void()> rpc_interruption_point = [] {};
     //! Dash
     std::unique_ptr<CEvoDB> evodb;
+    std::unique_ptr<CChainstateHelper> chain_helper;
     std::unique_ptr<CJContext> cj_ctx;
     std::unique_ptr<CMNHFManager> mnhf_manager;
     std::unique_ptr<LLMQContext> llmq_ctx;

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -75,6 +75,7 @@ struct NodeContext {
     std::unique_ptr<CChainstateHelper> chain_helper;
     std::unique_ptr<CJContext> cj_ctx;
     std::unique_ptr<CMNHFManager> mnhf_manager;
+    std::unique_ptr<CSporkManager> sporkman;
     std::unique_ptr<LLMQContext> llmq_ctx;
     CCreditPoolManager* cpoolman{nullptr};
     CDeterministicMNManager* dmnman{nullptr};
@@ -83,7 +84,6 @@ struct NodeContext {
     CMasternodeMetaMan* mn_metaman{nullptr};
     CMasternodeSync* mn_sync{nullptr};
     CNetFulfilledRequestManager* netfulfilledman{nullptr};
-    CSporkManager* sporkman{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <evo/chainhelper.h>
 #include <evo/deterministicmns.h>
 #include <governance/classes.h>
 #include <index/txindex.h>
@@ -465,10 +466,12 @@ static UniValue masternode_payments(const JSONRPCRequest& request, const Chainst
             nBlockFees += nValueIn - tx->GetValueOut();
         }
 
+        CHECK_NONFATAL(node.chain_helper);
+
         std::vector<CTxOut> voutMasternodePayments, voutDummy;
         CMutableTransaction dummyTx;
         CAmount blockSubsidy = GetBlockSubsidy(pindex, Params().GetConsensus());
-        MasternodePayments::FillBlockPayments(*node.sporkman, *node.govman, dummyTx, pindex->pprev, blockSubsidy, nBlockFees, voutMasternodePayments, voutDummy);
+        node.chain_helper->mn_payments->FillBlockPayments(dummyTx, pindex->pprev, blockSubsidy, nBlockFees, voutMasternodePayments, voutDummy);
 
         UniValue blockObj(UniValue::VOBJ);
         CAmount payedPerBlock{0};

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -275,7 +275,7 @@ static void quorum_dkgstatus_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static UniValue quorum_dkgstatus(const JSONRPCRequest& request, const ChainstateManager& chainman, const LLMQContext& llmq_ctx)
+static UniValue quorum_dkgstatus(const JSONRPCRequest& request, const ChainstateManager& chainman, const CSporkManager& sporkman, const LLMQContext& llmq_ctx)
 {
     quorum_dkgstatus_help(request);
 
@@ -319,11 +319,8 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request, const Chainstate
                     obj.pushKV("quorumHash", pQuorumBaseBlockIndex->GetBlockHash().ToString());
                     obj.pushKV("pindexTip", pindexTip->nHeight);
 
-                    auto allConnections = llmq::utils::GetQuorumConnections(llmq_params, pQuorumBaseBlockIndex,
-                                                                                 proTxHash, false);
-                    auto outboundConnections = llmq::utils::GetQuorumConnections(llmq_params,
-                                                                                      pQuorumBaseBlockIndex, proTxHash,
-                                                                                      true);
+                    auto allConnections = llmq::utils::GetQuorumConnections(llmq_params, sporkman, pQuorumBaseBlockIndex, proTxHash, false);
+                    auto outboundConnections = llmq::utils::GetQuorumConnections(llmq_params, sporkman, pQuorumBaseBlockIndex, proTxHash, true);
                     std::map<uint256, CAddress> foundConnections;
                     const NodeContext& node = EnsureAnyNodeContext(request.context);
                     node.connman->ForEachNode([&](const CNode* pnode) {
@@ -882,7 +879,7 @@ static UniValue _quorum(const JSONRPCRequest& request)
     } else if (command == "quorumdkginfo") {
         return quorum_dkginfo(new_request, llmq_ctx, chainman);
     } else if (command == "quorumdkgstatus") {
-        return quorum_dkgstatus(new_request, chainman, llmq_ctx);
+        return quorum_dkgstatus(new_request, chainman, *node.sporkman, llmq_ctx);
     } else if (command == "quorummemberof") {
         return quorum_memberof(new_request, chainman, node, llmq_ctx);
     } else if (command == "quorumsign" || command == "quorumverify" || command == "quorumhasrecsig" || command == "quorumgetrecsig" || command == "quorumisconflicting") {

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -23,8 +23,6 @@
 
 #include <string>
 
-std::unique_ptr<CSporkManager> sporkManager;
-
 const std::string SporkStore::SERIALIZATION_VERSION_STRING = "CSporkManager-Version-2";
 
 std::optional<SporkValue> CSporkManager::SporkValueIfActive(SporkId nSporkID) const

--- a/src/spork.h
+++ b/src/spork.h
@@ -78,7 +78,6 @@ struct CSporkDef
     MAKE_SPORK_DEF(SPORK_24_TEST_EHF,                      4070908800ULL), // OFF
 };
 #undef MAKE_SPORK_DEF
-extern std::unique_ptr<CSporkManager> sporkManager;
 
 /**
  * Sporks are network parameters used primarily to prevent forking and turn

--- a/src/test/block_reward_reallocation_tests.cpp
+++ b/src/test/block_reward_reallocation_tests.cpp
@@ -182,7 +182,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_ASSERT(dmnman.GetListAtChainTip().HasMN(tx.GetHash()));
         BOOST_CHECK(tip->nHeight < Params().GetConsensus().BRRHeight);
         // Creating blocks by different ways
-        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(m_node.chainman->ActiveChainstate(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
     }
     for ([[maybe_unused]] auto _ : irange::range(1999)) {
         CreateAndProcessBlock({}, coinbaseKey);
@@ -212,7 +212,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         BOOST_ASSERT(dmnman.GetListAtChainTip().HasMN(tx.GetHash()));
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(m_node.chainman->ActiveChainstate(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
     }
 
@@ -226,7 +226,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(m_node.chainman->ActiveChainstate(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 122209530);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, 61104762); // 0.4999999755
@@ -244,7 +244,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
             const bool isV20Active{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_V20)};
             const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
             const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-            const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(m_node.chainman->ActiveChainstate(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
         }
     }
@@ -262,7 +262,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         CAmount expected_block_reward = block_subsidy_potential - block_subsidy_potential / 5;
 
         const CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(m_node.chainman->ActiveChainstate(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), expected_block_reward);
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), 67550353);
         BOOST_CHECK_EQUAL(pblocktemplate->voutMasternodePayments[0].nValue, masternode_payment);
@@ -288,10 +288,10 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         const bool isMNRewardReallocated{DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_MN_RR)};
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(m_node.chainman->ActiveChainstate(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
 
         if (isMNRewardReallocated) {
-            const CAmount platform_payment = MasternodePayments::PlatformShare(masternode_payment);
+            const CAmount platform_payment = PlatformShare(masternode_payment);
             masternode_payment -= platform_payment;
         }
         size_t payment_index = isMNRewardReallocated ? 1 : 0;
@@ -308,9 +308,9 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         const CAmount block_subsidy = GetBlockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         const CAmount block_subsidy_sb = GetSuperblockSubsidyInner(tip->nBits, tip->nHeight, consensus_params, isV20Active);
         CAmount masternode_payment = GetMasternodePayment(tip->nHeight, block_subsidy, isV20Active);
-        const CAmount platform_payment = MasternodePayments::PlatformShare(masternode_payment);
+        const CAmount platform_payment = PlatformShare(masternode_payment);
         masternode_payment -= platform_payment;
-        const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, m_node.chainman->ActiveChainstate(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+        const auto pblocktemplate = BlockAssembler(m_node.chainman->ActiveChainstate(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
 
         CAmount block_subsidy_potential = block_subsidy + block_subsidy_sb;
         BOOST_CHECK_EQUAL(tip->nHeight, 3858);
@@ -319,7 +319,7 @@ BOOST_FIXTURE_TEST_CASE(block_reward_reallocation, TestChainBRRBeforeActivationS
         CAmount expected_block_reward = block_subsidy_potential - block_subsidy_potential / 5;
         // Since MNRewardReallocation, MN reward share is 75% of the block reward
         CAmount expected_masternode_reward = expected_block_reward * 3 / 4;
-        CAmount expected_mn_platform_payment = MasternodePayments::PlatformShare(expected_masternode_reward);
+        CAmount expected_mn_platform_payment = PlatformShare(expected_masternode_reward);
         CAmount expected_mn_core_payment = expected_masternode_reward - expected_mn_platform_payment;
 
         BOOST_CHECK_EQUAL(pblocktemplate->block.vtx[0]->GetValueOut(), expected_block_reward);

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -69,7 +69,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
     const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(::ChainstateActive(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, chainparams).CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
     block.hashPrevBlock = prev->GetBlockHash();
     block.nTime = prev->nTime + 1;

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     // Mock an outbound peer
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     banman->ClearBanned();
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     banman->ClearBanned();
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, m_node.cj_ctx,
+                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman, m_node.cj_ctx,
                                        m_node.llmq_ctx, false);
 
     banman->ClearBanned();

--- a/src/test/dynamic_activation_thresholds_tests.cpp
+++ b/src/test/dynamic_activation_thresholds_tests.cpp
@@ -81,7 +81,7 @@ struct TestChainDATSetup : public TestChainSetup
             BOOST_CHECK_EQUAL(g_versionbitscache.State(::ChainActive().Tip(), consensus_params, deployment_id), ThresholdState::STARTED);
             BOOST_CHECK_EQUAL(g_versionbitscache.Statistics(::ChainActive().Tip(), consensus_params, deployment_id).threshold, threshold(0));
             // Next block should be signaling by default
-            const auto pblocktemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
+            const auto pblocktemplate = BlockAssembler(::ChainstateActive(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(coinbasePubKey);
             const uint32_t bitmask = ((uint32_t)1) << consensus_params.vDeployments[deployment_id].bit;
             BOOST_CHECK_EQUAL(::ChainActive().Tip()->nVersion & bitmask, 0);
             BOOST_CHECK_EQUAL(pblocktemplate->block.nVersion & bitmask, bitmask);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -52,7 +52,7 @@ BlockAssembler MinerTestingSetup::AssemblerForTest(const CChainParams& params)
 
     options.nBlockMaxSize = DEFAULT_BLOCK_MAX_SIZE;
     options.blockMinFeeRate = blockMinFeeRate;
-    return BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, params, options);
+    return BlockAssembler(::ChainstateActive(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, params, options);
 }
 
 constexpr static struct {

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<CBlock> PrepareBlock(const NodeContext& node, const CScript& coi
 {
     assert(node.mempool);
     auto block = std::make_shared<CBlock>(
-        BlockAssembler{*node.sporkman, *node.govman, *node.llmq_ctx, *node.evodb, ::ChainstateActive(), *node.mempool, Params()}
+        BlockAssembler{::ChainstateActive(), *node.evodb, *node.chain_helper, *node.llmq_ctx, *node.mempool, Params()}
             .CreateNewBlock(coinbase_scriptPubKey)
             ->block);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -223,8 +223,7 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
     m_node.connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman); // Deterministic randomness for tests.
 
     m_node.sporkman = std::make_unique<CSporkManager>();
-    ::governance = std::make_unique<CGovernanceManager>();
-    m_node.govman = ::governance.get();
+    m_node.govman = std::make_unique<CGovernanceManager>();
     ::masternodeSync = std::make_unique<CMasternodeSync>(*m_node.connman, *m_node.govman);
     m_node.mn_sync = ::masternodeSync.get();
     ::dstxManager = std::make_unique<CDSTXManager>();
@@ -254,8 +253,7 @@ ChainTestingSetup::~ChainTestingSetup()
     ::dstxManager.reset();
     m_node.mn_sync = nullptr;
     ::masternodeSync.reset();
-    m_node.govman = nullptr;
-    ::governance.reset();
+    m_node.govman.reset();
     m_node.sporkman.reset();
     m_node.connman.reset();
     m_node.addrman.reset();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -222,8 +222,7 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
 
     m_node.connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman); // Deterministic randomness for tests.
 
-    ::sporkManager = std::make_unique<CSporkManager>();
-    m_node.sporkman = ::sporkManager.get();
+    m_node.sporkman = std::make_unique<CSporkManager>();
     ::governance = std::make_unique<CGovernanceManager>();
     m_node.govman = ::governance.get();
     ::masternodeSync = std::make_unique<CMasternodeSync>(*m_node.connman, *m_node.govman);
@@ -257,8 +256,7 @@ ChainTestingSetup::~ChainTestingSetup()
     ::masternodeSync.reset();
     m_node.govman = nullptr;
     ::governance.reset();
-    m_node.sporkman = nullptr;
-    ::sporkManager.reset();
+    m_node.sporkman.reset();
     m_node.connman.reset();
     m_node.addrman.reset();
     m_node.args = nullptr;
@@ -291,7 +289,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     m_node.banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.peerman = PeerManager::make(chainparams, *m_node.connman, *m_node.addrman, m_node.banman.get(),
                                        *m_node.scheduler, *m_node.chainman, *m_node.mempool, *m_node.govman,
-                                       m_node.cj_ctx, m_node.llmq_ctx, false);
+                                       *m_node.sporkman, m_node.cj_ctx, m_node.llmq_ctx, false);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::Block(const uint256& prev_hash)
     CScript pubKey;
     pubKey << i++ << OP_TRUE;
 
-    auto ptemplate = BlockAssembler(*m_node.sporkman, *m_node.govman, *m_node.llmq_ctx, *m_node.evodb, ::ChainstateActive(), *m_node.mempool, Params()).CreateNewBlock(pubKey);
+    auto ptemplate = BlockAssembler(::ChainstateActive(), *m_node.evodb, *m_node.chain_helper, *m_node.llmq_ctx, *m_node.mempool, Params()).CreateNewBlock(pubKey);
     auto pblock = std::make_shared<CBlock>(ptemplate->block);
     pblock->hashPrevBlock = prev_hash;
     pblock->nTime = ++time;

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(validation_chainstate_resize_caches)
         return outp;
     };
 
-    CChainState& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
+    CChainState& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, *m_node.evodb, m_node.chain_helper, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
     c1.InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);
     WITH_LOCK(::cs_main, c1.InitCoinsCache(1 << 23));

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
 
     // Create a legacy (IBD) chainstate.
     //
-    CChainState& c1 = WITH_LOCK(::cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
+    CChainState& c1 = WITH_LOCK(::cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, m_node.chain_helper, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
     chainstates.push_back(&c1);
     c1.InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
     //
     const uint256 snapshot_blockhash = GetRandHash();
     CChainState& c2 = WITH_LOCK(::cs_main, return manager.InitializeChainstate(
-        &mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor,
+        &mempool, *m_node.mnhf_manager, evodb, m_node.chain_helper, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor,
         snapshot_blockhash)
     );
     chainstates.push_back(&c2);
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
 
     // Create a legacy (IBD) chainstate.
     //
-    CChainState& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
+    CChainState& c1 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, m_node.chain_helper, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor));
     chainstates.push_back(&c1);
     c1.InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
 
     // Create a snapshot-based chainstate.
     //
-    CChainState& c2 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor, GetRandHash()));
+    CChainState& c2 = WITH_LOCK(cs_main, return manager.InitializeChainstate(&mempool, *m_node.mnhf_manager, evodb, m_node.chain_helper, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor, GetRandHash()));
     chainstates.push_back(&c2);
     c2.InitCoinsDB(
         /* cache_size_bytes */ 1 << 23, /* in_memory */ true, /* should_wipe */ false);

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
 {
     CTxMemPool mempool;
     BlockManager blockman{};
-    CChainState chainstate(&mempool, blockman, *m_node.mnhf_manager, *m_node.evodb, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
+    CChainState chainstate(&mempool, blockman, *m_node.mnhf_manager, *m_node.evodb, m_node.chain_helper, llmq::chainLocksHandler, llmq::quorumInstantSendManager, llmq::quorumBlockProcessor);
     chainstate.InitCoinsDB(/*cache_size_bytes*/ 1 << 10, /*in_memory*/ true, /*should_wipe*/ false);
     WITH_LOCK(::cs_main, chainstate.InitCoinsCache(1 << 10));
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -53,6 +53,7 @@
 #include <masternode/payments.h>
 #include <masternode/sync.h>
 
+#include <evo/chainhelper.h>
 #include <evo/deterministicmns.h>
 #include <evo/evodb.h>
 #include <evo/mnhftx.h>
@@ -1326,12 +1327,14 @@ CChainState::CChainState(CTxMemPool* mempool,
                          BlockManager& blockman,
                          CMNHFManager& mnhfManager,
                          CEvoDB& evoDb,
+                         const std::unique_ptr<CChainstateHelper>& chain_helper,
                          const std::unique_ptr<llmq::CChainLocksHandler>& clhandler,
                          const std::unique_ptr<llmq::CInstantSendManager>& isman,
                          const std::unique_ptr<llmq::CQuorumBlockProcessor>& quorum_block_processor,
                          std::optional<uint256> from_snapshot_blockhash)
     : m_mempool(mempool),
       m_params(::Params()),
+      m_chain_helper(chain_helper),
       m_clhandler(clhandler),
       m_isman(isman),
       m_quorum_block_processor(quorum_block_processor),
@@ -1744,6 +1747,7 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
 DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
 {
     AssertLockHeld(cs_main);
+    assert(m_chain_helper);
     assert(m_quorum_block_processor);
 
     bool fDIP0003Active = pindex->nHeight >= Params().GetConsensus().DIP0003Height;
@@ -2071,6 +2075,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     uint256 block_hash{block.GetHash()};
     assert(*pindex->phashBlock == block_hash);
 
+    assert(m_chain_helper);
     assert(m_clhandler);
     assert(m_isman);
     assert(m_quorum_block_processor);
@@ -2438,7 +2443,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     int64_t nTime5_3 = GetTimeMicros(); nTimeCreditPool += nTime5_3 - nTime5_2;
     LogPrint(BCLog::BENCHMARK, "      - CheckCreditPoolDiffForBlock: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_3 - nTime5_2), nTimeCreditPool * MICRO, nTimeCreditPool * MILLI / nBlocksTotal);
 
-    if (!MasternodePayments::IsBlockValueValid(*sporkManager, *governance, *::masternodeSync, block, pindex->nHeight, blockSubsidy + feeReward, strError)) {
+    if (!m_chain_helper->mn_payments->IsBlockValueValid(block, pindex->nHeight, blockSubsidy + feeReward, strError)) {
         // NOTE: Do not punish, the node might be missing governance data
         LogPrintf("ERROR: ConnectBlock(DASH): %s\n", strError);
         return state.Invalid(BlockValidationResult::BLOCK_RESULT_UNSET, "bad-cb-amount");
@@ -2447,7 +2452,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     int64_t nTime5_4 = GetTimeMicros(); nTimeValueValid += nTime5_4 - nTime5_3;
     LogPrint(BCLog::BENCHMARK, "      - IsBlockValueValid: %.2fms [%.2fs (%.2fms/blk)]\n", MILLI * (nTime5_4 - nTime5_3), nTimeValueValid * MICRO, nTimeValueValid * MILLI / nBlocksTotal);
 
-    if (!MasternodePayments::IsBlockPayeeValid(*sporkManager, *governance, *::masternodeSync, *block.vtx[0], pindex->pprev, blockSubsidy, feeReward)) {
+    if (!m_chain_helper->mn_payments->IsBlockPayeeValid(*block.vtx[0], pindex->pprev, blockSubsidy, feeReward)) {
         // NOTE: Do not punish, the node might be missing governance data
         LogPrintf("ERROR: ConnectBlock(DASH): couldn't find masternode or superblock payments\n");
         return state.Invalid(BlockValidationResult::BLOCK_RESULT_UNSET, "bad-cb-payee");
@@ -4873,6 +4878,7 @@ bool CVerifyDB::VerifyDB(
 /** Apply the effects of a block on the utxo cache, ignoring that it may already have been applied. */
 bool CChainState::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& inputs)
 {
+    assert(m_chain_helper);
     assert(m_quorum_block_processor);
 
     // TODO: merge with ConnectBlock
@@ -5721,6 +5727,7 @@ std::vector<CChainState*> ChainstateManager::GetAll()
 CChainState& ChainstateManager::InitializeChainstate(CTxMemPool* mempool,
                                                      CMNHFManager& mnhfManager,
                                                      CEvoDB& evoDb,
+                                                     const std::unique_ptr<CChainstateHelper>& chain_helper,
                                                      const std::unique_ptr<llmq::CChainLocksHandler>& clhandler,
                                                      const std::unique_ptr<llmq::CInstantSendManager>& isman,
                                                      const std::unique_ptr<llmq::CQuorumBlockProcessor>& quorum_block_processor,
@@ -5734,7 +5741,7 @@ CChainState& ChainstateManager::InitializeChainstate(CTxMemPool* mempool,
         throw std::logic_error("should not be overwriting a chainstate");
     }
 
-    to_modify.reset(new CChainState(mempool, m_blockman, mnhfManager, evoDb, clhandler, isman, quorum_block_processor, snapshot_blockhash));
+    to_modify.reset(new CChainState(mempool, m_blockman, mnhfManager, evoDb, chain_helper, clhandler, isman, quorum_block_processor, snapshot_blockhash));
 
     // Snapshot chainstates and initial IBD chaintates always become active.
     if (is_snapshot || (!is_snapshot && !m_active_chainstate)) {
@@ -5807,6 +5814,7 @@ bool ChainstateManager::ActivateSnapshot(
             /* mempool */ nullptr, m_blockman,
             this->ActiveChainstate().m_mnhfManager,
             this->ActiveChainstate().m_evoDb,
+            this->ActiveChainstate().m_chain_helper,
             this->ActiveChainstate().m_clhandler,
             this->ActiveChainstate().m_isman,
             this->ActiveChainstate().m_quorum_block_processor,

--- a/src/validation.h
+++ b/src/validation.h
@@ -62,6 +62,7 @@ class CMNHFManager;
 class CScriptCheck;
 class CTxMemPool;
 class TxValidationState;
+class CChainstateHelper;
 class ChainstateManager;
 struct PrecomputedTransactionData;
 struct ChainTxData;
@@ -662,6 +663,7 @@ protected:
     std::unique_ptr<CoinsViews> m_coins_views;
 
     //! Dash
+    const std::unique_ptr<CChainstateHelper>& m_chain_helper;
     const std::unique_ptr<llmq::CChainLocksHandler>& m_clhandler;
     const std::unique_ptr<llmq::CInstantSendManager>& m_isman;
     const std::unique_ptr<llmq::CQuorumBlockProcessor>& m_quorum_block_processor;
@@ -677,6 +679,7 @@ public:
                          BlockManager& blockman,
                          CMNHFManager& mnhfManager,
                          CEvoDB& evoDb,
+                         const std::unique_ptr<CChainstateHelper>& chain_helper,
                          const std::unique_ptr<llmq::CChainLocksHandler>& clhandler,
                          const std::unique_ptr<llmq::CInstantSendManager>& isman,
                          const std::unique_ptr<llmq::CQuorumBlockProcessor>& quorum_block_processor,
@@ -1027,6 +1030,7 @@ public:
     CChainState& InitializeChainstate(CTxMemPool* mempool,
                                       CMNHFManager& mnhfManager,
                                       CEvoDB& evoDb,
+                                      const std::unique_ptr<CChainstateHelper>& chain_helper,
                                       const std::unique_ptr<llmq::CChainLocksHandler>& clhandler,
                                       const std::unique_ptr<llmq::CInstantSendManager>& isman,
                                       const std::unique_ptr<llmq::CQuorumBlockProcessor>& quorum_block_processor,

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -92,6 +92,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "llmq/signing -> masternode/node -> validationinterface -> llmq/signing"
     "evo/mnhftx -> validation -> evo/mnhftx"
     "evo/deterministicmns -> validation -> evo/deterministicmns"
+    "evo/chainhelper -> masternode/payments -> validation -> evo/chainhelper"
 )
 
 EXIT_CODE=0


### PR DESCRIPTION
## Additional Information

* `PeerManager`'s initialization has been moved downwards (it used to be initialized _after_ `CGovernanceManager`) to now _after_ `CMasternodeSync`. This is to avoid having to pass `CSporkManager`'s `unique_ptr` container and instead pass the its dereferenced pointer.
* `CChainstateHelper` is just proxy for helper classes meant to hold references to managers that would be needed by functions that are called by `CChainState`. It's the alternative to passing every single manager into `CChainState` through `ChainstateManager`.
 
  Instead, they're all bunched up via `CChainstateHelper` and is accessible to `CChainState` through passing it as an argument. For this reason, it should ideally initialized _after_ all relevant managers are setup but _before_ the chain is validated. We would want to avoid deferred dereferencing if we can help it. 
  * Internal/private functions have been marked as `[[nodiscard]]`.

## Breaking Changes

None. Changes are limited to refactoring, no logical changes have been made.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
