### PR TITLE
docs: fix transifex link for Dash Core

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -947,7 +947,7 @@
          </property>
          <property name="text">
           <string>Language missing or translation incomplete? Help contributing translations here:
-https://www.transifex.com/projects/p/dash/</string>
+https://explore.transifex.com/dash/dash/</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>


### PR DESCRIPTION
## Issue being fixed or feature implemented
Current link to transifex is dead: https://www.transifex.com/projects/p/dash/


## What was done?
Link to transifex is updated to https://explore.transifex.com/dash/dash/

## How Has This Been Tested?
Click and see what is open in browser.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

