### PR TITLE
refactor: subsume CGovernanceTriggerManager into CGovernanceManager

### DIFF
--- a/src/governance/classes.h
+++ b/src/governance/classes.h
@@ -15,39 +15,11 @@ class CTransaction;
 
 class CSuperblock;
 class CGovernanceManager;
-class CGovernanceTriggerManager;
 class CSuperblockManager;
 
 using CSuperblock_sptr = std::shared_ptr<CSuperblock>;
 
-// DECLARE GLOBAL VARIABLES FOR GOVERNANCE CLASSES
-extern CGovernanceTriggerManager triggerman;
-
 CAmount ParsePaymentAmount(const std::string& strAmount);
-
-/**
-*   Trigger Manager
-*
-*   - Track governance objects which are triggers
-*   - After triggers are activated and executed, they can be removed
-*/
-
-class CGovernanceTriggerManager
-{
-    friend class CSuperblockManager;
-    friend class CGovernanceManager;
-
-private:
-    std::map<uint256, CSuperblock_sptr> mapTrigger;
-
-    std::vector<CSuperblock_sptr> GetActiveTriggers();
-    bool AddNewTrigger(uint256 nHash);
-    void CleanAndRemove();
-
-public:
-    CGovernanceTriggerManager() :
-        mapTrigger() {}
-};
 
 /**
 *   Superblock Manager

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -21,7 +21,6 @@ class CFlatDB;
 class CInv;
 
 class CGovernanceManager;
-class CGovernanceTriggerManager;
 class CGovernanceObject;
 class CGovernanceVote;
 class CSporkManager;
@@ -263,6 +262,7 @@ private:
     hash_s_t setRequestedVotes;
     bool fRateChecksEnabled;
     std::optional<uint256> votedFundingYesTriggerHash;
+    std::map<uint256, std::shared_ptr<CSuperblock>> mapTrigger;
 
 public:
     CGovernanceManager();
@@ -355,6 +355,15 @@ public:
 
     int RequestGovernanceObjectVotes(CNode& peer, CConnman& connman) const;
     int RequestGovernanceObjectVotes(Span<CNode*> vNodesCopy, CConnman& connman) const;
+
+    /*
+     * Trigger Management (formerly CGovernanceTriggerManager)
+     *   - Track governance objects which are triggers
+     *   - After triggers are activated and executed, they can be removed
+    */
+    std::vector<std::shared_ptr<CSuperblock>> GetActiveTriggers();
+    bool AddNewTrigger(uint256 nHash);
+    void CleanAndRemoveTriggers();
 
 private:
     std::optional<const CSuperblock> CreateSuperblockCandidate(int nHeight) const;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Having a dedicated manager to manipulate one variable, that relies almost exclusively on another manager doesn't make much sense. Rather than converting it into a unique_ptr, creating an alias and deglob'ing it, it's much easier to subsume it into its dependent manager.

## What was done?
See commit

## How Has This Been Tested?
Built locally; kudos @kwvg. Good idea!

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

