### PR TITLE
fix: check if message can be handled before attempting to deserialize

### DIFF
--- a/contrib/message-capture/message-capture-parser.py
+++ b/contrib/message-capture/message-capture-parser.py
@@ -122,8 +122,8 @@ def process_file(path: str, messages: List[Any], recv: bool, progress_bar: Optio
             msg_ser = BytesIO(f_in.read(length))
 
             # Determine message type
-            if msgtype not in MESSAGEMAP:
-                # Unrecognized message type
+            if msgtype not in MESSAGEMAP or MESSAGEMAP[msgtype] is None:
+                # Unrecognized or unhandled message type
                 try:
                     msgtype_tmp = msgtype.decode()
                     if not msgtype_tmp.isprintable():
@@ -131,10 +131,11 @@ def process_file(path: str, messages: List[Any], recv: bool, progress_bar: Optio
                     msg_dict["msgtype"] = msgtype_tmp
                 except UnicodeDecodeError:
                     msg_dict["msgtype"] = "UNREADABLE"
+                err_str = "Unrecognized" if msgtype not in MESSAGEMAP else "Unhandled"
                 msg_dict["body"] = msg_ser.read().hex()
-                msg_dict["error"] = "Unrecognized message type."
+                msg_dict["error"] = f"{err_str} message type"
                 messages.append(msg_dict)
-                print(f"WARNING - Unrecognized message type {msgtype} in {path}", file=sys.stderr)
+                print(f"WARNING - {msg_dict['error']} {msgtype} in {path}", file=sys.stderr)
                 continue
 
             # Deserialize the message


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently `message-capture-parser.py` crashes when encountering certain messages (e.g. mnauth). This at least makes it possible to run the script without crashing. There may be better options for solving this.

## What was done?
Check if the dictionary is going to return `None` before we attempt to do something further with it. Hide whitespace changes to see the few lines that were added: https://github.com/dashpay/dash/pull/5927/files?diff=unified&w=1

## How Has This Been Tested?
Running script locally

## Breaking Changes
N/A

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

