### PR TITLE
backport: bitcoin#14582, #16404, #17445, #19507, #19538, #19743, #19756, #19773, #19830, partial bitcoin#27053

### DIFF
--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -12,7 +12,7 @@ export DEP_OPTS="CC=clang-16 CXX='clang++-16 -stdlib=libc++'"
 export TEST_RUNNER_EXTRA="--extended --exclude feature_pruning,feature_dbcrash,wallet_multiwallet.py" # Temporarily suppress ASan heap-use-after-free (see issue #14163)
 export TEST_RUNNER_EXTRA="${TEST_RUNNER_EXTRA} --timeout-factor=4"  # Increase timeout because sanitizers slow down
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --with-gui=no --with-sanitizers=thread CC=clang-16 CXX=clang++-16 --with-boost-process"
+export BITCOIN_CONFIG="--enable-zmq --with-gui=no --with-sanitizers=thread CC=clang-16 CXX=clang++-16 CXXFLAGS='-g' --with-boost-process"
 export CPPFLAGS="-DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG"
 export PYZMQ=true
 export RUN_SYMBOL_TESTS=false

--- a/doc/release-notes-14582.md
+++ b/doc/release-notes-14582.md
@@ -1,0 +1,14 @@
+Configuration
+-------------
+
+A new configuration flag `-maxapsfee` has been added, which sets the max allowed
+avoid partial spends (APS) fee. It defaults to 0 (i.e. fee is the same with
+and without APS). Setting it to -1 will disable APS, unless `-avoidpartialspends`
+is set. (dash#5930)
+
+Wallet
+------
+
+The wallet will now avoid partial spends (APS) by default, if this does not result
+in a difference in fees compared to the non-APS variant. The allowed fee threshold
+can be adjusted using the new `-maxapsfee` configuration option. (dash#5930)

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -156,7 +156,9 @@ using other means such as firewalling.
 
 Note that when the block chain tip changes, a reorganisation may occur
 and just the tip will be notified. It is up to the subscriber to
-retrieve the chain from the last known block to the new tip.
+retrieve the chain from the last known block to the new tip. Also note
+that no notification occurs if the tip was in the active chain - this
+is the case after calling invalidateblock RPC.
 
 There are several possibilities that ZMQ notification can get lost
 during transmission depending on the communication type you are

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -36,6 +36,7 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
         "-disablewallet",
         "-instantsendnotify=<cmd>",
         "-keypool=<n>",
+        "-maxapsfee=<n>",
         "-maxtxfee=<amt>",
         "-rescan=<mode>",
         "-salvagewallet",

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -77,6 +77,8 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
                                                               CURRENCY_UNIT, FormatMoney(DEFAULT_DISCARD_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET_FEE);
     argsman.AddArg("-fallbackfee=<amt>", strprintf("A fee rate (in %s/kB) that will be used when fee estimation has insufficient data. 0 to entirely disable the fallbackfee feature. (default: %s)",
                                                                CURRENCY_UNIT, FormatMoney(DEFAULT_FALLBACK_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET_FEE);
+    argsman.AddArg("-maxapsfee=<n>", strprintf("Spend up to this amount in additional (absolute) fees (in %s) if it allows the use of partial spend avoidance (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_MAX_AVOIDPARTIALSPEND_FEE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+
     argsman.AddArg("-maxtxfee=<amt>", strprintf("Maximum total fees (in %s) to use in a single wallet transaction; setting this too low may abort large transactions (default: %s)",
                                                             CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)), ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-mintxfee=<amt>", strprintf("Fee rates (in %s/kB) smaller than this are considered zero fee for transaction creation (default: %s)",

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3769,6 +3769,13 @@ bool CWallet::CreateTransaction(
     if (res && nFeeRet > 0 /* 0 means non-functional fee rate estimation */ && m_max_aps_fee > -1 && !coin_control.m_avoid_partial_spends) {
         CCoinControl tmp_cc = coin_control;
         tmp_cc.m_avoid_partial_spends = true;
+
+        // Re-use the change destination from the first creation attempt to avoid skipping BIP44 indexes
+        const int ungrouped_change_pos = nChangePosInOut;
+        if (ungrouped_change_pos != -1) {
+            ExtractDestination(tx->vout[ungrouped_change_pos].scriptPubKey, tmp_cc.destChange);
+        }
+
         CAmount nFeeRet2;
         int nChangePosInOut2 = nChangePosIn;
         bilingual_str error2; // fired and forgotten; if an error occurs, we discard the results

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3376,7 +3376,15 @@ bool CWallet::GetBudgetSystemCollateralTX(CTransactionRef& tx, uint256 hash, CAm
     return true;
 }
 
-bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CAmount& nFeeRet, int& nChangePosInOut, bilingual_str& error, const CCoinControl& coin_control, bool sign, int nExtraPayloadSize)
+bool CWallet::CreateTransactionInternal(
+        const std::vector<CRecipient>& vecSend,
+        CTransactionRef& tx,
+        CAmount& nFeeRet,
+        int& nChangePosInOut,
+        bilingual_str& error,
+        const CCoinControl& coin_control,
+        bool sign,
+        int nExtraPayloadSize)
 {
     CAmount nValue = 0;
     ReserveDestination reservedest(this);
@@ -3742,6 +3750,40 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
               (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool) > 0.0 ? 100 * feeCalc.est.fail.withinTarget / (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool) : 0.0,
               feeCalc.est.fail.withinTarget, feeCalc.est.fail.totalConfirmed, feeCalc.est.fail.inMempool, feeCalc.est.fail.leftMempool);
     return true;
+}
+
+bool CWallet::CreateTransaction(
+        const std::vector<CRecipient>& vecSend,
+        CTransactionRef& tx,
+        CAmount& nFeeRet,
+        int& nChangePosInOut,
+        bilingual_str& error,
+        const CCoinControl& coin_control,
+        bool sign,
+        int nExtraPayloadSize)
+{
+    int nChangePosIn = nChangePosInOut;
+    CTransactionRef tx2 = tx;
+    bool res = CreateTransactionInternal(vecSend, tx, nFeeRet, nChangePosInOut, error, coin_control, sign, nExtraPayloadSize);
+    // try with avoidpartialspends unless it's enabled already
+    if (res && nFeeRet > 0 /* 0 means non-functional fee rate estimation */ && m_max_aps_fee > -1 && !coin_control.m_avoid_partial_spends) {
+        CCoinControl tmp_cc = coin_control;
+        tmp_cc.m_avoid_partial_spends = true;
+        CAmount nFeeRet2;
+        int nChangePosInOut2 = nChangePosIn;
+        bilingual_str error2; // fired and forgotten; if an error occurs, we discard the results
+        if (CreateTransactionInternal(vecSend, tx2, nFeeRet2, nChangePosInOut2, error2, tmp_cc, sign, nExtraPayloadSize)) {
+            // if fee of this alternative one is within the range of the max fee, we use this one
+            const bool use_aps = nFeeRet2 <= nFeeRet + m_max_aps_fee;
+            WalletLogPrintf("Fee non-grouped = %lld, grouped = %lld, using %s\n", nFeeRet, nFeeRet2, use_aps ? "grouped" : "non-grouped");
+            if (use_aps) {
+                tx = tx2;
+                nFeeRet = nFeeRet2;
+                nChangePosInOut = nChangePosInOut2;
+            }
+        }
+    }
+    return res;
 }
 
 void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm)
@@ -4648,6 +4690,21 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, interfaces::C
         }
 
         walletInstance->m_min_fee = CFeeRate{min_tx_fee.value()};
+    }
+
+    if (gArgs.IsArgSet("-maxapsfee")) {
+        CAmount n = 0;
+        if (gArgs.GetArg("-maxapsfee", "") == "-1") {
+            n = -1;
+        } else if (!ParseMoney(gArgs.GetArg("-maxapsfee", ""), n)) {
+            error = AmountErrMsg("maxapsfee", gArgs.GetArg("-maxapsfee", ""));
+            return nullptr;
+        }
+        if (n > HIGH_APS_FEE) {
+            warnings.push_back(AmountHighWarn("-maxapsfee") + Untranslated(" ") +
+                              _("This is the maximum transaction fee you pay to prioritize partial spend avoidance over regular coin selection."));
+        }
+        walletInstance->m_max_aps_fee = n;
     }
 
     if (gArgs.IsArgSet("-fallbackfee")) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4694,18 +4694,18 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, interfaces::C
 
     if (gArgs.IsArgSet("-maxapsfee")) {
         const std::string max_aps_fee{gArgs.GetArg("-maxapsfee", "")};
-        CAmount n = 0;
         if (max_aps_fee == "-1") {
-            n = -1;
-        } else if (!ParseMoney(max_aps_fee, n)) {
+            walletInstance->m_max_aps_fee = -1;
+        } else if (std::optional<CAmount> max_fee = ParseMoney(max_aps_fee)) {
+            if (max_fee.value() > HIGH_APS_FEE) {
+                warnings.push_back(AmountHighWarn("-maxapsfee") + Untranslated(" ") +
+                                  _("This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection."));
+            }
+            walletInstance->m_max_aps_fee = max_fee.value();
+        } else {
             error = AmountErrMsg("maxapsfee", max_aps_fee);
             return nullptr;
         }
-        if (n > HIGH_APS_FEE) {
-            warnings.push_back(AmountHighWarn("-maxapsfee") + Untranslated(" ") +
-                              _("This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection."));
-        }
-        walletInstance->m_max_aps_fee = n;
     }
 
     if (gArgs.IsArgSet("-fallbackfee")) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4693,16 +4693,17 @@ std::shared_ptr<CWallet> CWallet::Create(interfaces::Chain& chain, interfaces::C
     }
 
     if (gArgs.IsArgSet("-maxapsfee")) {
+        const std::string max_aps_fee{gArgs.GetArg("-maxapsfee", "")};
         CAmount n = 0;
-        if (gArgs.GetArg("-maxapsfee", "") == "-1") {
+        if (max_aps_fee == "-1") {
             n = -1;
-        } else if (!ParseMoney(gArgs.GetArg("-maxapsfee", ""), n)) {
-            error = AmountErrMsg("maxapsfee", gArgs.GetArg("-maxapsfee", ""));
+        } else if (!ParseMoney(max_aps_fee, n)) {
+            error = AmountErrMsg("maxapsfee", max_aps_fee);
             return nullptr;
         }
         if (n > HIGH_APS_FEE) {
             warnings.push_back(AmountHighWarn("-maxapsfee") + Untranslated(" ") +
-                              _("This is the maximum transaction fee you pay to prioritize partial spend avoidance over regular coin selection."));
+                              _("This is the maximum transaction fee you pay (in addition to the normal fee) to prioritize partial spend avoidance over regular coin selection."));
         }
         walletInstance->m_max_aps_fee = n;
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -283,7 +283,7 @@ int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* pwallet,
 class CWalletTx
 {
 private:
-    const CWallet* pwallet;
+    const CWallet* const pwallet;
 
     /** Constant used in hashBlock to indicate tx has been abandoned, only used at
      * serialization/deserialization to avoid ambiguity with conflicted.
@@ -524,7 +524,6 @@ public:
 
     bool InMempool() const;
     bool IsTrusted() const;
-    bool IsTrusted(std::set<uint256>& trusted_parents) const;
 
     int64_t GetTxTime() const;
 
@@ -888,6 +887,7 @@ public:
     interfaces::CoinJoin::Loader& coinjoin_loader() { assert(m_coinjoin_loader); return *m_coinjoin_loader; }
 
     const CWalletTx* GetWalletTx(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsTrusted(const CWalletTx& wtx, std::set<uint256>& trusted_parents) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) const override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -73,6 +73,16 @@ static const CAmount DEFAULT_FALLBACK_FEE = 1000;
 static const CAmount DEFAULT_DISCARD_FEE = 10000;
 //! -mintxfee default
 static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
+/**
+ * maximum fee increase allowed to do partial spend avoidance, even for nodes with this feature disabled by default
+ *
+ * A value of -1 disables this feature completely.
+ * A value of 0 (current default) means to attempt to do partial spend avoidance, and use its results if the fees remain *unchanged*
+ * A value > 0 means to do partial spend avoidance if the fee difference against a regular coin selection instance is in the range [0..value].
+ */
+static const CAmount DEFAULT_MAX_AVOIDPARTIALSPEND_FEE = 0;
+//! discourage APS fee higher than this amount
+constexpr CAmount HIGH_APS_FEE{COIN / 10000};
 //! minimum recommended increment for BIP 125 replacement txs
 static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 5000;
 //! Default for -spendzeroconfchange
@@ -806,6 +816,8 @@ private:
     // ScriptPubKeyMan::GetID. In many cases it will be the hash of an internal structure
     std::map<uint256, std::unique_ptr<ScriptPubKeyMan>> m_spk_managers;
 
+    bool CreateTransactionInternal(const std::vector<CRecipient>& vecSend, CTransactionRef& tx, CAmount& nFeeRet, int& nChangePosInOut, bilingual_str& error, const CCoinControl& coin_control, bool sign, int nExtraPayloadSize);
+
 public:
     /*
      * Main wallet lock.
@@ -1125,6 +1137,7 @@ public:
      */
     CFeeRate m_fallback_fee{DEFAULT_FALLBACK_FEE};
     CFeeRate m_discard_rate{DEFAULT_DISCARD_FEE};
+    CAmount m_max_aps_fee{DEFAULT_MAX_AVOIDPARTIALSPEND_FEE}; //!< note: this is absolute fee, not fee rate
     /** Absolute maximum transaction fee (in satoshis) used by default for the wallet */
     CAmount m_default_max_tx_fee{DEFAULT_TRANSACTION_MAXFEE};
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -150,7 +150,8 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
 
 void CZMQAbstractPublishNotifier::Shutdown()
 {
-    assert(psocket);
+    // Early return if Initialize was not called
+    if (!psocket) return;
 
     int count = mapPublishNotifiers.count(address);
 

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -64,6 +64,11 @@ class ZMQTest (BitcoinTestFramework):
         # Note that the publishing order is not defined in the documentation and
         # is subject to change.
         import zmq
+
+        # Invalid zmq arguments don't take down the node, see #17185.
+        self.restart_node(0, ["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
+        self.zmq_context = zmq.Context()
+
         address = 'tcp://127.0.0.1:28332'
         socket = self.ctx.socket(zmq.SUB)
         socket.set(zmq.RCVTIMEO, 60000)

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -59,10 +59,6 @@ class ZMQTest (BitcoinTestFramework):
             self.ctx.destroy(linger=None)
 
     def test_basic(self):
-        # All messages are received in the same socket which means
-        # that this test fails if the publishing order changes.
-        # Note that the publishing order is not defined in the documentation and
-        # is subject to change.
         import zmq
 
         # Invalid zmq arguments don't take down the node, see #17185.
@@ -70,18 +66,25 @@ class ZMQTest (BitcoinTestFramework):
         self.zmq_context = zmq.Context()
 
         address = 'tcp://127.0.0.1:28332'
-        socket = self.ctx.socket(zmq.SUB)
-        socket.set(zmq.RCVTIMEO, 60000)
+        sockets = []
+        subs = []
+        services = [b"hashblock", b"hashtx", b"rawblock", b"rawtx"]
+        for service in services:
+            sockets.append(self.ctx.socket(zmq.SUB))
+            sockets[-1].set(zmq.RCVTIMEO, 60000)
+            subs.append(ZMQSubscriber(sockets[-1], service))
 
         # Subscribe to all available topics.
-        hashblock = ZMQSubscriber(socket, b"hashblock")
-        hashtx = ZMQSubscriber(socket, b"hashtx")
-        rawblock = ZMQSubscriber(socket, b"rawblock")
-        rawtx = ZMQSubscriber(socket, b"rawtx")
+        hashblock = subs[0]
+        hashtx = subs[1]
+        rawblock = subs[2]
+        rawtx = subs[3]
 
         self.restart_node(0, ["-zmqpub%s=%s" % (sub.topic.decode(), address) for sub in [hashblock, hashtx, rawblock, rawtx]])
         self.connect_nodes(0, 1)
-        socket.connect(address)
+        for socket in sockets:
+            socket.connect(address)
+
         # Relax so that the subscriber is ready before publishing zmq messages
         sleep(0.2)
         self.import_deterministic_coinbase_privkeys()
@@ -101,15 +104,16 @@ class ZMQTest (BitcoinTestFramework):
             hex = rawtx.receive()
             assert_equal(hash256_reversed(hex), txid)
 
+            # Should receive the generated raw block.
+            block = rawblock.receive()
+            assert_equal(genhashes[x], dashhash_reversed(block[:80]).hex())
+
             # Should receive the generated block hash.
             hash = hashblock.receive().hex()
             assert_equal(genhashes[x], hash)
             # The block should only have the coinbase txid.
             assert_equal([txid.hex()], self.nodes[1].getblock(hash)["tx"])
 
-            # Should receive the generated raw block.
-            block = rawblock.receive()
-            assert_equal(genhashes[x], dashhash_reversed(block[:80]).hex())
 
         if self.is_wallet_compiled():
             self.log.info("Wait for tx from second node")
@@ -124,6 +128,13 @@ class ZMQTest (BitcoinTestFramework):
             hex = rawtx.receive()
             assert_equal(payment_txid, hash256_reversed(hex).hex())
 
+            # Mining the block with this tx should result in second notification
+            # after coinbase tx notification
+            self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_UNSPENDABLE)
+            hashtx.receive()
+            txid = hashtx.receive()
+            assert_equal(payment_txid, txid.hex())
+
 
         self.log.info("Test the getzmqnotifications RPC")
         assert_equal(self.nodes[0].getzmqnotifications(), [
@@ -137,30 +148,67 @@ class ZMQTest (BitcoinTestFramework):
 
 
     def test_reorg(self):
+        if not self.is_wallet_compiled():
+            self.log.info("Skipping reorg test because wallet is disabled")
+            return
+
         import zmq
         address = 'tcp://127.0.0.1:28333'
-        socket = self.ctx.socket(zmq.SUB)
-        socket.set(zmq.RCVTIMEO, 60000)
-        hashblock = ZMQSubscriber(socket, b'hashblock')
+
+        services = [b"hashblock", b"hashtx"]
+        sockets = []
+        subs = []
+        for service in services:
+            sockets.append(self.ctx.socket(zmq.SUB))
+            # 2 second timeout to check end of notifications
+            sockets[-1].set(zmq.RCVTIMEO, 2000)
+            subs.append(ZMQSubscriber(sockets[-1], service))
+
+        # Subscribe to all available topics.
+        hashblock = subs[0]
+        hashtx = subs[1]
 
         # Should only notify the tip if a reorg occurs
-        self.restart_node(0, ['-zmqpub%s=%s' % (hashblock.topic.decode(), address)])
-        socket.connect(address)
+        self.restart_node(0, ["-zmqpub%s=%s" % (sub.topic.decode(), address) for sub in [hashblock, hashtx]])
+        for socket in sockets:
+            socket.connect(address)
         # Relax so that the subscriber is ready before publishing zmq messages
         sleep(0.2)
 
-        # Generate 1 block in nodes[0] and receive all notifications
-        self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_UNSPENDABLE)
+        # Generate 1 block in nodes[0] with 1 mempool tx and receive all notifications
+        payment_txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
+        disconnect_block = self.nodes[0].generatetoaddress(1, ADDRESS_BCRT1_UNSPENDABLE)[0]
+        disconnect_cb = self.nodes[0].getblock(disconnect_block)["tx"][0]
         assert_equal(self.nodes[0].getbestblockhash(), hashblock.receive().hex())
+        assert_equal(hashtx.receive().hex(), payment_txid)
+        assert_equal(hashtx.receive().hex(), disconnect_cb)
 
         # Generate 2 blocks in nodes[1]
-        self.nodes[1].generatetoaddress(2, ADDRESS_BCRT1_UNSPENDABLE)
+        connect_blocks = self.nodes[1].generatetoaddress(2, ADDRESS_BCRT1_UNSPENDABLE)
 
         # nodes[0] will reorg chain after connecting back nodes[1]
         self.connect_nodes(0, 1)
+        self.sync_blocks() # tx in mempool valid but not advertised
 
         # Should receive nodes[1] tip
         assert_equal(self.nodes[1].getbestblockhash(), hashblock.receive().hex())
+
+        # During reorg:
+        # Get old payment transaction notification from disconnect and disconnected cb
+        assert_equal(hashtx.receive().hex(), payment_txid)
+        assert_equal(hashtx.receive().hex(), disconnect_cb)
+        # And the payment transaction again due to mempool entry
+        assert_equal(hashtx.receive().hex(), payment_txid)
+        assert_equal(hashtx.receive().hex(), payment_txid)
+        # And the new connected coinbases
+        for i in [0, 1]:
+            assert_equal(hashtx.receive().hex(), self.nodes[1].getblock(connect_blocks[i])["tx"][0])
+
+        # If we do a simple invalidate we announce the disconnected coinbase
+        self.nodes[0].invalidateblock(connect_blocks[1])
+        assert_equal(hashtx.receive().hex(), self.nodes[1].getblock(connect_blocks[1])["tx"][0])
+        # And the current tip
+        assert_equal(hashtx.receive().hex(), self.nodes[1].getblock(connect_blocks[0])["tx"][0])
 
     def test_multiple_interfaces(self):
         import zmq

--- a/test/functional/interface_zmq_dash.py
+++ b/test/functional/interface_zmq_dash.py
@@ -100,7 +100,7 @@ class TestP2PConn(P2PInterface):
 class DashZMQTest (DashTestFramework):
     def set_test_params(self):
         # That's where the zmq publisher will listen for subscriber
-        self.address = "tcp://127.0.0.1:28333"
+        self.address = "tcp://127.0.0.1:28331"
         # node0 creates all available ZMQ publisher
         node0_extra_args = ["-zmqpub%s=%s" % (pub.value, self.address) for pub in ZMQPublisher]
         node0_extra_args.append("-whitelist=127.0.0.1")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -201,6 +201,8 @@ BASE_SCRIPTS = [
     'rpc_deprecated.py',
     'wallet_disable.py',
     'wallet_disable.py --descriptors',
+    'wallet_change_address.py --legacy-wallet',
+    'wallet_change_address.py --descriptors',
     'p2p_addr_relay.py',
     'p2p_getaddr_caching.py',
     'p2p_getdata.py',

--- a/test/functional/wallet_change_address.py
+++ b/test/functional/wallet_change_address.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test wallet change address selection"""
+
+import re
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+
+class WalletChangeAddressTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        # discardfee is used to make change outputs less likely in the change_pos test
+        self.extra_args = [
+            [],
+            ["-discardfee=1"],
+            ["-avoidpartialspends", "-discardfee=1"]
+        ]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def assert_change_index(self, node, tx, index):
+        change_index = None
+        for vout in tx["vout"]:
+            info = node.getaddressinfo(vout["scriptPubKey"]["addresses"][0])
+            if (info["ismine"] and info["ischange"]):
+                change_index = int(re.findall(r'\d+', info["hdkeypath"])[-1])
+                break
+        assert_equal(change_index, index)
+
+    def assert_change_pos(self, wallet, tx, pos):
+        change_pos = None
+        for index, output in enumerate(tx["vout"]):
+            info = wallet.getaddressinfo(output["scriptPubKey"]["address"])
+            if (info["ismine"] and info["ischange"]):
+                change_pos = index
+                break
+        assert_equal(change_pos, pos)
+
+    def run_test(self):
+        self.log.info("Setting up")
+        # Mine some coins
+        self.nodes[0].generate(COINBASE_MATURITY + 1)
+
+        # Get some addresses from the two nodes
+        addr1 = [self.nodes[1].getnewaddress() for _ in range(3)]
+        addr2 = [self.nodes[2].getnewaddress() for _ in range(3)]
+        addrs = addr1 + addr2
+
+        # Send 1 + 0.5 coin to each address
+        [self.nodes[0].sendtoaddress(addr, 10) for addr in addrs]
+        [self.nodes[0].sendtoaddress(addr, 5) for addr in addrs]
+        self.nodes[0].generate(1)
+
+        for i in range(20):
+            for n in [1, 2]:
+                self.log.debug(f"Send transaction from node {n}: expected change index {i}")
+                txid = self.nodes[n].sendtoaddress(self.nodes[0].getnewaddress(), 2)
+                tx = self.nodes[n].getrawtransaction(txid, True)
+                # find the change output and ensure that expected change index was used
+                self.assert_change_index(self.nodes[n], tx, i)
+
+
+if __name__ == '__main__':
+    WalletChangeAddressTest().main()

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -104,6 +104,7 @@ class WalletGroupTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
         self.nodes[0].generate(1)
+        self.sync_all()
         txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
         tx4 = self.nodes[3].getrawtransaction(txid4, True)
         # tx4 should have 2 inputs and 2 outputs although one output would

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -15,8 +15,8 @@ from test_framework.util import (
 class WalletGroupTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 3
-        self.extra_args = [[], [], ['-avoidpartialspends']]
+        self.num_nodes = 4
+        self.extra_args = [[], [], ['-avoidpartialspends'], ["-maxapsfee=0.0001"]]
         self.rpc_timeout = 480
         self.supports_cli = False
 
@@ -64,6 +64,52 @@ class WalletGroupTest(BitcoinTestFramework):
         v.sort()
         assert_approx(v[0], 0.2)
         assert_approx(v[1], 1.3, 0.0001)
+
+        # Test 'avoid partial if warranted, even if disabled'
+        self.sync_all()
+        self.nodes[0].generate(1)
+        # Nodes 1-2 now have confirmed UTXOs (letters denote destinations):
+        # Node #1:      Node #2:
+        # - A  1.0      - D0 1.0
+        # - B0 1.0      - D1 0.5
+        # - B1 0.5      - E0 1.0
+        # - C0 1.0      - E1 0.5
+        # - C1 0.5      - F  ~1.3
+        # - D ~0.3
+        assert_approx(self.nodes[1].getbalance(), 4.3, 0.0001)
+        assert_approx(self.nodes[2].getbalance(), 4.3, 0.0001)
+        # Sending 1.4 btc should pick one 1.0 + one more. For node #1,
+        # this could be (A / B0 / C0) + (B1 / C1 / D). We ensure that it is
+        # B0 + B1 or C0 + C1, because this avoids partial spends while not being
+        # detrimental to transaction cost
+        txid3 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.4)
+        tx3 = self.nodes[1].getrawtransaction(txid3, True)
+        # tx3 should have 2 inputs and 2 outputs
+        assert_equal(2, len(tx3["vin"]))
+        assert_equal(2, len(tx3["vout"]))
+        # the accumulated value should be 1.5, so the outputs should be
+        # ~0.1 and 1.4 and should come from the same destination
+        values = [vout["value"] for vout in tx3["vout"]]
+        values.sort()
+        assert_approx(values[0], 0.1, 0.0001)
+        assert_approx(values[1], 1.4)
+
+        input_txids = [vin["txid"] for vin in tx3["vin"]]
+        input_addrs = [self.nodes[1].gettransaction(txid)['details'][0]['address'] for txid in input_txids]
+        assert_equal(input_addrs[0], input_addrs[1])
+        # Node 2 enforces avoidpartialspends so needs no checking here
+
+        # Test wallet option maxapsfee with Node 3
+        addr_aps = self.nodes[3].getnewaddress()
+        self.nodes[0].sendtoaddress(addr_aps, 1.0)
+        self.nodes[0].sendtoaddress(addr_aps, 1.0)
+        self.nodes[0].generate(1)
+        txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
+        tx4 = self.nodes[3].getrawtransaction(txid4, True)
+        # tx4 should have 2 inputs and 2 outputs although one output would
+        # have been enough and the transaction caused higher fees
+        assert_equal(2, len(tx4["vin"]))
+        assert_equal(2, len(tx4["vout"]))
 
         # Empty out node2's wallet
         self.nodes[2].sendtoaddress(address=self.nodes[0].getnewaddress(), amount=self.nodes[2].getbalance(), subtractfeefromamount=True)

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -15,8 +15,14 @@ from test_framework.util import (
 class WalletGroupTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 4
-        self.extra_args = [[], [], ['-avoidpartialspends'], ["-maxapsfee=0.0001"]]
+        self.num_nodes = 5
+        self.extra_args = [
+            [],
+            [],
+            ["-avoidpartialspends"],
+            ["-maxapsfee=0.00000293"],
+            ["-maxapsfee=0.00000294"],
+        ]
         self.rpc_timeout = 480
         self.supports_cli = False
 
@@ -51,8 +57,8 @@ class WalletGroupTest(BitcoinTestFramework):
         # one output should be 0.2, the other should be ~0.3
         v = [vout["value"] for vout in tx1["vout"]]
         v.sort()
-        assert_approx(v[0], 0.2)
-        assert_approx(v[1], 0.3, 0.0001)
+        assert_approx(v[0], vexp=0.2, vspan=0.0001)
+        assert_approx(v[1], vexp=0.3, vspan=0.0001)
 
         txid2 = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
         tx2 = self.nodes[2].getrawtransaction(txid2, True)
@@ -62,8 +68,8 @@ class WalletGroupTest(BitcoinTestFramework):
         # one output should be 0.2, the other should be ~1.3
         v = [vout["value"] for vout in tx2["vout"]]
         v.sort()
-        assert_approx(v[0], 0.2)
-        assert_approx(v[1], 1.3, 0.0001)
+        assert_approx(v[0], vexp=0.2, vspan=0.0001)
+        assert_approx(v[1], vexp=1.3, vspan=0.0001)
 
         # Test 'avoid partial if warranted, even if disabled'
         self.sync_all()
@@ -76,8 +82,8 @@ class WalletGroupTest(BitcoinTestFramework):
         # - C0 1.0      - E1 0.5
         # - C1 0.5      - F  ~1.3
         # - D ~0.3
-        assert_approx(self.nodes[1].getbalance(), 4.3, 0.0001)
-        assert_approx(self.nodes[2].getbalance(), 4.3, 0.0001)
+        assert_approx(self.nodes[1].getbalance(), vexp=4.3, vspan=0.0001)
+        assert_approx(self.nodes[2].getbalance(), vexp=4.3, vspan=0.0001)
         # Sending 1.4 btc should pick one 1.0 + one more. For node #1,
         # this could be (A / B0 / C0) + (B1 / C1 / D). We ensure that it is
         # B0 + B1 or C0 + C1, because this avoids partial spends while not being
@@ -91,8 +97,8 @@ class WalletGroupTest(BitcoinTestFramework):
         # ~0.1 and 1.4 and should come from the same destination
         values = [vout["value"] for vout in tx3["vout"]]
         values.sort()
-        assert_approx(values[0], 0.1, 0.0001)
-        assert_approx(values[1], 1.4)
+        assert_approx(values[0], vexp=0.1, vspan=0.0001)
+        assert_approx(values[1], vexp=1.4, vspan=0.0001)
 
         input_txids = [vin["txid"] for vin in tx3["vin"]]
         input_addrs = [self.nodes[1].gettransaction(txid)['details'][0]['address'] for txid in input_txids]
@@ -105,12 +111,37 @@ class WalletGroupTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(addr_aps, 1.0)
         self.nodes[0].generate(1)
         self.sync_all()
-        txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
+        with self.nodes[3].assert_debug_log(['Fee non-grouped = 225, grouped = 372, using grouped']):
+            txid4 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
         tx4 = self.nodes[3].getrawtransaction(txid4, True)
         # tx4 should have 2 inputs and 2 outputs although one output would
         # have been enough and the transaction caused higher fees
         assert_equal(2, len(tx4["vin"]))
         assert_equal(2, len(tx4["vout"]))
+
+        addr_aps2 = self.nodes[3].getnewaddress()
+        [self.nodes[0].sendtoaddress(addr_aps2, 1.0) for _ in range(5)]
+        self.nodes[0].generate(1)
+        self.sync_all()
+        with self.nodes[3].assert_debug_log(['Fee non-grouped = 519, grouped = 813, using non-grouped']):
+            txid5 = self.nodes[3].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
+        tx5 = self.nodes[3].getrawtransaction(txid5, True)
+        # tx5 should have 3 inputs (1.0, 1.0, 1.0) and 2 outputs
+        assert_equal(3, len(tx5["vin"]))
+        assert_equal(2, len(tx5["vout"]))
+
+        # Test wallet option maxapsfee with node 4, which sets maxapsfee
+        # 1 sat higher, crossing the threshold from non-grouped to grouped.
+        addr_aps3 = self.nodes[4].getnewaddress()
+        [self.nodes[0].sendtoaddress(addr_aps3, 1.0) for _ in range(5)]
+        self.nodes[0].generate(1)
+        self.sync_all()
+        with self.nodes[4].assert_debug_log(['Fee non-grouped = 519, grouped = 813, using grouped']):
+            txid6 = self.nodes[4].sendtoaddress(self.nodes[0].getnewaddress(), 2.95)
+        tx6 = self.nodes[4].getrawtransaction(txid6, True)
+        # tx6 should have 5 inputs and 2 outputs
+        assert_equal(5, len(tx6["vin"]))
+        assert_equal(2, len(tx6["vout"]))
 
         # Empty out node2's wallet
         self.nodes[2].sendtoaddress(address=self.nodes[0].getnewaddress(), amount=self.nodes[2].getbalance(), subtractfeefromamount=True)

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -331,7 +331,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                             wallet=wmulti_priv)
 
         assert_equal(wmulti_priv.getwalletinfo()['keypoolsize'], 1001) # Range end (1000) is inclusive, so 1001 addresses generated
-        addr = wmulti_priv.getnewaddress()
+        addr = wmulti_priv.getnewaddress() # uses receive 0
         assert_equal(addr, '8vEwYGKBMP3F2juEE36nNqh1uYpBv9QFyB') # Derived at m/84'/0'/0'/0
         change_addr = wmulti_priv.getrawchangeaddress()
         assert_equal(change_addr, '91WxMwg2NHD1PwHChhbAkeCN6nQ8ikdLEx')
@@ -339,7 +339,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         txid = w0.sendtoaddress(addr, 10)
         self.nodes[0].generate(6)
         self.sync_all()
-        wmulti_priv.sendtoaddress(w0.getnewaddress(), 8)
+        wmulti_priv.sendtoaddress(w0.getnewaddress(), 8) # uses change 1
         self.nodes[0].generate(6)
         self.sync_all()
 
@@ -364,9 +364,9 @@ class ImportDescriptorsTest(BitcoinTestFramework):
                             wallet=wmulti_pub)
 
         assert_equal(wmulti_pub.getwalletinfo()['keypoolsize'], 1000) # The first one was already consumed by previous import and is detected as used
-        addr = wmulti_pub.getnewaddress()
+        addr = wmulti_pub.getnewaddress() # uses receive 1
         assert_equal(addr, '91cA4fLGaDCr6b9W2c5j1ph9PDpq9WbEhk') # Derived at m/84'/0'/0'/1
-        change_addr = wmulti_pub.getrawchangeaddress()
+        change_addr = wmulti_pub.getrawchangeaddress() # uses receive 2
         assert_equal(change_addr, '91WxMwg2NHD1PwHChhbAkeCN6nQ8ikdLEx')
         assert_equal(wmulti_pub.getwalletinfo()['keypoolsize'], 999)
         txid = w0.sendtoaddress(addr, 10)

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -62,7 +62,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
                     assert_equal(keypath, "m/44'/1'/0'/0/%d" % i)
                 else:
                     keypath = node.getaddressinfo(out['scriptPubKey']['addresses'][0])['hdkeypath']
-                    assert_equal(keypath, "m/44'/1'/0'/1/%d" % (i * 2))
+                    assert_equal(keypath, "m/44'/1'/0'/1/%d" % i)
 
         self.bump_mocktime(1)
         node.generate(1)
@@ -134,7 +134,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         assert node.upgradetohd(mnemonic)
         assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
         assert_equal(chainid, node.getwalletinfo()['hdchainid'])
-        node.keypoolrefill(10)
+        node.keypoolrefill(5)
         assert balance_after != node.getbalance()
         node.rescanblockchain()
         assert_equal(balance_after, node.getbalance())
@@ -177,7 +177,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         # so we can't compare new balance to balance_non_HD here,
         # assert_equal(balance_non_HD, node.getbalance())  # won't work
         assert balance_non_HD != node.getbalance()
-        node.keypoolrefill(8)
+        node.keypoolrefill(4)
         node.rescanblockchain()
         # All coins should be recovered
         assert_equal(balance_after, node.getbalance())
@@ -201,7 +201,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         # so we can't compare new balance to balance_non_HD here,
         # assert_equal(balance_non_HD, node.getbalance())  # won't work
         assert balance_non_HD != node.getbalance()
-        node.keypoolrefill(8)
+        node.keypoolrefill(4)
         node.rescanblockchain()
         # All coins should be recovered
         assert_equal(balance_after, node.getbalance())

--- a/test/functional/wallet_upgradetohd.py
+++ b/test/functional/wallet_upgradetohd.py
@@ -62,7 +62,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
                     assert_equal(keypath, "m/44'/1'/0'/0/%d" % i)
                 else:
                     keypath = node.getaddressinfo(out['scriptPubKey']['addresses'][0])['hdkeypath']
-                    assert_equal(keypath, "m/44'/1'/0'/1/%d" % i)
+                    assert_equal(keypath, "m/44'/1'/0'/1/%d" % (i * 2))
 
         self.bump_mocktime(1)
         node.generate(1)
@@ -134,7 +134,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         assert node.upgradetohd(mnemonic)
         assert_equal(mnemonic, node.dumphdinfo()['mnemonic'])
         assert_equal(chainid, node.getwalletinfo()['hdchainid'])
-        node.keypoolrefill(5)
+        node.keypoolrefill(10)
         assert balance_after != node.getbalance()
         node.rescanblockchain()
         assert_equal(balance_after, node.getbalance())
@@ -177,7 +177,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         # so we can't compare new balance to balance_non_HD here,
         # assert_equal(balance_non_HD, node.getbalance())  # won't work
         assert balance_non_HD != node.getbalance()
-        node.keypoolrefill(4)
+        node.keypoolrefill(8)
         node.rescanblockchain()
         # All coins should be recovered
         assert_equal(balance_after, node.getbalance())
@@ -201,7 +201,7 @@ class WalletUpgradeToHDTest(BitcoinTestFramework):
         # so we can't compare new balance to balance_non_HD here,
         # assert_equal(balance_non_HD, node.getbalance())  # won't work
         assert balance_non_HD != node.getbalance()
-        node.keypoolrefill(4)
+        node.keypoolrefill(8)
         node.rescanblockchain()
         # All coins should be recovered
         assert_equal(balance_after, node.getbalance())

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -32,6 +32,7 @@ race:WalletBatch::WriteHDChain
 race:BerkeleyBatch
 race:BerkeleyDatabase
 race:DatabaseBatch
+race:leveldb::DBImpl::DeleteObsoleteFiles
 race:zmq::*
 race:bitcoin-qt
 # deadlock (TODO fix)

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -31,6 +31,7 @@ race:LoadWallet
 race:WalletBatch::WriteHDChain
 race:BerkeleyBatch
 race:BerkeleyDatabase
+race:DatabaseBatch
 race:zmq::*
 race:bitcoin-qt
 # deadlock (TODO fix)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Regular backports from bitcoin v21

## What was done?
 - bitcoin/bitcoin#19538
 - bitcoin/bitcoin#19830
 - bitcoin/bitcoin#19773
 - bitcoin/bitcoin#14582
 - bitcoin/bitcoin#19756
 - bitcoin/bitcoin#19743
 - bitcoin/bitcoin#16404
 - bitcoin/bitcoin#17445
 - bitcoin/bitcoin#19507
 - partial bitcoin/bitcoin#27053

+some extra fixes and missing changes from bitcoin/bitcoin#22220 for `maxapsfee`

+changed port for zmq in `interface_zmq_dash.py` to prevent intermittent error in `interface_zmq.py`

## How Has This Been Tested?
Run unit & functional tests

## Breaking Changes
`CreateTransaction` now uses sometime 2 private keys for one transaction instead one


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone