### PR TITLE
ci: fail clang-diff-format on failure

### DIFF
--- a/.github/workflows/clang-diff-format.yml
+++ b/.github/workflows/clang-diff-format.yml
@@ -13,5 +13,12 @@ jobs:
       - name: Fetch git
         run: git fetch
       - name: Run Clang-Format-Diff.py
-        run: git diff -U0 origin/develop -- . ':(exclude)src/qt/dashstrings.cpp' ':(exclude)src/qt/locale/' | ./contrib/devtools/clang-format-diff.py -p1
-
+        run: |
+          git diff -U0 origin/develop -- . ':(exclude)src/qt/dashstrings.cpp' ':(exclude)src/qt/locale/' | ./contrib/devtools/clang-format-diff.py -p1 > diff_output.txt
+          if [ -s diff_output.txt ]; then
+              echo "Clang format differences found:"
+              cat diff_output.txt
+              exit 1
+          else
+              echo "No Clang format differences found."
+          fi


### PR DESCRIPTION
## Issue being fixed or feature implemented
I have it now where CI marks this as not-required; but this will better inform us when someone should run clang-diff-format :) Should be ignored for backports or other instances where a diff would be annoying.

## What was done?
Fail CI

## How Has This Been Tested?
Run script locally

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

