### PR TITLE
backport: bitcoin#19528, #19455, #19717, #19849, #19994 - assert for RPCArg names

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -334,7 +334,7 @@ static bool rest_block_notxdetails(const CoreContext& context, HTTPRequest* req,
 }
 
 // A bit of a hack - dependency on a function defined in rpc/blockchain.cpp
-UniValue getblockchaininfo(const JSONRPCRequest& request);
+RPCHelpMan getblockchaininfo();
 
 static bool rest_chaininfo(const CoreContext& context, HTTPRequest* req, const std::string& strURIPart)
 {
@@ -347,7 +347,7 @@ static bool rest_chaininfo(const CoreContext& context, HTTPRequest* req, const s
     case RetFormat::JSON: {
         JSONRPCRequest jsonRequest(context);
         jsonRequest.params = UniValue(UniValue::VARR);
-        UniValue chainInfoObject = getblockchaininfo(jsonRequest);
+        UniValue chainInfoObject = getblockchaininfo().HandleRequest(jsonRequest);
         std::string strJSON = chainInfoObject.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2986,8 +2986,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "dumptxoutset",           &dumptxoutset,           {"path"} },
 };
 // clang-format on
-
-    for (const auto& command : commands) {
-        t.appendCommand(command.name, &command);
+    for (const auto& c : commands) {
+        t.appendCommand(c.name, &c);
     }
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -964,7 +964,7 @@ static RPCHelpMan getblockheaders()
         "\nIf verbose is false, each item is a string that is serialized, hex-encoded data for a single blockheader.\n"
         "If verbose is true, each item is an Object with information about a single blockheader.\n",
         {
-            {"hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash"},
+            {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash"},
             {"count", RPCArg::Type::NUM, /* default */ strprintf("%s", MAX_HEADERS_RESULTS), ""},
             {"verbose", RPCArg::Type::BOOL, /* default */ "true", "true for a json object, false for the hex-encoded data"},
         },
@@ -1100,7 +1100,7 @@ static RPCHelpMan getmerkleblocks()
         "\nReturns an array of hex-encoded merkleblocks for <count> blocks starting from <hash> which match <filter>.\n",
         {
             {"filter", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hex-encoded bloom filter"},
-            {"hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash"},
+            {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The block hash"},
             {"count", RPCArg::Type::NUM, /* default */ strprintf("%s", MAX_HEADERS_RESULTS), ""},
         },
         RPCResult{

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -242,9 +242,9 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
     return result;
 }
 
-static UniValue getblockcount(const JSONRPCRequest& request)
+static RPCHelpMan getblockcount()
 {
-    RPCHelpMan{"getblockcount",
+    return RPCHelpMan{"getblockcount",
         "\nReturns the height of the most-work fully-validated chain.\n"
         "The genesis block has height 0.\n",
         {},
@@ -254,16 +254,18 @@ static UniValue getblockcount(const JSONRPCRequest& request)
             HelpExampleCli("getblockcount", "")
     + HelpExampleRpc("getblockcount", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     LOCK(cs_main);
     return chainman.ActiveChain().Height();
+},
+    };
 }
 
-static UniValue getbestblockhash(const JSONRPCRequest& request)
+static RPCHelpMan getbestblockhash()
 {
-    RPCHelpMan{"getbestblockhash",
+    return RPCHelpMan{"getbestblockhash",
         "\nReturns the hash of the best (tip) block in the most-work fully-validated chain.\n",
         {},
         RPCResult{
@@ -272,16 +274,18 @@ static UniValue getbestblockhash(const JSONRPCRequest& request)
             HelpExampleCli("getbestblockhash", "")
     + HelpExampleRpc("getbestblockhash", "")
         },
-    }.Check(request);
-
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     LOCK(cs_main);
     return chainman.ActiveChain().Tip()->GetBlockHash().GetHex();
+},
+    };
 }
 
-static UniValue getbestchainlock(const JSONRPCRequest& request)
+static RPCHelpMan getbestchainlock()
 {
-    RPCHelpMan{"getbestchainlock",
+    return RPCHelpMan{"getbestchainlock",
         "\nReturns information about the best ChainLock. Throws an error if there is no known ChainLock yet.",
         {},
         RPCResult{
@@ -296,7 +300,8 @@ static UniValue getbestchainlock(const JSONRPCRequest& request)
             HelpExampleCli("getbestchainlock", "")
             + HelpExampleRpc("getbestchainlock", "")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     UniValue result(UniValue::VOBJ);
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
@@ -314,6 +319,8 @@ static UniValue getbestchainlock(const JSONRPCRequest& request)
     LOCK(cs_main);
     result.pushKV("known_block", chainman.m_blockman.LookupBlockIndex(clsig.getBlockHash()) != nullptr);
     return result;
+},
+    };
 }
 
 void RPCNotifyBlockChange(const CBlockIndex* pindex)
@@ -326,9 +333,9 @@ void RPCNotifyBlockChange(const CBlockIndex* pindex)
     cond_blockchange.notify_all();
 }
 
-static UniValue waitfornewblock(const JSONRPCRequest& request)
+static RPCHelpMan waitfornewblock()
 {
-    RPCHelpMan{"waitfornewblock",
+    return RPCHelpMan{"waitfornewblock",
         "\nWaits for a specific new block and returns useful info about it.\n"
         "\nReturns the current block on timeout or exit.\n",
         {
@@ -344,7 +351,8 @@ static UniValue waitfornewblock(const JSONRPCRequest& request)
             HelpExampleCli("waitfornewblock", "1000")
     + HelpExampleRpc("waitfornewblock", "1000")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     int timeout = 0;
     if (!request.params[0].isNull())
         timeout = request.params[0].get_int();
@@ -363,11 +371,13 @@ static UniValue waitfornewblock(const JSONRPCRequest& request)
     ret.pushKV("hash", block.hash.GetHex());
     ret.pushKV("height", block.height);
     return ret;
+},
+    };
 }
 
-static UniValue waitforblock(const JSONRPCRequest& request)
+static RPCHelpMan waitforblock()
 {
-    RPCHelpMan{"waitforblock",
+    return RPCHelpMan{"waitforblock",
         "\nWaits for a specific new block and returns useful info about it.\n"
         "\nReturns the current block on timeout or exit.\n",
         {
@@ -384,7 +394,8 @@ static UniValue waitforblock(const JSONRPCRequest& request)
             HelpExampleCli("waitforblock", "\"0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862\" 1000")
     + HelpExampleRpc("waitforblock", "\"0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862\", 1000")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     int timeout = 0;
 
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
@@ -406,11 +417,13 @@ static UniValue waitforblock(const JSONRPCRequest& request)
     ret.pushKV("hash", block.hash.GetHex());
     ret.pushKV("height", block.height);
     return ret;
+},
+    };
 }
 
-static UniValue waitforblockheight(const JSONRPCRequest& request)
+static RPCHelpMan waitforblockheight()
 {
-    RPCHelpMan{"waitforblockheight",
+    return RPCHelpMan{"waitforblockheight",
         "\nWaits for (at least) block height and returns the height and hash\n"
         "of the current tip.\n"
         "\nReturns the current block on timeout or exit.\n",
@@ -428,7 +441,8 @@ static UniValue waitforblockheight(const JSONRPCRequest& request)
             HelpExampleCli("waitforblockheight", "100 1000")
     + HelpExampleRpc("waitforblockheight", "100, 1000")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     int timeout = 0;
 
     int height = request.params[0].get_int();
@@ -449,11 +463,13 @@ static UniValue waitforblockheight(const JSONRPCRequest& request)
     ret.pushKV("hash", block.hash.GetHex());
     ret.pushKV("height", block.height);
     return ret;
+},
+    };
 }
 
-static UniValue syncwithvalidationinterfacequeue(const JSONRPCRequest& request)
+static RPCHelpMan syncwithvalidationinterfacequeue()
 {
-    RPCHelpMan{"syncwithvalidationinterfacequeue",
+    return RPCHelpMan{"syncwithvalidationinterfacequeue",
         "\nWaits for the validation interface queue to catch up on everything that was there when we entered this function.\n",
         {},
         RPCResult{RPCResult::Type::NONE, "", ""},
@@ -461,14 +477,17 @@ static UniValue syncwithvalidationinterfacequeue(const JSONRPCRequest& request)
             HelpExampleCli("syncwithvalidationinterfacequeue","")
     + HelpExampleRpc("syncwithvalidationinterfacequeue","")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     SyncWithValidationInterfaceQueue();
     return NullUniValue;
+},
+    };
 }
 
-static UniValue getdifficulty(const JSONRPCRequest& request)
+static RPCHelpMan getdifficulty()
 {
-    RPCHelpMan{"getdifficulty",
+    return RPCHelpMan{"getdifficulty",
         "\nReturns the proof-of-work difficulty as a multiple of the minimum difficulty.\n",
         {},
         RPCResult{
@@ -477,11 +496,14 @@ static UniValue getdifficulty(const JSONRPCRequest& request)
             HelpExampleCli("getdifficulty", "")
     + HelpExampleRpc("getdifficulty", "")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     LOCK(cs_main);
     return GetDifficulty(chainman.ActiveChain().Tip());
+},
+    };
 }
 
 static std::vector<RPCResult> MempoolEntryDescription() { return {
@@ -588,9 +610,9 @@ UniValue MempoolToJSON(const CTxMemPool& pool, llmq::CInstantSendManager* isman,
     }
 }
 
-static UniValue getrawmempool(const JSONRPCRequest& request)
+static RPCHelpMan getrawmempool()
 {
-    RPCHelpMan{"getrawmempool",
+    return RPCHelpMan{"getrawmempool",
         "\nReturns all transaction ids in memory pool as a json array of string transaction ids.\n"
         "\nHint: use getmempoolentry to fetch a specific transaction from the mempool.\n",
         {
@@ -612,8 +634,8 @@ static UniValue getrawmempool(const JSONRPCRequest& request)
             HelpExampleCli("getrawmempool", "true")
     + HelpExampleRpc("getrawmempool", "true")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     bool fVerbose = false;
     if (!request.params[0].isNull())
         fVerbose = request.params[0].get_bool();
@@ -622,11 +644,13 @@ static UniValue getrawmempool(const JSONRPCRequest& request)
     const CTxMemPool& mempool = EnsureMemPool(node);
     LLMQContext& llmq_ctx = EnsureLLMQContext(node);
     return MempoolToJSON(mempool, llmq_ctx.isman, fVerbose);
+},
+    };
 }
 
-static UniValue getmempoolancestors(const JSONRPCRequest& request)
+static RPCHelpMan getmempoolancestors()
 {
-    RPCHelpMan{"getmempoolancestors",
+    return RPCHelpMan{"getmempoolancestors",
         "\nIf txid is in the mempool, returns all in-mempool ancestors.\n",
         {
             {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id (must be in mempool)"},
@@ -646,8 +670,8 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
             HelpExampleCli("getmempoolancestors", "\"mytxid\"")
     + HelpExampleRpc("getmempoolancestors", "\"mytxid\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     bool fVerbose = false;
     if (!request.params[1].isNull())
         fVerbose = request.params[1].get_bool();
@@ -687,11 +711,13 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
         }
         return o;
     }
+},
+    };
 }
 
-static UniValue getmempooldescendants(const JSONRPCRequest& request)
+static RPCHelpMan getmempooldescendants()
 {
-    RPCHelpMan{"getmempooldescendants",
+    return RPCHelpMan{"getmempooldescendants",
         "\nIf txid is in the mempool, returns all in-mempool descendants.\n",
         {
             {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id (must be in mempool)"},
@@ -711,8 +737,8 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
             HelpExampleCli("getmempooldescendants", "\"mytxid\"")
     + HelpExampleRpc("getmempooldescendants", "\"mytxid\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     bool fVerbose = false;
     if (!request.params[1].isNull())
         fVerbose = request.params[1].get_bool();
@@ -753,11 +779,13 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
         }
         return o;
     }
+},
+    };
 }
 
-static UniValue getmempoolentry(const JSONRPCRequest& request)
+static RPCHelpMan getmempoolentry()
 {
-    RPCHelpMan{"getmempoolentry",
+    return RPCHelpMan{"getmempoolentry",
         "\nReturns mempool data for given transaction\n",
         {
             {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction id (must be in mempool)"},
@@ -768,7 +796,8 @@ static UniValue getmempoolentry(const JSONRPCRequest& request)
             HelpExampleCli("getmempoolentry", "\"mytxid\"")
     + HelpExampleRpc("getmempoolentry", "\"mytxid\"")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     uint256 hash(ParseHashV(request.params[0], "parameter 1"));
 
@@ -787,11 +816,13 @@ static UniValue getmempoolentry(const JSONRPCRequest& request)
     LLMQContext& llmq_ctx = EnsureLLMQContext(node);
     entryToJSON(mempool, info, e, llmq_ctx.isman);
     return info;
+},
+    };
 }
 
-static UniValue getblockhashes(const JSONRPCRequest& request)
+static RPCHelpMan getblockhashes()
 {
-    RPCHelpMan{"getblockhashes",
+    return RPCHelpMan{"getblockhashes",
         "\nReturns array of hashes of blocks within the timestamp range provided.\n",
         {
             {"high", RPCArg::Type::NUM, RPCArg::Optional::NO, "The newer block timestamp"},
@@ -804,8 +835,8 @@ static UniValue getblockhashes(const JSONRPCRequest& request)
             HelpExampleCli("getblockhashes", "1231614698 1231024505")
             + HelpExampleRpc("getblockhashes", "1231614698, 1231024505")
         },
-    }.Check(request);
-
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     unsigned int high = request.params[0].get_int();
     unsigned int low = request.params[1].get_int();
     std::vector<uint256> blockHashes;
@@ -820,11 +851,13 @@ static UniValue getblockhashes(const JSONRPCRequest& request)
     }
 
     return result;
+},
+    };
 }
 
-static UniValue getblockhash(const JSONRPCRequest& request)
+static RPCHelpMan getblockhash()
 {
-    RPCHelpMan{"getblockhash",
+    return RPCHelpMan{"getblockhash",
         "\nReturns hash of block in best-block-chain at height provided.\n",
         {
             {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "The height index"},
@@ -835,8 +868,8 @@ static UniValue getblockhash(const JSONRPCRequest& request)
             HelpExampleCli("getblockhash", "1000")
     + HelpExampleRpc("getblockhash", "1000")
         },
-    }.Check(request);
-
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     LOCK(cs_main);
     const CChain& active_chain = chainman.ActiveChain();
@@ -847,11 +880,13 @@ static UniValue getblockhash(const JSONRPCRequest& request)
 
     CBlockIndex* pblockindex = active_chain[nHeight];
     return pblockindex->GetBlockHash().GetHex();
+},
+    };
 }
 
-static UniValue getblockheader(const JSONRPCRequest& request)
+static RPCHelpMan getblockheader()
 {
-    RPCHelpMan{"getblockheader",
+    return RPCHelpMan{"getblockheader",
         "\nIf verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.\n"
         "If verbose is true, returns an Object with information about blockheader <hash>.\n",
         {
@@ -886,8 +921,8 @@ static UniValue getblockheader(const JSONRPCRequest& request)
             HelpExampleCli("getblockheader", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
     + HelpExampleRpc("getblockheader", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
         },
-    }.Check(request);
-
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     uint256 hash(ParseHashV(request.params[0], "hash"));
     const NodeContext& node = EnsureAnyNodeContext(request.context);
 
@@ -918,11 +953,13 @@ static UniValue getblockheader(const JSONRPCRequest& request)
 
     LLMQContext& llmq_ctx = EnsureLLMQContext(node);
     return blockheaderToJSON(tip, pblockindex, *llmq_ctx.clhandler, *llmq_ctx.isman);
+},
+    };
 }
 
-static UniValue getblockheaders(const JSONRPCRequest& request)
+static RPCHelpMan getblockheaders()
 {
-    RPCHelpMan{"getblockheaders",
+    return RPCHelpMan{"getblockheaders",
         "\nReturns an array of items with information about <count> blockheaders starting from <hash>.\n"
         "\nIf verbose is false, each item is a string that is serialized, hex-encoded data for a single blockheader.\n"
         "If verbose is true, each item is an Object with information about a single blockheader.\n",
@@ -962,7 +999,8 @@ static UniValue getblockheaders(const JSONRPCRequest& request)
             HelpExampleCli("getblockheaders", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" 2000")
     + HelpExampleRpc("getblockheaders", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" 2000")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
 
@@ -1021,6 +1059,8 @@ static UniValue getblockheaders(const JSONRPCRequest& request)
     }
 
     return arrHeaders;
+},
+    };
 }
 
 static CBlock GetBlockChecked(const CBlockIndex* pblockindex)
@@ -1054,9 +1094,9 @@ static CBlockUndo GetUndoChecked(const CBlockIndex* pblockindex)
     return blockUndo;
 }
 
-static UniValue getmerkleblocks(const JSONRPCRequest& request)
+static RPCHelpMan getmerkleblocks()
 {
-    RPCHelpMan{"getmerkleblocks",
+    return RPCHelpMan{"getmerkleblocks",
         "\nReturns an array of hex-encoded merkleblocks for <count> blocks starting from <hash> which match <filter>.\n",
         {
             {"filter", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hex-encoded bloom filter"},
@@ -1070,8 +1110,8 @@ static UniValue getmerkleblocks(const JSONRPCRequest& request)
             HelpExampleCli("getmerkleblocks", "\"2303028005802040100040000008008400048141010000f8400420800080025004000004130000000000000001\" \"00000000007e1432d2af52e8463278bf556b55cf5049262f25634557e2e91202\" 2000")
     + HelpExampleRpc("getmerkleblocks", "\"2303028005802040100040000008008400048141010000f8400420800080025004000004130000000000000001\" \"00000000007e1432d2af52e8463278bf556b55cf5049262f25634557e2e91202\" 2000")
         },
-    }.Check(request);
-
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     LOCK(cs_main);
 
@@ -1125,11 +1165,13 @@ static UniValue getmerkleblocks(const JSONRPCRequest& request)
         arrMerkleBlocks.push_back(strHex);
     }
     return arrMerkleBlocks;
+},
+    };
 }
 
-static UniValue getblock(const JSONRPCRequest& request)
+static RPCHelpMan getblock()
 {
-    RPCHelpMan{"getblock",
+    return RPCHelpMan{"getblock",
                 "\nIf verbosity is 0, returns a string that is serialized, hex-encoded data for block 'hash'.\n"
                 "If verbosity is 1, returns an Object with information about block <hash>.\n"
                 "If verbosity is 2, returns an Object with information about block <hash> and information about each transaction. \n",
@@ -1187,8 +1229,8 @@ static UniValue getblock(const JSONRPCRequest& request)
                     HelpExampleCli("getblock", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\"")
             + HelpExampleRpc("getblock", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\"")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
 
     int verbosity = 1;
@@ -1227,11 +1269,13 @@ static UniValue getblock(const JSONRPCRequest& request)
 
     LLMQContext& llmq_ctx = EnsureLLMQContext(node);
     return blockToJSON(block, tip, pblockindex, *llmq_ctx.clhandler, *llmq_ctx.isman, verbosity >= 2);
+},
+    };
 }
 
-static UniValue pruneblockchain(const JSONRPCRequest& request)
+static RPCHelpMan pruneblockchain()
 {
-    RPCHelpMan{"pruneblockchain", "",
+    return RPCHelpMan{"pruneblockchain", "",
         {
             {"height", RPCArg::Type::NUM, RPCArg::Optional::NO, "The block height to prune up to. May be set to a discrete height, or to a " + UNIX_EPOCH_TIME + "\n"
     "                  to prune blocks whose block time is at least 2 hours older than the provided timestamp."},
@@ -1242,8 +1286,8 @@ static UniValue pruneblockchain(const JSONRPCRequest& request)
             HelpExampleCli("pruneblockchain", "1000")
     + HelpExampleRpc("pruneblockchain", "1000")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     if (!fPruneMode)
         throw JSONRPCError(RPC_MISC_ERROR, "Cannot prune blocks because node is not in prune mode.");
 
@@ -1285,6 +1329,8 @@ static UniValue pruneblockchain(const JSONRPCRequest& request)
         block = block->pprev;
     }
     return uint64_t(block->nHeight);
+},
+    };
 }
 
 CoinStatsHashType ParseHashType(const std::string& hash_type_input)
@@ -1300,9 +1346,9 @@ CoinStatsHashType ParseHashType(const std::string& hash_type_input)
     }
 }
 
-static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
+static RPCHelpMan gettxoutsetinfo()
 {
-    RPCHelpMan{"gettxoutsetinfo",
+    return RPCHelpMan{"gettxoutsetinfo",
         "\nReturns statistics about the unspent transaction output set.\n"
         "Note this call may take some time if you are not using coinstatsindex.\n",
         {
@@ -1348,8 +1394,8 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
                 HelpExampleRpc("gettxoutsetinfo", R"("none", 1000)") +
                 HelpExampleRpc("gettxoutsetinfo", R"("none", "00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09")")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     UniValue ret(UniValue::VOBJ);
 
     CBlockIndex* pindex{nullptr};
@@ -1439,11 +1485,13 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Unable to read UTXO set");
     }
     return ret;
+},
+    };
 }
 
-static UniValue gettxout(const JSONRPCRequest& request)
+static RPCHelpMan gettxout()
 {
-    RPCHelpMan{"gettxout",
+    return RPCHelpMan{"gettxout",
         "\nReturns details about an unspent transaction output.\n",
         {
             {"txid", RPCArg::Type::STR, RPCArg::Optional::NO, "The transaction id"},
@@ -1475,7 +1523,8 @@ static UniValue gettxout(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("gettxout", "\"txid\", 1")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
 
@@ -1523,11 +1572,13 @@ static UniValue gettxout(const JSONRPCRequest& request)
     ret.pushKV("coinbase", (bool)coin.fCoinBase);
 
     return ret;
+},
+    };
 }
 
-static UniValue verifychain(const JSONRPCRequest& request)
+static RPCHelpMan verifychain()
 {
-    RPCHelpMan{"verifychain",
+    return RPCHelpMan{"verifychain",
         "\nVerifies blockchain database.\n",
         {
             {"checklevel", RPCArg::Type::NUM, /* default */ strprintf("%d, range=0-4", DEFAULT_CHECKLEVEL),
@@ -1540,8 +1591,8 @@ static UniValue verifychain(const JSONRPCRequest& request)
             HelpExampleCli("verifychain", "")
     + HelpExampleRpc("verifychain", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const int check_level(request.params[0].isNull() ? DEFAULT_CHECKLEVEL : request.params[0].get_int());
     const int check_depth{request.params[1].isNull() ? DEFAULT_CHECKBLOCKS : request.params[1].get_int()};
 
@@ -1553,6 +1604,8 @@ static UniValue verifychain(const JSONRPCRequest& request)
     CChainState& active_chainstate = chainman.ActiveChainstate();
     return CVerifyDB().VerifyDB(
         active_chainstate, Params(), active_chainstate.CoinsTip(), *node.evodb, check_level, check_depth);
+},
+    };
 }
 
 static void SoftForkDescPushBack(const CBlockIndex* active_chain_tip, UniValue& softforks, const Consensus::Params& params, Consensus::BuriedDeployment dep)
@@ -1628,9 +1681,9 @@ static void SoftForkDescPushBack(const CBlockIndex* active_chain_tip, const std:
     softforks.pushKV(DeploymentName(id), rv);
 }
 
-UniValue getblockchaininfo(const JSONRPCRequest& request)
+RPCHelpMan getblockchaininfo()
 {
-    RPCHelpMan{"getblockchaininfo",
+    return RPCHelpMan{"getblockchaininfo",
         "Returns an object containing various state info regarding blockchain processing.\n",
         {},
         RPCResult{
@@ -1683,7 +1736,8 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             HelpExampleCli("getblockchaininfo", "")
     + HelpExampleRpc("getblockchaininfo", "")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     LOCK(cs_main);
@@ -1748,6 +1802,8 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
 
     obj.pushKV("warnings", GetWarnings(false).original);
     return obj;
+},
+    };
 }
 
 /** Comparison function for sorting the getchaintips heads.  */
@@ -1765,9 +1821,9 @@ struct CompareBlocksByHeight
     }
 };
 
-static UniValue getchaintips(const JSONRPCRequest& request)
+static RPCHelpMan getchaintips()
 {
-    RPCHelpMan{"getchaintips",
+    return RPCHelpMan{"getchaintips",
         "Return information about all known tips in the block tree,"
         " including the main chain as well as orphaned branches.\n",
         {
@@ -1797,7 +1853,8 @@ static UniValue getchaintips(const JSONRPCRequest& request)
             HelpExampleCli("getchaintips", "")
     + HelpExampleRpc("getchaintips", "")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     LOCK(cs_main);
@@ -1886,6 +1943,8 @@ static UniValue getchaintips(const JSONRPCRequest& request)
     }
 
     return res;
+},
+    };
 }
 
 UniValue MempoolInfoToJSON(const CTxMemPool& pool, llmq::CInstantSendManager& isman)
@@ -1907,9 +1966,9 @@ UniValue MempoolInfoToJSON(const CTxMemPool& pool, llmq::CInstantSendManager& is
     return ret;
 }
 
-static UniValue getmempoolinfo(const JSONRPCRequest& request)
+static RPCHelpMan getmempoolinfo()
 {
-    RPCHelpMan{"getmempoolinfo",
+    return RPCHelpMan{"getmempoolinfo",
         "\nReturns details on the active state of the TX memory pool.\n",
         {},
         RPCResult{
@@ -1930,17 +1989,19 @@ static UniValue getmempoolinfo(const JSONRPCRequest& request)
             HelpExampleCli("getmempoolinfo", "")
     + HelpExampleRpc("getmempoolinfo", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const CTxMemPool& mempool = EnsureMemPool(node);
     LLMQContext& llmq_ctx = EnsureLLMQContext(node);
     return MempoolInfoToJSON(mempool, *llmq_ctx.isman);
+},
+    };
 }
 
-static UniValue preciousblock(const JSONRPCRequest& request)
+static RPCHelpMan preciousblock()
 {
-    RPCHelpMan{"preciousblock",
+    return RPCHelpMan{"preciousblock",
         "\nTreats a block as if it were received before others with the same work.\n"
         "\nA later preciousblock call can override the effect of an earlier one.\n"
         "\nThe effects of preciousblock are not retained across restarts.\n",
@@ -1952,8 +2013,8 @@ static UniValue preciousblock(const JSONRPCRequest& request)
             HelpExampleCli("preciousblock", "\"blockhash\"")
     + HelpExampleRpc("preciousblock", "\"blockhash\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
     CBlockIndex* pblockindex;
 
@@ -1974,11 +2035,13 @@ static UniValue preciousblock(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue invalidateblock(const JSONRPCRequest& request)
+static RPCHelpMan invalidateblock()
 {
-    RPCHelpMan{"invalidateblock",
+    return RPCHelpMan{"invalidateblock",
         "\nPermanently marks a block as invalid, as if it violated a consensus rule.\n",
         {
             {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "the hash of the block to mark as invalid"},
@@ -1988,8 +2051,8 @@ static UniValue invalidateblock(const JSONRPCRequest& request)
             HelpExampleCli("invalidateblock", "\"blockhash\"")
     + HelpExampleRpc("invalidateblock", "\"blockhash\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     uint256 hash(ParseHashV(request.params[0], "blockhash"));
     BlockValidationState state;
 
@@ -2015,11 +2078,13 @@ static UniValue invalidateblock(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue reconsiderblock(const JSONRPCRequest& request)
+static RPCHelpMan reconsiderblock()
 {
-    RPCHelpMan{"reconsiderblock",
+    return RPCHelpMan{"reconsiderblock",
         "\nRemoves invalidity status of a block, its ancestors and its descendants, reconsider them for activation.\n"
         "This can be used to undo the effects of invalidateblock.\n",
         {
@@ -2030,8 +2095,8 @@ static UniValue reconsiderblock(const JSONRPCRequest& request)
             HelpExampleCli("reconsiderblock", "\"blockhash\"")
     + HelpExampleRpc("reconsiderblock", "\"blockhash\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
     CChainState& active_chainstate = chainman.ActiveChainstate();
 
@@ -2055,11 +2120,13 @@ static UniValue reconsiderblock(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue getchaintxstats(const JSONRPCRequest& request)
+static RPCHelpMan getchaintxstats()
 {
-            RPCHelpMan{"getchaintxstats",
+    return RPCHelpMan{"getchaintxstats",
                 "\nCompute statistics about the total number and rate of transactions in the chain.\n",
                 {
                     {"nblocks", RPCArg::Type::NUM, /* default */ "one month", "Size of the window in number of blocks"},
@@ -2081,8 +2148,8 @@ static UniValue getchaintxstats(const JSONRPCRequest& request)
                     HelpExampleCli("getchaintxstats", "")
             + HelpExampleRpc("getchaintxstats", "2016")
                 },
-            }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     ChainstateManager& chainman = EnsureAnyChainman(request.context);
 
     CChain& active_chain = chainman.ActiveChain();
@@ -2135,6 +2202,8 @@ static UniValue getchaintxstats(const JSONRPCRequest& request)
     }
 
     return ret;
+},
+    };
 }
 
 template<typename T>
@@ -2193,9 +2262,9 @@ static inline bool SetHasKeys(const std::set<T>& set, const Tk& key, const Args&
 // outpoint (needed for the utxo index) + nHeight + fCoinBase
 static constexpr size_t PER_UTXO_OVERHEAD = sizeof(COutPoint) + sizeof(uint32_t) + sizeof(bool);
 
-static UniValue getblockstats(const JSONRPCRequest& request)
+static RPCHelpMan getblockstats()
 {
-    RPCHelpMan{"getblockstats",
+    return RPCHelpMan{"getblockstats",
                 "\nCompute per block statistics for a given window. All amounts are in duffs.\n"
                 "It won't work for some heights with pruning.\n",
                 {
@@ -2249,8 +2318,8 @@ static UniValue getblockstats(const JSONRPCRequest& request)
                     HelpExampleRpc("getblockstats", R"("00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09", ["minfeerate","avgfeerate"])") +
                     HelpExampleRpc("getblockstats", R"(1000, ["minfeerate","avgfeerate"])")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     if (g_txindex) {
         g_txindex->BlockUntilSyncedToCurrentChain();
     }
@@ -2405,11 +2474,13 @@ static UniValue getblockstats(const JSONRPCRequest& request)
         ret.pushKV(stat, value);
     }
     return ret;
+},
+    };
 }
 
-static UniValue getspecialtxes(const JSONRPCRequest& request)
+static RPCHelpMan getspecialtxes()
 {
-    RPCHelpMan{"getspecialtxes",
+    return RPCHelpMan{"getspecialtxes",
         "Returns an array of special transactions found in the specified block\n"
         "\nIf verbosity is 0, returns tx hash for each transaction.\n"
         "If verbosity is 1, returns hex-encoded data for each transaction.\n"
@@ -2436,8 +2507,8 @@ static UniValue getspecialtxes(const JSONRPCRequest& request)
             HelpExampleCli("getspecialtxes", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\"")
     + HelpExampleRpc("getspecialtxes", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
 
     ChainstateManager& chainman = EnsureChainman(node);
@@ -2510,13 +2581,14 @@ static UniValue getspecialtxes(const JSONRPCRequest& request)
             default : throw JSONRPCError(RPC_INTERNAL_ERROR, "Unsupported verbosity");
         }
     }
-
     return result;
+},
+    };
 }
 
-static UniValue savemempool(const JSONRPCRequest& request)
+static RPCHelpMan savemempool()
 {
-    RPCHelpMan{"savemempool",
+    return RPCHelpMan{"savemempool",
         "\nDumps the mempool to disk. It will fail until the previous dump is fully loaded.\n",
         {},
         RPCResult{RPCResult::Type::NONE, "", ""},
@@ -2524,8 +2596,8 @@ static UniValue savemempool(const JSONRPCRequest& request)
             HelpExampleCli("savemempool", "")
     + HelpExampleRpc("savemempool", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const CTxMemPool& mempool = EnsureAnyMemPool(request.context);
 
     if (!mempool.IsLoaded()) {
@@ -2537,6 +2609,8 @@ static UniValue savemempool(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
 namespace {
@@ -2600,9 +2674,9 @@ public:
     }
 };
 
-UniValue scantxoutset(const JSONRPCRequest& request)
+static RPCHelpMan scantxoutset()
 {
-    RPCHelpMan{"scantxoutset",
+    return RPCHelpMan{"scantxoutset",
         "\nEXPERIMENTAL warning: this call may be removed or changed in future releases.\n"
         "\nScans the unspent transaction output set for entries that match certain output descriptors.\n"
         "Examples of output descriptors are:\n"
@@ -2656,8 +2730,8 @@ UniValue scantxoutset(const JSONRPCRequest& request)
                 {RPCResult::Type::STR_AMOUNT, "total_amount", "The total amount of all found unspent outputs in " + CURRENCY_UNIT},
             }},
         RPCExamples{""},
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR});
 
     UniValue result(UniValue::VOBJ);
@@ -2751,11 +2825,13 @@ UniValue scantxoutset(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid command");
     }
     return result;
+},
+    };
 }
 
-static UniValue getblockfilter(const JSONRPCRequest& request)
+static RPCHelpMan getblockfilter()
 {
-    RPCHelpMan{"getblockfilter",
+    return RPCHelpMan{"getblockfilter",
         "\nRetrieve a BIP 157 content filter for a particular block.\n",
         {
             {"blockhash", RPCArg::Type::STR, RPCArg::Optional::NO, "The hash of the block"},
@@ -2771,8 +2847,8 @@ static UniValue getblockfilter(const JSONRPCRequest& request)
             HelpExampleCli("getblockfilter", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" \"basic\"")+
             HelpExampleRpc("getblockfilter", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\", \"basic\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     uint256 block_hash(ParseHashV(request.params[0], "blockhash"));
     std::string filtertype_name = "basic";
     if (!request.params[1].isNull()) {
@@ -2828,6 +2904,8 @@ static UniValue getblockfilter(const JSONRPCRequest& request)
     ret.pushKV("filter", HexStr(filter.GetEncodedFilter()));
     ret.pushKV("header", filter_header.GetHex());
     return ret;
+},
+    };
 }
 
 /**
@@ -2835,9 +2913,9 @@ static UniValue getblockfilter(const JSONRPCRequest& request)
  *
  * @see SnapshotMetadata
  */
-UniValue dumptxoutset(const JSONRPCRequest& request)
+static RPCHelpMan dumptxoutset()
 {
-    RPCHelpMan{
+    return RPCHelpMan{
         "dumptxoutset",
         "Write the serialized UTXO set to disk.",
         {
@@ -2854,9 +2932,9 @@ UniValue dumptxoutset(const JSONRPCRequest& request)
         },
         RPCExamples{
             HelpExampleCli("dumptxoutset", "utxo.dat")
-        }
-    }.Check(request);
-
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const fs::path path = fsbridge::AbsPathJoin(GetDataDir(), request.params[0].get_str());
     // Write to a temporary path and then move into `path` on completion
     // to avoid confusion due to an interruption.
@@ -2877,6 +2955,8 @@ UniValue dumptxoutset(const JSONRPCRequest& request)
 
     result.pushKV("path", path.string());
     return result;
+},
+    };
 }
 
 UniValue CreateUTXOSnapshot(NodeContext& node, CChainState& chainstate, CAutoFile& afile)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -183,7 +183,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "voteraw", 5, "time" },
     { "getblockhashes", 0, "high"},
     { "getblockhashes", 1, "low" },
-    { "getspentinfo", 0, "json" },
+    { "getspentinfo", 0, "request" },
     { "getaddresstxids", 0, "addresses" },
     { "getaddressbalance", 0, "addresses" },
     { "getaddressdeltas", 0, "addresses" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -109,7 +109,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "gettransaction", 1, "include_watchonly" },
     { "gettransaction", 2, "verbose" },
     { "getrawtransaction", 1, "verbose" },
-    { "getrawtransactionmulti", 0, "txid_map" },
+    { "getrawtransactionmulti", 0, "transactions" },
     { "getrawtransactionmulti", 1, "verbose" },
     { "gettxchainlocks", 0, "txids" },
     { "createrawtransaction", 0, "inputs" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -179,7 +179,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "logging", 0, "include" },
     { "logging", 1, "exclude" },
     { "sporkupdate", 1, "value" },
-    { "voteraw", 1, "tx_index" },
+    { "voteraw", 1, "mn-collateral-tx-index" },
     { "voteraw", 5, "time" },
     { "getblockhashes", 0, "high"},
     { "getblockhashes", 1, "low" },

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -21,9 +21,9 @@
 #include <univalue.h>
 
 #ifdef ENABLE_WALLET
-static UniValue coinjoin(const JSONRPCRequest& request)
+static RPCHelpMan coinjoin()
 {
-            RPCHelpMan{"coinjoin",
+            return RPCHelpMan{"coinjoin",
                 "\nAvailable commands:\n"
                 "  start       - Start mixing\n"
                 "  stop        - Stop mixing\n"
@@ -33,8 +33,8 @@ static UniValue coinjoin(const JSONRPCRequest& request)
                 },
                 RPCResults{},
                 RPCExamples{""},
-            }.Check(request);
-
+                [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
 
@@ -83,10 +83,12 @@ static UniValue coinjoin(const JSONRPCRequest& request)
     }
 
     return "Unknown command, please see \"help coinjoin\"";
+},
+    };
 }
 #endif // ENABLE_WALLET
 
-static UniValue getpoolinfo(const JSONRPCRequest& request)
+static RPCHelpMan getpoolinfo()
 {
     throw std::runtime_error(
             RPCHelpMan{"getpoolinfo",
@@ -97,9 +99,9 @@ static UniValue getpoolinfo(const JSONRPCRequest& request)
             .ToString());
 }
 
-static UniValue getcoinjoininfo(const JSONRPCRequest& request)
+static RPCHelpMan getcoinjoininfo()
 {
-            RPCHelpMan{"getcoinjoininfo",
+            return RPCHelpMan{"getcoinjoininfo",
                 "Returns an object containing an information about CoinJoin settings and state.\n",
                 {},
                 {
@@ -143,8 +145,8 @@ static UniValue getcoinjoininfo(const JSONRPCRequest& request)
                     HelpExampleCli("getcoinjoininfo", "")
             + HelpExampleRpc("getcoinjoininfo", "")
                 },
-            }.Check(request);
-
+                [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     UniValue obj(UniValue::VOBJ);
     const NodeContext& node = EnsureAnyNodeContext(request.context);
 
@@ -173,7 +175,10 @@ static UniValue getcoinjoininfo(const JSONRPCRequest& request)
 #endif // ENABLE_WALLET
 
     return obj;
+},
+    };
 }
+
 void RegisterCoinJoinRPCCommands(CRPCTable &t)
 {
 // clang-format off

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -90,13 +90,16 @@ static RPCHelpMan coinjoin()
 
 static RPCHelpMan getpoolinfo()
 {
-    throw std::runtime_error(
-            RPCHelpMan{"getpoolinfo",
+    return RPCHelpMan{"getpoolinfo",
                 "DEPRECATED. Please use getcoinjoininfo instead.\n",
                 {},
                 RPCResults{},
-                RPCExamples{""}}
-            .ToString());
+                RPCExamples{""},
+                [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+        throw JSONRPCError(RPC_METHOD_DEPRECATED, "Please use getcoinjoininfo instead");
+},
+    };
 }
 
 static RPCHelpMan getcoinjoininfo()
@@ -188,7 +191,7 @@ static const CRPCCommand commands[] =
         { "dash",               "getpoolinfo",            &getpoolinfo,            {} },
         { "dash",               "getcoinjoininfo",        &getcoinjoininfo,        {} },
 #ifdef ENABLE_WALLET
-        { "dash",               "coinjoin",               &coinjoin,               {} },
+        { "dash",               "coinjoin",               &coinjoin,               {"command"} },
 #endif // ENABLE_WALLET
 };
 // clang-format on

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -341,7 +341,7 @@ static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, const Cha
     JSONRPCRequest signRequest(request);
     signRequest.params.setArray();
     signRequest.params.push_back(HexStr(ds));
-    UniValue signResult = signrawtransactionwithwallet(signRequest);
+    UniValue signResult = signrawtransactionwithwallet().HandleRequest(signRequest);
 
     if (!fSubmit) {
         return signResult["hex"].get_str();

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -35,8 +35,8 @@
 #endif//ENABLE_WALLET
 
 #ifdef ENABLE_WALLET
-extern UniValue signrawtransaction(const JSONRPCRequest& request);
-extern UniValue sendrawtransaction(const JSONRPCRequest& request);
+extern RPCHelpMan signrawtransaction();
+extern RPCHelpMan sendrawtransaction();
 #else
 class CWallet;
 #endif//ENABLE_WALLET
@@ -350,7 +350,7 @@ static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, const Cha
     JSONRPCRequest sendRequest(request);
     sendRequest.params.setArray();
     sendRequest.params.push_back(signResult["hex"].get_str());
-    return sendrawtransaction(sendRequest).get_str();
+    return sendrawtransaction().HandleRequest(sendRequest).get_str();
 }
 
 static void protx_register_fund_help(const JSONRPCRequest& request, bool legacy)

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -1097,7 +1097,7 @@ static const CRPCCommand commands[] =
     { "dash",               "getgovernanceinfo",      &getgovernanceinfo,      {} },
     { "dash",               "getsuperblockbudget",    &getsuperblockbudget,    {"index"} },
     { "dash",               "gobject",                &gobject,                {} },
-    { "dash",               "voteraw",                &voteraw,                {"tx_hash","tx_index","gov_hash","signal","outcome","time","sig"} },
+    { "dash",               "voteraw",                &voteraw,                {"mn-collateral-tx-hash","mn-collateral-tx-index","governance-hash","vote-signal","vote-outcome","time","vote-sig"} },
 
 };
 // clang-format on

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -421,6 +421,18 @@ static UniValue generateblock(const JSONRPCRequest& request)
 }
 #endif // ENABLE_MINER
 
+static UniValue generate(const JSONRPCRequest& request)
+{
+    return RPCHelpMan{"generate", "has been replaced by the -generate cli option. Refer to -help for more information.", {}, {}, RPCExamples{""}, [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+
+    if (request.fHelp) {
+        throw std::runtime_error(self.ToString());
+    } else {
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND, self.ToString());
+    }
+    }};
+}
+
 static UniValue getmininginfo(const JSONRPCRequest& request)
 {
             RPCHelpMan{"getmininginfo",
@@ -1279,6 +1291,7 @@ static const CRPCCommand commands[] =
     { "util",               "estimatesmartfee",       &estimatesmartfee,       {"conf_target", "estimate_mode"} },
 
     { "hidden",             "estimaterawfee",         &estimaterawfee,         {"conf_target", "threshold"} },
+    { "hidden",             "generate",               &generate,               {} },
 };
 // clang-format on
     for (const auto& c : commands) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -306,19 +306,19 @@ static RPCHelpMan generateblock()
     return RPCHelpMan{"generateblock",
         "\nMine a block with a set of ordered transactions immediately to a specified address or descriptor (before the RPC call returns)\n",
         {
-            {"address/descriptor", RPCArg::Type::STR, RPCArg::Optional::NO, "The address or descriptor to send the newly generated coins to."},
+            {"output", RPCArg::Type::STR, RPCArg::Optional::NO, "The address or descriptor to send the newly generated coins to."},
             {"transactions", RPCArg::Type::ARR, RPCArg::Optional::NO, "An array of hex strings which are either txids or raw transactions.\n"
                 "Txids must reference transactions currently in the mempool.\n"
                 "All transactions must be valid and in valid order, otherwise the block will be rejected.",
                 {
                     {"rawtx/txid", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, ""},
                 },
-            }
+            },
         },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
             {
-                {RPCResult::Type::STR_HEX, "hash", "hash of generated block"}
+                {RPCResult::Type::STR_HEX, "hash", "hash of generated block"},
             }
         },
         RPCExamples{
@@ -1305,7 +1305,7 @@ static const CRPCCommand commands[] =
 #if ENABLE_MINER
     { "generating",         "generatetoaddress",      &generatetoaddress,      {"nblocks","address","maxtries"} },
     { "generating",         "generatetodescriptor",   &generatetodescriptor,   {"num_blocks","descriptor","maxtries"} },
-    { "generating",         "generateblock",          &generateblock,          {"address","transactions"} },
+    { "generating",         "generateblock",          &generateblock,          {"output","transactions"} },
 #else
     { "hidden",             "generatetoaddress",      &generatetoaddress,      {"nblocks","address","maxtries"} }, // Hidden as it isn't functional, just an error to let people know if miner isn't compiled
     { "hidden",             "generatetodescriptor",   &generatetodescriptor,   {"num_blocks","descriptor","maxtries"} },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1281,8 +1281,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "estimaterawfee",         &estimaterawfee,         {"conf_target", "threshold"} },
 };
 // clang-format on
-
-    for (const auto& command : commands) {
-        t.appendCommand(command.name, &command);
+    for (const auto& c : commands) {
+        t.appendCommand(c.name, &c);
     }
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -40,9 +40,9 @@
 
 #include <univalue.h>
 
-static UniValue debug(const JSONRPCRequest& request)
+static RPCHelpMan debug()
 {
-    RPCHelpMan{"debug",
+    return RPCHelpMan{"debug",
         "Change debug category on the fly. Specify single category or use '+' to specify many.\n"
         "The valid logging categories are: " + LogInstance().LogCategoriesString() + ".\n"
         "libevent logging is configured on startup and cannot be modified by this RPC during runtime.\n"
@@ -60,7 +60,9 @@ static UniValue debug(const JSONRPCRequest& request)
         RPCExamples {
             HelpExampleCli("debug", "dash")
     + HelpExampleRpc("debug", "dash+net")
-    }}.Check(request);
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::string strMode = request.params[0].get_str();
     LogInstance().DisableCategory(BCLog::ALL);
@@ -73,11 +75,13 @@ static UniValue debug(const JSONRPCRequest& request)
     }
 
     return "Debug mode: " + LogInstance().LogCategoriesString(/*enabled_only=*/true);
+},
+    };
 }
 
-static UniValue mnsync(const JSONRPCRequest& request)
+static RPCHelpMan mnsync()
 {
-    RPCHelpMan{"mnsync",
+    return RPCHelpMan{"mnsync",
         "Returns the sync status, updates to the next step or resets it entirely.\n",
         {
             {"mode", RPCArg::Type::STR, RPCArg::Optional::NO, "[status|next|reset]"},
@@ -97,7 +101,8 @@ static UniValue mnsync(const JSONRPCRequest& request)
                 RPCResult::Type::STR, "", ""},
         },
         RPCExamples{""},
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::string strMode = request.params[0].get_str();
 
@@ -127,15 +132,17 @@ static UniValue mnsync(const JSONRPCRequest& request)
         return "success";
     }
     return "failure";
+},
+    };
 }
 
 /*
     Used for updating/reading spork settings on the network
 */
-static UniValue spork(const JSONRPCRequest& request)
+static RPCHelpMan spork()
 {
     // default help, for basic mode
-    RPCHelpMan{"spork",
+    return RPCHelpMan{"spork",
         "\nShows information about current state of sporks\n",
         {
             {"command", RPCArg::Type::STR, RPCArg::Optional::NO, "'show' to show all current spork values, 'active' to show which sporks are active"},
@@ -155,8 +162,9 @@ static UniValue spork(const JSONRPCRequest& request)
         RPCExamples {
             HelpExampleCli("spork", "show")
             + HelpExampleRpc("spork", "\"show\"")
-        }
-    }.Check(request);
+        },
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     // basic mode, show info
     std:: string strCommand = request.params[0].get_str();
@@ -176,11 +184,13 @@ static UniValue spork(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue sporkupdate(const JSONRPCRequest& request)
+static RPCHelpMan sporkupdate()
 {
-    RPCHelpMan{"sporkupdate",
+    return RPCHelpMan{"sporkupdate",
         "\nUpdate the value of the specific spork. Requires \"-sporkkey\" to be set to sign the message.\n",
         {
             {"name", RPCArg::Type::STR, RPCArg::Optional::NO, "The name of the spork to update"},
@@ -193,7 +203,8 @@ static UniValue sporkupdate(const JSONRPCRequest& request)
             HelpExampleCli("sporkupdate", "SPORK_2_INSTANTSEND_ENABLED 4070908800")
             + HelpExampleRpc("sporkupdate", "\"SPORK_2_INSTANTSEND_ENABLED\", 4070908800")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     // advanced mode, update spork values
     SporkId nSporkID = CSporkManager::GetSporkIDByName(request.params[0].get_str());
@@ -215,11 +226,13 @@ static UniValue sporkupdate(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue validateaddress(const JSONRPCRequest& request)
+static RPCHelpMan validateaddress()
 {
-            RPCHelpMan{"validateaddress",
+    return RPCHelpMan{"validateaddress",
                 "\nReturn information about the given Dash address.\n",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The Dash address to validate"},
@@ -238,8 +251,8 @@ static UniValue validateaddress(const JSONRPCRequest& request)
                     HelpExampleCli("validateaddress", "\"" + EXAMPLE_ADDRESS[0] + "\"") +
                     HelpExampleRpc("validateaddress", "\"" + EXAMPLE_ADDRESS[0] + "\"")
                 },
-            }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::string error_msg;
     CTxDestination dest = DecodeDestination(request.params[0].get_str(), error_msg);
     const bool isValid = IsValidDestination(dest);
@@ -261,11 +274,13 @@ static UniValue validateaddress(const JSONRPCRequest& request)
     }
 
     return ret;
+},
+    };
 }
 
-static UniValue createmultisig(const JSONRPCRequest& request)
+static RPCHelpMan createmultisig()
 {
-            RPCHelpMan{"createmultisig",
+    return RPCHelpMan{"createmultisig",
                 "\nCreates a multi-signature address with n signature of m keys required.\n"
                 "It returns a json object with the address and redeemScript.\n",
                 {
@@ -289,8 +304,8 @@ static UniValue createmultisig(const JSONRPCRequest& request)
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("createmultisig", "2, \"[\\\"03789ed0bb717d88f7d321a368d905e7430207ebbd82bd342cf11ae157a7ace5fd\\\",\\\"03dbc6764b8884a92e871274b87583e6d5c2a58819473e17e107ef3f6aa5a61626\\\"]\"")
                 },
-            }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     int required = request.params[0].get_int();
 
     // Get the public keys
@@ -318,11 +333,13 @@ static UniValue createmultisig(const JSONRPCRequest& request)
     result.pushKV("descriptor", descriptor->ToString());
 
     return result;
+},
+    };
 }
 
-UniValue getdescriptorinfo(const JSONRPCRequest& request)
+static RPCHelpMan getdescriptorinfo()
 {
-    RPCHelpMan{"getdescriptorinfo",
+    return RPCHelpMan{"getdescriptorinfo",
         {"\nAnalyses a descriptor.\n"},
         {
             {"descriptor", RPCArg::Type::STR, RPCArg::Optional::NO, "The descriptor"},
@@ -340,8 +357,9 @@ UniValue getdescriptorinfo(const JSONRPCRequest& request)
         RPCExamples{
         "\nAnalyse a descriptor\n"
         + HelpExampleCli("getdescriptorinfo", "\"pkh([d34db33f/84h/0h/0h]0279be667ef9dcbbac55a06295Ce870b07029Bfcdb2dce28d959f2815b16f81798)\"")
-        }
-    }.Check(request);
+        },
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     RPCTypeCheck(request.params, {UniValue::VSTR});
 
@@ -359,11 +377,13 @@ UniValue getdescriptorinfo(const JSONRPCRequest& request)
     result.pushKV("issolvable", desc->IsSolvable());
     result.pushKV("hasprivatekeys", provider.keys.size() > 0);
     return result;
+},
+    };
 }
 
-UniValue deriveaddresses(const JSONRPCRequest& request)
+static RPCHelpMan deriveaddresses()
 {
-    RPCHelpMan{"deriveaddresses",
+    return RPCHelpMan{"deriveaddresses",
         "\nDerives one or more addresses corresponding to an output descriptor.\n"
         "Examples of output descriptors are:\n"
         "    pkh(<pubkey>)                        P2PKH outputs for the given pubkey\n"
@@ -385,8 +405,9 @@ UniValue deriveaddresses(const JSONRPCRequest& request)
             RPCExamples{
         "\nFirst three receive addresses\n"
         + HelpExampleCli("deriveaddresses", "\"pkh([d34db33f/84h/0h/0h]xpub6DJ2dNUysrn5Vt36jH2KLBT2i1auw1tTSSomg8PhqNiUtx8QX2SvC9nrHu81fT41fvDUnhMjEzQgXnQjKEu3oaqMSzhSrHMxyyoEAmUHQbY/0/*)#cjjspncu\" \"[0,2]\"")
-            }
-    }.Check(request);
+            },
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValueType()}); // Range argument is checked later
     const std::string desc_str = request.params[0].get_str();
@@ -438,11 +459,13 @@ UniValue deriveaddresses(const JSONRPCRequest& request)
     }
 
     return addresses;
+},
+    };
 }
 
-static UniValue verifymessage(const JSONRPCRequest& request)
+static RPCHelpMan verifymessage()
 {
-    RPCHelpMan{"verifymessage",
+    return RPCHelpMan{"verifymessage",
         "\nVerify a signed message\n",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The Dash address to use for the signature."},
@@ -462,7 +485,8 @@ static UniValue verifymessage(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("verifymessage", "\"" + EXAMPLE_ADDRESS[0] + "\", \"signature\", \"my message\"")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     LOCK(cs_main);
 
@@ -485,11 +509,13 @@ static UniValue verifymessage(const JSONRPCRequest& request)
     }
 
     return false;
+},
+    };
 }
 
-static UniValue signmessagewithprivkey(const JSONRPCRequest& request)
+static RPCHelpMan signmessagewithprivkey()
 {
-    RPCHelpMan{"signmessagewithprivkey",
+    return RPCHelpMan{"signmessagewithprivkey",
         "\nSign a message with the private key of an address\n",
         {
             {"privkey", RPCArg::Type::STR, RPCArg::Optional::NO, "The private key to sign the message with."},
@@ -506,7 +532,8 @@ static UniValue signmessagewithprivkey(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("signmessagewithprivkey", "\"privkey\", \"my message\"")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::string strPrivkey = request.params[0].get_str();
     std::string strMessage = request.params[1].get_str();
@@ -523,11 +550,13 @@ static UniValue signmessagewithprivkey(const JSONRPCRequest& request)
     }
 
     return signature;
+},
+    };
 }
 
-static UniValue setmocktime(const JSONRPCRequest& request)
+static RPCHelpMan setmocktime()
 {
-    RPCHelpMan{"setmocktime",
+    return RPCHelpMan{"setmocktime",
         "\nSet the local time to given timestamp (-regtest only)\n",
         {
             {"timestamp", RPCArg::Type::NUM, RPCArg::Optional::NO, UNIX_EPOCH_TIME + "\n"
@@ -535,7 +564,8 @@ static UniValue setmocktime(const JSONRPCRequest& request)
         },
         RPCResult{RPCResult::Type::NONE, "", ""},
         RPCExamples{""},
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     if (!Params().IsMockableChain()) {
         throw std::runtime_error("setmocktime is for regression testing (-regtest mode) only");
@@ -561,11 +591,13 @@ static UniValue setmocktime(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue mnauth(const JSONRPCRequest& request)
+static RPCHelpMan mnauth()
 {
-    RPCHelpMan{"mnauth",
+    return RPCHelpMan{"mnauth",
         "\nOverride MNAUTH processing results for the specified node with a user provided data (-regtest only).\n",
         {
             {"nodeId", RPCArg::Type::NUM, RPCArg::Optional::NO, "Internal peer id of the node the mock data gets added to."},
@@ -576,7 +608,8 @@ static UniValue mnauth(const JSONRPCRequest& request)
             RPCResult::Type::BOOL, "result", "true, if the node was updated"
         },
         RPCExamples{""},
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     if (!Params().MineBlocksOnDemand())
         throw std::runtime_error("mnauth for regression testing (-regtest mode) only");
@@ -604,6 +637,8 @@ static UniValue mnauth(const JSONRPCRequest& request)
     });
 
     return fSuccess;
+},
+    };
 }
 
 static bool getAddressFromIndex(const AddressType& type, const uint160 &hash, std::string &address)
@@ -673,9 +708,9 @@ static bool timestampSort(std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelt
     return a.second.m_time < b.second.m_time;
 }
 
-static UniValue getaddressmempool(const JSONRPCRequest& request)
+static RPCHelpMan getaddressmempool()
 {
-    RPCHelpMan{"getaddressmempool",
+    return RPCHelpMan{"getaddressmempool",
         "\nReturns all mempool deltas for an address (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::ARR, /* default */ "", "",
@@ -702,7 +737,8 @@ static UniValue getaddressmempool(const JSONRPCRequest& request)
             HelpExampleCli("getaddressmempool", "'{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}'")
     + HelpExampleRpc("getaddressmempool", "{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::vector<std::pair<uint160, AddressType> > addresses;
 
@@ -741,11 +777,13 @@ static UniValue getaddressmempool(const JSONRPCRequest& request)
     }
 
     return result;
+},
+    };
 }
 
-static UniValue getaddressutxos(const JSONRPCRequest& request)
+static RPCHelpMan getaddressutxos()
 {
-    RPCHelpMan{"getaddressutxos",
+    return RPCHelpMan{"getaddressutxos",
         "\nReturns all unspent outputs for an address (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::ARR, /* default */ "", "",
@@ -771,7 +809,8 @@ static UniValue getaddressutxos(const JSONRPCRequest& request)
             HelpExampleCli("getaddressutxos", "'{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}'")
     + HelpExampleRpc("getaddressutxos", "{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::vector<std::pair<uint160, AddressType> > addresses;
 
@@ -808,11 +847,13 @@ static UniValue getaddressutxos(const JSONRPCRequest& request)
     }
 
     return result;
+},
+    };
 }
 
-static UniValue getaddressdeltas(const JSONRPCRequest& request)
+static RPCHelpMan getaddressdeltas()
 {
-    RPCHelpMan{"getaddressdeltas",
+    return RPCHelpMan{"getaddressdeltas",
         "\nReturns all changes for an address (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::ARR, /* default */ "", "",
@@ -838,7 +879,8 @@ static UniValue getaddressdeltas(const JSONRPCRequest& request)
             HelpExampleCli("getaddressdeltas", "'{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}'")
     + HelpExampleRpc("getaddressdeltas", "{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
 
     UniValue startValue = find_value(request.params[0].get_obj(), "start");
@@ -894,11 +936,13 @@ static UniValue getaddressdeltas(const JSONRPCRequest& request)
     }
 
     return result;
+},
+    };
 }
 
-static UniValue getaddressbalance(const JSONRPCRequest& request)
+static RPCHelpMan getaddressbalance()
 {
-    RPCHelpMan{"getaddressbalance",
+    return RPCHelpMan{"getaddressbalance",
         "\nReturns the balance for an address(es) (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::ARR, /* default */ "", "",
@@ -919,7 +963,8 @@ static UniValue getaddressbalance(const JSONRPCRequest& request)
             HelpExampleCli("getaddressbalance", "'{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}'")
     + HelpExampleRpc("getaddressbalance", "{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::vector<std::pair<uint160, AddressType> > addresses;
 
@@ -963,11 +1008,13 @@ static UniValue getaddressbalance(const JSONRPCRequest& request)
 
     return result;
 
+},
+    };
 }
 
-static UniValue getaddresstxids(const JSONRPCRequest& request)
+static RPCHelpMan getaddresstxids()
 {
-    RPCHelpMan{"getaddresstxids",
+    return RPCHelpMan{"getaddresstxids",
         "\nReturns the txids for an address(es) (requires addressindex to be enabled).\n",
         {
             {"addresses", RPCArg::Type::ARR, /* default */ "", "",
@@ -984,7 +1031,8 @@ static UniValue getaddresstxids(const JSONRPCRequest& request)
             HelpExampleCli("getaddresstxids", "'{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}'")
     + HelpExampleRpc("getaddresstxids", "{\"addresses\": [\"" + EXAMPLE_ADDRESS[0] + "\"]}")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::vector<std::pair<uint160, AddressType> > addresses;
 
@@ -1041,11 +1089,13 @@ static UniValue getaddresstxids(const JSONRPCRequest& request)
 
     return result;
 
+},
+    };
 }
 
-static UniValue getspentinfo(const JSONRPCRequest& request)
+static RPCHelpMan getspentinfo()
 {
-    RPCHelpMan{"getspentinfo",
+    return RPCHelpMan{"getspentinfo",
         "\nReturns the txid and index where an output is spent.\n",
         {
             {"request", RPCArg::Type::OBJ, /* default */ "", "",
@@ -1065,7 +1115,8 @@ static UniValue getspentinfo(const JSONRPCRequest& request)
             HelpExampleCli("getspentinfo", "'{\"txid\": \"0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9\", \"index\": 0}'")
     + HelpExampleRpc("getspentinfo", "{\"txid\": \"0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9\", \"index\": 0}")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     UniValue txidValue = find_value(request.params[0].get_obj(), "txid");
     UniValue indexValue = find_value(request.params[0].get_obj(), "index");
@@ -1091,19 +1142,21 @@ static UniValue getspentinfo(const JSONRPCRequest& request)
     obj.pushKV("height", value.m_block_height);
 
     return obj;
+},
+    };
 }
 
-static UniValue mockscheduler(const JSONRPCRequest& request)
+static RPCHelpMan mockscheduler()
 {
-    RPCHelpMan{"mockscheduler",
+    return RPCHelpMan{"mockscheduler",
         "\nBump the scheduler into the future (-regtest only)\n",
         {
             {"delta_time", RPCArg::Type::NUM, RPCArg::Optional::NO, "Number of seconds to forward the scheduler into the future." },
         },
         RPCResults{},
         RPCExamples{""},
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     if (!Params().IsMockableChain()) {
         throw std::runtime_error("mockscheduler is for regression testing (-regtest mode) only");
     }
@@ -1122,6 +1175,8 @@ static UniValue mockscheduler(const JSONRPCRequest& request)
     node_context->scheduler->MockForward(std::chrono::seconds(delta_seconds));
 
     return NullUniValue;
+},
+    };
 }
 
 static UniValue RPCLockedMemoryInfo()
@@ -1156,12 +1211,12 @@ static std::string RPCMallocInfo()
 }
 #endif
 
-static UniValue getmemoryinfo(const JSONRPCRequest& request)
+static RPCHelpMan getmemoryinfo()
 {
     /* Please, avoid using the word "pool" here in the RPC interface or help,
      * as users will undoubtedly confuse it with the other "memory pool"
      */
-    RPCHelpMan{"getmemoryinfo",
+    return RPCHelpMan{"getmemoryinfo",
         "Returns an object containing information about memory usage.\n",
         {
             {"mode", RPCArg::Type::STR, /* default */ "\"stats\"", "determines what kind of information is returned.\n"
@@ -1191,7 +1246,8 @@ static UniValue getmemoryinfo(const JSONRPCRequest& request)
             HelpExampleCli("getmemoryinfo", "")
     + HelpExampleRpc("getmemoryinfo", "")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::string mode = request.params[0].isNull() ? "stats" : request.params[0].get_str();
     if (mode == "stats") {
@@ -1207,6 +1263,8 @@ static UniValue getmemoryinfo(const JSONRPCRequest& request)
     } else {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown mode " + mode);
     }
+},
+    };
 }
 
 static void EnableOrDisableLogCategories(UniValue cats, bool enable) {
@@ -1227,9 +1285,9 @@ static void EnableOrDisableLogCategories(UniValue cats, bool enable) {
     }
 }
 
-static UniValue logging(const JSONRPCRequest& request)
+static RPCHelpMan logging()
 {
-    RPCHelpMan{"logging",
+    return RPCHelpMan{"logging",
     "Gets and sets the logging configuration.\n"
     "When called without an argument, returns the list of categories with status that are currently being debug logged or not.\n"
     "When called with arguments, adds or removes categories from debug logging and return the lists above.\n"
@@ -1262,7 +1320,8 @@ static UniValue logging(const JSONRPCRequest& request)
             HelpExampleCli("logging", "\"[\\\"all\\\"]\" \"[\\\"http\\\"]\"")
     + HelpExampleRpc("logging", "[\"all\"], \"[libevent]\"")
         },
-    }.Check(request);
+    [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     uint64_t original_log_categories = LogInstance().GetCategoryMask();
     if (request.params[0].isArray()) {
@@ -1294,25 +1353,41 @@ static UniValue logging(const JSONRPCRequest& request)
     }
 
     return result;
+},
+    };
 }
 
-static UniValue echo(const JSONRPCRequest& request)
+static RPCHelpMan echo(const std::string& name)
 {
-    if (request.fHelp)
-        throw std::runtime_error(
-            RPCHelpMan{"echo|echojson ...",
+    return RPCHelpMan{name,
                 "\nSimply echo back the input arguments. This command is for testing.\n"
-                "\nIt will return an internal bug report when exactly 100 arguments are passed.\n"
+                "\nIt will return an internal bug report when arg9='trigger_internal_bug' is passed.\n"
                 "\nThe difference between echo and echojson is that echojson has argument conversion enabled in the client-side table in "
                 "dash-cli and the GUI. There is no server-side difference.",
-                {},
+                {
+                    {"arg0", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg1", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg2", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg3", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg4", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg5", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg6", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg7", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg8", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                    {"arg9", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, ""},
+                },
                 RPCResult{RPCResult::Type::NONE, "", "Returns whatever was passed in"},
                 RPCExamples{""},
-            }.ToString()
-        );
-    CHECK_NONFATAL(request.params.size() != 100);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    if (request.fHelp) throw std::runtime_error(self.ToString());
 
+    if (request.params[9].isStr()) {
+        CHECK_NONFATAL(request.params[9].get_str() != "trigger_internal_bug");
+    }
     return request.params;
+},
+    };
 }
 
 static UniValue SummaryToJSON(const IndexSummary&& summary, std::string index_name)
@@ -1373,6 +1448,9 @@ static RPCHelpMan getindexinfo()
     };
 }
 
+static RPCHelpMan echo() { return echo("echo"); }
+static RPCHelpMan echojson() { return echo("echojson"); }
+
 void RegisterMiscRPCCommands(CRPCTable &t)
 {
 static const CRPCCommand commands[] =
@@ -1406,12 +1484,11 @@ static const CRPCCommand commands[] =
     { "hidden",             "setmocktime",            &setmocktime,            {"timestamp"}},
     { "hidden",             "mockscheduler",          &mockscheduler,          {"delta_time"}},
     { "hidden",             "echo",                   &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
-    { "hidden",             "echojson",               &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
+    { "hidden",             "echojson",               &echojson,               {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "mnauth",                 &mnauth,                 {"nodeId", "proTxHash", "publicKey"}},
 };
 // clang-format on
-
-    for (const auto& command : commands) {
-        t.appendCommand(command.name, &command);
+    for (const auto& c : commands) {
+        t.appendCommand(c.name, &c);
     }
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1456,7 +1456,7 @@ void RegisterMiscRPCCommands(CRPCTable &t)
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
-    { "control",            "debug",                  &debug,                  {} },
+    { "control",            "debug",                  &debug,                  {"category"} },
     { "control",            "getmemoryinfo",          &getmemoryinfo,          {"mode"} },
     { "control",            "logging",                &logging,                {"include", "exclude"}},
     { "util",               "validateaddress",        &validateaddress,        {"address"} },
@@ -1466,7 +1466,7 @@ static const CRPCCommand commands[] =
     { "util",               "verifymessage",          &verifymessage,          {"address","signature","message"} },
     { "util",               "signmessagewithprivkey", &signmessagewithprivkey, {"privkey","message"} },
     { "util",               "getindexinfo",           &getindexinfo,           {"index_name"} },
-    { "blockchain",         "getspentinfo",           &getspentinfo,           {"json"} },
+    { "blockchain",         "getspentinfo",           &getspentinfo,           {"request"} },
 
     /* Address index */
     { "addressindex",       "getaddressmempool",      &getaddressmempool,      {"addresses"}  },
@@ -1476,7 +1476,7 @@ static const CRPCCommand commands[] =
     { "addressindex",       "getaddressbalance",      &getaddressbalance,      {"addresses"} },
 
     /* Dash features */
-    { "dash",               "mnsync",                 &mnsync,                 {} },
+    { "dash",               "mnsync",                 &mnsync,                 {"mode"} },
     { "dash",               "spork",                  &spork,                  {"command"} },
     { "dash",               "sporkupdate",            &sporkupdate,            {"name","value"} },
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -39,9 +39,9 @@ const std::vector<std::string> CONNECTION_TYPE_DOC{
         "feeler (short-lived automatic connection for testing addresses)"
 };
 
-static UniValue getconnectioncount(const JSONRPCRequest& request)
+static RPCHelpMan getconnectioncount()
 {
-    RPCHelpMan{"getconnectioncount",
+    return RPCHelpMan{"getconnectioncount",
         "\nReturns the number of connections to other nodes.\n",
         {},
         RPCResult{
@@ -51,18 +51,20 @@ static UniValue getconnectioncount(const JSONRPCRequest& request)
             HelpExampleCli("getconnectioncount", "")
     + HelpExampleRpc("getconnectioncount", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if(!node.connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
     return (int)node.connman->GetNodeCount(CConnman::CONNECTIONS_ALL);
+},
+    };
 }
 
-static UniValue ping(const JSONRPCRequest& request)
+static RPCHelpMan ping()
 {
-    RPCHelpMan{"ping",
+    return RPCHelpMan{"ping",
         "\nRequests that a ping be sent to all other nodes, to measure ping time.\n"
         "Results provided in getpeerinfo, pingtime and pingwait fields are decimal seconds.\n"
         "Ping command is handled in queue with all other commands, so it measures processing backlog, not just network ping.\n",
@@ -72,8 +74,8 @@ static UniValue ping(const JSONRPCRequest& request)
             HelpExampleCli("ping", "")
     + HelpExampleRpc("ping", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if(!node.connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
@@ -83,11 +85,13 @@ static UniValue ping(const JSONRPCRequest& request)
         pnode->fPingQueued = true;
     });
     return NullUniValue;
+},
+    };
 }
 
-static UniValue getpeerinfo(const JSONRPCRequest& request)
+static RPCHelpMan getpeerinfo()
 {
-    RPCHelpMan{"getpeerinfo",
+    return RPCHelpMan{"getpeerinfo",
         "\nReturns data about each connected network node as a json array of objects.\n",
         {},
         RPCResult{
@@ -160,8 +164,8 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             HelpExampleCli("getpeerinfo", "")
     + HelpExampleRpc("getpeerinfo", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if(!node.connman || !node.peerman) {
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
@@ -259,14 +263,13 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
     }
 
     return ret;
+},
+    };
 }
 
-static UniValue addnode(const JSONRPCRequest& request)
+static RPCHelpMan addnode()
 {
-    std::string strCommand;
-    if (!request.params[1].isNull())
-        strCommand = request.params[1].get_str();
-    RPCHelpMan{"addnode",
+    return RPCHelpMan{"addnode",
         "\nAttempts to add or remove a node from the addnode list.\n"
         "Or try a connection to a node once.\n"
         "Nodes added using addnode (or -connect) are protected from DoS disconnection and are not required to be\n"
@@ -280,7 +283,11 @@ static UniValue addnode(const JSONRPCRequest& request)
             HelpExampleCli("addnode", "\"192.168.0.6:9999\" \"onetry\"")
     + HelpExampleRpc("addnode", "\"192.168.0.6:9999\", \"onetry\"")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::string strCommand;
+    if (!request.params[1].isNull())
+        strCommand = request.params[1].get_str();
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if(!node.connman)
@@ -307,11 +314,13 @@ static UniValue addnode(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue disconnectnode(const JSONRPCRequest& request)
+static RPCHelpMan disconnectnode()
 {
-    RPCHelpMan{"disconnectnode",
+    return RPCHelpMan{"disconnectnode",
         "\nImmediately disconnects from the specified peer node.\n"
         "\nStrictly one out of 'address' and 'nodeid' can be provided to identify the node.\n"
         "\nTo disconnect by nodeid, either set 'address' to the empty string, or call using the named 'nodeid' argument only.\n",
@@ -326,7 +335,8 @@ static UniValue disconnectnode(const JSONRPCRequest& request)
     + HelpExampleRpc("disconnectnode", "\"192.168.0.6:9999\"")
     + HelpExampleRpc("disconnectnode", "\"\", 1")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if(!node.connman)
@@ -352,11 +362,13 @@ static UniValue disconnectnode(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue getaddednodeinfo(const JSONRPCRequest& request)
+static RPCHelpMan getaddednodeinfo()
 {
-            RPCHelpMan{"getaddednodeinfo",
+    return RPCHelpMan{"getaddednodeinfo",
                 "\nReturns information about the given added node, or all added nodes\n"
                 "(note that onetry addnodes are not listed here)\n",
                 {
@@ -384,7 +396,8 @@ static UniValue getaddednodeinfo(const JSONRPCRequest& request)
                     HelpExampleCli("getaddednodeinfo", "\"192.168.0.201\"")
             + HelpExampleRpc("getaddednodeinfo", "\"192.168.0.201\"")
                 },
-            }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if(!node.connman)
@@ -424,11 +437,13 @@ static UniValue getaddednodeinfo(const JSONRPCRequest& request)
     }
 
     return ret;
+},
+    };
 }
 
-static UniValue getnettotals(const JSONRPCRequest& request)
+static RPCHelpMan getnettotals()
 {
-    RPCHelpMan{"getnettotals",
+    return RPCHelpMan{"getnettotals",
         "\nReturns information about network traffic, including bytes in, bytes out,\n"
         "and current time.\n",
         {},
@@ -453,7 +468,8 @@ static UniValue getnettotals(const JSONRPCRequest& request)
             HelpExampleCli("getnettotals", "")
     + HelpExampleRpc("getnettotals", "")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if(!node.connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
@@ -472,6 +488,8 @@ static UniValue getnettotals(const JSONRPCRequest& request)
     outboundLimit.pushKV("time_left_in_cycle", count_seconds(node.connman->GetMaxOutboundTimeLeftInCycle()));
     obj.pushKV("uploadtarget", outboundLimit);
     return obj;
+},
+    };
 }
 
 static UniValue GetNetworksInfo()
@@ -493,9 +511,9 @@ static UniValue GetNetworksInfo()
     return networks;
 }
 
-static UniValue getnetworkinfo(const JSONRPCRequest& request)
+static RPCHelpMan getnetworkinfo()
 {
-            RPCHelpMan{"getnetworkinfo",
+    return RPCHelpMan{"getnetworkinfo",
                 "Returns an object containing various state info regarding P2P networking.\n",
                 {},
                 RPCResult{
@@ -549,8 +567,8 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
                     HelpExampleCli("getnetworkinfo", "")
             + HelpExampleRpc("getnetworkinfo", "")
                 },
-            }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     LOCK(cs_main);
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("version",       CLIENT_VERSION);
@@ -612,11 +630,13 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
     obj.pushKV("localaddresses", localAddresses);
     obj.pushKV("warnings",       GetWarnings(false).original);
     return obj;
+},
+    };
 }
 
-static UniValue setban(const JSONRPCRequest& request)
+static RPCHelpMan setban()
 {
-    const RPCHelpMan help{"setban",
+    return RPCHelpMan{"setban",
                 "\nAttempts to add or remove an IP/Subnet from the banned list.\n",
                 {
                     {"subnet", RPCArg::Type::STR, RPCArg::Optional::NO, "The IP/Subnet (see getpeerinfo for nodes IP) with an optional netmask (default is /32 = single IP)"},
@@ -630,7 +650,8 @@ static UniValue setban(const JSONRPCRequest& request)
                             + HelpExampleCli("setban", "\"192.168.0.0/24\" \"add\"")
                             + HelpExampleRpc("setban", "\"192.168.0.6\", \"add\", 86400")
                 },
-    };
+        [&](const RPCHelpMan& help, const JSONRPCRequest& request) -> UniValue
+{
     std::string strCommand;
     if (!request.params[1].isNull())
         strCommand = request.params[1].get_str();
@@ -693,11 +714,13 @@ static UniValue setban(const JSONRPCRequest& request)
         }
     }
     return NullUniValue;
+},
+    };
 }
 
-static UniValue listbanned(const JSONRPCRequest& request)
+static RPCHelpMan listbanned()
 {
-    RPCHelpMan{"listbanned",
+    return RPCHelpMan{"listbanned",
         "\nList all manually banned IPs/Subnets.\n",
         {},
         RPCResult{RPCResult::Type::ARR, "", "",
@@ -713,7 +736,8 @@ static UniValue listbanned(const JSONRPCRequest& request)
             HelpExampleCli("listbanned", "")
                     + HelpExampleRpc("listbanned", "")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if(!node.banman) {
@@ -736,11 +760,13 @@ static UniValue listbanned(const JSONRPCRequest& request)
     }
 
     return bannedAddresses;
+},
+    };
 }
 
-static UniValue clearbanned(const JSONRPCRequest& request)
+static RPCHelpMan clearbanned()
 {
-    RPCHelpMan{"clearbanned",
+    return RPCHelpMan{"clearbanned",
         "\nClear all banned IPs.\n",
         {},
         RPCResult{RPCResult::Type::NONE, "", ""},
@@ -748,7 +774,8 @@ static UniValue clearbanned(const JSONRPCRequest& request)
             HelpExampleCli("clearbanned", "")
                     + HelpExampleRpc("clearbanned", "")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if (!node.banman) {
         throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
@@ -757,11 +784,13 @@ static UniValue clearbanned(const JSONRPCRequest& request)
     node.banman->ClearBanned();
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue cleardiscouraged(const JSONRPCRequest& request)
+static RPCHelpMan cleardiscouraged()
 {
-    RPCHelpMan{"cleardiscouraged",
+    return RPCHelpMan{"cleardiscouraged",
                "\nClear all discouraged nodes.\n",
                {},
                RPCResult{RPCResult::Type::NONE, "", ""},
@@ -769,7 +798,8 @@ static UniValue cleardiscouraged(const JSONRPCRequest& request)
                        HelpExampleCli("cleardiscouraged", "")
                        + HelpExampleRpc("cleardiscouraged", "")
                },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if (!node.banman) {
         throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
@@ -778,18 +808,21 @@ static UniValue cleardiscouraged(const JSONRPCRequest& request)
     node.banman->ClearDiscouraged();
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue setnetworkactive(const JSONRPCRequest& request)
+static RPCHelpMan setnetworkactive()
 {
-    RPCHelpMan{"setnetworkactive",
+    return RPCHelpMan{"setnetworkactive",
         "\nDisable/enable all p2p network activity.\n",
         {
             {"state", RPCArg::Type::BOOL, RPCArg::Optional::NO, "true to enable networking, false to disable"},
         },
         RPCResult{RPCResult::Type::BOOL, "", "The value that was passed in"},
         RPCExamples{""},
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if (!node.connman) {
@@ -799,11 +832,13 @@ static UniValue setnetworkactive(const JSONRPCRequest& request)
     node.connman->SetNetworkActive(request.params[0].get_bool());
 
     return node.connman->GetNetworkActive();
+},
+    };
 }
 
-static UniValue getnodeaddresses(const JSONRPCRequest& request)
+static RPCHelpMan getnodeaddresses()
 {
-            RPCHelpMan{"getnodeaddresses",
+    return RPCHelpMan{"getnodeaddresses",
                 "\nReturn known addresses which can potentially be used to find new nodes in the network\n",
                 {
                     {"count", RPCArg::Type::NUM, /* default */ "1", "The maximum number of addresses to return. Specify 0 to return all known addresses."},
@@ -824,7 +859,8 @@ static UniValue getnodeaddresses(const JSONRPCRequest& request)
                     HelpExampleCli("getnodeaddresses", "8")
             + HelpExampleRpc("getnodeaddresses", "8")
                 },
-            }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if (!node.connman) {
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
@@ -850,11 +886,13 @@ static UniValue getnodeaddresses(const JSONRPCRequest& request)
         ret.push_back(obj);
     }
     return ret;
+},
+    };
 }
 
-static UniValue addpeeraddress(const JSONRPCRequest& request)
+static RPCHelpMan addpeeraddress()
 {
-    RPCHelpMan{"addpeeraddress",
+    return RPCHelpMan{"addpeeraddress",
         "\nAdd the address of a potential peer to the address manager. This RPC is for testing only.\n",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The IP address of the peer"},
@@ -870,7 +908,8 @@ static UniValue addpeeraddress(const JSONRPCRequest& request)
             HelpExampleCli("addpeeraddress", "\"1.2.3.4\" 9999")
     + HelpExampleRpc("addpeeraddress", "\"1.2.3.4\", 9999")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if (!node.addrman) {
@@ -898,6 +937,8 @@ static UniValue addpeeraddress(const JSONRPCRequest& request)
 
     obj.pushKV("success", true);
     return obj;
+},
+    };
 }
 
 void RegisterNetRPCCommands(CRPCTable &t)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -923,8 +923,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "addpeeraddress",         &addpeeraddress,         {"address", "port"} },
 };
 // clang-format on
-
-    for (const auto& command : commands) {
-        t.appendCommand(command.name, &command);
+    for (const auto& c : commands) {
+        t.appendCommand(c.name, &c);
     }
 }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2059,8 +2059,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "verifytxoutproof",             &verifytxoutproof,          {"proof"} },
 };
 // clang-format on
-
-    for (const auto& command : commands) {
-        t.appendCommand(command.name, &command);
+    for (const auto& c : commands) {
+        t.appendCommand(c.name, &c);
     }
 }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -112,9 +112,9 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, CTxMemPool& mempo
     entry.pushKV("chainlock", chainLock);
 }
 
-static UniValue getrawtransaction(const JSONRPCRequest& request)
+static RPCHelpMan getrawtransaction()
 {
-    RPCHelpMan{
+    return RPCHelpMan{
                 "getrawtransaction",
                 "\nReturn the raw transaction data.\n"
 
@@ -198,8 +198,8 @@ static UniValue getrawtransaction(const JSONRPCRequest& request)
             + HelpExampleCli("getrawtransaction", "\"mytxid\" false \"myblockhash\"")
             + HelpExampleCli("getrawtransaction", "\"mytxid\" true \"myblockhash\"")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     ChainstateManager& chainman = EnsureChainman(node);
 
@@ -264,10 +264,12 @@ static UniValue getrawtransaction(const JSONRPCRequest& request)
     if (blockindex) result.pushKV("in_active_chain", in_active_chain);
     TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *llmq_ctx.clhandler, *llmq_ctx.isman, result);
     return result;
+},
+    };
 }
 
-static UniValue getrawtransactionmulti(const JSONRPCRequest& request) {
-    RPCHelpMan{
+static RPCHelpMan getrawtransactionmulti() {
+    return RPCHelpMan{
             "getrawtransactionmulti",
             "\nReturns the raw transaction data for multiple transactions.\n"
             "\nThis call is an extension of getrawtransaction that supports multiple transactions.\n"
@@ -293,8 +295,8 @@ static UniValue getrawtransactionmulti(const JSONRPCRequest& request) {
                     + HelpExampleRpc("getrawtransactionmulti",
                                      R"('{"blockhash1":["txid1","txid2"], "0":["txid3"]})")
             },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     // Parse arguments
     UniValue transactions{request.params[0].get_obj()};
     // Accept either a bool (true) or a num (>=1) to indicate verbose output.
@@ -347,13 +349,14 @@ static UniValue getrawtransactionmulti(const JSONRPCRequest& request) {
             }
         }
     }
-
     return result;
+},
+    };
 }
 
-static UniValue gettxchainlocks(const JSONRPCRequest& request)
+static RPCHelpMan gettxchainlocks()
 {
-    RPCHelpMan{
+    return RPCHelpMan{
         "gettxchainlocks",
         "\nReturns the block height at which each transaction was mined, and indicates whether it is in the mempool, ChainLocked, or neither.\n",
         {
@@ -378,8 +381,8 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
             HelpExampleCli("gettxchainlocks", "'[\"mytxid\",...]'")
         + HelpExampleRpc("gettxchainlocks", "[\"mytxid\",...]")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
     const ChainstateManager& chainman = EnsureChainman(node);
@@ -433,11 +436,13 @@ static UniValue gettxchainlocks(const JSONRPCRequest& request)
         result_arr.push_back(result);
     }
     return result_arr;
+},
+    };
 }
 
-static void getassetunlockstatuses_help(const JSONRPCRequest& request)
+static RPCHelpMan getassetunlockstatuses()
 {
-    RPCHelpMan{
+    return RPCHelpMan{
             "getassetunlockstatuses",
             "\nReturns the status of given Asset Unlock indexes at the tip of the chain or at a specific block height if specified.\n",
             {
@@ -462,13 +467,8 @@ static void getassetunlockstatuses_help(const JSONRPCRequest& request)
                     HelpExampleCli("getassetunlockstatuses", "'[\"myindex\",...]'")
                     + HelpExampleRpc("getassetunlockstatuses", "[\"myindex\",...]")
             },
-    }.Check(request);
-}
-
-static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    getassetunlockstatuses_help(request);
-
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const CTxMemPool& mempool = EnsureMemPool(node);
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
@@ -562,11 +562,13 @@ static UniValue getassetunlockstatuses(const JSONRPCRequest& request)
     }
 
     return result_arr;
+},
+    };
 }
 
-static UniValue gettxoutproof(const JSONRPCRequest& request)
+static RPCHelpMan gettxoutproof()
 {
-    RPCHelpMan{"gettxoutproof",
+    return RPCHelpMan{"gettxoutproof",
         "\nReturns a hex-encoded proof that \"txid\" was included in a block.\n"
         "\nNOTE: By default this function only works sometimes. This is when there is an\n"
         "unspent output in the utxo for this transaction. To make it always work,\n"
@@ -588,8 +590,8 @@ static UniValue gettxoutproof(const JSONRPCRequest& request)
     + HelpExampleCli("gettxoutproof", "'[\"mytxid\",...]' \"blockhash\"")
     + HelpExampleRpc("gettxoutproof", "[\"mytxid\",...], \"blockhash\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::set<uint256> setTxids;
     UniValue txids = request.params[0].get_array();
     if (txids.empty()) {
@@ -665,11 +667,13 @@ static UniValue gettxoutproof(const JSONRPCRequest& request)
     ssMB << mb;
     std::string strHex = HexStr(ssMB);
     return strHex;
+},
+    };
 }
 
-static UniValue verifytxoutproof(const JSONRPCRequest& request)
+static RPCHelpMan verifytxoutproof()
 {
-    RPCHelpMan{"verifytxoutproof",
+    return RPCHelpMan{"verifytxoutproof",
         "\nVerifies that a proof points to a transaction in a block, returning the transaction it commits to\n"
         "and throwing an RPC error if the block is not in our best chain\n",
         {
@@ -685,8 +689,8 @@ static UniValue verifytxoutproof(const JSONRPCRequest& request)
             HelpExampleCli("verifytxoutproof", "\"proof\"")
     + HelpExampleRpc("gettxoutproof", "\"proof\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     CDataStream ssMB(ParseHexV(request.params[0], "proof"), SER_NETWORK, PROTOCOL_VERSION);
     CMerkleBlock merkleBlock;
     ssMB >> merkleBlock;
@@ -714,11 +718,13 @@ static UniValue verifytxoutproof(const JSONRPCRequest& request)
     }
 
     return res;
+},
+    };
 }
 
-static UniValue createrawtransaction(const JSONRPCRequest& request)
+static RPCHelpMan createrawtransaction()
 {
-    RPCHelpMan{"createrawtransaction",
+    return RPCHelpMan{"createrawtransaction",
         "\nCreate a transaction spending the given inputs and creating new outputs.\n"
         "Outputs can be addresses or data.\n"
         "Returns hex-encoded raw transaction.\n"
@@ -764,8 +770,8 @@ static UniValue createrawtransaction(const JSONRPCRequest& request)
     + HelpExampleRpc("createrawtransaction", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"[{\\\"address\\\":0.01}]\"")
     + HelpExampleRpc("createrawtransaction", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"[{\\\"data\\\":\\\"00010203\\\"}]\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {
         UniValue::VARR,
         UniValueType(), // ARR or OBJ, checked later
@@ -776,11 +782,13 @@ static UniValue createrawtransaction(const JSONRPCRequest& request)
     CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2]);
 
     return EncodeHexTx(CTransaction(rawTx));
+},
+    };
 }
 
-static UniValue decoderawtransaction(const JSONRPCRequest& request)
+static RPCHelpMan decoderawtransaction()
 {
-    RPCHelpMan{"decoderawtransaction",
+    return RPCHelpMan{"decoderawtransaction",
                 "\nReturn a JSON object representing the serialized, hex-encoded transaction.\n",
                 {
                     {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction hex string"},
@@ -834,8 +842,8 @@ static UniValue decoderawtransaction(const JSONRPCRequest& request)
                     HelpExampleCli("decoderawtransaction", "\"hexstring\"")
             + HelpExampleRpc("decoderawtransaction", "\"hexstring\"")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR});
 
     CMutableTransaction mtx;
@@ -847,6 +855,8 @@ static UniValue decoderawtransaction(const JSONRPCRequest& request)
     TxToUniv(CTransaction(std::move(mtx)), uint256(), result, false);
 
     return result;
+},
+    };
 }
 
 static std::string GetAllOutputTypes()
@@ -859,9 +869,9 @@ static std::string GetAllOutputTypes()
     return Join(ret, ", ");
 }
 
-static UniValue decodescript(const JSONRPCRequest& request)
+static RPCHelpMan decodescript()
 {
-    RPCHelpMan{"decodescript",
+    return RPCHelpMan{"decodescript",
                 "\nDecode a hex-encoded script.\n",
                 {
                     {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "the hex-encoded script"},
@@ -883,8 +893,8 @@ static UniValue decodescript(const JSONRPCRequest& request)
                     HelpExampleCli("decodescript", "\"hexstring\"")
             + HelpExampleRpc("decodescript", "\"hexstring\"")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR});
 
     UniValue r(UniValue::VOBJ);
@@ -908,11 +918,13 @@ static UniValue decodescript(const JSONRPCRequest& request)
     }
 
     return r;
+},
+    };
 }
 
-static UniValue combinerawtransaction(const JSONRPCRequest& request)
+static RPCHelpMan combinerawtransaction()
 {
-    RPCHelpMan{"combinerawtransaction",
+    return RPCHelpMan{"combinerawtransaction",
         "\nCombine multiple partially signed transactions into one transaction.\n"
         "The combined transaction may be another partially signed transaction or a \n"
         "fully signed transaction.",
@@ -929,8 +941,8 @@ static UniValue combinerawtransaction(const JSONRPCRequest& request)
         RPCExamples{
             HelpExampleCli("combinerawtransaction", R"('["myhex1", "myhex2", "myhex3"]')")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     UniValue txs = request.params[0].get_array();
     std::vector<CMutableTransaction> txVariants(txs.size());
@@ -992,11 +1004,13 @@ static UniValue combinerawtransaction(const JSONRPCRequest& request)
     }
 
     return EncodeHexTx(CTransaction(mergedTx));
+},
+    };
 }
 
-static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
+static RPCHelpMan signrawtransactionwithkey()
 {
-    RPCHelpMan{"signrawtransactionwithkey",
+    return RPCHelpMan{"signrawtransactionwithkey",
         "\nSign inputs for raw transaction (serialized, hex-encoded).\n"
         "The second argument is an array of base58-encoded private\n"
         "keys that will be the only keys used to sign the transaction.\n"
@@ -1053,8 +1067,8 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
             HelpExampleCli("signrawtransactionwithkey", "\"myhex\" \"[\\\"key1\\\",\\\"key2\\\"]\"")
     + HelpExampleRpc("signrawtransactionwithkey", "\"myhex\", \"[\\\"key1\\\",\\\"key2\\\"]\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR, UniValue::VARR, UniValue::VSTR}, true);
 
     CMutableTransaction mtx;
@@ -1087,11 +1101,13 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
     SignTransaction(mtx, &keystore, coins, request.params[3], result);
     return result;
+},
+    };
 }
 
-UniValue sendrawtransaction(const JSONRPCRequest& request)
+RPCHelpMan sendrawtransaction()
 {
-    RPCHelpMan{"sendrawtransaction",                "\nSubmit a raw transaction (serialized, hex-encoded) to local node and network.\n"
+    return RPCHelpMan{"sendrawtransaction",                "\nSubmit a raw transaction (serialized, hex-encoded) to local node and network.\n"
                 "\nThe transaction will be sent unconditionally to all peers, so using sendrawtransaction\n"
                 "for manual rebroadcast may degrade privacy by leaking the transaction's origin, as\n"
                 "nodes will normally not rebroadcast non-wallet transactions already in their mempool.\n"
@@ -1118,8 +1134,8 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("sendrawtransaction", "\"signedhex\"")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {
         UniValue::VSTR,
         UniValueType(), // VNUM or VSTR, checked inside AmountFromValue()
@@ -1150,11 +1166,13 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
     }
 
     return tx->GetHash().GetHex();
+},
+    };
 }
 
-static UniValue testmempoolaccept(const JSONRPCRequest& request)
+static RPCHelpMan testmempoolaccept()
 {
-    RPCHelpMan{"testmempoolaccept",
+    return RPCHelpMan{"testmempoolaccept",
                 "\nReturns result of mempool acceptance tests indicating if raw transaction (serialized, hex-encoded) would be accepted by mempool.\n"
                 "\nIf multiple transactions are passed in, parents must come before children and package policies apply: the transactions cannot conflict with any mempool transactions or each other.\n"
                 "\nIf one transaction fails, other transactions may not be fully validated (the 'allowed' key will be blank).\n"
@@ -1200,8 +1218,8 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("testmempoolaccept", "[\"signedhex\"]")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {
         UniValue::VARR,
         UniValueType(), // VNUM or VSTR, checked inside AmountFromValue()
@@ -1286,11 +1304,13 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
         rpc_result.push_back(result_inner);
     }
     return rpc_result;
+},
+    };
 }
 
-UniValue decodepsbt(const JSONRPCRequest& request)
+static RPCHelpMan decodepsbt()
 {
-    RPCHelpMan{"decodepsbt",
+    return RPCHelpMan{"decodepsbt",
         "\nReturn a JSON object representing the serialized, base64-encoded partially signed Dash transaction.\n",
         {
             {"psbt", RPCArg::Type::STR, RPCArg::Optional::NO, "The PSBT base64 string"},
@@ -1375,8 +1395,8 @@ UniValue decodepsbt(const JSONRPCRequest& request)
         RPCExamples{
             HelpExampleCli("decodepsbt", "\"psbt\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR});
 
     // Unserialize the transactions
@@ -1537,11 +1557,13 @@ UniValue decodepsbt(const JSONRPCRequest& request)
     }
 
     return result;
+},
+    };
 }
 
-UniValue combinepsbt(const JSONRPCRequest& request)
+static RPCHelpMan combinepsbt()
 {
-    RPCHelpMan{"combinepsbt",
+    return RPCHelpMan{"combinepsbt",
         "\nCombine multiple partially signed Dash transactions into one transaction.\n"
         "Implements the Combiner role.\n",
         {
@@ -1557,8 +1579,8 @@ UniValue combinepsbt(const JSONRPCRequest& request)
         RPCExamples{
             HelpExampleCli("combinepsbt", R"('["mybase64_1", "mybase64_2", "mybase64_3"]')")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VARR}, true);
 
     // Unserialize the transactions
@@ -1585,11 +1607,13 @@ UniValue combinepsbt(const JSONRPCRequest& request)
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << merged_psbt;
     return EncodeBase64(ssTx);
+},
+    };
 }
 
-UniValue finalizepsbt(const JSONRPCRequest& request)
+static RPCHelpMan finalizepsbt()
 {
-            RPCHelpMan{"finalizepsbt",
+    return RPCHelpMan{"finalizepsbt",
                 "Finalize the inputs of a PSBT. If the transaction is fully signed, it will produce a\n"
                 "network serialized transaction which can be broadcast with sendrawtransaction. Otherwise a PSBT will be\n"
                 "created which has the final_scriptSig field filled for inputs that are complete.\n"
@@ -1610,8 +1634,8 @@ UniValue finalizepsbt(const JSONRPCRequest& request)
                 RPCExamples{
                     HelpExampleCli("finalizepsbt", "\"psbt\"")
                 },
-            }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL}, true);
 
     // Unserialize the transactions
@@ -1642,11 +1666,13 @@ UniValue finalizepsbt(const JSONRPCRequest& request)
     result.pushKV("complete", complete);
 
     return result;
+},
+    };
 }
 
-UniValue createpsbt(const JSONRPCRequest& request)
+static RPCHelpMan createpsbt()
 {
-    RPCHelpMan{"createpsbt",
+    return RPCHelpMan{"createpsbt",
         "\nCreates a transaction in the Partially Signed Transaction format.\n"
         "Implements the Creator role.\n",
         {
@@ -1686,8 +1712,8 @@ UniValue createpsbt(const JSONRPCRequest& request)
         RPCExamples{
             HelpExampleCli("createpsbt", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     RPCTypeCheck(request.params, {
         UniValue::VARR,
@@ -1713,11 +1739,13 @@ UniValue createpsbt(const JSONRPCRequest& request)
     ssTx << psbtx;
 
     return EncodeBase64(ssTx);
+},
+    };
 }
 
-UniValue converttopsbt(const JSONRPCRequest& request)
+static RPCHelpMan converttopsbt()
 {
-    RPCHelpMan{"converttopsbt",
+    return RPCHelpMan{"converttopsbt",
                 "\nConverts a network serialized transaction to a PSBT. This should be used only with createrawtransaction and fundrawtransaction\n"
                 "createpsbt and walletcreatefundedpsbt should be used for new applications.\n",
                 {
@@ -1734,8 +1762,8 @@ UniValue converttopsbt(const JSONRPCRequest& request)
                             "\nConvert the transaction to a PSBT\n"
                             + HelpExampleCli("converttopsbt", "\"rawtransaction\"")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL, UniValue::VBOOL}, true);
 
     // parse hex string from parameter
@@ -1768,12 +1796,13 @@ UniValue converttopsbt(const JSONRPCRequest& request)
     ssTx << psbtx;
 
     return EncodeBase64(ssTx);
+},
+    };
 }
 
-UniValue utxoupdatepsbt(const JSONRPCRequest& request)
+static RPCHelpMan utxoupdatepsbt()
 {
-
-    RPCHelpMan{"utxoupdatepsbt",
+    return RPCHelpMan{"utxoupdatepsbt",
     "\nUpdates a PSBT with data from output descriptors, UTXOs retrieved from the UTXO set or the mempool.\n",
     {
         {"psbt", RPCArg::Type::STR, RPCArg::Optional::NO, "A base64 string of a PSBT"},
@@ -1790,7 +1819,9 @@ UniValue utxoupdatepsbt(const JSONRPCRequest& request)
     },
     RPCExamples {
         HelpExampleCli("utxoupdatepsbt", "\"psbt\"")
-    }}.Check(request);
+    },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR}, true);
 
     // Unserialize the transactions
@@ -1852,11 +1883,13 @@ UniValue utxoupdatepsbt(const JSONRPCRequest& request)
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << psbtx;
     return EncodeBase64(ssTx);
+},
+    };
 }
 
-UniValue joinpsbts(const JSONRPCRequest& request)
+static RPCHelpMan joinpsbts()
 {
-    RPCHelpMan{"joinpsbts",
+    return RPCHelpMan{"joinpsbts",
     "\nJoins multiple distinct PSBTs with different inputs and outputs into one PSBT with inputs and outputs from all of the PSBTs\n"
     "No input in any of the PSBTs can be in more than one of the PSBTs.\n",
     {
@@ -1870,8 +1903,9 @@ UniValue joinpsbts(const JSONRPCRequest& request)
     },
     RPCExamples {
         HelpExampleCli("joinpsbts", "\"psbt\"")
-    }}.Check(request);
-
+    },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VARR}, true);
 
     // Unserialize the transactions
@@ -1923,11 +1957,13 @@ UniValue joinpsbts(const JSONRPCRequest& request)
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << merged_psbt;
     return EncodeBase64(ssTx);
+},
+    };
 }
 
-UniValue analyzepsbt(const JSONRPCRequest& request)
+static RPCHelpMan analyzepsbt()
 {
-    RPCHelpMan{"analyzepsbt",
+    return RPCHelpMan{"analyzepsbt",
     "\nAnalyzes and provides information about the current status of a PSBT and its inputs\n",
     {
         {"psbt", RPCArg::Type::STR, RPCArg::Optional::NO, "A base64 string of a PSBT"}
@@ -1965,8 +2001,9 @@ UniValue analyzepsbt(const JSONRPCRequest& request)
     },
     RPCExamples {
         HelpExampleCli("analyzepsbt", "\"psbt\"")
-    }}.Check(request);
-
+    },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR});
 
     // Unserialize the transaction
@@ -2027,6 +2064,8 @@ UniValue analyzepsbt(const JSONRPCRequest& request)
     }
 
     return result;
+},
+    };
 }
 
 void RegisterRawTransactionRPCCommands(CRPCTable &t)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -2076,7 +2076,7 @@ static const CRPCCommand commands[] =
   //  --------------------- ------------------------        -----------------------     ----------
     { "rawtransactions",    "getassetunlockstatuses",       &getassetunlockstatuses,    {"indexes","height"} },
     { "rawtransactions",    "getrawtransaction",            &getrawtransaction,         {"txid","verbose","blockhash"} },
-    { "rawtransactions",    "getrawtransactionmulti",       &getrawtransactionmulti,    {"txid_map","verbose"} },
+    { "rawtransactions",    "getrawtransactionmulti",       &getrawtransactionmulti,    {"transactions","verbose"} },
     { "rawtransactions",    "gettxchainlocks",              &gettxchainlocks,           {"txids"} },
     { "rawtransactions",    "createrawtransaction",         &createrawtransaction,      {"inputs","outputs","locktime"} },
     { "rawtransactions",    "decoderawtransaction",         &decoderawtransaction,      {"hexstring"} },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -286,13 +286,8 @@ static const CRPCCommand vRPCCommands[] =
 
 CRPCTable::CRPCTable()
 {
-    unsigned int vcidx;
-    for (vcidx = 0; vcidx < (sizeof(vRPCCommands) / sizeof(vRPCCommands[0])); vcidx++)
-    {
-        const CRPCCommand *pcmd;
-
-        pcmd = &vRPCCommands[vcidx];
-        mapCommands[pcmd->name].push_back(pcmd);
+    for (const auto& c : vRPCCommands) {
+        appendCommand(c.name, &c);
     }
 }
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -291,13 +291,11 @@ CRPCTable::CRPCTable()
     }
 }
 
-bool CRPCTable::appendCommand(const std::string& name, const CRPCCommand* pcmd)
+void CRPCTable::appendCommand(const std::string& name, const CRPCCommand* pcmd)
 {
-    if (IsRPCRunning())
-        return false;
+    CHECK_NONFATAL(!IsRPCRunning()); // Only add commands before rpc is running
 
     mapCommands[name].push_back(pcmd);
-    return true;
 }
 
 bool CRPCTable::removeCommand(const std::string& name, const CRPCCommand* pcmd)

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -160,7 +160,7 @@ public:
     /**
      * Appends a CRPCCommand to the dispatch table.
      *
-     * Returns false if RPC server is already running (dump concurrency protection).
+     * Precondition: RPC server is not running
      *
      * Commands with different method names but the same unique_id will
      * be considered aliases, and only the first registered method name will
@@ -169,7 +169,7 @@ public:
      * between calls based on method name, and aliased commands can also
      * register different names, types, and numbers of parameters.
      */
-    bool appendCommand(const std::string& name, const CRPCCommand* pcmd);
+    void appendCommand(const std::string& name, const CRPCCommand* pcmd);
     bool removeCommand(const std::string& name, const CRPCCommand* pcmd);
 };
 

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -459,7 +459,7 @@ std::string RPCHelpMan::ToString() const
     ret += m_name;
     bool was_optional{false};
     for (const auto& arg : m_args) {
-        if (arg.m_hidden) continue;
+        if (arg.m_hidden) break; // Any arg that follows is also hidden
         const bool optional = arg.IsOptional();
         ret += " ";
         if (optional) {
@@ -481,7 +481,7 @@ std::string RPCHelpMan::ToString() const
     Sections sections;
     for (size_t i{0}; i < m_args.size(); ++i) {
         const auto& arg = m_args.at(i);
-        if (arg.m_hidden) continue;
+        if (arg.m_hidden) break; // Any arg that follows is also hidden
 
         if (i == 0) ret += "\nArguments:\n";
 

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -354,6 +354,7 @@ public:
         }
     }
 
+    // TODO: drop it, that's dash specific workaround
     [[ noreturn ]] inline void Throw() const {
         throw std::runtime_error(ToString());
     }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1835,7 +1835,6 @@ RPCHelpMan importdescriptors() {
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& main_request) -> UniValue
 {
-
     // Acquire the wallet
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(main_request);
     if (!wallet) return NullUniValue;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -68,9 +68,9 @@ static void RescanWallet(CWallet& wallet, const WalletRescanReserver& reserver, 
     }
 }
 
-UniValue importprivkey(const JSONRPCRequest& request)
+RPCHelpMan importprivkey()
 {
-    RPCHelpMan{"importprivkey",
+    return RPCHelpMan{"importprivkey",
         "\nAdds a private key (as returned by dumpprivkey) to your wallet. Requires a new wallet backup.\n"
         "Hint: use importmulti to import more than one private key.\n"
     "\nNote: This call can take over an hour to complete if rescan is true, during that time, other rpc calls\n"
@@ -93,8 +93,8 @@ UniValue importprivkey(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("importprivkey", "\"mykey\", \"testing\", false")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -156,11 +156,13 @@ UniValue importprivkey(const JSONRPCRequest& request)
         RescanWallet(*pwallet, reserver);
     }
     return NullUniValue;
+},
+    };
 }
 
-UniValue abortrescan(const JSONRPCRequest& request)
+RPCHelpMan abortrescan()
 {
-    RPCHelpMan{"abortrescan",
+    return RPCHelpMan{"abortrescan",
                 "\nStops current wallet rescan triggered by an RPC call, e.g. by an importprivkey call.\n",
                 {},
                 RPCResult{RPCResult::Type::BOOL, "", "Whether the abort was successful"},
@@ -172,20 +174,22 @@ UniValue abortrescan(const JSONRPCRequest& request)
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("abortrescan", "")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
 
     if (!pwallet->IsScanning() || pwallet->IsAbortingRescan()) return false;
-        pwallet->AbortRescan();
-        return true;
-    }
+    pwallet->AbortRescan();
+    return true;
+},
+    };
+}
 
-UniValue importaddress(const JSONRPCRequest& request)
+RPCHelpMan importaddress()
 {
-    RPCHelpMan{"importaddress",
+    return RPCHelpMan{"importaddress",
         "\nAdds an address or script (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.\n"
     "\nNote: This call can take over an hour to complete if rescan is true, during that time, other rpc calls\n"
     "may report that the imported address exists but related transactions are still missing, leading to temporarily incorrect/bogus balances and unspent outputs until rescan completes.\n"
@@ -208,8 +212,8 @@ UniValue importaddress(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("importaddress", "\"myaddress\", \"testing\", false")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -279,11 +283,13 @@ UniValue importaddress(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-UniValue importprunedfunds(const JSONRPCRequest& request)
+RPCHelpMan importprunedfunds()
 {
-    RPCHelpMan{"importprunedfunds",
+    return RPCHelpMan{"importprunedfunds",
         "\nImports funds without rescan. Corresponding address or script must previously be included in wallet. Aimed towards pruned wallets. The end-user is responsible to import additional transactions that subsequently spend the imported outputs or rescan after the point in the blockchain the transaction is included.\n",
         {
             {"rawtransaction", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "A raw transaction in hex funding an already-existing address in wallet"},
@@ -291,8 +297,8 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
         },
         RPCResult{RPCResult::Type::NONE, "", ""},
         RPCExamples{""},
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -336,11 +342,13 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     }
 
     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No addresses in wallet correspond to included transaction");
+},
+    };
 }
 
-UniValue removeprunedfunds(const JSONRPCRequest& request)
+RPCHelpMan removeprunedfunds()
 {
-    RPCHelpMan{"removeprunedfunds",
+    return RPCHelpMan{"removeprunedfunds",
         "\nDeletes the specified transaction from the wallet. Meant for use with pruned wallets and as a companion to importprunedfunds. This will affect wallet balances.\n",
         {
             {"txid", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hex-encoded id of the transaction you are deleting"},
@@ -351,8 +359,8 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("removeprunedfunds", "\"a8d0c0184dde994a09ec054286f1ce581bebf46446a512166eae7628734ea0a5\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -373,11 +381,13 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
-UniValue importpubkey(const JSONRPCRequest& request)
+RPCHelpMan importpubkey()
 {
-    RPCHelpMan{"importpubkey",
+    return RPCHelpMan{"importpubkey",
         "\nAdds a public key (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.\n"
         "Hint: use importmulti to import more than one public key.\n"
     "\nNote: This call can take over an hour to complete if rescan is true, during that time, other rpc calls\n"
@@ -396,8 +406,8 @@ UniValue importpubkey(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("importpubkey", "\"mypubkey\", \"testing\", false")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -453,12 +463,14 @@ UniValue importpubkey(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
 
-UniValue importwallet(const JSONRPCRequest& request)
+RPCHelpMan importwallet()
 {
-    RPCHelpMan{"importwallet",
+    return RPCHelpMan{"importwallet",
         "\nImports keys from a wallet dump file (see dumpwallet). Requires a new wallet backup to include imported keys.\n"
         "Note: Use \"getwalletinfo\" to query the scanning progress.\n",
         {
@@ -473,8 +485,8 @@ UniValue importwallet(const JSONRPCRequest& request)
     "\nImport using the json rpc call\n"
     + HelpExampleRpc("importwallet", "\"test\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -613,11 +625,13 @@ UniValue importwallet(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys/scripts to wallet");
 
     return NullUniValue;
+},
+    };
 }
 
-UniValue importelectrumwallet(const JSONRPCRequest& request)
+RPCHelpMan importelectrumwallet()
 {
-    RPCHelpMan{"importelectrumwallet",
+    return RPCHelpMan{"importelectrumwallet",
         "\nImports keys from an Electrum wallet export file (.csv or .json)\n",
         {
             {"filename", RPCArg::Type::STR, RPCArg::Optional::NO, "The Electrum wallet export file, should be in csv or json format"},
@@ -632,7 +646,8 @@ UniValue importelectrumwallet(const JSONRPCRequest& request)
     + HelpExampleRpc("importelectrumwallet", "\"test.csv\"")
     + HelpExampleRpc("importelectrumwallet", "\"test.json\"")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -790,11 +805,13 @@ UniValue importelectrumwallet(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");
 
     return NullUniValue;
+},
+    };
 }
 
-UniValue dumpprivkey(const JSONRPCRequest& request)
+RPCHelpMan dumpprivkey()
 {
-    RPCHelpMan{"dumpprivkey",
+    return RPCHelpMan{"dumpprivkey",
         "\nReveals the private key corresponding to 'address'.\n"
         "Then the importprivkey can be used with this output\n",
         {
@@ -808,8 +825,8 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     + HelpExampleCli("importprivkey", "\"mykey\"")
     + HelpExampleRpc("dumpprivkey", "\"myaddress\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -834,11 +851,13 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
     }
     return EncodeSecret(vchSecret);
+},
+    };
 }
 
-UniValue dumphdinfo(const JSONRPCRequest& request)
+RPCHelpMan dumphdinfo()
 {
-    RPCHelpMan{"dumphdinfo",
+    return RPCHelpMan{"dumphdinfo",
         "Returns an object containing sensitive private info about this HD wallet.\n",
         {},
         RPCResult{
@@ -853,8 +872,8 @@ UniValue dumphdinfo(const JSONRPCRequest& request)
             HelpExampleCli("dumphdinfo", "")
     + HelpExampleRpc("dumphdinfo", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -881,11 +900,13 @@ UniValue dumphdinfo(const JSONRPCRequest& request)
     obj.pushKV("mnemonicpassphrase", ssMnemonicPassphrase.c_str());
 
     return obj;
+},
+    };
 }
 
-UniValue dumpwallet(const JSONRPCRequest& request)
+RPCHelpMan dumpwallet()
 {
-    RPCHelpMan{"dumpwallet",
+    return RPCHelpMan{"dumpwallet",
         "\nDumps all wallet keys in a human-readable format to a server-side file. This does not allow overwriting existing files.\n"
         "Imported scripts are included in the dumpfile too, their corresponding addresses will be added automatically by importwallet.\n"
         "Note that if your wallet contains keys which are not derived from your HD seed (e.g. imported keys), these are not covered by\n"
@@ -905,8 +926,8 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             HelpExampleCli("dumpwallet", "\"test\"")
     + HelpExampleRpc("dumpwallet", "\"test\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;
 
@@ -1056,6 +1077,8 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     obj.pushKV("warning", strWarning);
 
     return obj;
+},
+    };
 }
 
 struct ImportData
@@ -1430,9 +1453,9 @@ static int64_t GetImportTimestamp(const UniValue& data, int64_t now)
     throw JSONRPCError(RPC_TYPE_ERROR, "Missing required timestamp field for key");
 }
 
-UniValue importmulti(const JSONRPCRequest& mainRequest)
+RPCHelpMan importmulti()
 {
-    RPCHelpMan{"importmulti",
+    return RPCHelpMan{"importmulti",
         "\nImport addresses/scripts (with private or public keys, redeem script (P2SH)), optionally rescanning the blockchain from the earliest creation time of the imported scripts. Requires a new wallet backup.\n"
         "If an address/script is imported without all of the private keys required to spend from that address, it will be watchonly. The 'watchonly' option must be set to true in this case or a warning will be returned.\n"
         "Conversely, if all the private keys are provided and the address/script is spendable, the watchonly option must be set to false, or a warning will be returned.\n"
@@ -1504,7 +1527,8 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
                                   "{ \"scriptPubKey\": { \"address\": \"<my 2nd address>\" }, \"label\": \"example 2\", \"timestamp\": 1455191480 }]'") +
             HelpExampleCli("importmulti", "'[{ \"scriptPubKey\": { \"address\": \"<my address>\" }, \"timestamp\":1455191478 }]' '{ \"rescan\": false}'")
         },
-    }.Check(mainRequest);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& mainRequest) -> UniValue
+{
 
 
     RPCTypeCheck(mainRequest.params, {UniValue::VARR, UniValue::VOBJ});
@@ -1614,6 +1638,8 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
     }
 
     return response;
+},
+    };
 }
 
 static UniValue ProcessDescriptorImport(CWallet * const pwallet, const UniValue& data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
@@ -1757,8 +1783,8 @@ static UniValue ProcessDescriptorImport(CWallet * const pwallet, const UniValue&
     return result;
 }
 
-UniValue importdescriptors(const JSONRPCRequest& main_request) {
-            RPCHelpMan{"importdescriptors",
+RPCHelpMan importdescriptors() {
+            return RPCHelpMan{"importdescriptors",
                 "\nImport descriptors. This will trigger a rescan of the blockchain based on the earliest timestamp of all descriptors being imported. Requires a new wallet backup.\n"
             "\nNote: This call can take over an hour to complete if using an early timestamp; during that time, other rpc calls\n"
             "may report that the imported keys, addresses or scripts exist but related transactions are still missing.\n",
@@ -1807,7 +1833,8 @@ UniValue importdescriptors(const JSONRPCRequest& main_request) {
                                           "{ \"desc\": \"<my desccriptor 2>\", \"label\": \"example 2\", \"timestamp\": 1455191480 }]'") +
                     HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"active\": true, \"range\": [0,100], \"label\": \"<my wallet>\" }]'")
                 },
-            }.Check(main_request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& main_request) -> UniValue
+{
 
     // Acquire the wallet
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(main_request);
@@ -1907,6 +1934,8 @@ UniValue importdescriptors(const JSONRPCRequest& main_request) {
     }
 
     return response;
+},
+    };
 }
 
 RPCHelpMan listdescriptors()

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4153,20 +4153,20 @@ static UniValue send(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue abortrescan(const JSONRPCRequest& request); // in rpcdump.cpp
-UniValue dumpprivkey(const JSONRPCRequest& request); // in rpcdump.cpp
-UniValue importprivkey(const JSONRPCRequest& request);
-UniValue importaddress(const JSONRPCRequest& request);
-UniValue importpubkey(const JSONRPCRequest& request);
-UniValue dumpwallet(const JSONRPCRequest& request);
-UniValue importwallet(const JSONRPCRequest& request);
-UniValue importprunedfunds(const JSONRPCRequest& request);
-UniValue removeprunedfunds(const JSONRPCRequest& request);
-UniValue importmulti(const JSONRPCRequest& request);
-UniValue importdescriptors(const JSONRPCRequest& request);
+RPCHelpMan abortrescan();
+RPCHelpMan dumpprivkey();
+RPCHelpMan importprivkey();
+RPCHelpMan importaddress();
+RPCHelpMan importpubkey();
+RPCHelpMan dumpwallet();
+RPCHelpMan importwallet();
+RPCHelpMan importprunedfunds();
+RPCHelpMan removeprunedfunds();
+RPCHelpMan importmulti();
+RPCHelpMan importdescriptors();
 RPCHelpMan listdescriptors();
-UniValue dumphdinfo(const JSONRPCRequest& request);
-UniValue importelectrumwallet(const JSONRPCRequest& request);
+RPCHelpMan dumphdinfo();
+RPCHelpMan importelectrumwallet();
 
 UniValue walletprocesspsbt(const JSONRPCRequest& request)
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -236,9 +236,9 @@ static void SetFeeEstimateMode(const CWallet* pwallet, CCoinControl& cc, const U
     }
 }
 
-UniValue getnewaddress(const JSONRPCRequest& request)
+RPCHelpMan getnewaddress()
 {
-    RPCHelpMan{"getnewaddress",
+    return RPCHelpMan{"getnewaddress",
         "\nReturns a new Dash address for receiving payments.\n"
         "If 'label' is specified, it is added to the address book \n"
         "so payments received with the address will be associated with 'label'.\n",
@@ -252,8 +252,8 @@ UniValue getnewaddress(const JSONRPCRequest& request)
             HelpExampleCli("getnewaddress", "")
     + HelpExampleRpc("getnewaddress", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -275,11 +275,13 @@ UniValue getnewaddress(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, error);
     }
     return EncodeDestination(dest);
+},
+    };
 }
 
-UniValue getrawchangeaddress(const JSONRPCRequest& request)
+RPCHelpMan getrawchangeaddress()
 {
-    RPCHelpMan{"getrawchangeaddress",
+    return RPCHelpMan{"getrawchangeaddress",
         "\nReturns a new Dash address, for receiving change.\n"
         "This is for use with raw transactions, NOT normal use.\n",
         {},
@@ -290,8 +292,8 @@ UniValue getrawchangeaddress(const JSONRPCRequest& request)
             HelpExampleCli("getrawchangeaddress", "")
     + HelpExampleRpc("getrawchangeaddress", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -308,12 +310,14 @@ UniValue getrawchangeaddress(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, error);
     }
     return EncodeDestination(dest);
+},
+    };
 }
 
 
-static UniValue setlabel(const JSONRPCRequest& request)
+static RPCHelpMan setlabel()
 {
-    RPCHelpMan{"setlabel",
+    return RPCHelpMan{"setlabel",
         "\nSets the label associated with the given address.\n",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The Dash address to be associated with a label."},
@@ -324,8 +328,8 @@ static UniValue setlabel(const JSONRPCRequest& request)
             HelpExampleCli("setlabel", "\"" + EXAMPLE_ADDRESS[0] + "\" \"tabby\"")
     + HelpExampleRpc("setlabel", "\"" + EXAMPLE_ADDRESS[0] + "\", \"tabby\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -346,6 +350,8 @@ static UniValue setlabel(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
 
@@ -384,13 +390,9 @@ static CTransactionRef SendMoney(CWallet* const pwallet, const CTxDestination& a
     return tx;
 }
 
-static UniValue sendtoaddress(const JSONRPCRequest& request)
+static RPCHelpMan sendtoaddress()
 {
-    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
-
-    RPCHelpMan{"sendtoaddress",
+    return RPCHelpMan{"sendtoaddress",
         "\nSend an amount to a given address." +
                 HELP_REQUIRING_PASSPHRASE,
         {
@@ -422,7 +424,11 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
     + HelpExampleCli("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\" 0.1 \"\" \"\" false true 2 " + (CURRENCY_ATOM + "/B"))
     + HelpExampleRpc("sendtoaddress", "\"" + EXAMPLE_ADDRESS[0] + "\", 0.1, \"donation\", \"seans outpost\"")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    if (!wallet) return NullUniValue;
+    CWallet* const pwallet = wallet.get();
 
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
@@ -469,21 +475,31 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
 
     CTransactionRef tx = SendMoney(pwallet, dest, nAmount, fSubtractFeeFromAmount, coin_control, std::move(mapValue));
     return tx->GetHash().GetHex();
+},
+    };
 }
 
 // DEPRECATED
-static UniValue instantsendtoaddress(const JSONRPCRequest& request)
+static RPCHelpMan instantsendtoaddress()
 {
-    if (request.fHelp) {
-        throw std::runtime_error("instantsendtoaddress is deprecated and sendtoaddress should be used instead");
-    }
+    return RPCHelpMan{"instantsendtoaddress",
+        "instantsendtoaddress is deprecated and sendtoaddress should be used instead",
+        {},
+        RPCResult{
+            RPCResult::Type::STR_HEX, "txid", "The transaction id."
+        },
+        RPCExamples{""},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     LogPrintf("WARNING: Used deprecated RPC method 'instantsendtoaddress'! Please use 'sendtoaddress' instead\n");
-    return sendtoaddress(request);
+    return sendtoaddress().HandleRequest(request);
+},
+    };
 }
 
-static UniValue listaddressgroupings(const JSONRPCRequest& request)
+static RPCHelpMan listaddressgroupings()
 {
-    RPCHelpMan{"listaddressgroupings",
+    return RPCHelpMan{"listaddressgroupings",
         "\nLists groups of addresses which have had their common ownership\n"
         "made public by common use as inputs or as the resulting change\n"
         "in past transactions\n",
@@ -505,8 +521,8 @@ static UniValue listaddressgroupings(const JSONRPCRequest& request)
             HelpExampleCli("listaddressgroupings", "")
     + HelpExampleRpc("listaddressgroupings", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -537,11 +553,13 @@ static UniValue listaddressgroupings(const JSONRPCRequest& request)
         jsonGroupings.push_back(jsonGrouping);
     }
     return jsonGroupings;
+},
+    };
 }
 
-static UniValue listaddressbalances(const JSONRPCRequest& request)
+static RPCHelpMan listaddressbalances()
 {
-    RPCHelpMan{"listaddressbalances",
+    return RPCHelpMan{"listaddressbalances",
         "\nLists addresses of this wallet and their balances\n",
         {
             {"minamount", RPCArg::Type::NUM, /* default */ "0", "Minimum balance in " + CURRENCY_UNIT + " an address should have to be shown in the list"},
@@ -557,9 +575,9 @@ static UniValue listaddressbalances(const JSONRPCRequest& request)
     + HelpExampleCli("listaddressbalances", "10")
     + HelpExampleRpc("listaddressbalances", "")
     + HelpExampleRpc("listaddressbalances", "10")
-        }
-    }.Check(request);
-
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -580,11 +598,13 @@ static UniValue listaddressbalances(const JSONRPCRequest& request)
             jsonBalances.pushKV(EncodeDestination(balance.first), ValueFromAmount(balance.second));
 
     return jsonBalances;
+},
+    };
 }
 
-static UniValue signmessage(const JSONRPCRequest& request)
+static RPCHelpMan signmessage()
 {
-    RPCHelpMan{"signmessage",
+    return RPCHelpMan{"signmessage",
         "\nSign a message with the private key of an address" +
                 HELP_REQUIRING_PASSPHRASE,
         {
@@ -604,8 +624,8 @@ static UniValue signmessage(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("signmessage", "\"" + EXAMPLE_ADDRESS[0] + "\", \"my message\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -636,6 +656,8 @@ static UniValue signmessage(const JSONRPCRequest& request)
     }
 
     return signature;
+},
+    };
 }
 
 static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool by_label) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
@@ -686,9 +708,9 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
 }
 
 
-static UniValue getreceivedbyaddress(const JSONRPCRequest& request)
+static RPCHelpMan getreceivedbyaddress()
 {
-    RPCHelpMan{"getreceivedbyaddress",
+    return RPCHelpMan{"getreceivedbyaddress",
         "\nReturns the total amount received by the given address in transactions with at least minconf confirmations.\n",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The Dash address for transactions."},
@@ -708,8 +730,8 @@ static UniValue getreceivedbyaddress(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("getreceivedbyaddress", "\"" + EXAMPLE_ADDRESS[0] + "\", 6")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -721,12 +743,14 @@ static UniValue getreceivedbyaddress(const JSONRPCRequest& request)
     LOCK(pwallet->cs_wallet);
 
     return ValueFromAmount(GetReceived(*pwallet, request.params, /* by_label */ false));
+},
+    };
 }
 
 
-static UniValue getreceivedbylabel(const JSONRPCRequest& request)
+static RPCHelpMan getreceivedbylabel()
 {
-    RPCHelpMan{"getreceivedbylabel",
+    return RPCHelpMan{"getreceivedbylabel",
         "\nReturns the total amount received by addresses with <label> in transactions with specified minimum number of confirmations.\n",
         {
             {"label", RPCArg::Type::STR, RPCArg::Optional::NO, "The selected label, may be the default label using \"\"."},
@@ -746,8 +770,8 @@ static UniValue getreceivedbylabel(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("getreceivedbylabel", "\"tabby\", 6")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -759,16 +783,14 @@ static UniValue getreceivedbylabel(const JSONRPCRequest& request)
     LOCK(pwallet->cs_wallet);
 
     return ValueFromAmount(GetReceived(*pwallet, request.params, /* by_label */ true));
+},
+    };
 }
 
 
-static UniValue getbalance(const JSONRPCRequest& request)
+static RPCHelpMan getbalance()
 {
-    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    RPCHelpMan{"getbalance",
+    return RPCHelpMan{"getbalance",
         "\nReturns the total available balance.\n"
         "The available balance is what the wallet considers currently spendable, and is\n"
         "thus affected by options which limit spendability such as -spendzeroconfchange.\n",
@@ -790,7 +812,11 @@ static UniValue getbalance(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("getbalance", "\"*\", 6")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    if (!wallet) return NullUniValue;
+    const CWallet* const pwallet = wallet.get();
 
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
@@ -820,16 +846,19 @@ static UniValue getbalance(const JSONRPCRequest& request)
     const auto bal = pwallet->GetBalance(min_depth, avoid_reuse, fAddLocked);
 
     return ValueFromAmount(bal.m_mine_trusted + (include_watchonly ? bal.m_watchonly_trusted : 0));
+},
+    };
 }
 
-static UniValue getunconfirmedbalance(const JSONRPCRequest &request)
+static RPCHelpMan getunconfirmedbalance()
 {
-    RPCHelpMan{"getunconfirmedbalance",
+    return RPCHelpMan{"getunconfirmedbalance",
         "DEPRECATED\nIdentical to getbalances().mine.untrusted_pending\n",
         {},
         RPCResult{RPCResult::Type::NUM, "", "The balance"},
         RPCExamples{""},
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
@@ -842,12 +871,14 @@ static UniValue getunconfirmedbalance(const JSONRPCRequest &request)
     LOCK(pwallet->cs_wallet);
 
     return ValueFromAmount(pwallet->GetBalance().m_mine_untrusted_pending);
+},
+    };
 }
 
 
-static UniValue sendmany(const JSONRPCRequest& request)
+static RPCHelpMan sendmany()
 {
-    RPCHelpMan{"sendmany",
+    return RPCHelpMan{"sendmany",
                 "\nSend multiple times. Amounts are double-precision floating point numbers." +
                         HELP_REQUIRING_PASSPHRASE,
                 {
@@ -886,8 +917,8 @@ static UniValue sendmany(const JSONRPCRequest& request)
             "\nAs a json rpc call\n"
             + HelpExampleRpc("sendmany", "\"\", \"{\\\"" + EXAMPLE_ADDRESS[0] + "\\\":0.01,\\\"" + EXAMPLE_ADDRESS[1] + "\\\":0.02}\", 6, false, \"testing\"")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -967,11 +998,13 @@ static UniValue sendmany(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, error.original);
     pwallet->CommitTransaction(tx, std::move(mapValue), {} /* orderForm */);
     return tx->GetHash().GetHex();
+},
+    };
 }
 
-UniValue addmultisigaddress(const JSONRPCRequest& request)
+RPCHelpMan addmultisigaddress()
 {
-    RPCHelpMan{"addmultisigaddress",
+    return RPCHelpMan{"addmultisigaddress",
         "\nAdd an nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup.\n"
         "Each key is a Dash address or hex-encoded public key.\n"
         "This functionality is only intended for use with non-watchonly addresses.\n"
@@ -1000,8 +1033,8 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("addmultisigaddress", "2, \"[\\\"" + EXAMPLE_ADDRESS[0] + "\\\",\\\"" + EXAMPLE_ADDRESS[1] + "\\\"]\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -1040,6 +1073,8 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
     result.pushKV("redeemScript", HexStr(inner));
     result.pushKV("descriptor", descriptor->ToString());
     return result;
+},
+    };
 }
 
 
@@ -1206,9 +1241,9 @@ static UniValue ListReceived(const CWallet * const pwallet, const UniValue& para
     return ret;
 }
 
-static UniValue listreceivedbyaddress(const JSONRPCRequest& request)
+static RPCHelpMan listreceivedbyaddress()
 {
-    RPCHelpMan{"listreceivedbyaddress",
+    return RPCHelpMan{"listreceivedbyaddress",
         "\nList balances by receiving address.\n",
         {
             {"minconf", RPCArg::Type::NUM, /* default */ "1", "The minimum number of confirmations before payments are included."},
@@ -1242,8 +1277,8 @@ static UniValue listreceivedbyaddress(const JSONRPCRequest& request)
     + HelpExampleRpc("listreceivedbyaddress", "6, false, true, true")
     + HelpExampleRpc("listreceivedbyaddress", "6, false, true, true, \"" + EXAMPLE_ADDRESS[0] + "\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -1255,11 +1290,13 @@ static UniValue listreceivedbyaddress(const JSONRPCRequest& request)
     LOCK(pwallet->cs_wallet);
 
     return ListReceived(pwallet, request.params, false);
+},
+    };
 }
 
-static UniValue listreceivedbylabel(const JSONRPCRequest& request)
+static RPCHelpMan listreceivedbylabel()
 {
-    RPCHelpMan{"listreceivedbylabel",
+    return RPCHelpMan{"listreceivedbylabel",
         "\nList received transactions by label.\n",
         {
             {"minconf", RPCArg::Type::NUM, /* default */ "1", "The minimum number of confirmations before payments are included."},
@@ -1284,8 +1321,8 @@ static UniValue listreceivedbylabel(const JSONRPCRequest& request)
     + HelpExampleCli("listreceivedbylabel", "6 true")
     + HelpExampleRpc("listreceivedbylabel", "6, true, true")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -1297,6 +1334,8 @@ static UniValue listreceivedbylabel(const JSONRPCRequest& request)
     LOCK(pwallet->cs_wallet);
 
     return ListReceived(pwallet, request.params, true);
+},
+    };
 }
 
 static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
@@ -1418,9 +1457,9 @@ static const std::vector<RPCResult> TransactionDescriptionString()
             {RPCResult::Type::STR, "comment", "If a comment is associated with the transaction."}};
 }
 
-static UniValue listtransactions(const JSONRPCRequest& request)
+static RPCHelpMan listtransactions()
 {
-    RPCHelpMan{"listtransactions",
+    return RPCHelpMan{"listtransactions",
         "\nIf a label name is provided, this will return only incoming transactions paying to addresses with the specified label.\n"
         "\nReturns up to 'count' most recent transactions skipping the first 'from' transactions.\n",
         {
@@ -1467,8 +1506,8 @@ static UniValue listtransactions(const JSONRPCRequest& request)
     "\nAs a json rpc call\n"
     + HelpExampleRpc("listtransactions", "\"\", 20, 100")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -1528,11 +1567,13 @@ static UniValue listtransactions(const JSONRPCRequest& request)
     UniValue result{UniValue::VARR};
     result.push_backV({ txs.rend() - nFrom - nCount, txs.rend() - nFrom }); // Return oldest to newest
     return result;
+},
+    };
 }
 
-static UniValue listsinceblock(const JSONRPCRequest& request)
+static RPCHelpMan listsinceblock()
 {
-    RPCHelpMan{"listsinceblock",
+    return RPCHelpMan{"listsinceblock",
         "\nGet all transactions in blocks since block [blockhash], or all transactions if omitted.\n"
         "If \"blockhash\" is no longer a part of the main chain, transactions from the fork point onward are included.\n"
         "Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the \"removed\" array.\n",
@@ -1582,8 +1623,8 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
     + HelpExampleCli("listsinceblock", "\"000000000000000bacf66f7497b7dc45ef753ee9a7d38571037cdb1a57f663ad\" 6")
     + HelpExampleRpc("listsinceblock", "\"000000000000000bacf66f7497b7dc45ef753ee9a7d38571037cdb1a57f663ad\", 6")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;
 
@@ -1665,11 +1706,13 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
     ret.pushKV("lastblock", lastblock.GetHex());
 
     return ret;
+},
+    };
 }
 
-static UniValue gettransaction(const JSONRPCRequest& request)
+static RPCHelpMan gettransaction()
 {
-    RPCHelpMan{"gettransaction",
+    return RPCHelpMan{"gettransaction",
         "\nGet detailed information about in-wallet transaction <txid>\n",
         {
             {"txid", RPCArg::Type::STR, RPCArg::Optional::NO, "The transaction id"},
@@ -1719,8 +1762,8 @@ static UniValue gettransaction(const JSONRPCRequest& request)
     + HelpExampleCli("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\" true")
     + HelpExampleRpc("gettransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -1773,11 +1816,13 @@ static UniValue gettransaction(const JSONRPCRequest& request)
     }
 
     return entry;
+},
+    };
 }
 
-static UniValue abandontransaction(const JSONRPCRequest& request)
+static RPCHelpMan abandontransaction()
 {
-    RPCHelpMan{"abandontransaction",
+    return RPCHelpMan{"abandontransaction",
         "\nMark in-wallet transaction <txid> as abandoned\n"
         "This will mark this transaction and all its in-wallet descendants as abandoned which will allow\n"
         "for their inputs to be respent.  It can be used to replace \"stuck\" or evicted transactions.\n"
@@ -1791,8 +1836,8 @@ static UniValue abandontransaction(const JSONRPCRequest& request)
             HelpExampleCli("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
     + HelpExampleRpc("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -1813,12 +1858,14 @@ static UniValue abandontransaction(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
 
-static UniValue backupwallet(const JSONRPCRequest& request)
+static RPCHelpMan backupwallet()
 {
-    RPCHelpMan{"backupwallet",
+    return RPCHelpMan{"backupwallet",
         "\nSafely copies current wallet file to destination, which can be a directory or a path with filename.\n",
         {
             {"destination", RPCArg::Type::STR, RPCArg::Optional::NO, "The destination directory or file"},
@@ -1828,8 +1875,8 @@ static UniValue backupwallet(const JSONRPCRequest& request)
             HelpExampleCli("backupwallet", "\"backup.dat\"")
     + HelpExampleRpc("backupwallet", "\"backup.dat\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -1846,12 +1893,14 @@ static UniValue backupwallet(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
 
-static UniValue keypoolrefill(const JSONRPCRequest& request)
+static RPCHelpMan keypoolrefill()
 {
-    RPCHelpMan{"keypoolrefill",
+    return RPCHelpMan{"keypoolrefill",
         "\nFills the keypool."+
                 HELP_REQUIRING_PASSPHRASE,
         {
@@ -1862,8 +1911,8 @@ static UniValue keypoolrefill(const JSONRPCRequest& request)
             HelpExampleCli("keypoolrefill", "")
     + HelpExampleRpc("keypoolrefill", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -1890,12 +1939,14 @@ static UniValue keypoolrefill(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
 
-static UniValue walletpassphrase(const JSONRPCRequest& request)
+static RPCHelpMan walletpassphrase()
 {
-    RPCHelpMan{"walletpassphrase",
+    return RPCHelpMan{"walletpassphrase",
         "\nStores the wallet decryption key in memory for 'timeout' seconds.\n"
         "This is needed prior to performing transactions related to private keys such as sending Dash\n"
         "\nNote:\n"
@@ -1917,8 +1968,8 @@ static UniValue walletpassphrase(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("walletpassphrase", "\"my pass phrase\", 60")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -1997,12 +2048,14 @@ static UniValue walletpassphrase(const JSONRPCRequest& request)
     }, nSleepTime);
 
     return NullUniValue;
+},
+    };
 }
 
 
-static UniValue walletpassphrasechange(const JSONRPCRequest& request)
+static RPCHelpMan walletpassphrasechange()
 {
-    RPCHelpMan{"walletpassphrasechange",
+    return RPCHelpMan{"walletpassphrasechange",
         "\nChanges the wallet passphrase from 'oldpassphrase' to 'newpassphrase'.\n",
         {
             {"oldpassphrase", RPCArg::Type::STR, RPCArg::Optional::NO, "The current passphrase"},
@@ -2013,8 +2066,8 @@ static UniValue walletpassphrasechange(const JSONRPCRequest& request)
             HelpExampleCli("walletpassphrasechange", "\"old one\" \"new one\"")
     + HelpExampleRpc("walletpassphrasechange", "\"old one\", \"new one\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -2044,12 +2097,14 @@ static UniValue walletpassphrasechange(const JSONRPCRequest& request)
     }
 
     return NullUniValue;
+},
+    };
 }
 
 
-static UniValue walletlock(const JSONRPCRequest& request)
+static RPCHelpMan walletlock()
 {
-    RPCHelpMan{"walletlock",
+    return RPCHelpMan{"walletlock",
         "\nRemoves the wallet encryption key from memory, locking the wallet.\n"
         "After calling this method, you will need to call walletpassphrase again\n"
         "before being able to call any methods which require the wallet to be unlocked.\n",
@@ -2065,8 +2120,8 @@ static UniValue walletlock(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("walletlock", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -2081,12 +2136,14 @@ static UniValue walletlock(const JSONRPCRequest& request)
     pwallet->nRelockTime = 0;
 
     return NullUniValue;
+},
+    };
 }
 
 
-static UniValue encryptwallet(const JSONRPCRequest& request)
+static RPCHelpMan encryptwallet()
 {
-    RPCHelpMan{"encryptwallet",
+    return RPCHelpMan{"encryptwallet",
         "\nEncrypts the wallet with 'passphrase'. This is for first time encryption.\n"
         "After this, any calls that interact with private keys such as sending or signing \n"
         "will require the passphrase to be set prior the making these calls.\n"
@@ -2108,8 +2165,8 @@ static UniValue encryptwallet(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("encryptwallet", "\"my pass phrase\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -2139,11 +2196,13 @@ static UniValue encryptwallet(const JSONRPCRequest& request)
     }
 
     return "wallet encrypted; The keypool has been flushed and a new HD seed was generated (if you are using HD). You need to make a new backup.";
+},
+    };
 }
 
-static UniValue lockunspent(const JSONRPCRequest& request)
+static RPCHelpMan lockunspent()
 {
-    RPCHelpMan{"lockunspent",
+    return RPCHelpMan{"lockunspent",
         "\nUpdates list of temporarily unspendable outputs.\n"
         "Temporarily lock (unlock=false) or unlock (unlock=true) specified transaction outputs.\n"
         "If no transaction outputs are specified when unlocking then all current locked transaction outputs are unlocked.\n"
@@ -2180,8 +2239,8 @@ static UniValue lockunspent(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("lockunspent", "false, \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -2263,11 +2322,13 @@ static UniValue lockunspent(const JSONRPCRequest& request)
     }
 
     return true;
+},
+    };
 }
 
-static UniValue listlockunspent(const JSONRPCRequest& request)
+static RPCHelpMan listlockunspent()
 {
-    RPCHelpMan{"listlockunspent",
+    return RPCHelpMan{"listlockunspent",
         "\nReturns list of temporarily unspendable outputs.\n"
         "See the lockunspent call to lock and unlock transactions for spending.\n",
         {},
@@ -2293,8 +2354,8 @@ static UniValue listlockunspent(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("listlockunspent", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -2315,11 +2376,13 @@ static UniValue listlockunspent(const JSONRPCRequest& request)
     }
 
     return ret;
+},
+    };
 }
 
-static UniValue settxfee(const JSONRPCRequest& request)
+static RPCHelpMan settxfee()
 {
-    RPCHelpMan{"settxfee",
+    return RPCHelpMan{"settxfee",
         "\nSet the transaction fee rate in " + CURRENCY_UNIT + "/kB for this wallet. Overrides the global -paytxfee command line parameter.\n"
         "Can be deactivated by passing 0 as the fee. In that case automatic fee selection will be used by default.\n",
         {
@@ -2332,8 +2395,8 @@ static UniValue settxfee(const JSONRPCRequest& request)
             HelpExampleCli("settxfee", "0.00001")
     + HelpExampleRpc("settxfee", "0.00001")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -2355,11 +2418,13 @@ static UniValue settxfee(const JSONRPCRequest& request)
 
     pwallet->m_pay_tx_fee = tx_fee_rate;
     return true;
+},
+    };
 }
 
-static UniValue setcoinjoinrounds(const JSONRPCRequest& request)
+static RPCHelpMan setcoinjoinrounds()
 {
-    RPCHelpMan{"setcoinjoinrounds",
+    return RPCHelpMan{"setcoinjoinrounds",
         "\nSet the number of rounds for CoinJoin.\n",
         {
             {"rounds", RPCArg::Type::NUM, RPCArg::Optional::NO,
@@ -2371,8 +2436,8 @@ static UniValue setcoinjoinrounds(const JSONRPCRequest& request)
             HelpExampleCli("setcoinjoinrounds", "4")
     + HelpExampleRpc("setcoinjoinrounds", "16")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
 
@@ -2384,11 +2449,13 @@ static UniValue setcoinjoinrounds(const JSONRPCRequest& request)
     CCoinJoinClientOptions::SetRounds(nRounds);
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue setcoinjoinamount(const JSONRPCRequest& request)
+static RPCHelpMan setcoinjoinamount()
 {
-    RPCHelpMan{"setcoinjoinamount",
+    return RPCHelpMan{"setcoinjoinamount",
         "\nSet the goal amount in " + CURRENCY_UNIT + " for CoinJoin.\n",
         {
             {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO,
@@ -2400,8 +2467,8 @@ static UniValue setcoinjoinamount(const JSONRPCRequest& request)
             HelpExampleCli("setcoinjoinamount", "500")
     + HelpExampleRpc("setcoinjoinamount", "208")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
 
@@ -2413,11 +2480,13 @@ static UniValue setcoinjoinamount(const JSONRPCRequest& request)
     CCoinJoinClientOptions::SetAmount(nAmount);
 
     return NullUniValue;
+},
+    };
 }
 
-static UniValue getbalances(const JSONRPCRequest& request)
+static RPCHelpMan getbalances()
 {
-    RPCHelpMan{"getbalances",
+    return RPCHelpMan{"getbalances",
                 "Returns an object with all balances in " + CURRENCY_UNIT + ".\n",
                 {},
                 RPCResult{
@@ -2443,8 +2512,8 @@ static UniValue getbalances(const JSONRPCRequest& request)
                     HelpExampleCli("getbalances", "") +
                     HelpExampleRpc("getbalances", "")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const rpc_wallet = GetWalletForJSONRPCRequest(request);
     if (!rpc_wallet) return NullUniValue;
     CWallet& wallet = *rpc_wallet;
@@ -2480,11 +2549,13 @@ static UniValue getbalances(const JSONRPCRequest& request)
         balances.pushKV("watchonly", balances_watchonly);
     }
     return balances;
+},
+    };
 }
 
-static UniValue getwalletinfo(const JSONRPCRequest& request)
+static RPCHelpMan getwalletinfo()
 {
-    RPCHelpMan{"getwalletinfo",
+    return RPCHelpMan{"getwalletinfo",
                 "Returns an object containing various wallet state info.\n",
                 {},
                 RPCResult{
@@ -2530,8 +2601,8 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
                     HelpExampleCli("getwalletinfo", "")
             + HelpExampleRpc("getwalletinfo", "")
                 },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -2602,11 +2673,13 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
     }
     obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     return obj;
+},
+    };
 }
 
-static UniValue listwalletdir(const JSONRPCRequest& request)
+static RPCHelpMan listwalletdir()
 {
-    RPCHelpMan{"listwalletdir",
+    return RPCHelpMan{"listwalletdir",
         "Returns a list of wallets in the wallet directory.\n",
         {},
         RPCResult{
@@ -2625,8 +2698,8 @@ static UniValue listwalletdir(const JSONRPCRequest& request)
             HelpExampleCli("listwalletdir", "")
     + HelpExampleRpc("listwalletdir", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     UniValue wallets(UniValue::VARR);
     for (const auto& path : ListDatabases(GetWalletDir())) {
         UniValue wallet(UniValue::VOBJ);
@@ -2637,11 +2710,13 @@ static UniValue listwalletdir(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
     result.pushKV("wallets", wallets);
     return result;
+},
+    };
 }
 
-static UniValue listwallets(const JSONRPCRequest& request)
+static RPCHelpMan listwallets()
 {
-    RPCHelpMan{"listwallets",
+    return RPCHelpMan{"listwallets",
         "Returns a list of currently loaded wallets.\n"
         "For full information on the wallet, use \"getwalletinfo\"\n",
         {},
@@ -2655,8 +2730,8 @@ static UniValue listwallets(const JSONRPCRequest& request)
             HelpExampleCli("listwallets", "")
     + HelpExampleRpc("listwallets", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     UniValue obj(UniValue::VARR);
 
     for (const std::shared_ptr<CWallet>& wallet : GetWallets()) {
@@ -2665,11 +2740,13 @@ static UniValue listwallets(const JSONRPCRequest& request)
     }
 
     return obj;
+},
+    };
 }
 
-static UniValue upgradetohd(const JSONRPCRequest& request)
+static RPCHelpMan upgradetohd()
 {
-    RPCHelpMan{"upgradetohd",
+    return RPCHelpMan{"upgradetohd",
         "\nUpgrades non-HD wallets to HD.\n"
         "\nWarning: You will need to make a new backup of your wallet after setting the HD wallet mnemonic.\n",
         {
@@ -2687,8 +2764,8 @@ static UniValue upgradetohd(const JSONRPCRequest& request)
     + HelpExampleCli("upgradetohd", "\"mnemonicword1 ... mnemonicwordN\" \"mnemonicpassphrase\"")
     + HelpExampleCli("upgradetohd", "\"mnemonicword1 ... mnemonicwordN\" \"mnemonicpassphrase\" \"walletpassphrase\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return NullUniValue;
 
@@ -2758,11 +2835,13 @@ static UniValue upgradetohd(const JSONRPCRequest& request)
     }
 
     return true;
+},
+    };
 }
 
-static UniValue loadwallet(const JSONRPCRequest& request)
+static RPCHelpMan loadwallet()
 {
-    RPCHelpMan{"loadwallet",
+    return RPCHelpMan{"loadwallet",
         "\nLoads a wallet from a wallet file or directory."
         "\nNote that all wallet command-line options used when starting dashd will be"
         "\napplied to the new wallet (eg, rescan, etc).\n",
@@ -2781,8 +2860,8 @@ static UniValue loadwallet(const JSONRPCRequest& request)
             HelpExampleCli("loadwallet", "\"test.dat\"")
     + HelpExampleRpc("loadwallet", "\"test.dat\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     WalletContext& context = EnsureWalletContext(request.context);
     const std::string name(request.params[0].get_str());
 
@@ -2816,20 +2895,18 @@ static UniValue loadwallet(const JSONRPCRequest& request)
     obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
 
     return obj;
+},
+    };
 }
 
-static UniValue setwalletflag(const JSONRPCRequest& request)
+static RPCHelpMan setwalletflag()
 {
-    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
-
     std::string flags = "";
     for (auto& it : WALLET_FLAG_MAP)
         if (it.second & MUTABLE_WALLET_FLAGS)
             flags += (flags == "" ? "" : ", ") + it.first;
 
-    RPCHelpMan{"setwalletflag",
+    return RPCHelpMan{"setwalletflag",
         "\nChange the state of the given wallet flag for a wallet.\n",
         {
             {"flag", RPCArg::Type::STR, RPCArg::Optional::NO, "The name of the flag to change. Current available flags: " + flags},
@@ -2847,7 +2924,12 @@ static UniValue setwalletflag(const JSONRPCRequest& request)
             HelpExampleCli("setwalletflag", "avoid_reuse")
       + HelpExampleRpc("setwalletflag", "\"avoid_reuse\"")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    if (!wallet) return NullUniValue;
+    CWallet* const pwallet = wallet.get();
+
 
     std::string flag_str = request.params[0].get_str();
     bool value = request.params[1].isNull() || request.params[1].get_bool();
@@ -2882,11 +2964,13 @@ static UniValue setwalletflag(const JSONRPCRequest& request)
     }
 
     return res;
+},
+    };
 }
 
-static UniValue createwallet(const JSONRPCRequest& request)
+static RPCHelpMan createwallet()
 {
-    RPCHelpMan{
+    return RPCHelpMan{
         "createwallet",
         "\nCreates and loads a new wallet.\n",
         {
@@ -2909,8 +2993,8 @@ static UniValue createwallet(const JSONRPCRequest& request)
             HelpExampleCli("createwallet", "\"testwallet\"")
             + HelpExampleRpc("createwallet", "\"testwallet\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     WalletContext& context = EnsureWalletContext(request.context);
     uint64_t flags = 0;
     if (!request.params[1].isNull() && request.params[1].get_bool()) {
@@ -2966,11 +3050,13 @@ static UniValue createwallet(const JSONRPCRequest& request)
     obj.pushKV("warning", Join(warnings, Untranslated("\n")).original);
 
     return obj;
+},
+    };
 }
 
-static UniValue unloadwallet(const JSONRPCRequest& request)
+static RPCHelpMan unloadwallet()
 {
-    RPCHelpMan{"unloadwallet",
+    return RPCHelpMan{"unloadwallet",
         "Unloads the wallet referenced by the request endpoint otherwise unloads the wallet specified in the argument.\n"
         "Specifying the wallet name on a wallet endpoint is invalid.",
         {
@@ -2984,8 +3070,8 @@ static UniValue unloadwallet(const JSONRPCRequest& request)
             HelpExampleCli("unloadwallet", "wallet_name")
     + HelpExampleRpc("unloadwallet", "wallet_name")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::string wallet_name;
     if (GetWalletNameFromJSONRPCRequest(request, wallet_name)) {
         if (!(request.params[0].isNull() || request.params[0].get_str() == wallet_name)) {
@@ -3014,15 +3100,13 @@ static UniValue unloadwallet(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
     result.pushKV("warning", Join(warnings, Untranslated("\n")).original);
     return result;
+},
+    };
 }
 
-static UniValue listunspent(const JSONRPCRequest& request)
+static RPCHelpMan listunspent()
 {
-    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    if (!wallet) return NullUniValue;
-    const CWallet* const pwallet = wallet.get();
-
-    RPCHelpMan{"listunspent",
+    return RPCHelpMan{"listunspent",
         "\nReturns array of unspent transaction outputs\n"
         "with between minconf and maxconf (inclusive) confirmations.\n"
         "Optionally filter to only include txouts paid to specified addresses.\n",
@@ -3078,7 +3162,11 @@ static UniValue listunspent(const JSONRPCRequest& request)
     + HelpExampleCli("listunspent", "6 9999999 '[]' true '{ \"minimumAmount\": 0.005 }'")
     + HelpExampleRpc("listunspent", "6, 9999999, [] , true, { \"minimumAmount\": 0.005 } ")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    if (!wallet) return NullUniValue;
+    const CWallet* const pwallet = wallet.get();
 
     int nMinDepth = 1;
     if (!request.params[0].isNull()) {
@@ -3233,6 +3321,8 @@ static UniValue listunspent(const JSONRPCRequest& request)
     }
 
     return results;
+},
+    };
 }
 
 void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& fee_out, int& change_position, UniValue options, CCoinControl& coinControl)
@@ -3349,9 +3439,9 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
     }
 }
 
-static UniValue fundrawtransaction(const JSONRPCRequest& request)
+static RPCHelpMan fundrawtransaction()
 {
-    RPCHelpMan{"fundrawtransaction",
+    return RPCHelpMan{"fundrawtransaction",
                 "\nIf the transaction has no inputs, they will be automatically selected to meet its out value.\n"
                 "It will add at most one change output to the outputs.\n"
                 "No existing outputs will be modified unless \"subtractFeeFromOutputs\" is specified.\n"
@@ -3407,7 +3497,8 @@ static UniValue fundrawtransaction(const JSONRPCRequest& request)
                             "\nSend the transaction\n"
                             + HelpExampleCli("sendrawtransaction", "\"signedtransactionhex\"")
                                 },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValueType(), UniValue::VBOOL});
 
@@ -3434,11 +3525,13 @@ static UniValue fundrawtransaction(const JSONRPCRequest& request)
     result.pushKV("changepos", change_position);
 
     return result;
+},
+    };
 }
 
-UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
+RPCHelpMan signrawtransactionwithwallet()
 {
-    RPCHelpMan{"signrawtransactionwithwallet",
+    return RPCHelpMan{"signrawtransactionwithwallet",
         "\nSign inputs for raw transaction (serialized, hex-encoded).\n"
         "The second optional argument (may be null) is an array of previous transaction outputs that\n"
         "this transaction depends on but may not yet be in the block chain." +
@@ -3488,7 +3581,8 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
             HelpExampleCli("signrawtransactionwithwallet", "\"myhex\"")
     + HelpExampleRpc("signrawtransactionwithwallet", "\"myhex\"")
         },
-    }.Check(request);
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
 
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR, UniValue::VSTR}, true);
 
@@ -3524,11 +3618,13 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
     SignTransactionResultToJSON(mtx, complete, coins, input_errors, result);
     return result;
+},
+    };
 }
 
-static UniValue rescanblockchain(const JSONRPCRequest& request)
+static RPCHelpMan rescanblockchain()
 {
-    RPCHelpMan{"rescanblockchain",
+    return RPCHelpMan{"rescanblockchain",
         "\nRescan the local blockchain for wallet related transactions.\n"
         "Note: Use \"getwalletinfo\" to query the scanning progress.\n",
         {
@@ -3546,8 +3642,8 @@ static UniValue rescanblockchain(const JSONRPCRequest& request)
             HelpExampleCli("rescanblockchain", "100000 120000")
     + HelpExampleRpc("rescanblockchain", "100000, 120000")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -3603,11 +3699,13 @@ static UniValue rescanblockchain(const JSONRPCRequest& request)
     response.pushKV("start_height", start_height);
     response.pushKV("stop_height", result.last_scanned_height ? *result.last_scanned_height : UniValue());
     return response;
+},
+    };
 }
 
-static UniValue wipewallettxes(const JSONRPCRequest& request)
+static RPCHelpMan wipewallettxes()
 {
-    RPCHelpMan{"wipewallettxes",
+    return RPCHelpMan{"wipewallettxes",
         "\nWipe wallet transactions.\n"
         "Note: Use \"rescanblockchain\" to initiate the scanning progress and recover wallet transactions.\n",
         {
@@ -3618,8 +3716,8 @@ static UniValue wipewallettxes(const JSONRPCRequest& request)
             HelpExampleCli("wipewallettxes", "")
     + HelpExampleRpc("wipewallettxes", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -3671,6 +3769,8 @@ static UniValue wipewallettxes(const JSONRPCRequest& request)
     pwallet->ShowProgress(strprintf("%s " + _("Wiping wallet transactions...").translated, pwallet->GetDisplayName()), 100);
 
     return NullUniValue;
+},
+    };
 }
 
 class DescribeWalletAddressVisitor
@@ -3746,9 +3846,9 @@ static UniValue AddressBookDataToJSON(const CAddressBookData& data, const bool v
     return ret;
 }
 
-UniValue getaddressinfo(const JSONRPCRequest& request)
+RPCHelpMan getaddressinfo()
 {
-    RPCHelpMan{"getaddressinfo",
+    return RPCHelpMan{"getaddressinfo",
         "\nReturn information about the given Dash address.\n"
         "Some of the information will only be present if the address is in the active wallet.\n",
         {
@@ -3793,8 +3893,8 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
             HelpExampleCli("getaddressinfo", EXAMPLE_ADDRESS[0])
     + HelpExampleRpc("getaddressinfo", EXAMPLE_ADDRESS[0])
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -3872,11 +3972,13 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
     ret.pushKV("labels", std::move(labels));
 
     return ret;
+},
+    };
 }
 
-static UniValue getaddressesbylabel(const JSONRPCRequest& request)
+static RPCHelpMan getaddressesbylabel()
 {
-    RPCHelpMan{"getaddressesbylabel",
+    return RPCHelpMan{"getaddressesbylabel",
         "\nReturns the list of addresses assigned the specified label.\n",
         {
             {"label", RPCArg::Type::STR, RPCArg::Optional::NO, "The label."},
@@ -3894,8 +3996,8 @@ static UniValue getaddressesbylabel(const JSONRPCRequest& request)
             HelpExampleCli("getaddressesbylabel", "\"tabby\"")
     + HelpExampleRpc("getaddressesbylabel", "\"tabby\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -3929,11 +4031,13 @@ static UniValue getaddressesbylabel(const JSONRPCRequest& request)
     }
 
     return ret;
+},
+    };
 }
 
-static UniValue listlabels(const JSONRPCRequest& request)
+static RPCHelpMan listlabels()
 {
-    RPCHelpMan{"listlabels",
+    return RPCHelpMan{"listlabels",
         "\nReturns the list of all labels, or labels that are assigned to addresses with a specific purpose.\n",
         {
             {"purpose", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "Address purpose to list labels for ('send','receive'). An empty string is the same as not providing this argument."},
@@ -3954,8 +4058,8 @@ static UniValue listlabels(const JSONRPCRequest& request)
     "\nAs a JSON-RPC call\n"
     + HelpExampleRpc("listlabels", "receive")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     const CWallet* const pwallet = wallet.get();
@@ -3982,11 +4086,13 @@ static UniValue listlabels(const JSONRPCRequest& request)
     }
 
     return ret;
+},
+    };
 }
 
-static UniValue send(const JSONRPCRequest& request)
+static RPCHelpMan send()
 {
-    RPCHelpMan{"send",
+    return RPCHelpMan{"send",
         "\nEXPERIMENTAL warning: this call may be changed in future releases.\n"
         "\nSend a transaction.\n",
         {
@@ -4056,9 +4162,9 @@ static UniValue send(const JSONRPCRequest& request)
         + HelpExampleCli("send", "'{\"" + EXAMPLE_ADDRESS[0] + "\": 0.1}' 1 " + CURRENCY_ATOM + "/B\n") +
             "\nCreate a transaction that should confirm the next block, with a specific input, and return result without adding to wallet or broadcasting to the network\n"
         + HelpExampleCli("send", "'{\"" + EXAMPLE_ADDRESS[0] + "\": 0.1}' 1 economical '{\"add_to_wallet\": false, \"inputs\": [{\"txid\":\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\", \"vout\":1}]}'")
-        }
-    }.Check(request);
-
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {
         UniValueType(), // ARR or OBJ, checked later
         UniValue::VNUM,
@@ -4151,6 +4257,8 @@ static UniValue send(const JSONRPCRequest& request)
     result.pushKV("complete", complete);
 
     return result;
+},
+    };
 }
 
 RPCHelpMan abortrescan();
@@ -4168,9 +4276,9 @@ RPCHelpMan listdescriptors();
 RPCHelpMan dumphdinfo();
 RPCHelpMan importelectrumwallet();
 
-UniValue walletprocesspsbt(const JSONRPCRequest& request)
+RPCHelpMan walletprocesspsbt()
 {
-    RPCHelpMan{"walletprocesspsbt",
+    return RPCHelpMan{"walletprocesspsbt",
         "\nUpdate a PSBT with input information from our wallet and then sign inputs\n"
         "that we can sign for." +
                 HELP_REQUIRING_PASSPHRASE,
@@ -4196,8 +4304,8 @@ UniValue walletprocesspsbt(const JSONRPCRequest& request)
         RPCExamples{
             HelpExampleCli("walletprocesspsbt", "\"psbt\"")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL, UniValue::VSTR});
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -4234,11 +4342,13 @@ UniValue walletprocesspsbt(const JSONRPCRequest& request)
     result.pushKV("complete", complete);
 
     return result;
+},
+    };
 }
 
-UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
+static RPCHelpMan walletcreatefundedpsbt()
 {
-    RPCHelpMan{"walletcreatefundedpsbt",
+    return RPCHelpMan{"walletcreatefundedpsbt",
         "\nCreates and funds a transaction in the Partially Signed Transaction format.\n"
         "Implements the Creator and Updater roles.\n",
         {
@@ -4306,8 +4416,8 @@ UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
                     "\nCreate a transaction with no inputs\n"
                     + HelpExampleCli("walletcreatefundedpsbt", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"[{\\\"data\\\":\\\"00010203\\\"}]\"")
                         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     RPCTypeCheck(request.params, {
         UniValue::VARR,
         UniValueType(), // ARR or OBJ, checked later
@@ -4350,11 +4460,13 @@ UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
     result.pushKV("fee", ValueFromAmount(fee));
     result.pushKV("changepos", change_position);
     return result;
+},
+    };
 }
 
-static UniValue upgradewallet(const JSONRPCRequest& request)
+static RPCHelpMan upgradewallet()
 {
-    RPCHelpMan{"upgradewallet",
+    return RPCHelpMan{"upgradewallet",
         "\nUpgrade the wallet. Upgrades to the latest version if no version number is specified\n"
         "New keys may be generated and a new wallet backup will need to be made.",
         {
@@ -4369,9 +4481,9 @@ static UniValue upgradewallet(const JSONRPCRequest& request)
         RPCExamples{
             HelpExampleCli("upgradewallet", "120200")
             + HelpExampleRpc("upgradewallet", "120200")
-        }
-    }.Check(request);
-
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
     CWallet* const pwallet = wallet.get();
@@ -4393,6 +4505,8 @@ static UniValue upgradewallet(const JSONRPCRequest& request)
         obj.pushKV("error", error.original);
     }
     return obj;
+},
+    };
 }
 
 Span<const CRPCCommand> GetWalletRPCCommands()

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -37,8 +37,8 @@ void EnsureWalletIsUnlocked(const CWallet *);
 WalletContext& EnsureWalletContext(const CoreContext& context);
 LegacyScriptPubKeyMan& EnsureLegacyScriptPubKeyMan(CWallet& wallet, bool also_create = false);
 
-UniValue getaddressinfo(const JSONRPCRequest& request);
-UniValue getrawchangeaddress(const JSONRPCRequest& request);
-UniValue addmultisigaddress(const JSONRPCRequest& request);
-UniValue signrawtransactionwithwallet(const JSONRPCRequest& request);
+RPCHelpMan getaddressinfo();
+RPCHelpMan getrawchangeaddress();
+RPCHelpMan addmultisigaddress();
+RPCHelpMan signrawtransactionwithwallet();
 #endif //BITCOIN_WALLET_RPCWALLET_H

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -29,9 +29,9 @@
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
 
-extern UniValue importmulti(const JSONRPCRequest& request);
-extern UniValue dumpwallet(const JSONRPCRequest& request);
-extern UniValue importwallet(const JSONRPCRequest& request);
+RPCHelpMan importmulti();
+RPCHelpMan dumpwallet();
+RPCHelpMan importwallet();
 extern UniValue getnewaddress(const JSONRPCRequest& request);
 extern UniValue getrawchangeaddress(const JSONRPCRequest& request);
 extern UniValue getaddressinfo(const JSONRPCRequest& request);
@@ -234,7 +234,7 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
         request.params.setArray();
         request.params.push_back(keys);
 
-        UniValue response = importmulti(request);
+        UniValue response = importmulti().HandleRequest(request);
         BOOST_CHECK_EQUAL(response.write(),
             strprintf("[{\"success\":false,\"error\":{\"code\":-1,\"message\":\"Rescan failed for key with creation "
                       "timestamp %d. There was an error reading a block from time %d, which is after or within %d "
@@ -287,7 +287,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.setArray();
         request.params.push_back(backup_file);
 
-        ::dumpwallet(request);
+        ::dumpwallet().HandleRequest(request);
         RemoveWallet(wallet, std::nullopt);
     }
 
@@ -304,7 +304,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.push_back(backup_file);
         AddWallet(wallet);
         wallet->SetLastBlockProcessed(::ChainActive().Height(), ::ChainActive().Tip()->GetBlockHash());
-        ::importwallet(request);
+        ::importwallet().HandleRequest(request);
         RemoveWallet(wallet, std::nullopt);
 
         BOOST_CHECK_EQUAL(wallet->mapWallet.size(), 3U);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -32,10 +32,10 @@
 RPCHelpMan importmulti();
 RPCHelpMan dumpwallet();
 RPCHelpMan importwallet();
-extern UniValue getnewaddress(const JSONRPCRequest& request);
-extern UniValue getrawchangeaddress(const JSONRPCRequest& request);
-extern UniValue getaddressinfo(const JSONRPCRequest& request);
-extern UniValue addmultisigaddress(const JSONRPCRequest& request);
+extern RPCHelpMan getnewaddress();
+extern RPCHelpMan getrawchangeaddress();
+extern RPCHelpMan getaddressinfo();
+extern RPCHelpMan addmultisigaddress();
 
 extern RecursiveMutex cs_wallets;
 
@@ -331,12 +331,12 @@ BOOST_FIXTURE_TEST_CASE(rpc_getaddressinfo, TestChain100Setup)
 
     // test p2pkh
     std::string addr;
-    BOOST_CHECK_NO_THROW(addr = ::getrawchangeaddress(request).get_str());
+    BOOST_CHECK_NO_THROW(addr = ::getrawchangeaddress().HandleRequest(request).get_str());
 
     request.params.clear();
     request.params.setArray();
     request.params.push_back(addr);
-    BOOST_CHECK_NO_THROW(response = ::getaddressinfo(request).get_obj());
+    BOOST_CHECK_NO_THROW(response = ::getaddressinfo().HandleRequest(request).get_obj());
 
     BOOST_CHECK_EQUAL(find_value(response, "ismine").get_bool(), true);
     BOOST_CHECK_EQUAL(find_value(response, "solvable").get_bool(), true);
@@ -351,8 +351,8 @@ BOOST_FIXTURE_TEST_CASE(rpc_getaddressinfo, TestChain100Setup)
     // test p2sh/multisig
     std::string addr1;
     std::string addr2;
-    BOOST_CHECK_NO_THROW(addr1 = ::getnewaddress(request).get_str());
-    BOOST_CHECK_NO_THROW(addr2 = ::getnewaddress(request).get_str());
+    BOOST_CHECK_NO_THROW(addr1 = ::getnewaddress().HandleRequest(request).get_str());
+    BOOST_CHECK_NO_THROW(addr2 = ::getnewaddress().HandleRequest(request).get_str());
 
     UniValue keys;
     keys.setArray();
@@ -364,14 +364,14 @@ BOOST_FIXTURE_TEST_CASE(rpc_getaddressinfo, TestChain100Setup)
     request.params.push_back(2);
     request.params.push_back(keys);
 
-    BOOST_CHECK_NO_THROW(response = ::addmultisigaddress(request));
+    BOOST_CHECK_NO_THROW(response = ::addmultisigaddress().HandleRequest(request));
 
     std::string multisig = find_value(response.get_obj(), "address").get_str();
 
     request.params.clear();
     request.params.setArray();
     request.params.push_back(multisig);
-    BOOST_CHECK_NO_THROW(response = ::getaddressinfo(request).get_obj());
+    BOOST_CHECK_NO_THROW(response = ::getaddressinfo().HandleRequest(request).get_obj());
 
     BOOST_CHECK_EQUAL(find_value(response, "ismine").get_bool(), true);
     BOOST_CHECK_EQUAL(find_value(response, "solvable").get_bool(), true);
@@ -801,7 +801,7 @@ public:
         CoreContext context{m_node};
         std::vector<CRecipient> vecRecipients;
         for (auto entry : vecEntries) {
-            vecRecipients.push_back({GetScriptForDestination(DecodeDestination(getnewaddress(JSONRPCRequest(context)).get_str())), entry.first, entry.second});
+            vecRecipients.push_back({GetScriptForDestination(DecodeDestination(getnewaddress().HandleRequest(JSONRPCRequest(context)).get_str())), entry.first, entry.second});
         }
         return vecRecipients;
     }

--- a/src/zmq/zmqrpc.cpp
+++ b/src/zmq/zmqrpc.cpp
@@ -13,9 +13,9 @@
 
 namespace {
 
-UniValue getzmqnotifications(const JSONRPCRequest& request)
+static RPCHelpMan getzmqnotifications()
 {
-    RPCHelpMan{"getzmqnotifications",
+    return RPCHelpMan{"getzmqnotifications",
         "\nReturns information about the active ZeroMQ notifications.\n",
         {},
         RPCResult{
@@ -33,8 +33,8 @@ UniValue getzmqnotifications(const JSONRPCRequest& request)
             HelpExampleCli("getzmqnotifications", "")
     + HelpExampleRpc("getzmqnotifications", "")
         },
-    }.Check(request);
-
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
     UniValue result(UniValue::VARR);
     if (g_zmq_notification_interface != nullptr) {
         for (const auto* n : g_zmq_notification_interface->GetActiveNotifiers()) {
@@ -47,6 +47,8 @@ UniValue getzmqnotifications(const JSONRPCRequest& request)
     }
 
     return result;
+},
+    };
 }
 
 const CRPCCommand commands[] =

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -17,7 +17,8 @@ class RPCGenerateTest(BitcoinTestFramework):
 
     def run_test(self):
         message = (
-            "generate ( nblocks maxtries ) has been replaced by the -generate "
+            "generate\n"
+            "has been replaced by the -generate "
             "cli option. Refer to -help for more information."
         )
 

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test generate RPC."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class RPCGenerateTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        message = (
+            "generate ( nblocks maxtries ) has been replaced by the -generate "
+            "cli option. Refer to -help for more information."
+        )
+
+        self.log.info("Test rpc generate raises with message to use cli option")
+        assert_raises_rpc_error(-32601, message, self.nodes[0].rpc.generate)
+
+        self.log.info("Test rpc generate help prints message to use cli option")
+        assert_equal(message, self.nodes[0].help("generate"))
+
+        self.log.info("Test rpc generate is a hidden command not discoverable in general help")
+        assert message not in self.nodes[0].help()
+
+
+if __name__ == "__main__":
+    RPCGenerateTest().main()

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -27,8 +27,8 @@ class RpcMiscTest(BitcoinTestFramework):
         self.log.info("test CHECK_NONFATAL")
         assert_raises_rpc_error(
             -1,
-            "Internal bug detected: 'request.params.size() != 100'",
-            lambda: node.echo(*[0] * 100),
+            'Internal bug detected: \'request.params[9].get_str() != "trigger_internal_bug"\'',
+            lambda: node.echo(arg9='trigger_internal_bug'),
         )
 
         self.log.info("test getmemoryinfo")

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -339,7 +339,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # 5. valid parameters - supply txid and True for non-verbose
         assert_equal(self.nodes[0].getrawtransaction(txId, True)["hex"], rawTxSigned['hex'])
-        assert_equal(self.nodes[0].getrawtransactionmulti({"0":[txId]}, True)[txId]['hex'], rawTxSigned['hex'])
+        assert_equal(self.nodes[0].getrawtransactionmulti(verbose=True, transactions={"0":[txId]})[txId]['hex'], rawTxSigned['hex'])
 
         # 6. invalid parameters - supply txid and string "Flase"
         assert_raises_rpc_error(-1, "not a boolean", self.nodes[0].getrawtransaction, txId, "Flase")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -243,6 +243,7 @@ BASE_SCRIPTS = [
     'p2p_eviction.py',
     'rpc_signmessage.py',
     'rpc_generateblock.py',
+    'rpc_generate.py',
     'wallet_balance.py',
     'wallet_balance.py --descriptors',
     'feature_nulldummy.py',
@@ -816,14 +817,16 @@ class RPCCoverage():
         Return a set of currently untested RPC commands.
 
         """
-        # This is shared from `test/functional/test-framework/coverage.py`
+        # This is shared from `test/functional/test_framework/coverage.py`
         reference_filename = 'rpc_interface.txt'
         coverage_file_prefix = 'coverage.'
 
         coverage_ref_filename = os.path.join(self.dir, reference_filename)
         coverage_filenames = set()
         all_cmds = set()
-        covered_cmds = set()
+        # Consider RPC generate covered, because it is overloaded in
+        # test_framework/test_node.py and not seen by the coverage check.
+        covered_cmds = set({'generate'})
 
         if not os.path.isfile(coverage_ref_filename):
             raise RuntimeError("No coverage reference found")


### PR DESCRIPTION
## Issue being fixed or feature implemented
This batch of backports asserts that RPCArg names are equal to CRPCCommand ones.

## What was done?
done backports:
 - bitcoin/bitcoin#19994
 - bitcoin/bitcoin#19849
 - bitcoin/bitcoin#19717
 - bitcoin/bitcoin#19455
 - bitcoin/bitcoin#19528
 
Beside that same changes are applied for src/coinjoin's rpc.

There's also applied multiple fixes for various rpcs for cases when RPCArg names are mismatched with CPCCommand

**Please, note, that this PR is not final fix for all RPCArgs**. There's a lot of dash's rpc that is not refactored that.
That it is not easy to implement for `quorum command` because the list of arguments (and even their numbers) are different for each sub-command. This fixes are out-of scope of this PR and should be done before bitcoin#18531 is backported. 

See also relevant bitcoin#21035.

## How Has This Been Tested?
I used this helper to see which exactly args are specified wrongly:
```cpp
diff --git a/src/rpc/server.h b/src/rpc/server.h
index d4a7ba60eb..cdfd741f54 100644
--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -16,6 +16,7 @@
 #include <string>
 
 #include <univalue.h>
+#include <logging.h>
 
 class CRPCCommand;
 
@@ -110,6 +111,19 @@ public:
               fn().GetArgNames(),
               intptr_t(fn))
     {
+        if (fn().m_name != name_in || fn().GetArgNames() != args_in) {
+            std::cerr << "names:  " << fn().m_name << ' ' << name_in << std::endl;
+            std::cerr << "arg names: " << fn().GetArgNames().size() << std::endl;
+            for (const auto& i : fn().GetArgNames()) {
+                std::cerr << "arg: " << i << std::endl;
+            }
+            std::cerr << "FIASCO FIASCO FIASCO FIASCO FIASCO FIASCO" << std::endl;
+        }
         CHECK_NONFATAL(fn().m_name == name_in);
         CHECK_NONFATAL(fn().GetArgNames() == args_in);
     }
```

## Breaking Changes
N/A

Some arguments are renamed in RPC but they have been broken (used incorrect name not same as in docs)


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone