### PR TITLE
feat: use 8 parallel threads for CI

### DIFF
--- a/ci/dash/test_integrationtests.sh
+++ b/ci/dash/test_integrationtests.sh
@@ -42,7 +42,7 @@ echo "Using socketevents mode: $SOCKETEVENTS"
 EXTRA_ARGS="--dashd-arg=-socketevents=$SOCKETEVENTS"
 
 set +e
-LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib ${TEST_RUNNER_ENV} ./test/functional/test_runner.py --ci --attempts=3 --ansi --combinedlogslen=4000 --timeout-factor=${TEST_RUNNER_TIMEOUT_FACTOR} ${TEST_RUNNER_EXTRA} --failfast --nocleanup --tmpdir=$(pwd)/testdatadirs $PASS_ARGS $EXTRA_ARGS
+LD_LIBRARY_PATH=$DEPENDS_DIR/$HOST/lib ${TEST_RUNNER_ENV} ./test/functional/test_runner.py --ci --attempts=3 --ansi --combinedlogslen=4000 --timeout-factor=${TEST_RUNNER_TIMEOUT_FACTOR} ${TEST_RUNNER_EXTRA} --failfast --nocleanup --tmpdir=$(pwd)/testdatadirs $PASS_ARGS $EXTRA_ARGS -j8
 RESULT=$?
 set -e
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Most time spend in functional tests are waiting until quorum is created and waiting data exchanges such as `sync_all` or similar. 

## What was done?
Bump to 8 parallel threads for functional tests instead 4.
The speed up is noticeable for non-CPU greedy test. Significant improvement for `linux64-test`, for `linux64_sqlite-test` and for `linux64_ubsan-test`. 

The test `tsan` requires a lot of CPU, so, time is almost same for 4, 6 and 8 jobs. 

## How Has This Been Tested?
Tested 4, 6, 8 and 12 jobs.
 - 4->6 - significant improvement for `linux64-test`, for `linux64_sqlite-test` and for `linux64_ubsan-test`
 - 6->8 - significant improvement also
 - 8->12 is slowed down:
```
j8: Runtime: 1116 s https://gitlab.com/dashpay/dash/-/jobs/6405918550
j12: Runtime: 1254 s https://gitlab.com/dashpay/dash/-/jobs/6406212552
```
pipeline with 4 jobs: https://gitlab.com/dashpay/dash/-/pipelines/1215412573 (baseline, other non-related PR)
pipeline with 6 jobs: https://gitlab.com/dashpay/dash/-/pipelines/1215460478
pipeline with 8 jobs: https://gitlab.com/dashpay/dash/-/pipelines/1215596060
pipeline with 12 jobs: https://gitlab.com/dashpay/dash/-/pipelines/1215555083

even if 10 jobs may be slightly faster than 8 jobs (or maybe 9, 11 is the fasted), the speed up will be minor. Let's keep 8 jobs.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone