### PR TITLE
ci: adjust amount of parallel jobs from 4 to variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,6 @@ builder-image:
     SDK_URL: https://bitcoincore.org/depends-sources/sdks
     XCODE_VERSION: "12.2"
     XCODE_BUILD_ID: 12B45b
-    MAKEJOBS: -j4
   before_script:
     - echo HOST=$HOST
     - |
@@ -63,7 +62,7 @@ builder-image:
         fi
       fi
   script:
-    - make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+    - make -j$(nproc) -C depends HOST=$HOST $DEP_OPTS
   cache:
     # Let all branches share the same cache, which is ok because the depends subsystem is able to handle this properly (it works with hashes of all scripts)
     key:


### PR DESCRIPTION
## What was done?
Bump CI yaml to use 8 threads for build depends


## How Has This Been Tested?
Builds logs says:
```
$ make -j$(nproc) -C depends HOST=$HOST $DEP_OPTS
make: Entering directory '/builds/dashpay/dash/depends'
```
https://gitlab.com/dashpay/dash/-/jobs/6409522172

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone