### PR TITLE
fix: avoid `hSocket` double lock

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -4237,7 +4237,7 @@ void CConnman::UnregisterEvents(CNode *pnode)
 {
 #ifdef USE_KQUEUE
     if (socketEventsMode == SOCKETEVENTS_KQUEUE) {
-        LOCK(pnode->cs_hSocket);
+        AssertLockHeld(pnode->cs_hSocket);
         if (pnode->hSocket == INVALID_SOCKET) {
             return;
         }
@@ -4255,7 +4255,7 @@ void CConnman::UnregisterEvents(CNode *pnode)
 #endif
 #ifdef USE_EPOLL
     if (socketEventsMode == SOCKETEVENTS_EPOLL) {
-        LOCK(pnode->cs_hSocket);
+        AssertLockHeld(pnode->cs_hSocket);
         if (pnode->hSocket == INVALID_SOCKET) {
             return;
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
It's is locked in `CloseSocketDisconnect()` already.

To be merged before #5511 or 19915 backport is going to cause issues otherwise.

## What was done?
Assert the lock is held already, instead of locking it again.

## How Has This Been Tested?
Run tests, run a node on testnet and drop connections to peers

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

