### PR TITLE
refactor: consolidate activeMasternodeInfo{Cs} into CActiveMasternodeManager, create NodeContext alias, reduce globals usage

### DIFF
--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -47,12 +47,10 @@ uint256 CCoinJoinQueue::GetSignatureHash() const
     return SerializeHash(*this, SER_GETHASH, PROTOCOL_VERSION);
 }
 
-bool CCoinJoinQueue::Sign()
+bool CCoinJoinQueue::Sign(const CActiveMasternodeManager& mn_activeman)
 {
-    if (!fMasternodeMode) return false;
-
     uint256 hash = GetSignatureHash();
-    CBLSSignature sig = ::activeMasternodeManager->Sign(hash, /*is_legacy=*/ false);
+    CBLSSignature sig = mn_activeman.Sign(hash, /*is_legacy=*/ false);
     if (!sig.IsValid()) {
         return false;
     }
@@ -99,12 +97,10 @@ uint256 CCoinJoinBroadcastTx::GetSignatureHash() const
     return SerializeHash(*this, SER_GETHASH, PROTOCOL_VERSION);
 }
 
-bool CCoinJoinBroadcastTx::Sign()
+bool CCoinJoinBroadcastTx::Sign(const CActiveMasternodeManager& mn_activeman)
 {
-    if (!fMasternodeMode) return false;
-
     uint256 hash = GetSignatureHash();
-    CBLSSignature sig = ::activeMasternodeManager->Sign(hash, /*is_legacy=*/ false);
+    CBLSSignature sig = mn_activeman.Sign(hash, /*is_legacy=*/ false);
     if (!sig.IsValid()) {
         return false;
     }

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -52,7 +52,7 @@ bool CCoinJoinQueue::Sign()
     if (!fMasternodeMode) return false;
 
     uint256 hash = GetSignatureHash();
-    CBLSSignature sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(hash, false));
+    CBLSSignature sig = ::activeMasternodeManager->Sign(hash, /*is_legacy=*/ false);
     if (!sig.IsValid()) {
         return false;
     }
@@ -104,7 +104,7 @@ bool CCoinJoinBroadcastTx::Sign()
     if (!fMasternodeMode) return false;
 
     uint256 hash = GetSignatureHash();
-    CBLSSignature sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(hash, false));
+    CBLSSignature sig = ::activeMasternodeManager->Sign(hash, /*is_legacy=*/ false);
     if (!sig.IsValid()) {
         return false;
     }

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -52,7 +52,7 @@ bool CCoinJoinQueue::Sign()
     if (!fMasternodeMode) return false;
 
     uint256 hash = GetSignatureHash();
-    CBLSSignature sig = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsKeyOperator->Sign(hash, false));
+    CBLSSignature sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(hash, false));
     if (!sig.IsValid()) {
         return false;
     }
@@ -104,7 +104,7 @@ bool CCoinJoinBroadcastTx::Sign()
     if (!fMasternodeMode) return false;
 
     uint256 hash = GetSignatureHash();
-    CBLSSignature sig = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsKeyOperator->Sign(hash, false));
+    CBLSSignature sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(hash, false));
     if (!sig.IsValid()) {
         return false;
     }

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -22,6 +22,7 @@
 #include <optional>
 #include <utility>
 
+class CActiveMasternodeManager;
 class CChainState;
 class CConnman;
 class CBLSPublicKey;
@@ -213,7 +214,7 @@ public:
      *     3) we signed the message successfully, and
      *     4) we verified the message successfully
      */
-    bool Sign();
+    bool Sign(const CActiveMasternodeManager& mn_activeman);
     /// Check if we have a valid Masternode address
     [[nodiscard]] bool CheckSignature(const CBLSPublicKey& blsPubKey) const;
 
@@ -284,7 +285,7 @@ public:
 
     [[nodiscard]] uint256 GetSignatureHash() const;
 
-    bool Sign();
+    bool Sign(const CActiveMasternodeManager& mn_activeman);
     [[nodiscard]] bool CheckSignature(const CBLSPublicKey& blsPubKey) const;
 
     void SetConfirmedHeight(std::optional<int> nConfirmedHeightIn) { assert(nConfirmedHeightIn == std::nullopt || *nConfirmedHeightIn > 0); nConfirmedHeight = nConfirmedHeightIn; }

--- a/src/coinjoin/context.cpp
+++ b/src/coinjoin/context.cpp
@@ -14,13 +14,13 @@
 #include <coinjoin/server.h>
 
 CJContext::CJContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CTxMemPool& mempool,
-                     const CMasternodeSync& mn_sync, bool relay_txes) :
+                     const CActiveMasternodeManager* mn_activeman, const CMasternodeSync& mn_sync, bool relay_txes) :
     dstxman{std::make_unique<CDSTXManager>()},
 #ifdef ENABLE_WALLET
     walletman{std::make_unique<CoinJoinWalletManager>(connman, dmnman, mempool, mn_sync, queueman)},
     queueman {relay_txes ? std::make_unique<CCoinJoinClientQueueManager>(connman, *walletman, dmnman, mn_sync) : nullptr},
 #endif // ENABLE_WALLET
-    server{std::make_unique<CCoinJoinServer>(chainstate, connman, dmnman, *dstxman, mempool, mn_sync)}
+    server{std::make_unique<CCoinJoinServer>(chainstate, connman, dmnman, *dstxman, mempool, mn_activeman, mn_sync)}
 {}
 
 CJContext::~CJContext() {}

--- a/src/coinjoin/context.h
+++ b/src/coinjoin/context.h
@@ -11,6 +11,7 @@
 
 #include <memory>
 
+class CActiveMasternodeManager;
 class CBlockPolicyEstimator;
 class CChainState;
 class CCoinJoinServer;
@@ -29,7 +30,7 @@ struct CJContext {
     CJContext() = delete;
     CJContext(const CJContext&) = delete;
     CJContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CTxMemPool& mempool,
-              const CMasternodeSync& mn_sync, bool relay_txes);
+              const CActiveMasternodeManager* mn_activeman, const CMasternodeSync& mn_sync, bool relay_txes);
     ~CJContext();
 
     const std::unique_ptr<CDSTXManager> dstxman;

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -43,6 +43,8 @@ PeerMsgRet CCoinJoinServer::ProcessMessage(CNode& peer, std::string_view msg_typ
 
 void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
 {
+    assert(m_mn_activeman);
+
     if (IsSessionReady()) {
         // too many users in this session already, reject new ones
         LogPrint(BCLog::COINJOIN, "DSACCEPT -- queue is already full!\n");
@@ -56,7 +58,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
     LogPrint(BCLog::COINJOIN, "DSACCEPT -- nDenom %d (%s)  txCollateral %s", dsa.nDenom, CoinJoin::DenominationToString(dsa.nDenom), dsa.txCollateral.ToString()); /* Continued */
 
     auto mnList = m_dmnman.GetListAtChainTip();
-    auto dmn = WITH_LOCK(::activeMasternodeManager->cs, return mnList.GetValidMNByCollateral(::activeMasternodeManager->GetOutPoint()));
+    auto dmn = WITH_LOCK(m_mn_activeman->cs, return mnList.GetValidMNByCollateral(m_mn_activeman->GetOutPoint()));
     if (!dmn) {
         PushStatus(peer, STATUS_REJECTED, ERR_MN_LIST);
         return;
@@ -67,7 +69,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
             TRY_LOCK(cs_vecqueue, lockRecv);
             if (!lockRecv) return;
 
-            auto mnOutpoint = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint());
+            auto mnOutpoint = WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetOutPoint());
 
             if (ranges::any_of(vecCoinJoinQueue,
                                [&mnOutpoint](const auto& q){return q.masternodeOutpoint == mnOutpoint;})) {
@@ -308,6 +310,8 @@ void CCoinJoinServer::CommitFinalTransaction()
     AssertLockNotHeld(cs_coinjoin);
     if (!fMasternodeMode) return; // check and relay final tx only on masternode
 
+    assert(m_mn_activeman);
+
     CTransactionRef finalTransaction = WITH_LOCK(cs_coinjoin, return MakeTransactionRef(finalMutableTransaction));
     uint256 hashTx = finalTransaction->GetHash();
 
@@ -331,10 +335,10 @@ void CCoinJoinServer::CommitFinalTransaction()
     // create and sign masternode dstx transaction
     if (!m_dstxman.GetDSTX(hashTx)) {
         CCoinJoinBroadcastTx dstxNew(finalTransaction,
-                                    WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint()),
-                                    WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()),
+                                    WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetOutPoint()),
+                                    WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()),
                                     GetAdjustedTime());
-        dstxNew.Sign();
+        dstxNew.Sign(*m_mn_activeman);
         m_dstxman.AddDSTX(dstxNew);
     }
 
@@ -495,16 +499,18 @@ void CCoinJoinServer::CheckForCompleteQueue()
 {
     if (!fMasternodeMode) return;
 
+    assert(m_mn_activeman);
+
     if (nState == POOL_STATE_QUEUE && IsSessionReady()) {
         SetState(POOL_STATE_ACCEPTING_ENTRIES);
 
         CCoinJoinQueue dsq(nSessionDenom,
-                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint()),
-                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()),
+                            WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetOutPoint()),
+                            WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()),
                             GetAdjustedTime(), true);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s) " /* Continued */
                                      "with %d participants\n", dsq.ToString(), vecSessionCollaterals.size());
-        dsq.Sign();
+        dsq.Sign(*m_mn_activeman);
         dsq.Relay(connman);
     }
 }
@@ -692,6 +698,8 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
 {
     if (!fMasternodeMode || nSessionID != 0) return false;
 
+    assert(m_mn_activeman);
+
     // new session can only be started in idle mode
     if (nState != POOL_STATE_IDLE) {
         nMessageIDRet = ERR_MODE;
@@ -713,11 +721,11 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
     if (!fUnitTest) {
         //broadcast that I'm accepting entries, only if it's the first entry through
         CCoinJoinQueue dsq(nSessionDenom,
-                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint()),
-                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()),
+                            WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetOutPoint()),
+                            WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()),
                             GetAdjustedTime(), false);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- signing and relaying new queue: %s\n", dsq.ToString());
-        dsq.Sign();
+        dsq.Sign(*m_mn_activeman);
         dsq.Relay(connman);
         LOCK(cs_vecqueue);
         vecCoinJoinQueue.push_back(dsq);

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -56,7 +56,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
     LogPrint(BCLog::COINJOIN, "DSACCEPT -- nDenom %d (%s)  txCollateral %s", dsa.nDenom, CoinJoin::DenominationToString(dsa.nDenom), dsa.txCollateral.ToString()); /* Continued */
 
     auto mnList = m_dmnman.GetListAtChainTip();
-    auto dmn = WITH_LOCK(::activeMasternodeManager->cs, return mnList.GetValidMNByCollateral(::activeMasternodeManager->m_info.outpoint));
+    auto dmn = WITH_LOCK(::activeMasternodeManager->cs, return mnList.GetValidMNByCollateral(::activeMasternodeManager->GetOutPoint()));
     if (!dmn) {
         PushStatus(peer, STATUS_REJECTED, ERR_MN_LIST);
         return;
@@ -67,7 +67,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
             TRY_LOCK(cs_vecqueue, lockRecv);
             if (!lockRecv) return;
 
-            auto mnOutpoint = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.outpoint);
+            auto mnOutpoint = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint());
 
             if (ranges::any_of(vecCoinJoinQueue,
                                [&mnOutpoint](const auto& q){return q.masternodeOutpoint == mnOutpoint;})) {
@@ -331,8 +331,8 @@ void CCoinJoinServer::CommitFinalTransaction()
     // create and sign masternode dstx transaction
     if (!m_dstxman.GetDSTX(hashTx)) {
         CCoinJoinBroadcastTx dstxNew(finalTransaction,
-                                    WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.outpoint),
-                                    WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash),
+                                    WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint()),
+                                    WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()),
                                     GetAdjustedTime());
         dstxNew.Sign();
         m_dstxman.AddDSTX(dstxNew);
@@ -499,8 +499,8 @@ void CCoinJoinServer::CheckForCompleteQueue()
         SetState(POOL_STATE_ACCEPTING_ENTRIES);
 
         CCoinJoinQueue dsq(nSessionDenom,
-                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.outpoint),
-                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash),
+                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint()),
+                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()),
                             GetAdjustedTime(), true);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s) " /* Continued */
                                      "with %d participants\n", dsq.ToString(), vecSessionCollaterals.size());
@@ -713,8 +713,8 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
     if (!fUnitTest) {
         //broadcast that I'm accepting entries, only if it's the first entry through
         CCoinJoinQueue dsq(nSessionDenom,
-                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.outpoint),
-                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash),
+                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint()),
+                            WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()),
                             GetAdjustedTime(), false);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- signing and relaying new queue: %s\n", dsq.ToString());
         dsq.Sign();

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -9,6 +9,7 @@
 
 #include <net_types.h>
 
+class CActiveMasternodeManager;
 class CChainState;
 class CCoinJoinServer;
 class CDataStream;
@@ -29,6 +30,7 @@ private:
     CDeterministicMNManager& m_dmnman;
     CDSTXManager& m_dstxman;
     CTxMemPool& mempool;
+    const CActiveMasternodeManager* m_mn_activeman;
     const CMasternodeSync& m_mn_sync;
 
     // Mixing uses collateral transactions to trust parties entering the pool
@@ -85,12 +87,13 @@ private:
 
 public:
     explicit CCoinJoinServer(CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman, CDSTXManager& dstxman,
-                             CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
+                             CTxMemPool& mempool, const CActiveMasternodeManager* mn_activeman, const CMasternodeSync& mn_sync) :
         m_chainstate(chainstate),
         connman(_connman),
         m_dmnman(dmnman),
         m_dstxman(dstxman),
         mempool(mempool),
+        m_mn_activeman(mn_activeman),
         m_mn_sync(mn_sync),
         vecSessionCollaterals(),
         fUnitTest(false)

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -27,7 +27,7 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip)
     uint256 signHash;
     {
         LOCK(::activeMasternodeManager->cs);
-        if (::activeMasternodeManager->m_info.proTxHash.IsNull()) {
+        if (::activeMasternodeManager->GetProTxHash().IsNull()) {
             return;
         }
 
@@ -46,14 +46,15 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip)
             nOurNodeVersion = gArgs.GetArg("-pushversion", PROTOCOL_VERSION);
         }
         const bool is_basic_scheme_active{DeploymentActiveAfter(tip, Params().GetConsensus(), Consensus::DEPLOYMENT_V19)};
-        const CBLSPublicKeyVersionWrapper pubKey(*::activeMasternodeManager->m_info.blsPubKeyOperator, !is_basic_scheme_active);
+        auto pk = ::activeMasternodeManager->GetPubKey();
+        const CBLSPublicKeyVersionWrapper pubKey(pk, !is_basic_scheme_active);
         if (peer.nVersion < MNAUTH_NODE_VER_VERSION || nOurNodeVersion < MNAUTH_NODE_VER_VERSION) {
             signHash = ::SerializeHash(std::make_tuple(pubKey, receivedMNAuthChallenge, peer.IsInboundConn()));
         } else {
             signHash = ::SerializeHash(std::make_tuple(pubKey, receivedMNAuthChallenge, peer.IsInboundConn(), nOurNodeVersion));
         }
 
-        mnauth.proRegTxHash = ::activeMasternodeManager->m_info.proTxHash;
+        mnauth.proRegTxHash = ::activeMasternodeManager->GetProTxHash();
     } // ::activeMasternodeManager->cs
 
     mnauth.sig = ::activeMasternodeManager->Sign(signHash);
@@ -132,7 +133,7 @@ PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, const CDeterm
     }
 
     const uint256 myProTxHash = fMasternodeMode ?
-                                WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash) :
+                                WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()) :
                                 uint256();
 
     connman.ForEachNode([&](CNode* pnode2) {

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -21,10 +21,10 @@
 
 void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip)
 {
+    if (!fMasternodeMode) return;
+
     LOCK(activeMasternodeInfoCs);
-    if (!fMasternodeMode || activeMasternodeInfo.proTxHash.IsNull()) {
-        return;
-    }
+    if (activeMasternodeInfo.proTxHash.IsNull()) return;
 
     uint256 signHash;
     const auto receivedMNAuthChallenge = peer.GetReceivedMNAuthChallenge();
@@ -127,7 +127,9 @@ PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, const CDeterm
         }
     }
 
-    const uint256 myProTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
+    const uint256 myProTxHash = fMasternodeMode ?
+                                WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash) :
+                                uint256();
 
     connman.ForEachNode([&](CNode* pnode2) {
         if (peer.fDisconnect) {

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -693,11 +693,11 @@ std::optional<const CGovernanceObject> CGovernanceManager::CreateGovernanceTrigg
 
     {
         LOCK(::activeMasternodeManager->cs);
-        if (mn_payees.front()->proTxHash != ::activeMasternodeManager->m_info.proTxHash) {
+        if (mn_payees.front()->proTxHash != ::activeMasternodeManager->GetProTxHash()) {
             LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s we are not the payee, skipping\n", __func__);
             return std::nullopt;
         }
-        gov_sb.SetMasternodeOutpoint(::activeMasternodeManager->m_info.outpoint);
+        gov_sb.SetMasternodeOutpoint(::activeMasternodeManager->GetOutPoint());
     } // ::activeMasternodeManager->cs
     gov_sb.Sign(*::activeMasternodeManager);
 
@@ -720,7 +720,7 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
 {
     // only active masternodes can vote on triggers
     if (!fMasternodeMode) return;
-    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash.IsNull())) return;
+    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash().IsNull())) return;
 
     LOCK2(cs_main, cs);
 
@@ -763,7 +763,7 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
 
 bool CGovernanceManager::VoteFundingTrigger(const uint256& nHash, const vote_outcome_enum_t outcome, CConnman& connman)
 {
-    CGovernanceVote vote(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.outpoint), nHash, VOTE_SIGNAL_FUNDING, outcome);
+    CGovernanceVote vote(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint()), nHash, VOTE_SIGNAL_FUNDING, outcome);
     vote.SetTime(GetAdjustedTime());
     vote.Sign(*::activeMasternodeManager);
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -719,7 +719,8 @@ std::optional<const CGovernanceObject> CGovernanceManager::CreateGovernanceTrigg
 void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGovernanceObject>& trigger_opt, CConnman& connman)
 {
     // only active masternodes can vote on triggers
-    if (!fMasternodeMode || WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) return;
+    if (!fMasternodeMode) return;
+    if (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) return;
 
     LOCK2(cs_main, cs);
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -698,8 +698,8 @@ std::optional<const CGovernanceObject> CGovernanceManager::CreateGovernanceTrigg
             return std::nullopt;
         }
         gov_sb.SetMasternodeOutpoint(::activeMasternodeManager->m_info.outpoint);
-        gov_sb.Sign( *::activeMasternodeManager->m_info.blsKeyOperator);
     } // ::activeMasternodeManager->cs
+    gov_sb.Sign(*::activeMasternodeManager);
 
     if (std::string strError; !gov_sb.IsValidLocally(m_dmnman->GetListAtChainTip(), strError, true)) {
         LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Created trigger is invalid:%s\n", __func__, strError);
@@ -765,7 +765,7 @@ bool CGovernanceManager::VoteFundingTrigger(const uint256& nHash, const vote_out
 {
     CGovernanceVote vote(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.outpoint), nHash, VOTE_SIGNAL_FUNDING, outcome);
     vote.SetTime(GetAdjustedTime());
-    vote.Sign(WITH_LOCK(::activeMasternodeManager->cs, return *::activeMasternodeManager->m_info.blsKeyOperator));
+    vote.Sign(*::activeMasternodeManager);
 
     CGovernanceException exception;
     if (!ProcessVoteAndRelay(vote, exception, connman)) {

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -692,14 +692,14 @@ std::optional<const CGovernanceObject> CGovernanceManager::CreateGovernanceTrigg
     }
 
     {
-        LOCK(activeMasternodeInfoCs);
-        if (mn_payees.front()->proTxHash != activeMasternodeInfo.proTxHash) {
+        LOCK(::activeMasternodeManager->cs);
+        if (mn_payees.front()->proTxHash != ::activeMasternodeManager->m_info.proTxHash) {
             LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s we are not the payee, skipping\n", __func__);
             return std::nullopt;
         }
-        gov_sb.SetMasternodeOutpoint(activeMasternodeInfo.outpoint);
-        gov_sb.Sign( *activeMasternodeInfo.blsKeyOperator);
-    } // activeMasternodeInfoCs
+        gov_sb.SetMasternodeOutpoint(::activeMasternodeManager->m_info.outpoint);
+        gov_sb.Sign( *::activeMasternodeManager->m_info.blsKeyOperator);
+    } // ::activeMasternodeManager->cs
 
     if (std::string strError; !gov_sb.IsValidLocally(m_dmnman->GetListAtChainTip(), strError, true)) {
         LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s Created trigger is invalid:%s\n", __func__, strError);
@@ -720,7 +720,7 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
 {
     // only active masternodes can vote on triggers
     if (!fMasternodeMode) return;
-    if (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) return;
+    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash.IsNull())) return;
 
     LOCK2(cs_main, cs);
 
@@ -763,9 +763,9 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
 
 bool CGovernanceManager::VoteFundingTrigger(const uint256& nHash, const vote_outcome_enum_t outcome, CConnman& connman)
 {
-    CGovernanceVote vote(WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.outpoint), nHash, VOTE_SIGNAL_FUNDING, outcome);
+    CGovernanceVote vote(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.outpoint), nHash, VOTE_SIGNAL_FUNDING, outcome);
     vote.SetTime(GetAdjustedTime());
-    vote.Sign(WITH_LOCK(activeMasternodeInfoCs, return *activeMasternodeInfo.blsKeyOperator));
+    vote.Sign(WITH_LOCK(::activeMasternodeManager->cs, return *::activeMasternodeManager->m_info.blsKeyOperator));
 
     CGovernanceException exception;
     if (!ProcessVoteAndRelay(vote, exception, connman)) {

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -11,6 +11,7 @@
 #include <governance/governance.h>
 #include <governance/validators.h>
 #include <masternode/meta.h>
+#include <masternode/node.h>
 #include <masternode/sync.h>
 #include <messagesigner.h>
 #include <net.h>
@@ -273,9 +274,9 @@ void CGovernanceObject::SetMasternodeOutpoint(const COutPoint& outpoint)
     m_obj.masternodeOutpoint = outpoint;
 }
 
-bool CGovernanceObject::Sign(const CBLSSecretKey& key)
+bool CGovernanceObject::Sign(const CActiveMasternodeManager& mn_activeman)
 {
-    CBLSSignature sig = key.Sign(GetSignatureHash(), false);
+    CBLSSignature sig = mn_activeman.Sign(GetSignatureHash(), false);
     if (!sig.IsValid()) {
         return false;
     }

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -13,7 +13,7 @@
 
 #include <univalue.h>
 
-class CBLSSecretKey;
+class CActiveMasternodeManager;
 class CBLSPublicKey;
 class CDeterministicMNList;
 class CGovernanceManager;
@@ -217,7 +217,7 @@ public:
     // Signature related functions
 
     void SetMasternodeOutpoint(const COutPoint& outpoint);
-    bool Sign(const CBLSSecretKey& key);
+    bool Sign(const CActiveMasternodeManager& mn_activeman);
     bool CheckSignature(const CBLSPublicKey& pubKey) const;
 
     uint256 GetSignatureHash() const;

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -8,6 +8,7 @@
 #include <bls/bls.h>
 #include <chainparams.h>
 #include <key.h>
+#include <masternode/node.h>
 #include <masternode/sync.h>
 #include <messagesigner.h>
 #include <net.h>
@@ -221,9 +222,9 @@ bool CGovernanceVote::CheckSignature(const CKeyID& keyID) const
     return true;
 }
 
-bool CGovernanceVote::Sign(const CBLSSecretKey& key)
+bool CGovernanceVote::Sign(const CActiveMasternodeManager& mn_activeman)
 {
-    CBLSSignature sig = key.Sign(GetSignatureHash(), false);
+    CBLSSignature sig = mn_activeman.Sign(GetSignatureHash(), false);
     if (!sig.IsValid()) {
         return false;
     }

--- a/src/governance/vote.h
+++ b/src/governance/vote.h
@@ -8,11 +8,11 @@
 #include <primitives/transaction.h>
 #include <uint256.h>
 
-class CGovernanceVote;
+class CActiveMasternodeManager;
 class CBLSPublicKey;
-class CBLSSecretKey;
 class CConnman;
 class CDeterministicMNList;
+class CGovernanceVote;
 class CKey;
 class CKeyID;
 
@@ -101,7 +101,7 @@ public:
 
     bool Sign(const CKey& key, const CKeyID& keyID);
     bool CheckSignature(const CKeyID& keyID) const;
-    bool Sign(const CBLSSecretKey& key);
+    bool Sign(const CActiveMasternodeManager& mn_activeman);
     bool CheckSignature(const CBLSPublicKey& pubKey) const;
     bool IsValid(const CDeterministicMNList& tip_mn_list, bool useVotingKey) const;
     void Relay(CConnman& connman, const CDeterministicMNList& tip_mn_list) const;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1606,8 +1606,11 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         StartScriptCheckWorkerThreads(script_threads);
     }
 
-    assert(activeMasternodeInfo.blsKeyOperator == nullptr);
-    assert(activeMasternodeInfo.blsPubKeyOperator == nullptr);
+    {
+        LOCK(activeMasternodeInfoCs);
+        assert(activeMasternodeInfo.blsKeyOperator == nullptr);
+        assert(activeMasternodeInfo.blsPubKeyOperator == nullptr);
+    }
     fMasternodeMode = false;
     std::string strMasterNodeBLSPrivKey = args.GetArg("-masternodeblsprivkey", "");
     if (!strMasterNodeBLSPrivKey.empty()) {
@@ -1620,11 +1623,11 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
             LOCK(activeMasternodeInfoCs);
             activeMasternodeInfo.blsKeyOperator = std::make_unique<CBLSSecretKey>(keyOperator);
             activeMasternodeInfo.blsPubKeyOperator = std::make_unique<CBLSPublicKey>(keyOperator.GetPublicKey());
+            // We don't know the actual scheme at this point, print both
+            LogPrintf("MASTERNODE:\n  blsPubKeyOperator legacy: %s\n  blsPubKeyOperator basic: %s\n",
+                    activeMasternodeInfo.blsPubKeyOperator->ToString(true),
+                    activeMasternodeInfo.blsPubKeyOperator->ToString(false));
         }
-        // We don't know the actual scheme at this point, print both
-        LogPrintf("MASTERNODE:\n  blsPubKeyOperator legacy: %s\n  blsPubKeyOperator basic: %s\n",
-                activeMasternodeInfo.blsPubKeyOperator->ToString(true),
-                activeMasternodeInfo.blsPubKeyOperator->ToString(false));
     } else {
         LOCK(activeMasternodeInfoCs);
         activeMasternodeInfo.blsKeyOperator = std::make_unique<CBLSSecretKey>();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1853,9 +1853,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         fMasternodeMode = true;
         {
             // Create and register activeMasternodeManager, will init later in ThreadImport
-            ::activeMasternodeManager = std::make_unique<CActiveMasternodeManager>(*node.connman, ::deterministicMNManager);
-            ::activeMasternodeManager->InitKeys(keyOperator);
-
+            ::activeMasternodeManager = std::make_unique<CActiveMasternodeManager>(keyOperator, *node.connman, ::deterministicMNManager);
             RegisterValidationInterface(::activeMasternodeManager.get());
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -369,7 +369,8 @@ void PrepareShutdown(NodeContext& node)
         pdsNotificationInterface = nullptr;
     }
     if (fMasternodeMode) {
-        UnregisterValidationInterface(::activeMasternodeManager.get());
+        UnregisterValidationInterface(node.mn_activeman);
+        node.mn_activeman = nullptr;
         ::activeMasternodeManager.reset();
     }
 
@@ -1854,7 +1855,8 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         {
             // Create and register activeMasternodeManager, will init later in ThreadImport
             ::activeMasternodeManager = std::make_unique<CActiveMasternodeManager>(keyOperator, *node.connman, ::deterministicMNManager);
-            RegisterValidationInterface(::activeMasternodeManager.get());
+            node.mn_activeman = ::activeMasternodeManager.get();
+            RegisterValidationInterface(node.mn_activeman);
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2199,7 +2199,8 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     // ********************************************************* Step 7c: Setup CoinJoin
 
-    node.cj_ctx = std::make_unique<CJContext>(chainman.ActiveChainstate(), *node.connman, *node.dmnman, *node.mempool, *node.mn_sync, !ignores_incoming_txs);
+    node.cj_ctx = std::make_unique<CJContext>(chainman.ActiveChainstate(), *node.connman, *node.dmnman, *node.mempool, node.mn_activeman,
+                                              *node.mn_sync, !ignores_incoming_txs);
 
 #ifdef ENABLE_WALLET
     node.coinjoin_loader = interfaces::MakeCoinJoinLoader(*node.cj_ctx->walletman);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -369,14 +369,14 @@ void PrepareShutdown(NodeContext& node)
         pdsNotificationInterface = nullptr;
     }
     if (fMasternodeMode) {
-        UnregisterValidationInterface(activeMasternodeManager.get());
+        UnregisterValidationInterface(::activeMasternodeManager.get());
 
-        LOCK(activeMasternodeInfoCs);
+        LOCK(::activeMasternodeManager->cs);
         // make sure to clean up BLS keys before global destructors are called (they have allocated from the secure memory pool)
-        activeMasternodeInfo.blsKeyOperator.reset();
-        activeMasternodeInfo.blsPubKeyOperator.reset();
+        ::activeMasternodeManager->m_info.blsKeyOperator.reset();
+        ::activeMasternodeManager->m_info.blsPubKeyOperator.reset();
 
-        activeMasternodeManager.reset();
+        ::activeMasternodeManager.reset();
     }
 
     node.chain_clients.clear();
@@ -1859,19 +1859,19 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         fMasternodeMode = true;
         {
             // Create and register activeMasternodeManager, will init later in ThreadImport
-            activeMasternodeManager = std::make_unique<CActiveMasternodeManager>(*node.connman, ::deterministicMNManager);
+            ::activeMasternodeManager = std::make_unique<CActiveMasternodeManager>(*node.connman, ::deterministicMNManager);
 
-            LOCK(activeMasternodeInfoCs);
-            assert(activeMasternodeInfo.blsKeyOperator == nullptr);
-            assert(activeMasternodeInfo.blsPubKeyOperator == nullptr);
-            activeMasternodeInfo.blsKeyOperator = std::make_unique<CBLSSecretKey>(keyOperator);
-            activeMasternodeInfo.blsPubKeyOperator = std::make_unique<CBLSPublicKey>(keyOperator.GetPublicKey());
+            LOCK(::activeMasternodeManager->cs);
+            assert(::activeMasternodeManager->m_info.blsKeyOperator == nullptr);
+            assert(::activeMasternodeManager->m_info.blsPubKeyOperator == nullptr);
+            ::activeMasternodeManager->m_info.blsKeyOperator = std::make_unique<CBLSSecretKey>(keyOperator);
+            ::activeMasternodeManager->m_info.blsPubKeyOperator = std::make_unique<CBLSPublicKey>(keyOperator.GetPublicKey());
             // We don't know the actual scheme at this point, print both
             LogPrintf("MASTERNODE:\n  blsPubKeyOperator legacy: %s\n  blsPubKeyOperator basic: %s\n",
-                    activeMasternodeInfo.blsPubKeyOperator->ToString(true),
-                    activeMasternodeInfo.blsPubKeyOperator->ToString(false));
+                    ::activeMasternodeManager->m_info.blsPubKeyOperator->ToString(true),
+                    ::activeMasternodeManager->m_info.blsPubKeyOperator->ToString(false));
 
-            RegisterValidationInterface(activeMasternodeManager.get());
+            RegisterValidationInterface(::activeMasternodeManager.get());
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1954,7 +1954,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
                     node.llmq_ctx->Stop();
                 }
                 node.llmq_ctx.reset();
-                node.llmq_ctx.reset(new LLMQContext(chainman.ActiveChainstate(), *node.connman, *node.dmnman, *node.evodb, *node.mnhf_manager, *node.sporkman, *node.mempool, node.peerman, false, fReset || fReindexChainState));
+                node.llmq_ctx.reset(new LLMQContext(chainman.ActiveChainstate(), *node.connman, *node.dmnman, *node.evodb, *node.mnhf_manager, *node.sporkman, *node.mempool, node.mn_activeman, node.peerman, false, fReset || fReindexChainState));
                 // Have to start it early to let VerifyDB check ChainLock signatures in coinbase
                 node.llmq_ctx->Start();
 

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -20,7 +20,7 @@
 #include <masternode/sync.h>
 
 LLMQContext::LLMQContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CEvoDB& evo_db,
-                         CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool,
+                         CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* mn_activeman,
                          const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe) :
     bls_worker{std::make_shared<CBLSWorker>()},
     dkg_debugman{std::make_unique<llmq::CDKGDebugManager>()},
@@ -29,14 +29,14 @@ LLMQContext::LLMQContext(CChainState& chainstate, CConnman& connman, CDeterminis
         llmq::quorumBlockProcessor = std::make_unique<llmq::CQuorumBlockProcessor>(chainstate, connman, dmnman, evo_db);
         return llmq::quorumBlockProcessor.get();
     }()},
-    qdkgsman{std::make_unique<llmq::CDKGSessionManager>(*bls_worker, chainstate, connman, dmnman, *dkg_debugman, *quorum_block_processor, sporkman, unit_tests, wipe)},
+    qdkgsman{std::make_unique<llmq::CDKGSessionManager>(*bls_worker, chainstate, connman, dmnman, *dkg_debugman, *quorum_block_processor, mn_activeman, sporkman, unit_tests, wipe)},
     qman{[&]() -> llmq::CQuorumManager* const {
         assert(llmq::quorumManager == nullptr);
-        llmq::quorumManager = std::make_unique<llmq::CQuorumManager>(*bls_worker, chainstate, connman, dmnman, *qdkgsman, evo_db, *quorum_block_processor, sporkman, ::masternodeSync);
+        llmq::quorumManager = std::make_unique<llmq::CQuorumManager>(*bls_worker, chainstate, connman, dmnman, *qdkgsman, evo_db, *quorum_block_processor, mn_activeman, sporkman, ::masternodeSync);
         return llmq::quorumManager.get();
     }()},
-    sigman{std::make_unique<llmq::CSigningManager>(connman, *llmq::quorumManager, unit_tests, wipe)},
-    shareman{std::make_unique<llmq::CSigSharesManager>(connman, *sigman, *llmq::quorumManager, sporkman, peerman)},
+    sigman{std::make_unique<llmq::CSigningManager>(connman, mn_activeman, *llmq::quorumManager, unit_tests, wipe)},
+    shareman{std::make_unique<llmq::CSigSharesManager>(connman, *sigman, mn_activeman, *llmq::quorumManager, sporkman, peerman)},
     clhandler{[&]() -> llmq::CChainLocksHandler* const {
         assert(llmq::chainLocksHandler == nullptr);
         llmq::chainLocksHandler = std::make_unique<llmq::CChainLocksHandler>(chainstate, connman, *::masternodeSync, *llmq::quorumManager, *sigman, *shareman, sporkman, mempool);

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -77,7 +77,9 @@ void LLMQContext::Start() {
     assert(isman == llmq::quorumInstantSendManager.get());
 
     bls_worker->Start();
-    qdkgsman->StartThreads();
+    if (fMasternodeMode) {
+        qdkgsman->StartThreads();
+    }
     qman->Start();
     shareman->RegisterAsRecoveredSigsListener();
     shareman->StartWorkerThread();
@@ -100,6 +102,8 @@ void LLMQContext::Stop() {
     shareman->UnregisterAsRecoveredSigsListener();
     sigman->StopWorkerThread();
     qman->Stop();
-    qdkgsman->StopThreads();
+    if (fMasternodeMode) {
+        qdkgsman->StopThreads();
+    }
     bls_worker->Stop();
 }

--- a/src/llmq/context.h
+++ b/src/llmq/context.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+class CActiveMasternodeManager;
 class CBLSWorker;
 class CChainState;
 class CConnman;
@@ -34,7 +35,7 @@ struct LLMQContext {
     LLMQContext() = delete;
     LLMQContext(const LLMQContext&) = delete;
     LLMQContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CEvoDB& evo_db,
-                CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool,
+                CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* mn_activeman,
                 const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe);
     ~LLMQContext();
 

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -199,7 +199,7 @@ void CDKGSession::SendContributions(CDKGPendingMessages& pendingMessages)
 
     logger.Batch("encrypted contributions. time=%d", t1.count());
 
-    qc.sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(qc.GetSignHash()));
+    qc.sig = ::activeMasternodeManager->Sign(qc.GetSignHash());
 
     logger.Flush();
 
@@ -517,7 +517,7 @@ void CDKGSession::SendComplaint(CDKGPendingMessages& pendingMessages)
 
     logger.Batch("sending complaint. badCount=%d, complaintCount=%d", badCount, complaintCount);
 
-    qc.sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(qc.GetSignHash()));
+    qc.sig = ::activeMasternodeManager->Sign(qc.GetSignHash());
 
     logger.Flush();
 
@@ -711,7 +711,7 @@ void CDKGSession::SendJustification(CDKGPendingMessages& pendingMessages, const 
         return;
     }
 
-    qj.sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(qj.GetSignHash()));
+    qj.sig = ::activeMasternodeManager->Sign(qj.GetSignHash());
 
     logger.Flush();
 
@@ -1003,7 +1003,7 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
         (*commitmentHash.begin())++;
     }
 
-    qc.sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(commitmentHash));
+    qc.sig = ::activeMasternodeManager->Sign(commitmentHash);
     qc.quorumSig = skShare.Sign(commitmentHash);
 
     if (lieType == 3) {

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -199,7 +199,7 @@ void CDKGSession::SendContributions(CDKGPendingMessages& pendingMessages)
 
     logger.Batch("encrypted contributions. time=%d", t1.count());
 
-    qc.sig = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsKeyOperator->Sign(qc.GetSignHash()));
+    qc.sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(qc.GetSignHash()));
 
     logger.Flush();
 
@@ -316,7 +316,7 @@ void CDKGSession::ReceiveMessage(const CDKGContribution& qc, bool& retBan)
 
     bool complain = false;
     CBLSSecretKey skContribution;
-    if (!qc.contributions->Decrypt(*myIdx, WITH_LOCK(activeMasternodeInfoCs, return *activeMasternodeInfo.blsKeyOperator), skContribution, PROTOCOL_VERSION)) {
+    if (!qc.contributions->Decrypt(*myIdx, WITH_LOCK(::activeMasternodeManager->cs, return *::activeMasternodeManager->m_info.blsKeyOperator), skContribution, PROTOCOL_VERSION)) {
         logger.Batch("contribution from %s could not be decrypted", member->dmn->proTxHash.ToString());
         complain = true;
     } else if (member->idx != myIdx && ShouldSimulateError(DKGError::type::COMPLAIN_LIE)) {
@@ -517,7 +517,7 @@ void CDKGSession::SendComplaint(CDKGPendingMessages& pendingMessages)
 
     logger.Batch("sending complaint. badCount=%d, complaintCount=%d", badCount, complaintCount);
 
-    qc.sig = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsKeyOperator->Sign(qc.GetSignHash()));
+    qc.sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(qc.GetSignHash()));
 
     logger.Flush();
 
@@ -711,7 +711,7 @@ void CDKGSession::SendJustification(CDKGPendingMessages& pendingMessages, const 
         return;
     }
 
-    qj.sig = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsKeyOperator->Sign(qj.GetSignHash()));
+    qj.sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(qj.GetSignHash()));
 
     logger.Flush();
 
@@ -1003,7 +1003,7 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
         (*commitmentHash.begin())++;
     }
 
-    qc.sig = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsKeyOperator->Sign(commitmentHash));
+    qc.sig = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.blsKeyOperator->Sign(commitmentHash));
     qc.quorumSig = skShare.Sign(commitmentHash);
 
     if (lieType == 3) {

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -199,7 +199,7 @@ void CDKGSession::SendContributions(CDKGPendingMessages& pendingMessages)
 
     logger.Batch("encrypted contributions. time=%d", t1.count());
 
-    qc.sig = ::activeMasternodeManager->Sign(qc.GetSignHash());
+    qc.sig = m_mn_activeman->Sign(qc.GetSignHash());
 
     logger.Flush();
 
@@ -316,7 +316,7 @@ void CDKGSession::ReceiveMessage(const CDKGContribution& qc, bool& retBan)
 
     bool complain = false;
     CBLSSecretKey skContribution;
-    if (!::activeMasternodeManager->Decrypt(*qc.contributions, *myIdx, skContribution, PROTOCOL_VERSION)) {
+    if (!m_mn_activeman->Decrypt(*qc.contributions, *myIdx, skContribution, PROTOCOL_VERSION)) {
         logger.Batch("contribution from %s could not be decrypted", member->dmn->proTxHash.ToString());
         complain = true;
     } else if (member->idx != myIdx && ShouldSimulateError(DKGError::type::COMPLAIN_LIE)) {
@@ -517,7 +517,7 @@ void CDKGSession::SendComplaint(CDKGPendingMessages& pendingMessages)
 
     logger.Batch("sending complaint. badCount=%d, complaintCount=%d", badCount, complaintCount);
 
-    qc.sig = ::activeMasternodeManager->Sign(qc.GetSignHash());
+    qc.sig = m_mn_activeman->Sign(qc.GetSignHash());
 
     logger.Flush();
 
@@ -711,7 +711,7 @@ void CDKGSession::SendJustification(CDKGPendingMessages& pendingMessages, const 
         return;
     }
 
-    qj.sig = ::activeMasternodeManager->Sign(qj.GetSignHash());
+    qj.sig = m_mn_activeman->Sign(qj.GetSignHash());
 
     logger.Flush();
 
@@ -1003,7 +1003,7 @@ void CDKGSession::SendCommitment(CDKGPendingMessages& pendingMessages)
         (*commitmentHash.begin())++;
     }
 
-    qc.sig = ::activeMasternodeManager->Sign(commitmentHash);
+    qc.sig = m_mn_activeman->Sign(commitmentHash);
     qc.quorumSig = skShare.Sign(commitmentHash);
 
     if (lieType == 3) {

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -316,7 +316,7 @@ void CDKGSession::ReceiveMessage(const CDKGContribution& qc, bool& retBan)
 
     bool complain = false;
     CBLSSecretKey skContribution;
-    if (!qc.contributions->Decrypt(*myIdx, WITH_LOCK(::activeMasternodeManager->cs, return *::activeMasternodeManager->m_info.blsKeyOperator), skContribution, PROTOCOL_VERSION)) {
+    if (!::activeMasternodeManager->Decrypt(*qc.contributions, *myIdx, skContribution, PROTOCOL_VERSION)) {
         logger.Batch("contribution from %s could not be decrypted", member->dmn->proTxHash.ToString());
         complain = true;
     } else if (member->idx != myIdx && ShouldSimulateError(DKGError::type::COMPLAIN_LIE)) {

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -15,11 +15,13 @@
 
 #include <optional>
 
-class UniValue;
+class CActiveMasternodeManager;
 class CInv;
 class CConnman;
 class CDeterministicMN;
 class CSporkManager;
+class UniValue;
+
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
 
 namespace llmq
@@ -273,6 +275,7 @@ private:
     CDeterministicMNManager& m_dmnman;
     CDKGSessionManager& dkgManager;
     CDKGDebugManager& dkgDebugManager;
+    const CActiveMasternodeManager* m_mn_activeman;
     const CSporkManager& m_sporkman;
 
     const CBlockIndex* m_quorum_base_block_index{nullptr};
@@ -314,8 +317,11 @@ private:
     std::set<uint256> validCommitments GUARDED_BY(invCs);
 
 public:
-    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager, CConnman& _connman, const CSporkManager& sporkman) :
-        params(_params), blsWorker(_blsWorker), cache(_blsWorker), m_dmnman(dmnman), dkgManager(_dkgManager), dkgDebugManager(_dkgDebugManager), m_sporkman(sporkman), connman(_connman) {}
+    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDeterministicMNManager& dmnman,
+                CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager, CConnman& _connman,
+                const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman) :
+        params(_params), blsWorker(_blsWorker), cache(_blsWorker), m_dmnman(dmnman), dkgManager(_dkgManager),
+        dkgDebugManager(_dkgDebugManager), m_mn_activeman(mn_activeman), m_sporkman(sporkman), connman(_connman) {}
 
     bool Init(gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex);
 

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -192,7 +192,7 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
     }
 
     auto mns = utils::GetAllQuorumMembers(params.type, m_dmnman, pQuorumBaseBlockIndex);
-    if (!curSession->Init(pQuorumBaseBlockIndex, mns, WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash), quorumIndex)) {
+    if (!curSession->Init(pQuorumBaseBlockIndex, mns, WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash), quorumIndex)) {
         LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d] mns[%d]\n", __func__, pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex, mns.size());
         return false;
     }

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -192,7 +192,7 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
     }
 
     auto mns = utils::GetAllQuorumMembers(params.type, m_dmnman, pQuorumBaseBlockIndex);
-    if (!curSession->Init(pQuorumBaseBlockIndex, mns, WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash), quorumIndex)) {
+    if (!curSession->Init(pQuorumBaseBlockIndex, mns, WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()), quorumIndex)) {
         LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d] mns[%d]\n", __func__, pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex, mns.size());
         return false;
     }

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -26,7 +26,8 @@ namespace llmq
 
 CDKGSessionHandler::CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
                                        CDKGDebugManager& _dkgDebugManager, CDKGSessionManager& _dkgManager, CQuorumBlockProcessor& _quorumBlockProcessor,
-                                       const CSporkManager& sporkman, const Consensus::LLMQParams& _params, int _quorumIndex) :
+                                       const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman, const Consensus::LLMQParams& _params,
+                                       int _quorumIndex) :
         blsWorker(_blsWorker),
         m_chainstate(chainstate),
         connman(_connman),
@@ -34,10 +35,11 @@ CDKGSessionHandler::CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chai
         dkgDebugManager(_dkgDebugManager),
         dkgManager(_dkgManager),
         quorumBlockProcessor(_quorumBlockProcessor),
+        m_mn_activeman(mn_activeman),
         m_sporkman(sporkman),
         params(_params),
         quorumIndex(_quorumIndex),
-        curSession(std::make_unique<CDKGSession>(_params, _blsWorker, dmnman, _dkgManager, _dkgDebugManager, _connman, sporkman)),
+        curSession(std::make_unique<CDKGSession>(_params, _blsWorker, dmnman, _dkgManager, _dkgDebugManager, _connman, m_mn_activeman, sporkman)),
         pendingContributions((size_t)_params.size * 2, MSG_QUORUM_CONTRIB), // we allow size*2 messages as we need to make sure we see bad behavior (double messages)
         pendingComplaints((size_t)_params.size * 2, MSG_QUORUM_COMPLAINT),
         pendingJustifications((size_t)_params.size * 2, MSG_QUORUM_JUSTIFICATION),
@@ -185,14 +187,14 @@ void CDKGSessionHandler::StopThread()
 
 bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
 {
-    curSession = std::make_unique<CDKGSession>(params, blsWorker, m_dmnman, dkgManager, dkgDebugManager, connman, m_sporkman);
+    curSession = std::make_unique<CDKGSession>(params, blsWorker, m_dmnman, dkgManager, dkgDebugManager, connman, m_mn_activeman, m_sporkman);
 
     if (!DeploymentDIP0003Enforced(pQuorumBaseBlockIndex->nHeight, Params().GetConsensus())) {
         return false;
     }
 
     auto mns = utils::GetAllQuorumMembers(params.type, m_dmnman, pQuorumBaseBlockIndex);
-    if (!curSession->Init(pQuorumBaseBlockIndex, mns, WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()), quorumIndex)) {
+    if (!curSession->Init(pQuorumBaseBlockIndex, mns, WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()), quorumIndex)) {
         LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d] mns[%d]\n", __func__, pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex, mns.size());
         return false;
     }

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <optional>
 
+class CActiveMasternodeManager;
 class CBlockIndex;
 class CBLSWorker;
 class CChainState;
@@ -125,6 +126,7 @@ private:
     CDKGDebugManager& dkgDebugManager;
     CDKGSessionManager& dkgManager;
     CQuorumBlockProcessor& quorumBlockProcessor;
+    const CActiveMasternodeManager* m_mn_activeman;
     const CSporkManager& m_sporkman;
     const Consensus::LLMQParams params;
     const int quorumIndex;
@@ -146,7 +148,8 @@ private:
 public:
     CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
                        CDKGDebugManager& _dkgDebugManager, CDKGSessionManager& _dkgManager, CQuorumBlockProcessor& _quorumBlockProcessor,
-                       const CSporkManager& sporkman, const Consensus::LLMQParams& _params, int _quorumIndex);
+                       const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman, const Consensus::LLMQParams& _params,
+                       int _quorumIndex);
     ~CDKGSessionHandler() = default;
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew);

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -25,8 +25,8 @@ static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
 CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
-                                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman,
-                                       bool unitTests, bool fWipe) :
+                                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* mn_activeman,
+                                       const CSporkManager& sporkman, bool unitTests, bool fWipe) :
     db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
     blsWorker(_blsWorker),
     m_chainstate(chainstate),
@@ -49,7 +49,7 @@ CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chai
         for (const auto i : irange::range(session_count)) {
             dkgSessionHandlers.emplace(std::piecewise_construct,
                                        std::forward_as_tuple(params.type, i),
-                                       std::forward_as_tuple(blsWorker, m_chainstate, connman, dmnman, dkgDebugManager, *this, quorumBlockProcessor, spork_manager, params, i));
+                                       std::forward_as_tuple(blsWorker, m_chainstate, connman, dmnman, dkgDebugManager, *this, quorumBlockProcessor, mn_activeman, spork_manager, params, i));
         }
     }
 }

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <memory>
 
+class CActiveMasternodeManager;
 class CBlockIndex;
 class CChainState;
 class CDBWrapper;
@@ -66,8 +67,8 @@ private:
 
 public:
     CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
-                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman,
-                       bool unitTests, bool fWipe);
+                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* mn_activeman,
+                       const CSporkManager& sporkman, bool unitTests, bool fWipe);
     ~CDKGSessionManager() = default;
 
     void StartThreads();

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -250,7 +250,10 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
         const auto vecQuorums = ScanQuorums(params.type, pIndex, params.keepOldConnections);
 
         // First check if we are member of any quorum of this type
-        auto proTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
+        const uint256 proTxHash = fMasternodeMode ?
+                                  WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash) :
+                                  uint256();
+
         bool fWeAreQuorumTypeMember = ranges::any_of(vecQuorums, [&proTxHash](const auto& pQuorum) {
             return pQuorum->IsValidMember(proTxHash);
         });
@@ -341,7 +344,10 @@ void CQuorumManager::CheckQuorumConnections(const Consensus::LLMQParams& llmqPar
         LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- llmqType[%d] h[%d] keeping mn quorum connections for quorum: [%d:%s]\n", __func__, ToUnderlying(llmqParams.type), pindexNew->nHeight, curDkgHeight, curDkgBlock.ToString());
     }
 
-    const auto myProTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
+    const uint256 myProTxHash = fMasternodeMode ?
+                                WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash) :
+                                uint256();
+
     bool isISType = llmqParams.type == Params().GetConsensus().llmqTypeDIP0024InstantSend;
 
     bool watchOtherISQuorums = isISType && !myProTxHash.IsNull() &&

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -103,7 +103,7 @@ bool CQuorum::SetVerificationVector(const std::vector<CBLSPublicKey>& quorumVecI
 
 bool CQuorum::SetSecretKeyShare(const CBLSSecretKey& secretKeyShare)
 {
-    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(WITH_LOCK(::activeMasternodeManager->cs, return GetMemberIndex(::activeMasternodeManager->m_info.proTxHash))))) {
+    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(WITH_LOCK(::activeMasternodeManager->cs, return GetMemberIndex(::activeMasternodeManager->GetProTxHash()))))) {
         return false;
     }
     LOCK(cs);
@@ -251,7 +251,7 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
 
         // First check if we are member of any quorum of this type
         const uint256 proTxHash = fMasternodeMode ?
-                                  WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash) :
+                                  WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()) :
                                   uint256();
 
         bool fWeAreQuorumTypeMember = ranges::any_of(vecQuorums, [&proTxHash](const auto& pQuorum) {
@@ -345,7 +345,7 @@ void CQuorumManager::CheckQuorumConnections(const Consensus::LLMQParams& llmqPar
     }
 
     const uint256 myProTxHash = fMasternodeMode ?
-                                WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash) :
+                                WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()) :
                                 uint256();
 
     bool isISType = llmqParams.type == Params().GetConsensus().llmqTypeDIP0024InstantSend;
@@ -658,7 +658,7 @@ size_t CQuorumManager::GetQuorumRecoveryStartOffset(const CQuorumCPtr pQuorum, c
         LOCK(::activeMasternodeManager->cs);
         for (const auto i : irange::range(vecProTxHashes.size())) {
             // cppcheck-suppress useStlAlgorithm
-            if (::activeMasternodeManager->m_info.proTxHash == vecProTxHashes[i]) {
+            if (::activeMasternodeManager->GetProTxHash() == vecProTxHashes[i]) {
                 nIndex = i;
                 break;
             }
@@ -916,7 +916,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
 
         vecMemberHashes.reserve(pQuorum->qc->validMembers.size());
         for (auto& member : pQuorum->members) {
-            if (pQuorum->IsValidMember(member->proTxHash) && member->proTxHash != WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash)) {
+            if (pQuorum->IsValidMember(member->proTxHash) && member->proTxHash != WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash())) {
                 vecMemberHashes.push_back(member->proTxHash);
             }
         }
@@ -965,7 +965,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                 printLog("Connect");
             }
 
-            auto proTxHash = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash);
+            auto proTxHash = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash());
             connman.ForEachNode([&](CNode* pNode) {
                 auto verifiedProRegTxHash = pNode->GetVerifiedProRegTxHash();
                 if (pCurrentMemberHash == nullptr || verifiedProRegTxHash != *pCurrentMemberHash) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -103,7 +103,7 @@ bool CQuorum::SetVerificationVector(const std::vector<CBLSPublicKey>& quorumVecI
 
 bool CQuorum::SetSecretKeyShare(const CBLSSecretKey& secretKeyShare)
 {
-    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(WITH_LOCK(activeMasternodeInfoCs, return GetMemberIndex(activeMasternodeInfo.proTxHash))))) {
+    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(WITH_LOCK(::activeMasternodeManager->cs, return GetMemberIndex(::activeMasternodeManager->m_info.proTxHash))))) {
         return false;
     }
     LOCK(cs);
@@ -251,7 +251,7 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
 
         // First check if we are member of any quorum of this type
         const uint256 proTxHash = fMasternodeMode ?
-                                  WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash) :
+                                  WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash) :
                                   uint256();
 
         bool fWeAreQuorumTypeMember = ranges::any_of(vecQuorums, [&proTxHash](const auto& pQuorum) {
@@ -345,7 +345,7 @@ void CQuorumManager::CheckQuorumConnections(const Consensus::LLMQParams& llmqPar
     }
 
     const uint256 myProTxHash = fMasternodeMode ?
-                                WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash) :
+                                WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash) :
                                 uint256();
 
     bool isISType = llmqParams.type == Params().GetConsensus().llmqTypeDIP0024InstantSend;
@@ -655,10 +655,10 @@ size_t CQuorumManager::GetQuorumRecoveryStartOffset(const CQuorumCPtr pQuorum, c
     std::sort(vecProTxHashes.begin(), vecProTxHashes.end());
     size_t nIndex{0};
     {
-        LOCK(activeMasternodeInfoCs);
+        LOCK(::activeMasternodeManager->cs);
         for (const auto i : irange::range(vecProTxHashes.size())) {
             // cppcheck-suppress useStlAlgorithm
-            if (activeMasternodeInfo.proTxHash == vecProTxHashes[i]) {
+            if (::activeMasternodeManager->m_info.proTxHash == vecProTxHashes[i]) {
                 nIndex = i;
                 break;
             }
@@ -834,7 +834,7 @@ PeerMsgRet CQuorumManager::ProcessMessage(CNode& pfrom, const std::string& msg_t
 
             std::vector<CBLSSecretKey> vecSecretKeys;
             vecSecretKeys.resize(vecEncrypted.size());
-            auto secret = WITH_LOCK(activeMasternodeInfoCs, return *activeMasternodeInfo.blsKeyOperator);
+            auto secret = WITH_LOCK(::activeMasternodeManager->cs, return *::activeMasternodeManager->m_info.blsKeyOperator);
             for (const auto i : irange::range(vecEncrypted.size())) {
                 if (!vecEncrypted[i].Decrypt(memberIdx, secret, vecSecretKeys[i], PROTOCOL_VERSION)) {
                     return errorHandler("Failed to decrypt");
@@ -917,7 +917,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
 
         vecMemberHashes.reserve(pQuorum->qc->validMembers.size());
         for (auto& member : pQuorum->members) {
-            if (pQuorum->IsValidMember(member->proTxHash) && member->proTxHash != WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash)) {
+            if (pQuorum->IsValidMember(member->proTxHash) && member->proTxHash != WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash)) {
                 vecMemberHashes.push_back(member->proTxHash);
             }
         }
@@ -966,7 +966,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                 printLog("Connect");
             }
 
-            auto proTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
+            auto proTxHash = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash);
             connman.ForEachNode([&](CNode* pNode) {
                 auto verifiedProRegTxHash = pNode->GetVerifiedProRegTxHash();
                 if (pCurrentMemberHash == nullptr || verifiedProRegTxHash != *pCurrentMemberHash) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -101,9 +101,9 @@ bool CQuorum::SetVerificationVector(const std::vector<CBLSPublicKey>& quorumVecI
     return true;
 }
 
-bool CQuorum::SetSecretKeyShare(const CBLSSecretKey& secretKeyShare)
+bool CQuorum::SetSecretKeyShare(const CBLSSecretKey& secretKeyShare, const CActiveMasternodeManager& mn_activeman)
 {
-    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(WITH_LOCK(::activeMasternodeManager->cs, return GetMemberIndex(::activeMasternodeManager->GetProTxHash()))))) {
+    if (!secretKeyShare.IsValid() || (secretKeyShare.GetPublicKey() != GetPubKeyShare(WITH_LOCK(mn_activeman.cs, return GetMemberIndex(mn_activeman.GetProTxHash()))))) {
         return false;
     }
     LOCK(cs);
@@ -205,8 +205,10 @@ bool CQuorum::ReadContributions(CEvoDB& evoDb)
     return true;
 }
 
-CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager,
-                               CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync) :
+CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
+                               CDKGSessionManager& _dkgManager, CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor,
+                               const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman,
+                               const std::unique_ptr<CMasternodeSync>& mn_sync) :
     blsWorker(_blsWorker),
     m_chainstate(chainstate),
     connman(_connman),
@@ -214,6 +216,7 @@ CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, 
     dkgManager(_dkgManager),
     m_evoDb(_evoDb),
     quorumBlockProcessor(_quorumBlockProcessor),
+    m_mn_activeman(mn_activeman),
     m_sporkman(sporkman),
     m_mn_sync(mn_sync)
 {
@@ -250,9 +253,11 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
         const auto vecQuorums = ScanQuorums(params.type, pIndex, params.keepOldConnections);
 
         // First check if we are member of any quorum of this type
-        const uint256 proTxHash = fMasternodeMode ?
-                                  WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()) :
-                                  uint256();
+        const uint256 proTxHash = [this]() {
+            if (!fMasternodeMode) return uint256();
+            assert(m_mn_activeman);
+            return WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash());
+        }();
 
         bool fWeAreQuorumTypeMember = ranges::any_of(vecQuorums, [&proTxHash](const auto& pQuorum) {
             return pQuorum->IsValidMember(proTxHash);
@@ -344,9 +349,11 @@ void CQuorumManager::CheckQuorumConnections(const Consensus::LLMQParams& llmqPar
         LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- llmqType[%d] h[%d] keeping mn quorum connections for quorum: [%d:%s]\n", __func__, ToUnderlying(llmqParams.type), pindexNew->nHeight, curDkgHeight, curDkgBlock.ToString());
     }
 
-    const uint256 myProTxHash = fMasternodeMode ?
-                                WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()) :
-                                uint256();
+    const uint256 myProTxHash = [this]() {
+        if (!fMasternodeMode) return uint256();
+        assert(m_mn_activeman);
+        return WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash());
+    }();
 
     bool isISType = llmqParams.type == Params().GetConsensus().llmqTypeDIP0024InstantSend;
 
@@ -646,6 +653,8 @@ CQuorumCPtr CQuorumManager::GetQuorum(Consensus::LLMQType llmqType, gsl::not_nul
 
 size_t CQuorumManager::GetQuorumRecoveryStartOffset(const CQuorumCPtr pQuorum, const CBlockIndex* pIndex) const
 {
+    assert(m_mn_activeman);
+
     auto mns = m_dmnman.GetListForBlock(pIndex);
     std::vector<uint256> vecProTxHashes;
     vecProTxHashes.reserve(mns.GetValidMNsCount());
@@ -655,10 +664,10 @@ size_t CQuorumManager::GetQuorumRecoveryStartOffset(const CQuorumCPtr pQuorum, c
     std::sort(vecProTxHashes.begin(), vecProTxHashes.end());
     size_t nIndex{0};
     {
-        LOCK(::activeMasternodeManager->cs);
+        LOCK(m_mn_activeman->cs);
         for (const auto i : irange::range(vecProTxHashes.size())) {
             // cppcheck-suppress useStlAlgorithm
-            if (::activeMasternodeManager->GetProTxHash() == vecProTxHashes[i]) {
+            if (m_mn_activeman->GetProTxHash() == vecProTxHashes[i]) {
                 nIndex = i;
                 break;
             }
@@ -819,6 +828,7 @@ PeerMsgRet CQuorumManager::ProcessMessage(CNode& pfrom, const std::string& msg_t
 
         // Check if request has ENCRYPTED_CONTRIBUTIONS data
         if (request.GetDataMask() & CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS) {
+            assert(fMasternodeMode);
 
             if (WITH_LOCK(pQuorum->cs, return pQuorum->quorumVvec->size() != size_t(pQuorum->params.threshold))) {
                 return errorHandler("No valid quorum verification vector available", 0); // Don't bump score because we asked for it
@@ -835,13 +845,13 @@ PeerMsgRet CQuorumManager::ProcessMessage(CNode& pfrom, const std::string& msg_t
             std::vector<CBLSSecretKey> vecSecretKeys;
             vecSecretKeys.resize(vecEncrypted.size());
             for (const auto i : irange::range(vecEncrypted.size())) {
-                if (!::activeMasternodeManager->Decrypt(vecEncrypted[i], memberIdx, vecSecretKeys[i], PROTOCOL_VERSION)) {
+                if (!Assert(m_mn_activeman)->Decrypt(vecEncrypted[i], memberIdx, vecSecretKeys[i], PROTOCOL_VERSION)) {
                     return errorHandler("Failed to decrypt");
                 }
             }
 
             CBLSSecretKey secretKeyShare = blsWorker.AggregateSecretKeys(vecSecretKeys);
-            if (!pQuorum->SetSecretKeyShare(secretKeyShare)) {
+            if (!pQuorum->SetSecretKeyShare(secretKeyShare, *m_mn_activeman)) {
                 return errorHandler("Invalid secret key share received");
             }
         }
@@ -883,6 +893,8 @@ void CQuorumManager::StartCachePopulatorThread(const CQuorumCPtr pQuorum) const
 
 void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, const CBlockIndex* pIndex, uint16_t nDataMaskIn) const
 {
+    assert(m_mn_activeman);
+
     if (pQuorum->fQuorumDataRecoveryThreadRunning) {
         LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- Already running\n", __func__);
         return;
@@ -916,7 +928,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
 
         vecMemberHashes.reserve(pQuorum->qc->validMembers.size());
         for (auto& member : pQuorum->members) {
-            if (pQuorum->IsValidMember(member->proTxHash) && member->proTxHash != WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash())) {
+            if (pQuorum->IsValidMember(member->proTxHash) && member->proTxHash != WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash())) {
                 vecMemberHashes.push_back(member->proTxHash);
             }
         }
@@ -965,7 +977,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
                 printLog("Connect");
             }
 
-            auto proTxHash = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash());
+            auto proTxHash = WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash());
             connman.ForEachNode([&](CNode* pNode) {
                 auto verifiedProRegTxHash = pNode->GetVerifiedProRegTxHash();
                 if (pCurrentMemberHash == nullptr || verifiedProRegTxHash != *pCurrentMemberHash) {

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -834,9 +834,8 @@ PeerMsgRet CQuorumManager::ProcessMessage(CNode& pfrom, const std::string& msg_t
 
             std::vector<CBLSSecretKey> vecSecretKeys;
             vecSecretKeys.resize(vecEncrypted.size());
-            auto secret = WITH_LOCK(::activeMasternodeManager->cs, return *::activeMasternodeManager->m_info.blsKeyOperator);
             for (const auto i : irange::range(vecEncrypted.size())) {
-                if (!vecEncrypted[i].Decrypt(memberIdx, secret, vecSecretKeys[i], PROTOCOL_VERSION)) {
+                if (!::activeMasternodeManager->Decrypt(vecEncrypted[i], memberIdx, vecSecretKeys[i], PROTOCOL_VERSION)) {
                     return errorHandler("Failed to decrypt");
                 }
             }

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <map>
 
+class CActiveMasternodeManager;
 class CBlockIndex;
 class CChainState;
 class CConnman;
@@ -192,7 +193,7 @@ public:
     void Init(CFinalCommitmentPtr _qc, const CBlockIndex* _pQuorumBaseBlockIndex, const uint256& _minedBlockHash, Span<CDeterministicMNCPtr> _members);
 
     bool SetVerificationVector(const std::vector<CBLSPublicKey>& quorumVecIn);
-    bool SetSecretKeyShare(const CBLSSecretKey& secretKeyShare);
+    bool SetSecretKeyShare(const CBLSSecretKey& secretKeyShare, const CActiveMasternodeManager& mn_activeman);
 
     bool HasVerificationVector() const;
     bool IsMember(const uint256& proTxHash) const;
@@ -223,6 +224,7 @@ private:
     CDKGSessionManager& dkgManager;
     CEvoDB& m_evoDb;
     CQuorumBlockProcessor& quorumBlockProcessor;
+    const CActiveMasternodeManager* m_mn_activeman;
     const CSporkManager& m_sporkman;
     const std::unique_ptr<CMasternodeSync>& m_mn_sync;
 
@@ -237,8 +239,9 @@ private:
     mutable CThreadInterrupt quorumThreadInterrupt;
 
 public:
-    CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager,
-                   CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync);
+    CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
+                   CDKGSessionManager& _dkgManager, CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor,
+                   const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync);
     ~CQuorumManager() { Stop(); };
 
     void Start();

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -895,9 +895,8 @@ void CSigningManager::UnregisterRecoveredSigsListener(CRecoveredSigsListener* l)
 
 bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigSharesManager& shareman, const uint256& id, const uint256& msgHash, const uint256& quorumHash, bool allowReSign)
 {
-    if (!fMasternodeMode || WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) {
-        return false;
-    }
+    if (!fMasternodeMode) return false;
+    if (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) return false;
 
     const CQuorumCPtr quorum = [&]() {
         if (quorumHash.IsNull()) {

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -896,7 +896,7 @@ void CSigningManager::UnregisterRecoveredSigsListener(CRecoveredSigsListener* l)
 bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigSharesManager& shareman, const uint256& id, const uint256& msgHash, const uint256& quorumHash, bool allowReSign)
 {
     if (!fMasternodeMode) return false;
-    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash.IsNull())) return false;
+    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash().IsNull())) return false;
 
     const CQuorumCPtr quorum = [&]() {
         if (quorumHash.IsNull()) {
@@ -918,7 +918,7 @@ bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigShares
         return false;
     }
 
-    if (!WITH_LOCK(::activeMasternodeManager->cs, return quorum->IsValidMember(::activeMasternodeManager->m_info.proTxHash))) {
+    if (!WITH_LOCK(::activeMasternodeManager->cs, return quorum->IsValidMember(::activeMasternodeManager->GetProTxHash()))) {
         return false;
     }
 

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -896,7 +896,7 @@ void CSigningManager::UnregisterRecoveredSigsListener(CRecoveredSigsListener* l)
 bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigSharesManager& shareman, const uint256& id, const uint256& msgHash, const uint256& quorumHash, bool allowReSign)
 {
     if (!fMasternodeMode) return false;
-    if (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) return false;
+    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash.IsNull())) return false;
 
     const CQuorumCPtr quorum = [&]() {
         if (quorumHash.IsNull()) {
@@ -918,7 +918,7 @@ bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigShares
         return false;
     }
 
-    if (!WITH_LOCK(activeMasternodeInfoCs, return quorum->IsValidMember(activeMasternodeInfo.proTxHash))) {
+    if (!WITH_LOCK(::activeMasternodeManager->cs, return quorum->IsValidMember(::activeMasternodeManager->m_info.proTxHash))) {
         return false;
     }
 

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -18,6 +18,7 @@
 
 #include <unordered_map>
 
+class CActiveMasternodeManager;
 class CConnman;
 class CDataStream;
 class CDBBatch;
@@ -162,6 +163,7 @@ private:
 
     CRecoveredSigsDb db;
     CConnman& connman;
+    const CActiveMasternodeManager* m_mn_activeman;
     const CQuorumManager& qman;
 
     std::atomic<PeerManager*> m_peerman{nullptr};
@@ -177,7 +179,7 @@ private:
     std::vector<CRecoveredSigsListener*> recoveredSigsListeners GUARDED_BY(cs);
 
 public:
-    CSigningManager(CConnman& _connman, const CQuorumManager& _qman, bool fMemory, bool fWipe);
+    CSigningManager(CConnman& _connman, const CActiveMasternodeManager* mn_activeman, const CQuorumManager& _qman, bool fMemory, bool fWipe);
 
     bool AlreadyHave(const CInv& inv) const;
     bool GetRecoveredSigForGetData(const uint256& hash, CRecoveredSig& ret) const;

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -219,7 +219,7 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const CSporkManager& 
 {
     // non-masternodes are not interested in sigshares
     if (!fMasternodeMode) return;
-    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash.IsNull())) return;
+    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash().IsNull())) return;
 
     if (sporkman.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && msg_type == NetMsgType::QSIGSHARE) {
         std::vector<CSigShare> receivedSigShares;
@@ -464,7 +464,7 @@ void CSigSharesManager::ProcessMessageSigShare(NodeId fromId, const CSigShare& s
         // quorum is too old
         return;
     }
-    if (!quorum->IsMember(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash))) {
+    if (!quorum->IsMember(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()))) {
         // we're not a member so we can't verify it (we actually shouldn't have received it)
         return;
     }
@@ -513,7 +513,7 @@ bool CSigSharesManager::PreVerifyBatchedSigShares(const CQuorumManager& quorum_m
         // quorum is too old
         return false;
     }
-    if (!session.quorum->IsMember(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash))) {
+    if (!session.quorum->IsMember(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()))) {
         // we're not a member so we can't verify it (we actually shouldn't have received it)
         return false;
     }
@@ -697,7 +697,7 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CConnma
 
     // prepare node set for direct-push in case this is our sig share
     std::set<NodeId> quorumNodes;
-    if (!IsAllMembersConnectedEnabled(llmqType, m_sporkman) && sigShare.getQuorumMember() == quorum->GetMemberIndex(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash))) {
+    if (!IsAllMembersConnectedEnabled(llmqType, m_sporkman) && sigShare.getQuorumMember() == quorum->GetMemberIndex(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()))) {
         quorumNodes = connman.GetMasternodeQuorumNodes(sigShare.getLlmqType(), sigShare.getQuorumHash());
     }
 
@@ -1488,7 +1488,7 @@ void CSigSharesManager::SignPendingSigShares()
 std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash) const
 {
     cxxtimer::Timer t(true);
-    auto activeMasterNodeProTxHash = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash);
+    auto activeMasterNodeProTxHash = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash());
 
     if (!quorum->IsValidMember(activeMasterNodeProTxHash)) {
         return std::nullopt;

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -219,7 +219,7 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const CSporkManager& 
 {
     // non-masternodes are not interested in sigshares
     if (!fMasternodeMode) return;
-    if (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) return;
+    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash.IsNull())) return;
 
     if (sporkman.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && msg_type == NetMsgType::QSIGSHARE) {
         std::vector<CSigShare> receivedSigShares;
@@ -464,7 +464,7 @@ void CSigSharesManager::ProcessMessageSigShare(NodeId fromId, const CSigShare& s
         // quorum is too old
         return;
     }
-    if (!quorum->IsMember(WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash))) {
+    if (!quorum->IsMember(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash))) {
         // we're not a member so we can't verify it (we actually shouldn't have received it)
         return;
     }
@@ -513,7 +513,7 @@ bool CSigSharesManager::PreVerifyBatchedSigShares(const CQuorumManager& quorum_m
         // quorum is too old
         return false;
     }
-    if (!session.quorum->IsMember(WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash))) {
+    if (!session.quorum->IsMember(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash))) {
         // we're not a member so we can't verify it (we actually shouldn't have received it)
         return false;
     }
@@ -697,7 +697,7 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CConnma
 
     // prepare node set for direct-push in case this is our sig share
     std::set<NodeId> quorumNodes;
-    if (!IsAllMembersConnectedEnabled(llmqType, m_sporkman) && sigShare.getQuorumMember() == quorum->GetMemberIndex(WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash))) {
+    if (!IsAllMembersConnectedEnabled(llmqType, m_sporkman) && sigShare.getQuorumMember() == quorum->GetMemberIndex(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash))) {
         quorumNodes = connman.GetMasternodeQuorumNodes(sigShare.getLlmqType(), sigShare.getQuorumHash());
     }
 
@@ -1488,7 +1488,7 @@ void CSigSharesManager::SignPendingSigShares()
 std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash) const
 {
     cxxtimer::Timer t(true);
-    auto activeMasterNodeProTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
+    auto activeMasterNodeProTxHash = WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash);
 
     if (!quorum->IsValidMember(activeMasterNodeProTxHash)) {
         return std::nullopt;

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -218,9 +218,8 @@ void CSigSharesManager::InterruptWorkerThread()
 void CSigSharesManager::ProcessMessage(const CNode& pfrom, const CSporkManager& sporkman, const std::string& msg_type, CDataStream& vRecv)
 {
     // non-masternodes are not interested in sigshares
-    if (!fMasternodeMode || WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) {
-        return;
-    }
+    if (!fMasternodeMode) return;
+    if (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash.IsNull())) return;
 
     if (sporkman.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && msg_type == NetMsgType::QSIGSHARE) {
         std::vector<CSigShare> receivedSigShares;

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -401,6 +401,7 @@ private:
 
     CConnman& connman;
     CSigningManager& sigman;
+    const CActiveMasternodeManager* m_mn_activeman;
     const CQuorumManager& qman;
     const CSporkManager& m_sporkman;
 
@@ -410,8 +411,9 @@ private:
     std::atomic<uint32_t> recoveredSigsCounter{0};
 
 public:
-    explicit CSigSharesManager(CConnman& _connman, CSigningManager& _sigman, const CQuorumManager& _qman, const CSporkManager& sporkman, const std::unique_ptr<PeerManager>& peerman) :
-        connman(_connman), sigman(_sigman), qman(_qman), m_sporkman(sporkman), m_peerman(peerman)
+    explicit CSigSharesManager(CConnman& _connman, CSigningManager& _sigman, const CActiveMasternodeManager* mn_activeman,
+                               const CQuorumManager& _qman, const CSporkManager& sporkman, const std::unique_ptr<PeerManager>& peerman) :
+        connman(_connman), sigman(_sigman), m_mn_activeman(mn_activeman), qman(_qman), m_sporkman(sporkman), m_peerman(peerman)
     {
         workInterrupt.reset();
     };
@@ -443,7 +445,8 @@ private:
     void ProcessMessageSigShare(NodeId fromId, const CSigShare& sigShare);
 
     static bool VerifySigSharesInv(Consensus::LLMQType llmqType, const CSigSharesInv& inv);
-    static bool PreVerifyBatchedSigShares(const CQuorumManager& quorum_manager, const CSigSharesNodeState::SessionInfo& session, const CBatchedSigShares& batchedSigShares, bool& retBan);
+    static bool PreVerifyBatchedSigShares(const CActiveMasternodeManager& mn_activeman, const CQuorumManager& quorum_manager,
+                                          const CSigSharesNodeState::SessionInfo& session, const CBatchedSigShares& batchedSigShares, bool& retBan);
 
     void CollectPendingSigSharesToVerify(size_t maxUniqueSessions,
             std::unordered_map<NodeId, std::vector<CSigShare>>& retSigShares,

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -11,6 +11,7 @@
 #include <net.h>
 #include <netbase.h>
 #include <protocol.h>
+#include <util/check.h>
 #include <validation.h>
 #include <warnings.h>
 
@@ -274,4 +275,11 @@ template bool CActiveMasternodeManager::Decrypt(const CBLSIESMultiRecipientObjec
 {
     AssertLockNotHeld(cs);
     return WITH_LOCK(cs, return Assert(m_info.blsKeyOperator)->Sign(hash, is_legacy));
+}
+
+// We need to pass a copy as opposed to a const ref because CBLSPublicKeyVersionWrapper
+// does not accept a const ref in its construction args
+[[nodiscard]] CBLSPublicKey CActiveMasternodeManager::GetPubKey() const
+{
+    return *Assert(m_info.blsPubKeyOperator);
 }

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -251,3 +251,15 @@ bool CActiveMasternodeManager::IsValidNetAddr(const CService& addrIn)
     return !Params().RequireRoutableExternalIP() ||
            (addrIn.IsIPv4() && IsReachable(addrIn) && addrIn.IsRoutable());
 }
+
+[[nodiscard]] CBLSSignature CActiveMasternodeManager::Sign(const uint256& hash) const
+{
+    AssertLockNotHeld(cs);
+    return WITH_LOCK(cs, return Assert(m_info.blsKeyOperator)->Sign(hash));
+}
+
+[[nodiscard]] CBLSSignature CActiveMasternodeManager::Sign(const uint256& hash, const bool is_legacy) const
+{
+    AssertLockNotHeld(cs);
+    return WITH_LOCK(cs, return Assert(m_info.blsKeyOperator)->Sign(hash, is_legacy));
+}

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -41,11 +41,12 @@ public:
     };
 
     mutable RecursiveMutex cs;
-    CActiveMasternodeInfo m_info GUARDED_BY(cs);
 
 private:
     masternode_state_t state{MASTERNODE_WAITING_FOR_PROTX};
+    CActiveMasternodeInfo m_info GUARDED_BY(cs);
     std::string strError;
+
     CConnman& connman;
     const std::unique_ptr<CDeterministicMNManager>& m_dmnman;
 
@@ -69,6 +70,13 @@ public:
         LOCKS_EXCLUDED(cs);
     [[nodiscard]] CBLSSignature Sign(const uint256& hash) const LOCKS_EXCLUDED(cs);
     [[nodiscard]] CBLSSignature Sign(const uint256& hash, const bool is_legacy) const LOCKS_EXCLUDED(cs);
+
+    /* TODO: Reconsider external locking */
+    [[nodiscard]] const COutPoint& GetOutPoint() const EXCLUSIVE_LOCKS_REQUIRED(cs) { return m_info.outpoint; }
+    [[nodiscard]] const uint256& GetProTxHash() const EXCLUSIVE_LOCKS_REQUIRED(cs) { return m_info.proTxHash; }
+    [[nodiscard]] const CService& GetService() const EXCLUSIVE_LOCKS_REQUIRED(cs) { return m_info.service; }
+    [[nodiscard]] CBLSPublicKey GetPubKey() const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    [[nodiscard]] const bool IsLegacy() const EXCLUSIVE_LOCKS_REQUIRED(cs) { return m_info.legacy; }
 
 private:
     bool GetLocalAddress(CService& addrRet);

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -44,9 +44,9 @@ public:
     mutable RecursiveMutex cs;
 
 private:
-    masternode_state_t m_state{MASTERNODE_WAITING_FOR_PROTX};
+    masternode_state_t m_state GUARDED_BY(cs) {MASTERNODE_WAITING_FOR_PROTX};
     CActiveMasternodeInfo m_info GUARDED_BY(cs);
-    std::string m_error;
+    std::string m_error GUARDED_BY(cs);
 
     CConnman& m_connman;
     const std::unique_ptr<CDeterministicMNManager>& m_dmnman;
@@ -74,7 +74,7 @@ public:
     [[nodiscard]] const uint256& GetProTxHash() const EXCLUSIVE_LOCKS_REQUIRED(cs) { return m_info.proTxHash; }
     [[nodiscard]] const CService& GetService() const EXCLUSIVE_LOCKS_REQUIRED(cs) { return m_info.service; }
     [[nodiscard]] CBLSPublicKey GetPubKey() const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    [[nodiscard]] const bool IsLegacy() const EXCLUSIVE_LOCKS_REQUIRED(cs) { return m_info.legacy; }
+    [[nodiscard]] bool IsLegacy() const EXCLUSIVE_LOCKS_REQUIRED(cs) { return m_info.legacy; }
 
 private:
     bool GetLocalAddress(CService& addrRet);

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -44,15 +44,15 @@ public:
     mutable RecursiveMutex cs;
 
 private:
-    masternode_state_t state{MASTERNODE_WAITING_FOR_PROTX};
+    masternode_state_t m_state{MASTERNODE_WAITING_FOR_PROTX};
     CActiveMasternodeInfo m_info GUARDED_BY(cs);
-    std::string strError;
+    std::string m_error;
 
-    CConnman& connman;
+    CConnman& m_connman;
     const std::unique_ptr<CDeterministicMNManager>& m_dmnman;
 
 public:
-    explicit CActiveMasternodeManager(const CBLSSecretKey& sk, CConnman& _connman, const std::unique_ptr<CDeterministicMNManager>& dmnman);
+    explicit CActiveMasternodeManager(const CBLSSecretKey& sk, CConnman& connman, const std::unique_ptr<CDeterministicMNManager>& dmnman);
 
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override;
 

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -7,18 +7,12 @@
 
 #include <netaddress.h>
 #include <primitives/transaction.h>
+#include <threadsafety.h>
 #include <validationinterface.h>
 
-class CActiveMasternodeManager;
 class CBLSPublicKey;
 class CBLSSecretKey;
 class CDeterministicMNManager;
-
-struct CActiveMasternodeInfo;
-
-extern CActiveMasternodeInfo activeMasternodeInfo;
-extern RecursiveMutex activeMasternodeInfoCs;
-extern std::unique_ptr<CActiveMasternodeManager> activeMasternodeManager;
 
 struct CActiveMasternodeInfo {
     // Keys for the active Masternode
@@ -32,7 +26,6 @@ struct CActiveMasternodeInfo {
     bool legacy{true};
 };
 
-
 class CActiveMasternodeManager final : public CValidationInterface
 {
 public:
@@ -45,6 +38,9 @@ public:
         MASTERNODE_READY,
         MASTERNODE_ERROR,
     };
+
+    mutable RecursiveMutex cs;
+    CActiveMasternodeInfo m_info GUARDED_BY(cs);
 
 private:
     masternode_state_t state{MASTERNODE_WAITING_FOR_PROTX};
@@ -69,5 +65,7 @@ public:
 private:
     bool GetLocalAddress(CService& addrRet);
 };
+
+extern std::unique_ptr<CActiveMasternodeManager> activeMasternodeManager;
 
 #endif // BITCOIN_MASTERNODE_NODE_H

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -12,6 +12,7 @@
 
 class CBLSPublicKey;
 class CBLSSecretKey;
+class CBLSSignature;
 class CDeterministicMNManager;
 
 struct CActiveMasternodeInfo {
@@ -62,6 +63,9 @@ public:
     std::string GetStatus() const;
 
     static bool IsValidNetAddr(const CService& addrIn);
+
+    [[nodiscard]] CBLSSignature Sign(const uint256& hash) const LOCKS_EXCLUDED(cs);
+    [[nodiscard]] CBLSSignature Sign(const uint256& hash, const bool is_legacy) const LOCKS_EXCLUDED(cs);
 
 private:
     bool GetLocalAddress(CService& addrRet);

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -51,11 +51,12 @@ private:
 public:
     explicit CActiveMasternodeManager(CConnman& _connman, const std::unique_ptr<CDeterministicMNManager>& dmnman) :
         connman(_connman), m_dmnman(dmnman) {};
-    ~CActiveMasternodeManager() = default;
+    ~CActiveMasternodeManager();
 
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override;
 
     void Init(const CBlockIndex* pindex);
+    void InitKeys(const CBLSSecretKey& sk) LOCKS_EXCLUDED(cs);
 
     std::string GetStateString() const;
     std::string GetStatus() const;

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -64,6 +64,9 @@ public:
 
     static bool IsValidNetAddr(const CService& addrIn);
 
+    template <template <typename> class EncryptedObj, typename Obj>
+    [[nodiscard]] bool Decrypt(const EncryptedObj<Obj>& obj, size_t idx, Obj& ret_obj, int version) const
+        LOCKS_EXCLUDED(cs);
     [[nodiscard]] CBLSSignature Sign(const uint256& hash) const LOCKS_EXCLUDED(cs);
     [[nodiscard]] CBLSSignature Sign(const uint256& hash, const bool is_legacy) const LOCKS_EXCLUDED(cs);
 

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -12,6 +12,7 @@
 
 class ArgsManager;
 class BanMan;
+class CActiveMasternodeManager;
 class CAddrMan;
 class CBlockPolicyEstimator;
 class CConnman;
@@ -79,6 +80,7 @@ struct NodeContext {
     std::unique_ptr<CNetFulfilledRequestManager> netfulfilledman;
     std::unique_ptr<CSporkManager> sporkman;
     std::unique_ptr<LLMQContext> llmq_ctx;
+    CActiveMasternodeManager* mn_activeman{nullptr};
     CDeterministicMNManager* dmnman{nullptr};
     CMasternodeMetaMan* mn_metaman{nullptr};
     CMasternodeSync* mn_sync{nullptr};

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -38,8 +38,9 @@ static RPCHelpMan coinjoin()
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
 
-    if (fMasternodeMode)
+    if (fMasternodeMode) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Client-side mixing is not supported on masternodes");
+    }
 
     if (!CCoinJoinClientOptions::IsEnabled()) {
         if (!gArgs.GetBoolArg("-enablecoinjoin", true)) {

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -318,12 +318,12 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 
     bool fMnFound{false};
     if (fMasternodeMode) {
-        LOCK(activeMasternodeInfoCs);
-        fMnFound = mnList.HasValidMNByCollateral(activeMasternodeInfo.outpoint);
+        LOCK(::activeMasternodeManager->cs);
+        fMnFound = mnList.HasValidMNByCollateral(::activeMasternodeManager->m_info.outpoint);
 
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
-                 (activeMasternodeInfo.blsPubKeyOperator ? activeMasternodeInfo.blsPubKeyOperator->ToString(activeMasternodeInfo.legacy) : "N/A"),
-                 activeMasternodeInfo.outpoint.ToStringShort(), request.params.size(), fMnFound);
+                (::activeMasternodeManager->m_info.blsPubKeyOperator ? ::activeMasternodeManager->m_info.blsPubKeyOperator->ToString(::activeMasternodeManager->m_info.legacy) : "N/A"),
+                ::activeMasternodeManager->m_info.outpoint.ToStringShort(), request.params.size(), fMnFound);
     } else {
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = N/A, outpoint = N/A, params.size() = %lld, fMnFound = %d\n",
                  request.params.size(), fMnFound);

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -322,7 +322,7 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
         fMnFound = mnList.HasValidMNByCollateral(::activeMasternodeManager->GetOutPoint());
 
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
-                (::activeMasternodeManager->GetPubKey().IsValid() ? ::activeMasternodeManager->GetPubKey().ToString(::activeMasternodeManager->IsLegacy()) : "N/A"),
+                ::activeMasternodeManager->GetPubKey().ToString(::activeMasternodeManager->IsLegacy()),
                 ::activeMasternodeManager->GetOutPoint().ToStringShort(), request.params.size(), fMnFound);
     } else {
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = N/A, outpoint = N/A, params.size() = %lld, fMnFound = %d\n",

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -315,11 +315,19 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
     }
 
     auto mnList = node.dmnman->GetListAtChainTip();
-    bool fMnFound = WITH_LOCK(activeMasternodeInfoCs, return mnList.HasValidMNByCollateral(activeMasternodeInfo.outpoint));
 
-    LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
-            (WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.blsPubKeyOperator ? activeMasternodeInfo.blsPubKeyOperator->ToString(activeMasternodeInfo.legacy) : "N/A")),
-            WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.outpoint.ToStringShort()), request.params.size(), fMnFound);
+    bool fMnFound{false};
+    if (fMasternodeMode) {
+        LOCK(activeMasternodeInfoCs);
+        fMnFound = mnList.HasValidMNByCollateral(activeMasternodeInfo.outpoint);
+
+        LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
+                 (activeMasternodeInfo.blsPubKeyOperator ? activeMasternodeInfo.blsPubKeyOperator->ToString(activeMasternodeInfo.legacy) : "N/A"),
+                 activeMasternodeInfo.outpoint.ToStringShort(), request.params.size(), fMnFound);
+    } else {
+        LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = N/A, outpoint = N/A, params.size() = %lld, fMnFound = %d\n",
+                 request.params.size(), fMnFound);
+    }
 
     // ASSEMBLE NEW GOVERNANCE OBJECT FROM USER PARAMETERS
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -316,17 +316,21 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 
     auto mnList = node.dmnman->GetListAtChainTip();
 
-    bool fMnFound{false};
     if (fMasternodeMode) {
-        LOCK(::activeMasternodeManager->cs);
-        fMnFound = mnList.HasValidMNByCollateral(::activeMasternodeManager->GetOutPoint());
+        CHECK_NONFATAL(node.mn_activeman);
+
+        LOCK(node.mn_activeman->cs);
+        const bool fMnFound = mnList.HasValidMNByCollateral(node.mn_activeman->GetOutPoint());
 
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
-                ::activeMasternodeManager->GetPubKey().ToString(::activeMasternodeManager->IsLegacy()),
-                ::activeMasternodeManager->GetOutPoint().ToStringShort(), request.params.size(), fMnFound);
+                 node.mn_activeman->GetPubKey().ToString(node.mn_activeman->IsLegacy()),
+                 node.mn_activeman->GetOutPoint().ToStringShort(),
+                 request.params.size(),
+                 fMnFound);
     } else {
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = N/A, outpoint = N/A, params.size() = %lld, fMnFound = %d\n",
-                 request.params.size(), fMnFound);
+                 request.params.size(),
+                 false);
     }
 
     // ASSEMBLE NEW GOVERNANCE OBJECT FROM USER PARAMETERS

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -319,11 +319,11 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
     bool fMnFound{false};
     if (fMasternodeMode) {
         LOCK(::activeMasternodeManager->cs);
-        fMnFound = mnList.HasValidMNByCollateral(::activeMasternodeManager->m_info.outpoint);
+        fMnFound = mnList.HasValidMNByCollateral(::activeMasternodeManager->GetOutPoint());
 
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",
-                (::activeMasternodeManager->m_info.blsPubKeyOperator ? ::activeMasternodeManager->m_info.blsPubKeyOperator->ToString(::activeMasternodeManager->m_info.legacy) : "N/A"),
-                ::activeMasternodeManager->m_info.outpoint.ToStringShort(), request.params.size(), fMnFound);
+                (::activeMasternodeManager->GetPubKey().IsValid() ? ::activeMasternodeManager->GetPubKey().ToString(::activeMasternodeManager->IsLegacy()) : "N/A"),
+                ::activeMasternodeManager->GetOutPoint().ToStringShort(), request.params.size(), fMnFound);
     } else {
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = N/A, outpoint = N/A, params.size() = %lld, fMnFound = %d\n",
                  request.params.size(), fMnFound);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -262,16 +262,17 @@ static UniValue masternode_status(const JSONRPCRequest& request)
     }
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CHECK_NONFATAL(node.mn_activeman);
 
     UniValue mnObj(UniValue::VOBJ);
     CDeterministicMNCPtr dmn;
     {
-        LOCK(::activeMasternodeManager->cs);
+        LOCK(node.mn_activeman->cs);
 
         // keep compatibility with legacy status for now (might get deprecated/removed later)
-        mnObj.pushKV("outpoint", ::activeMasternodeManager->GetOutPoint().ToStringShort());
-        mnObj.pushKV("service", ::activeMasternodeManager->GetService().ToString());
-        dmn = node.dmnman->GetListAtChainTip().GetMN(::activeMasternodeManager->GetProTxHash());
+        mnObj.pushKV("outpoint", node.mn_activeman->GetOutPoint().ToStringShort());
+        mnObj.pushKV("service", node.mn_activeman->GetService().ToString());
+        dmn = node.dmnman->GetListAtChainTip().GetMN(node.mn_activeman->GetProTxHash());
     }
     if (dmn) {
         mnObj.pushKV("proTxHash", dmn->proTxHash.ToString());
@@ -280,8 +281,8 @@ static UniValue masternode_status(const JSONRPCRequest& request)
         mnObj.pushKV("collateralIndex", (int)dmn->collateralOutpoint.n);
         mnObj.pushKV("dmnState", dmn->pdmnState->ToJson(dmn->nType));
     }
-    mnObj.pushKV("state", activeMasternodeManager->GetStateString());
-    mnObj.pushKV("status", activeMasternodeManager->GetStatus());
+    mnObj.pushKV("state", node.mn_activeman->GetStateString());
+    mnObj.pushKV("status", node.mn_activeman->GetStatus());
 
     return mnObj;
 }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -266,12 +266,12 @@ static UniValue masternode_status(const JSONRPCRequest& request)
     UniValue mnObj(UniValue::VOBJ);
     CDeterministicMNCPtr dmn;
     {
-        LOCK(activeMasternodeInfoCs);
+        LOCK(::activeMasternodeManager->cs);
 
         // keep compatibility with legacy status for now (might get deprecated/removed later)
-        mnObj.pushKV("outpoint", activeMasternodeInfo.outpoint.ToStringShort());
-        mnObj.pushKV("service", activeMasternodeInfo.service.ToString());
-        dmn = node.dmnman->GetListAtChainTip().GetMN(activeMasternodeInfo.proTxHash);
+        mnObj.pushKV("outpoint", ::activeMasternodeManager->m_info.outpoint.ToStringShort());
+        mnObj.pushKV("service", ::activeMasternodeManager->m_info.service.ToString());
+        dmn = node.dmnman->GetListAtChainTip().GetMN(::activeMasternodeManager->m_info.proTxHash);
     }
     if (dmn) {
         mnObj.pushKV("proTxHash", dmn->proTxHash.ToString());

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -257,8 +257,9 @@ static UniValue masternode_status(const JSONRPCRequest& request)
 {
     masternode_status_help(request);
 
-    if (!fMasternodeMode)
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "This is not a masternode");
+    if (!fMasternodeMode) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "This node does not run an active masternode.");
+    }
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -269,9 +269,9 @@ static UniValue masternode_status(const JSONRPCRequest& request)
         LOCK(::activeMasternodeManager->cs);
 
         // keep compatibility with legacy status for now (might get deprecated/removed later)
-        mnObj.pushKV("outpoint", ::activeMasternodeManager->m_info.outpoint.ToStringShort());
-        mnObj.pushKV("service", ::activeMasternodeManager->m_info.service.ToString());
-        dmn = node.dmnman->GetListAtChainTip().GetMN(::activeMasternodeManager->m_info.proTxHash);
+        mnObj.pushKV("outpoint", ::activeMasternodeManager->GetOutPoint().ToStringShort());
+        mnObj.pushKV("service", ::activeMasternodeManager->GetService().ToString());
+        dmn = node.dmnman->GetListAtChainTip().GetMN(::activeMasternodeManager->GetProTxHash());
     }
     if (dmn) {
         mnObj.pushKV("proTxHash", dmn->proTxHash.ToString());

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -295,7 +295,9 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request, CDeterministicMN
     CBlockIndex* pindexTip = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip());
     int tipHeight = pindexTip->nHeight;
 
-    auto proTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
+    const uint256 proTxHash = fMasternodeMode ?
+                              WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash) :
+                              uint256();
 
     UniValue minableCommitments(UniValue::VARR);
     UniValue quorumArrConnections(UniValue::VARR);

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -296,7 +296,7 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request, CDeterministicMN
     int tipHeight = pindexTip->nHeight;
 
     const uint256 proTxHash = fMasternodeMode ?
-                              WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash) :
+                              WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash) :
                               uint256();
 
     UniValue minableCommitments(UniValue::VARR);

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -296,7 +296,7 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request, CDeterministicMN
     int tipHeight = pindexTip->nHeight;
 
     const uint256 proTxHash = fMasternodeMode ?
-                              WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->m_info.proTxHash) :
+                              WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash()) :
                               uint256();
 
     UniValue minableCommitments(UniValue::VARR);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -111,7 +111,7 @@ void DashTestSetup(NodeContext& node, const CChainParams& chainparams)
 
     ::deterministicMNManager = std::make_unique<CDeterministicMNManager>(chainstate, *node.connman, *node.evodb);
     node.dmnman = ::deterministicMNManager.get();
-    node.cj_ctx = std::make_unique<CJContext>(chainstate, *node.connman, *node.dmnman, *node.mempool, *node.mn_sync, /* relay_txes */ true);
+    node.cj_ctx = std::make_unique<CJContext>(chainstate, *node.connman, *node.dmnman, *node.mempool, /* mn_activeman = */ nullptr, *node.mn_sync, /* relay_txes = */ true);
 #ifdef ENABLE_WALLET
     node.coinjoin_loader = interfaces::MakeCoinJoinLoader(*node.cj_ctx->walletman);
 #endif // ENABLE_WALLET

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -115,7 +115,8 @@ void DashTestSetup(NodeContext& node, const CChainParams& chainparams)
 #ifdef ENABLE_WALLET
     node.coinjoin_loader = interfaces::MakeCoinJoinLoader(*node.cj_ctx->walletman);
 #endif // ENABLE_WALLET
-    node.llmq_ctx = std::make_unique<LLMQContext>(chainstate, *node.connman, *node.dmnman, *node.evodb, *node.mnhf_manager, *node.sporkman, *node.mempool, node.peerman, true, false);
+    node.llmq_ctx = std::make_unique<LLMQContext>(chainstate, *node.connman, *node.dmnman, *node.evodb, *node.mnhf_manager, *node.sporkman, *node.mempool,
+                                                  /* mn_activeman = */ nullptr, node.peerman, /* unit_tests = */ true, /* wipe = */ false);
     node.chain_helper = std::make_unique<CChainstateHelper>(*node.cpoolman, *node.dmnman, *node.mnhf_manager, *node.govman, *(node.llmq_ctx->quorum_block_processor),
                                                             chainparams.GetConsensus(), *node.mn_sync, *node.sporkman, *(node.llmq_ctx->clhandler));
 }

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -93,7 +93,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "spork -> validation -> spork"
     "governance/governance -> validation -> governance/governance"
     "evo/deterministicmns -> validationinterface -> governance/vote -> evo/deterministicmns"
-    "governance/vote -> validation -> validationinterface -> governance/vote"
+    "governance/vote -> masternode/node -> validationinterface -> governance/vote"
     "llmq/signing -> masternode/node -> validationinterface -> llmq/signing"
     "evo/mnhftx -> validation -> evo/mnhftx"
     "evo/deterministicmns -> validation -> evo/deterministicmns"


### PR DESCRIPTION
## Additional Information

* `CActiveMasternodeManager`, unlike other managers, is _conditionally_ initialized (specifically, when the node is hosting a masternode). This means that checks need to be made to ensure that the conditions needed to initialize the manager are true or that the pointer leads to a valid manager instance.

  As the codebase currently checks (and fast-fails) based on the node being in "masternode mode" (`fMasternodeMode`) or not, we will continue with this approach, but with additional assertions _after_ the masternode mode check if the manager exists.

* Though, since `activeMasternodeInfo`(`Cs`) are global variables, they can be accessed _regardless_ of whether the corresponding manager exists. This means some parts of the codebase attempt to fetch information about the (nonexistent) active masternode _before_ determining if it should use the masternode mode path or not (looking at you, `CMNAuth::ProcessMessage`)

  Moving them into `CActiveMasternodeManager` meant adding checks _before_ attempting to access information about the masternode, as they would no longer be accessible with dummy values ([here](https://github.com/dashpay/dash/blob/2110c0c30983e8f3da02f11907bfe4e1b5dcd89f/src/init.cpp#L1633-L1635)) on account of being part of the conditionally initialized manager.
  * In an attempt to opportunistically dereference the manager, `CDKGSessionManager` (accepting a pointer) was dereferencing the manager before passing it to `CDKGSessionHandler`. This was done under the assumption that  `CDKGSessionManager` would only ever be initialized in masternode mode.

    This is not true. I can confirm that because I spent a few days trying to debug test failures. `CDKGSessionHandler` is initialized in two scenarios:

    * In masternode mode
    * If the `-watchquorums` flag is enabled

    The latter scenario doesn't initialize `CActiveMasternodeManager`.

    Furthermore, the DKG round thread is started unconditionally ([here](https://github.com/dashpay/dash/blob/2110c0c30983e8f3da02f11907bfe4e1b5dcd89f/src/llmq/context.cpp#L79)) and the `CDKGSessionHandler::StartThreads` > `CDKGSessionHandler::StartThread` > `CDKGSessionHandler::PhaseHandlerThread` > `CDKGSessionHandler::HandleDKGRound` > `CDKGSessionHandler::InitNewQuorum` > `CActiveMasternodeManager::GetProTxHash` call chain reveals an attempt to fetch active masternode information without any masternode mode checks.

    This behaviour has now been changed and the thread will only be spun up if in masternode mode.

  * Dereferencing so far has been limited to objects that primarily hold data (like `CCoinJoinBroadcastTx` or `CGovernanceObject`) as they should not have knowledge of node's state (that responsibility lies with whatever manager manipulates those objects), perform one-off operations and static functions.

* `activeMasternodeInfo` allowed its members to be read-write accessible to anybody who asked. Additionally, signing and decrypting involved borrowing the operator secret key from the active masternode state to perform those operations.

   This behaviour has now been changed. The internal state is now private and accessible read-only as a const ref (or copy) and `Decrypt`/`Sign` functions have been implemented to allow those operations to happen without having another manager access the operator private key in order to do so.

* You cannot combine a `WITH_LOCK` and an `Assert` (in either mutex or accessed value), doing so will cause errors if `-Werror=thread-safety` is enabled. This is why `assert`s are added even when it would intuitively seem that `Assert` would've been more appropriate to use.

## Future Considerations

Currently there are no unit tests that test the functionality of `CActiveMasternodeManager` as it's never initialized in test contexts, breakage had to be found using functional tests. Perhaps some (rudimentary) tests for `CActiveMasternodeManager` may prove to be valuable.

## Breaking Changes

Not _really_. Some behaviour has been modified but nothing that should necessitate updates or upgrades.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_