### PR TITLE
backport: merge bitcoin#20864 (Move SocketSendData lock annotation to header)

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -920,7 +920,7 @@ public:
     * @param[in]   pnode           The node which we are sending messages to.
     * @return                      True if there is more work to be done
     */
-    virtual bool SendMessages(CNode* pnode) = 0;
+    virtual bool SendMessages(CNode* pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_sendProcessing) = 0;
 
 
 protected:
@@ -1377,7 +1377,7 @@ private:
 
     NodeId GetNewNodeId();
 
-    size_t SocketSendData(CNode *pnode);
+    size_t SocketSendData(CNode& node) EXCLUSIVE_LOCKS_REQUIRED(node.cs_vSend);
     size_t SocketRecvData(CNode* pnode);
     void DumpAddresses();
 


### PR DESCRIPTION
## Additional Information

Broken off from upcoming backport PR relating to networking due to primarily move-only large diff. 

Review large-diff commit using `git diff develop..e432122cbd1cc9bec45cc01c3eb4194a05af1d0e --color-moved=dimmed-zebra --patience` ([source](https://github.com/bitcoin/bitcoin/pull/20864/commits/fa0a71781a964d944db9ecc002675ef32249f62e)) 

## Breaking Changes

None. Changes are primarily move-only with minor changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
