### PR TITLE
fix: delay in TimeOffset applied to AdjustedTime caused by send/recei…

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -880,6 +880,62 @@ size_t CConnman::SocketSendData(CNode *pnode) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs
     auto it = pnode->vSendMsg.begin();
     size_t nSentSize = 0;
 
+/*  Begin queue send delay time offset fix
+    The Sendtime is not the time this message was put in the queue,
+    it is Now(). Observed queue delays of 30 seconds or more are introduced
+    on hosts with restricted resources during "tip" folloowing and chain
+    re-org operations. This delay corrupts AdjustedTime on the receiving host
+    format of VERSION message in std::deque, not contiguous
+    (4)     message start
+    (12)    command = version
+    (4)     size
+    (4)     checksum
+------- chunk 2 -------
+    (4)     nVersion
+    (8)     nServiceInt
+    (8)     nTime
+    (x)     CAddress    addrMe
+    (x)     CAddress    addrFrom
+    (8)     nNonce
+    ........ and so on...
+*/
+    union uS
+    {
+        uint64_t ui64_tm;
+        u_char uchr_tm[8];
+    };
+    union uS uSendbuff;
+    const int bigint = 1;
+    auto& sh = *it;
+// at front of deque, hdrbuf is first
+    CMessageHeader * shdr = reinterpret_cast<CMessageHeader*>(sh.data());
+    std::string strCommand = shdr->GetCommand();
+    if (strCommand == NetMsgType::VERSION) {
+/*  do not increment "it", it corrupts deque
+    header and message are in 2 sequential non-contiguious chunks in the deque, see:
+    void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
+    ...
+        pnode->vSendMsg.push_back(std::move(serializedHeader));
+        if (nMessageSize)
+            pnode->vSendMsg.push_back(std::move(msg.data));
+*/
+        auto& sd = *(std::next(it, 1)); // point to next data chunk
+        memcpy(uSendbuff.uchr_tm, reinterpret_cast<unsigned char*>(sd.data() + 12), 8);
+        int64_t nSendtime = uSendbuff.ui64_tm;
+        int64_t nNow = (pnode->IsOutboundOrBlockRelayConn()) ? GetAdjustedTime() : GetTime();
+        int64_t nNewSendtime = nNow;
+        if (! *(char *)&bigint) {       // if bigendian
+            nSendtime = bswap_64(uSendbuff.ui64_tm);
+            nNewSendtime = bswap_64(nNow);
+        }
+//        LogPrintf("HACK %s size %d %" PRId64 " %" PRId64 "\n", strCommand.c_str(), shdr->nMessageSize, nSendtime
+        if (nSendtime != nNow) {
+             uSendbuff.ui64_tm = nNewSendtime;
+             memcpy(reinterpret_cast<unsigned char*>(sd.data() + 12), uSendbuff.uchr_tm, 8);
+        }
+    }
+// end time offset fix
+
     while (it != pnode->vSendMsg.end()) {
         const auto &data = *it;
         assert(data.size() > pnode->nSendOffset);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3069,7 +3069,16 @@ void PeerManagerImpl::ProcessMessage(
                   pfrom.nStartingHeight, addrMe.ToString(), pfrom.GetId(),
                   remoteAddr);
 
-        int64_t nTimeOffset = nTime - GetTime();
+/*  Begin queue receive delay time offset fix
+    The receive time is not the time this message is processed, it it the time
+    it was put in the queue nTimeReceived.
+    Observed queue delays of 30 seconds or more are introduced
+    on hosts with restricted resources during "tip" folloowing and chain
+    re-org operations. This delay corrupts AdjustedTime/
+*/
+//        int64_t nTimeOffset = nTime - GetTime();
+        int64_t nTimeOffset = nTime - (nTimeReceived/1000000);
+
         pfrom.nTimeOffset = nTimeOffset;
         AddTimeData(pfrom.addr, nTimeOffset);
 


### PR DESCRIPTION
On busy VPS and shared host with limited resources, the time between when a messages is sent to the 
tcpip send or receive queue and when it is sent in the case of send queue, or when it is processed 
(ProcessMessage) can be in excess of 30 seconds.This delay introduces a skew in AdjustedTime.

For the receive queue, the post processing uses the receive time prior to entering the queue to 
calculate TimeOffset rather than Now() which currently includes the delay in the queue.

For the send queue, the queued message is altered to update the nTime of the message to the actual 
time it is being sent rather than the time at which it was queued 

Was tested on an hp 370 G6 24 core 3ghz 192gb host with the daemon launched with -par=2 to restrict 
the resources of the daemon. Logging was added pre-patch to document the delay through the queue and 
was observed for both send and receive to be occasionally > 30 seconds when the daemon was busy 
following the tip or during reorgs when the cup utilization for the assigned core approached 100%. 
Significant queue delay occurs most often in the receive queue (several times a minute) and 
infrequently in the send queue ( 1 observation in several hours of testing ).
## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

