### PR TITLE
refactor: add cs_mapSocketToNode and cs_sendable_receivable_nodes to minimize cs_vNode contention (and document an undocumented lock requirement)

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -1432,7 +1432,8 @@ private:
     std::set<uint256> masternodePendingProbes GUARDED_BY(cs_vPendingMasternodes);
     std::vector<CNode*> vNodes GUARDED_BY(cs_vNodes);
     std::list<CNode*> vNodesDisconnected;
-    std::unordered_map<SOCKET, CNode*> mapSocketToNode;
+    mutable Mutex cs_mapSocketToNode;
+    std::unordered_map<SOCKET, CNode*> mapSocketToNode GUARDED_BY(cs_mapSocketToNode);
     mutable RecursiveMutex cs_vNodes;
     std::atomic<NodeId> nLastNodeId{0};
     unsigned int nPrevNodeCount{0};
@@ -1542,9 +1543,9 @@ private:
     int epollfd{-1};
 #endif
 
-    /** Protected by cs_vNodes */
-    std::unordered_map<NodeId, CNode*> mapReceivableNodes GUARDED_BY(cs_vNodes);
-    std::unordered_map<NodeId, CNode*> mapSendableNodes GUARDED_BY(cs_vNodes);
+    Mutex cs_sendable_receivable_nodes;
+    std::unordered_map<NodeId, CNode*> mapReceivableNodes GUARDED_BY(cs_sendable_receivable_nodes);
+    std::unordered_map<NodeId, CNode*> mapSendableNodes GUARDED_BY(cs_sendable_receivable_nodes);
     /** Protected by cs_mapNodesWithDataToSend */
     std::unordered_map<NodeId, CNode*> mapNodesWithDataToSend GUARDED_BY(cs_mapNodesWithDataToSend);
     mutable RecursiveMutex cs_mapNodesWithDataToSend;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Reduce locking contention on cs_vNode

## What was done?
added new mutex

## How Has This Been Tested?
Building running locally on testnet

## Breaking Changes
None

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
