### PR TITLE
refactor: add a default for CopyNodeVector(cond)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -4160,11 +4160,6 @@ std::vector<CNode*> CConnman::CopyNodeVector(std::function<bool(const CNode* pno
     return vecNodesCopy;
 }
 
-std::vector<CNode*> CConnman::CopyNodeVector()
-{
-    return CopyNodeVector(AllNodes);
-}
-
 void CConnman::ReleaseNodeVector(const std::vector<CNode*>& vecNodes)
 {
     for(size_t i = 0; i < vecNodes.size(); ++i) {

--- a/src/net.h
+++ b/src/net.h
@@ -1173,8 +1173,7 @@ public:
         ForEachNodeThen(FullyConnectedOnly, pre, post);
     }
 
-    std::vector<CNode*> CopyNodeVector(std::function<bool(const CNode* pnode)> cond);
-    std::vector<CNode*> CopyNodeVector();
+    std::vector<CNode*> CopyNodeVector(std::function<bool(const CNode* pnode)> cond = AllNodes);
     void ReleaseNodeVector(const std::vector<CNode*>& vecNodes);
 
     void RelayTransaction(const CTransaction& tx, const bool is_dstx);


### PR DESCRIPTION
## Issue being fixed or feature implemented
This is a custom function in the dash codebase; remove it and use default arg instead

## What was done?


## How Has This Been Tested?
Building

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

