### PR TITLE
feat: implement read write locks in threading and use them for CActiveMasternodeManager::cs

### DIFF
--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -58,7 +58,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
     LogPrint(BCLog::COINJOIN, "DSACCEPT -- nDenom %d (%s)  txCollateral %s", dsa.nDenom, CoinJoin::DenominationToString(dsa.nDenom), dsa.txCollateral.ToString()); /* Continued */
 
     auto mnList = m_dmnman.GetListAtChainTip();
-    auto dmn = WITH_LOCK(m_mn_activeman->cs, return mnList.GetValidMNByCollateral(m_mn_activeman->GetOutPoint()));
+    auto dmn = mnList.GetValidMNByCollateral(m_mn_activeman->GetOutPoint());
     if (!dmn) {
         PushStatus(peer, STATUS_REJECTED, ERR_MN_LIST);
         return;
@@ -69,7 +69,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
             TRY_LOCK(cs_vecqueue, lockRecv);
             if (!lockRecv) return;
 
-            auto mnOutpoint = WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetOutPoint());
+            auto mnOutpoint = m_mn_activeman->GetOutPoint();
 
             if (ranges::any_of(vecCoinJoinQueue,
                                [&mnOutpoint](const auto& q){return q.masternodeOutpoint == mnOutpoint;})) {
@@ -335,8 +335,8 @@ void CCoinJoinServer::CommitFinalTransaction()
     // create and sign masternode dstx transaction
     if (!m_dstxman.GetDSTX(hashTx)) {
         CCoinJoinBroadcastTx dstxNew(finalTransaction,
-                                    WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetOutPoint()),
-                                    WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()),
+                                    m_mn_activeman->GetOutPoint(),
+                                    m_mn_activeman->GetProTxHash(),
                                     GetAdjustedTime());
         dstxNew.Sign(*m_mn_activeman);
         m_dstxman.AddDSTX(dstxNew);
@@ -505,8 +505,8 @@ void CCoinJoinServer::CheckForCompleteQueue()
         SetState(POOL_STATE_ACCEPTING_ENTRIES);
 
         CCoinJoinQueue dsq(nSessionDenom,
-                            WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetOutPoint()),
-                            WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()),
+                            m_mn_activeman->GetOutPoint(),
+                            m_mn_activeman->GetProTxHash(),
                             GetAdjustedTime(), true);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s) " /* Continued */
                                      "with %d participants\n", dsq.ToString(), vecSessionCollaterals.size());
@@ -721,8 +721,8 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
     if (!fUnitTest) {
         //broadcast that I'm accepting entries, only if it's the first entry through
         CCoinJoinQueue dsq(nSessionDenom,
-                            WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetOutPoint()),
-                            WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()),
+                            m_mn_activeman->GetOutPoint(),
+                            m_mn_activeman->GetProTxHash(),
                             GetAdjustedTime(), false);
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- signing and relaying new queue: %s\n", dsq.ToString());
         dsq.Sign(*m_mn_activeman);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -691,14 +691,11 @@ std::optional<const CGovernanceObject> CGovernanceManager::CreateGovernanceTrigg
         return std::nullopt;
     }
 
-    {
-        LOCK(::activeMasternodeManager->cs);
-        if (mn_payees.front()->proTxHash != ::activeMasternodeManager->GetProTxHash()) {
-            LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s we are not the payee, skipping\n", __func__);
-            return std::nullopt;
-        }
-        gov_sb.SetMasternodeOutpoint(::activeMasternodeManager->GetOutPoint());
-    } // ::activeMasternodeManager->cs
+    if (mn_payees.front()->proTxHash != ::activeMasternodeManager->GetProTxHash()) {
+        LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s we are not the payee, skipping\n", __func__);
+        return std::nullopt;
+    }
+    gov_sb.SetMasternodeOutpoint(::activeMasternodeManager->GetOutPoint());
     gov_sb.Sign(*::activeMasternodeManager);
 
     if (std::string strError; !gov_sb.IsValidLocally(m_dmnman->GetListAtChainTip(), strError, true)) {
@@ -720,7 +717,7 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
 {
     // only active masternodes can vote on triggers
     if (!fMasternodeMode) return;
-    if (WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetProTxHash().IsNull())) return;
+    if (::activeMasternodeManager->GetProTxHash().IsNull()) return;
 
     LOCK2(cs_main, cs);
 
@@ -763,7 +760,7 @@ void CGovernanceManager::VoteGovernanceTriggers(const std::optional<const CGover
 
 bool CGovernanceManager::VoteFundingTrigger(const uint256& nHash, const vote_outcome_enum_t outcome, CConnman& connman)
 {
-    CGovernanceVote vote(WITH_LOCK(::activeMasternodeManager->cs, return ::activeMasternodeManager->GetOutPoint()), nHash, VOTE_SIGNAL_FUNDING, outcome);
+    CGovernanceVote vote(::activeMasternodeManager->GetOutPoint(), nHash, VOTE_SIGNAL_FUNDING, outcome);
     vote.SetTime(GetAdjustedTime());
     vote.Sign(*::activeMasternodeManager);
 

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -194,7 +194,7 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
     }
 
     auto mns = utils::GetAllQuorumMembers(params.type, m_dmnman, pQuorumBaseBlockIndex);
-    if (!curSession->Init(pQuorumBaseBlockIndex, mns, WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()), quorumIndex)) {
+    if (!curSession->Init(pQuorumBaseBlockIndex, mns, m_mn_activeman->GetProTxHash(), quorumIndex)) {
         LogPrintf("CDKGSessionManager::%s -- height[%d] quorum initialization failed for %s qi[%d] mns[%d]\n", __func__, pQuorumBaseBlockIndex->nHeight, curSession->params.name, quorumIndex, mns.size());
         return false;
     }

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -898,7 +898,7 @@ bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigShares
     if (!fMasternodeMode) return false;
 
     assert(m_mn_activeman);
-    if (WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash().IsNull())) return false;
+    if (m_mn_activeman->GetProTxHash().IsNull()) return false;
 
     const CQuorumCPtr quorum = [&]() {
         if (quorumHash.IsNull()) {
@@ -920,7 +920,7 @@ bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigShares
         return false;
     }
 
-    if (!WITH_LOCK(m_mn_activeman->cs, return quorum->IsValidMember(m_mn_activeman->GetProTxHash()))) {
+    if (!quorum->IsValidMember(m_mn_activeman->GetProTxHash())) {
         return false;
     }
 

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -221,7 +221,7 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const CSporkManager& 
     if (!fMasternodeMode) return;
 
     assert(m_mn_activeman);
-    if (WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash().IsNull())) return;
+    if (m_mn_activeman->GetProTxHash().IsNull()) return;
 
     if (sporkman.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && msg_type == NetMsgType::QSIGSHARE) {
         std::vector<CSigShare> receivedSigShares;
@@ -468,7 +468,7 @@ void CSigSharesManager::ProcessMessageSigShare(NodeId fromId, const CSigShare& s
         // quorum is too old
         return;
     }
-    if (!quorum->IsMember(WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()))) {
+    if (!quorum->IsMember(m_mn_activeman->GetProTxHash())) {
         // we're not a member so we can't verify it (we actually shouldn't have received it)
         return;
     }
@@ -518,7 +518,7 @@ bool CSigSharesManager::PreVerifyBatchedSigShares(const CActiveMasternodeManager
         // quorum is too old
         return false;
     }
-    if (!session.quorum->IsMember(WITH_LOCK(mn_activeman.cs, return mn_activeman.GetProTxHash()))) {
+    if (!session.quorum->IsMember(mn_activeman.GetProTxHash())) {
         // we're not a member so we can't verify it (we actually shouldn't have received it)
         return false;
     }
@@ -703,7 +703,7 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CConnma
 
     // prepare node set for direct-push in case this is our sig share
     std::set<NodeId> quorumNodes;
-    if (!IsAllMembersConnectedEnabled(llmqType, m_sporkman) && sigShare.getQuorumMember() == quorum->GetMemberIndex(WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash()))) {
+    if (!IsAllMembersConnectedEnabled(llmqType, m_sporkman) && sigShare.getQuorumMember() == quorum->GetMemberIndex(m_mn_activeman->GetProTxHash())) {
         quorumNodes = connman.GetMasternodeQuorumNodes(sigShare.getLlmqType(), sigShare.getQuorumHash());
     }
 
@@ -1496,7 +1496,7 @@ std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorumCPtr& qu
     assert(m_mn_activeman);
 
     cxxtimer::Timer t(true);
-    auto activeMasterNodeProTxHash = WITH_LOCK(m_mn_activeman->cs, return m_mn_activeman->GetProTxHash());
+    auto activeMasterNodeProTxHash = m_mn_activeman->GetProTxHash();
 
     if (!quorum->IsValidMember(activeMasterNodeProTxHash)) {
         return std::nullopt;

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -319,7 +319,6 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
     if (fMasternodeMode) {
         CHECK_NONFATAL(node.mn_activeman);
 
-        LOCK(node.mn_activeman->cs);
         const bool fMnFound = mnList.HasValidMNByCollateral(node.mn_activeman->GetOutPoint());
 
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -265,15 +265,10 @@ static UniValue masternode_status(const JSONRPCRequest& request)
     CHECK_NONFATAL(node.mn_activeman);
 
     UniValue mnObj(UniValue::VOBJ);
-    CDeterministicMNCPtr dmn;
-    {
-        LOCK(node.mn_activeman->cs);
-
-        // keep compatibility with legacy status for now (might get deprecated/removed later)
-        mnObj.pushKV("outpoint", node.mn_activeman->GetOutPoint().ToStringShort());
-        mnObj.pushKV("service", node.mn_activeman->GetService().ToString());
-        dmn = node.dmnman->GetListAtChainTip().GetMN(node.mn_activeman->GetProTxHash());
-    }
+    // keep compatibility with legacy status for now (might get deprecated/removed later)
+    mnObj.pushKV("outpoint", node.mn_activeman->GetOutPoint().ToStringShort());
+    mnObj.pushKV("service", node.mn_activeman->GetService().ToString());
+    CDeterministicMNCPtr dmn = node.dmnman->GetListAtChainTip().GetMN(node.mn_activeman->GetProTxHash());
     if (dmn) {
         mnObj.pushKV("proTxHash", dmn->proTxHash.ToString());
         mnObj.pushKV("type", std::string(GetMnType(dmn->nType).description));

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -299,7 +299,7 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request, CDeterministicMN
     const uint256 proTxHash = [&mn_activeman]() {
         if (!fMasternodeMode) return uint256();
         CHECK_NONFATAL(mn_activeman);
-        return WITH_LOCK(mn_activeman->cs, return mn_activeman->GetProTxHash());
+        return mn_activeman->GetProTxHash();
     }();
 
     UniValue minableCommitments(UniValue::VARR);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -223,8 +223,10 @@ void EnterCritical(const char* pszName, const char* pszFile, int nLine, MutexTyp
 }
 template void EnterCritical(const char*, const char*, int, Mutex*, bool);
 template void EnterCritical(const char*, const char*, int, RecursiveMutex*, bool);
+template void EnterCritical(const char*, const char*, int, SharedMutex*, bool);
 template void EnterCritical(const char*, const char*, int, std::mutex*, bool);
 template void EnterCritical(const char*, const char*, int, std::recursive_mutex*, bool);
+template void EnterCritical(const char*, const char*, int, std::shared_mutex*, bool);
 
 void CheckLastCritical(void* cs, std::string& lockname, const char* guardname, const char* file, int line)
 {
@@ -291,6 +293,7 @@ void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine,
 }
 template void AssertLockHeldInternal(const char*, const char*, int, Mutex*);
 template void AssertLockHeldInternal(const char*, const char*, int, RecursiveMutex*);
+template void AssertLockHeldInternal(const char*, const char*, int, SharedMutex*);
 
 void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs)
 {


### PR DESCRIPTION
## Issue being fixed or feature implemented
We have some caches or other information in codebase which are read from a lot; but rarely written to. We can use a RW lock here instead of a normal Mutex

## What was done?
Implement a RW lock and use them

## How Has This Been Tested?
Hasn't been much; looking for review atm. Maybe should deploy this on testnet for a bit and make sure it doesn't break. 
## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

