### PR TITLE
fix: deadlock over cs_main and contributionsCacheCs in dkssessionmgr

### DIFF
--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -390,7 +390,6 @@ void CDKGSessionManager::WriteEncryptedContributions(Consensus::LLMQType llmqTyp
 
 bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, const CBlockIndex* pQuorumBaseBlockIndex, const std::vector<bool>& validMembers, std::vector<uint16_t>& memberIndexesRet, std::vector<BLSVerificationVectorPtr>& vvecsRet, std::vector<CBLSSecretKey>& skContributionsRet) const
 {
-    LOCK(contributionsCacheCs);
     auto members = utils::GetAllQuorumMembers(llmqType, m_dmnman, pQuorumBaseBlockIndex);
 
     memberIndexesRet.clear();
@@ -399,6 +398,9 @@ bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, 
     memberIndexesRet.reserve(members.size());
     vvecsRet.reserve(members.size());
     skContributionsRet.reserve(members.size());
+
+    // NOTE: the `cs_main` should not be locked under scope of `contributionsCacheCs`
+    LOCK(contributionsCacheCs);
     for (const auto i : irange::range(members.size())) {
         if (validMembers[i]) {
             const uint256& proTxHash = members[i]->proTxHash;


### PR DESCRIPTION
## Issue being fixed or feature implemented
**It fixes rpc failure: "Work queue depth exceeded"**

As I checked on running `dashd` in deadlock condition:
Thread 78 is a thread that keep `cs_main`:
```
#14 0x0000aaaad1f8d604 in BuildSimplifiedMNListDiff () at evo/simplifiedmns.cpp:364
```
but it is locked by `contributionsCacheCs`
```
#8  llmq::CDKGSessionManager::GetVerifiedContributions () at llmq/dkgsessionmgr.cpp:392
```

On other hand, `contributionsCacheCs` is blocked by Thread 59
```
#17 0x0000aaaad1ba1940 in llmq::CDKGSessionManager::GetVerifiedContributions () at llmq/dkgsessionmgr.cpp:393
```
and it makes circuit lock by waiting `cs_main` in 
```
#9  ReadBlockFromDisk () at node/blockstorage.cpp:75
```

See https://github.com/dashpay/dash-issues/issues/69 for more details

Seems introduced there: dashpay/dash#3911

## What was done?
Deadlock is removed by reducing scope of mutex

## How Has This Been Tested?
I reviewed 2 different servers which have status `work queue exceeded`, both have same deadlock, so, this patch should fix this issue. Once this fix is merged, we can test it on testnet.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

