### PR TITLE
refactor: rearrange database initialization, trim globals use in net and net processing, move CheckSpecialTx into CSpecialTxProcessor

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -42,6 +42,8 @@ PeerMsgRet CCoinJoinClientQueueManager::ProcessMessage(const CNode& peer, std::s
 
 PeerMsgRet CCoinJoinClientQueueManager::ProcessDSQueue(const CNode& peer, CDataStream& vRecv)
 {
+    assert(::mmetaman->IsValid());
+
     CCoinJoinQueue dsq;
     vRecv >> dsq;
 
@@ -1117,6 +1119,8 @@ bool CCoinJoinClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, 
 
 bool CCoinJoinClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, CConnman& connman)
 {
+    assert(::mmetaman->IsValid());
+
     if (!CCoinJoinClientOptions::IsEnabled()) return false;
     if (nBalanceNeedsAnonymized <= 0) return false;
 

--- a/src/coinjoin/context.cpp
+++ b/src/coinjoin/context.cpp
@@ -14,7 +14,7 @@
 #include <coinjoin/server.h>
 
 CJContext::CJContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CTxMemPool& mempool,
-                     const CActiveMasternodeManager* mn_activeman, const CMasternodeSync& mn_sync, bool relay_txes) :
+                     const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync, bool relay_txes) :
     dstxman{std::make_unique<CDSTXManager>()},
 #ifdef ENABLE_WALLET
     walletman{std::make_unique<CoinJoinWalletManager>(connman, dmnman, mempool, mn_sync, queueman)},

--- a/src/coinjoin/context.h
+++ b/src/coinjoin/context.h
@@ -30,7 +30,7 @@ struct CJContext {
     CJContext() = delete;
     CJContext(const CJContext&) = delete;
     CJContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CTxMemPool& mempool,
-              const CActiveMasternodeManager* mn_activeman, const CMasternodeSync& mn_sync, bool relay_txes);
+              const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync, bool relay_txes);
     ~CJContext();
 
     const std::unique_ptr<CDSTXManager> dstxman;

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -44,6 +44,7 @@ PeerMsgRet CCoinJoinServer::ProcessMessage(CNode& peer, std::string_view msg_typ
 void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
 {
     assert(m_mn_activeman);
+    assert(::mmetaman->IsValid());
 
     if (IsSessionReady()) {
         // too many users in this session already, reject new ones
@@ -110,6 +111,8 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
 
 PeerMsgRet CCoinJoinServer::ProcessDSQUEUE(const CNode& peer, CDataStream& vRecv)
 {
+    assert(::mmetaman->IsValid());
+
     CCoinJoinQueue dsq;
     vRecv >> dsq;
 

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -30,7 +30,7 @@ private:
     CDeterministicMNManager& m_dmnman;
     CDSTXManager& m_dstxman;
     CTxMemPool& mempool;
-    const CActiveMasternodeManager* m_mn_activeman;
+    const CActiveMasternodeManager* const m_mn_activeman;
     const CMasternodeSync& m_mn_sync;
 
     // Mixing uses collateral transactions to trust parties entering the pool
@@ -87,7 +87,7 @@ private:
 
 public:
     explicit CCoinJoinServer(CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman, CDSTXManager& dstxman,
-                             CTxMemPool& mempool, const CActiveMasternodeManager* mn_activeman, const CMasternodeSync& mn_sync) :
+                             CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync) :
         m_chainstate(chainstate),
         connman(_connman),
         m_dmnman(dmnman),

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -134,7 +134,9 @@ void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBl
 void CDSNotificationInterface::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff)
 {
     CMNAuth::NotifyMasternodeListChanged(undo, oldMNList, diff, m_connman);
-    m_govman.UpdateCachesAndClean();
+    if (m_govman.IsValid()) {
+        m_govman.CheckAndRemove();
+    }
 }
 
 void CDSNotificationInterface::NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const llmq::CChainLockSig>& clsig)

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -63,6 +63,8 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip)
 
 PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv)
 {
+    assert(::mmetaman->IsValid());
+
     if (msg_type != NetMsgType::MNAUTH || !::masternodeSync->IsBlockchainSynced()) {
         // we can't verify MNAUTH messages when we don't have the latest MN list
         return {};

--- a/src/evo/mnauth.h
+++ b/src/evo/mnauth.h
@@ -49,6 +49,11 @@ public:
     }
 
     static void PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip);
+
+    /**
+     * @pre CMasternodeMetaMan's database must be successfully loaded before
+     *      attempting to call this function regardless of sync state
+     */
     static PeerMsgRet ProcessMessage(CNode& peer, CConnman& connman, const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv);
     static void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff, CConnman& connman);
 };

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -72,10 +72,10 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, const CTransact
     return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-tx-type-check");
 }
 
-bool CheckSpecialTx(CDeterministicMNManager& dmnman, const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs, TxValidationState& state)
+bool CSpecialTxProcessor::CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs, TxValidationState& state)
 {
     AssertLockHeld(cs_main);
-    return CheckSpecialTxInner(dmnman, tx, pindexPrev, view, std::nullopt, check_sigs, state);
+    return CheckSpecialTxInner(m_dmnman, tx, pindexPrev, view, std::nullopt, check_sigs, state);
 }
 
 [[nodiscard]] bool CSpecialTxProcessor::ProcessSpecialTx(const CTransaction& tx, const CBlockIndex* pindex, TxValidationState& state)

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -29,9 +29,6 @@ class CChainLocksHandler;
 
 extern RecursiveMutex cs_main;
 
-bool CheckSpecialTx(CDeterministicMNManager& dmnman, const CTransaction& tx, const CBlockIndex* pindexPrev,
-                    const CCoinsViewCache& view, bool check_sigs, TxValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-
 class CSpecialTxProcessor
 {
 private:
@@ -51,6 +48,8 @@ public:
                                  const Consensus::Params& consensus_params, const llmq::CChainLocksHandler& clhandler) :
         m_cpoolman(cpoolman), m_dmnman{dmnman}, m_mnhfman{mnhfman}, m_qblockman{qblockman}, m_consensus_params{consensus_params}, m_clhandler{clhandler} {}
 
+    bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache& view, bool check_sigs, TxValidationState& state)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, const CCoinsViewCache& view, bool fJustCheck,
                                   bool fCheckCbTxMerkleRoots, BlockValidationState& state, std::optional<MNListUpdates>& updatesRet)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -344,6 +344,9 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
 
 void CGovernanceManager::UpdateCachesAndClean()
 {
+    // Return if meta manager hasn't had a chance to load its database yet
+    if (!::mmetaman->IsValid()) return;
+
     // Return on initial sync, spammed the debug.log and provided no use
     if (::masternodeSync == nullptr || !::masternodeSync->IsBlockchainSynced()) return;
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -342,10 +342,9 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, CConnman
     GetMainSignals().NotifyGovernanceObject(std::make_shared<const Governance::Object>(govobj.Object()));
 }
 
-void CGovernanceManager::UpdateCachesAndClean()
+void CGovernanceManager::CheckAndRemove()
 {
-    // Return if meta manager hasn't had a chance to load its database yet
-    if (!::mmetaman->IsValid()) return;
+    assert(::mmetaman->IsValid());
 
     // Return on initial sync, spammed the debug.log and provided no use
     if (::masternodeSync == nullptr || !::masternodeSync->IsBlockchainSynced()) return;
@@ -797,7 +796,7 @@ void CGovernanceManager::DoMaintenance(CConnman& connman)
     RequestOrphanObjects(connman);
 
     // CHECK AND REMOVE - REPROCESS GOVERNANCE OBJECTS
-    UpdateCachesAndClean();
+    CheckAndRemove();
 }
 
 bool CGovernanceManager::ConfirmInventoryRequest(const CInv& inv)

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -304,9 +304,7 @@ public:
 
     void AddGovernanceObject(CGovernanceObject& govobj, CConnman& connman, const CNode* pfrom = nullptr);
 
-    void UpdateCachesAndClean();
-
-    void CheckAndRemove() { UpdateCachesAndClean(); }
+    void CheckAndRemove();
 
     UniValue ToJson() const;
 

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -82,6 +82,8 @@ CGovernanceObject::CGovernanceObject(const CGovernanceObject& other) :
 
 bool CGovernanceObject::ProcessVote(CGovernanceManager& govman, const CDeterministicMNList& tip_mn_list, const CGovernanceVote& vote, CGovernanceException& exception)
 {
+    assert(::mmetaman->IsValid());
+
     LOCK(cs);
 
     // do not process already known valid votes twice

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -426,7 +426,7 @@ bool CGovernanceObject::IsValidLocally(const CDeterministicMNList& tip_mn_list, 
     case GovernanceObject::PROPOSAL: {
         CProposalValidator validator(GetDataAsHexString());
         // Note: It's ok to have expired proposals
-        // they are going to be cleared by CGovernanceManager::UpdateCachesAndClean()
+        // they are going to be cleared by CGovernanceManager::CheckAndRemove()
         // TODO: should they be tagged as "expired" to skip vote downloading?
         if (!validator.Validate(false)) {
             strError = strprintf("Invalid proposal data, error messages: %s", validator.GetErrorMessages());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1735,8 +1735,9 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(chainparams, *node.connman, *node.addrman, node.banman.get(),
-                                     *node.scheduler, chainman, *node.mempool, *node.govman, *node.sporkman,
-                                     ::deterministicMNManager, node.cj_ctx, node.llmq_ctx, ignores_incoming_txs);
+                                     *node.scheduler, chainman, *node.mempool, *node.mn_metaman, *node.mn_sync,
+                                     *node.govman, *node.sporkman, ::deterministicMNManager,
+                                     node.cj_ctx, node.llmq_ctx, ignores_incoming_txs);
     RegisterValidationInterface(node.peerman.get());
 
     // sanitize comments per BIP-0014, format user agent and check total size

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2215,14 +2215,12 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     bool fLoadCacheFiles = !(fReindex || fReindexChainState) && (::ChainActive().Tip() != nullptr);
 
-    if (!fDisableGovernance) {
-        if (!node.govman->LoadCache(fLoadCacheFiles)) {
-            auto file_path = (GetDataDir() / "governance.dat").string();
-            if (fLoadCacheFiles && !fDisableGovernance) {
-                return InitError(strprintf(_("Failed to load governance cache from %s"), file_path));
-            }
-            return InitError(strprintf(_("Failed to clear governance cache at %s"), file_path));
+    if (!node.netfulfilledman->LoadCache(fLoadCacheFiles)) {
+        auto file_path = (GetDataDir() / "netfulfilled.dat").string();
+        if (fLoadCacheFiles) {
+            return InitError(strprintf(_("Failed to load fulfilled requests cache from %s"), file_path));
         }
+        return InitError(strprintf(_("Failed to clear fulfilled requests cache at %s"), file_path));
     }
 
     if (!node.mn_metaman->LoadCache(fLoadCacheFiles)) {
@@ -2233,12 +2231,14 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         return InitError(strprintf(_("Failed to clear masternode cache at %s"), file_path));
     }
 
-    if (!node.netfulfilledman->LoadCache(fLoadCacheFiles)) {
-        auto file_path = (GetDataDir() / "netfulfilled.dat").string();
-        if (fLoadCacheFiles) {
-            return InitError(strprintf(_("Failed to load fulfilled requests cache from %s"), file_path));
+    if (!fDisableGovernance) {
+        if (!node.govman->LoadCache(fLoadCacheFiles)) {
+            auto file_path = (GetDataDir() / "governance.dat").string();
+            if (fLoadCacheFiles && !fDisableGovernance) {
+                return InitError(strprintf(_("Failed to load governance cache from %s"), file_path));
+            }
+            return InitError(strprintf(_("Failed to clear governance cache at %s"), file_path));
         }
-        return InitError(strprintf(_("Failed to clear fulfilled requests cache at %s"), file_path));
     }
 
     // ********************************************************* Step 8: start indexers

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2306,7 +2306,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     node.scheduler->scheduleEvery(std::bind(&CNetFulfilledRequestManager::DoMaintenance, std::ref(*node.netfulfilledman)), std::chrono::minutes{1});
     node.scheduler->scheduleEvery(std::bind(&CMasternodeSync::DoMaintenance, std::ref(*node.mn_sync)), std::chrono::seconds{1});
-    node.scheduler->scheduleEvery(std::bind(&CMasternodeUtils::DoMaintenance, std::ref(*node.connman), std::ref(*node.mn_sync), std::ref(*node.cj_ctx)), std::chrono::minutes{1});
+    node.scheduler->scheduleEvery(std::bind(&CMasternodeUtils::DoMaintenance, std::ref(*node.connman), std::ref(*node.dmnman), std::ref(*node.mn_sync), std::ref(*node.cj_ctx)), std::chrono::minutes{1});
     node.scheduler->scheduleEvery(std::bind(&CDeterministicMNManager::DoMaintenance, std::ref(*node.dmnman)), std::chrono::seconds{10});
 
     if (!fDisableGovernance) {
@@ -2534,7 +2534,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
 
     connOptions.m_i2p_accept_incoming = args.GetBoolArg("-i2pacceptincoming", true);
 
-    if (!node.connman->Start(*node.scheduler, connOptions)) {
+    if (!node.connman->Start(*node.dmnman, *node.mn_metaman, *node.mn_sync, *node.scheduler, connOptions)) {
         return false;
     }
 

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -20,7 +20,7 @@
 #include <masternode/sync.h>
 
 LLMQContext::LLMQContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CEvoDB& evo_db,
-                         CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* mn_activeman,
+                         CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman,
                          const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe) :
     bls_worker{std::make_shared<CBLSWorker>()},
     dkg_debugman{std::make_unique<llmq::CDKGDebugManager>()},

--- a/src/llmq/context.h
+++ b/src/llmq/context.h
@@ -35,7 +35,7 @@ struct LLMQContext {
     LLMQContext() = delete;
     LLMQContext(const LLMQContext&) = delete;
     LLMQContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CEvoDB& evo_db,
-                CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* mn_activeman,
+                CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman,
                 const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe);
     ~LLMQContext();
 

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -450,6 +450,8 @@ void CDKGSession::VerifyAndComplain(CDKGPendingMessages& pendingMessages)
 
 void CDKGSession::VerifyConnectionAndMinProtoVersions() const
 {
+    assert(::mmetaman->IsValid());
+
     if (!IsQuorumPoseEnabled(params.type, m_sporkman)) {
         return;
     }

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -275,7 +275,7 @@ private:
     CDeterministicMNManager& m_dmnman;
     CDKGSessionManager& dkgManager;
     CDKGDebugManager& dkgDebugManager;
-    const CActiveMasternodeManager* m_mn_activeman;
+    const CActiveMasternodeManager* const m_mn_activeman;
     const CSporkManager& m_sporkman;
 
     const CBlockIndex* m_quorum_base_block_index{nullptr};
@@ -319,7 +319,7 @@ private:
 public:
     CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDeterministicMNManager& dmnman,
                 CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager, CConnman& _connman,
-                const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman) :
+                const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman) :
         params(_params), blsWorker(_blsWorker), cache(_blsWorker), m_dmnman(dmnman), dkgManager(_dkgManager),
         dkgDebugManager(_dkgDebugManager), m_mn_activeman(mn_activeman), m_sporkman(sporkman), connman(_connman) {}
 

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -26,7 +26,7 @@ namespace llmq
 
 CDKGSessionHandler::CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
                                        CDKGDebugManager& _dkgDebugManager, CDKGSessionManager& _dkgManager, CQuorumBlockProcessor& _quorumBlockProcessor,
-                                       const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman, const Consensus::LLMQParams& _params,
+                                       const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, const Consensus::LLMQParams& _params,
                                        int _quorumIndex) :
         blsWorker(_blsWorker),
         m_chainstate(chainstate),

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -126,7 +126,7 @@ private:
     CDKGDebugManager& dkgDebugManager;
     CDKGSessionManager& dkgManager;
     CQuorumBlockProcessor& quorumBlockProcessor;
-    const CActiveMasternodeManager* m_mn_activeman;
+    const CActiveMasternodeManager* const m_mn_activeman;
     const CSporkManager& m_sporkman;
     const Consensus::LLMQParams params;
     const int quorumIndex;
@@ -148,7 +148,7 @@ private:
 public:
     CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
                        CDKGDebugManager& _dkgDebugManager, CDKGSessionManager& _dkgManager, CQuorumBlockProcessor& _quorumBlockProcessor,
-                       const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman, const Consensus::LLMQParams& _params,
+                       const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, const Consensus::LLMQParams& _params,
                        int _quorumIndex);
     ~CDKGSessionHandler() = default;
 

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -25,7 +25,7 @@ static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
 CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
-                                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* mn_activeman,
+                                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* const mn_activeman,
                                        const CSporkManager& sporkman, bool unitTests, bool fWipe) :
     db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
     blsWorker(_blsWorker),

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -67,7 +67,7 @@ private:
 
 public:
     CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
-                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* mn_activeman,
+                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* const mn_activeman,
                        const CSporkManager& sporkman, bool unitTests, bool fWipe);
     ~CDKGSessionManager() = default;
 

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -207,8 +207,7 @@ bool CQuorum::ReadContributions(CEvoDB& evoDb)
 
 CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
                                CDKGSessionManager& _dkgManager, CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor,
-                               const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman,
-                               const std::unique_ptr<CMasternodeSync>& mn_sync) :
+                               const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync) :
     blsWorker(_blsWorker),
     m_chainstate(chainstate),
     connman(_connman),

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -224,7 +224,7 @@ private:
     CDKGSessionManager& dkgManager;
     CEvoDB& m_evoDb;
     CQuorumBlockProcessor& quorumBlockProcessor;
-    const CActiveMasternodeManager* m_mn_activeman;
+    const CActiveMasternodeManager* const m_mn_activeman;
     const CSporkManager& m_sporkman;
     const std::unique_ptr<CMasternodeSync>& m_mn_sync;
 
@@ -241,7 +241,7 @@ private:
 public:
     CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
                    CDKGSessionManager& _dkgManager, CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor,
-                   const CActiveMasternodeManager* mn_activeman, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync);
+                   const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync);
     ~CQuorumManager() { Stop(); };
 
     void Start();

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -539,7 +539,7 @@ void CRecoveredSigsDb::CleanupOldVotes(int64_t maxAge)
 
 //////////////////
 
-CSigningManager::CSigningManager(CConnman& _connman, const CActiveMasternodeManager* mn_activeman, const CQuorumManager& _qman,
+CSigningManager::CSigningManager(CConnman& _connman, const CActiveMasternodeManager* const mn_activeman, const CQuorumManager& _qman,
                                  bool fMemory, bool fWipe) :
     db(fMemory, fWipe), connman(_connman), m_mn_activeman(mn_activeman), qman(_qman)
 {

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -163,7 +163,7 @@ private:
 
     CRecoveredSigsDb db;
     CConnman& connman;
-    const CActiveMasternodeManager* m_mn_activeman;
+    const CActiveMasternodeManager* const m_mn_activeman;
     const CQuorumManager& qman;
 
     std::atomic<PeerManager*> m_peerman{nullptr};
@@ -179,7 +179,7 @@ private:
     std::vector<CRecoveredSigsListener*> recoveredSigsListeners GUARDED_BY(cs);
 
 public:
-    CSigningManager(CConnman& _connman, const CActiveMasternodeManager* mn_activeman, const CQuorumManager& _qman, bool fMemory, bool fWipe);
+    CSigningManager(CConnman& _connman, const CActiveMasternodeManager* const mn_activeman, const CQuorumManager& _qman, bool fMemory, bool fWipe);
 
     bool AlreadyHave(const CInv& inv) const;
     bool GetRecoveredSigForGetData(const uint256& hash, CRecoveredSig& ret) const;

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -401,7 +401,7 @@ private:
 
     CConnman& connman;
     CSigningManager& sigman;
-    const CActiveMasternodeManager* m_mn_activeman;
+    const CActiveMasternodeManager* const m_mn_activeman;
     const CQuorumManager& qman;
     const CSporkManager& m_sporkman;
 
@@ -411,7 +411,7 @@ private:
     std::atomic<uint32_t> recoveredSigsCounter{0};
 
 public:
-    explicit CSigSharesManager(CConnman& _connman, CSigningManager& _sigman, const CActiveMasternodeManager* mn_activeman,
+    explicit CSigSharesManager(CConnman& _connman, CSigningManager& _sigman, const CActiveMasternodeManager* const mn_activeman,
                                const CQuorumManager& _qman, const CSporkManager& sporkman, const std::unique_ptr<PeerManager>& peerman) :
         connman(_connman), sigman(_sigman), m_mn_activeman(mn_activeman), qman(_qman), m_sporkman(sporkman), m_peerman(peerman)
     {

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -812,6 +812,8 @@ void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman
                                const CDeterministicMNList& tip_mn_list, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
                                const uint256 &myProTxHash)
 {
+    assert(::mmetaman->IsValid());
+
     if (!IsQuorumPoseEnabled(llmqParams.type, sporkman)) {
         return;
     }

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -13,15 +13,16 @@ std::unique_ptr<CMasternodeMetaMan> mmetaman;
 
 const std::string MasternodeMetaStore::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-3";
 
-CMasternodeMetaMan::CMasternodeMetaMan(bool load_cache) :
-    m_db{std::make_unique<db_type>("mncache.dat", "magicMasternodeCache")},
-    is_valid{
-        [&]() -> bool {
-            assert(m_db != nullptr);
-            return load_cache ? m_db->Load(*this) : m_db->Store(*this);
-        }()
-    }
+CMasternodeMetaMan::CMasternodeMetaMan() :
+    m_db{std::make_unique<db_type>("mncache.dat", "magicMasternodeCache")}
 {
+}
+
+bool CMasternodeMetaMan::LoadCache(bool load_cache)
+{
+    assert(m_db != nullptr);
+    is_valid = load_cache ? m_db->Load(*this) : m_db->Store(*this);
+    return is_valid;
 }
 
 CMasternodeMetaMan::~CMasternodeMetaMan()

--- a/src/masternode/meta.h
+++ b/src/masternode/meta.h
@@ -150,13 +150,15 @@ private:
 
 private:
     const std::unique_ptr<db_type> m_db;
-    const bool is_valid{false};
+    bool is_valid{false};
 
     std::vector<uint256> vecDirtyGovernanceObjectHashes GUARDED_BY(cs);
 
 public:
-    explicit CMasternodeMetaMan(bool load_cache);
+    explicit CMasternodeMetaMan();
     ~CMasternodeMetaMan();
+
+    bool LoadCache(bool load_cache);
 
     bool IsValid() const { return is_valid; }
 

--- a/src/masternode/utils.cpp
+++ b/src/masternode/utils.cpp
@@ -15,7 +15,8 @@
 #include <util/ranges.h>
 #include <coinjoin/context.h>
 
-void CMasternodeUtils::DoMaintenance(CConnman& connman, const CMasternodeSync& mn_sync, const CJContext& cj_ctx)
+void CMasternodeUtils::DoMaintenance(CConnman& connman, CDeterministicMNManager& dmnman,
+                                     const CMasternodeSync& mn_sync, const CJContext& cj_ctx)
 {
     if (!mn_sync.IsBlockchainSynced()) return;
     if (ShutdownRequested()) return;
@@ -53,8 +54,9 @@ void CMasternodeUtils::DoMaintenance(CConnman& connman, const CMasternodeSync& m
             // we're only disconnecting m_masternode_connection connections
             if (!pnode->m_masternode_connection) return;
             if (!pnode->GetVerifiedProRegTxHash().IsNull()) {
+                const auto tip_mn_list = dmnman.GetListAtChainTip();
                 // keep _verified_ LLMQ connections
-                if (connman.IsMasternodeQuorumNode(pnode)) {
+                if (connman.IsMasternodeQuorumNode(pnode, tip_mn_list)) {
                     return;
                 }
                 // keep _verified_ LLMQ relay connections

--- a/src/masternode/utils.h
+++ b/src/masternode/utils.h
@@ -6,13 +6,15 @@
 #define BITCOIN_MASTERNODE_UTILS_H
 
 class CConnman;
+class CDeterministicMNManager;
 class CMasternodeSync;
 struct CJContext;
 
 class CMasternodeUtils
 {
 public:
-    static void DoMaintenance(CConnman &connman, const CMasternodeSync& mn_sync, const CJContext& cj_ctx);
+    static void DoMaintenance(CConnman &connman, CDeterministicMNManager& dmnman,
+                              const CMasternodeSync& mn_sync, const CJContext& cj_ctx);
 };
 
 #endif // BITCOIN_MASTERNODE_UTILS_H

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3309,7 +3309,8 @@ void PeerManagerImpl::ProcessMessage(
             // Tell our peer that he should send us CoinJoin queue messages
             m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::SENDDSQUEUE, true));
             // Tell our peer that he should send us intra-quorum messages
-            if (llmq::IsWatchQuorumsEnabled() && m_connman.IsMasternodeQuorumNode(&pfrom)) {
+            const auto tip_mn_list = Assert(m_dmnman)->GetListAtChainTip();
+            if (llmq::IsWatchQuorumsEnabled() && m_connman.IsMasternodeQuorumNode(&pfrom, tip_mn_list)) {
                 m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QWATCH));
             }
         }
@@ -3821,7 +3822,7 @@ void PeerManagerImpl::ProcessMessage(
         if (nInvType == MSG_DSTX) {
            // Validate DSTX and return bRet if we need to return from here
            uint256 hashTx = tx.GetHash();
-           const auto& [bRet, bDoReturn] = ValidateDSTX(*Assert(m_dmnman), *(m_cj_ctx->dstxman), m_chainman, m_mempool, dstx, hashTx);
+           const auto& [bRet, bDoReturn] = ValidateDSTX(*m_dmnman, *(m_cj_ctx->dstxman), m_chainman, m_mempool, dstx, hashTx);
            if (bDoReturn) {
                return;
            }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -15,6 +15,8 @@
 class CAddrMan;
 class CTxMemPool;
 class CDeterministicMNManager;
+class CMasternodeMetaMan;
+class CMasternodeSync;
 class ChainstateManager;
 class CCoinJoinServer;
 class CGovernanceManager;
@@ -48,7 +50,8 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman,
                                              BanMan* banman, CScheduler &scheduler, ChainstateManager& chainman,
-                                             CTxMemPool& pool, CGovernanceManager& govman, CSporkManager& sporkman,
+                                             CTxMemPool& pool, CMasternodeMetaMan& mn_metaman, CMasternodeSync& mn_sync,
+                                             CGovernanceManager& govman, CSporkManager& sporkman,
                                              const std::unique_ptr<CDeterministicMNManager>& dmnman,
                                              const std::unique_ptr<CJContext>& cj_ctx,
                                              const std::unique_ptr<LLMQContext>& llmq_ctx, bool ignore_incoming_txs);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -482,7 +482,7 @@ public:
     void setNetworkActive(bool active) override
     {
         if (m_context->connman) {
-            m_context->connman->SetNetworkActive(active);
+            m_context->connman->SetNetworkActive(active, m_context->mn_sync);
         }
     }
     bool getNetworkActive() override { return m_context->connman && m_context->connman->GetNetworkActive(); }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -891,7 +891,7 @@ static RPCHelpMan setnetworkactive()
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
     }
 
-    node.connman->SetNetworkActive(request.params[0].get_bool());
+    node.connman->SetNetworkActive(request.params[0].get_bool(), node.mn_sync);
 
     return node.connman->GetNetworkActive();
 },

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -275,7 +275,7 @@ static void quorum_dkgstatus_help(const JSONRPCRequest& request)
     }.Check(request);
 }
 
-static UniValue quorum_dkgstatus(const JSONRPCRequest& request, CDeterministicMNManager& dmnman, const CActiveMasternodeManager* mn_activeman,
+static UniValue quorum_dkgstatus(const JSONRPCRequest& request, CDeterministicMNManager& dmnman, const CActiveMasternodeManager* const mn_activeman,
                                  const ChainstateManager& chainman, const CSporkManager& sporkman, const LLMQContext& llmq_ctx)
 {
     quorum_dkgstatus_help(request);

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -65,8 +65,9 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman,
-                                       ::deterministicMNManager, m_node.cj_ctx, m_node.llmq_ctx, false);
+                                       *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
+                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager,
+                                       m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
@@ -136,8 +137,9 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     const CChainParams& chainparams = Params();
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman,
-                                       ::deterministicMNManager, m_node.cj_ctx, m_node.llmq_ctx, false);
+                                       *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
+                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager,
+                                       m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -210,8 +212,9 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman,
-                                       ::deterministicMNManager, m_node.cj_ctx, m_node.llmq_ctx, false);
+                                       *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
+                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager,
+                                       m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     banman->ClearBanned();
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
@@ -257,8 +260,9 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
-                                       *m_node.chainman, *m_node.mempool, *m_node.govman, *m_node.sporkman,
-                                       ::deterministicMNManager, m_node.cj_ctx, m_node.llmq_ctx, false);
+                                       *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
+                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager,
+                                       m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/fuzz/connman.cpp
+++ b/src/test/fuzz/connman.cpp
@@ -113,7 +113,7 @@ FUZZ_TARGET_INIT(connman, initialize_connman)
                 }
             },
             [&] {
-                connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool());
+                connman.SetNetworkActive(fuzzed_data_provider.ConsumeBool(), /* mn_sync = */ nullptr);
             },
             [&] {
                 connman.SetTryNewOutboundPeer(fuzzed_data_provider.ConsumeBool());

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -283,8 +283,9 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
 
     m_node.banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.peerman = PeerManager::make(chainparams, *m_node.connman, *m_node.addrman, m_node.banman.get(),
-                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool, *m_node.govman,
-                                       *m_node.sporkman, ::deterministicMNManager, m_node.cj_ctx, m_node.llmq_ctx, false);
+                                       *m_node.scheduler, *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
+                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager, m_node.cj_ctx, m_node.llmq_ctx,
+                                       /* ignore_incoming_txs = */ false);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -225,13 +225,13 @@ ChainTestingSetup::ChainTestingSetup(const std::string& chainName, const std::ve
 
     m_node.connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman); // Deterministic randomness for tests.
 
+    ::mmetaman = std::make_unique<CMasternodeMetaMan>();
+    m_node.mn_metaman = ::mmetaman.get();
     m_node.netfulfilledman = std::make_unique<CNetFulfilledRequestManager>();
     m_node.sporkman = std::make_unique<CSporkManager>();
     m_node.govman = std::make_unique<CGovernanceManager>(*m_node.netfulfilledman, ::deterministicMNManager);
     ::masternodeSync = std::make_unique<CMasternodeSync>(*m_node.connman, *m_node.netfulfilledman, *m_node.govman);
     m_node.mn_sync = ::masternodeSync.get();
-    ::mmetaman = std::make_unique<CMasternodeMetaMan>(/* load_cache */ false);
-    m_node.mn_metaman = ::mmetaman.get();
 
     // Start script-checking threads. Set g_parallel_script_checks to true so they are used.
     constexpr int script_check_threads = 2;
@@ -245,13 +245,13 @@ ChainTestingSetup::~ChainTestingSetup()
     StopScriptCheckWorkerThreads();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
-    m_node.mn_metaman = nullptr;
-    ::mmetaman.reset();
     m_node.mn_sync = nullptr;
     ::masternodeSync.reset();
     m_node.govman.reset();
     m_node.sporkman.reset();
     m_node.netfulfilledman.reset();
+    m_node.mn_metaman = nullptr;
+    ::mmetaman.reset();
     m_node.connman.reset();
     m_node.addrman.reset();
     m_node.args = nullptr;

--- a/src/validation.h
+++ b/src/validation.h
@@ -718,6 +718,12 @@ public:
      */
     std::set<CBlockIndex*, CBlockIndexWorkComparator> setBlockIndexCandidates;
 
+    CChainstateHelper& ChainHelper()
+    {
+        assert(m_chain_helper);
+        return *m_chain_helper;
+    }
+
     //! @returns A reference to the in-memory cache of the UTXO set.
     CCoinsViewCache& CoinsTip() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {


### PR DESCRIPTION
## Additional Information

* Dependency for https://github.com/dashpay/dash/pull/5980

* `CActiveMasternodeManager` construction is moved upwards (_before_ `PeerManager` construction) to avoid having to pass it as a `std::unique_ptr` const-ref. Shouldn't have any effect since _initialization_ is done in `ThreadImport`.

* `CConnman::SetNetworkActive` will require a pointer to `CMasternodeSync` in order to call `CMasternodeSync::Reset()`. As it is no longer available as a global, it will need to be manually called through for the effect to happen as the `CConnman` constructor will simply pass a `nullptr` when calling `SetNetworkActive`, bypassing the `Reset()` call. 
  
  `CMasternodeSync` is appropriately passed through in RPC (`setnetworkactive`) and interfaces.

* `CheckSpecialTx` was moved into `CSpecialTxProcessor` to avoid having to expose `CDeterministicMNManager` to `MemPoolAccept` (though it has been exposed to `CChainstateHelper` through a helper, `CChainState::ChainHelper()` that was introduced in this PR).
  * As a drawback, some RPC functions that otherwise only needed access to `CDeterministicMNManager`, will also be accessing `CChainstateHelper`.

## Concerns

* ~~Some tests seem to sporadically fail (fail as part of a suite but succeed when run individually, no changes in this PR should worsen resource contention) but attempting to reproduce them reliably hasn't succeeded so far.~~
  
  It appears the sporadic failure is shown in `p2p_node_network_limited.py` during TSan runs (see [failed run](https://gitlab.com/dashpay/dash/-/jobs/6529052189) for commit f95ffa7b70d5d20b6321ff11d37ad52425d446d1 that then succeeded in a [second attempt](https://gitlab.com/dashpay/dash/-/jobs/6530402585) versus a similar [failed run](https://gitlab.com/dashpay/dash/-/jobs/6546952668) for e210cb734e16e0ecef9601251fe0e074ed86827e that also succeeded on [second try](https://gitlab.com/dashpay/dash/-/jobs/6549470339)). Similar behaviour has not been observed on `develop` (as of this writing is 27c0813c08ac7e72d564120f966b3ba1e3804ae1).

## Breaking changes

`CMasternodeSync::Reset()` will not be called on every `CConnman` entity instantiated. Behaviour changes as a result of that are not substantiated. Protocol, networking or interface changes are not expected, changes are primarily refactoring.

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

