### PR TITLE
test: Fix `p2p_addr_relay.py`

### DIFF
--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -56,7 +56,7 @@ class AddrTest(BitcoinTestFramework):
                 'received: addr (301 bytes) peer=0',
         ]):
             addr_source.send_and_ping(msg)
-            self.nodes[0].setmocktime(int(time.time()) + 30 * 60)
+            self.bump_mocktime(30 * 60)
             addr_receiver.sync_with_ping()
 
 

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -20,7 +20,7 @@ from test_framework.util import (
 class AddrReceiver(P2PInterface):
     def on_addr(self, message):
         for addr in message.addrs:
-            assert_equal(addr.nServices, 9)
+            assert_equal(addr.nServices, 1)
             assert addr.ip.startswith('123.123.123.')
             assert (8333 <= addr.port < 8343)
 

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -54,6 +54,7 @@ class AddrTest(BitcoinTestFramework):
         with self.nodes[0].assert_debug_log([
                 'Added 10 addresses from 127.0.0.1: 0 tried',
                 'received: addr (301 bytes) peer=0',
+                'sending addr (301 bytes) peer=1',
         ]):
             addr_source.send_and_ping(msg)
             self.bump_mocktime(30 * 60)

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -16,17 +16,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
 )
-import time
-
-ADDRS = []
-for i in range(10):
-    addr = CAddress()
-    addr.time = int(time.time()) + i
-    addr.nServices = NODE_NETWORK
-    addr.ip = "123.123.123.{}".format(i % 256)
-    addr.port = 8333 + i
-    ADDRS.append(addr)
-
 
 class AddrReceiver(P2PInterface):
     def on_addr(self, message):
@@ -41,6 +30,15 @@ class AddrTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def run_test(self):
+        ADDRS = []
+        for i in range(10):
+            addr = CAddress()
+            addr.time = int(self.mocktime) + i
+            addr.nServices = NODE_NETWORK
+            addr.ip = "123.123.123.{}".format(i % 256)
+            addr.port = 8333 + i
+            ADDRS.append(addr)
+
         self.log.info('Create connection that sends addr messages')
         addr_source = self.nodes[0].add_p2p_connection(P2PInterface())
         msg = msg_addr()

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -17,6 +17,8 @@ from test_framework.util import (
     assert_equal,
 )
 
+ADDRS = []
+
 class AddrReceiver(P2PInterface):
     def on_addr(self, message):
         for addr in message.addrs:
@@ -30,7 +32,6 @@ class AddrTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def run_test(self):
-        ADDRS = []
         for i in range(10):
             addr = CAddress()
             addr.time = int(self.mocktime) + i


### PR DESCRIPTION
## Issue being fixed or feature implemented
`p2p_addr_relay.py` is broken but we don't see it in CI because it doesn't test everything it should atm. This weird behaviour was discovered by @kwvg while preparing #5964.

## What was done?
Bring back the missing check and fix the test. Borrowed one fix from #5964 to make this PR complete.

## How Has This Been Tested?
Run `p2p_addr_relay.py`

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

