### PR TITLE
guix: exclude debug symbols for apple from list of hashes due to its non-determinism

### DIFF
--- a/contrib/guix/guix-attest
+++ b/contrib/guix/guix-attest
@@ -192,6 +192,7 @@ mkdir -p "$outsigdir"
 
     if (( ${#noncodesigned_fragments[@]} )); then
         cat "${noncodesigned_fragments[@]}" \
+            | grep -v apple-darwin-debug.tar \
             | sort -u \
             | sort -k2 \
             | basenameify_SHA256SUMS \
@@ -220,6 +221,7 @@ mkdir -p "$outsigdir"
         # Note: all.SHA256SUMS attests to all of $sha256sum_fragments, but is
         #       not needed if there are no $codesigned_fragments
         cat "${sha256sum_fragments[@]}" \
+            | grep -v apple-darwin-debug.tar \
             | sort -u \
             | sort -k2 \
             | basenameify_SHA256SUMS \


### PR DESCRIPTION
## Issue being fixed or feature implemented
Debug symbols for apples are non-deterministic. Due to that all list of hash sums differ between build.
It causes to impossible to merge all GPG signatures to one file *.asc, because different files are signed.
For example these hash lists: https://github.com/dashpay/guix.sigs/blob/master/20.1.0/knst/all.SHA256SUMS#L6 and https://github.com/dashpay/guix.sigs/blob/master/20.1.0/thephez/all.SHA256SUMS#L6
are different:
```
ac87fd17eb19edcaa83b2cbf02e6d74ec12b1eaab50fc73789413bb04f1e04b5  dashcore-20.1.0-arm64-apple-darwin-debug.tar.gz
e16eaa02e24cdf643b58831c96bf1494c02602651e977994c8317f752b4c3ae3  dashcore-20.1.0-arm64-apple-darwin-debug.tar.gz
```


## What was done?
It excludes the line with hash of apples's debug artefact from the final list.

## How Has This Been Tested?
Run guix build and guix attest locally for 2 targets. There's output:
```
$ cat ~/projects/guix.sigs/20.1.0-317-ga29f82670b96/knst/noncodesigned.SHA256SUMS
f20cee2e348a850d39f79a6f06ce8019aca577bf5da0e81a3eb1d06013c0d3d9  dashcore-20.1.0-317-ga29f82670b96.tar.gz
e01c18b817793a7d71173c9b2d84b32d7bdc27e67fbd2ac35ad85457bed5b5c3  dashcore-20.1.0-317-ga29f82670b96-x86_64-apple-darwin-unsigned.dmg
0987f99859a4a7c5c1676a754f022f97dfe1dd8fdd8a35170e3144f43d317270  dashcore-20.1.0-317-ga29f82670b96-x86_64-apple-darwin-unsigned.tar.gz
2afdffd9e5b959dd1f54baadf2e8c7159147050ea032074b6d606945621e9a28  dashcore-20.1.0-317-ga29f82670b96-x86_64-apple-darwin.tar.gz
2f3af85fddb12cb6ff6f9c370b9bbb7b4893ed90748cefbb55fc4ce4d22cb3e9  dashcore-20.1.0-317-ga29f82670b96-x86_64-linux-gnu-debug.tar.gz
19daa1c8310d3097bf25713a551f2bcd59eccfa882b3b413db36591d6ec7c204  dashcore-20.1.0-317-ga29f82670b96-x86_64-linux-gnu.tar.gz
```
linux's debug is still here, apple's debug is not here as expected

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

