### PR TITLE
refactor: move C{ActiveMasternode, DeterministicMN}Manager, CMasternode{MetaMan, Sync} to NodeContext

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1890,7 +1890,6 @@ void CCoinJoinClientManager::GetJsonInfo(UniValue& obj) const
 }
 
 void CoinJoinWalletManager::Add(CWallet& wallet) {
-    assert(::masternodeSync != nullptr);
     m_wallet_manager_map.try_emplace(
         wallet.GetName(),
         std::make_unique<CCoinJoinClientManager>(wallet, *this, m_dmnman, m_mn_sync, m_queueman)

--- a/src/coinjoin/context.cpp
+++ b/src/coinjoin/context.cpp
@@ -13,14 +13,15 @@
 #endif // ENABLE_WALLET
 #include <coinjoin/server.h>
 
-CJContext::CJContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CTxMemPool& mempool,
-                     const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync, bool relay_txes) :
+CJContext::CJContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CMasternodeMetaMan& mn_metaman,
+                     CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync,
+                     bool relay_txes) :
     dstxman{std::make_unique<CDSTXManager>()},
 #ifdef ENABLE_WALLET
-    walletman{std::make_unique<CoinJoinWalletManager>(connman, dmnman, mempool, mn_sync, queueman)},
-    queueman {relay_txes ? std::make_unique<CCoinJoinClientQueueManager>(connman, *walletman, dmnman, mn_sync) : nullptr},
+    walletman{std::make_unique<CoinJoinWalletManager>(connman, dmnman, mn_metaman, mempool, mn_sync, queueman)},
+    queueman {relay_txes ? std::make_unique<CCoinJoinClientQueueManager>(connman, *walletman, dmnman, mn_metaman, mn_sync) : nullptr},
 #endif // ENABLE_WALLET
-    server{std::make_unique<CCoinJoinServer>(chainstate, connman, dmnman, *dstxman, mempool, mn_activeman, mn_sync)}
+    server{std::make_unique<CCoinJoinServer>(chainstate, connman, dmnman, *dstxman, mn_metaman, mempool, mn_activeman, mn_sync)}
 {}
 
 CJContext::~CJContext() {}

--- a/src/coinjoin/context.h
+++ b/src/coinjoin/context.h
@@ -18,6 +18,7 @@ class CCoinJoinServer;
 class CConnman;
 class CDeterministicMNManager;
 class CDSTXManager;
+class CMasternodeMetaMan;
 class CMasternodeSync;
 class CTxMemPool;
 
@@ -29,8 +30,9 @@ class CoinJoinWalletManager;
 struct CJContext {
     CJContext() = delete;
     CJContext(const CJContext&) = delete;
-    CJContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CTxMemPool& mempool,
-              const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync, bool relay_txes);
+    CJContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CMasternodeMetaMan& mn_metaman,
+              CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync,
+              bool relay_txes);
     ~CJContext();
 
     const std::unique_ptr<CDSTXManager> dstxman;

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -44,7 +44,7 @@ PeerMsgRet CCoinJoinServer::ProcessMessage(CNode& peer, std::string_view msg_typ
 void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
 {
     assert(m_mn_activeman);
-    assert(::mmetaman->IsValid());
+    assert(m_mn_metaman.IsValid());
 
     if (IsSessionReady()) {
         // too many users in this session already, reject new ones
@@ -81,9 +81,9 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
             }
         }
 
-        int64_t nLastDsq = mmetaman->GetMetaInfo(dmn->proTxHash)->GetLastDsq();
-        int64_t nDsqThreshold = mmetaman->GetDsqThreshold(dmn->proTxHash, mnList.GetValidMNsCount());
-        if (nLastDsq != 0 && nDsqThreshold > mmetaman->GetDsqCount()) {
+        int64_t nLastDsq = m_mn_metaman.GetMetaInfo(dmn->proTxHash)->GetLastDsq();
+        int64_t nDsqThreshold = m_mn_metaman.GetDsqThreshold(dmn->proTxHash, mnList.GetValidMNsCount());
+        if (nLastDsq != 0 && nDsqThreshold > m_mn_metaman.GetDsqCount()) {
             if (fLogIPs) {
                 LogPrint(BCLog::COINJOIN, "DSACCEPT -- last dsq too recent, must wait: peer=%d, addr=%s\n", peer.GetId(), peer.addr.ToString());
             } else {
@@ -111,7 +111,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
 
 PeerMsgRet CCoinJoinServer::ProcessDSQUEUE(const CNode& peer, CDataStream& vRecv)
 {
-    assert(::mmetaman->IsValid());
+    assert(m_mn_metaman.IsValid());
 
     CCoinJoinQueue dsq;
     vRecv >> dsq;
@@ -162,15 +162,15 @@ PeerMsgRet CCoinJoinServer::ProcessDSQUEUE(const CNode& peer, CDataStream& vRecv
     }
 
     if (!dsq.fReady) {
-        int64_t nLastDsq = mmetaman->GetMetaInfo(dmn->proTxHash)->GetLastDsq();
-        int64_t nDsqThreshold = mmetaman->GetDsqThreshold(dmn->proTxHash, tip_mn_list.GetValidMNsCount());
-        LogPrint(BCLog::COINJOIN, "DSQUEUE -- nLastDsq: %d  nDsqThreshold: %d  nDsqCount: %d\n", nLastDsq, nDsqThreshold, mmetaman->GetDsqCount());
+        int64_t nLastDsq = m_mn_metaman.GetMetaInfo(dmn->proTxHash)->GetLastDsq();
+        int64_t nDsqThreshold = m_mn_metaman.GetDsqThreshold(dmn->proTxHash, tip_mn_list.GetValidMNsCount());
+        LogPrint(BCLog::COINJOIN, "DSQUEUE -- nLastDsq: %d  nDsqThreshold: %d  nDsqCount: %d\n", nLastDsq, nDsqThreshold, m_mn_metaman.GetDsqCount());
         //don't allow a few nodes to dominate the queuing process
-        if (nLastDsq != 0 && nDsqThreshold > mmetaman->GetDsqCount()) {
+        if (nLastDsq != 0 && nDsqThreshold > m_mn_metaman.GetDsqCount()) {
             LogPrint(BCLog::COINJOIN, "DSQUEUE -- Masternode %s is sending too many dsq messages\n", dmn->pdmnState->addr.ToString());
             return {};
         }
-        mmetaman->AllowMixing(dmn->proTxHash);
+        m_mn_metaman.AllowMixing(dmn->proTxHash);
 
         LogPrint(BCLog::COINJOIN, "DSQUEUE -- new CoinJoin queue (%s) from masternode %s\n", dsq.ToString(), dmn->pdmnState->addr.ToString());
 

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -15,6 +15,7 @@ class CCoinJoinServer;
 class CDataStream;
 class CDeterministicMNManager;
 class CDSTXManager;
+class CMasternodeMetaMan;
 class CNode;
 class CTxMemPool;
 
@@ -29,6 +30,7 @@ private:
     CConnman& connman;
     CDeterministicMNManager& m_dmnman;
     CDSTXManager& m_dstxman;
+    CMasternodeMetaMan& m_mn_metaman;
     CTxMemPool& mempool;
     const CActiveMasternodeManager* const m_mn_activeman;
     const CMasternodeSync& m_mn_sync;
@@ -87,11 +89,13 @@ private:
 
 public:
     explicit CCoinJoinServer(CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman, CDSTXManager& dstxman,
-                             CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync) :
+                             CMasternodeMetaMan& mn_metaman, CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman,
+                             const CMasternodeSync& mn_sync) :
         m_chainstate(chainstate),
         connman(_connman),
         m_dmnman(dmnman),
         m_dstxman(dstxman),
+        m_mn_metaman(mn_metaman),
         mempool(mempool),
         m_mn_activeman(mn_activeman),
         m_mn_sync(mn_sync),

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -26,12 +26,14 @@
 CDSNotificationInterface::CDSNotificationInterface(CConnman& connman,
                                                    CMasternodeSync& mn_sync,
                                                    CGovernanceManager& govman,
+                                                   const CActiveMasternodeManager* const mn_activeman,
                                                    const std::unique_ptr<CDeterministicMNManager>& dmnman,
                                                    const std::unique_ptr<LLMQContext>& llmq_ctx,
                                                    const std::unique_ptr<CJContext>& cj_ctx)
   : m_connman(connman),
     m_mn_sync(mn_sync),
     m_govman(govman),
+    m_mn_activeman(mn_activeman),
     m_dmnman(dmnman),
     m_llmq_ctx(llmq_ctx),
     m_cj_ctx(cj_ctx) {}
@@ -94,7 +96,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     m_llmq_ctx->qdkgsman->UpdatedBlockTip(pindexNew, fInitialDownload);
     m_llmq_ctx->ehfSignalsHandler->UpdatedBlockTip(pindexNew);
 
-    if (!fDisableGovernance) m_govman.UpdatedBlockTip(pindexNew, m_connman);
+    if (!fDisableGovernance) m_govman.UpdatedBlockTip(pindexNew, m_connman, m_mn_activeman);
 }
 
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx, int64_t nAcceptTime)

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -7,6 +7,7 @@
 
 #include <validationinterface.h>
 
+class CActiveMasternodeManager;
 class CConnman;
 class CDeterministicMNManager;
 class CGovernanceManager;
@@ -20,6 +21,7 @@ public:
     explicit CDSNotificationInterface(CConnman& connman,
                                       CMasternodeSync& mn_sync,
                                       CGovernanceManager& govman,
+                                      const CActiveMasternodeManager* const mn_activeman,
                                       const std::unique_ptr<CDeterministicMNManager>& dmnman,
                                       const std::unique_ptr<LLMQContext>& llmq_ctx,
                                       const std::unique_ptr<CJContext>& cj_ctx);
@@ -47,6 +49,7 @@ private:
     CMasternodeSync& m_mn_sync;
     CGovernanceManager& m_govman;
 
+    const CActiveMasternodeManager* const m_mn_activeman;
     const std::unique_ptr<CDeterministicMNManager>& m_dmnman;
     const std::unique_ptr<LLMQContext>& m_llmq_ctx;
     const std::unique_ptr<CJContext>& m_cj_ctx;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -27,8 +27,6 @@
 static const std::string DB_LIST_SNAPSHOT = "dmn_S3";
 static const std::string DB_LIST_DIFF = "dmn_D3";
 
-std::unique_ptr<CDeterministicMNManager> deterministicMNManager;
-
 uint64_t CDeterministicMN::GetInternalId() const
 {
     // can't get it if it wasn't set yet

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -637,6 +637,4 @@ bool CheckProUpServTx(CDeterministicMNManager& dmnman, const CTransaction& tx, g
 bool CheckProUpRegTx(CDeterministicMNManager& dmnman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, TxValidationState& state, const CCoinsViewCache& view, bool check_sigs);
 bool CheckProUpRevTx(CDeterministicMNManager& dmnman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, TxValidationState& state, bool check_sigs);
 
-extern std::unique_ptr<CDeterministicMNManager> deterministicMNManager;
-
 #endif // BITCOIN_EVO_DETERMINISTICMNS_H

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -61,11 +61,12 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip)
     connman.PushMessage(&peer, CNetMsgMaker(peer.GetCommonVersion()).Make(NetMsgType::MNAUTH, mnauth));
 }
 
-PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv)
+PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, const CMasternodeSync& mn_sync,
+                                   const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv)
 {
     assert(::mmetaman->IsValid());
 
-    if (msg_type != NetMsgType::MNAUTH || !::masternodeSync->IsBlockchainSynced()) {
+    if (msg_type != NetMsgType::MNAUTH || !mn_sync.IsBlockchainSynced()) {
         // we can't verify MNAUTH messages when we don't have the latest MN list
         return {};
     }

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -62,10 +62,10 @@ void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CActiveMasternode
     connman.PushMessage(&peer, CNetMsgMaker(peer.GetCommonVersion()).Make(NetMsgType::MNAUTH, mnauth));
 }
 
-PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync,
-                                   const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv)
+PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, CMasternodeMetaMan& mn_metaman, const CActiveMasternodeManager* const mn_activeman,
+                                   const CMasternodeSync& mn_sync, const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv)
 {
-    assert(::mmetaman->IsValid());
+    assert(mn_metaman.IsValid());
 
     if (msg_type != NetMsgType::MNAUTH || !mn_sync.IsBlockchainSynced()) {
         // we can't verify MNAUTH messages when we don't have the latest MN list
@@ -125,7 +125,7 @@ PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, const CActive
     }
 
     if (!peer.IsInboundConn()) {
-        mmetaman->GetMetaInfo(mnauth.proRegTxHash)->SetLastOutboundSuccess(GetTime<std::chrono::seconds>().count());
+        mn_metaman.GetMetaInfo(mnauth.proRegTxHash)->SetLastOutboundSuccess(GetTime<std::chrono::seconds>().count());
         if (peer.m_masternode_probe_connection) {
             LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- Masternode probe successful for %s, disconnecting. peer=%d\n",
                      mnauth.proRegTxHash.ToString(), peer.GetId());

--- a/src/evo/mnauth.h
+++ b/src/evo/mnauth.h
@@ -16,6 +16,7 @@ class CDeterministicMN;
 class CDeterministicMNList;
 class CDeterministicMNListDiff;
 class CDeterministicMNManager;
+class CMasternodeSync;
 class CNode;
 
 class UniValue;
@@ -54,7 +55,8 @@ public:
      * @pre CMasternodeMetaMan's database must be successfully loaded before
      *      attempting to call this function regardless of sync state
      */
-    static PeerMsgRet ProcessMessage(CNode& peer, CConnman& connman, const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv);
+    static PeerMsgRet ProcessMessage(CNode& peer, CConnman& connman, const CMasternodeSync& mn_sync,
+                                     const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv);
     static void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff, CConnman& connman);
 };
 

--- a/src/evo/mnauth.h
+++ b/src/evo/mnauth.h
@@ -17,6 +17,7 @@ class CDeterministicMN;
 class CDeterministicMNList;
 class CDeterministicMNListDiff;
 class CDeterministicMNManager;
+class CMasternodeMetaMan;
 class CMasternodeSync;
 class CNode;
 
@@ -57,8 +58,8 @@ public:
      * @pre CMasternodeMetaMan's database must be successfully loaded before
      *      attempting to call this function regardless of sync state
      */
-    static PeerMsgRet ProcessMessage(CNode& peer, CConnman& connman, const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync,
-                                     const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv);
+    static PeerMsgRet ProcessMessage(CNode& peer, CConnman& connman, CMasternodeMetaMan& mn_metaman, const CActiveMasternodeManager* const mn_activeman,
+                                     const CMasternodeSync& mn_sync, const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv);
     static void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff, CConnman& connman);
 };
 

--- a/src/evo/mnauth.h
+++ b/src/evo/mnauth.h
@@ -9,6 +9,7 @@
 #include <net_types.h>
 #include <serialize.h>
 
+class CActiveMasternodeManager;
 class CBlockIndex;
 class CConnman;
 class CDataStream;
@@ -49,13 +50,14 @@ public:
         READWRITE(obj.proRegTxHash, obj.sig);
     }
 
-    static void PushMNAUTH(CNode& peer, CConnman& connman, const CBlockIndex* tip);
+    static void PushMNAUTH(CNode& peer, CConnman& connman, const CActiveMasternodeManager& mn_activeman,
+                           const CBlockIndex* tip);
 
     /**
      * @pre CMasternodeMetaMan's database must be successfully loaded before
      *      attempting to call this function regardless of sync state
      */
-    static PeerMsgRet ProcessMessage(CNode& peer, CConnman& connman, const CMasternodeSync& mn_sync,
+    static PeerMsgRet ProcessMessage(CNode& peer, CConnman& connman, const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync,
                                      const CDeterministicMNList& tip_mn_list, std::string_view msg_type, CDataStream& vRecv);
     static void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff, CConnman& connman);
 };

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_GOVERNANCE_GOVERNANCE_H
 #define BITCOIN_GOVERNANCE_GOVERNANCE_H
 
-#include <evo/deterministicmns.h>
 #include <governance/classes.h>
 #include <governance/object.h>
 
@@ -26,6 +25,7 @@ class CDeterministicMNManager;
 class CGovernanceManager;
 class CGovernanceObject;
 class CGovernanceVote;
+class CMasternodeSync;
 class CNetFulfilledRequestManager;
 class CSporkManager;
 
@@ -257,6 +257,7 @@ private:
 
     CNetFulfilledRequestManager& m_netfulfilledman;
     const std::unique_ptr<CDeterministicMNManager>& m_dmnman;
+    const std::unique_ptr<CMasternodeSync>& m_mn_sync;
 
     int64_t nTimeLastDiff;
     // keep track of current block height
@@ -270,7 +271,9 @@ private:
     std::map<uint256, std::shared_ptr<CSuperblock>> mapTrigger;
 
 public:
-    explicit CGovernanceManager(CNetFulfilledRequestManager& netfulfilledman, const std::unique_ptr<CDeterministicMNManager>& dmnman);
+    explicit CGovernanceManager(CNetFulfilledRequestManager& netfulfilledman,
+                                const std::unique_ptr<CDeterministicMNManager>& dmnman,
+                                const std::unique_ptr<CMasternodeSync>& mn_sync);
     ~CGovernanceManager();
 
     bool LoadCache(bool load_cache);
@@ -337,14 +340,7 @@ public:
 
     bool MasternodeRateCheck(const CGovernanceObject& govobj, bool fUpdateFailStatus, bool fForce, bool& fRateCheckBypassed);
 
-    bool ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception, CConnman& connman)
-    {
-        bool fOK = ProcessVote(nullptr, vote, exception, connman);
-        if (fOK) {
-            vote.Relay(connman, Assert(m_dmnman)->GetListAtChainTip());
-        }
-        return fOK;
-    }
+    bool ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception, CConnman& connman);
 
     void CheckPostponedObjects(CConnman& connman);
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -311,7 +311,7 @@ public:
 
     UniValue ToJson() const;
 
-    void UpdatedBlockTip(const CBlockIndex* pindex, CConnman& connman);
+    void UpdatedBlockTip(const CBlockIndex* pindex, CConnman& connman, const CActiveMasternodeManager* const mn_activeman);
     int64_t GetLastDiffTime() const { return nTimeLastDiff; }
     void UpdateLastDiffTime(int64_t nTimeIn) { nTimeLastDiff = nTimeIn; }
 
@@ -366,9 +366,12 @@ public:
 
 private:
     std::optional<const CSuperblock> CreateSuperblockCandidate(int nHeight) const;
-    std::optional<const CGovernanceObject> CreateGovernanceTrigger(const std::optional<const CSuperblock>& sb_opt, CConnman& connman);
-    void VoteGovernanceTriggers(const std::optional<const CGovernanceObject>& trigger_opt, CConnman& connman);
-    bool VoteFundingTrigger(const uint256& nHash, const vote_outcome_enum_t outcome, CConnman& connman);
+    std::optional<const CGovernanceObject> CreateGovernanceTrigger(const std::optional<const CSuperblock>& sb_opt, CConnman& connman,
+                                                                   const CActiveMasternodeManager* const mn_activeman);
+    void VoteGovernanceTriggers(const std::optional<const CGovernanceObject>& trigger_opt, CConnman& connman,
+                                const CActiveMasternodeManager* const mn_activeman);
+    bool VoteFundingTrigger(const uint256& nHash, const vote_outcome_enum_t outcome, CConnman& connman,
+                            const CActiveMasternodeManager* const mn_activeman);
     bool HasAlreadyVotedFundingTrigger() const;
 
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash, CConnman& connman, bool fUseFilter = false) const;

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -25,6 +25,7 @@ class CDeterministicMNManager;
 class CGovernanceManager;
 class CGovernanceObject;
 class CGovernanceVote;
+class CMasternodeMetaMan;
 class CMasternodeSync;
 class CNetFulfilledRequestManager;
 class CSporkManager;
@@ -255,6 +256,7 @@ private:
     const std::unique_ptr<db_type> m_db;
     bool is_valid{false};
 
+    CMasternodeMetaMan& m_mn_metaman;
     CNetFulfilledRequestManager& m_netfulfilledman;
     const std::unique_ptr<CDeterministicMNManager>& m_dmnman;
     const std::unique_ptr<CMasternodeSync>& m_mn_sync;
@@ -271,7 +273,7 @@ private:
     std::map<uint256, std::shared_ptr<CSuperblock>> mapTrigger;
 
 public:
-    explicit CGovernanceManager(CNetFulfilledRequestManager& netfulfilledman,
+    explicit CGovernanceManager(CMasternodeMetaMan& mn_metaman, CNetFulfilledRequestManager& netfulfilledman,
                                 const std::unique_ptr<CDeterministicMNManager>& dmnman,
                                 const std::unique_ptr<CMasternodeSync>& mn_sync);
     ~CGovernanceManager();

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -628,10 +628,10 @@ bool CGovernanceObject::GetCurrentMNVotes(const COutPoint& mnCollateralOutpoint,
     return true;
 }
 
-void CGovernanceObject::Relay(CConnman& connman) const
+void CGovernanceObject::Relay(CConnman& connman, const CMasternodeSync& mn_sync) const
 {
     // Do not relay until fully synced
-    if (!::masternodeSync->IsSynced()) {
+    if (!mn_sync.IsSynced()) {
         LogPrint(BCLog::GOBJECT, "CGovernanceObject::Relay -- won't relay until fully synced\n");
         return;
     }

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -80,9 +80,10 @@ CGovernanceObject::CGovernanceObject(const CGovernanceObject& other) :
 {
 }
 
-bool CGovernanceObject::ProcessVote(CGovernanceManager& govman, const CDeterministicMNList& tip_mn_list, const CGovernanceVote& vote, CGovernanceException& exception)
+bool CGovernanceObject::ProcessVote(CMasternodeMetaMan& mn_metaman, CGovernanceManager& govman, const CDeterministicMNList& tip_mn_list,
+                                    const CGovernanceVote& vote, CGovernanceException& exception)
 {
-    assert(::mmetaman->IsValid());
+    assert(mn_metaman.IsValid());
 
     LOCK(cs);
 
@@ -180,7 +181,7 @@ bool CGovernanceObject::ProcessVote(CGovernanceManager& govman, const CDetermini
         return false;
     }
 
-    if (!mmetaman->AddGovernanceVote(dmn->proTxHash, vote.GetParentHash())) {
+    if (!mn_metaman.AddGovernanceVote(dmn->proTxHash, vote.GetParentHash())) {
         std::ostringstream ostr;
         ostr << "CGovernanceObject::ProcessVote -- Unable to add governance vote"
              << ", MN outpoint = " << vote.GetMasternodeOutpoint().ToStringShort()

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -19,6 +19,7 @@ class CDeterministicMNList;
 class CGovernanceManager;
 class CGovernanceObject;
 class CGovernanceVote;
+class CMasternodeMetaMan;
 class CMasternodeSync;
 class CNode;
 
@@ -290,7 +291,8 @@ public:
     void LoadData();
     void GetData(UniValue& objResult) const;
 
-    bool ProcessVote(CGovernanceManager& govman, const CDeterministicMNList& tip_mn_list, const CGovernanceVote& vote, CGovernanceException& exception);
+    bool ProcessVote(CMasternodeMetaMan& mn_metaman, CGovernanceManager& govman, const CDeterministicMNList& tip_mn_list,
+                     const CGovernanceVote& vote, CGovernanceException& exception);
 
     /// Called when MN's which have voted on this object have been removed
     void ClearMasternodeVotes(const CDeterministicMNList& tip_mn_list);

--- a/src/governance/object.h
+++ b/src/governance/object.h
@@ -19,6 +19,7 @@ class CDeterministicMNList;
 class CGovernanceManager;
 class CGovernanceObject;
 class CGovernanceVote;
+class CMasternodeSync;
 class CNode;
 
 extern RecursiveMutex cs_main;
@@ -247,7 +248,7 @@ public:
 
     UniValue GetJSONObject() const;
 
-    void Relay(CConnman& connman) const;
+    void Relay(CConnman& connman, const CMasternodeSync& mn_sync) const;
 
     uint256 GetHash() const;
     uint256 GetDataHash() const;

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -122,10 +122,10 @@ std::string CGovernanceVote::ToString(const CDeterministicMNList& tip_mn_list) c
     return ostr.str();
 }
 
-void CGovernanceVote::Relay(CConnman& connman, const CDeterministicMNList& tip_mn_list) const
+void CGovernanceVote::Relay(CConnman& connman, const CMasternodeSync& mn_sync, const CDeterministicMNList& tip_mn_list) const
 {
     // Do not relay until fully synced
-    if (!::masternodeSync->IsSynced()) {
+    if (!mn_sync.IsSynced()) {
         LogPrint(BCLog::GOBJECT, "CGovernanceVote::Relay -- won't relay until fully synced\n");
         return;
     }

--- a/src/governance/vote.h
+++ b/src/governance/vote.h
@@ -13,6 +13,7 @@ class CBLSPublicKey;
 class CConnman;
 class CDeterministicMNList;
 class CGovernanceVote;
+class CMasternodeSync;
 class CKey;
 class CKeyID;
 
@@ -104,7 +105,7 @@ public:
     bool Sign(const CActiveMasternodeManager& mn_activeman);
     bool CheckSignature(const CBLSPublicKey& pubKey) const;
     bool IsValid(const CDeterministicMNList& tip_mn_list, bool useVotingKey) const;
-    void Relay(CConnman& connman, const CDeterministicMNList& tip_mn_list) const;
+    void Relay(CConnman& connman, const CMasternodeSync& mn_sync, const CDeterministicMNList& tip_mn_list) const;
 
     const COutPoint& GetMasternodeOutpoint() const { return masternodeOutpoint; }
 

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -25,17 +25,17 @@ namespace llmq
 {
 std::unique_ptr<CChainLocksHandler> chainLocksHandler;
 
-CChainLocksHandler::CChainLocksHandler(CChainState& chainstate, CConnman& _connman, CMasternodeSync& mn_sync, CQuorumManager& _qman,
+CChainLocksHandler::CChainLocksHandler(CChainState& chainstate, CConnman& _connman, CQuorumManager& _qman,
                                        CSigningManager& _sigman, CSigSharesManager& _shareman, CSporkManager& sporkman,
-                                       CTxMemPool& _mempool) :
+                                       CTxMemPool& _mempool, const CMasternodeSync& mn_sync) :
     m_chainstate(chainstate),
     connman(_connman),
-    m_mn_sync(mn_sync),
     qman(_qman),
     sigman(_sigman),
     shareman(_shareman),
     spork_manager(sporkman),
     mempool(_mempool),
+    m_mn_sync(mn_sync),
     scheduler(std::make_unique<CScheduler>()),
     scheduler_thread(std::make_unique<std::thread>(std::thread(util::TraceThread, "cl-schdlr", [&] { scheduler->serviceQueue(); })))
 {

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -47,12 +47,12 @@ class CChainLocksHandler : public CRecoveredSigsListener
 private:
     CChainState& m_chainstate;
     CConnman& connman;
-    CMasternodeSync& m_mn_sync;
     CQuorumManager& qman;
     CSigningManager& sigman;
     CSigSharesManager& shareman;
     CSporkManager& spork_manager;
     CTxMemPool& mempool;
+    const CMasternodeSync& m_mn_sync;
 
     std::unique_ptr<CScheduler> scheduler;
     std::unique_ptr<std::thread> scheduler_thread;
@@ -85,9 +85,9 @@ private:
     std::atomic<int64_t> lastCleanupTime{0};
 
 public:
-    explicit CChainLocksHandler(CChainState& chainstate, CConnman& _connman, CMasternodeSync& mn_sync, CQuorumManager& _qman,
+    explicit CChainLocksHandler(CChainState& chainstate, CConnman& _connman, CQuorumManager& _qman,
                                 CSigningManager& _sigman, CSigSharesManager& _shareman, CSporkManager& sporkman,
-                                CTxMemPool& _mempool);
+                                CTxMemPool& _mempool, const CMasternodeSync& mn_sync);
     ~CChainLocksHandler();
 
     void Start();

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -20,8 +20,9 @@
 #include <masternode/sync.h>
 
 LLMQContext::LLMQContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CEvoDB& evo_db,
-                         CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman,
-                         const CMasternodeSync& mn_sync, const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe) :
+                         CMasternodeMetaMan& mn_metaman, CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool,
+                         const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync,
+                         const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe) :
     bls_worker{std::make_shared<CBLSWorker>()},
     dkg_debugman{std::make_unique<llmq::CDKGDebugManager>()},
     quorum_block_processor{[&]() -> llmq::CQuorumBlockProcessor* const {
@@ -29,7 +30,7 @@ LLMQContext::LLMQContext(CChainState& chainstate, CConnman& connman, CDeterminis
         llmq::quorumBlockProcessor = std::make_unique<llmq::CQuorumBlockProcessor>(chainstate, connman, dmnman, evo_db);
         return llmq::quorumBlockProcessor.get();
     }()},
-    qdkgsman{std::make_unique<llmq::CDKGSessionManager>(*bls_worker, chainstate, connman, dmnman, *dkg_debugman, *quorum_block_processor, mn_activeman, sporkman, unit_tests, wipe)},
+    qdkgsman{std::make_unique<llmq::CDKGSessionManager>(*bls_worker, chainstate, connman, dmnman, *dkg_debugman, mn_metaman, *quorum_block_processor, mn_activeman, sporkman, unit_tests, wipe)},
     qman{[&]() -> llmq::CQuorumManager* const {
         assert(llmq::quorumManager == nullptr);
         llmq::quorumManager = std::make_unique<llmq::CQuorumManager>(*bls_worker, chainstate, connman, dmnman, *qdkgsman, evo_db, *quorum_block_processor, mn_activeman, mn_sync, sporkman);

--- a/src/llmq/context.h
+++ b/src/llmq/context.h
@@ -14,6 +14,7 @@ class CConnman;
 class CDeterministicMNManager;
 class CDBWrapper;
 class CEvoDB;
+class CMasternodeMetaMan;
 class CMasternodeSync;
 class CMNHFManager;
 class CSporkManager;
@@ -36,8 +37,9 @@ struct LLMQContext {
     LLMQContext() = delete;
     LLMQContext(const LLMQContext&) = delete;
     LLMQContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CEvoDB& evo_db,
-                CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman,
-                const CMasternodeSync& mn_sync, const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe);
+                CMasternodeMetaMan& mn_metaman, CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool,
+                const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync,
+                const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe);
     ~LLMQContext();
 
     void Interrupt();

--- a/src/llmq/context.h
+++ b/src/llmq/context.h
@@ -14,6 +14,7 @@ class CConnman;
 class CDeterministicMNManager;
 class CDBWrapper;
 class CEvoDB;
+class CMasternodeSync;
 class CMNHFManager;
 class CSporkManager;
 class CTxMemPool;
@@ -36,7 +37,7 @@ struct LLMQContext {
     LLMQContext(const LLMQContext&) = delete;
     LLMQContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CEvoDB& evo_db,
                 CMNHFManager& mnhfman, CSporkManager& sporkman, CTxMemPool& mempool, const CActiveMasternodeManager* const mn_activeman,
-                const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe);
+                const CMasternodeSync& mn_sync, const std::unique_ptr<PeerManager>& peerman, bool unit_tests, bool wipe);
     ~LLMQContext();
 
     void Interrupt();

--- a/src/llmq/dkgsession.cpp
+++ b/src/llmq/dkgsession.cpp
@@ -450,7 +450,7 @@ void CDKGSession::VerifyAndComplain(CDKGPendingMessages& pendingMessages)
 
 void CDKGSession::VerifyConnectionAndMinProtoVersions() const
 {
-    assert(::mmetaman->IsValid());
+    assert(m_mn_metaman.IsValid());
 
     if (!IsQuorumPoseEnabled(params.type, m_sporkman)) {
         return;
@@ -482,7 +482,7 @@ void CDKGSession::VerifyConnectionAndMinProtoVersions() const
             logger.Batch("%s does not have min proto version %d (has %d)", m->dmn->proTxHash.ToString(), MIN_MASTERNODE_PROTO_VERSION, it->second);
         }
 
-        if (mmetaman->GetMetaInfo(m->dmn->proTxHash)->OutboundFailedTooManyTimes()) {
+        if (m_mn_metaman.GetMetaInfo(m->dmn->proTxHash)->OutboundFailedTooManyTimes()) {
             m->badConnection = true;
             logger.Batch("%s failed to connect to it too many times", m->dmn->proTxHash.ToString());
         }

--- a/src/llmq/dkgsession.h
+++ b/src/llmq/dkgsession.h
@@ -19,6 +19,7 @@ class CActiveMasternodeManager;
 class CInv;
 class CConnman;
 class CDeterministicMN;
+class CMasternodeMetaMan;
 class CSporkManager;
 class UniValue;
 
@@ -272,9 +273,11 @@ private:
 
     CBLSWorker& blsWorker;
     CBLSWorkerCache cache;
+    CConnman& connman;
     CDeterministicMNManager& m_dmnman;
     CDKGSessionManager& dkgManager;
     CDKGDebugManager& dkgDebugManager;
+    CMasternodeMetaMan& m_mn_metaman;
     const CActiveMasternodeManager* const m_mn_activeman;
     const CSporkManager& m_sporkman;
 
@@ -297,7 +300,6 @@ private:
 
     uint256 myProTxHash;
     CBLSId myId;
-    CConnman& connman;
     std::optional<size_t> myIdx;
 
     // all indexed by msg hash
@@ -317,11 +319,12 @@ private:
     std::set<uint256> validCommitments GUARDED_BY(invCs);
 
 public:
-    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CDeterministicMNManager& dmnman,
-                CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager, CConnman& _connman,
-                const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman) :
-        params(_params), blsWorker(_blsWorker), cache(_blsWorker), m_dmnman(dmnman), dkgManager(_dkgManager),
-        dkgDebugManager(_dkgDebugManager), m_mn_activeman(mn_activeman), m_sporkman(sporkman), connman(_connman) {}
+    CDKGSession(const Consensus::LLMQParams& _params, CBLSWorker& _blsWorker, CConnman& _connman,
+                CDeterministicMNManager& dmnman, CDKGSessionManager& _dkgManager, CDKGDebugManager& _dkgDebugManager,
+                CMasternodeMetaMan& mn_metaman, const CActiveMasternodeManager* const mn_activeman,
+                const CSporkManager& sporkman) :
+        params(_params), blsWorker(_blsWorker), cache(_blsWorker), connman(_connman), m_dmnman(dmnman), dkgManager(_dkgManager),
+        dkgDebugManager(_dkgDebugManager), m_mn_metaman(mn_metaman), m_mn_activeman(mn_activeman), m_sporkman(sporkman) {}
 
     bool Init(gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, Span<CDeterministicMNCPtr> mns, const uint256& _myProTxHash, int _quorumIndex);
 

--- a/src/llmq/dkgsessionhandler.h
+++ b/src/llmq/dkgsessionhandler.h
@@ -19,6 +19,7 @@ class CBlockIndex;
 class CBLSWorker;
 class CChainState;
 class CDeterministicMNManager;
+class CMasternodeMetaMan;
 class CSporkManager;
 class PeerManager;
 
@@ -125,6 +126,7 @@ private:
     CDeterministicMNManager& m_dmnman;
     CDKGDebugManager& dkgDebugManager;
     CDKGSessionManager& dkgManager;
+    CMasternodeMetaMan& m_mn_metaman;
     CQuorumBlockProcessor& quorumBlockProcessor;
     const CActiveMasternodeManager* const m_mn_activeman;
     const CSporkManager& m_sporkman;
@@ -147,9 +149,9 @@ private:
 
 public:
     CDKGSessionHandler(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
-                       CDKGDebugManager& _dkgDebugManager, CDKGSessionManager& _dkgManager, CQuorumBlockProcessor& _quorumBlockProcessor,
-                       const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, const Consensus::LLMQParams& _params,
-                       int _quorumIndex);
+                       CDKGDebugManager& _dkgDebugManager, CDKGSessionManager& _dkgManager, CMasternodeMetaMan& mn_metaman,
+                       CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* const mn_activeman,
+                       const CSporkManager& sporkman, const Consensus::LLMQParams& _params, int _quorumIndex);
     ~CDKGSessionHandler() = default;
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew);

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -25,8 +25,8 @@ static const std::string DB_SKCONTRIB = "qdkg_S";
 static const std::string DB_ENC_CONTRIB = "qdkg_E";
 
 CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
-                                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* const mn_activeman,
-                                       const CSporkManager& sporkman, bool unitTests, bool fWipe) :
+                                       CDKGDebugManager& _dkgDebugManager, CMasternodeMetaMan& mn_metaman, CQuorumBlockProcessor& _quorumBlockProcessor,
+                                       const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, bool unitTests, bool fWipe) :
     db(std::make_unique<CDBWrapper>(unitTests ? "" : (GetDataDir() / "llmq/dkgdb"), 1 << 20, unitTests, fWipe)),
     blsWorker(_blsWorker),
     m_chainstate(chainstate),
@@ -49,7 +49,7 @@ CDKGSessionManager::CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chai
         for (const auto i : irange::range(session_count)) {
             dkgSessionHandlers.emplace(std::piecewise_construct,
                                        std::forward_as_tuple(params.type, i),
-                                       std::forward_as_tuple(blsWorker, m_chainstate, connman, dmnman, dkgDebugManager, *this, quorumBlockProcessor, mn_activeman, spork_manager, params, i));
+                                       std::forward_as_tuple(blsWorker, m_chainstate, connman, dmnman, dkgDebugManager, *this, mn_metaman, quorumBlockProcessor, mn_activeman, spork_manager, params, i));
         }
     }
 }

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -20,6 +20,7 @@ class CChainState;
 class CDBWrapper;
 class CDeterministicMNManager;
 class CDKGDebugManager;
+class CMasternodeMetaMan;
 class CSporkManager;
 class PeerManager;
 
@@ -67,8 +68,8 @@ private:
 
 public:
     CDKGSessionManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
-                       CDKGDebugManager& _dkgDebugManager, CQuorumBlockProcessor& _quorumBlockProcessor, const CActiveMasternodeManager* const mn_activeman,
-                       const CSporkManager& sporkman, bool unitTests, bool fWipe);
+                       CDKGDebugManager& _dkgDebugManager, CMasternodeMetaMan& mn_metaman, CQuorumBlockProcessor& _quorumBlockProcessor,
+                       const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, bool unitTests, bool fWipe);
     ~CDKGSessionManager() = default;
 
     void StartThreads();

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -207,7 +207,7 @@ bool CQuorum::ReadContributions(CEvoDB& evoDb)
 
 CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
                                CDKGSessionManager& _dkgManager, CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor,
-                               const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync) :
+                               const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync, const CSporkManager& sporkman) :
     blsWorker(_blsWorker),
     m_chainstate(chainstate),
     connman(_connman),
@@ -216,8 +216,8 @@ CQuorumManager::CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, 
     m_evoDb(_evoDb),
     quorumBlockProcessor(_quorumBlockProcessor),
     m_mn_activeman(mn_activeman),
-    m_sporkman(sporkman),
-    m_mn_sync(mn_sync)
+    m_mn_sync(mn_sync),
+    m_sporkman(sporkman)
 {
     utils::InitQuorumsCache(mapQuorumsCache, false);
     quorumThreadInterrupt.reset();
@@ -296,7 +296,7 @@ void CQuorumManager::TriggerQuorumDataRecoveryThreads(const CBlockIndex* pIndex)
 
 void CQuorumManager::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fInitialDownload) const
 {
-    if (!m_mn_sync->IsBlockchainSynced()) return;
+    if (!m_mn_sync.IsBlockchainSynced()) return;
 
     for (const auto& params : Params().GetConsensus().llmqs) {
         CheckQuorumConnections(params, pindexNew);
@@ -916,7 +916,7 @@ void CQuorumManager::StartQuorumDataRecoveryThread(const CQuorumCPtr pQuorum, co
         };
         printLog("Start");
 
-        while (!m_mn_sync->IsBlockchainSynced() && !quorumThreadInterrupt) {
+        while (!m_mn_sync.IsBlockchainSynced() && !quorumThreadInterrupt) {
             quorumThreadInterrupt.sleep_for(std::chrono::seconds(nRequestTimeout));
         }
 

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -225,8 +225,8 @@ private:
     CEvoDB& m_evoDb;
     CQuorumBlockProcessor& quorumBlockProcessor;
     const CActiveMasternodeManager* const m_mn_activeman;
+    const CMasternodeSync& m_mn_sync;
     const CSporkManager& m_sporkman;
-    const std::unique_ptr<CMasternodeSync>& m_mn_sync;
 
     mutable Mutex cs_map_quorums;
     mutable std::map<Consensus::LLMQType, unordered_lru_cache<uint256, CQuorumPtr, StaticSaltedHasher>> mapQuorumsCache GUARDED_BY(cs_map_quorums);
@@ -241,7 +241,7 @@ private:
 public:
     CQuorumManager(CBLSWorker& _blsWorker, CChainState& chainstate, CConnman& _connman, CDeterministicMNManager& dmnman,
                    CDKGSessionManager& _dkgManager, CEvoDB& _evoDb, CQuorumBlockProcessor& _quorumBlockProcessor,
-                   const CActiveMasternodeManager* const mn_activeman, const CSporkManager& sporkman, const std::unique_ptr<CMasternodeSync>& mn_sync);
+                   const CActiveMasternodeManager* const mn_activeman, const CMasternodeSync& mn_sync, const CSporkManager& sporkman);
     ~CQuorumManager() { Stop(); };
 
     void Start();

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -808,11 +808,11 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& 
     return true;
 }
 
-void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CDeterministicMNManager& dmnman, const CSporkManager& sporkman,
-                               const CDeterministicMNList& tip_mn_list, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
-                               const uint256 &myProTxHash)
+void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CDeterministicMNManager& dmnman,
+                               CMasternodeMetaMan& mn_metaman, const CSporkManager& sporkman, const CDeterministicMNList& tip_mn_list,
+                               gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256 &myProTxHash)
 {
-    assert(::mmetaman->IsValid());
+    assert(mn_metaman.IsValid());
 
     if (!IsQuorumPoseEnabled(llmqParams.type, sporkman)) {
         return;
@@ -826,7 +826,7 @@ void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman
         if (dmn->proTxHash == myProTxHash) {
             continue;
         }
-        auto lastOutbound = mmetaman->GetMetaInfo(dmn->proTxHash)->GetLastOutboundSuccess();
+        auto lastOutbound = mn_metaman.GetMetaInfo(dmn->proTxHash)->GetLastOutboundSuccess();
         if (curTime - lastOutbound < 10 * 60) {
             // avoid re-probing nodes too often
             continue;

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -19,8 +19,10 @@ class CBlockIndex;
 class CDeterministicMN;
 class CDeterministicMNList;
 class CDeterministicMNManager;
-using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
+class CMasternodeMetaMan;
 class CSporkManager;
+
+using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
 
 namespace llmq
 {
@@ -39,9 +41,9 @@ std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType,
 bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CDeterministicMNManager& dmnman, const CSporkManager& sporkman,
                              const CDeterministicMNList& tip_mn_list, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
                              const uint256& myProTxHash);
-void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CDeterministicMNManager& dmnman, const CSporkManager& sporkman,
-                               const CDeterministicMNList& tip_mn_list, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
-                               const uint256& myProTxHash);
+void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CDeterministicMNManager& dmnman,
+                               CMasternodeMetaMan& mn_metaman, const CSporkManager& sporkman, const CDeterministicMNList& tip_mn_list,
+                               gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& myProTxHash);
 
 template <typename CacheType>
 void InitQuorumsCache(CacheType& cache, bool limit_by_connections = true);

--- a/src/masternode/meta.cpp
+++ b/src/masternode/meta.cpp
@@ -9,8 +9,6 @@
 
 #include <sstream>
 
-std::unique_ptr<CMasternodeMetaMan> mmetaman;
-
 const std::string MasternodeMetaStore::SERIALIZATION_VERSION_STRING = "CMasternodeMetaMan-Version-3";
 
 CMasternodeMetaMan::CMasternodeMetaMan() :

--- a/src/masternode/meta.h
+++ b/src/masternode/meta.h
@@ -176,6 +176,4 @@ public:
     std::vector<uint256> GetAndClearDirtyGovernanceObjectHashes();
 };
 
-extern std::unique_ptr<CMasternodeMetaMan> mmetaman;
-
 #endif // BITCOIN_MASTERNODE_META_H

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -15,9 +15,6 @@
 #include <validation.h>
 #include <warnings.h>
 
-// Keep track of the active Masternode
-std::unique_ptr<CActiveMasternodeManager> activeMasternodeManager;
-
 CActiveMasternodeManager::CActiveMasternodeManager(const CBLSSecretKey& sk, CConnman& connman, const std::unique_ptr<CDeterministicMNManager>& dmnman) :
     m_info(sk, sk.GetPublicKey()),
     m_connman{connman},

--- a/src/masternode/node.h
+++ b/src/masternode/node.h
@@ -80,6 +80,4 @@ private:
     bool GetLocalAddress(CService& addrRet) EXCLUSIVE_LOCKS_REQUIRED(cs);
 };
 
-extern std::unique_ptr<CActiveMasternodeManager> activeMasternodeManager;
-
 #endif // BITCOIN_MASTERNODE_NODE_H

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -15,7 +15,6 @@
 #include <util/translation.h>
 
 class CMasternodeSync;
-std::unique_ptr<CMasternodeSync> masternodeSync;
 
 CMasternodeSync::CMasternodeSync(CConnman& _connman, CNetFulfilledRequestManager& netfulfilledman, const CGovernanceManager& govman) :
     nTimeAssetSyncStarted(GetTime()),

--- a/src/masternode/sync.h
+++ b/src/masternode/sync.h
@@ -26,8 +26,6 @@ static constexpr int MASTERNODE_SYNC_TICK_SECONDS    = 6;
 static constexpr int MASTERNODE_SYNC_TIMEOUT_SECONDS = 30; // our blocks are 2.5 minutes so 30 seconds should be fine
 static constexpr int MASTERNODE_SYNC_RESET_SECONDS   = 900; // Reset fReachedBestHeader in CMasternodeSync::Reset if UpdateBlockTip hasn't been called for this seconds
 
-extern std::unique_ptr<CMasternodeSync> masternodeSync;
-
 //
 // CMasternodeSync : Sync masternode assets in stages
 //

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -297,6 +297,7 @@ public:
                     CScheduler &scheduler, ChainstateManager& chainman, CTxMemPool& pool,
                     CMasternodeMetaMan& mn_metaman, CMasternodeSync& mn_sync,
                     CGovernanceManager& govman, CSporkManager& sporkman,
+                    const CActiveMasternodeManager* const mn_activeman,
                     const std::unique_ptr<CDeterministicMNManager>& dmnman,
                     const std::unique_ptr<CJContext>& cj_ctx,
                     const std::unique_ptr<LLMQContext>& llmq_ctx,
@@ -423,6 +424,7 @@ private:
     CMasternodeSync& m_mn_sync;
     CGovernanceManager& m_govman;
     CSporkManager& m_sporkman;
+    const CActiveMasternodeManager* const m_mn_activeman;
 
     /** The height of the best chain */
     std::atomic<int> m_best_height{-1};
@@ -1735,17 +1737,19 @@ std::unique_ptr<PeerManager> PeerManager::make(const CChainParams& chainparams, 
                                                CScheduler &scheduler, ChainstateManager& chainman, CTxMemPool& pool,
                                                CMasternodeMetaMan& mn_metaman, CMasternodeSync& mn_sync,
                                                CGovernanceManager& govman, CSporkManager& sporkman,
+                                               const CActiveMasternodeManager* const mn_activeman,
                                                const std::unique_ptr<CDeterministicMNManager>& dmnman,
                                                const std::unique_ptr<CJContext>& cj_ctx,
                                                const std::unique_ptr<LLMQContext>& llmq_ctx, bool ignore_incoming_txs)
 {
-    return std::make_unique<PeerManagerImpl>(chainparams, connman, addrman, banman, scheduler, chainman, pool, mn_metaman, mn_sync, govman, sporkman, dmnman, cj_ctx, llmq_ctx, ignore_incoming_txs);
+    return std::make_unique<PeerManagerImpl>(chainparams, connman, addrman, banman, scheduler, chainman, pool, mn_metaman, mn_sync, govman, sporkman, mn_activeman, dmnman, cj_ctx, llmq_ctx, ignore_incoming_txs);
 }
 
 PeerManagerImpl::PeerManagerImpl(const CChainParams& chainparams, CConnman& connman, CAddrMan& addrman, BanMan* banman,
                                  CScheduler &scheduler, ChainstateManager& chainman, CTxMemPool& pool,
                                  CMasternodeMetaMan& mn_metaman, CMasternodeSync& mn_sync,
                                  CGovernanceManager& govman, CSporkManager& sporkman,
+                                 const CActiveMasternodeManager* const mn_activeman,
                                  const std::unique_ptr<CDeterministicMNManager>& dmnman,
                                  const std::unique_ptr<CJContext>& cj_ctx,
                                  const std::unique_ptr<LLMQContext>& llmq_ctx,
@@ -1763,6 +1767,7 @@ PeerManagerImpl::PeerManagerImpl(const CChainParams& chainparams, CConnman& conn
       m_mn_sync(mn_sync),
       m_govman(govman),
       m_sporkman(sporkman),
+      m_mn_activeman(mn_activeman),
       m_ignore_incoming_txs(ignore_incoming_txs)
 {
     assert(std::addressof(g_chainman) == std::addressof(m_chainman));
@@ -3293,8 +3298,8 @@ void PeerManagerImpl::ProcessMessage(
                       pfrom.ConnectionTypeAsString());
         }
 
-        if (!pfrom.m_masternode_probe_connection) {
-            CMNAuth::PushMNAUTH(pfrom, m_connman, m_chainman.ActiveChain().Tip());
+        if (fMasternodeMode && !pfrom.m_masternode_probe_connection) {
+            CMNAuth::PushMNAUTH(pfrom, m_connman, *Assert(m_mn_activeman), m_chainman.ActiveChain().Tip());
         }
 
         // Tell our peer we prefer to receive headers rather than inv's
@@ -4625,7 +4630,7 @@ void PeerManagerImpl::ProcessMessage(
         ProcessPeerMsgRet(m_sporkman.ProcessMessage(pfrom, m_connman, msg_type, vRecv), pfrom);
         m_mn_sync.ProcessMessage(pfrom, msg_type, vRecv);
         ProcessPeerMsgRet(m_govman.ProcessMessage(pfrom, m_connman, msg_type, vRecv), pfrom);
-        ProcessPeerMsgRet(CMNAuth::ProcessMessage(pfrom, m_connman, m_mn_sync, m_dmnman->GetListAtChainTip(), msg_type, vRecv), pfrom);
+        ProcessPeerMsgRet(CMNAuth::ProcessMessage(pfrom, m_connman, m_mn_activeman, m_mn_sync, m_dmnman->GetListAtChainTip(), msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->quorum_block_processor->ProcessMessage(pfrom, msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->qdkgsman->ProcessMessage(pfrom, this, msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->qman->ProcessMessage(pfrom, msg_type, vRecv), pfrom);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4625,7 +4625,7 @@ void PeerManagerImpl::ProcessMessage(
         ProcessPeerMsgRet(m_sporkman.ProcessMessage(pfrom, m_connman, msg_type, vRecv), pfrom);
         m_mn_sync.ProcessMessage(pfrom, msg_type, vRecv);
         ProcessPeerMsgRet(m_govman.ProcessMessage(pfrom, m_connman, msg_type, vRecv), pfrom);
-        ProcessPeerMsgRet(CMNAuth::ProcessMessage(pfrom, m_connman, m_dmnman->GetListAtChainTip(), msg_type, vRecv), pfrom);
+        ProcessPeerMsgRet(CMNAuth::ProcessMessage(pfrom, m_connman, m_mn_sync, m_dmnman->GetListAtChainTip(), msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->quorum_block_processor->ProcessMessage(pfrom, msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->qdkgsman->ProcessMessage(pfrom, this, msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->qman->ProcessMessage(pfrom, msg_type, vRecv), pfrom);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4630,7 +4630,7 @@ void PeerManagerImpl::ProcessMessage(
         ProcessPeerMsgRet(m_sporkman.ProcessMessage(pfrom, m_connman, msg_type, vRecv), pfrom);
         m_mn_sync.ProcessMessage(pfrom, msg_type, vRecv);
         ProcessPeerMsgRet(m_govman.ProcessMessage(pfrom, m_connman, msg_type, vRecv), pfrom);
-        ProcessPeerMsgRet(CMNAuth::ProcessMessage(pfrom, m_connman, m_mn_activeman, m_mn_sync, m_dmnman->GetListAtChainTip(), msg_type, vRecv), pfrom);
+        ProcessPeerMsgRet(CMNAuth::ProcessMessage(pfrom, m_connman, m_mn_metaman, m_mn_activeman, m_mn_sync, m_dmnman->GetListAtChainTip(), msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->quorum_block_processor->ProcessMessage(pfrom, msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->qdkgsman->ProcessMessage(pfrom, this, msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->qman->ProcessMessage(pfrom, msg_type, vRecv), pfrom);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -12,6 +12,7 @@
 
 #include <atomic>
 
+class CActiveMasternodeManager;
 class CAddrMan;
 class CTxMemPool;
 class CDeterministicMNManager;
@@ -52,6 +53,7 @@ public:
                                              BanMan* banman, CScheduler &scheduler, ChainstateManager& chainman,
                                              CTxMemPool& pool, CMasternodeMetaMan& mn_metaman, CMasternodeSync& mn_sync,
                                              CGovernanceManager& govman, CSporkManager& sporkman,
+                                             const CActiveMasternodeManager* const mn_activeman,
                                              const std::unique_ptr<CDeterministicMNManager>& dmnman,
                                              const std::unique_ptr<CJContext>& cj_ctx,
                                              const std::unique_ptr<LLMQContext>& llmq_ctx, bool ignore_incoming_txs);

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -120,7 +120,7 @@ struct CImportingNow {
 };
 
 void ThreadImport(ChainstateManager& chainman, CDeterministicMNManager& dmnman, CDSNotificationInterface& dsnfi,
-                  std::vector<fs::path> vImportFiles, const ArgsManager& args)
+                  std::vector<fs::path> vImportFiles, CActiveMasternodeManager* const mn_activeman, const ArgsManager& args)
 {
     ScheduleBatchPriority();
 
@@ -210,8 +210,7 @@ void ThreadImport(ChainstateManager& chainman, CDeterministicMNManager& dmnman, 
     }
 
     if (fMasternodeMode) {
-        assert(activeMasternodeManager);
-        activeMasternodeManager->Init(::ChainActive().Tip());
+        Assert(mn_activeman)->Init(::ChainActive().Tip());
     }
 
     g_wallet_init_interface.AutoLockMasternodeCollaterals();

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <vector>
 
+class CActiveMasternodeManager;
 class ArgsManager;
 class CBlock;
 class CBlockIndex;
@@ -36,6 +37,6 @@ bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);
 FlatFilePos SaveBlockToDisk(const CBlock& block, int nHeight, CChain& active_chain, const CChainParams& chainparams, const FlatFilePos* dbp);
 
 void ThreadImport(ChainstateManager& chainman, CDeterministicMNManager& dmnman, CDSNotificationInterface& dsnfi,
-                  std::vector<fs::path> vImportFiles, const ArgsManager& args);
+                  std::vector<fs::path> vImportFiles, CActiveMasternodeManager* const mn_activeman, const ArgsManager& args);
 
 #endif // BITCOIN_NODE_BLOCKSTORAGE_H

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -15,6 +15,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
 #include <llmq/context.h>
+#include <masternode/node.h>
 #include <masternode/sync.h>
 #include <net.h>
 #include <netfulfilledman.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -15,6 +15,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
 #include <llmq/context.h>
+#include <masternode/meta.h>
 #include <masternode/node.h>
 #include <masternode/sync.h>
 #include <net.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -9,12 +9,13 @@
 #include <coinjoin/context.h>
 #include <evo/creditpool.h>
 #include <evo/chainhelper.h>
+#include <evo/evodb.h>
+#include <evo/mnhftx.h>
 #include <governance/governance.h>
 #include <interfaces/chain.h>
 #include <interfaces/coinjoin.h>
 #include <llmq/context.h>
-#include <evo/evodb.h>
-#include <evo/mnhftx.h>
+#include <masternode/sync.h>
 #include <net.h>
 #include <netfulfilledman.h>
 #include <net_processing.h>

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -7,8 +7,9 @@
 #include <addrman.h>
 #include <banman.h>
 #include <coinjoin/context.h>
-#include <evo/creditpool.h>
 #include <evo/chainhelper.h>
+#include <evo/creditpool.h>
+#include <evo/deterministicmns.h>
 #include <evo/evodb.h>
 #include <evo/mnhftx.h>
 #include <governance/governance.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -71,6 +71,7 @@ struct NodeContext {
     std::unique_ptr<CScheduler> scheduler;
     std::function<void()> rpc_interruption_point = [] {};
     //! Dash
+    std::unique_ptr<CActiveMasternodeManager> mn_activeman;
     std::unique_ptr<CCreditPoolManager> cpoolman;
     std::unique_ptr<CEvoDB> evodb;
     std::unique_ptr<CChainstateHelper> chain_helper;
@@ -81,7 +82,6 @@ struct NodeContext {
     std::unique_ptr<CNetFulfilledRequestManager> netfulfilledman;
     std::unique_ptr<CSporkManager> sporkman;
     std::unique_ptr<LLMQContext> llmq_ctx;
-    CActiveMasternodeManager* mn_activeman{nullptr};
     CDeterministicMNManager* dmnman{nullptr};
     CMasternodeMetaMan* mn_metaman{nullptr};
 

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -76,6 +76,7 @@ struct NodeContext {
     std::unique_ptr<CChainstateHelper> chain_helper;
     std::unique_ptr<CGovernanceManager> govman;
     std::unique_ptr<CJContext> cj_ctx;
+    std::unique_ptr<CMasternodeSync> mn_sync;
     std::unique_ptr<CMNHFManager> mnhf_manager;
     std::unique_ptr<CNetFulfilledRequestManager> netfulfilledman;
     std::unique_ptr<CSporkManager> sporkman;
@@ -83,7 +84,6 @@ struct NodeContext {
     CActiveMasternodeManager* mn_activeman{nullptr};
     CDeterministicMNManager* dmnman{nullptr};
     CMasternodeMetaMan* mn_metaman{nullptr};
-    CMasternodeSync* mn_sync{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -75,6 +75,7 @@ struct NodeContext {
     std::unique_ptr<CCreditPoolManager> cpoolman;
     std::unique_ptr<CEvoDB> evodb;
     std::unique_ptr<CChainstateHelper> chain_helper;
+    std::unique_ptr<CDeterministicMNManager> dmnman;
     std::unique_ptr<CGovernanceManager> govman;
     std::unique_ptr<CJContext> cj_ctx;
     std::unique_ptr<CMasternodeMetaMan> mn_metaman;
@@ -83,7 +84,6 @@ struct NodeContext {
     std::unique_ptr<CNetFulfilledRequestManager> netfulfilledman;
     std::unique_ptr<CSporkManager> sporkman;
     std::unique_ptr<LLMQContext> llmq_ctx;
-    CDeterministicMNManager* dmnman{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -77,13 +77,13 @@ struct NodeContext {
     std::unique_ptr<CChainstateHelper> chain_helper;
     std::unique_ptr<CGovernanceManager> govman;
     std::unique_ptr<CJContext> cj_ctx;
+    std::unique_ptr<CMasternodeMetaMan> mn_metaman;
     std::unique_ptr<CMasternodeSync> mn_sync;
     std::unique_ptr<CMNHFManager> mnhf_manager;
     std::unique_ptr<CNetFulfilledRequestManager> netfulfilledman;
     std::unique_ptr<CSporkManager> sporkman;
     std::unique_ptr<LLMQContext> llmq_ctx;
     CDeterministicMNManager* dmnman{nullptr};
-    CMasternodeMetaMan* mn_metaman{nullptr};
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -482,7 +482,7 @@ public:
     void setNetworkActive(bool active) override
     {
         if (m_context->connman) {
-            m_context->connman->SetNetworkActive(active, m_context->mn_sync);
+            m_context->connman->SetNetworkActive(active, m_context->mn_sync.get());
         }
     }
     bool getNetworkActive() override { return m_context->connman && m_context->connman->GetNetworkActive(); }

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -399,7 +399,7 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 
     if (fMissingConfirmations) {
         node.govman->AddPostponedObject(govobj);
-        govobj.Relay(*node.connman);
+        govobj.Relay(*node.connman, *node.mn_sync);
     } else {
         node.govman->AddGovernanceObject(govobj, *node.connman);
     }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -896,7 +896,7 @@ static RPCHelpMan setnetworkactive()
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
     }
 
-    node.connman->SetNetworkActive(request.params[0].get_bool(), node.mn_sync);
+    node.connman->SetNetworkActive(request.params[0].get_bool(), node.mn_sync.get());
 
     return node.connman->GetNetworkActive();
 },

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -884,7 +884,7 @@ static UniValue _quorum(const JSONRPCRequest& request)
     } else if (command == "quorumdkginfo") {
         return quorum_dkginfo(new_request, llmq_ctx, chainman);
     } else if (command == "quorumdkgstatus") {
-        return quorum_dkgstatus(new_request, *node.dmnman, node.mn_activeman, chainman, *node.sporkman, llmq_ctx);
+        return quorum_dkgstatus(new_request, *node.dmnman, node.mn_activeman.get(), chainman, *node.sporkman, llmq_ctx);
     } else if (command == "quorummemberof") {
         return quorum_memberof(new_request, chainman, node, llmq_ctx);
     } else if (command == "quorumsign" || command == "quorumverify" || command == "quorumhasrecsig" || command == "quorumgetrecsig" || command == "quorumisconflicting") {

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
                                        *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager,
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
                                        m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     // Mock an outbound peer
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
                                        *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager,
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
                                        m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
                                        *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager,
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
                                        m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     banman->ClearBanned();
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
                                        *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager,
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
                                        m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     banman->ClearBanned();

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
                                        *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, m_node.dmnman,
                                        m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     // Mock an outbound peer
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, nullptr, *m_node.scheduler,
                                        *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, m_node.dmnman,
                                        m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
                                        *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, m_node.dmnman,
                                        m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     banman->ClearBanned();
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman);
     auto peerLogic = PeerManager::make(chainparams, *connman, *m_node.addrman, banman.get(), *m_node.scheduler,
                                        *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, m_node.dmnman,
                                        m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
 
     banman->ClearBanned();

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <banman.h>
 #include <chainparams.h>
+#include <evo/deterministicmns.h>
 #include <llmq/context.h>
 #include <net.h>
 #include <net_processing.h>

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -640,6 +640,9 @@ void FuncTestMempoolReorg(TestChainSetup& setup)
     SignTransaction(*(setup.m_node.mempool), tx_reg, setup.coinbaseKey);
 
     CTxMemPool testPool;
+    if (setup.m_node.dmnman) {
+        testPool.ConnectManagers(setup.m_node.dmnman.get());
+    }
     TestMemPoolEntryHelper entry;
     LOCK2(cs_main, testPool.cs);
 
@@ -709,6 +712,9 @@ void FuncTestMempoolDualProregtx(TestChainSetup& setup)
     SignTransaction(*(setup.m_node.mempool), tx_reg2, setup.coinbaseKey);
 
     CTxMemPool testPool;
+    if (setup.m_node.dmnman) {
+        testPool.ConnectManagers(setup.m_node.dmnman.get());
+    }
     TestMemPoolEntryHelper entry;
     LOCK2(cs_main, testPool.cs);
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -284,8 +284,8 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     m_node.banman = std::make_unique<BanMan>(GetDataDir() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.peerman = PeerManager::make(chainparams, *m_node.connman, *m_node.addrman, m_node.banman.get(),
                                        *m_node.scheduler, *m_node.chainman, *m_node.mempool, *m_node.mn_metaman, *m_node.mn_sync,
-                                       *m_node.govman, *m_node.sporkman, ::deterministicMNManager, m_node.cj_ctx, m_node.llmq_ctx,
-                                       /* ignore_incoming_txs = */ false);
+                                       *m_node.govman, *m_node.sporkman, /* mn_activeman = */ nullptr, ::deterministicMNManager,
+                                       m_node.cj_ctx, m_node.llmq_ctx, /* ignore_incoming_txs = */ false);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -759,6 +759,7 @@ public:
     TxMempoolInfo info(const uint256& hash) const;
     std::vector<TxMempoolInfo> infoAll() const;
 
+    /** @pre Caller must ensure that CDeterministicMNManager exists */
     bool existsProviderTxConflict(const CTransaction &tx) const;
 
     size_t DynamicMemoryUsage() const;
@@ -816,6 +817,12 @@ private:
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
+    /**
+     * addUnchecked extension for Dash-specific transactions (ProTx).
+     * Depends on CDeterministicMNManager.
+     */
+    void addUncheckedProTx(indexed_transaction_set::iterator& newit, const CTransaction& tx);
+
     /** Before calling removeUnchecked for a given transaction,
      *  UpdateForRemoveFromMempool must be called on the entire (dependent) set
      *  of transactions being removed at the same time.  We use each
@@ -825,6 +832,8 @@ private:
      *  removal.
      */
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void removeUncheckedProTx(const CTransaction& tx);
+
 public:
     /** visited marks a CTxMemPoolEntry as having been traversed
      * during the lifetime of the most recently created Epoch::Guard


### PR DESCRIPTION
## Additional Information

* Depends on https://github.com/dashpay/dash/pull/5966

* `CTxMemPool`'s ProTx logic took the presence of `CDeterministicMNManager` for granted. To account for `CTxMemPool` instances that aren't seeded with the pointer to the manager (usually because the unit test doesn't call for them), refactoring was done to make ProTx code paths conditional on the manager pointer being set to something.
  * Setting the manager pointer is done through `CTxMemPool::Init()`, to avoid having to pass another `std::unique_ptr` const-ref and also because `CTxMemPool` can _technically_ work without the manager if ProTx logic is not needed (and `CTxMemPool::existsProviderTxConflict()` isn't called)

    * `CTxMemPool::Init()` doesn't allow overwriting a not-`nullptr` manager pointer. If that is desired, then `CTxMemPool::Reset()` should be called first. This was done to avoid unintentional double-initialization/overwriting.

## Breaking Changes

None. Changes are limited to refactoring.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

