### PR TITLE
trivial: remove boost::{function, lexical_cast} usage, backport bitcoin#25550, #24624, #24406, cleanup some gArgs usage in init

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -313,27 +313,3 @@ or building and depending on a local version of Berkeley DB 4.8. The readily ava
 `--with-incompatible-bdb` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/bitcoin/trunk/PKGBUILD).
 As mentioned above, when maintaining portability of the wallet between the standard Dash Core distributions and independently built
 node software is desired, Berkeley DB 4.8 must be used.
-
-
-ARM Cross-compilation
--------------------
-These steps can be performed on, for example, an Ubuntu VM. The depends system
-will also work on other Linux distributions, however the commands for
-installing the toolchain will be different.
-
-Make sure you install the build requirements mentioned above.
-Then, install the toolchain and curl:
-
-    sudo apt-get install g++-arm-linux-gnueabihf curl
-
-To build executables for ARM:
-
-    cd depends
-    make HOST=arm-linux-gnueabihf NO_QT=1
-    cd ..
-    ./autogen.sh
-    CONFIG_SITE=$PWD/depends/arm-linux-gnueabihf/share/config.site ./configure --enable-reduce-exports LDFLAGS=-static-libstdc++
-    make
-
-
-For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.

--- a/src/bench/string_cast.cpp
+++ b/src/bench/string_cast.cpp
@@ -7,7 +7,6 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 
-#include <boost/lexical_cast.hpp>
 #include <string>
 
 template <typename T>
@@ -25,21 +24,6 @@ static void int_atoi(benchmark::Bench& bench)
     });
 }
 
-static void int_lexical_cast(benchmark::Bench& bench)
-{
-    bench.run([&] {
-        boost::lexical_cast<int>("1");
-    });
-}
-
-static void strings_1_lexical_cast(benchmark::Bench& bench)
-{
-    int i{0};
-    bench.run([&] {
-        boost::lexical_cast<std::string>(++i);
-    });
-}
-
 static void strings_1_numberToString(benchmark::Bench& bench)
 {
     int i{0};
@@ -53,19 +37,6 @@ static void strings_1_tostring(benchmark::Bench& bench)
     int i{0};
     bench.run([&] {
         ToString(++i);
-    });
-}
-
-static void strings_2_multi_lexical_cast(benchmark::Bench& bench)
-{
-    int i{0};
-    bench.run([&] { static_cast<void>(
-        boost::lexical_cast<std::string>(i) +
-        boost::lexical_cast<std::string>(i+1) +
-        boost::lexical_cast<std::string>(i+2) +
-        boost::lexical_cast<std::string>(i+3) +
-        boost::lexical_cast<std::string>(i+4));
-        ++i;
     });
 }
 
@@ -97,11 +68,8 @@ static void strings_2_strptintf(benchmark::Bench& bench)
 }
 
 BENCHMARK(int_atoi);
-BENCHMARK(int_lexical_cast);
-BENCHMARK(strings_1_lexical_cast);
 BENCHMARK(strings_1_numberToString);
 BENCHMARK(strings_1_tostring);
-BENCHMARK(strings_2_multi_lexical_cast);
 BENCHMARK(strings_2_multi_numberToString);
 BENCHMARK(strings_2_multi_tostring);
 BENCHMARK(strings_2_strptintf);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -592,7 +592,7 @@ void SetupServerArgs(NodeContext& node)
     argsman.AddArg("-proxyrandomize", strprintf("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)", DEFAULT_PROXYRANDOMIZE), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-seednode=<ip>", "Connect to a node to retrieve peer addresses, and disconnect. This option can be specified multiple times to connect to multiple nodes.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-socketevents=<mode>", "Socket events mode, which must be one of 'select', 'poll', 'epoll' or 'kqueue', depending on your system (default: Linux - 'epoll', FreeBSD/Apple - 'kqueue', Windows - 'select')", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
-    gArgs.AddArg("-networkactive", "Enable all P2P network activity (default: 1). Can be changed by the setnetworkactive RPC command", ArgsManager::ALLOW_BOOL, OptionsCategory::CONNECTION);
+    argsman.AddArg("-networkactive", "Enable all P2P network activity (default: 1). Can be changed by the setnetworkactive RPC command", ArgsManager::ALLOW_BOOL, OptionsCategory::CONNECTION);
     argsman.AddArg("-timeout=<n>", strprintf("Specify socket connection timeout in milliseconds. If an initial attempt to connect is unsuccessful after this amount of time, drop it (minimum: 1, default: %d)", DEFAULT_CONNECT_TIMEOUT), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-torcontrol=<ip>:<port>", strprintf("Tor control port to use if onion listening enabled (default: %s)", DEFAULT_TOR_CONTROL), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-torpassword=<pass>", "Tor control port password (default: empty)", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::CONNECTION);
@@ -1663,7 +1663,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     assert(!node.banman);
     node.banman = std::make_unique<BanMan>(GetDataDir() / "banlist", &uiInterface, args.GetArg("-bantime", DEFAULT_MISBEHAVING_BANTIME));
     assert(!node.connman);
-    node.connman = std::make_unique<CConnman>(GetRand(std::numeric_limits<uint64_t>::max()), GetRand(std::numeric_limits<uint64_t>::max()), *node.addrman, gArgs.GetBoolArg("-networkactive", true));
+    node.connman = std::make_unique<CConnman>(GetRand(std::numeric_limits<uint64_t>::max()), GetRand(std::numeric_limits<uint64_t>::max()), *node.addrman, args.GetBoolArg("-networkactive", true));
 
     assert(!node.fee_estimator);
     // Don't initialize fee estimation with old data if we don't relay transactions,

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -49,6 +49,7 @@
 #include <QComboBox>
 #include <QDateTime>
 #include <QDragEnterEvent>
+#include <QKeySequence>
 #include <QListWidget>
 #include <QMenu>
 #include <QMenuBar>
@@ -373,7 +374,7 @@ void BitcoinGUI::createActions()
 
     quitAction = new QAction(tr("E&xit"), this);
     quitAction->setStatusTip(tr("Quit application"));
-    quitAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
+    quitAction->setShortcut(QKeySequence(tr("Ctrl+Q")));
     quitAction->setMenuRole(QAction::QuitRole);
     aboutAction = new QAction(tr("&About %1").arg(PACKAGE_NAME), this);
     aboutAction->setStatusTip(tr("Show information about %1").arg(PACKAGE_NAME));
@@ -463,7 +464,7 @@ void BitcoinGUI::createActions()
     showCoinJoinHelpAction->setStatusTip(tr("Show the %1 basic information").arg(strCoinJoinName));
 
     m_mask_values_action = new QAction(tr("&Discreet mode"), this);
-    m_mask_values_action->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_D));
+    m_mask_values_action->setShortcut(QKeySequence(tr("Ctrl+Shift+D")));
     m_mask_values_action->setStatusTip(tr("Mask the values in the Overview tab"));
     m_mask_values_action->setCheckable(true);
 
@@ -606,7 +607,7 @@ void BitcoinGUI::createMenuBar()
     QMenu* window_menu = appMenuBar->addMenu(tr("&Window"));
 
     QAction* minimize_action = window_menu->addAction(tr("Minimize"));
-    minimize_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_M));
+    minimize_action->setShortcut(QKeySequence(tr("Ctrl+M")));
     connect(minimize_action, &QAction::triggered, [] {
         QApplication::activeWindow()->showMinimized();
     });

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -52,6 +52,7 @@
 #include <QGuiApplication>
 #include <QJsonObject>
 #include <QKeyEvent>
+#include <QKeySequence>
 #include <QLatin1String>
 #include <QLineEdit>
 #include <QList>
@@ -613,7 +614,7 @@ void bringToFront(QWidget* w)
 
 void handleCloseWindowShortcut(QWidget* w)
 {
-    QObject::connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_W), w), &QShortcut::activated, w, &QWidget::close);
+    QObject::connect(new QShortcut(QKeySequence(QObject::tr("Ctrl+W")), w), &QShortcut::activated, w, &QWidget::close);
 }
 
 void openDebugLogfile()
@@ -1618,7 +1619,7 @@ void updateButtonGroupShortcuts(QButtonGroup* buttonGroup)
     int nKey = 0;
     for (auto button : buttonGroup->buttons()) {
         if (button->isVisible()) {
-            button->setShortcut(QKeySequence(modifier + Qt::Key_1 + nKey++));
+            button->setShortcut(QKeySequence(static_cast<int>(modifier) | static_cast<int>(Qt::Key_1) | nKey++));
         } else {
             button->setShortcut(QKeySequence());
         }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -41,6 +41,7 @@
 #include <QFontDatabase>
 #include <QDateTime>
 #include <QKeyEvent>
+#include <QKeySequence>
 #include <QMenu>
 #include <QMessageBox>
 #include <QScreen>
@@ -1459,11 +1460,11 @@ QString RPCConsole::tabTitle(TabTypes tab_type) const
 QKeySequence RPCConsole::tabShortcut(TabTypes tab_type) const
 {
     switch (tab_type) {
-    case TabTypes::INFO: return QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_I);
-    case TabTypes::CONSOLE: return QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_C);
-    case TabTypes::GRAPH: return QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_G);
-    case TabTypes::PEERS: return QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_P);
-    case TabTypes::REPAIR: return QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_R);
+    case TabTypes::INFO: return QKeySequence(tr("Ctrl+Shift+I"));
+    case TabTypes::CONSOLE: return QKeySequence(tr("Ctrl+Shift+C"));
+    case TabTypes::GRAPH: return QKeySequence(tr("Ctrl+Shift+G"));
+    case TabTypes::PEERS: return QKeySequence(tr("Ctrl+Shift+P"));
+    case TabTypes::REPAIR: return QKeySequence(tr("Ctrl+Shift+R"));
     } // no default case, so the compiler can warn about missing cases
 
     assert(false);

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -7,8 +7,6 @@
 
 #include <qt/trafficgraphdata.h>
 
-#include <boost/function.hpp>
-
 #include <QWidget>
 #include <QQueue>
 
@@ -37,7 +35,7 @@ public Q_SLOTS:
     void clear();
 
 private:
-    typedef boost::function<float(const TrafficSample&)> SampleChooser;
+    typedef std::function<float(const TrafficSample&)> SampleChooser;
     void paintPath(QPainterPath &path, const TrafficGraphData::SampleQueue &queue, SampleChooser chooser);
 
     QTimer *timer;

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -612,7 +612,7 @@ QWidget *TransactionView::createDateRangeWidget()
     QSettings settings;
 
     dateRangeWidget = new QFrame();
-    dateRangeWidget->setFrameStyle(QFrame::Panel | QFrame::Raised);
+    dateRangeWidget->setFrameStyle(static_cast<int>(QFrame::Panel) | static_cast<int>(QFrame::Raised));
     dateRangeWidget->setContentsMargins(1,1,1,1);
     QHBoxLayout *layout = new QHBoxLayout(dateRangeWidget);
     layout->setContentsMargins(0,0,0,0);

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -142,7 +142,7 @@ public:
      * - vvNew entries refer to the same addresses
      * - vvTried entries refer to the same addresses
      */
-    bool operator==(const CAddrManDeterministic& other)
+    bool operator==(const CAddrManDeterministic& other) const
     {
         LOCK2(cs, other.cs);
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -38,13 +38,13 @@ public:
         READWRITE(obj.txval);
     }
 
-    bool operator==(const CSerializeMethodsTestSingle& rhs)
+    bool operator==(const CSerializeMethodsTestSingle& rhs) const
     {
-        return  intval == rhs.intval && \
-                boolval == rhs.boolval && \
-                stringval == rhs.stringval && \
-                strcmp(charstrval, rhs.charstrval) == 0 && \
-                *txval == *rhs.txval;
+        return intval == rhs.intval &&
+               boolval == rhs.boolval &&
+               stringval == rhs.stringval &&
+               strcmp(charstrval, rhs.charstrval) == 0 &&
+               *txval == *rhs.txval;
     }
 };
 

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -53,7 +53,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/filesystem.hpp
     boost/filesystem/fstream.hpp
     boost/function.hpp
-    boost/lexical_cast.hpp
     boost/multi_index/hashed_index.hpp
     boost/multi_index/ordered_index.hpp
     boost/multi_index/sequenced_index.hpp

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -52,7 +52,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/date_time/posix_time/posix_time.hpp
     boost/filesystem.hpp
     boost/filesystem/fstream.hpp
-    boost/function.hpp
     boost/multi_index/hashed_index.hpp
     boost/multi_index/ordered_index.hpp
     boost/multi_index/sequenced_index.hpp


### PR DESCRIPTION
## Additional Information

When building Dash with `clang-16`, I use the following `CXXFLAGS`:

```
-Werror -Werror=reorder -Werror=thread-safety -Wno-unused-command-line-argument -Wno-deprecated-builtins -Wno-deprecated-volatile -Wno-ambiguous-reversed-operator -Wno-deprecated-enum-enum-conversion
```
The explanations of the `-Wno*` flags are as follows:

| Argument                               | Reason                                                       |
| -------------------------------------- | ------------------------------------------------------------ |
| `-Wno-unused-command-line-argument`    | Lingering use of `-static-libstdc++`, a GCC-ism that isn't recognized as a valid argument in Clang (no longer an issue thanks to https://github.com/dashpay/dash/pull/5958, thanks knst!) |
| `-Wno-deprecated-builtins`             | Due to usage of [deprecated builtins](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/bench/nanobench.h#L104-L110) in `nanobench` that exist even in the [most current version](https://github.com/martinus/nanobench/blob/a5a50c2b33eea2ff1fcb355cacdface43eb42b25/src/include/nanobench.h#L115-L121) (see below) |
| `-Wno-deprecated-volatile`             | The detection code for C++20 in the CI image (based on Ubuntu `focal`) relies on deprecated volatiles (see below) |
| `-Wno-ambiguous-reversed-operator`     | Due to an ambiguous operator in a Dash unit test ([source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/test/fuzz/addrman.cpp#L145)) (see below) |
| `-Wno-deprecated-enum-enum-conversion` | Due to key combination code in Dash Qt ([source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/qt/bitcoingui.cpp#L376)) (see below) |

<details>
<summary>-Wno-deprecated-builtins</summary>

```
> make
Making all in src
make[1]: Entering directory '/src/dash/src'
make[2]: Entering directory '/src/dash/src'
make[3]: Entering directory '/src/dash'
make[3]: Leaving directory '/src/dash'
  CXX      bench/bench_dash-addrman.o
In file included from bench/addrman.cpp:6:
In file included from ./bench/bench.h:16:
./bench/nanobench.h:952:13: error: builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead [-Werror,-Wdeprecated-builtins]
    return !ANKERL_NANOBENCH_IS_TRIVIALLY_COPYABLE(Decayed) || sizeof(Decayed) > sizeof(long) || std::is_pointer<Decayed>::value;
            ^
./bench/nanobench.h:107:57: note: expanded from macro 'ANKERL_NANOBENCH_IS_TRIVIALLY_COPYABLE'
#    define ANKERL_NANOBENCH_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
                                                        ^
1 error generated.
make[2]: *** [Makefile:14567: bench/bench_dash-addrman.o] Error 1
make[2]: Leaving directory '/src/dash/src'
make[1]: *** [Makefile:18568: all-recursive] Error 1
make[1]: Leaving directory '/src/dash/src'
make: *** [Makefile:800: all-recursive] Error 1
```

</details>


<details>
<summary>-Wno-deprecated-volatile</summary>

```
> ./configure [...]
[...]
checking whether clang++-16 supports C++20 features with -h std=c++20... no
checking whether clang++-16 supports C++20 features with -std=c++2a... no
checking whether clang++-16 supports C++20 features with +std=c++2a... no
checking whether clang++-16 supports C++20 features with -h std=c++2a... no
configure: error: *** A compiler with support for C++20 language features is required.

> cat config.log
This file contains any messages produced by compilers while
running configure, to aid debugging if configure makes a mistake.

It was created by Dash Core configure 21.0.0, which was
generated by GNU Autoconf 2.69.  Invocation command line was

  $ ./configure --prefix=/src/dash/depends/x86_64-pc-linux-gnu --enable-zmq --enable-reduce-exports --disable-crash-hooks --disable-stacktraces --enable-c++20 --enable-suppress-external-warnings --enable-debug --disable-ccache --with-sanitizers=thread
[...]
configure:4450: checking whether clang++-16 accepts -g
configure:4470: clang++-16 -c -g -I/src/dash/depends/x86_64-pc-linux-gnu/include/ -DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG conftest.cpp >&5
configure:4470: $? = 0
configure:4511: result: yes
configure:4537: checking whether make supports the include directive
configure:4552: make -f confmf.GNU && cat confinc.out
this is the am__doit target
configure:4555: $? = 0
configure:4574: result: yes (GNU style)
configure:4599: checking dependency style of clang++-16
configure:4710: result: gcc3
configure:4756: checking whether clang++-16 supports C++20 features with -std=c++20
configure:5558: clang++-16 -std=c++20 -c -pipe -O2 -Werror -Werror=reorder -Werror=thread-safety -Wno-deprecated-builtins -I/src/dash/depends/x86_64-pc-linux-gnu/include/ -DDEBUG_LOCKORDER -DENABLE_DASH_DEBUG -DARENA_DEBUG conftest.cpp >&5
conftest.cpp:109:36: error: volatile-qualified parameter type 'volatile int' is deprecated [-Werror,-Wdeprecated-volatile]
    test(const int c, volatile int v) // 'volatile is deprecated in C++20'
                                   ^
1 error generated.
```

</details>

<details>

<summary>-Wno-ambiguous-reversed-operator</summary>


```
> make
Making all in src
make[1]: Entering directory '/src/dash/src'
make[2]: Entering directory '/src/dash/src'
make[3]: Entering directory '/src/dash'
make[3]: Leaving directory '/src/dash'
[...]
  CXX      test/fuzz/fuzz-addrman.o
test/fuzz/addrman.cpp:329:22: error: ISO C++20 considers use of overloaded operator '==' (with operand types 'CAddrManDeterministic' and 'CAddrManDeterministic') to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
    assert(addr_man1 == addr_man2);
           ~~~~~~~~~ ^  ~~~~~~~~~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
     (static_cast <bool> (expr)                                         \
                          ^~~~
test/fuzz/addrman.cpp:145:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
    bool operator==(const CAddrManDeterministic& other)
         ^
test/fuzz/addrman.cpp:145:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
1 error generated.
make[2]: *** [Makefile:15393: test/fuzz/fuzz-addrman.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/src/dash/src/dashbls'
make[2]: Leaving directory '/src/dash/src'
make[1]: *** [Makefile:18568: all-recursive] Error 1
make[1]: Leaving directory '/src/dash/src'
make: *** [Makefile:800: all-recursive] Error 1
```

</details>

<details>

<summary>-Wno-deprecated-enum-enum-conversion</summary>


```
> make
Making all in src
make[1]: Entering directory '/src/dash/src'
make[2]: Entering directory '/src/dash/src'
make[3]: Entering directory '/src/dash'
make[3]: Leaving directory '/src/dash'
[...]
  CXX      qt/libbitcoinqt_a-bitcoingui.o
qt/bitcoingui.cpp:376:51: error: arithmetic between different enumeration types ('Qt::Modifier' and 'Qt::Key') is deprecated [-Werror,-Wdeprecated-enum-enum-conversion]
    quitAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Q));
                                         ~~~~~~~~ ^ ~~~~~~~~~
qt/bitcoingui.cpp:609:56: error: arithmetic between different enumeration types ('Qt::Modifier' and 'Qt::Key') is deprecated [-Werror,-Wdeprecated-enum-enum-conversion]
    minimize_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_M));
                                              ~~~~~~~~ ^ ~~~~~~~~~
2 errors generated.
make[2]: *** [Makefile:12803: qt/libbitcoinqt_a-bitcoingui.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/src/dash/src'
make[1]: *** [Makefile:18568: all-recursive] Error 1
make[1]: Leaving directory '/src/dash/src'
make: *** [Makefile:800: all-recursive] Error 1
```

</details>

This pull request removes the need for the last two `-Wno*` flags, removes some leftover `boost::`{`function`, `lexical_cast`} usage and some `gArgs` usage where a local variable would be more applicable.

Additionally, in some builds, there is an deprecation warning (`-Wdeprecation`) for using `[=]` and relying on its implicit capture of `this` (see below), this can be seen during GCC builds but not Clang builds and correspond to a proposal to the C++20 standard ([proposal](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0806r2.html)).

It has also been mentioned at https://en.cppreference.com/w/cpp/language/lambda, "The implicit capture of `*this` when the capture default is `=` is deprecated. _(since C++20)_". This has also been remedied as part of this PR.

<details>

<summary>-Wdeprecated</summary>

```
> make -j10
[...]
  CXX      qt/libbitcoinqt_a-trafficgraphwidget.o
qt/optionsdialog.cpp: In lambda function:
qt/optionsdialog.cpp:195:63: warning: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Wdeprecated]
  195 |     connect(appearance, &AppearanceWidget::appearanceChanged, [=](){
      |                                                               ^
qt/optionsdialog.cpp:195:63: note: add explicit 'this' or '*this' capture
qt/optionsdialog.cpp: In lambda function:
qt/optionsdialog.cpp:277:55: warning: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Wdeprecated]
  277 |     connect(ui->coinJoinEnabled, &QCheckBox::clicked, [=](bool fChecked) {
      |                                                       ^
qt/optionsdialog.cpp:277:55: note: add explicit 'this' or '*this' capture
qt/optionsdialog.cpp: In lambda function:
qt/optionsdialog.cpp:293:45: warning: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Wdeprecated]
  293 |     connect(this, &OptionsDialog::rejected, [=]() {
      |                                             ^
qt/optionsdialog.cpp:293:45: note: add explicit 'this' or '*this' capture
  CXX      qt/libbitcoinqt_a-utilitydialog.o
  CXX      qt/libbitcoinqt_a-addressbookpage.o
[...]
```

</details>

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

