### PR TITLE
refactor: reduce fMasternodeMode usage, remove fDisableGovernance global

### DIFF
--- a/src/coinjoin/context.cpp
+++ b/src/coinjoin/context.cpp
@@ -14,8 +14,8 @@ CJContext::CJContext(CChainState& chainstate, CConnman& connman, CDeterministicM
                      const std::unique_ptr<PeerManager>& peerman, bool relay_txes) :
     dstxman{std::make_unique<CDSTXManager>()},
 #ifdef ENABLE_WALLET
-    walletman{std::make_unique<CoinJoinWalletManager>(connman, dmnman, mn_metaman, mempool, mn_sync, queueman)},
-    queueman {relay_txes ? std::make_unique<CCoinJoinClientQueueManager>(connman, *walletman, dmnman, mn_metaman, mn_sync) : nullptr},
+    walletman{std::make_unique<CoinJoinWalletManager>(connman, dmnman, mn_metaman, mempool, mn_sync, queueman, /* is_masternode = */ mn_activeman != nullptr)},
+    queueman {relay_txes ? std::make_unique<CCoinJoinClientQueueManager>(connman, *walletman, dmnman, mn_metaman, mn_sync, /* is_masternode = */ mn_activeman != nullptr) : nullptr},
 #endif // ENABLE_WALLET
     server{std::make_unique<CCoinJoinServer>(chainstate, connman, dmnman, *dstxman, mn_metaman, mempool, mn_activeman, mn_sync, peerman)}
 {}

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -97,7 +97,7 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 
     m_llmq_ctx->qman->UpdatedBlockTip(pindexNew, fInitialDownload);
     m_llmq_ctx->qdkgsman->UpdatedBlockTip(pindexNew, fInitialDownload);
-    m_llmq_ctx->ehfSignalsHandler->UpdatedBlockTip(pindexNew);
+    m_llmq_ctx->ehfSignalsHandler->UpdatedBlockTip(pindexNew, /* is_masternode = */ m_mn_activeman != nullptr);
 
     if (!fDisableGovernance) m_govman.UpdatedBlockTip(pindexNew, m_connman, m_peerman, m_mn_activeman);
 }

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -99,7 +99,9 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     m_llmq_ctx->qdkgsman->UpdatedBlockTip(pindexNew, fInitialDownload);
     m_llmq_ctx->ehfSignalsHandler->UpdatedBlockTip(pindexNew, /* is_masternode = */ m_mn_activeman != nullptr);
 
-    if (!fDisableGovernance) m_govman.UpdatedBlockTip(pindexNew, m_connman, m_peerman, m_mn_activeman);
+    if (m_govman.IsValid()) {
+        m_govman.UpdatedBlockTip(pindexNew, m_connman, m_peerman, m_mn_activeman);
+    }
 }
 
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx, int64_t nAcceptTime)

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -22,8 +22,6 @@
 void CMNAuth::PushMNAUTH(CNode& peer, CConnman& connman, const CActiveMasternodeManager& mn_activeman,
                          const CBlockIndex* tip)
 {
-    assert(fMasternodeMode);
-
     CMNAuth mnauth;
     if (mn_activeman.GetProTxHash().IsNull()) {
         return;
@@ -134,9 +132,7 @@ PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, CMasternodeMe
         }
     }
 
-    const uint256 myProTxHash = fMasternodeMode ?
-                                Assert(mn_activeman)->GetProTxHash() :
-                                uint256();
+    const uint256 myProTxHash = mn_activeman != nullptr ? mn_activeman->GetProTxHash() : uint256();
 
     connman.ForEachNode([&](CNode* pnode2) {
         if (peer.fDisconnect) {
@@ -145,7 +141,7 @@ PeerMsgRet CMNAuth::ProcessMessage(CNode& peer, CConnman& connman, CMasternodeMe
         }
 
         if (pnode2->GetVerifiedProRegTxHash() == mnauth.proRegTxHash) {
-            if (fMasternodeMode && !myProTxHash.IsNull()) {
+            if (mn_activeman != nullptr && !myProTxHash.IsNull()) {
                 const auto deterministicOutbound = llmq::utils::DeterministicOutboundConnection(myProTxHash, mnauth.proRegTxHash);
                 LogPrint(BCLog::NET_NETCONN, "CMNAuth::ProcessMessage -- Masternode %s has already verified as peer %d, deterministicOutbound=%s. peer=%d\n",
                          mnauth.proRegTxHash.ToString(), pnode2->GetId(), deterministicOutbound.ToString(), peer.GetId());

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -121,7 +121,7 @@ bool CGovernanceManager::SerializeVoteForHash(const uint256& nHash, CDataStream&
 
 PeerMsgRet CGovernanceManager::ProcessMessage(CNode& peer, CConnman& connman, PeerManager& peerman, std::string_view msg_type, CDataStream& vRecv)
 {
-    if (fDisableGovernance) return {};
+    if (!IsValid()) return {};
     if (m_mn_sync == nullptr || !m_mn_sync->IsBlockchainSynced()) return {};
 
     const auto tip_mn_list = Assert(m_dmnman)->GetListAtChainTip();
@@ -565,7 +565,7 @@ struct sortProposalsByVotes {
 
 std::optional<const CSuperblock> CGovernanceManager::CreateSuperblockCandidate(int nHeight) const
 {
-    if (fDisableGovernance) return std::nullopt;
+    if (!IsValid()) return std::nullopt;
     if (m_mn_sync == nullptr || !m_mn_sync->IsSynced()) return std::nullopt;
     if (nHeight % Params().GetConsensus().nSuperblockCycle < Params().GetConsensus().nSuperblockCycle - Params().GetConsensus().nSuperblockMaturityWindow) return std::nullopt;
     if (HasAlreadyVotedFundingTrigger()) return std::nullopt;
@@ -793,7 +793,7 @@ void CGovernanceManager::ResetVotedFundingTrigger()
 
 void CGovernanceManager::DoMaintenance(CConnman& connman)
 {
-    if (fDisableGovernance) return;
+    if (!IsValid()) return;
     if (m_mn_sync == nullptr || !m_mn_sync->IsSynced()) return;
     if (ShutdownRequested()) return;
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -371,11 +371,11 @@ public:
 private:
     std::optional<const CSuperblock> CreateSuperblockCandidate(int nHeight) const;
     std::optional<const CGovernanceObject> CreateGovernanceTrigger(const std::optional<const CSuperblock>& sb_opt, PeerManager& peerman,
-                                                                   const CActiveMasternodeManager* const mn_activeman);
+                                                                   const CActiveMasternodeManager& mn_activeman);
     void VoteGovernanceTriggers(const std::optional<const CGovernanceObject>& trigger_opt, CConnman& connman, PeerManager& peerman,
-                                const CActiveMasternodeManager* const mn_activeman);
+                                const CActiveMasternodeManager& mn_activeman);
     bool VoteFundingTrigger(const uint256& nHash, const vote_outcome_enum_t outcome, CConnman& connman, PeerManager& peerman,
-                            const CActiveMasternodeManager* const mn_activeman);
+                            const CActiveMasternodeManager& mn_activeman);
     bool HasAlreadyVotedFundingTrigger() const;
 
     void RequestGovernanceObject(CNode* pfrom, const uint256& nHash, CConnman& connman, bool fUseFilter = false) const;

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -33,6 +33,7 @@ class CNetFulfilledRequestManager;
 class CSporkManager;
 
 static constexpr int RATE_BUFFER_SIZE = 5;
+static constexpr bool DEFAULT_GOVERNANCE_ENABLE{true};
 
 class CDeterministicMNList;
 using CDeterministicMNListPtr = std::shared_ptr<CDeterministicMNList>;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -366,7 +366,7 @@ void PrepareShutdown(NodeContext& node)
         delete pdsNotificationInterface;
         pdsNotificationInterface = nullptr;
     }
-    if (fMasternodeMode) {
+    if (node.mn_activeman) {
         UnregisterValidationInterface(node.mn_activeman.get());
         node.mn_activeman.reset();
     }
@@ -2316,7 +2316,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         node.scheduler->scheduleEvery(std::bind(&CGovernanceManager::DoMaintenance, std::ref(*node.govman), std::ref(*node.connman)), std::chrono::minutes{5});
     }
 
-    if (fMasternodeMode) {
+    if (node.mn_activeman) {
         node.scheduler->scheduleEvery(std::bind(&CCoinJoinServer::DoMaintenance, std::ref(*node.cj_ctx->server)), std::chrono::seconds{1});
         node.scheduler->scheduleEvery(std::bind(&llmq::CDKGSessionManager::CleanupOldContributions, std::ref(*node.llmq_ctx->qdkgsman)), std::chrono::hours{1});
 #ifdef ENABLE_WALLET

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1459,10 +1459,7 @@ bool AppInitParameterInteraction(const ArgsManager& args)
         }
     }
 
-    const bool is_governance_enabled{!args.GetBoolArg("-disablegovernance", !DEFAULT_GOVERNANCE_ENABLE)};
-    LogPrintf("fDisableGovernance %d\n", !is_governance_enabled);
-
-    if (!is_governance_enabled) {
+    if (args.GetBoolArg("-disablegovernance", !DEFAULT_GOVERNANCE_ENABLE)) {
         InitWarning(_("You are starting with governance validation disabled.") +
             (fPruneMode ?
                 Untranslated(" ") + _("This is expected because you are running a pruned node.") :

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2312,7 +2312,7 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     node.scheduler->scheduleEvery(std::bind(&CMasternodeUtils::DoMaintenance, std::ref(*node.connman), std::ref(*node.dmnman), std::ref(*node.mn_sync), std::ref(*node.cj_ctx)), std::chrono::minutes{1});
     node.scheduler->scheduleEvery(std::bind(&CDeterministicMNManager::DoMaintenance, std::ref(*node.dmnman)), std::chrono::seconds{10});
 
-    if (!fDisableGovernance) {
+    if (node.govman->IsValid()) {
         node.scheduler->scheduleEvery(std::bind(&CGovernanceManager::DoMaintenance, std::ref(*node.govman), std::ref(*node.connman)), std::chrono::minutes{5});
     }
 

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -65,6 +65,7 @@ public:
     virtual void getAllNewerThan(std::vector<CGovernanceObject> &objs, int64_t nMoreThanTime) = 0;
     virtual int32_t getObjAbsYesCount(const CGovernanceObject& obj, vote_signal_enum_t vote_signal) = 0;
     virtual bool getObjLocalValidity(const CGovernanceObject& obj, std::string& error, bool check_collateral) = 0;
+    virtual bool isEnabled() = 0;
     virtual void setContext(NodeContext* context) {}
 };
 
@@ -229,6 +230,9 @@ public:
 
     //! Is initial block download.
     virtual bool isInitialBlockDownload() = 0;
+
+    //! Is masternode.
+    virtual bool isMasternode() = 0;
 
     //! Get reindex.
     virtual bool getReindex() = 0;

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -28,7 +28,8 @@ std::unique_ptr<CChainLocksHandler> chainLocksHandler;
 
 CChainLocksHandler::CChainLocksHandler(CChainState& chainstate, CQuorumManager& _qman, CSigningManager& _sigman,
                                        CSigSharesManager& _shareman, CSporkManager& sporkman, CTxMemPool& _mempool,
-                                       const CMasternodeSync& mn_sync, const std::unique_ptr<PeerManager>& peerman) :
+                                       const CMasternodeSync& mn_sync, const std::unique_ptr<PeerManager>& peerman,
+                                       bool is_masternode) :
     m_chainstate(chainstate),
     qman(_qman),
     sigman(_sigman),
@@ -37,6 +38,7 @@ CChainLocksHandler::CChainLocksHandler(CChainState& chainstate, CQuorumManager& 
     mempool(_mempool),
     m_mn_sync(mn_sync),
     m_peerman(peerman),
+    m_is_masternode{is_masternode},
     scheduler(std::make_unique<CScheduler>()),
     scheduler_thread(std::make_unique<std::thread>(std::thread(util::TraceThread, "cl-schdlr", [&] { scheduler->serviceQueue(); })))
 {
@@ -238,7 +240,7 @@ void CChainLocksHandler::TrySignChainTip()
 {
     Cleanup();
 
-    if (!fMasternodeMode) {
+    if (!m_is_masternode) {
         return;
     }
 

--- a/src/llmq/chainlocks.h
+++ b/src/llmq/chainlocks.h
@@ -54,6 +54,7 @@ private:
     const CMasternodeSync& m_mn_sync;
     const std::unique_ptr<PeerManager>& m_peerman;
 
+    const bool m_is_masternode;
     std::unique_ptr<CScheduler> scheduler;
     std::unique_ptr<std::thread> scheduler_thread;
     mutable Mutex cs;
@@ -87,7 +88,8 @@ private:
 public:
     explicit CChainLocksHandler(CChainState& chainstate, CQuorumManager& _qman, CSigningManager& _sigman,
                                 CSigSharesManager& _shareman, CSporkManager& sporkman, CTxMemPool& _mempool,
-                                const CMasternodeSync& mn_sync, const std::unique_ptr<PeerManager>& peerman);
+                                const CMasternodeSync& mn_sync, const std::unique_ptr<PeerManager>& peerman,
+                                bool is_masternode);
     ~CChainLocksHandler();
 
     void Start();

--- a/src/llmq/context.h
+++ b/src/llmq/context.h
@@ -34,6 +34,10 @@ class CSigningManager;
 }
 
 struct LLMQContext {
+private:
+    const bool is_masternode;
+
+public:
     LLMQContext() = delete;
     LLMQContext(const LLMQContext&) = delete;
     LLMQContext(CChainState& chainstate, CConnman& connman, CDeterministicMNManager& dmnman, CEvoDB& evo_db,

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -532,7 +532,7 @@ void CDKGSessionHandler::HandleDKGRound()
     });
 
     const auto tip_mn_list = m_dmnman.GetListAtChainTip();
-    utils::EnsureQuorumConnections(params, connman, m_dmnman, m_sporkman, tip_mn_list, pQuorumBaseBlockIndex, curSession->myProTxHash);
+    utils::EnsureQuorumConnections(params, connman, m_dmnman, m_sporkman, tip_mn_list, pQuorumBaseBlockIndex, curSession->myProTxHash, /* is_masternode = */ m_mn_activeman != nullptr);
     if (curSession->AreWeMember()) {
         utils::AddQuorumProbeConnections(params, connman, m_dmnman, m_mn_metaman, m_sporkman, tip_mn_list, pQuorumBaseBlockIndex, curSession->myProTxHash);
     }

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -77,7 +77,7 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *pindexNew, bool fInitialDownload);
 
-    PeerMsgRet ProcessMessage(CNode& pfrom, PeerManager* peerman, const std::string& msg_type, CDataStream& vRecv);
+    PeerMsgRet ProcessMessage(CNode& pfrom, PeerManager* peerman, bool is_masternode, const std::string& msg_type, CDataStream& vRecv);
     bool AlreadyHave(const CInv& inv) const;
     bool GetContribution(const uint256& hash, CDKGContribution& ret) const;
     bool GetComplaint(const uint256& hash, CDKGComplaint& ret) const;

--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -44,11 +44,11 @@ CEHFSignalsHandler::~CEHFSignalsHandler()
     sigman.UnregisterRecoveredSigsListener(this);
 }
 
-void CEHFSignalsHandler::UpdatedBlockTip(const CBlockIndex* const pindexNew)
+void CEHFSignalsHandler::UpdatedBlockTip(const CBlockIndex* const pindexNew, bool is_masternode)
 {
     if (!DeploymentActiveAfter(pindexNew, Params().GetConsensus(), Consensus::DEPLOYMENT_V20)) return;
 
-    if (!fMasternodeMode || (Params().IsTestChain() && !sporkman.IsSporkActive(SPORK_24_TEST_EHF))) {
+    if (!is_masternode || (Params().IsTestChain() && !sporkman.IsSporkActive(SPORK_24_TEST_EHF))) {
         return;
     }
 

--- a/src/llmq/ehf_signals.h
+++ b/src/llmq/ehf_signals.h
@@ -49,7 +49,7 @@ public:
     /**
      * Since Tip is updated it could be a time to generate EHF Signal
      */
-    void UpdatedBlockTip(const CBlockIndex* const pindexNew);
+    void UpdatedBlockTip(const CBlockIndex* const pindexNew, bool is_masternode);
 
     void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) override LOCKS_EXCLUDED(cs);
 

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -474,7 +474,7 @@ void CInstantSendManager::Stop()
 
 void CInstantSendManager::ProcessTx(const CTransaction& tx, bool fRetroactive, const Consensus::Params& params)
 {
-    if (!fMasternodeMode || !IsInstantSendEnabled() || !m_mn_sync.IsBlockchainSynced()) {
+    if (!m_is_masternode || !IsInstantSendEnabled() || !m_mn_sync.IsBlockchainSynced()) {
         return;
     }
 

--- a/src/llmq/instantsend.cpp
+++ b/src/llmq/instantsend.cpp
@@ -1062,7 +1062,7 @@ void CInstantSendManager::ProcessInstantSendLock(NodeId from, const uint256& has
         // bump mempool counter to make sure newly locked txes are picked up by getblocktemplate
         mempool.AddTransactionsUpdated(1);
     } else {
-        AskNodesForLockedTx(islock->txid, connman, *m_peerman);
+        AskNodesForLockedTx(islock->txid, connman, *m_peerman, m_is_masternode);
     }
 }
 
@@ -1338,7 +1338,7 @@ void CInstantSendManager::RemoveMempoolConflictsForLock(const uint256& hash, con
         for (const auto& p : toDelete) {
             RemoveConflictedTx(*p.second);
         }
-        AskNodesForLockedTx(islock.txid, connman, *m_peerman);
+        AskNodesForLockedTx(islock.txid, connman, *m_peerman, m_is_masternode);
     }
 }
 
@@ -1443,7 +1443,7 @@ void CInstantSendManager::RemoveConflictingLock(const uint256& islockHash, const
     }
 }
 
-void CInstantSendManager::AskNodesForLockedTx(const uint256& txid, const CConnman& connman, const PeerManager& peerman)
+void CInstantSendManager::AskNodesForLockedTx(const uint256& txid, const CConnman& connman, const PeerManager& peerman, bool is_masternode)
 {
     std::vector<CNode*> nodesToAskFor;
     nodesToAskFor.reserve(4);
@@ -1476,7 +1476,7 @@ void CInstantSendManager::AskNodesForLockedTx(const uint256& txid, const CConnma
                       txid.ToString(), pnode->GetId());
 
             CInv inv(MSG_TX, txid);
-            RequestObject(pnode->GetId(), inv, GetTime<std::chrono::microseconds>(), true);
+            RequestObject(pnode->GetId(), inv, GetTime<std::chrono::microseconds>(), is_masternode, /* fForce = */ true);
         }
     }
     for (CNode* pnode : nodesToAskFor) {

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -301,7 +301,7 @@ private:
 
     void RemoveMempoolConflictsForLock(const uint256& hash, const CInstantSendLock& islock);
     void ResolveBlockConflicts(const uint256& islockHash, const CInstantSendLock& islock) LOCKS_EXCLUDED(cs_pendingLocks, cs_nonLocked);
-    static void AskNodesForLockedTx(const uint256& txid, const CConnman& connman, const PeerManager& peerman);
+    static void AskNodesForLockedTx(const uint256& txid, const CConnman& connman, const PeerManager& peerman, bool is_masternode);
     void ProcessPendingRetryLockTxs() LOCKS_EXCLUDED(cs_creating, cs_nonLocked, cs_pendingRetry);
 
     void WorkThreadMain();

--- a/src/llmq/instantsend.h
+++ b/src/llmq/instantsend.h
@@ -208,6 +208,7 @@ private:
     const CMasternodeSync& m_mn_sync;
     const std::unique_ptr<PeerManager>& m_peerman;
 
+    const bool m_is_masternode;
     std::atomic<bool> fUpgradedDB{false};
 
     std::thread workThread;
@@ -257,10 +258,11 @@ public:
     explicit CInstantSendManager(CChainLocksHandler& _clhandler, CChainState& chainstate, CConnman& _connman,
                                  CQuorumManager& _qman, CSigningManager& _sigman, CSigSharesManager& _shareman,
                                  CSporkManager& sporkman, CTxMemPool& _mempool, const CMasternodeSync& mn_sync,
-                                 const std::unique_ptr<PeerManager>& peerman, bool unitTests, bool fWipe) :
+                                 const std::unique_ptr<PeerManager>& peerman, bool is_masternode, bool unitTests, bool fWipe) :
         db(unitTests, fWipe),
         clhandler(_clhandler), m_chainstate(chainstate), connman(_connman), qman(_qman), sigman(_sigman),
-        shareman(_shareman), spork_manager(sporkman), mempool(_mempool), m_mn_sync(mn_sync), m_peerman(peerman)
+        shareman(_shareman), spork_manager(sporkman), mempool(_mempool), m_mn_sync(mn_sync), m_peerman(peerman),
+        m_is_masternode{is_masternode}
     {
         workInterrupt.reset();
     }

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -838,7 +838,7 @@ void CSigningManager::ProcessRecoveredSig(const std::shared_ptr<const CRecovered
         pendingReconstructedRecoveredSigs.erase(recoveredSig->GetHash());
     }
 
-    if (fMasternodeMode) {
+    if (m_mn_activeman != nullptr) {
         CInv inv(MSG_QUORUM_RECOVERED_SIG, recoveredSig->GetHash());
         connman.ForEachNode([&](CNode* pnode) {
             if (pnode->fSendRecSigs) {
@@ -895,9 +895,7 @@ void CSigningManager::UnregisterRecoveredSigsListener(CRecoveredSigsListener* l)
 
 bool CSigningManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigSharesManager& shareman, const uint256& id, const uint256& msgHash, const uint256& quorumHash, bool allowReSign)
 {
-    if (!fMasternodeMode) return false;
-
-    assert(m_mn_activeman);
+    if (m_mn_activeman == nullptr) return false;
     if (m_mn_activeman->GetProTxHash().IsNull()) return false;
 
     const CQuorumCPtr quorum = [&]() {

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -218,9 +218,7 @@ void CSigSharesManager::InterruptWorkerThread()
 void CSigSharesManager::ProcessMessage(const CNode& pfrom, const CSporkManager& sporkman, const std::string& msg_type, CDataStream& vRecv)
 {
     // non-masternodes are not interested in sigshares
-    if (!fMasternodeMode) return;
-
-    assert(m_mn_activeman);
+    if (m_mn_activeman == nullptr) return;
     if (m_mn_activeman->GetProTxHash().IsNull()) return;
 
     if (sporkman.IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && msg_type == NetMsgType::QSIGSHARE) {

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -755,9 +755,9 @@ std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType,
 
 bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CDeterministicMNManager& dmnman, const CSporkManager& sporkman,
                              const CDeterministicMNList& tip_mn_list, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
-                             const uint256& myProTxHash)
+                             const uint256& myProTxHash, bool is_masternode)
 {
-    if (!fMasternodeMode && !IsWatchQuorumsEnabled()) {
+    if (!is_masternode && !IsWatchQuorumsEnabled()) {
         return false;
     }
 

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -40,7 +40,7 @@ std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType,
 
 bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CDeterministicMNManager& dmnman, const CSporkManager& sporkman,
                              const CDeterministicMNList& tip_mn_list, gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex,
-                             const uint256& myProTxHash);
+                             const uint256& myProTxHash, bool is_masternode);
 void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CDeterministicMNManager& dmnman,
                                CMasternodeMetaMan& mn_metaman, const CSporkManager& sporkman, const CDeterministicMNList& tip_mn_list,
                                gsl::not_null<const CBlockIndex*> pQuorumBaseBlockIndex, const uint256& myProTxHash);

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -75,8 +75,6 @@ void CActiveMasternodeManager::InitInternal(const CBlockIndex* pindex)
 {
     AssertLockHeld(cs);
 
-    if (!fMasternodeMode) return;
-
     if (!DeploymentDIP0003Enforced(pindex->nHeight, Params().GetConsensus())) return;
 
     // Check that our local network configuration is correct
@@ -146,8 +144,6 @@ void CActiveMasternodeManager::InitInternal(const CBlockIndex* pindex)
 
 void CActiveMasternodeManager::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
 {
-    if (!fMasternodeMode) return;
-
     if (!DeploymentDIP0003Enforced(pindexNew->nHeight, Params().GetConsensus())) return;
 
     const auto [cur_state, cur_protx_hash] = WITH_READ_LOCK(cs, return std::make_pair(m_state, m_info.proTxHash));

--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -18,7 +18,6 @@
 #include <script/standard.h>
 #include <tinyformat.h>
 #include <util/ranges.h>
-#include <util/system.h>
 #include <validation.h>
 
 #include <cassert>
@@ -223,7 +222,7 @@ bool CMNPaymentsProcessor::IsBlockValueValid(const CBlock& block, const int nBlo
         return false;
     }
 
-    if(!m_mn_sync.IsSynced() || fDisableGovernance) {
+    if (!m_mn_sync.IsSynced() || !m_govman.IsValid()) {
         LogPrint(BCLog::MNPAYMENTS, "CMNPaymentsProcessor::%s -- WARNING! Not enough data, checked superblock max bounds only\n", __func__);
         // not enough data for full checks but at least we know that the superblock limits were honored.
         // We rely on the network to have followed the correct chain in this case
@@ -280,7 +279,7 @@ bool CMNPaymentsProcessor::IsBlockPayeeValid(const CTransaction& txNew, const CB
         return false;
     }
 
-    if (!m_mn_sync.IsSynced() || fDisableGovernance) {
+    if (!m_mn_sync.IsSynced() || !m_govman.IsValid()) {
         // governance data is either incomplete or non-existent
         LogPrint(BCLog::MNPAYMENTS, "CMNPaymentsProcessor::%s -- WARNING! Not enough data, skipping superblock payee checks\n", __func__);
         return true;  // not an error

--- a/src/masternode/sync.cpp
+++ b/src/masternode/sync.cpp
@@ -220,7 +220,7 @@ void CMasternodeSync::ProcessTick()
             // GOVOBJ : SYNC GOVERNANCE ITEMS FROM OUR PEERS
 
             if(nCurrentAsset == MASTERNODE_SYNC_GOVERNANCE) {
-                if (fDisableGovernance) {
+                if (!m_govman.IsValid()) {
                     SwitchToNextAsset();
                     connman.ReleaseNodeVector(vNodesCopy);
                     return;

--- a/src/net.h
+++ b/src/net.h
@@ -1564,7 +1564,7 @@ public:
 extern RecursiveMutex cs_main;
 
 void EraseObjectRequest(NodeId nodeId, const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-void RequestObject(NodeId nodeId, const CInv& inv, std::chrono::microseconds current_time, bool fForce=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+void RequestObject(NodeId nodeId, const CInv& inv, std::chrono::microseconds current_time, bool is_masternode, bool fForce=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 size_t GetRequestedObjectCount(NodeId nodeId) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Protect desirable or disadvantaged inbound peers from eviction by ratio.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4743,7 +4743,7 @@ void PeerManagerImpl::ProcessMessage(
         ProcessPeerMsgRet(m_govman.ProcessMessage(pfrom, m_connman, *this, msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(CMNAuth::ProcessMessage(pfrom, m_connman, m_mn_metaman, m_mn_activeman, m_mn_sync, m_dmnman->GetListAtChainTip(), msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->quorum_block_processor->ProcessMessage(pfrom, msg_type, vRecv), pfrom);
-        ProcessPeerMsgRet(m_llmq_ctx->qdkgsman->ProcessMessage(pfrom, this, msg_type, vRecv), pfrom);
+        ProcessPeerMsgRet(m_llmq_ctx->qdkgsman->ProcessMessage(pfrom, this, /* is_masternode = */ m_mn_activeman != nullptr, msg_type, vRecv), pfrom);
         ProcessPeerMsgRet(m_llmq_ctx->qman->ProcessMessage(pfrom, msg_type, vRecv), pfrom);
         m_llmq_ctx->shareman->ProcessMessage(pfrom, m_sporkman, msg_type, vRecv);
         ProcessPeerMsgRet(m_llmq_ctx->sigman->ProcessMessage(pfrom, this, msg_type, vRecv), pfrom);

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -209,8 +209,8 @@ void ThreadImport(ChainstateManager& chainman, CDeterministicMNManager& dmnman, 
         LogPrintf("Filling coin cache with masternode UTXOs: done in %dms\n", GetTimeMillis() - nStart);
     }
 
-    if (fMasternodeMode) {
-        Assert(mn_activeman)->Init(::ChainActive().Tip());
+    if (mn_activeman != nullptr) {
+        mn_activeman->Init(::ChainActive().Tip());
     }
 
     g_wallet_init_interface.AutoLockMasternodeCollaterals();

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -133,6 +133,13 @@ public:
         }
         return false;
     }
+    bool isEnabled() override
+    {
+        if (context().govman != nullptr) {
+            return context().govman->IsValid();
+        }
+        return false;
+    }
     void setContext(NodeContext* context) override
     {
         m_context = context;
@@ -476,6 +483,10 @@ public:
             assert(std::addressof(::ChainstateActive()) == std::addressof(*active_chainstate));
         }
         return active_chainstate->IsInitialBlockDownload();
+    }
+    bool isMasternode() override
+    {
+        return m_context->mn_activeman != nullptr;
     }
     bool getReindex() override { return ::fReindex; }
     bool getImporting() override { return ::fImporting; }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1483,7 +1483,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QStri
         tooltip += tr("Last received block was generated %1 ago.").arg(timeBehindText);
         tooltip += QString("<br>");
         tooltip += tr("Transactions after this will not yet be visible.");
-    } else if (fDisableGovernance) {
+    } else if (!m_node.gov().isEnabled()) {
         setAdditionalDataSyncProgress(1);
     }
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -474,7 +474,7 @@ void OverviewPage::coinJoinStatus(bool fForce)
     if (!fForce && (clientModel->node().shutdownRequested() || !clientModel->masternodeSync().isBlockchainSynced())) return;
 
     // Disable any PS UI for masternode or when autobackup is disabled or failed for whatever reason
-    if (fMasternodeMode || nWalletBackups <= 0) {
+    if (clientModel->node().isMasternode() || nWalletBackups <= 0) {
         DisableCoinJoinCompletely();
         if (nWalletBackups <= 0) {
             ui->labelCoinJoinEnabled->setToolTip(tr("Automatic backups are disabled, no mixing available!"));

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -38,7 +38,8 @@ static RPCHelpMan coinjoin()
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;
 
-    if (fMasternodeMode) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (node.mn_activeman) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Client-side mixing is not supported on masternodes");
     }
 
@@ -53,7 +54,6 @@ static RPCHelpMan coinjoin()
         }
     }
 
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
     auto cj_clientman = node.coinjoin_loader->walletman().Get(wallet->GetName());
     CHECK_NONFATAL(cj_clientman != nullptr);
 
@@ -152,9 +152,9 @@ static RPCHelpMan getcoinjoininfo()
                 [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     UniValue obj(UniValue::VOBJ);
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
 
-    if (fMasternodeMode) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (node.mn_activeman) {
         node.cj_ctx->server->GetJsonInfo(obj);
         return obj;
     }

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -316,9 +316,7 @@ static UniValue gobject_submit(const JSONRPCRequest& request)
 
     auto mnList = node.dmnman->GetListAtChainTip();
 
-    if (fMasternodeMode) {
-        CHECK_NONFATAL(node.mn_activeman);
-
+    if (node.mn_activeman) {
         const bool fMnFound = mnList.HasValidMNByCollateral(node.mn_activeman->GetOutPoint());
 
         LogPrint(BCLog::GOBJECT, "gobject_submit -- pubKeyOperator = %s, outpoint = %s, params.size() = %lld, fMnFound = %d\n",

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -257,12 +257,10 @@ static UniValue masternode_status(const JSONRPCRequest& request)
 {
     masternode_status_help(request);
 
-    if (!fMasternodeMode) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (!node.mn_activeman) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "This node does not run an active masternode.");
     }
-
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    CHECK_NONFATAL(node.mn_activeman);
 
     UniValue mnObj(UniValue::VOBJ);
     // keep compatibility with legacy status for now (might get deprecated/removed later)

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -296,11 +296,7 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request, CDeterministicMN
     CBlockIndex* pindexTip = WITH_LOCK(cs_main, return chainman.ActiveChain().Tip());
     int tipHeight = pindexTip->nHeight;
 
-    const uint256 proTxHash = [&mn_activeman]() {
-        if (!fMasternodeMode) return uint256();
-        CHECK_NONFATAL(mn_activeman);
-        return mn_activeman->GetProTxHash();
-    }();
+    const uint256 proTxHash = mn_activeman ? mn_activeman->GetProTxHash() : uint256();
 
     UniValue minableCommitments(UniValue::VARR);
     UniValue quorumArrConnections(UniValue::VARR);
@@ -316,7 +312,7 @@ static UniValue quorum_dkgstatus(const JSONRPCRequest& request, CDeterministicMN
             obj.pushKV("llmqType", std::string(llmq_params.name));
             obj.pushKV("quorumIndex", quorumIndex);
 
-            if (fMasternodeMode) {
+            if (mn_activeman) {
                 int quorumHeight = tipHeight - (tipHeight % llmq_params.dkgInterval) + quorumIndex;
                 if (quorumHeight <= tipHeight) {
                     const CBlockIndex* pQuorumBaseBlockIndex = WITH_LOCK(cs_main, return chainman.ActiveChain()[quorumHeight]);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -7,6 +7,8 @@
 #include <rpc/server.h>
 
 #include <chainparams.h>
+#include <node/context.h>
+#include <rpc/blockchain.h>
 #include <rpc/util.h>
 #include <shutdown.h>
 #include <sync.h>
@@ -511,8 +513,9 @@ UniValue CRPCTable::execute(const JSONRPCRequest &request) const
 
 static bool ExecuteCommand(const CRPCCommand& command, const JSONRPCRequest& request, UniValue& result, bool last_handler, const std::multimap<std::string, std::vector<UniValue>>& mapPlatformRestrictions)
 {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
     // Before executing the RPC Command, filter commands from platform rpc user
-    if (fMasternodeMode && request.authUser == gArgs.GetArg("-platform-user", defaultPlatformUser)) {
+    if (node.mn_activeman && request.authUser == gArgs.GetArg("-platform-user", defaultPlatformUser)) {
         // replace this with structured binding in c++20
         const auto& it = mapPlatformRestrictions.equal_range(request.strMethod);
         const auto& allowed_begin = it.first;

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -80,7 +80,6 @@ const int64_t nStartupTime = GetTime();
 
 //Dash only features
 bool fMasternodeMode = false;
-bool fDisableGovernance = false;
 const std::string gCoinJoinName = "CoinJoin";
 
 /**

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -37,7 +37,6 @@
 //Dash only features
 
 extern bool fMasternodeMode;
-extern bool fDisableGovernance;
 extern int nWalletBackups;
 extern const std::string gCoinJoinName;
 

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -105,6 +105,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "llmq/blockprocessor -> net_processing -> llmq/quorums -> llmq/blockprocessor"
     "llmq/chainlocks -> net_processing -> llmq/context -> llmq/chainlocks"
     "coinjoin/client -> coinjoin/coinjoin -> llmq/chainlocks -> net_processing -> coinjoin/client"
+    "rpc/blockchain -> rpc/server -> rpc/blockchain"
 )
 
 EXIT_CODE=0


### PR DESCRIPTION
## Motivation

Since https://github.com/dashpay/dash/pull/5940, `CActiveMasternodeManager` ceased to be a global variable and became a conditional smart pointer initialized based on the value of `fMasternodeMode`.

Likewise, since https://github.com/dashpay/dash/pull/5555, we can tell if any `CFlatDB`-based manager has successfully loaded its database. `CGovernanceManager` is one of them and conditionally loads its database based on the value of `fGovernanceDisabled`.

`fMasternodeMode` and `fGovernanceDisabled` were (and the former to a certain degree still is) unavoidable globals due to the way the functionality they influenced was structured (i.e. decided in initialization code with no way to query from the manager itself). As we can directly ask the managers now, we can start reducing the usage of these globals and at least in this PR, get rid of one of them.

This PR was the idea of PastaPastaPasta, special thanks for the suggestion!

## Additional Information

* There are two conventions being used for checking `nullptr`-ity of a pointer, `if (mn_activeman)` and `if (mn_activeman != nullptr)`. The former is used in initialization and RPC code due to existing conventions there ([source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/init.cpp#L1659-L1677), [source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/rpc/net.cpp#L942-L945), [source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/rpc/misc.cpp#L215-L218)). The latter is used whenever the value has to be passed as a `bool` (you cannot pass the implicit conversion to a `bool` argument without explicitly casting it) and in Dash-specific code where it is the prevalent convention ([source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/governance/governance.cpp#L125), [source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/coinjoin/client.cpp#L1064)).

  Unfortunately, that means this PR expresses the same thing sometimes in two different ways but this approach was taken so that reading is consistent within the same file. Codebase-wide harmonization is outside the scope of this PR.

* Where `mn_activeman` isn't directly available, the result of the check is passed as an argument named `is_masternode` and/or set for the manager during its construction as `m_is_masternode` (`const bool`) as it is expected for the `CActiveMasternodeManager`'s presence or absence to remain as-is for the duration of the manager's lifetime. 

  This does mean that some parts of the codebase check for `mn_activeman` while others check for {`m_`}`is_masternode`, which does reduce clarity while reading. Suggestions on improving this are welcomed.

* One of the reasons this PR was made was to avoid having to deal the _possibility_ of `fMasternodeMode` or `fDisableGovernance` from desynchronizing from the behaviour of the managers it's suppose to influence. It's why additional assertions were placed in to make sure that `fMasternodeMode` and the existence of `mn_activeman` were always in sync ([source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/evo/mnauth.cpp#L137-L139), [source](https://github.com/dashpay/dash/blob/2dacfb08bdf02fdaf0740edac19435bfaa0e52d3/src/rpc/governance.cpp#L319-L320)).

  But removing the tracking global and relying on a manager's state itself prevents a potential desync, which is what this PR is aiming to do.

## Breaking Changes

None expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
