### PR TITLE
test: disable ipv6 tests for now

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -147,10 +147,12 @@ def test_ipv6_local():
     '''
     # By using SOCK_DGRAM this will not actually make a connection, but it will
     # fail if there is no route to IPv6 localhost.
-    have_ipv6 = True
-    try:
-        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        s.connect(('::1', 1))
-    except socket.error:
-        have_ipv6 = False
-    return have_ipv6
+    return False
+    # TODO: disabled until amazon ipv6 issues are resolved
+    # have_ipv6 = True
+    # try:
+    #     s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+    #     s.connect(('::1', 1))
+    # except socket.error:
+    #     have_ipv6 = False
+    # return have_ipv6


### PR DESCRIPTION
## Issue being fixed or feature implemented
Our CI nodes on Amazon have issues running tests using ipv6.

## What was done?
Pretend we don't have ipv6 when we run tests for now

## How Has This Been Tested?
See CI results for this PR.

## Breaking Changes
n/a but we'll have ipv6 not being tested for some time.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

