### PR TITLE
refactor: minimize locking in ChainLocks Cleanup

### DIFF
--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -619,6 +619,7 @@ void CChainLocksHandler::Cleanup()
     if (GetTimeMillis() - lastCleanupTime < CLEANUP_INTERVAL) {
         return;
     }
+    lastCleanupTime = GetTimeMillis();
 
     {
         LOCK(cs);
@@ -665,8 +666,6 @@ void CChainLocksHandler::Cleanup()
             ++it;
         }
     }
-
-    lastCleanupTime = GetTimeMillis();
 }
 
 bool AreChainLocksEnabled(const CSporkManager& sporkman)

--- a/src/llmq/chainlocks.cpp
+++ b/src/llmq/chainlocks.cpp
@@ -620,17 +620,19 @@ void CChainLocksHandler::Cleanup()
         return;
     }
 
+    {
+        LOCK(cs);
+        for (auto it = seenChainLocks.begin(); it != seenChainLocks.end(); ) {
+            if (GetTimeMillis() - it->second >= CLEANUP_SEEN_TIMEOUT) {
+                it = seenChainLocks.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
     // need mempool.cs due to GetTransaction calls
     LOCK2(cs_main, mempool.cs);
     LOCK(cs);
-
-    for (auto it = seenChainLocks.begin(); it != seenChainLocks.end(); ) {
-        if (GetTimeMillis() - it->second >= CLEANUP_SEEN_TIMEOUT) {
-            it = seenChainLocks.erase(it);
-        } else {
-            ++it;
-        }
-    }
 
     for (auto it = blockTxs.begin(); it != blockTxs.end(); ) {
         const auto* pindex = m_chainstate.m_blockman.LookupBlockIndex(it->first);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Simple changes, just look at the two commits: first we minimize scope of cs_main to what actually needs it. Then we change where we update the `lastCleanupTime` to right after we check it to minimize any chance of two threads entering at the same time.

## What was done?


## How Has This Been Tested?
Built, ran for a bit

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

