### PR TITLE
fix(qt): remove stretchers from Overview page when it's not needed

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -37,23 +37,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,1">
-     <item>
-      <spacer name="horizontalSpacerLeft">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
@@ -577,19 +561,6 @@
       </layout>
      </item>
      <item>
-      <spacer name="horizontalSpacerCenter">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <widget class="QFrame" name="frame_2">
@@ -657,22 +628,6 @@
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <spacer name="horizontalSpacerRight">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
## Issue being fixed or feature implemented
Overview page has strange stretching on sides, which make balance moving left-right when window is scalled.
![image](https://github.com/dashpay/dash/assets/545784/a2b3332a-55f4-4abc-a96f-9ca6c1184360)
![image](https://github.com/dashpay/dash/assets/545784/1b8e7eca-d0db-4574-a337-096bfa645242)
 

## What was done?
Removed stretches for Overview Page from the sides, it makes window a little more balanced. This PR lets to do backport of bitcoin-core/gui#176 which improves behavior further more be increasing size of "transaction list" part of window.


## How Has This Been Tested?
See screenshot. Resized window with/without patch, in "Discreet mode" off and on. Both looks not perfect but better than before.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone