### PR TITLE
doc: replace gfd() function to recommendation to use `git diff-range`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,20 +348,9 @@ a worthwhile change based on the judgement of the maintainers.
 
 When someone rebases their PR, it can often be very difficult to ensure that
 extra changes were not included in that force push. This changes could be anything
-from merge conflicts to someone attempting to sneak something into the PR. To check
-that a PR is the same before and after force push, you can use the following function.
-Place this function in your `~/.bashrc`. In order for this function to work, both the
-before and after commits must be present locally.
-
-```
-function gfd() {
-        local fp1=$(git show-branch --merge-base develop $1)
-        local fp2=$(git show-branch --merge-base develop $2)
-        echo fp1=$fp1
-        echo fp2=$fp2
-        diff --color=always -u -I'^[^-+]' <(git diff $fp1..$1) <(git diff $fp2..$2)
-}
-```
+from merge conflicts to someone attempting to sneak something into the PR.
+In order for `git range-diff` to work, both the before and after commits must be
+present locally. See chapter [rebasing changes](#rebasing-changes)
 
 ### Finding Reviewers
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
`gfd` is less convenient to use, `git range-diff` is more functional. Dropped recommendation to use it.

## What was done?
Updated `CONTRIBUTION.md` file

## How Has This Been Tested?
Run `git range-diff` to ensure that it indeed works

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

