### PR TITLE
fix(qt): tab switching via shortcuts doesn't work after 5986

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1612,14 +1612,14 @@ void updateButtonGroupShortcuts(QButtonGroup* buttonGroup)
         return;
     }
 #ifdef Q_OS_MAC
-    auto modifier = Qt::CTRL;
+    auto modifier = "Ctrl";
 #else
-    auto modifier = Qt::ALT;
+    auto modifier = "Alt";
 #endif
-    int nKey = 0;
+    int nKey = 1;
     for (auto button : buttonGroup->buttons()) {
         if (button->isVisible()) {
-            button->setShortcut(QKeySequence(static_cast<int>(modifier) | static_cast<int>(Qt::Key_1) | nKey++));
+            button->setShortcut(QKeySequence(QString("%1+%2").arg(modifier).arg(nKey++)));
         } else {
             button->setShortcut(QKeySequence());
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Looks like 3265b54a2f656995addb45892bb9a88ecb75dbfc (#5986) broke it

## What was done?


## How Has This Been Tested?
run dash-qt, try using shortcuts `cmd+1`, `cmd+2` etc. (on macos)

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

