### PR TITLE
refactor: move {`epoll`, `kqueue`} (de)init logic and wakeup pipes logic out of `CConnman` and into `EdgeTriggeredEvents` and `WakeupPipes`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -363,6 +363,7 @@ BITCOIN_CORE_H = \
   util/ui_change_type.h \
   util/url.h \
   util/vector.h \
+  util/wpipe.h \
   validation.h \
   validationinterface.h \
   versionbits.h \
@@ -797,6 +798,7 @@ libbitcoin_util_a_SOURCES = \
   util/thread.cpp \
   util/threadnames.cpp \
   util/tokenpipe.cpp \
+  util/wpipe.cpp \
   $(BITCOIN_CORE_H)
 
 if USE_LIBEVENT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -327,6 +327,7 @@ BITCOIN_CORE_H = \
   util/bip32.h \
   util/bytevectorhash.h \
   util/check.h \
+  util/edge.h \
   util/enumerate.h \
   util/epochguard.h \
   util/error.h \
@@ -776,6 +777,7 @@ libbitcoin_util_a_SOURCES = \
   util/bip32.cpp \
   util/bytevectorhash.cpp \
   util/check.cpp \
+  util/edge.cpp \
   util/error.cpp \
   util/fees.cpp \
   util/hasher.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2515,23 +2515,9 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
         }
     }
 
-    std::string strSocketEventsMode = args.GetArg("-socketevents", DEFAULT_SOCKETEVENTS);
-    if (strSocketEventsMode == "select") {
-        connOptions.socketEventsMode = CConnman::SOCKETEVENTS_SELECT;
-#ifdef USE_POLL
-    } else if (strSocketEventsMode == "poll") {
-        connOptions.socketEventsMode = CConnman::SOCKETEVENTS_POLL;
-#endif
-#ifdef USE_EPOLL
-    } else if (strSocketEventsMode == "epoll") {
-        connOptions.socketEventsMode = CConnman::SOCKETEVENTS_EPOLL;
-#endif
-#ifdef USE_KQUEUE
-    } else if (strSocketEventsMode == "kqueue") {
-        connOptions.socketEventsMode = CConnman::SOCKETEVENTS_KQUEUE;
-#endif
-    } else {
-        return InitError(strprintf(_("Invalid -socketevents ('%s') specified. Only these modes are supported: %s"), strSocketEventsMode, GetSupportedSocketEventsStr()));
+    std::string sem_str = args.GetArg("-socketevents", DEFAULT_SOCKETEVENTS);
+    if (SEMFromString(sem_str) == SocketEventsMode::Unknown) {
+        return InitError(strprintf(_("Invalid -socketevents ('%s') specified. Only these modes are supported: %s"), sem_str, GetSupportedSocketEventsStr()));
     }
 
     const std::string& i2psam_arg = args.GetArg("-i2psam", "");

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3385,31 +3385,9 @@ bool CConnman::Start(CDeterministicMNManager& dmnman, CMasternodeMetaMan& mn_met
         if (fcntl(wakeupPipe[1], F_SETFL, fFlags | O_NONBLOCK) == -1) {
             LogPrint(BCLog::NET, "fcntl for O_NONBLOCK on wakeupPipe failed\n");
         }
-#ifdef USE_KQUEUE
-        if (socketEventsMode == SocketEventsMode::KQueue) {
-            struct kevent event;
-            EV_SET(&event, wakeupPipe[0], EVFILT_READ, EV_ADD, 0, 0, nullptr);
-            int r = kevent(Assert(m_edge_trig_events)->m_fd, &event, 1, nullptr, 0, nullptr);
-            if (r != 0) {
-                LogPrint(BCLog::NET, "%s -- kevent(%d, %d, %d, ...) failed. error: %s\n", __func__,
-                         m_edge_trig_events->m_fd, EV_ADD, wakeupPipe[0], NetworkErrorString(WSAGetLastError()));
-                return false;
-            }
+        if (m_edge_trig_events && !m_edge_trig_events->RegisterPipe(wakeupPipe[0])) {
+            LogPrint(BCLog::NET, "EdgeTriggeredEvents::RegisterPipe() failed\n");
         }
-#endif
-#ifdef USE_EPOLL
-        if (socketEventsMode == SocketEventsMode::EPoll) {
-            epoll_event event;
-            event.events = EPOLLIN;
-            event.data.fd = wakeupPipe[0];
-            int r = epoll_ctl(Assert(m_edge_trig_events)->m_fd, EPOLL_CTL_ADD, wakeupPipe[0], &event);
-            if (r != 0) {
-                LogPrint(BCLog::NET, "%s -- epoll_ctl(%d, %d, %d, ...) failed. error: %s\n", __func__,
-                         m_edge_trig_events->m_fd, EPOLL_CTL_ADD, wakeupPipe[0], NetworkErrorString(WSAGetLastError()));
-                return false;
-            }
-        }
-#endif
     }
 #endif
 
@@ -3578,24 +3556,14 @@ void CConnman::StopNodes()
     semOutbound.reset();
     semAddnode.reset();
 
-#ifdef USE_KQUEUE
-    if (socketEventsMode == SocketEventsMode::KQueue && Assert(m_edge_trig_events)->m_fd != -1) {
+    if (m_edge_trig_events) {
 #ifdef USE_WAKEUP_PIPE
-        struct kevent event;
-        EV_SET(&event, wakeupPipe[0], EVFILT_READ, EV_DELETE, 0, 0, nullptr);
-        kevent(m_edge_trig_events->m_fd, &event, 1, nullptr, 0, nullptr);
+        if (!m_edge_trig_events->UnregisterPipe(wakeupPipe[0])) {
+            LogPrintf("EdgeTriggeredEvents::UnregisterPipe() failed\n");
+        }
 #endif
         m_edge_trig_events.reset();
     }
-#endif
-#ifdef USE_EPOLL
-    if (socketEventsMode == SocketEventsMode::EPoll && Assert(m_edge_trig_events)->m_fd != -1) {
-#ifdef USE_WAKEUP_PIPE
-        epoll_ctl(m_edge_trig_events->m_fd, EPOLL_CTL_DEL, wakeupPipe[0], nullptr);
-#endif
-        m_edge_trig_events.reset();
-    }
-#endif
 
 #ifdef USE_WAKEUP_PIPE
     if (wakeupPipe[0] != -1) close(wakeupPipe[0]);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1598,7 +1598,7 @@ void CConnman::SocketEventsKqueue(std::set<SOCKET>& recv_set,
     timeout.tv_nsec = (only_poll ? 0 : SELECT_TIMEOUT_MILLISECONDS % 1000) * 1000 * 1000;
 
     int n{-1};
-    ToggleWakeupPipe([&](){n = kevent(Assert(m_edge_trig_events)->m_fd, nullptr, 0, events, maxEvents, &timeout);});
+    ToggleWakeupPipe([&](){n = kevent(Assert(m_edge_trig_events)->GetFileDescriptor(), nullptr, 0, events, maxEvents, &timeout);});
     if (n == -1) {
         LogPrintf("kevent wait error\n");
     } else if (n > 0) {
@@ -1631,7 +1631,7 @@ void CConnman::SocketEventsEpoll(std::set<SOCKET>& recv_set,
     epoll_event events[maxEvents];
 
     int n{-1};
-    ToggleWakeupPipe([&](){n = epoll_wait(Assert(m_edge_trig_events)->m_fd, events, maxEvents, only_poll ? 0 : SELECT_TIMEOUT_MILLISECONDS);});
+    ToggleWakeupPipe([&](){n = epoll_wait(Assert(m_edge_trig_events)->GetFileDescriptor(), events, maxEvents, only_poll ? 0 : SELECT_TIMEOUT_MILLISECONDS);});
     for (int i = 0; i < n; i++) {
         auto& e = events[i];
         if((e.events & EPOLLERR) || (e.events & EPOLLHUP)) {

--- a/src/net.h
+++ b/src/net.h
@@ -822,13 +822,6 @@ class CConnman
 {
 friend class CNode;
 public:
-    enum SocketEventsMode {
-        SOCKETEVENTS_SELECT = 0,
-        SOCKETEVENTS_POLL = 1,
-        SOCKETEVENTS_EPOLL = 2,
-        SOCKETEVENTS_KQUEUE = 3,
-    };
-
     struct Options
     {
         ServiceFlags nLocalServices = NODE_NONE;
@@ -852,7 +845,7 @@ public:
         bool m_use_addrman_outgoing = true;
         std::vector<std::string> m_specified_outgoing;
         std::vector<std::string> m_added_nodes;
-        SocketEventsMode socketEventsMode = SOCKETEVENTS_SELECT;
+        SocketEventsMode socketEventsMode = SocketEventsMode::Select;
         std::vector<bool> m_asmap;
         bool m_i2p_accept_incoming;
     };

--- a/src/net.h
+++ b/src/net.h
@@ -28,9 +28,10 @@
 #include <sync.h>
 #include <threadinterrupt.h>
 #include <uint256.h>
+#include <util/check.h>
+#include <util/edge.h>
 #include <util/system.h>
 #include <consensus/params.h>
-#include <util/check.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -1514,12 +1515,7 @@ private:
     std::atomic<bool> wakeupSelectNeeded{false};
 
     SocketEventsMode socketEventsMode;
-#ifdef USE_KQUEUE
-    int kqueuefd{-1};
-#endif
-#ifdef USE_EPOLL
-    int epollfd{-1};
-#endif
+    std::unique_ptr<EdgeTriggeredEvents> m_edge_trig_events{nullptr};
 
     Mutex cs_sendable_receivable_nodes;
     std::unordered_map<NodeId, CNode*> mapReceivableNodes GUARDED_BY(cs_sendable_receivable_nodes);

--- a/src/net.h
+++ b/src/net.h
@@ -1371,9 +1371,6 @@ private:
     // Whether the node should be passed out in ForEach* callbacks
     static bool NodeFullyConnected(const CNode* pnode);
 
-    void RegisterEvents(CNode* pnode);
-    void UnregisterEvents(CNode* pnode);
-
     // Network usage totals
     mutable Mutex m_total_bytes_sent_mutex;
     std::atomic<uint64_t> nTotalBytesRecv{0};

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -669,24 +669,9 @@ static RPCHelpMan getnetworkinfo()
         obj.pushKV("connections_mn",   (int)node.connman->GetNodeCount(ConnectionDirection::Verified));
         obj.pushKV("connections_mn_in",   (int)node.connman->GetNodeCount(ConnectionDirection::VerifiedIn));
         obj.pushKV("connections_mn_out",   (int)node.connman->GetNodeCount(ConnectionDirection::VerifiedOut));
-        std::string strSocketEvents;
-        switch (node.connman->GetSocketEventsMode()) {
-            case CConnman::SOCKETEVENTS_SELECT:
-                strSocketEvents = "select";
-                break;
-            case CConnman::SOCKETEVENTS_POLL:
-                strSocketEvents = "poll";
-                break;
-            case CConnman::SOCKETEVENTS_EPOLL:
-                strSocketEvents = "epoll";
-                break;
-            case CConnman::SOCKETEVENTS_KQUEUE:
-                strSocketEvents = "kqueue";
-                break;
-            default:
-                CHECK_NONFATAL(false);
-        }
-        obj.pushKV("socketevents", strSocketEvents);
+        std::string sem_str = SEMToString(node.connman->GetSocketEventsMode());
+        CHECK_NONFATAL(sem_str != "unknown");
+        obj.pushKV("socketevents", sem_str);
     }
     obj.pushKV("networks",      GetNetworksInfo());
     obj.pushKV("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK()));

--- a/src/util/edge.cpp
+++ b/src/util/edge.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2020-2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/edge.h>
+
+#include <logging.h>
+#include <util/sock.h>
+
+#include <assert.h>
+
+#ifdef USE_EPOLL
+#include <sys/epoll.h>
+#endif
+
+#ifdef USE_KQUEUE
+#include <sys/event.h>
+#endif
+
+EdgeTriggeredEvents::EdgeTriggeredEvents(SocketEventsMode events_mode)
+    : m_mode(events_mode)
+{
+    if (m_mode == SocketEventsMode::EPoll) {
+#ifdef USE_EPOLL
+        m_fd = epoll_create1(0);
+        if (m_fd == -1) {
+            LogPrintf("Unable to initialize EdgeTriggeredEvents, epoll_create1 returned -1\n");
+            return;
+        }
+#else
+        LogPrintf("Attempting to initialize EdgeTriggeredEvents for epoll without support compiled in!\n");
+        return;
+#endif /* USE_EPOLL */
+    } else if (m_mode == SocketEventsMode::KQueue) {
+#ifdef USE_KQUEUE
+        m_fd = kqueue();
+        if (m_fd == -1) {
+            LogPrintf("Unable to initialize EdgeTriggeredEvents, kqueue returned -1\n");
+            return;
+        }
+#else
+        LogPrintf("Attempting to initialize EdgeTriggeredEvents for kqueue without support compiled in!\n");
+        return;
+#endif /* USE_KQUEUE */
+    } else {
+        assert(false);
+    }
+    m_valid = true;
+}
+
+EdgeTriggeredEvents::~EdgeTriggeredEvents()
+{
+    if (m_valid) {
+#if defined(USE_KQUEUE) || defined(USE_EPOLL)
+        close(m_fd);
+#else
+        assert(false);
+#endif /* defined(USE_KQUEUE) || defined(USE_EPOLL) */
+    }
+}

--- a/src/util/edge.cpp
+++ b/src/util/edge.cpp
@@ -7,8 +7,6 @@
 #include <logging.h>
 #include <util/sock.h>
 
-#include <assert.h>
-
 #ifdef USE_EPOLL
 #include <sys/epoll.h>
 #endif

--- a/src/util/edge.cpp
+++ b/src/util/edge.cpp
@@ -52,7 +52,10 @@ EdgeTriggeredEvents::~EdgeTriggeredEvents()
 {
     if (m_valid) {
 #if defined(USE_KQUEUE) || defined(USE_EPOLL)
-        close(m_fd);
+        if (close(m_fd) != 0) {
+            LogPrintf("Destroying EdgeTriggeredEvents instance, close() failed for m_fd = %d with error %s\n", m_fd,
+                      NetworkErrorString(WSAGetLastError()));
+        }
 #else
         assert(false);
 #endif /* defined(USE_KQUEUE) || defined(USE_EPOLL) */

--- a/src/util/edge.cpp
+++ b/src/util/edge.cpp
@@ -22,7 +22,8 @@ EdgeTriggeredEvents::EdgeTriggeredEvents(SocketEventsMode events_mode)
 #ifdef USE_EPOLL
         m_fd = epoll_create1(0);
         if (m_fd == -1) {
-            LogPrintf("Unable to initialize EdgeTriggeredEvents, epoll_create1 returned -1\n");
+            LogPrintf("Unable to initialize EdgeTriggeredEvents, epoll_create1 returned -1 with error %s\n",
+                      NetworkErrorString(WSAGetLastError()));
             return;
         }
 #else
@@ -33,7 +34,8 @@ EdgeTriggeredEvents::EdgeTriggeredEvents(SocketEventsMode events_mode)
 #ifdef USE_KQUEUE
         m_fd = kqueue();
         if (m_fd == -1) {
-            LogPrintf("Unable to initialize EdgeTriggeredEvents, kqueue returned -1\n");
+            LogPrintf("Unable to initialize EdgeTriggeredEvents, kqueue returned -1 with error %s\n",
+                      NetworkErrorString(WSAGetLastError()));
             return;
         }
 #else

--- a/src/util/edge.h
+++ b/src/util/edge.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_UTIL_EDGE_H
 #define BITCOIN_UTIL_EDGE_H
 
+#include <compat.h>
+
 #include <cstdint>
 
 enum class SocketEventsMode : int8_t;
@@ -18,6 +20,11 @@ class EdgeTriggeredEvents
 public:
     explicit EdgeTriggeredEvents(SocketEventsMode events_mode);
     ~EdgeTriggeredEvents();
+
+    /* Add socket to interest list */
+    bool AddSocket(SOCKET socket) const;
+    /* Remove socket from interest list */
+    bool RemoveSocket(SOCKET socket) const;
 
     bool IsValid() const { return m_valid; }
 

--- a/src/util/edge.h
+++ b/src/util/edge.h
@@ -28,6 +28,11 @@ public:
 
     bool IsValid() const { return m_valid; }
 
+    /* Register events for socket */
+    bool RegisterEvents(SOCKET socket) const;
+    /* Unregister events for socket */
+    bool UnregisterEvents(SOCKET socket) const;
+
 public:
     /* File descriptor used to interact with events mode */
     int m_fd{-1};

--- a/src/util/edge.h
+++ b/src/util/edge.h
@@ -8,6 +8,7 @@
 #include <compat.h>
 
 #include <cstdint>
+#include <string>
 
 enum class SocketEventsMode : int8_t;
 
@@ -21,23 +22,34 @@ public:
     explicit EdgeTriggeredEvents(SocketEventsMode events_mode);
     ~EdgeTriggeredEvents();
 
+    bool IsValid() const { return m_valid; }
+
     /* Add socket to interest list */
     bool AddSocket(SOCKET socket) const;
     /* Remove socket from interest list */
     bool RemoveSocket(SOCKET socket) const;
 
-    bool IsValid() const { return m_valid; }
+    /* Register wakeup pipe with EdgeTriggeredEvents instance */
+    bool RegisterPipe(int wakeup_pipe);
+    /* Unregister wakeup pipe with EdgeTriggeredEvents instance */
+    bool UnregisterPipe(int wakeup_pipe);
 
     /* Register events for socket */
     bool RegisterEvents(SOCKET socket) const;
     /* Unregister events for socket */
     bool UnregisterEvents(SOCKET socket) const;
 
+private:
+    bool RegisterEntity(int entity, std::string entity_name) const;
+    bool UnregisterEntity(int entity, std::string entity_name) const;
+
 public:
     /* File descriptor used to interact with events mode */
     int m_fd{-1};
 
 private:
+    /* Flag set if pipe has been registered with instance */
+    bool m_pipe_registered{false};
     /* Instance validity flag set during construction */
     bool m_valid{false};
     /* Flag for storing selected socket events mode */

--- a/src/util/edge.h
+++ b/src/util/edge.h
@@ -7,6 +7,7 @@
 
 #include <compat.h>
 
+#include <assert.h>
 #include <cstdint>
 #include <string>
 
@@ -23,16 +24,12 @@ public:
     ~EdgeTriggeredEvents();
 
     bool IsValid() const { return m_valid; }
+    int GetFileDescriptor() const { assert(m_fd != -1); return m_fd; }
 
     /* Add socket to interest list */
     bool AddSocket(SOCKET socket) const;
     /* Remove socket from interest list */
     bool RemoveSocket(SOCKET socket) const;
-
-    /* Register wakeup pipe with EdgeTriggeredEvents instance */
-    bool RegisterPipe(int wakeup_pipe);
-    /* Unregister wakeup pipe with EdgeTriggeredEvents instance */
-    bool UnregisterPipe(int wakeup_pipe);
 
     /* Register events for socket */
     bool RegisterEvents(SOCKET socket) const;
@@ -40,12 +37,15 @@ public:
     bool UnregisterEvents(SOCKET socket) const;
 
 private:
+    friend class WakeupPipe;
+    /* Register wakeup pipe with EdgeTriggeredEvents instance */
+    bool RegisterPipe(int wakeup_pipe);
+    /* Unregister wakeup pipe with EdgeTriggeredEvents instance */
+    bool UnregisterPipe(int wakeup_pipe);
+
+private:
     bool RegisterEntity(int entity, std::string entity_name) const;
     bool UnregisterEntity(int entity, std::string entity_name) const;
-
-public:
-    /* File descriptor used to interact with events mode */
-    int m_fd{-1};
 
 private:
     /* Flag set if pipe has been registered with instance */
@@ -54,6 +54,8 @@ private:
     bool m_valid{false};
     /* Flag for storing selected socket events mode */
     SocketEventsMode m_mode;
+    /* File descriptor used to interact with events mode */
+    int m_fd{-1};
 };
 
 #endif /* BITCOIN_UTIL_EDGE_H */

--- a/src/util/edge.h
+++ b/src/util/edge.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2020-2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_EDGE_H
+#define BITCOIN_UTIL_EDGE_H
+
+#include <cstdint>
+
+enum class SocketEventsMode : int8_t;
+
+/**
+ * A manager for abstracting logic surrounding edge-triggered socket events
+ * modes like kqueue and epoll.
+ */
+class EdgeTriggeredEvents
+{
+public:
+    explicit EdgeTriggeredEvents(SocketEventsMode events_mode);
+    ~EdgeTriggeredEvents();
+
+    bool IsValid() const { return m_valid; }
+
+public:
+    /* File descriptor used to interact with events mode */
+    int m_fd{-1};
+
+private:
+    /* Instance validity flag set during construction */
+    bool m_valid{false};
+    /* Flag for storing selected socket events mode */
+    SocketEventsMode m_mode;
+};
+
+#endif /* BITCOIN_UTIL_EDGE_H */

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -18,6 +18,54 @@
  */
 static constexpr auto MAX_WAIT_FOR_IO = 1s;
 
+enum class SocketEventsMode : int8_t {
+    Select = 0,
+    Poll = 1,
+    EPoll = 2,
+    KQueue = 3,
+
+    Unknown = -1
+};
+
+/* Converts SocketEventsMode value to string with additional check to report modes not compiled for as unknown */
+static std::string SEMToString(const SocketEventsMode val)
+{
+    switch (val) {
+        case (SocketEventsMode::Select):
+            return "select";
+#ifdef USE_POLL
+        case (SocketEventsMode::Poll):
+            return "poll";
+#endif /* USE_POLL */
+#ifdef USE_EPOLL
+        case (SocketEventsMode::EPoll):
+            return "epoll";
+#endif /* USE_EPOLL */
+#ifdef USE_KQUEUE
+        case (SocketEventsMode::KQueue):
+            return "kqueue";
+#endif /* USE_KQUEUE */
+        default:
+            return "unknown";
+    };
+}
+
+/* Converts string to SocketEventsMode value with additional check to report modes not compiled for as unknown */
+static SocketEventsMode SEMFromString(const std::string str)
+{
+    if (str == "select") { return SocketEventsMode::Select; }
+#ifdef USE_POLL
+    else if (str == "poll")   { return SocketEventsMode::Poll;   }
+#endif /* USE_POLL */
+#ifdef USE_EPOLL
+    else if (str == "epoll")  { return SocketEventsMode::EPoll;  }
+#endif /* USE_EPOLL */
+#ifdef USE_KQUEUE
+    else if (str == "kqueue") { return SocketEventsMode::KQueue; }
+#endif /* USE_KQUEUE */
+    else { return SocketEventsMode::Unknown; }
+}
+
 /**
  * RAII helper class that manages a socket. Mimics `std::unique_ptr`, but instead of a pointer it
  * contains a socket and closes it automatically when it goes out of scope.

--- a/src/util/wpipe.cpp
+++ b/src/util/wpipe.cpp
@@ -8,23 +8,28 @@
 #include <util/edge.h>
 #include <util/sock.h>
 
+static constexpr int EXPECTED_PIPE_WRITTEN_BYTES = 1;
+
 WakeupPipe::WakeupPipe(EdgeTriggeredEvents* edge_trig_events)
     : m_edge_trig_events{edge_trig_events}
 {
 #ifdef USE_WAKEUP_PIPE
     if (pipe(m_pipe.data()) != 0) {
-        LogPrintf("Unable to initialize WakeupPipe, pipe() for m_pipe failed\n");
+        LogPrintf("Unable to initialize WakeupPipe, pipe() for m_pipe failed with error %s\n",
+                  NetworkErrorString(WSAGetLastError()));
         return;
     }
     for (size_t idx = 0; idx < m_pipe.size(); idx++) {
         int flags = fcntl(m_pipe[idx], F_GETFL, 0);
         if (fcntl(m_pipe[idx], F_SETFL, flags | O_NONBLOCK) == -1) {
-            LogPrintf("Unable to initialize WakeupPipe, fcntl for O_NONBLOCK on m_pipe[%d] failed\n", idx);
+            LogPrintf("Unable to initialize WakeupPipe, fcntl for O_NONBLOCK on m_pipe[%d] failed with error %s\n", idx,
+                      NetworkErrorString(WSAGetLastError()));
             return;
         }
     }
     if (edge_trig_events && !edge_trig_events->RegisterPipe(m_pipe[0])) {
-        LogPrintf("Unable to initialize WakeupPipe, EdgeTriggeredEvents::RegisterPipe() failed\n");
+        LogPrintf("Unable to initialize WakeupPipe, EdgeTriggeredEvents::RegisterPipe() failed for m_pipe[0] = %d\n",
+                  m_pipe[0]);
         return;
     }
     m_valid = true;
@@ -38,7 +43,8 @@ WakeupPipe::~WakeupPipe()
     if (m_valid) {
 #ifdef USE_WAKEUP_PIPE
         if (m_edge_trig_events && !m_edge_trig_events->UnregisterPipe(m_pipe[0])) {
-            LogPrintf("Destroying WakeupPipe instance, EdgeTriggeredEvents::UnregisterPipe() failed\n");
+            LogPrintf("Destroying WakeupPipe instance, EdgeTriggeredEvents::UnregisterPipe() failed for m_pipe[0] = %d\n",
+                      m_pipe[0]);
         }
         for (size_t idx = 0; idx < m_pipe.size(); idx++) {
             if (close(m_pipe[idx]) != 0) {
@@ -72,9 +78,14 @@ void WakeupPipe::Write()
 #ifdef USE_WAKEUP_PIPE
     assert(m_valid && m_pipe[1] != -1);
 
-    std::array<uint8_t, 1> buf;
-    if (write(m_pipe[1], buf.data(), buf.size()) != 1) {
-        LogPrintf("Write to m_pipe[1] failed\n");
+    std::array<uint8_t, EXPECTED_PIPE_WRITTEN_BYTES> buf;
+    int ret = write(m_pipe[1], buf.data(), buf.size());
+    if (ret == -1) {
+        LogPrintf("write() to m_pipe[1] = %d failed with error %s\n", m_pipe[1], NetworkErrorString(WSAGetLastError()));
+    }
+    if (ret != EXPECTED_PIPE_WRITTEN_BYTES) {
+        LogPrintf("write() to m_pipe[1] = %d succeeded with unexpected result %d (expected %d)\n", m_pipe[1], ret,
+                  EXPECTED_PIPE_WRITTEN_BYTES);
     }
 
     m_need_wakeup = false;

--- a/src/util/wpipe.cpp
+++ b/src/util/wpipe.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2020-2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/wpipe.h>
+
+#include <logging.h>
+#include <util/edge.h>
+
+WakeupPipe::WakeupPipe(EdgeTriggeredEvents* edge_trig_events)
+    : m_edge_trig_events{edge_trig_events}
+{
+#ifdef USE_WAKEUP_PIPE
+    if (pipe(m_pipe.data()) != 0) {
+        LogPrintf("Unable to initialize WakeupPipe, pipe() for m_pipe failed\n");
+        return;
+    }
+    for (size_t idx = 0; idx < m_pipe.size(); idx++) {
+        int flags = fcntl(m_pipe[idx], F_GETFL, 0);
+        if (fcntl(m_pipe[idx], F_SETFL, flags | O_NONBLOCK) == -1) {
+            LogPrintf("Unable to initialize WakeupPipe, fcntl for O_NONBLOCK on m_pipe[%d] failed\n", idx);
+            return;
+        }
+    }
+    if (edge_trig_events && !edge_trig_events->RegisterPipe(m_pipe[0])) {
+        LogPrintf("Unable to initialize WakeupPipe, EdgeTriggeredEvents::RegisterPipe() failed\n");
+        return;
+    }
+    m_valid = true;
+#else
+    LogPrintf("Attempting to initialize WakeupPipe without support compiled in!\n");
+#endif /* USE_WAKEUP_PIPE */
+}
+
+WakeupPipe::~WakeupPipe()
+{
+    if (m_valid) {
+#ifdef USE_WAKEUP_PIPE
+        if (m_edge_trig_events && !m_edge_trig_events->UnregisterPipe(m_pipe[0])) {
+            LogPrintf("Destroying WakeupPipe instance, EdgeTriggeredEvents::UnregisterPipe() failed\n");
+        }
+        close(m_pipe[0]);
+        close(m_pipe[1]);
+#else
+        assert(false);
+#endif /* USE_WAKEUP_PIPE */
+    }
+}
+
+void WakeupPipe::Drain() const
+{
+#ifdef USE_WAKEUP_PIPE
+    assert(m_valid && m_pipe[0] != -1);
+
+    int ret{0};
+    std::array<uint8_t, 128> buf;
+    do {
+        ret = read(m_pipe[0], buf.data(), buf.size());
+    } while (ret > 0);
+#else
+    assert(false);
+#endif /* USE_WAKEUP_PIPE */
+}
+
+void WakeupPipe::Write()
+{
+#ifdef USE_WAKEUP_PIPE
+    assert(m_valid && m_pipe[1] != -1);
+
+    std::array<uint8_t, 1> buf;
+    if (write(m_pipe[1], buf.data(), buf.size()) != 1) {
+        LogPrintf("Write to m_pipe[1] failed\n");
+    }
+
+    m_need_wakeup = false;
+#else
+    assert(false);
+#endif /* USE_WAKEUP_PIPE */
+}

--- a/src/util/wpipe.cpp
+++ b/src/util/wpipe.cpp
@@ -6,6 +6,7 @@
 
 #include <logging.h>
 #include <util/edge.h>
+#include <util/sock.h>
 
 WakeupPipe::WakeupPipe(EdgeTriggeredEvents* edge_trig_events)
     : m_edge_trig_events{edge_trig_events}
@@ -39,8 +40,12 @@ WakeupPipe::~WakeupPipe()
         if (m_edge_trig_events && !m_edge_trig_events->UnregisterPipe(m_pipe[0])) {
             LogPrintf("Destroying WakeupPipe instance, EdgeTriggeredEvents::UnregisterPipe() failed\n");
         }
-        close(m_pipe[0]);
-        close(m_pipe[1]);
+        for (size_t idx = 0; idx < m_pipe.size(); idx++) {
+            if (close(m_pipe[idx]) != 0) {
+                LogPrintf("Destroying WakeupPipe instance, close() failed for m_pipe[%d] = %d with error %s\n",
+                          idx, m_pipe[idx], NetworkErrorString(WSAGetLastError()));
+            }
+        }
 #else
         assert(false);
 #endif /* USE_WAKEUP_PIPE */

--- a/src/util/wpipe.h
+++ b/src/util/wpipe.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_WPIPE_H
+#define BITCOIN_UTIL_WPIPE_H
+
+#include <array>
+#include <assert.h>
+#include <atomic>
+
+#ifndef WIN32
+#define USE_WAKEUP_PIPE
+#endif
+
+class EdgeTriggeredEvents;
+
+/**
+ * A manager for abstracting logic surrounding wakeup pipes. Supported only on
+ * platforms with a POSIX API. Disabled on Windows.
+ */
+class WakeupPipe
+{
+public:
+    explicit WakeupPipe(EdgeTriggeredEvents* edge_trig_events);
+    ~WakeupPipe();
+
+    bool IsValid() const { return m_valid; };
+
+    /* Drain pipe of all contents */
+    void Drain() const;
+    /* Write a byte to the pipe */
+    void Write();
+
+    /* Used to wrap calls around m_need_wakeup toggling */
+    template <typename Callable>
+    void Toggle(Callable&& func)
+    {
+        assert(m_valid);
+
+        m_need_wakeup = true;
+        func();
+        m_need_wakeup = false;
+    }
+
+public:
+    /* File descriptors for read and write data channels */
+    std::array<int, 2> m_pipe{{ -1, -1 }};
+    /* Flag used to determine if Write() needs to be called. Used occasionally */
+    std::atomic<bool> m_need_wakeup{false};
+
+private:
+    /* Instance validity flag set during construction */
+    bool m_valid{false};
+    /* Pointer to EdgeTriggeredEvents instance used for pipe (de)registration if using supported events modes */
+    EdgeTriggeredEvents* m_edge_trig_events{nullptr};
+};
+
+#endif /* BITCOIN_UTIL_WPIPE_H */


### PR DESCRIPTION
## Motivation

`CConnman` is an entity that contains a lot of platform-specific implementation logic, both inherited from upstream and added upon by Dash (support for edge-triggered socket events modes like `epoll` on Linux and `kqueue` on FreeBSD/Darwin).

Bitcoin has since moved to strip down `CConnman` by moving peer-related logic to the `Peer` struct in `net_processing` (portions of which are backported in #5982 and friends, tracking efforts from https://github.com/bitcoin/bitcoin/issues/19398) and moving socket-related logic to `Sock` (portions of which are aimed to be backported in #6004, tracking efforts from https://github.com/bitcoin/bitcoin/pull/21878).

Due to the direction being taken and the difference in how edge-triggered events modes operate (utilizing interest lists and events instead of iterating over each socket) in comparison to level-triggered modes (which are inherited from upstream), it would be reasonable to therefore, isolate Dash-specific code into its own entities and minimize the information `CConnman` has about its internal workings. 

One of the visible benefits of this approach is comparing `develop` (as of this writing, d44b0d5dcb9b54821d582b267a8b92264be2da1b) and this pull request for interactions between wakeup pipes logic and {`epoll`, `kqueue`} logic.

This is what construction looks like:

https://github.com/dashpay/dash/blob/d44b0d5dcb9b54821d582b267a8b92264be2da1b/src/net.cpp#L3358-L3397

But, if we segment wakeup pipes logic (that work on any platform with POSIX APIs and excludes Windows) and {`epoll`, `kqueue`} logic (calling them `EdgeTriggeredEvents` instead), construction looks different:

https://github.com/dashpay/dash/blob/907a3515170abed4ce9018115ed591e6ca9f4800/src/util/wpipe.cpp#L12-L38

Now wakeup pipes logic doesn't need to know what socket events mode is being used nor are the implementation aspects of (de)registering it its concern, that is now `EdgeTriggeredEvents` problem.

## Additional Information

* This pull request will need testing on macOS (FreeBSD isn't a tier-one target) to ensure that lack of breakage in `kqueue`-specific logic.

## Breaking Changes

* Dependency for https://github.com/dashpay/dash/pull/6018
* More logging has been introduced and existing log messages have been made more exhaustive. If there is parsing that relies on a particular template, they will have to be updated.
* If `EdgeTriggeredEvents` or `WakeupPipes` fail to initialize or are incorrectly initialized and not destroyed immediately, any further attempts at calling any of its functions will result in an `assert`-induced crash. Earlier behavior may have allowed for silent failure but segmentation of logic from `CConnman` means the newly created instances must only exist if the circumstances needed for it to initialize correctly are present.

  This is to ensure that `CConnman` doesn't have to concern itself with internal workings of either entities.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

