### PR TITLE
backport: Merge bitcoin/bitcoin#28097: depends: xcb-proto 1.15.2 - fix ubuntu 24.04

### DIFF
--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -1,8 +1,8 @@
 package=xcb_proto
-$(package)_version=1.14.1
+$(package)_version=1.15.2
 $(package)_download_path=https://xorg.freedesktop.org/archive/individual/proto
 $(package)_file_name=xcb-proto-$($(package)_version).tar.xz
-$(package)_sha256_hash=f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3
+$(package)_sha256_hash=7072beb1f680a2fe3f9e535b797c146d22528990c72f63ddb49d2f350a3653ed
 
 define $(package)_config_cmds
   $($(package)_autoconf)


### PR DESCRIPTION
## Issue being fixed or feature implemented
  Resolves build failures with Python 3.12, i.e building on rawhide:
  ```bash
  make -C depends -j9
  ...
  make[3]: Nothing to be done for 'install-exec-am'.
   /usr/bin/mkdir -p '/bitcoin/depends/work/staging/aarch64-unknown-linux-gnu/xcb_proto/1.14.1-4a91ac9dc41/bitcoin/depends/aarch64-unknown-linux-gnu/lib/python3.12/site-packages/xcbgen'
   /usr/bin/install -c -m 644 __init__.py error.py expr.py align.py matcher.py state.py xtypes.py '/bitcoin/depends/work/staging/aarch64-unknown-linux-gnu/xcb_proto/1.14.1-4a91ac9dc41/bitcoin/depends/aarch64-unknown-linux-gnu/lib/python3.12/site-packages/xcbgen'
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
  ModuleNotFoundError: No module named 'imp'
  make[3]: *** [Makefile:271: install-pkgpythonPYTHON] Error 1
  ```

  `imp` was removed in 3.12: https://docs.python.org/3/library/imp.html.



## What was done?
Bitcoin backport bitcoin#28097

## How Has This Been Tested?
Run build `depends` with clean - it doesn't fail

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone