### PR TITLE
backport: merge bitcoin#24356 (replace `CConnman::SocketEvents()` with mockable `Sock::WaitMany()`), implement `Sock::WaitMany{Epoll,KQueue}()`

### DIFF
--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -160,7 +160,7 @@ bool Session::Accept(Connection& conn)
 
     while (!*m_interrupt) {
         Sock::Event occurred;
-        if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, &occurred)) {
+        if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, SEM_LT_DEFAULT, &occurred)) {
             errmsg = "wait on socket failed";
             break;
         }

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -160,7 +160,7 @@ bool Session::Accept(Connection& conn)
 
     while (!*m_interrupt) {
         Sock::Event occurred;
-        if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, SEM_LT_DEFAULT, &occurred)) {
+        if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, SocketEventsParams(), &occurred)) {
             errmsg = "wait on socket failed";
             break;
         }

--- a/src/i2p.cpp
+++ b/src/i2p.cpp
@@ -160,7 +160,7 @@ bool Session::Accept(Connection& conn)
 
     while (!*m_interrupt) {
         Sock::Event occurred;
-        if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, SocketEventsParams(), &occurred)) {
+        if (!conn.sock->Wait(MAX_WAIT_FOR_IO, Sock::RECV, SocketEventsParams{::g_socket_events_mode}, &occurred)) {
             errmsg = "wait on socket failed";
             break;
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -480,21 +480,6 @@ static void OnRPCStopped()
     LogPrint(BCLog::RPC, "RPC stopped.\n");
 }
 
-std::string GetSupportedSocketEventsStr()
-{
-    std::string strSupportedModes = "'select'";
-#ifdef USE_POLL
-    strSupportedModes += ", 'poll'";
-#endif
-#ifdef USE_EPOLL
-    strSupportedModes += ", 'epoll'";
-#endif
-#ifdef USE_KQUEUE
-    strSupportedModes += ", 'kqueue'";
-#endif
-    return strSupportedModes;
-}
-
 void SetupServerArgs(ArgsManager& argsman)
 {
     SetupHelpOptions(argsman);
@@ -2533,6 +2518,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         return InitError(strprintf(_("Invalid -socketevents ('%s') specified. Only these modes are supported: %s"), sem_str, GetSupportedSocketEventsStr()));
     }
     connOptions.socketEventsMode = sem;
+    ::g_socket_events_mode = sem;
 
     const std::string& i2psam_arg = args.GetArg("-i2psam", "");
     if (!i2psam_arg.empty()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1627,6 +1627,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
     }
 
+    std::string sem_str = args.GetArg("-socketevents", DEFAULT_SOCKETEVENTS);
+    ::g_socket_events_mode = SEMFromString(sem_str);
+    if (::g_socket_events_mode == SocketEventsMode::Unknown) {
+        return InitError(strprintf(_("Invalid -socketevents ('%s') specified. Only these modes are supported: %s"), sem_str, GetSupportedSocketEventsStr()));
+    }
+
     assert(!node.banman);
     node.banman = std::make_unique<BanMan>(gArgs.GetDataDirNet() / "banlist", &uiInterface, args.GetIntArg("-bantime", DEFAULT_MISBEHAVING_BANTIME));
     assert(!node.connman);
@@ -2405,6 +2411,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     connOptions.m_added_nodes = args.GetArgs("-addnode");
     connOptions.nMaxOutboundLimit = *opt_max_upload;
     connOptions.m_peer_connect_timeout = peer_connect_timeout;
+    connOptions.socketEventsMode = ::g_socket_events_mode;
 
     // Port to bind to if `-bind=addr` is provided without a `:port` suffix.
     const uint16_t default_bind_port =
@@ -2511,14 +2518,6 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             LogPrintf("-dnsseed is ignored when -connect is used and -proxy is specified\n");
         }
     }
-
-    std::string sem_str = args.GetArg("-socketevents", DEFAULT_SOCKETEVENTS);
-    const auto sem = SEMFromString(sem_str);
-    if (sem == SocketEventsMode::Unknown) {
-        return InitError(strprintf(_("Invalid -socketevents ('%s') specified. Only these modes are supported: %s"), sem_str, GetSupportedSocketEventsStr()));
-    }
-    connOptions.socketEventsMode = sem;
-    ::g_socket_events_mode = sem;
 
     const std::string& i2psam_arg = args.GetArg("-i2psam", "");
     if (!i2psam_arg.empty()) {

--- a/src/masternode/node.cpp
+++ b/src/masternode/node.cpp
@@ -156,7 +156,7 @@ void CActiveMasternodeManager::InitInternal(const CBlockIndex* pindex)
     // Check socket connectivity
     LogPrintf("CActiveMasternodeManager::Init -- Checking inbound connection to '%s'\n", m_info.service.ToStringAddrPort());
     std::unique_ptr<Sock> sock{ConnectDirectly(m_info.service, /*manual_connection=*/true)};
-    bool fConnected{sock && sock->IsSelectable()};
+    bool fConnected{sock && sock->IsSelectable(/*is_select=*/::g_socket_events_mode == SocketEventsMode::Select)};
     sock = std::make_unique<Sock>(INVALID_SOCKET);
     if (!fConnected && Params().RequireRoutableExternalIP()) {
         m_state = MasternodeState::SOME_ERROR;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -56,14 +56,6 @@
 #include <ifaddrs.h>
 #endif
 
-#ifdef USE_EPOLL
-#include <sys/epoll.h>
-#endif
-
-#ifdef USE_KQUEUE
-#include <sys/event.h>
-#endif
-
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -2375,79 +2367,6 @@ Sock::EventsPerSock CConnman::GenerateWaitSockets(Span<CNode* const> nodes)
     return events_per_sock;
 }
 
-#ifdef USE_KQUEUE
-void CConnman::SocketEventsKqueue(std::set<SOCKET>& recv_set,
-                                  std::set<SOCKET>& send_set,
-                                  std::set<SOCKET>& error_set,
-                                  bool only_poll)
-{
-    std::array<struct kevent, MAX_EVENTS> events{};
-    struct timespec timeout = MillisToTimespec(only_poll ? 0 : SELECT_TIMEOUT_MILLISECONDS);
-
-    int ret{-1};
-    ToggleWakeupPipe([&](){
-        ret = kevent(Assert(m_edge_trig_events)->GetFileDescriptor(), nullptr, 0, events.data(), events.size(), &timeout);
-    });
-    if (ret == SOCKET_ERROR) {
-        LogPrintf("kevent wait error\n");
-        return;
-    }
-
-    for (int i = 0; i < ret; i++) {
-        auto& event = events[i];
-        if ((event.flags & EV_ERROR) || (event.flags & EV_EOF)) {
-            error_set.insert((SOCKET)event.ident);
-            continue;
-        }
-
-        if (event.filter == EVFILT_READ) {
-            recv_set.insert((SOCKET)event.ident);
-        }
-
-        if (event.filter == EVFILT_WRITE) {
-            send_set.insert((SOCKET)event.ident);
-        }
-    }
-}
-#endif
-
-#ifdef USE_EPOLL
-void CConnman::SocketEventsEpoll(std::set<SOCKET>& recv_set,
-                                 std::set<SOCKET>& send_set,
-                                 std::set<SOCKET>& error_set,
-                                 bool only_poll)
-{
-    std::array<epoll_event, MAX_EVENTS> events{};
-
-    int ret{-1};
-    ToggleWakeupPipe([&](){
-        ret = epoll_wait(Assert(m_edge_trig_events)->GetFileDescriptor(), events.data(), events.size(),
-                         only_poll ? 0 : SELECT_TIMEOUT_MILLISECONDS);
-    });
-
-    if (ret == SOCKET_ERROR) {
-        LogPrintf("epoll_wait error\n");
-        return;
-    }
-
-    for (int i = 0; i < ret; i++) {
-        auto& e = events[i];
-        if((e.events & EPOLLERR) || (e.events & EPOLLHUP)) {
-            error_set.insert((SOCKET)e.data.fd);
-            continue;
-        }
-
-        if (e.events & EPOLLIN) {
-            recv_set.insert((SOCKET)e.data.fd);
-        }
-
-        if (e.events & EPOLLOUT) {
-            send_set.insert((SOCKET)e.data.fd);
-        }
-    }
-}
-#endif
-
 void CConnman::SocketHandler(CMasternodeSync& mn_sync)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
@@ -2480,7 +2399,7 @@ void CConnman::SocketHandler(CMasternodeSync& mn_sync)
         // select(2)). If none are ready, wait for a short while and return
         // empty sets.
         events_per_sock = GenerateWaitSockets(snap.Nodes());
-        if ((is_lt && events_per_sock.empty()) || !Sock::WaitManyInternal(timeout, events_per_sock, socketEventsMode)) {
+        if ((is_lt && events_per_sock.empty()) || !Sock::WaitManyInternal(timeout, events_per_sock, SocketEventsParams{socketEventsMode, GetModeFileDescriptor()})) {
             if (is_lt) {
                 interruptNet.sleep_for(std::chrono::milliseconds(SELECT_TIMEOUT_MILLISECONDS));
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1928,7 +1928,7 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
         return;
     }
 
-    if (!sock->IsSelectable()) {
+    if (!sock->IsSelectable(/*is_select=*/::g_socket_events_mode == SocketEventsMode::Select)) {
         LogPrintf("%s: non-selectable socket\n", strDropped);
         return;
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2399,7 +2399,7 @@ void CConnman::SocketHandler(CMasternodeSync& mn_sync)
         // select(2)). If none are ready, wait for a short while and return
         // empty sets.
         events_per_sock = GenerateWaitSockets(snap.Nodes());
-        if ((is_lt && events_per_sock.empty()) || !Sock::WaitManyInternal(timeout, events_per_sock, SocketEventsParams{socketEventsMode, GetModeFileDescriptor()})) {
+        if ((is_lt && events_per_sock.empty()) || !Sock::WaitManyInternal(timeout, events_per_sock, SocketEventsParams{socketEventsMode, GetModeFileDescriptor(), ToggleWakeupPipe})) {
             if (is_lt) {
                 interruptNet.sleep_for(std::chrono::milliseconds(SELECT_TIMEOUT_MILLISECONDS));
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -56,10 +56,6 @@
 #include <ifaddrs.h>
 #endif
 
-#ifdef USE_POLL
-#include <poll.h>
-#endif
-
 #ifdef USE_EPOLL
 #include <sys/epoll.h>
 #endif
@@ -2338,13 +2334,12 @@ bool CConnman::InactivityCheck(const CNode& node) const
     return false;
 }
 
-bool CConnman::GenerateSelectSet(const std::vector<CNode*>& nodes,
-                                 std::set<SOCKET>& recv_set,
-                                 std::set<SOCKET>& send_set,
-                                 std::set<SOCKET>& error_set)
+Sock::EventsPerSock CConnman::GenerateWaitSockets(Span<CNode* const> nodes)
 {
+    Sock::EventsPerSock events_per_sock;
+
     for (const ListenSocket& hListenSocket : vhListenSocket) {
-        recv_set.insert(hListenSocket.sock->Get());
+        events_per_sock.emplace(hListenSocket.sock->Get(), Sock::Events{Sock::RECV});
     }
 
     for (CNode* pnode : nodes) {
@@ -2357,13 +2352,15 @@ bool CConnman::GenerateSelectSet(const std::vector<CNode*>& nodes,
             continue;
         }
 
-        error_set.insert(pnode->m_sock->Get());
+        Sock::Event requested{0};
         if (select_send) {
-            send_set.insert(pnode->m_sock->Get());
+            requested |= Sock::SEND;
         }
         if (select_recv) {
-            recv_set.insert(pnode->m_sock->Get());
+            requested |= Sock::RECV;
         }
+
+        events_per_sock.emplace(pnode->m_sock->Get(), Sock::Events{requested});
     }
 
     if (m_wakeup_pipe) {
@@ -2372,10 +2369,10 @@ bool CConnman::GenerateSelectSet(const std::vector<CNode*>& nodes,
         // This is currently only implemented for POSIX compliant systems. This means that Windows will fall back to
         // timing out after 50ms and then trying to send. This is ok as we assume that heavy-load daemons are usually
         // run on Linux and friends.
-        recv_set.insert(m_wakeup_pipe->m_pipe[0]);
+        events_per_sock.emplace(m_wakeup_pipe->m_pipe[0], Sock::Events{Sock::RECV});
     }
 
-    return !recv_set.empty() || !send_set.empty() || !error_set.empty();
+    return events_per_sock;
 }
 
 #ifdef USE_KQUEUE
@@ -2451,173 +2448,11 @@ void CConnman::SocketEventsEpoll(std::set<SOCKET>& recv_set,
 }
 #endif
 
-#ifdef USE_POLL
-void CConnman::SocketEventsPoll(const std::vector<CNode*>& nodes,
-                                std::set<SOCKET>& recv_set,
-                                std::set<SOCKET>& send_set,
-                                std::set<SOCKET>& error_set,
-                                bool only_poll)
-{
-    std::set<SOCKET> recv_select_set, send_select_set, error_select_set;
-    if (!GenerateSelectSet(nodes, recv_select_set, send_select_set, error_select_set)) {
-        if (!only_poll) interruptNet.sleep_for(std::chrono::milliseconds(SELECT_TIMEOUT_MILLISECONDS));
-        return;
-    }
-
-    std::unordered_map<SOCKET, struct pollfd> pollfds;
-    for (SOCKET socket_id : recv_select_set) {
-        pollfds[socket_id].fd = socket_id;
-        pollfds[socket_id].events |= POLLIN;
-    }
-
-    for (SOCKET socket_id : send_select_set) {
-        pollfds[socket_id].fd = socket_id;
-        pollfds[socket_id].events |= POLLOUT;
-    }
-
-    for (SOCKET socket_id : error_select_set) {
-        pollfds[socket_id].fd = socket_id;
-        // These flags are ignored, but we set them for clarity
-        pollfds[socket_id].events |= POLLERR|POLLHUP;
-    }
-
-    std::vector<struct pollfd> vpollfds;
-    vpollfds.reserve(pollfds.size());
-    for (auto it : pollfds) {
-        vpollfds.push_back(std::move(it.second));
-    }
-
-    int r{-1};
-    ToggleWakeupPipe([&](){r = poll(vpollfds.data(), vpollfds.size(), only_poll ? 0 : SELECT_TIMEOUT_MILLISECONDS);});
-    if (r < 0) {
-        return;
-    }
-
-    if (interruptNet) return;
-
-    for (struct pollfd pollfd_entry : vpollfds) {
-        if (pollfd_entry.revents & POLLIN)            recv_set.insert(pollfd_entry.fd);
-        if (pollfd_entry.revents & POLLOUT)           send_set.insert(pollfd_entry.fd);
-        if (pollfd_entry.revents & (POLLERR|POLLHUP)) error_set.insert(pollfd_entry.fd);
-    }
-}
-#endif
-
-void CConnman::SocketEventsSelect(const std::vector<CNode*>& nodes,
-                                  std::set<SOCKET>& recv_set,
-                                  std::set<SOCKET>& send_set,
-                                  std::set<SOCKET>& error_set,
-                                  bool only_poll)
-{
-    std::set<SOCKET> recv_select_set, send_select_set, error_select_set;
-    if (!GenerateSelectSet(nodes, recv_select_set, send_select_set, error_select_set)) {
-        interruptNet.sleep_for(std::chrono::milliseconds(SELECT_TIMEOUT_MILLISECONDS));
-        return;
-    }
-
-    //
-    // Find which sockets have data to receive
-    //
-    struct timeval timeout;
-    timeout.tv_sec  = 0;
-    timeout.tv_usec = only_poll ? 0 : SELECT_TIMEOUT_MILLISECONDS * 1000; // frequency to poll pnode->vSend
-
-    fd_set fdsetRecv;
-    fd_set fdsetSend;
-    fd_set fdsetError;
-    FD_ZERO(&fdsetRecv);
-    FD_ZERO(&fdsetSend);
-    FD_ZERO(&fdsetError);
-    SOCKET hSocketMax = 0;
-
-    for (SOCKET hSocket : recv_select_set) {
-        FD_SET(hSocket, &fdsetRecv);
-        hSocketMax = std::max(hSocketMax, hSocket);
-    }
-
-    for (SOCKET hSocket : send_select_set) {
-        FD_SET(hSocket, &fdsetSend);
-        hSocketMax = std::max(hSocketMax, hSocket);
-    }
-
-    for (SOCKET hSocket : error_select_set) {
-        FD_SET(hSocket, &fdsetError);
-        hSocketMax = std::max(hSocketMax, hSocket);
-    }
-
-    int nSelect{-1};
-    ToggleWakeupPipe([&](){nSelect = select(hSocketMax + 1, &fdsetRecv, &fdsetSend, &fdsetError, &timeout);});
-    if (interruptNet)
-        return;
-
-    if (nSelect == SOCKET_ERROR)
-    {
-        int nErr = WSAGetLastError();
-        LogPrintf("socket select error %s\n", NetworkErrorString(nErr));
-        for (unsigned int i = 0; i <= hSocketMax; i++)
-            FD_SET(i, &fdsetRecv);
-        FD_ZERO(&fdsetSend);
-        FD_ZERO(&fdsetError);
-        if (!interruptNet.sleep_for(std::chrono::milliseconds(SELECT_TIMEOUT_MILLISECONDS)))
-            return;
-    }
-
-    for (SOCKET hSocket : recv_select_set) {
-        if (FD_ISSET(hSocket, &fdsetRecv)) {
-            recv_set.insert(hSocket);
-        }
-    }
-
-    for (SOCKET hSocket : send_select_set) {
-        if (FD_ISSET(hSocket, &fdsetSend)) {
-            send_set.insert(hSocket);
-        }
-    }
-
-    for (SOCKET hSocket : error_select_set) {
-        if (FD_ISSET(hSocket, &fdsetError)) {
-            error_set.insert(hSocket);
-        }
-    }
-}
-
-void CConnman::SocketEvents(const std::vector<CNode*>& nodes,
-                            std::set<SOCKET>& recv_set,
-                            std::set<SOCKET>& send_set,
-                            std::set<SOCKET>& error_set,
-                            bool only_poll)
-{
-    switch (socketEventsMode) {
-#ifdef USE_KQUEUE
-        case SocketEventsMode::KQueue:
-            SocketEventsKqueue(recv_set, send_set, error_set, only_poll);
-            break;
-#endif
-#ifdef USE_EPOLL
-        case SocketEventsMode::EPoll:
-            SocketEventsEpoll(recv_set, send_set, error_set, only_poll);
-            break;
-#endif
-#ifdef USE_POLL
-        case SocketEventsMode::Poll:
-            SocketEventsPoll(nodes, recv_set, send_set, error_set, only_poll);
-            break;
-#endif
-        case SocketEventsMode::Select:
-            SocketEventsSelect(nodes, recv_set, send_set, error_set, only_poll);
-            break;
-        default:
-            assert(false);
-    }
-}
-
 void CConnman::SocketHandler(CMasternodeSync& mn_sync)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
 
-    std::set<SOCKET> recv_set;
-    std::set<SOCKET> send_set;
-    std::set<SOCKET> error_set;
+    Sock::EventsPerSock events_per_sock;
 
     bool only_poll = [this]() {
         // Check if we have work to do and thus should avoid waiting for events
@@ -2637,72 +2472,64 @@ void CConnman::SocketHandler(CMasternodeSync& mn_sync)
     {
         const NodesSnapshot snap{*this, /* cond = */ CConnman::AllNodes, /* shuffle = */ false};
 
+        const auto timeout = std::chrono::milliseconds(only_poll ? 0 : SELECT_TIMEOUT_MILLISECONDS);
+        const bool is_lt = socketEventsMode == SocketEventsMode::Poll || socketEventsMode == SocketEventsMode::Select;
+
         // Check for the readiness of the already connected sockets and the
         // listening sockets in one call ("readiness" as in poll(2) or
         // select(2)). If none are ready, wait for a short while and return
         // empty sets.
-        SocketEvents(snap.Nodes(), recv_set, send_set, error_set, only_poll);
+        events_per_sock = GenerateWaitSockets(snap.Nodes());
+        if ((is_lt && events_per_sock.empty()) || !Sock::WaitManyInternal(timeout, events_per_sock, socketEventsMode)) {
+            if (is_lt) {
+                interruptNet.sleep_for(std::chrono::milliseconds(SELECT_TIMEOUT_MILLISECONDS));
+            }
+        }
 
-    // Drain the wakeup pipe
-    if (m_wakeup_pipe && recv_set.count(m_wakeup_pipe->m_pipe[0])) {
-        m_wakeup_pipe->Drain();
-    }
+        // Drain the wakeup pipe
+        if (m_wakeup_pipe && events_per_sock.find(m_wakeup_pipe->m_pipe[0]) != events_per_sock.end()) {
+            m_wakeup_pipe->Drain();
+        }
 
         // Service (send/receive) each of the already connected nodes.
-        SocketHandlerConnected(recv_set, send_set, error_set);
+        SocketHandlerConnected(events_per_sock);
     }
 
     // Accept new connections from listening sockets.
-    SocketHandlerListening(recv_set, mn_sync);
+    SocketHandlerListening(events_per_sock, mn_sync);
 }
 
-void CConnman::SocketHandlerConnected(const std::set<SOCKET>& recv_set,
-                                      const std::set<SOCKET>& send_set,
-                                      const std::set<SOCKET>& error_set)
+void CConnman::SocketHandlerConnected(const Sock::EventsPerSock& events_per_sock)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
 
     if (interruptNet) return;
 
-    std::set<CNode*> vErrorNodes;
-    std::set<CNode*> vReceivableNodes;
-    std::set<CNode*> vSendableNodes;
+    std::set<CNode*> node_err_set;
+    std::set<CNode*> node_recv_set;
+    std::set<CNode*> node_send_set;
     {
         LOCK(cs_mapSocketToNode);
-        for (auto hSocket : error_set) {
-            auto it = mapSocketToNode.find(hSocket);
-            if (it == mapSocketToNode.end()) {
-                continue;
+        for (const auto& [sock, events] : events_per_sock) {
+            auto it = mapSocketToNode.find(sock);
+            if (it == mapSocketToNode.end()) continue;
+            if (events.occurred & Sock::ERR) {
+                it->second->AddRef();
+                node_err_set.emplace(it->second);
             }
-            it->second->AddRef();
-            vErrorNodes.emplace(it->second);
-        }
-        for (auto hSocket : recv_set) {
-            if (error_set.count(hSocket)) {
-                // no need to handle it twice
-                continue;
+            if (events.occurred & Sock::RECV) {
+                if (events.occurred & Sock::ERR) continue;
+                LOCK(cs_sendable_receivable_nodes);
+                auto jt = mapReceivableNodes.emplace(it->second->GetId(), it->second);
+                assert(jt.first->second == it->second);
+                it->second->fHasRecvData = true;
             }
-
-            auto it = mapSocketToNode.find(hSocket);
-            if (it == mapSocketToNode.end()) {
-                continue;
+            if (events.occurred & Sock::SEND) {
+                LOCK(cs_sendable_receivable_nodes);
+                auto jt = mapSendableNodes.emplace(it->second->GetId(), it->second);
+                assert(jt.first->second == it->second);
+                it->second->fCanSendData = true;
             }
-
-            LOCK(cs_sendable_receivable_nodes);
-            auto jt = mapReceivableNodes.emplace(it->second->GetId(), it->second);
-            assert(jt.first->second == it->second);
-            it->second->fHasRecvData = true;
-        }
-        for (auto hSocket : send_set) {
-            auto it = mapSocketToNode.find(hSocket);
-            if (it == mapSocketToNode.end()) {
-                continue;
-            }
-
-            LOCK(cs_sendable_receivable_nodes);
-            auto jt = mapSendableNodes.emplace(it->second->GetId(), it->second);
-            assert(jt.first->second == it->second);
-            it->second->fCanSendData = true;
         }
     }
 
@@ -2719,17 +2546,17 @@ void CConnman::SocketHandlerConnected(const std::set<SOCKET>& recv_set,
         if (pnode->fHasRecvData && !pnode->fPauseRecv && !pnode->fDisconnect &&
             (!pnode->m_transport->ReceivedMessageComplete() || to_send.empty())) {
             pnode->AddRef();
-            vReceivableNodes.emplace(pnode);
+            node_recv_set.emplace(pnode);
         }
 
         // Collect nodes that have data to send and have a socket with non-empty write buffers
         if (pnode->fCanSendData && (!pnode->m_transport->ReceivedMessageComplete() || !to_send.empty())) {
             pnode->AddRef();
-            vSendableNodes.emplace(pnode);
+            node_send_set.emplace(pnode);
         }
     });
 
-    for (CNode* pnode : vSendableNodes) {
+    for (CNode* pnode : node_send_set) {
         if (interruptNet) {
             break;
         }
@@ -2746,13 +2573,13 @@ void CConnman::SocketHandlerConnected(const std::set<SOCKET>& recv_set,
             // sending actually succeeded to make sure progress is always made; otherwise a
             // deadlock would be possible when both sides have data to send, but neither is
             // receiving.
-            if (data_left && vReceivableNodes.erase(pnode)) {
+            if (data_left && node_recv_set.erase(pnode)) {
                 pnode->Release();
             }
         }
     }
 
-    for (CNode* pnode : vErrorNodes)
+    for (CNode* pnode : node_err_set)
     {
         if (interruptNet) {
             break;
@@ -2761,7 +2588,7 @@ void CConnman::SocketHandlerConnected(const std::set<SOCKET>& recv_set,
         SocketRecvData(pnode);
     }
 
-    for (CNode* pnode : vReceivableNodes)
+    for (CNode* pnode : node_recv_set)
     {
         if (interruptNet) {
             break;
@@ -2773,13 +2600,13 @@ void CConnman::SocketHandlerConnected(const std::set<SOCKET>& recv_set,
         SocketRecvData(pnode);
     }
 
-    for (auto& node : vErrorNodes) {
+    for (auto& node : node_err_set) {
         node->Release();
     }
-    for (auto& node : vReceivableNodes) {
+    for (auto& node : node_recv_set) {
         node->Release();
     }
-    for (auto& node : vSendableNodes) {
+    for (auto& node : node_send_set) {
         node->Release();
     }
 
@@ -2811,13 +2638,14 @@ void CConnman::SocketHandlerConnected(const std::set<SOCKET>& recv_set,
     }
 }
 
-void CConnman::SocketHandlerListening(const std::set<SOCKET>& recv_set, CMasternodeSync& mn_sync)
+void CConnman::SocketHandlerListening(const Sock::EventsPerSock& events_per_sock, CMasternodeSync& mn_sync)
 {
     for (const ListenSocket& listen_socket : vhListenSocket) {
         if (interruptNet) {
             return;
         }
-        if (recv_set.count(listen_socket.sock->Get()) > 0) {
+        const auto it = events_per_sock.find(listen_socket.sock->Get());
+        if (it != events_per_sock.end() && (it->second.occurred & Sock::RECV)) {
             AcceptConnection(listen_socket, mn_sync);
         }
     }

--- a/src/net.h
+++ b/src/net.h
@@ -1862,15 +1862,14 @@ private:
         return INVALID_SOCKET;
     }
 
-    template <typename Callable>
-    void ToggleWakeupPipe(Callable&& func)
+    SocketEventsParams::wrap_fn ToggleWakeupPipe = [&](std::function<void()>&& func)
     {
         if (m_wakeup_pipe) {
             m_wakeup_pipe->Toggle(func);
         } else {
             func();
         }
-    }
+    };
 
     Mutex cs_sendable_receivable_nodes;
     std::unordered_map<NodeId, CNode*> mapReceivableNodes GUARDED_BY(cs_sendable_receivable_nodes);

--- a/src/net.h
+++ b/src/net.h
@@ -1623,19 +1623,6 @@ private:
      */
     Sock::EventsPerSock GenerateWaitSockets(Span<CNode* const> nodes);
 
-#ifdef USE_KQUEUE
-    void SocketEventsKqueue(std::set<SOCKET>& recv_set,
-                            std::set<SOCKET>& send_set,
-                            std::set<SOCKET>& error_set,
-                            bool only_poll);
-#endif
-#ifdef USE_EPOLL
-    void SocketEventsEpoll(std::set<SOCKET>& recv_set,
-                           std::set<SOCKET>& send_set,
-                           std::set<SOCKET>& error_set,
-                           bool only_poll);
-#endif
-
     /**
      * Check connected and listening sockets for IO readiness and process them accordingly.
      */
@@ -1866,6 +1853,14 @@ private:
     SocketEventsMode socketEventsMode;
     std::unique_ptr<EdgeTriggeredEvents> m_edge_trig_events{nullptr};
     std::unique_ptr<WakeupPipe> m_wakeup_pipe{nullptr};
+
+    SOCKET GetModeFileDescriptor()
+    {
+        if (m_edge_trig_events) {
+            return static_cast<SOCKET>(m_edge_trig_events->GetFileDescriptor());
+        }
+        return INVALID_SOCKET;
+    }
 
     template <typename Callable>
     void ToggleWakeupPipe(Callable&& func)

--- a/src/net.h
+++ b/src/net.h
@@ -118,16 +118,6 @@ static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
 static constexpr bool DEFAULT_V2_TRANSPORT{true};
 
-#if defined USE_KQUEUE
-#define DEFAULT_SOCKETEVENTS "kqueue"
-#elif defined USE_EPOLL
-#define DEFAULT_SOCKETEVENTS "epoll"
-#elif defined USE_POLL
-#define DEFAULT_SOCKETEVENTS "poll"
-#else
-#define DEFAULT_SOCKETEVENTS "select"
-#endif
-
 typedef int64_t NodeId;
 
 struct AddedNodeParams {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -572,7 +572,7 @@ static bool ConnectToSocket(const Sock& sock, struct sockaddr* sockaddr, socklen
             // synchronously to check for successful connection with a timeout.
             const Sock::Event requested = Sock::RECV | Sock::SEND;
             Sock::Event occurred;
-            if (!sock.Wait(std::chrono::milliseconds{nConnectTimeout}, requested, &occurred)) {
+            if (!sock.Wait(std::chrono::milliseconds{nConnectTimeout}, requested, SEM_LT_DEFAULT, &occurred)) {
                 LogPrintf("wait for connect to %s failed: %s\n",
                           dest_str,
                           NetworkErrorString(WSAGetLastError()));

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -572,7 +572,7 @@ static bool ConnectToSocket(const Sock& sock, struct sockaddr* sockaddr, socklen
             // synchronously to check for successful connection with a timeout.
             const Sock::Event requested = Sock::RECV | Sock::SEND;
             Sock::Event occurred;
-            if (!sock.Wait(std::chrono::milliseconds{nConnectTimeout}, requested, SEM_LT_DEFAULT, &occurred)) {
+            if (!sock.Wait(std::chrono::milliseconds{nConnectTimeout}, requested, SocketEventsParams(), &occurred)) {
                 LogPrintf("wait for connect to %s failed: %s\n",
                           dest_str,
                           NetworkErrorString(WSAGetLastError()));

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -270,7 +270,7 @@ bool FuzzedSock::IsSelectable(bool is_select) const
     return m_selectable;
 }
 
-bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsMode event_mode, Event* occurred) const
+bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsParams event_params, Event* occurred) const
 {
     constexpr std::array wait_errnos{
         EBADF,
@@ -287,7 +287,7 @@ bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Socket
     return true;
 }
 
-bool FuzzedSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsMode event_mode) const
+bool FuzzedSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsParams event_params) const
 {
     for (auto& [sock, events] : events_per_sock) {
         (void)sock;

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -270,7 +270,7 @@ bool FuzzedSock::IsSelectable() const
     return m_selectable;
 }
 
-bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
+bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsMode event_mode, Event* occurred) const
 {
     constexpr std::array wait_errnos{
         EBADF,

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -265,7 +265,7 @@ bool FuzzedSock::SetNonBlocking() const
     return true;
 }
 
-bool FuzzedSock::IsSelectable() const
+bool FuzzedSock::IsSelectable(bool is_select) const
 {
     return m_selectable;
 }

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -287,6 +287,15 @@ bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Socket
     return true;
 }
 
+bool FuzzedSock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsMode event_mode) const
+{
+    for (auto& [sock, events] : events_per_sock) {
+        (void)sock;
+        events.occurred = m_fuzzed_data_provider.ConsumeBool() ? events.requested : 0;
+    }
+    return true;
+}
+
 bool FuzzedSock::IsConnected(std::string& errmsg) const
 {
     if (m_fuzzed_data_provider.ConsumeBool()) {

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -89,9 +89,9 @@ public:
 
     bool IsSelectable(bool is_select) const override;
 
-    bool Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsMode event_mode = SEM_LT_DEFAULT, Event* occurred = nullptr) const override;
+    bool Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsParams event_params = SocketEventsParams(), Event* occurred = nullptr) const override;
 
-    bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsMode event_mode = SEM_LT_DEFAULT) const override;
+    bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsParams event_params = SocketEventsParams()) const override;
 
     bool IsConnected(std::string& errmsg) const override;
 };

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -89,9 +89,9 @@ public:
 
     bool IsSelectable(bool is_select) const override;
 
-    bool Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsParams event_params = SocketEventsParams(), Event* occurred = nullptr) const override;
+    bool Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsParams event_params, Event* occurred = nullptr) const override;
 
-    bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsParams event_params = SocketEventsParams()) const override;
+    bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsParams event_params) const override;
 
     bool IsConnected(std::string& errmsg) const override;
 };

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -89,7 +89,7 @@ public:
 
     bool IsSelectable() const override;
 
-    bool Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const override;
+    bool Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsMode event_mode = SEM_LT_DEFAULT, Event* occurred = nullptr) const override;
 
     bool IsConnected(std::string& errmsg) const override;
 };

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -87,7 +87,7 @@ public:
 
     bool SetNonBlocking() const override;
 
-    bool IsSelectable() const override;
+    bool IsSelectable(bool is_select) const override;
 
     bool Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsMode event_mode = SEM_LT_DEFAULT, Event* occurred = nullptr) const override;
 

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -91,6 +91,8 @@ public:
 
     bool Wait(std::chrono::milliseconds timeout, Event requested, SocketEventsMode event_mode = SEM_LT_DEFAULT, Event* occurred = nullptr) const override;
 
+    bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsMode event_mode = SEM_LT_DEFAULT) const override;
+
     bool IsConnected(std::string& errmsg) const override;
 };
 

--- a/src/test/sock_tests.cpp
+++ b/src/test/sock_tests.cpp
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(wait)
     Sock sock0(s[0]);
     Sock sock1(s[1]);
 
-    std::thread waiter([&sock0]() { (void)sock0.Wait(24h, Sock::RECV); });
+    std::thread waiter([&sock0]() { (void)sock0.Wait(24h, Sock::RECV, SocketEventsParams{::g_socket_events_mode}); });
 
     BOOST_REQUIRE_EQUAL(sock1.Send("a", 1, 0), 1);
 

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -202,6 +202,7 @@ public:
 
     bool Wait(std::chrono::milliseconds timeout,
               Event requested,
+              SocketEventsMode event_mode = SEM_LT_DEFAULT,
               Event* occurred = nullptr) const override
     {
         if (occurred != nullptr) {

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -211,6 +211,15 @@ public:
         return true;
     }
 
+    bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsMode event_mode = SEM_LT_DEFAULT) const override
+    {
+        for (auto& [sock, events] : events_per_sock) {
+            (void)sock;
+            events.occurred = events.requested;
+        }
+        return true;
+    }
+
 private:
     const std::string m_contents;
     mutable size_t m_consumed;

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -202,7 +202,7 @@ public:
 
     bool Wait(std::chrono::milliseconds timeout,
               Event requested,
-              SocketEventsParams event_params = SocketEventsParams(),
+              SocketEventsParams event_params,
               Event* occurred = nullptr) const override
     {
         if (occurred != nullptr) {
@@ -213,7 +213,7 @@ public:
 
     bool WaitMany(std::chrono::milliseconds timeout,
                   EventsPerSock& events_per_sock,
-                  SocketEventsParams event_params = SocketEventsParams()) const override
+                  SocketEventsParams event_params) const override
     {
         for (auto& [sock, events] : events_per_sock) {
             (void)sock;

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -198,7 +198,7 @@ public:
 
     bool SetNonBlocking() const override { return true; }
 
-    bool IsSelectable() const override { return true; }
+    bool IsSelectable(bool is_select) const override { return true; }
 
     bool Wait(std::chrono::milliseconds timeout,
               Event requested,

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -202,7 +202,7 @@ public:
 
     bool Wait(std::chrono::milliseconds timeout,
               Event requested,
-              SocketEventsMode event_mode = SEM_LT_DEFAULT,
+              SocketEventsParams event_params = SocketEventsParams(),
               Event* occurred = nullptr) const override
     {
         if (occurred != nullptr) {
@@ -211,7 +211,9 @@ public:
         return true;
     }
 
-    bool WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsMode event_mode = SEM_LT_DEFAULT) const override
+    bool WaitMany(std::chrono::milliseconds timeout,
+                  EventsPerSock& events_per_sock,
+                  SocketEventsParams event_params = SocketEventsParams()) const override
     {
         for (auto& [sock, events] : events_per_sock) {
             (void)sock;

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -180,49 +180,27 @@ bool Sock::WaitMany(std::chrono::milliseconds timeout, EventsPerSock& events_per
 
 bool Sock::WaitManyInternal(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock, SocketEventsParams event_params)
 {
-    std::string debug_str;
-
     switch (event_params.m_event_mode)
     {
-        case SocketEventsMode::Poll:
 #ifdef USE_POLL
+        case SocketEventsMode::Poll:
             return WaitManyPoll(timeout, events_per_sock, event_params.m_wrap_func);
-#else
-            debug_str += "Sock::Wait -- Support for poll not compiled in, falling back on ";
-            break;
 #endif /* USE_POLL */
         case SocketEventsMode::Select:
             return WaitManySelect(timeout, events_per_sock, event_params.m_wrap_func);
-        case SocketEventsMode::EPoll:
 #ifdef USE_EPOLL
+        case SocketEventsMode::EPoll:
             assert(event_params.m_event_fd != INVALID_SOCKET);
             return WaitManyEPoll(timeout, events_per_sock, event_params.m_event_fd, event_params.m_wrap_func);
-#else
-            debug_str += "Sock::Wait -- Support for epoll not compiled in, falling back on ";
-            break;
 #endif /* USE_EPOLL */
-        case SocketEventsMode::KQueue:
 #ifdef USE_KQUEUE
+        case SocketEventsMode::KQueue:
             assert(event_params.m_event_fd != INVALID_SOCKET);
             return WaitManyKQueue(timeout, events_per_sock, event_params.m_event_fd, event_params.m_wrap_func);
-#else
-            debug_str += "Sock::Wait -- Support for kqueue not compiled in, falling back on ";
-            break;
 #endif /* USE_KQUEUE */
         default:
             assert(false);
     }
-#ifdef USE_POLL
-    debug_str += "poll";
-#else
-    debug_str += "select";
-#endif /* USE_POLL*/
-    LogPrint(BCLog::NET, "%s\n", debug_str);
-#ifdef USE_POLL
-    return WaitManyPoll(timeout, events_per_sock, event_params.m_wrap_func);
-#else
-    return WaitManySelect(timeout, events_per_sock, event_params.m_wrap_func);
-#endif /* USE_POLL */
 }
 
 #ifdef USE_EPOLL

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -143,6 +143,15 @@ bool Sock::IsSelectable() const
 bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
 {
 #ifdef USE_POLL
+    return WaitPoll(timeout, requested, occurred);
+#else
+    return WaitSelect(timeout, requested, occurred);
+#endif /* USE_POLL */
+}
+
+#ifdef USE_POLL
+bool Sock::WaitPoll(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
+{
     pollfd fd;
     fd.fd = m_socket;
     fd.events = 0;
@@ -171,7 +180,11 @@ bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occur
     }
 
     return true;
-#else
+}
+#endif /* USE_POLL */
+
+bool Sock::WaitSelect(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
+{
     if (!IsSelectable()) {
         return false;
     }
@@ -213,7 +226,6 @@ bool Sock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occur
     }
 
     return true;
-#endif /* USE_POLL */
 }
 
 void Sock::SendComplete(const std::string& data,

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -287,7 +287,11 @@ bool Sock::WaitManyKQueue(std::chrono::milliseconds timeout, EventsPerSock& even
                 occurred |= SEND;
             }
         }
-        events_per_sock.emplace(static_cast<SOCKET>(ev.ident), Sock::Events{/*req=*/RECV | SEND, occurred});
+        if (auto it = events_per_sock.find(static_cast<SOCKET>(ev.ident)); it != events_per_sock.end()) {
+            it->second.occurred |= occurred;
+        } else {
+            events_per_sock.emplace(static_cast<SOCKET>(ev.ident), Sock::Events{/*req=*/RECV | SEND, occurred});
+        }
     }
 
     return true;

--- a/src/util/sock.cpp
+++ b/src/util/sock.cpp
@@ -301,6 +301,8 @@ bool Sock::WaitManyKQueue(std::chrono::milliseconds timeout, EventsPerSock& even
 #ifdef USE_POLL
 bool Sock::WaitManyPoll(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock)
 {
+    if (events_per_sock.empty()) return true;
+
     std::vector<pollfd> pfds;
     for (const auto& [socket, events] : events_per_sock) {
         pfds.emplace_back();
@@ -341,6 +343,8 @@ bool Sock::WaitManyPoll(std::chrono::milliseconds timeout, EventsPerSock& events
 
 bool Sock::WaitManySelect(std::chrono::milliseconds timeout, EventsPerSock& events_per_sock)
 {
+    if (events_per_sock.empty()) return true;
+
     fd_set recv;
     fd_set send;
     fd_set err;

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -221,6 +221,10 @@ public:
     [[nodiscard]] virtual bool Wait(std::chrono::milliseconds timeout,
                                     Event requested,
                                     Event* occurred = nullptr) const;
+#ifdef USE_POLL
+    bool WaitPoll(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const;
+#endif /* USE_POLL */
+    bool WaitSelect(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const;
 
     /* Higher level, convenience, methods. These may throw. */
 

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -19,6 +19,8 @@
  */
 static constexpr auto MAX_WAIT_FOR_IO = 1s;
 
+static constexpr size_t MAX_EVENTS = 64;
+
 enum class SocketEventsMode : int8_t {
     Select = 0,
     Poll = 1,

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -28,6 +28,12 @@ enum class SocketEventsMode : int8_t {
     Unknown = -1
 };
 
+#ifdef USE_POLL
+#define SEM_LT_DEFAULT SocketEventsMode::Poll
+#else
+#define SEM_LT_DEFAULT SocketEventsMode::Select
+#endif /* USE_POLL */
+
 /* Converts SocketEventsMode value to string with additional check to report modes not compiled for as unknown */
 constexpr std::string_view SEMToString(const SocketEventsMode val) {
     switch (val) {
@@ -212,6 +218,7 @@ public:
      * Wait for readiness for input (recv) or output (send).
      * @param[in] timeout Wait this much for at least one of the requested events to occur.
      * @param[in] requested Wait for those events, bitwise-or of `RECV` and `SEND`.
+     * @param[in] event_mode Wait using the API specified.
      * @param[out] occurred If not nullptr and the function returns `true`, then this
      * indicates which of the requested events occurred (`ERR` will be added, even if
      * not requested, if an exceptional event occurs on the socket).
@@ -220,6 +227,7 @@ public:
      */
     [[nodiscard]] virtual bool Wait(std::chrono::milliseconds timeout,
                                     Event requested,
+                                    SocketEventsMode event_mode = SEM_LT_DEFAULT,
                                     Event* occurred = nullptr) const;
 #ifdef USE_POLL
     bool WaitPoll(std::chrono::milliseconds timeout, Event requested, Event* occurred = nullptr) const;

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -15,6 +15,16 @@
 #include <string>
 #include <unordered_map>
 
+#if defined(USE_EPOLL)
+#define DEFAULT_SOCKETEVENTS "epoll"
+#elif defined(USE_KQUEUE)
+#define DEFAULT_SOCKETEVENTS "kqueue"
+#elif defined(USE_POLL)
+#define DEFAULT_SOCKETEVENTS "poll"
+#else
+#define DEFAULT_SOCKETEVENTS "select"
+#endif
+
 /**
  * Maximum time to wait for I/O readiness.
  * It will take up until this time to break off in case of an interruption.

--- a/src/util/sock.h
+++ b/src/util/sock.h
@@ -194,7 +194,7 @@ public:
      * Check if the underlying socket can be used for `select(2)` (or the `Wait()` method).
      * @return true if selectable
      */
-    [[nodiscard]] virtual bool IsSelectable() const;
+    [[nodiscard]] virtual bool IsSelectable(bool is_select = (SEM_LT_DEFAULT == SocketEventsMode::Select)) const;
 
     using Event = uint8_t;
 

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -108,12 +108,25 @@ int64_t ParseISO8601DateTime(const std::string& str)
     return (ptime - epoch).total_seconds();
 }
 
+struct timespec MillisToTimespec(int64_t nTimeout)
+{
+    struct timespec timeout;
+    timeout.tv_sec = nTimeout / 1000;
+    timeout.tv_nsec = (nTimeout % 1000) * 1000 * 1000;
+    return timeout;
+}
+
 struct timeval MillisToTimeval(int64_t nTimeout)
 {
     struct timeval timeout;
     timeout.tv_sec  = nTimeout / 1000;
     timeout.tv_usec = (nTimeout % 1000) * 1000;
     return timeout;
+}
+
+struct timespec MillisToTimespec(std::chrono::milliseconds ms)
+{
+    return MillisToTimespec(count_milliseconds(ms));
 }
 
 struct timeval MillisToTimeval(std::chrono::milliseconds ms)

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -116,10 +116,12 @@ int64_t ParseISO8601DateTime(const std::string& str);
  * Convert milliseconds to a struct timeval for e.g. select.
  */
 struct timeval MillisToTimeval(int64_t nTimeout);
+struct timespec MillisToTimespec(int64_t nTimeout);
 
 /**
  * Convert milliseconds to a struct timeval for e.g. select.
  */
 struct timeval MillisToTimeval(std::chrono::milliseconds ms);
+struct timespec MillisToTimespec(std::chrono::milliseconds ms);
 
 #endif // BITCOIN_UTIL_TIME_H

--- a/src/util/wpipe.cpp
+++ b/src/util/wpipe.cpp
@@ -21,15 +21,17 @@ WakeupPipe::WakeupPipe(EdgeTriggeredEvents* edge_trig_events)
     }
     for (size_t idx = 0; idx < m_pipe.size(); idx++) {
         int flags = fcntl(m_pipe[idx], F_GETFL, 0);
-        if (fcntl(m_pipe[idx], F_SETFL, flags | O_NONBLOCK) == -1) {
+        if (fcntl(m_pipe[idx], F_SETFL, flags | O_NONBLOCK) == SOCKET_ERROR) {
             LogPrintf("Unable to initialize WakeupPipe, fcntl for O_NONBLOCK on m_pipe[%d] failed with error %s\n", idx,
                       NetworkErrorString(WSAGetLastError()));
+            Close();
             return;
         }
     }
     if (edge_trig_events && !edge_trig_events->RegisterPipe(m_pipe[0])) {
         LogPrintf("Unable to initialize WakeupPipe, EdgeTriggeredEvents::RegisterPipe() failed for m_pipe[0] = %d\n",
                   m_pipe[0]);
+        Close();
         return;
     }
     m_valid = true;
@@ -46,16 +48,26 @@ WakeupPipe::~WakeupPipe()
             LogPrintf("Destroying WakeupPipe instance, EdgeTriggeredEvents::UnregisterPipe() failed for m_pipe[0] = %d\n",
                       m_pipe[0]);
         }
-        for (size_t idx = 0; idx < m_pipe.size(); idx++) {
-            if (close(m_pipe[idx]) != 0) {
-                LogPrintf("Destroying WakeupPipe instance, close() failed for m_pipe[%d] = %d with error %s\n",
-                          idx, m_pipe[idx], NetworkErrorString(WSAGetLastError()));
-            }
-        }
+        Close();
 #else
         assert(false);
 #endif /* USE_WAKEUP_PIPE */
     }
+}
+
+void WakeupPipe::Close()
+{
+#ifdef USE_WAKEUP_PIPE
+    for (size_t idx{0}; idx < m_pipe.size(); idx++) {
+        if (m_pipe[idx] != -1 && close(m_pipe[idx]) != 0) {
+            LogPrintf("close() failed for m_pipe[%d] = %d with error %s\n", idx, m_pipe[idx],
+                      NetworkErrorString(WSAGetLastError()));
+        }
+        m_pipe[idx] = -1;
+    }
+#else
+    assert(false);
+#endif /* USE_WAKEUP_PIPE */
 }
 
 void WakeupPipe::Drain() const
@@ -80,7 +92,7 @@ void WakeupPipe::Write()
 
     std::array<uint8_t, EXPECTED_PIPE_WRITTEN_BYTES> buf{};
     int ret = write(m_pipe[1], buf.data(), buf.size());
-    if (ret == -1) {
+    if (ret == SOCKET_ERROR) {
         LogPrintf("write() to m_pipe[1] = %d failed with error %s\n", m_pipe[1], NetworkErrorString(WSAGetLastError()));
     }
     if (ret != EXPECTED_PIPE_WRITTEN_BYTES) {

--- a/src/util/wpipe.cpp
+++ b/src/util/wpipe.cpp
@@ -44,6 +44,7 @@ WakeupPipe::~WakeupPipe()
 {
     if (m_valid) {
 #ifdef USE_WAKEUP_PIPE
+        Drain();
         if (m_edge_trig_events && !m_edge_trig_events->UnregisterPipe(m_pipe[0])) {
             LogPrintf("Destroying WakeupPipe instance, EdgeTriggeredEvents::UnregisterPipe() failed for m_pipe[0] = %d\n",
                       m_pipe[0]);

--- a/src/util/wpipe.h
+++ b/src/util/wpipe.h
@@ -21,6 +21,10 @@ class EdgeTriggeredEvents;
  */
 class WakeupPipe
 {
+private:
+    /* Iterate through m_pipe and ::close() them */
+    void Close();
+
 public:
     explicit WakeupPipe(EdgeTriggeredEvents* edge_trig_events);
     ~WakeupPipe();


### PR DESCRIPTION
## Additional information

* Dependent on https://github.com/dashpay/dash/pull/6004
* Dependent on https://github.com/dashpay/dash/pull/6007
* Dependent on https://github.com/dashpay/dash/pull/6027
* Deviations from upstream

    | Bitcoin                                                      | Dash                                                         | Reason                                                       |
    | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
    | `EventsPerSock` is a unordered map of `shared_ptr`s of `Sock` **wrappers** and `Events` | `EventsPerSock` is an unordered map of **raw** socket file descriptors (`SOCKET`) and `Events` | Dash implements `WakeupPipes`, which is constructed and destroyed using an entity outside `Sock`'s control. We need to be able to insert the read pipe raw socket into equivalent of the `recv` socket set and query for it later on.<br /><br />It would be _technically_ possible, though cumbersome, to wrap the read pipe raw socket in a `Sock` and overwrite the destructor if it wasn't for the support of edge-triggered modes which have an event-socket relationship, as opposed to level triggered modes, that have a socket-event relationship. |
    | Sockets passed in an `EventsPerSock` map will **always** return with event data for every corresponding entry. | Sockets passed in an  `EventsPerSock` map **may** return with event data for its corresponding entry. | The behaviour defined for Bitcoin will also be presented in Dash **if** the socket events mode (SEM) is `poll` or `select`. Otherwise, it will behave as described.<br /><br />This is due to the inversion of the socket-event relationship in edge-triggered modes (`epoll` and `kqueue`), as alluded to earlier. As edge-triggered modes return events and their corresponding socket (sockets registered through `EdgeTriggeredEvents::RegisterEntity()` and friends), the `EventsPerSock` map, will **have its contents completely discarded** and substituted with the results of {`epoll`, `kqueue`}. |
    | You **must** have a `Sock` entity to call `Sock::WaitMany()` | You can directly access `Sock::WaitMany()`'s underlying logic through calling `Sock::WaitManyInternal()` (and access any *specific* event mode's implementation) **without** a `Sock` entity. | This change has been made as Bitcoin's behaviour was to call `WaitMany` by seeking to the first element to access it. This was possible because the unordered map consisted of `Sock` entities. As that isn't the case for Dash and `WaitMany` doesn't truly rely on instance-specific member values of a particular `Sock` instance (the values it relies on should remain constant throughout program runtime), it can be safely made a `static` function and that was exactly what was done.<br /><br />It has been named `WaitManyInternal()` as one of `Sock`'s purposes is mockability and `WaitMany()` (simply a passthrough to `WaitManyInternal()`) has been defined as a `virtual` function. |
    | `Sock`'s usage of platform-specific APIs is *decided* exclusively at **compile-time**. | `Sock`'s usage of platform-specific APIs is determined by what is *supported* at compile-time and *decided* at **runtime** (mostly). | `Sock::Wait()` (which is transformed into `Sock::WaitMany()` in this pull request) supported only `poll` and `select` and behaved as described for Bitcoin.<br /><br />The described behaviour for Dash was only applicable for `CConnman::SocketEvents()`. But, as `SocketEvents()` is being replaced wholesale with `WaitMany()`, `WaitMany()` needed to be adapted to mirror `SocketEvents()` behaviour.<br /><br />This has resulted in changes that now require knowledge of the expected runtime SEM and file descriptor (if using an edge-triggered mode). |
    | `Sock::Wait()` and `Sock::WaitMany()` behave **identically** | `Sock::Wait()` will respect the SEM selection argument **if** it is level-triggered **but** will fallback to `poll` or `select` (determined at compile-time) **if** the SEM selection is edge-triggered. | Due to the event-socket relationship of edge-triggered modes, they are unsuitable for querying the state of a *particular* socket.<br /><br />Because of that and **a)** the unlikelihood of the socket probed being registered with `EdgeTriggeredEvents::RegisterEntity()` and **b)** the overhead involved in fetching a list, filtering out for the particular socket we care about and flagging the result, it is more practical to use an LT-SEM instead. |

## How Has This Been Tested?

Correctness of `socket`, `poll` and `epoll` SEMs were tested using a Debian 12 (`bookworm`) Docker container with additional logging to ensure the correct syscalls were being made. Correctness of the `kqueue` SEM was tested using a GhostBSD 23.10.1 (based on FreeBSD 13.2-STABLE) virtual machine with similar additional logging.

## Breaking Changes

None expected. Behaviour should remain unchanged.

## Checklist
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

