### PR TITLE
fix: actually use `-socketevents`

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2516,9 +2516,11 @@ bool AppInitMain(const CoreContext& context, NodeContext& node, interfaces::Bloc
     }
 
     std::string sem_str = args.GetArg("-socketevents", DEFAULT_SOCKETEVENTS);
-    if (SEMFromString(sem_str) == SocketEventsMode::Unknown) {
+    const auto sem = SEMFromString(sem_str);
+    if (sem == SocketEventsMode::Unknown) {
         return InitError(strprintf(_("Invalid -socketevents ('%s') specified. Only these modes are supported: %s"), sem_str, GetSupportedSocketEventsStr()));
     }
+    connOptions.socketEventsMode = sem;
 
     const std::string& i2psam_arg = args.GetArg("-i2psam", "");
     if (!i2psam_arg.empty()) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
#6007 follow-up

## What was done?

## How Has This Been Tested?
check `socketevents` in `getnetworkinfo` response

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

