### PR TITLE
backport: bitcoin/bitcoin#28769: build: Update `qt` package up to 5.15.11 - fix crash at Kubuntu 24.04

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,9 +1,9 @@
 package=qt
-$(package)_version=5.15.10
+$(package)_version=5.15.11
 $(package)_download_path=https://download.qt.io/official_releases/qt/5.15/$($(package)_version)/submodules
 $(package)_suffix=everywhere-opensource-src-$($(package)_version).tar.xz
 $(package)_file_name=qtbase-$($(package)_suffix)
-$(package)_sha256_hash=c0d06cb18d20f10bf7ad53552099e097ec39362d30a5d6f104724f55fa1c8fb9
+$(package)_sha256_hash=425ad301acd91ca66c10c0dabee0704e2d0cd2801a6b670115800cbb95f84846
 $(package)_linux_dependencies=freetype fontconfig libxcb libxkbcommon libxcb_util libxcb_util_render libxcb_util_keysyms libxcb_util_image libxcb_util_wm
 $(package)_qt_libs=corelib network widgets gui plugins testlib
 $(package)_linguist_tools = lrelease lupdate lconvert
@@ -25,10 +25,10 @@ $(package)_patches += fix-macos-linker.patch
 $(package)_patches += memory_resource.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
-$(package)_qttranslations_sha256_hash=38b942bc7e62794dd072945c8a92bb9dfffed24070aea300327a3bb42f855609
+$(package)_qttranslations_sha256_hash=a31785948c640b7c66d9fe2db4993728ca07f64e41c560b3625ad191b276ff20
 
 $(package)_qttools_file_name=qttools-$($(package)_suffix)
-$(package)_qttools_sha256_hash=66f46c9729c831dce431778a9c561cca32daceaede1c7e58568d7a5898167dae
+$(package)_qttools_sha256_hash=7cd847ae6ff09416df617136eadcaf0eb98e3bc9b89979219a3ea8111fb8d339
 
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)

--- a/depends/patches/qt/fix_android_jni_static.patch
+++ b/depends/patches/qt/fix_android_jni_static.patch
@@ -1,6 +1,6 @@
 --- old/qtbase/src/plugins/platforms/android/androidjnimain.cpp
 +++ new/qtbase/src/plugins/platforms/android/androidjnimain.cpp
-@@ -980,6 +980,14 @@ Q_DECL_EXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void */*reserved*/)
+@@ -979,6 +979,14 @@ Q_DECL_EXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void */*reserved*/)
          __android_log_print(ANDROID_LOG_FATAL, "Qt", "registerNatives failed");
          return -1;
      }

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -21,7 +21,7 @@ These are the dependencies currently used by Dash Core. You can find instruction
 | PCRE |  |  |  |  | [Yes](https://github.com/dashpay/dash/blob/develop/depends/packages/qt.mk) |
 | Python (tests) |  | [3.8](https://www.python.org/downloads) |  |  |  |
 | qrencode | [3.4.4](https://fukuchi.org/works/qrencode) |  | No |  |  |
-| Qt | [5.15.10](https://download.qt.io/official_releases/qt/) | [5.11.3](https://github.com/bitcoin/bitcoin/pull/24132) | No | |  |
+| Qt | [5.15.11](https://download.qt.io/official_releases/qt/) | [5.11.3](https://github.com/bitcoin/bitcoin/pull/24132) | No | |  |
 | SQLite | [3.32.1](https://sqlite.org/download.html) | [3.7.17](https://github.com/bitcoin/bitcoin/pull/19077) |  |  |  |
 | XCB |  |  |  |  | [Yes](https://github.com/dashpay/dash/blob/develop/depends/packages/qt.mk) (Linux only) |
 | xkbcommon |  |  |  |  | [Yes](https://github.com/dashpay/dash/blob/develop/depends/packages/qt.mk) (Linux only) |


### PR DESCRIPTION
## Issue being fixed or feature implemented
It fixes crash of qt app on Kubuntu 24.04

```
*** buffer overflow detected ***: terminated

#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=<optimized out>, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007ffff764526e in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007ffff76288ff in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007ffff76297b6 in __libc_message_impl (fmt=fmt@entry=0x7ffff77ce765 "*** %s ***: terminated\n") at ../sysdeps/posix/libc_fatal.c:132
#6  0x00007ffff7736c19 in __GI___fortify_fail (msg=msg@entry=0x7ffff77ce74c "buffer overflow detected") at ./debug/fortify_fail.c:24
#7  0x00007ffff77365d4 in __GI___chk_fail () at ./debug/chk_fail.c:28
#8  0x00007ffff7737a67 in __readlink_chk (path=<optimized out>, buf=<optimized out>, len=<optimized out>, buflen=<optimized out>) at ./debug/readlink_chk.c:31
#9  0x0000555556988ab3 in qt_readlink(char const*) ()
#10 0x0000555556a1f18b in QLockFilePrivate::processNameByPid(long long) ()
#11 0x0000555556a1aa7b in QLockFilePrivate::lockFileContents() const ()
#12 0x0000555556a1eccf in QLockFilePrivate::tryLock_sys() ()
#13 0x0000555556a1bf01 in QLockFile::tryLock(int) ()
#14 0x0000555556a1c094 in QLockFile::tryLock(int) ()
#15 0x0000555556a1c094 in QLockFile::tryLock(int) ()
#16 0x00005555568d8dd3 in QConfFileSettingsPrivate::syncConfFile(QConfFile*) ()
#17 0x00005555568d9753 in QConfFileSettingsPrivate::sync() ()
#18 0x00005555568c8ef5 in QSettings::~QSettings() ()
#19 0x0000555555721f82 in Intro::showIfNeeded (did_show_intro=<optimized out>, prune_MiB=@0x7fffffffd2f0: 0) at qt/intro.cpp:275
#20 0x00005555556ddab6 in GuiMain (argc=3, argv=0x7fffffffd828) at qt/bitcoin.cpp:629
#21 0x00007ffff762a1ca in __libc_start_call_main (main=main@entry=0x5555556d7f00 <main(int, char**)>, argc=argc@entry=3, argv=argv@entry=0x7fffffffd828) at ../sysdeps/nptl/libc_start_call_main.h:58
#22 0x00007ffff762a28b in __libc_start_main_impl (main=0x5555556d7f00 <main(int, char**)>, argc=3, argv=0x7fffffffd828, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffd818) at ../csu/libc-start.c:360
#23 0x00005555556d7e35 in _start ()
```

Every usage of `QSettings` cause this crash on one of my PC, but not other. `-resetguisettings` doesn't help. gcc/clang - same crash. Removing data doesn't help.


## What was done?
Bump QT to the newer version.
See also related PR: https://github.com/dashpay/dash/pull/6011

## How Has This Been Tested?
Build & Run

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

