### PR TITLE
fix: re-enable ipv6 tests

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -151,15 +151,13 @@ def test_ipv6_local():
     '''
     # By using SOCK_DGRAM this will not actually make a connection, but it will
     # fail if there is no route to IPv6 localhost.
-    return False
-    # TODO: disabled until amazon ipv6 issues are resolved
-    # have_ipv6 = True
-    # try:
-    #     s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-    #     s.connect(('::1', 1))
-    # except socket.error:
-    #     have_ipv6 = False
-    # return have_ipv6
+    have_ipv6 = True
+    try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        s.connect(('::1', 1))
+    except socket.error:
+        have_ipv6 = False
+    return have_ipv6
 
 def test_unix_socket():
     '''Return True if UNIX sockets are available on this platform.'''


### PR DESCRIPTION
**Latesst update 29th July 2025: https://github.com/dashpay/dash/actions/runs/16577153505/job/46884675000?pr=6038**
**Latest update 29th October 2024: https://gitlab.com/dashpay/dash/-/jobs/8212452793**
**Latest update 7th August 2024: https://gitlab.com/dashpay/dash/-/jobs/7761559496**


## Issue being fixed or feature implemented
It is a draft PR to test occasionally if ipv6 is fixed back on amazon's instances for our CI.
The IPv6 is not broken itself but CI fails: see #5988

## What was done?
This reverts commit 0bb188a07708cf7136225b81399c32749c8f1466, reversing changes made to 45bdfa582d3b0db209d296eb2ecee8bc5416a24c - Merge #5988: test: disable ipv6 tests for now


## How Has This Been Tested?
Run CI

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone (NO MILESTONE - until it doesn't work)