### PR TITLE
refactor: proper support for composite commands such as 'bls generate'

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -253,7 +253,7 @@ public:
     virtual UniValue executeRpc(const std::string& command, const UniValue& params, const std::string& uri) = 0;
 
     //! List rpc commands.
-    virtual std::vector<std::string> listRpcCommands() = 0;
+    virtual std::vector<std::pair<std::string, std::string>> listRpcCommands() = 0;
 
     //! Set RPC timer interface if unset.
     virtual void rpcSetTimerInterfaceIfUnset(RPCTimerInterface* iface) = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -506,7 +506,7 @@ public:
         req.URI = uri;
         return ::tableRPC.execute(req);
     }
-    std::vector<std::string> listRpcCommands() override { return ::tableRPC.listCommands(); }
+    std::vector<std::pair<std::string, std::string>> listRpcCommands() override { return ::tableRPC.listCommands(); }
     void rpcSetTimerInterfaceIfUnset(RPCTimerInterface* iface) override { RPCSetTimerInterfaceIfUnset(iface); }
     void rpcUnsetTimerInterface(RPCTimerInterface* iface) override { RPCUnsetTimerInterface(iface); }
     bool getUnspentOutput(const COutPoint& output, Coin& coin) override
@@ -710,14 +710,14 @@ public:
                 throw;
             }
         };
-        ::tableRPC.appendCommand(m_command.name, &m_command);
+        ::tableRPC.appendCommand(m_command.name, m_command.subname, &m_command);
     }
 
     void disconnect() override final
     {
         if (m_wrapped_command) {
             m_wrapped_command = nullptr;
-            ::tableRPC.removeCommand(m_command.name, &m_command);
+            ::tableRPC.removeCommand(m_command.name, m_command.subname, &m_command);
         }
     }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -705,11 +705,15 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
 
         //Setup autocomplete and attach it
         QStringList wordList;
-        std::vector<std::string> commandList = m_node.listRpcCommands();
+        std::vector<std::pair<std::string, std::string>> commandList = m_node.listRpcCommands();
         for (size_t i = 0; i < commandList.size(); ++i)
         {
-            wordList << commandList[i].c_str();
-            wordList << ("help " + commandList[i]).c_str();
+            std::string command = commandList[i].first;
+            if (!commandList[i].second.empty()) {
+                command = command + " " + commandList[i].second;
+            }
+            wordList << command.c_str();
+            wordList << ("help " + command).c_str();
         }
 
         wordList << "help-console";

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -95,8 +95,8 @@ public:
     using Actor = std::function<bool(const JSONRPCRequest& request, UniValue& result, bool last_handler)>;
 
     //! Constructor taking Actor callback supporting multiple handlers.
-    CRPCCommand(std::string category, std::string name, Actor actor, std::vector<std::string> args, intptr_t unique_id)
-        : category(std::move(category)), name(std::move(name)), actor(std::move(actor)), argNames(std::move(args)),
+    CRPCCommand(std::string category, std::string name, std::string subname, Actor actor, std::vector<std::string> args, intptr_t unique_id)
+        : category(std::move(category)), name(std::move(name)), subname(subname), actor(std::move(actor)), argNames(std::move(args)),
           unique_id(unique_id)
     {
     }
@@ -106,6 +106,7 @@ public:
         : CRPCCommand(
               category,
               fn().m_name,
+              "",
               [fn](const JSONRPCRequest& request, UniValue& result, bool) { result = fn().HandleRequest(request); return true; },
               fn().GetArgNames(),
               intptr_t(fn))
@@ -114,9 +115,28 @@ public:
         CHECK_NONFATAL(fn().GetArgNames() == args_in);
     }
 
+    //! Simplified constructor taking plain RpcMethodFnType function pointer with sub-command.
+    CRPCCommand(std::string category, std::string name_in, std::string subname_in, RpcMethodFnType fn, std::vector<std::string> args_in)
+        : CRPCCommand(
+              category,
+              name_in,
+              subname_in,
+              [fn](const JSONRPCRequest& request, UniValue& result, bool) { result = fn().HandleRequest(request); return true; },
+              fn().GetArgNames(),
+              intptr_t(fn))
+    {
+        if (subname_in.empty()) {
+            CHECK_NONFATAL(fn().m_name == name_in);
+        } else {
+            CHECK_NONFATAL(fn().m_name == name_in + " " + subname_in);
+        }
+
+        CHECK_NONFATAL(fn().GetArgNames() == args_in);
+    }
+
     //! Simplified constructor taking plain rpcfn_type function pointer.
     CRPCCommand(const char* category, const char* name, rpcfn_type fn, std::initializer_list<const char*> args)
-        : CRPCCommand(category, name,
+        : CRPCCommand(category, name, "",
                       [fn](const JSONRPCRequest& request, UniValue& result, bool) { result = fn(request); return true; },
                       {args.begin(), args.end()}, intptr_t(fn))
     {
@@ -124,6 +144,7 @@ public:
 
     std::string category;
     std::string name;
+    std::string subname;
     Actor actor;
     std::vector<std::string> argNames;
     intptr_t unique_id;
@@ -135,7 +156,7 @@ public:
 class CRPCTable
 {
 private:
-    std::map<std::string, std::vector<const CRPCCommand*>> mapCommands;
+    std::map<std::pair<std::string, std::string>, std::vector<const CRPCCommand*>> mapCommands;
     std::multimap<std::string, std::vector<UniValue>> mapPlatformRestrictions;
 public:
     CRPCTable();
@@ -155,7 +176,7 @@ public:
     * Returns a list of registered commands
     * @returns List of registered commands.
     */
-    std::vector<std::string> listCommands() const;
+    std::vector<std::pair<std::string, std::string>> listCommands() const;
 
     /**
      * Appends a CRPCCommand to the dispatch table.
@@ -170,7 +191,8 @@ public:
      * register different names, types, and numbers of parameters.
      */
     void appendCommand(const std::string& name, const CRPCCommand* pcmd);
-    bool removeCommand(const std::string& name, const CRPCCommand* pcmd);
+    void appendCommand(const std::string& name, const std::string& subname, const CRPCCommand* pcmd);
+    bool removeCommand(const std::string& name, const std::string& subname, const CRPCCommand* pcmd);
 };
 
 bool IsDeprecatedRPCEnabled(const std::string& method);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -49,7 +49,7 @@ UniValue RPCTestingSetup::TransformParams(const UniValue& params, std::vector<st
 {
     UniValue transformed_params;
     CRPCTable table;
-    CRPCCommand command{"category", "method", [&](const JSONRPCRequest& request, UniValue&, bool) -> bool { transformed_params = request.params; return true; }, arg_names, /*unique_id=*/0};
+    CRPCCommand command{"category", "method", "subcommand", [&](const JSONRPCRequest& request, UniValue&, bool) -> bool { transformed_params = request.params; return true; }, arg_names, /*unique_id=*/0};
     table.appendCommand("method", &command);
     CoreContext context{m_node};
     JSONRPCRequest request(context);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -572,7 +572,7 @@ public:
     void registerRpcs() override
     {
         for (const CRPCCommand& command : GetWalletRPCCommands()) {
-            m_rpc_commands.emplace_back(command.category, command.name, [this, &command](const JSONRPCRequest& request, UniValue& result, bool last_handler) {
+            m_rpc_commands.emplace_back(command.category, command.name, command.subname, [this, &command](const JSONRPCRequest& request, UniValue& result, bool last_handler) {
                 return command.actor({request, m_context}, result, last_handler);
             }, command.argNames, command.unique_id);
             m_rpc_handlers.emplace_back(m_context.chain->handleRpc(m_rpc_commands.back()));

--- a/test/lint/check-rpc-mappings.py
+++ b/test/lint/check-rpc-mappings.py
@@ -60,6 +60,12 @@ def process_commands(fname):
                     in_rpcs = False
                 elif '{' in line and '"' in line:
                     m = re.search(r'{ *("[^"]*"), *("[^"]*"), *&([^,]*), *{([^}]*)} *},', line)
+                    # that's a quick fix for composite command
+                    # no proper implementation is needed so far as this linter would be removed soon with bitcoin#20012
+                    if not m:
+                        m = re.search(r'{ *("[^"]*"), *("[^"]*"), *("[^"]*"), *&([^,]*), *{([^}]*)} *},', line)
+                        if m:
+                            continue
                     assert m, 'No match to table expression: %s' % line
                     name = parse_string(m.group(2))
                     args_str = m.group(4).strip()


### PR DESCRIPTION
## Issue being fixed or feature implemented
We have composite commands such as 'bls generate' that do not exist in bitcoin's implementation of rpc.
It doesn't let to backport yet bitcoin#18531 which enforced extra checks for arguments name (name of rpc and list arguments in rpc help and actual implementation must match).


## What was done?
This PR improves support of composite commands in Dash Core. New style of composite commands are applied for `bls` composite commands: `bls generate` and `bls fromsecret` as proof of concept.
Once this PR is merged, I will provide similar fixes for other "compose" rpc commands: `protx`, `masternode` (and everything else if any).

Beside better validation of arguments and command names, it improves suggest menu in Qt app (see a screenshot) for composite commands.

![image](https://github.com/dashpay/dash/assets/545784/08dcc0b4-df92-4090-b163-af498bf200ef)


## How Has This Been Tested?
Run unit and functional tests. Also extra tests to conduct in qt app:
 - check suggest for 'bls ....' and 'help bls ...'
 - check output of next commands:
```
help bls
help bls generate
help bls from secret
bls
bls generate
bls generate 1
```
 - also let's see that old-fashion composite commands are not broken:
```
help protx
help protx diff
protx diff 00000021c7604b9992254f9f1ed91de5d65eaade33c773abea63a7b0e93293ee 000000e44f9894838ebf768b464177cfce8859dcf92b0509f5c2fba774315996
```

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone