### PR TITLE
trivial: add a missing dash-specific files in util/ to linter lists

### DIFF
--- a/src/util/edge.cpp
+++ b/src/util/edge.cpp
@@ -62,7 +62,7 @@ EdgeTriggeredEvents::~EdgeTriggeredEvents()
     }
 }
 
-bool EdgeTriggeredEvents::RegisterEntity(int entity, std::string entity_name) const
+bool EdgeTriggeredEvents::RegisterEntity(int entity, const std::string& entity_name) const
 {
     assert(m_valid);
 
@@ -97,7 +97,7 @@ bool EdgeTriggeredEvents::RegisterEntity(int entity, std::string entity_name) co
     return true;
 }
 
-bool EdgeTriggeredEvents::UnregisterEntity(int entity, std::string entity_name) const
+bool EdgeTriggeredEvents::UnregisterEntity(int entity, const std::string& entity_name) const
 {
     assert(m_valid);
 

--- a/src/util/edge.h
+++ b/src/util/edge.h
@@ -44,8 +44,8 @@ private:
     bool UnregisterPipe(int wakeup_pipe);
 
 private:
-    bool RegisterEntity(int entity, std::string entity_name) const;
-    bool UnregisterEntity(int entity, std::string entity_name) const;
+    bool RegisterEntity(int entity, const std::string& entity_name) const;
+    bool UnregisterEntity(int entity, const std::string& entity_name) const;
 
 private:
     /* Flag set if pipe has been registered with instance */

--- a/src/util/ranges_set.cpp
+++ b/src/util/ranges_set.cpp
@@ -37,7 +37,7 @@ bool CRangesSet::Add(uint64_t value)
     if (next != ranges.end()) {
         if (next->begin == value + 1) {
             new_range.end = next->end;
-            it = ranges.erase(next);
+            ranges.erase(next);
         }
     }
     const auto ret = ranges.insert(new_range);

--- a/test/lint/lint-cppcheck-dash.sh
+++ b/test/lint/lint-cppcheck-dash.sh
@@ -85,7 +85,7 @@ then
     mkdir $CPPCHECK_DIR
 fi
 WARNINGS=$(echo "${FILES}" | \
-    xargs cppcheck --enable=all --inline-suppr --suppress=missingIncludeSystem --cppcheck-build-dir=$CPPCHECK_DIR -j "$(getconf _NPROCESSORS_ONLN)" --language=c++ --std=c++17 --template=gcc -D__cplusplus -DENABLE_WALLET -DCLIENT_VERSION_BUILD -DCLIENT_VERSION_IS_RELEASE -DCLIENT_VERSION_MAJOR -DCLIENT_VERSION_MINOR -DCOPYRIGHT_YEAR -DDEBUG -DCHAR_BIT=8 -I src/ -q 2>&1 | sort -u | \
+    xargs cppcheck --enable=all --inline-suppr --suppress=missingIncludeSystem --cppcheck-build-dir=$CPPCHECK_DIR -j "$(getconf _NPROCESSORS_ONLN)" --language=c++ --std=c++17 --template=gcc -D__cplusplus -DENABLE_WALLET -DCLIENT_VERSION_BUILD -DCLIENT_VERSION_IS_RELEASE -DCLIENT_VERSION_MAJOR -DCLIENT_VERSION_MINOR -DCOPYRIGHT_YEAR -DDEBUG -DUSE_EPOLL -DCHAR_BIT=8 -I src/ -q 2>&1 | sort -u | \
     grep -E "${ENABLED_CHECKS_REGEXP}" | \
     grep -vE "${IGNORED_WARNINGS_REGEXP}" | \
     grep -E "${FILES_REGEXP}")

--- a/test/util/data/non-backported.txt
+++ b/test/util/data/non-backported.txt
@@ -37,5 +37,11 @@ src/test/dynamic_activation*.cpp
 src/test/evo*.cpp
 src/test/governance*.cpp
 src/unordered_lru_cache.h
+src/util/edge.*
+src/util/enumerate.h
+src/util/irange.h
+src/util/ranges.h
+src/util/ranges_set.*
+src/util/wpipe.*
 src/wallet/bip39*
 src/wallet/hdchain.*


### PR DESCRIPTION
## Issue being fixed or feature implemented
Some source files in src/util is missing to specify as dash specific for linters

## What was done?
Added to list of dash's linters

## How Has This Been Tested?
Run `test/lint/lint-all.sh`

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone