### PR TITLE
backport: trivial 2024 06 11

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -31,7 +31,7 @@ Files: src/qt/res/icons/proxy.png
 Copyright: Cristian Mircea Messel
 License: public-domain
 
-Files: src/qt/fonts/RobotoMono-Bold.ttf
+Files: src/qt/res/fonts/RobotoMono-Bold.ttf
 License: Apache-2.0
 Comment: Site: https://fonts.google.com/specimen/Roboto+Mono
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -105,13 +105,12 @@ static constexpr auto FEELER_SLEEP_WINDOW{1s};
 /** Used to pass flags to the Bind() function */
 enum BindFlags {
     BF_NONE         = 0,
-    BF_EXPLICIT     = (1U << 0),
-    BF_REPORT_ERROR = (1U << 1),
+    BF_REPORT_ERROR = (1U << 0),
     /**
      * Do not call AddLocal() for our special addresses, e.g., for incoming
      * Tor connections, to prevent gossiping them over the network.
      */
-    BF_DONT_ADVERTISE = (1U << 2),
+    BF_DONT_ADVERTISE = (1U << 1),
 };
 
 #ifndef USE_WAKEUP_PIPE
@@ -3329,9 +3328,6 @@ bool CConnman::Bind(const CService& addr_, unsigned int flags, NetPermissionFlag
 {
     const CService addr{MaybeFlipIPv6toCJDNS(addr_)};
 
-    if (!(flags & BF_EXPLICIT) && !IsReachable(addr)) {
-        return false;
-    }
     bilingual_str strError;
     if (!BindListenPort(addr, strError, permissions)) {
         if ((flags & BF_REPORT_ERROR) && clientInterface) {
@@ -3351,13 +3347,13 @@ bool CConnman::InitBinds(const Options& options)
 {
     bool fBound = false;
     for (const auto& addrBind : options.vBinds) {
-        fBound |= Bind(addrBind, (BF_EXPLICIT | BF_REPORT_ERROR), NetPermissionFlags::None);
+        fBound |= Bind(addrBind, BF_REPORT_ERROR, NetPermissionFlags::None);
     }
     for (const auto& addrBind : options.vWhiteBinds) {
-        fBound |= Bind(addrBind.m_service, (BF_EXPLICIT | BF_REPORT_ERROR), addrBind.m_flags);
+        fBound |= Bind(addrBind.m_service, BF_REPORT_ERROR, addrBind.m_flags);
     }
     for (const auto& addr_bind : options.onion_binds) {
-        fBound |= Bind(addr_bind, BF_EXPLICIT | BF_DONT_ADVERTISE, NetPermissionFlags::None);
+        fBound |= Bind(addr_bind, BF_DONT_ADVERTISE, NetPermissionFlags::None);
     }
     if (options.bind_on_any) {
         struct in_addr inaddr_any;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -47,7 +47,6 @@
 
 #include <QApplication>
 #include <QDebug>
-#include <QFontDatabase>
 #include <QLatin1String>
 #include <QLibraryInfo>
 #include <QLocale>
@@ -577,7 +576,7 @@ int GuiMain(int argc, char* argv[])
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
     BitcoinApplication app;
-    QFontDatabase::addApplicationFont(":/fonts/monospace");
+    GUIUtil::LoadFont(QStringLiteral(":/fonts/monospace"));
 
     /// 2. Parse command-line options. We do this after qt in order to show an error if there are problems parsing these
     // Command-line options take precedence:

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -493,6 +493,12 @@ bool hasEntryData(const QAbstractItemView *view, int column, int role)
     return !selection.at(0).data(role).toString().isEmpty();
 }
 
+void LoadFont(const QString& file_name)
+{
+    const int id = QFontDatabase::addApplicationFont(file_name);
+    assert(id != -1);
+}
+
 QString getDefaultDataDirectory()
 {
     return PathToQString(GetDefaultDataDir());

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1673,14 +1673,26 @@ QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction
 {
     QString prefix;
     if (prepend_direction) {
-        prefix = (conn_type == ConnectionType::INBOUND) ? QObject::tr("Inbound") : QObject::tr("Outbound") + " ";
+        prefix = (conn_type == ConnectionType::INBOUND) ?
+                     /*: An inbound connection from a peer. An inbound connection
+                         is a connection initiated by a peer. */
+                     QObject::tr("Inbound") :
+                     /*: An outbound connection to a peer. An outbound connection
+                         is a connection initiated by us. */
+                     QObject::tr("Outbound") + " ";
     }
     switch (conn_type) {
     case ConnectionType::INBOUND: return prefix;
+    //: Peer connection type that relays all network information.
     case ConnectionType::OUTBOUND_FULL_RELAY: return prefix + QObject::tr("Full Relay");
+    /*: Peer connection type that relays network information about
+        blocks and not transactions or addresses. */
     case ConnectionType::BLOCK_RELAY: return prefix + QObject::tr("Block Relay");
+    //: Peer connection type established manually through one of several methods.
     case ConnectionType::MANUAL: return prefix + QObject::tr("Manual");
+    //: Short-lived peer connection type that tests the aliveness of known addresses.
     case ConnectionType::FEELER: return prefix + QObject::tr("Feeler");
+    //: Short-lived peer connection type that solicits known addresses from a peer.
     case ConnectionType::ADDR_FETCH: return prefix + QObject::tr("Address Fetch");
     } // no default case, so the compiler can warn about missing cases
     assert(false);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -173,6 +173,11 @@ namespace GUIUtil
     void setClipboard(const QString& str);
 
     /**
+     * Loads the font from the file specified by file_name, aborts if it fails.
+     */
+    void LoadFont(const QString& file_name);
+
+    /**
      * Determine default data directory for operating system.
      */
     QString getDefaultDataDirectory();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -503,14 +503,28 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent, Qt::WindowFlags 
 
     constexpr QChar nonbreaking_hyphen(8209);
     const std::vector<QString> CONNECTION_TYPE_DOC{
+        //: Explanatory text for an inbound peer connection.
         tr("Inbound: initiated by peer"),
+        /*: Explanatory text for an outbound peer connection that
+            relays all network information. This is the default behavior for
+            outbound connections. */
         tr("Outbound Full Relay: default"),
+        /*: Explanatory text for an outbound peer connection that relays
+            network information about blocks and not transactions or addresses. */
         tr("Outbound Block Relay: does not relay transactions or addresses"),
+        /*: Explanatory text for an outbound peer connection that was
+            established manually through one of several methods. The numbered
+            arguments are stand-ins for the methods available to establish
+            manual connections. */
         tr("Outbound Manual: added using RPC %1 or %2/%3 configuration options")
             .arg("addnode")
             .arg(QString(nonbreaking_hyphen) + "addnode")
             .arg(QString(nonbreaking_hyphen) + "connect"),
+        /*: Explanatory text for a short-lived outbound peer connection that
+            is used to test the aliveness of known addresses. */
         tr("Outbound Feeler: short-lived, for testing addresses"),
+        /*: Explanatory text for a short-lived outbound peer connection that is used
+            to request addresses from a peer. */
         tr("Outbound Address Fetch: short-lived, for soliciting addresses")};
     const QString list{"<ul><li>" + Join(CONNECTION_TYPE_DOC, QString("</li><li>")) + "</li></ul>"};
     ui->peerConnectionTypeLabel->setToolTip(ui->peerConnectionTypeLabel->toolTip().arg(list));

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -508,9 +508,9 @@ class FormatArg
 {
     public:
         FormatArg()
-            : m_value(NULL),
-            m_formatImpl(NULL),
-            m_toIntImpl(NULL)
+            : m_value(nullptr),
+            m_formatImpl(nullptr),
+            m_toIntImpl(nullptr)
         { }
 
         template<typename T>
@@ -1005,7 +1005,8 @@ class FormatListN : public FormatList
 // Special 0-arg version - MSVC says zero-sized C array in struct is nonstandard
 template<> class FormatListN<0> : public FormatList
 {
-    public: FormatListN() : FormatList(0, 0) {}
+public:
+    FormatListN() : FormatList(nullptr, 0) {}
 };
 
 } // namespace detail

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -237,7 +237,15 @@ class ProxyTest(BitcoinTestFramework):
             return r
 
         self.log.info("Test RPC getnetworkinfo")
-        n0 = networks_dict(self.nodes[0].getnetworkinfo())
+        nodes_network_info = []
+
+        self.log.debug("Test that setting -proxy disables local address discovery, i.e. -discover=0")
+        for node in self.nodes:
+            network_info = node.getnetworkinfo()
+            assert_equal(network_info["localaddresses"], [])
+            nodes_network_info.append(network_info)
+
+        n0 = networks_dict(nodes_network_info[0])
         assert_equal(NETWORKS, n0.keys())
         for net in NETWORKS:
             if net == NET_I2P:
@@ -252,7 +260,7 @@ class ProxyTest(BitcoinTestFramework):
         assert_equal(n0['i2p']['reachable'], False)
         assert_equal(n0['cjdns']['reachable'], False)
 
-        n1 = networks_dict(self.nodes[1].getnetworkinfo())
+        n1 = networks_dict(nodes_network_info[1])
         assert_equal(NETWORKS, n1.keys())
         for net in ['ipv4', 'ipv6']:
             assert_equal(n1[net]['proxy'], f'{self.conf1.addr[0]}:{self.conf1.addr[1]}')
@@ -264,7 +272,7 @@ class ProxyTest(BitcoinTestFramework):
         assert_equal(n1['i2p']['proxy_randomize_credentials'], False)
         assert_equal(n1['i2p']['reachable'], True)
 
-        n2 = networks_dict(self.nodes[2].getnetworkinfo())
+        n2 = networks_dict(nodes_network_info[2])
         assert_equal(NETWORKS, n2.keys())
         proxy = f'{self.conf2.addr[0]}:{self.conf2.addr[1]}'
         for net in NETWORKS:
@@ -281,7 +289,7 @@ class ProxyTest(BitcoinTestFramework):
         assert_equal(n2['cjdns']['reachable'], False)
 
         if self.have_ipv6:
-            n3 = networks_dict(self.nodes[3].getnetworkinfo())
+            n3 = networks_dict(nodes_network_info[3])
             assert_equal(NETWORKS, n3.keys())
             proxy = f'[{self.conf3.addr[0]}]:{self.conf3.addr[1]}'
             for net in NETWORKS:
@@ -292,7 +300,7 @@ class ProxyTest(BitcoinTestFramework):
             assert_equal(n3['i2p']['reachable'], False)
             assert_equal(n3['cjdns']['reachable'], False)
 
-        n4 = networks_dict(self.nodes[4].getnetworkinfo())
+        n4 = networks_dict(nodes_network_info[4])
         assert_equal(NETWORKS, n4.keys())
         for net in NETWORKS:
             if net == NET_I2P:

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -15,7 +15,7 @@ import re
 
 FOLDER_GREP = 'src'
 FOLDER_TEST = 'src/test/'
-REGEX_ARG = r'(?:ForceSet|SoftSet|Get|Is)(?:Bool)?Args?(?:Set)?\("(-[^"]+)"'
+REGEX_ARG = r'\b(?:GetArg|GetArgs|GetBoolArg|GetIntArg|GetPathArg|IsArgSet|get_net)\("(-[^"]+)"'
 REGEX_DOC = r'AddArg\("(-[^"=]+?)(?:=|")'
 CMD_ROOT_DIR = '$(git rev-parse --show-toplevel)/{}'.format(FOLDER_GREP)
 CMD_GREP_ARGS = r"git grep --perl-regexp '{}' -- {} ':(exclude){}'".format(REGEX_ARG, CMD_ROOT_DIR, FOLDER_TEST)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Trivial backports

## What was done?


## How Has This Been Tested?
Built and ran tests locally; p2p_addr_relay.py fails locally. Not sure why

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

