### PR TITLE
fix: reset rounds to 0 when tx fee is not 0

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1413,6 +1413,13 @@ int CWallet::GetRealOutpointCoinJoinRounds(const COutPoint& outpoint, int nRound
         }
     }
 
+    // make sure we spent all of it with 0 fee, reset to 0 rounds otherwise
+    if (wtx->GetDebit(ISMINE_SPENDABLE) != wtx->GetCredit(ISMINE_SPENDABLE)) {
+        *nRoundsRef = 0;
+        WalletCJLogPrint((*this), "%s UPDATED   %-70s %3d\n", __func__, outpoint.ToStringShort(), *nRoundsRef);
+        return *nRoundsRef;
+    }
+
     int nShortest = -10; // an initial value, should be no way to get this by calculations
     bool fDenomFound = false;
     // only denoms here so let's look up


### PR DESCRIPTION
## Issue being fixed or feature implemented
> a coinjoin send with say 10x 1 + 0.001 denom -> 10 denom, and this doesn’t reset rounds to 0

reported by @PastaPastaPasta 👍 

## What was done?
only real coinjoin tx can be a 0 fee tx with denoms, use that fact to avoid the edge case described above

## How Has This Been Tested?
reproduced the issue

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

