### PR TITLE
fix: build with gcc 13.2.0 - missing header memory in addrdb

### DIFF
--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -10,6 +10,7 @@
 #include <net_types.h> // For banmap_t
 #include <univalue.h>
 
+#include <memory>
 #include <optional>
 #include <vector>
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
```
In file included from test/addrman_tests.cpp:5:
./addrdb.h:51:99: error: ‘std::unique_ptr’ has not been declared
   51 | std::optional<bilingual_str> LoadAddrman(const std::vector<bool>& asmap, const ArgsManager& args, std::unique_ptr<AddrMan>& addrman);
      |                                                                                                   ^~~
./addrdb.h:51:114: error: expected ‘,’ or ‘...’ before ‘<’ token
   51 | std::optional<bilingual_str> LoadAddrman(const std::vector<bool>& asmap, const ArgsManager& args, std::unique_ptr<AddrMan>& addrman);
      |                    
```


## What was done?
adds missing header `<memory>` in addrdb

## How Has This Been Tested?
Run build - it works

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

