### PR TITLE
feat: Let addrman handle multiple ports for all networks

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -57,7 +57,7 @@ class AddrMan
     const std::unique_ptr<AddrManImpl> m_impl;
 
 public:
-    explicit AddrMan(std::vector<bool> asmap, bool deterministic, int32_t consistency_check_ratio, bool discriminate_ports = false);
+    explicit AddrMan(std::vector<bool> asmap, bool deterministic, int32_t consistency_check_ratio);
 
     ~AddrMan();
 

--- a/src/addrman_impl.h
+++ b/src/addrman_impl.h
@@ -99,7 +99,7 @@ public:
 class AddrManImpl
 {
 public:
-    AddrManImpl(std::vector<bool>&& asmap, bool deterministic, int32_t consistency_check_ratio, bool discriminate_ports);
+    AddrManImpl(std::vector<bool>&& asmap, bool deterministic, int32_t consistency_check_ratio);
 
     ~AddrManImpl();
 
@@ -226,9 +226,6 @@ private:
     // If a new asmap was provided, the existing records
     // would be re-bucketed accordingly.
     const std::vector<bool> m_asmap;
-
-    //! Discriminate entries based on port.
-    bool m_discriminate_ports GUARDED_BY(cs);
 
     //! Find an entry.
     AddrInfo* Find(const CService& addr, int* pnId = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -1056,11 +1056,6 @@ std::string CService::ToString() const
     return ToStringIPPort();
 }
 
-void CService::SetPort(uint16_t portIn)
-{
-    port = portIn;
-}
-
 CSubNet::CSubNet():
     valid(false)
 {

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -544,7 +544,6 @@ public:
     CService(const CNetAddr& ip, uint16_t port);
     CService(const struct in_addr& ipv4Addr, uint16_t port);
     explicit CService(const struct sockaddr_in& addr);
-    void SetPort(uint16_t portIn);
     uint16_t GetPort() const;
     bool GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const;
     bool SetSockAddr(const struct sockaddr* paddr);


### PR DESCRIPTION
## Issue being fixed or feature implemented
There is really no need to do have this restriction in `addrman`, we check `AllowMultiplePorts()` in `connman` which should be enough already. We can safely re-align `addrman` to its upstream implementation as suggested in #6043.

## What was done?
Drop port "discrimination" in `addrman`, remove related tests.

## How Has This Been Tested?
Run tests, run dash-qt on mainnet/testnet

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

