### PR TITLE
fix: add missing checks for not nullptr in rpc for dash specific code

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1605,6 +1605,7 @@ static RPCHelpMan verifychain()
     const int check_depth{request.params[1].isNull() ? DEFAULT_CHECKBLOCKS : request.params[1].get_int()};
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CHECK_NONFATAL(node.evodb);
 
     ChainstateManager& chainman = EnsureChainman(node);
     LOCK(cs_main);
@@ -2962,7 +2963,8 @@ static RPCHelpMan dumptxoutset()
     FILE* file{fsbridge::fopen(temppath, "wb")};
     CAutoFile afile{file, SER_DISK, CLIENT_VERSION};
     NodeContext& node = EnsureAnyNodeContext(request.context);
-    UniValue result = CreateUTXOSnapshot(node, node.chainman->ActiveChainstate(), afile);
+    const ChainstateManager& chainman = EnsureChainman(node);
+    UniValue result = CreateUTXOSnapshot(node, chainman.ActiveChainstate(), afile);
     fs::rename(temppath, path);
 
     result.pushKV("path", path.string());

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -7,6 +7,7 @@
 #include <coinjoin/context.h>
 #include <coinjoin/server.h>
 #include <rpc/blockchain.h>
+#include <rpc/net.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <util/strencodings.h>
@@ -69,8 +70,8 @@ static RPCHelpMan coinjoin()
         }
 
         CTxMemPool& mempool = EnsureMemPool(node);
-        CHECK_NONFATAL(node.connman);
-        bool result = cj_clientman->DoAutomaticDenominating(*node.connman, mempool);
+        CConnman& connman = EnsureConnman(node);
+        bool result = cj_clientman->DoAutomaticDenominating(connman, mempool);
         return "Mixing " + (result ? "started successfully" : ("start failed: " + cj_clientman->GetStatuses().original + ", will retry"));
     }
 

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -69,6 +69,7 @@ static RPCHelpMan coinjoin()
         }
 
         CTxMemPool& mempool = EnsureMemPool(node);
+        CHECK_NONFATAL(node.connman);
         bool result = cj_clientman->DoAutomaticDenominating(*node.connman, mempool);
         return "Mixing " + (result ? "started successfully" : ("start failed: " + cj_clientman->GetStatuses().original + ", will retry"));
     }

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1697,6 +1697,7 @@ static UniValue protx(const JSONRPCRequest& request)
     } else if (command == "protxinfo") {
         return protx_info(new_request, dmnman, mn_metaman, chainman);
     } else if (command == "protxdiff") {
+        CHECK_NONFATAL(node.llmq_ctx);
         return protx_diff(new_request, dmnman, chainman, *node.llmq_ctx);
     } else if (command == "protxlistdiff") {
         return protx_listdiff(new_request, dmnman, chainman);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -47,6 +47,8 @@ static RPCHelpMan masternode_connect()
         throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Incorrect masternode address %s", strAddress));
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CHECK_NONFATAL(node.connman);
+
     node.connman->OpenMasternodeConnection(CAddress(addr, NODE_NETWORK));
     if (!node.connman->IsConnected(CAddress(addr, NODE_NETWORK), CConnman::AllNodes))
         throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Couldn't connect to masternode %s", strAddress));
@@ -133,6 +135,7 @@ static RPCHelpMan masternode_winner()
     }
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CHECK_NONFATAL(node.dmnman);
     return GetNextMasternodeForPayment(*node.dmnman, 10);
 },
     };
@@ -152,6 +155,7 @@ static RPCHelpMan masternode_current()
     }
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CHECK_NONFATAL(node.dmnman);
     return GetNextMasternodeForPayment(*node.dmnman, 1);
 },
     };
@@ -204,6 +208,7 @@ static RPCHelpMan masternode_status()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CHECK_NONFATAL(node.dmnman);
     if (!node.mn_activeman) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "This node does not run an active masternode.");
     }
@@ -302,6 +307,7 @@ static RPCHelpMan masternode_winners()
     int nStartHeight = std::max(nChainTipHeight - nCount, 1);
 
     CHECK_NONFATAL(node.dmnman);
+    CHECK_NONFATAL(node.govman);
 
     const auto tip_mn_list = node.dmnman->GetListAtChainTip();
     for (int h = nStartHeight; h <= nChainTipHeight; h++) {
@@ -384,6 +390,8 @@ static RPCHelpMan masternode_payments()
     // A temporary vector which is used to sort results properly (there is no "reverse" in/for UniValue)
     std::vector<UniValue> vecPayments;
 
+    CHECK_NONFATAL(node.chain_helper);
+    CHECK_NONFATAL(node.dmnman);
     while (vecPayments.size() < uint64_t(std::abs(nCount)) && pindex != nullptr) {
         CBlock block;
         if (!ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
@@ -406,8 +414,6 @@ static RPCHelpMan masternode_payments()
             }
             nBlockFees += nValueIn - tx->GetValueOut();
         }
-
-        CHECK_NONFATAL(node.chain_helper);
 
         std::vector<CTxOut> voutMasternodePayments, voutDummy;
         CMutableTransaction dummyTx;
@@ -548,6 +554,7 @@ static RPCHelpMan masternodelist_helper(bool is_composite)
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const ChainstateManager& chainman = EnsureChainman(node);
+    CHECK_NONFATAL(node.dmnman);
 
     UniValue obj(UniValue::VOBJ);
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -15,6 +15,7 @@
 #include <net.h>
 #include <netbase.h>
 #include <rpc/blockchain.h>
+#include <rpc/net.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <univalue.h>
@@ -47,10 +48,10 @@ static RPCHelpMan masternode_connect()
         throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Incorrect masternode address %s", strAddress));
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
-    CHECK_NONFATAL(node.connman);
+    CConnman& connman = EnsureConnman(node);
 
-    node.connman->OpenMasternodeConnection(CAddress(addr, NODE_NETWORK));
-    if (!node.connman->IsConnected(CAddress(addr, NODE_NETWORK), CConnman::AllNodes))
+    connman.OpenMasternodeConnection(CAddress(addr, NODE_NETWORK));
+    if (!connman.IsConnected(CAddress(addr, NODE_NETWORK), CConnman::AllNodes))
         throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Couldn't connect to masternode %s", strAddress));
 
     return "successfully connected";

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -393,6 +393,8 @@ static RPCHelpMan generateblock()
     block.vtx.insert(block.vtx.end(), txs.begin(), txs.end());
 
     {
+        CHECK_NONFATAL(node.evodb);
+
         LOCK(cs_main);
 
         BlockValidationState state;
@@ -704,6 +706,7 @@ static RPCHelpMan getblocktemplate()
             }
 
             LLMQContext& llmq_ctx = EnsureLLMQContext(node);
+            CHECK_NONFATAL(node.evodb);
 
             CBlockIndex* const pindexPrev = active_chain.Tip();
             // TestBlockValidity only supports blocks built on the current Tip
@@ -733,6 +736,7 @@ static RPCHelpMan getblocktemplate()
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
 
     const CConnman& connman = EnsureConnman(node);
+    CHECK_NONFATAL(node.sporkman);
     if (connman.GetNodeCount(ConnectionDirection::Both) == 0)
         throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, PACKAGE_NAME " is not connected!");
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -108,6 +108,7 @@ static RPCHelpMan mnsync()
     std::string strMode = request.params[0].get_str();
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CHECK_NONFATAL(node.mn_sync);
     auto& mn_sync = *node.mn_sync;
 
     if(strMode == "status") {
@@ -170,6 +171,7 @@ static RPCHelpMan spork()
     // basic mode, show info
     std:: string strCommand = request.params[0].get_str();
     const NodeContext& node = EnsureAnyNodeContext(request.context);
+    CHECK_NONFATAL(node.sporkman);
     if (strCommand == "show") {
         UniValue ret(UniValue::VOBJ);
         for (const auto& sporkDef : sporkDefs) {
@@ -215,6 +217,7 @@ static RPCHelpMan sporkupdate()
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     PeerManager& peerman = EnsurePeerman(node);
+    CHECK_NONFATAL(node.sporkman);
 
     // SPORK VALUE
     int64_t nValue = request.params[1].get_int64();

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -279,6 +279,9 @@ static RPCHelpMan quorum_dkgstatus()
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const ChainstateManager& chainman = EnsureChainman(node);
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
+    CHECK_NONFATAL(node.connman);
+    CHECK_NONFATAL(node.dmnman);
+    CHECK_NONFATAL(node.sporkman);
 
     int detailLevel = 0;
     if (!request.params[0].isNull()) {
@@ -381,6 +384,7 @@ static RPCHelpMan quorum_memberof()
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const ChainstateManager& chainman = EnsureChainman(node);
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
+    CHECK_NONFATAL(node.connman);
 
     uint256 protxHash(ParseHashV(request.params[0], "proTxHash"));
     int scanQuorumsCount = -1;
@@ -747,6 +751,7 @@ static RPCHelpMan quorum_getdata()
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const ChainstateManager& chainman = EnsureChainman(node);
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
+    CHECK_NONFATAL(node.connman);
 
     NodeId nodeId = ParseInt64V(request.params[0], "nodeId");
     Consensus::LLMQType llmqType = static_cast<Consensus::LLMQType>(ParseInt32V(request.params[1], "llmqType"));
@@ -791,6 +796,7 @@ static RPCHelpMan quorum_rotationinfo()
 {
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     const LLMQContext& llmq_ctx = EnsureLLMQContext(node);
+    CHECK_NONFATAL(node.dmnman);
 
     llmq::CGetQuorumRotationInfo cmd;
     llmq::CQuorumRotationInfo quorumRotationInfoRet;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -490,6 +490,8 @@ static RPCHelpMan getassetunlockstatuses()
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No blocks in chain");
     }
 
+    CHECK_NONFATAL(node.cpoolman);
+
     std::optional<CCreditPool> poolCL{std::nullopt};
     std::optional<CCreditPool> poolOnTip{std::nullopt};
     std::optional<int> nSpecificCoreHeight{std::nullopt};


### PR DESCRIPTION
## Issue being fixed or feature implemented
There're some usages of unique pointers in RPC code that are not guarded by non-nullptr checks

## What was done?
Added missing `CHECK_NON_FATAL` and refactored some of them to `EnsureConnman` and `EnsurePeerman`

## How Has This Been Tested?
Run unit/functional tests

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone

