### PR TITLE
refactor: use new type of composite commands for protx NNN

### DIFF
--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -923,38 +923,6 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
     }
 }
 
-static UniValue protx_register_evo(const JSONRPCRequest& request, CChainstateHelper& chain_helper, const ChainstateManager& chainman)
-{
-    bool isExternalRegister = request.strMethod == "protxregister_evo";
-    bool isFundRegister = request.strMethod == "protxregister_fund_evo";
-    bool isPrepareRegister = request.strMethod == "protxregister_prepare_evo";
-    if (request.strMethod.find("_hpmn") != std::string::npos) {
-        if (!IsDeprecatedRPCEnabled("hpmn")) {
-            throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated. Use the related *_evo methods or set -deprecatedrpc=hpmn to enable them");
-        }
-        isExternalRegister = request.strMethod == "protxregister_hpmn";
-        isFundRegister = request.strMethod == "protxregister_fund_hpmn";
-        isPrepareRegister = request.strMethod == "protxregister_prepare_hpmn";
-    }
-    return protx_register_common_wrapper(request, chain_helper, chainman, false, isExternalRegister, isFundRegister, isPrepareRegister, MnType::Evo);
-}
-
-static UniValue protx_register(const JSONRPCRequest& request, CChainstateHelper& chain_helper, const ChainstateManager& chainman)
-{
-    bool isExternalRegister = request.strMethod == "protxregister";
-    bool isFundRegister = request.strMethod == "protxregister_fund";
-    bool isPrepareRegister = request.strMethod == "protxregister_prepare";
-    return protx_register_common_wrapper(request, chain_helper, chainman, false, isExternalRegister, isFundRegister, isPrepareRegister, MnType::Regular);
-}
-
-static UniValue protx_register_legacy(const JSONRPCRequest& request, CChainstateHelper& chain_helper, const ChainstateManager& chainman)
-{
-    bool isExternalRegister = request.strMethod == "protxregister_legacy";
-    bool isFundRegister = request.strMethod == "protxregister_fund_legacy";
-    bool isPrepareRegister = request.strMethod == "protxregister_prepare_legacy";
-    return protx_register_common_wrapper(request, chain_helper, chainman, true, isExternalRegister, isFundRegister, isPrepareRegister, MnType::Regular);
-}
-
 static RPCHelpMan protx_register_submit()
 {
     return RPCHelpMan{"protx register_submit",

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -354,8 +354,6 @@ enum class ProTxRegisterAction
 } // anonumous namespace
 
 static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
-                                              CChainstateHelper& chain_helper,
-                                              const ChainstateManager& chainman,
                                               const bool specific_legacy_bls_scheme,
                                               ProTxRegisterAction action,
                                               const MnType mnType);
@@ -398,13 +396,7 @@ static RPCHelpMan protx_register_fund_wrapper(const bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    CHECK_NONFATAL(node.chain_helper);
-    CChainstateHelper& chain_helper = *node.chain_helper;
-
-    return protx_register_common_wrapper(request, chain_helper, chainman, legacy, ProTxRegisterAction::Fund, MnType::Regular);
+    return protx_register_common_wrapper(request, legacy, ProTxRegisterAction::Fund, MnType::Regular);
 },
     };
 }
@@ -451,13 +443,7 @@ static RPCHelpMan protx_register_wrapper(bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    CHECK_NONFATAL(node.chain_helper);
-    CChainstateHelper& chain_helper = *node.chain_helper;
-
-    return protx_register_common_wrapper(request, chain_helper, chainman, legacy, ProTxRegisterAction::External, MnType::Regular);
+    return protx_register_common_wrapper(request, legacy, ProTxRegisterAction::External, MnType::Regular);
 },
     };
 }
@@ -505,13 +491,7 @@ static RPCHelpMan protx_register_prepare_wrapper(const bool legacy)
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    CHECK_NONFATAL(node.chain_helper);
-    CChainstateHelper& chain_helper = *node.chain_helper;
-
-    return protx_register_common_wrapper(request, chain_helper, chainman, legacy, ProTxRegisterAction::Prepare, MnType::Regular);
+    return protx_register_common_wrapper(request, legacy, ProTxRegisterAction::Prepare, MnType::Regular);
 },
     };
 }
@@ -565,13 +545,7 @@ static RPCHelpMan protx_register_fund_evo_wrapper(bool use_hpmn_suffix)
         throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated. Use the related *_evo methods or set -deprecatedrpc=hpmn to enable them");
     }
 
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    CHECK_NONFATAL(node.chain_helper);
-    CChainstateHelper& chain_helper = *node.chain_helper;
-
-    return protx_register_common_wrapper(request, chain_helper, chainman, false, ProTxRegisterAction::Fund, MnType::Evo);
+    return protx_register_common_wrapper(request, false, ProTxRegisterAction::Fund, MnType::Evo);
 },
     };
 }
@@ -624,13 +598,7 @@ static RPCHelpMan protx_register_evo_wrapper(bool use_hpmn_suffix)
         throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated. Use the related *_evo methods or set -deprecatedrpc=hpmn to enable them");
     }
 
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    CHECK_NONFATAL(node.chain_helper);
-    CChainstateHelper& chain_helper = *node.chain_helper;
-
-    return protx_register_common_wrapper(request, chain_helper, chainman, false, ProTxRegisterAction::External, MnType::Evo);
+    return protx_register_common_wrapper(request, false, ProTxRegisterAction::External, MnType::Evo);
 },
     };
 }
@@ -680,13 +648,7 @@ static RPCHelpMan protx_register_prepare_evo_wrapper(bool use_hpmn_suffix)
         throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated. Use the related *_evo methods or set -deprecatedrpc=hpmn to enable them");
     }
 
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    CHECK_NONFATAL(node.chain_helper);
-    CChainstateHelper& chain_helper = *node.chain_helper;
-
-    return protx_register_common_wrapper(request, chain_helper, chainman, false, ProTxRegisterAction::Prepare, MnType::Evo);
+    return protx_register_common_wrapper(request, false, ProTxRegisterAction::Prepare, MnType::Evo);
 },
     };
 }
@@ -702,12 +664,16 @@ static RPCHelpMan protx_register_prepare_hpmn()
 }
 
 static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
-                                              CChainstateHelper& chain_helper,
-                                              const ChainstateManager& chainman,
                                               const bool specific_legacy_bls_scheme,
                                               const ProTxRegisterAction action,
                                               const MnType mnType)
 {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    const ChainstateManager& chainman = EnsureChainman(node);
+
+    CHECK_NONFATAL(node.chain_helper);
+    CChainstateHelper& chain_helper = *node.chain_helper;
+
     const bool isEvoRequested = mnType == MnType::Evo;
 
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -353,7 +353,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
                                               const bool isPrepareRegister,
                                               const MnType mnType);
 
-static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& request, CChainstateHelper& chain_helper, CDeterministicMNManager& dmnman, const ChainstateManager& chainman, const MnType mnType);
+static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& request, const MnType mnType);
 
 
 static RPCHelpMan protx_register_fund_wrapper(const bool legacy)
@@ -1004,16 +1004,7 @@ static RPCHelpMan protx_update_service()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    CHECK_NONFATAL(node.dmnman);
-    CDeterministicMNManager& dmnman = *node.dmnman;
-
-    CHECK_NONFATAL(node.chain_helper);
-    CChainstateHelper& chain_helper = *node.chain_helper;
-
-    return protx_update_service_common_wrapper(request, chain_helper, dmnman, chainman, MnType::Regular);
+    return protx_update_service_common_wrapper(request, MnType::Regular);
 },
     };
 }
@@ -1047,16 +1038,7 @@ static RPCHelpMan protx_update_service_evo_wrapper(bool use_hpmn_suffix)
         throw JSONRPCError(RPC_METHOD_DEPRECATED, "*_hpmn methods are deprecated. Use the related *_evo methods or set -deprecatedrpc=hpmn to enable them");
     }
 
-    const NodeContext& node = EnsureAnyNodeContext(request.context);
-    const ChainstateManager& chainman = EnsureChainman(node);
-
-    CHECK_NONFATAL(node.dmnman);
-    CDeterministicMNManager& dmnman = *node.dmnman;
-
-    CHECK_NONFATAL(node.chain_helper);
-    CChainstateHelper& chain_helper = *node.chain_helper;
-
-    return protx_update_service_common_wrapper(request, chain_helper, dmnman, chainman, MnType::Evo);
+    return protx_update_service_common_wrapper(request, MnType::Evo);
 },
     };
 }
@@ -1071,8 +1053,17 @@ static RPCHelpMan protx_update_service_hpmn()
     return protx_update_service_evo_wrapper(true);
 }
 
-static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& request, CChainstateHelper& chain_helper, CDeterministicMNManager& dmnman, const ChainstateManager& chainman, const MnType mnType)
+static UniValue protx_update_service_common_wrapper(const JSONRPCRequest& request, const MnType mnType)
 {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    const ChainstateManager& chainman = EnsureChainman(node);
+
+    CHECK_NONFATAL(node.dmnman);
+    CDeterministicMNManager& dmnman = *node.dmnman;
+
+    CHECK_NONFATAL(node.chain_helper);
+    CChainstateHelper& chain_helper = *node.chain_helper;
+
     const bool isEvoRequested = mnType == MnType::Evo;
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     if (!wallet) return NullUniValue;


### PR DESCRIPTION
## Issue being fixed or feature implemented
See #6051

## What was done?
Commands starting from 'protx ...' uses new a new way to make composite commands.


## How Has This Been Tested?
Run unit/functional tests.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone