### PR TITLE
feat: add logging for RPC HTTP requests: command, user, http-code, time of running

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -154,8 +154,8 @@ static struct evhttp* eventHTTP = nullptr;
 static std::vector<CSubNet> rpc_allow_subnets;
 //! Work queue for handling longer requests off the event loop thread
 static std::unique_ptr<WorkQueue<HTTPClosure>> g_work_queue{nullptr};
-//! List of 'external' RPC users
-static std::vector<std::string> g_external_usernames;
+//! List of 'external' RPC users (global variable, used by httprpc)
+std::vector<std::string> g_external_usernames;
 //! Handlers for (sub)paths
 static std::vector<HTTPPathHandler> pathHandlers;
 //! Bound listening sockets


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently there is no way to gather stats for http rpc in dash core. This PR aim to change it.

## What was done?
Implemented some basic stats for each RPC request:
 - rpc command
 - flag "is external"
 - http status
 - time to serve query (rpc time, not http time)

## How Has This Been Tested?
See new logs:
```log
[httpworker.0] [httprpc.cpp:100] [~RpcHttpRequest] -- HTTP RPC request handled: user=platform-user command=getbestblockhash is_external=false status=200 elapsed_time_ms=0
[httpworker.2] [httprpc.cpp:100] [~RpcHttpRequest] -- HTTP RPC request handled: user=platform-user command=quorum is_external=false status=500 elapsed_time_ms=0
[httpworker.3] [httprpc.cpp:100] [~RpcHttpRequest] -- HTTP RPC request handled: user=platform-user command= is_external=false status=401 elapsed_time_ms=0
[httpworker.3] [httprpc.cpp:100] [~RpcHttpRequest] -- HTTP RPC request handled: user=platform-user command=getbestblockhash is_external=true status=200 elapsed_time_ms=28
[httpworker.0] [httprpc.cpp:100] [~RpcHttpRequest] -- HTTP RPC request handled: user=operator command=getbestblockhash is_external=false status=200 elapsed_time_ms=0
```

## Breaking Changes
N/A
It doesn't change behavior of rpc server and http server.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone