### PR TITLE
feat: bump protocol version to distinguish v21 from v20.1

### DIFF
--- a/doc/release-notes-6080.md
+++ b/doc/release-notes-6080.md
@@ -1,0 +1,4 @@
+P2P and network changes
+-----------------------
+
+- The protocol version has been bumped to 70232. This should be identical in behavior to 70231.

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  */
 
 
-static const int PROTOCOL_VERSION = 70231;
+static const int PROTOCOL_VERSION = 70232;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -20,7 +20,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION = 70215;
 
 //! minimum proto version of masternode to accept in DKGs
-static const int MIN_MASTERNODE_PROTO_VERSION = 70230;
+static const int MIN_MASTERNODE_PROTO_VERSION = 70232;
 
 //! protocol version is included in MNAUTH starting with this version
 static const int MNAUTH_NODE_VER_VERSION = 70218;


### PR DESCRIPTION
## Issue being fixed or feature implemented
See commit

## What was done?


## How Has This Been Tested?


## Breaking Changes
None really; will require MNs to upgrade in order to not be banned

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

