### PR TITLE
refactor: move Get*Index to rpc/index_util.cpp, const-ify functions and arguments, add lock annotations and some minor housekeeping

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -286,6 +286,7 @@ BITCOIN_CORE_H = \
   reverse_iterator.h \
   rpc/blockchain.h \
   rpc/client.h \
+  rpc/index_util.h \
   rpc/mining.h \
   rpc/protocol.h \
   rpc/rawtransaction_util.h \
@@ -502,6 +503,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/blockchain.cpp \
   rpc/coinjoin.cpp \
   rpc/evo.cpp \
+  rpc/index_util.cpp \
   rpc/masternode.cpp \
   rpc/governance.cpp \
   rpc/mining.cpp \

--- a/src/addressindex.h
+++ b/src/addressindex.h
@@ -17,6 +17,9 @@
 #include <tuple>
 
 class CScript;
+struct CAddressIndexKey;
+struct CMempoolAddressDelta;
+struct CMempoolAddressDeltaKey;
 
 enum class AddressType : uint8_t {
     P2PK_OR_P2PKH = 1,
@@ -25,6 +28,9 @@ enum class AddressType : uint8_t {
     UNKNOWN = 0
 };
 template<> struct is_serializable_enum<AddressType> : std::true_type {};
+
+using CAddressIndexEntry = std::pair<CAddressIndexKey, CAmount>;
+using CMempoolAddressDeltaEntry = std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta>;
 
 struct CMempoolAddressDelta
 {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -835,7 +835,7 @@ static RPCHelpMan getblockhashes()
     unsigned int low = request.params[1].get_int();
     std::vector<uint256> blockHashes;
 
-    if (!GetTimestampIndex(high, low, blockHashes)) {
+    if (LOCK(::cs_main); !GetTimestampIndex(*pblocktree, high, low, blockHashes)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for block hashes");
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -30,6 +30,7 @@
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <rpc/index_util.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>
 #include <rpc/util.h>

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -33,7 +33,7 @@ bool GetAddressUnspentIndex(uint160 addressHash, AddressType type,
     return true;
 }
 
-bool GetSpentIndex(CTxMemPool& mempool, CSpentIndexKey& key, CSpentIndexValue& value)
+bool GetSpentIndex(const CTxMemPool& mempool, CSpentIndexKey& key, CSpentIndexValue& value)
 {
     if (!fSpentIndex)
         return false;

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -34,6 +34,19 @@ bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
     return true;
 }
 
+bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
+                                 const std::vector<CMempoolAddressDeltaKey>& addressDeltaIndex,
+                                 std::vector<CMempoolAddressDeltaEntry>& addressDeltaEntries)
+{
+    if (!fAddressIndex)
+        return error("Address index not enabled");
+
+    if (!mempool.getAddressIndex(addressDeltaIndex, addressDeltaEntries))
+        return error("Unable to get address delta information");
+
+    return true;
+}
+
 bool GetSpentIndex(const CTxMemPool& mempool, const CSpentIndexKey& key, CSpentIndexValue& value)
 {
     if (!fSpentIndex)

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -9,26 +9,30 @@
 #include <uint256.h>
 #include <validation.h>
 
-bool GetAddressIndex(const uint160& addressHash, const AddressType type,
+bool GetAddressIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
                      std::vector<CAddressIndexEntry>& addressIndex,
                      const int32_t start, const int32_t end)
 {
+    AssertLockHeld(::cs_main);
+
     if (!fAddressIndex)
         return error("Address index not enabled");
 
-    if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex, start, end))
+    if (!block_tree_db.ReadAddressIndex(addressHash, type, addressIndex, start, end))
         return error("Unable to get txids for address");
 
     return true;
 }
 
-bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
+bool GetAddressUnspentIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
                             std::vector<CAddressUnspentIndexEntry>& unspentOutputs)
 {
+    AssertLockHeld(::cs_main);
+
     if (!fAddressIndex)
         return error("Address index not enabled");
 
-    if (!pblocktree->ReadAddressUnspentIndex(addressHash, type, unspentOutputs))
+    if (!block_tree_db.ReadAddressUnspentIndex(addressHash, type, unspentOutputs))
         return error("Unable to get txids for address");
 
     return true;
@@ -47,26 +51,32 @@ bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
     return true;
 }
 
-bool GetSpentIndex(const CTxMemPool& mempool, const CSpentIndexKey& key, CSpentIndexValue& value)
+bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const CSpentIndexKey& key,
+                   CSpentIndexValue& value)
 {
+    AssertLockHeld(::cs_main);
+
     if (!fSpentIndex)
         return error("Spent index not enabled");
 
     if (mempool.getSpentIndex(key, value))
         return true;
 
-    if (!pblocktree->ReadSpentIndex(key, value))
+    if (!block_tree_db.ReadSpentIndex(key, value))
         return error("Unable to get spend information");
 
     return true;
 }
 
-bool GetTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes)
+bool GetTimestampIndex(CBlockTreeDB& block_tree_db, const uint32_t high, const uint32_t low,
+                       std::vector<uint256>& hashes)
 {
+    AssertLockHeld(::cs_main);
+
     if (!fTimestampIndex)
         return error("Timestamp index not enabled");
 
-    if (!pblocktree->ReadTimestampIndex(high, low, hashes))
+    if (!block_tree_db.ReadTimestampIndex(high, low, hashes))
         return error("Unable to get hashes for timestamps");
 
     return true;

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -10,7 +10,7 @@
 #include <validation.h>
 
 bool GetAddressIndex(const uint160& addressHash, const AddressType type,
-                     std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
+                     std::vector<CAddressIndexEntry>& addressIndex,
                      const int32_t start, const int32_t end)
 {
     if (!fAddressIndex)
@@ -23,7 +23,7 @@ bool GetAddressIndex(const uint160& addressHash, const AddressType type,
 }
 
 bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
-                            std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs)
+                            std::vector<CAddressUnspentIndexEntry>& unspentOutputs)
 {
     if (!fAddressIndex)
         return error("Address index not enabled");

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 BitPay, Inc.
+// Copyright (c) 2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <rpc/index_util.h>
+
+#include <txmempool.h>
+#include <uint256.h>
+#include <validation.h>
+
+bool GetAddressIndex(uint160 addressHash, AddressType type,
+                     std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex, int32_t start, int32_t end)
+{
+    if (!fAddressIndex)
+        return error("address index not enabled");
+
+    if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex, start, end))
+        return error("unable to get txids for address");
+
+    return true;
+}
+
+bool GetAddressUnspentIndex(uint160 addressHash, AddressType type,
+                            std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs)
+{
+    if (!fAddressIndex)
+        return error("address index not enabled");
+
+    if (!pblocktree->ReadAddressUnspentIndex(addressHash, type, unspentOutputs))
+        return error("unable to get txids for address");
+
+    return true;
+}
+
+bool GetSpentIndex(CTxMemPool& mempool, CSpentIndexKey& key, CSpentIndexValue& value)
+{
+    if (!fSpentIndex)
+        return false;
+
+    if (mempool.getSpentIndex(key, value))
+        return true;
+
+    if (!pblocktree->ReadSpentIndex(key, value))
+        return false;
+
+    return true;
+}
+
+bool GetTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes)
+{
+    if (!fTimestampIndex)
+        return error("Timestamp index not enabled");
+
+    if (!pblocktree->ReadTimestampIndex(high, low, hashes))
+        return error("Unable to get hashes for timestamps");
+
+    return true;
+}

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -14,10 +14,10 @@ bool GetAddressIndex(const uint160& addressHash, const AddressType type,
                      const int32_t start, const int32_t end)
 {
     if (!fAddressIndex)
-        return error("address index not enabled");
+        return error("Address index not enabled");
 
     if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex, start, end))
-        return error("unable to get txids for address");
+        return error("Unable to get txids for address");
 
     return true;
 }
@@ -26,10 +26,10 @@ bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
                             std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs)
 {
     if (!fAddressIndex)
-        return error("address index not enabled");
+        return error("Address index not enabled");
 
     if (!pblocktree->ReadAddressUnspentIndex(addressHash, type, unspentOutputs))
-        return error("unable to get txids for address");
+        return error("Unable to get txids for address");
 
     return true;
 }
@@ -37,13 +37,13 @@ bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
 bool GetSpentIndex(const CTxMemPool& mempool, const CSpentIndexKey& key, CSpentIndexValue& value)
 {
     if (!fSpentIndex)
-        return false;
+        return error("Spent index not enabled");
 
     if (mempool.getSpentIndex(key, value))
         return true;
 
     if (!pblocktree->ReadSpentIndex(key, value))
-        return false;
+        return error("Unable to get spend information");
 
     return true;
 }

--- a/src/rpc/index_util.cpp
+++ b/src/rpc/index_util.cpp
@@ -9,8 +9,9 @@
 #include <uint256.h>
 #include <validation.h>
 
-bool GetAddressIndex(uint160 addressHash, AddressType type,
-                     std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex, int32_t start, int32_t end)
+bool GetAddressIndex(const uint160& addressHash, const AddressType type,
+                     std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
+                     const int32_t start, const int32_t end)
 {
     if (!fAddressIndex)
         return error("address index not enabled");
@@ -21,7 +22,7 @@ bool GetAddressIndex(uint160 addressHash, AddressType type,
     return true;
 }
 
-bool GetAddressUnspentIndex(uint160 addressHash, AddressType type,
+bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
                             std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs)
 {
     if (!fAddressIndex)
@@ -33,7 +34,7 @@ bool GetAddressUnspentIndex(uint160 addressHash, AddressType type,
     return true;
 }
 
-bool GetSpentIndex(const CTxMemPool& mempool, CSpentIndexKey& key, CSpentIndexValue& value)
+bool GetSpentIndex(const CTxMemPool& mempool, const CSpentIndexKey& key, CSpentIndexValue& value)
 {
     if (!fSpentIndex)
         return false;

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -27,7 +27,7 @@ bool GetAddressIndex(uint160 addressHash, AddressType type,
                      int32_t start = 0, int32_t end = 0);
 bool GetAddressUnspentIndex(uint160 addressHash, AddressType type,
                             std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs);
-bool GetSpentIndex(CTxMemPool& mempool, CSpentIndexKey& key, CSpentIndexValue& value);
+bool GetSpentIndex(const CTxMemPool& mempool, CSpentIndexKey& key, CSpentIndexValue& value);
 bool GetTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes);
 
 #endif // BITCOIN_RPC_CLIENT_H

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -10,23 +10,20 @@
 #include <vector>
 
 #include <amount.h>
+#include <addressindex.h>
+#include <spentindex.h>
 
 class CTxMemPool;
 class uint160;
 class uint256;
-struct CAddressIndexKey;
-struct CAddressUnspentKey;
-struct CAddressUnspentValue;
-struct CSpentIndexKey;
-struct CSpentIndexValue;
 
 enum class AddressType : uint8_t;
 
 bool GetAddressIndex(const uint160& addressHash, const AddressType type,
-                     std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
+                     std::vector<CAddressIndexEntry>& addressIndex,
                      const int32_t start = 0, const int32_t end = 0);
 bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
-                            std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs);
+                            std::vector<CAddressUnspentIndexEntry>& unspentOutputs);
 bool GetSpentIndex(const CTxMemPool& mempool, const CSpentIndexKey& key, CSpentIndexValue& value);
 bool GetTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes);
 

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -22,12 +22,12 @@ struct CSpentIndexValue;
 
 enum class AddressType : uint8_t;
 
-bool GetAddressIndex(uint160 addressHash, AddressType type,
+bool GetAddressIndex(const uint160& addressHash, const AddressType type,
                      std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
-                     int32_t start = 0, int32_t end = 0);
-bool GetAddressUnspentIndex(uint160 addressHash, AddressType type,
+                     const int32_t start = 0, const int32_t end = 0);
+bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
                             std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs);
-bool GetSpentIndex(const CTxMemPool& mempool, CSpentIndexKey& key, CSpentIndexValue& value);
+bool GetSpentIndex(const CTxMemPool& mempool, const CSpentIndexKey& key, CSpentIndexValue& value);
 bool GetTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes);
 
 #endif // BITCOIN_RPC_CLIENT_H

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -24,6 +24,9 @@ bool GetAddressIndex(const uint160& addressHash, const AddressType type,
                      const int32_t start = 0, const int32_t end = 0);
 bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
                             std::vector<CAddressUnspentIndexEntry>& unspentOutputs);
+bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
+                                 const std::vector<CMempoolAddressDeltaKey>& addressDeltaIndex,
+                                 std::vector<CMempoolAddressDeltaEntry>& addressDeltaEntries);
 bool GetSpentIndex(const CTxMemPool& mempool, const CSpentIndexKey& key, CSpentIndexValue& value);
 bool GetTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes);
 

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -12,22 +12,33 @@
 #include <amount.h>
 #include <addressindex.h>
 #include <spentindex.h>
+#include <sync.h>
+#include <threadsafety.h>
 
+class CBlockTreeDB;
 class CTxMemPool;
 class uint160;
 class uint256;
 
 enum class AddressType : uint8_t;
 
-bool GetAddressIndex(const uint160& addressHash, const AddressType type,
+extern RecursiveMutex cs_main;
+
+bool GetAddressIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
                      std::vector<CAddressIndexEntry>& addressIndex,
-                     const int32_t start = 0, const int32_t end = 0);
-bool GetAddressUnspentIndex(const uint160& addressHash, const AddressType type,
-                            std::vector<CAddressUnspentIndexEntry>& unspentOutputs);
+                     const int32_t start = 0, const int32_t end = 0)
+    EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+bool GetAddressUnspentIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
+                            std::vector<CAddressUnspentIndexEntry>& unspentOutputs)
+    EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
                                  const std::vector<CMempoolAddressDeltaKey>& addressDeltaIndex,
                                  std::vector<CMempoolAddressDeltaEntry>& addressDeltaEntries);
-bool GetSpentIndex(const CTxMemPool& mempool, const CSpentIndexKey& key, CSpentIndexValue& value);
-bool GetTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes);
+bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const CSpentIndexKey& key,
+                   CSpentIndexValue& value)
+    EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+bool GetTimestampIndex(CBlockTreeDB& block_tree_db, const uint32_t high, const uint32_t low,
+                       std::vector<uint256>& hashes)
+    EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 #endif // BITCOIN_RPC_CLIENT_H

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -29,11 +29,12 @@ bool GetAddressIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, co
                      const int32_t start = 0, const int32_t end = 0)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 bool GetAddressUnspentIndex(CBlockTreeDB& block_tree_db, const uint160& addressHash, const AddressType type,
-                            std::vector<CAddressUnspentIndexEntry>& unspentOutputs)
+                            std::vector<CAddressUnspentIndexEntry>& unspentOutputs, const bool height_sort = false)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 bool GetMempoolAddressDeltaIndex(const CTxMemPool& mempool,
                                  const std::vector<CMempoolAddressDeltaKey>& addressDeltaIndex,
-                                 std::vector<CMempoolAddressDeltaEntry>& addressDeltaEntries);
+                                 std::vector<CMempoolAddressDeltaEntry>& addressDeltaEntries,
+                                 const bool timestamp_sort = false);
 bool GetSpentIndex(CBlockTreeDB& block_tree_db, const CTxMemPool& mempool, const CSpentIndexKey& key,
                    CSpentIndexValue& value)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/rpc/index_util.h
+++ b/src/rpc/index_util.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2016 BitPay, Inc.
+// Copyright (c) 2024 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RPC_INDEX_UTIL_H
+#define BITCOIN_RPC_INDEX_UTIL_H
+
+#include <cstdint>
+#include <vector>
+
+#include <amount.h>
+
+class CTxMemPool;
+class uint160;
+class uint256;
+struct CAddressIndexKey;
+struct CAddressUnspentKey;
+struct CAddressUnspentValue;
+struct CSpentIndexKey;
+struct CSpentIndexValue;
+
+enum class AddressType : uint8_t;
+
+bool GetAddressIndex(uint160 addressHash, AddressType type,
+                     std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
+                     int32_t start = 0, int32_t end = 0);
+bool GetAddressUnspentIndex(uint160 addressHash, AddressType type,
+                            std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs);
+bool GetSpentIndex(CTxMemPool& mempool, CSpentIndexKey& key, CSpentIndexValue& value);
+bool GetTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes);
+
+#endif // BITCOIN_RPC_CLIENT_H

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -701,13 +701,11 @@ static bool getAddressesFromParams(const UniValue& params, std::vector<std::pair
     return true;
 }
 
-static bool heightSort(std::pair<CAddressUnspentKey, CAddressUnspentValue> a,
-                std::pair<CAddressUnspentKey, CAddressUnspentValue> b) {
+static bool heightSort(CAddressUnspentIndexEntry a, CAddressUnspentIndexEntry b) {
     return a.second.m_block_height < b.second.m_block_height;
 }
 
-static bool timestampSort(std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> a,
-                   std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> b) {
+static bool timestampSort(CMempoolAddressDeltaEntry a, CMempoolAddressDeltaEntry b) {
     return a.second.m_time < b.second.m_time;
 }
 
@@ -749,7 +747,7 @@ static RPCHelpMan getaddressmempool()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
-    std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > indexes;
+    std::vector<CMempoolAddressDeltaEntry> indexes;
 
     CTxMemPool& mempool = EnsureAnyMemPool(request.context);
     if (!mempool.getAddressIndex(addresses, indexes)) {
@@ -821,7 +819,7 @@ static RPCHelpMan getaddressutxos()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
-    std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > unspentOutputs;
+    std::vector<CAddressUnspentIndexEntry> unspentOutputs;
 
     for (const auto& address : addresses) {
         if (!GetAddressUnspentIndex(address.first, address.second, unspentOutputs)) {
@@ -906,7 +904,7 @@ static RPCHelpMan getaddressdeltas()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
-    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+    std::vector<CAddressIndexEntry> addressIndex;
 
     for (const auto& address : addresses) {
         if (start > 0 && end > 0) {
@@ -975,7 +973,7 @@ static RPCHelpMan getaddressbalance()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
-    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+    std::vector<CAddressIndexEntry> addressIndex;
 
     for (const auto& address : addresses) {
         if (!GetAddressIndex(address.first, address.second, addressIndex)) {
@@ -1054,7 +1052,7 @@ static RPCHelpMan getaddresstxids()
         }
     }
 
-    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+    std::vector<CAddressIndexEntry> addressIndex;
 
     for (const auto& address : addresses) {
         if (start > 0 && end > 0) {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -19,6 +19,7 @@
 #include <net.h>
 #include <node/context.h>
 #include <rpc/blockchain.h>
+#include <rpc/index_util.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>
 #include <rpc/util.h>
@@ -823,7 +824,7 @@ static RPCHelpMan getaddressutxos()
     std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > unspentOutputs;
 
     for (const auto& address : addresses) {
-        if (!GetAddressUnspent(address.first, address.second, unspentOutputs)) {
+        if (!GetAddressUnspentIndex(address.first, address.second, unspentOutputs)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
         }
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -26,6 +26,7 @@
 #include <primitives/transaction.h>
 #include <psbt.h>
 #include <rpc/blockchain.h>
+#include <rpc/index_util.h>
 #include <rpc/rawtransaction_util.h>
 #include <rpc/server.h>
 #include <rpc/server_util.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -59,6 +59,8 @@
 
 void TxToJSON(const CTransaction& tx, const uint256 hashBlock, CTxMemPool& mempool, CChainState& active_chainstate, llmq::CChainLocksHandler& clhandler, llmq::CInstantSendManager& isman, UniValue& entry)
 {
+    LOCK(::cs_main);
+
     // Call into TxToUniv() in bitcoin-common to decode the transaction hex.
     //
     // Blockchain contextual information (confirmations and blocktime) is not
@@ -73,7 +75,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, CTxMemPool& mempo
         if (!tx.IsCoinBase()) {
             CSpentIndexValue spentInfo;
             CSpentIndexKey spentKey(txin.prevout.hash, txin.prevout.n);
-            if (GetSpentIndex(mempool, spentKey, spentInfo)) {
+            if (GetSpentIndex(*pblocktree, mempool, spentKey, spentInfo)) {
                 txSpentInfo.mSpentInfo.emplace(spentKey, spentInfo);
             }
         }
@@ -81,7 +83,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, CTxMemPool& mempo
     for (unsigned int i = 0; i < tx.vout.size(); i++) {
         CSpentIndexValue spentInfo;
         CSpentIndexKey spentKey(txid, i);
-        if (GetSpentIndex(mempool, spentKey, spentInfo)) {
+        if (GetSpentIndex(*pblocktree, mempool, spentKey, spentInfo)) {
             txSpentInfo.mSpentInfo.emplace(spentKey, spentInfo);
         }
     }
@@ -90,8 +92,6 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, CTxMemPool& mempo
 
     bool chainLock = false;
     if (!hashBlock.IsNull()) {
-        LOCK(cs_main);
-
         entry.pushKV("blockhash", hashBlock.GetHex());
         CBlockIndex* pindex = active_chainstate.m_blockman.LookupBlockIndex(hashBlock);
         if (pindex) {

--- a/src/spentindex.h
+++ b/src/spentindex.h
@@ -16,6 +16,14 @@
 
 #include <tuple>
 
+struct CAddressUnspentKey;
+struct CAddressUnspentValue;
+struct CSpentIndexKey;
+struct CSpentIndexValue;
+
+using CAddressUnspentIndexEntry = std::pair<CAddressUnspentKey, CAddressUnspentValue>;
+using CSpentIndexEntry = std::pair<CSpentIndexKey, CSpentIndexValue>;
+
 struct CSpentIndexKey {
 public:
     uint256 m_tx_hash;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -263,13 +263,13 @@ bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockF
     return WriteBatch(batch, true);
 }
 
-bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) {
+bool CBlockTreeDB::ReadSpentIndex(const CSpentIndexKey key, CSpentIndexValue& value) {
     return Read(std::make_pair(DB_SPENTINDEX, key), value);
 }
 
-bool CBlockTreeDB::UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> >&vect) {
+bool CBlockTreeDB::UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue>>& vect) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<CSpentIndexKey,CSpentIndexValue> >::const_iterator it=vect.begin(); it!=vect.end(); it++) {
+    for (std::vector<std::pair<CSpentIndexKey,CSpentIndexValue>>::const_iterator it=vect.begin(); it!=vect.end(); it++) {
         if (it->second.IsNull()) {
             batch.Erase(std::make_pair(DB_SPENTINDEX, it->first));
         } else {
@@ -279,9 +279,9 @@ bool CBlockTreeDB::UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, 
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue > >&vect) {
+bool CBlockTreeDB::UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& vect) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> >::const_iterator it=vect.begin(); it!=vect.end(); it++) {
+    for (std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>::const_iterator it=vect.begin(); it!=vect.end(); it++) {
         if (it->second.IsNull()) {
             batch.Erase(std::make_pair(DB_ADDRESSUNSPENTINDEX, it->first));
         } else {
@@ -291,9 +291,9 @@ bool CBlockTreeDB::UpdateAddressUnspentIndex(const std::vector<std::pair<CAddres
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::ReadAddressUnspentIndex(uint160 addressHash, AddressType type,
-                                           std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs) {
-
+bool CBlockTreeDB::ReadAddressUnspentIndex(const uint160& addressHash, const AddressType type,
+                                           std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs)
+{
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
     pcursor->Seek(std::make_pair(DB_ADDRESSUNSPENTINDEX, CAddressIndexIteratorKey(type, addressHash)));
@@ -316,24 +316,24 @@ bool CBlockTreeDB::ReadAddressUnspentIndex(uint160 addressHash, AddressType type
     return true;
 }
 
-bool CBlockTreeDB::WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount > >&vect) {
+bool CBlockTreeDB::WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount>>& vect) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
+    for (std::vector<std::pair<CAddressIndexKey, CAmount>>::const_iterator it=vect.begin(); it!=vect.end(); it++)
         batch.Write(std::make_pair(DB_ADDRESSINDEX, it->first), it->second);
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount > >&vect) {
+bool CBlockTreeDB::EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount>>& vect) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
+    for (std::vector<std::pair<CAddressIndexKey, CAmount>>::const_iterator it=vect.begin(); it!=vect.end(); it++)
         batch.Erase(std::make_pair(DB_ADDRESSINDEX, it->first));
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, AddressType type,
-                                    std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
-                                    int start, int end) {
-
+bool CBlockTreeDB::ReadAddressIndex(const uint160& addressHash, const AddressType type,
+                                    std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
+                                    const int32_t start, const int32_t end)
+{
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
     if (start > 0 && end > 0) {
@@ -363,7 +363,7 @@ bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, AddressType type,
     return true;
 }
 
-bool CBlockTreeDB::WriteTimestampIndex(const CTimestampIndexKey &timestampIndex) {
+bool CBlockTreeDB::WriteTimestampIndex(const CTimestampIndexKey& timestampIndex) {
     CDBBatch batch(*this);
     batch.Write(std::make_pair(DB_TIMESTAMPINDEX, timestampIndex), 0);
     return WriteBatch(batch);
@@ -376,8 +376,7 @@ bool CBlockTreeDB::EraseTimestampIndex(const CTimestampIndexKey& timestampIndex)
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::ReadTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &hashes) {
-
+bool CBlockTreeDB::ReadTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes) {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
     pcursor->Seek(std::make_pair(DB_TIMESTAMPINDEX, CTimestampIndexIteratorKey(low)));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -267,7 +267,7 @@ bool CBlockTreeDB::ReadSpentIndex(const CSpentIndexKey key, CSpentIndexValue& va
     return Read(std::make_pair(DB_SPENTINDEX, key), value);
 }
 
-bool CBlockTreeDB::UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue>>& vect) {
+bool CBlockTreeDB::UpdateSpentIndex(const std::vector<CSpentIndexEntry>& vect) {
     CDBBatch batch(*this);
     for (std::vector<std::pair<CSpentIndexKey,CSpentIndexValue>>::const_iterator it=vect.begin(); it!=vect.end(); it++) {
         if (it->second.IsNull()) {
@@ -279,9 +279,9 @@ bool CBlockTreeDB::UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, 
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& vect) {
+bool CBlockTreeDB::UpdateAddressUnspentIndex(const std::vector<CAddressUnspentIndexEntry>& vect) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>::const_iterator it=vect.begin(); it!=vect.end(); it++) {
+    for (std::vector<CAddressUnspentIndexEntry>::const_iterator it=vect.begin(); it!=vect.end(); it++) {
         if (it->second.IsNull()) {
             batch.Erase(std::make_pair(DB_ADDRESSUNSPENTINDEX, it->first));
         } else {
@@ -292,7 +292,7 @@ bool CBlockTreeDB::UpdateAddressUnspentIndex(const std::vector<std::pair<CAddres
 }
 
 bool CBlockTreeDB::ReadAddressUnspentIndex(const uint160& addressHash, const AddressType type,
-                                           std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& unspentOutputs)
+                                           std::vector<CAddressUnspentIndexEntry>& unspentOutputs)
 {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
@@ -316,22 +316,22 @@ bool CBlockTreeDB::ReadAddressUnspentIndex(const uint160& addressHash, const Add
     return true;
 }
 
-bool CBlockTreeDB::WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount>>& vect) {
+bool CBlockTreeDB::WriteAddressIndex(const std::vector<CAddressIndexEntry>& vect) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<CAddressIndexKey, CAmount>>::const_iterator it=vect.begin(); it!=vect.end(); it++)
+    for (std::vector<CAddressIndexEntry>::const_iterator it=vect.begin(); it!=vect.end(); it++)
         batch.Write(std::make_pair(DB_ADDRESSINDEX, it->first), it->second);
     return WriteBatch(batch);
 }
 
-bool CBlockTreeDB::EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount>>& vect) {
+bool CBlockTreeDB::EraseAddressIndex(const std::vector<CAddressIndexEntry>& vect) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<CAddressIndexKey, CAmount>>::const_iterator it=vect.begin(); it!=vect.end(); it++)
+    for (std::vector<CAddressIndexEntry>::const_iterator it=vect.begin(); it!=vect.end(); it++)
         batch.Erase(std::make_pair(DB_ADDRESSINDEX, it->first));
     return WriteBatch(batch);
 }
 
 bool CBlockTreeDB::ReadAddressIndex(const uint160& addressHash, const AddressType type,
-                                    std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
+                                    std::vector<CAddressIndexEntry>& addressIndex,
                                     const int32_t start, const int32_t end)
 {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -84,19 +84,24 @@ public:
     bool ReadLastBlockFile(int &nFile);
     bool WriteReindexing(bool fReindexing);
     void ReadReindexing(bool &fReindexing);
-    bool ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
-    bool UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> >&vect);
-    bool UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue > >&vect);
-    bool ReadAddressUnspentIndex(uint160 addressHash, AddressType type,
-                                 std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &vect);
-    bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
-    bool EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
-    bool ReadAddressIndex(uint160 addressHash, AddressType type,
-                          std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
-                          int start = 0, int end = 0);
-    bool WriteTimestampIndex(const CTimestampIndexKey &timestampIndex);
+
+    bool ReadSpentIndex(const CSpentIndexKey key, CSpentIndexValue& value);
+    bool UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue>>& vect);
+
+    bool ReadAddressUnspentIndex(const uint160& addressHash, const AddressType type,
+                                 std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& vect);
+    bool UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& vect);
+
+    bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount>>& vect);
+    bool EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount>>& vect);
+    bool ReadAddressIndex(const uint160& addressHash, const AddressType type,
+                          std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
+                          const int32_t start = 0, const int32_t end = 0);
+
+    bool WriteTimestampIndex(const CTimestampIndexKey& timestampIndex);
     bool EraseTimestampIndex(const CTimestampIndexKey& timestampIndex);
-    bool ReadTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &vect);
+    bool ReadTimestampIndex(const uint32_t high, const uint32_t low, std::vector<uint256>& hashes);
+
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts(const Consensus::Params& consensusParams, std::function<CBlockIndex*(const uint256&)> insertBlockIndex);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -86,16 +86,16 @@ public:
     void ReadReindexing(bool &fReindexing);
 
     bool ReadSpentIndex(const CSpentIndexKey key, CSpentIndexValue& value);
-    bool UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue>>& vect);
+    bool UpdateSpentIndex(const std::vector<CSpentIndexEntry>& vect);
 
     bool ReadAddressUnspentIndex(const uint160& addressHash, const AddressType type,
-                                 std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& vect);
-    bool UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>>& vect);
+                                 std::vector<CAddressUnspentIndexEntry>& vect);
+    bool UpdateAddressUnspentIndex(const std::vector<CAddressUnspentIndexEntry>& vect);
 
-    bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount>>& vect);
-    bool EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount>>& vect);
+    bool WriteAddressIndex(const std::vector<CAddressIndexEntry>& vect);
+    bool EraseAddressIndex(const std::vector<CAddressIndexEntry>& vect);
     bool ReadAddressIndex(const uint160& addressHash, const AddressType type,
-                          std::vector<std::pair<CAddressIndexKey, CAmount>>& addressIndex,
+                          std::vector<CAddressIndexEntry>& addressIndex,
                           const int32_t start = 0, const int32_t end = 0);
 
     bool WriteTimestampIndex(const CTimestampIndexKey& timestampIndex);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -470,13 +470,14 @@ void CTxMemPool::addAddressIndex(const CTxMemPoolEntry& entry, const CCoinsViewC
     mapAddressInserted.insert(std::make_pair(txhash, inserted));
 }
 
-bool CTxMemPool::getAddressIndex(const std::vector<std::pair<uint160, AddressType>>& addresses,
+bool CTxMemPool::getAddressIndex(const std::vector<CMempoolAddressDeltaKey>& addresses,
                                  std::vector<CMempoolAddressDeltaEntry>& results) const
 {
     LOCK(cs);
     for (const auto& address : addresses) {
-        addressDeltaMap::const_iterator ait = mapAddress.lower_bound(CMempoolAddressDeltaKey(address.second, address.first));
-        while (ait != mapAddress.end() && (*ait).first.m_address_bytes == address.first && (*ait).first.m_address_type == address.second) {
+        addressDeltaMap::const_iterator ait = mapAddress.lower_bound(address);
+        while (ait != mapAddress.end() && (*ait).first.m_address_bytes == address.m_address_bytes
+               && (*ait).first.m_address_type == address.m_address_type) {
             results.push_back(*ait);
             ait++;
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -427,7 +427,7 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     }
 }
 
-void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view)
+void CTxMemPool::addAddressIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view)
 {
     LOCK(cs);
     const CTransaction& tx = entry.GetTx();
@@ -470,12 +470,12 @@ void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewC
     mapAddressInserted.insert(std::make_pair(txhash, inserted));
 }
 
-bool CTxMemPool::getAddressIndex(std::vector<std::pair<uint160, AddressType> > &addresses,
-                                 std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results)
+bool CTxMemPool::getAddressIndex(const std::vector<std::pair<uint160, AddressType>>& addresses,
+                                 std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta>>& results) const
 {
     LOCK(cs);
     for (const auto& address : addresses) {
-        addressDeltaMap::iterator ait = mapAddress.lower_bound(CMempoolAddressDeltaKey(address.second, address.first));
+        addressDeltaMap::const_iterator ait = mapAddress.lower_bound(CMempoolAddressDeltaKey(address.second, address.first));
         while (ait != mapAddress.end() && (*ait).first.m_address_bytes == address.first && (*ait).first.m_address_type == address.second) {
             results.push_back(*ait);
             ait++;
@@ -500,7 +500,7 @@ bool CTxMemPool::removeAddressIndex(const uint256 txhash)
     return true;
 }
 
-void CTxMemPool::addSpentIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view)
+void CTxMemPool::addSpentIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view)
 {
     LOCK(cs);
 
@@ -530,12 +530,11 @@ void CTxMemPool::addSpentIndex(const CTxMemPoolEntry &entry, const CCoinsViewCac
     mapSpentInserted.insert(make_pair(txhash, inserted));
 }
 
-bool CTxMemPool::getSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value)
+bool CTxMemPool::getSpentIndex(const CSpentIndexKey& key, CSpentIndexValue& value) const
 {
     LOCK(cs);
-    mapSpentIndex::iterator it;
+    mapSpentIndex::const_iterator it = mapSpent.find(key);
 
-    it = mapSpent.find(key);
     if (it != mapSpent.end()) {
         value = it->second;
         return true;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -471,7 +471,7 @@ void CTxMemPool::addAddressIndex(const CTxMemPoolEntry& entry, const CCoinsViewC
 }
 
 bool CTxMemPool::getAddressIndex(const std::vector<std::pair<uint160, AddressType>>& addresses,
-                                 std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta>>& results) const
+                                 std::vector<CMempoolAddressDeltaEntry>& results) const
 {
     LOCK(cs);
     for (const auto& address : addresses) {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -636,7 +636,7 @@ public:
     void addUnchecked(const CTxMemPoolEntry& entry, setEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
     void addAddressIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view);
-    bool getAddressIndex(const std::vector<std::pair<uint160, AddressType>>& addresses,
+    bool getAddressIndex(const std::vector<CMempoolAddressDeltaKey>& addresses,
                          std::vector<CMempoolAddressDeltaEntry>& results) const;
     bool removeAddressIndex(const uint256 txhash);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -637,7 +637,7 @@ public:
 
     void addAddressIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view);
     bool getAddressIndex(const std::vector<std::pair<uint160, AddressType>>& addresses,
-                         std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta>>& results) const;
+                         std::vector<CMempoolAddressDeltaEntry>& results) const;
     bool removeAddressIndex(const uint256 txhash);
 
     void addSpentIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -635,13 +635,13 @@ public:
     void addUnchecked(const CTxMemPoolEntry& entry, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
     void addUnchecked(const CTxMemPoolEntry& entry, setEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
-    void addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view);
-    bool getAddressIndex(std::vector<std::pair<uint160, AddressType> > &addresses,
-                         std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results);
+    void addAddressIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view);
+    bool getAddressIndex(const std::vector<std::pair<uint160, AddressType>>& addresses,
+                         std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta>>& results) const;
     bool removeAddressIndex(const uint256 txhash);
 
-    void addSpentIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view);
-    bool getSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
+    void addSpentIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view);
+    bool getSpentIndex(const CSpentIndexKey& key, CSpentIndexValue& value) const;
     bool removeSpentIndex(const uint256 txhash);
 
     void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1055,56 +1055,6 @@ PackageMempoolAcceptResult ProcessNewPackage(CChainState& active_chainstate, CTx
     return result;
 }
 
-bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &hashes)
-{
-    if (!fTimestampIndex)
-        return error("Timestamp index not enabled");
-
-    if (!pblocktree->ReadTimestampIndex(high, low, hashes))
-        return error("Unable to get hashes for timestamps");
-
-    return true;
-}
-
-bool GetSpentIndex(CTxMemPool& mempool, CSpentIndexKey &key, CSpentIndexValue &value)
-{
-    if (!fSpentIndex)
-        return false;
-
-    if (mempool.getSpentIndex(key, value))
-        return true;
-
-    if (!pblocktree->ReadSpentIndex(key, value))
-        return false;
-
-    return true;
-}
-
-bool GetAddressIndex(uint160 addressHash, AddressType type,
-                     std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex, int start, int end)
-{
-    if (!fAddressIndex)
-        return error("address index not enabled");
-
-    if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex, start, end))
-        return error("unable to get txids for address");
-
-    return true;
-}
-
-bool GetAddressUnspent(uint160 addressHash, AddressType type,
-                       std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs)
-{
-    if (!fAddressIndex)
-        return error("address index not enabled");
-
-    if (!pblocktree->ReadAddressUnspentIndex(addressHash, type, unspentOutputs))
-        return error("unable to get txids for address");
-
-    return true;
-}
-
-
 double ConvertBitsToDouble(unsigned int nBits)
 {
     int nShift = (nBits >> 24) & 0xff;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1685,9 +1685,9 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
         return DISCONNECT_FAILED;
     }
 
-    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
-    std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > addressUnspentIndex;
-    std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> > spentIndex;
+    std::vector<CAddressIndexEntry> addressIndex;
+    std::vector<CAddressUnspentIndexEntry> addressUnspentIndex;
+    std::vector<CSpentIndexEntry> spentIndex;
 
     std::optional<MNListUpdates> mnlist_updates_opt{std::nullopt};
     if (!m_chain_helper->special_tx->UndoSpecialTxsInBlock(block, pindex, mnlist_updates_opt)) {
@@ -2152,9 +2152,9 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     int nInputs = 0;
     unsigned int nSigOps = 0;
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
-    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
-    std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > addressUnspentIndex;
-    std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> > spentIndex;
+    std::vector<CAddressIndexEntry> addressIndex;
+    std::vector<CAddressUnspentIndexEntry> addressUnspentIndex;
+    std::vector<CSpentIndexEntry> spentIndex;
 
     bool fDIP0001Active_context = pindex->nHeight >= Params().GetConsensus().DIP0001Height;
 
@@ -4782,9 +4782,9 @@ bool CChainState::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& i
             pindex->GetBlockHash().ToString(), state.ToString());
     }
 
-    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
-    std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > addressUnspentIndex;
-    std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> > spentIndex;
+    std::vector<CAddressIndexEntry> addressIndex;
+    std::vector<CAddressUnspentIndexEntry> addressUnspentIndex;
+    std::vector<CSpentIndexEntry> spentIndex;
 
     for (size_t i = 0; i < block.vtx.size(); i++) {
         const CTransactionRef& tx = block.vtx[i];

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,7 +22,6 @@
 #include <txdb.h>
 #include <txmempool.h> // For CTxMemPool::cs
 #include <serialize.h>
-#include <spentindex.h>
 #include <util/check.h>
 #include <util/hasher.h>
 
@@ -379,13 +378,6 @@ public:
     ScriptError GetScriptError() const { return error; }
 };
 
-bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &hashes);
-bool GetSpentIndex(CTxMemPool& mempool, CSpentIndexKey &key, CSpentIndexValue &value);
-bool GetAddressIndex(uint160 addressHash, AddressType type,
-                     std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
-                     int start = 0, int end = 0);
-bool GetAddressUnspent(uint160 addressHash, AddressType type,
-                       std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs);
 /** Initializes the script-execution cache */
 void InitScriptExecutionCache();
 


### PR DESCRIPTION
## Additional Information

This pull request is motivated by [bitcoin#22371](https://github.com/bitcoin/bitcoin/pull/22371), which gets rid of the `pblocktree` global.

The sole usage of `pblocktree` introduced by Dash is for managing our {address, spent, timestamp} indexes with most of invocations within `BlockManager` or `CChainState`, granting them internal access to `pblocktree` (now `m_block_tree_db`). The sole exception being `Get*Index`, that relies on accessing the global and has no direct internal access.

This pull request aims to refactor code associated with `Get*Index` with the eventual aim of moving gaining access to the global out of the function. `Get*Index` is called exclusively called through RPC, which makes giving it access to `ChainstateManager` quite easy, which makes switching from the global to accessing it through `ChainstateManager` when backporting  [bitcoin#22371](https://github.com/bitcoin/bitcoin/pull/22371) a drop-in replacement.

Alongside that, the surrounding code has been given some TLC:

* Moving code out of `validation.cpp` and into `rpc/index_util.cpp`. The code is exclusively used in RPC logic and doesn't aid in validation.
* Add lock annotations for accessing `pblocktree` (while already protected by `::cs_main`, said protection is currently not enforced but will be once moved into `BlockManager` in the backport)
* `const`-ing input arguments and using pass-by-value for input arguments that can be written inline (i.e. types like `CSpentIndexKey` are still pass-by-ref).
  * While `const`ing `CTxMemPool` functions were possible (courtesy of the presence of `const_iterator`s), the same is currently not possible with `CBlockTreeDB` functions as the iterator is non-`const`.
* Extend error messages to `GetSpentIndex` to bring it line with other `Get*Index`es.
* Define key-value pairings as a `*Entry` typedef and replacing all explicit type constructions with it.
* Make `CTxMemPool::getAddressIndex` indifferent to how `CMempoolAddressDeltaKey` is constructed.
  * Current behaviour is to accept a `std::pair<uint160, AddressType>` and construct the `CMempoolAddressDeltaKey` internally, this was presumably done to account for the return type of `getAddressesFromParams` in the sole call for the `CTxMemPool::getAddressIndex`.
  * This has been changed, moving the construction into the RPC call.
 * Moving {height, timestamp} sorting out of RPC and into the applicable `Get*Index` functions.

## Breaking Changes

None expected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (note: N/A)
- [x] I have added or updated relevant unit/integration/functional/e2e tests (note: N/A)
- [x] I have made corresponding changes to the documentation (note: N/A)
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

