### PR TITLE
feat: add a marker experimental for descriptor wallets

### DIFF
--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -102,10 +102,10 @@
       <item>
        <widget class="QCheckBox" name="descriptor_checkbox">
         <property name="toolTip">
-         <string>Use descriptors for scriptPubKey management</string>
+         <string>Use descriptors for scriptPubKey management. This feature is well-tested but still considered experimental and not recommended for use yet.</string>
         </property>
         <property name="text">
-         <string>Descriptor Wallet</string>
+         <string>Descriptor Wallet (EXPERIMENTAL)</string>
         </property>
        </widget>
       </item>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2987,7 +2987,7 @@ static RPCHelpMan createwallet()
             {"blank", RPCArg::Type::BOOL, /* default */ "false", "Create a blank wallet. A blank wallet has no keys or HD seed. One can be set using upgradetohd (by mnemonic) or sethdseed (WIF private key)."},
             {"passphrase", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Encrypt the wallet with this passphrase."},
             {"avoid_reuse", RPCArg::Type::BOOL, /* default */ "false", "Keep track of coin reuse, and treat dirty and clean coins differently with privacy considerations in mind."},
-            {"descriptors", RPCArg::Type::BOOL, /* default */ "false", "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation"},
+            {"descriptors", RPCArg::Type::BOOL, /* default */ "false", "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation. This feature is well-tested but still considered experimental."},
             {"load_on_startup", RPCArg::Type::BOOL, /* default */ "null", "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
         },
         RPCResult{


### PR DESCRIPTION
## Issue being fixed or feature implemented
Descriptor wallets pass most of functional tests now, but they are not really tested in-the-real-environment by multiple users.

## What was done?
Add a marker "experimental" for 'createwallet' rpc, for create wallet UI form.

## How Has This Been Tested?
Run and check

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone