### PR TITLE
fix: crash if try to upgradetohd descriptor wallet

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5014,6 +5014,11 @@ bool CWallet::UpgradeToHD(const SecureString& secureMnemonic, const SecureString
         return false;
     }
 
+    if (IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
+        error = Untranslated("Use RPC 'importdescriptors' to add new descriptors to Descriptor Wallets");
+        return false;
+    }
+
     WalletLogPrintf("Upgrading wallet to HD\n");
     SetMinVersion(FEATURE_HD);
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

If `upgradetohd` is called for blank descriptor wallet it can cause a crash:
```
Posix Signal: Segmentation fault
   0#: (0x55A0C7658814) stl_vector.h:115        - std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_Vector_impl_data::_M_copy_data(std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_Vector_impl_data const&)
   1#: (0x55A0C7658814) stl_vector.h:127        - std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_Vector_impl_data::_M_swap_data(std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_Vector_impl_data&)
   2#: (0x55A0C7658814) stl_vector.h:1959       - std::vector<unsigned long, std::allocator<unsigned long> >::_M_move_assign(std::vector<unsigned long, std::allocator<unsigned long> >&&, std::integral_constant<bool, true>)
   3#: (0x55A0C7658814) stl_vector.h:768        - std::vector<unsigned long, std::allocator<unsigned long> >::operator=(std::vector<unsigned long, std::allocator<unsigned long> >&&)
   4#: (0x55A0C7658814) stacktraces.cpp:777     - HandlePosixSignal
   5#: (0x744F89C42990) libc_sigaction.c        - ???
   6#: (0x55A0C7789926) scriptpubkeyman.cpp:418 - LegacyScriptPubKeyMan::GenerateNewHDChain(std::__cxx11::basic_string<char, std::char_traits<char>, secure_allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, secure_allocator<char> > const&)
   7#: (0x55A0C77BEC2E) wallet.cpp:5033         - CWallet::UpgradeToHD(std::__cxx11::basic_string<char, std::char_traits<char>, secure_allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, secure_allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, secure_allocator<char> > const&, bilingual_str&)
   8#: (0x55A0C775B85F) rpcwallet.cpp:2839      - operator()
   9#: (0x55A0C775BBB4) std_function.h:292      - _M_invoke
  10#: (0x55A0C72D4BC2) univalue.h:17           - UniValue::operator=(UniValue&&)
  11#: (0x55A0C72D4BC2) server.h:110            - CRPCCommand::CRPCCommand(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RPCHelpMan (*)(), std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >)::{lambda(JSONRPCRequest const&, UniValue&, bool)#1}::operator()(JSONRPCRequest const&, UniValue&, bool) const
  12#: (0x55A0C76ED57C) basic_string.h:792      - std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string()
  13#: (0x55A0C76ED57C) request.h:29            - JSONRPCRequest::~JSONRPCRequest()
  14#: (0x55A0C76ED57C) interfaces.cpp:576      - operator()
  15#: (0x55A0C723B3D9) std_function.h:292      - _M_invoke
  16#: (0x55A0C73D4FFC) std_function.h:591      - std::function<bool (JSONRPCRequest const&, UniValue&, bool)>::operator()(JSONRPCRequest const&, UniValue&, bool) const
  17#: (0x55A0C73D4FFC) server.cpp:609          - ExecuteCommand
  18#: (0x55A0C73D4FFC) server.cpp:528          - CRPCTable::execute(JSONRPCRequest const&) const
  19#: (0x55A0C72421FB) basic_string.h:223      - std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const
  20#: (0x55A0C72421FB) basic_string.h:264      - std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_is_local() const
  21#: (0x55A0C72421FB) basic_string.h:282      - std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose()
  22#: (0x55A0C72421FB) basic_string.h:792      - std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string()
  23#: (0x55A0C72421FB) request.h:29            - JSONRPCRequest::~JSONRPCRequest()
  24#: (0x55A0C72421FB) interfaces.cpp:487      - executeRpc
  25#: (0x55A0C6F37700) univalue.h:17           - UniValue::operator=(UniValue&&)
  26#: (0x55A0C6F37700) rpcconsole.cpp:338      - RPCConsole::RPCParseCommandLine(interfaces::Node*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, WalletModel const*)
  27#: (0x55A0C6F38475) rpcconsole.cpp:444      - RPCExecutor::request(QString const&, WalletModel const*)
  28#: (0x55A0C8064490) <unknown-file>          - ???
  29#: (0x55A0C82E95B2) <unknown-file>          - ???
Aborted (core dumped)
```

## What was done?
Added a guard in UpgradeToHD that wallet is not descriptor wallet.

## How Has This Been Tested?
Create wallet "Blank" + "Descriptor".
Call rpc "upgradetohd" -> no crash

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone