### PR TITLE
fix: auto backup issue with descriptor wallets for CJ

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -715,6 +715,9 @@ bool CCoinJoinClientManager::CheckAutomaticBackup()
 {
     if (!CCoinJoinClientOptions::IsEnabled() || !IsMixing()) return false;
 
+    // We don't need auto-backups for descriptor wallets
+    if (!m_wallet.IsLegacy()) return true;
+
     switch (nWalletBackups) {
     case 0:
         strAutoDenomResult = _("Automatic backups disabled") + Untranslated(", ") + _("no mixing available.");


### PR DESCRIPTION
## Issue being fixed or feature implemented
Qt CoinJoin session has problems (https://github.com/dashpay/dash/pull/5579#pullrequestreview-1912946808):
 - Autobackup problems
 - False keypool depletion reporting

https://github.com/dashpay/dash-issues/issues/59


## What was done?
Disables check for "remaining keys left" and "auto-backups" for non-legacy wallet.

## How Has This Been Tested?
Run unit/functional test
Try to run CJ mixing for descriptor wallet.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone